### PR TITLE
ci: fail cursor auto-PR when required workflow dispatch fails

### DIFF
--- a/.github/workflows/cursor_auto_pr.yml
+++ b/.github/workflows/cursor_auto_pr.yml
@@ -68,7 +68,10 @@ jobs:
                   });
                   core.info(`dispatched ${w.id} on ${head} (PR exists)`);
                 } catch (e) {
-                  core.warning(`failed dispatch ${w.id}: ${e.message}`);
+                  const detail = e?.response?.data?.message || e?.message || String(e);
+                  throw new Error(
+                    `createWorkflowDispatch failed: workflow_id=${w.id} ref=${head}: ${detail}`
+                  );
                 }
               }
               return;
@@ -154,7 +157,10 @@ jobs:
                 });
                 core.info(`dispatched ${w.id} on ${ref}`);
               } catch (e) {
-                core.warning(`failed dispatch ${w.id}: ${e.message}`);
+                const detail = e?.response?.data?.message || e?.message || String(e);
+                throw new Error(
+                  `createWorkflowDispatch failed: workflow_id=${w.id} ref=${ref}: ${detail}`
+                );
               }
             }
 


### PR DESCRIPTION
Summary
- makes cursor_auto_pr fail fast when createWorkflowDispatch fails
- prevents false-green auto-PR runs that leave required checks missing on the PR
- keeps the fix scoped to cursor_auto_pr only

What changed
- .github/workflows/cursor_auto_pr.yml
  - updates both createWorkflowDispatch catch blocks
  - replaces warning-only behavior with an explicit thrown error
  - includes workflow_id and ref in the failure path
  - includes API message text when available

Behavior change
- before:
  - dispatch failures were logged as warnings
  - step/job could stay green even though required workflow dispatch never happened
- after:
  - dispatch failure makes the step/job fail
  - missing required-check dispatch is surfaced immediately in Actions

Scope / non-goals
- no change to trigger definitions
- no change to branch-protection context names
- no change to workflow lists
- no change to other workflows

Verification
- python3 YAML parse of .github/workflows/cursor_auto_pr.yml
- manual diff review of the single workflow file

Why this is the smallest fix
- the root-cause analysis showed required checks were missing while cursor_auto_pr still passed
- failing on dispatch error is the minimal behavior change that makes the problem visible at the source

Made with [Cursor](https://cursor.com)