### PR TITLE
ci: single workflow_dispatch pass per cursor auto-PR run

### DIFF
--- a/.github/workflows/cursor_auto_pr.yml
+++ b/.github/workflows/cursor_auto_pr.yml
@@ -46,34 +46,9 @@ jobs:
 
             if (prs.data.length > 0) {
               core.info(`EXISTS: PR #${prs.data[0].number} ${prs.data[0].html_url}`);
-              // Still dispatch required checks so docs-only PRs get all required contexts
-              const workflows = [
-                { id: 'ci.yml', inputs: { force_matrix: 'true' } },
-                { id: 'lint_gate.yml' },
-                { id: 'policy_critic_gate.yml' },
-                { id: 'policy_tracked_reports_guard.yml' },
-                { id: 'audit.yml' },
-                { id: 'ci-workflow-dispatch-guard.yml' },
-                { id: 'docs-token-policy-gate.yml' },
-                { id: 'docs_reference_targets_gate.yml' },
-                { id: 'truth_gates_pr.yml' },
-              ];
-              for (const w of workflows) {
-                try {
-                  await github.rest.actions.createWorkflowDispatch({
-                    owner, repo,
-                    workflow_id: w.id,
-                    ref: head,
-                    inputs: w.inputs || {}
-                  });
-                  core.info(`dispatched ${w.id} on ${head} (PR exists)`);
-                } catch (e) {
-                  const detail = e?.response?.data?.message || e?.message || String(e);
-                  throw new Error(
-                    `createWorkflowDispatch failed: workflow_id=${w.id} ref=${head}: ${detail}`
-                  );
-                }
-              }
+              core.info(
+                "Required workflows are dispatched once in the next step only (avoids duplicate ci.yml / concurrency cancel)."
+              );
               return;
             }
 
@@ -134,6 +109,8 @@ jobs:
             const owner = context.repo.owner;
             const repo  = context.repo.repo;
             const ref   = context.ref.replace('refs/heads/', '');
+
+            core.info("Single workflow_dispatch sequence for required checks (one pass per cursor_auto_pr run).");
 
             const workflows = [
               { id: 'ci.yml', inputs: { force_matrix: 'true' } },


### PR DESCRIPTION
Summary
- makes cursor_auto_pr dispatch required workflows only once per run
- removes the duplicate dispatch sequence for already-open PRs
- keeps the existing fail-on-error behavior for dispatch failures

What changed
- .github/workflows/cursor_auto_pr.yml
  - in the "PR already exists" path, the first script block no longer dispatches required workflows
  - dispatches now happen only in the later "Dispatch required checks" step
  - existing throw-on-dispatch-failure behavior remains in place
  - adds a log hint clarifying that dispatch happens only once in the dedicated step

Behavior change
- before:
  - existing PR path could dispatch the same workflow set twice in one run
  - this created duplicate workflow_dispatch calls, including duplicate ci.yml runs
  - with cancel-in-progress behavior, duplicate dispatches could cancel each other and make required checks unreliable
- after:
  - each cursor_auto_pr run performs exactly one workflow_dispatch pass
  - duplicate dispatches for the same push are avoided
  - dispatch failures still fail the job immediately

Scope / non-goals
- no change to branch-protection context names
- no change to other workflow files
- no change to workflow lists beyond removing the duplicate pass
- no change to docs or product code

Verification
- python3 YAML parse of .github/workflows/cursor_auto_pr.yml
- manual diff review of the single workflow file

Why this is the smallest fix
- the post-fix root-cause analysis pointed to duplicate dispatches as the most plausible remaining cause
- removing the duplicate pass is the narrowest change that addresses that cause directly
