### PR TITLE
feat(levelup): define v0 dump-empty error contract

### DIFF
--- a/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
+++ b/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
@@ -57,7 +57,8 @@ Alles Folgende bezieht sich auf den **Ist**-Stand der genannten Dateien:
 - **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>` und `dump-empty <manifest>` (`argparse`-`prog` in `cli.py`). **validate** schreibt **genau eine JSON-Zeile auf stdout** (stderr leer im erwarteten Fehlerpfad):
   - **Erfolg:** `ok: true`, plus `schema`, `slices` (Anzahl).
   - **Fehler:** `ok: false`, `error` (`input` | `validation`), `reason` (z. B. `json_parse_failed`, `manifest_read_failed`, `model_validation_failed`), knappe `message`; bei `validation` zusätzlich `issues` (gekürzte Pydantic-Fehlerliste).
-  - **Exit-Codes:** `0` = Validierung ok; `2` = Usage/Eingabe (u. a. fehlende Datei, Lesefehler, ungültiges JSON, UTF-8-Dekodierung); `3` = JSON parsebar, Modell-/Schema-Validierung fehlgeschlagen. `dump-empty` schreibt ein leeres Manifest und gibt eine JSON-Zeile mit `ok`/`wrote` zurück (Erfolg `0`).
-  - Subprozess-Checks: `test_cli_validate_and_dump_empty` in `tests/levelup/test_v0_manifest.py`, `test_v0_validate_cli.py` in `tests/levelup/`.
+  - **Exit-Codes:** `0` = Validierung ok; `2` = Usage/Eingabe (u. a. fehlende Datei, Lesefehler, ungültiges JSON, UTF-8-Dekodierung); `3` = JSON parsebar, Modell-/Schema-Validierung fehlgeschlagen.
+  - **dump-empty:** schreibt ein leeres Manifest; **Erfolg:** eine JSON-Zeile auf stdout mit `ok: true`, `wrote` (Pfad), Exit `0`, stderr leer. **Fehler (Schreib-/Pfadproblem):** eine JSON-Zeile mit `ok: false`, `error: input`, `reason` (`target_path_is_directory` wenn der Zielpfad ein Verzeichnis ist, sonst bei `OSError` am Schreibpfad typischerweise `manifest_write_failed`), `message`; Exit `2`, stderr leer im erwarteten Operator-Pfad.
+  - Subprozess-Checks: `test_cli_validate_and_dump_empty`, `test_cli_dump_empty_target_path_is_directory`, `test_cli_dump_empty_not_writable_target_file` in `tests/levelup/test_v0_manifest.py`, `test_v0_validate_cli.py` in `tests/levelup/`.
 
 **Non-claims:** Keine Aussage über Integration in Deployments, CI-Pflicht oder Freigabeprozesse — sofern nicht separat und repo-evidenced dokumentiert.

--- a/src/levelup/cli.py
+++ b/src/levelup/cli.py
@@ -7,6 +7,10 @@ validate exit contract (stdout is one JSON object per invocation):
 - 0 — manifest parsed and model-validated
 - 2 — usage / input problem (unreadable path, invalid JSON, UTF-8 decode)
 - 3 — JSON ok but model / schema validation failed
+
+dump-empty exit contract (stdout is one JSON object per invocation):
+- 0 — empty manifest written
+- 2 — usage / path / write problem (e.g. target is a directory, mkdir/write permission)
 """
 
 from __future__ import annotations
@@ -19,7 +23,7 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from src.levelup.v0_io import read_manifest
+from src.levelup.v0_io import read_manifest, write_manifest
 from src.levelup.v0_models import LevelUpManifestV0
 
 EXIT_VALIDATION_OK = 0
@@ -95,9 +99,29 @@ def _cmd_validate(path: Path) -> int:
 
 def _cmd_dump_empty(path: Path) -> int:
     m = LevelUpManifestV0()
-    from src.levelup.v0_io import write_manifest
+    try:
+        write_manifest(path, m)
+    except IsADirectoryError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "target_path_is_directory",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
+    except OSError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "manifest_write_failed",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
 
-    write_manifest(path, m)
     _emit_json({"ok": True, "wrote": str(path)})
     return EXIT_VALIDATION_OK
 

--- a/tests/levelup/test_v0_manifest.py
+++ b/tests/levelup/test_v0_manifest.py
@@ -109,6 +109,37 @@ def test_cli_validate_and_dump_empty(tmp_path: Path) -> None:
     assert meta["slices"] == 0
 
 
+def test_cli_dump_empty_target_path_is_directory(tmp_path: Path) -> None:
+    """Directory as output path → exit 2, reason target_path_is_directory."""
+    d = tmp_path / "out_dir"
+    d.mkdir()
+    r = _run_levelup_cli(["dump-empty", str(d)])
+    assert r.returncode == 2, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "target_path_is_directory"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod write-deny semantics differ on Windows")
+def test_cli_dump_empty_not_writable_target_file(tmp_path: Path) -> None:
+    """Existing file without write permission → exit 2, reason manifest_write_failed."""
+    manifest = tmp_path / "locked.json"
+    manifest.write_text("{}", encoding="utf-8")
+    manifest.chmod(0o444)
+    try:
+        r = _run_levelup_cli(["dump-empty", str(manifest)])
+    finally:
+        manifest.chmod(0o644)
+    assert r.returncode == 2, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "manifest_write_failed"
+
+
 def test_cli_validate_utf8_decode_failed(tmp_path: Path) -> None:
     """Invalid UTF-8 bytes → exit 2, reason utf8_decode_failed (Path.read_text)."""
     bad = tmp_path / "not_utf8.json"


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen, additiven Delta-Slice um: dump-empty-Fehlerkontrakt + Schreib-IO-Fehlerpfad für LevelUp v0 materialisieren.

Ausgangspunkt
Bereits vorhanden:
- src/levelup/__init__.py
- src/levelup/cli.py
- src/levelup/v0_io.py
- src/levelup/v0_models.py
- tests/levelup/test_v0_manifest.py
- docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md

Read-only Empfehlung
Nächste größere additive Slice:
- dump-empty-Fehlerkontrakt + Schreib-IO-Fehlerpfad
- strukturierte JSON-Fehlerausgabe
- Exit 2 bei Schreib-/Pfadfehlern
- gezielte negative Subprozess-Tests
- kleines verifiziertes Docs-Update

Verbindlicher PR-Fokus
Nur ein Thema:
- operator-facing Fehlerkontrakt für dump-empty / write path

In scope
1. src/levelup/cli.py
   - dump-empty-Pfad auf klaren Fehlerkontrakt bringen
   - strukturierte JSON-Fehlerausgabe für Schreib-/Pfadfehler
   - definierter Exit-Code 2 für usage/path/write problems, soweit sauber zum bestehenden CLI-Kontrakt passend
2. src/levelup/v0_io.py
   - nur minimal ändern, falls nötig, um den Schreib-Fehlerpfad kontrolliert und testbar abzubilden
   - keine breite IO-Refaktorierung
3. tests/levelup/test_v0_manifest.py
   - gezielte negative Subprozess-Tests für dump-empty / write path
   - bevorzugt:
     - Zielpfad ist Verzeichnis
     - nicht schreibbarer / ungültiger Zielpfad, soweit stabil testbar
     - Erfolgspfad bleibt ungebrochen
4. docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
   - kleines verifiziertes Update zur dump-empty-Surface:
     - success/error-Verhalten
     - Exit-2-Fall für Schreib-/Pfadfehler in enger Form
   - keine neue Autorität, keine Runtime-Überdehnung

Explizite Nicht-Ziele
- keine neue CLI-Funktion außerhalb dump-empty
- keine allgemeine IO-Härtung jenseits des fokussierten Schreibpfads
- keine neue Manifest-Semantik
- keine v1/vnext-Struktur
- keine Parallel-CLI

Delta-Anforderung
Am Ende muss ein echter Delta-Diff bestehen:
- mindestens 1 Code-Diff in cli.py und/oder v0_io.py
- mindestens 1 neuer/erweiterter negativer Subprozess-Test
- kleines Docs-Delta in LEVELUP_V0_CANONICAL_SURFACE.md

Bevorzugte Richtung
- minimal additive
- reuse over invention
- Fehlerpfad stabil, knapp, testbar
- keine unkontrollierten Tracebacks im erwarteten Operator-Fehlerpfad

Arbeitsmodus
1. zuerst read-only prüfen:
   - aktuellen dump-empty-Pfad in src/levelup/cli.py
   - Schreiblogik in src/levelup/v0_io.py
   - bestehende Tests
   - aktuelle Doku in LEVELUP_V0_CANONICAL_SURFACE.md
2. dann minimalen Delta-Diff erzeugen
3. danach Checks:
   - uv run pytest tests/levelup -q
   - uv run ruff check src/levelup tests/levelup
   - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
   - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Akzeptanzkriterien
1. PR bleibt ein Thema
2. dump-empty-/write-Fehlerpfad ist strukturiert und testbar
3. Exit-Code-Verhalten ist definiert und konsistent
4. Negative Subprozess-Tests decken relevante Write-/Path-Failures ab
5. Docs-Update bleibt klein und verifiziert
6. Echter Delta-Diff vorhanden
7. Alle vier Checks grün

Abschlussnotiz
- Executive Summary
- exakt geänderte Dateien
- finaler dump-empty-Fehlerkontrakt
- Exit-Codes
- Testabdeckung
- Check-Resultate
- Branch-Name
- Commit-Hash

Branch-Name
feat/levelup-v0-dump-empty-error-contract

Commit-Message
feat(levelup): define v0 dump-empty error contract
