### PR TITLE
tests: extend deterministic reconciliation fixtures for lb-rec-001 phase6

### DIFF
--- a/tests/execution/test_reconcile_lb_rec_001_phase1_recorded_fixtures.py
+++ b/tests/execution/test_reconcile_lb_rec_001_phase1_recorded_fixtures.py
@@ -1,5 +1,5 @@
 """
-LB-REC-001 — recorded JSON fixtures for ReconciliationEngine (phase 1+2+3+4+5).
+LB-REC-001 — recorded JSON fixtures for ReconciliationEngine (phase 1+2+3+4+5+6).
 
 Loads repo-stable cases from tests/fixtures/reconciliation/lb_rec_001_phase1/.
 Mock-only, deterministic, no network. Reduces LB-REC-001 harness coverage;
@@ -121,4 +121,4 @@ def test_lb_rec_001_phase1_recorded_fixture_contract(fixture_path: Path) -> None
 
 def test_lb_rec_001_phase1_fixture_dir_has_cases() -> None:
     cases = list(FIXTURE_DIR.glob("case_*.json"))
-    assert len(cases) >= 11, "expected at least eleven recorded cases (phase 1–4 + phase 5 slice)"
+    assert len(cases) >= 12, "expected at least twelve recorded cases (phase 1–5 + phase 6 slice)"

--- a/tests/fixtures/reconciliation/lb_rec_001_phase1/README.md
+++ b/tests/fixtures/reconciliation/lb_rec_001_phase1/README.md
@@ -17,3 +17,5 @@ Schema: `lb_rec_001_phase1_v1` (see `case_*.json`).
 **Phase 4 (LB-REC-001):** `case_multi_symbol_exchange_omits_eth.json` (internal two symbols, external omits one row); `case_position_external_zero_qty_fail.json` (external zero qty vs internal position). Mock-only; does not close LB-REC-001 or imply live-approved reconciliation.
 
 **Phase 5 (LB-REC-001):** `case_netted_flat_empty_external.json` (BUY+SELL net flat; ledger row qty 0; external `positions` empty). Mock-only; not an exchange baseline.
+
+**Phase 6 (LB-REC-001):** `case_multi_symbol_both_position_fail.json` (BTC+ETH internal; external wrong on both symbols → two POSITION FAIL). Mock-only; does not close LB-REC-001.

--- a/tests/fixtures/reconciliation/lb_rec_001_phase1/case_multi_symbol_both_position_fail.json
+++ b/tests/fixtures/reconciliation/lb_rec_001_phase1/case_multi_symbol_both_position_fail.json
@@ -1,0 +1,45 @@
+{
+  "schema": "lb_rec_001_phase1_v1",
+  "id": "multi_symbol_both_position_fail",
+  "notes": "LB-REC-001 Phase 6: two internal symbols; external qty wrong on both → two POSITION FAILs (harness only; not an exchange baseline).",
+  "as_of_time": "2026-04-08T12:00:00+00:00",
+  "internal": {
+    "initial_cash": "200000.00",
+    "fills": [
+      {
+        "fill_id": "lbrec_fill_p6_a",
+        "client_order_id": "lbrec_co_p6_a",
+        "exchange_order_id": "lbrec_ex_p6_a",
+        "symbol": "BTC/EUR",
+        "side": "BUY",
+        "quantity": "1.0",
+        "price": "50000.00",
+        "fee": "5.00"
+      },
+      {
+        "fill_id": "lbrec_fill_p6_b",
+        "client_order_id": "lbrec_co_p6_b",
+        "exchange_order_id": "lbrec_ex_p6_b",
+        "symbol": "ETH/EUR",
+        "side": "BUY",
+        "quantity": "2.0",
+        "price": "3000.00",
+        "fee": "3.00"
+      }
+    ]
+  },
+  "external": {
+    "positions": {
+      "BTC/EUR": "0.5",
+      "ETH/EUR": "1.0"
+    },
+    "cash_balance": { "mode": "match_internal" }
+  },
+  "expect": {
+    "diff_count": 2,
+    "min_fail": 2,
+    "first_diff_type": "POSITION",
+    "first_severity": "FAIL",
+    "all_diff_types": ["POSITION", "POSITION"]
+  }
+}


### PR DESCRIPTION
## Summary
- extend the next deterministic reconciliation fixture/harness slice for LB-REC-001
- add the multi-symbol both-position-fail recorded case
- reduce LB-REC-001 while keeping scope mock-only and repo-local

## Scope
- `tests/execution/test_reconcile_lb_rec_001_phase1_recorded_fixtures.py`
- `tests/fixtures/reconciliation/lb_rec_001_phase1/README.md`
- `tests/fixtures/reconciliation/lb_rec_001_phase1/case_multi_symbol_both_position_fail.json`

## Non-goals
- no live unlock
- no network/exchange integration
- no external approval substitution
- no LB-EXE-001, LB-EMG-001, or LB-OPE-001 closure
- no claim of production-ready reconciliation

## Verification
- `python3 -m pytest -q tests/execution/test_reconcile_lb_rec_001_phase1_recorded_fixtures.py`
- `python3 -m pytest -q tests/execution/`
- `bash scripts/ops/verify_docs_reference_targets.sh`

Made with [Cursor](https://cursor.com)