### PR TITLE
refactor(strategies): remove legacy MACD helper API

### DIFF
--- a/src/strategies/macd.py
+++ b/src/strategies/macd.py
@@ -14,7 +14,6 @@ Konzept:
 from __future__ import annotations
 
 import pandas as pd
-import numpy as np
 from typing import Any, Dict, Optional, Tuple
 
 from .base import BaseStrategy, StrategyMetadata
@@ -217,96 +216,8 @@ class MACDStrategy(BaseStrategy):
 
 
 # ============================================================================
-# LEGACY API (Backwards Compatibility)
+# Module-level metadata helper (registry / reporting)
 # ============================================================================
-# NOTE: Siehe docs/TECH_DEBT_BACKLOG.md (Eintrag "Legacy-API Cleanup: macd.py")
-# Legacy-Funktion für Backwards Compatibility. Sollte entfernt werden, sobald
-# alle Pipelines auf MACDStrategy (OOP) umgestellt sind.
-
-
-def calculate_macd(
-    prices: pd.Series, fast_period: int = 12, slow_period: int = 26, signal_period: int = 9
-) -> tuple[pd.Series, pd.Series, pd.Series]:
-    """
-    Berechnet MACD-Indikatoren.
-
-    Args:
-        prices: Close-Preise
-        fast_period: Schnelle EMA
-        slow_period: Langsame EMA
-        signal_period: Signal-Linie EMA
-
-    Returns:
-        (macd_line, signal_line, histogram)
-    """
-    # EMAs berechnen
-    ema_fast = prices.ewm(span=fast_period, adjust=False).mean()
-    ema_slow = prices.ewm(span=slow_period, adjust=False).mean()
-
-    # MACD Line = Fast EMA - Slow EMA
-    macd_line = ema_fast - ema_slow
-
-    # Signal Line = EMA der MACD Line
-    signal_line = macd_line.ewm(span=signal_period, adjust=False).mean()
-
-    # Histogram = Differenz
-    histogram = macd_line - signal_line
-
-    return macd_line, signal_line, histogram
-
-
-def generate_signals(df: pd.DataFrame, params: Dict) -> pd.Series:
-    """
-    Generiert MACD-basierte Signale.
-
-    Args:
-        df: OHLCV-DataFrame
-        params: Dict mit 'fast_ema', 'slow_ema', 'signal_ema'
-
-    Returns:
-        Series mit Signalen (1 = Long, 0 = Neutral, -1 = Exit)
-    """
-    # Parameter
-    fast = params.get("fast_ema", 12)
-    slow = params.get("slow_ema", 26)
-    signal = params.get("signal_ema", 9)
-
-    # MACD berechnen
-    macd_line, signal_line, histogram = calculate_macd(
-        df["close"], fast_period=fast, slow_period=slow, signal_period=signal
-    )
-
-    # Signale initialisieren
-    signals = pd.Series(0, index=df.index, dtype=int)
-
-    # Bullish Crossover: MACD kreuzt Signal von unten
-    cross_up = (macd_line.shift(1) < signal_line.shift(1)) & (macd_line > signal_line)
-    signals[cross_up] = 1
-
-    # Bearish Crossover: MACD kreuzt Signal von oben
-    cross_down = (macd_line.shift(1) > signal_line.shift(1)) & (macd_line < signal_line)
-    signals[cross_down] = -1
-
-    return signals
-
-
-def add_macd_indicators(df: pd.DataFrame, params: Dict) -> pd.DataFrame:
-    """Fügt MACD-Indikatoren zum DataFrame hinzu."""
-    df = df.copy()
-
-    fast = params.get("fast_ema", 12)
-    slow = params.get("slow_ema", 26)
-    signal = params.get("signal_ema", 9)
-
-    macd_line, signal_line, histogram = calculate_macd(
-        df["close"], fast_period=fast, slow_period=slow, signal_period=signal
-    )
-
-    df["macd"] = macd_line
-    df["macd_signal"] = signal_line
-    df["macd_histogram"] = histogram
-
-    return df
 
 
 def get_strategy_description(params: Dict) -> str:

--- a/tests/test_new_strategies.py
+++ b/tests/test_new_strategies.py
@@ -12,7 +12,7 @@ import pandas as pd
 import numpy as np
 
 from src.strategies.bollinger import generate_signals as bb_signals
-from src.strategies.macd import generate_signals as macd_signals
+from src.strategies.macd import MACDStrategy
 from src.strategies.ecm import generate_signals as ecm_signals, calculate_ecm_phase
 from src.core import get_strategy_cfg
 from datetime import datetime
@@ -89,7 +89,12 @@ def test_macd_signals():
     df = create_test_data(200)
     params = {"fast_ema": 12, "slow_ema": 26, "signal_ema": 9, "stop_pct": 0.025}
 
-    signals = macd_signals(df, params)
+    strategy = MACDStrategy(
+        fast_ema=params["fast_ema"],
+        slow_ema=params["slow_ema"],
+        signal_ema=params["signal_ema"],
+    )
+    signals = strategy.generate_signals(df)
     assert len(signals) == len(df)
 
 


### PR DESCRIPTION
## Summary
- Removes module-level legacy helpers from `src/strategies/macd.py`: `calculate_macd`, `add_macd_indicators`, module-level `generate_signals`, and the obsolete LEGACY comment block.
- Keeps `_calculate_macd`, `MACDStrategy`, and `get_strategy_description`.
- Updates `tests/test_new_strategies.py` to exercise `MACDStrategy` instead of the module-level signal helper.

## Note
- PR #2598 (Bollinger legacy cleanup) was still open when this branch was created; consider merging #2598 first if you want `main` to match the intended ordering.

## Verification
- `pytest tests/test_new_strategies.py`
- `pytest tests/strategies`
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`
