### PR TITLE
fix(ops): fix unbound variable error in merge-log workflow

### DIFF
--- a/scripts/ops/run_merge_log_workflow_robust.sh
+++ b/scripts/ops/run_merge_log_workflow_robust.sh
@@ -138,7 +138,7 @@ gh pr view "$PR" --json number,state,mergedAt,title,url | jq .
 
 echo ""
 echo "🚀 Running: create_and_open_merge_log_pr.sh for PR #${PR}..."
-bash scripts/ops/create_and_open_merge_log_pr.sh --pr "$PR" "${MODE_ARGS[@]}"
+bash scripts/ops/create_and_open_merge_log_pr.sh --pr "$PR" ${MODE_ARGS[@]+"${MODE_ARGS[@]}"}
 
 # ─────────────────────────────────────────────────────────────
 # Ultra-Robust PR Detection


### PR DESCRIPTION
## Problem
`make mlog-auto PR=229` fails with:
```
scripts/ops/run_merge_log_workflow_robust.sh: line 141: MODE_ARGS[@]: unbound variable
```

## Root Cause
With `set -u` (treat unbound variables as error), accessing `"${MODE_ARGS[@]}"` fails when the array is empty, even though it's declared as `MODE_ARGS=()`.

## Solution
Use parameter expansion: `${MODE_ARGS[@]+"${MODE_ARGS[@]}"}`
- Only expands if MODE_ARGS is set
- Safe with `set -u`
- Works with empty arrays

## Testing
```bash
# Before: fails
make mlog-auto PR=229

# After: succeeds
make mlog-auto PR=229
```

## Impact
- **Risk:** 🟢 Minimal (1-line bash fix)
- **Scope:** Only affects merge-log workflow automation
- **Urgency:** High (blocks merge-log workflow for PR #228, #229)

## Related
- Fixes workflow introduced in PR #228
- Blocks merge-log creation for PR #229
