### PR TITLE
test: add research cli strategy-profile list-strategies smoke

### DIFF
--- a/tests/test_research_cli.py
+++ b/tests/test_research_cli.py
@@ -405,6 +405,22 @@ class TestMain:
         )
         assert exit_code == 0
 
+    def test_main_strategy_profile_list_strategies_exits_zero(self):
+        """strategy-profile --list-strategies beendet mit Code 0 (Registry-IDs, kein Profil-Lauf).
+
+        --strategy-id ist im Parser required; bei --list-strategies wird sie nicht ausgewertet.
+        Beispiel-ID rsi_reversion ist in src/strategies/registry.py registriert.
+        """
+        exit_code = research_cli.main(
+            [
+                "strategy-profile",
+                "--strategy-id",
+                "rsi_reversion",
+                "--list-strategies",
+            ]
+        )
+        assert exit_code == 0
+
     def test_main_unknown_command_returns_error(self):
         """Unbekanntes Command gibt Fehler zurück."""
         with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- add a focused smoke test for `research_cli.main(["strategy-profile", "--strategy-id", "rsi_reversion", "--list-strategies"])`
- assert that the registry/discoverability path exits with code `0` without relying on fragile output assertions
- keep the slice test-only and reuse the existing main-test pattern

## Testing
- uv run pytest tests/test_research_cli.py -q
- uv run ruff check tests/test_research_cli.py
- uv run ruff format --check tests/test_research_cli.py
