### PR TITLE
feat(p2.2): optional OpenTelemetry wiring + lake spans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ web = [
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
 ]
+otel = [
+    "opentelemetry-api>=1.24.0",
+    "opentelemetry-sdk>=1.24.0",
+    "opentelemetry-exporter-otlp>=1.24.0",
+]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/obs/__init__.py
+++ b/src/obs/__init__.py
@@ -1,0 +1,23 @@
+"""Observability helpers (optional).
+
+This package is optional and designed for graceful degradation when dependencies
+are missing.
+"""
+
+from .otel import (
+    OTelHandle,
+    OTelNotAvailableError,
+    get_tracer,
+    init_otel,
+    instrument_lake,
+    is_otel_available,
+)
+
+__all__ = [
+    "OTelHandle",
+    "OTelNotAvailableError",
+    "get_tracer",
+    "init_otel",
+    "instrument_lake",
+    "is_otel_available",
+]

--- a/src/obs/otel.py
+++ b/src/obs/otel.py
@@ -1,0 +1,212 @@
+"""Minimal OpenTelemetry wiring (optional).
+
+Design goals:
+- Optional dependencies (no import crashes).
+- Useful defaults, but no forced global auto-instrumentation.
+- Simple LakeClient span wrappers via instrument_lake().
+
+Exported API:
+- is_otel_available
+- init_otel
+- get_tracer
+- instrument_lake
+- OTelHandle
+- OTelNotAvailableError
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Optional, TYPE_CHECKING
+import contextlib
+import functools
+
+ExporterType = Literal["none", "console", "otlp"]
+
+if TYPE_CHECKING:  # pragma: no cover
+    # Only for typing; must not be required at runtime.
+    from opentelemetry.sdk.trace import TracerProvider  # type: ignore
+    from opentelemetry.trace import Tracer  # type: ignore
+
+
+class OTelNotAvailableError(RuntimeError):
+    """Raised when OpenTelemetry is requested but dependencies are missing."""
+
+    def __init__(self, message: str | None = None) -> None:
+        msg = message or ("OpenTelemetry is not available. Install with: pip install -e '.[otel]'")
+        super().__init__(msg)
+
+
+@dataclass(frozen=True)
+class OTelHandle:
+    """Result of init_otel()."""
+
+    provider: Any
+    service_name: str
+    exporter_type: ExporterType
+    is_noop: bool
+
+
+class _NoOpSpan:
+    def __enter__(self) -> "_NoOpSpan":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        return None
+
+    def record_exception(self, exc: BaseException) -> None:
+        return None
+
+    def set_status(self, status: Any) -> None:
+        return None
+
+
+class _NoOpTracer:
+    @contextlib.contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any):
+        yield _NoOpSpan()
+
+
+def is_otel_available() -> bool:
+    """Return True if OpenTelemetry API+SDK are importable."""
+    try:
+        import opentelemetry.trace  # noqa: F401
+        import opentelemetry.sdk.trace  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def init_otel(
+    service_name: str,
+    exporter: ExporterType = "none",
+    endpoint: Optional[str] = None,
+) -> OTelHandle:
+    """Initialize tracing.
+
+    exporter="none": always returns a no-op handle (no deps required).
+    exporter!="none": requires OpenTelemetry deps, otherwise raises OTelNotAvailableError.
+    """
+    if exporter == "none":
+        return OTelHandle(
+            provider=None, service_name=service_name, exporter_type=exporter, is_noop=True
+        )
+
+    if not is_otel_available():
+        raise OTelNotAvailableError()
+
+    # Lazy imports
+    from opentelemetry import trace
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+
+    if exporter == "console":
+        from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+
+        provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    elif exporter == "otlp":
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        except Exception as e:  # pragma: no cover
+            raise OTelNotAvailableError(
+                "OTLP exporter not available. Install with: pip install -e '.[otel]'"
+            ) from e
+
+        kwargs: dict[str, Any] = {}
+        if endpoint:
+            kwargs["endpoint"] = endpoint
+        provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(**kwargs)))
+    else:  # pragma: no cover
+        raise ValueError(f"Unsupported exporter: {exporter}")
+
+    # Best-effort set global provider (doesn't need to be relied upon)
+    try:
+        trace.set_tracer_provider(provider)
+    except Exception:
+        # If provider already set, do not fail.
+        pass
+
+    return OTelHandle(
+        provider=provider, service_name=service_name, exporter_type=exporter, is_noop=False
+    )
+
+
+def get_tracer(name: str, provider: Any | None = None) -> Any:
+    """Get a tracer. Returns a no-op tracer if deps missing."""
+    if not is_otel_available():
+        return _NoOpTracer()
+
+    from opentelemetry import trace
+
+    if provider is not None:
+        return trace.get_tracer(name, tracer_provider=provider)
+    return trace.get_tracer(name)
+
+
+def instrument_lake(client: Any, provider: Any | None = None) -> Any:
+    """Wrap common LakeClient methods to emit spans.
+
+    Returns the same client instance (methods are wrapped in-place).
+    If OpenTelemetry is unavailable, returns client unchanged.
+    """
+    if not is_otel_available():
+        return client
+
+    tracer = get_tracer("src.obs.instrument_lake", provider=provider)
+
+    def _wrap(method_name: str, span_name: str):
+        if not hasattr(client, method_name):
+            return
+        orig = getattr(client, method_name)
+        if not callable(orig):
+            return
+
+        @functools.wraps(orig)
+        def wrapped(*args: Any, **kwargs: Any):
+            # Lazy imports for status handling
+            try:
+                from opentelemetry.trace.status import Status, StatusCode
+            except Exception:  # pragma: no cover
+                Status = None  # type: ignore
+                StatusCode = None  # type: ignore
+
+            with tracer.start_as_current_span(span_name) as span:
+                # Common attributes
+                try:
+                    span.set_attribute("lake.method", method_name)
+                    if args and isinstance(args[0], str) and method_name in ("query", "execute"):
+                        span.set_attribute("db.statement", args[0])
+                    if "path" in kwargs and isinstance(kwargs["path"], str):
+                        span.set_attribute("lake.path", kwargs["path"])
+                except Exception:
+                    pass
+
+                try:
+                    return orig(*args, **kwargs)
+                except Exception as e:
+                    try:
+                        span.record_exception(e)
+                        if Status is not None and StatusCode is not None:
+                            span.set_status(Status(StatusCode.ERROR, str(e)))
+                    except Exception:
+                        pass
+                    raise
+
+        setattr(client, method_name, wrapped)
+
+    _wrap("query", "lake.query")
+    _wrap("execute", "lake.execute")
+    _wrap("create_table_from_df", "lake.create_table_from_df")
+    _wrap("register_parquet_file", "lake.register_parquet_file")
+    _wrap("register_parquet_folder", "lake.register_parquet_folder")
+    _wrap("close", "lake.close")
+
+    return client

--- a/tests/obs/test_otel.py
+++ b/tests/obs/test_otel.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+
+from src.obs import (
+    OTelNotAvailableError,
+    get_tracer,
+    init_otel,
+    instrument_lake,
+    is_otel_available,
+)
+
+
+def test_is_otel_available_returns_bool():
+    v = is_otel_available()
+    assert isinstance(v, bool)
+
+
+def test_get_tracer_never_crashes():
+    tr = get_tracer("test")
+    assert tr is not None
+
+
+def test_init_otel_none_always_returns_noop_handle():
+    h = init_otel("peak_trade", exporter="none")
+    assert h.is_noop is True
+    assert h.exporter_type == "none"
+
+
+def test_init_otel_console_requires_deps_or_raises():
+    if not is_otel_available():
+        with pytest.raises(OTelNotAvailableError):
+            init_otel("peak_trade", exporter="console")
+    else:
+        h = init_otel("peak_trade", exporter="console")
+        assert h.is_noop is False
+        assert h.provider is not None
+
+
+def test_instrument_lake_returns_same_object():
+    class DummyLake:
+        def query(self, sql: str):
+            return {"ok": True, "sql": sql}
+
+    lake = DummyLake()
+    out = instrument_lake(lake)
+    assert out is lake
+
+
+@pytest.mark.skipif(not is_otel_available(), reason="OpenTelemetry deps not installed")
+def test_instrument_lake_emits_spans_with_provider():
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    class DummyLake:
+        def query(self, sql: str):
+            return {"ok": True}
+
+    lake = DummyLake()
+    instrument_lake(lake, provider=provider)
+
+    lake.query("select 1")
+    spans = exporter.get_finished_spans()
+    assert any(s.name == "lake.query" for s in spans)
+
+
+@pytest.mark.skipif(not is_otel_available(), reason="OpenTelemetry deps not installed")
+def test_instrument_lake_records_exception_and_reraises():
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    from opentelemetry.trace.status import StatusCode
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    class DummyLake:
+        def query(self, sql: str):
+            raise ValueError("boom")
+
+    lake = DummyLake()
+    instrument_lake(lake, provider=provider)
+
+    with pytest.raises(ValueError):
+        lake.query("select 1")
+
+    spans = exporter.get_finished_spans()
+    err_spans = [s for s in spans if s.name == "lake.query"]
+    assert err_spans, "expected lake.query span"
+    assert err_spans[0].status.status_code == StatusCode.ERROR


### PR DESCRIPTION
## Summary
Implements **P2.2 minimal OpenTelemetry wiring** as an optional feature.

## Changes
- `src/obs/`: `otel.py` + public exports
- `tests/obs/`: coverage with skip behavior depending on deps
- `pyproject.toml`: adds `otel` extras group

## Behavior
- Graceful degradation: import-safe; `exporter="none"` returns no-op handle; `console/otlp` require deps with clear error.
- `instrument_lake()` wraps common LakeClient-style methods and emits spans.

## Non-goals
- No Grafana/Loki/Tempo/Prometheus (P2.3)
- No global auto-instrumentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)