### PR TITLE
risk(validation): delegate Christoffersen checks to canonical engine

### DIFF
--- a/src/risk/validation/christoffersen.py
+++ b/src/risk/validation/christoffersen.py
@@ -92,9 +92,7 @@ def conditional_coverage_test(
             f"breaches_bool length ({len(seq)}) must match observations ({observations})"
         )
     if sum(seq) != breaches:
-        raise ValueError(
-            f"breaches_bool sum ({sum(seq)}) must match breaches ({breaches})"
-        )
+        raise ValueError(f"breaches_bool sum ({sum(seq)}) must match breaches ({breaches})")
 
     n = len(seq)
     if n < 2:

--- a/src/risk/validation/christoffersen.py
+++ b/src/risk/validation/christoffersen.py
@@ -1,18 +1,34 @@
 """
-Christoffersen Independence + Conditional Coverage Tests (Stub for Phase 8C dev).
+Christoffersen Independence + Conditional Coverage Tests (validation layer).
 
-NOTE: This is a minimal stub. Full implementation should come from PR #422.
-For Phase 8C development/testing only.
+Thin wrappers around the canonical stdlib implementation in
+``src.risk_layer.var_backtest.christoffersen_tests`` (Phase 8B), mirroring the
+pattern used for Kupiec in ``kupiec_pof.py``.
+
+Legacy API (``ChristoffersenIndependenceResult``, ``independence_test``, …)
+is preserved for ``suite_runner`` and existing call sites.
+
+References:
+-----------
+- Christoffersen, P. F. (1998). Evaluating Interval Forecasts.
+  International Economic Review, 39(4), 841-862.
 """
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 
 import pandas as pd
 
+from src.risk_layer.var_backtest.christoffersen_tests import (
+    christoffersen_lr_cc as _canonical_christoffersen_lr_cc,
+    christoffersen_lr_ind as _canonical_christoffersen_lr_ind,
+)
+
 
 @dataclass
 class ChristoffersenIndependenceResult:
-    """Stub result for Independence Test."""
+    """Result of Independence Test (legacy shape for suite reports)."""
 
     is_valid: bool
     p_value: float
@@ -21,7 +37,7 @@ class ChristoffersenIndependenceResult:
 
 @dataclass
 class ChristoffersenConditionalCoverageResult:
-    """Stub result for Conditional Coverage Test."""
+    """Result of Conditional Coverage Test (legacy shape for suite reports)."""
 
     is_valid: bool
     p_value: float
@@ -29,15 +45,30 @@ class ChristoffersenConditionalCoverageResult:
 
 
 def independence_test(
-    breaches_bool: pd.Series, significance: float = 0.05
+    breaches_bool: pd.Series,
+    significance: float = 0.05,
 ) -> ChristoffersenIndependenceResult:
     """
-    Stub implementation of Independence Test.
+    Christoffersen independence test (LR-IND) on a breach indicator series.
 
-    In real implementation (PR #422): Tests temporal independence of breaches.
+    Delegates to :func:`christoffersen_lr_ind` with the same breach convention
+    as the suite runner (True = loss exceeds VaR).
     """
