### PR TITLE
R&D Dashboard v0: read-only experiments read-model + list API (Phase 76 slice 1)

### DIFF
--- a/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
+++ b/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
@@ -53,7 +53,7 @@ Die folgenden Checkboxen spiegeln den **Ist-Stand der read-only Ops-Cockpit-Lini
 Siehe Milestones/DoD in [`PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md`](PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md).
 
 - [x] Read-only **Listen-API** + defensive Read-Model-Schicht für lokale JSONs
-      (`GET /api/r_and_d/experiments`, `src/r_and_d/experiments_read_model.py`) — Slice 1;
+      (`GET /api&#47;r_and_d&#47;experiments`, `src&#47;r_and_d&#47;experiments_read_model.py`) — Slice 1;
       Filter + `sort_by`/`sort_order`; keine Write-/Trigger-Routen.
 - [ ] Backend-/API-Erweiterungen für Summarys/Aggregationen nach Phase-76-Spec §5 (wenn gewünscht).
 - [ ] List View + Filter (an CLI-Logik angelehnt) — UI weiter ausbauen; API-Liste vorhanden.

--- a/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
+++ b/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
@@ -52,8 +52,11 @@ Die folgenden Checkboxen spiegeln den **Ist-Stand der read-only Ops-Cockpit-Lini
 
 Siehe Milestones/DoD in [`PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md`](PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md).
 
-- [ ] Backend-Service bzw. Anbindung + API für Experimente und Summarys.
-- [ ] List View + Filter (an CLI-Logik angelehnt).
+- [x] Read-only **Listen-API** + defensive Read-Model-Schicht für lokale JSONs
+      (`GET /api/r_and_d/experiments`, `src/r_and_d/experiments_read_model.py`) — Slice 1;
+      Filter + `sort_by`/`sort_order`; keine Write-/Trigger-Routen.
+- [ ] Backend-/API-Erweiterungen für Summarys/Aggregationen nach Phase-76-Spec §5 (wenn gewünscht).
+- [ ] List View + Filter (an CLI-Logik angelehnt) — UI weiter ausbauen; API-Liste vorhanden.
 - [ ] Experiment-Detail inkl. Metriken + JSON-Rohsicht.
 - [ ] Aggregationen (Preset / Strategy).
 - [ ] Mind. zwei Charts (z. B. Sharpe-Verteilung, Sharpe vs. Return).

--- a/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
+++ b/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
@@ -97,6 +97,12 @@ R&D-Bausteinen aufsetzt:
 - **Struktur:** Konsistent mit dem, was `view_r_and_d_experiments.py` und
   `r_and_d_experiment_analysis_template.py` bereits nutzen.
 
+**Slice 1 (read-only Read-Model):** Defensive JSON-Ladung und Sortier-Helfer für
+Listen-Daten liegen in `src/r_and_d/experiments_read_model.py` (keine Schreibpfade,
+keine Netzwerk-Calls). Die WebUI-API `GET /api/r_and_d/experiments` in
+`src/webui/r_and_d_api.py` nutzt diese Schicht und unterstützt Filter sowie
+`sort_by` / `sort_order` wie in §5.2 beschrieben.
+
 ### 4.2 Aggregations-Layer
 
 Für das Dashboard v0 gibt es zwei mögliche Ansätze:

--- a/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
+++ b/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
@@ -11,9 +11,9 @@
 Phase 76 liefert ein erstes **R&D Dashboard v0**, das auf den bestehenden
 R&D-Bausteinen aufsetzt:
 
-- Strategy-Profiling via `scripts/research_cli.py strategy-profile`
-- R&D Experiments Viewer CLI `scripts/view_r_and_d_experiments.py`
-- Analyse-Template `notebooks/r_and_d_experiment_analysis_template.py`
+- Strategy-Profiling via `scripts&#47;research_cli.py strategy-profile`
+- R&D Experiments Viewer CLI `scripts&#47;view_r_and_d_experiments.py`
+- Analyse-Template `notebooks&#47;r_and_d_experiment_analysis_template.py`
 - Operator-Workflow aus Phase 75 (R&D-Wave v1/v2)
 
 **Ziel von Phase 76:**
