### PR TITLE
docs(ops): dedupe ops README audit entries for PR #61-63

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -168,9 +168,6 @@ Konvention:
 - PR #45 – CI Fast Lane Verification Log: `docs/ops/PR_45_FINAL_REPORT.md`
 - PR #51 – Live Eval CLI + Metrics Final Report: `docs/ops/PR_51_FINAL_REPORT.md`
 - PR #53 – Final Closeout Report: `docs/ops/PR_53_FINAL_REPORT.md`
-- PR #61 – Final Report
-- PR #62 – Final Report
-- PR #63 – Final Report
 
 ---
 - PR #61 – Final Report: `docs/ops/PR_61_FINAL_REPORT.md`


### PR DESCRIPTION
Removes duplicate PR #61–#63 audit log entries without file paths; keeps the canonical entries with docs/ops/PR_6x_FINAL_REPORT.md paths.