### PR TITLE
feat(webui): deepen incident/evidence observation in Ops Cockpit operator summary (read-only)

### DIFF
--- a/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
+++ b/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
@@ -17,8 +17,8 @@
 |------------------------------|------------------------------|----------------|
 | System State | `system_state.mode`, `system_state.execution_model`; optional Kurzbezug: `dependencies_state.summary`, `evidence_state.summary` | `src/webui/ops_cockpit.py` — `_render_operator_summary_surface`, section **System status (observation)** |
 | Go / No-Go (observation, not approval) | `policy_state.action`, `policy_state.blocked`, `incident_state.summary`, `incident_state.requires_operator_attention`, kill-switch flags in payload | Same — section **Go / No-Go observation (not approval)** |
-| Incident / Safety (compact observation) | `incident_state.status`, `incident_state.degraded`, `incident_state.requires_operator_attention`; `dependencies_state.summary`, `dependencies_state.degraded` | Same — section **Incident observation (read-only)** |
-| Evidence / Freshness (compact observation) | `evidence_state.summary`, `evidence_state.freshness_status`, `evidence_state.audit_trail`, `evidence_state.source_freshness`, optional `evidence_state.telemetry_evidence` | Same — section **Evidence freshness observation (read-only)** |
+| Incident / Safety (compact observation) | `incident_state.status`, `incident_state.degraded`, `incident_state.requires_operator_attention`, `incident_state.incident_stop_invoked`, `incident_state.entry_permitted`, `incident_state.operator_authoritative_state`; `dependencies_state.summary`, `dependencies_state.telemetry`, `dependencies_state.exchange`, `dependencies_state.degraded` | Same — section **Incident observation (read-only)** |
+| Evidence / Freshness (compact observation) | `evidence_state.summary`, `evidence_state.freshness_status`, `evidence_state.audit_trail`, `evidence_state.last_verified_utc`, `evidence_state.source_freshness`, optional `evidence_state.telemetry_evidence` | Same — section **Evidence freshness observation (read-only)** |
 | Kompakte Rollups (Truth / Freshness / Sources) | `executive_summary` (nested levels/labels), top-level `truth_status` / `freshness_status` / `source_coverage_status`, `critical_flags`, `unknown_flags` | `_render_status_at_a_glance_inner` (Status-at-a-glance cards) |
 
 ## Related

--- a/src/webui/ops_cockpit.py
+++ b/src/webui/ops_cockpit.py
@@ -1840,7 +1840,12 @@ def _render_operator_summary_surface(payload: Dict[str, object]) -> str:
 
     incident_status = escape(str(inc.get("status", "unknown")))
     incident_degraded = escape(str(inc.get("degraded", "unknown")))
+    incident_stop_invoked = escape(str(inc.get("incident_stop_invoked", "unknown")))
+    incident_entry_permitted = escape(str(inc.get("entry_permitted", "unknown")))
+    incident_authoritative = escape(str(inc.get("operator_authoritative_state", "unknown")))
     dep_summary = escape(str(deps.get("summary", "unknown")))
+    dep_telemetry = escape(str(deps.get("telemetry", "unknown")))
+    dep_exchange = escape(str(deps.get("exchange", "unknown")))
     dep_degraded = deps.get("degraded")
     dep_degraded_count = 0
     dep_degraded_preview = ""
@@ -1853,8 +1858,18 @@ def _render_operator_summary_surface(payload: Dict[str, object]) -> str:
         f"<code>{incident_status}</code></p>"
         "<p><strong>incident_state.degraded</strong> (observation): "
         f"<code>{incident_degraded}</code></p>"
+        "<p><strong>incident_state.incident_stop_invoked</strong> (observation): "
+        f"<code>{incident_stop_invoked}</code></p>"
+        "<p><strong>incident_state.entry_permitted</strong> (observation): "
+        f"<code>{incident_entry_permitted}</code></p>"
+        "<p><strong>incident_state.operator_authoritative_state</strong> (observation): "
+        f"<code>{incident_authoritative}</code></p>"
         "<p><strong>dependencies_state.summary</strong> (observation): "
         f"<code>{dep_summary}</code></p>"
