### PR TITLE
docs: anchor levelup v0 canonical surface

### DIFF
--- a/docs/KNOWLEDGE_BASE_INDEX.md
+++ b/docs/KNOWLEDGE_BASE_INDEX.md
@@ -14,6 +14,10 @@
 - Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
 - Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
 
+### LevelUp v0 (additive Manifest-/IO-/CLI-Oberfläche)
+
+- Kanonische Ops-/Spec-Oberfläche (klein, ohne neue Autorität): [docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md](ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md)
+
 ---
 
 ## Quick Navigation

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -22,6 +22,8 @@
 - Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
 - Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
 
+- LevelUp **v0** (additive Manifest-/IO-/CLI-Grundlage, keine neue Autorität): [`docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md`](specs/LEVELUP_V0_CANONICAL_SURFACE.md)
+
 ## HTTP path index — Operator WebUI & live.web (local defaults)
 
 Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.live.web.app` via `scripts/ops/run_live_webui.sh`) are **local defaults** on `127.0.0.1`. Processes are **separate**; there is **no shared control plane**. Paths below are for **orientation / navigation** (read-only UI posture; no change to execution or approval semantics).

--- a/docs/ops/RUNBOOK_INDEX.md
+++ b/docs/ops/RUNBOOK_INDEX.md
@@ -12,6 +12,8 @@
 - Normative Kurzregel: `Governance`, `Safety`, `Kill-Switch` und `Risk&#47;Exposure Caps` sind bindend; `Switch-Gate` und `AI Orchestrator` sind advisory, sofern nicht separat und ausdrücklich anderweitig durch canonical authority definiert.
 - Claim-Disziplin: Ist-/Runtime-/E2E-Behauptungen nur mit verifizierbarer Repo-Evidenz; sonst klar als `Soll` / `intended` / `documented` / `unclear` trennen (Klassen und Definitionen: Spec, Abschnitt 6).
 
+- LevelUp **v0** — kanonische Ops-/Spec-Oberfläche (Manifest-/IO-/CLI, ohne neue Autorität): [`LEVELUP_V0_CANONICAL_SURFACE.md`](specs/LEVELUP_V0_CANONICAL_SURFACE.md)
+
 ---
 
 ## Runbooks

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -19,6 +19,11 @@ Sie strukturiert nur die **organisatorische** Freigabe-Hülle; **Repo-Merge**, D
 
 **Sprach-Mapping (externes Feld „Strategy Version“):** [`docs/ops/LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md`](../LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md) — Registry-Schlüssel vs. Laufzeit-ID vs. Git/Artefakt vs. KI-/Model-Registry; **Draft-/Approval-Hilfe**; **kein** technischer Unlock; **keine** implizite Live-Freigabe.
 
+## Canonical: LevelUp v0 — additive Manifest-/IO-/CLI-Oberfläche
+
+Kanonische **Ops-/Spec-Oberfläche** (Auffindbarkeit, Claim-Grenzen; **keine** neue Governance-/Risk-/Safety-Autorität): [`docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md`](../specs/LEVELUP_V0_CANONICAL_SURFACE.md).  
+**Drift-Guard-Kopplung (Slice A):** Eine explizite Regel in `config/ops/docs_truth_map.yaml` ist für `src/levelup/` zum Zeitpunkt dieses Slices **nicht** vorgesehen; bei künftiger Ergänzung ist die naheliegende Paarung: `sensitive` → Präfix `src/levelup/`, `required_docs` → mindestens `docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md` (gleiches Muster wie z. B. `forward-run-manifest-helper`). Bis dahin: Änderungen unter `src/levelup/` bewusst mit dieser Canonical-Datei oder einem nachfolgenden Truth-Map-Eintrag unter „Änderungsnachweis“ abgleichen.
+
 ## Wie das Mapping funktioniert
 
 1. Regeln stehen in `config/ops/docs_truth_map.yaml` (`rules[]`).
@@ -63,6 +68,8 @@ Kurzablauf, wenn **`src/orders/`** (Prefix-Regel) geändert wird:
 Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im **selben Diff** **`docs/ops/registry/DOCS_TRUTH_MAP.md`** (diese Datei) einen kurzen Eintrag unter „Änderungsnachweis“ erhalten — damit bleibt die Registry-Landkarte mit der Branch-Protection-Referenz im Einklang (siehe Regel `truth-branch-protection-canonical` in `config/ops/docs_truth_map.yaml`).
 
 ## Änderungsnachweis (Slice A)
