### PR TITLE
feat(live-web): Ops Cockpit deep link on main dashboard

### DIFF
--- a/src/live/web/app.py
+++ b/src/live/web/app.py
@@ -394,6 +394,11 @@ def _generate_dashboard_html(
                     <a href="http://127.0.0.1:8000/" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000/</a>
                     · default local port per README; separate process, not this app.
                 </p>
+                <p class="companion-hint">
+                    Ops Cockpit (companion navigation): read-only Operator WebUI —
+                    <a href="http://127.0.0.1:8000/ops" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000/ops</a>
+                    · default local host/port per README; separate process; no shared control plane.
+                </p>
             </div>
             <div class="status" id="status">Connecting...</div>
         </header>

--- a/tests/test_live_web.py
+++ b/tests/test_live_web.py
@@ -442,6 +442,17 @@ class TestDashboardEndpoint:
         assert "Operator WebUI" in text
         assert "separate process" in text.lower()
 
+    def test_dashboard_contains_ops_cockpit_deeplink(self, test_client: TestClient) -> None:
+        """Haupt-Dashboard (/ und /dashboard) enthält expliziten Companion-Deep-Link zu /ops."""
+        for path in ("/", "/dashboard"):
+            response = test_client.get(path)
+            assert response.status_code == 200
+            text = response.text
+            assert "http://127.0.0.1:8000/ops" in text
+            assert "Ops Cockpit" in text
+            assert "companion navigation" in text.lower()
+            assert "no shared control plane" in text.lower()
+
     def test_watch_overview_contains_companion_strip_to_operator_webui(
         self, test_client: TestClient
     ) -> None:


### PR DESCRIPTION
Summary
- adds a small read-only Ops Cockpit deep link to the live.web main dashboard
- makes the /ops entrypoint explicit from live.web / and /dashboard
- keeps the change limited to dashboard HTML plus a focused test

What changed
- src/live/web/app.py
  - adds a second companion hint paragraph in _generate_dashboard_html
  - links to http://127.0.0.1:8000/ops
- tests/test_live_web.py
  - adds test_dashboard_contains_ops_cockpit_deeplink

Visible UI details
- text: Ops Cockpit (companion navigation): read-only Operator WebUI
- link: http://127.0.0.1:8000/ops
- wording includes:
  - default local host/port per README
  - separate process
  - no shared control plane

Truth-first / safety posture
- navigation/discoverability only
- no new route
- no new API
- no backend or runtime changes
- no execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_live_web.py -q
- python3 -m ruff check src/live/web/app.py tests/test_live_web.py
- python3 -m ruff format --check src/live/web/app.py tests/test_live_web.py

Manual check
- open / and /dashboard in live.web and confirm the Ops Cockpit companion deep link is visible
- confirm the link points to http://127.0.0.1:8000/ops
- confirm wording remains read-only, separate-process, and no-shared-control-plane
