### PR TITLE
test: add research cli run-experiment list-presets smoke

### DIFF
--- a/tests/test_research_cli.py
+++ b/tests/test_research_cli.py
@@ -384,6 +384,11 @@ class TestMain:
         assert exit_code == 0
         assert mock_run_pipeline.called
 
+    def test_main_run_experiment_list_presets_exits_zero(self):
+        """run-experiment --list-presets beendet mit Code 0 (Preset-Katalog, kein Backtest)."""
+        exit_code = research_cli.main(["run-experiment", "--list-presets"])
+        assert exit_code == 0
+
     def test_main_unknown_command_returns_error(self):
         """Unbekanntes Command gibt Fehler zurück."""
         with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- add a focused smoke test for `research_cli.main(["run-experiment", "--list-presets"])`
- assert that the preset listing path exits with code `0` without relying on fragile output assertions
- keep the slice test-only and reuse the existing main-test pattern

## Testing
- uv run pytest tests/test_research_cli.py -q
- uv run ruff check tests/test_research_cli.py
- uv run ruff format --check tests/test_research_cli.py
