### PR TITLE
feat(webui): Live status snapshot card on home

### DIFF
--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -71,6 +71,7 @@ System:
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -372,6 +373,70 @@ def load_live_sessions(limit: int = 10) -> Dict[str, Any]:
     }
 
 
+_HOME_SNAPSHOT_DETAILS_PREVIEW_MAX = 200
+_HOME_SNAPSHOT_META_PREVIEW_MAX = 240
+
+
+def load_live_status_snapshot_home_context() -> Dict[str, Any]:
+    """
+    Read-only Live Status Snapshot for the home dashboard.
+
+    Uses the same builder path as ``GET /api/live/status/snapshot.json`` (Phase 57).
+    Fail-soft: does not raise; returns ``available=False`` on failure so ``GET /`` still renders.
+    """
+    try:
+        from src.reporting.live_status_snapshot_builder import build_live_status_snapshot_auto
+        from src.reporting.status_snapshot_schema import model_dump_helper
+
+        snapshot = build_live_status_snapshot_auto(meta={"source": "webui_api"})
+        data = model_dump_helper(snapshot)
+        panels_out: List[Dict[str, Any]] = []
+        for p in data.get("panels") or []:
+            if not isinstance(p, dict):
+                continue
+            det = p.get("details") or {}
+            try:
+                det_str = json.dumps(det, sort_keys=True, ensure_ascii=False)
+            except (TypeError, ValueError):
+                det_str = str(det)
+            if len(det_str) > _HOME_SNAPSHOT_DETAILS_PREVIEW_MAX:
+                det_str = det_str[:_HOME_SNAPSHOT_DETAILS_PREVIEW_MAX] + "…"
+            panels_out.append(
+                {
+                    "id": p.get("id", ""),
+                    "title": p.get("title", ""),
+                    "status": p.get("status", "unknown"),
+                    "details_preview": det_str,
+                }
+            )
+        meta = data.get("meta") or {}
+        try:
+            meta_preview = json.dumps(meta, sort_keys=True, ensure_ascii=False)
+        except (TypeError, ValueError):
+            meta_preview = str(meta)
+        if len(meta_preview) > _HOME_SNAPSHOT_META_PREVIEW_MAX:
+            meta_preview = meta_preview[:_HOME_SNAPSHOT_META_PREVIEW_MAX] + "…"
+
+        return {
+            "available": True,
+            "version": data.get("version"),
+            "generated_at": data.get("generated_at"),
+            "meta_preview": meta_preview,
+            "panels": panels_out,
+            "error": None,
+        }
+    except Exception as e:
+        logger.warning("Home live status snapshot unavailable: %s", e)
+        return {
+            "available": False,
+            "version": None,
+            "generated_at": None,
+            "meta_preview": "",
+            "panels": [],
+            "error": type(e).__name__,
+        }
+
+
 def create_app() -> FastAPI:
     app = FastAPI(
         title="Peak_Trade Dashboard v1.2",
@@ -476,6 +541,7 @@ def create_app() -> FastAPI:
         live_track["stats"] = get_session_stats()
 
         workflow_officer_panel = build_workflow_officer_panel_context(BASE_DIR)
+        live_status_snapshot_home = load_live_status_snapshot_home_context()
 
         return templates.TemplateResponse(
             request,
@@ -485,6 +551,7 @@ def create_app() -> FastAPI:
                 "strategy_tiering": strategy_tiering,
                 "live_track": live_track,
                 "workflow_officer_panel": workflow_officer_panel,
+                "live_status_snapshot_home": live_status_snapshot_home,
             },
         )
 

--- a/templates/peak_trade_dashboard/index.html
+++ b/templates/peak_trade_dashboard/index.html
@@ -100,6 +100,99 @@
   </section>
 </div>
 
