### PR TITLE
feat(levelup): add v0 format cli

### DIFF
--- a/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
+++ b/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
@@ -41,7 +41,7 @@ Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANO
 | `src/levelup/__init__.py` | Öffentliche Re-Exports der v0-API. |
 | `src/levelup/v0_models.py` | Pydantic-Modelle, Schema-String `levelup&#47;manifest&#47;v0`. |
 | `src/levelup/v0_io.py` | JSON einlesen/ausgeben (Path). |
-| `src/levelup/cli.py` | CLI-Einstieg (`validate`, `dump-empty`). |
+| `src/levelup/cli.py` | CLI-Einstieg (`validate`, `dump-empty`, `format`). |
 | `tests/levelup/test_v0_manifest.py` | Roundtrip-, Validierungs- und Basis-CLI-Tests. |
 | `tests/levelup/test_v0_validate_cli.py` | Subprozess-Tests für `validate`-Exit-Codes und JSON-Fehlerobjekt. |
 
@@ -54,11 +54,13 @@ Alles Folgende bezieht sich auf den **Ist**-Stand der genannten Dateien:
 - **Slice-IDs:** `slice_id`-Werte müssen innerhalb eines Manifests **eindeutig** sein (`test_manifest_rejects_duplicate_slice_id` in `tests/levelup/test_v0_manifest.py`).
 - **Evidence-Pfade:** `EvidenceBundleRefV0.relative_dir` muss mit `out/ops/` beginnen; Traversal wird abgewiesen (Validator in `v0_models.py`); abgelehnte Beispiele und Roundtrip-Verhalten sind in `tests/levelup/test_v0_manifest.py` abgedeckt.
 - **IO:** `read_manifest` nutzt `model_validate_json` auf Dateiinhalt; `write_manifest` schreibt formatiertes JSON (inkl. Elternverzeichnis-Anlage).
-- **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>` und `dump-empty <manifest>` (`argparse`-`prog` in `cli.py`). **validate** schreibt **genau eine JSON-Zeile auf stdout** (stderr leer im erwarteten Fehlerpfad):
+- **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>`, `dump-empty <manifest>` und `format <manifest>` (`argparse`-`prog` in `cli.py`). **validate** schreibt **genau eine JSON-Zeile auf stdout** (stderr leer im erwarteten Fehlerpfad):
   - **Erfolg:** `ok: true`, plus `schema`, `slices` (Anzahl).
   - **Fehler:** `ok: false`, `error` (`input` | `validation`), `reason` (z. B. `json_parse_failed`, `manifest_read_failed`, `model_validation_failed`), knappe `message`; bei `validation` zusätzlich `issues` (gekürzte Pydantic-Fehlerliste).
   - **Exit-Codes:** `0` = Validierung ok; `2` = Usage/Eingabe (u. a. fehlende Datei, Lesefehler, ungültiges JSON, UTF-8-Dekodierung); `3` = JSON parsebar, Modell-/Schema-Validierung fehlgeschlagen.
   - **dump-empty:** schreibt ein leeres Manifest; **Erfolg:** eine JSON-Zeile auf stdout mit `ok: true`, `wrote` (Pfad), Exit `0`, stderr leer. **Fehler (Schreib-/Pfadproblem):** eine JSON-Zeile mit `ok: false`, `error: input`, `reason` (`target_path_is_directory` wenn der Zielpfad ein Verzeichnis ist, sonst bei `OSError` am Schreibpfad typischerweise `manifest_write_failed`), `message`; Exit `2`, stderr leer im erwarteten Operator-Pfad.
+  - **format:** liest ein bestehendes Manifest, validiert gegen `LevelUpManifestV0` und schreibt es kanonisch an denselben Pfad zurück. **Erfolg:** eine JSON-Zeile mit `ok: true`, `wrote`, `schema`, `slices`, Exit `0`, stderr leer. **Fehler:** Read-/Decode-/JSON-Inputfehler wie bei `validate` (`error: input`, Exit `2`), Modell-/Schemafehler wie bei `validate` (`error: validation`, `reason: model_validation_failed`, Exit `3`), sowie Schreibfehler (`error: input`, `reason: manifest_write_failed` oder `target_path_is_directory`, Exit `2`).
   - Subprozess-Checks: `test_cli_validate_and_dump_empty`, `test_cli_dump_empty_target_path_is_directory`, `test_cli_dump_empty_not_writable_target_file` in `tests/levelup/test_v0_manifest.py`, `test_v0_validate_cli.py` in `tests/levelup/`.
+  - Zusätzliche format-Checks: `test_cli_format_success_canonical_rewrite`, `test_cli_format_invalid_manifest_model_validation_failed`, `test_cli_format_not_writable_target_file` in `tests/levelup/test_v0_manifest.py`.
 
 **Non-claims:** Keine Aussage über Integration in Deployments, CI-Pflicht oder Freigabeprozesse — sofern nicht separat und repo-evidenced dokumentiert.

