### PR TITLE
docs: Audit ops/runbooks README + Tracker (Runbooks/Ops Batch)

### DIFF
--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -138,6 +138,8 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 - `docs/ops/runbooks/README.md`
 - `docs/ops/runbooks/RUNBOOK_TO_FINISH_MASTER.md` (falls abweichend)
 
+> **Hinweis (2026-04):** Index `docs/ops/runbooks/README.md` auditiert — siehe Findings unten.
+
 ---
 
 ## Offene Top-Gaps (Priorisierung)
@@ -164,6 +166,11 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 ### `docs/RUNBOOK_TO_FINISH_MASTER.md` und `docs/ops/runbooks/RUNBOOK_TO_FINISH_MASTER.md` — **done (docs-only runbook)**
 - **Befund**:
   - Referenzierte Runbooks/Targets existieren (D2/D3/D4, Finish-C pointer, Option-B Pfade, etc.).
+
+### `docs/ops/runbooks/README.md` — **done (vorläufig)**
+- **Befund**:
+  - Relativer Index: verlinkte Runbook-/Ops-Ziele existieren; keine `python`-/`python3`-Drift in dieser Datei; Docs-Token-Policy (Inline-Code) ohne Verstöße.
+  - Minimal-Fix: Link-Ziel für `RUNBOOK_CURSOR_MA_FEHLENDE_FEATURES_OPEN_POINTS_2026-02-10.md` mit `./`-Präfix wie bei anderen Einträgen; „Last Updated“ auf Audit-Datum gesetzt.
 
 ---
 

--- a/docs/ops/runbooks/README.md
+++ b/docs/ops/runbooks/README.md
@@ -10,7 +10,7 @@
 
 ## Research & New Listings (CEX+DEX Crawler, AI Layers)
 
-- [RUNBOOK_CURSOR_MA_FEHLENDE_FEATURES_OPEN_POINTS_2026-02-10.md](RUNBOOK_CURSOR_MA_FEHLENDE_FEATURES_OPEN_POINTS_2026-02-10.md) — Cursor Multi-Agent Runbook für offene Peak_Trade Features (Einstieg→Endpunkt, Blöcke A–J).
+- [RUNBOOK_CURSOR_MA_FEHLENDE_FEATURES_OPEN_POINTS_2026-02-10.md](./RUNBOOK_CURSOR_MA_FEHLENDE_FEATURES_OPEN_POINTS_2026-02-10.md) — Cursor Multi-Agent Runbook für offene Peak_Trade Features (Einstieg→Endpunkt, Blöcke A–J).
 - [New Listings Crawler Runbook](./new_listings_crawler_runbook.md)
 
 ## Runbook Categories
@@ -173,5 +173,5 @@ This hybrid approach balances discoverability (all findable from this index) wit
 
 ---
 
-**Last Updated:** 2026-04-06  
+**Last Updated:** 2026-04-15  
 **Maintainer:** ops


### PR DESCRIPTION
## Summary
- audit `docs/ops/runbooks/README.md`: verify relative links, token-policy-sensitive inline code, and consistency of one runbook link target (`./` prefix)
- update `docs/DOCS_AUDIT_TRACKER.md` with a short batch note and a **done (vorläufig)** finding for the ops runbooks index README

## Scope
- `docs/ops/runbooks/README.md`
- `docs/DOCS_AUDIT_TRACKER.md`
- no code/runtime changes

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `python3 scripts/ops/validate_docs_token_policy.py --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh`
