### PR TITLE
test(web): make web-ui tests optional via extras + importorskip

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ python scripts/run_strategy_from_config.py --strategy ma_crossover --symbol BTC/
 # 3. Tests ausführen
 pytest -m smoke -q  # Schnelle Smoke-Tests (~1 Sekunde)
 pytest -q           # Full Suite (~70 Sekunden)
+
+# 4. Optionale Web-UI Dependencies (für Dashboard/API Tests)
+uv sync --extra web  # oder: pip install -e ".[web]"
+pytest -m web        # Web-UI Tests ausführen
 ```
+
+**Hinweis:** Web-UI Tests werden automatisch übersprungen, wenn FastAPI nicht installiert ist. Core-Tests laufen ohne Web-Stack.
 
 **Nächste Schritte:**
 - 📖 **Architektur & Überblick:** [`docs/PEAK_TRADE_OVERVIEW.md`](docs/PEAK_TRADE_OVERVIEW.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dev = [
 web = [
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
+    "jinja2>=3.1.0",
+    "httpx>=0.25.0",  # Required by FastAPI TestClient
 ]
 otel = [
     "opentelemetry-api>=1.24.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -30,6 +30,7 @@ markers =
     requires_scipy: Tests die SciPy benötigen (optional dependency)
     requires_optional: Tests die optionale Dependencies benötigen (Catch-All)
     smoke: Fast smoke tests for CI gate (<5s total, critical path only)
+    web: Tests that require the FastAPI/web stack (install with: uv sync --extra web)
 
 # Warning-Filter
 # ==============

--- a/tests/test_bouchaud_gatheral_cont_strategies.py
+++ b/tests/test_bouchaud_gatheral_cont_strategies.py
@@ -17,6 +17,13 @@ import pandas as pd
 import numpy as np
 from typing import Dict, Any
 
+# Check if FastAPI is available for web-related tests
+try:
+    import fastapi
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
 
 # =============================================================================
 # BOUCHAUD MICROSTRUCTURE STRATEGY TESTS
@@ -344,6 +351,8 @@ class TestStrategyTiering:
 # =============================================================================
 
 
+@pytest.mark.web
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
 class TestStrategyTieringAPI:
     """Tests für API-Integration der Skeleton-Strategien."""
 
@@ -424,19 +433,18 @@ class TestResearchStrategySafety:
 # =============================================================================
 
 
+@pytest.mark.web
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
 class TestFastAPIEndpoints:
     """Integration-Tests für FastAPI-Endpoints mit Skeleton-Strategien."""
 
     @pytest.fixture
     def client(self):
         """FastAPI TestClient."""
-        try:
-            from fastapi.testclient import TestClient
-            from src.webui.app import app
+        from fastapi.testclient import TestClient
+        from src.webui.app import app
 
-            return TestClient(app)
-        except ImportError:
-            pytest.skip("fastapi.testclient nicht verfügbar")
+        return TestClient(app)
 
     def test_api_includes_bouchaud_with_research_flag(self, client):
         """Test: API inkludiert Bouchaud mit include_research=true."""

--- a/tests/test_ehlers_lopez_strategies.py
+++ b/tests/test_ehlers_lopez_strategies.py
@@ -19,6 +19,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, Any
 
+# Check if FastAPI is available for web-related tests
+try:
+    import fastapi
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
 
 # =============================================================================
 # EHLERS CYCLE FILTER STRATEGY TESTS
@@ -411,6 +418,8 @@ class TestResearchModules:
 # =============================================================================
 
 
+@pytest.mark.web
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
 class TestStrategyTieringAPI:
     """Tests für API-Integration der neuen Strategien."""
 
@@ -502,19 +511,18 @@ class TestResearchStrategySafety:
 # =============================================================================
 
 
+@pytest.mark.web
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
 class TestFastAPIEndpoints:
     """Integration-Tests für FastAPI-Endpoints mit neuen Strategien."""
 
     @pytest.fixture
     def client(self):
         """FastAPI TestClient."""
-        try:
-            from fastapi.testclient import TestClient
-            from src.webui.app import app
+        from fastapi.testclient import TestClient
+        from src.webui.app import app
 
-            return TestClient(app)
-        except ImportError:
-            pytest.skip("fastapi.testclient nicht verfügbar")
+        return TestClient(app)
 
     def test_api_includes_ehlers_with_research_flag(self, client):
         """Test: API inkludiert Ehlers mit include_research=true."""

--- a/tests/test_live_status_snapshot_api.py
+++ b/tests/test_live_status_snapshot_api.py
@@ -19,7 +19,13 @@ from __future__ import annotations
 import json
 import pytest
 
+# Skip if FastAPI not installed
+pytest.importorskip("fastapi")
+
 from fastapi.testclient import TestClient
+
+# Mark all tests in this module as web tests
+pytestmark = pytest.mark.web
 
 
 # =============================================================================

--- a/tests/test_live_web.py
+++ b/tests/test_live_web.py
@@ -20,25 +20,14 @@ from typing import Any, Dict, List
 import pandas as pd
 import pytest
 
-# FastAPI TestClient importieren
-try:
-    from fastapi.testclient import TestClient
-    FASTAPI_AVAILABLE = True
-except ImportError:
-    FASTAPI_AVAILABLE = False
-    TestClient = None
+# Skip if FastAPI not installed - must be done before any FastAPI imports
+pytest.importorskip("fastapi")
 
+from fastapi.testclient import TestClient
 from src.live.web.app import create_app, WebUIConfig
 
-
-# =============================================================================
-# Skip if FastAPI not available
-# =============================================================================
-
-pytestmark = pytest.mark.skipif(
-    not FASTAPI_AVAILABLE,
-    reason="FastAPI not installed"
-)
+# Mark all tests in this module as web tests
+pytestmark = pytest.mark.web
 
 
 # =============================================================================

--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -40,7 +40,13 @@ import pytest
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+# Skip if FastAPI not installed
+pytest.importorskip("fastapi")
+
 from fastapi.testclient import TestClient
+
+# Mark all tests in this module as web tests
+pytestmark = pytest.mark.web
 
 from src.webui.app import create_app
 from src.webui.r_and_d_api import (

--- a/tests/test_research_strategies.py
+++ b/tests/test_research_strategies.py
@@ -19,6 +19,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, Any
 
+# Check if FastAPI is available for web-related tests
+try:
+    import fastapi
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
 # =============================================================================
 # Strategy Import Tests
 # =============================================================================
@@ -278,6 +285,8 @@ class TestStrategyTiering:
         assert "Research" in TIER_LABELS["r_and_d"]
 
 
+@pytest.mark.web
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
 class TestAllRnDStrategiesInTiering:
     """Tests: Alle R&D-Strategien sind in der Tiering-Struktur mit korrekten Feldern."""
 
@@ -436,6 +445,8 @@ class TestAllRnDStrategiesInTiering:
 # =============================================================================
 
 
+@pytest.mark.web
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
 class TestStrategyTieringAPI:
     """Tests für Strategy-Tiering API-Endpoints."""
 
@@ -504,6 +515,8 @@ class TestStrategyTieringAPI:
 # =============================================================================
 
 
+@pytest.mark.web
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
 class TestResearchStrategySafety:
     """Tests für Safety-Constraints von Research-Strategien."""
 
@@ -554,19 +567,18 @@ class TestResearchStrategySafety:
 # =============================================================================
 
 
+@pytest.mark.web
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="FastAPI not installed")
 class TestStrategyTieringAPIEndpoints:
     """Integration-Tests für FastAPI-Endpoints."""
 
     @pytest.fixture
     def client(self):
         """FastAPI TestClient."""
-        try:
-            from fastapi.testclient import TestClient
-            from src.webui.app import app
+        from fastapi.testclient import TestClient
+        from src.webui.app import app
 
-            return TestClient(app)
-        except ImportError:
-            pytest.skip("fastapi.testclient nicht verfügbar")
+        return TestClient(app)
 
     def test_api_strategy_tiering_excludes_research_by_default(self, client):
         """Test: API /api/strategy_tiering schließt R&D standardmäßig aus."""

--- a/tests/test_stage1_router.py
+++ b/tests/test_stage1_router.py
@@ -6,9 +6,15 @@ import json
 from pathlib import Path
 
 import pytest
-from fastapi.testclient import TestClient
 
+# Skip if FastAPI not installed
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
 from src.webui.app import create_app
+
+# Mark all tests in this module as web tests
+pytestmark = pytest.mark.web
 
 
 def test_stage1_router_imports():

--- a/tests/test_webui_live_track.py
+++ b/tests/test_webui_live_track.py
@@ -29,6 +29,12 @@ from typing import Any, Dict
 
 import pytest
 
+# Skip if FastAPI not installed - all tests in this module require web stack
+pytest.importorskip("fastapi")
+
+# Mark all tests in this module as web tests
+pytestmark = pytest.mark.web
+
 
 # =============================================================================
 # Fixtures


### PR DESCRIPTION
## Ziel
Web-UI / FastAPI-abhängige Tests sollen im Core-Setup (ohne Web-Stack) **automatisch geskipped** werden – keine ImportErrors, kein Zwang zu FastAPI/Starlette/etc. für die Core-Suite.

## Änderung
- Web-Tests sind jetzt **optional** (via `extras = web` + `pytest.importorskip(...)` / Skips)
- Entwickler können Web-Tests gezielt aktivieren (install + Marker)

## Testnachweis (lokal)
### Run 1 — ohne Web-Stack
`uv run pytest -q`
→ 3929 passed, 54 skipped, 35 failed (matplotlib), 0 errors  
✅ keine ImportErrors mehr  
✅ Web-Tests sauber geskipped

### Run 2 — mit Web-Stack
`uv sync --extra web`
`uv run pytest -q -m web`
→ 279 passed, 0 failed  
✅ alle Web-Tests laufen

## Hinweis / Follow-up
Die verbleibenden 35 Failures sind matplotlib-bezogen und **separat** (nicht Web-Stack). Falls CI die Minimal-Suite ohne matplotlib fährt, wäre ein kleiner Follow-up sinnvoll: matplotlib-Tests ebenfalls via extras/markers optionalisieren.
