### PR TITLE
docs: add HTTP route crosslinks in live web runbook §10d

### DIFF
--- a/docs/LIVE_OPERATIONAL_RUNBOOKS.md
+++ b/docs/LIVE_OPERATIONAL_RUNBOOKS.md
@@ -1486,6 +1486,8 @@ Nach dem Start sind folgende URLs verfügbar:
 - **Run-Events (JSON):** `http://localhost:8000/runs/{run_id}/tail?limit=100`
 - **Run-Alerts (JSON):** `http://localhost:8000/runs/{run_id}/alerts?limit=20`
 
+**Kanonische HTTP-/Route-Orientierung:** Operator-WebUI und live.web laufen **getrennt** (README-Defaults z. B. `127.0.0.1:8000` für die Operator-WebUI, `127.0.0.1:8010` für live.web mit `scripts/ops/run_live_webui.sh`). Vollständige Pfadlisten: [`README.md`](../README.md), [`docs/ops/README.md`](ops/README.md). Kompakte Schnellübersicht für Operator:innen: [`docs/CLI_CHEATSHEET.md`](CLI_CHEATSHEET.md#18-live-web-dashboard-phase-67) (Abschnitt 18).
+
 ### 10d.4 API-Endpunkte
 
 **GET /health**


### PR DESCRIPTION
Summary
- adds compact HTTP route crosslinks to the live web operational runbook section 10d
- points operators to the canonical route index in README.md and docs/ops/README.md
- points to docs/CLI_CHEATSHEET.md section 18 for quick operator navigation
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/LIVE_OPERATIONAL_RUNBOOKS.md
  - adds a compact crosslink paragraph in section 10d.3
  - clarifies separate processes and local defaults
  - links to:
    - README.md
    - docs/ops/README.md
    - docs/CLI_CHEATSHEET.md#18-live-web-dashboard-phase-67

Documentation posture
- read-only / navigation framing
- Operator WebUI and live.web described as separate processes
- local defaults 8000 / 8010 referenced
- no runtime, UI, or backend behavior changes

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/LIVE_OPERATIONAL_RUNBOOKS.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
