### PR TITLE
ui(dashboard): align index footer version with v1.2

### DIFF
--- a/templates/peak_trade_dashboard/index.html
+++ b/templates/peak_trade_dashboard/index.html
@@ -916,7 +916,7 @@
 
 <section class="mt-8 text-xs text-slate-500 flex items-center justify-between">
   <p>
-    Dashboard v1.1 – read-only Session Explorer · Shadow/Testnet Mode
+    Dashboard v1.2 – read-only Session Explorer · Shadow/Testnet Mode
   </p>
   <p>
     API:


### PR DESCRIPTION
Summary
- aligns the visible Session Explorer footer line in templates/peak_trade_dashboard/index.html from v1.1 to v1.2
- removes the remaining visible version drift after the base.html v1.2 alignment
- keeps the change to a single template line with no runtime or routing changes

What changed
- templates/peak_trade_dashboard/index.html
  - before: Dashboard v1.1 – read-only Session Explorer · Shadow/Testnet Mode
  - after:  Dashboard v1.2 – read-only Session Explorer · Shadow/Testnet Mode

Scope / non-goals
- no routing changes
- no payload changes
- no runtime changes
- no test changes were needed

Verification
- python3 -m pytest tests/test_webui_live_track.py::TestDashboardRendering::test_dashboard_returns_200 tests/test_webui_live_track.py::TestDashboardWithFilters::test_dashboard_session_explorer_title -q
