### PR TITLE
docs(ops): truth-map changelog for PR #2481–#2482

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -71,6 +71,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 - 2026-04-10 — PR #2477–#2479: sichtbare Dashboard-v1.2-Strings in `templates/peak_trade_dashboard/base.html` (`<title>`), `templates/peak_trade_dashboard/index.html` (Session-Explorer-Fußzeile), `templates/peak_trade_dashboard/r_and_d_experiments.html` (R&D-Hub-Unterzeile); `tests/test_r_and_d_api.py` angepasst (#2479); reine Template-/Test-Kohärenz; keine Routing-/Laufzeit-Änderung; kein technischer Unlock.
 
+- 2026-04-10 — PR #2481–#2482: `tests/test_r_and_d_api.py` — R&D-Hub-HTML-Testklasse `TestRAndDExperimentsPageV11` → `TestRAndDExperimentsPageV12` und Klassen-Docstring (#2481); Methoden-Docstrings in `TestRAndDExperimentsPageV12` auf v1.2 (#2482); reine Test-/Naming-Hygiene; keine Produktionscode-Änderung; kein technischer Unlock.
+
 - 2026-04-09 — LB-APR-001: `DOCS_TRUTH_MAP.md` ergänzt um kanonischen Auffindbarkeits-Hinweis auf `docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md` (externe Freigabe-Hülle / Arbeitshilfe; kein technischer Unlock; keine Live-Freigabe impliziert).
 
 - 2026-04-09 — LB-EXE-001 Phase 2 updated `docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` to record deny-by-default guard hardening around `src/execution/networked/transport_gate_v1.py` and related networked guard tests; no live approval or outbound execution unlock implied.


### PR DESCRIPTION
Summary
- adds one truth-map changelog line for the R&D test hygiene PRs #2481–#2482
- records the repo-truth that the R&D hub test class/name/docstrings were aligned to the visible V12/v1.2 reality
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/ops/registry/DOCS_TRUTH_MAP.md
  - adds one bullet under "Änderungsnachweis (Slice A)" covering:
    - PR #2481: TestRAndDExperimentsPageV11 -> TestRAndDExperimentsPageV12 and class docstring update
    - PR #2482: V12 method docstrings aligned to v1.2

Documentation posture
- truth-first changelog only
- no production code changes
- no runtime changes
- no technical unlock implications

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/ops/registry/DOCS_TRUTH_MAP.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
