### PR TITLE
test: exit 1 when strategy returns manifest loader fails in run_portfolio_robustness

### DIFF
--- a/tests/test_research_cli_portfolio_presets.py
+++ b/tests/test_research_cli_portfolio_presets.py
@@ -645,3 +645,22 @@ def test_phase53_run_from_args_fails_when_manifest_file_missing(
     assert mock_build_cache.called is False
     assert mock_run_robustness.called is False
     assert mock_report.called is False
+
+
+def test_phase53_run_from_args_exit_one_when_manifest_loader_raises(
+    mock_args_phase53_preset_manifest: argparse.Namespace,
+    tmp_path: Path,
+) -> None:
+    """Manifest path is valid, but data-backed loader raises: CLI returns 1."""
+    from src.experiments.strategy_returns_manifest_loader import StrategyReturnsManifestError
+
+    args = argparse.Namespace(**vars(mock_args_phase53_preset_manifest))
+    args.output_dir = str(tmp_path / "portfolio_reports")
+
+    with patch(
+        "scripts.run_portfolio_robustness.load_returns_for_strategy_from_manifest",
+        side_effect=StrategyReturnsManifestError("contract: loader failed"),
+    ):
+        exit_code = portfolio_script.run_from_args(args)
+
+    assert exit_code == 1


### PR DESCRIPTION
## Summary
- add explicit runner/CLI contract coverage for the manifest-loader failure path
- verify that `run_from_args(...)` returns exit code `1` when `load_returns_for_strategy_from_manifest(...)` raises

## Changes
- add `test_phase53_run_from_args_exit_one_when_manifest_loader_raises`
- patch `scripts.run_portfolio_robustness.load_returns_for_strategy_from_manifest`
- exercise the real `run_from_args(...)` path with an existing manifest file and temp output dir
- keep production code unchanged

## Verification
- `python3 -m pytest tests/test_research_cli_portfolio_presets.py::test_phase53_run_from_args_exit_one_when_manifest_loader_raises`
- `python3 -m pytest tests/test_research_cli_portfolio_presets.py -q`
- `python3 -m pytest tests -q --tb=line`

## Risk
- tests only
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)