### PR TITLE
feat(webui): Phase 57 snapshot discoverability in Ops Cockpit

### DIFF
--- a/src/webui/ops_cockpit.py
+++ b/src/webui/ops_cockpit.py
@@ -906,6 +906,22 @@ def _render_policy_guard_observation_card(payload: Dict[str, object]) -> str:
     )
 
 
+def _render_phase57_snapshot_discoverability_card() -> str:
+    """HTML block: discoverability links to existing Phase 57 snapshot API (read-only, no new semantics)."""
+    return (
+        f'<div class="card truth-card" style="margin-bottom:20px;">'
+        f"<h2>Live status snapshot (Phase 57) — endpoints</h2>"
+        f"<p><strong>Read-only.</strong> Same JSON/HTML feeds as the home dashboard; observation only — "
+        f"not operational approval or go-live implication.</p>"
+        f"<p style='font-size:0.95em;'>"
+        f'<a href="/api/live/status/snapshot.json">/api/live/status/snapshot.json</a>'
+        f" · "
+        f'<a href="/api/live/status/snapshot.html">/api/live/status/snapshot.html</a>'
+        f"</p>"
+        f"</div>"
+    )
+
+
 def build_workflow_officer_panel_context(repo_root: Path | None = None) -> Dict[str, object]:
     """Read-only WebUI slice: latest Workflow Officer ``report.json`` (no writes)."""
     from src.ops.workflow_officer import build_workflow_officer_dashboard_view
@@ -1729,6 +1745,7 @@ def render_ops_cockpit_html(
     supporting_cards = "".join(_render_doc_card(doc) for doc in groups["supporting_truth"])
     exec_summary_html = _render_exec_summary_status_grid(payload)
     policy_guard_observation_html = _render_policy_guard_observation_card(payload)
+    phase57_snapshot_discoverability_html = _render_phase57_snapshot_discoverability_card()
     phase83_eligibility_html = _render_phase83_eligibility_card(
         payload.get("phase83_eligibility_snapshot") or {}
     )
@@ -1785,6 +1802,7 @@ def render_ops_cockpit_html(
 <body>
   {exec_summary_html}
   {policy_guard_observation_html}
+  {phase57_snapshot_discoverability_html}
   {phase83_eligibility_html}
   <div class="hero">
     <h1>Ops Cockpit v3 — Truth-First</h1>

--- a/tests/webui/test_ops_cockpit.py
+++ b/tests/webui/test_ops_cockpit.py
@@ -158,6 +158,14 @@ def test_ops_cockpit_html_contains_policy_guard_observation_card(tmp_path: Path)
     assert "not a control surface" in html
 
 
+def test_ops_cockpit_html_contains_phase57_snapshot_discoverability_links(tmp_path: Path) -> None:
+    html = render_ops_cockpit_html(repo_root=tmp_path)
+    assert "Live status snapshot (Phase 57) — endpoints" in html
+    assert "/api/live/status/snapshot.json" in html
+    assert "/api/live/status/snapshot.html" in html
+    assert "observation only" in html.lower()
+
+
 def test_phase83_eligibility_snapshot_ok_with_real_repo_tiering() -> None:
     repo = Path(__file__).resolve().parents[2]
     if not (repo / "config" / "strategy_tiering.toml").exists():


### PR DESCRIPTION
Summary
- adds a small read-only discoverability card in Ops Cockpit for the existing Phase 57 live status snapshot endpoints
- improves operator-side visibility of the existing snapshot feeds without adding new payload or backend behavior
- keeps the change limited to HTML rendering plus a focused test

What changed
- src/webui/ops_cockpit.py
  - adds _render_phase57_snapshot_discoverability_card()
  - renders the card between the Policy/Guard observation card and the Phase 83 eligibility card
- tests/webui/test_ops_cockpit.py
  - adds test_ops_cockpit_html_contains_phase57_snapshot_discoverability_links

Visible UI details
- heading: Live status snapshot (Phase 57) — endpoints
- copy: Read-only. Same JSON/HTML feeds as the home dashboard; observation only — not operational approval or go-live implication.
- links:
  - /api/live/status/snapshot.json
  - /api/live/status/snapshot.html

Truth-first / safety posture
- read-only discoverability only
- no new payload
- no new API path
- no backend, runtime, execution, gate, policy/guard, or live-unlock semantics changes

Verification
- python3 -m pytest tests/webui/test_ops_cockpit.py -q
- python3 -m ruff check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py
- python3 -m ruff format --check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py

Manual check
- open /ops and confirm the new Phase 57 snapshot discoverability card appears between the Policy/Guard card and the Phase 83 eligibility card
- confirm both snapshot endpoint links are visible
- confirm wording stays observational and explicitly avoids approval / go-live implications
