### PR TITLE
docs(ops): add PR #121 merge log

### DIFF
--- a/docs/ops/PR_121_MERGE_LOG.md
+++ b/docs/ops/PR_121_MERGE_LOG.md
@@ -1,0 +1,39 @@
+# PR #121 — Merge Log
+
+## PR
+- Title: chore(ops): default expected head in post-merge verify
+- URL: https://github.com/rauterfrank-ui/Peak_Trade/pull/121
+- Base: main
+- Head: priceless-banach
+
+## Merge
+- Merge SHA: 94a1e728a380b5e4239f8411595458cb88472a9b
+- Merged at: 2025-12-17T22:12:45Z
+- Diffstat: +11 / -5 (files changed: 1)
+
+## Summary
+- Make `--expected-head` optional in `scripts/automation/post_merge_verify.sh`
+- Default to `origin/main` after `git fetch origin` when omitted
+- Emit clear warning on stderr when default is used
+- Keep all verification semantics + exit codes unchanged (0/2/4)
+
+## Why
+- Reduces friction in standard post-merge workflow
+- Eliminates need to manually pass `$(git rev-parse origin/main)`
+- Preserves strict validation for automated/CI use cases
+
+## Verification
+- CI: All PR checks green (tests, audit, strategy-smoke, health-gate)
+- Local: `scripts/automation/post_merge_verify.sh` (no args) → exit 0 + WARN visible
+- Post-merge: `scripts/validate_git_state.sh` → OK
+
+## Testing
+```bash
+# Default mode (new)
+scripts/automation/post_merge_verify.sh
+# ⚠️  WARN: --expected-head not provided; defaulting to origin/main after git fetch
+# ✅ HEAD matches expected: 94a1e72...
+
+# Explicit mode (unchanged)
+scripts/automation/post_merge_verify.sh --expected-head $(git rev-parse origin/main)
+```

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -236,3 +236,4 @@ python scripts/evaluate_live_session.py \
 - PR #110 – feat(reporting): Quarto smoke report
   - docs/ops/PR_110_MERGE_LOG.md
 - PR #116: docs/ops/PR_116_MERGE_LOG.md
+- PR #121 – chore(ops): default expected head in post-merge verify – `docs/ops/PR_121_MERGE_LOG.md`


### PR DESCRIPTION
## Summary
- Document PR #121 (post-merge verify default expected-head feature)
- Add merge log to ops documentation index

## Changes
- `docs/ops/PR_121_MERGE_LOG.md` - Full merge documentation
- `docs/ops/README.md` - Index entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)