### PR TITLE
🔥 HOTFIX: Policy Critic CI gate must block on BLOCK severity

### DIFF
--- a/src/risk/hotfix_smoke_test.py
+++ b/src/risk/hotfix_smoke_test.py
@@ -1,9 +1,0 @@
-"""Smoke test for Policy Critic CI gate hotfix - INTENTIONAL BLOCK TRIGGER."""
-# This file contains AWS credentials patterns to verify the CI gate correctly blocks.
-# Expected: Policy Critic workflow should FAIL (red) and prevent merge.
-
-# Test AWS credentials (will trigger NO_SECRETS rule):
-aws_access_key_id = "AKIAIOSFODNN7EXAMPLE"
-aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-
-# DO NOT MERGE - This is a smoke test file for hotfix validation.


### PR DESCRIPTION
## Problem
Policy Critic workflow had a critical bug where exit code 2 (BLOCK) did not prevent PR merge.

**Root Cause:** `continue-on-error: true` caused step to fail before `EXIT_CODE=$?` could capture the exit code, so the conditional check never triggered.

## Solution
1. Replace `continue-on-error: true` with `set +e` and explicit `exit 0`
2. Ensures EXIT_CODE is reliably captured as output
3. Add `if: always()` to Parse, Upload artifact, and Summary steps
4. Hard-fail step now correctly blocks on exit code 2

## Test Plan
- ✅ Local CLI test: exit code 2 on BLOCK violations
- 🔄 **This PR contains intentional BLOCK trigger** (AWS credentials in src/risk/hotfix_smoke_test.py)
- **Expected:** Policy Critic check should FAIL (red) and block merge
- After validation: remove smoke test file, merge hotfix

## Impact
**CRITICAL** - Without this fix, the governance gate does not prevent risky changes from being merged.

---
/cc @rauterfrank-ui - Please verify Policy Critic check shows RED/FAILED before merging.