### PR TITLE
feat(webui): Ops Cockpit operator summary surface (vNext-aligned, read-only)

### DIFF
--- a/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
+++ b/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
@@ -1,0 +1,31 @@
+# OPS Cockpit — Operator Summary Surface (vNext-aligned)
+
+**status:** active  
+**last_updated:** 2026-04-11  
+**purpose:** Map OPS Suite / Dashboard vNext „Required Views“ (Teilmenge) to the JSON payload served at `GET &#47;api&#47;ops-cockpit` (same shape as the `/ops` HTML page) and HTML render helpers — read-only, no execution authority.
+
+**docs_token:** `DOCS_TOKEN_OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE`
+
+## Non-Goals
+
+- No live unlock, no approval semantics, no gate weakening.
+- No new API routes; payload semantics unchanged (presentation-only HTML).
+
+## Required View ↔ Payload ↔ Render
+
+| vNext Required View (Auszug) | Payload keys (observation) | HTML / helper |
+|------------------------------|------------------------------|----------------|
+| System State | `system_state.mode`, `system_state.execution_model`; optional Kurzbezug: `dependencies_state.summary`, `evidence_state.summary` | `src/webui/ops_cockpit.py` — `_render_operator_summary_surface`, section **System status (observation)** |
+| Go / No-Go (observation, not approval) | `policy_state.action`, `policy_state.blocked`, `incident_state.summary`, `incident_state.requires_operator_attention`, kill-switch flags in payload | Same — section **Go / No-Go observation (not approval)** |
+| Kompakte Rollups (Truth / Freshness / Sources) | `executive_summary` (nested levels/labels), top-level `truth_status` / `freshness_status` / `source_coverage_status`, `critical_flags`, `unknown_flags` | `_render_status_at_a_glance_inner` (Status-at-a-glance cards) |
+
+## Related
+
+- [`OPS_SUITE_DASHBOARD_VNEXT_SPEC.md`](OPS_SUITE_DASHBOARD_VNEXT_SPEC.md) — operator-facing target spec.
+- [`RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md`](../runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md) — phased plan; Folgeslice: Incident/Evidence-Freshness vertieft.
+
+## Code references
+
+- Payload builder: `build_ops_cockpit_payload` in `src/webui/ops_cockpit.py`
+- HTML entry: `render_ops_cockpit_html` in `src/webui/ops_cockpit.py`
+- Tests: `tests/webui/test_ops_cockpit.py`

--- a/src/webui/ops_cockpit.py
+++ b/src/webui/ops_cockpit.py
@@ -1730,8 +1730,8 @@ def _status_badge_class(status: str) -> str:
     return "status-badge--ok"
 
 
-def _render_exec_summary_status_grid(payload: Dict[str, object]) -> str:
-    """Render compact v3 Executive Summary. 4 status cards, flags only if present. Read-only."""
+def _render_status_at_a_glance_inner(payload: Dict[str, object]) -> str:
+    """Status grid + attribution + flags — reuses badge helpers; read-only."""
     exec_sum = payload.get("executive_summary") or {}
     t_obj = exec_sum.get("truth_status") or {}
     f_obj = exec_sum.get("freshness_status") or {}
