### PR TITLE
chore(dev): suppress MLflow startup warnings with empty env vars

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,2 +1,6 @@
 # macOS: 5000 kann belegt sein (AirPlay). Default hier 5001.
 MLFLOW_PORT=5001
+
+# Suppress MLflow startup warnings (file-based storage is default for local dev)
+MLFLOW_BACKEND_STORE_URI=
+MLFLOW_DEFAULT_ARTIFACT_ROOT=

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,9 +39,15 @@ Edit `docker/.env` to customize (auto-created from `.env.example`):
 ```bash
 # Port for MLflow UI (default: 5001)
 MLFLOW_PORT=5001
+
+# Suppress MLflow startup warnings (file-based storage is default for local dev)
+MLFLOW_BACKEND_STORE_URI=
+MLFLOW_DEFAULT_ARTIFACT_ROOT=
 ```
 
-**Note:** Port 5000 is often occupied by macOS AirPlay Receiver. Using 5001 avoids conflicts.
+**Notes:**
+- Port 5000 is often occupied by macOS AirPlay Receiver. Using 5001 avoids conflicts.
+- Empty `MLFLOW_BACKEND_STORE_URI` and `MLFLOW_DEFAULT_ARTIFACT_ROOT` suppress startup warnings while using default file-based storage.
 
 ## Persistence
 
@@ -56,16 +62,18 @@ MLFLOW_PORT=5001
 
 Use `mlflow-reset` when you want a clean slate or to free disk space.
 
-## Expected Warnings (Non-Critical)
+## Startup Warnings
 
-When starting MLflow, you may see:
+The default `.env.example` includes empty values for `MLFLOW_BACKEND_STORE_URI` and `MLFLOW_DEFAULT_ARTIFACT_ROOT` to suppress startup warnings.
+
+If you remove these from your `.env`, MLflow will show:
 
 ```
 The "MLFLOW_BACKEND_STORE_URI" variable is not set. Defaulting to a blank string.
 The "MLFLOW_DEFAULT_ARTIFACT_ROOT" variable is not set. Defaulting to a blank string.
 ```
 
-**This is expected and safe.** MLflow defaults to file-based local storage (suitable for development). These warnings can be ignored unless you're configuring an external database backend.
+**This is safe.** MLflow defaults to file-based local storage (suitable for development). The warnings can be ignored or suppressed by setting the variables to empty strings as shown in Configuration above.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Suppress MLflow startup warnings by explicitly setting `MLFLOW_BACKEND_STORE_URI` and `MLFLOW_DEFAULT_ARTIFACT_ROOT` to empty strings in `.env.example`.

## Problem

When starting MLflow, users see these warnings:
```
The "MLFLOW_BACKEND_STORE_URI" variable is not set. Defaulting to a blank string.
The "MLFLOW_DEFAULT_ARTIFACT_ROOT" variable is not set. Defaulting to a blank string.
```

While these warnings are harmless (file-based storage is the intended default for local dev), they create unnecessary noise in the logs.

## Solution

Add these variables to `docker/.env.example` with empty values:

```bash
MLFLOW_BACKEND_STORE_URI=
MLFLOW_DEFAULT_ARTIFACT_ROOT=
```

Setting them to empty strings explicitly tells MLflow to use default file-based storage **without** generating warnings.

## Changes

### `docker/.env.example` (+4 lines)
- Added `MLFLOW_BACKEND_STORE_URI=` (empty)
- Added `MLFLOW_DEFAULT_ARTIFACT_ROOT=` (empty)
- Added explanatory comment

### `docker/README.md` (+12 lines, -4 lines)
- Updated Configuration section to show new env vars
- Renamed "Expected Warnings (Non-Critical)" → "Startup Warnings"
- Explained that warnings are now suppressed by default
- Documented what happens if user removes these vars

## Benefits

- **Cleaner logs:** No warnings on `make mlflow-up`
- **Better UX:** New users don't see confusing warnings
- **Documented:** README explains the suppression mechanism
- **Opt-out:** Users can remove vars if they want to see warnings
- **No functional change:** File-based storage behavior unchanged

## Testing

Verified that:
- Empty values suppress warnings (same behavior as blank strings)
- MLflow still uses default file-based storage
- No impact on existing functionality

## Notes

- This is a **quality-of-life improvement** (UX/logging cleanup)
- No breaking changes
- No functional changes to MLflow behavior
- Existing `.env` files are unaffected (auto-created from `.env.example` on first run)