### PR TITLE
feat(webui): Ops hub links in base navigation

### DIFF
--- a/templates/peak_trade_dashboard/base.html
+++ b/templates/peak_trade_dashboard/base.html
@@ -40,6 +40,27 @@
             <a href="/" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Dashboard
             </a>
+            <a
+              href="/ops"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only Ops Cockpit (navigation only; same Operator WebUI process as this dashboard)."
+            >
+              Ops Cockpit
+            </a>
+            <a
+              href="/ops/stage1"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only Stage1 ops view (navigation only; no new capability)."
+            >
+              Stage1
+            </a>
+            <a
+              href="/ops/workflows"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only ops workflows hub (navigation only; no new capability)."
+            >
+              Workflows
+            </a>
             <a href="/execution_watch" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Execution Watch
             </a>

--- a/tests/test_live_status_snapshot_api.py
+++ b/tests/test_live_status_snapshot_api.py
@@ -410,6 +410,18 @@ def test_home_includes_companion_link_to_run_ui(test_client):
     assert "Run UI (companion)" in text
 
 
+def test_home_base_nav_includes_ops_hub_links(test_client):
+    """GET / base navigation lists Ops hub routes (discoverability only; read-only wording in titles)."""
+    response = test_client.get("/")
+    assert response.status_code == 200
+    text = response.text
+    assert 'href="/ops"' in text
+    assert 'href="/ops/stage1"' in text
+    assert 'href="/ops/workflows"' in text
+    assert "Ops Cockpit" in text
+    assert "navigation only" in text
+
+
 def test_home_includes_readme_mirror_two_dashboards_card(test_client):
     """GET / enthält README-ausgerichtete Orientierungskarte für Operator-WebUI vs Run UI."""
     response = test_client.get("/")


### PR DESCRIPTION
Summary
- adds Ops hub links to the shared base navigation in the Operator WebUI
- improves discoverability for /ops, /ops/stage1, and /ops/workflows
- keeps the change limited to template navigation plus a focused HTML test

What changed
- templates/peak_trade_dashboard/base.html
  - adds nav links for:
    - /ops
    - /ops/stage1
    - /ops/workflows
- tests/test_live_status_snapshot_api.py
  - adds test_home_base_nav_includes_ops_hub_links

Visible UI details
- Ops Cockpit -> /ops
- Stage1 -> /ops/stage1
- Workflows -> /ops/workflows
- title wording keeps all three links navigation-only / read-only

Truth-first / safety posture
- navigation/discoverability only
- no new routes
- no new API
- no backend or runtime changes
- no execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_live_status_snapshot_api.py -q
- python3 -m ruff check tests/test_live_status_snapshot_api.py
- python3 -m ruff format --check tests/test_live_status_snapshot_api.py

Manual check
- open / and confirm the base navigation now includes Ops Cockpit, Stage1, and Workflows
- confirm tooltip/title wording remains navigation-only and read-only
