### PR TITLE
docs: add /api/v0 teaser to live web runbook §10d

### DIFF
--- a/docs/LIVE_OPERATIONAL_RUNBOOKS.md
+++ b/docs/LIVE_OPERATIONAL_RUNBOOKS.md
@@ -1515,6 +1515,16 @@ Nach dem Start sind folgende URLs verfügbar:
 - Response: Liste von Alerts (rule_id, severity, message, run_id, timestamp)
 - HTTP 404 wenn Run nicht gefunden
 
+**Zusätzlich: read-only JSON unter `/api/v0` (Watch-/Status-Zugriff)**
+
+Unabhängig von den obigen **Legacy**-Pfaden (`/runs`, … — gleicher live.web-Prozess wie in §10d.3) existiert ein weiterer **read-only**-JSON-Baum mit Präfix **`/api/v0`**, den die Watch-/Dashboard-Oberfläche u. a. per `fetch` nutzt. Kanonische Implementierung: [`src/live/web/api_v0.py`](../src/live/web/api_v0.py). Beispiele (Auszug, nicht vollständig):
+
+- `GET &#47;api&#47;v0&#47;health`
+- `GET &#47;api&#47;v0&#47;runs`
+- `GET &#47;api&#47;v0&#47;runs&#47;{run_id}`
+
+Nur Lesen/Beobachten — keine Order-Erzeugung und kein Start/Stop über diese Oberfläche.
+
 ### 10d.5 Dashboard-Features
 
 Das HTML-Dashboard bietet:


### PR DESCRIPTION
Summary
- adds a small /api/v0 teaser to the live web runbook section 10d
- clarifies that live.web exposes an additional read-only /api/v0 JSON tree alongside the legacy /runs paths
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/LIVE_OPERATIONAL_RUNBOOKS.md
  - adds a short read-only /api/v0 note after the legacy GET examples in section 10d.4
  - points to src/live/web/api_v0.py as the canonical code source
  - includes a small set of stable GET examples:
    - /api/v0/health
    - /api/v0/runs
    - /api/v0/runs/{run_id}

Documentation posture
- read-only / observation framing
- no order creation
- no start/stop semantics
- no runtime, UI, or backend behavior changes

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/LIVE_OPERATIONAL_RUNBOOKS.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
