### PR TITLE
docs: anchor runbook index to canonical vocab spec

### DIFF
--- a/docs/KNOWLEDGE_BASE_INDEX.md
+++ b/docs/KNOWLEDGE_BASE_INDEX.md
@@ -68,6 +68,7 @@
 ### 🚦 Live Operations
 
 #### Operations & Monitoring
+- [Ops Runbook Index](ops/RUNBOOK_INDEX.md) - Runbook-Hub (zentraler Ops-Einstieg zu Runbooks, Workflows und Ops-Dokumentation)
 - [Live Ops CLI](PHASE_51_LIVE_OPS_CLI.md) - Live operations tools
 - [Live Status Reports](LIVE_STATUS_REPORTS.md) - Monitoring and reporting
 - [Live Track Dashboard](PHASE_82_LIVE_TRACK_DASHBOARD.md) - Dashboard overview

--- a/docs/ops/RUNBOOK_INDEX.md
+++ b/docs/ops/RUNBOOK_INDEX.md
@@ -6,6 +6,14 @@
 
 ---
 
+## Canonical Vocabulary / Authority / Provenance v0
+
+- Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- Normative Kurzregel: `Governance`, `Safety`, `Kill-Switch` und `Risk&#47;Exposure Caps` sind bindend; `Switch-Gate` und `AI Orchestrator` sind advisory, sofern nicht separat und ausdrücklich anderweitig durch canonical authority definiert.
+- Claim-Disziplin: Ist-/Runtime-/E2E-Behauptungen nur mit verifizierbarer Repo-Evidenz; sonst klar als `Soll` / `intended` / `documented` / `unclear` trennen (Klassen und Definitionen: Spec, Abschnitt 6).
+
+---
+
 ## Runbooks
 
 | Kategorie | Pfad | Hinweis |


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen docs-only Slice um: den verbleibenden Ops-Runbook-Hub auf second-wave Canonical-Anker-Parität bringen und die Sichtbarkeit aus der Knowledge Base verbessern.

Ausgangspunkt
Bereits vorhanden und nicht neu definieren:
- docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
- docs/INDEX.md
- docs/ops/README.md
- docs/governance/README.md
- docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md
- docs/ops/runbooks/README.md
- docs/ops/registry/INDEX.md
- docs/KNOWLEDGE_BASE_INDEX.md
- docs/PEAK_TRADE_OVERVIEW.md
- docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md
- docs/ops/registry/DOCS_TRUTH_MAP.md

Verbindlicher PR-Fokus
Nur diese Dateien anfassen:
- docs/ops/RUNBOOK_INDEX.md
- docs/KNOWLEDGE_BASE_INDEX.md

Nicht in diesem Slice
- Root-README.md
- neue Spec-Dateien
- Code / Tests / Config
- neue Normen / neue Authority-Definitionen / neue Runtime-Claims
- Prosa-Umbauten außerhalb des minimal nötigen Anchor-/Link-Slices
- Änderungen an bereits abgedeckten Frontdoor-/Hub-Dateien außer der gezielten Sichtbarkeitsverlinkung in KNOWLEDGE_BASE_INDEX.md

Aufgabe
1. Lies read-only das etablierte Canonical-Anker-Muster aus docs/INDEX.md sowie die bereits vorhandenen Anker auf den Frontdoor-/Hub-Seiten.
2. Ergänze in docs/ops/RUNBOOK_INDEX.md einen kurzen Canonical-Ankerblock in derselben Aussageform:
   - Link auf docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
   - kurze normative Einordnung:
     - Governance / Safety / Kill-Switch / Risk-Caps bindend
     - Switch-Gate / AI Orchestrator advisory unless separately and explicitly defined otherwise by canonical authority
   - Claim-Disziplin:
     - Ist-/Runtime-/E2E-Behauptungen nur mit verifizierbarer Repo-Evidenz
     - sonst Soll / intended / documented / unclear trennen
3. Ergänze in docs/KNOWLEDGE_BASE_INDEX.md eine kleine, sichtbare Verlinkung auf docs/ops/RUNBOOK_INDEX.md, so dass der Runbook-Hub als relevanter Ops-Einstieg klarer auffindbar ist.
4. Halte den Diff minimal und konsistent.

Platzierung
- docs/ops/RUNBOOK_INDEX.md:
  - möglichst direkt nach Header-/Introbereich, früh sichtbar
- docs/KNOWLEDGE_BASE_INDEX.md:
  - nur kleine sichtbare Ergänzung an passender Navigationsstelle; kein Umbau der Seite

Strikte Constraints
- Wortgleiche Wiederverwendung bevorzugen; nur relative Pfade minimal anpassen
- Kein zweiter konkurrierender Authority-Text
- Keine Umschreibung bestehender langer Abschnitte
- Keine inhaltliche Erweiterung der Canonical Spec
- Keine Behauptung, dass etwas in Runtime so implementiert sei, falls nur dokumentarisch verankert
- PR muss klar als docs-only / anchor-only / visibility-link reviewbar sein

Akzeptanzkriterien
1. Nur die zwei Ziel-Dateien geändert
2. RUNBOOK_INDEX enthält einen kurzen Canonical-Ankerblock mit Spec-Link
3. KNOWLEDGE_BASE_INDEX enthält eine kleine sichtbare Verlinkung auf den Runbook-Hub
4. Keine neue Norm außer Verweis-/Einordnungsfunktion
5. Keine zusätzlichen themenfremden Änderungen
6. Docs-Checks grün:
   - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
   - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Arbeitsmodus
- zuerst read-only Muster prüfen
- dann minimalen Diff erzeugen
- danach nur die zwei Docs-Checks
- am Ende kurze Abschlussnotiz mit:
  - Executive Summary
  - exakt geänderte Dateien
  - Begründung der Platzierung je Datei
  - Check-Resultate
  - Branch-Name
  - Commit-Hash

Branch-Name
docs/runbook-index-canonical-anchor-v0

Commit-Message
docs: anchor runbook index to canonical vocab spec

Rollen
- A0 orchestriert strikt einen Topic-Slice
- A3 macht den minimalen Docs-Diff
- A5 prüft Claim-Disziplin / keine neue Autorität / keine Runtime-Überdehnung
