### PR TITLE
chore: align dev_workflow usage docs with python3

### DIFF
--- a/scripts/dev_workflow.py
+++ b/scripts/dev_workflow.py
@@ -6,11 +6,11 @@ Peak_Trade Developer Workflow Assistant
 Automates common development workflows to improve productivity.
 
 Usage:
-    python scripts/dev_workflow.py --help
-    python scripts/dev_workflow.py setup
-    python scripts/dev_workflow.py test --module strategies
-    python scripts/dev_workflow.py perf-check
-    python scripts/dev_workflow.py docs-validate
+    python3 scripts/dev_workflow.py --help
+    python3 scripts/dev_workflow.py setup
+    python3 scripts/dev_workflow.py test --module strategies
+    python3 scripts/dev_workflow.py perf-check
+    python3 scripts/dev_workflow.py docs-validate
 
 Scope note (J3 / dev-workflow slice): ``create_strategy_scaffold`` emits neutral
 author hints (no conventional task-prefix markers in generated strategy/test files). The
@@ -432,7 +432,7 @@ class Test{pascal_name}:
     print_info(f"1. Edit {strategy_file} to implement your strategy")
     print_info(f"2. Edit {test_file} to add comprehensive tests")
     print_info(
-        f"3. Run tests: python scripts/dev_workflow.py test --module strategies/test_{snake_name}"
+        f"3. Run tests: python3 scripts/dev_workflow.py test --module strategies/test_{snake_name}"
     )
 
 


### PR DESCRIPTION
## Summary
- align user-facing `scripts/dev_workflow.py` usage/help text with the repo's `python3` convention
- keep runtime behavior unchanged

## Changes
- update the module `Usage:` examples from `python scripts/dev_workflow.py ...` to `python3 scripts/dev_workflow.py ...`
- update the scaffold/test-run hint string to use `python3 scripts/dev_workflow.py ...`
- leave `DEV_PYTHON = sys.executable` and command execution logic unchanged

## Verification
- `python3 -m pytest tests/scripts/test_dev_workflow_interpreter_smoke.py -q`
- `python3 -m pytest tests -q --tb=line`
- `python3 scripts/dev_workflow.py --help`

## Risk
- string/docs-only change inside the script
- no logic changes
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)