### PR TITLE
docs: add lb-apr account-type mapping guidance

### DIFF
--- a/docs/ops/LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md
+++ b/docs/ops/LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md
@@ -1,0 +1,61 @@
+# LB-APR-001 — Feld „Account Type“ (extern) ↔ interne Begriffe
+
+**Status:** Entwurf — **Draft-/Approval-Hilfe** für konsistente Befüllung externer Formulare.  
+**Geltung:** Dieses Dokument **ändert keine** technische Semantik im Code, **keinen** technischen Unlock und **keine** Live-Freigabe. Es ordnet **Sprache** und **Kontexte** fürs Inventar und für Tickets ein.
+
+---
+
+## Zweck
+
+- Ein **kanonischer, minimale** Bezugsrahmen, damit das externe Pflichtfeld **„Account Type“** (englische Formularbezeichnung) **nicht** willkürlich mit internen Laufzeitbegriffen verwechselt wird.
+- Klarstellung, welche internen Begriffe **parallel** existieren (Manifest, Runbooks, Execution-Modi) — **ohne** behauptete 1:1-Übersetzung in Produktcode.
+
+## Nicht-Zweck
+
+- **Kein** Ersatz für LB-APR-001-Sign-off, Owner-/Risk-Entscheid oder externes Ticket.
+- **Keine** neue Aussage darüber, welche Konten oder Modi „freigegeben“ sind.
+- **Keine** Zuordnung zu Secrets, API-Keys oder konkreten Exchange-API-Feldern (bleibt außerhalb dieser Scheibe).
+
+---
+
+## Externes Feld „Account Type“
+
+- In **englischsprachigen** Freigabe-/GRC-Formularen taucht häufig **„Account Type“** als Pflichtfeld auf.
+- In der **deutschsprachigen** LB-APR-001-Arbeitsvorlage entspricht dem inhaltlich der Eintrag **„Kontotyp“** (ein Wert, z. B. Spot vs. Margin/Futures) im Scope-Abschnitt — siehe [`LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`](templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md) § 3 und die Manifest-Tabelle in [`CANARY_LIVE_ENTRY_CRITERIA.md`](runbooks/CANARY_LIVE_ENTRY_CRITERIA.md) (Spalte „Kontotyp“).
+
+**Lesart:** „Account Type“ / „Kontotyp“ bezieht sich hier auf die **vom Exchange/Produkt definierte Art des Handelskontos** (z. B. Spot), **nicht** auf interne Peak_Trade-Runner- oder Pipeline-Modus-Strings.
+
+---
+
+## Interne Begriffe / Kontexte (Überblick)
+
+Die folgenden Begriffe beschreiben **unterschiedliche Ebenen** — sie sind **nicht** synonym mit „Account Type“:
+
+| Kontext | Typische Bedeutung (kurz) |
+|--------|---------------------------|
+| **Execution-/Pipeline-Modus** (z. B. paper, shadow) | Simulierte oder nicht-outbound Ausführung; siehe z. B. Übersichten in [`PHASE_24_SHADOW_EXECUTION.md`](../PHASE_24_SHADOW_EXECUTION.md). |
+| **Umgebung / Phase** (z. B. Research, Canary Live, NO-LIVE-Default) | Governance- und Phasenbegriffe im Runbook [`CANARY_LIVE_ENTRY_CRITERIA.md`](runbooks/CANARY_LIVE_ENTRY_CRITERIA.md). |
+| **Manifest-Feld „Umgebung / Scope“** | Benannter Freigabe-Scope (z. B. Canary vs. anderer exakt benannter Scope) im LB-APR-001-Template — **parallel** zu Exchange/Kontotyp/Symbol, nicht Ersatz für „Kontotyp“. |
+
+---
+
+## Was heute klar zuordenbar ist
+
+- **„Account Type“ / „Kontotyp“** im Sinne von LB-APR-001 ↔ **ein** vom Antrag klar benannter **Exchange-Produkt-/Kontotyp** (wie im Freigabe-Manifest und in der Vorlage gefordert).
+- **Canary** ist im Freigabe-Template ein Eintrag unter **„Umgebung / Scope“** (siehe LB-APR-001 § 3) — das ist eine **Freigabe-Kategorie**, **kein** Ersatzwert für „Account Type“ und **kein** interner Modus-String.
+
+---
+
+## Was bewusst nicht 1:1 gemappt werden darf
+
+- **Interne Modus-Strings** (z. B. `paper`, `shadow`) **nicht** als Wert in ein externes **„Account Type“**-Feld schreiben — falsche Ebene (Produktkonto vs. Laufzeitmodus).
+- **„Canary“** **nicht** als Synonym für einen brokerseitigen Kontotyp verwenden; Canary bezeichnet hier die **beantragte Freigabe-Umgebung**, nicht die **Kontenart** beim Anbieter.
+- **Keine** stillschweigende Gleichsetzung von **Testnet/Spot/Subaccount**-Labels aus Inventaren mit **internen** Gate-Namen — bei Unklarheit bleibt der externe Wert **TBD** bis zur Klärung durch Owner/Risk mit Bezug auf das konkrete Formular.
+
+---
+
+## Querverweise
+
+- [`LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`](templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md)
+- [`CANARY_LIVE_ENTRY_CRITERIA.md`](runbooks/CANARY_LIVE_ENTRY_CRITERIA.md)
+- [`DOCS_TRUTH_MAP.md`](registry/DOCS_TRUTH_MAP.md) — Auffindbarkeit LB-APR-001

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -15,6 +15,8 @@ Dieses Mapping verknüpft **Bereiche** (Triggers) mit **Canonical-Docs** (mindes
 Kanonische **Arbeitsvorlage** für das **externe** Ticket/Formular (LB-APR-001): [`docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md).  
 Sie strukturiert nur die **organisatorische** Freigabe-Hülle; **Repo-Merge**, Doku und diese Vorlage **begründen keinen** technischen Canary-/Live-Unlock und **keine** `live-approved`-Eigenschaft im Sinne des Runbooks.
 
+**Sprach-Mapping (externes Feld „Account Type“):** [`docs/ops/LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md`](../LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md) — Abgrenzung zur LB-APR-„Kontotyp“-Zeile und zu internen Laufzeit-/Phasenbegriffen; **Draft-/Approval-Hilfe**; **kein** technischer Unlock; **keine** implizite Live-Freigabe.
+
 ## Wie das Mapping funktioniert
 
 1. Regeln stehen in `config/ops/docs_truth_map.yaml` (`rules[]`).
@@ -59,6 +61,8 @@ Kurzablauf, wenn **`src/orders/`** (Prefix-Regel) geändert wird:
 Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im **selben Diff** **`docs/ops/registry/DOCS_TRUTH_MAP.md`** (diese Datei) einen kurzen Eintrag unter „Änderungsnachweis“ erhalten — damit bleibt die Registry-Landkarte mit der Branch-Protection-Referenz im Einklang (siehe Regel `truth-branch-protection-canonical` in `config/ops/docs_truth_map.yaml`).
 
 ## Änderungsnachweis (Slice A)
+- 2026-04-10 — LB-APR-001: `docs/ops/LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md` ergänzt (externes „Account Type“ vs. interne Kontexte; Draft-/Approval-Hilfe; kein technischer Unlock; keine Live-Freigabe impliziert); Pointer in diesem Abschnitt.
+
 - 2026-04-09 — LB-APR-001: `DOCS_TRUTH_MAP.md` ergänzt um kanonischen Auffindbarkeits-Hinweis auf `docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md` (externe Freigabe-Hülle / Arbeitshilfe; kein technischer Unlock; keine Live-Freigabe impliziert).
 
 - 2026-04-09 — LB-EXE-001 Phase 2 updated `docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` to record deny-by-default guard hardening around `src/execution/networked/transport_gate_v1.py` and related networked guard tests; no live approval or outbound execution unlock implied.


### PR DESCRIPTION
## Summary
- add a small canonical mapping guide for the external LB-APR field "Account Type"
- clarify how external approval language relates to internal runtime/execution contexts
- improve fillability of the external draft without implying approval or execution unlock

## Scope
- `docs/ops/LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`

## Non-goals
- no live unlock
- no execution behavior change
- no approval substitution
- no claim that Canary is already a fully encoded account/runtime type

## Verification
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/validate_docs_token_policy.py --changed --base origin/main`

Made with [Cursor](https://cursor.com)