### PR TITLE
test: assert stable JSON shape for ops health endpoint

### DIFF
--- a/tests/webui/test_health_endpoint_json_contract.py
+++ b/tests/webui/test_health_endpoint_json_contract.py
@@ -1,0 +1,55 @@
+"""
+Contract test for GET /health (src.webui.health_endpoint): minimal stable JSON shape.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.webui.health_endpoint import router
+
+
+@pytest.fixture
+def health_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_health_basic_json_contract_stable_keys(health_client: TestClient) -> None:
+    """GET /health returns a JSON object with stable top-level keys when checks succeed."""
+    with patch(
+        "src.webui.health_endpoint.health_check.is_system_healthy",
+        return_value=True,
+    ):
+        response = health_client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("application/json")
+    data = response.json()
+    assert isinstance(data, dict)
+    assert set(data.keys()) >= {"status", "timestamp"}
+    assert data["status"] == "healthy"
+    assert isinstance(data["timestamp"], str)
+    assert len(data["timestamp"]) >= 10
+
+
+def test_health_basic_json_contract_unhealthy_returns_503(health_client: TestClient) -> None:
+    """Unhealthy system: still JSON with status + timestamp; HTTP 503."""
+    with patch(
+        "src.webui.health_endpoint.health_check.is_system_healthy",
+        return_value=False,
+    ):
+        response = health_client.get("/health")
+
+    assert response.status_code == 503
+    data = response.json()
+    assert isinstance(data, dict)
+    assert data["status"] == "unhealthy"
+    assert "timestamp" in data


### PR DESCRIPTION
## Summary
- add a focused contract test for the existing `GET /health` endpoint
- assert a minimal stable JSON shape with `status` and `timestamp`
- keep the test deterministic by patching the health state and avoid production changes

## Testing
- uv run pytest tests/webui/test_health_endpoint_json_contract.py -q
- uv run pytest tests/webui -q
- uv run ruff check src/webui tests/webui
