### PR TITLE
docs: add truth-map pointer for lb-apr-001 external approval template

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -10,6 +10,11 @@ Einige **sensible Code- und Dokumentationspfade** (Execution, Orders, Environmen
 
 Dieses Mapping verknüpft **Bereiche** (Triggers) mit **Canonical-Docs** (mindestens eine Datei aus der Liste muss bei einer Änderung im Bereich mitgeändert werden — im selben Diff gegenüber dem gewählten Basis-Ref, z. B. `origin&#47;main`).
 
+## Canonical: LB-APR-001 — externes Freigabe-Artefakt (Vorlage)
+
+Kanonische **Arbeitsvorlage** für das **externe** Ticket/Formular (LB-APR-001): [`docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md).  
+Sie strukturiert nur die **organisatorische** Freigabe-Hülle; **Repo-Merge**, Doku und diese Vorlage **begründen keinen** technischen Canary-/Live-Unlock und **keine** `live-approved`-Eigenschaft im Sinne des Runbooks.
+
 ## Wie das Mapping funktioniert
 
 1. Regeln stehen in `config/ops/docs_truth_map.yaml` (`rules[]`).
@@ -54,6 +59,8 @@ Kurzablauf, wenn **`src/orders/`** (Prefix-Regel) geändert wird:
 Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im **selben Diff** **`docs/ops/registry/DOCS_TRUTH_MAP.md`** (diese Datei) einen kurzen Eintrag unter „Änderungsnachweis“ erhalten — damit bleibt die Registry-Landkarte mit der Branch-Protection-Referenz im Einklang (siehe Regel `truth-branch-protection-canonical` in `config/ops/docs_truth_map.yaml`).
 
 ## Änderungsnachweis (Slice A)
+- 2026-04-09 — LB-APR-001: `DOCS_TRUTH_MAP.md` ergänzt um kanonischen Auffindbarkeits-Hinweis auf `docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md` (externe Freigabe-Hülle / Arbeitshilfe; kein technischer Unlock; keine Live-Freigabe impliziert).
+
 - 2026-04-09 — LB-EXE-001 Phase 2 updated `docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` to record deny-by-default guard hardening around `src/execution/networked/transport_gate_v1.py` and related networked guard tests; no live approval or outbound execution unlock implied.
 
 - 2026-04-09 — LB-EXE-001 Phase 1 updated `docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` to record deny-by-default guard hardening in `src/execution/networked/entry_contract_v1.py`, `src/execution/networked/transport_gate_v1.py`, and `src/execution/networked/canary_live_gate_v1.py`; no live approval or outbound execution unlock implied.

--- a/docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md
+++ b/docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md
@@ -1,0 +1,112 @@
+# LB-APR-001 — Externes Freigabe-Artefakt
+
+**Status (Pflicht):** ENTWURF / NICHT FREIGEGEBEN — bis ausdrücklich anders vermerkt.
+
+> **Operative Kernaussage:** Solange **Dokumentstatus** nicht **Approved** ist und **Sign-off** nicht erteilt wurde, ist dieses Artefakt **nur** eine Review-/Planungshülle. Es **ändert** den Live-Readiness-**NO-GO**-Zustand **nicht** und **aktiviert** keinen technischen Canary-/Live-Unlock.
+>
+> **Scope-Regel:** **Änderung eines Pflichtfelds** (siehe Abschnitt 3) **macht dieses Artefakt ungültig** und **erfordert eine neue Freigabe** (neues Artefakt / neue Version mit eigener Review- und Sign-off-Kette).
+>
+> **Repo-Referenzen:** Die unten genannten **festen Repo-Pfade** sind die kanonischen Bezüge — Review und Audit sollen **deterministisch** dieselben Dateien öffnen (nicht nur freie Abschnittsnamen).
+
+---
+
+## 1. Metadaten
+
+- Freigabe-Referenz: `<Ticket-ID &#47; Formular-ID &#47; Vorgangsnummer>`
+- Erstellungsdatum (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
+- Gültig ab (UTC): `<...>`
+- Gültig bis (UTC): `<...>`
+- Artefakt-Version: `v1`
+- Dokumentstatus: `Draft` / `Pending Review` / `Approved` / `Rejected` / `Expired`
+
+---
+
+## 2. Verantwortlichkeiten
+
+- Owner / Systemverantwortlicher: `<Name &#47; Rolle>`
+- Risk Officer: `<Name &#47; Rolle>`
+- Reviewer(s): `<Name &#47; Rolle>`
+- Approver / Sign-off: `<Name &#47; Rolle>`
+
+---
+
+## 3. Scope der beantragten Freigabe
+
+**Gilt die Scope-Regel aus dem Kasten oben:** jede Änderung eines der folgenden Pflichtfelder nach erfolgter Freigabe → Artefakt ungültig → **neue** Freigabe erforderlich.
+
+- Exchange: `<...>`
+- Kontotyp: `<...>`
+- Symbol(e): `<...>`
+- Strategie-Version: `<Name &#47; Version>`
+- Git-Revision / Commit: `<sha>`
+- Artefakt-ID / Build-Referenz: `<...>`
+- Erlaubte Ordertypen: `<...>`
+- Umgebung: `Canary` / anderes klar benanntes Scope
+- Explizit nicht umfasst: `<z. B. Live, weitere Symbole, weitere Strategien>`
+
+---
+
+## 4. Gating- und Sicherheitsrahmen
+
+- Enabled/Armed-Anforderungen: `<...>`
+- Confirm-Token / Session-Bindung: `<...>`
+- Dry-Run-/Non-Outbound-Grenzen: `<...>`
+- Zusätzliche technische Preconditions: `<...>`
+
+---
+
+## 5. Risiko- und Betriebsbedingungen
+
+- Risikolimits: `<...>`
+- Reconciliation-Anforderungen: `<...>`
+- Stop-/Abort-Kriterien: `<...>`
+- Bedingungen für Session-Abbruch: `<...>`
+- Monitoring-/Alerting-Voraussetzungen: `<...>`
+
+---
+
+## 6. Referenzen in das Repo (feste Pfade)
+
+| Referenz | Repo-Pfad (kanonisch) |
+|----------|------------------------|
+| Canary-Kriterien & Freigabe-Artefakt (LB-APR-001), Manifest, Risiko-/Gating-Abschnitte | [`docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md`](../runbooks/CANARY_LIVE_ENTRY_CRITERIA.md) |
+| Manifest-Struktur & Scope-Tabelle (Vorlage) | [`docs/ops/templates/CANARY_LIVE_MANIFEST_TEMPLATE.md`](CANARY_LIVE_MANIFEST_TEMPLATE.md) |
+| Rollen (Owner, Risk Officer), NO-LIVE-Default | [`docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md`](../../GOVERNANCE_AND_SAFETY_OVERVIEW.md) |
+| Evidence-Packs vs. originale Freigabe | [`docs/ops/evidence/README.md`](../evidence/README.md) |
+| Relevante Audit-Referenz (optional): | `<z. B. out&#47;ops&#47;live_readiness_audit&#47;<Audit-ID>&#47;report.json>` |
+
+---
+
+## 7. Review-Ergebnisse
+
+- Risk-Officer-Review durchgeführt: `Yes` / `No`
+- Datum Review (UTC): `<...>`
+- Ergebnis: `Approved` / `Conditionally Approved` / `Rejected`
+- Offene Auflagen / Bedingungen: `<...>`
+
+**Conditional Approval:** Ohne **erfüllte Auflagen**, ohne **Frist** und ohne **Nachweis** der Erfüllung liegt **kein aktiver** Freigabe-Status vor — das Artefakt bleibt **nicht** wirksam für Canary/Live bis zur dokumentierten Erledigung.
+
+---
+
+## 8. Sign-off
+
+- Sign-off erteilt: `Yes` / `No`
+- Sign-off durch: `<Name &#47; Rolle>`
+- Datum Sign-off (UTC): `<...>`
+- Kommentar / Begründung: `<...>`
+
+---
+
+## 9. Explizite Nicht-Aussagen
+
+- Dieses Artefakt ersetzt keinen technischen Unlock außerhalb des definierten Scopes.
+- Repo-Dokumentation, Merge oder Templates allein sind keine Freigabe.
+- Ohne gültige Rollen, Review und Sign-off besteht keine aktive Canary-/Live-Freigabe.
+- Alles außerhalb des oben definierten Scopes bleibt nicht freigegeben.
+
+---
+
+## 10. Optionale Pointer
+
+- Externes Originalsystem: `<Jira &#47; Formular &#47; anderes System>`
+- Repo-Pointer unter `docs/ops/evidence/`: `<optional, nur Verweis — ersetzt nicht das originale Artefakt>`


### PR DESCRIPTION
## Summary
- add a small canonical pointer in DOCS_TRUTH_MAP.md to the LB-APR-001 external approval artifact template
- improve discoverability of the external approval template
- keep explicit boundary that the template is not live approval and does not unlock execution

## Scope
- `docs/ops/registry/DOCS_TRUTH_MAP.md`

## Non-goals
- no live unlock
- no change to execution behavior
- no change to KNOWN_LIMITATIONS unless strictly required
- no substitution for the actual external approval artifact

## Verification
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`

Made with [Cursor](https://cursor.com)