### PR TITLE
docs(ops): document CI fast lane behavior

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -40,6 +40,16 @@ make audit
 3. Download `audit-artifacts.zip`
 4. Extract and review `summary.md` and `summary.json`
 
+## CI Fast Lane
+
+- **Pull Requests (Fast Lane):** nur **Python 3.11** (schnelles Feedback, typ. ~3–4 min)
+- **main (Full Matrix):** **Python 3.9 / 3.10 / 3.11** (vollständige Kompatibilitätsprüfung nach Merge)
+- **Manuell & geplant:** Full Matrix via `workflow_dispatch` und `schedule`
+- **Hardening:**
+  - `fail-fast: false` (Matrix läuft vollständig durch, auch bei Fehlern)
+  - `concurrency` mit `cancel-in-progress` (alte Runs werden abgebrochen)
+  - **Timeouts:** `tests=20min`, `strategy-smoke=10min`
+
 ### Audit Checks
 
 The audit system runs:


### PR DESCRIPTION
## Summary
Adds operations documentation for the **CI Fast Lane** setup (already implemented in PRs #43, #44).

### Documented Behavior
- **Pull Requests (Fast Lane):** run **Python 3.11 only** for fast feedback (~3-4 min)
- **main (Full Matrix):** run **Python 3.9 / 3.10 / 3.11** for full compatibility check after merge
- **Manual & Scheduled:** full matrix via `workflow_dispatch` and `schedule` (Mon 03:00 UTC)
- **Hardening:** fail-fast=false, concurrency cancel-in-progress, timeouts (tests=20min, strategy-smoke=10min)

## Changes
- docs/ops/README.md — new "CI Fast Lane" section

## Notes
- CI implementation (`.github/workflows/ci.yml`) was already merged via PRs #43 and #44
- This PR adds only the missing documentation