### PR TITLE
docs: add /session/{session_id} to HTTP route index in README and ops docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Ports **8000** (Operator-WebUI) und **8010** (live.web mit `scripts/ops/run_live
 - `/ops/stage1` — Stage1 Ops Dashboard
 - `/ops/workflows` — Ops-Workflow-Hub
 - `/ops/ci-health` — CI & Governance Health
+- `/session/{session_id}` — Session-Detail (HTML, read-only)
 
 **Weitere Operator-WebUI-Nav** (read-only; Anzeigenamen wie in der Kopfzeile: `templates/peak_trade_dashboard/base.html`):
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -14,6 +14,7 @@ Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.li
 - `/ops/stage1` — Stage1 ops dashboard
 - `/ops/workflows` — Ops workflow hub
 - `/ops/ci-health` — CI & governance health panel
+- `/session/{session_id}` — session detail HTML (read-only)
 
 **Additional Operator WebUI nav** (read-only; labels as in the header: `templates/peak_trade_dashboard/base.html`):
 


### PR DESCRIPTION
Summary
- adds /session/{session_id} to the compact HTTP route index in README.md and docs/ops/README.md
- documents the existing read-only HTML session detail page
- keeps the change documentation-only with targeted docs-policy verification

What changed
- README.md
  - adds:
    - /session/{session_id} — Session-Detail (HTML, read-only)
- docs/ops/README.md
  - adds:
    - /session/{session_id} — session detail HTML (read-only)

Documentation posture
- read-only / route-discoverability only
- repo-truth aligned with src/webui/app.py
- no runtime, UI, or backend behavior changes

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for README.md and docs/ops/README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
