### PR TITLE
docs(cli): add R&D nested HTML paths to cheatsheet section 18

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -683,6 +683,8 @@ Sekundäre Navigationspfade:
 - `/execution_watch` — Execution Watch
 - `/live/alerts` — Alerts
 - `/r_and_d` — R&D Experiments
+- `/r_and_d/experiment/{run_id}` — R&D Experiment-Detail (HTML, read-only)
+- `/r_and_d/comparison` — R&D Multi-Run-Vergleich (HTML, read-only)
 - `/live/telemetry` — Telemetry
 
 Vollständiger HTTP-Route-Index (Operator-WebUI und live.web): [`README.md`](../README.md), [`docs/ops/README.md`](ops/README.md).


### PR DESCRIPTION
Summary
- adds the nested R&D HTML routes to CLI cheatsheet section 18
- aligns the cheatsheet with README.md and docs/ops/README.md
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/CLI_CHEATSHEET.md
  - adds:
    - /r_and_d/experiment/{run_id} — R&D Experiment-Detail (HTML, read-only)
    - /r_and_d/comparison — R&D Multi-Run-Vergleich (HTML, read-only)

Documentation posture
- read-only / route-discoverability only
- repo-truth aligned with src/webui/app.py
- no runtime, UI, or backend behavior changes

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/CLI_CHEATSHEET.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q

Made with [Cursor](https://cursor.com)