### PR TITLE
feat(ops-cockpit): operator workflow observation surface (vNext Phase 4, read-only)

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md
+++ b/docs/ops/runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md
@@ -51,7 +51,7 @@ Create a safe, operator-facing OPS Suite / Dashboard expansion plan that improve
 3. feat/ops-suite-incident-risk-surface
 4. feat/ops-suite-operator-workflow-visibility
 
-**Ist-Stand (Ops Cockpit HTML):** read-only **Policy &#47; Governance observation (vNext RV6)** bündelt `policy_state`, `guard_state`, `ai_boundary_state`, `human_supervision_state` und einen Evidence-/Audit-Cross-Ref zu `evidence_state` — keine neue Autorität, Presentation-only (`src/webui/ops_cockpit.py`). **Phase 4:** `workflow_officer_state` aus `out/ops/workflow_officer` (read-only, startet den Officer nicht).
+**Ist-Stand (Ops Cockpit HTML):** read-only **Policy &#47; Governance observation (vNext RV6)** bündelt `policy_state`, `guard_state`, `ai_boundary_state`, `human_supervision_state` und einen Evidence-/Audit-Cross-Ref zu `evidence_state` — keine neue Autorität, Presentation-only (`src/webui/ops_cockpit.py`). **Phase 4:** `workflow_officer_state` aus `out&#47;ops&#47;workflow_officer` (read-only, startet den Officer nicht).
 
 ## Explicit Non-Goals
 - no live-trading enablement

--- a/docs/ops/runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md
+++ b/docs/ops/runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md
@@ -51,7 +51,7 @@ Create a safe, operator-facing OPS Suite / Dashboard expansion plan that improve
 3. feat/ops-suite-incident-risk-surface
 4. feat/ops-suite-operator-workflow-visibility
 
-**Ist-Stand (Ops Cockpit HTML):** read-only **Policy &#47; Governance observation (vNext RV6)** bündelt `policy_state`, `guard_state`, `ai_boundary_state`, `human_supervision_state` und einen Evidence-/Audit-Cross-Ref zu `evidence_state` — keine neue Autorität, Presentation-only (`src/webui/ops_cockpit.py`).
+**Ist-Stand (Ops Cockpit HTML):** read-only **Policy &#47; Governance observation (vNext RV6)** bündelt `policy_state`, `guard_state`, `ai_boundary_state`, `human_supervision_state` und einen Evidence-/Audit-Cross-Ref zu `evidence_state` — keine neue Autorität, Presentation-only (`src/webui/ops_cockpit.py`). **Phase 4:** `workflow_officer_state` aus `out/ops/workflow_officer` (read-only, startet den Officer nicht).
 
 ## Explicit Non-Goals
 - no live-trading enablement

--- a/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
+++ b/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
@@ -21,7 +21,7 @@
 | Evidence / Freshness (compact observation) | `evidence_state.summary`, `evidence_state.freshness_status`, `evidence_state.audit_trail`, `evidence_state.last_verified_utc`, `evidence_state.source_freshness`, optional `evidence_state.telemetry_evidence` | Same — section **Evidence freshness observation (read-only)** |
 | Kompakte Rollups (Truth / Freshness / Sources) | `executive_summary` (nested levels/labels), top-level `truth_status` / `freshness_status` / `source_coverage_status`, `critical_flags`, `unknown_flags` | `_render_status_at_a_glance_inner` (Status-at-a-glance cards) |
 | Policy &#47; Governance (vNext RV6) | `policy_state`, `guard_state`, `ai_boundary_state`, `human_supervision_state`; evidence/audit cross-ref from `evidence_state` (full card below) | `_render_policy_governance_observation_surface` — block **Policy &#47; Governance observation (vNext RV6)** (`id=policy-governance-observation-surface`); Evidence State card `id=evidence-state-card` |
