### PR TITLE
feat: validate env and CLI args early in P99 ops loop CLI

### DIFF
--- a/src/ops/p99/ops_loop_cli_v1.py
+++ b/src/ops/p99/ops_loop_cli_v1.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -68,9 +69,17 @@ def _bundle_dir(evi: Path) -> Path:
     return bundle
 
 
+def _env_parse_fail(exc: ValueError) -> int:
+    print(str(exc), file=sys.stderr)
+    return 2
+
+
 def main(argv: list[str] | None = None) -> int:
-    max_age_default = _parse_int_env("MAX_AGE_SEC", "900")
-    min_ticks_default = _parse_int_env("MIN_TICKS", "2")
+    try:
+        max_age_default = _parse_int_env("MAX_AGE_SEC", "900")
+        min_ticks_default = _parse_int_env("MIN_TICKS", "2")
+    except ValueError as e:
+        return _env_parse_fail(e)
 
     ap = argparse.ArgumentParser(prog="p99_ops_loop_cli_v1", add_help=True)
     ap.add_argument("--mode", default=os.environ.get("MODE", "shadow"))
@@ -100,7 +109,24 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     if args.mode not in ("paper", "shadow"):
-        raise SystemExit("mode must be paper|shadow (live/record not supported)")
+        print(
+            "mode must be paper|shadow (live/record not supported)",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.max_age_sec <= 0:
+        print(
+            "--max-age-sec / MAX_AGE_SEC must be a positive integer",
+            file=sys.stderr,
+        )
+        return 2
+    if args.min_ticks <= 0:
+        print(
+            "--min-ticks / MIN_TICKS must be a positive integer",
+            file=sys.stderr,
+        )
+        return 2
 
     ts = args.ts or _utc_ts()
     root = _repo_root()

--- a/tests/p99/test_ops_loop_cli_v1_env_contract.py
+++ b/tests/p99/test_ops_loop_cli_v1_env_contract.py
@@ -1,4 +1,4 @@
-"""Contract tests for p99 ops loop CLI integer env defaults."""
+"""Contract tests for p99 ops loop CLI integer env defaults and early validation."""
 
 from __future__ import annotations
 
@@ -7,13 +7,44 @@ import pytest
 from src.ops.p99.ops_loop_cli_v1 import main
 
 
-def test_main_invalid_max_age_sec_env_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_invalid_max_age_sec_env_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.setenv("MAX_AGE_SEC", "not-an-int")
-    with pytest.raises(ValueError, match="MAX_AGE_SEC must be a decimal integer"):
-        main([])
+    assert main([]) == 2
+    err = capsys.readouterr().err
+    assert "MAX_AGE_SEC must be a decimal integer" in err
 
 
-def test_main_invalid_min_ticks_env_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_invalid_min_ticks_env_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.setenv("MIN_TICKS", "bogus")
-    with pytest.raises(ValueError, match="MIN_TICKS must be a decimal integer"):
-        main([])
+    assert main([]) == 2
+    err = capsys.readouterr().err
+    assert "MIN_TICKS must be a decimal integer" in err
+
+
+def test_main_empty_max_age_sec_env_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Set-but-empty env is not a valid integer (missing effective value)."""
+    monkeypatch.setenv("MAX_AGE_SEC", "")
+    assert main([]) == 2
+    err = capsys.readouterr().err
+    assert "MAX_AGE_SEC must be a decimal integer" in err
+
+
+def test_main_max_age_sec_zero_returns_2(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--max-age-sec", "0"]) == 2
+    assert "positive integer" in capsys.readouterr().err
+
+
+def test_main_min_ticks_zero_returns_2(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--min-ticks", "0"]) == 2
+    assert "positive integer" in capsys.readouterr().err
+
+
+def test_main_invalid_mode_returns_2(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--mode", "live"]) == 2
+    assert "paper|shadow" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- validate critical env values early in the P99 ops loop CLI before entering the orchestrator
- return a stable operator-friendly exit code and stderr message for invalid env and CLI argument cases
- keep orchestrator behavior and evidence paths unchanged while extending focused test coverage

## Testing
- uv run pytest tests/p99 -q
- uv run ruff check src/ops/p99/ops_loop_cli_v1.py tests/p99
