### PR TITLE
docs: add lb-apr strategy-version mapping guidance

### DIFF
--- a/docs/ops/LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md
+++ b/docs/ops/LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md
@@ -1,0 +1,74 @@
+# LB-APR-001 — Feld „Strategy Version“ (extern) ↔ interne Bezeichner
+
+**Status:** Entwurf — **Draft-/Approval-Hilfe** für konsistente Befüllung externer Formulare.  
+**Geltung:** Dieses Dokument **ändert keine** technische Semantik im Code, **keinen** technischen Unlock und **keine** Live-Freigabe. Es ordnet **Sprache** und **Kontexte** fürs Inventar und für Tickets ein.
+
+---
+
+## Zweck
+
+- Ein **kanonischer, minimaler** Bezugsrahmen, damit das externe Pflichtfeld **„Strategy Version“** (englische Formularbezeichnung) **nicht** willkürlich mit internen Laufzeit-IDs, Git-Labels oder KI-/Model-Registry-Einträgen verwechselt wird.
+- Orientierung für **approval-taugliche** Freitexte: welche **Kombination** aus stabilem Strategiebezeichner und **nachweisbarer** Code-/Artefakt-Referenz die stärkste Lesart bildet — **ohne** behauptete 1:1-Zwangsumsetzung in Produktcode.
+
+## Nicht-Zweck
+
+- **Kein** Ersatz für LB-APR-001-Sign-off, Owner-/Risk-Entscheid oder externes Ticket.
+- **Keine** neue Aussage darüber, welche Strategie oder welche Version „freigegeben“ ist.
+- **Kein** Ersatz für eine spätere formale „Trading-Strategie-Freigabeversion“-Policy (falls das Unternehmen eine eigene Nummerierung einführt).
+
+---
+
+## Externes Feld „Strategy Version“
+
+- In **englischsprachigen** Freigabe-/GRC-Formularen taucht häufig **„Strategy Version“** (oder ähnlich) als Pflichtfeld auf.
+- Solange **keine** vom Antragsteller und Risk gemeinsam fixierte **externe** Versionsnummer existiert, bleibt der Wert in Inventaren **TBD** — das ist **korrekt**, bis eine **kanonische externe Lesart** vereinbart ist.
+
+**Lesart dieses Dokuments:** „Strategy Version“ bezieht sich auf die **beantragte und dokumentierte Trading-Strategie-Freigabe** im Sinne des Antrags — **nicht** auf beliebige technische IDs aus anderen Registries.
+
+---
+
+## Stärkste aktuelle Kandidatenstruktur (ohne neue Approval-Behauptung)
+
+Aus **read-only** Inventar- und Abgleichspraxis (ohne Bindung an einen einzelnen Snapshot-Pfad):
+
+1. **Primärbezeichner:** ein stabiler, in Konfiguration/Registry nachweisbarer Schlüssel — im Abgleich typischerweise **`strategy_registry_key`** (oder gleichwertig benannter Registry-Eintrag zur Strategie).
+2. **Ergänzend (Pflicht zur Nachvollziehbarkeit):** mindestens **eine** der folgenden, explizit im Antrag/Ticket genannten Referenzen:
+   - **Git-Revision** (z. B. Commit-SHA des freigegebenen Repo-Stands), und/oder
+   - **Artefakt-Referenz** (z. B. Build-/Release-Label oder nachvollziehbares Dokument/Anhang, wie im Formular verlangt).
+
+Damit bleibt die externe Zeile **überprüfbar** und von bloßen Laufzeit-Strings unterscheidbar.
+
+---
+
+## Verhältnis zu internen Begriffen (Überblick)
+
+| Begriff | Rolle (kurz) | Verhältnis zu „Strategy Version“ (extern) |
+|--------|--------------|-------------------------------------------|
+| **`strategy_registry_key`** (o. ä.) | Stabiler Schlüssel der Strategie in der Strategie-Registry/Konfiguration | **Stärkster Kandidat** für den **Strategie**-Teil einer Freigabezeile — typischerweise **gepaart** mit Git-Revision und/oder Artefakt-Referenz. |
+| **`active_strategy_id`** | Laufzeit: welche Strategie-ID aktiv geschaltet ist | **Konfigurations-/Laufzeitbezeichner**, **kein** approval-ready externes Versionslabel **allein**; Kombinationen wie `active_strategy_id@<git-sha>` sind **keine** saubere, alleinstehende **externe Freigabeversion**. |
+| **Git-Revision** | Fixierter Repo-Stand | **Nachweis** für „welcher Code-Stand“ — **kein** Ersatz für eine semantische „Strategie-Version“ ohne klaren Strategiebezug im Antrag. |
+| **Artefakt-Referenz** | Build-/Dokument-/Release-Pointer | **Nachweis** parallel zum Schlüssel — wie im jeweiligen Formular gefordert. |
+| **KI-/Model-Registry-IDs** | Andere Domäne (Modell-/Inference-Lifecycle) | **Nicht** dasselbe wie **Trading-Strategie-Freigabeversionen** — **nicht** 1:1 ins Feld „Strategy Version“ übernehmen. |
+
+---
+
+## Was heute klar verwendbar ist
+
+- **TBD** im externen Feld, solange keine vereinbarte externe Versionsform existiert — **absichtlich korrekt**.
+- Sobald Antrag und Referenzen stehen: **benannter Registry-/Strategie-Schlüssel** **plus** **Git-Revision und/oder Artefakt-Referenz** als **strukturierte Freitext-Lesart** im Ticket — **ohne** implizite Live-Freigabe.
+
+---
+
+## Was bewusst nicht als externe Freigabeversion verwendet werden soll
+
+- **`active_strategy_id@<git-sha>`** (oder ähnliche reine technische Zusammensetzungen) **allein** als „die“ Strategy Version — **zu wenig** semantisch für GRC, **kein** approval-ready Label ohne weitere Antragskontexte.
+- **KI-/Model-Registry- oder Inference-IDs** — **falsche Ebene** (Modell-Lifecycle ≠ Trading-Strategie-Freigabe im LB-APR-Sinne).
+- **Beliebige interne Kurzstrings** ohne Bezug zu Registry + nachweisbarem Stand — vermeiden; bei Unklarheit **TBD** oder explizite Klärung mit Owner/Risk.
+
+---
+
+## Querverweise
+
+- [`LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md`](templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md)
+- [`DOCS_TRUTH_MAP.md`](registry/DOCS_TRUTH_MAP.md) — Auffindbarkeit LB-APR-001  
+- Siehe auch: [`LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md`](LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md) (analoges Muster für ein anderes externes Pflichtfeld)

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -17,6 +17,8 @@ Sie strukturiert nur die **organisatorische** Freigabe-Hülle; **Repo-Merge**, D
 
 **Sprach-Mapping (externes Feld „Account Type“):** [`docs/ops/LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md`](../LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md) — Abgrenzung zur LB-APR-„Kontotyp“-Zeile und zu internen Laufzeit-/Phasenbegriffen; **Draft-/Approval-Hilfe**; **kein** technischer Unlock; **keine** implizite Live-Freigabe.
 
