### PR TITLE
docs(cli): Docs Truth Map pointer in CLI cheatsheet

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -5,6 +5,7 @@ Schnellreferenz für alle CLI-Tools im Peak_Trade Framework.
 > **Neu bei Peak_Trade?**
 > - Lies zuerst: [`docs/GETTING_STARTED.md`](GETTING_STARTED.md)
 > - Sieh dir danach dieses Cheatsheet für eine Übersicht der wichtigsten Kommandos an.
+> - [Docs Truth Map](ops/registry/DOCS_TRUTH_MAP.md) — kanonische Ops-Doku-Registry und Änderungsnachweis (truth-first)
 >
 > **Hinweis (macOS/pyenv):** In diesem Cheatsheet ist `python3` der Standard-Runner.
 


### PR DESCRIPTION
Summary
- adds a minimal truth-first pointer to the Docs Truth Map in the CLI cheatsheet intro
- improves discoverability for the canonical ops documentation registry and changelog
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/CLI_CHEATSHEET.md
  - adds one bullet in the "Neu bei Peak_Trade?" block:
    - Docs Truth Map — kanonische Ops-Doku-Registry und Änderungsnachweis (truth-first)

Scope / non-goals
- no runtime changes
- no UI changes
- no routing changes
- no payload changes
- no other docs files were changed

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/CLI_CHEATSHEET.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
