### PR TITLE
docs(ops): add PR #87 merge log

### DIFF
--- a/docs/ops/PR_87_MERGE_LOG.md
+++ b/docs/ops/PR_87_MERGE_LOG.md
@@ -1,0 +1,30 @@
+# PR #87 - Merge Log Documentation (MERGED ✅)
+
+## Merge Details
+
+- PR: #87 – docs(ops): add git state validation documentation
+- Merged At: 2025-12-16T13:22:13Z
+- Merge Commit: fd7d3e1db69625334f9042ac7ae2646afc62d0ee
+
+## Diffstat
+
+ docs/ops/GIT_STATE_VALIDATION.md | 31 +++++++++++++++++++++++++++++++
+ docs/ops/README.md               |  1 +
+ 2 files changed, 32 insertions(+)
+
+## CI Status
+
+audit	pending	0	https://github.com/rauterfrank-ui/Peak_Trade/actions/runs/20269400733/job/58200876031	
+tests (3.11)	pending	0	https://github.com/rauterfrank-ui/Peak_Trade/actions/runs/20269400823/job/58200876156	
+CI Health Gate (weekly_core)	pass	43s	https://github.com/rauterfrank-ui/Peak_Trade/actions/runs/20269400742/job/58200876051	
+
+## What Was Delivered
+
+- Created `docs/ops/GIT_STATE_VALIDATION.md`
+- Linked the doc in `docs/ops/README.md`
+
+## Post-Merge Validation
+
+- ✅ main updated to merge commit fd7d3e1
+- ✅ Manual verification passed (clean tree, correct HEAD)
+- ⚠️ post_merge_verify.sh script not yet implemented

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -188,6 +188,7 @@ Post-merge documentation logs for operational PRs.
 
 - PR #76 – Merge Log: `docs/ops/PR_76_MERGE_LOG.md`
 - PR #85 – Merge Log: `docs/ops/PR_85_MERGE_LOG.md`
+- PR #87 – Merge Log: `docs/ops/PR_87_MERGE_LOG.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Adds merge log documentation for PR #87.

- New: `docs/ops/PR_87_MERGE_LOG.md`
- Link added in `docs/ops/README.md`

## Validation

- ✅ Branch created from main (fd7d3e1)
- ✅ Only merge log changes (2 files, 31 additions)
- ✅ Manual verification passed (post_merge_verify.sh not yet implemented)
- ✅ Clean diff from main

## Notes

- Replaces closed PR #88 (incorrect base)
- Documentation-only changes