+**Sprach-Mapping (externes Feld „Strategy Version“):** [`docs/ops/LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md`](../LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md) — Registry-Schlüssel vs. Laufzeit-ID vs. Git/Artefakt vs. KI-/Model-Registry; **Draft-/Approval-Hilfe**; **kein** technischer Unlock; **keine** implizite Live-Freigabe.
+
 ## Wie das Mapping funktioniert
 
 1. Regeln stehen in `config/ops/docs_truth_map.yaml` (`rules[]`).
@@ -61,6 +63,8 @@ Kurzablauf, wenn **`src/orders/`** (Prefix-Regel) geändert wird:
 Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im **selben Diff** **`docs/ops/registry/DOCS_TRUTH_MAP.md`** (diese Datei) einen kurzen Eintrag unter „Änderungsnachweis“ erhalten — damit bleibt die Registry-Landkarte mit der Branch-Protection-Referenz im Einklang (siehe Regel `truth-branch-protection-canonical` in `config/ops/docs_truth_map.yaml`).
 
 ## Änderungsnachweis (Slice A)
+- 2026-04-10 — LB-APR-001: `docs/ops/LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md` ergänzt (externes „Strategy Version“ vs. `strategy_registry_key` / `active_strategy_id` / Git / Artefakt / KI-Registry; Draft-/Approval-Hilfe; kein technischer Unlock; keine Live-Freigabe impliziert); Pointer in diesem Abschnitt.
+
 - 2026-04-10 — LB-APR-001: `docs/ops/LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md` ergänzt (externes „Account Type“ vs. interne Kontexte; Draft-/Approval-Hilfe; kein technischer Unlock; keine Live-Freigabe impliziert); Pointer in diesem Abschnitt.
 
 - 2026-04-09 — LB-APR-001: `DOCS_TRUTH_MAP.md` ergänzt um kanonischen Auffindbarkeits-Hinweis auf `docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md` (externe Freigabe-Hülle / Arbeitshilfe; kein technischer Unlock; keine Live-Freigabe impliziert).


### PR DESCRIPTION
## Summary
- add a small canonical mapping guide for the external LB-APR field "Strategy Version"
- clarify how external approval language relates to internal strategy/registry/git identifiers
- improve fillability of the external draft without implying approval or execution unlock

## Scope
- `docs/ops/LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`

## Non-goals
- no live unlock
- no execution behavior change
- no approval substitution
- no claim that current internal identifiers already form a fully approval-ready strategy version label

## Verification
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/validate_docs_token_policy.py --changed --base origin/main`

Made with [Cursor](https://cursor.com)