### PR TITLE
docs: README truth refresh for live.web companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Weitere Einträge der Operator-WebUI-Navigation (u. a. Execution Watch, Alerts, 
 - `/watch/runs/{run_id}` — Run-Detail (Watch)
 - `/sessions/{run_id}` — Alias zum gleichen Run-Detail
 
-Die Companion-Hinweise in live.web verlinken **lesend** auf die Operator-WebUI auf Port **8000** (Navigation only; siehe `src/live/web/app.py`).
+Die **Companion**-Hinweise in live.web (Haupt-Dashboard und Watch-/Session-HTML) verlinken **lesend** (Navigation only) auf **`http://127.0.0.1:8000/`**, **`http://127.0.0.1:8000/ops`**, **`http://127.0.0.1:8000/ops/ci-health`** und den Run-UI-Standard **`http://127.0.0.1:8010/`** — README-Default-Hosts/-Ports, **getrennte Prozesse**, **keine gemeinsame Control Plane** (Implementierung: `src/live/web/app.py`).
 
 Details: [`docs/CLI_CHEATSHEET.md`](docs/CLI_CHEATSHEET.md#18-live-web-dashboard-phase-67), [`docs/LIVE_OPERATIONAL_RUNBOOKS.md`](docs/LIVE_OPERATIONAL_RUNBOOKS.md) Abschnitt 10d.
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -24,7 +24,7 @@ Additional Operator WebUI nav targets (e.g. execution watch, alerts, R&D, teleme
 - `/watch/runs/{run_id}` — run detail (watch)
 - `/sessions/{run_id}` — alias to the same run detail
 
-Companion strips in live.web point read-only at Operator WebUI on port **8000** (see `src/live/web/app.py`).
+The live.web companion strips (main dashboard and watch/session HTML) are **read-only navigation** to **`http://127.0.0.1:8000/`**, **`http://127.0.0.1:8000/ops`**, **`http://127.0.0.1:8000/ops/ci-health`**, and the Run UI default **`http://127.0.0.1:8010/`** — local defaults per README, **separate processes**, **no shared control plane** (see `src/live/web/app.py`).
 
 For scripts and port notes, see the root [`README.md`](../../README.md) section **Web UI**.
 


### PR DESCRIPTION
Summary
- refreshes README.md and docs/ops/README.md so the live.web companion description matches the current repo state
- documents all four current companion targets instead of describing only the Operator WebUI root on port 8000
- keeps the change documentation-only with targeted docs-policy verification

What changed
- README.md
  - updates the live.web companion wording under the HTTP route index / Web UI area
- docs/ops/README.md
  - updates the matching companion wording for ops docs

Four documented companion targets
- http://127.0.0.1:8000/      Operator WebUI root
- http://127.0.0.1:8000/ops  Ops Cockpit
- http://127.0.0.1:8000/ops/ci-health  CI Health
- http://127.0.0.1:8010/     Run UI default

Documentation posture
- local defaults only
- read-only / navigation framing
- separate processes
- no shared control plane
- repo-truth aligned with src/live/web/app.py

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for README.md and docs/ops/README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
