### PR TITLE
docs(index): clarify status doc navigation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,6 +30,10 @@
 - [ops/](ops/) — Ops-Docs, Merge-Logs
 - [runbooks/](runbooks/) — Runbooks (docs&#47;runbooks&#47;; Ops-Runbooks siehe ops&#47;RUNBOOK_INDEX.md)
 
+<!-- docs INDEX status navigation note -->
+- `docs&#47;ops&#47;STATUS_MATRIX.md` — kompakte Status-Matrix und schneller Navigations-/Lookup-Einstieg.
+- `docs&#47;ops&#47;STATUS_OVERVIEW_2026-02-19.md` — datierter Überblick mit narrativem Kontext und zeitgebundener Operator-Einordnung.
+
 ### Historical (Referenz)
 - [audit/GOVERNANCE_DATAFLOW_REPORT.md](audit/GOVERNANCE_DATAFLOW_REPORT.md) — Historisch: Dataflow & Governance
 - [audit/REPO_AUDIT_REPORT.md](audit/REPO_AUDIT_REPORT.md) — Historisch: Repo-Inventory & Feature-Matrix


### PR DESCRIPTION
## Summary
- add index navigation guidance for the two status docs in `docs/INDEX.md`
- point readers to `docs&#47;ops&#47;STATUS_MATRIX.md` for compact lookup/navigation
- point readers to `docs&#47;ops&#47;STATUS_OVERVIEW_2026-02-19.md` for dated narrative context

## Testing
- python3 scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh

Made with [Cursor](https://cursor.com)