### PR TITLE
test(webui): document PEAK_TRADE_EXECUTION_WATCH_METRICS_ENABLED only enables on literal "1"

### DIFF
--- a/tests/webui/test_execution_watch_metrics_env_contract.py
+++ b/tests/webui/test_execution_watch_metrics_env_contract.py
@@ -1,0 +1,33 @@
+"""Contract tests for execution watch metrics env flag (read-only helper)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.webui.execution_watch_api_v0_2 import _enabled_exec_watch_metrics
+
+_ENV = "PEAK_TRADE_EXECUTION_WATCH_METRICS_ENABLED"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expect_enabled"),
+    [
+        (None, False),
+        ("0", False),
+        ("1", True),
+        ("true", False),
+        ("1 ", False),
+        (" 1", False),
+    ],
+)
+def test_peak_trade_execution_watch_metrics_enabled_strict_literal_one(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str | None,
+    expect_enabled: bool,
+) -> None:
+    """``os.getenv(..., '0') == '1'`` — no strip; only exact ``1`` enables (current contract)."""
+    if raw is None:
+        monkeypatch.delenv(_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_ENV, raw)
+    assert _enabled_exec_watch_metrics() is expect_enabled


### PR DESCRIPTION
## Summary
- add contract coverage for the execution-watch metrics enable flag
- document that `PEAK_TRADE_EXECUTION_WATCH_METRICS_ENABLED` only enables metrics on exact literal `"1"`
- keep production code unchanged

## Changes
- add `tests/webui/test_execution_watch_metrics_env_contract.py`
- cover:
  - unset -> disabled
  - `"0"` -> disabled
  - `"1"` -> enabled
  - `"true"` -> disabled
  - `"1 "` -> disabled
  - `" 1"` -> disabled
- keep `src/webui/execution_watch_api_v0_2.py` unchanged
- do not touch local stashed docs changes

## Verification
- `python3 -m pytest tests -q -k "execution_watch"`
- `python3 -m pytest tests/webui/test_execution_watch_metrics_env_contract.py -q`
- `python3 -m pytest tests -q --tb=line`

## Risk
- tests only
- documents the current strict env-parsing contract for execution-watch metrics
- no changes to Live/Paper/Shadow/Testnet or execution paths

Made with [Cursor](https://cursor.com)