### PR TITLE
fix(ops): improve label_merge_log_prs.sh to find open PRs

### DIFF
--- a/scripts/ops/label_merge_log_prs.sh
+++ b/scripts/ops/label_merge_log_prs.sh
@@ -59,14 +59,14 @@ TMP="/tmp/peak_trade_merge_log_prs.txt"
 TMP_JSON="/tmp/peak_trade_prs.json"
 rm -f "$TMP" "$TMP_JSON"
 
-# PR Nummern extrahieren (closed, full)
-gh pr list --state closed --limit "$LIMIT" --json number,title > "$TMP_JSON"
+# PR Nummern extrahieren (all states: open + closed)
+gh pr list --state all --limit "$LIMIT" --json number,title > "$TMP_JSON"
 
 "$PYBIN" - <<'PY' > "$TMP"
 import json, re, sys
 from pathlib import Path
 data = json.loads(Path("/tmp/peak_trade_prs.json").read_text())
-rx = re.compile(r"^docs\(ops\): add PR #\d+ merge log", re.I)
+rx = re.compile(r"^docs\(ops\): (?:add|align|update) PR #\d+ merge log", re.I)
 nums = [str(pr["number"]) for pr in data if rx.search(pr.get("title",""))]
 print("\n".join(nums))
 PY


### PR DESCRIPTION
## Summary
Fixes `label_merge_log_prs.sh` to properly find **open** merge-log PRs and handle more title variants.

## Changes
- **Line 63:** `--state closed` → `--state all` (finds open+closed PRs)
- **Line 69:** Regex extended: `add` → `(?:add|align|update)` (matches more title variants)

## Why
- PR #151, #145, #139 were missed because they were **open** (script only searched closed)
- PR #145 was missed because title starts with `align` not `add`

## Verification
**Before fixes:**
- Found 31 PRs (only closed, only 'add' prefix)

**After fixes:**
- Found 35 PRs (including 3 open: #151, #145, #139)
- Successfully labeled all 3 open merge-log PRs

## Risk
🟢 **Low** - Only affects ops tooling script; no production code changes

## Testing
```bash
# Dry run (safe)
DRY_RUN=1 scripts/ops/label_merge_log_prs.sh

# Verify it finds PRs #151, #145, #139
grep -E '^(151|145|139)$' /tmp/peak_trade_merge_log_prs.txt
```