@@ -92,15 +92,15 @@ R&D-Bausteinen aufsetzt:
 
 ### 4.1 Primäre Datenquelle
 
-- **Verzeichnis:** `reports/r_and_d_experiments/`
+- **Verzeichnis:** `reports&#47;r_and_d_experiments&#47;`
 - **Format:** JSON-Dateien pro Experiment
 - **Struktur:** Konsistent mit dem, was `view_r_and_d_experiments.py` und
   `r_and_d_experiment_analysis_template.py` bereits nutzen.
 
 **Slice 1 (read-only Read-Model):** Defensive JSON-Ladung und Sortier-Helfer für
-Listen-Daten liegen in `src/r_and_d/experiments_read_model.py` (keine Schreibpfade,
-keine Netzwerk-Calls). Die WebUI-API `GET /api/r_and_d/experiments` in
-`src/webui/r_and_d_api.py` nutzt diese Schicht und unterstützt Filter sowie
+Listen-Daten liegen in `src&#47;r_and_d&#47;experiments_read_model.py` (keine Schreibpfade,
+keine Netzwerk-Calls). Die WebUI-API `GET /api&#47;r_and_d&#47;experiments` in
+`src&#47;webui&#47;r_and_d_api.py` nutzt diese Schicht und unterstützt Filter sowie
 `sort_by` / `sort_order` wie in §5.2 beschrieben.
 
 ### 4.2 Aggregations-Layer
@@ -384,7 +384,7 @@ templates/
 | Aspekt | Live-Track Dashboard (Phase 82/85) | R&D Dashboard (Phase 76) |
 |--------|-----------------------------------|--------------------------|
 | **Fokus** | Live-/Shadow-/Testnet-Sessions | Offline R&D-Experimente |
-| **Datenquelle** | `reports/experiments/live_sessions/` | `reports/r_and_d_experiments/` |
+| **Datenquelle** | `reports&#47;experiments&#47;live_sessions&#47;` | `reports&#47;r_and_d_experiments&#47;` |
 | **Zeitbezug** | Laufende/abgeschlossene Sessions | Historische Backtests |
 | **Safety-Relevanz** | Hoch (Live-Monitoring) | Niedrig (Read-Only Research) |
 | **Zielgruppe** | Operatoren | Researcher, Quants |

--- a/src/r_and_d/__init__.py
+++ b/src/r_and_d/__init__.py
@@ -1,0 +1,1 @@
+"""R&D Dashboard read-only building blocks (filesystem / local artifacts only)."""

