### PR TITLE
feat(levelup): define v0 validate cli contract

### DIFF
--- a/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
+++ b/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
@@ -16,8 +16,8 @@ LevelUp **v0** ist im Repo aktuell eine **kleine, additive** Grundlage: typisier
 |--------|---------------------------|
 | **Modelle** | `EvidenceBundleRefV0`, `SliceContractV0`, `LevelUpManifestV0` — nur soweit aus `src/levelup/v0_models.py` ablesbar. |
 | **JSON/IO** | `read_manifest`, `write_manifest` in `src/levelup/v0_io.py` — **offline**, repo-lokale Pfade. |
-| **CLI** | Nur das, was `src/levelup/cli.py` und `tests/levelup/test_v0_manifest.py` eindeutig belegen (siehe Abschnitt 6). |
-| **Tests** | `tests/levelup/test_v0_manifest.py` als Verifikationsanker. |
+| **CLI** | Nur das, was `src/levelup/cli.py` sowie `tests/levelup/test_v0_manifest.py` und `tests/levelup/test_v0_validate_cli.py` eindeutig belegen (siehe Abschnitt 6). |
+| **Tests** | `tests/levelup/test_v0_manifest.py`, `tests/levelup/test_v0_validate_cli.py` als Verifikationsanker. |
 
 **Out-of-Scope:** LevelUp v1/vNext, Runtime-/E2E-Garantien, Produktions-Gates, Execution- oder Order-Autorität.
 
@@ -42,7 +42,8 @@ Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANO
 | `src/levelup/v0_models.py` | Pydantic-Modelle, Schema-String `levelup&#47;manifest&#47;v0`. |
 | `src/levelup/v0_io.py` | JSON einlesen/ausgeben (Path). |
 | `src/levelup/cli.py` | CLI-Einstieg (`validate`, `dump-empty`). |
-| `tests/levelup/test_v0_manifest.py` | Roundtrip-, Validierungs- und CLI-Tests. |
+| `tests/levelup/test_v0_manifest.py` | Roundtrip-, Validierungs- und Basis-CLI-Tests. |
+| `tests/levelup/test_v0_validate_cli.py` | Subprozess-Tests für `validate`-Exit-Codes und JSON-Fehlerobjekt. |
 
 ## 6) Current verified surface (eng, aus Code/Test)
 
@@ -51,6 +52,10 @@ Alles Folgende bezieht sich auf den **Ist**-Stand der genannten Dateien:
 - **Schema:** `LevelUpManifestV0.schema_version` ist fix `levelup&#47;manifest&#47;v0` (`src/levelup/v0_models.py`).
 - **Evidence-Pfade:** `EvidenceBundleRefV0.relative_dir` muss mit `out/ops/` beginnen; Traversal wird abgewiesen (Validator in `v0_models.py`); abgelehnte Beispiele und Roundtrip-Verhalten sind in `tests/levelup/test_v0_manifest.py` abgedeckt.
 - **IO:** `read_manifest` nutzt `model_validate_json` auf Dateiinhalt; `write_manifest` schreibt formatiertes JSON (inkl. Elternverzeichnis-Anlage).
-- **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>` und `dump-empty <manifest>` (`argparse`-`prog` in `cli.py`). `validate` gibt eine JSON-Zeile mit `ok`, `schema`, `slices` aus; `dump-empty` schreibt ein leeres Manifest und gibt `ok`/`wrote` zurück. Subprozess-Checks: `test_cli_validate_and_dump_empty` in `tests/levelup/test_v0_manifest.py`.
+- **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>` und `dump-empty <manifest>` (`argparse`-`prog` in `cli.py`). **validate** schreibt **genau eine JSON-Zeile auf stdout** (stderr leer im erwarteten Fehlerpfad):
+  - **Erfolg:** `ok: true`, plus `schema`, `slices` (Anzahl).
+  - **Fehler:** `ok: false`, `error` (`input` | `validation`), `reason` (z. B. `json_parse_failed`, `manifest_read_failed`, `model_validation_failed`), knappe `message`; bei `validation` zusätzlich `issues` (gekürzte Pydantic-Fehlerliste).
+  - **Exit-Codes:** `0` = Validierung ok; `2` = Usage/Eingabe (u. a. fehlende Datei, Lesefehler, ungültiges JSON, UTF-8-Dekodierung); `3` = JSON parsebar, Modell-/Schema-Validierung fehlgeschlagen. `dump-empty` schreibt ein leeres Manifest und gibt eine JSON-Zeile mit `ok`/`wrote` zurück (Erfolg `0`).
+  - Subprozess-Checks: `test_cli_validate_and_dump_empty` in `tests/levelup/test_v0_manifest.py`, `test_v0_validate_cli.py` in `tests/levelup/`.
 
 **Non-claims:** Keine Aussage über Integration in Deployments, CI-Pflicht oder Freigabeprozesse — sofern nicht separat und repo-evidenced dokumentiert.

