### PR TITLE
test: cover market data cache observation config and unmapped health

### DIFF
--- a/tests/ops/test_market_data_cache_observation_reader.py
+++ b/tests/ops/test_market_data_cache_observation_reader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from src.data.kraken_cache_loader import KrakenDataHealth
@@ -91,3 +92,67 @@ def test_unknown_when_health_check_raises(
     out = read_market_data_cache_observation(tmp_path, cfg)
     assert out["market_data_cache"] == "unknown"
     assert out["observation_reason"] == "health_check_failed"
+
+
+@patch("src.data.kraken_cache_loader.get_real_market_smokes_config")
+def test_unknown_when_config_load_raises(
+    mock_rms: MagicMock,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "config" / "config.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("[general]\n", encoding="utf-8")
+    mock_rms.side_effect = ValueError("rms load failed")
+    out = read_market_data_cache_observation(tmp_path, cfg)
+    assert out["market_data_cache"] == "unknown"
+    assert out["observation_reason"] == "config_load_failed"
+
+
+@patch("src.data.kraken_cache_loader.check_data_health_only")
+@patch("src.data.kraken_cache_loader.get_real_market_smokes_config")
+def test_unknown_when_health_status_unmapped(
+    mock_rms: MagicMock,
+    mock_health: MagicMock,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "config" / "config.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("# x\n", encoding="utf-8")
+    (tmp_path / "data" / "cache").mkdir(parents=True)
+    mock_rms.return_value = {
+        "base_path": "data/cache",
+        "default_market": "BTC/EUR",
+        "default_timeframe": "1h",
+        "min_bars": 10,
+    }
+    mock_health.return_value = KrakenDataHealth(
+        status=cast(Any, "not_a_mapped_status"),
+        num_bars=0,
+    )
+    out = read_market_data_cache_observation(tmp_path, cfg)
+    assert out["market_data_cache"] == "unknown"
+    assert out["observation_reason"] == "unmapped_health_status"
+    assert out["provenance"].get("kraken_health_status") == "not_a_mapped_status"
+
+
+@patch("src.data.kraken_cache_loader.check_data_health_only")
+@patch("src.data.kraken_cache_loader.get_real_market_smokes_config")
+def test_warn_when_health_status_other(
+    mock_rms: MagicMock,
+    mock_health: MagicMock,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "config" / "config.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("# x\n", encoding="utf-8")
+    (tmp_path / "data" / "cache").mkdir(parents=True)
+    mock_rms.return_value = {
+        "base_path": "data/cache",
+        "default_market": "BTC/EUR",
+        "default_timeframe": "1h",
+        "min_bars": 10,
+    }
+    mock_health.return_value = KrakenDataHealth(status="other", num_bars=1, notes="n")
+    out = read_market_data_cache_observation(tmp_path, cfg)
+    assert out["market_data_cache"] == "warn"
+    assert out["observation_reason"] == "kraken_cache_health_other"


### PR DESCRIPTION
## Summary
- add coverage for the market data cache observation reader config-load failure path
- add coverage for unmapped health status and the `other -> warn` rollout path
- keep production logic unchanged and document the current observation semantics in tests

## Verification
- uv run pytest tests/ops/test_market_data_cache_observation_reader.py -q
- uv run ruff check tests/ops/test_market_data_cache_observation_reader.py
- uv run ruff format --check tests/ops/test_market_data_cache_observation_reader.py

Made with [Cursor](https://cursor.com)