### PR TITLE
feat(webui): add market surface v0

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -1,0 +1,17 @@
+# Market Surface v0 (read-only)
+
+## Routen
+
+| Methode | Pfad | Beschreibung |
+|---------|------|----------------|
+| GET | `/market` | HTML: Close-Line-Chart (Chart.js), Parameter per Query |
+| GET | `/api/market/ohlcv` | JSON: OHLCV-Bars (`open`/`high`/`low`/`close`/`volume`, Zeit `ts`) |
+
+## Query-Parameter (beide Endpunkte)
+
+- `symbol` — z. B. `BTC&#47;USD`
+- `timeframe` — `1m` \| `5m` \| `15m` \| `1h` \| `4h` \| `1d` (Kraken-Pfad; Dummy bleibt synthetisch 1h)
+- `limit` — 1 … 720
+- `source` — `dummy` (Default, offline) \| `kraken` (öffentliche OHLCV, Netzwerk)
+
+Keine Kopplung an OPS Cockpit (`/ops`). Keine Trading-Aktionen.

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -50,6 +50,7 @@ HTML Pages:
 - GET /r_and_d/experiment/{run_id} (R&D Experiment Detail - Phase 77, Alias)
 - GET /r_and_d/experiments/{run_id} (R&D Experiment Detail - Phase 76 kanonisch)
 - GET /r_and_d/comparison (R&D Multi-Run Comparison - Phase 78)
+- GET /market (Market Surface v0 — read-only OHLCV, Close-Line-Chart)
 
 API Endpoints:
 Live-Track:
@@ -76,6 +77,9 @@ Knowledge DB (v1.0):
 
 System:
 - GET /api/health (Health-Check)
