### PR TITLE
feat(ops-cockpit): read-only run state observation card

### DIFF
--- a/src/webui/ops_cockpit.py
+++ b/src/webui/ops_cockpit.py
@@ -975,6 +975,60 @@ def _render_incident_observation_card(payload: Dict[str, object]) -> str:
     )
 
 
+def _render_run_state_observation_card(payload: Dict[str, object]) -> str:
+    """HTML block: compact run-state rollup from existing ``run_state`` keys only (read-only wording)."""
+    rs_raw = payload.get("run_state")
+    rs = rs_raw if isinstance(rs_raw, dict) else {}
+
+    def _fmt_val(val: object) -> str:
+        if val is True:
+            return "true"
+        if val is False:
+            return "false"
+        if val is None:
+            return "n/a"
+        return str(val)
+
+    rows_html: List[str] = []
+    for label, key in (
+        ("run_state.status", "status"),
+        ("run_state.active", "active"),
+        ("run_state.last_run_status", "last_run_status"),
+        ("run_state.session_active", "session_active"),
+        ("run_state.generated_at", "generated_at"),
+        ("run_state.freshness_status", "freshness_status"),
+    ):
+        if key not in rs:
+            continue
+        v = escape(_fmt_val(rs.get(key)))
+        rows_html.append(
+            f"<tr><td style='padding:4px 8px 4px 0;vertical-align:top;'><code>{escape(label)}</code></td>"
+            f"<td style='padding:4px 0;'><code>{v}</code></td></tr>"
+        )
+
+    if not rows_html:
+        return ""
+
+    table_html = (
+        "<table style='width:100%;border-collapse:collapse;font-size:0.9em;'>"
+        "<tbody>"
+        f"{''.join(rows_html)}"
+        "</tbody></table>"
+    )
+    intro = (
+        "Subset of <code>run_state</code> already present in this page’s JSON payload (same object as "
+        "<code>GET /api/ops-cockpit</code>). Observation only — not a control surface; does not start or "
+        "stop runs or change execution semantics."
+    )
+    return (
+        f'<div class="card truth-card" style="margin-bottom:20px;">'
+        f"<h2>Run state — observed rollup</h2>"
+        f"<p><strong>Read-only.</strong> {intro}</p>"
+        f"{table_html}"
+        f"</div>"
+    )
+
+
 def build_workflow_officer_panel_context(repo_root: Path | None = None) -> Dict[str, object]:
     """Read-only WebUI slice: latest Workflow Officer ``report.json`` (no writes)."""
     from src.ops.workflow_officer import build_workflow_officer_dashboard_view
@@ -1800,6 +1854,7 @@ def render_ops_cockpit_html(
     policy_guard_observation_html = _render_policy_guard_observation_card(payload)
     phase57_snapshot_discoverability_html = _render_phase57_snapshot_discoverability_card()
     incident_observation_html = _render_incident_observation_card(payload)
+    run_state_observation_html = _render_run_state_observation_card(payload)
     phase83_eligibility_html = _render_phase83_eligibility_card(
         payload.get("phase83_eligibility_snapshot") or {}
     )
@@ -1858,6 +1913,7 @@ def render_ops_cockpit_html(
   {policy_guard_observation_html}
   {phase57_snapshot_discoverability_html}
   {incident_observation_html}
+  {run_state_observation_html}
   {phase83_eligibility_html}
   <div class="hero">
     <h1>Ops Cockpit v3 — Truth-First</h1>

--- a/tests/webui/test_ops_cockpit.py
+++ b/tests/webui/test_ops_cockpit.py
@@ -166,6 +166,14 @@ def test_ops_cockpit_html_contains_incident_observation_card(tmp_path: Path) -> 
     assert "not a control surface" in html
 
 
+def test_ops_cockpit_html_contains_run_state_observation_card(tmp_path: Path) -> None:
+    html = render_ops_cockpit_html(repo_root=tmp_path)
+    assert "Run state — observed rollup" in html
+    assert "run_state.status" in html
+    assert "run_state.last_run_status" in html
+    assert "not a control surface" in html
+
+
 def test_ops_cockpit_html_contains_phase57_snapshot_discoverability_links(tmp_path: Path) -> None:
     html = render_ops_cockpit_html(repo_root=tmp_path)
     assert "Live status snapshot (Phase 57) — endpoints" in html


### PR DESCRIPTION
Summary
- adds a compact read-only run_state observation card to Ops Cockpit
- surfaces only existing run_state fields already present in the current payload
- keeps the change limited to HTML rendering plus a focused test

What changed
- src/webui/ops_cockpit.py
  - adds _render_run_state_observation_card()
  - renders the card after the incident observation card and before the Phase 83 eligibility card
- tests/webui/test_ops_cockpit.py
  - adds test_ops_cockpit_html_contains_run_state_observation_card

Observed payload fields surfaced
- run_state.status
- run_state.active
- run_state.last_run_status
- run_state.session_active
- run_state.generated_at
- run_state.freshness_status

Truth-first / safety posture
- read-only observational UI only
- not a control surface
- does not start or stop runs
- no new payload fields
- no new API path
- no backend, runtime, execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/webui/test_ops_cockpit.py -q
- python3 -m ruff check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py
- python3 -m ruff format --check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py

Manual check
- open /ops and confirm the new "Run state — observed rollup" card appears between the incident observation card and the Phase 83 eligibility card
- confirm the card shows the existing run_state.* keys
- confirm wording stays observational and explicitly says it does not start or stop runs
