### PR TITLE
docs: note PR #2618 portfolio format cross-ref in DOCS_AUDIT_TRACKER

### DIFF
--- a/docs/DOCS_AUDIT_TRACKER.md
+++ b/docs/DOCS_AUDIT_TRACKER.md
@@ -134,7 +134,8 @@ Alle Markdown-Dateien unter `docs/` werden **nach und nach** analysiert und mit 
 ## Nächster Fokus (Start)
 - **Erledigt (2026-04):** `docs/KNOWLEDGE_SOURCES_REGISTRY.md` — Ingestion vs. Repo im Abschnitt **„Repo-Abgleich“** dokumentiert (siehe **Bereits geprüft (5)**).
 - **Erledigt (2026-04):** Hub-Metadaten — `docs/INDEX.md` **Stand** (PR #2615); `docs/KNOWLEDGE_BASE_INDEX.md` **Last Updated** (PR #2616).
-- **Optional weiter:** Phase‑53-Ergonomie nur bei Bedarf (siehe **„Zur Einordnung“** unten).
+- **Erledigt (2026-04):** `docs/PORTFOLIO_RECIPES_AND_PRESETS.md` — Cross-Ref zu **Format-Enums** im Tracker (PR #2618).
+- **Optional weiter:** weitere optionale Klein-Doku nach Bedarf (ohne Pflicht-Top-Gap); siehe **„Zur Einordnung“** unten.
 
 > **Erledigt (Referenz):** Runbooks / Frontdoor / Ops — siehe Abschnitt **„Runbooks/Frontdoor Batch — Findings“** unten (Stand: Audit 2026-04, inkl. `docs/ops/runbooks/README.md`).
 


### PR DESCRIPTION
## Summary
- update `docs/DOCS_AUDIT_TRACKER.md` after the merged portfolio format cross-ref slice
- make the tracker explicitly show that the Phase-53 format ergonomics follow-up was completed in `PR #2618`

## Changes
- add a small completed/audit-trail note for the `PORTFOLIO_RECIPES_AND_PRESETS.md` format cross-ref
- cite `PR #2618` explicitly
- tighten the remaining `Optional weiter` wording so it no longer implies that this completed slice is still open

## Verification
- `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Risk
- tracker/docs only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)