### PR TITLE
ui(dashboard): align index.html dev comments to v1.2

### DIFF
--- a/templates/peak_trade_dashboard/index.html
+++ b/templates/peak_trade_dashboard/index.html
@@ -446,7 +446,7 @@
     </div>
   </div>
 
-  <!-- Stats-Kacheln (v1.1) -->
+  <!-- Stats-Kacheln (v1.2) -->
   {% if live_track.stats %}
   <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
     <div class="bg-slate-950/60 rounded-lg border border-slate-800/60 px-3 py-2">
@@ -674,7 +674,7 @@
     {% endif %}
   </div>
 
-  <!-- Tabelle: Letzte N Sessions (Phase 85: klickbare Zeilen, v1.1 Polish, Phase 87: Risk-Ampel) -->
+  <!-- Tabelle: Letzte N Sessions (Phase 85: klickbare Zeilen, v1.2 Polish, Phase 87: Risk-Ampel) -->
   <div class="overflow-hidden rounded-xl border border-slate-800/80 bg-slate-950/60">
     <table class="w-full text-sm">
       <thead class="bg-slate-900/90 text-slate-400 text-xs uppercase tracking-wider border-b border-slate-700/50">


### PR DESCRIPTION
Summary
- updates two non-rendered HTML comments in templates/peak_trade_dashboard/index.html from v1.1 to v1.2
- removes the remaining internal version drift in index.html after the visible v1.2 alignment work
- keeps the change comment-only with no visible UI or behavior changes

What changed
- templates/peak_trade_dashboard/index.html
  - before: <!-- Stats-Kacheln (v1.1) -->
  - after:  <!-- Stats-Kacheln (v1.2) -->
  - before: <!-- Tabelle: Letzte N Sessions (Phase 85: klickbare Zeilen, v1.1 Polish, Phase 87: Risk-Ampel) -->
  - after:  <!-- Tabelle: Letzte N Sessions (Phase 85: klickbare Zeilen, v1.2 Polish, Phase 87: Risk-Ampel) -->

Scope / non-goals
- no rendered UI changes
- no routing changes
- no payload changes
- no runtime changes
- no test changes were needed

Verification
- python3 -m pytest tests/test_webui_live_track.py::TestDashboardRendering::test_dashboard_returns_200 -q
