### PR TITLE
feat(webui): hub parity for standalone CI Health

### DIFF
--- a/templates/peak_trade_dashboard/ops_ci_health.html
+++ b/templates/peak_trade_dashboard/ops_ci_health.html
@@ -22,14 +22,34 @@
             <a href="/" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Dashboard
             </a>
+            <a
+              href="/ops"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only Ops Cockpit (navigation only; same Operator WebUI process as this dashboard)."
+            >
+              Ops Cockpit
+            </a>
+            <a
+              href="/ops/ci-health"
+              class="text-xs text-blue-400"
+              title="Read-only CI health dashboard (navigation only; same Operator WebUI process; no new capability beyond the existing page)."
+            >
+              CI Health
+            </a>
             <a href="/ops/stage1" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Stage1
             </a>
             <a href="/ops/workflows" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               Workflows
             </a>
-            <a href="/ops/ci-health" class="text-xs text-blue-400">
-              CI Health
+            <a
+              href="http://127.0.0.1:8010/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Separate Run-monitoring UI (companion). Default http://127.0.0.1:8010/ when using scripts/ops/run_live_webui.sh per README — different process than this dashboard."
+            >
+              Run UI (companion)
             </a>
           </nav>
         </div>

--- a/tests/webui/test_ops_ci_health_router.py
+++ b/tests/webui/test_ops_ci_health_router.py
@@ -123,6 +123,17 @@ def client(test_app: FastAPI) -> TestClient:
     return TestClient(test_app)
 
 
+@pytest.fixture
+def client_real_ops_ci_health_template(mock_repo_root: Path) -> TestClient:
+    """GET /ops/ci-health using the repo's ops_ci_health.html (hub nav parity)."""
+    repo_root = Path(__file__).resolve().parents[2]
+    templates = Jinja2Templates(directory=str(repo_root / "templates" / "peak_trade_dashboard"))
+    set_ci_health_config(mock_repo_root, templates)
+    app = FastAPI()
+    app.include_router(ci_health_router)
+    return TestClient(app)
+
+
 # =============================================================================
 # TESTS: HTML Dashboard Endpoint
 # =============================================================================
@@ -135,6 +146,22 @@ def test_ci_health_dashboard_renders(client: TestClient) -> None:
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
     assert "CI & Governance Health" in response.text
+
+
+def test_ci_health_dashboard_standalone_hub_nav(
+    client_real_ops_ci_health_template: TestClient,
+) -> None:
+    """Standalone CI Health page includes same hub crosslinks as other Ops standalones."""
+    response = client_real_ops_ci_health_template.get("/ops/ci-health")
+    assert response.status_code == 200
+    html = response.text
+    assert 'href="/ops"' in html
+    assert "Ops Cockpit" in html
+    assert 'href="/ops/stage1"' in html
+    assert 'href="/ops/workflows"' in html
+    assert 'href="/ops/ci-health"' in html
+    assert "http://127.0.0.1:8010/" in html
+    assert "Run UI (companion)" in html
 
 
 def test_ci_health_dashboard_shows_status(client: TestClient) -> None:


### PR DESCRIPTION
Summary
- aligns the standalone CI Health page with the existing standalone ops templates
- adds hub navigation links to Dashboard, Ops Cockpit, Stage1, Workflows, and the Run UI companion
- keeps the change limited to template navigation plus a focused router HTML test

What changed
- templates/peak_trade_dashboard/ops_ci_health.html
  - adds sticky header nav parity with the standalone ops templates
  - includes:
    - /            (Dashboard)
    - /ops         (Ops Cockpit)
    - /ops/ci-health (active)
    - /ops/stage1
    - /ops/workflows
    - http://127.0.0.1:8010/ (Run UI companion)
- tests/webui/test_ops_ci_health_router.py
  - adds a real-template fixture
  - adds test_ci_health_dashboard_standalone_hub_nav

Visible UI details
- Dashboard -> /
- Ops Cockpit -> /ops
- CI Health -> /ops/ci-health
- Stage1 -> /ops/stage1
- Workflows -> /ops/workflows
- Run UI (companion) -> http://127.0.0.1:8010/

Truth-first / safety posture
- navigation/discoverability only
- no new route
- no new API
- no backend or runtime changes
- no execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/webui/test_ops_ci_health_router.py -q
- python3 -m ruff check tests/webui/test_ops_ci_health_router.py
- python3 -m ruff format --check tests/webui/test_ops_ci_health_router.py

Manual check
- open /ops/ci-health and confirm the standalone header nav now matches the broader ops hub posture
- confirm CI Health is the active item
- confirm the Run UI companion link points to http://127.0.0.1:8010/
