### PR TITLE
fix: make portfolio dummy returns timeline deterministic

### DIFF
--- a/scripts/run_monte_carlo_robustness.py
+++ b/scripts/run_monte_carlo_robustness.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -51,6 +50,7 @@ import numpy as np
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from src.experiments.dummy_returns_timeline import create_dummy_returns
 from src.experiments.monte_carlo import (
     MonteCarloConfig,
     run_monte_carlo_from_returns,
@@ -68,28 +68,6 @@ def setup_logging(verbose: bool = False) -> None:
         format="%(asctime)s | %(levelname)-7s | %(message)s",
         datefmt="%H:%M:%S",
     )
-
-
-def create_dummy_returns(n_bars: int = 500, seed: int = 42) -> pd.Series:
-    """
-    Erstellt Dummy-Returns für Tests.
-
-    Args:
-        n_bars: Anzahl der Bars
-        seed: Random Seed
-
-    Returns:
-        Returns-Serie mit DatetimeIndex
-    """
-    np.random.seed(seed)
-    start = datetime.now() - timedelta(hours=n_bars)
-    dates = pd.date_range(start, periods=n_bars, freq="1h")
-
-    # Simuliere Returns (leicht positiv mit Volatilität)
-    returns = np.random.normal(0.0005, 0.02, n_bars)  # ~0.05% pro Stunde, 2% Vol
-    returns_series = pd.Series(returns, index=dates)
-
-    return returns_series
 
 
 def create_dummy_equity(n_bars: int = 500, seed: int = 42) -> pd.Series:

--- a/scripts/run_portfolio_robustness.py
+++ b/scripts/run_portfolio_robustness.py
@@ -40,13 +40,13 @@ import sys
 from pathlib import Path
 from typing import Optional, Sequence
 
-import numpy as np
 import pandas as pd
 
 # Projekt-Root zum Path hinzufügen
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from src.experiments.dummy_returns_timeline import create_dummy_returns
 from src.experiments.portfolio_recipes import get_portfolio_recipe
 from src.experiments.portfolio_robustness import (
     PortfolioComponent,
@@ -71,30 +71,6 @@ def setup_logging(verbose: bool = False) -> None:
         format="%(asctime)s | %(levelname)-7s | %(message)s",
         datefmt="%H:%M:%S",
     )
