### PR TITLE
test(ops): document PEAK_RECON_ENABLED only enables on literal "1"

### DIFF
--- a/tests/ops/test_recon_hook.py
+++ b/tests/ops/test_recon_hook.py
@@ -44,3 +44,31 @@ def test_config_from_env_invalid_position_abs_raises(monkeypatch: pytest.MonkeyP
     monkeypatch.delenv("PEAK_RECON_ENABLED", raising=False)
     with pytest.raises(ValueError):
         config_from_env()
+
+
+def test_config_from_env_peak_recon_enabled_unset_is_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PEAK_RECON_ENABLED unset defaults to disabled (current contract)."""
+    monkeypatch.delenv("PEAK_RECON_ENABLED", raising=False)
+    monkeypatch.setenv("PEAK_RECON_BALANCE_ABS", "0")
+    monkeypatch.setenv("PEAK_RECON_POSITION_ABS", "0")
+    assert config_from_env().enabled is False
+
+
+@pytest.mark.parametrize(
+    ("peak_recon_enabled", "expect_enabled"),
+    [
+        ("1", True),
+        ("0", False),
+        ("true", False),
+        ("yes", False),
+        ("1 ", False),
+    ],
+)
+def test_config_from_env_peak_recon_enabled_strict_literal_one(
+    monkeypatch: pytest.MonkeyPatch, peak_recon_enabled: str, expect_enabled: bool
+) -> None:
+    """Only PEAK_RECON_ENABLED exactly ``1`` enables recon; no truthy strings, no strip (current contract)."""
+    monkeypatch.setenv("PEAK_RECON_ENABLED", peak_recon_enabled)
+    monkeypatch.setenv("PEAK_RECON_BALANCE_ABS", "0")
+    monkeypatch.setenv("PEAK_RECON_POSITION_ABS", "0")
+    assert config_from_env().enabled is expect_enabled


### PR DESCRIPTION
## Summary
- add contract coverage for the strict `PEAK_RECON_ENABLED` parsing behavior
- document the current behavior without changing production code

## Changes
- add `test_config_from_env_peak_recon_enabled_unset_is_false`
- add a parameterized test covering strict literal parsing for `PEAK_RECON_ENABLED`
- verify:
  - `"1"` -> `enabled=True`
  - `"0"` -> `enabled=False`
  - `"true"` -> `enabled=False`
  - `"yes"` -> `enabled=False`
  - `"1 "` -> `enabled=False`
- keep `src/ops/recon/recon_hook.py` unchanged

## Verification
- `python3 -m pytest tests/ops/test_recon_hook.py -q`
- `python3 -m pytest tests -q --tb=line`

## Risk
- tests only
- documents the current strict recon-enabled env contract
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)