### PR TITLE
test: allow risk gate when market data age equals max age

### DIFF
--- a/tests/ops/test_risk_gate.py
+++ b/tests/ops/test_risk_gate.py
@@ -51,6 +51,19 @@ def test_stale_data_denies():
     assert dec.details.get("max_data_age_seconds") == "10"
 
 
+def test_stale_data_allows_when_age_equals_max():
+    """Boundary: data age exactly at limit must not trigger STALE_DATA (strict >)."""
+    lim = RiskLimits(
+        max_notional_usd=1000,
+        max_order_size=10,
+        max_position=10,
+        max_data_age_seconds=10,
+    )
+    dec = evaluate_risk(lim, base_ctx(market_data_age_seconds=10))
+    assert dec.allow is True
+    assert dec.reason is None
+
+
 def test_notional_denies():
     lim = RiskLimits(max_notional_usd=50)
     dec = evaluate_risk(lim, base_ctx(order_notional_usd=51.0))


### PR DESCRIPTION
## Summary
- add a boundary test for stale market data at the exact configured max age
- assert the risk gate still allows when `market_data_age_seconds == max_data_age_seconds`
- keep production logic unchanged and document the current `>` semantics in tests

## Verification
- uv run pytest tests/ops/test_risk_gate.py -q
- uv run ruff check tests/ops/test_risk_gate.py
- uv run ruff format --check tests/ops/test_risk_gate.py

Made with [Cursor](https://cursor.com)