### PR TITLE
docs: add second-wave canonical hub anchors

### DIFF
--- a/docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md
+++ b/docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md
@@ -6,6 +6,14 @@
 
 ---
 
+## Canonical Vocabulary / Authority / Provenance v0
+
+- Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
+- Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
+
+---
+
 ## 1. Einleitung
 
 ### Was ist Governance in Peak_Trade?

--- a/docs/KNOWLEDGE_BASE_INDEX.md
+++ b/docs/KNOWLEDGE_BASE_INDEX.md
@@ -8,6 +8,14 @@
 
 ---
 
+## Canonical Vocabulary / Authority / Provenance v0
+
+- Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
+- Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
+
+---
+
 ## Quick Navigation
 
 ### 🚀 Getting Started

--- a/docs/PEAK_TRADE_OVERVIEW.md
+++ b/docs/PEAK_TRADE_OVERVIEW.md
@@ -6,6 +6,14 @@
 
 ---
 
+## Canonical Vocabulary / Authority / Provenance v0
+
+- Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
+- Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
+
+---
+
 ## Architektur-Map
 
 Peak_Trade folgt einer klaren Pipeline-Architektur mit strikter Separation of Concerns:

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -64,6 +64,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-16: `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` — second-wave canonical hub anchors (PR #2664, docs-only); Truth-Map-Pflege; paired with `governance-overview-canonical`; keine Live-Freigabe.
+
 - 2026-04-13: Top-Level-Key **`safety_state`** im Ops-Cockpit-Payload — `src&#47;ops&#47;safety_state.py` (`build_safety_state`); Projektion aus bestehenden `safety_posture_observation`, `incident_safety_observation`, `incident_state`; Contract/Operator-Summary/Coverage-Matrix angepasst; Tests `tests&#47;ops&#47;test_safety_state.py`, `tests&#47;ops&#47;test_ops_cockpit_payload_top_level_contract.py`, `tests&#47;webui&#47;test_ops_cockpit.py`; **keine** Gate-Abschwächung, **keine** Freigabe-Semantik.
 
 - 2026-04-13: Operator-Summary-HTML — **`safety_state`** als read-only Block **Safety state (vNext projection)** in `src&#47;webui&#47;ops_cockpit.py` (`_render_operator_summary_surface`, `id=operator-summary-safety-state-projection`); Doku `OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md`, `OPS_COCKPIT_VNEXT_REQUIRED_VIEWS_COVERAGE.md` (RV1); Test-Anker in `tests&#47;webui&#47;test_ops_cockpit.py`; **keine** neue Autorität, **keine** Freigabe-Semantik.


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen docs-only Slice um: second-wave canonical hub anchors für zentrale Narrative-/Hub-Seiten, die aktuell noch keinen Canonical-Vocab-/Authority-/Provenance-v0-Anker tragen.

Ausgangspunkt
Bereits vorhanden und nicht erneut verändern außer zwingend für minimale Pfadangleichung:
- docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
- docs/INDEX.md
- docs/ops/README.md
- docs/governance/README.md
- docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md
- docs/ops/runbooks/README.md
- docs/ops/registry/INDEX.md

Verbindlicher PR-Fokus
Nur diese drei Dateien anfassen:
- docs/KNOWLEDGE_BASE_INDEX.md
- docs/PEAK_TRADE_OVERVIEW.md
- docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md

Nicht in diesem Slice
- docs/ops/RUNBOOK_INDEX.md
- Root-README.md
- neue Spec-Dateien
- Code / Tests / Config
- Prosa-Umbauten bestehender Governance-/Safety-Abschnitte
- neue Normen / neue Authority-Definitionen / neue Runtime-Claims

Aufgabe
Füge in jede der drei Ziel-Dateien einen kurzen Canonical-Ankerblock ein, der in Struktur und Aussage so nah wie möglich am bereits etablierten Muster aus docs/INDEX.md bleibt:
- Link auf docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
- kurze normative Einordnung:
  - Governance / Safety / Kill-Switch / Risk-Caps sind bindend
  - Switch-Gate / AI Orchestrator advisory unless separately and explicitly defined otherwise by canonical authority
- Claim-Disziplin:
  - Ist-/Runtime-/E2E-Behauptungen nur mit verifizierbarer Repo-Evidenz
  - sonst Soll / intended / documented / unclear trennen

Platzierung
- docs/KNOWLEDGE_BASE_INDEX.md:
  - direkt nach dem oberen Navigations-/Introblock; möglichst früh sichtbar
- docs/PEAK_TRADE_OVERVIEW.md:
  - nach dem Einleitungsblock, vor tiefer Architektur-/Narrativ-Entfaltung
- docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md:
  - direkt nach Header/Status/Scope-Intro und vor dem ersten inhaltlichen Governance-Abschnitt

Strikte Constraints
- Wortgleiche Wiederverwendung bevorzugen; nur relative Pfade minimal anpassen
- Kein zweiter konkurrierender Authority-Text
- Keine Umschreibung bestehender langen Abschnitte
- Keine inhaltliche Erweiterung der Canonical Spec
- Keine Behauptung, dass etwas in Runtime so implementiert sei, falls nur dokumentarisch verankert
- PR muss klar als docs-only / anchor-only reviewbar sein

Akzeptanzkriterien
1. Genau die drei Ziel-Dateien geändert
2. Jede Datei enthält einen kurzen Canonical-Ankerblock mit Spec-Link
3. Keine neue Norm außer Verweis-/Einordnungsfunktion
4. Keine zusätzlichen themenfremden Doc-Änderungen
5. Docs-Checks grün:
   - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
   - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Arbeitsmodus
- zuerst read-only prüfen, wie der Block in docs/INDEX.md formuliert ist
- dann minimalen Diff erzeugen
- danach nur die zwei Docs-Checks
- am Ende kurze Abschlussnotiz mit:
  - Executive Summary
  - exakt geänderte Dateien
  - Begründung der Platzierung je Datei
  - Check-Resultate
  - Branch-Name
  - Commit-Hash

Branch-Name
docs/second-wave-canonical-hub-anchors-v0

Commit-Message
docs: add second-wave canonical hub anchors

Rollen
- A0 orchestriert strikt einen Topic-Slice
- A3 macht den minimalen Docs-Diff
- A5 prüft Claim-Disziplin / keine neue Autorität / keine Runtime-Überdehnung
