### PR TITLE
feat(levelup): add v0 canonical check cli

### DIFF
--- a/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
+++ b/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
@@ -41,7 +41,7 @@ Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANO
 | `src/levelup/__init__.py` | Öffentliche Re-Exports der v0-API. |
 | `src/levelup/v0_models.py` | Pydantic-Modelle, Schema-String `levelup&#47;manifest&#47;v0`. |
 | `src/levelup/v0_io.py` | JSON einlesen/ausgeben (Path). |
-| `src/levelup/cli.py` | CLI-Einstieg (`validate`, `dump-empty`, `format`). |
+| `src/levelup/cli.py` | CLI-Einstieg (`validate`, `dump-empty`, `format`, `canonical-check`). |
 | `tests/levelup/test_v0_manifest.py` | Roundtrip-, Validierungs- und Basis-CLI-Tests. |
 | `tests/levelup/test_v0_validate_cli.py` | Subprozess-Tests für `validate`-Exit-Codes und JSON-Fehlerobjekt. |
 
@@ -54,13 +54,15 @@ Alles Folgende bezieht sich auf den **Ist**-Stand der genannten Dateien:
 - **Slice-IDs:** `slice_id`-Werte müssen innerhalb eines Manifests **eindeutig** sein (`test_manifest_rejects_duplicate_slice_id` in `tests/levelup/test_v0_manifest.py`).
 - **Evidence-Pfade:** `EvidenceBundleRefV0.relative_dir` muss mit `out/ops/` beginnen; Traversal wird abgewiesen (Validator in `v0_models.py`); abgelehnte Beispiele und Roundtrip-Verhalten sind in `tests/levelup/test_v0_manifest.py` abgedeckt.
 - **IO:** `read_manifest` nutzt `model_validate_json` auf Dateiinhalt; `write_manifest` schreibt formatiertes JSON (inkl. Elternverzeichnis-Anlage).
