### PR TITLE
feat(telemetry): retention + rotation (Phase 16E)

### DIFF
--- a/config/execution_telemetry.toml
+++ b/config/execution_telemetry.toml
@@ -1,0 +1,52 @@
+# Execution Telemetry - Retention & Compression Configuration
+# Phase 16E - Automated log lifecycle management
+
+[execution_telemetry.retention]
+# Master switch for automatic retention/cleanup
+enabled = true
+
+# Age-based retention (days)
+# Logs older than this will be deleted (unless protected by keep_last_n_sessions)
+max_age_days = 30
+
+# Session-count protection
+# Always keep the last N sessions, even if they exceed max_age_days
+# Set to 0 to disable session-count protection
+keep_last_n_sessions = 200
+
+# Total size limit (MB)
+# If total log size exceeds this, delete oldest logs first (respecting keep_last_n_sessions)
+# Set to 0 to disable size limit
+max_total_mb = 2048
+
+# Compression settings
+# Compress logs older than N days using gzip (.jsonl -> .jsonl.gz)
+# Compressed logs are ~10-20% of original size
+# Set to 0 to disable compression
+compress_after_days = 7
+
+# Protect recent sessions from compression
+# If true, logs in keep_last_n_sessions will NOT be compressed (even if old enough)
+# If false, all logs older than compress_after_days will be compressed
+protect_keep_last_from_compress = false
+
+# Example scenarios:
+#
+# Scenario 1: Keep last 30 days, compress after 7 days
+#   max_age_days = 30
+#   compress_after_days = 7
+#   Result: Logs 0-7 days: raw .jsonl
+#           Logs 7-30 days: .jsonl.gz
+#           Logs > 30 days: deleted
+#
+# Scenario 2: Keep last 200 sessions forever, compress old ones
+#   max_age_days = 365  # effectively disabled
+#   keep_last_n_sessions = 200
+#   compress_after_days = 7
+#   Result: Last 200 sessions kept, old ones (>7d) compressed
+#
+# Scenario 3: Aggressive cleanup, no compression
+#   max_age_days = 7
+#   keep_last_n_sessions = 50
+#   compress_after_days = 0  # disabled
+#   Result: Keep max 7 days or 50 sessions (whichever is larger), no compression

