### PR TITLE
fix: include truncated out snippet in p98 step failures

### DIFF
--- a/src/ops/p98/ops_loop_orchestrator_v1.py
+++ b/src/ops/p98/ops_loop_orchestrator_v1.py
@@ -6,6 +6,17 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+# Max characters of stdout+stderr to embed in step failure RuntimeError (deterministic cap).
+_MAX_STEP_FAILURE_OUT_SNIPPET_CHARS = 512
+
+
+def _truncate_for_step_failure(out: str, max_len: int = _MAX_STEP_FAILURE_OUT_SNIPPET_CHARS) -> str:
+    """Return a bounded snippet for error messages; strip outer whitespace; suffix … if truncated."""
+    stripped = out.strip()
+    if len(stripped) <= max_len:
+        return stripped
+    return stripped[: max_len - 1] + "…"
+
 
 @dataclass(frozen=True)
 class P98OpsLoopContextV1:
@@ -41,7 +52,8 @@ def run_ops_loop_orchestrator_v1(ctx: P98OpsLoopContextV1) -> dict:
         rc, out = _sh(cmd, env=env, cwd=str(root))
         steps.append({"name": name, "rc": rc, "out": out})
         if rc != 0:
-            raise RuntimeError(f"{name} failed rc={rc}")
+            snippet = _truncate_for_step_failure(out)
+            raise RuntimeError(f"{name} failed rc={rc} out_snippet={snippet!r}")
 
     # A) Ensure supervisor is alive (status-only; do not start here)
     step("p95_meta_gate", ["bash", str(root / "scripts/ops/p95_ops_health_meta_gate_v1.sh")])

--- a/tests/p98/test_p98_ops_loop_step_failure_snippet.py
+++ b/tests/p98/test_p98_ops_loop_step_failure_snippet.py
@@ -1,0 +1,50 @@
+import pytest
+
+from src.ops.p98 import P98OpsLoopContextV1, run_ops_loop_orchestrator_v1
+from src.ops.p98.ops_loop_orchestrator_v1 import (
+    _MAX_STEP_FAILURE_OUT_SNIPPET_CHARS,
+    _truncate_for_step_failure,
+)
+
+
+def test_truncate_for_step_failure_short_unchanged() -> None:
+    assert _truncate_for_step_failure("hello\n") == "hello"
+    assert _truncate_for_step_failure("") == ""
+
+
+def test_truncate_for_step_failure_exact_max_len_no_ellipsis() -> None:
+    s = "a" * _MAX_STEP_FAILURE_OUT_SNIPPET_CHARS
+    assert _truncate_for_step_failure(s) == s
+
+
+def test_truncate_for_step_failure_long_gets_ellipsis() -> None:
+    s = "b" * (_MAX_STEP_FAILURE_OUT_SNIPPET_CHARS + 10)
+    out = _truncate_for_step_failure(s)
+    assert len(out) == _MAX_STEP_FAILURE_OUT_SNIPPET_CHARS
+    assert out.endswith("…")
+
+
+def test_step_failure_runtime_error_includes_truncated_repr(monkeypatch: pytest.MonkeyPatch) -> None:
+    long_out = "E" * 800
+
+    def fake_sh(cmd, env=None, cwd=None):
+        return 1, long_out
+
+    monkeypatch.setattr("src.ops.p98.ops_loop_orchestrator_v1._sh", fake_sh)
+    with pytest.raises(RuntimeError, match="p95_meta_gate") as ei:
+        run_ops_loop_orchestrator_v1(P98OpsLoopContextV1())
+    msg = str(ei.value)
+    assert "rc=1" in msg
+    assert "out_snippet=" in msg
+    expected = _truncate_for_step_failure(long_out)
+    assert repr(expected) in msg
+
+
+def test_step_failure_empty_out_snippet(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_sh(cmd, env=None, cwd=None):
+        return 1, "   \n  "
+
+    monkeypatch.setattr("src.ops.p98.ops_loop_orchestrator_v1._sh", fake_sh)
+    with pytest.raises(RuntimeError) as ei:
+        run_ops_loop_orchestrator_v1(P98OpsLoopContextV1())
+    assert "out_snippet=''" in str(ei.value)

--- a/tests/p98/test_p98_ops_loop_step_failure_snippet.py
+++ b/tests/p98/test_p98_ops_loop_step_failure_snippet.py
@@ -24,7 +24,9 @@ def test_truncate_for_step_failure_long_gets_ellipsis() -> None:
     assert out.endswith("…")
 
 
-def test_step_failure_runtime_error_includes_truncated_repr(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_step_failure_runtime_error_includes_truncated_repr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     long_out = "E" * 800
 
     def fake_sh(cmd, env=None, cwd=None):


### PR DESCRIPTION
## Summary
- include a deterministic truncated `out` snippet in P98 step failure exceptions
- keep failure messages bounded and readable for CI/Ops diagnosis
- add targeted regression tests for truncation, error surfacing, and empty output

## Changes
- add `_MAX_STEP_FAILURE_OUT_SNIPPET_CHARS = 512`
- add `_truncate_for_step_failure(...)` in `src/ops/p98/ops_loop_orchestrator_v1.py`
- extend the step failure path to raise:
  - `RuntimeError(f"{name} failed rc={rc} out_snippet={snippet!r}")`
- add `tests/p98/test_p98_ops_loop_step_failure_snippet.py`

## Snippet rule
- strip outer whitespace from the full combined `out`
- if length is `<= 512`, keep as-is
- if longer, use the first `511` chars plus `…`
- embed via `repr(...)` so control characters and newlines stay readable on one line

## Verification
- `uv run pytest tests/p98/test_p98_ops_loop_step_failure_snippet.py -q`
- `uv run ruff check src/ops/p98/ops_loop_orchestrator_v1.py tests/p98/test_p98_ops_loop_step_failure_snippet.py`
- `uv run pytest -q`

## Full test note
`uv run pytest -q` was green for this slice except for unrelated environment/optional-dependency failures in `tests/test_meta_labeling.py` caused by `ModuleNotFoundError: sklearn`.

## Non-goals
- no `_sh` refactor
- no step ordering changes
- no P117 behavior change
- no docs/ops changes
- no Live/Paper/Shadow/Testnet changes
