### PR TITLE
feat(webui): hub crosslinks on standalone Ops templates

### DIFF
--- a/templates/peak_trade_dashboard/ops_stage1.html
+++ b/templates/peak_trade_dashboard/ops_stage1.html
@@ -22,6 +22,20 @@
             <a href="/" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Dashboard
             </a>
+            <a
+              href="/ops"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only Ops Cockpit (navigation only; same Operator WebUI process as this dashboard)."
+            >
+              Ops Cockpit
+            </a>
+            <a
+              href="/ops/ci-health"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only CI health dashboard (navigation only; same Operator WebUI process; no new capability beyond the existing page)."
+            >
+              CI Health
+            </a>
             <a href="/ops/stage1" class="text-xs text-emerald-400">
               Stage1
             </a>

--- a/templates/peak_trade_dashboard/ops_workflows.html
+++ b/templates/peak_trade_dashboard/ops_workflows.html
@@ -22,6 +22,20 @@
             <a href="/" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Dashboard
             </a>
+            <a
+              href="/ops"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only Ops Cockpit (navigation only; same Operator WebUI process as this dashboard)."
+            >
+              Ops Cockpit
+            </a>
+            <a
+              href="/ops/ci-health"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only CI health dashboard (navigation only; same Operator WebUI process; no new capability beyond the existing page)."
+            >
+              CI Health
+            </a>
             <a href="/ops/stage1" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Stage1
             </a>

--- a/tests/test_ops_workflows_router.py
+++ b/tests/test_ops_workflows_router.py
@@ -39,6 +39,10 @@ def test_workflows_html_endpoint():
     assert "scripts/post_merge_workflow.sh" in content
     assert "Run UI (companion)" in content
     assert "http://127.0.0.1:8010/" in content
+    assert 'href="/ops"' in content
+    assert 'href="/ops/ci-health"' in content
+    assert "Ops Cockpit" in content
+    assert "CI Health" in content
 
 
 def test_workflows_json_endpoint():

--- a/tests/test_stage1_router.py
+++ b/tests/test_stage1_router.py
@@ -44,6 +44,10 @@ def test_stage1_endpoints_in_app():
     html = response.text
     assert "Run UI (companion)" in html
     assert "http://127.0.0.1:8010/" in html
+    assert 'href="/ops"' in html
+    assert 'href="/ops/ci-health"' in html
+    assert "Ops Cockpit" in html
+    assert "CI Health" in html
 
 
 def test_stage1_latest_endpoint_with_data(tmp_path):


### PR DESCRIPTION
Summary
- adds hub crosslinks to the standalone Stage1 and Ops Workflows templates
- improves discoverability for /ops and /ops/ci-health from standalone operator pages
- keeps the change limited to template navigation plus focused router HTML tests

What changed
- templates/peak_trade_dashboard/ops_stage1.html
  - adds links for:
    - /ops
    - /ops/ci-health
- templates/peak_trade_dashboard/ops_workflows.html
  - adds the same links
- tests/test_stage1_router.py
  - extends the /ops/stage1 HTML assertions
- tests/test_ops_workflows_router.py
  - extends the /ops/workflows HTML assertions

Visible UI details
- Ops Cockpit -> /ops
- CI Health -> /ops/ci-health
- title wording keeps both links navigation-only / read-only

Truth-first / safety posture
- navigation/discoverability only
- no new route
- no new API
- no backend or runtime changes
- no execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_stage1_router.py tests/test_ops_workflows_router.py -q
- python3 -m ruff check tests/test_stage1_router.py tests/test_ops_workflows_router.py
- python3 -m ruff format --check tests/test_stage1_router.py tests/test_ops_workflows_router.py

Manual check
- open /ops/stage1 and confirm Ops Cockpit and CI Health appear in the header nav
- open /ops/workflows and confirm the same links appear there
- confirm tooltip/title wording remains navigation-only and read-only
