### PR TITLE
docs(ops): wire merge+format-sweep runbook into indexes

### DIFF
--- a/docs/PEAK_TRADE_STATUS_OVERVIEW.md
+++ b/docs/PEAK_TRADE_STATUS_OVERVIEW.md
@@ -1377,6 +1377,7 @@ is_feature_approved_for_year("live_order_execution", 2026)       # → False
 **Peak_Trade** – Ein produktionsnahes Trading-Research-Framework mit integrierter Safety-First-Architektur.
 
 ## Changelog
+- 2025-12-21 — PR #220 merged: added comprehensive ops runbook for merge+format-sweep workflow (413 lines, includes quickstart, scenarios, troubleshooting, CI integration).
 - 2025-12-21 — PR #218 merged: added PR #217 post-merge ops documentation; verified Quarto non-blocking + path filter.
 - 2025-12-21 — PR #217 merged: added workflow script `merge_and_format_sweep.sh` for automated merge + format-sweep operations.
 - 2025-12-21 — PR #213 merged: added merge log for PR #212.

--- a/docs/ops/WORKFLOW_SCRIPTS.md
+++ b/docs/ops/WORKFLOW_SCRIPTS.md
@@ -25,6 +25,9 @@ Diese Datei dokumentiert die Peak_Trade Ops-Automations-Skripte für **Post-Merg
 | `scripts/post_merge_workflow_pr203.sh` | All-in-One: Docs erstellen + PR-Flow | PR #203 Merge-Log vollautomatisch |
 | `scripts/quick_pr_merge.sh` | Quick PR-Merge | Wenn Docs bereits committet sind |
 | `scripts/post_merge_workflow.sh` | Generisches Post-Merge Verification | Hygiene + Verification nach jedem Merge |
+| `scripts/workflows/merge_and_format_sweep.sh` | PR Merge + Format-Sweep + Large-PR Test | Automated merge + format sweep workflow |
+
+**Siehe auch:** [WORKFLOW_MERGE_AND_FORMAT_SWEEP.md](WORKFLOW_MERGE_AND_FORMAT_SWEEP.md) — Comprehensive ops runbook für Merge + Format Sweep Workflow (inkl. CI Large-PR Handling, Quickstart, Scenarios, Troubleshooting).
 
 ---
 


### PR DESCRIPTION
## Was / What

Adds missing cross-references for the new Merge + Format Sweep Runbook (PR #220) to central documentation indexes.

## Warum / Why

PR #220 added `WORKFLOW_MERGE_AND_FORMAT_SWEEP.md` but left some index updates incomplete:
- ✅ `docs/ops/README.md` already had the entry (done in PR #220)
- ⚠️ `docs/PEAK_TRADE_STATUS_OVERVIEW.md` — missing changelog for PR #220
- ℹ️ `docs/ops/WORKFLOW_SCRIPTS.md` — missing cross-reference

**Ops Workflow Hub** (Web-UI at `/ops/workflows`) was considered but skipped per instructions (would require code changes, not just docs).

## Changes / Änderungen

### 1. `docs/PEAK_TRADE_STATUS_OVERVIEW.md`
- Added changelog entry for PR #220 (2025-12-21)
- Follows established format (1 line, includes key metrics: 413 lines, quickstart, scenarios, troubleshooting)

### 2. `docs/ops/WORKFLOW_SCRIPTS.md`  
- Added `merge_and_format_sweep.sh` to overview table
- Added "Siehe auch" cross-reference to `WORKFLOW_MERGE_AND_FORMAT_SWEEP.md`
- Provides context: CI Large-PR Handling, Quickstart, Scenarios, Troubleshooting

## Verification / Verifikation

```bash
# Ruff check (passed)
uv run ruff check . --quiet
✅ ruff check passed

# Pytest skipped (docs-only change, no code logic affected)
# Would run: uv run pytest -q
# Rationale: Pure documentation updates, no test coverage needed
```

**Pre-commit hooks:** ✅ All passed (end-of-file-fixer, trim-trailing-whitespace, check-yaml, etc.)

## Risiko / Risk

🟢 **MINIMAL**

**Begründung:**
- Pure documentation (Markdown only)
- No code changes
- No new dependencies
- No logic paths affected
- Cross-references are relative paths (work in all contexts)
- No duplicate links introduced

## Related

- PR #220: `WORKFLOW_MERGE_AND_FORMAT_SWEEP.md` (Ops Runbook)
- PR #217: `scripts/workflows/merge_and_format_sweep.sh` (Workflow Script)
- PR #216: `CI_LARGE_PR_HANDLING.md` (CI System Docs)
- PR #208: Ops Workflow Hub (Web-UI)

---

**Size:** 2 files changed, 4 insertions