### PR TITLE
feat(webui): README mirror card for two web UIs on home

### DIFF
--- a/templates/peak_trade_dashboard/index.html
+++ b/templates/peak_trade_dashboard/index.html
@@ -100,6 +100,57 @@
   </section>
 </div>
 
+<!-- README-aligned: two local web UIs (read-only orientation; same defaults as docs/Web UI) -->
+<section
+  class="mt-8 bg-slate-900/60 rounded-2xl border border-slate-800 p-4 text-sm"
+>
+  <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
+    <div>
+      <h2 class="text-sm font-semibold text-slate-200">
+        Zwei Web-Oberflächen (README, lokale Defaults)
+      </h2>
+      <p class="text-xs text-slate-500 mt-0.5">
+        Read-only Orientierung — zwei getrennte Prozesse, keine gemeinsame Control Plane.
+      </p>
+    </div>
+    <span class="text-xs px-2 py-0.5 rounded bg-slate-500/10 text-slate-400 border border-slate-600/30 shrink-0">
+      Navigation
+    </span>
+  </div>
+  <div class="grid gap-4 sm:grid-cols-2 text-xs text-slate-300">
+    <div class="rounded-xl border border-slate-800/80 bg-slate-950/40 p-3">
+      <p class="text-[11px] font-semibold text-slate-200 mb-1">Operator-WebUI</p>
+      <p class="text-slate-400 leading-relaxed mb-2">
+        Session Explorer, R&amp;D, Ops Cockpit und verwandte Operator-Ansichten (diese App bei
+        Standard-Start per <code class="text-slate-500">run_webui.sh</code>).
+      </p>
+      <p class="text-slate-500 mb-1">Lokaler Default (README): Port 8000</p>
+      <a
+        href="http://127.0.0.1:8000/"
+        class="text-sky-400 hover:underline font-mono text-[11px] break-all"
+        >http://127.0.0.1:8000/</a>
+    </div>
+    <div class="rounded-xl border border-slate-800/80 bg-slate-950/40 p-3">
+      <p class="text-[11px] font-semibold text-slate-200 mb-1">Run UI / live.web</p>
+      <p class="text-slate-400 leading-relaxed mb-2">
+        Run-zentriertes Monitoring: Runs-Liste, Snapshots, Alerts (Shadow-/Testnet-Beobachtung;
+        <code class="text-slate-500">src.live.web.app</code>).
+      </p>
+      <p class="text-slate-500 mb-1">Lokaler Default (README): Port 8010</p>
+      <a
+        href="http://127.0.0.1:8010/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-sky-400 hover:underline font-mono text-[11px] break-all"
+        >http://127.0.0.1:8010/</a>
+    </div>
+  </div>
+  <p class="text-[10px] text-slate-600 mt-3">
+    Ports gelten als lokale README-Defaults; andere Hosts/Ports sind möglich — keine
+    automatische Erkennung.
+  </p>
+</section>
+
 <!-- Phase 57: Live status snapshot (read-only; same builder as /api/live/status/snapshot.json) -->
 <section
   class="mt-8 bg-slate-900/60 rounded-2xl border border-slate-800 p-4 text-sm"

--- a/tests/test_live_status_snapshot_api.py
+++ b/tests/test_live_status_snapshot_api.py
@@ -410,6 +410,21 @@ def test_home_includes_companion_link_to_run_ui(test_client):
     assert "Run UI (companion)" in text
 
 
+def test_home_includes_readme_mirror_two_dashboards_card(test_client):
+    """GET / enthält README-ausgerichtete Orientierungskarte für Operator-WebUI vs Run UI."""
+    response = test_client.get("/")
+    assert response.status_code == 200
+    text = response.text
+    assert "Zwei Web-Oberflächen (README, lokale Defaults)" in text
+    assert "http://127.0.0.1:8000/" in text
+    assert "http://127.0.0.1:8010/" in text
+    assert "Operator-WebUI" in text
+    assert "Run UI / live.web" in text
+    assert "Lokaler Default (README): Port 8000" in text
+    assert "Lokaler Default (README): Port 8010" in text
+    assert "keine gemeinsame Control Plane" in text
+
+
 def test_home_renders_when_snapshot_builder_fails(test_client, monkeypatch):
     """GET / still returns 200 if home snapshot context fails (fail-soft)."""
 


### PR DESCRIPTION
Summary
- adds a compact read-only home card mirroring the README description of the two web UIs
- clarifies the distinct roles of Operator WebUI and Run UI / live.web
- mirrors README default local ports 8000 and 8010 as orientation hints only

What changed
- templates/peak_trade_dashboard/index.html
  - adds a new home section between the top grid and the Phase 57 snapshot card
  - presents the two web UIs with concise role descriptions and local default links
- tests/test_live_status_snapshot_api.py
  - adds a focused assertion for the new README mirror card
- src/webui/app.py
  - unchanged

Visible UI copy
- "Zwei Web-Oberflächen (README, lokale Defaults)"
- "Read-only Orientierung — zwei getrennte Prozesse, keine gemeinsame Control Plane."
- Operator-WebUI with local default port 8000
- Run UI / live.web with local default port 8010
- README/default/no auto-detection footnote

Truth-first / safety posture
- read-only orientation only
- no backend or runtime changes
- no auto-discovery
- no port or process coupling
- no execution, policy, gate, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_live_status_snapshot_api.py -q
- python3 -m ruff check tests/test_live_status_snapshot_api.py
- python3 -m ruff format --check tests/test_live_status_snapshot_api.py

Manual check
- open / and confirm the new two-UI README mirror card appears above the Phase 57 snapshot card
- confirm both local default URLs are visible
- confirm the wording explicitly states two separate processes and no shared control plane
