### PR TITLE
docs(ops): add PR #85 merge log

### DIFF
--- a/docs/ops/PR_85_MERGE_LOG.md
+++ b/docs/ops/PR_85_MERGE_LOG.md
@@ -1,0 +1,53 @@
+# PR #85 – Merge Log
+
+## Metadata
+- **PR:** https://github.com/rauterfrank-ui/Peak_Trade/pull/85
+- **Title:** feat(reporting): phase57 live status snapshot endpoints (json+html)
+- **State:** MERGED
+- **Merged At (UTC):** 2025-12-16T10:20:04Z
+- **Merge Commit:** `b2ae369a22584229d363ebbf4be095112dbc59cd`
+- **Base → Head:** `main` ← `feat/phase-57-live-status-snapshot-builder-api`
+- **Author:** `rauterfrank-ui`
+- **Diffstat:** +1432 / −0
+- **Log Generated (UTC):** 2025-12-16T10:25:00Z
+
+## Purpose
+- Documents the successful merge of PR #85 and the post-merge verification steps.
+
+## What PR #85 Delivered
+- Phase 57 Extension: Live Status Snapshot system with JSON + HTML endpoints
+- Panel Provider Pattern for modular panel builders
+- XSS-safe HTML rendering with deterministic output
+- Comprehensive test coverage (59 tests, all passing)
+- Zero breaking changes (additive endpoints only)
+
+## Changed Files in PR #85
+- `.github/workflows/guard-reports-ignored.yml`
+- `.gitignore`
+- `README.md`
+- `docs/ARCHITECTURE.md`
+- `src/reporting/live_status_snapshot_builder.py`
+- `src/reporting/status_snapshot_schema.py`
+- `src/webui/app.py`
+- `tests/test_live_status_snapshot_builder.py`
+- `tests/test_live_status_snapshot_api.py`
+
+## Post-Merge Verifications
+- Main branch updated successfully via fast-forward merge
+- All CI checks passed (audit, strategy-smoke, tests on Python 3.11)
+- Post-merge test suite executed: 59 tests passed in 1.32s
+- Working tree clean after merge
+
+## Key Technical Features
+- `/live/status` endpoint for JSON snapshot
+- `/live/status/html` endpoint for HTML rendering
+- Schema-first snapshot model (`StatusSnapshot` from `status_snapshot_schema.py`)
+- Panel Provider Pattern: each panel builder isolated with graceful degradation
+- Deterministic output: stable sort of panels/details, no random IDs
+- Security: HTML is escaped/XSS-safe by design
+
+## Notes
+- This is a major feature addition to the reporting system
+- Read-only endpoints with no automatic actions or side effects
+- Defensive error handling per panel ensures partial failures degrade gracefully
+- Tests confirm all endpoints return correct status codes and valid data

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -187,6 +187,7 @@ Konvention:
 Post-merge documentation logs for operational PRs.
 
 - PR #76 – Merge Log: `docs/ops/PR_76_MERGE_LOG.md`
+- PR #85 – Merge Log: `docs/ops/PR_85_MERGE_LOG.md`
 
 ---
 


### PR DESCRIPTION
Adds the merge log for the recently merged PR #85 and indexes it in docs/ops/README.md.

## Notes
- Generated for PR #85 (Phase 57 Live Status Snapshot endpoints)
- Documents post-merge verification: 59 tests passed, all CI checks green
- Safe, additive documentation-only change
- Follows established merge log pattern (see PR #76)