### PR TITLE
ui(dashboard): align base.html title with v1.2 badge

### DIFF
--- a/templates/peak_trade_dashboard/base.html
+++ b/templates/peak_trade_dashboard/base.html
@@ -3,7 +3,7 @@
 <html lang="de">
   <head>
     <meta charset="utf-8" />
-    <title>Peak_Trade Dashboard v1.1</title>
+    <title>Peak_Trade Dashboard v1.2</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Tailwind über CDN für schnelles Styling -->
     <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
Summary
- aligns the HTML <title> in templates/peak_trade_dashboard/base.html with the visible v1.2 badge
- removes the remaining v1.1/v1.2 drift in the shared dashboard shell
- keeps the change to a single template line with no runtime or routing changes

What changed
- templates/peak_trade_dashboard/base.html
  - before: <title>Peak_Trade Dashboard v1.1</title>
  - after:  <title>Peak_Trade Dashboard v1.2</title>

Scope / non-goals
- no routing changes
- no payload changes
- no runtime changes
- no additional template edits beyond the title line

Verification
- python3 -m pytest tests/test_webui_live_track.py::TestDashboardRendering::test_dashboard_returns_200 -q