--- a/src/levelup/cli.py
+++ b/src/levelup/cli.py
@@ -1,5 +1,5 @@
 """
-Minimal CLI for Level-Up v0 manifests (validate / round-trip checks).
+Minimal CLI for Level-Up v0 manifests (validate / format / round-trip checks).
 
 Does not connect to exchanges or change execution posture.
 
@@ -11,6 +11,11 @@ validate exit contract (stdout is one JSON object per invocation):
 dump-empty exit contract (stdout is one JSON object per invocation):
 - 0 — empty manifest written
 - 2 — usage / path / write problem (e.g. target is a directory, mkdir/write permission)
+
+format exit contract (stdout is one JSON object per invocation):
+- 0 — manifest validated and canonically rewritten
+- 2 — usage / input problem (unreadable path, invalid JSON, UTF-8 decode) or write problem
+- 3 — JSON ok but model / schema validation failed
 """
 
 from __future__ import annotations
@@ -35,7 +40,7 @@ def _emit_json(payload: object) -> None:
     print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
 
 
-def _cmd_validate(path: Path) -> int:
+def _read_manifest_with_contract(path: Path) -> tuple[LevelUpManifestV0 | None, int | None]:
     try:
         m = read_manifest(path)
     except OSError as exc:
@@ -47,7 +52,7 @@ def _cmd_validate(path: Path) -> int:
                 "message": str(exc),
             }
         )
-        return EXIT_INPUT
+        return None, EXIT_INPUT
     except UnicodeDecodeError as exc:
         _emit_json(
             {
@@ -57,7 +62,7 @@ def _cmd_validate(path: Path) -> int:
                 "message": str(exc),
             }
         )
-        return EXIT_INPUT
+        return None, EXIT_INPUT
     except JSONDecodeError as exc:
         _emit_json(
             {
@@ -67,7 +72,7 @@ def _cmd_validate(path: Path) -> int:
                 "message": str(exc),
             }
         )
-        return EXIT_INPUT
+        return None, EXIT_INPUT
     except ValidationError as exc:
         issues = exc.errors()
         if issues and issues[0].get("type") == "json_invalid":
@@ -80,7 +85,7 @@ def _cmd_validate(path: Path) -> int:
                     "message": msg,
                 }
             )
-            return EXIT_INPUT
+            return None, EXIT_INPUT
         issues = issues[:8]
         _emit_json(
             {
@@ -91,8 +96,17 @@ def _cmd_validate(path: Path) -> int:
                 "issues": issues,
             }
         )
-        return EXIT_VALIDATION_FAILED
+        return None, EXIT_VALIDATION_FAILED
 
+    return m, None
+
+
+def _cmd_validate(path: Path) -> int:
+    m, error_exit = _read_manifest_with_contract(path)
+    if error_exit is not None:
+        return error_exit
+
+    assert m is not None
     _emit_json({"ok": True, "schema": m.schema_version, "slices": len(m.slices)})
     return EXIT_VALIDATION_OK
 
@@ -126,6 +140,41 @@ def _cmd_dump_empty(path: Path) -> int:
     return EXIT_VALIDATION_OK
 
 
+def _cmd_format(path: Path) -> int:
+    m, error_exit = _read_manifest_with_contract(path)
+    if error_exit is not None:
+        return error_exit
+
+    assert m is not None
+    try:
+        write_manifest(path, m)
+    except IsADirectoryError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "target_path_is_directory",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
+    except OSError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "manifest_write_failed",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
+
+    _emit_json(
+        {"ok": True, "wrote": str(path), "schema": m.schema_version, "slices": len(m.slices)}
+    )
+    return EXIT_VALIDATION_OK
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="python -m src.levelup.cli")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -139,11 +188,19 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_dump.add_argument("manifest", type=Path, help="Output path")
 
+    p_format = sub.add_parser(
+        "format",
+        help="Validate and canonically rewrite an existing v0 manifest in place.",
+    )
+    p_format.add_argument("manifest", type=Path, help="Path to existing manifest.json")
+
     args = parser.parse_args(argv)
     if args.cmd == "validate":
         return _cmd_validate(args.manifest)
     if args.cmd == "dump-empty":
         return _cmd_dump_empty(args.manifest)
+    if args.cmd == "format":
+        return _cmd_format(args.manifest)
     return EXIT_INPUT
 
 

--- a/tests/levelup/test_v0_manifest.py
+++ b/tests/levelup/test_v0_manifest.py
@@ -177,3 +177,51 @@ def test_cli_validate_empty_file_json_parse_failed(tmp_path: Path) -> None:
     assert payload["ok"] is False
     assert payload["error"] == "input"
     assert payload["reason"] == "json_parse_failed"
