### PR TITLE
feat(live.web): companion deep link to CI Health

### DIFF
--- a/src/live/web/app.py
+++ b/src/live/web/app.py
@@ -191,6 +191,12 @@ def _companion_operator_webui_hint_html_watch() -> str:
         "http://127.0.0.1:8000/ops</a>"
         " · default local host/port per README; separate process; no shared control plane."
         "</div>"
+        "<div class='companion-strip'>"
+        "<strong>CI Health (companion navigation):</strong> read-only Operator WebUI — "
+        "<a href='http://127.0.0.1:8000/ops/ci-health' target='_blank' rel='noopener noreferrer'>"
+        "http://127.0.0.1:8000/ops/ci-health</a>"
+        " · default local host/port per README; separate process; no shared control plane."
+        "</div>"
     )
 
 
@@ -403,6 +409,11 @@ def _generate_dashboard_html(
                 <p class="companion-hint">
                     Ops Cockpit (companion navigation): read-only Operator WebUI —
                     <a href="http://127.0.0.1:8000/ops" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000/ops</a>
+                    · default local host/port per README; separate process; no shared control plane.
+                </p>
+                <p class="companion-hint">
+                    CI Health (companion navigation): read-only Operator WebUI —
+                    <a href="http://127.0.0.1:8000/ops/ci-health" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000/ops/ci-health</a>
                     · default local host/port per README; separate process; no shared control plane.
                 </p>
             </div>

--- a/tests/test_live_web.py
+++ b/tests/test_live_web.py
@@ -498,6 +498,29 @@ class TestDashboardEndpoint:
             assert "companion navigation" in text.lower()
             assert "no shared control plane" in text.lower()
 
+    def test_dashboard_contains_ci_health_deeplink(self, test_client: TestClient) -> None:
+        """Haupt-Dashboard (/ und /dashboard) enthält Companion-Deep-Link zu /ops/ci-health."""
+        for path in ("/", "/dashboard"):
+            response = test_client.get(path)
+            assert response.status_code == 200
+            text = response.text
+            assert "http://127.0.0.1:8000/ops/ci-health" in text
+            assert "CI Health" in text
+            assert "companion navigation" in text.lower()
+            assert "no shared control plane" in text.lower()
+
+    def test_watch_pages_contain_ci_health_deeplink(self, test_client: TestClient) -> None:
+        """Watch-/Session-HTML enthält Companion-Deep-Link zu /ops/ci-health (gleicher Block wie Dashboard)."""
+        run_id = "20251204_180000_paper_ma_crossover_BTC-EUR_1m"
+        for path in ("/watch", f"/watch/runs/{run_id}", f"/sessions/{run_id}"):
+            response = test_client.get(path)
+            assert response.status_code == 200
+            text = response.text
+            assert "http://127.0.0.1:8000/ops/ci-health" in text
+            assert "CI Health" in text
+            assert "companion navigation" in text.lower()
+            assert "no shared control plane" in text.lower()
+
     def test_dashboard_alias(self, test_client: TestClient) -> None:
         """Test Dashboard unter /dashboard."""
         response = test_client.get("/dashboard")


### PR DESCRIPTION
Summary
- adds a CI Health companion deep link to live.web main dashboard and watch/session companion areas
- improves discoverability for the existing Operator WebUI CI Health page from live.web
- keeps the change limited to HTML rendering plus focused tests

What changed
- src/live/web/app.py
  - adds a CI Health companion block to _companion_operator_webui_hint_html_watch()
  - adds a CI Health companion hint paragraph to _generate_dashboard_html
- tests/test_live_web.py
  - adds test_dashboard_contains_ci_health_deeplink
  - adds test_watch_pages_contain_ci_health_deeplink

Visible UI details
- CI Health (companion navigation): read-only Operator WebUI
- link: http://127.0.0.1:8000/ops/ci-health
- wording includes:
  - default local host/port per README
  - separate process
  - no shared control plane

Truth-first / safety posture
- navigation/discoverability only
- no new route
- no new API
- no backend or runtime changes
- no execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_live_web.py -q
- python3 -m ruff check src/live/web/app.py tests/test_live_web.py
- python3 -m ruff format --check src/live/web/app.py tests/test_live_web.py

Manual check
- open / and /dashboard in live.web and confirm the CI Health companion deep link is visible
- open /watch, /watch/runs/{run_id}, and /sessions/{run_id} and confirm the same link is visible
- confirm wording remains read-only, separate-process, and no-shared-control-plane
