### PR TITLE
docs: HTTP path index for Operator WebUI and live.web

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,29 @@ RELOAD=1 ./scripts/ops/run_live_webui.sh
 | `python3 scripts/live_web_server.py` | 8000 | Empfohlen in Runbooks, CLI-Argumente |
 | `python -m scripts.serve_live_dashboard` | 8000 | Config aus `config/config.toml` |
 
+### HTTP-Routen — Operator-WebUI, Ops-Hub & live.web (Local Defaults)
+
+Ports **8000** (Operator-WebUI) und **8010** (live.web mit `scripts/ops/run_live_webui.sh`) sind **README-Defaults** auf `127.0.0.1`. Die Prozesse sind **getrennt**; es gibt **keine gemeinsame Control Plane**. Die Pfade dienen der **Orientierung** (read-only UI; keine Änderung an Ausführungs- oder Freigabesemantik).
+
+**Operator-WebUI** (Standard `http://127.0.0.1:8000`):
+
+- `/` — Haupt-Dashboard
+- `/ops` — Ops Cockpit
+- `/ops/stage1` — Stage1 Ops Dashboard
+- `/ops/workflows` — Ops-Workflow-Hub
+- `/ops/ci-health` — CI & Governance Health
+
+Weitere Einträge der Operator-WebUI-Navigation (u. a. Execution Watch, Alerts, R&D, Telemetry) sind in `templates/peak_trade_dashboard/base.html` als Pfade hinterlegt.
+
+**live.web** (Standard `http://127.0.0.1:8010` mit `scripts/ops/run_live_webui.sh`):
+
+- `/` und `/dashboard` — Live-Dashboard (Runs)
+- `/watch` — Watch-Übersicht
+- `/watch/runs/{run_id}` — Run-Detail (Watch)
+- `/sessions/{run_id}` — Alias zum gleichen Run-Detail
+
+Die Companion-Hinweise in live.web verlinken **lesend** auf die Operator-WebUI auf Port **8000** (Navigation only; siehe `src/live/web/app.py`).
+
 Details: [`docs/CLI_CHEATSHEET.md`](docs/CLI_CHEATSHEET.md#18-live-web-dashboard-phase-67), [`docs/LIVE_OPERATIONAL_RUNBOOKS.md`](docs/LIVE_OPERATIONAL_RUNBOOKS.md) Abschnitt 10d.
 
 ---

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -3,6 +3,30 @@
 - PR #999 — docs(grafana): fix DS_LOCAL uid templating in execution watch dashboard: docs/ops/PR_999_MERGE_LOG.md
 <!-- MERGE_LOG_EXAMPLES:END -->
 
+## HTTP path index — Operator WebUI & live.web (local defaults)
+
+Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.live.web.app` via `scripts/ops/run_live_webui.sh`) are **local defaults** on `127.0.0.1`. Processes are **separate**; there is **no shared control plane**. Paths below are for **orientation / navigation** (read-only UI posture; no change to execution or approval semantics).
+
+**Operator WebUI** (default `http://127.0.0.1:8000`):
+
+- `/` — main dashboard
+- `/ops` — Ops Cockpit (read-only, local artifacts)
+- `/ops/stage1` — Stage1 ops dashboard
+- `/ops/workflows` — Ops workflow hub
+- `/ops/ci-health` — CI & governance health panel
+
+Additional Operator WebUI nav targets (e.g. execution watch, alerts, R&D, telemetry) live in `templates/peak_trade_dashboard/base.html`.
+
+**live.web** (default `http://127.0.0.1:8010`):
+
+- `/` and `/dashboard` — live runs dashboard HTML
+- `/watch` — watch overview HTML
+- `/watch/runs/{run_id}` — run detail (watch)
+- `/sessions/{run_id}` — alias to the same run detail
+
+Companion strips in live.web point read-only at Operator WebUI on port **8000** (see `src/live/web/app.py`).
+
+For scripts and port notes, see the root [`README.md`](../../README.md) section **Web UI**.
 
 - `docs/ops/specs/OPS_SUITE_DASHBOARD_VNEXT_SPEC.md` — OPS Suite / Dashboard vNext Spezifikation
 - `docs/ops/runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md` — Phasenplan für spätere Umsetzung


### PR DESCRIPTION
Summary
- adds a compact HTTP path index for Operator WebUI, Ops Hub, and live.web
- improves route discoverability in both the root README and docs/ops/README.md
- keeps the change documentation-only with targeted docs-policy verification

What changed
- README.md
  - adds "HTTP-Routen — Operator-WebUI, Ops-Hub & live.web (Local Defaults)" under the Web UI section
- docs/ops/README.md
  - adds "HTTP path index — Operator WebUI & live.web (local defaults)"
  - points readers back to the root README Web UI section

Routes documented
- Operator WebUI default: http://127.0.0.1:8000
  - /
  - /ops
  - /ops/stage1
  - /ops/workflows
  - /ops/ci-health
- live.web default: http://127.0.0.1:8010
  - /
  - /dashboard
  - /watch
  - /watch/runs/{run_id}
  - /sessions/{run_id}

Documentation posture
- local defaults only
- separate processes
- no shared control plane
- read-only / orientation framing
- no runtime, UI, or backend behavior changes

Verification
- targeted DocsTokenPolicyValidator check for README.md and docs/ops/README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