--- a/src/r_and_d/experiments_read_model.py
+++ b/src/r_and_d/experiments_read_model.py
@@ -1,0 +1,95 @@
+"""
+Read-only R&D experiment JSON load + ordering helpers.
+
+Source directory (typical): ``reports/r_and_d_experiments/*.json`` — same contract as
+``scripts/view_r_and_d_experiments.py`` and ``src/webui/r_and_d_api.py``.
+
+No writes, no network, no job triggers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_SORT_KEYS = frozenset({"timestamp", "sharpe", "return", "total_return"})
+_SORT_ORDERS = frozenset({"asc", "desc"})
+
+
+def load_experiment_json_file(filepath: Path) -> Optional[Dict[str, Any]]:
+    """
+    Load a single experiment JSON file. Returns None on missing file or parse error.
+    Adds ``_filepath`` and ``_filename`` for downstream helpers.
+    """
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        data["_filepath"] = str(filepath)
+        data["_filename"] = filepath.name
+        return data
+    except (json.JSONDecodeError, OSError, TypeError):
+        return None
+
+
+def load_experiments_from_directory(experiments_dir: Path) -> List[Dict[str, Any]]:
+    """
+    Load all ``*.json`` under ``experiments_dir``, skip broken files, newest first.
+
+    Sort key: ``experiment.timestamp`` (string, descending). Empty directory → [].
+    """
+    if not experiments_dir.exists():
+        return []
+
+    experiments: List[Dict[str, Any]] = []
+    for json_file in sorted(experiments_dir.glob("*.json")):
+        data = load_experiment_json_file(json_file)
+        if data is not None:
+            experiments.append(data)
+
+    def get_timestamp(exp: Dict[str, Any]) -> str:
+        return str(exp.get("experiment", {}).get("timestamp", "") or "")
+
+    experiments.sort(key=get_timestamp, reverse=True)
+    return experiments
+
+
+def sort_raw_experiments(
+    experiments: List[Dict[str, Any]],
+    sort_by: str = "timestamp",
+    sort_order: str = "desc",
+) -> List[Dict[str, Any]]:
+    """
+    Stable sort of raw experiment dicts (pre-``extract_flat_fields``).
+
+    - ``sort_by``: ``timestamp`` | ``sharpe`` | ``return`` (alias ``total_return``)
+    - ``sort_order``: ``asc`` | ``desc`` (invalid values fall back to ``desc``)
+    """
+    key = (sort_by or "timestamp").lower()
+    if key not in _SORT_KEYS:
+        key = "timestamp"
+    order = (sort_order or "desc").lower()
+    if order not in _SORT_ORDERS:
+        order = "desc"
+    reverse = order == "desc"
+
+    def sort_key(exp: Dict[str, Any]) -> Any:
+        ex = exp.get("experiment", {})
+        res = exp.get("results", {}) or {}
+        if key == "timestamp":
+            return str(ex.get("timestamp", "") or "")
+        if key == "sharpe":
+            try:
+                return float(res.get("sharpe", 0.0))
+            except (TypeError, ValueError):
+                return 0.0
+        # return / total_return
+        try:
+            return float(res.get("total_return", 0.0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    # timestamp: string compare works for YYYYMMDD_HHMMSS; desc = newest first
+    return sorted(experiments, key=sort_key, reverse=reverse)

--- a/src/webui/r_and_d_api.py
+++ b/src/webui/r_and_d_api.py
@@ -31,11 +31,12 @@ v1.1 Änderungen:
 - Experiment-Kategorien nach R&D-Taxonomie
 
 Basis: reports/r_and_d_experiments/, view_r_and_d_experiments.py, Notebook-Template
+
+Read-model I/O (filesystem JSON only): ``src/r_and_d/experiments_read_model.py``.
 """
 
 from __future__ import annotations
 
-import json
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
@@ -43,6 +44,12 @@ from typing import Any, Dict, List, Optional, TypedDict
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
+
+from src.r_and_d.experiments_read_model import (
+    load_experiment_json_file,
+    load_experiments_from_directory,
+    sort_raw_experiments,
+)
 
 
 # =============================================================================
@@ -258,51 +265,19 @@ def load_experiment_json(filepath: Path) -> Optional[Dict[str, Any]]:
     """
     Lädt eine einzelne Experiment-JSON-Datei.
 
-    Args:
-        filepath: Pfad zur JSON-Datei
-
-    Returns:
-        Experiment-Dict mit Metadaten oder None bei Fehler
+    Delegiert an :func:`src.r_and_d.experiments_read_model.load_experiment_json_file`.
     """
