### PR TITLE
tests: extend deterministic reconciliation fixtures for lb-rec-001 phase7

### DIFF
--- a/tests/execution/test_reconcile_lb_rec_001_phase1_recorded_fixtures.py
+++ b/tests/execution/test_reconcile_lb_rec_001_phase1_recorded_fixtures.py
@@ -1,5 +1,5 @@
 """
-LB-REC-001 — recorded JSON fixtures for ReconciliationEngine (phase 1+2+3+4+5+6).
+LB-REC-001 — recorded JSON fixtures for ReconciliationEngine (phase 1+2+3+4+5+6+7).
 
 Loads repo-stable cases from tests/fixtures/reconciliation/lb_rec_001_phase1/.
 Mock-only, deterministic, no network. Reduces LB-REC-001 harness coverage;
@@ -121,4 +121,4 @@ def test_lb_rec_001_phase1_recorded_fixture_contract(fixture_path: Path) -> None
 
 def test_lb_rec_001_phase1_fixture_dir_has_cases() -> None:
     cases = list(FIXTURE_DIR.glob("case_*.json"))
-    assert len(cases) >= 12, "expected at least twelve recorded cases (phase 1–5 + phase 6 slice)"
+    assert len(cases) >= 13, "expected at least thirteen recorded cases (phase 1–6 + phase 7 slice)"

--- a/tests/fixtures/reconciliation/lb_rec_001_phase1/README.md
+++ b/tests/fixtures/reconciliation/lb_rec_001_phase1/README.md
@@ -19,3 +19,5 @@ Schema: `lb_rec_001_phase1_v1` (see `case_*.json`).
 **Phase 5 (LB-REC-001):** `case_netted_flat_empty_external.json` (BUY+SELL net flat; ledger row qty 0; external `positions` empty). Mock-only; not an exchange baseline.
 
 **Phase 6 (LB-REC-001):** `case_multi_symbol_both_position_fail.json` (BTC+ETH internal; external wrong on both symbols → two POSITION FAIL). Mock-only; does not close LB-REC-001.
+
+**Phase 7 (LB-REC-001):** `case_multi_symbol_positions_match_cash_fail.json` (BTC+ETH; external positions match internal; fixed external cash wrong → CASH FAIL only). Mock-only; does not close LB-REC-001.

--- a/tests/fixtures/reconciliation/lb_rec_001_phase1/case_multi_symbol_positions_match_cash_fail.json
+++ b/tests/fixtures/reconciliation/lb_rec_001_phase1/case_multi_symbol_positions_match_cash_fail.json
@@ -1,0 +1,45 @@
+{
+  "schema": "lb_rec_001_phase1_v1",
+  "id": "multi_symbol_positions_match_cash_fail",
+  "notes": "LB-REC-001 Phase 7: BTC+ETH internal; external positions match internal; fixed external cash wrong → single CASH FAIL only (no POSITION diffs). Mock-only; not an exchange baseline.",
+  "as_of_time": "2026-04-08T12:00:00+00:00",
+  "internal": {
+    "initial_cash": "200000.00",
+    "fills": [
+      {
+        "fill_id": "lbrec_fill_p7_a",
+        "client_order_id": "lbrec_co_p7_a",
+        "exchange_order_id": "lbrec_ex_p7_a",
+        "symbol": "BTC/EUR",
+        "side": "BUY",
+        "quantity": "1.0",
+        "price": "50000.00",
+        "fee": "5.00"
+      },
+      {
+        "fill_id": "lbrec_fill_p7_b",
+        "client_order_id": "lbrec_co_p7_b",
+        "exchange_order_id": "lbrec_ex_p7_b",
+        "symbol": "ETH/EUR",
+        "side": "BUY",
+        "quantity": "2.0",
+        "price": "3000.00",
+        "fee": "3.00"
+      }
+    ]
+  },
+  "external": {
+    "positions": {
+      "BTC/EUR": "1.0",
+      "ETH/EUR": "2.0"
+    },
+    "cash_balance": { "mode": "fixed", "value": "0" }
+  },
+  "expect": {
+    "diff_count": 1,
+    "min_fail": 1,
+    "first_diff_type": "CASH",
+    "first_severity": "FAIL",
+    "all_diff_types": ["CASH"]
+  }
+}


### PR DESCRIPTION
## Summary
- extend the next deterministic reconciliation fixture/harness slice for LB-REC-001
- strengthen reproducible reconciliation coverage without implying live approval
- reduce LB-REC-001 while keeping scope mock-only and repo-local

## Scope
- only the files changed on this branch relative to origin/main

## Non-goals
- no live unlock
- no network/exchange integration
- no external approval substitution
- no LB-EXE-001, LB-EMG-001, or LB-OPE-001 closure
- no claim of production-ready reconciliation

## Verification
- `python3 -m pytest -q tests/execution/test_reconcile_lb_rec_001_phase1_recorded_fixtures.py`
- `python3 -m pytest -q tests/execution/`
- `bash scripts/ops/verify_docs_reference_targets.sh`

Made with [Cursor](https://cursor.com)