### PR TITLE
fix: serialize risk gate deny details as JSON in execution guard errors

### DIFF
--- a/src/ops/wiring/execution_guards.py
+++ b/src/ops/wiring/execution_guards.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Optional
 
@@ -54,9 +55,9 @@ def apply_execution_guards(
     if cfg.risk_enabled:
         risk_dec = evaluate_risk(inputs.limits, inputs.ctx)
         if not risk_dec.allow:
+            details_json = json.dumps(risk_dec.details, sort_keys=True)
             raise RuntimeError(
-                f"Execution blocked: risk_gate deny reason={risk_dec.reason} "
-                f"details={risk_dec.details}"
+                f"Execution blocked: risk_gate deny reason={risk_dec.reason} details={details_json}"
             )
 
     return GuardResult(allow=True, risk=risk_dec)

--- a/tests/ops/test_execution_guards.py
+++ b/tests/ops/test_execution_guards.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 from src.ops.wiring.execution_guards import (
     GuardConfig,
@@ -83,5 +85,13 @@ def test_risk_gate_denies_when_enabled():
         limits=limits,
         ctx=base_ctx(order_notional_usd=60),
     )
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as ei:
         apply_execution_guards(cfg, gate=gate, inputs=inputs)
+    msg = str(ei.value)
+    assert msg.startswith("Execution blocked: risk_gate deny")
+    assert "details=" in msg
+    _, rest = msg.split("details=", 1)
+    parsed = json.loads(rest)
+    assert list(parsed.keys()) == sorted(parsed.keys())
+    assert float(parsed["max_notional_usd"]) == 50.0
+    assert float(parsed["notional_usd"]) == 60.0


### PR DESCRIPTION
## Summary
- serialize `risk_dec.details` as stable sorted JSON in execution guard deny errors
- preserve existing guard and risk decision behavior
- add focused test coverage for parseable JSON details in the deny path

## Testing
- uv run pytest tests/ops/test_execution_guards.py tests/ops/test_live_gates_verification.py -q
- uv run ruff check src/ops/wiring/execution_guards.py tests/ops/test_execution_guards.py tests/ops/test_live_gates_verification.py
