### PR TITLE
docs(ops): anchor authority/veto precedence in entry docs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,6 +15,14 @@
 
 ---
 
+## Canonical Vocabulary / Authority / Provenance v0
+
+- Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
+- Claim-Disziplin: Claims nur als `repo-evidenced` oder `documented` formulieren; `operator-stated` explizit markieren; `unverified` und `not-claimed` nicht als Fakt formulieren; keine impliziten E2E-/Runtime-Behauptungen.
+
+---
+
 ## Gruppierung
 
 ### Canonical / Current (autoritativ)

--- a/docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md
+++ b/docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md
@@ -23,6 +23,12 @@ Es ist bewusst **kurz, normativ und umsetzungsorientiert**. Detaillierte Inhalte
 - *Front Door* = Wie wir liefern (Rollen, Task-Packet, PR-Contract, Gates, Stop-Regeln).  
 - *Appendices* = Was genau wir liefern (Phase-Matrix, Befehle, Troubleshooting, Repo-Anker/Current Reality).
 
+## Canonical Vocabulary / Authority / Provenance v0
+
+- Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
+- Claim-Disziplin: Claims nur als `repo-evidenced` oder `documented` formulieren; `operator-stated` explizit markieren; `unverified` und `not-claimed` nicht als Fakt formulieren; keine impliziten E2E-/Runtime-Behauptungen.
+
 ---
 
 ## 1.1 Start in 60 Sekunden

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -3,11 +3,24 @@
 - PR #999 — docs(grafana): fix DS_LOCAL uid templating in execution watch dashboard: docs/ops/PR_999_MERGE_LOG.md
 <!-- MERGE_LOG_EXAMPLES:END -->
 
+
+
+
+
+
+
+
 **[Docs Truth Map](registry/DOCS_TRUTH_MAP.md)** — canonical ops documentation registry and change log (truth-first).
 
 <!-- ops readme status navigation note -->
 - Projektstatus / Navigation: `docs&#47;INDEX.md` ist der zentrale Einstieg für Docs-Navigation.
 - Für kompakten Status-/Lookup-Einstieg nutze `docs&#47;ops&#47;STATUS_MATRIX.md`; für datierten narrativen Kontext nutze `docs&#47;ops&#47;STATUS_OVERVIEW_2026-02-19.md`.
+
+## Canonical Vocabulary / Authority / Provenance v0
+
+- Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
+- Claim-Disziplin: Claims nur als `repo-evidenced` oder `documented` formulieren; `operator-stated` explizit markieren; `unverified` und `not-claimed` nicht als Fakt formulieren; keine impliziten E2E-/Runtime-Behauptungen.
 
 ## HTTP path index — Operator WebUI & live.web (local defaults)
 


### PR DESCRIPTION
## Summary
- add a small, consistent `Canonical Vocabulary / Authority / Provenance v0` section to the core entry docs
- backlink the canonical spec and anchor the authority/veto precedence summary
- add concise provenance-aware claim language for entry-point readers

## Scope
- docs-only
- no runtime, API, model, policy, config, paper, shadow, or evidence mutations

## Changed files
- docs/INDEX.md
- docs/ops/README.md
- docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md

## Verification
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root "docs"

Made with [Cursor](https://cursor.com)