### PR TITLE
docs(ops): add audit logs index

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -160,6 +160,12 @@ git clean -fdX
 
 ---
 
+## Audit Logs (Ops)
+
+- PR #45 – CI Fast Lane Verification Log: `docs/ops/PR_45_FINAL_REPORT.md`
+
+---
+
 ## Related Documentation
 
 - `scripts/run_audit.sh` - Audit script implementation


### PR DESCRIPTION
Adds a small index in docs/ops/README.md to make ops audit/verification logs easier to find. Docs-only.