### PR TITLE
test(ops): document config_from_env behavior for invalid PEAK_RECON_* floats

### DIFF
--- a/tests/ops/test_recon_hook.py
+++ b/tests/ops/test_recon_hook.py
@@ -4,8 +4,10 @@ Unit tests for Runbook-B recon hook (offline, pure).
 
 from __future__ import annotations
 
+import pytest
+
 from src.ops.recon.models import BalanceSnapshot
-from src.ops.recon.recon_hook import ReconConfig, run_recon_if_enabled
+from src.ops.recon.recon_hook import ReconConfig, config_from_env, run_recon_if_enabled
 
 
 def test_recon_hook_disabled_is_ok():
@@ -24,3 +26,21 @@ def test_recon_hook_enabled_detects_drift():
     rep = run_recon_if_enabled(cfg, expected_balances=e, observed_balances=o)
     assert rep.ok is False
     assert len(rep.drifts) == 1
+
+
+def test_config_from_env_invalid_balance_abs_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-numeric PEAK_RECON_BALANCE_ABS propagates float() ValueError (current contract)."""
+    monkeypatch.setenv("PEAK_RECON_BALANCE_ABS", "not-a-number")
+    monkeypatch.delenv("PEAK_RECON_POSITION_ABS", raising=False)
+    monkeypatch.delenv("PEAK_RECON_ENABLED", raising=False)
+    with pytest.raises(ValueError):
+        config_from_env()
+
+
+def test_config_from_env_invalid_position_abs_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-numeric PEAK_RECON_POSITION_ABS propagates float() ValueError (current contract)."""
+    monkeypatch.setenv("PEAK_RECON_BALANCE_ABS", "0")
+    monkeypatch.setenv("PEAK_RECON_POSITION_ABS", "not-a-number")
+    monkeypatch.delenv("PEAK_RECON_ENABLED", raising=False)
+    with pytest.raises(ValueError):
+        config_from_env()


### PR DESCRIPTION
## Summary
- add contract coverage for `config_from_env()` when recon float env vars are invalid
- document the current behavior without changing production code

## Changes
- import `config_from_env` into `tests/ops/test_recon_hook.py`
- add `test_config_from_env_invalid_balance_abs_raises`
- add `test_config_from_env_invalid_position_abs_raises`
- use `monkeypatch` to inject invalid `PEAK_RECON_*` env strings
- keep `src/ops/recon/recon_hook.py` unchanged

## Verification
- `python3 -m pytest tests/ops/test_recon_hook.py -q`
- `python3 -m pytest tests -q --tb=line`

## Risk
- tests only
- documents the current contract for invalid recon env floats
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)