### PR TITLE
docs(readme): Docs Truth Map link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Für Entwickler, die mit Peak_Trade arbeiten oder Strategien entwickeln:
 - 🔒 **[Security Notes](SECURITY_NOTES.md)** — Known vulnerabilities, Python version limitations, CVE tracking
 - 🔍 **[Audit Runbook](docs/audit/AUDIT_RUNBOOK_COMPLETE.md)** — Complete audit procedures (Security, Dependencies, Quality)
 - 🛡️ **[Governance & AI Autonomy](docs/governance/README.md)** — Governance-first guardrails, Policy Critic, Evidence Packs
+- 🗺️ **[Docs Truth Map](docs/ops/registry/DOCS_TRUTH_MAP.md)** — Kanonische Ops-Doku-Registry und Änderungsnachweis (truth-first)
 
 ---
 


### PR DESCRIPTION
Summary
- adds a minimal truth-first pointer to the Docs Truth Map in the root README
- improves root-level discoverability for the canonical ops documentation registry and changelog
- keeps the change documentation-only with targeted docs-policy verification

What changed
- README.md
  - adds one bullet in the Security & Audit section:
    - Docs Truth Map — canonical ops documentation registry and truth-first changelog

Scope / non-goals
- no runtime changes
- no UI changes
- no routing changes
- no payload changes
- docs/ops/README.md was intentionally left unchanged

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
