### PR TITLE
feat(levelup): add v0 manifest models and io

### DIFF
--- a/src/levelup/__init__.py
+++ b/src/levelup/__init__.py
@@ -1,0 +1,14 @@
+"""Level-Up (Evidence-first) — domain contracts and manifests (v0 foundation)."""
+
+from __future__ import annotations
+
+from src.levelup.v0_io import read_manifest, write_manifest
+from src.levelup.v0_models import EvidenceBundleRefV0, LevelUpManifestV0, SliceContractV0
+
+__all__ = [
+    "EvidenceBundleRefV0",
+    "LevelUpManifestV0",
+    "SliceContractV0",
+    "read_manifest",
+    "write_manifest",
+]

--- a/src/levelup/cli.py
+++ b/src/levelup/cli.py
@@ -1,0 +1,55 @@
+"""
+Minimal CLI for Level-Up v0 manifests (validate / round-trip checks).
+
+Does not connect to exchanges or change execution posture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from src.levelup.v0_io import read_manifest
+from src.levelup.v0_models import LevelUpManifestV0
+
+
+def _cmd_validate(path: Path) -> int:
+    m = read_manifest(path)
+    print(json.dumps({"ok": True, "schema": m.schema_version, "slices": len(m.slices)}))
+    return 0
+
+
+def _cmd_dump_empty(path: Path) -> int:
+    m = LevelUpManifestV0()
+    from src.levelup.v0_io import write_manifest
+
+    write_manifest(path, m)
+    print(json.dumps({"ok": True, "wrote": str(path)}))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m src.levelup.cli")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_val = sub.add_parser("validate", help="Validate a levelup manifest JSON file.")
+    p_val.add_argument("manifest", type=Path, help="Path to manifest.json")
+
+    p_dump = sub.add_parser(
+        "dump-empty",
+        help="Write an empty v0 manifest (template) to the given path.",
+    )
+    p_dump.add_argument("manifest", type=Path, help="Output path")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "validate":
+        return _cmd_validate(args.manifest)
+    if args.cmd == "dump-empty":
+        return _cmd_dump_empty(args.manifest)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/levelup/v0_io.py
+++ b/src/levelup/v0_io.py
@@ -1,0 +1,17 @@
+"""JSON persistence for :class:`LevelUpManifestV0` (offline, repo-local files only)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.levelup.v0_models import LevelUpManifestV0
+
+
+def read_manifest(path: Path) -> LevelUpManifestV0:
+    raw = path.read_text(encoding="utf-8")
+    return LevelUpManifestV0.model_validate_json(raw)
+
+
+def write_manifest(path: Path, manifest: LevelUpManifestV0) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(manifest.model_dump_json(indent=2) + "\n", encoding="utf-8")

--- a/src/levelup/v0_models.py
+++ b/src/levelup/v0_models.py
@@ -1,0 +1,66 @@
+"""
+Typed v0 contracts for Level-Up work units (Evidence-first roadmap alignment).
+
+These types do not perform live trading, broker I/O, or unlock gates — they describe
+slice metadata and pointers to under-repo evidence directories (typically ``out/ops/``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_SCHEMA = "levelup/manifest/v0"
+_EVIDENCE_PREFIX = "out/ops/"
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._\-/]*$")
+
+
+class EvidenceBundleRefV0(BaseModel):
+    """Reference to an evidence bundle directory under the repo (offline pointer)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    relative_dir: str = Field(
+        ...,
+        description="Path relative to repository root; must stay under out/ops/.",
+    )
+
+    @field_validator("relative_dir")
+    @classmethod
+    def _must_be_ops_evidence(cls, v: str) -> str:
+        s = v.strip().replace("\\", "/")
+        if not s.startswith(_EVIDENCE_PREFIX):
+            raise ValueError(f"evidence path must start with {_EVIDENCE_PREFIX!r}, got {v!r}")
+        if ".." in s or s.startswith("/"):
+            raise ValueError("path traversal not allowed")
+        rest = s[len(_EVIDENCE_PREFIX) :]
+        if not rest or not _SAFE_SEGMENT.match(rest):
+            raise ValueError("invalid evidence path segments")
+        return s
+
+
+class SliceContractV0(BaseModel):
+    """One Level-Up work unit: contract summary + optional evidence pointer."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    slice_id: str = Field(..., min_length=1, max_length=256)
+    title: str = Field(..., min_length=1, max_length=512)
+    contract_summary: str = Field(
+        ...,
+        description="What is guaranteed / what blocks (operator-facing, short).",
+        max_length=8000,
+    )
+    evidence: Optional[EvidenceBundleRefV0] = None
+
+
+class LevelUpManifestV0(BaseModel):
+    """Root document for a Level-Up v0 manifest (serializable JSON artifact)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    schema_version: Literal["levelup/manifest/v0"] = _SCHEMA
+    title: str = Field(default="Peak Trade Level-Up (Evidence-first)", max_length=512)
+    slices: tuple[SliceContractV0, ...] = ()

