### PR TITLE
feat(live-web): Ops Cockpit deep link in watch companion strip

### DIFF
--- a/src/live/web/app.py
+++ b/src/live/web/app.py
@@ -185,6 +185,12 @@ def _companion_operator_webui_hint_html_watch() -> str:
         " · default local port per README; separate process, not this app; "
         "no shared control plane."
         "</div>"
+        "<div class='companion-strip'>"
+        "<strong>Ops Cockpit (companion navigation):</strong> read-only Operator WebUI — "
+        "<a href='http://127.0.0.1:8000/ops' target='_blank' rel='noopener noreferrer'>"
+        "http://127.0.0.1:8000/ops</a>"
+        " · default local host/port per README; separate process; no shared control plane."
+        "</div>"
     )
 
 

--- a/tests/test_live_web.py
+++ b/tests/test_live_web.py
@@ -486,6 +486,18 @@ class TestDashboardEndpoint:
         assert "Companion (navigation):" in r_sess.text
         assert "http://127.0.0.1:8000/" in r_sess.text
 
+    def test_watch_pages_contain_ops_cockpit_deeplink(self, test_client: TestClient) -> None:
+        """Watch-/Session-HTML enthält Companion-Deep-Link zu /ops (symmetrisch zum Haupt-Dashboard)."""
+        run_id = "20251204_180000_paper_ma_crossover_BTC-EUR_1m"
+        for path in ("/watch", f"/watch/runs/{run_id}", f"/sessions/{run_id}"):
+            response = test_client.get(path)
+            assert response.status_code == 200
+            text = response.text
+            assert "http://127.0.0.1:8000/ops" in text
+            assert "Ops Cockpit" in text
+            assert "companion navigation" in text.lower()
+            assert "no shared control plane" in text.lower()
+
     def test_dashboard_alias(self, test_client: TestClient) -> None:
         """Test Dashboard unter /dashboard."""
         response = test_client.get("/dashboard")


### PR DESCRIPTION
Summary
- adds an Ops Cockpit companion deep link to the live.web watch/session HTML companion strip
- aligns /watch, /watch/runs/{run_id}, and /sessions/{run_id} with the explicit /ops entrypoint already shown on the main dashboard
- keeps the change limited to HTML rendering plus a focused test

What changed
- src/live/web/app.py
  - updates _companion_operator_webui_hint_html_watch()
  - keeps the existing Operator WebUI root companion hint
  - adds a second companion strip for Ops Cockpit at http://127.0.0.1:8000/ops
- tests/test_live_web.py
  - adds test_watch_pages_contain_ops_cockpit_deeplink

Visible UI details
- existing:
  - Companion (navigation): Operator WebUI -> http://127.0.0.1:8000/
- new:
  - Ops Cockpit (companion navigation): read-only Operator WebUI -> http://127.0.0.1:8000/ops
- wording includes:
  - default local host/port per README
  - separate process
  - no shared control plane

Truth-first / safety posture
- navigation/discoverability only
- no new route
- no new API
- no backend or runtime changes
- no execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_live_web.py -q
- python3 -m ruff check src/live/web/app.py tests/test_live_web.py
- python3 -m ruff format --check src/live/web/app.py tests/test_live_web.py

Manual check
- open /watch and confirm the new Ops Cockpit companion deep link is visible
- open /watch/runs/{run_id} and confirm the same link is visible
- open /sessions/{run_id} and confirm the same link is visible
- confirm wording remains read-only, separate-process, and no-shared-control-plane