-
-
-def create_dummy_returns(n_bars: int = 500, seed: int = 42) -> pd.Series:
-    """
-    Erstellt Dummy-Returns für Tests.
-
-    Args:
-        n_bars: Anzahl der Bars
-        seed: Random Seed
-
-    Returns:
-        Returns-Serie mit DatetimeIndex
-    """
-    np.random.seed(seed)
-    from datetime import datetime, timedelta
-
-    start = datetime.now() - timedelta(hours=n_bars)
-    dates = pd.date_range(start, periods=n_bars, freq="1h")
-
-    # Simuliere Returns (leicht positiv mit Volatilität)
-    returns = np.random.normal(0.0005, 0.02, n_bars)  # ~0.05% pro Stunde, 2% Vol
-    returns_series = pd.Series(returns, index=dates)
-
-    return returns_series
 
 
 def _build_strategy_returns_cache(

--- a/scripts/run_stress_tests.py
+++ b/scripts/run_stress_tests.py
@@ -52,6 +52,7 @@ import numpy as np
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from src.experiments.dummy_returns_timeline import create_dummy_returns
 from src.experiments.stress_tests import (
     StressScenarioConfig,
     StressTestSuiteResult,
@@ -73,30 +74,6 @@ def setup_logging(verbose: bool = False) -> None:
         format="%(asctime)s | %(levelname)-7s | %(message)s",
         datefmt="%H:%M:%S",
     )
-
-
-def create_dummy_returns(n_bars: int = 500, seed: int = 42) -> pd.Series:
-    """
-    Erstellt Dummy-Returns für Tests.
-
-    Args:
-        n_bars: Anzahl der Bars
-        seed: Random Seed
-
-    Returns:
-        Returns-Serie mit DatetimeIndex
-    """
-    np.random.seed(seed)
-    from datetime import datetime, timedelta
-
-    start = datetime.now() - timedelta(hours=n_bars)
-    dates = pd.date_range(start, periods=n_bars, freq="1h")
-
-    # Simuliere Returns (leicht positiv mit Volatilität)
-    returns = np.random.normal(0.0005, 0.02, n_bars)  # ~0.05% pro Stunde, 2% Vol
-    returns_series = pd.Series(returns, index=dates)
-
-    return returns_series
 
 
 def build_stats_fn() -> callable:

--- a/src/experiments/dummy_returns_timeline.py
+++ b/src/experiments/dummy_returns_timeline.py
@@ -1,0 +1,31 @@
+# src/experiments/dummy_returns_timeline.py
+"""Deterministic dummy return series for offline portfolio/research CLIs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import numpy as np
+import pandas as pd
+
+# Fixed UTC anchor: for a given ``n_bars``, every series shares this hourly DatetimeIndex;
+# only pseudo-random values differ by ``seed``. Enables reproducible tests and multi-component
+# portfolio inner joins without relying on ``datetime.now()`` per call.
+DUMMY_RETURNS_TIMELINE_START = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def create_dummy_returns(n_bars: int = 500, seed: int = 42) -> pd.Series:
+    """
+    Erstellt Dummy-Returns für Tests mit fester Zeitachse.
+
+    Args:
+        n_bars: Anzahl der Bars
+        seed: Random Seed (beeinflusst nur die Werte, nicht den Index)
+
+    Returns:
+        Returns-Serie mit DatetimeIndex (UTC, stündlich ab DUMMY_RETURNS_TIMELINE_START)
+    """
+    np.random.seed(seed)
+    dates = pd.date_range(DUMMY_RETURNS_TIMELINE_START, periods=n_bars, freq="1h")
+    returns = np.random.normal(0.0005, 0.02, n_bars)
+    return pd.Series(returns, index=dates)

--- a/tests/test_portfolio_robustness_dummy_path_smoke.py
+++ b/tests/test_portfolio_robustness_dummy_path_smoke.py
@@ -15,18 +15,27 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 import scripts.run_portfolio_robustness as portfolio_script
+from src.experiments.dummy_returns_timeline import (
+    DUMMY_RETURNS_TIMELINE_START,
+    create_dummy_returns,
+)
 from src.experiments.portfolio_robustness import (
     PortfolioComponent,
     build_portfolio_returns,
 )
 
 
-def test_dummy_returns_loader_single_component_portfolio_smoke(tmp_path: Path) -> None:
-    """Offline: Dummy-Loader aus run_portfolio_robustness + Portfolio-Synthese ohne Sweep-Artefakte.
+def test_dummy_returns_timeline_stable_across_seeds() -> None:
+    """Gleiche n_bars + verschiedene Seeds → identischer Index, unterschiedliche Werte."""
+    a = create_dummy_returns(48, seed=1)
+    b = create_dummy_returns(48, seed=99)
+    pd.testing.assert_index_equal(a.index, b.index)
+    assert a.index[0] == DUMMY_RETURNS_TIMELINE_START
+    assert not np.allclose(a.to_numpy(), b.to_numpy())
 
-    Eine Komponente: create_dummy_returns nutzt pro Aufruf datetime.now() für den Index;
-    mehrere Komponenten hätten disjunkte Zeitachsen und keinen inner join.
-    """
+
+def test_dummy_returns_loader_single_component_portfolio_smoke(tmp_path: Path) -> None:
+    """Offline: Dummy-Loader aus run_portfolio_robustness + Portfolio-Synthese ohne Sweep-Artefakte."""
     loader = portfolio_script.build_returns_loader(
         sweep_name="smoke_sweep",
         experiments_dir=tmp_path,
@@ -35,6 +44,25 @@ def test_dummy_returns_loader_single_component_portfolio_smoke(tmp_path: Path) -
     )
     components = [
         PortfolioComponent(strategy_name="rsi", config_id="config_1", weight=1.0),
+    ]
+    out = build_portfolio_returns(components, loader)
+    assert isinstance(out, pd.Series)
+    assert len(out) == 48
+    assert out.notna().all()
+    assert np.isfinite(out.to_numpy(dtype=float)).all()
+
+
+def test_dummy_returns_loader_two_component_portfolio_smoke(tmp_path: Path) -> None:
+    """Zwei Komponenten: gemeinsame deterministische Zeitachse → voller Inner-Join über alle Bars."""
+    loader = portfolio_script.build_returns_loader(
+        sweep_name="smoke_sweep",
+        experiments_dir=tmp_path,
+        use_dummy_data=True,
+        dummy_bars=48,
+    )
+    components = [
+        PortfolioComponent(strategy_name="rsi", config_id="config_1", weight=0.5),
+        PortfolioComponent(strategy_name="ma", config_id="config_2", weight=0.5),
     ]
     out = build_portfolio_returns(components, loader)
     assert isinstance(out, pd.Series)


### PR DESCRIPTION
## Summary
- centralize dummy returns generation on a fixed UTC hourly timeline starting at `2020-01-01T00:00:00+00:00`
- remove per-call `datetime.now()` behavior so dummy indices are reproducible and overlap across components
- reuse the shared helper in the affected research CLIs and extend focused dummy-path smoke coverage

## Testing
- uv run pytest tests/test_portfolio_robustness_dummy_path_smoke.py tests/test_research_cli_portfolio_presets.py tests/test_strategy_returns_manifest_loader.py -q
- uv run pytest tests/test_portfolio_robustness.py -q
- uv run ruff check src/experiments scripts/run_portfolio_robustness.py scripts/run_monte_carlo_robustness.py scripts/run_stress_tests.py tests/test_portfolio_robustness_dummy_path_smoke.py tests/test_research_cli_portfolio_presets.py tests/test_strategy_returns_manifest_loader.py
