### PR TITLE
test(levelup): cover v0 validate edge cases

### DIFF
--- a/tests/levelup/test_v0_manifest.py
+++ b/tests/levelup/test_v0_manifest.py
@@ -17,6 +17,18 @@ from src.levelup.v0_io import read_manifest, write_manifest
 from src.levelup.v0_models import EvidenceBundleRefV0, LevelUpManifestV0, SliceContractV0
 
 
+def _run_levelup_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "src.levelup.cli", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
 def test_manifest_roundtrip_empty(tmp_path: Path) -> None:
     m = LevelUpManifestV0()
     p = tmp_path / "m.json"
@@ -85,27 +97,52 @@ def test_manifest_root_title_strips_surrounding_whitespace() -> None:
 
 def test_cli_validate_and_dump_empty(tmp_path: Path) -> None:
     manifest = tmp_path / "manifest.json"
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(REPO_ROOT)
-    exe = subprocess.run(
-        [sys.executable, "-m", "src.levelup.cli", "dump-empty", str(manifest)],
-        cwd=REPO_ROOT,
-        env=env,
-        text=True,
-        capture_output=True,
-    )
+    exe = _run_levelup_cli(["dump-empty", str(manifest)])
     assert exe.returncode == 0, exe.stderr
     out = json.loads(exe.stdout.strip())
     assert out["ok"] is True
 
-    v = subprocess.run(
-        [sys.executable, "-m", "src.levelup.cli", "validate", str(manifest)],
-        cwd=REPO_ROOT,
-        env=env,
-        text=True,
-        capture_output=True,
-    )
+    v = _run_levelup_cli(["validate", str(manifest)])
     assert v.returncode == 0, v.stderr
     meta = json.loads(v.stdout.strip())
     assert meta["ok"] is True
     assert meta["slices"] == 0
+
+
+def test_cli_validate_utf8_decode_failed(tmp_path: Path) -> None:
+    """Invalid UTF-8 bytes → exit 2, reason utf8_decode_failed (Path.read_text)."""
+    bad = tmp_path / "not_utf8.json"
+    bad.write_bytes(b"\xff\xfe\x00")
+    r = _run_levelup_cli(["validate", str(bad)])
+    assert r.returncode == 2, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "utf8_decode_failed"
+
+
+def test_cli_validate_path_is_directory(tmp_path: Path) -> None:
+    """A directory path is not a readable manifest file → OSError, manifest_read_failed."""
+    d = tmp_path / "not_a_file"
+    d.mkdir()
+    r = _run_levelup_cli(["validate", str(d)])
+    assert r.returncode == 2, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "manifest_read_failed"
+
+
+def test_cli_validate_empty_file_json_parse_failed(tmp_path: Path) -> None:
+    """Empty file is not valid JSON → exit 2, json_parse_failed."""
+    empty = tmp_path / "empty.json"
+    empty.write_text("", encoding="utf-8")
+    r = _run_levelup_cli(["validate", str(empty)])
+    assert r.returncode == 2, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "json_parse_failed"


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen, additiven Delta-Slice um: fehlende negative/edge-case Tests für den LevelUp-v0-validate-/Manifest-Ladepfad vervollständigen, mit minimalem Code-/Docs-Fix nur falls die Tests einen echten Widerspruch zum aktuellen Kontrakt zeigen.

Ausgangspunkt
Bereits vorhanden:
- src/levelup/__init__.py
- src/levelup/cli.py
- src/levelup/v0_io.py
- src/levelup/v0_models.py
- tests/levelup/test_v0_manifest.py
- docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md

Read-only Empfehlung
Nächste größere additive Slice:
- Validate-CLI-Kontrakt & Manifest-Lade-Edge-Cases (Test-Abschluss)

Verbindlicher PR-Fokus
Nur ein Thema:
- fehlende negative/edge-case Tests rund um validate + Manifest-Laden

In scope
1. tests/levelup/test_v0_manifest.py
   - gezielte negative/edge-case Tests ergänzen, bevorzugt:
     - utf8_decode_failed
     - Verzeichnispfad / OSError-Fall
     - leere Datei
   - Success-/Failure-Erwartungen klar und reviewbar formulieren
2. src/levelup/cli.py und/oder src/levelup/v0_io.py
   - nur minimal ändern, falls die neuen Tests einen echten Kontrakt-Widerspruch oder unkontrollierten Fehlerpfad aufdecken
   - keine breite Refaktorierung
3. docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
   - nur kleines verifiziertes Update, falls sich der tatsächlich dokumentierbare Fehlerpfad/Exit-Code-/Fehlermodus durch den minimalen Fix präzisiert

Explizite Nicht-Ziele
- keine neue CLI-Funktion
- keine breite IO-Härtung
- keine neue Manifest-Semantik
- keine v1/vnext-Struktur
- keine Änderungen außerhalb gezielter Tests und ggf. minimalem Fix

Delta-Anforderung
Am Ende muss ein echter Delta-Diff bestehen:
- mindestens 1 neuer/erweiterter negativer Edge-Case-Test
- Code-/Docs-Diff nur wenn nötig und eng begrenzt

Bevorzugte Richtung
- test-first / contradiction-first
- nur minimale Produktionsänderung, wenn Tests eine echte Lücke zeigen
- keine künstliche Änderung nur um einen Diff zu erzwingen

Arbeitsmodus
1. zuerst read-only prüfen:
   - aktueller validate-/Ladepfad in cli.py und v0_io.py
   - bestehende Tests in tests/levelup/test_v0_manifest.py
   - aktueller dokumentierter Kontrakt in LEVELUP_V0_CANONICAL_SURFACE.md
2. dann gezielte Edge-Case-Tests ergänzen
3. nur falls Tests scheitern: minimalen Code-/Docs-Fix hinzufügen
4. danach Checks:
   - uv run pytest tests/levelup -q
   - uv run ruff check src/levelup tests/levelup
   - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
   - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Akzeptanzkriterien
1. PR bleibt ein Thema
2. Edge-Case-Tests decken die identifizierten Lücken ab
3. Produktionscode ändert sich nur bei echter Notwendigkeit
4. Docs ändern sich nur bei verifizierter Kontrakt-Präzisierung
5. Echter Delta-Diff vorhanden
6. Alle vier Checks grün

Abschlussnotiz
- Executive Summary
- exakt geänderte Dateien
- welche Edge-Cases ergänzt wurden
- ob Produktionscode nötig war oder nicht
- Check-Resultate
- Branch-Name
- Commit-Hash

Branch-Name
test/levelup-v0-validate-edge-cases

Commit-Message
test(levelup): cover v0 validate edge cases