+
+Market Surface v0 (read-only):
+- GET /api/market/ohlcv (JSON — öffentliche OHLCV oder Dummy)
 """
 
 from __future__ import annotations
@@ -179,6 +183,7 @@ from .ops_ci_health_router import (
 
 from .execution_watch_api_v0 import router as execution_watch_v0_router
 from .execution_watch_api_v0_2 import router as execution_watch_v0_2_router
+from .market_surface import create_market_router
 
 
 # Wir gehen davon aus: src/webui/app.py -> src/webui -> src -> REPO_ROOT
@@ -493,6 +498,9 @@ def create_app() -> FastAPI:
     app.include_router(execution_watch_v0_router)
     # Execution Watch Dashboard v0.2 — watch-only (read-only APIs)
     app.include_router(execution_watch_v0_2_router)
+
+    # Market Surface v0 — read-only OHLCV (kein OPS-Cockpit-Bezug)
+    app.include_router(create_market_router(templates, get_project_status))
 
     # JSON API Alias für /api/ops/workflows
     @app.get("/api/ops/workflows")

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -1,0 +1,213 @@
+# src/webui/market_surface.py
+"""
+Read-only Market Surface v0 — öffentliche OHLCV + minimale Chart-UI.
+
+- GET /market — HTML (Close-Line-Chart, Chart.js)
+- GET /api/market/ohlcv — JSON (OHLCV-Bars)
+
+Keine Orders, kein OPS-Cockpit-Bezug. Dummy-Quelle für Offline/CI; Kraken über fetch_ohlcv_df.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Literal
+
+import pandas as pd
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+logger = logging.getLogger(__name__)
+
+# Aligniert mit scripts/_shared_forward_args.OHLCV_TIMEFRAME_CHOICES / Kraken-ccxt-Übliches
+MARKET_TIMEFRAMES: tuple[str, ...] = ("1m", "5m", "15m", "1h", "4h", "1d")
+MAX_OHLCV_LIMIT = 720
+DEFAULT_SYMBOL = "BTC/USD"
+DEFAULT_TIMEFRAME = "1h"
+DEFAULT_LIMIT = 120
+
+_dummy_loader_mod: Any = None
+
+
+def _get_shared_ohlcv_loader():
+    """Lädt scripts/_shared_ohlcv_loader.py dynamisch (scripts ist kein Package)."""
+    global _dummy_loader_mod
+    if _dummy_loader_mod is not None:
+        return _dummy_loader_mod
+    root = Path(__file__).resolve().parents[2]
+    path = root / "scripts" / "_shared_ohlcv_loader.py"
+    if not path.is_file():
+        raise RuntimeError(f"Erwartet: {path}")
+    spec = importlib.util.spec_from_file_location("peak_trade_shared_ohlcv_loader", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Konnte _shared_ohlcv_loader nicht laden")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    _dummy_loader_mod = mod
+    return mod
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_source(raw: str) -> Literal["kraken", "dummy"]:
+    key = (raw or "dummy").strip().lower()
+    if key not in ("kraken", "dummy"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"source muss 'kraken' oder 'dummy' sein, nicht {raw!r}",
+        )
+    return key  # type: ignore[return-value]
+
+
+def load_ohlcv_dataframe(
+    *,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    source: Literal["kraken", "dummy"],
+) -> tuple[pd.DataFrame, Dict[str, Any]]:
+    """
+    Liefert OHLCV-DataFrame (DatetimeIndex UTC) und Meta-Hinweise.
+
+    Dummy: load_dummy_ohlcv — synthetische 1h-Bars (timeframe-Query wird nur dokumentiert).
+    Kraken: fetch_ohlcv_df — öffentliche REST-OHLCV.
+    """
+    meta: Dict[str, Any] = {}
+    if source == "dummy":
+        mod = _get_shared_ohlcv_loader()
+        df = mod.load_dummy_ohlcv(symbol, n_bars=limit)
+        meta["note"] = (
+            "dummy: synthetische 1h-Bars; Parameter timeframe betrifft die Serie nicht "
+            "(nur Kraken-Pfad nutzt timeframe)."
+        )
+        return df, meta
+
+    from src.core.errors import CacheError, ProviderError
+    from src.data.kraken import fetch_ohlcv_df
+
+    try:
+        df = fetch_ohlcv_df(
+            symbol=symbol,
+            timeframe=timeframe,
+            limit=min(limit, MAX_OHLCV_LIMIT),
+            use_cache=True,
+        )
+    except ProviderError as e:
+        logger.warning("Kraken ProviderError: %s", e)
+        raise HTTPException(status_code=503, detail=str(e)) from e
+    except CacheError as e:
+        logger.warning("Kraken CacheError: %s", e)
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+    return df, meta
+
+
+def dataframe_to_bars(df: pd.DataFrame) -> List[Dict[str, Any]]:
+    """Serialisiert DataFrame mit open/high/low/close/volume in JSON-Bar-Objekte."""
+    bars: List[Dict[str, Any]] = []
+    for ts, row in df.iterrows():
+        t_iso = pd.Timestamp(ts).isoformat()
+        bars.append(
+            {
+                "ts": t_iso,
+                "open": float(row["open"]),
+                "high": float(row["high"]),
+                "low": float(row["low"]),
+                "close": float(row["close"]),
+                "volume": float(row["volume"]),
+            }
+        )
+    return bars
+
+
+def build_market_payload(
+    *,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    source: Literal["kraken", "dummy"],
+) -> Dict[str, Any]:
+    df, meta = load_ohlcv_dataframe(symbol=symbol, timeframe=timeframe, limit=limit, source=source)
+    bars = dataframe_to_bars(df)
+    return {
+        "generated_at_utc": _utc_now_iso(),
+        "source": source,
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "limit_requested": limit,
+        "bars_returned": len(bars),
+        "meta": meta,
+        "bars": bars,
+    }
+
+
+def create_market_router(
+    templates: Jinja2Templates,
+    get_project_status: Callable[[], Dict[str, Any]],
+) -> APIRouter:
+    router = APIRouter(tags=["market-readonly"])
+
+    @router.get("/api/market/ohlcv")
+    async def api_market_ohlcv(
+        symbol: str = Query(DEFAULT_SYMBOL, description="Trading-Paar, z.B. BTC/USD"),
+        timeframe: str = Query(
+            DEFAULT_TIMEFRAME,
+            description="Timeframe (Kraken); Dummy ignoriert (synthetisch 1h)",
+        ),
+        limit: int = Query(
+            DEFAULT_LIMIT,
+            ge=1,
+            le=MAX_OHLCV_LIMIT,
+            description="Anzahl Bars (max 720)",
+        ),
+        source: str = Query(
+            "dummy",
+            description="dummy = offline synthetisch; kraken = öffentliche OHLCV",
+        ),
+    ) -> Dict[str, Any]:
+        if timeframe not in MARKET_TIMEFRAMES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"timeframe muss einer von {list(MARKET_TIMEFRAMES)} sein, nicht {timeframe!r}",
+            )
+        src = _normalize_source(source)
+        return build_market_payload(symbol=symbol, timeframe=timeframe, limit=limit, source=src)
+
+    @router.get("/market", response_class=HTMLResponse)
+    async def market_v0_page(
+        request: Request,
+        symbol: str = Query(DEFAULT_SYMBOL),
+        timeframe: str = Query(DEFAULT_TIMEFRAME),
+        limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_OHLCV_LIMIT),
+        source: str = Query("dummy"),
+    ) -> Any:
+        if timeframe not in MARKET_TIMEFRAMES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"timeframe muss einer von {list(MARKET_TIMEFRAMES)} sein, nicht {timeframe!r}",
+            )
+        src = _normalize_source(source)
+        payload = build_market_payload(symbol=symbol, timeframe=timeframe, limit=limit, source=src)
+        proj_status = get_project_status()
+        return templates.TemplateResponse(
+            request,
+            "market_v0.html",
+            {
+                "status": proj_status,
+                "payload": payload,
+                "query": {
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "limit": limit,
+                    "source": src,
+                },
+            },
+        )
+
+    return router

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -1,0 +1,127 @@
+<!-- templates/peak_trade_dashboard/market_v0.html -->
+<!-- Market Surface v0 — read-only, Close-Line-Chart (Chart.js) -->
+{% extends "base.html" %}
+
+{% block content %}
+<div
+  class="space-y-6 max-w-6xl mx-auto"
+  data-section="market-v0"
+  data-market-source="{{ query.source }}"
+  data-market-bars="{{ payload.bars_returned }}"
+  data-market-symbol="{{ query.symbol }}"
+>
+  <header class="bg-gradient-to-r from-slate-900/80 to-slate-900/40 rounded-2xl border border-slate-800 p-6">
+    <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+      <div>
+        <p class="text-xs uppercase tracking-wide text-slate-500 mb-1">Market Surface</p>
+        <h1 class="text-2xl font-bold text-slate-100">v0 · Read-only OHLCV</h1>
+        <p class="text-sm text-slate-400 mt-2 max-w-2xl">
+          READ-ONLY · Keine Orders · Öffentliche OHLCV (Kraken) oder offline Dummy-Daten.
+          Chart: Schlusskurs-Linie (V0 — bewusst minimal, kein Candlestick-Plugin).
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <a href="/" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-800 hover:bg-slate-700 text-slate-300">
+          ← Dashboard
+        </a>
+        <a href="/r_and_d/charts" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-slate-800 hover:bg-slate-700 text-slate-300">
+          R&amp;D Charts
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <section aria-label="Parameter" class="bg-slate-900/60 rounded-xl border border-slate-800 p-4 text-xs text-slate-400">
+    <p class="font-medium text-slate-300 mb-2">Aktuelle Abfrage</p>
+    <ul class="font-mono space-y-1">
+      <li>symbol={{ query.symbol }}</li>
+      <li>timeframe={{ query.timeframe }} (Kraken; Dummy bleibt synthetisch 1h)</li>
+      <li>limit={{ query.limit }}</li>
+      <li>source={{ query.source }} — für Live-Daten: <span class="text-sky-400">?source=kraken</span> (Netzwerk)</li>
+    </ul>
+  </section>
+
+  <section
+    aria-label="Close-Preis"
+    class="bg-slate-900/60 rounded-xl border border-slate-800 p-4"
+    data-chart="market-v0-close-line"
+  >
+    <h2 class="text-sm font-medium text-slate-200 mb-3">Schlusskurs (Close)</h2>
+    <div class="relative h-80 w-full">
+      <canvas id="chart-market-v0-close"></canvas>
+    </div>
+  </section>
+
+  <script type="application/json" id="market-v0-payload">{{ payload | tojson }}</script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script>
+    (function () {
+      const el = document.getElementById("market-v0-payload");
+      if (!el) return;
+      let payload;
+      try {
+        payload = JSON.parse(el.textContent || "{}");
+      } catch (e) {
+        return;
+      }
+      const bars = payload.bars || [];
+      if (!bars.length) return;
+
+      const labels = bars.map(function (b) { return b.ts; });
+      const closes = bars.map(function (b) { return b.close; });
+
+      const canvas = document.getElementById("chart-market-v0-close");
+      if (!canvas || !window.Chart) return;
+
+      const grid = "rgba(148, 163, 184, 0.15)";
+      const tick = "#94a3b8";
+      const line = "rgba(56, 189, 248, 0.85)";
+
+      new Chart(canvas.getContext("2d"), {
+        type: "line",
+        data: {
+          labels: labels,
+          datasets: [
+            {
+              label: "Close",
+              data: closes,
+              borderColor: line,
+              backgroundColor: "rgba(56, 189, 248, 0.12)",
+              borderWidth: 1.5,
+              fill: true,
+              tension: 0.1,
+              pointRadius: 0,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: { mode: "index", intersect: false },
+          plugins: {
+            legend: { labels: { color: tick } },
+            tooltip: {
+              callbacks: {
+                label: function (ctx) {
+                  var v = ctx.parsed.y;
+                  return v != null ? "close: " + v.toFixed(2) : "";
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              ticks: { color: tick, maxRotation: 45, minRotation: 0, font: { size: 9 } },
+              grid: { color: grid },
+            },
+            y: {
+              ticks: { color: tick },
+              grid: { color: grid },
+            },
+          },
+        },
+      });
+    })();
+  </script>
+</div>
+{% endblock %}

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Tests für read-only Market Surface v0 (GET /market, GET /api/market/ohlcv)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+class TestMarketSurfaceJson:
+    def test_ohlcv_dummy_ok_shape(self, client: TestClient) -> None:
+        resp = client.get(
+            "/api/market/ohlcv",
+            params={
+                "symbol": "BTC/USD",
+                "timeframe": "1h",
+                "limit": 30,
+                "source": "dummy",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] == "dummy"
+        assert data["symbol"] == "BTC/USD"
+        assert data["timeframe"] == "1h"
+        assert data["limit_requested"] == 30
+        assert data["bars_returned"] == 30
+        assert "generated_at_utc" in data
+        assert "meta" in data
+        assert len(data["bars"]) == 30
+        b0 = data["bars"][0]
+        assert set(b0.keys()) >= {"ts", "open", "high", "low", "close", "volume"}
+
+    def test_ohlcv_invalid_timeframe_422(self, client: TestClient) -> None:
+        r = client.get("/api/market/ohlcv", params={"timeframe": "2h", "source": "dummy"})
+        assert r.status_code == 422
+
+    def test_ohlcv_invalid_source_422(self, client: TestClient) -> None:
+        r = client.get("/api/market/ohlcv", params={"source": "paper"})
+        assert r.status_code == 422
+
+
+class TestMarketSurfaceHtml:
+    def test_market_page_dummy_ok_markers(self, client: TestClient) -> None:
+        resp = client.get("/market", params={"source": "dummy", "limit": 20})
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers.get("content-type", "")
+        body = resp.text
+        assert 'data-section="market-v0"' in body
+        assert 'data-market-source="dummy"' in body
+        assert 'data-market-bars="20"' in body
+        assert 'data-chart="market-v0-close-line"' in body
+        assert 'id="market-v0-payload"' in body
+        assert "chart.js@4.4.1" in body.lower() or "chart.umd.min.js" in body
+        assert 'method="POST"' not in body


### PR DESCRIPTION
## Summary
Add Market Surface v0 to the WebUI:
- `/market` HTML surface
- `/api/market/ohlcv` JSON endpoint
- minimal template, docs, and API tests

## Scope
- `src/webui/app.py`
- `src/webui/market_surface.py`
- `templates/peak_trade_dashboard/market_v0.html`
- `docs/webui/MARKET_SURFACE_V0.md`
- `tests/test_market_surface_api.py`

## Validation
- `uv run pytest tests/test_market_surface_api.py -q`
- `uv run ruff check src/webui/app.py src/webui/market_surface.py tests/test_market_surface_api.py`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)