### PR TITLE
feat(webui): Run UI companion link on Stage1 and Ops Workflows pages

### DIFF
--- a/templates/peak_trade_dashboard/ops_stage1.html
+++ b/templates/peak_trade_dashboard/ops_stage1.html
@@ -25,6 +25,15 @@
             <a href="/ops/stage1" class="text-xs text-emerald-400">
               Stage1
             </a>
+            <a
+              href="http://127.0.0.1:8010/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Separate Run-monitoring UI (companion). Default http://127.0.0.1:8010/ when using scripts/ops/run_live_webui.sh per README — different process than this dashboard."
+            >
+              Run UI (companion)
+            </a>
           </nav>
         </div>
       </header>

--- a/templates/peak_trade_dashboard/ops_workflows.html
+++ b/templates/peak_trade_dashboard/ops_workflows.html
@@ -28,6 +28,15 @@
             <a href="/ops/workflows" class="text-xs text-blue-400">
               Workflows
             </a>
+            <a
+              href="http://127.0.0.1:8010/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Separate Run-monitoring UI (companion). Default http://127.0.0.1:8010/ when using scripts/ops/run_live_webui.sh per README — different process than this dashboard."
+            >
+              Run UI (companion)
+            </a>
           </nav>
         </div>
       </header>

--- a/tests/test_ops_workflows_router.py
+++ b/tests/test_ops_workflows_router.py
@@ -37,6 +37,8 @@ def test_workflows_html_endpoint():
     assert "Ops Workflow Hub" in content
     assert "scripts/quick_pr_merge.sh" in content
     assert "scripts/post_merge_workflow.sh" in content
+    assert "Run UI (companion)" in content
+    assert "http://127.0.0.1:8010/" in content
 
 
 def test_workflows_json_endpoint():

--- a/tests/test_stage1_router.py
+++ b/tests/test_stage1_router.py
@@ -41,6 +41,9 @@ def test_stage1_endpoints_in_app():
     response = client.get("/ops/stage1")
     # HTML endpoint should always return 200 (may show empty state)
     assert response.status_code == 200
+    html = response.text
+    assert "Run UI (companion)" in html
+    assert "http://127.0.0.1:8010/" in html
 
 
 def test_stage1_latest_endpoint_with_data(tmp_path):


### PR DESCRIPTION
Summary
- adds the existing Run UI (companion) navigation pattern to the standalone ops_stage1 and ops_workflows templates
- aligns those standalone pages with the base.html navigation posture
- keeps the change template-only with minimal HTML assertions

What changed
- templates/peak_trade_dashboard/ops_stage1.html
  - adds Run UI (companion) link in the header nav
- templates/peak_trade_dashboard/ops_workflows.html
  - adds the same Run UI (companion) link
- tests/test_ops_workflows_router.py
  - extends the HTML endpoint test with companion-link assertions
- tests/test_stage1_router.py
  - extends the /ops/stage1 HTML assertion with the same companion-link checks

Visible UI details
- label: Run UI (companion)
- url: http://127.0.0.1:8010/
- target: _blank
- rel: noopener noreferrer
- title: Separate Run-monitoring UI (companion). Default http://127.0.0.1:8010/ when using scripts/ops/run_live_webui.sh per README — different process than this dashboard.

Truth-first / safety posture
- read-only navigation/orientation only
- matches the existing base.html companion pattern
- no backend changes
- no runtime or port changes
- no execution, gate, policy, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_ops_workflows_router.py tests/test_stage1_router.py -q
- python3 -m ruff check tests/test_ops_workflows_router.py tests/test_stage1_router.py
- python3 -m ruff format --check tests/test_ops_workflows_router.py tests/test_stage1_router.py

Manual check
- open /ops/stage1 and confirm the Run UI (companion) link appears in the header nav
- open /ops/workflows and confirm the same link appears there
- confirm wording and tooltip match the existing companion-link posture
