### PR TITLE
docs(getting-started): Docs Truth Map pointer

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -8,6 +8,8 @@ Dieses Dokument führt dich Schritt für Schritt durch deine erste Stunde mit Pe
 - Live-/Ops-Flow (Health, Portfolio, Status-Reports)
 - **Ohne echte Live-Trades** – alles im Safe-Mode
 
+**Docs Truth Map:** [kanonische Ops-Doku-Registry und Änderungsnachweis](ops/registry/DOCS_TRUTH_MAP.md) (truth-first)
+
 ---
 
 ## 1. Voraussetzungen


### PR DESCRIPTION
Summary
- adds a minimal truth-first pointer to the Docs Truth Map in GETTING_STARTED.md
- improves getting-started discoverability for the canonical ops documentation registry and changelog
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/GETTING_STARTED.md
  - adds one line after the intro list:
    - Docs Truth Map — kanonische Ops-Doku-Registry und Änderungsnachweis (truth-first)

Scope / non-goals
- no runtime changes
- no UI changes
- no routing changes
- no payload changes
- no other docs files were changed

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/GETTING_STARTED.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
