### PR TITLE
feat: suggest candidate strategy ids when manifest lookup fails

### DIFF
--- a/src/experiments/strategy_returns_manifest_loader.py
+++ b/src/experiments/strategy_returns_manifest_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import difflib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -46,6 +47,18 @@ def _extract_mapping(data: dict[str, Any]) -> dict[str, str]:
     return out
 
 
+def _missing_strategy_id_message(strategy_id: str, mapping: dict[str, str]) -> str:
+    """Error line for unknown strategy_id; may append close manifest keys (sorted, bounded)."""
+    base = f"strategy_id_missing_in_manifest: {strategy_id}"
+    keys = sorted(mapping.keys())
+    if not keys:
+        return base
+    close = difflib.get_close_matches(strategy_id, keys, n=3, cutoff=0.55)
+    if not close:
+        return base
+    return base + " candidate_strategy_ids=" + ",".join(close)
+
+
 def resolve_strategy_run_dir(
     *,
     strategy_id: str,
@@ -57,7 +70,7 @@ def resolve_strategy_run_dir(
     mapping = _extract_mapping(data)
 
     if strategy_id not in mapping:
-        raise StrategyReturnsManifestError(f"strategy_id_missing_in_manifest: {strategy_id}")
+        raise StrategyReturnsManifestError(_missing_strategy_id_message(strategy_id, mapping))
 
     raw_path = Path(mapping[strategy_id])
     if raw_path.is_absolute():

--- a/tests/test_strategy_returns_manifest_loader.py
+++ b/tests/test_strategy_returns_manifest_loader.py
@@ -93,6 +93,63 @@ strategy_a = "runs/strategy_a"
         )
 
 
+def test_missing_strategy_id_suggests_close_manifest_keys(tmp_path: Path) -> None:
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[strategy_returns]
+strategy_a = "runs/strategy_a"
+strategy_bb = "runs/strategy_bb"
+""".strip()
+        + "\n",
+    )
+
+    with pytest.raises(StrategyReturnsManifestError) as ei:
+        resolve_strategy_run_dir(strategy_id="strategy_b", manifest_path=manifest)
+    msg = str(ei.value)
+    assert "strategy_id_missing_in_manifest: strategy_b" in msg
+    assert "candidate_strategy_ids=" in msg
+    assert "strategy_a" in msg
+
+
+def test_missing_strategy_id_no_candidates_when_no_close_match(tmp_path: Path) -> None:
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[strategy_returns]
+alpha = "runs/a"
+beta = "runs/b"
+gamma = "runs/g"
+""".strip()
+        + "\n",
+    )
+
+    with pytest.raises(StrategyReturnsManifestError) as ei:
+        resolve_strategy_run_dir(strategy_id="zzzzzzzz", manifest_path=manifest)
+    msg = str(ei.value)
+    assert msg.startswith("strategy_id_missing_in_manifest: zzzzzzzz")
+    assert "candidate_strategy_ids=" not in msg
+
+
+def test_missing_strategy_id_empty_mapping_no_candidates(tmp_path: Path) -> None:
+    manifest = tmp_path / "strategy_returns_map.toml"
+    _write_manifest(
+        manifest,
+        """
+[strategy_returns]
+""".strip()
+        + "\n",
+    )
+
+    with pytest.raises(StrategyReturnsManifestError) as ei:
+        resolve_strategy_run_dir(strategy_id="any", manifest_path=manifest)
+    msg = str(ei.value)
+    assert "strategy_id_missing_in_manifest: any" in msg
+    assert "candidate_strategy_ids=" not in msg
+
+
 def test_load_returns_for_strategy_from_manifest_missing_manifest(tmp_path: Path) -> None:
     manifest = tmp_path / "missing_strategy_returns_map.toml"
 


### PR DESCRIPTION
## Summary
- suggest plausible candidate strategy ids when a manifest lookup misses
- preserve the existing `strategy_id_missing_in_manifest` error path and append `candidate_strategy_ids=...` only when plausible matches exist
- add focused tests for candidate suggestions, no-match, and empty-mapping cases

## Testing
- uv run pytest tests/test_strategy_returns_manifest_loader.py -q
- uv run ruff check src/experiments/strategy_returns_manifest_loader.py tests/test_strategy_returns_manifest_loader.py
