### PR TITLE
test(execution): document get_config ValueError on invalid PT_FAULT_INJECT_* numeric env

### DIFF
--- a/tests/execution/test_fault_injection_contract.py
+++ b/tests/execution/test_fault_injection_contract.py
@@ -67,3 +67,27 @@ def test_no_trade_safety_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
     # No side effects from reading config
     _ = should_inject(config, FaultScenario.LATENCY, "x")
     _ = get_latency_ms(config, "x")
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    (
+        "PT_FAULT_INJECT_LATENCY_MS",
+        "PT_FAULT_INJECT_TIMEOUT_MS",
+        "PT_FAULT_INJECT_RATE_LIMIT_AFTER",
+        "PT_FAULT_INJECT_500_PROB",
+        "PT_FAULT_INJECT_MALFORMED_PROB",
+    ),
+)
+def test_get_config_invalid_numeric_env_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch, env_name: str
+) -> None:
+    """Non-numeric PT_FAULT_INJECT_* values make int()/float() fail with ValueError.
+
+    Applies even when PT_FAULT_INJECT is unset (disabled): _parse_env still reads
+    numeric knobs. (PT_FAULT_INJECT_SEED is handled separately with a fallback.)
+    """
+    monkeypatch.delenv("PT_FAULT_INJECT", raising=False)
+    monkeypatch.setenv(env_name, "not-a-number")
+    with pytest.raises(ValueError):
+        get_config()


### PR DESCRIPTION
## Summary
- add contract coverage for invalid numeric `PT_FAULT_INJECT_*` env values in fault injection config parsing
- document the current behavior without changing production code

## Changes
- add a parameterized test in `tests/execution/test_fault_injection_contract.py`
- cover invalid numeric values for:
  - `PT_FAULT_INJECT_LATENCY_MS`
  - `PT_FAULT_INJECT_TIMEOUT_MS`
  - `PT_FAULT_INJECT_RATE_LIMIT_AFTER`
  - `PT_FAULT_INJECT_500_PROB`
  - `PT_FAULT_INJECT_MALFORMED_PROB`
- assert that `get_config()` raises `ValueError`
- keep `PT_FAULT_INJECT_SEED` behavior unchanged and keep production code unchanged

## Verification
- `python3 -m pytest tests/execution/test_fault_injection_contract.py -q`
- `python3 -m pytest tests -q --tb=line`

## Risk
- tests only
- documents the current contract for invalid numeric fault-injection env values
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)