### PR TITLE
research(portfolio): add manifest-backed strategy returns loader

### DIFF
--- a/scripts/run_portfolio_robustness.py
+++ b/scripts/run_portfolio_robustness.py
@@ -55,6 +55,7 @@ from src.experiments.portfolio_robustness import (
     run_portfolio_robustness,
 )
 from src.experiments.stress_tests import load_returns_for_top_config
+from src.experiments.strategy_returns_manifest_loader import load_returns_for_strategy_from_manifest
 from src.experiments.topn_promotion import load_top_n_configs_for_sweep
 from src.reporting.portfolio_robustness_report import build_portfolio_robustness_report
 
@@ -325,6 +326,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Verwende Dummy-Daten für Tests",
     )
     parser.add_argument(
+        "--strategy-returns-manifest",
+        type=str,
+        default=None,
+        help=(
+            "TOML mit [strategy_returns] strategy_id -> Run-Verzeichnis (relativ zum Manifest "
+            "oder absolut). Data-backed Modus für Presets mit strategies=[...]; "
+            "ohne --use-dummy-data."
+        ),
+    )
+    parser.add_argument(
         "--dummy-bars",
         type=int,
         default=500,
@@ -580,21 +591,33 @@ def run_from_args(args: argparse.Namespace) -> int:
 
         # 6. Erstelle Returns-Loader
         if strategies_mode:
-            if not args.use_dummy_data:
-                logger.error(
-                    "Presets mit 'strategies' benötigen aktuell --use-dummy-data, "
-                    "da kein data-backed Returns-Loader implementiert ist."
+            if args.use_dummy_data:
+                cache = _build_strategy_returns_cache(
+                    strategies,
+                    dummy_bars=args.dummy_bars,
+                    seed=42,
                 )
-                return 1
 
-            cache = _build_strategy_returns_cache(
-                strategies,
-                dummy_bars=args.dummy_bars,
-                seed=42,
-            )
+                def returns_loader(strategy_name: str, config_id: str) -> Optional[pd.Series]:
+                    return cache.get(config_id)
+            else:
+                if not args.strategy_returns_manifest:
+                    logger.error(
+                        "Presets mit 'strategies' benötigen --use-dummy-data oder "
+                        "--strategy-returns-manifest (data-backed Returns aus Manifest)."
+                    )
+                    return 1
 
-            def returns_loader(strategy_name: str, config_id: str) -> Optional[pd.Series]:
-                return cache.get(config_id)
+                manifest_path = Path(args.strategy_returns_manifest)
+                if not manifest_path.is_file():
+                    logger.error(f"Strategy-Returns-Manifest nicht gefunden: {manifest_path}")
+                    return 1
+
+                def returns_loader(strategy_name: str, config_id: str) -> Optional[pd.Series]:
+                    return load_returns_for_strategy_from_manifest(
+                        strategy_id=config_id,
+                        manifest_path=manifest_path,
+                    )
 
         else:
             returns_loader = build_returns_loader(

--- a/src/experiments/strategy_returns_manifest_loader.py
+++ b/src/experiments/strategy_returns_manifest_loader.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import toml
+
+from src.experiments.equity_loader import equity_to_returns, load_equity_curves_from_run_dir
+
+
+class StrategyReturnsManifestError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class StrategyReturnsSource:
+    strategy_id: str
+    run_dir: Path
+
+
+def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+    if not manifest_path.exists():
+        raise StrategyReturnsManifestError(f"manifest_not_found: {manifest_path}")
+    data = toml.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise StrategyReturnsManifestError("manifest_invalid: top_level_not_dict")
+    return data
+
+
+def _extract_mapping(data: dict[str, Any]) -> dict[str, str]:
+    mapping = data.get("strategy_returns")
+    if not isinstance(mapping, dict):
+        raise StrategyReturnsManifestError("manifest_invalid: missing [strategy_returns] table")
+    out: dict[str, str] = {}
+    for key, value in mapping.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise StrategyReturnsManifestError(
+                "manifest_invalid: strategy_returns entries must be str->str"
+            )
+        out[key] = value
+    return out
+
+
+def resolve_strategy_run_dir(
+    *,
+    strategy_id: str,
+    manifest_path: str | Path,
+    base_dir: str | Path | None = None,
+) -> StrategyReturnsSource:
+    manifest_path = Path(manifest_path)
+    data = _load_manifest(manifest_path)
+    mapping = _extract_mapping(data)
+
+    if strategy_id not in mapping:
+        raise StrategyReturnsManifestError(f"strategy_id_missing_in_manifest: {strategy_id}")
+
+    raw_path = Path(mapping[strategy_id])
+    if raw_path.is_absolute():
+        run_dir = raw_path
+    else:
+        anchor = Path(base_dir) if base_dir is not None else manifest_path.parent
+        run_dir = (anchor / raw_path).resolve()
+
+    if not run_dir.exists():
+        raise StrategyReturnsManifestError(f"run_dir_not_found: {strategy_id}: {run_dir}")
+    if not run_dir.is_dir():
+        raise StrategyReturnsManifestError(f"run_dir_not_directory: {strategy_id}: {run_dir}")
+
+    return StrategyReturnsSource(strategy_id=strategy_id, run_dir=run_dir)
+
+
+def load_returns_for_strategy_from_manifest(
+    *,
+    strategy_id: str,
+    manifest_path: str | Path,
+    base_dir: str | Path | None = None,
+) -> pd.Series:
+    source = resolve_strategy_run_dir(
+        strategy_id=strategy_id,
+        manifest_path=manifest_path,
+        base_dir=base_dir,
+    )
+
+    try:
+        curves = load_equity_curves_from_run_dir(source.run_dir, max_curves=1)
+    except (FileNotFoundError, ValueError) as e:
+        raise StrategyReturnsManifestError(
+            f"equity_load_failed: {strategy_id}: {source.run_dir}: {e}"
+        ) from e
+
+    try:
+        return equity_to_returns(curves[0])
+    except ValueError as e:
+        raise StrategyReturnsManifestError(
+            f"returns_derive_failed: {strategy_id}: {source.run_dir}: {e}"
+        ) from e

--- a/tests/test_strategy_returns_manifest_loader.py
+++ b/tests/test_strategy_returns_manifest_loader.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.experiments.strategy_returns_manifest_loader import (
+    StrategyReturnsManifestError,
+    load_returns_for_strategy_from_manifest,
+    resolve_strategy_run_dir,
+)
+
+
+def _write_manifest(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_run_equity_csv(run_dir: Path) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            "timestamp": [
+                "2026-01-01T00:00:00Z",
+                "2026-01-02T00:00:00Z",
+                "2026-01-03T00:00:00Z",
+            ],
+            "equity": [100.0, 101.0, 103.0],
+        }
+    )
+    # equity_loader accepts *equity.csv
+    df.to_csv(run_dir / "phase53_equity.csv", index=False)
+
+
+def test_resolve_strategy_run_dir_success(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "strategy_a"
+    run_dir.mkdir(parents=True)
+
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[strategy_returns]
+strategy_a = "runs/strategy_a"
+""".strip()
+        + "\n",
+    )
+
+    source = resolve_strategy_run_dir(strategy_id="strategy_a", manifest_path=manifest)
+    assert source.strategy_id == "strategy_a"
+    assert source.run_dir == run_dir.resolve()
+
+
+def test_load_returns_for_strategy_from_manifest_success(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "strategy_a"
+    _write_run_equity_csv(run_dir)
+
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[strategy_returns]
+strategy_a = "runs/strategy_a"
+""".strip()
+        + "\n",
+    )
+
+    returns = load_returns_for_strategy_from_manifest(
+        strategy_id="strategy_a",
+        manifest_path=manifest,
+    )
+
+    assert isinstance(returns, pd.Series)
+    assert len(returns) == 2
+    assert returns.notna().all()
+
+
+def test_load_returns_for_strategy_from_manifest_missing_strategy_id(tmp_path: Path) -> None:
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[strategy_returns]
+strategy_a = "runs/strategy_a"
+""".strip()
+        + "\n",
+    )
+
+    with pytest.raises(StrategyReturnsManifestError, match="strategy_id_missing_in_manifest"):
+        load_returns_for_strategy_from_manifest(
+            strategy_id="strategy_b",
+            manifest_path=manifest,
+        )


### PR DESCRIPTION
## Summary
- add a manifest-backed data-backed returns loader for `portfolio_recipes.strategies` / strategies_mode
- wire `scripts/run_portfolio_robustness.py` to use `--strategy-returns-manifest` when not running with `--use-dummy-data`
- add focused tests for manifest resolution, successful load, and missing strategy-id failure

## Scope
- narrow research-only slice
- no live / paper / shadow / testnet behavior changes
- no dummy-data fallback changes beyond explicit manifest wiring for strategies_mode

## Testing
- python3 -m pytest tests/test_strategy_returns_manifest_loader.py
- python3 -m pytest tests/test_research_cli_portfolio_presets.py
- python3 scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh

Made with [Cursor](https://cursor.com)