--- a/scripts/ops/telemetry_retention.py
+++ b/scripts/ops/telemetry_retention.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Telemetry Retention & Compression CLI - Phase 16E
+
+Manage telemetry log lifecycle: compress old logs, delete expired logs.
+
+Usage:
+    # Dry-run (default, safe)
+    python scripts/ops/telemetry_retention.py
+
+    # Apply changes
+    python scripts/ops/telemetry_retention.py --apply
+
+    # Custom root directory
+    python scripts/ops/telemetry_retention.py --root logs/execution
+
+    # JSON output
+    python scripts/ops/telemetry_retention.py --json
+
+    # Custom policy
+    python scripts/ops/telemetry_retention.py --apply \\
+        --max-age-days 14 \\
+        --keep-last-n 100 \\
+        --compress-after-days 3
+
+Safety:
+- Dry-run is default (--apply required to modify files)
+- Root directory validation (must contain "execution"/"telemetry"/"logs")
+- Session-count protection (keeps last N sessions even if old)
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.execution.telemetry_retention import (
+    RetentionPolicy,
+    apply_plan,
+    build_plan,
+    discover_sessions,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Telemetry retention & compression (Phase 16E)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    
+    # Root directory
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("logs/execution"),
+        help="Telemetry logs root directory (default: logs/execution)",
+    )
+    
+    # Apply changes
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply changes (default: dry-run only)",
+    )
+    
+    # Policy overrides
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=30,
+        help="Delete logs older than N days (default: 30)",
+    )
+    
+    parser.add_argument(
+        "--keep-last-n",
+        type=int,
+        default=200,
+        help="Always keep last N sessions (default: 200)",
+    )
+    
+    parser.add_argument(
+        "--max-total-mb",
+        type=int,
+        default=2048,
+        help="Max total size in MB (default: 2048)",
+    )
+    
+    parser.add_argument(
+        "--compress-after-days",
+        type=int,
+        default=7,
+        help="Compress logs older than N days (default: 7, 0=disable)",
+    )
+    
+    parser.add_argument(
+        "--protect-keep-last",
+        action="store_true",
+        help="Protect last N sessions from compression",
+    )
+    
+    parser.add_argument(
+        "--disabled",
+        action="store_true",
+        help="Disable all retention (show stats only)",
+    )
+    
+    # Output format
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    
+    args = parser.parse_args()
+    
+    # Build policy
+    policy = RetentionPolicy(
+        enabled=not args.disabled,
+        max_age_days=args.max_age_days,
+        keep_last_n_sessions=args.keep_last_n,
+        max_total_mb=args.max_total_mb,
+        compress_after_days=args.compress_after_days,
+        protect_keep_last_from_compress=args.protect_keep_last,
+    )
+    
+    # Discover sessions
+    try:
+        sessions = discover_sessions(args.root)
+    except ValueError as e:
+        logger.error(f"Invalid root directory: {e}")
+        return 2
+    except Exception as e:
+        logger.error(f"Failed to discover sessions: {e}")
+        return 3
+    
+    if not sessions:
+        logger.info(f"No telemetry logs found in {args.root}")
+        return 0
+    
+    # Build plan
+    plan = build_plan(sessions, policy)
+    
+    # Apply plan
+    dry_run = not args.apply
+    stats = apply_plan(plan, dry_run=dry_run)
+    
+    # Output
+    if args.json:
+        output = {
+            "root": str(args.root),
+            "dry_run": dry_run,
+            "policy": {
+                "enabled": policy.enabled,
+                "max_age_days": policy.max_age_days,
+                "keep_last_n_sessions": policy.keep_last_n_sessions,
+                "max_total_mb": policy.max_total_mb,
+                "compress_after_days": policy.compress_after_days,
+                "protect_keep_last_from_compress": policy.protect_keep_last_from_compress,
+            },
+            "plan": {
+                "sessions_total": plan.sessions_total,
+                "sessions_kept": plan.sessions_kept,
+                "size_before_mb": plan.size_before_mb,
+                "size_after_mb": plan.size_after_mb,
+                "compression_savings_mb": plan.compression_savings_mb,
+                "deleted_mb": plan.deleted_mb,
+                "actions": [
+                    {
+                        "kind": a.kind,
+                        "path": str(a.path),
+                        "reason": a.reason,
+                        "size_mb": a.size_mb,
+                    }
+                    for a in plan.actions
+                ],
+            },
+            "stats": stats,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        # Human-readable output
+        mode = "DRY-RUN" if dry_run else "APPLIED"
+        print(f"\n{'=' * 60}")
+        print(f"Telemetry Retention & Compression - {mode}")
+        print(f"{'=' * 60}")
+        print(f"Root: {args.root}")
+        print(f"Policy: {'ENABLED' if policy.enabled else 'DISABLED'}")
+        
+        if policy.enabled:
+            print(f"  Max age: {policy.max_age_days} days")
+            print(f"  Keep last: {policy.keep_last_n_sessions} sessions")
+            print(f"  Max total: {policy.max_total_mb} MB")
+            print(f"  Compress after: {policy.compress_after_days} days")
+            print(f"  Protect from compress: {policy.protect_keep_last_from_compress}")
+        
+        print(f"\nSummary:")
+        print(f"  Total sessions: {plan.sessions_total}")
+        print(f"  Sessions kept: {plan.sessions_kept}")
+        print(f"  Size before: {plan.size_before_mb:.1f} MB")
+        print(f"  Size after: {plan.size_after_mb:.1f} MB")
+        print(f"  Compression savings: {plan.compression_savings_mb:.1f} MB")
+        print(f"  Deleted: {plan.deleted_mb:.1f} MB")
+        
+        if plan.actions:
+            print(f"\nActions ({len(plan.actions)}):")
+            
+            # Group by kind
+            compress_actions = [a for a in plan.actions if a.kind == "compress"]
+            delete_actions = [a for a in plan.actions if a.kind == "delete"]
+            
+            if compress_actions:
+                print(f"\n  Compress ({len(compress_actions)}):")
+                for action in compress_actions[:10]:  # Show first 10
+                    print(f"    - {action.path.name} ({action.size_mb:.1f} MB)")
+                    print(f"      Reason: {action.reason}")
+                
+                if len(compress_actions) > 10:
+                    print(f"    ... and {len(compress_actions) - 10} more")
+            
+            if delete_actions:
+                print(f"\n  Delete ({len(delete_actions)}):")
+                for action in delete_actions[:10]:  # Show first 10
+                    print(f"    - {action.path.name} ({action.size_mb:.1f} MB)")
+                    print(f"      Reason: {action.reason}")
+                
+                if len(delete_actions) > 10:
+                    print(f"    ... and {len(delete_actions) - 10} more")
+        else:
+            print(f"\nNo actions needed.")
+        
+        if stats["errors"]:
+            print(f"\nErrors ({len(stats['errors'])}):")
+            for error in stats["errors"]:
+                print(f"  - {error}")
+        
+        print(f"\n{'=' * 60}")
+        
+        if dry_run:
+            print("DRY-RUN: No files were modified.")
+            print("Use --apply to execute changes.")
+        else:
+            print(f"APPLIED: {stats['actions_executed']} actions executed.")
+            print(f"  Compressed: {stats['compressed']}")
+            print(f"  Deleted: {stats['deleted']}")
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/execution/telemetry_retention.py
+++ b/src/execution/telemetry_retention.py
@@ -1,0 +1,413 @@
+"""
+Telemetry Retention & Compression - Phase 16E
+
+Automated log lifecycle management for execution telemetry logs.
+
+Features:
+- Age-based deletion (with session-count protection)
+- Size-based deletion (enforce total size limits)
+- Automatic compression (gzip after N days)
+- Dry-run mode (safe planning)
+- Deterministic sorting (oldest first)
+
+Safety:
+- Root directory validation
+- Dry-run default
+- Session-count protection (keep last N sessions)
+- No silent failures (all errors logged/raised)
+"""
+
+import gzip
+import logging
+import os
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionMeta:
+    """Metadata for a single telemetry session log file."""
+    
+    path: Path
+    session_id: str
+    size_bytes: int
+    mtime: datetime  # UTC
+    is_compressed: bool
+    
+    @property
+    def age_days(self) -> float:
+        """Age in days (from mtime to now UTC)."""
+        now = datetime.now(timezone.utc)
+        # Handle both aware and naive datetimes
+        if self.mtime.tzinfo is None:
+            # Assume UTC if naive
+            mtime_utc = self.mtime.replace(tzinfo=timezone.utc)
+        else:
+            mtime_utc = self.mtime
+        return (now - mtime_utc).total_seconds() / 86400.0
+    
+    @property
+    def size_mb(self) -> float:
+        """Size in MB."""
+        return self.size_bytes / (1024 * 1024)
+
+
+@dataclass
+class RetentionPolicy:
+    """Retention policy configuration."""
+    
+    enabled: bool = True
+    max_age_days: int = 30
+    keep_last_n_sessions: int = 200
+    max_total_mb: int = 2048
+    compress_after_days: int = 7
+    protect_keep_last_from_compress: bool = False
+
+
+@dataclass
+class Action:
+    """A single retention action (compress or delete)."""
+    
+    kind: str  # "compress" | "delete"
+    path: Path
+    reason: str
+    size_bytes: int = 0
+    
+    @property
+    def size_mb(self) -> float:
+        """Size in MB."""
+        return self.size_bytes / (1024 * 1024)
+
+
+@dataclass
+class RetentionPlan:
+    """A plan of retention actions to execute."""
+    
+    actions: List[Action] = field(default_factory=list)
+    sessions_total: int = 0
+    sessions_kept: int = 0
+    size_before_mb: float = 0.0
+    size_after_mb: float = 0.0
+    
+    @property
+    def compression_savings_mb(self) -> float:
+        """Estimated compression savings (assumes 80% reduction)."""
+        compress_bytes = sum(a.size_bytes for a in self.actions if a.kind == "compress")
+        return (compress_bytes * 0.8) / (1024 * 1024)
+    
+    @property
+    def deleted_mb(self) -> float:
+        """Total MB deleted."""
+        return sum(a.size_mb for a in self.actions if a.kind == "delete")
+
+
+def is_safe_telemetry_root(path: Path) -> bool:
+    """
+    Validate that path is a safe telemetry log directory.
+    
+    Safety checks:
+    - Path exists and is a directory
+    - Path name contains "execution" or "telemetry" or "logs"
+    - Not a system directory (/, /home, /usr, etc.)
+    
+    Args:
+        path: Directory to validate
+        
+    Returns:
+        True if safe, False otherwise
+    """
+    if not path.exists():
+        return False
+    
+    if not path.is_dir():
+        return False
+    
+    # Resolve to absolute path
+    abs_path = path.resolve()
+    
+    # Check for dangerous root paths
+    dangerous_roots = {
+        Path("/"),
+        Path("/home"),
+        Path("/usr"),
+        Path("/etc"),
+        Path("/var"),
+        Path("/tmp"),
+        Path.home(),
+    }
+    
+    if abs_path in dangerous_roots:
+        logger.error(f"Refusing to operate on system directory: {abs_path}")
+        return False
+    
+    # Check path contains telemetry/execution/logs keywords
+    path_str = str(abs_path).lower()
+    safe_keywords = ["execution", "telemetry", "logs", "log"]
+    
+    if not any(keyword in path_str for keyword in safe_keywords):
+        logger.warning(f"Path does not contain safe keywords: {abs_path}")
+        return False
+    
+    return True
+
+
+def discover_sessions(
+    root: Path,
+    include_compressed: bool = True
+) -> List[SessionMeta]:
+    """
+    Discover all telemetry session log files in root directory.
+    
+    Args:
+        root: Directory to scan (e.g., logs/execution)
+        include_compressed: If True, include .jsonl.gz files
+        
+    Returns:
+        List of SessionMeta objects, sorted by mtime (oldest first)
+        
+    Raises:
+        ValueError: If root is not a safe telemetry directory
+    """
+    if not is_safe_telemetry_root(root):
+        raise ValueError(f"Unsafe or invalid telemetry root: {root}")
+    
+    sessions: List[SessionMeta] = []
+    
+    # Find .jsonl files
+    for path in root.glob("*.jsonl"):
+        if not path.is_file():
+            continue
+        
+        stat = path.stat()
+        session_id = path.stem  # filename without extension
+        
+        sessions.append(SessionMeta(
+            path=path,
+            session_id=session_id,
+            size_bytes=stat.st_size,
+            mtime=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+            is_compressed=False,
+        ))
+    
+    # Find .jsonl.gz files (if enabled)
+    if include_compressed:
+        for path in root.glob("*.jsonl.gz"):
+            if not path.is_file():
+                continue
+            
+            stat = path.stat()
+            # Remove .jsonl.gz to get session_id
+            session_id = path.name.replace(".jsonl.gz", "")
+            
+            sessions.append(SessionMeta(
+                path=path,
+                session_id=session_id,
+                size_bytes=stat.st_size,
+                mtime=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+                is_compressed=True,
+            ))
+    
+    # Sort by mtime (oldest first) for deterministic processing
+    sessions.sort(key=lambda s: s.mtime)
+    
+    return sessions
+
+
+def build_plan(
+    sessions: List[SessionMeta],
+    policy: RetentionPolicy,
+) -> RetentionPlan:
+    """
+    Build a retention plan based on discovered sessions and policy.
+    
+    Args:
+        sessions: List of session metadata (should be sorted by mtime)
+        policy: Retention policy configuration
+        
+    Returns:
+        RetentionPlan with actions to execute
+    """
+    if not policy.enabled:
+        return RetentionPlan(
+            sessions_total=len(sessions),
+            sessions_kept=len(sessions),
+            size_before_mb=sum(s.size_mb for s in sessions),
+            size_after_mb=sum(s.size_mb for s in sessions),
+        )
+    
+    plan = RetentionPlan(
+        sessions_total=len(sessions),
+        size_before_mb=sum(s.size_mb for s in sessions),
+    )
+    
+    # Identify "protected" sessions (last N sessions by mtime)
+    # These are protected from age-based deletion
+    sessions_by_mtime = sorted(sessions, key=lambda s: s.mtime, reverse=True)
+    protected_sessions = set(
+        s.path for s in sessions_by_mtime[:policy.keep_last_n_sessions]
+    )
+    
+    # Phase 1: Age-based deletion (with protection)
+    age_cutoff = datetime.now(timezone.utc) - timedelta(days=policy.max_age_days)
+    
+    for session in sessions:
+        # Handle both aware and naive datetimes
+        if session.mtime.tzinfo is None:
+            mtime_utc = session.mtime.replace(tzinfo=timezone.utc)
+        else:
+            mtime_utc = session.mtime
+        
+        if mtime_utc < age_cutoff and session.path not in protected_sessions:
+            plan.actions.append(Action(
+                kind="delete",
+                path=session.path,
+                reason=f"Older than {policy.max_age_days} days (age: {session.age_days:.1f}d)",
+                size_bytes=session.size_bytes,
+            ))
+    
+    # Calculate remaining sessions after age-based deletion
+    deleted_paths = {a.path for a in plan.actions if a.kind == "delete"}
+    remaining_sessions = [s for s in sessions if s.path not in deleted_paths]
+    
+    # Phase 2: Size-based deletion (if over limit)
+    if policy.max_total_mb > 0:
+        current_size_mb = sum(s.size_mb for s in remaining_sessions)
+        
+        if current_size_mb > policy.max_total_mb:
+            # Delete oldest sessions first (already sorted)
+            # But respect keep_last_n_sessions protection
+            for session in remaining_sessions:
+                if session.path in protected_sessions:
+                    continue
+                
+                if current_size_mb <= policy.max_total_mb:
+                    break
+                
+                # Check if already marked for deletion
+                if session.path in deleted_paths:
+                    continue
+                
+                plan.actions.append(Action(
+                    kind="delete",
+                    path=session.path,
+                    reason=f"Total size limit exceeded ({current_size_mb:.1f}MB > {policy.max_total_mb}MB)",
+                    size_bytes=session.size_bytes,
+                ))
+                
+                deleted_paths.add(session.path)
+                current_size_mb -= session.size_mb
+    
+    # Recalculate remaining sessions after size-based deletion
+    remaining_sessions = [s for s in sessions if s.path not in deleted_paths]
+    
+    # Phase 3: Compression (if enabled)
+    if policy.compress_after_days > 0:
+        compress_cutoff = datetime.now(timezone.utc) - timedelta(days=policy.compress_after_days)
+        
+        for session in remaining_sessions:
+            # Skip if already compressed
+            if session.is_compressed:
+                continue
+            
+            # Handle both aware and naive datetimes
+            if session.mtime.tzinfo is None:
+                mtime_utc = session.mtime.replace(tzinfo=timezone.utc)
+            else:
+                mtime_utc = session.mtime
+            
+            # Check age
+            if mtime_utc >= compress_cutoff:
+                continue
+            
+            # Check protection
+            if policy.protect_keep_last_from_compress and session.path in protected_sessions:
+                continue
+            
+            plan.actions.append(Action(
+                kind="compress",
+                path=session.path,
+                reason=f"Older than {policy.compress_after_days} days (age: {session.age_days:.1f}d)",
+                size_bytes=session.size_bytes,
+            ))
+    
+    # Calculate final stats
+    plan.sessions_kept = len(remaining_sessions)
+    
+    # Estimate size after compression (80% reduction)
+    compressed_bytes = sum(a.size_bytes for a in plan.actions if a.kind == "compress")
+    deleted_bytes = sum(a.size_bytes for a in plan.actions if a.kind == "delete")
+    remaining_bytes = sum(s.size_bytes for s in remaining_sessions) - compressed_bytes - deleted_bytes
+    
+    plan.size_after_mb = (remaining_bytes + compressed_bytes * 0.2) / (1024 * 1024)
+    
+    return plan
+
+
+def apply_plan(
+    plan: RetentionPlan,
+    dry_run: bool = True,
+) -> dict:
+    """
+    Apply a retention plan (compress/delete files).
+    
+    Args:
+        plan: Retention plan to execute
+        dry_run: If True, don't actually modify files (default: True)
+        
+    Returns:
+        Stats dict with results
+        
+    Raises:
+        IOError: If file operations fail
+    """
+    stats = {
+        "dry_run": dry_run,
+        "actions_planned": len(plan.actions),
+        "actions_executed": 0,
+        "compressed": 0,
+        "deleted": 0,
+        "errors": [],
+    }
+    
+    for action in plan.actions:
+        try:
+            if action.kind == "compress":
+                if not dry_run:
+                    # Compress .jsonl -> .jsonl.gz
+                    gz_path = action.path.with_suffix(action.path.suffix + ".gz")
+                    
+                    with open(action.path, "rb") as f_in:
+                        with gzip.open(gz_path, "wb") as f_out:
+                            shutil.copyfileobj(f_in, f_out)
+                    
+                    # Preserve mtime
+                    stat = action.path.stat()
+                    os.utime(gz_path, (stat.st_atime, stat.st_mtime))
+                    
+                    # Delete original
+                    action.path.unlink()
+                    
+                    logger.info(f"Compressed: {action.path} -> {gz_path}")
+                
+                stats["compressed"] += 1
+            
+            elif action.kind == "delete":
+                if not dry_run:
+                    action.path.unlink()
+                    logger.info(f"Deleted: {action.path}")
+                
+                stats["deleted"] += 1
+            
+            stats["actions_executed"] += 1
+        
+        except Exception as e:
+            error_msg = f"Failed to {action.kind} {action.path}: {e}"
+            logger.error(error_msg)
+            stats["errors"].append(error_msg)
+    
+    return stats

--- a/tests/execution/test_telemetry_retention_policy.py
+++ b/tests/execution/test_telemetry_retention_policy.py
@@ -1,0 +1,454 @@
+"""
+Tests for Telemetry Retention & Compression - Phase 16E
+
+Tests cover:
+- Session discovery
+- Retention policy (age, count, size)
+- Compression logic
+- Dry-run mode
+- Root safety
+- Edge cases
+"""
+
+import gzip
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.execution.telemetry_retention import (
+    Action,
+    RetentionPolicy,
+    SessionMeta,
+    apply_plan,
+    build_plan,
+    discover_sessions,
+    is_safe_telemetry_root,
+)
+
+
+# ==============================================================================
+# Fixtures
+# ==============================================================================
+
+
+@pytest.fixture
+def telemetry_root(tmp_path):
+    """Create a temporary telemetry logs directory."""
+    root = tmp_path / "logs" / "execution"
+    root.mkdir(parents=True)
+    return root
+
+
+def create_log_file(root: Path, session_id: str, age_days: int, size_kb: int = 10):
+    """
+    Create a fake telemetry log file with specific age.
+    
+    Args:
+        root: Log directory
+        session_id: Session ID (filename stem)
+        age_days: Age in days (sets mtime)
+        size_kb: File size in KB
+    
+    Returns:
+        Path to created file
+    """
+    path = root / f"{session_id}.jsonl"
+    
+    # Write fake content (create approximately size_kb KB)
+    line = '{"ts": "2025-12-20T10:00:00Z", "kind": "test"}\n'
+    line_size = len(line.encode('utf-8'))
+    num_lines = (size_kb * 1024) // line_size
+    content = line * num_lines
+    path.write_text(content)
+    
+    # Set mtime to simulate age
+    mtime = datetime.now(timezone.utc) - timedelta(days=age_days)
+    mtime_timestamp = mtime.timestamp()
+    os.utime(path, (mtime_timestamp, mtime_timestamp))
+    
+    return path
+
+
+# ==============================================================================
+# Test: Root Safety
+# ==============================================================================
+
+
+def test_root_safety_valid(telemetry_root):
+    """Valid telemetry root should pass safety check."""
+    assert is_safe_telemetry_root(telemetry_root)
+
+
+def test_root_safety_system_dir():
+    """System directories should fail safety check."""
+    assert not is_safe_telemetry_root(Path("/"))
+    assert not is_safe_telemetry_root(Path("/home"))
+    assert not is_safe_telemetry_root(Path("/usr"))
+
+
+def test_root_safety_nonexistent():
+    """Nonexistent directory should fail safety check."""
+    assert not is_safe_telemetry_root(Path("/tmp/does_not_exist_telemetry"))
+
+
+def test_root_safety_no_keywords(tmp_path):
+    """Directory without safe keywords should fail (with warning)."""
+    unsafe = tmp_path / "unsafe_dir"
+    unsafe.mkdir()
+    # Should return False because no "execution"/"telemetry"/"logs" in path
+    assert not is_safe_telemetry_root(unsafe)
+
+
+# ==============================================================================
+# Test: Session Discovery
+# ==============================================================================
+
+
+def test_discover_sessions_empty(telemetry_root):
+    """Empty directory should return empty list."""
+    sessions = discover_sessions(telemetry_root)
+    assert len(sessions) == 0
+
+
+def test_discover_sessions_basic(telemetry_root):
+    """Discover basic .jsonl files."""
+    create_log_file(telemetry_root, "session_001", age_days=1)
+    create_log_file(telemetry_root, "session_002", age_days=2)
+    create_log_file(telemetry_root, "session_003", age_days=3)
+    
+    sessions = discover_sessions(telemetry_root)
+    
+    assert len(sessions) == 3
+    assert all(isinstance(s, SessionMeta) for s in sessions)
+    assert all(not s.is_compressed for s in sessions)
+    
+    # Should be sorted by mtime (oldest first)
+    assert sessions[0].session_id == "session_003"  # 3 days old
+    assert sessions[1].session_id == "session_002"  # 2 days old
+    assert sessions[2].session_id == "session_001"  # 1 day old
+
+
+def test_discover_sessions_compressed(telemetry_root):
+    """Discover compressed .jsonl.gz files."""
+    # Create .jsonl file
+    path = create_log_file(telemetry_root, "session_001", age_days=10)
+    
+    # Compress it manually
+    gz_path = path.with_suffix(".jsonl.gz")
+    with open(path, "rb") as f_in:
+        with gzip.open(gz_path, "wb") as f_out:
+            f_out.write(f_in.read())
+    
+    # Set mtime on compressed file
+    stat = path.stat()
+    os.utime(gz_path, (stat.st_atime, stat.st_mtime))
+    
+    # Remove original
+    path.unlink()
+    
+    sessions = discover_sessions(telemetry_root, include_compressed=True)
+    
+    assert len(sessions) == 1
+    assert sessions[0].is_compressed
+    assert sessions[0].path.suffix == ".gz"
+
+
+def test_discover_sessions_mixed(telemetry_root):
+    """Discover mix of .jsonl and .jsonl.gz files."""
+    create_log_file(telemetry_root, "session_001", age_days=1)
+    
+    # Create compressed file
+    path = create_log_file(telemetry_root, "session_002", age_days=10)
+    gz_path = path.with_suffix(".jsonl.gz")
+    with open(path, "rb") as f_in:
+        with gzip.open(gz_path, "wb") as f_out:
+            f_out.write(f_in.read())
+    stat = path.stat()
+    os.utime(gz_path, (stat.st_atime, stat.st_mtime))
+    path.unlink()
+    
+    sessions = discover_sessions(telemetry_root)
+    
+    assert len(sessions) == 2
+    assert sessions[0].is_compressed  # Older
+    assert not sessions[1].is_compressed  # Newer
+
+
+# ==============================================================================
+# Test: Build Plan - Age-based Deletion
+# ==============================================================================
+
+
+def test_plan_age_based_deletion(telemetry_root):
+    """Delete logs older than max_age_days."""
+    create_log_file(telemetry_root, "session_old_1", age_days=40)
+    create_log_file(telemetry_root, "session_old_2", age_days=35)
+    create_log_file(telemetry_root, "session_new", age_days=10)
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(
+        enabled=True,
+        max_age_days=30,
+        keep_last_n_sessions=0,  # Disable protection
+        compress_after_days=0,  # Disable compression
+    )
+    
+    plan = build_plan(sessions, policy)
+    
+    assert len(plan.actions) == 2
+    assert all(a.kind == "delete" for a in plan.actions)
+    assert plan.sessions_kept == 1
+
+
+def test_plan_keep_last_n_protection(telemetry_root):
+    """Keep last N sessions even if old."""
+    create_log_file(telemetry_root, "session_1", age_days=50)
+    create_log_file(telemetry_root, "session_2", age_days=45)
+    create_log_file(telemetry_root, "session_3", age_days=10)
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(
+        enabled=True,
+        max_age_days=30,
+        keep_last_n_sessions=2,  # Protect last 2
+        compress_after_days=0,
+    )
+    
+    plan = build_plan(sessions, policy)
+    
+    # Should delete oldest (session_1), but keep session_2 (protected by keep_last_n)
+    assert len(plan.actions) == 1
+    assert plan.actions[0].kind == "delete"
+    assert "session_1" in str(plan.actions[0].path)
+    assert plan.sessions_kept == 2
+
+
+# ==============================================================================
+# Test: Build Plan - Size-based Deletion
+# ==============================================================================
+
+
+def test_plan_size_limit_enforcement(telemetry_root):
+    """Delete oldest logs when total size exceeds limit."""
+    # Create files (10 KB each)
+    create_log_file(telemetry_root, "session_1", age_days=10, size_kb=10)
+    create_log_file(telemetry_root, "session_2", age_days=9, size_kb=10)
+    create_log_file(telemetry_root, "session_3", age_days=8, size_kb=10)
+    create_log_file(telemetry_root, "session_4", age_days=7, size_kb=10)
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(
+        enabled=True,
+        max_age_days=100,  # Don't delete by age
+        keep_last_n_sessions=2,  # Protect last 2
+        max_total_mb=0.02,  # 20 KB limit (should delete 2 oldest)
+        compress_after_days=0,
+    )
+    
+    plan = build_plan(sessions, policy)
+    
+    # Should delete 2 oldest (session_1, session_2)
+    # But keep last 2 (session_3, session_4)
+    delete_actions = [a for a in plan.actions if a.kind == "delete"]
+    assert len(delete_actions) == 2
+    assert "session_1" in str(delete_actions[0].path)
+    assert "session_2" in str(delete_actions[1].path)
+
+
+# ==============================================================================
+# Test: Build Plan - Compression
+# ==============================================================================
+
+
+def test_plan_compression_by_age(telemetry_root):
+    """Compress logs older than compress_after_days."""
+    create_log_file(telemetry_root, "session_old", age_days=10)
+    create_log_file(telemetry_root, "session_new", age_days=3)
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(
+        enabled=True,
+        max_age_days=100,
+        compress_after_days=7,  # Compress after 7 days
+    )
+    
+    plan = build_plan(sessions, policy)
+    
+    compress_actions = [a for a in plan.actions if a.kind == "compress"]
+    assert len(compress_actions) == 1
+    assert "session_old" in str(compress_actions[0].path)
+
+
+def test_plan_compression_protect_last_n(telemetry_root):
+    """Don't compress last N sessions if protected."""
+    create_log_file(telemetry_root, "session_1", age_days=20)
+    create_log_file(telemetry_root, "session_2", age_days=15)
+    create_log_file(telemetry_root, "session_3", age_days=10)
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(
+        enabled=True,
+        max_age_days=100,
+        keep_last_n_sessions=2,
+        compress_after_days=5,
+        protect_keep_last_from_compress=True,  # Protect last 2
+    )
+    
+    plan = build_plan(sessions, policy)
+    
+    compress_actions = [a for a in plan.actions if a.kind == "compress"]
+    # Should only compress session_1 (oldest, not in last 2)
+    assert len(compress_actions) == 1
+    assert "session_1" in str(compress_actions[0].path)
+
+
+def test_plan_skip_already_compressed(telemetry_root):
+    """Don't compress already compressed files."""
+    # Create compressed file
+    path = create_log_file(telemetry_root, "session_old", age_days=10)
+    gz_path = path.with_suffix(".jsonl.gz")
+    with open(path, "rb") as f_in:
+        with gzip.open(gz_path, "wb") as f_out:
+            f_out.write(f_in.read())
+    stat = path.stat()
+    os.utime(gz_path, (stat.st_atime, stat.st_mtime))
+    path.unlink()
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(
+        enabled=True,
+        compress_after_days=5,
+    )
+    
+    plan = build_plan(sessions, policy)
+    
+    # Should not try to compress already compressed file
+    compress_actions = [a for a in plan.actions if a.kind == "compress"]
+    assert len(compress_actions) == 0
+
+
+# ==============================================================================
+# Test: Apply Plan
+# ==============================================================================
+
+
+def test_apply_plan_dry_run(telemetry_root):
+    """Dry-run should not modify files."""
+    path = create_log_file(telemetry_root, "session_001", age_days=10)
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(compress_after_days=5)
+    plan = build_plan(sessions, policy)
+    
+    stats = apply_plan(plan, dry_run=True)
+    
+    assert stats["dry_run"] is True
+    assert stats["compressed"] == 1
+    assert stats["deleted"] == 0
+    assert path.exists()  # File should still exist
+    assert not path.with_suffix(".jsonl.gz").exists()
+
+
+def test_apply_plan_compress(telemetry_root):
+    """Apply compression."""
+    path = create_log_file(telemetry_root, "session_001", age_days=10)
+    original_mtime = path.stat().st_mtime
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(compress_after_days=5)
+    plan = build_plan(sessions, policy)
+    
+    stats = apply_plan(plan, dry_run=False)
+    
+    assert stats["dry_run"] is False
+    assert stats["compressed"] == 1
+    assert not path.exists()  # Original should be deleted
+    
+    gz_path = path.with_suffix(".jsonl.gz")
+    assert gz_path.exists()  # Compressed file should exist
+    
+    # Check mtime preserved
+    assert abs(gz_path.stat().st_mtime - original_mtime) < 1.0
+
+
+def test_apply_plan_delete(telemetry_root):
+    """Apply deletion."""
+    path = create_log_file(telemetry_root, "session_old", age_days=40)
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(
+        max_age_days=30,
+        keep_last_n_sessions=0,
+        compress_after_days=0,
+    )
+    plan = build_plan(sessions, policy)
+    
+    stats = apply_plan(plan, dry_run=False)
+    
+    assert stats["deleted"] == 1
+    assert not path.exists()
+
+
+# ==============================================================================
+# Test: Edge Cases
+# ==============================================================================
+
+
+def test_policy_disabled(telemetry_root):
+    """Disabled policy should not produce actions."""
+    create_log_file(telemetry_root, "session_old", age_days=100)
+    
+    sessions = discover_sessions(telemetry_root)
+    policy = RetentionPolicy(enabled=False)
+    
+    plan = build_plan(sessions, policy)
+    
+    assert len(plan.actions) == 0
+    assert plan.sessions_kept == len(sessions)
+
+
+def test_empty_sessions_list():
+    """Empty sessions list should produce empty plan."""
+    policy = RetentionPolicy()
+    plan = build_plan([], policy)
+    
+    assert len(plan.actions) == 0
+    assert plan.sessions_total == 0
+
+
+def test_discover_unsafe_root():
+    """Discover should raise ValueError for unsafe root."""
+    with pytest.raises(ValueError, match="Unsafe or invalid"):
+        discover_sessions(Path("/"))
+
+
+def test_session_meta_age_calculation():
+    """SessionMeta.age_days should calculate correctly."""
+    now = datetime.now(timezone.utc)
+    ten_days_ago = now - timedelta(days=10)
+    
+    session = SessionMeta(
+        path=Path("/tmp/test.jsonl"),
+        session_id="test",
+        size_bytes=1024,
+        mtime=ten_days_ago,
+        is_compressed=False,
+    )
+    
+    assert 9.9 < session.age_days < 10.1  # Allow small float tolerance
+
+
+def test_session_meta_size_mb():
+    """SessionMeta.size_mb should calculate correctly."""
+    session = SessionMeta(
+        path=Path("/tmp/test.jsonl"),
+        session_id="test",
+        size_bytes=2 * 1024 * 1024,  # 2 MB
+        mtime=datetime.now(timezone.utc),
+        is_compressed=False,
+    )
+    
+    assert abs(session.size_mb - 2.0) < 0.01


### PR DESCRIPTION
Implements Phase 16E: safe-by-default telemetry retention/rotation.

- Retention policy: max_age_days / keep_last_n_sessions / max_total_mb
- Compression: .jsonl -> .jsonl.gz (compress_after_days)
- Ops CLI: scripts/ops/telemetry_retention.py (default dry-run, --apply)
- Tests + docs

Safety:
- Default dry-run
- Deterministic action plan
- Root-safety checks (never delete outside telemetry root)

No breaking changes.