-- **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>`, `dump-empty <manifest>` und `format <manifest>` (`argparse`-`prog` in `cli.py`). **validate** schreibt **genau eine JSON-Zeile auf stdout** (stderr leer im erwarteten Fehlerpfad):
+- **CLI (read-only Doku):** Einstieg `python -m src.levelup.cli` mit Unterbefehlen `validate <manifest>`, `dump-empty <manifest>`, `format <manifest>` und `canonical-check <manifest>` (`argparse`-`prog` in `cli.py`). **validate** schreibt **genau eine JSON-Zeile auf stdout** (stderr leer im erwarteten Fehlerpfad):
   - **Erfolg:** `ok: true`, plus `schema`, `slices` (Anzahl).
   - **Fehler:** `ok: false`, `error` (`input` | `validation`), `reason` (z. B. `json_parse_failed`, `manifest_read_failed`, `model_validation_failed`), knappe `message`; bei `validation` zusätzlich `issues` (gekürzte Pydantic-Fehlerliste).
   - **Exit-Codes:** `0` = Validierung ok; `2` = Usage/Eingabe (u. a. fehlende Datei, Lesefehler, ungültiges JSON, UTF-8-Dekodierung); `3` = JSON parsebar, Modell-/Schema-Validierung fehlgeschlagen.
   - **dump-empty:** schreibt ein leeres Manifest; **Erfolg:** eine JSON-Zeile auf stdout mit `ok: true`, `wrote` (Pfad), Exit `0`, stderr leer. **Fehler (Schreib-/Pfadproblem):** eine JSON-Zeile mit `ok: false`, `error: input`, `reason` (`target_path_is_directory` wenn der Zielpfad ein Verzeichnis ist, sonst bei `OSError` am Schreibpfad typischerweise `manifest_write_failed`), `message`; Exit `2`, stderr leer im erwarteten Operator-Pfad.
   - **format:** liest ein bestehendes Manifest, validiert gegen `LevelUpManifestV0` und schreibt es kanonisch an denselben Pfad zurück. **Erfolg:** eine JSON-Zeile mit `ok: true`, `wrote`, `schema`, `slices`, Exit `0`, stderr leer. **Fehler:** Read-/Decode-/JSON-Inputfehler wie bei `validate` (`error: input`, Exit `2`), Modell-/Schemafehler wie bei `validate` (`error: validation`, `reason: model_validation_failed`, Exit `3`), sowie Schreibfehler (`error: input`, `reason: manifest_write_failed` oder `target_path_is_directory`, Exit `2`).
+  - **canonical-check (read-only):** liest und validiert ein bestehendes Manifest, vergleicht den aktuellen Dateiinhalt gegen die kanonische Serialisierung (gleiche Normalisierung wie `write_manifest`/`format`), schreibt **nichts** zurück. **Erfolg:** eine JSON-Zeile mit `ok: true`, `canonical: true`, `schema`, `slices`, Exit `0`, stderr leer. **Fehler:** Input-/Read-/Decode-/JSON-Pfade wie bei `validate` (Exit `2`); Modell-/Schemafehler wie bei `validate` (Exit `3`); valide aber nicht-kanonische Datei: `ok: false`, `error: validation`, `reason: manifest_not_canonical`, `canonical: false`, Exit `3`.
   - Subprozess-Checks: `test_cli_validate_and_dump_empty`, `test_cli_dump_empty_target_path_is_directory`, `test_cli_dump_empty_not_writable_target_file` in `tests/levelup/test_v0_manifest.py`, `test_v0_validate_cli.py` in `tests/levelup/`.
   - Zusätzliche format-Checks: `test_cli_format_success_canonical_rewrite`, `test_cli_format_invalid_manifest_model_validation_failed`, `test_cli_format_not_writable_target_file` in `tests/levelup/test_v0_manifest.py`.
+  - Zusätzliche canonical-check-Checks: `test_cli_canonical_check_already_canonical`, `test_cli_canonical_check_valid_but_not_canonical`, `test_cli_canonical_check_invalid_manifest_model_validation_failed`, `test_cli_canonical_check_empty_file_json_parse_failed` in `tests/levelup/test_v0_manifest.py`.
 
 **Non-claims:** Keine Aussage über Integration in Deployments, CI-Pflicht oder Freigabeprozesse — sofern nicht separat und repo-evidenced dokumentiert.

--- a/src/levelup/cli.py
+++ b/src/levelup/cli.py
@@ -16,6 +16,11 @@ format exit contract (stdout is one JSON object per invocation):
 - 0 — manifest validated and canonically rewritten
 - 2 — usage / input problem (unreadable path, invalid JSON, UTF-8 decode) or write problem
 - 3 — JSON ok but model / schema validation failed
+
+canonical-check exit contract (stdout is one JSON object per invocation):
+- 0 — manifest validated and already canonical
+- 2 — usage / input problem (unreadable path, invalid JSON, UTF-8 decode)
+- 3 — model / schema validation failed, or manifest is valid but not canonical
 """
 
 from __future__ import annotations
@@ -28,7 +33,7 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from src.levelup.v0_io import read_manifest, write_manifest
+from src.levelup.v0_io import canonical_manifest_json, read_manifest, write_manifest
 from src.levelup.v0_models import LevelUpManifestV0
 
 EXIT_VALIDATION_OK = 0
@@ -175,6 +180,54 @@ def _cmd_format(path: Path) -> int:
     return EXIT_VALIDATION_OK
 
 
+def _cmd_canonical_check(path: Path) -> int:
+    m, error_exit = _read_manifest_with_contract(path)
+    if error_exit is not None:
+        return error_exit
+
+    assert m is not None
+    try:
+        current = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "manifest_read_failed",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
+    except UnicodeDecodeError as exc:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "input",
+                "reason": "utf8_decode_failed",
+                "message": str(exc),
+            }
+        )
+        return EXIT_INPUT
+
+    expected = canonical_manifest_json(m)
+    if current != expected:
+        _emit_json(
+            {
+                "ok": False,
+                "error": "validation",
+                "reason": "manifest_not_canonical",
+                "message": "manifest is valid but not in canonical serialized form",
+                "canonical": False,
+                "schema": m.schema_version,
+                "slices": len(m.slices),
+            }
+        )
+        return EXIT_VALIDATION_FAILED
+
+    _emit_json({"ok": True, "canonical": True, "schema": m.schema_version, "slices": len(m.slices)})
+    return EXIT_VALIDATION_OK
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="python -m src.levelup.cli")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -194,6 +247,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_format.add_argument("manifest", type=Path, help="Path to existing manifest.json")
 
+    p_check = sub.add_parser(
+        "canonical-check",
+        help="Validate a v0 manifest and check if it is already canonical (read-only).",
+    )
+    p_check.add_argument("manifest", type=Path, help="Path to existing manifest.json")
+
     args = parser.parse_args(argv)
     if args.cmd == "validate":
         return _cmd_validate(args.manifest)
@@ -201,6 +260,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_dump_empty(args.manifest)
     if args.cmd == "format":
         return _cmd_format(args.manifest)
+    if args.cmd == "canonical-check":
+        return _cmd_canonical_check(args.manifest)
     return EXIT_INPUT
 
 

--- a/src/levelup/v0_io.py
+++ b/src/levelup/v0_io.py
@@ -12,6 +12,10 @@ def read_manifest(path: Path) -> LevelUpManifestV0:
     return LevelUpManifestV0.model_validate_json(raw)
 
 
+def canonical_manifest_json(manifest: LevelUpManifestV0) -> str:
+    return manifest.model_dump_json(indent=2) + "\n"
+
+
 def write_manifest(path: Path, manifest: LevelUpManifestV0) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(manifest.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    path.write_text(canonical_manifest_json(manifest), encoding="utf-8")

--- a/tests/levelup/test_v0_manifest.py
+++ b/tests/levelup/test_v0_manifest.py
@@ -225,3 +225,59 @@ def test_cli_format_not_writable_target_file(tmp_path: Path) -> None:
     assert payload["ok"] is False
     assert payload["error"] == "input"
     assert payload["reason"] == "manifest_write_failed"
+
+
+def test_cli_canonical_check_already_canonical(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    write_manifest(manifest, LevelUpManifestV0())
+    r = _run_levelup_cli(["canonical-check", str(manifest)])
+    assert r.returncode == 0, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is True
+    assert payload["canonical"] is True
+    assert payload["schema"] == "levelup/manifest/v0"
+    assert payload["slices"] == 0
+
+
+def test_cli_canonical_check_valid_but_not_canonical(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        '{"title":"  Trim me  ","schema_version":"levelup/manifest/v0","slices":[]}',
+        encoding="utf-8",
+    )
+    r = _run_levelup_cli(["canonical-check", str(manifest)])
+    assert r.returncode == 3, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "validation"
+    assert payload["reason"] == "manifest_not_canonical"
+    assert payload["canonical"] is False
+    assert payload["schema"] == "levelup/manifest/v0"
+    assert payload["slices"] == 0
+
+
+def test_cli_canonical_check_invalid_manifest_model_validation_failed(tmp_path: Path) -> None:
+    bad = tmp_path / "bad_manifest.json"
+    bad.write_text('{"schema_version":"not-a-valid-manifest-schema"}', encoding="utf-8")
+    r = _run_levelup_cli(["canonical-check", str(bad)])
+    assert r.returncode == 3, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "validation"
+    assert payload["reason"] == "model_validation_failed"
+
+
+def test_cli_canonical_check_empty_file_json_parse_failed(tmp_path: Path) -> None:
+    """Leere Datei ist kein gültiges JSON → Exit 2, json_parse_failed (wie validate)."""
+    empty = tmp_path / "empty.json"
+    empty.write_text("", encoding="utf-8")
+    r = _run_levelup_cli(["canonical-check", str(empty)])
+    assert r.returncode == 2, r.stderr
+    assert r.stderr.strip() == ""
+    payload = json.loads(r.stdout.strip())
+    assert payload["ok"] is False
+    assert payload["error"] == "input"
+    assert payload["reason"] == "json_parse_failed"


### PR DESCRIPTION
Titel
LevelUp v0 — read-only canonical check CLI (nach format-CLI)

Ziel
Setze exakt einen kleinen, additiven Delta-Slice um: Operatoren können ohne Schreibzugriff feststellen, ob eine Manifest-Datei bereits bytegenau der kanonischen Serialisierung entspricht.

Ausgangspunkt
Bereits vorhanden:
- src/levelup/cli.py
- src/levelup/v0_io.py
- src/levelup/v0_models.py
- tests/levelup/test_v0_manifest.py
- docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md

Single Source of Truth
Für „kanonisch“ gilt exakt dieselbe Normalisierung wie im bestehenden Schreib-/Format-Pfad:
- gleiche Semantik wie write_manifest / format
- kanonischer String repo-konsistent
- Duplikation der Serialisierungsformel vermeiden

Verbindlicher PR-Fokus
Nur ein Thema:
- read-only canonical check CLI für LevelUp v0

Scope (In)
1. src/levelup/cli.py
   - neuen read-only Subparser ergänzen, z. B. canonical-check oder check-canonical
   - gemeinsame Logik mit bestehendem Manifest-Lade-/Vertrags-Pfad wiederverwenden
   - stdout: genau eine JSON-Zeile pro Lauf
   - stderr: im erwarteten Erfolgs-/Fehlerpfad leer, analog zu bestehenden Befehlen
2. src/levelup/v0_io.py
   - nur minimal ändern, falls nötig, um die kanonische String-Erzeugung zentral wiederzuverwenden
   - keine breite IO-Refaktorierung
3. tests/levelup/test_v0_manifest.py
   - Subprozess-Tests für:
     - kanonische Datei
     - valide aber absichtlich nicht-kanonische Datei
     - ungültiges Manifest analog validate
   - Exit-/JSON-Vertrag explizit prüfen
4. docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
   - im selben Diff knapp aktualisieren:
     - neuer read-only Befehl
     - Erfolg-/Fehlerverhalten
     - Exit-Code-Vertrag

Scope (Out)
- keine Änderung an Governance/Risk/Execution
- keine neuen Evidence-Pfad-Regeln
- keine stdin-Pipeline
- kein pyproject-Console-Entry
- keine Änderung an paper/shadow/evidence-Trees
- keine neue Authority
- keine Parallel-CLI

Kontrakt-Richtung
- an bestehenden Exit-Code-Vertrag 0/2/3 anbinden, wenn sauber passend
- falls „valide aber nicht kanonisch“ einen eigenen Exit-Code braucht:
  - nur mit expliziter Spezifikation in Doku und Tests
  - kein stiller Semantik-Sprung
- JSON-Ausgabe muss knapp, stabil und testbar sein

Bevorzugte Richtung
- zuerst write_manifest und bestehende Format-Tests als Source of Truth lesen
- Serialisierungslogik nicht kopieren, wenn kleine gemeinsame Hilfsfunktion möglich ist
- read-only bleiben: keine Dateiänderung im Erfolgsfall

Delta-Anforderung
Am Ende muss ein echter Delta-Diff bestehen:
- mindestens 1 Code-Diff in cli.py und/oder v0_io.py
- mindestens 1 neuer canonical-check-Test
- kleines Docs-Delta in LEVELUP_V0_CANONICAL_SURFACE.md

Arbeitsmodus
1. zuerst read-only prüfen:
   - write_manifest / format-Pfad
   - bestehende CLI-Kontrakte
   - bestehende Format-Tests
2. dann minimalen Delta-Diff erzeugen
3. danach Checks:
   - uv run pytest tests/levelup -q
   - uv run ruff check src/levelup tests/levelup
   - uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
   - bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Akzeptanzkriterien
1. PR bleibt ein Thema
2. Neuer Befehl ist read-only
3. JSON-/Exit-Vertrag ist stabil und testbar
4. Tests decken kanonisch / nicht-kanonisch / ungültig ab
5. Docs und Code beschreiben dasselbe Verhalten
6. Echter Delta-Diff vorhanden
7. Alle vier Checks grün

Abschlussnotiz
- Executive Summary
- exakt geänderte Dateien
- finaler canonical-check-Kontrakt
- Exit-Codes
- Testabdeckung
- Check-Resultate
- Branch-Name
- Commit-Hash

Branch-Name
feat/levelup-v0-canonical-check-cli

Commit-Message
feat(levelup): add v0 canonical check cli
EOF && git checkout -b feat/levelup-v0-canonical-check-cli