### PR TITLE
ci: retire legacy required-checks narrative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   # ============================================================================
   # Change Detection (pragmatic flow)
   # ============================================================================
-  # Outputs: code_changed (legacy), run_matrix, run_fast_lane, docs_only, workflow_only.
+  # Outputs: code_changed (historical output name), run_matrix, run_fast_lane, docs_only, workflow_only.
   # - run_fast_lane: always true (Fast-Lane always runs).
   # - run_matrix: true when code paths changed (or workflow_dispatch force_matrix=true).
   # - run_fast: always true. run_fast_lane: alias.
@@ -369,11 +369,12 @@ jobs:
           retention-days: 30
 
   # ============================================================================
-  # PR Gate (single required check for branch protection)
+  # PR Gate (informational aggregate check)
   # ============================================================================
   # When run_matrix=false: Fast-Lane + (tests/strategy-smoke skip) → SUCCESS.
   # When run_matrix=true: Fast-Lane + tests (3.9/3.10/3.11) + strategy-smoke → SUCCESS.
-  # Branch protection: require only "PR Gate".
+  # Branch-protection required contexts are managed via
+  # config/ci/required_status_checks.json (required_contexts - ignored_contexts).
   # ============================================================================
   pr-gate:
     name: PR Gate

--- a/docs/ops/CI.md
+++ b/docs/ops/CI.md
@@ -4,9 +4,10 @@
 
 Peak_Trade uses GitHub Actions for continuous integration. The primary workflow is `.github/workflows/ci.yml`.
 
-**Branch Protection:** Die Config (`config&#47;ci&#47;required_status_checks.json`) ist an die GitHub Branch-Protection ausgerichtet (9 required contexts: Guard tracked files, audit, tests (3.11), strategy-smoke, Policy Critic Gate, Lint Gate, dispatch-guard, docs-token-policy-gate, docs-reference-targets-gate). PR Gate wird von CI produziert, ist aber nicht in der Branch-Protection.
+**Required Checks SSOT:** Die kanonische Quelle ist `config/ci/required_status_checks.json`.  
+Blocking-Semantik: `effective_required_contexts = required_contexts - ignored_contexts`.
 
-Hinweis: `config&#47;ci&#47;required_status_checks.json` beschreibt den Repo-Vertrag (required_contexts&#47;ignored_contexts). Die tatsächlichen GitHub Branch-Protection-Einstellungen werden separat verwaltet und können abweichen. Aktueller Stand: `gh api repos/<owner>/<repo>/branches/main/protection`.
+Hinweis: GitHub Branch-Protection wird separat verwaltet; Live-Settings sind ein Abgleichssignal und nicht die zweite Semantikquelle. Aktueller Stand: `gh api repos/<owner>/<repo>/branches/main/protection`.
 
 ## CI: RL v0.1 Fast Lane (Smoke)
 

--- a/tests/ci/test_required_checks_narrative_retirement.py
+++ b/tests/ci/test_required_checks_narrative_retirement.py
@@ -1,0 +1,18 @@
+"""Invariants for required-checks SSOT narrative surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_ci_workflow_does_not_claim_pr_gate_only_branch_protection() -> None:
+    workflow_text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert 'Branch protection: require only "PR Gate".' not in workflow_text
+    assert "single required check for branch protection" not in workflow_text
+    assert "required_contexts - ignored_contexts" in workflow_text
+
+
+def test_ops_ci_doc_states_json_ssot_effective_required_contexts() -> None:
+    doc_text = Path("docs/ops/CI.md").read_text(encoding="utf-8")
+    assert "Required Checks SSOT" in doc_text
+    assert "effective_required_contexts = required_contexts - ignored_contexts" in doc_text


### PR DESCRIPTION
## Summary
- retire remaining legacy required-checks narrative in canonical ops surfaces
- align docs and ops helper surfaces to the JSON SSOT model
- add invariants to keep the legacy narrative from reappearing

## Validation
- uv run pytest tests/ci -q
- uv run ruff check scripts/ci tests/ci
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