--- a/src/levelup/cli.py
+++ b/src/levelup/cli.py
@@ -2,6 +2,11 @@
 Minimal CLI for Level-Up v0 manifests (validate / round-trip checks).
 
 Does not connect to exchanges or change execution posture.
+
+validate exit contract (stdout is one JSON object per invocation):
+- 0 — manifest parsed and model-validated
+- 2 — usage / input problem (unreadable path, invalid JSON, UTF-8 decode)
+- 3 — JSON ok but model / schema validation failed
 """
 
 from __future__ import annotations
@@ -9,16 +14,83 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from json import JSONDecodeError
 from pathlib import Path
+
+from pydantic import ValidationError
 
 from src.levelup.v0_io import read_manifest
 from src.levelup.v0_models import LevelUpManifestV0
 
+EXIT_VALIDATION_OK = 0
+EXIT_INPUT = 2
+EXIT_VALIDATION_FAILED = 3
+
+
+def _emit_json(payload: object) -> None:
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
 
 def _cmd_validate(path: Path) -> int:
-    m = read_manifest(path)
-    print(json.dumps({"ok": True, "schema": m.schema_version, "slices": len(m.slices)}))
-    return 0
+    try:
+        m = read_manifest(path)
+    except OSError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "manifest_read_failed",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
+    except UnicodeDecodeError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "utf8_decode_failed",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
+    except JSONDecodeError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "json_parse_failed",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
+    except ValidationError as exc:
+        issues = exc.errors()
+        if issues and issues[0].get("type") == "json_invalid":
+            msg = str(issues[0].get("msg") or "invalid JSON")
+            _emit_json(
+                {
+                    "ok": False,
+                    "error": "input",
+                    "reason": "json_parse_failed",
+                    "message": msg,
+                }
+            )
+            return EXIT_INPUT
+        issues = issues[:8]
+        _emit_json(
+            {
+                "ok": False,
+                "error": "validation",
+                "reason": "model_validation_failed",
+                "message": "manifest failed LevelUpManifestV0 validation",
+                "issues": issues,
+            }
+        )
+        return EXIT_VALIDATION_FAILED
+
+    _emit_json({"ok": True, "schema": m.schema_version, "slices": len(m.slices)})
+    return EXIT_VALIDATION_OK
 
 
 def _cmd_dump_empty(path: Path) -> int:
@@ -26,8 +98,8 @@ def _cmd_dump_empty(path: Path) -> int:
     from src.levelup.v0_io import write_manifest
 
     write_manifest(path, m)
-    print(json.dumps({"ok": True, "wrote": str(path)}))
-    return 0
+    _emit_json({"ok": True, "wrote": str(path)})
+    return EXIT_VALIDATION_OK
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -48,7 +120,7 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_validate(args.manifest)
     if args.cmd == "dump-empty":
         return _cmd_dump_empty(args.manifest)
-    return 2
+    return EXIT_INPUT
 
 
 if __name__ == "__main__":

--- a/tests/levelup/test_v0_validate_cli.py
+++ b/tests/levelup/test_v0_validate_cli.py
@@ -1,0 +1,92 @@
+"""Subprocess tests for LevelUp v0 `validate` CLI contract (exit codes + JSON on stdout)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_cli(args: list[str], cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "src.levelup.cli", *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_validate_cli_success(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    w = _run_cli(["dump-empty", str(manifest)])
+    assert w.returncode == 0, w.stderr
+
+    v = _run_cli(["validate", str(manifest)])
+    assert v.returncode == 0, v.stderr
+    assert v.stderr.strip() == ""
+    out = json.loads(v.stdout.strip())
+    assert out["ok"] is True
+    assert out["schema"] == "levelup/manifest/v0"
+    assert out["slices"] == 0
+
+
+def test_validate_cli_invalid_json(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ not json", encoding="utf-8")
+    r = _run_cli(["validate", str(bad)])
+    assert r.returncode == 2
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "json_parse_failed"
+
+
+def test_validate_cli_model_validation_failure(tmp_path: Path) -> None:
+    p = tmp_path / "invalid_model.json"
+    p.write_text('{"schema_version": "not-a-valid-manifest-schema"}', encoding="utf-8")
+    r = _run_cli(["validate", str(p)])
+    assert r.returncode == 3
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "validation"
+    assert payload["reason"] == "model_validation_failed"
+    assert isinstance(payload.get("issues"), list)
+
+
+def test_validate_cli_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.json"
+    r = _run_cli(["validate", str(missing)])
+    assert r.returncode == 2
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "manifest_read_failed"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod semantics differ on Windows")
+def test_validate_cli_unreadable_file(tmp_path: Path) -> None:
+    manifest = tmp_path / "locked.json"
+    manifest.write_text('{"schema_version": "levelup/manifest/v0"}', encoding="utf-8")
+    manifest.chmod(0)
+    try:
+        r = _run_cli(["validate", str(manifest)])
+    finally:
+        manifest.chmod(0o644)
+    assert r.returncode == 2
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "manifest_read_failed"


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen, echten Delta-Slice um: LevelUp v0 validate-CLI mit präzisem Fehler-/Exit-Code-Kontrakt materialisieren, inklusive gezielter Tests und kleinem verifiziertem Doku-Update.

Ausgangspunkt
Bereits vorhanden:
- src/levelup/__init__.py
- src/levelup/cli.py
- src/levelup/v0_io.py
- src/levelup/v0_models.py
- tests/levelup/test_v0_manifest.py
- docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md

Wichtiger Befund
- Der vorige Versuch war ein No-Op gegenüber main.
- Deshalb ist dieser Brief strikt delta-orientiert.
- Es muss am Ende ein echter Code-/Test-/Docs-Diff existieren.

Verbindlicher PR-Fokus
Nur ein Thema:
- validate-CLI-Kontrakt für LevelUp v0 schärfen

In scope
1. src/levelup/cli.py
   - validate-Subcommand explizit auf festen Kontrakt bringen
   - definierte Exit-Codes
   - stabile, strukturierte Fehlerausgabe
2. tests/levelup/
   - subprocess-/CLI-Tests für validate
   - mindestens:
     - Success Path
     - invalid JSON / parse failure
     - schema/model validation failure
     - missing file / unreadable path, falls vom aktuellen Codepfad relevant
3. docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
   - nur knapp die verifizierte validate-CLI-Surface ergänzen:
     - Kommando
     - Erfolg / Fehler
     - Exit-Code-Verhalten in enger Form
   - keine neue Autorität, keine Runtime-Überdehnung

Explizite Nicht-Ziele
- keine neue Manifest-v1/vnext-Struktur
- keine breite Manifest-Semantik-Erweiterung
- keine allgemeine IO-Refaktorierung
- keine Parallel-CLI
- keine Änderungen außerhalb LevelUp-v0-CLI/Test/kleinem Docs-Update

Delta-Anforderung
Am Ende muss mindestens Folgendes materialisiert sein:
- mindestens 1 Code-Diff in src/levelup/cli.py
- mindestens 1 neuer oder geänderter CLI-Test
- kleines Docs-Delta in LEVELUP_V0_CANONICAL_SURFACE.md

Kontrakt-Richtung
Bevorzugt eine kleine, klare Exit-Code-Tabelle, z. B.:
- 0 = validation_ok
- 2 = usage / input problem
- 3 = validation_failed
Nur übernehmen, wenn es sauber zum bestehenden Code passt; sonst minimal evidenzbasiert an aktuelle Struktur anlehnen.

Fehlerausgabe
- stabil
- knapp
- testbar
- keine unkontrollierten Tracebacks im erwarteten Operator-Fehlerpfad

Arbeitsmodus
1. zuerst read-only prüfen:
   - aktueller CLI-Stand
   - vorhandene Validierungslogik
   - bestehende Tests
2. dann echten Delta-Diff erzeugen
3. danach Checks:
   - uv run pytest tests/levelup -q
   - uv run ruff check src/levelup tests/levelup
   - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
   - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Akzeptanzkriterien
1. PR bleibt ein Thema
2. validate-CLI hat definierte, getestete Exit-Codes
3. Fehlerausgabe ist strukturiert und testbar
4. Subprozess-Tests decken Success + relevante Failure-Pfade
5. Docs-Update bleibt klein und verifiziert
6. Echter Delta-Diff vorhanden
7. Alle vier Checks grün

Abschlussnotiz
- Executive Summary
- exakt geänderte Dateien
- finaler validate-Kontrakt
- Exit-Codes
- Testabdeckung
- Check-Resultate
- Branch-Name
- Commit-Hash

Branch-Name
feat/levelup-v0-validate-cli-delta

Commit-Message
feat(levelup): define v0 validate cli contract
