### PR TITLE
fix: harden p99 ops loop cli invalid int env contract

### DIFF
--- a/src/ops/p99/ops_loop_cli_v1.py
+++ b/src/ops/p99/ops_loop_cli_v1.py
@@ -18,6 +18,15 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
+def _parse_int_env(env_name: str, default_str: str) -> int:
+    """Parse ``os.environ[env_name]`` as base-10 int; invalid values raise ``ValueError`` with context."""
+    raw = os.environ.get(env_name, default_str)
+    try:
+        return int(raw, 10)
+    except ValueError as e:
+        raise ValueError(f"{env_name} must be a decimal integer, got {raw!r}") from e
+
+
 def _write_text(p: Path, s: str) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(s, encoding="utf-8")
@@ -60,17 +69,20 @@ def _bundle_dir(evi: Path) -> Path:
 
 
 def main(argv: list[str] | None = None) -> int:
+    max_age_default = _parse_int_env("MAX_AGE_SEC", "900")
+    min_ticks_default = _parse_int_env("MIN_TICKS", "2")
+
     ap = argparse.ArgumentParser(prog="p99_ops_loop_cli_v1", add_help=True)
     ap.add_argument("--mode", default=os.environ.get("MODE", "shadow"))
     ap.add_argument(
         "--max-age-sec",
         type=int,
-        default=int(os.environ.get("MAX_AGE_SEC", "900")),
+        default=max_age_default,
     )
     ap.add_argument(
         "--min-ticks",
         type=int,
-        default=int(os.environ.get("MIN_TICKS", "2")),
+        default=min_ticks_default,
     )
     ap.add_argument(
         "--dry-run",

--- a/tests/p99/test_ops_loop_cli_v1_env_contract.py
+++ b/tests/p99/test_ops_loop_cli_v1_env_contract.py
@@ -1,0 +1,19 @@
+"""Contract tests for p99 ops loop CLI integer env defaults."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ops.p99.ops_loop_cli_v1 import main
+
+
+def test_main_invalid_max_age_sec_env_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MAX_AGE_SEC", "not-an-int")
+    with pytest.raises(ValueError, match="MAX_AGE_SEC must be a decimal integer"):
+        main([])
+
+
+def test_main_invalid_min_ticks_env_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIN_TICKS", "bogus")
+    with pytest.raises(ValueError, match="MIN_TICKS must be a decimal integer"):
+        main([])


### PR DESCRIPTION
## Summary
- harden p99 ops loop CLI integer env parsing for MAX_AGE_SEC and MIN_TICKS
- add explicit ValueError context with env name and raw value
- add contract tests for both invalid env cases

## Changes
- add `_parse_int_env(env_name, default_str)` in `src/ops/p99/ops_loop_cli_v1.py`
- parse defaults once before wiring argparse defaults
- add `tests/p99/test_ops_loop_cli_v1_env_contract.py`

## Verification
- `python3 -m pytest tests/p99/test_ops_loop_cli_v1_env_contract.py -q`
- `python3 -m pytest tests -q --tb=line`
- `ruff check src/ops/p99/ops_loop_cli_v1.py tests/p99/test_ops_loop_cli_v1_env_contract.py`

## Non-goals
- no other env-contract changes
- no MODE / DRY_RUN / P98 orchestrator changes
- no docs/ops changes