@@ -1787,14 +1787,100 @@ def _render_exec_summary_status_grid(payload: Dict[str, object]) -> str:
         flags_html = f'<p class="status-flags">{" ".join(parts)}</p>'
 
     return (
-        '<div class="exec-summary">'
-        "<h2>Executive Summary</h2>"
-        "<p><strong>Read-only.</strong> No write actions. Operator snapshot.</p>"
         '<div class="status-grid">'
         f"{''.join(cards)}"
         "</div>"
         '<p class="status-attribution"><strong>Sources:</strong> operator snapshot, system state, truth sections</p>'
         f"{flags_html}"
+    )
+
+
+def _render_operator_summary_surface(payload: Dict[str, object]) -> str:
+    """vNext-aligned operator summary: system status, go/no-go observation, status at a glance. Read-only."""
+    sys_state = payload.get("system_state") or {}
+    ps = payload.get("policy_state") if isinstance(payload.get("policy_state"), dict) else {}
+    inc = payload.get("incident_state") if isinstance(payload.get("incident_state"), dict) else {}
+    deps = (
+        payload.get("dependencies_state")
+        if isinstance(payload.get("dependencies_state"), dict)
+        else {}
+    )
+    ev = payload.get("evidence_state") if isinstance(payload.get("evidence_state"), dict) else {}
+
+    mode_s = escape(str(sys_state.get("mode", "unknown")))
+    exec_m = escape(str(sys_state.get("execution_model", "unknown")))
+
+    dep_extra = ""
+    dep_sum = deps.get("summary")
+    if dep_sum is not None and str(dep_sum).strip() != "":
+        dep_extra = (
+            "<p><strong>dependencies_state.summary</strong> (observation): "
+            f"<code>{escape(str(dep_sum))}</code></p>"
+        )
+
+    ev_extra = ""
+    ev_sum = ev.get("summary")
+    if ev_sum is not None and str(ev_sum).strip() != "":
+        ev_extra = (
+            "<p><strong>evidence_state.summary</strong> (observation): "
+            f"<code>{escape(str(ev_sum))}</code></p>"
+        )
+
+    action = escape(str(ps.get("action", "unknown")))
+    blocked = ps.get("blocked")
+    blocked_s = escape(str(blocked))
+    ks_ps = bool(ps.get("kill_switch_active"))
+    ks_inc = bool(inc.get("kill_switch_active"))
+    ks_active = ks_ps or ks_inc
+    req_att = inc.get("requires_operator_attention")
+    inc_summary = escape(str(inc.get("summary", "unknown")))
+
+    go_no_go_intro = (
+        "<p><strong>Observation only.</strong> The labels below quote "
+        "<code>policy_state</code> and <code>incident_state</code> from this page&apos;s JSON "
+        "payload. They describe configured gates and rollups — "
+        "<strong>not an approval, not an unlock,</strong> not live permission.</p>"
+    )
+    go_lines = (
+        f"<p><strong>policy_state.action</strong> (observation): <code>{action}</code></p>"
+        f"<p><strong>policy_state.blocked</strong> (observation): <code>{blocked_s}</code></p>"
+        f"<p><strong>incident_state.summary</strong> (observation): <code>{inc_summary}</code></p>"
+        f"<p><strong>incident_state.requires_operator_attention</strong> (observation): "
+        f"<code>{escape(str(req_att))}</code></p>"
+    )
+    if ks_active:
+        go_lines += (
+            "<p><strong>Kill switch signal</strong> (observation): active in payload — "
+            "downstream enforcement remains authoritative; this page does not clear it.</p>"
+        )
+
+    glance_intro = (
+        "<p><strong>Read-only.</strong> Same rollup fields as before (v3 executive summary cards); "
+        "no write actions.</p>"
+    )
+
+    inner = _render_status_at_a_glance_inner(payload)
+
+    return (
+        '<div class="operator-summary-surface exec-summary">'
+        "<h2>Operator summary (read-only)</h2>"
+        '<p class="operator-summary-disclaimer"><strong>Observation only.</strong> '
+        "Read-only snapshot from local artifacts and the <code>GET /api/ops-cockpit</code> "
+        "payload shape. <strong>Not an approval, not an unlock,</strong> not a substitute for "
+        "your governance process.</p>"
+        "<h3>System status (observation)</h3>"
+        "<p><strong>system_state.mode</strong> (observation): "
+        f"<code>{mode_s}</code></p>"
+        "<p><strong>system_state.execution_model</strong> (observation): "
+        f"<code>{exec_m}</code></p>"
+        f"{dep_extra}"
+        f"{ev_extra}"
+        "<h3>Go / No-Go observation (not approval)</h3>"
+        f"{go_no_go_intro}"
+        f"{go_lines}"
+        "<h3>Status at a glance</h3>"
+        f"{glance_intro}"
+        f"{inner}"
         "</div>"
     )
 
