### PR TITLE
feat(levelup): tighten v0 manifest semantics

### DIFF
--- a/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
+++ b/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
@@ -50,6 +50,8 @@ Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANO
 Alles Folgende bezieht sich auf den **Ist**-Stand der genannten Dateien:
 
 - **Schema:** `LevelUpManifestV0.schema_version` ist fix `levelup&#47;manifest&#47;v0` (`src/levelup/v0_models.py`).
+- **Manifest-Titel:** `LevelUpManifestV0.title` wird an den Enden getrimmt; nur nicht-leer nach dem Trim ist gültig (Leer- bzw. Nur-Whitespace-Titel werden abgewiesen). Positiv-/Negativfälle: `test_manifest_root_title_strips_surrounding_whitespace`, `test_manifest_root_title_rejects_empty_after_strip` in `tests/levelup/test_v0_manifest.py`.
+- **Slice-IDs:** `slice_id`-Werte müssen innerhalb eines Manifests **eindeutig** sein (`test_manifest_rejects_duplicate_slice_id` in `tests/levelup/test_v0_manifest.py`).
 - **Evidence-Pfade:** `EvidenceBundleRefV0.relative_dir` muss mit `out/ops/` beginnen; Traversal wird abgewiesen (Validator in `v0_models.py`); abgelehnte Beispiele und Roundtrip-Verhalten sind in `tests/levelup/test_v0_manifest.py` abgedeckt.
 - **IO:** `read_manifest` nutzt `model_validate_json` auf Dateiinhalt; `write_manifest` schreibt formatiertes JSON (inkl. Elternverzeichnis-Anlage).
 - **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>` und `dump-empty <manifest>` (`argparse`-`prog` in `cli.py`). **validate** schreibt **genau eine JSON-Zeile auf stdout** (stderr leer im erwarteten Fehlerpfad):

--- a/src/levelup/v0_models.py
+++ b/src/levelup/v0_models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import re
 from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 _SCHEMA = "levelup/manifest/v0"
 _EVIDENCE_PREFIX = "out/ops/"
@@ -62,5 +62,22 @@ class LevelUpManifestV0(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     schema_version: Literal["levelup/manifest/v0"] = _SCHEMA
-    title: str = Field(default="Peak Trade Level-Up (Evidence-first)", max_length=512)
+    title: str = Field(default="Peak Trade Level-Up (Evidence-first)", min_length=1, max_length=512)
     slices: tuple[SliceContractV0, ...] = ()
+
+    @field_validator("title")
+    @classmethod
+    def _root_title_stripped_nonempty(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("manifest title must be non-empty after stripping whitespace")
+        return s
+
+    @model_validator(mode="after")
+    def _slice_ids_unique(self) -> LevelUpManifestV0:
+        seen: set[str] = set()
+        for sl in self.slices:
+            if sl.slice_id in seen:
+                raise ValueError(f"duplicate slice_id in manifest: {sl.slice_id!r}")
+            seen.add(sl.slice_id)
+        return self

--- a/tests/levelup/test_v0_manifest.py
+++ b/tests/levelup/test_v0_manifest.py
@@ -56,6 +56,33 @@ def test_evidence_path_rejected(bad: str) -> None:
         EvidenceBundleRefV0(relative_dir=bad)
 
 
+def test_manifest_rejects_duplicate_slice_id() -> None:
+    sl_a = SliceContractV0(
+        slice_id="SAME",
+        title="First",
+        contract_summary="x",
+    )
+    sl_b = SliceContractV0(
+        slice_id="SAME",
+        title="Second",
+        contract_summary="y",
+    )
+    with pytest.raises(ValidationError) as exc:
+        LevelUpManifestV0(slices=(sl_a, sl_b))
+    assert "duplicate slice_id" in str(exc.value).lower()
+
+
+@pytest.mark.parametrize("bad_title", ["", "   ", "\t\n"])
+def test_manifest_root_title_rejects_empty_after_strip(bad_title: str) -> None:
+    with pytest.raises(ValidationError):
+        LevelUpManifestV0(title=bad_title)
+
+
+def test_manifest_root_title_strips_surrounding_whitespace() -> None:
+    m = LevelUpManifestV0(title="  Trimmed  ")
+    assert m.title == "Trimmed"
+
+
 def test_cli_validate_and_dump_empty(tmp_path: Path) -> None:
     manifest = tmp_path / "manifest.json"
     env = os.environ.copy()


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen, additiven Delta-Slice um: striktere Manifest-Semantik für LevelUp v0 materialisieren.

Ausgangspunkt
Bereits vorhanden:
- src/levelup/__init__.py
- src/levelup/cli.py
- src/levelup/v0_io.py
- src/levelup/v0_models.py
- tests/levelup/test_v0_manifest.py
- docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md

Read-only Empfehlung
Die nächste größere additive Slice ist:
- zusätzliche Modell-Constraints in v0_models.py
- gezielte Tests
- kleines verifiziertes Docs-Update

Verbindlicher PR-Fokus
Nur ein Thema:
- striktere Manifest-Semantik / Modell-Constraints für LevelUp v0

In scope
1. src/levelup/v0_models.py
   - kleine, klar begründete zusätzliche Constraints
   - bevorzugt:
     - eindeutige slice_id über alle slices
     - konsistentere Root-title-Validierung
   - nur sofern sauber am bestehenden Modell ansetzbar
2. tests/levelup/test_v0_manifest.py
   - gezielte positive/negative Tests für die neuen Constraints
   - Failure-Pfade stabil und reviewbar
3. docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
   - kleiner verifizierter Update-Block zu den zusätzlichen validierten Semantikregeln
   - keine neue Autorität, keine Runtime-Überdehnung

Explizite Nicht-Ziele
- keine IO-Refaktorierung
- keine CLI-Erweiterung
- keine v1/vnext-Manifeststruktur
- keine breite Schema-Neudefinition
- keine Änderungen außerhalb v0_models / fokussierter Tests / kleinem Docs-Update

Delta-Anforderung
Am Ende muss ein echter Diff bestehen:
- mindestens 1 Code-Diff in src/levelup/v0_models.py
- mindestens 1 neuer/erweiterter Testfall
- kleines Docs-Delta in LEVELUP_V0_CANONICAL_SURFACE.md

Bevorzugte Richtung
- reuse over invention
- nur additive Härtung
- keine Parallelvalidierung neben bestehender Modelllogik
- Constraints nur dann ergänzen, wenn sie aus der vorhandenen Modellstruktur natürlich ableitbar sind

Arbeitsmodus
1. zuerst read-only prüfen:
   - aktueller Stand in src/levelup/v0_models.py
   - welche Semantik schon validiert wird
   - welche Lücken im Test aktuell offen sind
2. dann minimalen Delta-Diff erzeugen
3. danach Checks:
   - uv run pytest tests/levelup -q
   - uv run ruff check src/levelup tests/levelup
   - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
   - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Akzeptanzkriterien
1. PR bleibt ein Thema
2. Neue Constraints sind klein, klar und testbar
3. Negative Tests decken neue Failure-Pfade ab
4. Docs-Update bleibt klein und verifiziert
5. Echter Delta-Diff vorhanden
6. Alle vier Checks grün

Abschlussnotiz
- Executive Summary
- exakt geänderte Dateien
- neue Constraints
- neue/erweiterte Tests
- Check-Resultate
- Branch-Name
- Commit-Hash

Branch-Name
feat/levelup-v0-stricter-manifest-semantics

Commit-Message
feat(levelup): tighten v0 manifest semantics
