### PR TITLE
test(r-and-d): align V12 hub method docstrings to v1.2

### DIFF
--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -651,32 +651,32 @@ class TestRAndDExperimentsPageV12:
     """Tests für sichtbare R&D Hub HTML-Seite (v1.2-Strings)."""
 
     def test_page_shows_hub_header(self, client):
-        """Page zeigt R&D Hub Header (v1.1)."""
+        """Page zeigt R&D Hub Header (v1.2)."""
         resp = client.get("/r_and_d")
         assert resp.status_code == 200
         assert "R&D Experiments Hub" in resp.text
         assert "v1.2" in resp.text
 
     def test_page_shows_daily_summary(self, client):
-        """Page zeigt Daily Summary (v1.1)."""
+        """Page zeigt Daily Summary (v1.2)."""
         resp = client.get("/r_and_d")
         assert resp.status_code == 200
         assert "Heute fertig" in resp.text or "heute" in resp.text.lower()
 
     def test_page_shows_status_column(self, client):
-        """Page zeigt Status-Spalte (v1.1)."""
+        """Page zeigt Status-Spalte (v1.2)."""
         resp = client.get("/r_and_d")
         assert resp.status_code == 200
         assert "Status" in resp.text
 
     def test_page_shows_type_column(self, client):
-        """Page zeigt Type-Spalte (v1.1)."""
+        """Page zeigt Type-Spalte (v1.2)."""
         resp = client.get("/r_and_d")
         assert resp.status_code == 200
         assert "Type" in resp.text
 
     def test_page_has_run_type_filter(self, client):
-        """Page hat Run-Type Filter (v1.1)."""
+        """Page hat Run-Type Filter (v1.2)."""
         resp = client.get("/r_and_d")
         assert resp.status_code == 200
         assert "Run-Type" in resp.text or "run_type" in resp.text


### PR DESCRIPTION
Summary
- updates the remaining V12 R&D hub test method docstrings from v1.1 to v1.2
- aligns method-level test descriptions with the already renamed V12 class and the visible v1.2 hub strings
- keeps the change test-only with no assertion or production changes

What changed
- tests/test_r_and_d_api.py
  - updates these method docstrings to v1.2:
    - test_page_shows_hub_header
    - test_page_shows_daily_summary
    - test_page_shows_status_column
    - test_page_shows_type_column
    - test_page_has_run_type_filter

Scope / non-goals
- no production code changes
- no routing changes
- no payload changes
- no assertion logic changes

Verification
- python3 -m pytest tests/test_r_and_d_api.py::TestRAndDExperimentsPageV12 -q