+<!-- Phase 57: Live status snapshot (read-only; same builder as /api/live/status/snapshot.json) -->
+<section
+  class="mt-8 bg-slate-900/60 rounded-2xl border border-slate-800 p-4 text-sm"
+>
+  <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
+    <div>
+      <h2 class="text-sm font-semibold text-slate-200">
+        Live status snapshot (Phase 57)
+      </h2>
+      <p class="text-xs text-slate-500 mt-0.5">
+        Read-only status overview — not the same label as “Snapshot-Commit” in Projekt-Status
+      </p>
+    </div>
+    <span class="text-xs px-2 py-0.5 rounded bg-sky-500/10 text-sky-300 border border-sky-500/20 shrink-0">
+      Observation
+    </span>
+  </div>
+  {% if live_status_snapshot_home.available %}
+  <p class="text-xs text-slate-500 mb-3">
+    Observed builder output only. No operational approval or go-live implication.
+  </p>
+  <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3 text-xs">
+    <div class="bg-slate-950/50 rounded border border-slate-800/60 px-2 py-1.5">
+      <p class="text-[10px] text-slate-500">Schema version</p>
+      <p class="font-mono text-slate-200">{{ live_status_snapshot_home.version }}</p>
+    </div>
+    <div class="bg-slate-950/50 rounded border border-slate-800/60 px-2 py-1.5 sm:col-span-2">
+      <p class="text-[10px] text-slate-500">generated_at (UTC)</p>
+      <p class="font-mono text-slate-300 break-all">{{ live_status_snapshot_home.generated_at }}</p>
+    </div>
+  </div>
+  {% if live_status_snapshot_home.meta_preview %}
+  <p class="text-[10px] text-slate-500 mb-1">meta (preview)</p>
+  <pre class="text-[10px] leading-snug text-slate-400 whitespace-pre-wrap font-mono bg-slate-950/80 border border-slate-800/80 rounded p-2 max-h-24 overflow-y-auto mb-3">{{ live_status_snapshot_home.meta_preview }}</pre>
+  {% endif %}
+  <p class="text-[10px] text-slate-500 mb-1">Panels (summary)</p>
+  <div class="overflow-x-auto rounded border border-slate-800/80">
+    <table class="w-full text-xs text-left">
+      <thead class="bg-slate-900/80 text-slate-400 uppercase tracking-wide text-[10px]">
+        <tr>
+          <th class="px-2 py-1.5">id</th>
+          <th class="px-2 py-1.5">title</th>
+          <th class="px-2 py-1.5">status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in live_status_snapshot_home.panels %}
+        <tr class="border-t border-slate-800/80">
+          <td class="px-2 py-1 font-mono text-slate-300">{{ row.id }}</td>
+          <td class="px-2 py-1 text-slate-300">{{ row.title }}</td>
+          <td class="px-2 py-1">
+            {% if row.status == "ok" %}
+            <span class="text-emerald-400">{{ row.status }}</span>
+            {% elif row.status == "warn" %}
+            <span class="text-amber-400">{{ row.status }}</span>
+            {% elif row.status == "error" %}
+            <span class="text-rose-400">{{ row.status }}</span>
+            {% else %}
+            <span class="text-slate-400">{{ row.status }}</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% if row.details_preview %}
+        <tr class="border-t border-slate-800/40 bg-slate-950/40">
+          <td class="px-2 py-1 text-[10px] text-slate-500" colspan="3">
+            <span class="text-slate-500">details preview:</span>
+            <span class="font-mono text-slate-400 break-all">{{ row.details_preview }}</span>
+          </td>
+        </tr>
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p class="text-xs text-slate-500 mb-2">
+    Snapshot not available for this page load.
+    {% if live_status_snapshot_home.error %}
+    <span class="font-mono text-slate-400">({{ live_status_snapshot_home.error }})</span>
+    {% endif %}
+  </p>
+  <p class="text-xs text-slate-600">
+    Other dashboard sections are unchanged. This is a read-only observation slot.
+  </p>
+  {% endif %}
+  <p class="text-xs text-slate-500 mt-4">
+    Endpoints:
+    <a href="/api/live/status/snapshot.json" class="text-sky-400 hover:underline">/api/live/status/snapshot.json</a>
+    ·
+    <a href="/api/live/status/snapshot.html" class="text-sky-400 hover:underline">/api/live/status/snapshot.html</a>
+  </p>
+</section>
+
 <!-- Workflow Officer (read-only; latest local report.json) -->
 <section
   class="mt-8 bg-slate-900/60 rounded-2xl border border-slate-800 p-4 text-sm"

--- a/tests/test_live_status_snapshot_api.py
+++ b/tests/test_live_status_snapshot_api.py
@@ -383,3 +383,37 @@ def test_json_panel_status_values(test_client):
 
     for panel in data["panels"]:
         assert panel["status"] in valid_statuses, f"Invalid status: {panel['status']}"
+
+
+# =============================================================================
+# Tests: Home dashboard snapshot card (GET /)
+# =============================================================================
+
+
+def test_home_includes_live_status_snapshot_card(test_client):
+    """GET / renders the Phase 57 snapshot section when builder succeeds."""
+    response = test_client.get("/")
+    assert response.status_code == 200
+    text = response.text
+    assert "Live status snapshot (Phase 57)" in text
+    assert "/api/live/status/snapshot.json" in text
+    assert "/api/live/status/snapshot.html" in text
+    assert "Observed builder output only" in text
+
+
+def test_home_renders_when_snapshot_builder_fails(test_client, monkeypatch):
+    """GET / still returns 200 if home snapshot context fails (fail-soft)."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated snapshot failure")
+
+    monkeypatch.setattr(
+        "src.reporting.live_status_snapshot_builder.build_live_status_snapshot_auto",
+        _boom,
+    )
+
+    response = test_client.get("/")
+    assert response.status_code == 200
+    assert "Live status snapshot (Phase 57)" in response.text
+    assert "Snapshot not available" in response.text
+    assert "RuntimeError" in response.text


### PR DESCRIPTION
Summary
- adds a compact read-only "Live status snapshot (Phase 57)" card to the home dashboard
- reuses the existing live status snapshot API build path for GET /
- keeps home rendering fail-soft if snapshot generation is unavailable
- no changes to builder semantics, providers, execution, or live.web

What changed
- src/webui/app.py
  - adds load_live_status_snapshot_home_context()
  - reuses build_live_status_snapshot_auto(meta={"source": "webui_api"}) + model_dump_helper
  - passes live_status_snapshot_home into the home template
  - fail-soft on exceptions with available=false and error type
- templates/peak_trade_dashboard/index.html
  - adds a new home section for the live status snapshot
  - clearly separates it from the existing project-status "Snapshot-Commit"
  - shows compact panel and preview fields plus links to snapshot endpoints
- tests/test_live_status_snapshot_api.py
  - adds focused tests for home rendering with available snapshot and builder failure

Truth-first / safety posture
- read-only observational UI only
- no change to live_status_snapshot_builder
- no change to status providers
- no change to src/live/web/app.py
- no execution or live-unlock implications

Verification
- python3 -m pytest tests/test_live_status_snapshot_api.py -q
- python3 -m ruff check src/webui/app.py tests/test_live_status_snapshot_api.py
- python3 -m ruff format --check src/webui/app.py tests/test_live_status_snapshot_api.py

Manual check
- open / and confirm the new "Live status snapshot (Phase 57)" card is visible
- confirm links to /api/live/status/snapshot.json and /api/live/status/snapshot.html
- confirm home still renders if snapshot generation fails
