### PR TITLE
docs: refresh KNOWLEDGE_BASE_INDEX Last Updated and tracker hub focus

### DIFF
--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -133,7 +133,8 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 
 ## Nächster Fokus (Start)
 - **Erledigt (2026-04):** `docs/KNOWLEDGE_SOURCES_REGISTRY.md` — Ingestion vs. Repo im Abschnitt **„Repo-Abgleich“** dokumentiert (siehe **Bereits geprüft (5)**).
-- **Optional weiter:** kleine Hub-/Index-Pflege ohne Zwang (z. B. `docs/INDEX.md` Standzeile); oder Phase‑53-Ergonomie nur bei Bedarf (siehe **„Zur Einordnung“** unten).
+- **Erledigt (2026-04):** Hub-Metadaten — `docs/INDEX.md` **Stand** (PR #2615); `docs/KNOWLEDGE_BASE_INDEX.md` **Last Updated** (gleicher Audit-Kontext).
+- **Optional weiter:** Phase‑53-Ergonomie nur bei Bedarf (siehe **„Zur Einordnung“** unten).
 
 > **Erledigt (Referenz):** Runbooks / Frontdoor / Ops — siehe Abschnitt **„Runbooks/Frontdoor Batch — Findings“** unten (Stand: Audit 2026-04, inkl. `docs/ops/runbooks/README.md`).
 

--- a/docs/KNOWLEDGE_BASE_INDEX.md
+++ b/docs/KNOWLEDGE_BASE_INDEX.md
@@ -4,7 +4,7 @@
 >
 > **Target Audience:** All developers, operators, researchers, and stakeholders working with Peak_Trade
 >
-> **Last Updated:** 2025-12-19
+> **Last Updated:** 2026-04-15
 
 ---
 


### PR DESCRIPTION
## Summary
- refresh `docs/KNOWLEDGE_BASE_INDEX.md` hub metadata for the current 2026-04 audit context
- update `docs/DOCS_AUDIT_TRACKER.md` next-focus navigation after `docs/INDEX.md` was already refreshed in #2615

## Changes
- update `Last Updated:` in `docs/KNOWLEDGE_BASE_INDEX.md` from `2025-12-19` to `2026-04-15`
- remove the stale optional `docs/INDEX.md` follow-up wording from the tracker
- keep tracker navigation aligned with the merged `#2615` INDEX metadata refresh
- leave optional further work limited to the next small docs ergonomics follow-up

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Risk
- docs metadata / tracker navigation only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)