### PR TITLE
feat(ops): merge log generator + format guard

### DIFF
--- a/scripts/audit/check_ops_merge_logs.py
+++ b/scripts/audit/check_ops_merge_logs.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Guard für Ops Merge Log Format-Compliance (Pflichtsektionen Check)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+# Pflicht-Sektionen (H2) für Merge Logs
+REQUIRED_SECTIONS = [
+    "Zusammenfassung",
+    "Warum",
+    "Änderungen",
+    "Verifikation",
+    "Risiko",
+    "Operator How-To",
+    "Referenzen",
+]
+
+
+def find_merge_logs(repo_root: Path) -> list[Path]:
+    """
+    Findet alle Merge Log Dateien im ops Directory.
+
+    Args:
+        repo_root: Repository root directory
+
+    Returns:
+        Liste von Merge Log Pfaden (sortiert)
+    """
+    ops_dir = repo_root / "docs" / "ops"
+    if not ops_dir.exists():
+        return []
+
+    # Pattern: PR_<N>_MERGE_LOG.md
+    merge_logs = list(ops_dir.glob("PR_*_MERGE_LOG.md"))
+    return sorted(merge_logs)
+
+
+def check_required_sections(merge_log_path: Path) -> list[str]:
+    """
+    Prüft, ob alle Pflicht-Sektionen in einem Merge Log vorhanden sind.
+
+    Args:
+        merge_log_path: Pfad zum Merge Log
+
+    Returns:
+        Liste der fehlenden Sektionen (leer wenn alles ok)
+    """
+    content = merge_log_path.read_text(encoding="utf-8")
+
+    # Finde alle H2 Sektionen (## Sektionsname)
+    h2_pattern = re.compile(r"^##\s+(.+?)$", re.MULTILINE)
+    found_sections = set(h2_pattern.findall(content))
+
+    # Prüfe, welche Pflicht-Sektionen fehlen
+    missing = []
+    for required in REQUIRED_SECTIONS:
+        if required not in found_sections:
+            missing.append(required)
+
+    return missing
+
+
+def main() -> int:
+    """
+    Main entry point.
+
+    Exit codes:
+        0 - Alle Merge Logs compliant
+        1 - Violations gefunden (fehlende Sektionen)
+        2 - Unerwarteter Fehler
+    """
+    try:
+        repo_root = Path(__file__).parent.parent.parent
+        merge_logs = find_merge_logs(repo_root)
+
+        if not merge_logs:
+            print("✅ Keine Merge Logs gefunden (docs/ops/PR_*_MERGE_LOG.md)")
+            return 0
+
+        print(f"🔍 Prüfe {len(merge_logs)} Merge Log(s) auf Pflicht-Sektionen...")
+        print()
+
+        violations = []
+
+        for merge_log_path in merge_logs:
+            missing = check_required_sections(merge_log_path)
+            if missing:
+                violations.append((merge_log_path, missing))
+
+        if violations:
+            print("❌ VIOLATIONS GEFUNDEN:")
+            print()
+            for path, missing in violations:
+                print(f"  {path.relative_to(repo_root)}")
+                for section in missing:
+                    print(f"    ⚠️  Fehlende Sektion: ## {section}")
+                print()
+
+            print(f"❌ {len(violations)} Merge Log(s) mit fehlenden Sektionen")
+            print()
+            print("Pflicht-Sektionen (H2):")
+            for section in REQUIRED_SECTIONS:
+                print(f"  - ## {section}")
+
+            return 1
+
+        print(f"✅ Alle {len(merge_logs)} Merge Log(s) sind compliant")
+        print()
+        print("Geprüfte Pflicht-Sektionen:")
+        for section in REQUIRED_SECTIONS:
+            print(f"  ✓ ## {section}")
+
+        return 0
+
+    except Exception as exc:
+        print(f"❌ Unerwarteter Fehler: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/create_merge_log.py
+++ b/scripts/ops/create_merge_log.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Generator für Ops Merge Logs im standardisierten Format."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def load_template(repo_root: Path) -> str:
+    """
+    Lädt das Merge Log Template.
+
+    Args:
+        repo_root: Repository root directory
+
+    Returns:
+        Template als String
+
+    Raises:
+        FileNotFoundError: Wenn Template nicht gefunden wurde
+    """
+    template_path = repo_root / "docs" / "ops" / "MERGE_LOG_TEMPLATE_COMPACT.md"
+    if not template_path.exists():
+        msg = f"Template nicht gefunden: {template_path}"
+        raise FileNotFoundError(msg)
+    return template_path.read_text(encoding="utf-8")
+
+
+def generate_merge_log_content(
+    pr_number: int,
+    title: str,
+    date: str,
+    commit: str,
+    pr_url: str,
+    branch: str,
+    branch_status: str = "deleted",
+) -> str:
+    """
+    Generiert Merge Log Inhalt aus Template.
+
+    Args:
+        pr_number: PR Nummer
+        title: PR Titel (format: "type(scope): description")
+        date: Merge Datum (YYYY-MM-DD)
+        commit: Merge Commit SHA
+        pr_url: PR URL
+        branch: Branch Name
+        branch_status: Branch Status (default: "deleted")
+
+    Returns:
+        Gefülltes Merge Log Template als String
+    """
+    # Template-Ersetzungen
+    replacements = {
+        "{{PR_NUMBER}}": str(pr_number),
+        "{{TYPE}}({{SCOPE}}): {{TITLE}}": title,
+        "{{PR_URL}}": pr_url,
+        "{{MERGE_DATE_YYYY_MM_DD}}": date,
+        "{{MERGE_COMMIT_SHA}}": commit,
+        "{{BRANCH_NAME}}": branch,
+        "{{BRANCH_STATUS}}": branch_status,
+    }
+
+    # Versuche Template zu laden, ansonsten generiere Minimal-Template
+    try:
+        repo_root = Path(__file__).parent.parent.parent
+        content = load_template(repo_root)
+    except FileNotFoundError:
+        # Fallback: Minimales Template
+        content = _generate_minimal_template()
+
+    # Ersetze Platzhalter
+    for placeholder, value in replacements.items():
+        content = content.replace(placeholder, value)
+
+    return content
+
+
+def _generate_minimal_template() -> str:
+    """Generiert minimales Merge Log Template als Fallback."""
+    return """# MERGE LOG — PR #{{PR_NUMBER}} — {{TYPE}}({{SCOPE}}): {{TITLE}}
+
+**PR:** {{PR_URL}}
+**Merged:** {{MERGE_DATE_YYYY_MM_DD}}
+**Merge Commit:** {{MERGE_COMMIT_SHA}}
+**Branch:** {{BRANCH_NAME}} ({{BRANCH_STATUS}})
+
+---
+
+## Zusammenfassung
+- _TODO: Was wurde geändert?_
+- _TODO: Welchen Impact/Wert bringt es?_
+
+## Warum
+- _TODO: Root Cause oder Kontext_
+- _TODO: Warum jetzt?_
+
+## Änderungen
+**Geändert**
+- `path/to/file` — _TODO: Beschreibung_
+
+**Neu**
+- `path/to/file` — _TODO: Beschreibung_
+
+## Verifikation
+**CI**
+- _TODO: Check Name_ — PASS/FAIL
+
+**Lokal**
+- _TODO: Durchgeführte Tests_
+
+## Risiko
+**Risk:** 🟢 Minimal / 🟡 Medium / 🔴 High
+**Begründung**
+- _TODO: Warum dieses Risk Level?_
+
+## Operator How-To
+- _TODO: Schritt 1_
+- _TODO: Schritt 2_
+
+## Referenzen
+- PR: {{PR_URL}}
+- Commit: {{MERGE_COMMIT_SHA}}
+
+---
+"""
+
+
+def write_merge_log(
+    repo_root: Path,
+    pr_number: int,
+    content: str,
+    dry_run: bool = False,
+) -> Path:
+    """
+    Schreibt Merge Log Datei.
+
+    Args:
+        repo_root: Repository root directory
+        pr_number: PR Nummer
+        content: Merge Log Inhalt
+        dry_run: Wenn True, nur Ausgabe ohne Schreiben
+
+    Returns:
+        Path zum geschriebenen Merge Log
+    """
+    merge_log_path = repo_root / "docs" / "ops" / f"PR_{pr_number}_MERGE_LOG.md"
+
+    if dry_run:
+        print(f"[DRY-RUN] Würde schreiben: {merge_log_path}")
+        print(content)
+        return merge_log_path
+
+    merge_log_path.parent.mkdir(parents=True, exist_ok=True)
+    merge_log_path.write_text(content, encoding="utf-8")
+    print(f"[created] {merge_log_path}")
+
+    return merge_log_path
+
+
+def update_readme(
+    repo_root: Path,
+    pr_number: int,
+    title: str,
+    date: str,
+    dry_run: bool = False,
+) -> None:
+    """
+    Aktualisiert docs/ops/README.md mit neuem Merge Log Link (idempotent).
+
+    Args:
+        repo_root: Repository root directory
+        pr_number: PR Nummer
+        title: PR Titel
+        date: Merge Datum (YYYY-MM-DD)
+        dry_run: Wenn True, nur Ausgabe ohne Schreiben
+    """
+    readme_path = repo_root / "docs" / "ops" / "README.md"
+
+    # Signature für Duplikat-Schutz
+    signature = f"PR-{pr_number}-MERGE-LOG"
+
+    if not readme_path.exists():
+        if dry_run:
+            print(f"[DRY-RUN] README nicht gefunden: {readme_path}")
+            return
+        # Erstelle minimale README
+        readme_path.parent.mkdir(parents=True, exist_ok=True)
+        initial_content = """# Operations Guide
+
+Quick reference for Peak_Trade operational tasks.
+
+---
+
+## Merge Logs
+
+Post-merge documentation logs for operational PRs.
+
+"""
+        readme_path.write_text(initial_content, encoding="utf-8")
+        print(f"[created] {readme_path}")
+
+    text = readme_path.read_text(encoding="utf-8")
+
+    # Prüfe auf Duplikat (via signature oder PR-Link)
+    pr_link = f"[PR #{pr_number}](PR_{pr_number}_MERGE_LOG.md)"
+    if signature in text or pr_link in text:
+        print(f"[skip] PR #{pr_number} bereits in README vorhanden")
+        return
+
+    # Entry erstellen
+    entry = f"- {pr_link} — {title} (merged {date}) <!-- {signature} -->\n"
+
+    # Finde "## Merge Logs" Section
+    section_header = "## Merge Logs"
+    if section_header not in text:
+        # Section existiert nicht, füge sie hinzu
+        if dry_run:
+            print(f"[DRY-RUN] Würde Section '{section_header}' hinzufügen")
+            return
+
+        if not text.endswith("\n\n"):
+            text += "\n\n"
+        text += f"{section_header}\n\n"
+        text += "Post-merge documentation logs for operational PRs.\n\n"
+        text += entry
+        readme_path.write_text(text, encoding="utf-8")
+        print(f"[add] Section + Entry in {readme_path}")
+        return
+
+    if dry_run:
+        print(f"[DRY-RUN] Würde Entry hinzufügen: {entry.strip()}")
+        return
+
+    # Insert nach dem Section Header (top insertion)
+    before, after = text.split(section_header, 1)
+
+    # Finde erste Zeile nach Header (könnte leer sein oder Text)
+    lines_after = after.split("\n")
+    # Überspringe Leerzeilen und einleitenden Text bis zur ersten Liste
+    insert_idx = 0
+    for i, line in enumerate(lines_after):
+        if line.strip() and not line.startswith("-") and not line.startswith("#"):
+            # Einleitungstext, überspringe
+            insert_idx = i + 1
+        elif line.startswith("-"):
+            # Erste Liste gefunden
+            insert_idx = i
+            break
+        elif line.strip() == "":
+            # Leerzeile
+            continue
+        else:
+            # Nächster Header oder anderer Content
+            insert_idx = i
+            break
+
+    # Baue neuen Content zusammen
+    lines_after.insert(insert_idx, entry.rstrip())
+    new_after = "\n".join(lines_after)
+    new_text = before + section_header + new_after
+
+    readme_path.write_text(new_text, encoding="utf-8")
+    print(f"[insert] Entry in {readme_path}")
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Generiert Ops Merge Log im standardisierten Format"
+    )
+    parser.add_argument("--pr", type=int, required=True, help="PR Nummer")
+    parser.add_argument("--title", type=str, required=True, help="PR Titel")
+    parser.add_argument("--date", type=str, required=True, help="Merge Datum (YYYY-MM-DD)")
+    parser.add_argument("--commit", type=str, required=True, help="Merge Commit SHA")
+    parser.add_argument("--pr-url", type=str, required=True, help="PR URL")
+    parser.add_argument("--branch", type=str, required=True, help="Branch Name")
+    parser.add_argument(
+        "--branch-status",
+        type=str,
+        default="deleted",
+        help="Branch Status (default: deleted)",
+    )
+    parser.add_argument(
+        "--update-readme",
+        action="store_true",
+        default=True,
+        help="README aktualisieren (default: true)",
+    )
+    parser.add_argument(
+        "--no-update-readme",
+        dest="update_readme",
+        action="store_false",
+        help="README nicht aktualisieren",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Nur Ausgabe, keine Änderungen")
+
+    args = parser.parse_args()
+
+    # Validiere Datum
+    try:
+        datetime.strptime(args.date, "%Y-%m-%d")
+    except ValueError as exc:
+        print(f"[error] Ungültiges Datumsformat: {args.date} (erwartet: YYYY-MM-DD)")
+        return 2
+
+    try:
+        repo_root = Path(__file__).parent.parent.parent
+
+        # Generiere Merge Log Content
+        content = generate_merge_log_content(
+            pr_number=args.pr,
+            title=args.title,
+            date=args.date,
+            commit=args.commit,
+            pr_url=args.pr_url,
+            branch=args.branch,
+            branch_status=args.branch_status,
+        )
+
+        # Schreibe Merge Log
+        write_merge_log(
+            repo_root=repo_root,
+            pr_number=args.pr,
+            content=content,
+            dry_run=args.dry_run,
+        )
+
+        # Update README (optional)
+        if args.update_readme:
+            update_readme(
+                repo_root=repo_root,
+                pr_number=args.pr,
+                title=args.title,
+                date=args.date,
+                dry_run=args.dry_run,
+            )
+
+        if args.dry_run:
+            print("\n[DRY-RUN] Keine Änderungen vorgenommen")
+        else:
+            print(f"\n✅ Merge Log für PR #{args.pr} erfolgreich erstellt")
+
+        return 0
+
+    except Exception as exc:
+        print(f"[error] Unerwarteter Fehler: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ops_merge_log_generator.py
+++ b/tests/test_ops_merge_log_generator.py
@@ -1,0 +1,321 @@
+"""Tests für Ops Merge Log Generator."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def test_repo_structure(tmp_path: Path) -> Path:
+    """
+    Erstellt minimale Repo-Struktur für Tests.
+
+    Args:
+        tmp_path: pytest tmp_path fixture
+
+    Returns:
+        Path zum Mock-Repo-Root
+    """
+    repo_root = tmp_path / "peak_trade"
+    repo_root.mkdir()
+
+    # docs/ops/ Verzeichnis
+    ops_dir = repo_root / "docs" / "ops"
+    ops_dir.mkdir(parents=True)
+
+    # Minimale README mit Merge Logs Section
+    readme_content = """# Operations Guide
+
+Quick reference for Peak_Trade operational tasks.
+
+---
+
+## Merge Logs
+
+Post-merge documentation logs for operational PRs.
+
+- [PR #100](PR_100_MERGE_LOG.md) — test(ops): existing entry (merged 2025-01-01) <!-- PR-100-MERGE-LOG -->
+
+"""
+    (ops_dir / "README.md").write_text(readme_content, encoding="utf-8")
+
+    # Template
+    template_content = """# MERGE LOG — PR #{{PR_NUMBER}} — {{TYPE}}({{SCOPE}}): {{TITLE}}
+
+**PR:** {{PR_URL}}
+**Merged:** {{MERGE_DATE_YYYY_MM_DD}}
+**Merge Commit:** {{MERGE_COMMIT_SHA}}
+**Branch:** {{BRANCH_NAME}} ({{BRANCH_STATUS}})
+
+---
+
+## Zusammenfassung
+- TODO
+
+## Warum
+- TODO
+
+## Änderungen
+**Geändert**
+- TODO
+
+## Verifikation
+**CI**
+- TODO
+
+## Risiko
+**Risk:** 🟢 Minimal
+**Begründung**
+- TODO
+
+## Operator How-To
+- TODO
+
+## Referenzen
+- PR: {{PR_URL}}
+- Commit: {{MERGE_COMMIT_SHA}}
+
+---
+"""
+    (ops_dir / "MERGE_LOG_TEMPLATE_COMPACT.md").write_text(template_content, encoding="utf-8")
+
+    return repo_root
+
+
+def test_generate_merge_log_creates_file(test_repo_structure: Path, monkeypatch):
+    """Test: Generator erstellt Merge Log Datei mit allen Pflicht-Sektionen."""
+    # Importiere Generator Modul (mock __file__ auf test repo)
+    monkeypatch.syspath_prepend(Path(__file__).parent.parent / "scripts" / "ops")
+
+    import create_merge_log
+
+    # Mock __file__ für repo_root discovery
+    monkeypatch.setattr(
+        create_merge_log,
+        "__file__",
+        str(test_repo_structure / "scripts" / "ops" / "create_merge_log.py"),
+    )
+
+    # Generiere Merge Log Content
+    content = create_merge_log.generate_merge_log_content(
+        pr_number=226,
+        title="feat(ops): test feature",
+        date="2025-12-21",
+        commit="abc1234",
+        pr_url="https://github.com/user/repo/pull/226",
+        branch="feat/test",
+        branch_status="deleted",
+    )
+
+    # Prüfe, dass Content alle Pflicht-Sektionen enthält
+    required_sections = [
+        "## Zusammenfassung",
+        "## Warum",
+        "## Änderungen",
+        "## Verifikation",
+        "## Risiko",
+        "## Operator How-To",
+        "## Referenzen",
+    ]
+
+    for section in required_sections:
+        assert section in content, f"Pflicht-Sektion fehlt: {section}"
+
+    # Prüfe Platzhalter-Ersetzungen
+    assert "PR #226" in content
+    assert "feat(ops): test feature" in content
+    assert "2025-12-21" in content
+    assert "abc1234" in content
+    assert "https://github.com/user/repo/pull/226" in content
+    assert "feat/test" in content
+    assert "deleted" in content
+
+
+def test_write_merge_log_creates_file(test_repo_structure: Path, monkeypatch):
+    """Test: write_merge_log schreibt Datei korrekt."""
+    monkeypatch.syspath_prepend(Path(__file__).parent.parent / "scripts" / "ops")
+
+    import create_merge_log
+
+    content = "# Test Merge Log\n\n## Zusammenfassung\nTest content"
+
+    merge_log_path = create_merge_log.write_merge_log(
+        repo_root=test_repo_structure,
+        pr_number=226,
+        content=content,
+        dry_run=False,
+    )
+
+    assert merge_log_path.exists()
+    assert merge_log_path.name == "PR_226_MERGE_LOG.md"
+    assert merge_log_path.read_text(encoding="utf-8") == content
+
+
+def test_update_readme_adds_entry(test_repo_structure: Path, monkeypatch):
+    """Test: update_readme fügt neuen Entry hinzu."""
+    monkeypatch.syspath_prepend(Path(__file__).parent.parent / "scripts" / "ops")
+
+    import create_merge_log
+
+    create_merge_log.update_readme(
+        repo_root=test_repo_structure,
+        pr_number=226,
+        title="feat(ops): test feature",
+        date="2025-12-21",
+        dry_run=False,
+    )
+
+    readme_path = test_repo_structure / "docs" / "ops" / "README.md"
+    readme_content = readme_path.read_text(encoding="utf-8")
+
+    # Prüfe, dass neuer Entry vorhanden ist
+    assert "[PR #226](PR_226_MERGE_LOG.md)" in readme_content
+    assert "feat(ops): test feature" in readme_content
+    assert "merged 2025-12-21" in readme_content
+    assert "PR-226-MERGE-LOG" in readme_content  # Signature
+
+
+def test_update_readme_idempotent(test_repo_structure: Path, monkeypatch):
+    """Test: update_readme ist idempotent (keine Duplikate)."""
+    monkeypatch.syspath_prepend(Path(__file__).parent.parent / "scripts" / "ops")
+
+    import create_merge_log
+
+    # Erste Einfügung
+    create_merge_log.update_readme(
+        repo_root=test_repo_structure,
+        pr_number=226,
+        title="feat(ops): test feature",
+        date="2025-12-21",
+        dry_run=False,
+    )
+
+    readme_path = test_repo_structure / "docs" / "ops" / "README.md"
+    content_after_first = readme_path.read_text(encoding="utf-8")
+
+    # Zweite Einfügung (sollte nichts tun)
+    create_merge_log.update_readme(
+        repo_root=test_repo_structure,
+        pr_number=226,
+        title="feat(ops): test feature",
+        date="2025-12-21",
+        dry_run=False,
+    )
+
+    content_after_second = readme_path.read_text(encoding="utf-8")
+
+    # Content sollte identisch sein
+    assert content_after_first == content_after_second
+
+    # Prüfe, dass Entry nur einmal vorkommt
+    count = content_after_second.count("[PR #226](PR_226_MERGE_LOG.md)")
+    assert count == 1, f"Entry sollte nur einmal vorkommen, gefunden: {count}"
+
+
+def test_guard_detects_missing_sections(test_repo_structure: Path, monkeypatch):
+    """Test: Guard erkennt fehlende Pflicht-Sektionen."""
+    monkeypatch.syspath_prepend(Path(__file__).parent.parent / "scripts" / "audit")
+
+    import check_ops_merge_logs
+
+    # Erstelle Merge Log mit fehlenden Sektionen
+    incomplete_log = """# MERGE LOG — PR #227 — test
+
+## Zusammenfassung
+- Test
+
+## Warum
+- Test
+
+## Referenzen
+- Test
+"""
+
+    merge_log_path = test_repo_structure / "docs" / "ops" / "PR_227_MERGE_LOG.md"
+    merge_log_path.write_text(incomplete_log, encoding="utf-8")
+
+    # Mock __file__ für repo_root discovery
+    monkeypatch.setattr(
+        check_ops_merge_logs,
+        "__file__",
+        str(test_repo_structure / "scripts" / "audit" / "check_ops_merge_logs.py"),
+    )
+
+    missing = check_ops_merge_logs.check_required_sections(merge_log_path)
+
+    # Erwarte fehlende Sektionen
+    expected_missing = ["Änderungen", "Verifikation", "Risiko", "Operator How-To"]
+    assert sorted(missing) == sorted(expected_missing)
+
+
+def test_guard_accepts_complete_log(test_repo_structure: Path, monkeypatch):
+    """Test: Guard akzeptiert vollständiges Merge Log."""
+    monkeypatch.syspath_prepend(Path(__file__).parent.parent / "scripts" / "audit")
+
+    import check_ops_merge_logs
+
+    # Erstelle vollständiges Merge Log
+    complete_log = """# MERGE LOG — PR #228 — test
+
+## Zusammenfassung
+- Test
+
+## Warum
+- Test
+
+## Änderungen
+- Test
+
+## Verifikation
+- Test
+
+## Risiko
+- Test
+
+## Operator How-To
+- Test
+
+## Referenzen
+- Test
+"""
+
+    merge_log_path = test_repo_structure / "docs" / "ops" / "PR_228_MERGE_LOG.md"
+    merge_log_path.write_text(complete_log, encoding="utf-8")
+
+    # Mock __file__
+    monkeypatch.setattr(
+        check_ops_merge_logs,
+        "__file__",
+        str(test_repo_structure / "scripts" / "audit" / "check_ops_merge_logs.py"),
+    )
+
+    missing = check_ops_merge_logs.check_required_sections(merge_log_path)
+
+    # Keine fehlenden Sektionen
+    assert missing == []
+
+
+def test_dry_run_does_not_write(test_repo_structure: Path, monkeypatch):
+    """Test: dry_run schreibt keine Dateien."""
+    monkeypatch.syspath_prepend(Path(__file__).parent.parent / "scripts" / "ops")
+
+    import create_merge_log
+
+    content = "# Test Merge Log"
+
+    merge_log_path = create_merge_log.write_merge_log(
+        repo_root=test_repo_structure,
+        pr_number=229,
+        content=content,
+        dry_run=True,
+    )
+
+    # Datei sollte NICHT existieren
+    assert not merge_log_path.exists()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Adds a generator that creates docs/ops/PR_<N>_MERGE_LOG.md and updates docs/ops/README.md idempotently. Adds a lightweight guard that validates required headings.

## What
- **Generator:** `scripts/ops/create_merge_log.py` - creates standardized merge logs from template
- **Guard:** `scripts/audit/check_ops_merge_logs.py` - validates required H2 sections
- **Tests:** `tests/test_ops_merge_log_generator.py` - full coverage (7 tests)

## Why
Standardizes merge log creation for operational PRs, ensuring consistency and completeness.

## How to Use
```bash
# Generate merge log for PR 226
uv run python scripts/ops/create_merge_log.py \
  --pr 226 \
  --title "docs(ops): add PR #225 merge log" \
  --date 2025-12-21 \
  --commit abc1234 \
  --pr-url https://github.com/rauterfrank-ui/Peak_Trade/pull/226 \
  --branch docs/ops-pr226-merge-log

# Validate all merge logs
uv run python scripts/audit/check_ops_merge_logs.py
```

## Verification
- ✅ All tests passing (7/7)
- ✅ Ruff clean
- ✅ Guard detects violations in existing logs (expected behavior)