### PR TITLE
test(ops): document PEAK_KILL_SWITCH fallback only blocks on literal "1"

### DIFF
--- a/tests/ops/test_risk_gate.py
+++ b/tests/ops/test_risk_gate.py
@@ -124,7 +124,27 @@ def test_kill_switch_should_block_trading_file_active_no_block(tmp_path, monkeyp
     assert kill_switch_should_block_trading(explicit_active=False) is False
 
 
-def test_kill_switch_should_block_trading_env_when_no_file(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("peak_kill_switch", "expect_block"),
+    [
+        (None, False),
+        ("0", False),
+        ("1", True),
+        ("true", False),
+        ("01", False),
+        ("1 ", False),
+    ],
+)
+def test_kill_switch_should_block_trading_env_fallback_strict_literal_one(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    peak_kill_switch: str | None,
+    expect_block: bool,
+) -> None:
+    """When state file is missing, only PEAK_KILL_SWITCH exactly ``1`` blocks (current contract)."""
     monkeypatch.setenv("PEAK_KILL_SWITCH_STATE_PATH", str(tmp_path / "nope.json"))
-    monkeypatch.setenv("PEAK_KILL_SWITCH", "1")
-    assert kill_switch_should_block_trading(explicit_active=False) is True
+    if peak_kill_switch is None:
+        monkeypatch.delenv("PEAK_KILL_SWITCH", raising=False)
+    else:
+        monkeypatch.setenv("PEAK_KILL_SWITCH", peak_kill_switch)
+    assert kill_switch_should_block_trading(explicit_active=False) is expect_block


### PR DESCRIPTION
## Summary
- add contract coverage for the strict `PEAK_KILL_SWITCH` env-fallback behavior in risk gate
- document the current behavior without changing production code

## Changes
- replace the single env-fallback positive test with a parameterized test in `tests/ops/test_risk_gate.py`
- cover the missing-state-file fallback path for:
  - unset -> no block
  - `"0"` -> no block
  - `"1"` -> block
  - `"true"` -> no block
  - `"01"` -> no block
  - `"1 "` -> no block
- keep `src/ops/gates/risk_gate.py` unchanged
- do not touch local stashed docs changes

## Verification
- `python3 -m pytest tests/ops/test_risk_gate.py -q`
- `python3 -m pytest tests -q --tb=line`

## Risk
- tests only
- documents the current strict kill-switch env fallback contract
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)