-| Operator workflow (vNext Phase 4) | `workflow_officer_state` (from `build_workflow_officer_panel_context` &#47; latest `out/ops/workflow_officer` `report.json` when present) | `_render_workflow_officer_observation_surface` — block **Operator workflow observation (vNext Phase 4)** (`id=operator-workflow-observation-surface`) |
+| Operator workflow (vNext Phase 4) | `workflow_officer_state` (from `build_workflow_officer_panel_context` &#47; latest `out&#47;ops&#47;workflow_officer` `report.json` when present) | `_render_workflow_officer_observation_surface` — block **Operator workflow observation (vNext Phase 4)** (`id=operator-workflow-observation-surface`) |
 
 ### Exposure / Risk (separate card, read-only)
 

--- a/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
+++ b/docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md
@@ -9,7 +9,7 @@
 ## Non-Goals
 
 - No live unlock, no approval semantics, no gate weakening.
-- No new API routes; payload semantics unchanged (presentation-only HTML).
+- No new API routes; existing payload keys keep the same meaning. Additive **read-only** keys (e.g. `workflow_officer_state`) are allowed when they surface existing artifacts with no new authority.
 
 ## Required View ↔ Payload ↔ Render
 
@@ -21,6 +21,7 @@
 | Evidence / Freshness (compact observation) | `evidence_state.summary`, `evidence_state.freshness_status`, `evidence_state.audit_trail`, `evidence_state.last_verified_utc`, `evidence_state.source_freshness`, optional `evidence_state.telemetry_evidence` | Same — section **Evidence freshness observation (read-only)** |
 | Kompakte Rollups (Truth / Freshness / Sources) | `executive_summary` (nested levels/labels), top-level `truth_status` / `freshness_status` / `source_coverage_status`, `critical_flags`, `unknown_flags` | `_render_status_at_a_glance_inner` (Status-at-a-glance cards) |
 | Policy &#47; Governance (vNext RV6) | `policy_state`, `guard_state`, `ai_boundary_state`, `human_supervision_state`; evidence/audit cross-ref from `evidence_state` (full card below) | `_render_policy_governance_observation_surface` — block **Policy &#47; Governance observation (vNext RV6)** (`id=policy-governance-observation-surface`); Evidence State card `id=evidence-state-card` |
+| Operator workflow (vNext Phase 4) | `workflow_officer_state` (from `build_workflow_officer_panel_context` &#47; latest `out/ops/workflow_officer` `report.json` when present) | `_render_workflow_officer_observation_surface` — block **Operator workflow observation (vNext Phase 4)** (`id=operator-workflow-observation-surface`) |
 
 ### Exposure / Risk (separate card, read-only)
 
@@ -68,7 +69,7 @@ Maps vNext **Session / Run State** and parts of **Health / Drift** to existing p
 ## Related
 
 - [`OPS_SUITE_DASHBOARD_VNEXT_SPEC.md`](OPS_SUITE_DASHBOARD_VNEXT_SPEC.md) — operator-facing target spec.
-- [`RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md`](../runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md) — phased plan; RV6 Policy/Governance observation surface shipped read-only (HTML bundle).
+- [`RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md`](../runbooks/RUNBOOK_OPS_SUITE_DASHBOARD_VNEXT_PLAN.md) — phased plan; RV6 Policy/Governance and Phase 4 Workflow Officer observation surfaces shipped read-only (HTML bundle).
 - [`RUNBOOK_PR_CI_VERIFICATION.md`](../runbooks/RUNBOOK_PR_CI_VERIFICATION.md) — PR/CI events and verification (truth-first).
 
 ## Code references

--- a/docs/ops/specs/OPS_SUITE_DASHBOARD_VNEXT_SPEC.md
+++ b/docs/ops/specs/OPS_SUITE_DASHBOARD_VNEXT_SPEC.md
@@ -105,6 +105,8 @@ Expose capital separation, exposure, and anomaly summaries.
 ### Phase 4 — Operator Workflow Surface
 Expose explicit go/no-go and acknowledgement flows without changing execution authority.
 
+**Ops Cockpit (read-only HTML):** latest Workflow Officer dashboard view is exposed as `workflow_officer_state` (observation only; does not run the officer) — see [`OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md`](OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md).
+
 ## Dependencies / Inputs
 - existing Ops Cockpit truth-first model
 - existing governance docs and runbooks

--- a/src/webui/ops_cockpit.py
+++ b/src/webui/ops_cockpit.py
@@ -1140,6 +1140,152 @@ def _render_run_state_observation_card(payload: Dict[str, object]) -> str:
     )
 
 
+def _render_workflow_officer_observation_surface(payload: Dict[str, object]) -> str:
+    """vNext Phase 4: latest Workflow Officer dashboard view — ``workflow_officer_state`` only (read-only)."""
+    wo_raw = payload.get("workflow_officer_state")
+    wo = wo_raw if isinstance(wo_raw, dict) else {}
+    present = wo.get("present") is True
+    intro = (
+        "<p><strong>Read-only.</strong> Same object as <code>workflow_officer_state</code> in this "
+        "page&apos;s JSON payload — from <code>build_workflow_officer_panel_context</code> "
+        "(latest <code>report.json</code> under <code>out/ops/workflow_officer</code> when present). "
+        "<strong>Observation only</strong> — <strong>not approval</strong>, <strong>not unlock</strong>; "
+        "does not execute Workflow Officer.</p>"
+    )
+    head = (
+        f'<div class="group-block operator-workflow-observation-surface" '
+        f'id="operator-workflow-observation-surface" style="margin-bottom:20px;">'
+        f'<div class="card truth-card">'
+        f"<h2>Operator workflow observation (vNext Phase 4)</h2>"
+        f"{intro}"
+    )
+    if not present:
+        er = wo.get("empty_reason")
+        er_s = escape(str(er)) if er is not None else "unknown"
+        return (
+            f"{head}"
+            f"<p><strong>workflow_officer_state.present</strong> (observation): <code>false</code></p>"
+            f"<p><strong>workflow_officer_state.empty_reason</strong> (observation): <code>{er_s}</code></p>"
+            "<p>No Workflow Officer artifacts observed at this repo root (or report not readable). "
+            "Filesystem observation only — not guidance to skip governance checks.</p>"
+            f"</div></div>"
+        )
+
+    rollup = wo.get("rollup") if isinstance(wo.get("rollup"), dict) else {}
+    ex = wo.get("executive") if isinstance(wo.get("executive"), dict) else {}
+    pf_raw = wo.get("primary_followup")
+    pf = pf_raw if isinstance(pf_raw, dict) else None
+
+    def _cell(val: object) -> str:
+        return escape(_fmt_observation_cell(val))
+
+    rows_html: List[str] = []
+    for label, key in (
+        ("workflow_officer_state.run_dir_name", "run_dir_name"),
+        ("workflow_officer_state.report_rel_path", "report_rel_path"),
+        ("workflow_officer_state.officer_version", "officer_version"),
+        ("workflow_officer_state.profile", "profile"),
+        ("workflow_officer_state.mode", "mode"),
+        ("workflow_officer_state.success", "success"),
+        ("workflow_officer_state.finished_at", "finished_at"),
+    ):
+        if key not in wo:
+            continue
+        rows_html.append(
+            f"<tr><td style='padding:4px 8px 4px 0;vertical-align:top;'><code>{escape(label)}</code></td>"
+            f"<td style='padding:4px 0;'><code>{_cell(wo.get(key))}</code></td></tr>"
+        )
+    for label, key in (
+        ("workflow_officer_state.rollup.total_checks", "total_checks"),
+        ("workflow_officer_state.rollup.hard_failures", "hard_failures"),
+        ("workflow_officer_state.rollup.warnings", "warnings"),
+        ("workflow_officer_state.rollup.infos", "infos"),
+        ("workflow_officer_state.rollup.strict", "strict"),
+    ):
+        if key not in rollup:
+            continue
+        rows_html.append(
+            f"<tr><td style='padding:4px 8px 4px 0;vertical-align:top;'><code>{escape(label)}</code></td>"
+            f"<td style='padding:4px 0;'><code>{_cell(rollup.get(key))}</code></td></tr>"
+        )
+    for label, key in (
+        ("workflow_officer_state.executive.urgency_label", "urgency_label"),
+        ("workflow_officer_state.executive.attention_rationale", "attention_rationale"),
+    ):
+        if key not in ex:
+            continue
+        rows_html.append(
+            f"<tr><td style='padding:4px 8px 4px 0;vertical-align:top;'><code>{escape(label)}</code></td>"
+            f"<td style='padding:4px 0;'><code>{_cell(ex.get(key))}</code></td></tr>"
+        )
+
+    snap = str(wo.get("operator_snapshot_line") or "").strip()
+    snap_p = (
+        f"<p><strong>operator_snapshot_line</strong> (observation): <code>{escape(snap)}</code></p>"
+        if snap
+        else ""
+    )
+
+    pf_block = ""
+    if pf:
+        pf_lines: List[str] = []
+        for label, key in (
+            ("workflow_officer_state.primary_followup.check_id", "check_id"),
+            (
+                "workflow_officer_state.primary_followup.recommended_priority",
+                "recommended_priority",
+            ),
+            ("workflow_officer_state.primary_followup.effective_level", "effective_level"),
+            (
+                "workflow_officer_state.primary_followup.recommended_action_excerpt",
+                "recommended_action_excerpt",
+            ),
+        ):
+            if key not in pf:
+                continue
+            pf_lines.append(
+                f"<tr><td style='padding:4px 8px 4px 0;vertical-align:top;'><code>{escape(label)}</code></td>"
+                f"<td style='padding:4px 0;'><code>{_cell(pf.get(key))}</code></td></tr>"
+            )
+        if pf_lines:
+            pf_block = (
+                "<h3>Primary follow-up (payload)</h3>"
+                "<table style='width:100%;border-collapse:collapse;font-size:0.9em;'>"
+                "<tbody>"
+                f"{''.join(pf_lines)}"
+                "</tbody></table>"
+            )
+
+    top_raw = wo.get("top_followups")
+    top_ul = ""
+    if isinstance(top_raw, list) and top_raw:
+        items: List[str] = []
+        for row in top_raw[:3]:
+            if not isinstance(row, dict):
+                continue
+            cid = str(row.get("check_id", "")).strip()
+            if not cid:
+                continue
+            items.append(
+                "<li>"
+                f"<code>{escape(cid)}</code> "
+                f"(priority {_cell(row.get('recommended_priority'))}, "
+                f"level {_cell(row.get('effective_level'))})"
+                "</li>"
+            )
+        if items:
+            top_ul = "<h3>Top follow-ups (preview)</h3><ul>" + "".join(items) + "</ul>"
+
+    table_html = (
+        "<h3>Workflow Officer snapshot (payload)</h3>"
+        "<table style='width:100%;border-collapse:collapse;font-size:0.9em;'>"
+        "<tbody>"
+        f"{''.join(rows_html)}"
+        "</tbody></table>"
+    )
+    return f"{head}{snap_p}{table_html}{pf_block}{top_ul}</div></div>"
+
+
 def _render_dependencies_state_card_body(dependencies: Dict[str, object]) -> str:
     """HTML inner block for Dependencies State — existing ``dependencies_state`` keys only (read-only)."""
     dep = dependencies if isinstance(dependencies, dict) else {}
@@ -1666,6 +1812,7 @@ def build_ops_cockpit_payload(
             run_dir=update_officer_run_dir,
         )
     phase83_eligibility_snapshot = _build_phase83_eligibility_snapshot(repo_root)
+    workflow_officer_state: Dict[str, object] = build_workflow_officer_panel_context(repo_root)
     return {
         "system_state": {
             "mode": "truth_first_ops_cockpit_v3",
@@ -1700,6 +1847,7 @@ def build_ops_cockpit_payload(
         "critical_flags": v3_summary["critical_flags"],
         "unknown_flags": v3_summary["unknown_flags"],
         "phase83_eligibility_snapshot": phase83_eligibility_snapshot,
+        "workflow_officer_state": workflow_officer_state,
         "update_officer_ui": update_officer_ui,
     }
 
@@ -2169,6 +2317,7 @@ def render_ops_cockpit_html(
     phase57_snapshot_discoverability_html = _render_phase57_snapshot_discoverability_card()
     incident_observation_html = _render_incident_observation_card(payload)
     run_state_observation_html = _render_run_state_observation_card(payload)
+    workflow_officer_observation_html = _render_workflow_officer_observation_surface(payload)
     phase83_eligibility_html = _render_phase83_eligibility_card(
         payload.get("phase83_eligibility_snapshot") or {}
     )
@@ -2202,6 +2351,7 @@ def render_ops_cockpit_html(
     .operator-summary-disclaimer {{ border-left: 4px solid #607d8b; padding-left: 12px; margin: 12px 0; }}
     .operator-summary-surface h3 {{ font-size: 1.05em; margin-top: 18px; margin-bottom: 8px; }}
     .policy-governance-observation-surface h3 {{ font-size: 1.05em; margin-top: 18px; margin-bottom: 8px; }}
+    .operator-workflow-observation-surface h3 {{ font-size: 1.05em; margin-top: 18px; margin-bottom: 8px; }}
     .status-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin: 12px 0; }}
     .status-card {{ padding: 10px; border-radius: 8px; border: 1px solid #e0e0e0; }}
     .status-label {{ display: block; font-size: 0.85em; color: #555; margin-bottom: 4px; }}
@@ -2231,6 +2381,7 @@ def render_ops_cockpit_html(
   {phase57_snapshot_discoverability_html}
   {incident_observation_html}
   {run_state_observation_html}
+  {workflow_officer_observation_html}
   {phase83_eligibility_html}
   <div class="hero">
     <h1>Ops Cockpit v3 — Truth-First</h1>

--- a/tests/webui/test_ops_cockpit.py
+++ b/tests/webui/test_ops_cockpit.py
@@ -46,6 +46,7 @@ def test_ops_cockpit_truth_sections_present(tmp_path: Path) -> None:
     assert "session_end_mismatch_state" in payload
     assert "human_supervision_state" in payload
     assert "phase83_eligibility_snapshot" in payload
+    assert "workflow_officer_state" in payload
     sup = payload["human_supervision_state"]
     assert sup["status"] == "operator_supervised"
     assert sup["mode"] == "intended"
@@ -1386,6 +1387,8 @@ def test_api_ops_cockpit_query_params_explicit_path(ops_client: TestClient, tmp_
     )
     assert response.status_code == 200
     data = response.json()
+    assert "workflow_officer_state" in data
+    assert isinstance(data["workflow_officer_state"], dict)
     assert data["update_officer_ui"]["available"] is True
     assert data["update_officer_ui"]["next_topic"] == "python_dependencies"
 
@@ -1637,6 +1640,80 @@ def test_ops_cockpit_workflow_officer_empty_state_wording(tmp_path: Path) -> Non
     assert ctx["present"] is False
     assert ctx["empty_reason"] == "no_officer_output_dir"
     assert (ctx.get("executive_panel") or {}).get("present") is False
+
+
+def test_ops_cockpit_payload_contains_workflow_officer_state(tmp_path: Path) -> None:
+    payload = build_ops_cockpit_payload(repo_root=tmp_path)
+    assert "workflow_officer_state" in payload
+    w = payload["workflow_officer_state"]
+    assert isinstance(w, dict)
+    assert w.get("present") is False
+    assert w.get("empty_reason") == "no_officer_output_dir"
+
+
+def test_ops_cockpit_html_contains_operator_workflow_observation_empty(tmp_path: Path) -> None:
+    html = render_ops_cockpit_html(repo_root=tmp_path)
+    assert 'id="operator-workflow-observation-surface"' in html
+    assert "Operator workflow observation (vNext Phase 4)" in html
+    assert "workflow_officer_state.empty_reason" in html
+    assert "no_officer_output_dir" in html
+    assert "not approval" in html.lower()
+    assert "does not execute Workflow Officer" in html
+
+
+def test_ops_cockpit_html_contains_operator_workflow_observation_with_report(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "out" / "ops" / "workflow_officer" / "20260201T000000Z"
+    run_dir.mkdir(parents=True)
+    report = {
+        "officer_version": "v1-min",
+        "profile": "docs_only_pr",
+        "mode": "audit",
+        "success": True,
+        "finished_at": "2026-02-01",
+        "summary": {
+            "total_checks": 1,
+            "hard_failures": 0,
+            "warnings": 0,
+            "infos": 0,
+            "strict": False,
+            "executive_summary": {
+                "executive_summary_schema_version": "workflow_officer.executive_summary/v0",
+                "urgency_label": "clear",
+                "attention_rationale": "No blocking errors.",
+            },
+            "operator_report": {
+                "operator_report_schema_version": "workflow_officer.operator_report/v0",
+                "primary_followup": {
+                    "check_id": "chk_a",
+                    "recommended_priority": "p3",
+                    "effective_level": "ok",
+                    "recommended_action": "No action.",
+                },
+                "rollup": {
+                    "total_checks": 1,
+                    "hard_failures": 0,
+                    "warnings": 0,
+                    "infos": 0,
+                },
+                "top_followups": [
+                    {
+                        "rank": 1,
+                        "check_id": "chk_a",
+                        "recommended_priority": "p3",
+                        "effective_level": "ok",
+                    }
+                ],
+            },
+        },
+    }
+    (run_dir / "report.json").write_text(json.dumps(report), encoding="utf-8")
+    html = render_ops_cockpit_html(repo_root=tmp_path)
+    assert "workflow_officer_state.run_dir_name" in html
+    assert "20260201T000000Z" in html
+    assert "workflow_officer_state.primary_followup.check_id" in html
+    assert "chk_a" in html
 
 
 def test_ops_cockpit_workflow_officer_report_contains_operator_rollup_label(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds additive `workflow_officer_state` to `build_ops_cockpit_payload` via `build_workflow_officer_panel_context` (read-only; latest `out/ops/workflow_officer` / `report.json` when present).
- Renders **Operator workflow observation (vNext Phase 4)** block on `/ops` with empty-state handling (`empty_reason`) and bounded payload fields when present.
- Updates operator summary spec, vNext dashboard spec, and vNext plan runbook.

## Non-goals
- No Workflow Officer execution from the page
- No new routes or POSTs
- No `app.py` changes

## Verification
- `python3 -m ruff check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py`
- `python3 -m ruff format src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py`
- `python3 -m pytest tests/webui/test_ops_cockpit.py -q`
- `python3 -m pytest tests/test_webui_live_track.py -q`
- `bash scripts/ops/verify_docs_reference_targets.sh`
- `python3 scripts/ops/validate_docs_token_policy.py --base origin/main`

## Review notes
- Confirm wording remains observation-only / read-only / not approval / not unlock.
- Confirm no Workflow Officer execution path was introduced.
- Confirm values come only from `workflow_officer_state` / existing artifact-backed context.
