### PR TITLE
docs(portfolio): document manifest-backed strategies mode

### DIFF
--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -18,6 +18,12 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 ## Bereits geprüft (bisherige Session)
 
 ### 1) `docs/PORTFOLIO_RECIPES_AND_PRESETS.md` — **done (vorläufig)**
+
+<!-- phase53 manifest loader tracker note -->
+> Update: a manifest-backed strategies-mode returns-loader path is now available via `scripts&#47;run_portfolio_robustness.py --strategy-returns-manifest`.
+> Follow-up work is now about documentation, manifest ergonomics, and additional negative-path tests rather than the original missing loader path.
+> Contract: `docs&#47;adr&#47;ADR_0002_Phase53_Data_Backed_Returns_Loader_Strategies_Mode.md`.
+
 - **Implementiert**:
   - `src/experiments/portfolio_recipes.py` (Loader + Validierung, inkl. `strategies` (Phase 53))
   - `config/portfolio_recipes.toml` (Recipes, inkl. Phase 53/75 Abschnitte)

--- a/docs/PORTFOLIO_RECIPES_AND_PRESETS.md
+++ b/docs/PORTFOLIO_RECIPES_AND_PRESETS.md
@@ -142,6 +142,30 @@ python3 scripts/research_cli.py portfolio \
 
 ## Prioritätsregeln: Preset vs. CLI-Argumente
 
+
+<!-- phase53 strategies_mode manifest loader note -->
+## Data-backed `strategies_mode` via manifest
+
+For `portfolio_recipes.strategies` presets, `scripts&#47;run_portfolio_robustness.py` now supports data-backed execution via `--strategy-returns-manifest`.
+The manifest uses a `[strategy_returns]` table that maps each strategy key from the preset to one explicit run directory.
+Each mapped run directory is expected to follow the existing experiment-run equity convention consumed by the equity loader.
+Use this path when you want explicit, deterministic returns loading without `--use-dummy-data`.
+See `docs&#47;adr&#47;ADR_0002_Phase53_Data_Backed_Returns_Loader_Strategies_Mode.md` for the contract and non-goals.
+
+```toml
+[strategy_returns]
+rsi_reversion_btc_moderate = "runs/rsi_reversion_btc_moderate"
+ma_trend_btc_moderate = "runs/ma_trend_btc_moderate"
+```
+
+Example:
+
+```bash
+python3 scripts/run_portfolio_robustness.py \
+  --portfolio-preset <preset_name> \
+  --strategy-returns-manifest <path/to/strategy_returns_map.toml>
+```
+
 **Grundregel:** CLI-Argumente überschreiben Preset-Werte.
 
 | Parameter | Preset-Wert | CLI-Argument | Ergebnis |


### PR DESCRIPTION
## Summary
- document manifest-backed data-backed `strategies_mode` in `docs&#47;PORTFOLIO_RECIPES_AND_PRESETS.md`
- add a tracker update in `docs&#47;DOCS_AUDIT_TRACKER.md`
- reference `docs&#47;adr&#47;ADR_0002_Phase53_Data_Backed_Returns_Loader_Strategies_Mode.md`
- include a correct CLI example using `--portfolio-preset` and `--strategy-returns-manifest`

## Testing
- python3 scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh

Made with [Cursor](https://cursor.com)