+
+- 2026-04-16: `docs&#47;ops&#47;specs&#47;LEVELUP_V0_CANONICAL_SURFACE.md` neu — kanonische Ops-/Spec-Oberfläche für LevelUp v0 (Manifest-/IO-/CLI; keine neue Autorität); Querverweise in `docs&#47;KNOWLEDGE_BASE_INDEX.md`, `docs&#47;ops&#47;README.md`, `docs&#47;ops&#47;RUNBOOK_INDEX.md`; Truth-Map-Abschnitt „Canonical: LevelUp v0“; **keine** `config&#47;ops&#47;docs_truth_map.yaml`-Regel in diesem Slice; keine Runtime-/E2E-Ausweitung.
 
 - 2026-04-16: `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` — second-wave canonical hub anchors (PR #2664, docs-only); Truth-Map-Pflege; paired with `governance-overview-canonical`; keine Live-Freigabe.
 

--- a/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
+++ b/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
@@ -39,7 +39,7 @@ Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANO
 | Pfad | Rolle |
 |------|--------|
 | `src/levelup/__init__.py` | Öffentliche Re-Exports der v0-API. |
-| `src/levelup/v0_models.py` | Pydantic-Modelle, Schema-String `levelup/manifest/v0`. |
+| `src/levelup/v0_models.py` | Pydantic-Modelle, Schema-String `levelup&#47;manifest&#47;v0`. |
 | `src/levelup/v0_io.py` | JSON einlesen/ausgeben (Path). |
 | `src/levelup/cli.py` | CLI-Einstieg (`validate`, `dump-empty`). |
 | `tests/levelup/test_v0_manifest.py` | Roundtrip-, Validierungs- und CLI-Tests. |
@@ -48,7 +48,7 @@ Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANO
 
 Alles Folgende bezieht sich auf den **Ist**-Stand der genannten Dateien:
 
-- **Schema:** `LevelUpManifestV0.schema_version` ist fix `levelup/manifest/v0` (`src/levelup/v0_models.py`).
+- **Schema:** `LevelUpManifestV0.schema_version` ist fix `levelup&#47;manifest&#47;v0` (`src/levelup/v0_models.py`).
 - **Evidence-Pfade:** `EvidenceBundleRefV0.relative_dir` muss mit `out/ops/` beginnen; Traversal wird abgewiesen (Validator in `v0_models.py`); abgelehnte Beispiele und Roundtrip-Verhalten sind in `tests/levelup/test_v0_manifest.py` abgedeckt.
 - **IO:** `read_manifest` nutzt `model_validate_json` auf Dateiinhalt; `write_manifest` schreibt formatiertes JSON (inkl. Elternverzeichnis-Anlage).
 - **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>` und `dump-empty <manifest>` (`argparse`-`prog` in `cli.py`). `validate` gibt eine JSON-Zeile mit `ok`, `schema`, `slices` aus; `dump-empty` schreibt ein leeres Manifest und gibt `ok`/`wrote` zurück. Subprozess-Checks: `test_cli_validate_and_dump_empty` in `tests/levelup/test_v0_manifest.py`.

--- a/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
+++ b/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
@@ -1,0 +1,56 @@
+# LevelUp v0 — Canonical Ops/Spec Surface (additive)
+
+**status:** active  
+**last_updated:** 2026-04-16  
+**purpose:** Kanonische **Auffindbarkeit** und **Claim-Grenzen** für die kleine LevelUp-v0-Schicht (Manifest-/IO-/CLI-Grundlage). Keine neue Governance-, Risk- oder Safety-Autorität.
+
+**docs_token:** `DOCS_TOKEN_LEVELUP_V0_CANONICAL_SURFACE`
+
+## 1) Zweck
+
+LevelUp **v0** ist im Repo aktuell eine **kleine, additive** Grundlage: typisierte Manifest-Modelle, JSON-Lese-/Schreib-Hilfen und ein minimales CLI für Validierung und leere Template-Ausgabe. Sie dient der **Evidence-first**-Ausrichtung (Slice-Metadaten und Zeiger unter `out/ops/`), **ohne** Live-Trading, Broker-I/O oder Gate-Unlocks zu behaupten (siehe Modul-Docstrings in `src/levelup/v0_models.py`).
+
+## 2) Scope (strikt)
+
+| Bereich | In-Scope für diese Datei |
+|--------|---------------------------|
+| **Modelle** | `EvidenceBundleRefV0`, `SliceContractV0`, `LevelUpManifestV0` — nur soweit aus `src/levelup/v0_models.py` ablesbar. |
+| **JSON/IO** | `read_manifest`, `write_manifest` in `src/levelup/v0_io.py` — **offline**, repo-lokale Pfade. |
+| **CLI** | Nur das, was `src/levelup/cli.py` und `tests/levelup/test_v0_manifest.py` eindeutig belegen (siehe Abschnitt 6). |
+| **Tests** | `tests/levelup/test_v0_manifest.py` als Verifikationsanker. |
+
+**Out-of-Scope:** LevelUp v1/vNext, Runtime-/E2E-Garantien, Produktions-Gates, Execution- oder Order-Autorität.
+
+## 3) Claim-Disziplin
+
+- **Ist (repo-evidenced):** Nur Aussagen, die sich direkt aus genannten Quelldateien oder dem Test ableiten lassen.
+- **Intended / documented:** Geplante oder narrative Erweiterungen — klar als solche kennzeichnen, nicht als implementierte Garantie.
+- **Unclear:** Offene Punkte explizit benennen; nicht als Fakt ausgeben.
+
+Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md`](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) (Abschnitt 6 — Claim-Klassen). **Diese Datei** normiert keine zusätzlichen Authority-Reihenfolgen.
+
+## 4) Authority-Hinweis
+
+- **Diese Spezifikation definiert keine neue** Governance-, Risk-, Safety- oder Execution-Autorität.
+- Bindende Canonical-Vocabulary-/Authority-/Provenance-Regeln bleiben in [`CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md`](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md).
+
+## 5) Repo-Verweise (Quellen)
+
+| Pfad | Rolle |
+|------|--------|
+| `src/levelup/__init__.py` | Öffentliche Re-Exports der v0-API. |
+| `src/levelup/v0_models.py` | Pydantic-Modelle, Schema-String `levelup/manifest/v0`. |
+| `src/levelup/v0_io.py` | JSON einlesen/ausgeben (Path). |
+| `src/levelup/cli.py` | CLI-Einstieg (`validate`, `dump-empty`). |
+| `tests/levelup/test_v0_manifest.py` | Roundtrip-, Validierungs- und CLI-Tests. |
+
+## 6) Current verified surface (eng, aus Code/Test)
+
+Alles Folgende bezieht sich auf den **Ist**-Stand der genannten Dateien:
+
+- **Schema:** `LevelUpManifestV0.schema_version` ist fix `levelup/manifest/v0` (`src/levelup/v0_models.py`).
+- **Evidence-Pfade:** `EvidenceBundleRefV0.relative_dir` muss mit `out/ops/` beginnen; Traversal wird abgewiesen (Validator in `v0_models.py`); abgelehnte Beispiele und Roundtrip-Verhalten sind in `tests/levelup/test_v0_manifest.py` abgedeckt.
+- **IO:** `read_manifest` nutzt `model_validate_json` auf Dateiinhalt; `write_manifest` schreibt formatiertes JSON (inkl. Elternverzeichnis-Anlage).
+- **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>` und `dump-empty <manifest>` (`argparse`-`prog` in `cli.py`). `validate` gibt eine JSON-Zeile mit `ok`, `schema`, `slices` aus; `dump-empty` schreibt ein leeres Manifest und gibt `ok`/`wrote` zurück. Subprozess-Checks: `test_cli_validate_and_dump_empty` in `tests/levelup/test_v0_manifest.py`.
+
+**Non-claims:** Keine Aussage über Integration in Deployments, CI-Pflicht oder Freigabeprozesse — sofern nicht separat und repo-evidenced dokumentiert.


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen docs/mapping-first Slice um, der LevelUp v0 als kanonisch dokumentierte Ops-/Spec-Oberfläche sichtbar verankert, ohne Runtime-/Authority-Ausweitung.

Ausgangspunkt
Bereits vorhanden:
- src/levelup/__init__.py
- src/levelup/cli.py
- src/levelup/v0_io.py
- src/levelup/v0_models.py
- tests/levelup/test_v0_manifest.py

Bereits vorhandene Canonical-/Truth-/Hub-Dokumente:
- docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
- docs/INDEX.md
- docs/ops/README.md
- docs/governance/README.md
- docs/ops/CURSOR_MULTI_AGENT_RUNBOOK_FRONTDOOR.md
- docs/ops/runbooks/README.md
- docs/ops/registry/INDEX.md
- docs/ops/RUNBOOK_INDEX.md
- docs/ops/registry/DOCS_TRUTH_MAP.md
- docs/KNOWLEDGE_BASE_INDEX.md

Verbindlicher PR-Fokus
Nur docs-/mapping-first für LevelUp v0:
1. eine kleine kanonische Ops-/Spec-Datei für LevelUp v0 anlegen
2. sichtbare Verlinkung von bestehenden Hub-/Ops-Einstiegen
3. erforderliche Truth-Map-/Drift-Guard-Kopplung ergänzen
4. optional nur read-only CLI-Erwähnung, falls eindeutig evidenzbasiert aus src/levelup/cli.py ableitbar

Ziel-Dateien
- neu: docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
- update: docs/KNOWLEDGE_BASE_INDEX.md
- update: docs/ops/README.md
- update: docs/ops/RUNBOOK_INDEX.md
- update: docs/ops/registry/DOCS_TRUTH_MAP.md

Nicht in diesem Slice
- keine Codeänderungen
- keine Tests ändern
- keine neue Authority definieren
- keine Runtime- oder E2E-Claims ohne Repo-Evidenz
- keine Ausweitung auf LevelUp v1/vnext
- keine neue Parallel-Spec neben bereits existierenden bindenden Canonical-Regeln

Inhalt der neuen Spec-Datei
Klein und strikt additive Orientierung für LevelUp v0:
- Zweck: LevelUp v0 ist aktuell eine kleine, additive Manifest-/IO-/CLI-Grundlage
- Scope: Modelle, JSON/IO, CLI-Einstieg nur soweit direkt verifizierbar
- Claim-Disziplin: Ist vs intended vs unclear sauber trennen
- Authority-Hinweis:
  - diese Datei definiert keine neue Governance-/Risk-/Safety-Autorität
  - bindende Canonical-Vocabulary-/Authority-/Provenance-Regeln bleiben in CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md
- Verweise auf die konkret vorhandenen src/levelup-Dateien und den Test
- optional ein kleiner Abschnitt „Current verified surface“ mit präzisen, engen Aussagen nur aus Code/Test lesbar

Verlinkung / Auffindbarkeit
- docs/ops/README.md: kleiner Hinweis/Link in passender Ops-/Spec-Nähe
- docs/ops/RUNBOOK_INDEX.md: kleiner Link/Hinweis in passender Navigationsstelle
- docs/KNOWLEDGE_BASE_INDEX.md: kleine sichtbare Verlinkung
- keine langen Umbauten

Truth-Map
- Ergänze nur die minimal nötige Zuordnung in docs/ops/registry/DOCS_TRUTH_MAP.md
- formatkonsistent
- so, dass künftige Drift-Guards für diese LevelUp-v0-Doku sauber gekoppelt sind, falls dort ein Muster existiert
- keine erfundenen Regeln; nur vorhandenes Format fortsetzen

Arbeitsmodus
- zuerst read-only prüfen:
  - Stil existierender docs/ops/specs/*.md
  - Format von DOCS_TRUTH_MAP.md
  - verifizierbare Surface in src/levelup/cli.py, v0_io.py, v0_models.py, tests/levelup/test_v0_manifest.py
- dann minimalen Diff erzeugen
- danach Checks:
  - uv run pytest tests/levelup/test_v0_manifest.py -q
  - uv run ruff check src/levelup tests/levelup
  - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
  - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Akzeptanzkriterien
1. PR bleibt klar docs/mapping-first
2. Neue LevelUp-v0-Spec-Datei ist klein, präzise, ohne neue Autorität
3. Hub-/Ops-Auffindbarkeit verbessert
4. Truth-Map-Kopplung minimal und konsistent ergänzt
5. Keine Runtime-/E2E-Überdehnung
6. Alle vier Checks grün

Abschlussnotiz
- Executive Summary
- exakt geänderte Dateien
- verifizierte Surface-Aussagen
- Truth-Map-Ergänzung
- Check-Resultate
- Branch-Name
- Commit-Hash

Branch-Name
docs/levelup-v0-canonical-surface-anchor

Commit-Message
docs: anchor levelup v0 canonical surface
