### PR TITLE
docs(ops): index PR #76 merge log

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -182,6 +182,14 @@ Konvention:
 
 ---
 
+## Merge Logs (Ops)
+
+Post-merge documentation logs for operational PRs.
+
+- PR #76 – Merge Log: `docs/ops/PR_76_MERGE_LOG.md`
+
+---
+
 ## Live Session Evaluation
 
 Offline tool for analyzing live trading sessions from `fills.csv`.


### PR DESCRIPTION
Adds an index entry for the PR #76 merge log (docs-only).