### PR TITLE
ui(r-and-d): align experiments hub subtitle to v1.2

### DIFF
--- a/templates/peak_trade_dashboard/r_and_d_experiments.html
+++ b/templates/peak_trade_dashboard/r_and_d_experiments.html
@@ -160,7 +160,7 @@
           <div>
             <h1 class="text-2xl font-bold text-slate-100">R&D Experiments Hub</h1>
             <p class="text-sm text-slate-400 mt-0.5">
-              Zentrale Übersicht für Research & Development · v1.1
+              Zentrale Übersicht für Research & Development · v1.2
             </p>
           </div>
         </div>

--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -655,7 +655,7 @@ class TestRAndDExperimentsPageV11:
         resp = client.get("/r_and_d")
         assert resp.status_code == 200
         assert "R&D Experiments Hub" in resp.text
-        assert "v1.1" in resp.text
+        assert "v1.2" in resp.text
 
     def test_page_shows_daily_summary(self, client):
         """Page zeigt Daily Summary (v1.1)."""


### PR DESCRIPTION
Summary
- aligns the visible R&D Experiments hub subtitle from v1.1 to v1.2
- updates the matching explicit assertion in tests/test_r_and_d_api.py
- keeps the change minimal with no runtime or routing changes

What changed
- templates/peak_trade_dashboard/r_and_d_experiments.html
  - before: Zentrale Übersicht für Research & Development · v1.1
  - after:  Zentrale Übersicht für Research & Development · v1.2
- tests/test_r_and_d_api.py
  - updates the explicit header assertion from v1.1 to v1.2

Scope / non-goals
- no routing changes
- no payload changes
- no runtime changes
- no broader test changes beyond the matching assertion

Verification
- python3 -m pytest tests/test_r_and_d_api.py::TestRAndDExperimentsPageV11::test_page_shows_hub_header -q
