### PR TITLE
feat(live.web): companion link to Run UI 8010

### DIFF
--- a/src/live/web/app.py
+++ b/src/live/web/app.py
@@ -197,6 +197,13 @@ def _companion_operator_webui_hint_html_watch() -> str:
         "http://127.0.0.1:8000/ops/ci-health</a>"
         " · default local host/port per README; separate process; no shared control plane."
         "</div>"
+        "<div class='companion-strip'>"
+        "<strong>Run UI (companion navigation):</strong> separate Run-monitoring UI — "
+        "<a href='http://127.0.0.1:8010/' target='_blank' rel='noopener noreferrer'>"
+        "http://127.0.0.1:8010/</a>"
+        " · default local host/port per README (scripts/ops/run_live_webui.sh); "
+        "separate process from Operator WebUI; no shared control plane."
+        "</div>"
     )
 
 
@@ -415,6 +422,11 @@ def _generate_dashboard_html(
                     CI Health (companion navigation): read-only Operator WebUI —
                     <a href="http://127.0.0.1:8000/ops/ci-health" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000/ops/ci-health</a>
                     · default local host/port per README; separate process; no shared control plane.
+                </p>
+                <p class="companion-hint">
+                    Run UI (companion navigation): separate Run-monitoring UI —
+                    <a href="http://127.0.0.1:8010/" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8010/</a>
+                    · default local host/port per README (scripts/ops/run_live_webui.sh); separate process from Operator WebUI; no shared control plane.
                 </p>
             </div>
             <div class="status" id="status">Connecting...</div>

--- a/tests/test_live_web.py
+++ b/tests/test_live_web.py
@@ -521,6 +521,29 @@ class TestDashboardEndpoint:
             assert "companion navigation" in text.lower()
             assert "no shared control plane" in text.lower()
 
+    def test_dashboard_contains_run_ui_8010_deeplink(self, test_client: TestClient) -> None:
+        """Haupt-Dashboard (/ und /dashboard) enthält Companion-Link zur Run-UI-Default-URL 8010."""
+        for path in ("/", "/dashboard"):
+            response = test_client.get(path)
+            assert response.status_code == 200
+            text = response.text
+            assert "http://127.0.0.1:8010/" in text
+            assert "Run UI" in text
+            assert "companion navigation" in text.lower()
+            assert "separate process" in text.lower()
+
+    def test_watch_pages_contain_run_ui_8010_deeplink(self, test_client: TestClient) -> None:
+        """Watch-/Session-HTML enthält denselben Run-UI-8010-Companion wie das Haupt-Dashboard."""
+        run_id = "20251204_180000_paper_ma_crossover_BTC-EUR_1m"
+        for path in ("/watch", f"/watch/runs/{run_id}", f"/sessions/{run_id}"):
+            response = test_client.get(path)
+            assert response.status_code == 200
+            text = response.text
+            assert "http://127.0.0.1:8010/" in text
+            assert "Run UI" in text
+            assert "companion navigation" in text.lower()
+            assert "separate process" in text.lower()
+
     def test_dashboard_alias(self, test_client: TestClient) -> None:
         """Test Dashboard unter /dashboard."""
         response = test_client.get("/dashboard")


### PR DESCRIPTION
Summary
- adds a Run UI companion deep link to live.web main dashboard and watch/session companion areas
- improves companion symmetry by surfacing the default local Run UI entrypoint alongside the existing Operator WebUI links
- keeps the change limited to HTML rendering plus focused tests

What changed
- src/live/web/app.py
  - adds a Run UI companion block to _companion_operator_webui_hint_html_watch()
  - adds a Run UI companion hint paragraph to _generate_dashboard_html
- tests/test_live_web.py
  - adds test_dashboard_contains_run_ui_8010_deeplink
  - adds test_watch_pages_contain_run_ui_8010_deeplink

Visible UI details
- Run UI (companion navigation): separate Run-monitoring UI
- link: http://127.0.0.1:8010/
- wording includes:
  - default local host/port per README
  - scripts/ops/run_live_webui.sh
  - separate process from Operator WebUI
  - no shared control plane

Truth-first / safety posture
- navigation/discoverability only
- no new route
- no new API
- no backend or runtime changes
- no execution, gate, policy/guard, incident, or live-unlock semantics changes

Verification
- python3 -m pytest tests/test_live_web.py -q
- python3 -m ruff check src/live/web/app.py tests/test_live_web.py
- python3 -m ruff format --check src/live/web/app.py tests/test_live_web.py

Manual check
- open / and /dashboard in live.web and confirm the Run UI companion link is visible
- open /watch, /watch/runs/{run_id}, and /sessions/{run_id} and confirm the same link is visible
- confirm wording remains separate-process and no-shared-control-plane
