### PR TITLE
docs(ops): add PR #53 final closeout report

### DIFF
--- a/docs/ops/PR_53_FINAL_REPORT.md
+++ b/docs/ops/PR_53_FINAL_REPORT.md
@@ -1,0 +1,51 @@
+# PR #53 – Final Closeout Report
+
+**PR:** https://github.com/rauterfrank-ui/Peak_Trade/pull/53
+**Status:** MERGED
+**Merged at:** 2025-12-15T20:20:47Z
+**Merge Commit:** `c5ac5aa`
+
+## Scope Summary
+
+Diese PR finalisiert reine Operator-/Ops-Dokumentation rund um den Live Session Evaluation Ablauf (Closeout & Konsistenz-Updates).
+
+## Changes
+
+### Neu
+- `docs/ops/PR_51_FINAL_REPORT.md` (114 Zeilen)
+  Abschlussbericht für PR #51 inkl. Safety Notes (4/4 Checkmarks) + dokumentierten Follow-ups
+
+### Update
+- `docs/ops/LIVE_SESSION_EVALUATION.md` (+7 Zeilen)
+  Safety Notes erweitert für Konsistenz (4 neue Checkmarks), Data Quality Warnung beibehalten
+
+## Validation Summary (CI)
+
+- ✅ CI Health Gate: pass (41s)
+- ✅ audit: pass (1m49s)
+- ✅ strategy-smoke: pass (45s)
+- ✅ tests (3.11): pass (3m48s)
+
+## Safety Notes (OFFLINE ONLY / No live paths affected)
+
+- ✅ Nur `docs/ops/` Dateien geändert
+- ✅ Keine Code-Änderungen
+- ✅ Keine CI/Makefile-Änderungen
+- ✅ Keine Live-Trading-Pfade betroffen
+- ✅ Pure Dokumentation (121 Zeilen +, 1 Zeile -)
+
+## Worktree Status
+
+Worktree `nostalgic-pasteur` ist noch aktiv und wurde auf `main` umgeschaltet:
+
+- Path: `/Users/frnkhrz/.claude-worktrees/Peak_Trade/nostalgic-pasteur`
+- Branch: `main` (`c5ac5aa`)
+- Status: Clean
+
+Optional kann der Worktree entfernt werden (Operator-Entscheidung).
+
+## Follow-ups (optional, NICHT implementiert)
+
+- ⏸️ Makefile target: `make live-eval-smoke`
+- ⏸️ CI integration: Smoke test
+- ⏸️ JSON schema export: `.json` schema file

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -167,6 +167,8 @@ Konvention:
 - Regel: Wenn ein Ops-PR einen auditierbaren Verification Log erzeugt, hier verlinken.
 
 - PR #45 – CI Fast Lane Verification Log: `docs/ops/PR_45_FINAL_REPORT.md`
+- PR #51 – Live Eval CLI + Metrics Final Report: `docs/ops/PR_51_FINAL_REPORT.md`
+- PR #53 – Final Closeout Report: `docs/ops/PR_53_FINAL_REPORT.md`
 
 ---
 


### PR DESCRIPTION
## Summary
Pure docs-only update. Adds a final closeout report for PR #53 and links it from the Ops Audit Logs index.

## Changes
- Add `docs/ops/PR_53_FINAL_REPORT.md` (final closeout report)
- Update `docs/ops/README.md` (Audit Logs (Ops) index entries for PR #51 and PR #53)

## Safety (OFFLINE ONLY)
- [x] Only `docs/ops/` files changed
- [x] No code changes
- [x] No CI/Makefile changes
- [x] No live-trading paths affected