### PR TITLE
docs: refresh DOCS_AUDIT_TRACKER next-batch pointer after Batch 3 (#2612)

### DIFF
--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -130,20 +130,16 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 
 ---
 
-## Nächste Batch (Start)
-**Runbooks / Frontdoor / Ops** (Priorität: operational & viele Quer-Verweise)
-- `docs/RUNBOOKS_AND_INCIDENT_HANDLING.md`
-- `docs/WORKFLOW_FRONTDOOR.md`
-- `docs/RUNBOOK_TO_FINISH_MASTER.md`
-- `docs/ops/runbooks/README.md`
-- `docs/ops/runbooks/RUNBOOK_TO_FINISH_MASTER.md` (falls abweichend)
+## Nächster Fokus (Start)
+**Kleiner Follow-up / optionaler Mini-Audit** (nach abgeschlossenen Ops/Runbook-Batches):
+- `docs/KNOWLEDGE_SOURCES_REGISTRY.md` — siehe **Bereits geprüft (5)**: offenes Feintuning, ob genannte Ingestion-Skripte im Repo real oder nur illustrativ gemeint sind (kein Blocker; Registry ist ohne harten Runtime-Contract).
 
-> **Hinweis (2026-04):** Index `docs/ops/runbooks/README.md` auditiert — siehe Findings unten.
+> **Erledigt (Referenz):** Runbooks / Frontdoor / Ops — siehe Abschnitt **„Runbooks/Frontdoor Batch — Findings“** unten (Stand: Audit 2026-04, inkl. `docs/ops/runbooks/README.md`).
 
 ---
 
 ## Offene Top-Gaps (Priorisierung)
-1) **Runbooks / Frontdoor / Ops** — nächster Docs-Batch (siehe „Nächste Batch“): operational, viele Quer-Verweise, ggf. Command-Drift.
+1) **`docs/KNOWLEDGE_SOURCES_REGISTRY.md` (optional)** — Ingestion-/Skript-Hinweise vs. Repo klären (siehe „Bereits geprüft“ Punkt 5); kein Kern-Blocker.
 
 **Zur Einordnung (keine „offenen Top-Gaps“ mehr in diesem Sinne):**
 - **Phase‑53 `strategies` / Manifest:** Preset → Portfolio-Build → Robustness/Report ist umgesetzt; Loader-/Runner-Aspekte sind durch PR #2602/#2604/#2605 testseitig abgedeckt (siehe Phase‑53-Note oben). Verbleibend: ggf. **optionale** Ergonomie- oder Klein-Doku-Punkte—**nicht** „fehlende Kern-Tests“.
@@ -151,7 +147,7 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 
 ---
 
-## Runbooks/Frontdoor Batch — Findings (laufend)
+## Runbooks/Frontdoor Batch — Findings (abgeschlossen, Stand 2026-04)
 
 ### `docs/RUNBOOKS_AND_INCIDENT_HANDLING.md` — **done (vorläufig)**
 - **Fixes (applied)**:
@@ -197,7 +193,7 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 
 ---
 
-## Batch 3 (Research Playbooks) — Findings (laufend)
+## Batch 3 (Research Playbooks) — Status (PR #2612 / Audit Follow-up abgeschlossen)
 
 ### `docs/PEAK_TRADE_RESEARCH_GOLDEN_PATHS.md` — **done (Audit Follow-up)**
 - **Fixes (applied)**:


### PR DESCRIPTION
## Summary
- refresh `docs/DOCS_AUDIT_TRACKER.md` navigation after Batch 3 / Runbooks closeout
- remove stale next-priority references to already completed Runbooks/Frontdoor work
- point the next small tracker-backed follow-up at `docs/KNOWLEDGE_SOURCES_REGISTRY.md`

## Changes
- rename `Nächste Batch (Start)` to `Nächster Fokus (Start)`
- replace stale Runbooks/Frontdoor next-priority wording with current tracker-backed follow-up guidance
- update `Offene Top-Gaps` to remove the obsolete Runbooks blocker
- mark Runbooks/Frontdoor and Batch 3 status sections consistently as completed / post-follow-up

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Risk
- tracker/docs only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)