-    try:
-        with open(filepath, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        data["_filepath"] = str(filepath)
-        data["_filename"] = filepath.name
-        return data
-    except (json.JSONDecodeError, FileNotFoundError, IOError):
-        return None
+    return load_experiment_json_file(filepath)
 
 
 def load_experiments_from_dir(dir_path: Optional[Path] = None) -> List[Dict[str, Any]]:
     """
     Lädt alle R&D-Experimente aus dem Verzeichnis.
 
-    Args:
-        dir_path: Pfad zum Experiment-Verzeichnis (default: get_r_and_d_dir())
-
-    Returns:
-        Liste von Experiment-Dicts, sortiert nach Timestamp (neueste zuerst)
+    Delegiert an :func:`src.r_and_d.experiments_read_model.load_experiments_from_directory`.
     """
     experiments_dir = dir_path or get_r_and_d_dir()
-
-    if not experiments_dir.exists():
-        return []
-
-    experiments: List[Dict[str, Any]] = []
-    json_files = list(experiments_dir.glob("*.json"))
-
-    for json_file in json_files:
-        data = load_experiment_json(json_file)
-        if data is not None:
-            experiments.append(data)
-
-    # Sortiere nach Timestamp (neueste zuerst)
-    def get_timestamp(exp: Dict[str, Any]) -> str:
-        return exp.get("experiment", {}).get("timestamp", "")
-
-    experiments.sort(key=get_timestamp, reverse=True)
-    return experiments
+    return load_experiments_from_directory(experiments_dir)
 
 
 def extract_flat_fields(exp: Dict[str, Any]) -> Dict[str, Any]:
@@ -919,6 +894,11 @@ async def list_experiments(
     date_to: Optional[str] = Query(None, description="Filter bis Datum (YYYY-MM-DD)"),
     with_trades: bool = Query(False, description="Nur Experimente mit Trades > 0"),
     limit: int = Query(200, ge=1, le=5000, description="Maximale Anzahl (1-5000)"),
+    sort_by: str = Query(
+        "timestamp",
+        description="Sortierung: timestamp | sharpe | return (total_return)",
+    ),
+    sort_order: str = Query("desc", description="asc oder desc"),
 ) -> Dict[str, Any]:
     """
     Liste aller R&D-Experimente mit Filtern.
@@ -944,8 +924,10 @@ async def list_experiments(
 
     filtered_count = len(filtered)
 
-    # Limit anwenden
-    limited = filtered[:limit]
+    sorted_exps = sort_raw_experiments(filtered, sort_by=sort_by, sort_order=sort_order)
+
+    # Limit anwenden (nach Sortierung)
+    limited = sorted_exps[:limit]
 
     # In Summary-Format konvertieren
     items = [extract_flat_fields(exp) for exp in limited]
@@ -955,6 +937,8 @@ async def list_experiments(
         "total": len(experiments),
         "filtered": filtered_count,
         "returned": len(items),
+        "sort_by": sort_by,
+        "sort_order": sort_order,
     }
 
 

--- a/tests/r_and_d/test_experiments_read_model.py
+++ b/tests/r_and_d/test_experiments_read_model.py
@@ -1,0 +1,89 @@
+"""Unit tests for src.r_and_d.experiments_read_model (filesystem read-only)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.r_and_d.experiments_read_model import (
+    load_experiment_json_file,
+    load_experiments_from_directory,
+    sort_raw_experiments,
+)
+
+
+def _minimal_exp(timestamp: str, sharpe: float, total_return: float, name: str) -> dict:
+    return {
+        "experiment": {
+            "preset_id": "p",
+            "strategy": "s",
+            "symbol": "X",
+            "timeframe": "1h",
+            "tag": "t",
+            "timestamp": timestamp,
+        },
+        "results": {
+            "total_return": total_return,
+            "sharpe": sharpe,
+            "max_drawdown": 0.0,
+            "total_trades": 1,
+            "win_rate": 0.5,
+        },
+        "meta": {},
+        "_filename": name,
+    }
+
+
+def test_load_experiment_json_file_invalid_returns_none(tmp_path: Path) -> None:
+    bad = tmp_path / "x.json"
+    bad.write_text("not json", encoding="utf-8")
+    assert load_experiment_json_file(bad) is None
+
+
+def test_load_experiment_json_file_ok(tmp_path: Path) -> None:
+    p = tmp_path / "a.json"
+    raw = _minimal_exp("20240101_120000", 1.0, 0.1, "a.json")
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    loaded = load_experiment_json_file(p)
+    assert loaded is not None
+    assert loaded["_filename"] == "a.json"
+    assert loaded["experiment"]["timestamp"] == "20240101_120000"
+
+
+def test_load_experiments_skips_bad_file(tmp_path: Path) -> None:
+    (tmp_path / "bad.json").write_text("{", encoding="utf-8")
+    good_raw = _minimal_exp("20240201_120000", 2.0, 0.2, "good.json")
+    (tmp_path / "good.json").write_text(json.dumps(good_raw), encoding="utf-8")
+    out = load_experiments_from_directory(tmp_path)
+    assert len(out) == 1
+    assert out[0]["_filename"] == "good.json"
+
+
+def test_load_experiments_empty_dir(tmp_path: Path) -> None:
+    assert load_experiments_from_directory(tmp_path) == []
+
+
+def test_load_experiments_missing_dir(tmp_path: Path) -> None:
+    assert load_experiments_from_directory(tmp_path / "nope") == []
+
+
+def test_sort_by_sharpe_desc() -> None:
+    a = _minimal_exp("20240101_120000", 1.0, 0.5, "a.json")
+    b = _minimal_exp("20240102_120000", 3.0, 0.1, "b.json")
+    c = _minimal_exp("20240103_120000", 2.0, 0.2, "c.json")
+    got = sort_raw_experiments([a, b, c], sort_by="sharpe", sort_order="desc")
+    assert [x["_filename"] for x in got] == ["b.json", "c.json", "a.json"]
+
+
+def test_sort_by_return_asc() -> None:
+    a = _minimal_exp("20240101_120000", 1.0, 0.1, "a.json")
+    b = _minimal_exp("20240102_120000", 1.0, 0.3, "b.json")
+    got = sort_raw_experiments([a, b], sort_by="return", sort_order="asc")
+    assert [x["_filename"] for x in got] == ["a.json", "b.json"]
+
+
+def test_sort_invalid_sort_by_falls_back_to_timestamp() -> None:
+    a = _minimal_exp("20240101_120000", 1.0, 0.1, "a.json")
+    b = _minimal_exp("20240102_120000", 1.0, 0.1, "b.json")
+    got = sort_raw_experiments([a, b], sort_by="bogus", sort_order="desc")
+    assert [x["_filename"] for x in got] == ["b.json", "a.json"]

--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -331,6 +331,15 @@ class TestAPIExperiments:
         data = resp.json()
         assert data["returned"] <= 1
 
+    def test_list_experiments_sort_params_echo(self, client):
+        """sort_by / sort_order (Phase-76-Design) werden angewendet und zurückgegeben."""
+        resp = client.get("/api/r_and_d/experiments?sort_by=sharpe&sort_order=desc")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sort_by"] == "sharpe"
+        assert data["sort_order"] == "desc"
+        assert "items" in data
+
 
 class TestAPIExperimentDetail:
     """Tests für /api/r_and_d/experiments/{run_id}."""


### PR DESCRIPTION
## Summary
- add a defensive read-only experiments read-model module for local R&D experiment JSON files
- wire the list API to the read-model layer instead of inline file loading
- add sort_by and sort_order support to GET /api/r_and_d/experiments
- add read-model unit tests and list API regression coverage
- update Phase 76 design and dashboard checklist for this slice

## Details
This PR adds `src/r_and_d/experiments_read_model.py` and keeps the R&D dashboard slice strictly read-only. The module loads local JSON artifacts from `reports/r_and_d_experiments&#47;*.json`, handles malformed files defensively, and provides deterministic sorting helpers.

`src/webui/r_and_d_api.py` now delegates experiment loading to the read-model layer and supports:
- `sort_by=timestamp|sharpe|return`
- `sort_order=asc|desc`

The response keeps existing list fields (`items`, `total`, `filtered`, `returned`) and adds `sort_by` and `sort_order` as additive metadata.

## Guardrails
- read-only only
- no writes or job triggers
- no exchange or broker API calls
- no network calls to external services
- no ops cockpit changes
- no live/execution/paper/shadow coupling

## Verification
- `uv run ruff check src/r_and_d/__init__.py src/r_and_d/experiments_read_model.py src/webui/r_and_d_api.py tests/r_and_d/test_experiments_read_model.py tests/test_r_and_d_api.py`
- `uv run pytest tests/r_and_d/test_experiments_read_model.py tests/test_r_and_d_api.py`


Made with [Cursor](https://cursor.com)