### PR TITLE
docs: add Operator WebUI secondary paths and HTTP index pointers in CLI cheatsheet §18

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -676,6 +676,17 @@ python3 scripts/live_web_server.py --reload
 - Run-Events (JSON): `http://localhost:8000/runs/{run_id}/tail?limit=100`
 - Live Alerts (JSON): `http://localhost:8000/runs/{run_id}/alerts?limit=20`
 
+**Operator WebUI** (read-only; **separater Prozess** gegenüber live.web — README-Defaults: Operator `http://127.0.0.1:8000`, live.web `http://127.0.0.1:8010` mit `scripts/ops/run_live_webui.sh`):
+
+Sekundäre Navigationspfade:
+
+- `/execution_watch` — Execution Watch
+- `/live/alerts` — Alerts
+- `/r_and_d` — R&D Experiments
+- `/live/telemetry` — Telemetry
+
+Vollständiger HTTP-Route-Index (Operator-WebUI und live.web): [`README.md`](../README.md), [`docs/ops/README.md`](ops/README.md).
+
 **Siehe:** [`LIVE_OPERATIONAL_RUNBOOKS.md`](LIVE_OPERATIONAL_RUNBOOKS.md) Abschnitt 10d für Details.
 
 ---


### PR DESCRIPTION
Summary
- extends CLI cheatsheet section 18 with secondary Operator WebUI navigation paths
- adds a compact pointer to the full HTTP route index in README.md and docs/ops/README.md
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/CLI_CHEATSHEET.md
  - adds an Operator WebUI note under section 18
  - documents these secondary paths:
    - /execution_watch
    - /live/alerts
    - /r_and_d
    - /live/telemetry
  - points readers to:
    - README.md
    - docs/ops/README.md

Documentation posture
- read-only / navigation framing
- Operator WebUI and live.web described as separate processes
- local defaults 8000 / 8010 referenced
- no runtime, UI, or backend behavior changes

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/CLI_CHEATSHEET.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
