### PR TITLE
docs: RUNBOOKS_AND_INCIDENT_HANDLING Audit abschließen + Tracker

### DIFF
--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -151,12 +151,11 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 
 ## Runbooks/Frontdoor Batch — Findings (laufend)
 
-### `docs/RUNBOOKS_AND_INCIDENT_HANDLING.md` — **needs_fix → teilweise gefixt**
-- **Gefundene Mismatches (fix applied)**:
-  - `scripts/experiments_explorer.py` benötigt einen Subcommand, z.B. `list` (statt direkte Flags ohne Subcommand).
-  - `scripts/report_experiment.py` verwendet `--id` (nicht `--run-id`).
-- **Status**:
-  - Commands im Abschnitt „Ergebnisse prüfen“ wurden korrigiert (doc-only).
+### `docs/RUNBOOKS_AND_INCIDENT_HANDLING.md` — **done (vorläufig)**
+- **Fixes (applied)**:
+  - `scripts/experiments_explorer.py` / `scripts/report_experiment.py`: Subcommand `list` bzw. `--id` im Abschnitt „Ergebnisse prüfen“ (bereits früher; Re-Audit ok).
+  - Shadow-Run-Beispiele: `--config config/config.toml` für Copy/Paste-SSoT; CSV-Beispiel an `run_shadow_execution.py` angeglichen; Troubleshooting-Hinweis zu Config-Pfad.
+  - Referenzen: korrekter Repo-Pfad zu `ops/runbooks/RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md`.
 
 ### `docs/WORKFLOW_FRONTDOOR.md` — **done (navigation only)**
 - **Befund**:

--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -154,8 +154,8 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 ### `docs/RUNBOOKS_AND_INCIDENT_HANDLING.md` — **done (vorläufig)**
 - **Fixes (applied)**:
   - `scripts/experiments_explorer.py` / `scripts/report_experiment.py`: Subcommand `list` bzw. `--id` im Abschnitt „Ergebnisse prüfen“ (bereits früher; Re-Audit ok).
-  - Shadow-Run-Beispiele: `--config config/config.toml` für Copy/Paste-SSoT; CSV-Beispiel an `run_shadow_execution.py` angeglichen; Troubleshooting-Hinweis zu Config-Pfad.
-  - Referenzen: korrekter Repo-Pfad zu `ops/runbooks/RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md`.
+  - Shadow-Run-Beispiele: `--config` mit `config/config.toml` für Copy/Paste-SSoT; CSV-Beispiel an `run_shadow_execution.py` angeglichen; Troubleshooting-Hinweis zu Config-Pfad.
+  - Referenzen: korrekter Repo-Pfad zu `docs/ops/runbooks/RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md`.
 
 ### `docs/WORKFLOW_FRONTDOOR.md` — **done (navigation only)**
 - **Befund**:

--- a/docs/RUNBOOKS_AND_INCIDENT_HANDLING.md
+++ b/docs/RUNBOOKS_AND_INCIDENT_HANDLING.md
@@ -335,7 +335,7 @@ Der **Kill-Switch** ist die letzte Verteidigungslinie:
 | `SAFETY_POLICY_TESTNET_AND_LIVE.md` | Safety-Policies |
 | `LIVE_READINESS_CHECKLISTS.md` | Checklisten für Stufen-Übergänge |
 | `PHASE_24_SHADOW_EXECUTION.md` | Shadow-Execution-Dokumentation |
-| `ops/runbooks/RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md` | Tech-Debt Top-3 ROI bis Finish (Cursor Multi-Agent, NO-LIVE) |
+| `docs/ops/runbooks/RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md` | Tech-Debt Top-3 ROI bis Finish (Cursor Multi-Agent, NO-LIVE) |
 | `INCIDENT_SIMULATION_AND_DRILLS.md` | Incident-Drill-Playbook (Phase 56) |
 | `INCIDENT_DRILL_LOG.md` | Drill-Log für dokumentierte Übungen |
 
@@ -353,4 +353,4 @@ Der **Kill-Switch** ist die letzte Verteidigungslinie:
 - **Phase 56** (2025-12): Incident-Drills ergänzt
   - Verweise auf Incident-Drill-Playbook hinzugefügt
   - Hinweis auf aktive Übung von Runbooks ergänzt
-- **Docs-Audit (2026-04):** Shadow-CLI-Beispiele mit `config/config.toml` abgeglichen; CSV-Beispielpfad an `run_shadow_execution.py` angeglichen; Referenzpfad `RUNBOOK_TECH_DEBT_*` korrigiert (`ops/runbooks/…`).
+- **Docs-Audit (2026-04):** Shadow-CLI-Beispiele mit `config/config.toml` abgeglichen; CSV-Beispielpfad an `run_shadow_execution.py` angeglichen; Referenzpfad `RUNBOOK_TECH_DEBT_*` korrigiert (`docs/ops/runbooks/RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md`).

