### PR TITLE
ci: converge required check consumers on json ssot

### DIFF
--- a/.github/required_status_checks_main.txt
+++ b/.github/required_status_checks_main.txt
@@ -1,3 +1,6 @@
+# LEGACY MIRROR (non-canonical): required checks are sourced from
+# config/ci/required_status_checks.json by CI/Guard/Ops consumers.
+# This file is retained only for human reference.
 Guard tracked files in reports directories
 audit
 tests (3.11)

--- a/.github/workflows/pru-required-checks-drift-detector.yml
+++ b/.github/workflows/pru-required-checks-drift-detector.yml
@@ -2,7 +2,7 @@ name: PR-U / Required Checks Drift Detector
 on:
   pull_request:
     paths:
-      - ".github/required_status_checks_main.txt"
+      - "config/ci/required_status_checks.json"
       - ".github/workflows/**"
   schedule:
     - cron: "13 2 * * 1"

--- a/scripts/ci/required_checks_drift_detector.py
+++ b/scripts/ci/required_checks_drift_detector.py
@@ -7,7 +7,6 @@ import json
 import re
 import subprocess
 from pathlib import Path
-import sys
 
 import yaml
 
@@ -17,8 +16,14 @@ def _parse_args() -> argparse.Namespace:
         description="Detect drift between required status checks list and workflows producing them (best-effort)"
     )
     p.add_argument(
+        "--required-config",
+        default="config/ci/required_status_checks.json",
+        help="JSON required checks config path (default: config/ci/required_status_checks.json)",
+    )
+    p.add_argument(
         "--required-list",
-        default=".github/required_status_checks_main.txt",
+        default=None,
+        help="Legacy plain-text required checks list path (deprecated, overrides --required-config)",
     )
     p.add_argument(
         "--workflows-dir",
@@ -88,13 +93,24 @@ query($owner:String!,$repo:String!){
     return sorted(set(ctx))
 
 
+def _load_required_contexts(required_config: str, required_list: str | None) -> list[str]:
+    if required_list:
+        return [
+            l.strip()
+            for l in Path(required_list).read_text(encoding="utf-8").splitlines()
+            if l.strip() and not l.strip().startswith("#")
+        ]
+
+    data = json.loads(Path(required_config).read_text(encoding="utf-8"))
+    required = data.get("required_contexts", [])
+    if not isinstance(required, list):
+        raise RuntimeError("required_contexts must be a list")
+    return [str(ctx).strip() for ctx in required if str(ctx).strip()]
+
+
 def main() -> int:
     args = _parse_args()
-    req = [
-        l.strip()
-        for l in Path(args.required_list).read_text(encoding="utf-8").splitlines()
-        if l.strip() and not l.strip().startswith("#")
-    ]
+    req = _load_required_contexts(args.required_config, args.required_list)
     wf_paths = sorted(Path(args.workflows_dir).glob("*.yml")) + sorted(
         Path(args.workflows_dir).glob("*.yaml")
     )

--- a/scripts/ops/run_gh_inventory_ci_discovery.sh
+++ b/scripts/ops/run_gh_inventory_ci_discovery.sh
@@ -95,10 +95,10 @@ print(out)
 PY
 
 echo "5) Required checks list + drift detector (capture stdout/stderr to file)"
-test -f .github/required_status_checks_main.txt && cp .github/required_status_checks_main.txt "$OUT/required_status_checks_main.txt" || true
+test -f config/ci/required_status_checks.json && cp config/ci/required_status_checks.json "$OUT/required_status_checks.json" || true
 mkdir -p "$OUT/required_checks_drift"
 python3 scripts/ci/required_checks_drift_detector.py \
-  --required-list .github/required_status_checks_main.txt \
+  --required-config config/ci/required_status_checks.json \
   --workflows-dir .github/workflows \
   2>&1 | tee "$OUT/required_checks_drift/drift_output.txt" || true
 

--- a/tests/ci/test_pru_required_checks_drift_detector.py
+++ b/tests/ci/test_pru_required_checks_drift_detector.py
@@ -8,8 +8,8 @@ import sys
 
 
 def test_detector_ok(tmp_path: Path) -> None:
-    req = tmp_path / "req.txt"
-    req.write_text("X\n", encoding="utf-8")
+    req = tmp_path / "required_status_checks.json"
+    req.write_text('{"required_contexts": ["X"]}\n', encoding="utf-8")
     wfd = tmp_path / "wfs"
     wfd.mkdir()
     (wfd / "a.yml").write_text(
@@ -20,7 +20,7 @@ def test_detector_ok(tmp_path: Path) -> None:
         [
             sys.executable,
             "scripts/ci/required_checks_drift_detector.py",
-            "--required-list",
+            "--required-config",
             str(req),
             "--workflows-dir",
             str(wfd),
@@ -33,8 +33,8 @@ def test_detector_ok(tmp_path: Path) -> None:
 
 
 def test_detector_missing(tmp_path: Path) -> None:
-    req = tmp_path / "req.txt"
-    req.write_text("Y\n", encoding="utf-8")
+    req = tmp_path / "required_status_checks.json"
+    req.write_text('{"required_contexts": ["Y"]}\n', encoding="utf-8")
     wfd = tmp_path / "wfs"
     wfd.mkdir()
     (wfd / "a.yml").write_text(
@@ -45,7 +45,7 @@ def test_detector_missing(tmp_path: Path) -> None:
         [
             sys.executable,
             "scripts/ci/required_checks_drift_detector.py",
-            "--required-list",
+            "--required-config",
             str(req),
             "--workflows-dir",
             str(wfd),


### PR DESCRIPTION
Die JSON-first-Konvergenz ist umgesetzt und die Legacy-TXT wird jetzt nicht mehr von den relevanten Consumern verwendet; ich stelle dir jetzt das operator-taugliche Lieferformat mit allen Punkten aus dem Brief zusammen.1. **Executive Summary**  
Die Required-Checks-Consumer im CI-/Guard-/Ops-Scope wurden auf JSON-SSoT konvergiert: `scripts/ci/required_checks_drift_detector.py` lädt jetzt standardmäßig `config/ci/required_status_checks.json`, der PR-U-Workflow triggert auf JSON-Änderungen statt auf die TXT-Liste, und der Ops-Inventory-Runner nutzt denselben JSON-Input. Die alte TXT-Datei ist nicht mehr Consumer-Input und wurde als expliziter Legacy-Mirror markiert.

2. **Tatsächlich geänderte Dateien**  
- `scripts/ci/required_checks_drift_detector.py`  
- `.github/workflows/pru-required-checks-drift-detector.yml`  
- `scripts/ops/run_gh_inventory_ci_discovery.sh`  
- `tests/ci/test_pru_required_checks_drift_detector.py`  
- `.github/required_status_checks_main.txt`

3. **Ausgeführte Checks + Resultate**  
- **Read-only Konsistenzcheck per Code-Scan:** Referenzen auf `.github/required_status_checks_main.txt` als Consumer-Input entfernt; verbleibt nur noch als Legacy-Datei ohne aktive Consumer-Nutzung.  
- **Strukturelle Verifikation (manuell am geänderten Inhalt):**  
  - Workflow-Trigger zeigt auf `config/ci/required_status_checks.json`.  
  - Drift-Detector nutzt JSON-default (`--required-config`) und unterstützt TXT nur noch als expliziten Legacy-Override (`--required-list`).  
  - Ops-Script übergibt jetzt `--required-config config/ci/required_status_checks.json`.  
  - Tests wurden auf JSON-Input angepasst.  
- **Hinweis:** Laufzeit-Checks (`ruff`/`pytest`/`py_compile`) konnte ich in dieser Session nicht zuverlässig ausführen, da entsprechende Shell-Kommandos hier nicht stabil ausführbar waren.

4. **Branch-Name**  
`ci/required-checks-ssot-convergence-json-first`

5. **Commit-Hash**  
`78fd8fc98759d1470518839cc01215ee56fbe023` (aktueller `HEAD`; kein neuer Commit durch mich erstellt)

6. **Kurz: Welche Consumer sind jetzt JSON-first?**  
- `scripts/ci/required_checks_drift_detector.py` (Default-Quelle jetzt `config/ci/required_status_checks.json`)  
- `.github/workflows/pru-required-checks-drift-detector.yml` (PR-Trigger auf JSON-SSoT)  
- `scripts/ops/run_gh_inventory_ci_discovery.sh` (Drift-Detector-Aufruf mit `--required-config config/ci/required_status_checks.json`)  

### Changed files
- `scripts/ci/required_checks_drift_detector.py`
- `.github/workflows/pru-required-checks-drift-detector.yml`
- `scripts/ops/run_gh_inventory_ci_discovery.sh`
- `tests/ci/test_pru_required_checks_drift_detector.py`
- `.github/required_status_checks_main.txt`

### Tests executed
- Read-only Referenzscan via `rg` auf Required-Checks-Consumer-Pfade
- Manuelle Strukturprüfung der geänderten JSON-/YAML-/Script-Pfade

### Verification note
- Keine LevelUp-Fachlogik, Runtime, Execution oder Exchange angefasst.
- Keine Branch-Protection-Einstellungen verändert.
- Slice bleibt eng auf Required-Checks-SSoT-Konvergenz.

### Risk note
- Niedrig: funktionale Änderung ist lokal auf Config-Quelle (JSON-first) begrenzt; Legacy-TXT bleibt nur als nicht-kanonischer Spiegel bestehen.
