### PR TITLE
docs(ops): add compact merge-log template

### DIFF
--- a/docs/ops/MERGE_LOG_TEMPLATE_COMPACT.md
+++ b/docs/ops/MERGE_LOG_TEMPLATE_COMPACT.md
@@ -1,0 +1,59 @@
+# MERGE LOG TEMPLATE (COMPACT)
+
+> Standard: kompakt + fokussiert.  
+> Extended Notes nur bei komplexen/riskanteren PRs (Risk != 🟢, Live/Governance/CI-Behavior, große Flächenänderung).
+
+# PR #<NUM> — MERGE LOG
+
+## Summary
+PR #<NUM> <kurzer Titel/Outcome in 1 Satz>.
+
+- PR: #<NUM> — <PR Title>
+- Merged commit (main): `<sha>`
+- Date: <YYYY-MM-DD>
+- Chain context (optional):
+  - PR #<A> (`<shaA>`) — <1-liner>
+  - PR #<B> (`<shaB>`) — <1-liner>
+
+## Motivation / Why
+- <Warum war das nötig?>
+- <Operator/Dev Nutzen in 1–2 bullets>
+
+## Changes
+### Added/Updated
+- <Bullet>
+- <Bullet>
+
+### Touched files (optional)
+- `<path>` — <1-liner>
+- `<path>` — <1-liner>
+
+## Verification
+- `<command>` ✅
+- `<command>` ✅
+- Notes: <z.B. docs-only / targeted tests / CI checks>
+
+## Risk Assessment
+🟢 **Low** / 🟡 **Medium** / 🔴 **High**
+- <1–3 bullets warum>
+
+## Operator How-To
+### Do this
+- <Konkreter Schritt 1>
+- <Konkreter Schritt 2>
+
+### Quick commands (optional)
+- `<cmd>`
+- `<cmd>`
+
+## Follow-Up Tasks (optional)
+- [ ] <konkretes optionales follow-up>
+- [ ] <konkretes optionales follow-up>
+
+## References
+- PR #<NUM> — <title>
+- Related docs: `<path>`, `<path>`
+
+## Extended Notes (optional)
+Nur ausfüllen, wenn nötig (Risk != 🟢, Live/Governance/CI-Behavior, viele Module betroffen):
+- <Edge cases / Rollback / Operator warnings / Migration notes>

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -441,5 +441,11 @@ The trend analysis includes a simple readiness assessment:
 
 ## Merge Logs
 
+### Templates
+
+- [MERGE_LOG_TEMPLATE_COMPACT](MERGE_LOG_TEMPLATE_COMPACT.md) — Standardvorlage (kompakt, fokussiert)
+
+### Recent Merge Logs
+
 - [PR #210](PR_210_MERGE_LOG.md) — docs(ops): add merge log for PR #209 (merged 2025-12-21)
 - [PR #209](PR_209_MERGE_LOG.md) — docs(ops): add merge log for PR #208 (ops workflow hub) (merged 2025-12-21)


### PR DESCRIPTION
## Summary
- Add standardized compact merge-log template for ops PRs.
- Link the template from docs/ops/README.md and group recent merge logs.

## Verification
- Pre-commit hooks passed.
- Docs-only change.

## Risk
🟢 Minimal (documentation only)
