### PR TITLE
feat(webui): CI Health link in base navigation

### DIFF
--- a/templates/peak_trade_dashboard/base.html
+++ b/templates/peak_trade_dashboard/base.html
@@ -61,6 +61,13 @@
             >
               Workflows
             </a>
+            <a
+              href="/ops/ci-health"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only CI health dashboard (navigation only; same Operator WebUI process; no new capability beyond the existing page)."
+            >
+              CI Health
+            </a>
             <a href="/execution_watch" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Execution Watch
             </a>

--- a/tests/test_live_status_snapshot_api.py
+++ b/tests/test_live_status_snapshot_api.py
@@ -418,7 +418,9 @@ def test_home_base_nav_includes_ops_hub_links(test_client):
     assert 'href="/ops"' in text
     assert 'href="/ops/stage1"' in text
     assert 'href="/ops/workflows"' in text
+    assert 'href="/ops/ci-health"' in text
     assert "Ops Cockpit" in text
+    assert "CI Health" in text
     assert "navigation only" in text
 
 


### PR DESCRIPTION
Summary
- adds a CI Health link to the shared base navigation in the Operator WebUI
- improves discoverability for the existing /ops/ci-health page
- keeps the change limited to template navigation plus a focused HTML test

What changed
- templates/peak_trade_dashboard/base.html
  - adds nav link for:
    - /ops/ci-health
- tests/test_live_status_snapshot_api.py
  - extends test_home_base_nav_includes_ops_hub_links with CI Health assertions

Visible UI details
- CI Health -> /ops/ci-health
- title: Read-only CI health dashboard (navigation only; same Operator WebUI process; no new capability beyond the existing page).

Truth-first / safety posture
- navigation/discoverability only
- no new route
- no new API
- no backend or runtime changes
- no execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_live_status_snapshot_api.py -q
- python3 -m ruff check tests/test_live_status_snapshot_api.py
- python3 -m ruff format --check tests/test_live_status_snapshot_api.py

Manual check
- open / and confirm the base navigation now includes CI Health
- confirm tooltip/title wording remains navigation-only and read-only
