### PR TITLE
R&D Dashboard v0: list UI parity with experiments API (Phase 76 slice 2)

### DIFF
--- a/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
+++ b/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
@@ -56,7 +56,7 @@ Siehe Milestones/DoD in [`PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md`](PHASE_76_R_A
       (`GET /api&#47;r_and_d&#47;experiments`, `src&#47;r_and_d&#47;experiments_read_model.py`) — Slice 1;
       Filter + `sort_by`/`sort_order`; keine Write-/Trigger-Routen.
 - [ ] Backend-/API-Erweiterungen für Summarys/Aggregationen nach Phase-76-Spec §5 (wenn gewünscht).
-- [ ] List View + Filter (an CLI-Logik angelehnt) — UI weiter ausbauen; API-Liste vorhanden.
+- [x] List View: GET-Query-Parität zur Listen-API (Filter/Sort/Limit/Datum, read-only) — Phase 76 slice 2; weiterer UI-Ausbau optional.
 - [ ] Experiment-Detail inkl. Metriken + JSON-Rohsicht.
 - [ ] Aggregationen (Preset / Strategy).
 - [ ] Mind. zwei Charts (z. B. Sharpe-Verteilung, Sharpe vs. Return).

--- a/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
+++ b/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
@@ -103,6 +103,11 @@ keine Netzwerk-Calls). Die WebUI-API `GET /api&#47;r_and_d&#47;experiments` in
 `src&#47;webui&#47;r_and_d_api.py` nutzt diese Schicht und unterstützt Filter sowie
 `sort_by` / `sort_order` wie in §5.2 beschrieben.
 
+**Slice 2 (list UI GET parity):** Die HTML-Route `GET /r_and_d` reicht dieselben
+relevanten Query-Parameter wie `GET /api&#47;r_and_d&#47;experiments` read-only durch
+(Filter, Datumsfenster, `sort_by`/`sort_order`, `limit`; optional zusätzlich UI-`run_type`).
+Keine POST-Routen und keine Job-Trigger in diesem Slice.
+
 ### 4.2 Aggregations-Layer
 
 Für das Dashboard v0 gibt es zwei mögliche Ansätze:

--- a/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
+++ b/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
@@ -103,7 +103,7 @@ keine Netzwerk-Calls). Die WebUI-API `GET /api&#47;r_and_d&#47;experiments` in
 `src&#47;webui&#47;r_and_d_api.py` nutzt diese Schicht und unterstützt Filter sowie
 `sort_by` / `sort_order` wie in §5.2 beschrieben.
 
-**Slice 2 (list UI GET parity):** Die HTML-Route `GET /r_and_d` reicht dieselben
+**Slice 2 (list UI GET parity):** Die HTML-Route `GET &#47;r_and_d` reicht dieselben
 relevanten Query-Parameter wie `GET /api&#47;r_and_d&#47;experiments` read-only durch
 (Filter, Datumsfenster, `sort_by`/`sort_order`, `limit`; optional zusätzlich UI-`run_type`).
 Keine POST-Routen und keine Job-Trigger in diesem Slice.

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -99,6 +99,7 @@ from .r_and_d_api import (
     filter_experiments,
     extract_flat_fields,
     compute_global_stats,
+    sort_raw_experiments,
     # v1.3 (Phase 78)
     find_experiment_by_run_id,
     build_experiment_detail,
@@ -583,11 +584,19 @@ def create_app() -> FastAPI:
         preset: Optional[str] = Query(None, description="Filter nach Preset-ID"),
         strategy: Optional[str] = Query(None, description="Filter nach Strategy-ID"),
         tag_substr: Optional[str] = Query(None, description="Filter nach Tag-Substring"),
+        date_from: Optional[str] = Query(None, description="Filter ab Datum (YYYY-MM-DD)"),
+        date_to: Optional[str] = Query(None, description="Filter bis Datum (YYYY-MM-DD)"),
         run_type: Optional[str] = Query(None, description="Filter nach Run-Type"),
         with_trades: bool = Query(False, description="Nur Experimente mit Trades"),
-        limit: int = Query(100, ge=1, le=500, description="Max. Anzahl"),
+        limit: int = Query(200, ge=1, le=5000, description="Max. Anzahl (wie Listen-API)"),
+        sort_by: str = Query("timestamp", description="Sortierung: timestamp | sharpe | return"),
+        sort_order: str = Query("desc", description="asc oder desc"),
     ) -> Any:
