### PR TITLE
docs(ops): Docs Truth Map pointer in ops README

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -3,6 +3,8 @@
 - PR #999 — docs(grafana): fix DS_LOCAL uid templating in execution watch dashboard: docs/ops/PR_999_MERGE_LOG.md
 <!-- MERGE_LOG_EXAMPLES:END -->
 
+**[Docs Truth Map](registry/DOCS_TRUTH_MAP.md)** — canonical ops documentation registry and change log (truth-first).
+
 ## HTTP path index — Operator WebUI & live.web (local defaults)
 
 Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.live.web.app` via `scripts/ops/run_live_webui.sh`) are **local defaults** on `127.0.0.1`. Processes are **separate**; there is **no shared control plane**. Paths below are for **orientation / navigation** (read-only UI posture; no change to execution or approval semantics).


### PR DESCRIPTION
Summary
- adds a minimal truth-first pointer to the Docs Truth Map in docs/ops/README.md
- improves ops-index discoverability symmetrically to the root README
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/ops/README.md
  - adds one line before the HTTP path index:
    - Docs Truth Map — canonical ops documentation registry and change log (truth-first)

Scope / non-goals
- no runtime changes
- no UI changes
- no routing changes
- no payload changes
- no other docs files were changed

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/ops/README.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
