### PR TITLE
test: wire research cli main to strategy-profile runner

### DIFF
--- a/tests/test_research_cli.py
+++ b/tests/test_research_cli.py
@@ -421,6 +421,18 @@ class TestMain:
         )
         assert exit_code == 0
 
+    @patch("scripts.research_cli.run_strategy_profile")
+    def test_main_strategy_profile_calls_profile_runner(self, mock_run_profile):
+        """strategy-profile dispatcht auf run_strategy_profile (kein echter Profil-Lauf)."""
+        mock_run_profile.return_value = 0
+
+        exit_code = research_cli.main(["strategy-profile", "--strategy-id", "rsi_reversion"])
+
+        assert exit_code == 0
+        mock_run_profile.assert_called_once()
+        call_args = mock_run_profile.call_args[0][0]
+        assert call_args.command == "strategy-profile"
+
     @patch("scripts.research_cli.run_armstrong_elkaroui_combi")
     def test_main_armstrong_elkaroui_combi_calls_combi_runner(self, mock_run_combi):
         """armstrong-elkaroui-combi dispatcht auf run_armstrong_elkaroui_combi."""


### PR DESCRIPTION
## Summary
- add a TestMain dispatch test for the strategy-profile subcommand
- patch `run_strategy_profile` and assert `main([...])` returns 0
- verify the parsed namespace carries `command == "strategy-profile"`

## Verification
- uv run pytest tests/test_research_cli.py -q
- uv run ruff check tests/test_research_cli.py
- uv run ruff format --check tests/test_research_cli.py

Made with [Cursor](https://cursor.com)