### PR TITLE
docs(policy-critic): clarify canonical runner vs always-run gate

### DIFF
--- a/docs/governance/POLICY_CRITIC_STATUS.md
+++ b/docs/governance/POLICY_CRITIC_STATUS.md
@@ -102,6 +102,10 @@ tests/governance/policy_critic/
   └── test_auto_apply_gate.py        # Auto-apply tests
 ```
 
+The canonical Policy Critic CI path is `.github&#47;workflows&#47;policy_critic.yml`, which runs `scripts&#47;run_policy_critic.py`.
+The separate `.github&#47;workflows&#47;policy_critic_gate.yml` workflow is an always-run gate for branch-protection continuity and may degrade to a placeholder path.
+It should not be read as the canonical Policy Critic runner.
+
 ---
 
 ## Recent Changes


### PR DESCRIPTION
## Summary
- clarify the canonical Policy Critic CI path in POLICY_CRITIC_STATUS.md
- document that policy_critic.yml + scripts/run_policy_critic.py are the canonical runner path
- note that policy_critic_gate.yml is an always-run branch-protection continuity gate and may degrade to a placeholder path

## Testing
- python3 scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh

Made with [Cursor](https://cursor.com)