### PR TITLE
docs(ops): truth-map changelog for PR #2477–#2479

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -69,6 +69,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 - 2026-04-10 — LB-APR-001: `docs/ops/LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md` ergänzt (externes „Account Type“ vs. interne Kontexte; Draft-/Approval-Hilfe; kein technischer Unlock; keine Live-Freigabe impliziert); Pointer in diesem Abschnitt.
 
+- 2026-04-10 — PR #2477–#2479: sichtbare Dashboard-v1.2-Strings in `templates/peak_trade_dashboard/base.html` (`<title>`), `templates/peak_trade_dashboard/index.html` (Session-Explorer-Fußzeile), `templates/peak_trade_dashboard/r_and_d_experiments.html` (R&D-Hub-Unterzeile); `tests/test_r_and_d_api.py` angepasst (#2479); reine Template-/Test-Kohärenz; keine Routing-/Laufzeit-Änderung; kein technischer Unlock.
+
 - 2026-04-09 — LB-APR-001: `DOCS_TRUTH_MAP.md` ergänzt um kanonischen Auffindbarkeits-Hinweis auf `docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md` (externe Freigabe-Hülle / Arbeitshilfe; kein technischer Unlock; keine Live-Freigabe impliziert).
 
 - 2026-04-09 — LB-EXE-001 Phase 2 updated `docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` to record deny-by-default guard hardening around `src/execution/networked/transport_gate_v1.py` and related networked guard tests; no live approval or outbound execution unlock implied.


### PR DESCRIPTION
Summary
- adds one truth-map changelog line for the dashboard v1.2 alignment PRs #2477–#2479
- records the repo-truth that the visible v1.2 strings were aligned across base shell, index footer, and R&D hub subtitle
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/ops/registry/DOCS_TRUTH_MAP.md
  - adds one bullet under "Änderungsnachweis (Slice A)" covering:
    - PR #2477: base.html title -> v1.2
    - PR #2478: index footer -> v1.2
    - PR #2479: R&D hub subtitle -> v1.2 and matching test assertion update

Documentation posture
- truth-first changelog only
- no routing changes
- no runtime changes
- no technical unlock implications

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/ops/registry/DOCS_TRUTH_MAP.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
