### PR TITLE
docs(ops): PR/CI verification runbook and session/stale/run mapping for Ops Cockpit

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_PR_CI_VERIFICATION.md
+++ b/docs/ops/runbooks/RUNBOOK_PR_CI_VERIFICATION.md
@@ -1,0 +1,58 @@
+# RUNBOOK — PR / CI Verifikation (Feature-Branches)
+
+**status:** active  
+**last_updated:** 2026-04-12  
+**purpose:** Truth-first Anleitung, welche **CI**-Läufe bei Pull Requests gegen `main` entstehen, wie man sie zuverlässig beobachtet und wie sie sich von manuellen Dispatch-Läufen unterscheiden — **ohne** Gate-Abschwächung und **ohne** Ausführungsautorität.
+
+**docs_token:** `DOCS_TOKEN_RUNBOOK_PR_CI_VERIFICATION`
+
+## Non-Goals
+
+- Keine Änderung an Workflows, Branch-Protection oder Required Checks.
+- Keine Empfehlung, Checks zu umgehen oder Merge-Regeln zu lockern.
+
+## Kanonische Quelle
+
+- Workflow **`CI`**: [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml) (Repository-Wurzel).
+
+## `on:`-Ereignisse (Kurzüberblick)
+
+| Mechanismus | Wann es feuert (laut Workflow) |
+|-------------|--------------------------------|
+| **`push`** | Nur für Branches **`main`** und **`master`**. Ein **Push auf einen Feature-Branch** löst **diesen** `push`-Pfad **nicht** aus. |
+| **`pull_request`** | PRs gegen **`main`/`master`** (`opened`, `synchronize`, `reopened`, `ready_for_review`). Aktualisiert den PR-Head (z. B. nach weiterem Commit) → **`synchronize`**. |
+| **`workflow_dispatch`** | Manuell in der GitHub-Actions-UI oder per `gh workflow run …`; optional Input **`force_matrix`**. **Kein** Ersatz für ein `pull_request`-Ereignis — anderes Event, anderer Kontext in der Run-Liste. |
+| **`merge_group`** / **`schedule`** | Separate Pfade; für typische Feature-PR-Verifikation sekundär. |
+
+**Truth-first:** „Push auf Feature-Branch startet **nicht** automatisch den `on.push`-CI“ — korrekt für dieses Repo. Für PRs gegen `main` ist **`pull_request`** der regelmäßige Pfad.
+
+## Welchen Run beobachten?
+
+- **`gh pr checks <PR> --watch`** zeigt oft nur einen **Teil** der Checks und kann **früh** enden, wenn nicht alle GitHub-Apps/Workflows in derselben Ansicht hängen.
+- Für den **vollständigen** Workflow **`CI`** mit Job-Matrix (**`tests (3.9)`**, **`tests (3.11)`**, **`strategy-smoke`**, …): Run-ID ermitteln und **`gh run watch <RUN_ID>`** verwenden, z. B.  
+  `gh run list --branch <feature-branch> --json databaseId,workflowName,event --limit 20`  
+  und Eintrag mit **`workflowName` == `CI`** und **`event` == `pull_request`** wählen.
+
+## `strategy-smoke` und Reihenfolge
+
+- Im Workflow ist der Job **`strategy-smoke`** mit **`needs: [changes, tests]`** definiert — er startet **nach** den **`tests`**, Matrix inkl. **`tests (3.11)`**.  
+- Ein Check-Run **`strategy-smoke`** kann auf dem Commit **fehlen**, solange **`tests (3.11)`** (oder die Matrix) noch **in Bearbeitung** ist — das ist **erwartetes** Verhalten, kein „fehlender“ Required-Check-Name durch Umbenennung.
+
+## Required Status Checks (Namen)
+
+- Branch-Protection auf `main` verlangt **exakte** Kontext-Namen (z. B. **`tests (3.11)`**, **`strategy-smoke`**, **`Lint Gate`**, …).  
+- Abweichungen zwischen **Workflow-Job-`name:`** und Protection-**`context`** blockieren Merges — bei Umbenennungen immer **Workflow** und **Protection** gemeinsam prüfen (siehe auch `scripts/ops/check_required_ci_contexts_present.sh` im **`CI`**-Job **`ci-required-contexts-contract`**).
+
+## Leerer Commit
+
+- **`git commit --allow-empty`** + **`git push`** auf den Feature-Branch erzeugt einen neuen Commit und triggert bei offenem PR typischerweise **`pull_request`** (**`synchronize`**).  
+- Er **ersetzt** keinen **`workflow_dispatch`** und startet **keinen** zusätzlichen `push`-CI auf dem Feature-Branch (siehe oben).
+
+## Ops Cockpit (Lesekontext)
+
+- Session-, Stale- und Run-Zustände im Cockpit sind **read-only** und an Payload-Keys gebunden — siehe [`OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md`](../specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md) (Abschnitt Session / Run / Stale).
+
+## Related
+
+- [`CI.md`](../CI.md) — CI-Überblick und Branch-Protection-Kontext.
+- [`ci_required_checks_matrix_naming_contract.md`](../ci_required_checks_matrix_naming_contract.md) — Namenskonventionen für Required Checks.

