### PR TITLE
docs: clarify STRATEGY_REGISTRY excerpt in STRATEGY_RESEARCH_TRACK_PHASE_27.md

### DIFF
--- a/docs/STRATEGY_RESEARCH_TRACK_PHASE_27.md
+++ b/docs/STRATEGY_RESEARCH_TRACK_PHASE_27.md
@@ -169,7 +169,9 @@ price_col = "close"
 
 ## Registry-Integration
 
-Alle Strategien sind in `STRATEGY_REGISTRY` registriert:
+Die vollständige Zuordnung Strategie-Name → Modulpfad steht in `src/strategies/__init__.py`. Das folgende Snippet ist ein **Auszug** (Phase-27-Track plus Kommentar-Platzhalter) und ersetzt nicht die gesamte `STRATEGY_REGISTRY` (u. a. weitere Keys aus anderen Phasen/R&D). Für die **klassenbasierte** Registry (`StrategySpec`, z. B. `create_strategy_from_config`) siehe `src/strategies/registry.py`.
+
+Die Phase-27-Strategien sind dort unter anderem so eingetragen:
 
 ```python
 STRATEGY_REGISTRY = {


### PR DESCRIPTION
## Summary
- clarify that the `STRATEGY_REGISTRY` snippet in `docs/STRATEGY_RESEARCH_TRACK_PHASE_27.md` is an excerpt, not the full registry
- point readers to the full mapping in `src/strategies/__init__.py`
- optionally mention the class/config-based registry entry point in `src/strategies/registry.py`

## Scope
- `docs/STRATEGY_RESEARCH_TRACK_PHASE_27.md` only
- no production/runtime changes

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`
