### PR TITLE
docs(ops): add PR #209 merge log

### DIFF
--- a/docs/PEAK_TRADE_STATUS_OVERVIEW.md
+++ b/docs/PEAK_TRADE_STATUS_OVERVIEW.md
@@ -1377,6 +1377,7 @@ is_feature_approved_for_year("live_order_execution", 2026)       # → False
 **Peak_Trade** – Ein produktionsnahes Trading-Research-Framework mit integrierter Safety-First-Architektur.
 
 ## Changelog
+- 2025-12-21 — PR #209 merged: added merge log for PR #208 (Ops Workflow Hub).
 - 2025-12-21: PR #204 – docs(ops): workflow scripts documentation + automation infrastructure (vollständige Dokumentation + Helper-Scripts)
 - 2025-12-21: PR #203 – test(viz): matplotlib-based report/plot tests optional via extras (Core ohne Viz-Dependencies lauffähig)
 - 2025-12-21: PR #201 – Web-UI tests optional via extras (Core ohne Web-Stack lauffähig)

--- a/docs/ops/PR_209_MERGE_LOG.md
+++ b/docs/ops/PR_209_MERGE_LOG.md
@@ -1,0 +1,64 @@
+# PR #209 — Merge Log
+
+- PR: #209 — docs(ops): add PR #208 merge log  
+- URL: https://github.com/rauterfrank-ui/Peak_Trade/pull/209  
+- Merge: Squash-Merge ✅  
+- Squash Commit: 24cc6fa  
+- Date: 2025-12-21  
+- Scope: Docs-only (merge-log meta)  
+
+---
+
+## Summary
+
+This PR adds the post-merge documentation for PR #208 ("Ops Workflow Hub") by introducing the merge log file `docs/ops/PR_208_MERGE_LOG.md`.
+
+## Motivation
+
+Keep the Ops documentation complete and auditable: every merged PR should have a standardized merge log capturing scope, verification, risk, and operator notes.
+
+## Changes
+
+- Added: `docs/ops/PR_208_MERGE_LOG.md` (116 additions, 0 deletions)
+- No code changes, no config changes, no runtime impact.
+
+## Verification
+
+CI (all green):
+
+- ✅ CI Health Gate — 44s
+- ✅ audit — 2m03s
+- ✅ strategy-smoke — 46s
+- ✅ tests (3.11) — 4m18s
+
+Local:
+
+- Docs-only change; no additional local runtime verification required.
+
+## Risk Assessment
+
+🟢 Minimal
+
+- Documentation-only
+- No behavioral changes
+- No dependency changes
+
+## Operator How-To
+
+- Review the PR #208 merge log:
+  - `docs/ops/PR_208_MERGE_LOG.md`
+- Use it as reference for:
+  - Ops Workflow Hub usage
+  - API/UI change summary
+  - Verification record
+
+## Follow-Up Tasks
+
+- (Optional) Ensure `docs/ops/README.md` merge-log index references PR #209 merge log.
+- (Optional) Ensure `docs/PEAK_TRADE_STATUS_OVERVIEW.md` reflects the latest ops-docs bookkeeping.
+
+## References
+
+- PR #209: https://github.com/rauterfrank-ui/Peak_Trade/pull/209
+- Squash commit: 24cc6fa
+

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -431,3 +431,7 @@ The trend analysis includes a simple readiness assessment:
 - Stage1 Scripts schreiben zusätzliche JSON Files (bestehende Markdown Reports unverändert)
 - Keine Breaking Changes an bestehenden Workflows
 - Falls JSON Files fehlen: Empty State im Dashboard, keine Errors
+
+## Merge Logs
+
+- [PR #209](PR_209_MERGE_LOG.md) — docs(ops): add merge log for PR #208 (ops workflow hub) (merged 2025-12-21)


### PR DESCRIPTION
Adds post-merge ops documentation for PR #209 (docs-only). Updates ops merge-log index + status overview.