### PR TITLE
docs: clarify STRATEGY_REGISTRY excerpt in REGISTRY_BACKTEST_API.md

### DIFF
--- a/docs/REGISTRY_BACKTEST_API.md
+++ b/docs/REGISTRY_BACKTEST_API.md
@@ -263,6 +263,8 @@ rsi_strategy = 0.34
 
 ### Strategie-Modul-Mapping
 
+Das folgende Snippet ist ein **Auszug** (häufig genutzte Kern-Keys); die **vollständige** Zuordnung Strategie-Name → Modulpfad steht im Quellcode in `src/strategies/__init__.py`. Für den **klassenbasierten**, konfigurationsgetriebenen Einstieg (`StrategySpec`, z. B. `create_strategy_from_config`) siehe `src/strategies/registry.py`.
+
 **File:** `src/strategies/__init__.py`
 
 ```python


### PR DESCRIPTION
## Summary
- clarify under "Strategie-Modul-Mapping" that the shown `STRATEGY_REGISTRY` snippet is an excerpt, not the full registry
- point readers to the full mapping in `src/strategies/__init__.py`
- add one sentence about the class/config-based registry entry point in `src/strategies/registry.py`

## Scope
- `docs/REGISTRY_BACKTEST_API.md` only
- no production/runtime changes

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`
