### PR TITLE
chore(repo): ignore reports/ test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ tmp/
 
 # Local audit outputs
 reports/audit/
+
+# Test/runtime artifacts
+reports/


### PR DESCRIPTION
Ignore generated runtime/test artifacts under reports/ so local test runs don't leave untracked files (prevents gh 'uncommitted change' warnings).