### PR TITLE
docs(ops): add PR #93 merge log

### DIFF
--- a/docs/ops/PR_93_MERGE_LOG.md
+++ b/docs/ops/PR_93_MERGE_LOG.md
@@ -1,0 +1,144 @@
+# PR #93 - Merge Log Documentation (MERGED ✅)
+
+## Merge Details
+
+- **PR**: #93 – docs(ops): add PR #92 merge log
+- **Merged At**: 2025-12-16T17:01:59Z
+- **Merge Commit**: `d0ce9fb7335ffb8c14392d2d040b68c4f611a8fe`
+- **Author**: rauterfrank-ui
+- **Reviewers**: (self-merged after validation)
+
+## Summary
+
+Adds merge log documentation for PR #92, closing the traceability loop for the previous operational PR merge.
+
+## Diffstat
+
+```
+ docs/ops/README.md | 1 +
+ 1 file changed, 1 insertion(+)
+```
+
+## What Was Delivered
+
+Merge log documentation for PR #92:
+
+### Documentation Updates
+- Added entry to `docs/ops/README.md` indexing PR #92 merge log
+- Maintained chronological order in merge logs section
+- Integrated with existing merge log entries (PRs #76, #85, #87, #90)
+
+### Traceability Closeout
+This PR completes the documentation cycle for PR #92, which itself documented the merge of a previous operational PR. This follows the established pattern where operational/meta PRs receive their own merge documentation for full traceability.
+
+## CI Status
+
+- ✅ **CI Health Gate (weekly_core)**: pass (39s)
+- ✅ **audit**: pass (1m53s)
+- ✅ **tests (3.11)**: pass (3m33s)
+- ✅ **strategy-smoke**: pass (42s)
+- ⏭️ **Daily/Manual/Weekly checks**: skipped (as expected)
+
+All required CI checks passed before merge.
+
+## Pre-Merge Validation
+
+**Review Checklist:**
+- ✅ Documentation format consistent with existing merge logs
+- ✅ Index entry added to README.md
+- ✅ No duplicate entries
+- ✅ Chronological ordering maintained
+- ✅ CI checks passed
+
+**Merge Conflict Resolution:**
+During merge preparation, a conflict occurred in `docs/ops/README.md` due to concurrent updates to the merge logs section. Resolution steps:
+1. Fetched and merged `origin/main` into feature branch
+2. Resolved conflict by preserving all merge log entries (PRs #85, #87, #90, #92)
+3. Maintained chronological order
+4. Pushed resolved merge commit
+5. CI re-validated successfully
+
+## Post-Merge Validation
+
+**Verification Steps:**
+1. ✅ PR merged via GitHub (squash)
+2. ✅ Switched to main worktree (`/Users/frnkhrz/.claude-worktrees/Peak_Trade/competent-hugle`)
+3. ✅ Pulled latest changes (fast-forward to d0ce9fb)
+4. ✅ Ran git state validation
+5. ✅ Ran post-merge verification
+
+**Git State Validation Output:**
+```bash
+Repo: /Users/frnkhrz/.claude-worktrees/Peak_Trade/competent-hugle
+HEAD: d0ce9fb7335ffb8c14392d2d040b68c4f611a8fe
+Branch: main (expected: main)
+Dirty: 0
+Remote: origin  FetchOK: 1  Divergence: ahead=0 behind=0
+Warnings: none
+Result: OK
+```
+
+**Post-Merge Verification Output:**
+```bash
+Verification Result
+✅ HEAD matches expected: d0ce9fb
+Repo: /Users/frnkhrz/.claude-worktrees/Peak_Trade/competent-hugle
+Branch: main (expected: main)
+Divergence vs origin/main: behind=0 ahead=0
+Warnings: none
+```
+
+## Technical Notes
+
+### Design Decisions
+
+1. **Documentation-only change**
+   - Single file modification (README.md index)
+   - No code changes required
+   - Low risk, high traceability value
+
+2. **Merge conflict handling**
+   - Conflict resolved locally before merge
+   - All concurrent merge log entries preserved
+   - CI re-validated after conflict resolution
+
+3. **Worktree workflow**
+   - Used separate worktree for feature branch
+   - Main worktree updated post-merge
+   - Verification scripts run in main worktree context
+
+### Merge Process
+
+**Conflict Resolution:**
+- Resolved merge conflict in `docs/ops/README.md`
+- Integrated merge log entries from PRs #85, #87, #90 (from main)
+- Added PR #92 entry (from feature branch)
+- Maintained chronological order
+
+**Merge Method:**
+- Squash merge via GitHub
+- Branch `angry-shockley` deleted after merge
+- Fast-forward update in main worktree
+
+## Related Documentation
+
+- `docs/ops/PR_92_MERGE_LOG.md` - Previous merge log (subject of this PR)
+- `docs/ops/README.md` - Operations guide index
+- `docs/ops/PR_REPORT_AUTOMATION_RUNBOOK.md` - PR report automation
+
+## Lessons Learned
+
+1. **Concurrent updates**: When multiple PRs update the same documentation index, expect merge conflicts
+2. **Conflict resolution workflow**: Resolve locally, push, let CI re-validate - works smoothly
+3. **Worktree management**: Post-merge verification requires running in the correct worktree (main)
+
+## Follow-up Actions
+
+- ✅ Create merge log for PR #93 (this document) - **IN PROGRESS**
+- Continue established traceability pattern for future operational PRs
+
+---
+
+**Merge verified**: 2025-12-16
+**Documentation location**: `docs/ops/`
+**Status**: ✅ Merged and validated

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -191,6 +191,7 @@ Post-merge documentation logs for operational PRs.
 - PR #87 – Merge Log: `docs/ops/PR_87_MERGE_LOG.md`
 - PR #90 – chore(ops): add git state + post-merge verification scripts – `docs/ops/PR_90_MERGE_LOG.md`
 - PR #92 – Merge Log: `docs/ops/PR_92_MERGE_LOG.md`
+- PR #93 – Merge Log: `docs/ops/PR_93_MERGE_LOG.md`
 
 ---
 


### PR DESCRIPTION
Add merge log for PR #93 (traceability closeout).

## Summary
- ✅ Added docs: `docs/ops/PR_93_MERGE_LOG.md`
- ✅ Updated index: `docs/ops/README.md`
- ✅ Merge commit (short SHA): `d0ce9fb` (commit time: 2025-12-16T17:01:59Z)
- ✅ All validations passed

## Verification
- `scripts/validate_git_state.sh`: OK (no warnings, no divergence)
- `scripts/automation/post_merge_verify.sh --expected-head d0ce9fb --merge-log-pr 93`: OK (HEAD match, synced)

## Notes
This PR only adds documentation and closes the traceability loop for PR #93.