### PR TITLE
docs: add lb-apr-001 start-copy and template refinements

### DIFF
--- a/docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_START_COPY.md
+++ b/docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_START_COPY.md
@@ -1,0 +1,108 @@
+# LB-APR-001 — Externes Freigabe-Artefakt
+
+**Status:** ENTWURF / NICHT FREIGEGEBEN
+
+**Hinweis:** Diese Datei ist die **Startfassung** zum Kopieren in ein externes Ticket/Formular — nur die Platzhalter (`<...>`) und Freitextfelder ausfüllen. Für die strukturierte Vorlage siehe [`LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`](LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md).
+
+## 0. Geltungshinweis
+
+Dieses Artefakt ist nur wirksam, wenn alle folgenden Bedingungen erfüllt sind:
+
+- Dokumentstatus = Approved
+- Risk-Officer-Review dokumentiert
+- Sign-off erteilt
+- alle Auflagen erfüllt und nachgewiesen
+
+Bis dahin gilt:
+
+- keine aktive Canary-/Live-Freigabe
+- kein technischer Unlock
+- Repo-Dokumentation, Template, Merge oder Pointer ersetzen dieses Artefakt nicht
+
+Änderung eines Pflichtfelds macht dieses Artefakt ungültig und erfordert eine neue Freigabe.
+
+## 1. Metadaten
+
+- Freigabe-Referenz: `<TICKET-ID &#47; FORM-ID &#47; GRC-ID>`
+- Artefakt-Version: v1
+- Dokumentstatus: Draft
+- Erstellungsdatum (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
+- Gültig ab (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
+- Gültig bis (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
+
+## 2. Verantwortlichkeiten
+
+- Owner / Systemverantwortlicher: `<NAME &#47; ROLLE>`
+- Risk Officer: `<NAME &#47; ROLLE>`
+- Reviewer(s): `<NAME &#47; ROLLE>`
+- Finaler Approver / Sign-off: `<NAME &#47; ROLLE>`
+
+## 3. Scope der beantragten Freigabe
+
+- Exchange: `<GENAU EIN WERT>`
+- Kontotyp: `<GENAU EIN WERT>`
+- Symbol(e): `<GENAU DEFINIERTER SCOPE>`
+- Strategie-Version: `<NAME &#47; VERSION>`
+- Git-Revision: `6f6d7d8bf2f40fb8bb0cb40bf2cd9d158ef1ffac`
+- Artefakt-ID / Build-Referenz: `<OPTIONAL>`
+- Erlaubte Ordertypen: `<EXPLIZITE LISTE>`
+- Umgebung / Scope: `<CANARY ODER ANDERER EXAKT BENANNTER SCOPE>`
+- Explizit nicht umfasst: `<LIVE &#47; WEITERE SYMBOLE &#47; WEITERE STRATEGIEN &#47; WEITERE ORDERTYPEN &#47; ...>`
+
+**Regel:** Jede Änderung an Exchange, Kontotyp, Symbol, Strategie-Version, Git-Revision oder erlaubten Ordertypen macht dieses Artefakt ungültig und erfordert neue Prüfung und neue Freigabe.
+
+## 4. Gating- und Sicherheitsrahmen
+
+- Enabled/Armed-Anforderungen: `<KONKRET>`
+- Confirm-Token / Session-Bindung: `<KONKRET>`
+- Dry-Run-Grenzen: `<KONKRET>`
+- Non-Outbound-/Canary-Grenzen: `<KONKRET>`
+- Zusätzliche technische Preconditions: `<KONKRET>`
+
+## 5. Risiko- und Betriebsbedingungen
+
+- Risikolimits: `<KONKRET>`
+- Reconciliation-Anforderungen: `<KONKRET>`
+- Stop-/Abort-Kriterien: `<KONKRET>`
+- Bedingungen für Session-Abbruch: `<KONKRET>`
+- Monitoring-/Alerting-Voraussetzungen: `<KONKRET>`
+
+## 6. Verbindliche Repo-Referenzen
+
+- `docs&#47;ops&#47;runbooks&#47;CANARY_LIVE_ENTRY_CRITERIA.md`
+- `docs&#47;ops&#47;templates&#47;CANARY_LIVE_MANIFEST_TEMPLATE.md`
+- `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md`
+- `docs&#47;ops&#47;evidence&#47;README.md`
+- `docs&#47;ops&#47;templates&#47;LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`
+- `docs&#47;ops&#47;templates&#47;LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE_COMPACT.md`
+- Optionale Audit-Referenz: `out&#47;ops&#47;live_readiness_audit&#47;20260409T222029Z&#47;summary.md`
+
+## 7. Review-Ergebnis
+
+- Risk-Officer-Review durchgeführt: No
+- Review-Datum (UTC): `<YYYY-MM-DDTHH:MM:SSZ ODER N&#47;A>`
+- Ergebnis: Pending Review
+- Auflagen / Bedingungen: `<LISTE ODER NONE>`
+- Frist zur Erfüllung (UTC): `<YYYY-MM-DDTHH:MM:SSZ ODER N&#47;A>`
+- Nachweis der Erfüllung: `<TICKET-KOMMENTAR &#47; LINK &#47; ANHANG &#47; NONE>`
+
+**Regel:** Conditionally Approved ist nicht aktiv wirksam, solange Auflagen, Frist und Nachweis nicht vollständig erfüllt und dokumentiert sind.
+
+## 8. Sign-off
+
+- Sign-off erteilt: No
+- Sign-off durch: `<NAME &#47; ROLLE ODER N&#47;A>`
+- Sign-off-Datum (UTC): `<YYYY-MM-DDTHH:MM:SSZ ODER N&#47;A>`
+- Begründung / Kommentar: Entwurf zur Prüfung erstellt; keine aktive Canary-/Live-Freigabe.
+
+## 9. Explizite Nicht-Aussagen
+
+- Dieses Artefakt ersetzt keinen technischen Unlock außerhalb des definierten Scopes.
+- Repo-Dokumentation, Merge oder Templates allein sind keine Freigabe.
+- Ohne gültige Rollen, Review und Sign-off besteht keine aktive Canary-/Live-Freigabe.
+- Alles außerhalb des oben definierten Scopes bleibt nicht freigegeben.
+
+## 10. Optionale Pointer
+
+- Externes Originalsystem: `<JIRA &#47; FORMULAR &#47; GRC &#47; ANDERES SYSTEM>`
+- Repo-Pointer unter `docs&#47;ops&#47;evidence&#47;`: `<OPTIONAL, NUR VERWEIS>`

--- a/docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md
+++ b/docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md
@@ -1,23 +1,37 @@
 # LB-APR-001 — Externes Freigabe-Artefakt
 
-**Status (Pflicht):** ENTWURF / NICHT FREIGEGEBEN — bis ausdrücklich anders vermerkt.
+**Kompakt (1 Seite):** [`LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE_COMPACT.md`](LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE_COMPACT.md)  
+**Startfassung (externes Ticket/Formular):** [`LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_START_COPY.md`](LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_START_COPY.md)
 
-> **Operative Kernaussage:** Solange **Dokumentstatus** nicht **Approved** ist und **Sign-off** nicht erteilt wurde, ist dieses Artefakt **nur** eine Review-/Planungshülle. Es **ändert** den Live-Readiness-**NO-GO**-Zustand **nicht** und **aktiviert** keinen technischen Canary-/Live-Unlock.
->
-> **Scope-Regel:** **Änderung eines Pflichtfelds** (siehe Abschnitt 3) **macht dieses Artefakt ungültig** und **erfordert eine neue Freigabe** (neues Artefakt / neue Version mit eigener Review- und Sign-off-Kette).
->
-> **Repo-Referenzen:** Die unten genannten **festen Repo-Pfade** sind die kanonischen Bezüge — Review und Audit sollen **deterministisch** dieselben Dateien öffnen (nicht nur freie Abschnittsnamen).
+**Status:** ENTWURF / NICHT FREIGEGEBEN
+
+## 0. Geltungshinweis
+
+Dieses Artefakt ist nur wirksam, wenn alle folgenden Bedingungen erfüllt sind:
+
+- Dokumentstatus = Approved
+- Risk-Officer-Review dokumentiert
+- Sign-off erteilt
+- alle Auflagen erfüllt und nachgewiesen
+
+Bis dahin gilt:
+
+- keine aktive Canary-/Live-Freigabe
+- kein technischer Unlock
+- Repo-Dokumentation, Template, Merge oder Pointer ersetzen dieses Artefakt nicht
+
+Änderung eines Pflichtfelds macht dieses Artefakt ungültig und erfordert eine neue Freigabe.
 
 ---
 
 ## 1. Metadaten
 
-- Freigabe-Referenz: `<Ticket-ID &#47; Formular-ID &#47; Vorgangsnummer>`
-- Erstellungsdatum (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
-- Gültig ab (UTC): `<...>`
-- Gültig bis (UTC): `<...>`
+- Freigabe-Referenz: `<TICKET-ID &#47; FORM-ID &#47; GRC-ID>`
 - Artefakt-Version: `v1`
 - Dokumentstatus: `Draft` / `Pending Review` / `Approved` / `Rejected` / `Expired`
+- Erstellungsdatum (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
+- Gültig ab (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
+- Gültig bis (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
 
 ---
 
@@ -26,74 +40,77 @@
 - Owner / Systemverantwortlicher: `<Name &#47; Rolle>`
 - Risk Officer: `<Name &#47; Rolle>`
 - Reviewer(s): `<Name &#47; Rolle>`
-- Approver / Sign-off: `<Name &#47; Rolle>`
+- Finaler Approver / Sign-off: `<Name &#47; Rolle>`
 
 ---
 
 ## 3. Scope der beantragten Freigabe
 
-**Gilt die Scope-Regel aus dem Kasten oben:** jede Änderung eines der folgenden Pflichtfelder nach erfolgter Freigabe → Artefakt ungültig → **neue** Freigabe erforderlich.
-
-- Exchange: `<...>`
-- Kontotyp: `<...>`
-- Symbol(e): `<...>`
+- Exchange: `<genau ein Wert>`
+- Kontotyp: `<genau ein Wert>`
+- Symbol(e): `<genau definierter Scope>`
 - Strategie-Version: `<Name &#47; Version>`
-- Git-Revision / Commit: `<sha>`
-- Artefakt-ID / Build-Referenz: `<...>`
-- Erlaubte Ordertypen: `<...>`
-- Umgebung: `Canary` / anderes klar benanntes Scope
-- Explizit nicht umfasst: `<z. B. Live, weitere Symbole, weitere Strategien>`
+- Git-Revision: `<commit sha>`
+- Artefakt-ID / Build-Referenz: `<optional, falls vorhanden>`
+- Erlaubte Ordertypen: `<explizite Liste>`
+- Umgebung / Scope: `<Canary &#47; anderer exakt benannter Scope>`
+- Explizit nicht umfasst: `<alles, was ausgeschlossen ist>`
+
+**Regel:** Jede Änderung an Exchange, Kontotyp, Symbol, Strategie-Version, Git-Revision oder erlaubten Ordertypen macht dieses Artefakt ungültig und erfordert neue Prüfung und neue Freigabe.
 
 ---
 
 ## 4. Gating- und Sicherheitsrahmen
 
-- Enabled/Armed-Anforderungen: `<...>`
-- Confirm-Token / Session-Bindung: `<...>`
-- Dry-Run-/Non-Outbound-Grenzen: `<...>`
-- Zusätzliche technische Preconditions: `<...>`
+- Enabled/Armed-Anforderungen: `<konkret>`
+- Confirm-Token / Session-Bindung: `<konkret>`
+- Dry-Run-Grenzen: `<konkret>`
+- Non-Outbound-/Canary-Grenzen: `<konkret>`
+- Zusätzliche technische Preconditions: `<konkret>`
 
 ---
 
 ## 5. Risiko- und Betriebsbedingungen
 
-- Risikolimits: `<...>`
-- Reconciliation-Anforderungen: `<...>`
-- Stop-/Abort-Kriterien: `<...>`
-- Bedingungen für Session-Abbruch: `<...>`
-- Monitoring-/Alerting-Voraussetzungen: `<...>`
+- Risikolimits: `<konkret>`
+- Reconciliation-Anforderungen: `<konkret>`
+- Stop-/Abort-Kriterien: `<konkret>`
+- Bedingungen für Session-Abbruch: `<konkret>`
+- Monitoring-/Alerting-Voraussetzungen: `<konkret>`
 
 ---
 
-## 6. Referenzen in das Repo (feste Pfade)
+## 6. Verbindliche Repo-Referenzen
 
-| Referenz | Repo-Pfad (kanonisch) |
-|----------|------------------------|
-| Canary-Kriterien & Freigabe-Artefakt (LB-APR-001), Manifest, Risiko-/Gating-Abschnitte | [`docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md`](../runbooks/CANARY_LIVE_ENTRY_CRITERIA.md) |
-| Manifest-Struktur & Scope-Tabelle (Vorlage) | [`docs/ops/templates/CANARY_LIVE_MANIFEST_TEMPLATE.md`](CANARY_LIVE_MANIFEST_TEMPLATE.md) |
-| Rollen (Owner, Risk Officer), NO-LIVE-Default | [`docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md`](../../GOVERNANCE_AND_SAFETY_OVERVIEW.md) |
-| Evidence-Packs vs. originale Freigabe | [`docs/ops/evidence/README.md`](../evidence/README.md) |
-| Relevante Audit-Referenz (optional): | `<z. B. out&#47;ops&#47;live_readiness_audit&#47;<Audit-ID>&#47;report.json>` |
+- [`docs&#47;ops&#47;runbooks&#47;CANARY_LIVE_ENTRY_CRITERIA.md`](../runbooks/CANARY_LIVE_ENTRY_CRITERIA.md) — § Freigabe-Artefakt (LB-APR-001)
+- [`docs&#47;ops&#47;templates&#47;CANARY_LIVE_MANIFEST_TEMPLATE.md`](CANARY_LIVE_MANIFEST_TEMPLATE.md)
+- [`docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md`](../../GOVERNANCE_AND_SAFETY_OVERVIEW.md)
+- [`docs&#47;ops&#47;evidence&#47;README.md`](../evidence/README.md)
+- [`docs&#47;ops&#47;templates&#47;LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`](LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md) (dieses Template)
+- [`docs&#47;ops&#47;templates&#47;LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE_COMPACT.md`](LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE_COMPACT.md)
+- Optionale Audit-Referenz: `<z. B. out&#47;ops&#47;live_readiness_audit&#47;...&#47;summary.md>`
 
 ---
 
-## 7. Review-Ergebnisse
+## 7. Review-Ergebnis
 
 - Risk-Officer-Review durchgeführt: `Yes` / `No`
-- Datum Review (UTC): `<...>`
-- Ergebnis: `Approved` / `Conditionally Approved` / `Rejected`
-- Offene Auflagen / Bedingungen: `<...>`
+- Review-Datum (UTC): `<YYYY-MM-DDTHH:MM:SSZ oder N&#47;A>`
+- Ergebnis: `Pending Review` / `Approved` / `Conditionally Approved` / `Rejected`
+- Auflagen / Bedingungen: `<Liste oder none>`
+- Frist zur Erfüllung (UTC): `<YYYY-MM-DDTHH:MM:SSZ oder N&#47;A>`
+- Nachweis der Erfüllung: `<Ticket-Kommentar &#47; Link &#47; Anhang &#47; none>`
 
-**Conditional Approval:** Ohne **erfüllte Auflagen**, ohne **Frist** und ohne **Nachweis** der Erfüllung liegt **kein aktiver** Freigabe-Status vor — das Artefakt bleibt **nicht** wirksam für Canary/Live bis zur dokumentierten Erledigung.
+**Regel:** `Conditionally Approved` ist nicht aktiv wirksam, solange Auflagen, Frist und Nachweis nicht vollständig erfüllt und dokumentiert sind.
 
 ---
 
 ## 8. Sign-off
 
 - Sign-off erteilt: `Yes` / `No`
-- Sign-off durch: `<Name &#47; Rolle>`
-- Datum Sign-off (UTC): `<...>`
-- Kommentar / Begründung: `<...>`
+- Sign-off durch: `<Name &#47; Rolle oder N&#47;A>`
+- Sign-off-Datum (UTC): `<YYYY-MM-DDTHH:MM:SSZ oder N&#47;A>`
+- Begründung / Kommentar: `<frei>`
 
 ---
 
@@ -108,5 +125,5 @@
 
 ## 10. Optionale Pointer
 
-- Externes Originalsystem: `<Jira &#47; Formular &#47; anderes System>`
-- Repo-Pointer unter `docs/ops/evidence/`: `<optional, nur Verweis — ersetzt nicht das originale Artefakt>`
+- Externes Originalsystem: `<Jira &#47; Formular &#47; GRC &#47; anderes System>`
+- Repo-Pointer unter `docs&#47;ops&#47;evidence&#47;`: `<optional, nur Verweis>`


### PR DESCRIPTION
## Summary
- add the LB-APR-001 start-copy helper under docs/ops/templates
- carry the remaining template refinements that were still local-only
- keep the documents explicitly non-effective and non-approval-bearing

## Scope
- `docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`
- `docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_START_COPY.md`

## Non-goals
- no live unlock
- no external approval substitution
- no claim that these docs are an effective approval artifact

## Verification
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/validate_docs_token_policy.py --changed --base origin/main`

Made with [Cursor](https://cursor.com)