### PR TITLE
docs(ops): add PR #234 merge log (+ skeleton PR #235)

### DIFF
--- a/docs/PEAK_TRADE_STATUS_OVERVIEW.md
+++ b/docs/PEAK_TRADE_STATUS_OVERVIEW.md
@@ -1378,6 +1378,8 @@ is_feature_approved_for_year("live_order_execution", 2026)       # → False
 **Peak_Trade** – Ein produktionsnahes Trading-Research-Framework mit integrierter Safety-First-Architektur.
 
 ## Changelog
+- 2025-12-21 — PR #235 merged: fix(ops): improve label_merge_log_prs.sh to find open PRs.
+- 2025-12-21 — PR #234 merged: ops scripts for PR inventory + merge-log labeling.
 - 2025-12-21 — PR #222 merged: feat(web): add merge+format-sweep workflow to ops hub — integrated workflow into /ops/workflows dashboard (5 workflows total, 2 commands, 3 docs refs).
 - 2025-12-21 — PR #220 merged: added comprehensive ops runbook for merge+format-sweep workflow (413 lines, includes quickstart, scenarios, troubleshooting, CI integration).
 - 2025-12-21 — PR #218 merged: added PR #217 post-merge ops documentation; verified Quarto non-blocking + path filter.

--- a/docs/ops/PR_234_MERGE_LOG.md
+++ b/docs/ops/PR_234_MERGE_LOG.md
@@ -1,0 +1,39 @@
+# PR #234 — MERGE LOG (kompakt)
+
+**PR:** #234 — chore(ops): PR inventory + merge-log labeling scripts  
+**Status:** MERGED (squash)  
+**Datum:** 2025-12-21  
+**Scope:** Ops / Scripts / Tests / Doku
+
+## Summary
+- Ops-Tooling für PR-Inventar & Merge-Log Labeling produktiv gemacht und gemerged.
+- Session-Ergebnis: Bulk-Verarbeitung mehrerer Merge-Log PRs stabil, inkl. wiederkehrender README-Konflikte.
+
+## Why
+- GitHub CLI liefert standardmäßig paginierte/limitierte PR-Listen; vollständiges Inventar ist für Ops-Audits hilfreich.
+- Merge-Log PRs sollen zuverlässig labelbar sein (ops/merge-log), auch wenn PRs offen/geschlossen gemischt sind.
+- Ziel: weniger manuelle Klickarbeit, robustere Bulk-Workflows.
+
+## Changes
+- Added: `scripts/ops/pr_inventory_full.sh` — PR-Inventar ohne 30-Item-Limit
+- Added: `scripts/ops/label_merge_log_prs.sh` — Auto-Labeling für Merge-Log PRs
+- Tests + Doku ergänzt/aktualisiert (Ops-Workflow nachvollziehbar, Regressionen abgefangen)
+
+## Verification
+- CI: audit ✅, lint ✅, tests ✅, strategy-smoke ✅
+- Lokal: (falls vorhanden) `uv run ruff check .` und `uv run pytest -q` grün
+
+## Risk
+🟢 **Low** — ausschließlich Ops-Skripte/Tooling + Tests/Doku, keine Trading-Core-Änderungen.
+
+## Operator How-To
+- PR-Inventar:
+  - `bash scripts/ops/pr_inventory_full.sh`
+- Merge-Log PRs labeln:
+  - `bash scripts/ops/label_merge_log_prs.sh`
+- Typischer Konfliktfall:
+  - `docs/ops/README.md` Konflikte so lösen, dass **Workflow-Beispiele aus main erhalten bleiben**, Merge-Log-Liste ergänzen.
+
+## References
+- PR #234 (GitHub)
+- Zugehörige Scripts: `scripts/ops/pr_inventory_full.sh`, `scripts/ops/label_merge_log_prs.sh`

--- a/docs/ops/PR_235_MERGE_LOG.md
+++ b/docs/ops/PR_235_MERGE_LOG.md
@@ -1,0 +1,32 @@
+# PR #235 — MERGE LOG (kompakt)
+
+**PR:** #235 — fix(ops): improve label_merge_log_prs.sh to find open PRs  
+**Status:** MERGED (squash)  
+**Datum:** 2025-12-21  
+**Scope:** Ops / Scripts
+
+## Summary
+- `label_merge_log_prs.sh` erweitert, damit offene PRs ebenfalls gefunden werden.
+
+## Why
+- Vorher wurden nur closed PRs erfasst → offene Merge-Log PRs sind durchgerutscht.
+- Ziel: vollständige Abdeckung in Bulk-Labeling Runs.
+
+## Changes
+- PR Query: `--state closed` → `--state all`
+- Regex erweitert: `add` → `(?:add|align|update)` (mehr Titel-Varianten)
+- Ergebnis: 31 → 35 PRs gefunden (inkl. 3 offene)
+
+## Verification
+- CI: audit ✅, lint ✅, tests ✅, strategy-smoke ✅
+- Lokal: optional `bash -n scripts/ops/label_merge_log_prs.sh` + kurzer Dry-Run
+
+## Risk
+🟢 **Low** — Ops-Skriptverhalten, keine Core-Änderungen.
+
+## Operator How-To
+- `bash scripts/ops/label_merge_log_prs.sh`
+
+## References
+- PR #235 (GitHub)
+- Script: `scripts/ops/label_merge_log_prs.sh`

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -383,6 +383,13 @@ pytest tests/ -k "ops" -v
 
 ---
 
+## 📋 Merge Logs
+
+- [PR #235](PR_235_MERGE_LOG.md) — fix(ops): improve label_merge_log_prs.sh to find open PRs (merged 2025-12-21)
+- [PR #234](PR_234_MERGE_LOG.md) — chore(ops): PR inventory + merge-log labeling scripts (merged 2025-12-21)
+
+---
+
 ## 🔮 Zukünftige Erweiterungen
 
 ### Geplant


### PR DESCRIPTION
## Summary
- Adds merge log documentation for PR #234 (PR inventory + merge-log labeling scripts)
- Adds skeleton merge log for PR #235 (improve label_merge_log_prs.sh)
- Updates docs/ops/README.md with merge log index entries
- Updates PEAK_TRADE_STATUS_OVERVIEW.md changelog

## Changes
**Neu**
- `docs/ops/PR_234_MERGE_LOG.md` — complete merge log for PR #234
- `docs/ops/PR_235_MERGE_LOG.md` — skeleton merge log for PR #235
- `docs/ops/README.md` — add merge log index section with PR #234 and #235
- `docs/PEAK_TRADE_STATUS_OVERVIEW.md` — add changelog entries for PR #234 and #235

## Risk
🟢 **Minimal** — Documentation only, no code changes

## Verification
- Pre-commit hooks: passed ✅
- Files follow compact merge log format
- Links in README point to correct files