### PR TITLE
test: add research cli sweep help exit smoke

### DIFF
--- a/tests/test_research_cli.py
+++ b/tests/test_research_cli.py
@@ -59,6 +59,13 @@ class TestBuildParser:
             parser.parse_args(["--help"])
         assert exc_info.value.code == 0
 
+    def test_sweep_subcommand_help_exits_zero(self):
+        """sweep --help beendet mit Code 0 (Subparser-Pfad stabil)."""
+        parser = research_cli.build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["sweep", "--help"])
+        assert exc_info.value.code == 0
+
     def test_sweep_subparser_has_required_args(self):
         """Sweep-Subparser hat erwartete Argumente."""
         parser = research_cli.build_parser()


### PR DESCRIPTION
## Summary
- add a focused smoke test for the research CLI `sweep --help` path
- assert that `build_parser().parse_args(["sweep", "--help"])` exits with code `0`
- keep the slice test-only and avoid brittle help-text assertions

## Testing
- uv run pytest tests/test_research_cli.py -q
- uv run ruff check tests/test_research_cli.py
- uv run ruff format --check tests/test_research_cli.py
