### PR TITLE
test(r-and-d): rename R&D hub HTML test class to V12

### DIFF
--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -647,8 +647,8 @@ class TestAPICategoriesEndpoint:
         assert "backtest" in data["run_type_labels"]
 
 
-class TestRAndDExperimentsPageV11:
-    """Tests für v1.1 Features der HTML-Page."""
+class TestRAndDExperimentsPageV12:
+    """Tests für sichtbare R&D Hub HTML-Seite (v1.2-Strings)."""
 
     def test_page_shows_hub_header(self, client):
         """Page zeigt R&D Hub Header (v1.1)."""


### PR DESCRIPTION
Summary
- renames the R&D hub HTML test class from V11 to V12
- aligns the test naming and docstring with the already visible v1.2 hub strings
- keeps the change test-only with no production code or assertion changes

What changed
- tests/test_r_and_d_api.py
  - renames:
    - TestRAndDExperimentsPageV11
    - to TestRAndDExperimentsPageV12
  - updates the class docstring to reflect the v1.2-visible hub reality

Scope / non-goals
- no production code changes
- no routing changes
- no payload changes
- no assertion logic changes

Verification
- python3 -m pytest tests/test_r_and_d_api.py::TestRAndDExperimentsPageV12::test_page_shows_hub_header -q
- python3 -m pytest tests/test_r_and_d_api.py::TestRAndDExperimentsPageV12 -q
