### PR TITLE
docs(ops): align claim and provenance terminology v0

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@
 
 - Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
 - Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
-- Claim-Disziplin: Claims nur als `repo-evidenced` oder `documented` formulieren; `operator-stated` explizit markieren; `unverified` und `not-claimed` nicht als Fakt formulieren; keine impliziten E2E-/Runtime-Behauptungen.
+- Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
 
 ---
 

--- a/docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md
+++ b/docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md
@@ -27,7 +27,7 @@ Es ist bewusst **kurz, normativ und umsetzungsorientiert**. Detaillierte Inhalte
 
 - Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
 - Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
-- Claim-Disziplin: Claims nur als `repo-evidenced` oder `documented` formulieren; `operator-stated` explizit markieren; `unverified` und `not-claimed` nicht als Fakt formulieren; keine impliziten E2E-/Runtime-Behauptungen.
+- Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
 
 ---
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -20,7 +20,7 @@
 
 - Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
 - Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
-- Claim-Disziplin: Claims nur als `repo-evidenced` oder `documented` formulieren; `operator-stated` explizit markieren; `unverified` und `not-claimed` nicht als Fakt formulieren; keine impliziten E2E-/Runtime-Behauptungen.
+- Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
 
 ## HTTP path index — Operator WebUI & live.web (local defaults)
 

--- a/docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
+++ b/docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
@@ -117,12 +117,15 @@ Klassifikation bezieht sich auf die **typische Fehlinterpretationslage**, nicht 
 - **Business Decision Core** ist nicht identisch mit der **Execution Pipeline**; Entscheidung und Ausfuehrung bleiben getrennte Autoritaetsdomaenen.
 - **AI Orchestrator** ist koordinierend, aber keine eigenstaendige Execution Authority.
 
-## 6) Provenance Boundary Notes
+## 6) Provenance Boundary Notes / Claim-Klassen
 
-- **nachweisbar**: Es existieren lokale Artefakte fuer Replay-/Provenance-Bausteine, die Teilaspekte der Nachvollziehbarkeit dokumentieren.
-- **teilweise nachweisbar**: Mehrere Begriffe und Kontrollgrenzen sind in unterschiedlichen Dokumenten beschrieben, aber nicht durchgaengig als einheitlicher End-to-End-Strang belegt.
-- **unklar**: Einzelne Authority-Uebergaenge zwischen Decision-, Gate- und Execution-Ebenen sind dokumentarisch nicht in jeder Richtung explizit verknuepft.
-- **nicht als kanonischer End-to-End-Pfad nachgewiesen**: Eine vollstaendig kanonisch integrierte E2E-Kette aus Vocabulary, Authority und Provenance wird hier nicht behauptet.
+Die folgenden **Kurzlabels** sind die Kurzform fuer Reviews und Entry-Docs; sie entsprechen eins zu eins den zuvor normierten deutschsprachigen Grenznotizen.
+
+- **`repo-evidenced`** (*nachweisbar*): Es existieren lokale Artefakte fuer Replay-/Provenance-Bausteine, die Teilaspekte der Nachvollziehbarkeit dokumentieren.
+- **`documented`** (*teilweise nachweisbar*): Mehrere Begriffe und Kontrollgrenzen sind in unterschiedlichen Dokumenten beschrieben, aber nicht durchgaengig als einheitlicher End-to-End-Strang belegt.
+- **`unverified`** (*unklar*): Einzelne Authority-Uebergaenge zwischen Decision-, Gate- und Execution-Ebenen sind dokumentarisch nicht in jeder Richtung explizit verknuepft.
+- **`not-claimed`** (*nicht als kanonischer End-to-End-Pfad nachgewiesen*): Eine vollstaendig kanonisch integrierte E2E-Kette aus Vocabulary, Authority und Provenance wird hier nicht behauptet.
+- **`operator-stated`**: Kennzeichnung fuer Operator- oder Review-Sprache ohne zusaetzliche Autoritaetsbehauptung (vgl. Abschnitt 4, E6); kein Grenzzustand neben den vier Eintraegen oben, sondern explizite Attributierung.
 
 ## 7) Offene Luecken / nicht nachgewiesene Punkte
 
@@ -135,7 +138,7 @@ Klassifikation bezieht sich auf die **typische Fehlinterpretationslage**, nicht 
 
 - Keine Runtime-Ableitung aus diesem Dokument ohne subsystem-spezifische Spezifikation.
 - Keine Gleichsetzung der in Abschnitt 3 verbotenen Paare in Design-, Implementierungs- oder Review-Claims.
-- Claims sind ausschliesslich in den Klassen **nachweisbar**, **teilweise nachweisbar**, **unklar** oder **nicht als kanonischer End-to-End-Pfad nachgewiesen** zu formulieren.
+- Claims sind ausschliesslich in den Klassen **`repo-evidenced`**, **`documented`**, **`unverified`** oder **`not-claimed`** zu formulieren (Definitionen Abschnitt 6; deutsch: *nachweisbar*, *teilweise nachweisbar*, *unklar*, *nicht als kanonischer End-to-End-Pfad nachgewiesen*). **`unverified`** und **`not-claimed`** nicht als verifizierte oder vollstaendig belegte Aussagen ausgeben. **`operator-stated`** explizit markieren, wo zutreffend (Abschnitt 6 und Abschnitt 4, E6).
 - Jede spaetere Runtime-Arbeit muss die Authority-Veto-Hierarchie sowie die Provenance-Boundaries explizit referenzieren.
 
 ## Verifizierte Cross-Links (knapp)


### PR DESCRIPTION
## Summary
- harmonize claim / provenance terminology between the canonical spec and the three entry / frontdoor blurbs
- keep the canonical spec as the primary norm source and the entry docs as concise mirrors
- reduce wording drift without adding new semantics, runtime claims, or policy implications

## Scope
- docs-only
- no runtime, API, model, policy, config, paper, shadow, or evidence mutations

## Changed files
- docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
- docs/INDEX.md
- docs/ops/README.md
- docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md

## Verification
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root "docs"

Made with [Cursor](https://cursor.com)