### PR TITLE
docs: map levelup v0 to canonical surface

### DIFF
--- a/config/ops/docs_truth_map.yaml
+++ b/config/ops/docs_truth_map.yaml
@@ -62,3 +62,9 @@ rules:
       - "scripts/_forward_run_manifest.py"
     required_docs:
       - "docs/ops/CLI_RUN_MANIFEST_RUN_ID.md"
+
+  - id: levelup-v0-layer
+    sensitive:
+      - "src/levelup/"
+    required_docs:
+      - "docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md"

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -22,7 +22,11 @@ Sie strukturiert nur die **organisatorische** Freigabe-Hülle; **Repo-Merge**, D
 ## Canonical: LevelUp v0 — additive Manifest-/IO-/CLI-Oberfläche
 
 Kanonische **Ops-/Spec-Oberfläche** (Auffindbarkeit, Claim-Grenzen; **keine** neue Governance-/Risk-/Safety-Autorität): [`docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md`](../specs/LEVELUP_V0_CANONICAL_SURFACE.md).  
-**Drift-Guard-Kopplung (Slice A):** Eine explizite Regel in `config/ops/docs_truth_map.yaml` ist für `src/levelup/` zum Zeitpunkt dieses Slices **nicht** vorgesehen; bei künftiger Ergänzung ist die naheliegende Paarung: `sensitive` → Präfix `src/levelup/`, `required_docs` → mindestens `docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md` (gleiches Muster wie z. B. `forward-run-manifest-helper`). Bis dahin: Änderungen unter `src/levelup/` bewusst mit dieser Canonical-Datei oder einem nachfolgenden Truth-Map-Eintrag unter „Änderungsnachweis“ abgleichen.
+**Drift-Guard-Kopplung (Slice A):** Regel `levelup-v0-layer` in `config/ops/docs_truth_map.yaml` — `sensitive` → Präfix `src/levelup/`, `required_docs` → `docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md` (gleiches Muster wie z. B. `forward-run-manifest-helper`).
+
+## Operator: `levelup-v0-layer`
+
+Wenn **`src/levelup/`** (Prefix-Regel) geändert wird, muss im **selben Diff** mindestens **`docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md`** mitaktualisiert werden (siehe Regel `levelup-v0-layer` in `config/ops/docs_truth_map.yaml`).
 
 ## Wie das Mapping funktioniert
 
@@ -69,7 +73,9 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
-- 2026-04-16: `docs&#47;ops&#47;specs&#47;LEVELUP_V0_CANONICAL_SURFACE.md` neu — kanonische Ops-/Spec-Oberfläche für LevelUp v0 (Manifest-/IO-/CLI; keine neue Autorität); Querverweise in `docs&#47;KNOWLEDGE_BASE_INDEX.md`, `docs&#47;ops&#47;README.md`, `docs&#47;ops&#47;RUNBOOK_INDEX.md`; Truth-Map-Abschnitt „Canonical: LevelUp v0“; **keine** `config&#47;ops&#47;docs_truth_map.yaml`-Regel in diesem Slice; keine Runtime-/E2E-Ausweitung.
+- 2026-04-16: `docs&#47;ops&#47;specs&#47;LEVELUP_V0_CANONICAL_SURFACE.md` neu — kanonische Ops-/Spec-Oberfläche für LevelUp v0 (Manifest-/IO-/CLI; keine neue Autorität); Querverweise in `docs&#47;KNOWLEDGE_BASE_INDEX.md`, `docs&#47;ops&#47;README.md`, `docs&#47;ops&#47;RUNBOOK_INDEX.md`; Truth-Map-Abschnitt „Canonical: LevelUp v0“; zunächst ohne `docs_truth_map.yaml`-Regel; keine Runtime-/E2E-Ausweitung.
+
+- 2026-04-16: `config&#47;ops&#47;docs_truth_map.yaml` — Regel `levelup-v0-layer` (`src&#47;levelup&#47;` → `docs&#47;ops&#47;specs&#47;LEVELUP_V0_CANONICAL_SURFACE.md`); Truth-Map-Abschnitt „Canonical: LevelUp v0“ + Operator-Stub `levelup-v0-layer` aligned; Drift-Guard wie `forward-run-manifest-helper`; keine neue Autorität.
 
 - 2026-04-16: `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` — second-wave canonical hub anchors (PR #2664, docs-only); Truth-Map-Pflege; paired with `governance-overview-canonical`; keine Live-Freigabe.
 


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen mapping-/governance-first Slice um: Änderungen unter src/levelup/ sollen künftig die kanonische LevelUp-v0-Doku mitziehen müssen.

Ausgangspunkt
Bereits vorhanden:
- src/levelup/__init__.py
- src/levelup/cli.py
- src/levelup/v0_io.py
- src/levelup/v0_models.py
- tests/levelup/test_v0_manifest.py
- docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
- docs/ops/registry/DOCS_TRUTH_MAP.md

Verbindlicher PR-Fokus
Nur die minimal nötige Drift-Guard-/Truth-Map-Kopplung für LevelUp v0 ergänzen, damit Änderungen an src/levelup/ die kanonische Doc-Oberfläche nicht still driften lassen.

Ziel-Dateien
- docs/ops/registry/DOCS_TRUTH_MAP.md
- nur falls zwingend nötig zusätzlich die bereits vorhandene Guard-/Mapping-Konfigurationsdatei, falls das Repo-Muster dies erfordert
- keine neue Spec-Datei
- keine Codeänderungen
- keine Teständerungen
- keine breiten Docs-Umbauten

Aufgabe
1. Lies read-only:
   - docs/ops/registry/DOCS_TRUTH_MAP.md
   - bestehende Drift-Guard-/Truth-Map-Muster für andere Themenfamilien
   - ggf. die Workflow-/Script-Stellen, die docs-drift-guard / truth-gates auswerten
2. Ergänze minimal und formatkonsistent die Zuordnung für die LevelUp-v0-Familie:
   - Änderungen unter src/levelup/ sollen docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md mitziehen
3. Falls das bestehende Repo-Muster zusätzlich eine zweite Mapping-/Regelstelle verlangt, nur diese eine Stelle minimal mitziehen.
4. Keine neue Norm, keine Runtime-Claims, keine Authority-Ausweitung.

Constraints
- Ein Thema
- minimaler Diff
- exakt am bestehenden Repo-Muster orientieren
- keine erfundene Guard-Logik
- keine neuen Check-Kategorien
- kein Themenmix mit Validation/CLI-Ausbau

Verifikation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- falls lokal sinnvoll: relevante Truth-/Drift-Guard-Dateien read-only gegen bestehende Muster prüfen
- nach PR-Erstellung CI auf spezifischen Drift-Guard-/Truth-Gates beobachten

Akzeptanzkriterien
1. PR bleibt mapping-/governance-first
2. src/levelup/-Familie ist minimal an LEVELUP_V0_CANONICAL_SURFACE.md gekoppelt
3. Keine weitere Semantik eingeführt
4. Docs-Checks grün
5. Diff ist klein und klar reviewbar

Abschlussnotiz
- Executive Summary
- exakt geänderte Datei(en)
- welche Kopplung ergänzt wurde
- warum sie dem bestehenden Guard-Muster entspricht
- Check-Resultate
- Branch-Name
- Commit-Hash

Branch-Name
docs/levelup-v0-drift-guard

Commit-Message
docs: map levelup v0 to canonical surface
