### PR TITLE
R&D Dashboard v0: aggregation UI for presets and strategies (Phase 76 slice 3)

### DIFF
--- a/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
+++ b/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
@@ -58,7 +58,7 @@ Siehe Milestones/DoD in [`PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md`](PHASE_76_R_A
 - [ ] Backend-/API-Erweiterungen für Summarys/Aggregationen nach Phase-76-Spec §5 (wenn gewünscht; JSON-API für Preset/Strategy ist bereits vorhanden).
 - [x] List View: GET-Query-Parität zur Listen-API (Filter/Sort/Limit/Datum, read-only) — Phase 76 slice 2; weiterer UI-Ausbau optional.
 - [ ] Experiment-Detail inkl. Metriken + JSON-Rohsicht.
-- [x] Aggregationen (Preset / Strategy): read-only HTML (`GET /r_and_d/presets`, `GET /r_and_d/strategies`) aligned zu den bestehenden JSON-Endpunkten — Phase 76 slice 3.
+- [x] Aggregationen (Preset / Strategy): read-only HTML (`GET &#47;r_and_d&#47;presets`, `GET &#47;r_and_d&#47;strategies`) aligned zu den bestehenden JSON-Endpunkten — Phase 76 slice 3.
 - [ ] Mind. zwei Charts (z. B. Sharpe-Verteilung, Sharpe vs. Return).
 - [ ] Tests (Design nennt u. a. mind. zehn API-Tests) + Doku aktualisieren.
 

--- a/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
+++ b/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
@@ -55,10 +55,10 @@ Siehe Milestones/DoD in [`PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md`](PHASE_76_R_A
 - [x] Read-only **Listen-API** + defensive Read-Model-Schicht für lokale JSONs
       (`GET /api&#47;r_and_d&#47;experiments`, `src&#47;r_and_d&#47;experiments_read_model.py`) — Slice 1;
       Filter + `sort_by`/`sort_order`; keine Write-/Trigger-Routen.
-- [ ] Backend-/API-Erweiterungen für Summarys/Aggregationen nach Phase-76-Spec §5 (wenn gewünscht).
+- [ ] Backend-/API-Erweiterungen für Summarys/Aggregationen nach Phase-76-Spec §5 (wenn gewünscht; JSON-API für Preset/Strategy ist bereits vorhanden).
 - [x] List View: GET-Query-Parität zur Listen-API (Filter/Sort/Limit/Datum, read-only) — Phase 76 slice 2; weiterer UI-Ausbau optional.
 - [ ] Experiment-Detail inkl. Metriken + JSON-Rohsicht.
-- [ ] Aggregationen (Preset / Strategy).
+- [x] Aggregationen (Preset / Strategy): read-only HTML (`GET /r_and_d/presets`, `GET /r_and_d/strategies`) aligned zu den bestehenden JSON-Endpunkten — Phase 76 slice 3.
 - [ ] Mind. zwei Charts (z. B. Sharpe-Verteilung, Sharpe vs. Return).
 - [ ] Tests (Design nennt u. a. mind. zehn API-Tests) + Doku aktualisieren.
 

--- a/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
+++ b/docs/DASHBOARD_COMPLETION_MASTER_CHECKLIST.md
@@ -56,7 +56,7 @@ Siehe Milestones/DoD in [`PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md`](PHASE_76_R_A
       (`GET /api&#47;r_and_d&#47;experiments`, `src&#47;r_and_d&#47;experiments_read_model.py`) — Slice 1;
       Filter + `sort_by`/`sort_order`; keine Write-/Trigger-Routen.
 - [ ] Backend-/API-Erweiterungen für Summarys/Aggregationen nach Phase-76-Spec §5 (wenn gewünscht).
-- [ ] List View + Filter (an CLI-Logik angelehnt) — UI weiter ausbauen; API-Liste vorhanden.
+- [x] List View: GET-Query-Parität zur Listen-API (Filter/Sort/Limit/Datum, read-only) — Phase 76 slice 2; weiterer UI-Ausbau optional.
 - [ ] Experiment-Detail inkl. Metriken + JSON-Rohsicht.
 - [ ] Aggregationen (Preset / Strategy).
 - [ ] Mind. zwei Charts (z. B. Sharpe-Verteilung, Sharpe vs. Return).

--- a/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
+++ b/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
@@ -108,6 +108,11 @@ relevanten Query-Parameter wie `GET /api&#47;r_and_d&#47;experiments` read-only 
 (Filter, Datumsfenster, `sort_by`/`sort_order`, `limit`; optional zusätzlich UI-`run_type`).
 Keine POST-Routen und keine Job-Trigger in diesem Slice.
 
+**Slice 3 (aggregation UI GET):** Read-only HTML unter `GET &#47;r_and_d&#47;presets` und
+`GET &#47;r_and_d&#47;strategies` nutzt dieselbe Aggregationslogik wie
+`GET /api&#47;r_and_d&#47;presets` bzw. `GET /api&#47;r_and_d&#47;strategies` (Tabellen,
+KPIs, defensive Empty States; keine Charts, keine Writes).
+
 ### 4.2 Aggregations-Layer
 
 Für das Dashboard v0 gibt es zwei mögliche Ansätze:
@@ -429,6 +434,7 @@ templates/
 | Datum | Änderung |
 |-------|----------|
 | 2025-12-09 | Initiale Design-Version erstellt |
+| 2026-04-13 | Slice 3 dokumentiert: read-only HTML-Aggregation für Preset/Strategy (`GET /r_and_d/presets`, `GET /r_and_d/strategies`) aligned zu den JSON-Endpunkten |
 
 ---
 

--- a/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
+++ b/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
@@ -103,6 +103,11 @@ keine Netzwerk-Calls). Die WebUI-API `GET /api&#47;r_and_d&#47;experiments` in
 `src&#47;webui&#47;r_and_d_api.py` nutzt diese Schicht und unterstützt Filter sowie
 `sort_by` / `sort_order` wie in §5.2 beschrieben.
 
+**Slice 2 (list UI GET parity):** Die HTML-Route `GET /r_and_d` reicht dieselben
+relevanten Query-Parameter wie `GET /api&#47;r_and_d&#47;experiments` read-only durch
+(Filter, Datumsfenster, `sort_by`/`sort_order`, `limit`; optional zusätzlich UI-`run_type`).
+Keine POST-Routen und keine Job-Trigger in diesem Slice.
+
 ### 4.2 Aggregations-Layer
 
 Für das Dashboard v0 gibt es zwei mögliche Ansätze:

--- a/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
+++ b/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
@@ -434,7 +434,7 @@ templates/
 | Datum | Änderung |
 |-------|----------|
 | 2025-12-09 | Initiale Design-Version erstellt |
-| 2026-04-13 | Slice 3 dokumentiert: read-only HTML-Aggregation für Preset/Strategy (`GET /r_and_d/presets`, `GET /r_and_d/strategies`) aligned zu den JSON-Endpunkten |
+| 2026-04-13 | Slice 3 dokumentiert: read-only HTML-Aggregation für Preset/Strategy (`GET &#47;r_and_d&#47;presets`, `GET &#47;r_and_d&#47;strategies`) aligned zu den JSON-Endpunkten |
 
 ---
 

--- a/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
+++ b/docs/PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md
@@ -103,7 +103,7 @@ keine Netzwerk-Calls). Die WebUI-API `GET /api&#47;r_and_d&#47;experiments` in
 `src&#47;webui&#47;r_and_d_api.py` nutzt diese Schicht und unterstützt Filter sowie
 `sort_by` / `sort_order` wie in §5.2 beschrieben.
 
-**Slice 2 (list UI GET parity):** Die HTML-Route `GET /r_and_d` reicht dieselben
+**Slice 2 (list UI GET parity):** Die HTML-Route `GET &#47;r_and_d` reicht dieselben
 relevanten Query-Parameter wie `GET /api&#47;r_and_d&#47;experiments` read-only durch
 (Filter, Datumsfenster, `sort_by`/`sort_order`, `limit`; optional zusätzlich UI-`run_type`).
 Keine POST-Routen und keine Job-Trigger in diesem Slice.

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -99,6 +99,7 @@ from .r_and_d_api import (
     filter_experiments,
     extract_flat_fields,
     compute_global_stats,
+    sort_raw_experiments,
     # v1.3 (Phase 78)
     find_experiment_by_run_id,
     build_experiment_detail,
@@ -583,11 +584,19 @@ def create_app() -> FastAPI:
         preset: Optional[str] = Query(None, description="Filter nach Preset-ID"),
         strategy: Optional[str] = Query(None, description="Filter nach Strategy-ID"),
         tag_substr: Optional[str] = Query(None, description="Filter nach Tag-Substring"),
+        date_from: Optional[str] = Query(None, description="Filter ab Datum (YYYY-MM-DD)"),
+        date_to: Optional[str] = Query(None, description="Filter bis Datum (YYYY-MM-DD)"),
         run_type: Optional[str] = Query(None, description="Filter nach Run-Type"),
         with_trades: bool = Query(False, description="Nur Experimente mit Trades"),
-        limit: int = Query(100, ge=1, le=500, description="Max. Anzahl"),
+        limit: int = Query(200, ge=1, le=5000, description="Max. Anzahl (wie Listen-API)"),
+        sort_by: str = Query("timestamp", description="Sortierung: timestamp | sharpe | return"),
+        sort_order: str = Query("desc", description="asc oder desc"),
     ) -> Any:
-        """HTML Overview-Page für R&D-Experimente (Phase 76 v1.1)."""
+        """HTML Overview-Page für R&D-Experimente (Phase 76 v1.1).
+
+        Query-Parameter sind an ``GET /api/r_and_d/experiments`` angeglichen (read-only);
+        zusätzlich optional ``run_type`` (UI-Filter nach extrahiertem Run-Type).
+        """
         from datetime import date
 
         proj_status = get_project_status()
@@ -598,12 +607,14 @@ def create_app() -> FastAPI:
         # Alle Experimente zu flachen Dicts konvertieren (für Stats)
         all_flat = [extract_flat_fields(exp) for exp in all_experiments]
 
-        # Filter anwenden
+        # Filter anwenden (gleiche Signatur wie Listen-API)
         filtered_experiments = filter_experiments(
             all_experiments,
             preset=preset,
             strategy=strategy,
             tag_substr=tag_substr,
+            date_from=date_from,
+            date_to=date_to,
             with_trades=with_trades,
         )
 
@@ -615,8 +626,13 @@ def create_app() -> FastAPI:
                 if extract_flat_fields(exp).get("run_type") == run_type
             ]
 
