### PR TITLE
docs(ops): add PR #210 merge log

### DIFF
--- a/docs/PEAK_TRADE_STATUS_OVERVIEW.md
+++ b/docs/PEAK_TRADE_STATUS_OVERVIEW.md
@@ -1377,6 +1377,7 @@ is_feature_approved_for_year("live_order_execution", 2026)       # → False
 **Peak_Trade** – Ein produktionsnahes Trading-Research-Framework mit integrierter Safety-First-Architektur.
 
 ## Changelog
+- 2025-12-21 — PR #210 merged: added merge log for PR #209.
 - 2025-12-21 — PR #209 merged: added merge log for PR #208 (Ops Workflow Hub).
 - 2025-12-21: PR #204 – docs(ops): workflow scripts documentation + automation infrastructure (vollständige Dokumentation + Helper-Scripts)
 - 2025-12-21: PR #203 – test(viz): matplotlib-based report/plot tests optional via extras (Core ohne Viz-Dependencies lauffähig)

--- a/docs/ops/PR_210_MERGE_LOG.md
+++ b/docs/ops/PR_210_MERGE_LOG.md
@@ -1,0 +1,64 @@
+# PR #210 — Merge Log
+
+- PR: #210 — docs(ops): add PR #209 merge log
+- URL: https://github.com/rauterfrank-ui/Peak_Trade/pull/210
+- Merge: Squash-Merge ✅
+- Squash Commit: d056a6d
+- Date: 2025-12-21
+- Scope: Docs-only (merge-log bookkeeping)
+
+---
+
+## Summary
+
+This PR adds the post-merge documentation for PR #209 by introducing the merge log `docs/ops/PR_209_MERGE_LOG.md` and updating the ops index and project status overview.
+
+## Motivation
+
+Keep the Ops documentation complete and auditable: every merged PR should have a standardized merge log capturing scope, verification, risk, and operator notes.
+
+## Changes
+
+- Added: `docs/ops/PR_209_MERGE_LOG.md` (new, 64 lines)
+- Updated: `docs/ops/README.md` (merge-log index)
+- Updated: `docs/PEAK_TRADE_STATUS_OVERVIEW.md` (changelog)
+
+## Verification
+
+CI (all green):
+
+- ✅ CI Health Gate — 49s
+- ✅ audit — 2m08s
+- ✅ strategy-smoke — 47s
+- ✅ tests (3.11) — 3m53s
+
+Local:
+
+- Docs-only change; no runtime verification required.
+
+## Risk Assessment
+
+🟢 Minimal
+
+- Documentation-only
+- No behavioral changes
+- No dependency changes
+
+## Operator How-To
+
+- Read PR #209 merge log:
+  - `docs/ops/PR_209_MERGE_LOG.md`
+- Use the ops merge-log index:
+  - `docs/ops/README.md`
+- Check global status/changelog:
+  - `docs/PEAK_TRADE_STATUS_OVERVIEW.md`
+
+## Follow-Up Tasks
+
+- None required. Optional: keep continuing the merge-log chain for future ops PRs.
+
+## References
+
+- PR #210: https://github.com/rauterfrank-ui/Peak_Trade/pull/210
+- Squash commit: d056a6d
+- PR #209: https://github.com/rauterfrank-ui/Peak_Trade/pull/209

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -434,4 +434,5 @@ The trend analysis includes a simple readiness assessment:
 
 ## Merge Logs
 
+- [PR #210](PR_210_MERGE_LOG.md) — docs(ops): add merge log for PR #209 (merged 2025-12-21)
 - [PR #209](PR_209_MERGE_LOG.md) — docs(ops): add merge log for PR #208 (ops workflow hub) (merged 2025-12-21)


### PR DESCRIPTION
Adds post-merge ops documentation for PR #210 (docs-only). Updates ops merge-log index + status overview.