### PR TITLE
docs(dev): polish local MLflow docker quickstart

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,19 +1,133 @@
 # Peak_Trade – Docker (local)
 
-## Start
+Local MLflow tracking server for development and experimentation.
+
+## Quick Start
+
+### Prerequisites
+- Docker & Docker Compose installed
+- Port 5001 available (or customize via `docker/.env`)
+
+### Start MLflow
 ```bash
-docker compose -f docker/compose.yml up -d --build
+make mlflow-up
+# Or directly:
+# docker compose -f docker/compose.yml up -d --build
 ```
 
-## UI
+### Access UI
 http://localhost:5001
 
-## Stop
+### Stop MLflow
 ```bash
-docker compose -f docker/compose.yml down
+make mlflow-down
+# Or directly:
+# docker compose -f docker/compose.yml down
 ```
 
-## Reset (löscht MLflow DB + Artifacts)
+### Full Reset (deletes all data)
 ```bash
-docker compose -f docker/compose.yml down -v
+make mlflow-reset
+# Or directly:
+# docker compose -f docker/compose.yml down -v
 ```
+
+## Configuration
+
+Edit `docker/.env` to customize (auto-created from `.env.example`):
+
+```bash
+# Port for MLflow UI (default: 5001)
+MLFLOW_PORT=5001
+```
+
+**Note:** Port 5000 is often occupied by macOS AirPlay Receiver. Using 5001 avoids conflicts.
+
+## Persistence
+
+### What Persists Between Restarts
+- **Experiments & Runs:** Stored in `mlruns/` volume
+- **Artifacts:** Stored in `mlartifacts/` volume
+- **Configuration:** `docker/.env` (gitignored, safe to customize locally)
+
+### What Gets Deleted
+- `make mlflow-down`: Stops container, **keeps data**
+- `make mlflow-reset`: **Destroys volumes** (all experiments/artifacts lost)
+
+Use `mlflow-reset` when you want a clean slate or to free disk space.
+
+## Expected Warnings (Non-Critical)
+
+When starting MLflow, you may see:
+
+```
+The "MLFLOW_BACKEND_STORE_URI" variable is not set. Defaulting to a blank string.
+The "MLFLOW_DEFAULT_ARTIFACT_ROOT" variable is not set. Defaulting to a blank string.
+```
+
+**This is expected and safe.** MLflow defaults to file-based local storage (suitable for development). These warnings can be ignored unless you're configuring an external database backend.
+
+## Troubleshooting
+
+### Port Already in Use
+
+**Symptoms:**
+```
+Error: bind: address already in use
+```
+
+**Solutions:**
+1. Check if port 5001 is occupied:
+   ```bash
+   lsof -i :5001
+   ```
+
+2. Kill conflicting process or change port in `docker/.env`:
+   ```bash
+   MLFLOW_PORT=5002
+   ```
+
+3. On macOS, disable AirPlay Receiver if using port 5000:
+   - System Preferences → Sharing → AirPlay Receiver (turn off)
+
+### UI Not Reachable
+
+**Checklist:**
+- [ ] Container running? `docker ps | grep mlflow`
+- [ ] Logs show errors? `make mlflow-logs`
+- [ ] Port correct? Check `docker/.env` for `MLFLOW_PORT`
+- [ ] Firewall blocking? Temporarily disable or allow port 5001
+
+### Docker Not Found
+
+**Error:**
+```
+docker: command not found
+```
+
+**Solution:** Install Docker Desktop:
+- macOS: https://docs.docker.com/desktop/install/mac-install/
+- Linux: https://docs.docker.com/engine/install/
+
+### Container Crashes on Startup
+
+**Steps:**
+1. Check logs: `make mlflow-logs`
+2. Try full reset: `make mlflow-reset && make mlflow-up`
+3. Verify disk space: `df -h`
+
+## Make Targets
+
+| Command | Description |
+|---------|-------------|
+| `make mlflow-up` | Build & start MLflow container |
+| `make mlflow-down` | Stop container (keeps data) |
+| `make mlflow-logs` | Follow container logs (Ctrl+C to exit) |
+| `make mlflow-reset` | **Destructive:** Remove container + volumes |
+| `make mlflow-smoke` | Smoke test: log test run to verify setup |
+
+## Notes
+
+- **Dev/Local only:** Not production-ready (no external DB, no S3 artifacts)
+- **No CI integration:** MLflow runs locally only (not in automated tests)
+- **Data safety:** Volumes persist between restarts unless you use `mlflow-reset`


### PR DESCRIPTION
## Summary

Polishes the local MLflow Docker setup with enhanced documentation. No functional changes - pure documentation improvements.

## Changes

**Enhanced `docker/README.md`:**

### Quick Start Improvements
- Added Prerequisites section (Docker, port availability)
- Highlighted `make` targets as primary interface (with raw docker-compose fallback)
- Clear distinction between stop (keeps data) vs reset (destroys data)

### New Sections

1. **Configuration**
   - How to customize `docker/.env`
   - Port 5000 conflict explanation (macOS AirPlay)

2. **Persistence**
   - What persists: `mlruns/`, `mlartifacts/` volumes, `.env`
   - What gets deleted: `mlflow-down` vs `mlflow-reset` behavior
   - Clear warning about data loss with `mlflow-reset`

3. **Expected Warnings (Non-Critical)**
   - Explains `MLFLOW_BACKEND_STORE_URI` / `MLFLOW_DEFAULT_ARTIFACT_ROOT` warnings
   - Confirms file-based storage is intentional for local dev
   - Users can safely ignore these warnings

4. **Troubleshooting**
   - **Port conflicts:** Check `lsof`, change port, disable AirPlay
   - **UI not reachable:** Checklist (container running, logs, port, firewall)
   - **Docker not found:** Installation links
   - **Container crashes:** Diagnostic steps

5. **Make Targets Reference**
   - Table format with descriptions
   - Clear "Destructive" label on `mlflow-reset`

6. **Notes**
   - Dev/local scope reminder
   - No CI integration
   - Data persistence behavior

## Diff Summary

- **File:** `docker/README.md`
- **Changes:** +121 lines, -7 lines (net +114 lines)
- **Type:** Documentation only (no code changes)

## Benefits

- New users get clear troubleshooting guidance
- Port conflict (macOS AirPlay) is documented upfront
- MLflow warnings are explained (prevents confusion)
- Persistence behavior is crystal clear (prevents accidental data loss)
- Make targets are the recommended interface

## Testing

No functional changes - documentation only. Verified:
- Markdown formatting renders correctly
- Links are valid
- Commands are copy-pasteable

---

Closes requirement from PR #150 post-merge feedback: document expected warnings and troubleshooting.