### PR TITLE
feat(webui): globale Companion-Links WebUI ↔ live.web (read-only)

### DIFF
--- a/src/live/web/app.py
+++ b/src/live/web/app.py
@@ -211,7 +211,7 @@ def _generate_dashboard_html(
         header {{
             display: flex;
             justify-content: space-between;
-            align-items: center;
+            align-items: flex-start;
             margin-bottom: 30px;
             padding-bottom: 15px;
             border-bottom: 1px solid #333;
@@ -219,6 +219,16 @@ def _generate_dashboard_html(
         h1 {{
             color: #00d4ff;
             font-size: 1.8em;
+        }}
+        .companion-hint {{
+            font-size: 0.75em;
+            color: #888;
+            margin-top: 8px;
+            max-width: 42rem;
+            line-height: 1.4;
+        }}
+        .companion-hint a {{
+            color: #7dd3fc;
         }}
         .status {{
             font-size: 0.9em;
@@ -364,7 +374,14 @@ def _generate_dashboard_html(
 <body>
     <div class="container">
         <header>
-            <h1>Peak_Trade Live Dashboard</h1>
+            <div>
+                <h1>Peak_Trade Live Dashboard</h1>
+                <p class="companion-hint">
+                    Companion (navigation): Operator WebUI —
+                    <a href="http://127.0.0.1:8000/" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000/</a>
+                    · default local port per README; separate process, not this app.
+                </p>
+            </div>
             <div class="status" id="status">Connecting...</div>
         </header>
 

--- a/templates/peak_trade_dashboard/base.html
+++ b/templates/peak_trade_dashboard/base.html
@@ -52,6 +52,15 @@
             <a href="/live/telemetry" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               📊 Telemetry
             </a>
+            <a
+              href="http://127.0.0.1:8010/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Separate Run-monitoring UI (companion). Default http://127.0.0.1:8010/ when using scripts/ops/run_live_webui.sh per README — different process than this dashboard."
+            >
+              Run UI (companion)
+            </a>
             <span class="text-slate-600">|</span>
             <span class="text-xs text-slate-500">
               {{ status.version }} · {{ status.snapshot_commit }}
@@ -65,8 +74,10 @@
       </main>
 
       <footer class="border-t border-slate-800/50 bg-slate-900/30 mt-8">
-        <div class="max-w-6xl mx-auto px-4 py-3 text-xs text-slate-500 flex items-center justify-between">
-          <span>Peak_Trade Dashboard v1.2 · Read-Only · Shadow/Testnet Mode · R&D Dashboard (Phase 76)</span>
+        <div class="max-w-6xl mx-auto px-4 py-3 text-xs text-slate-500 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
+          <span>Peak_Trade Dashboard v1.2 · Read-Only · Shadow/Testnet Mode · R&D Dashboard (Phase 76)
+            · Companion Run UI default <code class="text-slate-400">127.0.0.1:8010</code> (local;
+            README)</span>
           <span>🔒 Live-Execution ist deaktiviert</span>
         </div>
       </footer>

--- a/tests/test_live_status_snapshot_api.py
+++ b/tests/test_live_status_snapshot_api.py
@@ -401,6 +401,15 @@ def test_home_includes_live_status_snapshot_card(test_client):
     assert "Observed builder output only" in text
 
 
+def test_home_includes_companion_link_to_run_ui(test_client):
+    """GET / enthält globalen Companion-Link zur Live-Run-UI (Default-README-Port)."""
+    response = test_client.get("/")
+    assert response.status_code == 200
+    text = response.text
+    assert "http://127.0.0.1:8010/" in text
+    assert "Run UI (companion)" in text
+
+
 def test_home_renders_when_snapshot_builder_fails(test_client, monkeypatch):
     """GET / still returns 200 if home snapshot context fails (fail-soft)."""
 

--- a/tests/test_live_web.py
+++ b/tests/test_live_web.py
@@ -431,6 +431,17 @@ class TestDashboardEndpoint:
         assert "text/html" in response.headers["content-type"]
         assert "Peak_Trade" in response.text
 
+    def test_dashboard_contains_companion_link_to_operator_webui(
+        self, test_client: TestClient
+    ) -> None:
+        """HTML enthält read-only Companion-Hinweis zur Operator-WebUI (Default-README-Port)."""
+        response = test_client.get("/")
+        assert response.status_code == 200
+        text = response.text
+        assert "http://127.0.0.1:8000/" in text
+        assert "Operator WebUI" in text
+        assert "separate process" in text.lower()
+
     def test_dashboard_alias(self, test_client: TestClient) -> None:
         """Test Dashboard unter /dashboard."""
         response = test_client.get("/dashboard")


### PR DESCRIPTION
Summary
- adds small read-only companion navigation links between Operator WebUI and live.web
- improves orientation between the two existing UIs without coupling runtime behavior
- uses README default local ports only as companion hints

What changed
- templates/peak_trade_dashboard/base.html
  - adds global nav link to Run UI (companion)
  - adds footer hint for default local Run UI port 127.0.0.1:8010
- src/live/web/app.py
  - adds companion navigation hint and link back to Operator WebUI
  - uses default local Operator WebUI port 127.0.0.1:8000 as a README-aligned hint
- tests/test_live_status_snapshot_api.py
  - adds focused home assertion for the Run UI companion link
- tests/test_live_web.py
  - adds focused live.web assertion for the Operator WebUI companion link

Truth-first / safety posture
- read-only navigation/orientation only
- no port changes
- no runtime auto-discovery
- no backend coupling
- no builder, execution, snapshot, or gate semantics changes
- separate process wording kept explicit on both sides

Verification
- python3 -m pytest tests/test_live_web.py::TestDashboardEndpoint::test_dashboard_contains_companion_link_to_operator_webui tests/test_live_status_snapshot_api.py::test_home_includes_companion_link_to_run_ui tests/test_live_status_snapshot_api.py::test_home_includes_live_status_snapshot_card -vv --tb=short
- python3 -m ruff check src/live/web/app.py tests/test_live_web.py tests/test_live_status_snapshot_api.py
- python3 -m ruff format --check src/live/web/app.py tests/test_live_web.py tests/test_live_status_snapshot_api.py

Manual check
- open WebUI and confirm "Run UI (companion)" points to http://127.0.0.1:8010/
- open live.web and confirm companion link points to http://127.0.0.1:8000/
- confirm wording stays observational and clearly marks both as separate processes