-        """HTML Overview-Page für R&D-Experimente (Phase 76 v1.1)."""
+        """HTML Overview-Page für R&D-Experimente (Phase 76 v1.1).
+
+        Query-Parameter sind an ``GET /api/r_and_d/experiments`` angeglichen (read-only);
+        zusätzlich optional ``run_type`` (UI-Filter nach extrahiertem Run-Type).
+        """
         from datetime import date
 
         proj_status = get_project_status()
@@ -598,12 +607,14 @@ def create_app() -> FastAPI:
         # Alle Experimente zu flachen Dicts konvertieren (für Stats)
         all_flat = [extract_flat_fields(exp) for exp in all_experiments]
 
-        # Filter anwenden
+        # Filter anwenden (gleiche Signatur wie Listen-API)
         filtered_experiments = filter_experiments(
             all_experiments,
             preset=preset,
             strategy=strategy,
             tag_substr=tag_substr,
+            date_from=date_from,
+            date_to=date_to,
             with_trades=with_trades,
         )
 
@@ -615,8 +626,13 @@ def create_app() -> FastAPI:
                 if extract_flat_fields(exp).get("run_type") == run_type
             ]
 
-        # Limit anwenden
-        limited_experiments = filtered_experiments[:limit]
+        sorted_experiments = sort_raw_experiments(
+            filtered_experiments,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+
+        limited_experiments = sorted_experiments[:limit]
 
         # Zu flachen Dicts konvertieren für Template
         experiments = [extract_flat_fields(exp) for exp in limited_experiments]
@@ -637,13 +653,17 @@ def create_app() -> FastAPI:
         stats["today_failed"] = sum(1 for e in today_experiments if e.get("status") == "failed")
         stats["running_count"] = len(running_experiments)
 
-        # Filter-State für Template
+        # Filter-State für Template (inkl. API-parity-Parameter)
         filters = {
             "preset": preset,
             "strategy": strategy,
             "tag_substr": tag_substr,
+            "date_from": date_from,
+            "date_to": date_to,
             "run_type": run_type,
             "with_trades": with_trades,
+            "sort_by": sort_by,
+            "sort_order": sort_order,
         }
 
         return templates.TemplateResponse(

--- a/templates/peak_trade_dashboard/r_and_d_experiments.html
+++ b/templates/peak_trade_dashboard/r_and_d_experiments.html
@@ -172,7 +172,7 @@
 
       {# Quick-Actions #}
       <div class="flex flex-wrap items-center gap-2">
-        {{ quick_action("Alle", "/r_and_d", "📋", not filters.with_trades and not filters.preset and not filters.strategy) }}
+        {{ quick_action("Alle", "/r_and_d", "📋", not filters.with_trades and not filters.preset and not filters.strategy and not filters.tag_substr and not filters.run_type and not filters.date_from and not filters.date_to and filters.sort_by == 'timestamp' and filters.sort_order == 'desc' and limit == 200) }}
         {{ quick_action("Mit Trades", "/r_and_d?with_trades=true", "✅", filters.with_trades) }}
         <a
           href="/"
@@ -289,6 +289,13 @@
   {# SECTION 4: Filter-Form + aktive Filter                                  #}
   {# ======================================================================= #}
   <section aria-label="Filter">
+    {# Labels für Sortierung (API: timestamp | sharpe | return | total_return) #}
+    {% set sort_label_map = {
+      'timestamp': 'Timestamp',
+      'sharpe': 'Sharpe',
+      'return': 'Return',
+      'total_return': 'Return',
+    } %}
     <form method="GET" action="/r_and_d" class="bg-slate-900/60 rounded-xl border border-slate-800 p-4">
 
       {# Filter-Inputs Grid (kompakter in v1.1) #}
@@ -395,8 +402,85 @@
         </div>
       </div>
 
+      {# Zeile 2: Datum, Sortierung, Limit — GET-Parität zu /api/r_and_d/experiments #}
+      <div class="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 mt-3 pt-3 border-t border-slate-800/40">
+        <div class="flex flex-col gap-1">
+          <label for="filter-date-from" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Von (Datum)
+          </label>
+          <input
+            id="filter-date-from"
+            type="date"
+            name="date_from"
+            value="{{ filters.date_from or '' }}"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="filter-date-to" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Bis (Datum)
+          </label>
+          <input
+            id="filter-date-to"
+            type="date"
+            name="date_to"
+            value="{{ filters.date_to or '' }}"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="filter-sort-by" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Sortierung
+          </label>
+          <select
+            id="filter-sort-by"
+            name="sort_by"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          >
+            <option value="timestamp" {% if filters.sort_by == 'timestamp' %}selected{% endif %}>Timestamp</option>
+            <option value="sharpe" {% if filters.sort_by == 'sharpe' %}selected{% endif %}>Sharpe</option>
+            <option value="return" {% if filters.sort_by == 'return' or filters.sort_by == 'total_return' %}selected{% endif %}>Return</option>
+          </select>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="filter-sort-order" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Reihenfolge
+          </label>
+          <select
+            id="filter-sort-order"
+            name="sort_order"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          >
+            <option value="desc" {% if filters.sort_order == 'desc' %}selected{% endif %}>Absteigend</option>
+            <option value="asc" {% if filters.sort_order == 'asc' %}selected{% endif %}>Aufsteigend</option>
+          </select>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="filter-limit" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Limit
+          </label>
+          <input
+            id="filter-limit"
+            type="number"
+            name="limit"
+            min="1"
+            max="5000"
+            value="{{ limit }}"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          />
+        </div>
+        <div class="flex flex-col gap-1 justify-end">
+          <span class="text-xs text-slate-500 hidden lg:block">&nbsp;</span>
+          <p class="text-xs text-slate-500 leading-snug">
+            Gleiche GET-Parameter wie
+            <code class="bg-slate-800 px-1 rounded text-slate-400">/api/r_and_d/experiments</code>
+            (read-only).
+          </p>
+        </div>
+      </div>
+
       {# Aktive Filter Badges + Result Count #}
-      {% set has_active_filters = filters.preset or filters.strategy or filters.tag_substr or filters.with_trades or filters.run_type %}
+      {% set has_active_filters = filters.preset or filters.strategy or filters.tag_substr or filters.with_trades or filters.run_type or filters.date_from or filters.date_to or filters.sort_by != 'timestamp' or filters.sort_order != 'desc' or limit != 200 %}
       {% if has_active_filters or experiments|length > 0 %}
       <div class="mt-4 pt-3 border-t border-slate-800/50 flex flex-wrap items-center gap-2">
 
@@ -438,6 +522,31 @@
         {% if filters.with_trades %}
         <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-300 border border-emerald-500/30">
           ✓ mit Trades
+        </span>
+        {% endif %}
+
+        {% if filters.date_from %}
+        <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-cyan-500/10 text-cyan-300 border border-cyan-500/30">
+          ab {{ filters.date_from }}
+        </span>
+        {% endif %}
+
+        {% if filters.date_to %}
+        <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-cyan-500/10 text-cyan-300 border border-cyan-500/30">
+          bis {{ filters.date_to }}
+        </span>
+        {% endif %}
+
+        {% if filters.sort_by != 'timestamp' or filters.sort_order != 'desc' %}
+        <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-indigo-500/10 text-indigo-300 border border-indigo-500/30">
+          sort: {{ sort_label_map.get(filters.sort_by, filters.sort_by) }}
+          · {% if filters.sort_order == 'desc' %}absteigend{% else %}aufsteigend{% endif %}
+        </span>
+        {% endif %}
+
+        {% if limit != 200 %}
+        <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-slate-500/10 text-slate-300 border border-slate-500/30">
+          limit {{ limit }}
         </span>
         {% endif %}
 
@@ -670,7 +779,15 @@
           {% endif %}
         </span>
         <span class="text-xs text-slate-500">
-          Limit: {{ limit }} · Sortiert nach Timestamp (neueste zuerst)
+          Limit: {{ limit }}
+          · Sortierung: {{ sort_label_map.get(filters.sort_by, filters.sort_by) }}
+          {% if filters.sort_by == 'timestamp' and filters.sort_order == 'desc' %}
+          (neueste zuerst)
+          {% elif filters.sort_by == 'timestamp' and filters.sort_order == 'asc' %}
+          (älteste zuerst)
+          {% else %}
+          · {{ 'absteigend' if filters.sort_order == 'desc' else 'aufsteigend' }}
+          {% endif %}
         </span>
       </div>
       {% endif %}

--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -31,6 +31,7 @@ v1.1: Neue Tests für:
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any, Dict
@@ -477,6 +478,60 @@ class TestRAndDExperimentsPage:
         """Page mit Run-Type Filter (v1.1)."""
         resp = client.get("/r_and_d?run_type=backtest")
         assert resp.status_code == 200
+
+    def test_page_list_filter_form_has_api_parity_get_controls(self, client):
+        """Listen-Form: GET-Controls für dieselben Kernparameter wie die Experiments-API."""
+        resp = client.get("/r_and_d")
+        assert resp.status_code == 200
+        text = resp.text
+        assert 'name="sort_by"' in text
+        assert 'name="sort_order"' in text
+        assert 'name="date_from"' in text
+        assert 'name="date_to"' in text
+        assert 'name="limit"' in text
+        assert 'name="preset"' in text
+        assert 'name="strategy"' in text
+        assert 'name="tag_substr"' in text
+
+    def test_page_filter_form_is_get_not_post(self, client):
+        """Kein POST auf dem Haupt-Filterformular (read-only)."""
+        resp = client.get("/r_and_d")
+        assert resp.status_code == 200
+        start = resp.text.find("<form")
+        assert start != -1
+        end = resp.text.find("</form>", start)
+        form_html = resp.text[start:end]
+        assert 'method="GET"' in form_html
+        assert 'method="POST"' not in form_html
+
+    def test_page_sort_sharpe_desc_puts_higher_sharpe_first(self, client):
+        """sort_by=sharpe&sort_order=desc: höheres Sharpe zuerst (Fixture: 1.5 vs 0.0)."""
+        resp = client.get("/r_and_d?sort_by=sharpe&sort_order=desc")
+        assert resp.status_code == 200
+        ids = list(dict.fromkeys(re.findall(r'data-run-id="([^"]+)"', resp.text)))
+        assert ids
+        assert ids[0] == "exp_test_v1_20241208_120000"
+
+    def test_page_limit_one_single_row(self, client):
+        """limit=1 liefert genau eine Tabellenzeile mit data-run-id."""
+        resp = client.get("/r_and_d?limit=1&sort_by=timestamp&sort_order=desc")
+        assert resp.status_code == 200
+        ids = list(dict.fromkeys(re.findall(r'data-run-id="([^"]+)"', resp.text)))
+        assert len(ids) == 1
+
+    def test_page_date_from_excludes_older_run(self, client):
+        """date_from filtert nach Experiment-Datum (Fixture leerer Run am Vortag)."""
+        resp = client.get("/r_and_d?date_from=2024-12-08")
+        assert resp.status_code == 200
+        assert "exp_test_v1_20241208_120000" in resp.text
+        assert "exp_empty_20241207_100000" not in resp.text
+
+    def test_page_footer_reflects_sort_query(self, client):
+        """Tabellenfuß nennt gewählte Sortierung (sichtbarer Marker)."""
+        resp = client.get("/r_and_d?sort_by=sharpe&sort_order=asc")
+        assert resp.status_code == 200
+        assert "Sharpe" in resp.text
+        assert "aufsteigend" in resp.text
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- align GET /r_and_d list UI controls with the read-only experiments list API
- add date, sort, order, and limit controls to the R&D experiments page
- keep the page strictly read-only with GET-only filter interaction
- add focused page tests for filter/sort/limit/date behavior
- update Phase 76 design notes and dashboard checklist

## Details
This PR brings the R&D experiments page closer to API/UI parity for the existing read-only experiments list flow. The handler already used the same filter and sorting path; this change makes those controls visible and usable in the HTML list UI.

Supported read-only GET parameters in the page flow:
- preset
- strategy
- tag_substr
- date_from
- date_to
- with_trades
- limit
- sort_by
- sort_order

The page remains read-only. No POST routes, no job triggers, no charts, no aggregation UI, and no Ops Cockpit changes are introduced. The existing UI-only run_type filter remains optional and separate from the JSON list API contract.

## Guardrails
- read-only only
- GET form only
- no POST or write routes
- no job triggers
- no exchange or broker API calls
- no live/execution/paper/shadow coupling
- no charts or aggregation slice expansion
- no Ops Cockpit changes

## Verification
- `uv run ruff check src/webui/app.py tests/test_r_and_d_api.py`
- `uv run pytest tests/test_r_and_d_api.py::TestRAndDExperimentsPage -q`


Made with [Cursor](https://cursor.com)