### PR TITLE
feat: include configured limits in risk gate deny details

### DIFF
--- a/src/ops/gates/risk_gate.py
+++ b/src/ops/gates/risk_gate.py
@@ -121,9 +121,20 @@ def kill_switch_should_block_trading(*, explicit_active: bool = False) -> bool:
 
 def evaluate_risk(limits: RiskLimits, ctx: RiskContext) -> RiskDecision:
     if not limits.enabled:
-        return RiskDecision(False, RiskDenyReason.DISABLED, {"enabled": "false"})
+        return RiskDecision(
+            False,
+            RiskDenyReason.DISABLED,
+            {"enabled": "false", "limits_enabled": str(limits.enabled).lower()},
+        )
     if limits.kill_switch:
-        return RiskDecision(False, RiskDenyReason.KILL_SWITCH, {"kill_switch": "true"})
+        return RiskDecision(
+            False,
+            RiskDenyReason.KILL_SWITCH,
+            {
+                "kill_switch": "true",
+                "limits_kill_switch": str(limits.kill_switch).lower(),
+            },
+        )
 
     if (
         limits.max_data_age_seconds > 0
@@ -132,35 +143,50 @@ def evaluate_risk(limits: RiskLimits, ctx: RiskContext) -> RiskDecision:
         return RiskDecision(
             False,
             RiskDenyReason.STALE_DATA,
-            {"age_s": str(ctx.market_data_age_seconds)},
+            {
+                "age_s": str(ctx.market_data_age_seconds),
+                "max_data_age_seconds": str(limits.max_data_age_seconds),
+            },
         )
 
     if limits.max_notional_usd > 0 and ctx.order_notional_usd > limits.max_notional_usd:
         return RiskDecision(
             False,
             RiskDenyReason.MAX_NOTIONAL,
-            {"notional_usd": str(ctx.order_notional_usd)},
+            {
+                "notional_usd": str(ctx.order_notional_usd),
+                "max_notional_usd": str(limits.max_notional_usd),
+            },
         )
 
     if limits.max_order_size > 0 and abs(ctx.order_size) > limits.max_order_size:
         return RiskDecision(
             False,
             RiskDenyReason.MAX_ORDER_SIZE,
-            {"order_size": str(ctx.order_size)},
+            {
+                "order_size": str(ctx.order_size),
+                "max_order_size": str(limits.max_order_size),
+            },
         )
 
     if limits.max_position > 0 and abs(ctx.current_position + ctx.order_size) > limits.max_position:
         return RiskDecision(
             False,
             RiskDenyReason.MAX_POSITION,
-            {"next_pos": str(ctx.current_position + ctx.order_size)},
+            {
+                "next_pos": str(ctx.current_position + ctx.order_size),
+                "max_position": str(limits.max_position),
+            },
         )
 
     if limits.max_session_loss_usd > 0 and ctx.session_pnl_usd < -abs(limits.max_session_loss_usd):
         return RiskDecision(
             False,
             RiskDenyReason.LOSS_LIMIT,
-            {"session_pnl_usd": str(ctx.session_pnl_usd)},
+            {
+                "session_pnl_usd": str(ctx.session_pnl_usd),
+                "max_session_loss_usd": str(limits.max_session_loss_usd),
+            },
         )
 
     return RiskDecision(True, None, {})

--- a/tests/ops/test_risk_gate.py
+++ b/tests/ops/test_risk_gate.py
@@ -32,12 +32,14 @@ def test_disabled_denies():
     dec = evaluate_risk(RiskLimits(enabled=False), base_ctx())
     assert dec.allow is False
     assert dec.reason == RiskDenyReason.DISABLED
+    assert dec.details.get("limits_enabled") == "false"
 
 
 def test_kill_switch_denies():
     dec = evaluate_risk(RiskLimits(kill_switch=True), base_ctx())
     assert dec.allow is False
     assert dec.reason == RiskDenyReason.KILL_SWITCH
+    assert dec.details.get("limits_kill_switch") == "true"
 
 
 def test_stale_data_denies():
@@ -45,13 +47,44 @@ def test_stale_data_denies():
     dec = evaluate_risk(lim, base_ctx(market_data_age_seconds=11))
     assert dec.allow is False
     assert dec.reason == RiskDenyReason.STALE_DATA
+    assert dec.details.get("age_s") == "11"
+    assert dec.details.get("max_data_age_seconds") == "10"
 
 
 def test_notional_denies():
     lim = RiskLimits(max_notional_usd=50)
-    dec = evaluate_risk(lim, base_ctx(order_notional_usd=51))
+    dec = evaluate_risk(lim, base_ctx(order_notional_usd=51.0))
     assert dec.allow is False
     assert dec.reason == RiskDenyReason.MAX_NOTIONAL
+    assert float(dec.details["notional_usd"]) == 51.0
+    assert float(dec.details["max_notional_usd"]) == 50.0
+
+
+def test_order_size_denies():
+    lim = RiskLimits(max_order_size=2.0)
+    dec = evaluate_risk(lim, base_ctx(order_size=3.0))
+    assert dec.allow is False
+    assert dec.reason == RiskDenyReason.MAX_ORDER_SIZE
+    assert dec.details.get("order_size") == "3.0"
+    assert dec.details.get("max_order_size") == "2.0"
+
+
+def test_max_position_denies():
+    lim = RiskLimits(max_position=5.0)
+    dec = evaluate_risk(lim, base_ctx(current_position=2.0, order_size=4.0))
+    assert dec.allow is False
+    assert dec.reason == RiskDenyReason.MAX_POSITION
+    assert dec.details.get("next_pos") == "6.0"
+    assert dec.details.get("max_position") == "5.0"
+
+
+def test_loss_limit_denies():
+    lim = RiskLimits(max_session_loss_usd=100.0)
+    dec = evaluate_risk(lim, base_ctx(session_pnl_usd=-101.0))
+    assert dec.allow is False
+    assert dec.reason == RiskDenyReason.LOSS_LIMIT
+    assert dec.details.get("session_pnl_usd") == "-101.0"
+    assert dec.details.get("max_session_loss_usd") == "100.0"
 
 
 def test_allow_happy_path():


### PR DESCRIPTION
## Summary
- include configured limit values in `RiskDecision.details` for deny paths
- keep the existing allow/deny comparisons unchanged
- improve operator diagnostics by surfacing actual vs configured values together

## Changes
- extend deny-path details in `src/ops/gates/risk_gate.py`
- update/add targeted assertions in `tests/ops/test_risk_gate.py`
- keep `tests/ops/test_live_gates_verification.py` green

## Added deny details
- `DISABLED`: `limits_enabled`
- `KILL_SWITCH`: `limits_kill_switch`
- `STALE_DATA`: `max_data_age_seconds`
- `MAX_NOTIONAL`: `max_notional_usd`
- `MAX_ORDER_SIZE`: `max_order_size`
- `MAX_POSITION`: `max_position`
- `LOSS_LIMIT`: `max_session_loss_usd`

## Representation
- bool values are surfaced as lowercase strings: `"true"` / `"false"`
- numeric values continue to be stringified consistently with the existing details format

## Verification
- `uv run pytest tests/ops/test_risk_gate.py tests/ops/test_live_gates_verification.py -q`
- `uv run ruff check src/ops/gates/risk_gate.py tests/ops/test_risk_gate.py`

## Non-goals
- no changes to allow/deny decision logic
- no Treasury / Manifest / Portfolio follow-up work
- no docs/ops changes
- no Live/Paper/Shadow/Testnet changes
