### PR TITLE
docs: add format enum cross-ref in PORTFOLIO_RECIPES_AND_PRESETS

### DIFF
--- a/docs/PORTFOLIO_RECIPES_AND_PRESETS.md
+++ b/docs/PORTFOLIO_RECIPES_AND_PRESETS.md
@@ -110,6 +110,8 @@ python3 scripts/research_cli.py portfolio \
 - Lädt Preset `rsi_reversion_balanced`
 - Überschreibt `format` von `"both"` (Preset) auf `"md"` (CLI)
 
+**Siehe auch:** Unterschiede zwischen Research-CLI **`md`/`html`/`both`** und **`markdown`** in anderen Report-Tools sind im Repo eingegrenzt; Details und gültige `choices` je CLI stehen in **`docs/DOCS_AUDIT_TRACKER.md`** im Abschnitt *Format-Enums: `md` vs `markdown` — validiert*.
+
 ### 4. Preset + Override: Andere Gewichte
 
 ```bash


### PR DESCRIPTION
## Summary
- add a small format-enum cross-reference in `docs/PORTFOLIO_RECIPES_AND_PRESETS.md`
- point readers to the already validated tracker note for `md` vs `markdown` differences

## Changes
- add a short `Siehe auch` line near the preset + `--format` override section
- link to `docs/DOCS_AUDIT_TRACKER.md` for the validated format-enum context
- no new matrix or broader docs rewrite

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Risk
- docs navigation only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)