### PR TITLE
test: add research cli help exit smoke

### DIFF
--- a/tests/test_research_cli.py
+++ b/tests/test_research_cli.py
@@ -52,6 +52,13 @@ class TestBuildParser:
         assert "portfolio" in subparsers_action.choices
         assert "pipeline" in subparsers_action.choices
 
+    def test_build_parser_help_exits_zero(self):
+        """--help beendet mit Code 0 (Help-/Discoverability-Pfad stabil)."""
+        parser = research_cli.build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--help"])
+        assert exc_info.value.code == 0
+
     def test_sweep_subparser_has_required_args(self):
         """Sweep-Subparser hat erwartete Argumente."""
         parser = research_cli.build_parser()


### PR DESCRIPTION
## Summary
- add a focused smoke test for the research CLI help path
- assert that `build_parser().parse_args(["--help"])` exits with code `0`
- keep the slice test-only and avoid brittle help-text assertions

## Testing
- uv run pytest tests/test_research_cli.py -q
- uv run ruff check tests/test_research_cli.py
- uv run ruff format --check tests/test_research_cli.py
