### PR TITLE
test: require non-empty primary strategies in research e2e scenarios

### DIFF
--- a/tests/test_research_e2e_scenarios.py
+++ b/tests/test_research_e2e_scenarios.py
@@ -271,7 +271,9 @@ class TestScenarioE2EWorkflow:
         for name, config in scenario_configs.items():
             applicable = config["scenario"]["applicable_strategies"]
             primary = applicable["primary"]
-            assert isinstance(primary, list), f"{name}: applicable_strategies.primary must be a list"
+            assert isinstance(primary, list), (
+                f"{name}: applicable_strategies.primary must be a list"
+            )
             assert len(primary) >= 1, f"{name}: applicable_strategies.primary must be non-empty"
 
     def test_scenario_expectations_have_drawdown_limits(self, scenario_configs):

--- a/tests/test_research_e2e_scenarios.py
+++ b/tests/test_research_e2e_scenarios.py
@@ -266,6 +266,14 @@ class TestScenarioE2EWorkflow:
             applicable = config["scenario"]["applicable_strategies"]
             assert "primary" in applicable, f"{name}: missing applicable_strategies.primary"
 
+    def test_scenario_primary_strategies_nonempty(self, scenario_configs):
+        """Jedes Szenario hat mindestens eine Primary-Strategie (kein stiller Leer-Pfad)."""
+        for name, config in scenario_configs.items():
+            applicable = config["scenario"]["applicable_strategies"]
+            primary = applicable["primary"]
+            assert isinstance(primary, list), f"{name}: applicable_strategies.primary must be a list"
+            assert len(primary) >= 1, f"{name}: applicable_strategies.primary must be non-empty"
+
     def test_scenario_expectations_have_drawdown_limits(self, scenario_configs):
         """Alle Szenarien haben Drawdown-Limits."""
         for name, config in scenario_configs.items():


### PR DESCRIPTION
## Summary
- add a focused research E2E contract test requiring non-empty `applicable_strategies.primary`
- reuse the existing scenario workflow fixtures and keep the slice test-only
- protect a core research read path from silent regressions in scenario configuration

## Testing
- uv run pytest tests/test_research_e2e_scenarios.py -q
- uv run pytest tests -q -k "research and e2e or scenario"
- uv run ruff check src tests
