### PR TITLE
docs: list secondary Operator WebUI nav paths in HTTP route index

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,12 @@ Ports **8000** (Operator-WebUI) und **8010** (live.web mit `scripts/ops/run_live
 - `/ops/workflows` — Ops-Workflow-Hub
 - `/ops/ci-health` — CI & Governance Health
 
-Weitere Einträge der Operator-WebUI-Navigation (u. a. Execution Watch, Alerts, R&D, Telemetry) sind in `templates/peak_trade_dashboard/base.html` als Pfade hinterlegt.
+**Weitere Operator-WebUI-Nav** (read-only; Anzeigenamen wie in der Kopfzeile: `templates/peak_trade_dashboard/base.html`):
+
+- `/execution_watch` — Execution Watch
+- `/live/alerts` — Alerts
+- `/r_and_d` — R&D Experiments
+- `/live/telemetry` — Telemetry
 
 **live.web** (Standard `http://127.0.0.1:8010` mit `scripts/ops/run_live_webui.sh`):
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -15,7 +15,12 @@ Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.li
 - `/ops/workflows` — Ops workflow hub
 - `/ops/ci-health` — CI & governance health panel
 
-Additional Operator WebUI nav targets (e.g. execution watch, alerts, R&D, telemetry) live in `templates/peak_trade_dashboard/base.html`.
+**Additional Operator WebUI nav** (read-only; labels as in the header: `templates/peak_trade_dashboard/base.html`):
+
+- `/execution_watch` — Execution Watch
+- `/live/alerts` — Alerts
+- `/r_and_d` — R&D Experiments
+- `/live/telemetry` — Telemetry
 
 **live.web** (default `http://127.0.0.1:8010`):
 


### PR DESCRIPTION
Summary
- extends the HTTP route index in README.md and docs/ops/README.md with secondary Operator WebUI navigation paths
- improves route discoverability for execution-watch, alerts, R&D, and telemetry pages
- keeps the change documentation-only with targeted docs-policy verification

What changed
- README.md
  - replaces the generic note about additional nav entries with a concrete list of secondary Operator WebUI paths
- docs/ops/README.md
  - adds the same compact secondary-nav list in English

Secondary Operator WebUI paths documented
- /execution_watch — Execution Watch
- /live/alerts — Alerts
- /r_and_d — R&D Experiments
- /live/telemetry — Telemetry

Documentation posture
- read-only / navigation framing
- labels aligned with templates/peak_trade_dashboard/base.html
- no runtime, UI, or backend behavior changes

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for README.md and docs/ops/README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
