### PR TITLE
docs(ops): cursor_auto_pr single-dispatch truth blurb

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -38,6 +38,8 @@ The live.web companion strips (main dashboard and watch/session HTML) are **read
 
 For scripts and port notes, see the root [`README.md`](../../README.md) section **Web UI**.
 
+**Cursor Auto-PR (`feat&#47;**` → `main`):** On pushes to `feat&#47;**`, [`.github/workflows/cursor_auto_pr.yml`](../../.github/workflows/cursor_auto_pr.yml) runs. Each workflow run performs **one** `workflow_dispatch` pass for required checks (the "Dispatch required checks" step); when an open PR already exists, the first step only logs and does **not** dispatch again, so there is no duplicate dispatch sequence in the same run (post–PR #2475).
+
 - `docs/ops/specs/OPS_SUITE_DASHBOARD_VNEXT_SPEC.md` — OPS Suite / Dashboard vNext Spezifikation
 - `docs/ops/runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md` — Phasenplan für spätere Umsetzung
 - `docs/ops/specs/PILOT_READY_EXECUTION_REVIEW_SPEC.md` — Pilot-Ready Execution Review Spezifikation


### PR DESCRIPTION
Summary
- adds a short ops-index note documenting the current cursor_auto_pr single-dispatch behavior
- clarifies that each cursor_auto_pr run performs one workflow_dispatch pass for required checks
- clarifies that the PR-exists path no longer dispatches a second time in the same run after PR #2475

What changed
- docs/ops/README.md
  - adds a compact truth-first note for Cursor Auto-PR on feat/** -> main
  - links to .github/workflows/cursor_auto_pr.yml

Documented behavior
- on pushes to feat/**, cursor_auto_pr runs
- each workflow run performs one workflow_dispatch pass for required checks
- when an open PR already exists, the first step logs only and does not dispatch again
- this avoids duplicate dispatch sequences in the same run
- behavior reflects the post-PR #2475 state

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/ops/README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
