### PR TITLE
docs: clarify KNOWLEDGE_SOURCES_REGISTRY ingestion vs repo

### DIFF
--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -52,7 +52,8 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 
 ### 5) `docs/KNOWLEDGE_SOURCES_REGISTRY.md` — **done (vorläufig)**
 - **Befund**:
-  - Eher Registry/Prozessdoku, kein harter Runtime-Contract. Später prüfen: ob erwähnte Ingestion-Skripte real/illustrativ sind.
+  - Eher Registry/Prozessdoku, kein harter Runtime-Contract.
+- **Audit Follow-up (2026-04, Truth):** Ingestion-Skript-Namen unter `scripts/` für Backtests/Strategy-Docs/Research-Papers sind **illustrativ** (keine entsprechenden Dateien im Repo); Portfolio-Zeitreihen nutzen `src/knowledge/timeseries_db.py`. Siehe Abschnitt **„Repo-Abgleich“** in der Datei.
 
 ### 6) `docs/KNOWLEDGE_BASE_INDEX.md` — **done (vorläufig)**
 - **Fixes (applied)**:
@@ -131,15 +132,15 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 ---
 
 ## Nächster Fokus (Start)
-**Kleiner Follow-up / optionaler Mini-Audit** (nach abgeschlossenen Ops/Runbook-Batches):
-- `docs/KNOWLEDGE_SOURCES_REGISTRY.md` — siehe **Bereits geprüft (5)**: offenes Feintuning, ob genannte Ingestion-Skripte im Repo real oder nur illustrativ gemeint sind (kein Blocker; Registry ist ohne harten Runtime-Contract).
+- **Erledigt (2026-04):** `docs/KNOWLEDGE_SOURCES_REGISTRY.md` — Ingestion vs. Repo im Abschnitt **„Repo-Abgleich“** dokumentiert (siehe **Bereits geprüft (5)**).
+- **Optional weiter:** kleine Hub-/Index-Pflege ohne Zwang (z. B. `docs/INDEX.md` Standzeile); oder Phase‑53-Ergonomie nur bei Bedarf (siehe **„Zur Einordnung“** unten).
 
 > **Erledigt (Referenz):** Runbooks / Frontdoor / Ops — siehe Abschnitt **„Runbooks/Frontdoor Batch — Findings“** unten (Stand: Audit 2026-04, inkl. `docs/ops/runbooks/README.md`).
 
 ---
 
 ## Offene Top-Gaps (Priorisierung)
-1) **`docs/KNOWLEDGE_SOURCES_REGISTRY.md` (optional)** — Ingestion-/Skript-Hinweise vs. Repo klären (siehe „Bereits geprüft“ Punkt 5); kein Kern-Blocker.
+1) **Kein verpflichtender Top-Gap** nach Knowledge-Sources-Truth (2026-04); siehe **„Bereits geprüft“** Punkt 5 und **„Nächster Fokus“** für optionale Folgearbeiten.
 
 **Zur Einordnung (keine „offenen Top-Gaps“ mehr in diesem Sinne):**
 - **Phase‑53 `strategies` / Manifest:** Preset → Portfolio-Build → Robustness/Report ist umgesetzt; Loader-/Runner-Aspekte sind durch PR #2602/#2604/#2605 testseitig abgedeckt (siehe Phase‑53-Note oben). Verbleibend: ggf. **optionale** Ergonomie- oder Klein-Doku-Punkte—**nicht** „fehlende Kern-Tests“.

--- a/docs/KNOWLEDGE_SOURCES_REGISTRY.md
+++ b/docs/KNOWLEDGE_SOURCES_REGISTRY.md
@@ -4,7 +4,15 @@
 
 Dieses Dokument registriert alle externen Wissensquellen, die in die Peak_Trade Knowledge Databases integriert sind.
 
-**Letzte Aktualisierung:** Dezember 2024
+**Letzte Aktualisierung:** April 2026 (Docs-Audit: Ingestion vs. Repo)
+
+---
+
+## Repo-Abgleich (Truth, Stand 2026-04)
+
+Mehrere unter **„Ingestion-Script“** genannte Pfade unter `scripts/` sind **Zielbild / Platzhalter** und **liegen nicht** als Dateien im Repository; sie sind in den jeweiligen Abschnitten **(illustrative)** gekennzeichnet. Es besteht **keine** implizite Verpflichtung, diese Skripte zu liefern.
+
+**Im Repo vorhanden:** Modul `src/knowledge/timeseries_db.py` (Einbindung Portfolio-Zeitreihen über `src.knowledge.timeseries_db`).
 
 ---
 