-        # Limit anwenden
-        limited_experiments = filtered_experiments[:limit]
+        sorted_experiments = sort_raw_experiments(
+            filtered_experiments,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+
+        limited_experiments = sorted_experiments[:limit]
 
         # Zu flachen Dicts konvertieren für Template
         experiments = [extract_flat_fields(exp) for exp in limited_experiments]
@@ -637,13 +653,17 @@ def create_app() -> FastAPI:
         stats["today_failed"] = sum(1 for e in today_experiments if e.get("status") == "failed")
         stats["running_count"] = len(running_experiments)
 
-        # Filter-State für Template
+        # Filter-State für Template (inkl. API-parity-Parameter)
         filters = {
             "preset": preset,
             "strategy": strategy,
             "tag_substr": tag_substr,
+            "date_from": date_from,
+            "date_to": date_to,
             "run_type": run_type,
             "with_trades": with_trades,
+            "sort_by": sort_by,
+            "sort_order": sort_order,
         }
 
         return templates.TemplateResponse(

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -39,6 +39,8 @@ HTML Pages:
 - GET / (Dashboard Home)
 - GET /session/{session_id} (Session Detail)
 - GET /r_and_d (R&D Experiments Overview - Phase 76)
+- GET /r_and_d/presets (R&D Preset-Aggregation HTML - Phase 76 Slice 3)
+- GET /r_and_d/strategies (R&D Strategy-Aggregation HTML - Phase 76 Slice 3)
 - GET /r_and_d/experiment/{run_id} (R&D Experiment Detail - Phase 77)
 - GET /r_and_d/comparison (R&D Multi-Run Comparison - Phase 78)
 
@@ -99,6 +101,8 @@ from .r_and_d_api import (
     filter_experiments,
     extract_flat_fields,
     compute_global_stats,
+    compute_preset_stats,
+    compute_strategy_stats,
     sort_raw_experiments,
     # v1.3 (Phase 78)
     find_experiment_by_run_id,
@@ -677,6 +681,51 @@ def create_app() -> FastAPI:
                 "total": len(all_experiments),
                 "filtered": len(filtered_experiments),
                 "limit": limit,
+            },
+        )
+
+    @app.get("/r_and_d/presets", response_class=HTMLResponse)
+    async def r_and_d_presets_aggregation_page(request: Request) -> Any:
+        """
+        HTML-Ansicht: Kennzahlen pro Preset (Phase 76 Slice 3).
+
+        Nutzt dieselbe Aggregationslogik wie ``GET /api/r_and_d/presets`` (keine Duplikation
+        der Berechnung). Rein lesend, keine Trigger.
+        """
+        proj_status = get_project_status()
+        all_experiments = load_experiments_from_dir()
+        preset_rows = compute_preset_stats(all_experiments)
+        stats = compute_global_stats(all_experiments)
+        return templates.TemplateResponse(
+            request,
+            "r_and_d_presets.html",
+            {
+                "status": proj_status,
+                "preset_rows": preset_rows,
+                "stats": stats,
+                "total_experiments": len(all_experiments),
+            },
+        )
+
+    @app.get("/r_and_d/strategies", response_class=HTMLResponse)
+    async def r_and_d_strategies_aggregation_page(request: Request) -> Any:
+        """
+        HTML-Ansicht: Kennzahlen pro Strategy (Phase 76 Slice 3).
+
+        Nutzt dieselbe Aggregationslogik wie ``GET /api/r_and_d/strategies``. Rein lesend.
+        """
+        proj_status = get_project_status()
+        all_experiments = load_experiments_from_dir()
+        strategy_rows = compute_strategy_stats(all_experiments)
+        stats = compute_global_stats(all_experiments)
+        return templates.TemplateResponse(
+            request,
+            "r_and_d_strategies.html",
+            {
+                "status": proj_status,
+                "strategy_rows": strategy_rows,
+                "stats": stats,
+                "total_experiments": len(all_experiments),
             },
         )
 

--- a/templates/peak_trade_dashboard/r_and_d_experiments.html
+++ b/templates/peak_trade_dashboard/r_and_d_experiments.html
@@ -172,7 +172,7 @@
 
       {# Quick-Actions #}
       <div class="flex flex-wrap items-center gap-2">
-        {{ quick_action("Alle", "/r_and_d", "📋", not filters.with_trades and not filters.preset and not filters.strategy) }}
+        {{ quick_action("Alle", "/r_and_d", "📋", not filters.with_trades and not filters.preset and not filters.strategy and not filters.tag_substr and not filters.run_type and not filters.date_from and not filters.date_to and filters.sort_by == 'timestamp' and filters.sort_order == 'desc' and limit == 200) }}
         {{ quick_action("Mit Trades", "/r_and_d?with_trades=true", "✅", filters.with_trades) }}
         <a
           href="/"
@@ -289,6 +289,13 @@
   {# SECTION 4: Filter-Form + aktive Filter                                  #}
   {# ======================================================================= #}
   <section aria-label="Filter">
+    {# Labels für Sortierung (API: timestamp | sharpe | return | total_return) #}
+    {% set sort_label_map = {
+      'timestamp': 'Timestamp',
+      'sharpe': 'Sharpe',
+      'return': 'Return',
+      'total_return': 'Return',
+    } %}
     <form method="GET" action="/r_and_d" class="bg-slate-900/60 rounded-xl border border-slate-800 p-4">
 
       {# Filter-Inputs Grid (kompakter in v1.1) #}
@@ -395,8 +402,85 @@
         </div>
       </div>
 
+      {# Zeile 2: Datum, Sortierung, Limit — GET-Parität zu /api/r_and_d/experiments #}
+      <div class="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 mt-3 pt-3 border-t border-slate-800/40">
+        <div class="flex flex-col gap-1">
+          <label for="filter-date-from" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Von (Datum)
+          </label>
+          <input
+            id="filter-date-from"
+            type="date"
+            name="date_from"
+            value="{{ filters.date_from or '' }}"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="filter-date-to" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Bis (Datum)
+          </label>
+          <input
+            id="filter-date-to"
+            type="date"
+            name="date_to"
+            value="{{ filters.date_to or '' }}"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="filter-sort-by" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Sortierung
+          </label>
+          <select
+            id="filter-sort-by"
+            name="sort_by"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          >
+            <option value="timestamp" {% if filters.sort_by == 'timestamp' %}selected{% endif %}>Timestamp</option>
+            <option value="sharpe" {% if filters.sort_by == 'sharpe' %}selected{% endif %}>Sharpe</option>
+            <option value="return" {% if filters.sort_by == 'return' or filters.sort_by == 'total_return' %}selected{% endif %}>Return</option>
+          </select>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="filter-sort-order" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Reihenfolge
+          </label>
+          <select
+            id="filter-sort-order"
+            name="sort_order"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          >
+            <option value="desc" {% if filters.sort_order == 'desc' %}selected{% endif %}>Absteigend</option>
+            <option value="asc" {% if filters.sort_order == 'asc' %}selected{% endif %}>Aufsteigend</option>
+          </select>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="filter-limit" class="text-xs uppercase tracking-wide text-slate-500 font-medium">
+            Limit
+          </label>
+          <input
+            id="filter-limit"
+            type="number"
+            name="limit"
+            min="1"
+            max="5000"
+            value="{{ limit }}"
+            class="rounded-lg px-3 py-2 bg-slate-950 border border-slate-700 text-sm text-slate-100 focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 focus:outline-none transition-colors"
+          />
+        </div>
+        <div class="flex flex-col gap-1 justify-end">
+          <span class="text-xs text-slate-500 hidden lg:block">&nbsp;</span>
+          <p class="text-xs text-slate-500 leading-snug">
+            Gleiche GET-Parameter wie
+            <code class="bg-slate-800 px-1 rounded text-slate-400">/api/r_and_d/experiments</code>
+            (read-only).
+          </p>
+        </div>
+      </div>
+
       {# Aktive Filter Badges + Result Count #}
-      {% set has_active_filters = filters.preset or filters.strategy or filters.tag_substr or filters.with_trades or filters.run_type %}
+      {% set has_active_filters = filters.preset or filters.strategy or filters.tag_substr or filters.with_trades or filters.run_type or filters.date_from or filters.date_to or filters.sort_by != 'timestamp' or filters.sort_order != 'desc' or limit != 200 %}
       {% if has_active_filters or experiments|length > 0 %}
       <div class="mt-4 pt-3 border-t border-slate-800/50 flex flex-wrap items-center gap-2">
 
@@ -438,6 +522,31 @@
         {% if filters.with_trades %}
         <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-300 border border-emerald-500/30">
           ✓ mit Trades
+        </span>
+        {% endif %}
+
+        {% if filters.date_from %}
+        <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-cyan-500/10 text-cyan-300 border border-cyan-500/30">
+          ab {{ filters.date_from }}
+        </span>
+        {% endif %}
+
+        {% if filters.date_to %}
+        <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-cyan-500/10 text-cyan-300 border border-cyan-500/30">
+          bis {{ filters.date_to }}
+        </span>
+        {% endif %}
+
+        {% if filters.sort_by != 'timestamp' or filters.sort_order != 'desc' %}
+        <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-indigo-500/10 text-indigo-300 border border-indigo-500/30">
+          sort: {{ sort_label_map.get(filters.sort_by, filters.sort_by) }}
+          · {% if filters.sort_order == 'desc' %}absteigend{% else %}aufsteigend{% endif %}
+        </span>
+        {% endif %}
+
+        {% if limit != 200 %}
+        <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-slate-500/10 text-slate-300 border border-slate-500/30">
+          limit {{ limit }}
         </span>
         {% endif %}
 
@@ -670,7 +779,15 @@
           {% endif %}
         </span>
         <span class="text-xs text-slate-500">
-          Limit: {{ limit }} · Sortiert nach Timestamp (neueste zuerst)
+          Limit: {{ limit }}
+          · Sortierung: {{ sort_label_map.get(filters.sort_by, filters.sort_by) }}
+          {% if filters.sort_by == 'timestamp' and filters.sort_order == 'desc' %}
+          (neueste zuerst)
+          {% elif filters.sort_by == 'timestamp' and filters.sort_order == 'asc' %}
+          (älteste zuerst)
+          {% else %}
+          · {{ 'absteigend' if filters.sort_order == 'desc' else 'aufsteigend' }}
+          {% endif %}
         </span>
       </div>
       {% endif %}

--- a/templates/peak_trade_dashboard/r_and_d_experiments.html
+++ b/templates/peak_trade_dashboard/r_and_d_experiments.html
@@ -175,6 +175,22 @@
         {{ quick_action("Alle", "/r_and_d", "📋", not filters.with_trades and not filters.preset and not filters.strategy and not filters.tag_substr and not filters.run_type and not filters.date_from and not filters.date_to and filters.sort_by == 'timestamp' and filters.sort_order == 'desc' and limit == 200) }}
         {{ quick_action("Mit Trades", "/r_and_d?with_trades=true", "✅", filters.with_trades) }}
         <a
+          href="/r_and_d/presets"
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors bg-slate-800 hover:bg-slate-700 text-slate-300"
+          title="Aggregation nach Preset (read-only)"
+        >
+          <span>📊</span>
+          <span>Presets</span>
+        </a>
+        <a
+          href="/r_and_d/strategies"
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors bg-slate-800 hover:bg-slate-700 text-slate-300"
+          title="Aggregation nach Strategy (read-only)"
+        >
+          <span>🎯</span>
+          <span>Strategies</span>
+        </a>
+        <a
           href="/"
           class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-slate-800 hover:bg-slate-700 text-slate-300 transition-colors"
         >

--- a/templates/peak_trade_dashboard/r_and_d_presets.html
+++ b/templates/peak_trade_dashboard/r_and_d_presets.html
@@ -1,0 +1,107 @@
+<!-- templates/peak_trade_dashboard/r_and_d_presets.html -->
+<!-- Phase 76 Slice 3: Preset-Aggregation (read-only, gleiche Semantik wie GET /api/r_and_d/presets) -->
+{% extends "base.html" %}
+
+{% block content %}
+<div class="space-y-6 max-w-6xl mx-auto">
+  <header class="bg-gradient-to-r from-slate-900/80 to-slate-900/40 rounded-2xl border border-slate-800 p-6">
+    <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+      <div>
+        <p class="text-xs uppercase tracking-wide text-slate-500 mb-1">R&D Dashboard v0</p>
+        <h1 class="text-2xl font-bold text-slate-100">Aggregation nach Preset</h1>
+        <p class="text-sm text-slate-400 mt-2 max-w-2xl">
+          Nur-Lese-Ansicht aus lokalen R&D-Experiment-JSONs. Keine Jobs, keine Writes.
+          Kennzahlen entsprechen <code class="text-xs bg-slate-800 px-1 rounded">GET /api/r_and_d/presets</code>.
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <a href="/r_and_d" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-sky-600 text-white hover:bg-sky-500">
+          ← Experimentenliste
+        </a>
+        <a href="/r_and_d/strategies" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-slate-800 hover:bg-slate-700 text-slate-300">
+          Nach Strategy →
+        </a>
+        <a href="/" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-slate-800 hover:bg-slate-700 text-slate-300">
+          Dashboard
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <section aria-label="Globale Kennzahlen" class="grid grid-cols-2 md:grid-cols-4 gap-3">
+    <div class="bg-slate-900/60 rounded-xl border border-slate-800 px-4 py-3">
+      <p class="text-xs text-slate-500">Experimente gesamt</p>
+      <p class="text-xl font-semibold text-slate-100 tabular-nums">{{ total_experiments }}</p>
+    </div>
+    <div class="bg-slate-900/60 rounded-xl border border-slate-800 px-4 py-3">
+      <p class="text-xs text-slate-500">Unique Presets</p>
+      <p class="text-xl font-semibold text-slate-100 tabular-nums">{{ stats.unique_presets }}</p>
+    </div>
+    <div class="bg-slate-900/60 rounded-xl border border-slate-800 px-4 py-3">
+      <p class="text-xs text-slate-500">Ø Sharpe (global)</p>
+      <p class="text-xl font-semibold text-slate-100 tabular-nums">{{ "%.3f"|format(stats.avg_sharpe) }}</p>
+    </div>
+    <div class="bg-slate-900/60 rounded-xl border border-slate-800 px-4 py-3">
+      <p class="text-xs text-slate-500">Median Return</p>
+      <p class="text-xl font-semibold text-slate-100 tabular-nums">{{ "%.3f"|format(stats.median_return) }}</p>
+    </div>
+  </section>
+
+  <section
+    data-section="r-and-d-preset-aggregation"
+    aria-label="Preset-Aggregationstabelle"
+    class="bg-slate-900/60 rounded-xl border border-slate-800 overflow-hidden"
+  >
+    <div class="px-4 py-3 border-b border-slate-800 flex items-center justify-between">
+      <h2 class="text-sm font-medium text-slate-200">Presets</h2>
+      {% if preset_rows|length > 0 %}
+      <span class="text-xs text-slate-500">{{ preset_rows|length }} Gruppe(n)</span>
+      {% endif %}
+    </div>
+    {% if preset_rows|length == 0 %}
+    <div class="p-8 text-center text-slate-500 text-sm">
+      <p class="font-medium text-slate-400 mb-1">Keine Preset-Gruppen</p>
+      <p>Es liegen keine Experimente mit gesetztem <code class="text-xs bg-slate-800 px-1 rounded">preset_id</code> vor, oder das Verzeichnis ist leer.</p>
+    </div>
+    {% else %}
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead>
+          <tr class="bg-slate-900/80 text-left text-xs text-slate-400 uppercase tracking-wide">
+            <th class="px-4 py-3 border-b border-slate-800">Preset</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Runs</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Mit Trades</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Ø Return</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Ø Sharpe</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Ø MaxDD</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Ø WinRate</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Σ Trades</th>
+            <th class="px-4 py-3 border-b border-slate-800">Liste</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-800/80">
+          {% for row in preset_rows %}
+          <tr class="hover:bg-slate-800/40">
+            <td class="px-4 py-2.5 font-mono text-xs text-sky-300">{{ row.preset_id }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-200">{{ row.experiment_count }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ row.experiments_with_trades }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ "%.4f"|format(row.avg_return) }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ "%.4f"|format(row.avg_sharpe) }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ "%.4f"|format(row.avg_max_drawdown) }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ "%.4f"|format(row.avg_win_rate) }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ row.total_trades }}</td>
+            <td class="px-4 py-2.5">
+              <a
+                class="text-xs text-sky-400 hover:text-sky-300 underline"
+                href="/r_and_d?preset={{ row.preset_id }}"
+              >Filtern</a>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/templates/peak_trade_dashboard/r_and_d_strategies.html
+++ b/templates/peak_trade_dashboard/r_and_d_strategies.html
@@ -1,0 +1,105 @@
+<!-- templates/peak_trade_dashboard/r_and_d_strategies.html -->
+<!-- Phase 76 Slice 3: Strategy-Aggregation (read-only, gleiche Semantik wie GET /api/r_and_d/strategies) -->
+{% extends "base.html" %}
+
+{% block content %}
+<div class="space-y-6 max-w-6xl mx-auto">
+  <header class="bg-gradient-to-r from-slate-900/80 to-slate-900/40 rounded-2xl border border-slate-800 p-6">
+    <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+      <div>
+        <p class="text-xs uppercase tracking-wide text-slate-500 mb-1">R&D Dashboard v0</p>
+        <h1 class="text-2xl font-bold text-slate-100">Aggregation nach Strategy</h1>
+        <p class="text-sm text-slate-400 mt-2 max-w-2xl">
+          Nur-Lese-Ansicht aus lokalen R&D-Experiment-JSONs. Keine Jobs, keine Writes.
+          Kennzahlen entsprechen <code class="text-xs bg-slate-800 px-1 rounded">GET /api/r_and_d/strategies</code>.
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <a href="/r_and_d" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-sky-600 text-white hover:bg-sky-500">
+          ← Experimentenliste
+        </a>
+        <a href="/r_and_d/presets" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-slate-800 hover:bg-slate-700 text-slate-300">
+          ← Nach Preset
+        </a>
+        <a href="/" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-slate-800 hover:bg-slate-700 text-slate-300">
+          Dashboard
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <section aria-label="Globale Kennzahlen" class="grid grid-cols-2 md:grid-cols-4 gap-3">
+    <div class="bg-slate-900/60 rounded-xl border border-slate-800 px-4 py-3">
+      <p class="text-xs text-slate-500">Experimente gesamt</p>
+      <p class="text-xl font-semibold text-slate-100 tabular-nums">{{ total_experiments }}</p>
+    </div>
+    <div class="bg-slate-900/60 rounded-xl border border-slate-800 px-4 py-3">
+      <p class="text-xs text-slate-500">Unique Strategies</p>
+      <p class="text-xl font-semibold text-slate-100 tabular-nums">{{ stats.unique_strategies }}</p>
+    </div>
+    <div class="bg-slate-900/60 rounded-xl border border-slate-800 px-4 py-3">
+      <p class="text-xs text-slate-500">Ø Sharpe (global)</p>
+      <p class="text-xl font-semibold text-slate-100 tabular-nums">{{ "%.3f"|format(stats.avg_sharpe) }}</p>
+    </div>
+    <div class="bg-slate-900/60 rounded-xl border border-slate-800 px-4 py-3">
+      <p class="text-xs text-slate-500">Median Return</p>
+      <p class="text-xl font-semibold text-slate-100 tabular-nums">{{ "%.3f"|format(stats.median_return) }}</p>
+    </div>
+  </section>
+
+  <section
+    data-section="r-and-d-strategy-aggregation"
+    aria-label="Strategy-Aggregationstabelle"
+    class="bg-slate-900/60 rounded-xl border border-slate-800 overflow-hidden"
+  >
+    <div class="px-4 py-3 border-b border-slate-800 flex items-center justify-between">
+      <h2 class="text-sm font-medium text-slate-200">Strategies</h2>
+      {% if strategy_rows|length > 0 %}
+      <span class="text-xs text-slate-500">{{ strategy_rows|length }} Gruppe(n)</span>
+      {% endif %}
+    </div>
+    {% if strategy_rows|length == 0 %}
+    <div class="p-8 text-center text-slate-500 text-sm">
+      <p class="font-medium text-slate-400 mb-1">Keine Strategy-Gruppen</p>
+      <p>Es liegen keine Experimente mit gesetztem <code class="text-xs bg-slate-800 px-1 rounded">strategy</code> vor, oder das Verzeichnis ist leer.</p>
+    </div>
+    {% else %}
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead>
+          <tr class="bg-slate-900/80 text-left text-xs text-slate-400 uppercase tracking-wide">
+            <th class="px-4 py-3 border-b border-slate-800">Strategy</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Runs</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Mit Trades</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Ø Return</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Ø Sharpe</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Ø MaxDD</th>
+            <th class="px-4 py-3 border-b border-slate-800 tabular-nums">Σ Trades</th>
+            <th class="px-4 py-3 border-b border-slate-800">Liste</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-800/80">
+          {% for row in strategy_rows %}
+          <tr class="hover:bg-slate-800/40">
+            <td class="px-4 py-2.5 font-mono text-xs text-emerald-300">{{ row.strategy }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-200">{{ row.experiment_count }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ row.experiments_with_trades }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ "%.4f"|format(row.avg_return) }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ "%.4f"|format(row.avg_sharpe) }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ "%.4f"|format(row.avg_max_drawdown) }}</td>
+            <td class="px-4 py-2.5 tabular-nums text-slate-300">{{ row.total_trades }}</td>
+            <td class="px-4 py-2.5">
+              <a
+                class="text-xs text-sky-400 hover:text-sky-300 underline"
+                href="/r_and_d?strategy={{ row.strategy }}"
+              >Filtern</a>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -162,6 +162,21 @@ def client(temp_experiments_dir) -> TestClient:
     return TestClient(app)
 
 
+@pytest.fixture
+def empty_experiments_dir(tmp_path: Path) -> Path:
+    """Repo-Layout ohne JSON-Dateien (defensive Empty-State)."""
+    exp_dir = tmp_path / "reports" / "r_and_d_experiments"
+    exp_dir.mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def empty_experiments_client(empty_experiments_dir: Path) -> TestClient:
+    app = create_app()
+    set_base_dir(empty_experiments_dir)
+    return TestClient(app)
+
+
 # =============================================================================
 # UNIT TESTS - Hilfsfunktionen
 # =============================================================================
@@ -532,6 +547,53 @@ class TestRAndDExperimentsPage:
         assert resp.status_code == 200
         assert "Sharpe" in resp.text
         assert "aufsteigend" in resp.text
+
+    def test_hub_links_to_aggregation_pages(self, client):
+        """Experimentenliste verlinkt read-only auf Preset-/Strategy-Aggregation."""
+        resp = client.get("/r_and_d")
+        assert resp.status_code == 200
+        text = resp.text
+        assert 'href="/r_and_d/presets"' in text
+        assert 'href="/r_and_d/strategies"' in text
+
+
+class TestRnDAggregationHtmlPages:
+    """Phase 76 Slice 3: HTML für Preset-/Strategy-Aggregation (Parität zu JSON-API)."""
+
+    def test_presets_page_ok_and_markers(self, client):
+        resp = client.get("/r_and_d/presets")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers.get("content-type", "")
+        body = resp.text
+        assert 'data-section="r-and-d-preset-aggregation"' in body
+        assert "Aggregation nach Preset" in body
+        assert "test_preset_v1" in body
+        assert 'method="POST"' not in body
+
+    def test_strategies_page_ok_and_markers(self, client):
+        resp = client.get("/r_and_d/strategies")
+        assert resp.status_code == 200
+        body = resp.text
+        assert 'data-section="r-and-d-strategy-aggregation"' in body
+        assert "Aggregation nach Strategy" in body
+        assert "test_strategy" in body
+        assert 'method="POST"' not in body
+
+    def test_presets_html_matches_api_row_count(self, client):
+        api = client.get("/api/r_and_d/presets")
+        assert api.status_code == 200
+        presets = api.json()
+        html = client.get("/r_and_d/presets").text
+        for row in presets:
+            assert row["preset_id"] in html
+
+    def test_empty_repo_presets_and_strategies_defensive(self, empty_experiments_client):
+        p = empty_experiments_client.get("/r_and_d/presets")
+        assert p.status_code == 200
+        assert "Keine Preset-Gruppen" in p.text
+        s = empty_experiments_client.get("/r_and_d/strategies")
+        assert s.status_code == 200
+        assert "Keine Strategy-Gruppen" in s.text
 
 
 # =============================================================================

--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -31,6 +31,7 @@ v1.1: Neue Tests für:
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any, Dict
@@ -477,6 +478,60 @@ class TestRAndDExperimentsPage:
         """Page mit Run-Type Filter (v1.1)."""
         resp = client.get("/r_and_d?run_type=backtest")
         assert resp.status_code == 200
+
+    def test_page_list_filter_form_has_api_parity_get_controls(self, client):
+        """Listen-Form: GET-Controls für dieselben Kernparameter wie die Experiments-API."""
+        resp = client.get("/r_and_d")
+        assert resp.status_code == 200
+        text = resp.text
+        assert 'name="sort_by"' in text
+        assert 'name="sort_order"' in text
+        assert 'name="date_from"' in text
+        assert 'name="date_to"' in text
+        assert 'name="limit"' in text
+        assert 'name="preset"' in text
+        assert 'name="strategy"' in text
+        assert 'name="tag_substr"' in text
+
+    def test_page_filter_form_is_get_not_post(self, client):
+        """Kein POST auf dem Haupt-Filterformular (read-only)."""
+        resp = client.get("/r_and_d")
+        assert resp.status_code == 200
+        start = resp.text.find("<form")
+        assert start != -1
+        end = resp.text.find("</form>", start)
+        form_html = resp.text[start:end]
+        assert 'method="GET"' in form_html
+        assert 'method="POST"' not in form_html
+
+    def test_page_sort_sharpe_desc_puts_higher_sharpe_first(self, client):
+        """sort_by=sharpe&sort_order=desc: höheres Sharpe zuerst (Fixture: 1.5 vs 0.0)."""
+        resp = client.get("/r_and_d?sort_by=sharpe&sort_order=desc")
+        assert resp.status_code == 200
+        ids = list(dict.fromkeys(re.findall(r'data-run-id="([^"]+)"', resp.text)))
+        assert ids
+        assert ids[0] == "exp_test_v1_20241208_120000"
+
+    def test_page_limit_one_single_row(self, client):
+        """limit=1 liefert genau eine Tabellenzeile mit data-run-id."""
+        resp = client.get("/r_and_d?limit=1&sort_by=timestamp&sort_order=desc")
+        assert resp.status_code == 200
+        ids = list(dict.fromkeys(re.findall(r'data-run-id="([^"]+)"', resp.text)))
+        assert len(ids) == 1
+
+    def test_page_date_from_excludes_older_run(self, client):
+        """date_from filtert nach Experiment-Datum (Fixture leerer Run am Vortag)."""
+        resp = client.get("/r_and_d?date_from=2024-12-08")
+        assert resp.status_code == 200
+        assert "exp_test_v1_20241208_120000" in resp.text
+        assert "exp_empty_20241207_100000" not in resp.text
+
+    def test_page_footer_reflects_sort_query(self, client):
+        """Tabellenfuß nennt gewählte Sortierung (sichtbarer Marker)."""
+        resp = client.get("/r_and_d?sort_by=sharpe&sort_order=asc")
+        assert resp.status_code == 200
+        assert "Sharpe" in resp.text
+        assert "aufsteigend" in resp.text
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add read-only HTML aggregation pages for presets and strategies
- reuse the existing preset/strategy aggregation semantics from `r_and_d_api.py`
- add navigation from the R&D experiments hub to the aggregation pages
- add defensive empty states, KPI tiles, and links back to filtered experiment lists
- update focused tests and minimal Phase 76 / checklist docs

## Details
This PR adds:
- `GET /r_and_d/presets`
- `GET /r_and_d/strategies`

Both pages are strictly read-only and reuse `compute_preset_stats` / `compute_strategy_stats` from `src/webui/r_and_d_api.py`, matching the semantics of the existing JSON APIs:
- `GET /api/r_and_d/presets`
- `GET /api/r_and_d/strategies`

The pages include:
- KPI summary tiles
- aggregation tables
- defensive empty states
- links back to `/r_and_d`
- GET links to filtered experiment lists such as `/r_and_d?preset=...` and `/r_and_d?strategy=...`

No writes, no POST routes, no job triggers, no charts, and no Ops Cockpit changes are introduced.

## Guardrails
- read-only only
- no POST or write routes
- no job triggers
- no exchange or broker API calls
- no network calls to external services
- no live/execution/paper/shadow coupling
- no charts in this slice
- no Ops Cockpit changes

## Verification
- `uv run ruff check src/webui/app.py tests/test_r_and_d_api.py`
- `uv run pytest tests/test_r_and_d_api.py`


Made with [Cursor](https://cursor.com)