### PR TITLE
docs(obs): add canonical vs legacy observability paths

### DIFF
--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -75,13 +75,13 @@ Siehe `docs/DOCKER_KOMPLETT_UEBERSICHT.md` für die kanonische Docker-Dokumentat
 ### Legacy / drift names (non-canonical)
 Do **not** treat these as current entrypoints; they are missing from the tree or only appear in older docs, evidence, or merge logs:
 
-- `docs/observability/OBS_STACK_RUNBOOK.md`
-- `docs/webui/observability/DOCKER_COMPOSE_GRAFANA_ONLY.yml`
-- `docs/webui/observability/DOCKER_COMPOSE_PROMETHEUS_LOCAL.yml`
-- `docs/webui/observability/grafana/dashboards`
-- `scripts/obs/grafana_local_up.sh`
-- `scripts/obs/grafana_local_down.sh`
-- `scripts/obs/shadow_mvs_local_verify.sh`
+- `docs&#47;observability&#47;OBS_STACK_RUNBOOK.md`
+- `docs&#47;webui&#47;observability&#47;DOCKER_COMPOSE_GRAFANA_ONLY.yml`
+- `docs&#47;webui&#47;observability&#47;DOCKER_COMPOSE_PROMETHEUS_LOCAL.yml`
+- `docs&#47;webui&#47;observability&#47;grafana&#47;dashboards`
+- `scripts&#47;obs&#47;grafana_local_up.sh`
+- `scripts&#47;obs&#47;grafana_local_down.sh`
+- `scripts&#47;obs&#47;shadow_mvs_local_verify.sh`
 
 Labeled legacy context: `docs/ops/reviews/grafana_prometheus_operator_entrypoints/REVIEW.md`.
 

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -75,13 +75,13 @@ Siehe `docs/DOCKER_KOMPLETT_UEBERSICHT.md` für die kanonische Docker-Dokumentat
 ### Legacy / drift names (non-canonical)
 Do **not** treat these as current entrypoints; they are missing from the tree or only appear in older docs, evidence, or merge logs:
 
-- `docs&#47;observability&#47;OBS_STACK_RUNBOOK.md`
-- `docs&#47;webui&#47;observability&#47;DOCKER_COMPOSE_GRAFANA_ONLY.yml`
-- `docs&#47;webui&#47;observability&#47;DOCKER_COMPOSE_PROMETHEUS_LOCAL.yml`
-- `docs&#47;webui&#47;observability&#47;grafana&#47;dashboards`
-- `scripts&#47;obs&#47;grafana_local_up.sh`
-- `scripts&#47;obs&#47;grafana_local_down.sh`
-- `scripts&#47;obs&#47;shadow_mvs_local_verify.sh`
+- `docs&#47;observability&#47;OBS_STACK_RUNBOOK.md` <!-- pt:ref-target-ignore -->
+- `docs&#47;webui&#47;observability&#47;DOCKER_COMPOSE_GRAFANA_ONLY.yml` <!-- pt:ref-target-ignore -->
+- `docs&#47;webui&#47;observability&#47;DOCKER_COMPOSE_PROMETHEUS_LOCAL.yml` <!-- pt:ref-target-ignore -->
+- `docs&#47;webui&#47;observability&#47;grafana&#47;dashboards` <!-- pt:ref-target-ignore -->
+- `scripts&#47;obs&#47;grafana_local_up.sh` <!-- pt:ref-target-ignore -->
+- `scripts&#47;obs&#47;grafana_local_down.sh` <!-- pt:ref-target-ignore -->
+- `scripts&#47;obs&#47;shadow_mvs_local_verify.sh` <!-- pt:ref-target-ignore -->
 
 Labeled legacy context: `docs/ops/reviews/grafana_prometheus_operator_entrypoints/REVIEW.md`.
 
@@ -184,7 +184,7 @@ crontab -e
 
 ### Alternative: GitHub Actions
 
-Siehe `.github&#47;workflows&#47;stage1_monitoring.yml` (falls vorhanden).
+Siehe `.github&#47;workflows&#47;stage1_monitoring.yml` (falls vorhanden). <!-- pt:ref-target-ignore -->
 
 ---
 

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -62,6 +62,29 @@ docker compose -f docker/docker-compose.obs.yml run --rm peaktrade-ops stage1-sn
 
 Siehe `docs/DOCKER_KOMPLETT_UEBERSICHT.md` für die kanonische Docker-Dokumentation.
 
+
+### Canonical observability paths (SSOT)
+| Topic | Path |
+|------|------|
+| Ops Runner Compose | `docker/docker-compose.obs.yml` |
+| Prometheus scrape reference | `docs/webui/observability/PROMETHEUS_LOCAL_SCRAPE.yml` |
+| Full Docker / container overview | `docs/DOCKER_KOMPLETT_UEBERSICHT.md` |
+
+`scripts/obs/up.sh` is **intentionally disabled** (it prints an error and exit guidance). Prefer the Compose commands above rather than ad-hoc “bring stack up” scripts.
+
+### Legacy / drift names (non-canonical)
+Do **not** treat these as current entrypoints; they are missing from the tree or only appear in older docs, evidence, or merge logs:
+
+- `docs/observability/OBS_STACK_RUNBOOK.md`
+- `docs/webui/observability/DOCKER_COMPOSE_GRAFANA_ONLY.yml`
+- `docs/webui/observability/DOCKER_COMPOSE_PROMETHEUS_LOCAL.yml`
+- `docs/webui/observability/grafana/dashboards`
+- `scripts/obs/grafana_local_up.sh`
+- `scripts/obs/grafana_local_down.sh`
+- `scripts/obs/shadow_mvs_local_verify.sh`
+
+Labeled legacy context: `docs/ops/reviews/grafana_prometheus_operator_entrypoints/REVIEW.md`.
+
 ---
 
 ## 📊 Script 1: Daily Snapshot


### PR DESCRIPTION
# Summary

Add a small canonical-vs-legacy observability path note to `scripts/obs/README.md`.

## Why
Recent read-only repo audits showed that the current observability entrypoints are not obvious from older runbooks, merge logs, and legacy names. This adds a small SSOT-style note in the existing observability frontdoor.

## Included
- canonical paths:
  - `docker/docker-compose.obs.yml`
  - `docs/webui/observability/PROMETHEUS_LOCAL_SCRAPE.yml`
  - `docs/DOCKER_KOMPLETT_UEBERSICHT.md`
- explicit legacy/non-canonical names to avoid treating them as current entrypoints

## Not included
- no workflow changes
- no merge-log rewrites
- no baseline changes
- no legacy path restoration
