### PR TITLE
docs(todo-board): add operator quick commands to generated README

### DIFF
--- a/docs/00_overview/README_TODO_BOARD.md
+++ b/docs/00_overview/README_TODO_BOARD.md
@@ -10,6 +10,14 @@ python3 scripts/build_todo_board_html.py
 
 Öffne dann `docs/00_overview/PEAK_TRADE_TODO_BOARD.html` in deinem Browser.
 
+### Operator Quick Commands
+
+```bash
+make todo-board                # Generiere TODO Board
+make todo-board-check          # Validierung (Idempotenz + Tests)
+./scripts/check_todo_board_ci.sh  # CI Guard direkt
+```
+
 ## Features
 
 - 3-spaltige Kanban-Ansicht (TODO, DOING, DONE)

--- a/scripts/build_todo_board_html.py
+++ b/scripts/build_todo_board_html.py
@@ -901,6 +901,14 @@ python3 scripts/build_todo_board_html.py
 
 Öffne dann `docs/00_overview/PEAK_TRADE_TODO_BOARD.html` in deinem Browser.
 
+### Operator Quick Commands
+
+```bash
+make todo-board                # Generiere TODO Board
+make todo-board-check          # Validierung (Idempotenz + Tests)
+./scripts/check_todo_board_ci.sh  # CI Guard direkt
+```
+
 ## Features
 
 - 3-spaltige Kanban-Ansicht (TODO, DOING, DONE)


### PR DESCRIPTION
## Summary

- Add "Operator Quick Commands" section to the generated `README_TODO_BOARD.md`
- Documents the three primary commands for TODO board operations:
  - `make todo-board`
  - `make todo-board-check`
  - `./scripts/check_todo_board_ci.sh`

## Changes

- Modified `scripts/build_todo_board_html.py` to include Quick Commands section in generated README
- The section is automatically generated each time the TODO board is built
- Keeps documentation compact (8 lines total including heading and code block)

## Validation

✅ `make todo-board-check` passes:
- Idempotency test (2x generator run produces identical output)
- Working tree stays clean (diff-zero)
- Smoke tests (4/4 passed)
- Idempotency regression test (1/1 passed)

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Notes

This is a docs-only change with no functional modifications to generator logic, workflows, or test scripts. The Quick Commands section helps operators quickly find the key commands for working with the TODO board system.