### PR TITLE
docs: add /api/v0 pointer to CLI cheatsheet section 18

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -687,6 +687,8 @@ Sekundäre Navigationspfade:
 
 Vollständiger HTTP-Route-Index (Operator-WebUI und live.web): [`README.md`](../README.md), [`docs/ops/README.md`](ops/README.md).
 
+Zusätzlich stellt live.web **read-only** JSON unter dem Präfix **`/api/v0`** bereit (u. a. für Watch-/Status-Zugriff); Details und Beispiele: [`LIVE_OPERATIONAL_RUNBOOKS.md`](LIVE_OPERATIONAL_RUNBOOKS.md) (Abschnitt 10d.4), Implementierung [`src/live/web/api_v0.py`](../src/live/web/api_v0.py).
+
 **Siehe:** [`LIVE_OPERATIONAL_RUNBOOKS.md`](LIVE_OPERATIONAL_RUNBOOKS.md) Abschnitt 10d für Details.
 
 ---


### PR DESCRIPTION
Summary
- adds a compact /api/v0 pointer to CLI cheatsheet section 18
- aligns the cheatsheet with the existing runbook and README/docs/ops live.web API notes
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/CLI_CHEATSHEET.md
  - adds a short note that live.web also exposes read-only JSON under /api/v0
  - points readers to:
    - LIVE_OPERATIONAL_RUNBOOKS.md section 10d.4
    - src/live/web/api_v0.py

Documentation posture
- read-only / watch-status API framing
- no runtime, UI, or backend behavior changes
- keeps section 18 compact and scanable

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/CLI_CHEATSHEET.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
