### PR TITLE
docs: add R&D nested HTML routes to HTTP route index

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Ports **8000** (Operator-WebUI) und **8010** (live.web mit `scripts/ops/run_live
 - `/execution_watch` — Execution Watch
 - `/live/alerts` — Alerts
 - `/r_and_d` — R&D Experiments
+- `/r_and_d/experiment/{run_id}` — R&D Experiment-Detail (HTML, read-only)
+- `/r_and_d/comparison` — R&D Multi-Run-Vergleich (HTML, read-only)
 - `/live/telemetry` — Telemetry
 
 **live.web** (Standard `http://127.0.0.1:8010` mit `scripts/ops/run_live_webui.sh`):

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -21,6 +21,8 @@ Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.li
 - `/execution_watch` — Execution Watch
 - `/live/alerts` — Alerts
 - `/r_and_d` — R&D Experiments
+- `/r_and_d/experiment/{run_id}` — R&D experiment detail HTML (read-only)
+- `/r_and_d/comparison` — R&D multi-run comparison HTML (read-only)
 - `/live/telemetry` — Telemetry
 
 **live.web** (default `http://127.0.0.1:8010`):


### PR DESCRIPTION
Summary
- adds the nested R&D HTML routes to the compact HTTP route index in README.md and docs/ops/README.md
- improves discoverability for the existing R&D experiment detail and multi-run comparison pages
- keeps the change documentation-only with targeted docs-policy verification

What changed
- README.md
  - adds:
    - /r_and_d/experiment/{run_id} — R&D Experiment-Detail (HTML, read-only)
    - /r_and_d/comparison — R&D Multi-Run-Vergleich (HTML, read-only)
- docs/ops/README.md
  - adds:
    - /r_and_d/experiment/{run_id} — R&D experiment detail HTML (read-only)
    - /r_and_d/comparison — R&D multi-run comparison HTML (read-only)

Documentation posture
- read-only / route-discoverability only
- repo-truth aligned with src/webui/app.py
- no runtime, UI, or backend behavior changes

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for README.md and docs/ops/README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