@@ -1850,7 +1936,7 @@ def render_ops_cockpit_html(
     canonical_cards = "".join(_render_doc_card(doc) for doc in groups["canonical_boundary"])
     runtime_cards = "".join(_render_doc_card(doc) for doc in groups["runtime_resolution"])
     supporting_cards = "".join(_render_doc_card(doc) for doc in groups["supporting_truth"])
-    exec_summary_html = _render_exec_summary_status_grid(payload)
+    operator_summary_surface_html = _render_operator_summary_surface(payload)
     policy_guard_observation_html = _render_policy_guard_observation_card(payload)
     phase57_snapshot_discoverability_html = _render_phase57_snapshot_discoverability_card()
     incident_observation_html = _render_incident_observation_card(payload)
@@ -1885,6 +1971,8 @@ def render_ops_cockpit_html(
     .group-block {{ margin-top: 22px; }}
     code {{ background: #f5f5f5; padding: 2px 4px; border-radius: 4px; }}
     .exec-summary {{ border: 1px solid #333; border-radius: 12px; padding: 16px; margin-bottom: 20px; background: #fafafa; }}
+    .operator-summary-disclaimer {{ border-left: 4px solid #607d8b; padding-left: 12px; margin: 12px 0; }}
+    .operator-summary-surface h3 {{ font-size: 1.05em; margin-top: 18px; margin-bottom: 8px; }}
     .status-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin: 12px 0; }}
     .status-card {{ padding: 10px; border-radius: 8px; border: 1px solid #e0e0e0; }}
     .status-label {{ display: block; font-size: 0.85em; color: #555; margin-bottom: 4px; }}
@@ -1909,7 +1997,7 @@ def render_ops_cockpit_html(
   </style>
 </head>
 <body>
-  {exec_summary_html}
+  {operator_summary_surface_html}
   {policy_guard_observation_html}
   {phase57_snapshot_discoverability_html}
   {incident_observation_html}

--- a/tests/webui/test_ops_cockpit.py
+++ b/tests/webui/test_ops_cockpit.py
@@ -1040,9 +1040,12 @@ def test_v3_executive_summary_keys_present(tmp_path: Path) -> None:
         assert "detail" in obj
 
 
-def test_v3_html_contains_executive_summary(tmp_path: Path) -> None:
+def test_v3_html_contains_operator_summary_surface(tmp_path: Path) -> None:
     html = render_ops_cockpit_html(repo_root=tmp_path)
-    assert "Executive Summary" in html
+    assert "Operator summary (read-only)" in html
+    assert "System status (observation)" in html
+    assert "Go / No-Go observation (not approval)" in html
+    assert "Status at a glance" in html
     assert "status-grid" in html
     assert "status-label" in html
     assert "Truth" in html
@@ -1050,6 +1053,7 @@ def test_v3_html_contains_executive_summary(tmp_path: Path) -> None:
     assert "Sources" in html
     assert "Mode" in html
     assert "operator snapshot, system state, truth sections" in html
+    assert "Not an approval, not an unlock" in html
 
 
 def test_v3_unknown_stale_no_data_stable(tmp_path: Path) -> None:
@@ -1084,9 +1088,9 @@ def test_build_ops_cockpit_payload_includes_v3_executive_summary(tmp_path: Path)
 
 
 def test_render_ops_cockpit_html_renders_v3_summary(tmp_path: Path) -> None:
-    """HTML rendert v3 Executive Summary mit allen Status-Karten."""
+    """HTML rendert Operator Summary Surface mit Status-at-a-glance-Karten (v3-Rollup)."""
     html = render_ops_cockpit_html(repo_root=tmp_path)
-    assert "Executive Summary" in html
+    assert "Operator summary (read-only)" in html
     assert "Truth" in html
     assert "Freshness" in html
     assert "Sources" in html


### PR DESCRIPTION
## Summary
- Adds a consolidated **Operator summary (read-only)** region at the top of `/ops`: **System status**, **Go/No-Go observation (not approval)**, and **Status at a glance** (same v3 status cards as before).
- Presentation-only: **`build_ops_cockpit_payload` unchanged**; **`GET /api/ops-cockpit`** JSON shape unchanged.
- New mapping doc: `docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md`.

## Non-goals
- No new routes, no execution/gate/config changes, no live unlock, no approval semantics.

## Verification
- `python3 -m ruff check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py`
- `python3 -m pytest tests/webui/test_ops_cockpit.py -q`
- `python3 -m pytest tests/test_webui_live_track.py -q`
- `bash scripts/ops/verify_docs_reference_targets.sh`
- docs token policy check for the new spec

## Follow-up
- Incident / evidence-freshness panels as separate slice (per vNext plan).

Made with [Cursor](https://cursor.com)