+
+
+def test_cli_format_success_canonical_rewrite(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        '{"title":"  Trimmed title  ","schema_version":"levelup/manifest/v0","slices":[]}',
+        encoding="utf-8",
+    )
+    r = _run_levelup_cli(["format", str(manifest)])
+    assert r.returncode == 0, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is True
+    assert payload["wrote"] == str(manifest)
+    assert payload["schema"] == "levelup/manifest/v0"
+    assert payload["slices"] == 0
+
+    expected = LevelUpManifestV0(title="  Trimmed title  ").model_dump_json(indent=2) + "\n"
+    assert manifest.read_text(encoding="utf-8") == expected
+
+
+def test_cli_format_invalid_manifest_model_validation_failed(tmp_path: Path) -> None:
+    bad = tmp_path / "bad_manifest.json"
+    bad.write_text('{"schema_version":"not-a-valid-manifest-schema"}', encoding="utf-8")
+    r = _run_levelup_cli(["format", str(bad)])
+    assert r.returncode == 3, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "validation"
+    assert payload["reason"] == "model_validation_failed"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod write-deny semantics differ on Windows")
+def test_cli_format_not_writable_target_file(tmp_path: Path) -> None:
+    manifest = tmp_path / "locked.json"
+    write_manifest(manifest, LevelUpManifestV0())
+    manifest.chmod(0o444)
+    try:
+        r = _run_levelup_cli(["format", str(manifest)])
+    finally:
+        manifest.chmod(0o644)
+    assert r.returncode == 2, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "manifest_write_failed"


### PR DESCRIPTION
Ziel
Setze exakt einen kleinen, additiven Delta-Slice um: neuer operator-facing CLI-Unterbefehl für kanonisches Re-Write/Format von LevelUp-v0-Manifests.

Ausgangspunkt
Bereits vorhanden:
- src/levelup/__init__.py
- src/levelup/cli.py
- src/levelup/v0_io.py
- src/levelup/v0_models.py
- tests/levelup/test_v0_manifest.py
- docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md

Read-only Empfehlung
Nächste größere additive Slice:
- neuer CLI-Unterbefehl für kanonisches Re-Write/Format
- auf Basis vorhandener read_manifest/write_manifest-Logik
- konsistenter JSON-/Exit-Kontrakt analog zu validate/dump-empty
- gezielte Subprozess-Tests
- kleines verifiziertes Docs-Update

Verbindlicher PR-Fokus
Nur ein Thema:
- format-Subcommand für LevelUp v0

In scope
1. src/levelup/cli.py
   - neuen Unterbefehl format ergänzen
   - Eingabe: vorhandenes Manifest lesen
   - Ausgabe: kanonisch neu schreiben
   - Fehler-/Exit-Kontrakt konsistent zu bestehenden CLI-Pfaden
2. src/levelup/v0_io.py
   - nur minimal ändern, falls nötig, um das kanonische Re-Write stabil zu unterstützen
   - keine breite IO-Refaktorierung
3. tests/levelup/test_v0_manifest.py
   - gezielte Subprozess-Tests für format
   - bevorzugt:
     - success path
     - invalid manifest -> definierter Fehlerpfad
     - Zielpfad-/Schreibfehler nur falls für format relevant
     - Nachweis des kanonischen Rewrite-Verhaltens in enger Form
4. docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
   - kleines verifiziertes Update:
     - format-Subcommand
     - success/error-Verhalten
     - Exit-Code-Verhalten in enger Form
   - keine neue Autorität, keine Runtime-Überdehnung

Explizite Nicht-Ziele
- keine neue Manifest-Semantik
- keine breite CLI-Erweiterung über format hinaus
- keine v1/vnext-Struktur
- keine allgemeine IO-Härtung außerhalb des für format nötigen Pfads
- keine Parallel-CLI

Delta-Anforderung
Am Ende muss ein echter Delta-Diff bestehen:
- mindestens 1 Code-Diff in cli.py und/oder v0_io.py
- mindestens 1 neuer format-bezogener Test
- kleines Docs-Delta in LEVELUP_V0_CANONICAL_SURFACE.md

Bevorzugte Richtung
- reuse over invention
- Format-Pfad soll vorhandene read-/write-Bausteine wiederverwenden
- Fehlerpfade knapp, strukturiert, testbar
- keine unkontrollierten Tracebacks im erwarteten Operator-Fehlerpfad

Arbeitsmodus
1. zuerst read-only prüfen:
   - aktuellen CLI-Stand
   - vorhandene read_manifest/write_manifest-Bausteine
   - bestehende Tests
   - aktuelle Doku
2. dann minimalen Delta-Diff erzeugen
3. danach Checks:
   - uv run pytest tests/levelup -q
   - uv run ruff check src/levelup tests/levelup
   - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
   - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Akzeptanzkriterien
1. PR bleibt ein Thema
2. format-Subcommand ist operator-facing klar und testbar
3. JSON-/Exit-Kontrakt ist konsistent zu den bestehenden CLI-Pfaden
4. Tests decken success + relevante failure paths ab
5. Docs-Update bleibt klein und verifiziert
6. Echter Delta-Diff vorhanden
7. Alle vier Checks grün

Abschlussnotiz
- Executive Summary
- exakt geänderte Dateien
- finaler format-Kontrakt
- Exit-Codes
- Testabdeckung
- Check-Resultate
- Branch-Name
- Commit-Hash

Branch-Name
feat/levelup-v0-format-cli

Commit-Message
feat(levelup): add v0 format cli
EOF && test -f /tmp/CURSOR_MULTI_AGENT_BRIEF_LEVELUP_V0_FORMAT_CLI.md && wc -l /tmp/CURSOR_MULTI_AGENT_BRIEF_LEVELUP_V0_FORMAT_CLI.md