--- a/tests/levelup/test_v0_manifest.py
+++ b/tests/levelup/test_v0_manifest.py
@@ -1,0 +1,84 @@
+"""Tests for Level-Up v0 manifest contracts (offline, no live I/O)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+from pydantic import ValidationError
+
+from src.levelup.v0_io import read_manifest, write_manifest
+from src.levelup.v0_models import EvidenceBundleRefV0, LevelUpManifestV0, SliceContractV0
+
+
+def test_manifest_roundtrip_empty(tmp_path: Path) -> None:
+    m = LevelUpManifestV0()
+    p = tmp_path / "m.json"
+    write_manifest(p, m)
+    loaded = read_manifest(p)
+    assert loaded == m
+    assert loaded.schema_version == "levelup/manifest/v0"
+
+
+def test_manifest_with_slice_and_evidence(tmp_path: Path) -> None:
+    ev = EvidenceBundleRefV0(relative_dir="out/ops/slice_demo_001/")
+    sl = SliceContractV0(
+        slice_id="S1-R3",
+        title="Live execution gated",
+        contract_summary="Without enabled+armed+token → no order.",
+        evidence=ev,
+    )
+    m = LevelUpManifestV0(title="Test", slices=(sl,))
+    p = tmp_path / "m.json"
+    write_manifest(p, m)
+    loaded = read_manifest(p)
+    assert loaded.slices[0].evidence is not None
+    assert loaded.slices[0].evidence.relative_dir == "out/ops/slice_demo_001/"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "out/evidence/x",
+        "../out/ops/x",
+        "out/ops/../other",
+        "out/ops/",
+    ],
+)
+def test_evidence_path_rejected(bad: str) -> None:
+    with pytest.raises(ValidationError):
+        EvidenceBundleRefV0(relative_dir=bad)
+
+
+def test_cli_validate_and_dump_empty(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    exe = subprocess.run(
+        [sys.executable, "-m", "src.levelup.cli", "dump-empty", str(manifest)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    assert exe.returncode == 0, exe.stderr
+    out = json.loads(exe.stdout.strip())
+    assert out["ok"] is True
+
+    v = subprocess.run(
+        [sys.executable, "-m", "src.levelup.cli", "validate", str(manifest)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    assert v.returncode == 0, v.stderr
+    meta = json.loads(v.stdout.strip())
+    assert meta["ok"] is True
+    assert meta["slices"] == 0


### PR DESCRIPTION
## Summary
Add LevelUp v0 manifest foundations:
- manifest models
- JSON/IO layer
- CLI entrypoint
- focused v0 manifest tests

## Scope
- `src/levelup/__init__.py`
- `src/levelup/cli.py`
- `src/levelup/v0_io.py`
- `src/levelup/v0_models.py`
- `tests/levelup/test_v0_manifest.py`

## Validation
- `uv run pytest tests/levelup/test_v0_manifest.py -q`
- `uv run ruff check src/levelup tests/levelup`

Made with [Cursor](https://cursor.com)