-    # Stub: Always return PASS with dummy p-value
-    return ChristoffersenIndependenceResult(is_valid=True, p_value=0.5, lr_statistic=0.0)
+    seq = [bool(x) for x in breaches_bool.tolist()]
+    n = len(seq)
+    if n < 2:
+        return ChristoffersenIndependenceResult(
+            is_valid=False,
+            p_value=1.0,
+            lr_statistic=0.0,
+        )
+
+    r = _canonical_christoffersen_lr_ind(seq, p_threshold=significance)
+    return ChristoffersenIndependenceResult(
+        is_valid=(r.verdict == "PASS"),
+        p_value=float(r.p_value),
+        lr_statistic=float(r.lr_ind),
+    )
 
 
 def conditional_coverage_test(
@@ -48,9 +79,44 @@ def conditional_coverage_test(
     significance: float = 0.05,
 ) -> ChristoffersenConditionalCoverageResult:
     """
-    Stub implementation of Conditional Coverage Test.
+    Christoffersen conditional coverage test (LR-CC).
 
-    In real implementation (PR #422): Combined UC + IND test.
+    ``alpha`` for the joint test is the expected exceedance rate ``1 - confidence_level``
+    (e.g. 95%% VaR → 5%% tail).
+
+    Delegates to :func:`christoffersen_lr_cc`.
     """
-    # Stub: Always return PASS with dummy p-value
-    return ChristoffersenConditionalCoverageResult(is_valid=True, p_value=0.5, lr_cc_statistic=0.0)
+    seq = [bool(x) for x in breaches_bool.tolist()]
+    if len(seq) != observations:
+        raise ValueError(
+            f"breaches_bool length ({len(seq)}) must match observations ({observations})"
+        )
+    if sum(seq) != breaches:
+        raise ValueError(
+            f"breaches_bool sum ({sum(seq)}) must match breaches ({breaches})"
+        )
+
+    n = len(seq)
+    if n < 2:
+        return ChristoffersenConditionalCoverageResult(
+            is_valid=False,
+            p_value=1.0,
+            lr_cc_statistic=0.0,
+        )
+
+    alpha_exceedance = 1.0 - confidence_level
+    if not 0 < alpha_exceedance < 1:
+        raise ValueError(
+            f"Invalid implied exceedance rate {alpha_exceedance} from confidence_level={confidence_level}"
+        )
+
+    r = _canonical_christoffersen_lr_cc(
+        seq,
+        alpha_exceedance,
+        p_threshold=significance,
+    )
+    return ChristoffersenConditionalCoverageResult(
+        is_valid=(r.verdict == "PASS"),
+        p_value=float(r.p_value),
+        lr_cc_statistic=float(r.lr_cc),
+    )

--- a/tests/risk/validation/test_christoffersen_delegation.py
+++ b/tests/risk/validation/test_christoffersen_delegation.py
@@ -1,0 +1,57 @@
+"""Verify validation-layer Christoffersen wrappers match canonical engine."""
+
+import pandas as pd
+import pytest
+
+from src.risk.validation.christoffersen import (
+    conditional_coverage_test,
+    independence_test,
+)
+from src.risk_layer.var_backtest.christoffersen_tests import (
+    christoffersen_lr_cc,
+    christoffersen_lr_ind,
+)
+
+
+class TestChristoffersenEquivalence:
+    """Legacy wrappers vs canonical ``risk_layer`` implementation."""
+
+    def test_independence_matches_canonical(self) -> None:
+        exceed = [False] * 40 + [True, False, True, False] + [False] * 56
+        s = pd.Series(exceed)
+
+        leg = independence_test(s, significance=0.05)
+        can = christoffersen_lr_ind(exceed, p_threshold=0.05)
+
+        assert leg.is_valid == (can.verdict == "PASS")
+        assert leg.p_value == pytest.approx(can.p_value, rel=0, abs=1e-12)
+        assert leg.lr_statistic == pytest.approx(can.lr_ind, rel=0, abs=1e-12)
+
+    def test_conditional_coverage_matches_canonical(self) -> None:
+        exceed = [False] * 90 + [True] * 10
+        s = pd.Series(exceed)
+        conf = 0.95
+        alpha = 1.0 - conf
+
+        leg = conditional_coverage_test(
+            breaches=10,
+            observations=100,
+            breaches_bool=s,
+            confidence_level=conf,
+            significance=0.05,
+        )
+        can = christoffersen_lr_cc(exceed, alpha, p_threshold=0.05)
+
+        assert leg.is_valid == (can.verdict == "PASS")
+        assert leg.p_value == pytest.approx(can.p_value, rel=0, abs=1e-12)
+        assert leg.lr_cc_statistic == pytest.approx(can.lr_cc, rel=0, abs=1e-12)
+
+    def test_inconsistent_breaches_raises(self) -> None:
+        s = pd.Series([True, False, False])
+        with pytest.raises(ValueError, match="must match breaches"):
+            conditional_coverage_test(
+                breaches=2,
+                observations=3,
+                breaches_bool=s,
+                confidence_level=0.95,
+            )


### PR DESCRIPTION
## Summary
Replace the placeholder Christoffersen validation stubs with thin delegation wrappers to the canonical implementation in `src/risk_layer/var_backtest/christoffersen_tests.py`.

## What changed
- `independence_test` now delegates to canonical LR-IND logic
- `conditional_coverage_test` now delegates to canonical LR-CC logic
- added consistency checks for breach counts vs. series length
- return restrictive invalid result for fewer than 2 observations
- added delegation tests for parity and mismatch error path

## Why
The previous implementation returned placeholder PASS-style outputs and dummy p-values. This PR makes the validation layer statistically real while keeping the existing API surface.

## Risk
- scope limited to `src/risk/**`
- validation/reporting layer only
- no live execution changes
- downstream fixtures expecting stub-like values may need updates later

## Verification
- `python3 -m pytest tests/risk/validation/ -q`
- `python3 -m pytest tests/risk_layer/var_backtest/test_christoffersen.py -q`

Made with [Cursor](https://cursor.com)