--- a/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
+++ b/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
@@ -1,7 +1,7 @@
 # OPS Cockpit — Operator Summary Surface (vNext-aligned)
 
 **status:** active  
-**last_updated:** 2026-04-11  
+**last_updated:** 2026-04-12  
 **purpose:** Map OPS Suite / Dashboard vNext „Required Views“ (Teilmenge) to the JSON payload served at `GET &#47;api&#47;ops-cockpit` (same shape as the `/ops` HTML page) and HTML render helpers — read-only, no execution authority.
 
 **docs_token:** `DOCS_TOKEN_OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE`
@@ -52,10 +52,23 @@ Presentation-only **Evidence State** card — `_render_evidence_state_card_body`
 | Source counts | `source_freshness` (`fresh` / `stale` / `older`) |
 | Optional | `telemetry_evidence` (shown as `n&#47;a` when absent in payload) |
 
+### Session / Run / Stale (cards + rollup, read-only)
+
+Maps vNext **Session / Run State** and parts of **Health / Drift** to existing payload objects — observation only; not approval, not unlock. PR/CI context for feature branches: [`RUNBOOK_PR_CI_VERIFICATION.md`](../runbooks/RUNBOOK_PR_CI_VERIFICATION.md).
+
+| Observation | Payload keys | HTML / helper |
+|-------------|----------------|---------------|
+| Run / session rollup | `run_state.status`, `run_state.active`, `run_state.last_run_status`, `run_state.session_active`, `run_state.generated_at`, `run_state.freshness_status` (subset on page) | `_render_run_state_observation_card` |
+| Stale / reconciliation | `stale_state.summary`, `stale_state.balance`, `stale_state.position`, `stale_state.order`, `stale_state.exposure` | **Stale State** card in `render_ops_cockpit_html` |
+| Session end (read model) | `session_end_mismatch_state.status`, `summary`, `blocked_next_session`, `runbook` | **Session End Mismatch** card in `render_ops_cockpit_html` |
+
+**Note:** `stale_state.order` is currently the literal payload value **`unknown`** in the builder where no order-staleness signal is supplied — display is **observation-only**, not a forecast.
+
 ## Related
 
 - [`OPS_SUITE_DASHBOARD_VNEXT_SPEC.md`](OPS_SUITE_DASHBOARD_VNEXT_SPEC.md) — operator-facing target spec.
 - [`RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md`](../runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md) — phased plan; Folgeslice: Incident/Evidence-Freshness vertieft.
+- [`RUNBOOK_PR_CI_VERIFICATION.md`](../runbooks/RUNBOOK_PR_CI_VERIFICATION.md) — PR/CI events and verification (truth-first).
 
 ## Code references
 

--- a/scripts/ops/pr_safe_flow.sh
+++ b/scripts/ops/pr_safe_flow.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 # - Make upstream explicit
 # - Require explicit confirmation for merge automation
 #
+# CI on PRs: feature-branch push does not trigger workflow "CI" on:push (main/master
+# only). Use pull_request runs and gh run watch for full matrix — see
+# docs/ops/runbooks/RUNBOOK_PR_CI_VERIFICATION.md
+#
 # Usage:
 #   ./scripts/ops/pr_safe_flow.sh preflight
 #   ./scripts/ops/pr_safe_flow.sh create --fill


### PR DESCRIPTION
## Summary
- Adds `docs/ops/runbooks/RUNBOOK_PR_CI_VERIFICATION.md`: truth-first PR/CI verification (push scope on `main`/`master`, `pull_request`/`synchronize`, `workflow_dispatch` vs PR events, `gh run watch`, required checks + `strategy-smoke` `needs`, empty commit vs dispatch).
- Extends `OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md` with Session/Run/Stale mapping (`run_state`, `stale_state`, `session_end_mismatch_state`; `stale_state.order` observation-only).
- Adds a minimal comment in `scripts/ops/pr_safe_flow.sh` pointing to the runbook.

## Verification
- `bash scripts/ops/verify_docs_reference_targets.sh`
- `python3 scripts/ops/validate_docs_token_policy.py --base origin/main`
- `bash -n scripts/ops/pr_safe_flow.sh`

## Out of scope
- No CI workflow changes
- No `app.py` changes
- No payload/build changes
- No dashboard UI changes
- No paper/shadow/test evidence changes

## Review notes
- Confirm no sentence claims that a feature-branch push triggers CI through the workflow `push:` branch filter.
- Confirm `pull_request synchronize` and `workflow_dispatch` are clearly separated.
- Confirm `stale_state.order` remains explicitly observation-only / unknown.
