### PR TITLE
docs: cite PR #2616 in DOCS_AUDIT_TRACKER hub metadata line

### DIFF
--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -133,7 +133,7 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 
 ## Nächster Fokus (Start)
 - **Erledigt (2026-04):** `docs/KNOWLEDGE_SOURCES_REGISTRY.md` — Ingestion vs. Repo im Abschnitt **„Repo-Abgleich“** dokumentiert (siehe **Bereits geprüft (5)**).
-- **Erledigt (2026-04):** Hub-Metadaten — `docs/INDEX.md` **Stand** (PR #2615); `docs/KNOWLEDGE_BASE_INDEX.md` **Last Updated** (gleicher Audit-Kontext).
+- **Erledigt (2026-04):** Hub-Metadaten — `docs/INDEX.md` **Stand** (PR #2615); `docs/KNOWLEDGE_BASE_INDEX.md` **Last Updated** (PR #2616).
 - **Optional weiter:** Phase‑53-Ergonomie nur bei Bedarf (siehe **„Zur Einordnung“** unten).
 
 > **Erledigt (Referenz):** Runbooks / Frontdoor / Ops — siehe Abschnitt **„Runbooks/Frontdoor Batch — Findings“** unten (Stand: Audit 2026-04, inkl. `docs/ops/runbooks/README.md`).


### PR DESCRIPTION
## Summary
- make the hub-metadata tracker line symmetric by citing the merged KB-index metadata slice
- improve audit-trail traceability in `docs/DOCS_AUDIT_TRACKER.md`

## Changes
- add explicit `PR #2616` reference for the `docs/KNOWLEDGE_BASE_INDEX.md` Last Updated refresh
- leave the existing `PR #2615` `docs/INDEX.md` reference intact
- no other tracker or docs changes

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Risk
- tracker/docs only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)