### PR TITLE
docs(ops): add PR #154 merge log

### DIFF
--- a/docs/ops/PR_154_MERGE_LOG.md
+++ b/docs/ops/PR_154_MERGE_LOG.md
@@ -1,0 +1,112 @@
+# PR #154 Merge Log
+
+## TL;DR
+
+- Suppresses MLflow Docker Compose startup warnings by setting empty env vars
+- No functional changes: file-based storage remains default for local dev
+- Clean logs improve developer UX
+- Changes limited to `docker/.env.example` and `docker/README.md`
+
+## Merge Metadata
+
+- **PR:** [#154](https://github.com/rauterfrank-ui/Peak_Trade/pull/154)
+- **Title:** chore(dev): suppress MLflow startup warnings with empty env vars
+- **Branch:** `chore/mlflow-suppress-warnings` (deleted)
+- **Merge Method:** Squash merge
+- **Merged At:** 2025-12-19T00:20:44Z
+- **Merged By:** rauterfrank-ui
+- **Main HEAD After Merge:** `cb304d3`
+
+## CI Status
+
+All checks passed before merge:
+
+| Check | Status | Duration | Details |
+|-------|--------|----------|---------|
+| tests (3.11) | pass | 3m42s | [Job](https://github.com/rauterfrank-ui/Peak_Trade/actions/runs/20355417719/job/58489710155) |
+| strategy-smoke | pass | 46s | [Job](https://github.com/rauterfrank-ui/Peak_Trade/actions/runs/20355417719/job/58489940947) |
+| audit | pass | 1m55s | [Job](https://github.com/rauterfrank-ui/Peak_Trade/actions/runs/20355417709/job/58489710028) |
+| CI Health Gate (weekly_core) | pass | 48s | [Job](https://github.com/rauterfrank-ui/Peak_Trade/actions/runs/20355417710/job/58489710120) |
+
+## Scope / Change Summary
+
+### Files Modified
+
+- **`docker/.env.example`**: Added explicit empty values for `MLFLOW_BACKEND_STORE_URI` and `MLFLOW_DEFAULT_ARTIFACT_ROOT`
+- **`docker/README.md`**: Updated Configuration and Startup Warnings sections to explain the mechanism
+
+### What Changed
+
+Previously, Docker Compose printed warnings on `make mlflow-up`:
+```
+The "MLFLOW_BACKEND_STORE_URI" variable is not set. Defaulting to a blank string.
+The "MLFLOW_DEFAULT_ARTIFACT_ROOT" variable is not set. Defaulting to a blank string.
+```
+
+**Root Cause:** Docker Compose treats unset variables differently from variables set to empty values. An unset variable triggers a warning, while a variable explicitly set to an empty string (`VAR=`) is considered "set" and doesn't warn.
+
+**Solution:** Added to `.env.example`:
+```bash
+# Suppress MLflow startup warnings (file-based storage is default for local dev)
+MLFLOW_BACKEND_STORE_URI=
+MLFLOW_DEFAULT_ARTIFACT_ROOT=
+```
+
+### Behavior
+
+- **Before:** MLflow starts correctly with file-based storage, but shows warnings
+- **After:** MLflow starts correctly with file-based storage, no warnings
+- **No functional change:** Default file-based behavior is intentional and unchanged
+
+## Operator Notes
+
+### Opt-Out
+
+If you prefer to see the warnings (e.g., as a reminder to configure external storage), you can:
+1. Remove `MLFLOW_BACKEND_STORE_URI=` and `MLFLOW_DEFAULT_ARTIFACT_ROOT=` from your `.env`
+2. The warnings will reappear but behavior remains unchanged
+
+### Production Consideration
+
+This change only affects local development. For production deployments:
+- Set `MLFLOW_BACKEND_STORE_URI` to a database URL (PostgreSQL/MySQL)
+- Set `MLFLOW_DEFAULT_ARTIFACT_ROOT` to an object storage path (S3/Azure Blob)
+- See [MLflow Tracking Server documentation](https://mlflow.org/docs/latest/tracking.html#mlflow-tracking-servers)
+
+## Verification Steps
+
+Verified that warnings are suppressed while maintaining correct behavior:
+
+```bash
+# 1. Create fresh .env from updated template
+rm -f docker/.env
+cp docker/.env.example docker/.env
+
+# 2. Start MLflow
+make mlflow-up
+
+# 3. Check logs - should show only normal gunicorn startup
+make mlflow-logs | tail -n 80
+# Expected output:
+# [2025-12-19 00:21:15 +0000] [19] [INFO] Starting gunicorn 22.0.0
+# [2025-12-19 00:21:15 +0000] [19] [INFO] Listening at: http://0.0.0.0:5000 (19)
+# [2025-12-19 00:21:15 +0000] [19] [INFO] Using worker: sync
+# [2025-12-19 00:21:15 +0000] [20] [INFO] Booting worker with pid: 20
+# (No warnings about MLFLOW_BACKEND_STORE_URI or MLFLOW_DEFAULT_ARTIFACT_ROOT)
+
+# 4. Clean up
+make mlflow-down
+```
+
+**Result:** Clean startup logs, no warnings, normal gunicorn output only.
+
+## Links
+
+- **PR:** https://github.com/rauterfrank-ui/Peak_Trade/pull/154
+- **Docker Compose Env Docs:** https://docs.docker.com/compose/environment-variables/
+- **MLflow Tracking:** https://mlflow.org/docs/latest/tracking.html
+- **Related Docs:** `docker/README.md` (Configuration section)
+
+## Additional Context
+
+This is a quality-of-life improvement for developers. The warnings were cosmetic but created unnecessary noise during local development. By explicitly setting the variables to empty strings, we document that file-based storage is the intentional default for local dev while keeping logs clean.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -195,6 +195,7 @@ Post-merge documentation logs for operational PRs.
 - PR #116 – Merge Log: `docs/ops/PR_116_MERGE_LOG.md`
 - PR #121 – chore(ops): default expected head in post-merge verify – `docs/ops/PR_121_MERGE_LOG.md`
 - PR #136 – feat(stability): wave A contracts, cache integrity, errors, reproducibility – `docs/ops/PR_136_MERGE_LOG.md`
+- PR #154 – chore(dev): suppress MLflow startup warnings with empty env vars – `docs/ops/PR_154_MERGE_LOG.md`
 
 ---
 - PR #80 – Merge Log: `docs/ops/PR_80_MERGE_LOG.md`


### PR DESCRIPTION
## Summary

Adds post-merge operational documentation for PR #154 (suppress MLflow startup warnings).

## Changes

- **New:** `docs/ops/PR_154_MERGE_LOG.md` - Comprehensive merge log with:
  - TL;DR and merge metadata (squash merge, timestamp UTC, commit cb304d3)
  - CI status (all checks passed)
  - Change summary (docker/.env.example + docker/README.md)
  - Technical explanation (empty env vars suppress Compose warnings)
  - Operator notes (opt-out, production considerations)
  - Verification steps (smoke test)
  - Links to PR and related docs

- **Updated:** `docs/ops/README.md` - Added PR #154 entry to "Merge Logs (Ops)" section

## Context

Following repo conventions for operational PR documentation. PR #154 was a chore that improved developer UX by suppressing cosmetic Docker Compose warnings while maintaining default file-based MLflow behavior.

Generated with [Claude Code](https://claude.com/claude-code)