### PR TITLE
feat(dev): local MLflow via docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ live_runs/
 # Temporary test artifacts (Policy Critic cycles, etc.)
 tmp/
 reports/
+docker/.env

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,25 @@ report-smoke:
 report-smoke-open: report-smoke
 	@echo "Opening smoke report in browser..."
 	open reports/quarto/smoke.html
+# --- Dev Infra: MLflow via Docker Compose ---
+DOCKER_COMPOSE ?= docker compose -f docker/compose.yml --env-file docker/.env
+
+.PHONY: mlflow-up mlflow-down mlflow-logs mlflow-reset mlflow-smoke
+
+mlflow-up:
+	@cp -n docker/.env.example docker/.env 2>/dev/null || true
+	@$(DOCKER_COMPOSE) up -d --build
+	@echo "MLflow UI: http://localhost:$${MLFLOW_PORT:-5001}"
+
+mlflow-down:
+	@$(DOCKER_COMPOSE) down
+
+mlflow-logs:
+	@$(DOCKER_COMPOSE) logs -f mlflow
+
+mlflow-reset:
+	@$(DOCKER_COMPOSE) down -v
+
+mlflow-smoke:
+	@echo "Using MLFLOW_TRACKING_URI=http://localhost:$${MLFLOW_PORT:-5001}"
+	@MLFLOW_TRACKING_URI="http://localhost:$${MLFLOW_PORT:-5001}" python3 -c 'import mlflow; mlflow.set_experiment("peak_trade_local_docker"); r = mlflow.start_run(run_name="make_mlflow_smoke"); mlflow.log_param("ui_port", 5001); mlflow.log_metric("ok", 1.0); mlflow.end_run(); print("✅ logged run to", mlflow.get_tracking_uri())'

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,2 @@
+# macOS: 5000 kann belegt sein (AirPlay). Default hier 5001.
+MLFLOW_PORT=5001

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,19 @@
+# Peak_Trade – Docker (local)
+
+## Start
+```bash
+docker compose -f docker/compose.yml up -d --build
+```
+
+## UI
+http://localhost:5001
+
+## Stop
+```bash
+docker compose -f docker/compose.yml down
+```
+
+## Reset (löscht MLflow DB + Artifacts)
+```bash
+docker compose -f docker/compose.yml down -v
+```

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,25 @@
+name: peak-trade
+
+services:
+  mlflow:
+    build:
+      context: ..
+      dockerfile: docker/mlflow/Dockerfile
+    container_name: peak-trade-mlflow
+    ports:
+      - "${MLFLOW_PORT:-5001}:5000"
+    environment:
+      # Wird im Container genutzt (sqlite + artifacts lokal im Volume)
+      MLFLOW_BACKEND_STORE_URI: sqlite:////mlflow/mlflow.db
+      MLFLOW_DEFAULT_ARTIFACT_ROOT: /mlflow/artifacts
+    volumes:
+      - peak_trade_mlflow:/mlflow
+    command: >
+      mlflow server
+      --host 0.0.0.0
+      --port 5000
+      --backend-store-uri ${MLFLOW_BACKEND_STORE_URI}
+      --default-artifact-root ${MLFLOW_DEFAULT_ARTIFACT_ROOT}
+
+volumes:
+  peak_trade_mlflow:

--- a/docker/mlflow/Dockerfile
+++ b/docker/mlflow/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Pin optional via build arg (falls du später reproduzierbar werden willst)
+ARG MLFLOW_VERSION=2.15.1
+RUN pip install --no-cache-dir --upgrade pip \
+  && pip install --no-cache-dir "mlflow==${MLFLOW_VERSION}"
+
+EXPOSE 5000


### PR DESCRIPTION
Adds a minimal local-only MLflow stack via Docker Compose (SQLite + volume artifacts) and Make targets (mlflow-up/down/logs/reset/smoke).

Notes:
- macOS-friendly default port 5001 (AirPlay conflict workaround)
- docker/.env is gitignored to avoid committing local config