### PR TITLE
test: align live alerts hub navigation contract

### DIFF
--- a/tests/webui/test_live_alerts_hub_nav_contract.py
+++ b/tests/webui/test_live_alerts_hub_nav_contract.py
@@ -1,0 +1,36 @@
+"""
+Hub navigation parity for GET /live/alerts (same crosslinks as other Operator WebUI pages).
+
+Alerts dashboard extends ``templates/peak_trade_dashboard/base.html``; nav alignment mirrors
+``test_execution_watch_dashboard_hub_nav_parity``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app_client() -> TestClient:
+    from src.webui.app import app
+
+    return TestClient(app)
+
+
+def test_live_alerts_dashboard_hub_nav_parity(app_client: TestClient) -> None:
+    """Live Alerts page includes same hub crosslinks as other Operator WebUI standalones."""
+    response = app_client.get("/live/alerts")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    html = response.text
+    assert "Alert-Historie" in html
+    assert 'href="/ops"' in html
+    assert "Ops Cockpit" in html
+    assert 'href="/ops/stage1"' in html
+    assert 'href="/ops/workflows"' in html
+    assert 'href="/ops/ci-health"' in html
+    assert "http://127.0.0.1:8010/" in html
+    assert "Run UI (companion)" in html


### PR DESCRIPTION
## Summary
- add a focused hub-navigation parity contract test for `GET /live/alerts`
- mirror the existing execution-watch parity pattern and verify the shared hub links
- keep the slice test-only because the alerts page already inherits the expected shared navigation

## Testing
- uv run pytest tests/webui/test_live_alerts_hub_nav_contract.py -q
- uv run pytest tests/webui -q
- uv run ruff check src/webui tests/webui