+        "<p><strong>dependencies_state.telemetry</strong> (observation): "
+        f"<code>{dep_telemetry}</code></p>"
+        "<p><strong>dependencies_state.exchange</strong> (observation): "
+        f"<code>{dep_exchange}</code></p>"
         "<p><strong>dependencies_state.degraded_count</strong> (observation): "
         f"<code>{dep_degraded_count}</code></p>"
     )
@@ -1867,6 +1882,7 @@ def _render_operator_summary_surface(payload: Dict[str, object]) -> str:
     evidence_summary = escape(str(ev.get("summary", "unknown")))
     evidence_freshness = escape(str(ev.get("freshness_status", "unknown")))
     evidence_audit = escape(str(ev.get("audit_trail", "unknown")))
+    evidence_last_verified = escape(str(ev.get("last_verified_utc", "unknown")))
     source_freshness = ev.get("source_freshness")
     sf_fresh = sf_stale = sf_older = "unknown"
     if isinstance(source_freshness, dict):
@@ -1880,6 +1896,8 @@ def _render_operator_summary_surface(payload: Dict[str, object]) -> str:
         f"<code>{evidence_freshness}</code></p>"
         "<p><strong>evidence_state.audit_trail</strong> (observation): "
         f"<code>{evidence_audit}</code></p>"
+        "<p><strong>evidence_state.last_verified_utc</strong> (observation): "
+        f"<code>{evidence_last_verified}</code></p>"
         "<p><strong>evidence_state.source_freshness</strong> (observation): "
         f"<code>fresh={sf_fresh}, stale={sf_stale}, older={sf_older}</code></p>"
     )

--- a/tests/webui/test_ops_cockpit.py
+++ b/tests/webui/test_ops_cockpit.py
@@ -1047,9 +1047,15 @@ def test_v3_html_contains_operator_summary_surface(tmp_path: Path) -> None:
     assert "Go / No-Go observation (not approval)" in html
     assert "Incident observation (read-only)" in html
     assert "incident_state.status" in html
+    assert "incident_state.incident_stop_invoked" in html
+    assert "incident_state.entry_permitted" in html
+    assert "incident_state.operator_authoritative_state" in html
     assert "dependencies_state.degraded_count" in html
+    assert "dependencies_state.telemetry" in html
+    assert "dependencies_state.exchange" in html
     assert "Evidence freshness observation (read-only)" in html
     assert "evidence_state.freshness_status" in html
+    assert "evidence_state.last_verified_utc" in html
     assert "evidence_state.source_freshness" in html
     assert "Status at a glance" in html
     assert "status-grid" in html


### PR DESCRIPTION
## Summary
- Deepens the Ops Cockpit operator summary by surfacing additional existing read-model fields for incident/evidence/dependencies.
- HTML-only/read-only change: no new routes, no new APIs, no payload semantic changes.
- Preserves strict wording: observation-only, not approval, not unlock.
- Updates targeted summary test assertions and mapping spec.

## Scope
- `src/webui/ops_cockpit.py` (`_render_operator_summary_surface`)
- `tests/webui/test_ops_cockpit.py`
- `docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md`

## Non-goals
- No changes to `build_ops_cockpit_payload`
- No changes to `src/webui/app.py`
- No execution/gate/config/live logic changes
- No exposure/risk full slice in this PR

## Verification
- `python3 -m ruff check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py`
- `python3 -m pytest tests/webui/test_ops_cockpit.py -q`
- `python3 -m pytest tests/test_webui_live_track.py -q`
- `bash scripts/ops/verify_docs_reference_targets.sh`
- docs token policy check for `OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md`

## Review notes
- Confirm every new line cites existing payload keys only, with no new heuristic/judgment.
- Confirm observation / read-only / not approval / not unlock remains clearly visible.
- Confirm no POST/action paths and no API/routing changes were introduced.

Made with [Cursor](https://cursor.com)