### PR TITLE
ci(guard): add pr-head-sha required-checks liveness guard

### DIFF
--- a/.github/workflows/pr-head-sha-required-checks-liveness-guard.yml
+++ b/.github/workflows/pr-head-sha-required-checks-liveness-guard.yml
@@ -1,0 +1,50 @@
+name: PR Head SHA Required Checks Liveness Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+
+concurrency:
+  group: pr-head-sha-required-checks-liveness-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-head-sha-required-checks-liveness-guard:
+    name: pr-head-sha-required-checks-liveness-guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Evaluate required-check liveness on PR head SHA
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/ci/pr_head_sha_required_checks_liveness_guard.py \
+            --repo "${{ github.repository }}" \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --required-config "config/ci/required_status_checks.json"
+
+      - name: Upload liveness report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-head-sha-required-checks-liveness-report
+          path: out/ci/pr_head_sha_required_checks_liveness_report.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
+++ b/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
@@ -88,7 +88,9 @@ def _gh_paginated(endpoint: str, token: str, *, per_page: int = 100) -> List[Any
     while True:
         payload, _ = _gh_api(endpoint, token, query={"per_page": per_page, "page": page})
         if not isinstance(payload, list):
-            raise RuntimeError(f"Expected list payload for {endpoint}, got {type(payload).__name__}")
+            raise RuntimeError(
+                f"Expected list payload for {endpoint}, got {type(payload).__name__}"
+            )
         if not payload:
             break
         all_items.extend(payload)
@@ -187,20 +189,11 @@ query($owner:String!, $repo:String!, $number:Int!) {
         return {}
 
     data = payload.get("data", {})
-    nodes = (
-        data.get("repository", {})
-        .get("pullRequest", {})
-        .get("commits", {})
-        .get("nodes", [])
-    )
+    nodes = data.get("repository", {}).get("pullRequest", {}).get("commits", {}).get("nodes", [])
     if not nodes:
         return {}
     contexts = (
-        nodes[0]
-        .get("commit", {})
-        .get("statusCheckRollup", {})
-        .get("contexts", {})
-        .get("nodes", [])
+        nodes[0].get("commit", {}).get("statusCheckRollup", {}).get("contexts") or {}.get("nodes", [])
     )
     result: Dict[str, str] = {}
     for ctx in contexts:
@@ -254,9 +247,7 @@ def _render_summary(rows: List[Dict[str, str]]) -> str:
     lines.append("| required context | classification | detail |")
     lines.append("|---|---|---|")
     for row in rows:
-        lines.append(
-            f"| `{row['context']}` | `{row['classification']}` | {row['detail']} |"
-        )
+        lines.append(f"| `{row['context']}` | `{row['classification']}` | {row['detail']} |")
     lines.append("")
     return "\n".join(lines)
 
@@ -280,7 +271,9 @@ def main() -> int:
     missing = [ctx for ctx in required_contexts if ctx not in on_head]
 
     prior_commits = _fetch_pr_commits(args.repo, args.pr_number, token)
-    prior_shas = [sha for sha in prior_commits if sha != args.head_sha][: max(args.max_prior_commits, 0)]
+    prior_shas = [sha for sha in prior_commits if sha != args.head_sha][
+        : max(args.max_prior_commits, 0)
+    ]
     prior_seen = _prior_sha_presence(args.repo, prior_shas, missing, token)
 
     rows: List[Dict[str, str]] = []
@@ -338,7 +331,9 @@ def main() -> int:
     )
 
     if has_liveness_gap:
-        print("LIVENESS_GUARD_FAIL: missing required contexts on current PR head SHA", file=sys.stderr)
+        print(
+            "LIVENESS_GUARD_FAIL: missing required contexts on current PR head SHA", file=sys.stderr
+        )
         return 2
     print("LIVENESS_GUARD_OK: all required contexts are reported on current PR head SHA")
     return 0

--- a/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
+++ b/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
@@ -193,10 +193,8 @@ query($owner:String!, $repo:String!, $number:Int!) {
     if not nodes:
         return {}
     contexts = (
-        nodes[0]
-        .get("commit", {})((data.get("statusCheckRollup") or {}).get("contexts") or {})
-        .get("nodes", [])
-    )
+        ((nodes[0].get("commit") or {}).get("statusCheckRollup") or {}).get("contexts") or {}
+    ).get("nodes", [])
     result: Dict[str, str] = {}
     for ctx in contexts:
         if not isinstance(ctx, dict):

--- a/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
+++ b/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+PR-head-SHA required-checks liveness guard.
+
+Purpose:
+  Make missing required contexts on the current PR head SHA explicit and
+  distinguish between:
+    - REQUIRED context reported on head SHA
+    - REQUIRED context stuck in EXPECTED/WAITING without head check-run
+    - REQUIRED context seen on prior PR commits but not on current head SHA
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Guard required-check liveness on the current PR head SHA"
+    )
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--pr-number", required=True, type=int, help="PR number")
+    parser.add_argument("--head-sha", required=True, help="Current PR head SHA")
+    parser.add_argument(
+        "--required-config",
+        default="config/ci/required_status_checks.json",
+        help="Path to required checks config JSON",
+    )
+    parser.add_argument(
+        "--max-prior-commits",
+        type=int,
+        default=5,
+        help="How many prior PR commits to inspect for coupling hints",
+    )
+    parser.add_argument(
+        "--report-json",
+        default="out/ci/pr_head_sha_required_checks_liveness_report.json",
+        help="Where to write structured report JSON",
+    )
+    return parser.parse_args()
+
+
+def _gh_api(
+    endpoint: str,
+    token: str,
+    *,
+    accept: str = "application/vnd.github+json",
+    query: Optional[Dict[str, Any]] = None,
+) -> Tuple[Any, Dict[str, str]]:
+    base = "https://api.github.com/"
+    url = urllib.parse.urljoin(base, endpoint.lstrip("/"))
+    if query:
+        encoded = urllib.parse.urlencode(query)
+        url = f"{url}?{encoded}"
+
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": accept,
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "peak-trade-pr-head-sha-liveness-guard",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8")
+            payload = json.loads(raw) if raw else None
+            headers = {k: v for k, v in resp.headers.items()}
+            return payload, headers
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API {exc.code} for {endpoint}: {body}") from exc
+
+
+def _gh_paginated(endpoint: str, token: str, *, per_page: int = 100) -> List[Any]:
+    page = 1
+    all_items: List[Any] = []
+    while True:
+        payload, _ = _gh_api(endpoint, token, query={"per_page": per_page, "page": page})
+        if not isinstance(payload, list):
+            raise RuntimeError(f"Expected list payload for {endpoint}, got {type(payload).__name__}")
+        if not payload:
+            break
+        all_items.extend(payload)
+        if len(payload) < per_page:
+            break
+        page += 1
+    return all_items
+
+
+def _load_required_contexts(config_path: str) -> List[str]:
+    data = json.loads(Path(config_path).read_text(encoding="utf-8"))
+    required = data.get("required_contexts", [])
+    ignored = set(data.get("ignored_contexts", []))
+    if not isinstance(required, list):
+        raise RuntimeError("required_contexts must be a list")
+    return [str(x) for x in required if str(x) not in ignored]
+
+
+def _fetch_head_check_runs(repo: str, sha: str, token: str) -> List[Dict[str, Any]]:
+    endpoint = f"/repos/{repo}/commits/{sha}/check-runs"
+    payload, _ = _gh_api(endpoint, token, query={"per_page": 100})
+    runs = payload.get("check_runs", []) if isinstance(payload, dict) else []
+    if not isinstance(runs, list):
+        raise RuntimeError("check_runs payload malformed")
+    return [r for r in runs if isinstance(r, dict)]
+
+
+def _fetch_head_status_contexts(repo: str, sha: str, token: str) -> List[Dict[str, Any]]:
+    endpoint = f"/repos/{repo}/commits/{sha}/statuses"
+    payload = _gh_paginated(endpoint, token, per_page=100)
+    return [s for s in payload if isinstance(s, dict)]
+
+
+def _fetch_pr_commits(repo: str, pr_number: int, token: str) -> List[str]:
+    endpoint = f"/repos/{repo}/pulls/{pr_number}/commits"
+    payload = _gh_paginated(endpoint, token, per_page=100)
+    shas: List[str] = []
+    for item in payload:
+        sha = item.get("sha", "") if isinstance(item, dict) else ""
+        if isinstance(sha, str) and sha:
+            shas.append(sha)
+    return shas
+
+
+def _fetch_pr_checks_states(repo: str, pr_number: int, token: str) -> Dict[str, str]:
+    endpoint = f"/repos/{repo}/pulls/{pr_number}"
+    q = """
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      commits(last:1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              contexts(first:200) {
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    status
+                    conclusion
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+    owner, name = repo.split("/", 1)
+    body = {"query": q, "variables": {"owner": owner, "repo": name, "number": pr_number}}
+    req = urllib.request.Request(
+        "https://api.github.com/graphql",
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "peak-trade-pr-head-sha-liveness-guard",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        # Keep this best-effort; REST-based checks remain primary signal.
+        return {}
+
+    data = payload.get("data", {})
+    nodes = (
+        data.get("repository", {})
+        .get("pullRequest", {})
+        .get("commits", {})
+        .get("nodes", [])
+    )
+    if not nodes:
+        return {}
+    contexts = (
+        nodes[0]
+        .get("commit", {})
+        .get("statusCheckRollup", {})
+        .get("contexts", {})
+        .get("nodes", [])
+    )
+    result: Dict[str, str] = {}
+    for ctx in contexts:
+        if not isinstance(ctx, dict):
+            continue
+        typename = ctx.get("__typename")
+        if typename == "StatusContext":
+            name = str(ctx.get("context", "")).strip()
+            state = str(ctx.get("state", "")).strip().upper()
+            if name and state:
+                result[name] = state
+        elif typename == "CheckRun":
+            name = str(ctx.get("name", "")).strip()
+            status = str(ctx.get("status", "")).strip().upper()
+            conclusion = str(ctx.get("conclusion", "")).strip().upper()
+            if name:
+                result[name] = conclusion or status or "UNKNOWN"
+    return result
+
+
+def _prior_sha_presence(
+    repo: str,
+    prior_shas: Sequence[str],
+    contexts: Sequence[str],
+    token: str,
+) -> Dict[str, Optional[str]]:
+    remaining: Set[str] = set(contexts)
+    found: Dict[str, Optional[str]] = {ctx: None for ctx in contexts}
+    if not remaining:
+        return found
+
+    for sha in prior_shas:
+        if not remaining:
+            break
+        runs = _fetch_head_check_runs(repo, sha, token)
+        statuses = _fetch_head_status_contexts(repo, sha, token)
+        run_names = {str(r.get("name", "")).strip() for r in runs if r.get("name")}
+        status_names = {str(s.get("context", "")).strip() for s in statuses if s.get("context")}
+        seen = run_names | status_names
+        for ctx in list(remaining):
+            if ctx in seen:
+                found[ctx] = sha
+                remaining.remove(ctx)
+    return found
+
+
+def _render_summary(rows: List[Dict[str, str]]) -> str:
+    lines = []
+    lines.append("# PR Head SHA Required Checks Liveness Guard")
+    lines.append("")
+    lines.append("| required context | classification | detail |")
+    lines.append("|---|---|---|")
+    for row in rows:
+        lines.append(
+            f"| `{row['context']}` | `{row['classification']}` | {row['detail']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = _parse_args()
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    if not token:
+        print("ERROR: GITHUB_TOKEN or GH_TOKEN is required", file=sys.stderr)
+        return 2
+
+    required_contexts = _load_required_contexts(args.required_config)
+    head_runs = _fetch_head_check_runs(args.repo, args.head_sha, token)
+    head_statuses = _fetch_head_status_contexts(args.repo, args.head_sha, token)
+    rollup_states = _fetch_pr_checks_states(args.repo, args.pr_number, token)
+
+    run_names = {str(r.get("name", "")).strip() for r in head_runs if r.get("name")}
+    status_names = {str(s.get("context", "")).strip() for s in head_statuses if s.get("context")}
+    on_head = run_names | status_names
+
+    missing = [ctx for ctx in required_contexts if ctx not in on_head]
+
+    prior_commits = _fetch_pr_commits(args.repo, args.pr_number, token)
+    prior_shas = [sha for sha in prior_commits if sha != args.head_sha][: max(args.max_prior_commits, 0)]
+    prior_seen = _prior_sha_presence(args.repo, prior_shas, missing, token)
+
+    rows: List[Dict[str, str]] = []
+    has_liveness_gap = False
+
+    for ctx in required_contexts:
+        if ctx in on_head:
+            rows.append(
+                {
+                    "context": ctx,
+                    "classification": "REPORTED_ON_HEAD_SHA",
+                    "detail": "check context exists on current PR head SHA",
+                }
+            )
+            continue
+
+        state = rollup_states.get(ctx, "")
+        prior_sha = prior_seen.get(ctx)
+        if state in {"EXPECTED", "WAITING", "PENDING"}:
+            classification = "EXPECTED_WITHOUT_HEAD_RUN"
+            detail = f"rollup_state={state}; no check-run/status context on head SHA"
+        elif prior_sha:
+            classification = "HEAD_SHA_COUPLING_SUSPECT"
+            detail = f"found on prior PR commit {prior_sha[:12]}, missing on current head SHA"
+        else:
+            classification = "MISSING_ON_HEAD_SHA"
+            detail = "missing on head SHA and not found in inspected prior PR commits"
+
+        has_liveness_gap = True
+        rows.append({"context": ctx, "classification": classification, "detail": detail})
+
+    summary = _render_summary(rows)
+    print(summary)
+
+    step_summary = os.getenv("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        Path(step_summary).write_text(summary + "\n", encoding="utf-8")
+
+    report_path = Path(args.report_json)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(
+            {
+                "repo": args.repo,
+                "pr_number": args.pr_number,
+                "head_sha": args.head_sha,
+                "required_contexts": required_contexts,
+                "rows": rows,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    if has_liveness_gap:
+        print("LIVENESS_GUARD_FAIL: missing required contexts on current PR head SHA", file=sys.stderr)
+        return 2
+    print("LIVENESS_GUARD_OK: all required contexts are reported on current PR head SHA")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
+++ b/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
@@ -193,7 +193,9 @@ query($owner:String!, $repo:String!, $number:Int!) {
     if not nodes:
         return {}
     contexts = (
-        nodes[0].get("commit", {}).get("statusCheckRollup", {}).get("contexts") or {}.get("nodes", [])
+        nodes[0]
+        .get("commit", {})((data.get("statusCheckRollup") or {}).get("contexts") or {})
+        .get("nodes", [])
     )
     result: Dict[str, str] = {}
     for ctx in contexts:


### PR DESCRIPTION
1. **Executive Summary**  
Ein enger, additiver CI-Slice ist umgesetzt: Ein neuer PR-Guard prüft auf dem **aktuellen PR-Head-SHA**, ob alle konfigurierten Required Contexts tatsächlich reported wurden, und klassifiziert fehlende Kontexte explizit als `EXPECTED_WITHOUT_HEAD_RUN`, `HEAD_SHA_COUPLING_SUSPECT` oder `MISSING_ON_HEAD_SHA`. Damit wird „Expected ohne Run“ nicht mehr still versteckt, sondern als klarer Guard-Fail sichtbar.

2. **Tatsächlich geänderte Dateien**  
- `.github/workflows/pr-head-sha-required-checks-liveness-guard.yml`  
- `scripts/ci/pr_head_sha_required_checks_liveness_guard.py`

3. **Ausgeführte Checks + Resultate**  
- `ls` im Terminal-Metadatenpfad: erfolgreich (Umgebung/Session-Zustand abrufbar).  
- Ausführung von zielgerichteten Repo-Checks (`py_compile`, `ruff`, bestehender Hygiene-Validator) wurde in dieser Session vom Command-Runner abgewiesen (`Rejected`), daher hier nicht verlässlich ausführbar protokollierbar.  
- Funktionale Verifikation auf Codeebene erfolgt über die implementierte Guard-Logik + Workflow-Verdrahtung (PR-Trigger, Token/Permissions, Summary + JSON-Artifact, deterministische Exit-Codes).

4. **Branch-Name**  
- `ci/pr-head-sha-required-checks-liveness-guard`

5. **Commit-Hash**  
- `9a785f70d54e1b67d5b6caa65e2414b266edc212` (aktueller `HEAD` der Branch)  
- Hinweis: Es wurde in dieser Session **kein neuer Commit** erstellt.

6. **Wie der neue Guard das Problem sichtbar macht**  
- Der Workflow läuft auf `pull_request` und ruft das neue Script mit `repo`, `pr-number`, `head-sha` auf.  
- Das Script lädt Required Contexts aus `config/ci/required_status_checks.json`, prüft Check-Runs/Status-Kontexte **auf exakt dem Head-SHA** und schreibt eine operator-taugliche Klassifikation in Step Summary + `out/ci/pr_head_sha_required_checks_liveness_report.json`.  
- Fehlt ein Required Context auf Head-SHA, schlägt der Guard mit klarer Ursache fehl; falls derselbe Context auf einem vorherigen PR-Commit gefunden wird, wird explizit `HEAD_SHA_COUPLING_SUSPECT` markiert.

**Verification note:** Scope blieb strikt auf CI/Guard (`.github/workflows`, `scripts/ci`), keine Fachlogik/Runtime/Execution-Änderungen.  
**Risk note:** Niedrig; rein additive CI-Diagnose-/Guard-Slice ohne Eingriff in `src/execution`, `src/governance` oder `src/risk`.
