### PR TITLE
test: extend strategy returns manifest loader negative paths

### DIFF
--- a/src/experiments/strategy_returns_manifest_loader.py
+++ b/src/experiments/strategy_returns_manifest_loader.py
@@ -23,7 +23,10 @@ class StrategyReturnsSource:
 def _load_manifest(manifest_path: Path) -> dict[str, Any]:
     if not manifest_path.exists():
         raise StrategyReturnsManifestError(f"manifest_not_found: {manifest_path}")
-    data = toml.loads(manifest_path.read_text(encoding="utf-8"))
+    try:
+        data = toml.loads(manifest_path.read_text(encoding="utf-8"))
+    except toml.TomlDecodeError as e:
+        raise StrategyReturnsManifestError(f"manifest_invalid: toml_parse_failed: {e}") from e
     if not isinstance(data, dict):
         raise StrategyReturnsManifestError("manifest_invalid: top_level_not_dict")
     return data

--- a/tests/test_strategy_returns_manifest_loader.py
+++ b/tests/test_strategy_returns_manifest_loader.py
@@ -183,7 +183,8 @@ strategy_a = 123
     )
 
     with pytest.raises(
-        StrategyReturnsManifestError, match="manifest_invalid: strategy_returns entries must be str->str"
+        StrategyReturnsManifestError,
+        match="manifest_invalid: strategy_returns entries must be str->str",
     ):
         resolve_strategy_run_dir(strategy_id="strategy_a", manifest_path=manifest)
 

--- a/tests/test_strategy_returns_manifest_loader.py
+++ b/tests/test_strategy_returns_manifest_loader.py
@@ -140,3 +140,76 @@ strategy_a = "runs/strategy_a"
             strategy_id="strategy_a",
             manifest_path=manifest,
         )
+
+
+def test_resolve_strategy_run_dir_missing_strategy_returns_table(tmp_path: Path) -> None:
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[other]
+foo = "bar"
+""".strip()
+        + "\n",
+    )
+
+    with pytest.raises(StrategyReturnsManifestError, match="manifest_invalid: missing"):
+        resolve_strategy_run_dir(strategy_id="strategy_a", manifest_path=manifest)
+
+
+def test_resolve_strategy_run_dir_strategy_returns_not_a_table(tmp_path: Path) -> None:
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+strategy_returns = "not_a_table"
+""".strip()
+        + "\n",
+    )
+
+    with pytest.raises(StrategyReturnsManifestError, match="manifest_invalid: missing"):
+        resolve_strategy_run_dir(strategy_id="strategy_a", manifest_path=manifest)
+
+
+def test_resolve_strategy_run_dir_non_str_mapping_entries(tmp_path: Path) -> None:
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[strategy_returns]
+strategy_a = 123
+""".strip()
+        + "\n",
+    )
+
+    with pytest.raises(
+        StrategyReturnsManifestError, match="manifest_invalid: strategy_returns entries must be str->str"
+    ):
+        resolve_strategy_run_dir(strategy_id="strategy_a", manifest_path=manifest)
+
+
+def test_resolve_strategy_run_dir_run_path_is_file(tmp_path: Path) -> None:
+    fake_run = tmp_path / "runs" / "strategy_a"
+    fake_run.parent.mkdir(parents=True, exist_ok=True)
+    fake_run.write_text("not_a_directory", encoding="utf-8")
+
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[strategy_returns]
+strategy_a = "runs/strategy_a"
+""".strip()
+        + "\n",
+    )
+
+    with pytest.raises(StrategyReturnsManifestError, match="run_dir_not_directory"):
+        resolve_strategy_run_dir(strategy_id="strategy_a", manifest_path=manifest)
+
+
+def test_resolve_strategy_run_dir_invalid_toml(tmp_path: Path) -> None:
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(manifest, "[not closed\n")
+
+    with pytest.raises(StrategyReturnsManifestError, match="manifest_invalid: toml_parse_failed"):
+        resolve_strategy_run_dir(strategy_id="strategy_a", manifest_path=manifest)


### PR DESCRIPTION
## Summary
- extends negative-path coverage for the Phase-53 strategy returns manifest loader
- adds tests for:
  - missing `[strategy_returns]` table
  - non-table `strategy_returns` value
  - non `str -> str` mapping entries
  - `run_dir` path pointing to a file instead of a directory
  - invalid TOML input
- normalizes TOML parse failures to `StrategyReturnsManifestError` with a `manifest_invalid: toml_parse_failed: ...` prefix

## Scope
- no registry refactor
- no execution/live/paper/shadow/testnet changes
- no docs changes

## Verification
- `uv run pytest tests/test_strategy_returns_manifest_loader.py -q`
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`
