### PR TITLE
docs(overview): Docs Truth Map pointer

### DIFF
--- a/docs/PEAK_TRADE_OVERVIEW.md
+++ b/docs/PEAK_TRADE_OVERVIEW.md
@@ -2,6 +2,8 @@
 
 > **Modulares Trading-Framework mit Safety-First-Ansatz**
 
+**Docs Truth Map:** [kanonische Ops-Doku-Registry und Änderungsnachweis](ops/registry/DOCS_TRUTH_MAP.md) (truth-first)
+
 ---
 
 ## Architektur-Map


### PR DESCRIPTION
Summary
- adds a minimal truth-first pointer to the Docs Truth Map in PEAK_TRADE_OVERVIEW.md
- improves overview-level discoverability for the canonical ops documentation registry and changelog
- keeps the change documentation-only with targeted docs-policy verification

What changed
- docs/PEAK_TRADE_OVERVIEW.md
  - adds one line after the opening blockquote:
    - Docs Truth Map — kanonische Ops-Doku-Registry und Änderungsnachweis (truth-first)

Scope / non-goals
- no runtime changes
- no UI changes
- no routing changes
- no payload changes
- no other docs files were changed

Verification
- bash scripts/ops/verify_docs_reference_targets.sh
- targeted DocsTokenPolicyValidator scan for docs/PEAK_TRADE_OVERVIEW.md
- python3 -m pytest tests/ops/test_autofix_docs_token_policy_v2.py -q
