### PR TITLE
docs(ops): Docs Truth Map pointer in live runbooks

### DIFF
--- a/docs/LIVE_OPERATIONAL_RUNBOOKS.md
+++ b/docs/LIVE_OPERATIONAL_RUNBOOKS.md
@@ -7,6 +7,8 @@
 
 > **Live-Ops Pack (Finish Plan PR 6):** Ergänzend [Incident Simulation & Drills](./INCIDENT_SIMULATION_AND_DRILLS.md), [Safety Policy Testnet & Live](./SAFETY_POLICY_TESTNET_AND_LIVE.md), [Workflow Frontdoor](./WORKFLOW_FRONTDOOR.md) (Navigation). **NO‑LIVE:** keine Aktivierungsanleitungen; nur Dokumentation.
 
+> **[Docs Truth Map](ops/registry/DOCS_TRUTH_MAP.md)** — kanonische Ops-Doku-Registry und Änderungsnachweis (truth-first)
+
 ---
 
 ## Env File Contexts


### PR DESCRIPTION
Summary
- adds a minimal truth-first pointer to the Docs Truth Map in the live runbooks header
- improves runbook-level discoverability for the canonical ops documentation registry and changelog
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/LIVE_OPERATIONAL_RUNBOOKS.md
  - adds one blockquote line after the Live-Ops Pack block:
    - Docs Truth Map — kanonische Ops-Doku-Registry und Änderungsnachweis (truth-first)

Scope / non-goals
- no runtime changes
- no UI changes
- no routing changes
- no payload changes
- no other docs files were changed

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/LIVE_OPERATIONAL_RUNBOOKS.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
