### PR TITLE
docs(status): clarify roles of matrix and dated overview

### DIFF
--- a/docs/ops/STATUS_MATRIX.md
+++ b/docs/ops/STATUS_MATRIX.md
@@ -1,5 +1,10 @@
 # Status Matrix Contract
 
+
+<!-- STATUS_MATRIX role note -->
+> Role note: Use `docs&#47;ops&#47;STATUS_MATRIX.md` as the compact status map.
+> For dated narrative context, change history, and time-scoped operator framing, read `docs&#47;ops&#47;STATUS_OVERVIEW_2026-02-19.md`.
+
 **Scope:** Contract/Status-Werte für Tabellen; normativ für Evidence-Level. Für operativen Projektstatus siehe [STATUS_OVERVIEW_2026-02-19.md](STATUS_OVERVIEW_2026-02-19.md).
 
 ## Motivation

--- a/docs/ops/STATUS_OVERVIEW_2026-02-19.md
+++ b/docs/ops/STATUS_OVERVIEW_2026-02-19.md
@@ -1,5 +1,10 @@
 # Peak_Trade — Status-Übersicht & Implementierungsliste
 
+
+<!-- STATUS_OVERVIEW role note -->
+> Role note: Use `docs&#47;ops&#47;STATUS_OVERVIEW_2026-02-19.md` for dated narrative context and operator orientation at that point in time.
+> For the compact cross-topic status map, current navigation, and quick lookup, read `docs&#47;ops&#47;STATUS_MATRIX.md`.
+
 **Scope:** Aktueller Projektstatus, Runbook-Landschaft, Implementierungsliste; operativer Snapshot. Für Status-Contract/Evidence-Level siehe [STATUS_MATRIX.md](STATUS_MATRIX.md).
 
 **Stand:** 2026-02-19  


### PR DESCRIPTION
## Summary
- clarify the distinct roles of `docs/ops/STATUS_MATRIX.md` and `docs/ops/STATUS_OVERVIEW_2026-02-19.md`
- add short role notes directly under the top heading in both files
- make the reading order clearer for operators choosing between compact status lookup and dated narrative context

## Testing
- python3 scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh

Made with [Cursor](https://cursor.com)