@@ -22,7 +30,7 @@ Dieses Dokument registriert alle externen Wissensquellen, die in die Peak_Trade 
 - **Update-Frequenz:** Nach jedem Research-Run
 - **Integration:** Vector DB (ChromaDB)
 - **Metadaten-Tags:** `internal_backtest`, `strategy`, `performance`
-- **Ingestion-Script:** `scripts&#47;ingest_backtest_reports.py` (illustrative) <!-- pt:ref-target-ignore -->
+- **Ingestion-Script:** `scripts&#47;ingest_backtest_reports.py` (illustrative; keine Datei im Repo — siehe „Repo-Abgleich“) <!-- pt:ref-target-ignore -->
 
 **Verantwortlich:** Data Owner  
 **Review-Status:** Approved  
@@ -42,7 +50,7 @@ Dieses Dokument registriert alle externen Wissensquellen, die in die Peak_Trade 
 - **Update-Frequenz:** Täglich (für Live/Testnet)
 - **Integration:** Time-Series DB (Parquet)
 - **Metadaten-Tags:** `portfolio`, `performance`, `equity_curve`
-- **Ingestion-Script:** Automatisch via `src.knowledge.timeseries_db`
+- **Ingestion-Script:** Automatisch via `src.knowledge.timeseries_db` (Modul `src/knowledge/timeseries_db.py` vorhanden)
 
 **Verantwortlich:** Data Owner  
 **Review-Status:** Approved  
@@ -62,7 +70,7 @@ Dieses Dokument registriert alle externen Wissensquellen, die in die Peak_Trade 
 - **Update-Frequenz:** Bei Code-Änderungen
 - **Integration:** Vector DB (ChromaDB)
 - **Metadaten-Tags:** `strategy`, `definition`, `parameters`
-- **Ingestion-Script:** `scripts&#47;ingest_strategy_docs.py` (illustrative) <!-- pt:ref-target-ignore -->
+- **Ingestion-Script:** `scripts&#47;ingest_strategy_docs.py` (illustrative; keine Datei im Repo — siehe „Repo-Abgleich“) <!-- pt:ref-target-ignore -->
 
 **Verantwortlich:** Developer  
 **Review-Status:** Approved  
@@ -125,7 +133,7 @@ Dieses Dokument registriert alle externen Wissensquellen, die in die Peak_Trade 
 - **Update-Frequenz:** Monatlich (manuelle Selektion)
 - **Integration:** Vector DB (ChromaDB)
 - **Metadaten-Tags:** `research`, `paper`, `arxiv`, `ssrn`
-- **Ingestion-Script:** Manuell + `scripts&#47;ingest_research_paper.py` (illustrative) <!-- pt:ref-target-ignore -->
+- **Ingestion-Script:** Manuell + `scripts&#47;ingest_research_paper.py` (illustrative; keine Datei im Repo — siehe „Repo-Abgleich“) <!-- pt:ref-target-ignore -->
 
 **Lizenz:** CC-BY-4.0 (arXiv), SSRN (Check per Paper)  
 **Verantwortlich:** Researcher  
@@ -218,7 +226,7 @@ Benötigte Environment Variables:
 | Datum | Änderung | Autor |
 |-------|----------|-------|
 | 2024-12-20 | Initial Registry erstellt | System |
-| - | - | - |
+| 2026-04-15 | Repo-Abgleich: illustrative vs. vorhandene Ingestion-Pfade | Docs-Audit |
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify `docs/KNOWLEDGE_SOURCES_REGISTRY.md` against current repo reality
- make illustrative vs real ingestion/module references explicit
- update `docs/DOCS_AUDIT_TRACKER.md` after the tracker-backed mini audit follow-up

## Changes
- add a small repo-alignment/truth note in `docs/KNOWLEDGE_SOURCES_REGISTRY.md`
- keep missing ingestion script references clearly illustrative
- keep the `src/knowledge/timeseries_db.py` reference file-precise for docs reference-target checks
- update last-updated / change-log metadata
- refresh tracker point 5 plus next-focus / top-gap wording based on the completed mini audit

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Risk
- docs/tracker only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)