--- a/docs/RUNBOOKS_AND_INCIDENT_HANDLING.md
+++ b/docs/RUNBOOKS_AND_INCIDENT_HANDLING.md
@@ -73,19 +73,21 @@ ls -la data/*.csv
 **Schritt 3: Shadow-Run starten**
 
 ```bash
-# Standard-Run mit ma_crossover
-python3 scripts/run_shadow_execution.py --strategy ma_crossover --verbose
+# Standard-Run mit ma_crossover (Config-SSoT im Repo: config/config.toml)
+python3 scripts/run_shadow_execution.py --config config/config.toml --strategy ma_crossover --verbose
 
-# Mit CSV-Daten und Datumsbeschränkung
+# Mit CSV-Daten und Datumsbeschränkung (Beispielpfad wie im Script; ohne --data-file: Dummy-Daten)
 python3 scripts/run_shadow_execution.py \
+    --config config/config.toml \
     --strategy rsi_strategy \
-    --data-file data/btc_eur_1h.csv \
+    --data-file data/eth_1h.csv \
     --start 2023-01-01 \
     --end 2023-12-31 \
     --tag shadow_run_v1
 
 # Mit Fee-/Slippage-Überschreibung
 python3 scripts/run_shadow_execution.py \
+    --config config/config.toml \
     --fee-rate 0.001 \
     --slippage-bps 10 \
     --verbose
@@ -111,7 +113,7 @@ python3 scripts/report_experiment.py --id <RUN_ID>
 
 | Problem | Mögliche Ursache | Lösung |
 |---------|------------------|--------|
-| "Config nicht gefunden" | Falscher Pfad | `--config` mit korrektem Pfad |
+| "Config nicht gefunden" | Falscher Pfad | `--config` mit korrektem Pfad (im Repo typisch: `config/config.toml`) |
 | "Strategie nicht gefunden" | Tippfehler oder nicht registriert | `get_available_strategy_keys()` prüfen |
 | "Keine Daten" | CSV fehlt oder leer | Datenquelle prüfen |
 | "Shadow disabled" | `[shadow].enabled = false` | Config korrigieren |
@@ -333,7 +335,7 @@ Der **Kill-Switch** ist die letzte Verteidigungslinie:
 | `SAFETY_POLICY_TESTNET_AND_LIVE.md` | Safety-Policies |
 | `LIVE_READINESS_CHECKLISTS.md` | Checklisten für Stufen-Übergänge |
 | `PHASE_24_SHADOW_EXECUTION.md` | Shadow-Execution-Dokumentation |
-| `RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md` | Tech-Debt Top-3 ROI bis Finish (Cursor Multi-Agent, NO-LIVE) |
+| `ops/runbooks/RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md` | Tech-Debt Top-3 ROI bis Finish (Cursor Multi-Agent, NO-LIVE) |
 | `INCIDENT_SIMULATION_AND_DRILLS.md` | Incident-Drill-Playbook (Phase 56) |
 | `INCIDENT_DRILL_LOG.md` | Drill-Log für dokumentierte Übungen |
 
@@ -351,3 +353,4 @@ Der **Kill-Switch** ist die letzte Verteidigungslinie:
 - **Phase 56** (2025-12): Incident-Drills ergänzt
   - Verweise auf Incident-Drill-Playbook hinzugefügt
   - Hinweis auf aktive Übung von Runbooks ergänzt
+- **Docs-Audit (2026-04):** Shadow-CLI-Beispiele mit `config/config.toml` abgeglichen; CSV-Beispielpfad an `run_shadow_execution.py` angeglichen; Referenzpfad `RUNBOOK_TECH_DEBT_*` korrigiert (`ops/runbooks/…`).


### PR DESCRIPTION
## Summary
- finish a doc-only audit of `docs/RUNBOOKS_AND_INCIDENT_HANDLING.md`
- align Shadow CLI examples with the repo config source of truth (`config/config.toml`)
- align the CSV example with `run_shadow_execution.py`
- fix the Tech-Debt runbook path in the reference table
- add a small troubleshooting/config-path clarification
- update `docs/DOCS_AUDIT_TRACKER.md` to mark this runbook as **done (vorläufig)** with the concrete fixes applied

## Scope
- `docs/RUNBOOKS_AND_INCIDENT_HANDLING.md`
- `docs/DOCS_AUDIT_TRACKER.md`
- no code/runtime changes

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`
