### PR TITLE
docs(ci): clarify pragmatic flow scope vs required checks

### DIFF
--- a/docs/ops/ci_pragmatic_flow_inventory.md
+++ b/docs/ops/ci_pragmatic_flow_inventory.md
@@ -1,5 +1,10 @@
 # CI Pragmatic Flow — Inventar (Workflows & Jobs)
 
+
+<!-- ci pragmatic flow staleness scope note -->
+> Scope note: This document is a pragmatic inventory and should not be read as the canonical source for the current required PR checks by itself.
+> For the current gate catalog and branch-protection view, use `docs&#47;ops&#47;GATES_OVERVIEW.md`, `docs&#47;ops&#47;CI.md`, and `config&#47;ci&#47;required_status_checks.json`.
+
 **Canonical reference:** [GATES_OVERVIEW.md](GATES_OVERVIEW.md) ist SSoT für Gates. Dieses Doc beschreibt pragmatische Flow-Details.
 
 **Stand:** 2026-02-07. Branch Protection: nur **PR Gate** als required check (TODO: in GitHub einstellen).

--- a/docs/ops/ci_pragmatic_flow_meta_gate.md
+++ b/docs/ops/ci_pragmatic_flow_meta_gate.md
@@ -1,5 +1,10 @@
 # CI Pragmatic Flow — PR Gate (Single Required Check)
 
+
+<!-- ci pragmatic flow staleness scope note -->
+> Scope note: This document captures pragmatic CI flow context and may describe a narrower gate view than the current required-check set.
+> For the current gate catalog and branch-protection view, use `docs&#47;ops&#47;GATES_OVERVIEW.md`, `docs&#47;ops&#47;CI.md`, and `config&#47;ci&#47;required_status_checks.json`.
+
 **Canonical reference:** [GATES_OVERVIEW.md](GATES_OVERVIEW.md) ist SSoT für Gates. Dieses Doc beschreibt PR-Gate-Details.
 
 **Ziel:** Für Branch Protection nur **einen** Required Check: **PR Gate**.  


### PR DESCRIPTION
## Summary
- add scope/staleness notes to the CI pragmatic flow docs
- clarify that these files are not the sole canonical source for the current required PR checks
- point readers to `docs&#47;ops&#47;GATES_OVERVIEW.md`, `docs&#47;ops&#47;CI.md`, and `config&#47;ci&#47;required_status_checks.json`

## Testing
- python3 scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh

Made with [Cursor](https://cursor.com)