### PR TITLE
docs: mention live.web /api/v0 JSON in README and ops HTTP index

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ Ports **8000** (Operator-WebUI) und **8010** (live.web mit `scripts/ops/run_live
 - `/watch/runs/{run_id}` — Run-Detail (Watch)
 - `/sessions/{run_id}` — Alias zum gleichen Run-Detail
 
+Zusätzlich stellt live.web **read-only** JSON unter dem Präfix **`/api/v0`** bereit (u. a. für Watch-/Status-Zugriff); Details und Beispiele: [`docs/LIVE_OPERATIONAL_RUNBOOKS.md`](docs/LIVE_OPERATIONAL_RUNBOOKS.md) (Abschnitt 10d.4), Implementierung: [`src/live/web/api_v0.py`](src/live/web/api_v0.py).
+
 Die **Companion**-Hinweise in live.web (Haupt-Dashboard und Watch-/Session-HTML) verlinken **lesend** (Navigation only) auf **`http://127.0.0.1:8000/`**, **`http://127.0.0.1:8000/ops`**, **`http://127.0.0.1:8000/ops/ci-health`** und den Run-UI-Standard **`http://127.0.0.1:8010/`** — README-Default-Hosts/-Ports, **getrennte Prozesse**, **keine gemeinsame Control Plane** (Implementierung: `src/live/web/app.py`).
 
 Details: [`docs/CLI_CHEATSHEET.md`](docs/CLI_CHEATSHEET.md#18-live-web-dashboard-phase-67), [`docs/LIVE_OPERATIONAL_RUNBOOKS.md`](docs/LIVE_OPERATIONAL_RUNBOOKS.md) Abschnitt 10d.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -30,6 +30,8 @@ Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.li
 - `/watch/runs/{run_id}` — run detail (watch)
 - `/sessions/{run_id}` — alias to the same run detail
 
+live.web also exposes **read-only** JSON under the **`/api/v0`** prefix (watch/status API); details and examples: [`LIVE_OPERATIONAL_RUNBOOKS.md`](../LIVE_OPERATIONAL_RUNBOOKS.md) (section 10d.4), implementation: [`src/live/web/api_v0.py`](../../src/live/web/api_v0.py).
+
 The live.web companion strips (main dashboard and watch/session HTML) are **read-only navigation** to **`http://127.0.0.1:8000/`**, **`http://127.0.0.1:8000/ops`**, **`http://127.0.0.1:8000/ops/ci-health`**, and the Run UI default **`http://127.0.0.1:8010/`** — local defaults per README, **separate processes**, **no shared control plane** (see `src/live/web/app.py`).
 
 For scripts and port notes, see the root [`README.md`](../../README.md) section **Web UI**.


### PR DESCRIPTION
Summary
- adds a compact live.web /api/v0 note to README.md and docs/ops/README.md
- mirrors the existing runbook documentation without expanding the short HTTP index into a full API section
- keeps the change documentation-only with targeted docs-policy verification

What changed
- README.md
  - adds a short note after the live.web HTML route bullets
  - points to docs/LIVE_OPERATIONAL_RUNBOOKS.md section 10d.4
  - points to src/live/web/api_v0.py as the implementation source
- docs/ops/README.md
  - adds the same short /api/v0 note in the ops HTTP path index

Documentation posture
- read-only / watch-status API framing
- no runtime, UI, or backend behavior changes
- keeps the HTTP index compact and scanable

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for README.md and docs/ops/README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
