### PR TITLE
docs: refresh docs/INDEX metadata stand line

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,7 +1,7 @@
 # Peak_Trade Documentation Index
 
 > **Zweck:** Zentraler Einstieg in die Peak_Trade-Dokumentation  
-> **Stand:** 2026-03-10  
+> **Stand:** 2026-04-15  
 > **Status:** canonical
 
 ---


### PR DESCRIPTION
## Summary
- refresh the `Stand:` metadata in `docs/INDEX.md`
- align the doc hub index date with the current April 2026 audit/merge context

## Changes
- update `docs/INDEX.md` `Stand:` from `2026-03-10` to `2026-04-15`
- no other content changes

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Risk
- docs metadata only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)