### PR TITLE
test: wire research cli main to armstrong-elkaroui-combi runner

### DIFF
--- a/tests/test_research_cli.py
+++ b/tests/test_research_cli.py
@@ -421,6 +421,18 @@ class TestMain:
         )
         assert exit_code == 0
 
+    @patch("scripts.research_cli.run_armstrong_elkaroui_combi")
+    def test_main_armstrong_elkaroui_combi_calls_combi_runner(self, mock_run_combi):
+        """armstrong-elkaroui-combi dispatcht auf run_armstrong_elkaroui_combi."""
+        mock_run_combi.return_value = 0
+
+        exit_code = research_cli.main(["armstrong-elkaroui-combi"])
+
+        assert exit_code == 0
+        assert mock_run_combi.called
+        call_args = mock_run_combi.call_args[0][0]
+        assert call_args.command == "armstrong-elkaroui-combi"
+
     def test_main_unknown_command_returns_error(self):
         """Unbekanntes Command gibt Fehler zurück."""
         with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- add a focused `TestMain` dispatch test for `armstrong-elkaroui-combi`
- assert that `research_cli.main(["armstrong-elkaroui-combi"])` returns `0` and calls the patched runner
- keep the slice test-only and avoid running the actual combi experiment

## Testing
- uv run pytest tests/test_research_cli.py -q
- uv run ruff check tests/test_research_cli.py
- uv run ruff format --check tests/test_research_cli.py
