### PR TITLE
test(ops): workflow scripts bash syntax smoke guard

### DIFF
--- a/docs/ops/WORKFLOW_SCRIPTS.md
+++ b/docs/ops/WORKFLOW_SCRIPTS.md
@@ -291,6 +291,34 @@ bash scripts/quick_pr_merge.sh
 
 ---
 
+## CI Smoke Guard
+
+Peak_Trade enthält einen minimalen Pytest-Smoke-Test, der sicherstellt:
+- Die 4 Ops-Workflow-Scripts existieren
+- Ihre Bash-Syntax korrekt ist (`bash -n` Check)
+- CI-sicher: Bei fehlendem `bash` wird der Test sauber übersprungen
+
+**Wichtig:** Der Test führt die Scripts **nicht aus** – kein `gh`, keine Auth, keine Side-Effects. Nur Syntaxprüfung.
+
+### Lokal ausführen
+
+```bash
+# Targeted Test (nur Workflow-Scripts)
+uv run pytest -q tests/test_ops_workflow_scripts_syntax.py
+
+# Oder im Full-Suite enthalten
+uv run pytest -q
+```
+
+### Geprüfte Scripts
+
+- `scripts/post_merge_workflow_pr203.sh`
+- `scripts/quick_pr_merge.sh`
+- `scripts/post_merge_workflow.sh`
+- `scripts/finalize_workflow_docs_pr.sh`
+
+---
+
 ## Best Practices
 
 ### 1. Immer auf aktuellem main starten

--- a/tests/test_ops_workflow_scripts_syntax.py
+++ b/tests/test_ops_workflow_scripts_syntax.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS = [
+    Path("scripts/post_merge_workflow_pr203.sh"),
+    Path("scripts/quick_pr_merge.sh"),
+    Path("scripts/post_merge_workflow.sh"),
+    Path("scripts/finalize_workflow_docs_pr.sh"),
+]
+
+
+def _has_bash() -> bool:
+    return shutil.which("bash") is not None
+
+
+@pytest.mark.parametrize("script_path", SCRIPTS)
+def test_ops_workflow_script_exists(script_path: Path) -> None:
+    assert script_path.exists(), f"Missing workflow script: {script_path}"
+
+
+@pytest.mark.parametrize("script_path", SCRIPTS)
+def test_ops_workflow_script_bash_syntax_ok(script_path: Path) -> None:
+    if not _has_bash():
+        pytest.skip("bash not available on this system")
+    # Syntax check only (no execution)
+    proc = subprocess.run(
+        ["bash", "-n", str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"Bash syntax error in {script_path}\n"
+        f"STDOUT:\n{proc.stdout}\n"
+        f"STDERR:\n{proc.stderr}\n"
+    )
+


### PR DESCRIPTION
Adds a minimal CI-safe smoke test that checks existence + 'bash -n' syntax for ops workflow scripts. No script execution, no side effects.