### PR TITLE
docs(ops): truth-map changelog for PR #2488

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -75,6 +75,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 - 2026-04-10 — PR #2484–#2486: #2484 — `templates/peak_trade_dashboard/index.html` Dev-/HTML-Kommentare auf v1.2 ausgerichtet (Ergänzung zu den sichtbaren v1.2-Strings aus #2477–#2479; keine Laufzeit- oder Routing-Änderung); #2485 — `README.md` Root-Pointer auf diese Truth-Map; #2486 — `docs/ops/README.md` Truth-Map-Pointer für Ops-Index-Discoverability; reine Template-/Docs-Discoverability; kein technischer Unlock.
 
+- 2026-04-10 — PR #2488: `docs/CLI_CHEATSHEET.md` — Truth-Map-Pointer im Block „Neu bei Peak_Trade?“ (CLI-Discoverability); reine Docs-Änderung; kein technischer Unlock.
+
 - 2026-04-09 — LB-APR-001: `DOCS_TRUTH_MAP.md` ergänzt um kanonischen Auffindbarkeits-Hinweis auf `docs/ops/templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md` (externe Freigabe-Hülle / Arbeitshilfe; kein technischer Unlock; keine Live-Freigabe impliziert).
 
 - 2026-04-09 — LB-EXE-001 Phase 2 updated `docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` to record deny-by-default guard hardening around `src/execution/networked/transport_gate_v1.py` and related networked guard tests; no live approval or outbound execution unlock implied.


### PR DESCRIPTION
Summary
- adds one truth-map changelog bullet for PR #2488
- records the repo-truth that the CLI cheatsheet now includes a Docs Truth Map pointer
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/ops/registry/DOCS_TRUTH_MAP.md
  - adds one bullet under "Änderungsnachweis (Slice A)" covering:
    - PR #2488: docs/CLI_CHEATSHEET.md Truth-Map pointer in the "Neu bei Peak_Trade?" block

Documentation posture
- truth-first changelog only
- no runtime changes
- no routing changes
- no technical unlock implications

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/ops/registry/DOCS_TRUTH_MAP.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
