### PR TITLE
docs: align README quick start with python3 / pytest -m conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Peak_Trade ist ein modulares, research-getriebenes Trading-Framework mit konsequ
 pip install -e .
 
 # 2. Ersten Backtest laufen lassen
-python scripts/run_strategy_from_config.py --strategy ma_crossover --symbol BTC/USDT
+python3 scripts/run_strategy_from_config.py --strategy ma_crossover --symbol BTC/USDT
 
 # 3. Tests ausführen
-pytest -m smoke -q  # Schnelle Smoke-Tests (~1 Sekunde)
-pytest -q           # Full Suite (~70 Sekunden)
+python3 -m pytest -m smoke -q  # Schnelle Smoke-Tests (~1 Sekunde)
+python3 -m pytest -q           # Full Suite (~70 Sekunden)
 
 # 4. Optionale Web-UI Dependencies (für Dashboard/API Tests)
 uv sync --extra web  # oder: pip install -e ".[web]"
-pytest -m web        # Web-UI Tests ausführen
+python3 -m pytest -m web        # Web-UI Tests ausführen
 ```
 
 **Hinweis:** Web-UI Tests werden automatisch übersprungen, wenn FastAPI nicht installiert ist. Core-Tests laufen ohne Web-Stack.
@@ -93,10 +93,10 @@ Peak_Trade ist so gebaut, dass AI-Tools wie Cursor, Claude und ChatGPT beim Entw
 - 🛠️ **Developer Workflow Script**
   Automatisierung häufiger Entwicklungsaufgaben:
   ```bash
-  python scripts/dev_workflow.py --help
-  python scripts/dev_workflow.py setup    # Environment setup
-  python scripts/dev_workflow.py test     # Run tests
-  python scripts/dev_workflow.py health   # Health check
+  python3 scripts/dev_workflow.py --help
+  python3 scripts/dev_workflow.py setup    # Environment setup
+  python3 scripts/dev_workflow.py test     # Run tests
+  python3 scripts/dev_workflow.py health   # Health check
   ```
 
 ---


### PR DESCRIPTION
## Summary
- align the upper `README.md` quick-start/developer snippets with the repo's `python3` / `python3 -m pytest` convention
- improve copy-paste robustness without broad README churn

## Changes
- update the early quick-start backtest/examples block from `python` to `python3`
- update nearby test commands from `pytest ...` to `python3 -m pytest ...`
- update the `Developer Workflow Script` examples from `python` to `python3`
- leave deeper/lower README occurrences untouched for a later follow-up if needed

## Verification
- `bash scripts/ops/verify_docs_reference_targets.sh`
- note: `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs` stays green, but root `README.md` is outside that `docs/**/*.md` scan scope

## Risk
- README/docs only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)