### PR TITLE
ci: fast-lane python matrix for PRs (full on main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,12 @@ on:
     branches: ["main", "master"]
   pull_request:
     branches: ["main", "master"]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"  # Monday 03:00 UTC
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,8 +19,9 @@ jobs:
     timeout-minutes: 20
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ${{ fromJSON((github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master'))) && '["3.9","3.10","3.11"]' || '["3.11"]') }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Speed up CI by running only Python 3.11 on pull requests and non-main pushes, while keeping full 3.9/3.10/3.11 coverage on main/master and manual/scheduled runs.

## Behavior
- PRs + pushes to non-main/master → Python 3.11 only
- Push to main/master + workflow_dispatch + schedule → Python 3.9/3.10/3.11
- fail-fast: false so full matrix completes even if one version fails
- concurrency cancel-in-progress to avoid wasted runs
- job timeouts to prevent hanging builds

## Files
- .github/workflows/ci.yml