### PR TITLE
ci: quarantine remaining legacy required-checks narrative

### DIFF
--- a/.github/workflows/pr-head-sha-required-checks-liveness-guard.yml
+++ b/.github/workflows/pr-head-sha-required-checks-liveness-guard.yml
@@ -38,6 +38,8 @@ jobs:
             --repo "${{ github.repository }}" \
             --pr-number "${{ github.event.pull_request.number }}" \
             --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --liveness-wait-seconds 90 \
+            --poll-interval-seconds 5 \
             --required-config "config/ci/required_status_checks.json"
 
       - name: Upload liveness report

--- a/docs/ops/ci/trigger_runbook.md
+++ b/docs/ops/ci/trigger_runbook.md
@@ -39,7 +39,7 @@ Falls Checks dauerhaft fehlen oder Branch Protection inkonsistent wirkt:
 
 2. **Dokumentation**
    - [docs/ops/BRANCH_PROTECTION_REQUIRED_CHECKS.md](../BRANCH_PROTECTION_REQUIRED_CHECKS.md)
-   - [config/ci/required_status_checks.json](../../../config/ci/required_status_checks.json) (Pragmatic Flow: nur "PR Gate" als required)
+   - [config/ci/required_status_checks.json](../../../config/ci/required_status_checks.json) (JSON-SSOT: effective required contexts = required_contexts - ignored_contexts)
 
 3. **Drift Guard (falls vorhanden)**
    ```bash

--- a/docs/ops/ci_pragmatic_flow_inventory.md
+++ b/docs/ops/ci_pragmatic_flow_inventory.md
@@ -7,23 +7,23 @@
 
 **Canonical reference:** [GATES_OVERVIEW.md](GATES_OVERVIEW.md) ist SSoT für Gates. Dieses Doc beschreibt pragmatische Flow-Details.
 
-**Stand:** 2026-02-07. Branch Protection: nur **PR Gate** als required check (TODO: in GitHub einstellen).
+**Stand:** 2026-02-07 (historischer Pragmatic-Flow-Kontext). Aktuelle Required-Checks-Semantik ist JSON-SSOT (`config/ci/required_status_checks.json`).
 
 ## Relevante Workflows und Jobs
 
 | Workflow | Job(s) | Kontext-Name (für Branch Protection) | Derzeit required? |
 |----------|--------|--------------------------------------|-------------------|
-| `.github/workflows/ci.yml` | changes | (kein eigener Check) | — |
-| | fast-lane | **Fast-Lane** | nein |
-| | tests | **tests (3.9)**, **tests (3.10)**, **tests (3.11)** | nein (nur PR Gate) |
-| | strategy-smoke | **strategy-smoke** | nein |
-| | pr-gate | **PR Gate** | **ja (einziger)** |
+| `.github/workflows/ci.yml` | changes | (kein eigener Check) | siehe JSON SSOT |
+| | fast-lane | **Fast-Lane** | siehe JSON SSOT |
+| | tests | **tests (3.9)**, **tests (3.10)**, **tests (3.11)** | siehe JSON SSOT |
+| | strategy-smoke | **strategy-smoke** | siehe JSON SSOT |
+| | pr-gate | **PR Gate** | siehe JSON SSOT |
 | `.github/workflows/lint_gate.yml` | lint-gate | **Lint Gate** | nein |
 | `.github/workflows/docs-token-policy-gate.yml` | (job) | **docs-token-policy-gate** | nein |
 | `.github/workflows/docs_reference_targets_gate.yml` | (job) | **docs-reference-targets-gate** | nein |
 | `.github/workflows/test_health.yml` | ci-health-gate | **CI Health Gate (weekly_core)** | nein |
 
-**Branch Protection (main):** Nur **PR Gate** als required eintragen. Lint/Docs/CI Health laufen weiter, blockieren Merge aber nur indirekt, wenn sie in anderen Rulesets gefordert sind.
+**Branch Protection (main):** Required contexts folgen JSON-SSOT (`required_contexts - ignored_contexts`) und der aktuellen Ruleset-Policy.
 
 ## Change-Classification (Outputs vom `changes`-Job)
 

--- a/docs/ops/ci_pragmatic_flow_meta_gate.md
+++ b/docs/ops/ci_pragmatic_flow_meta_gate.md
@@ -1,4 +1,4 @@
-# CI Pragmatic Flow — PR Gate (Single Required Check)
+# CI Pragmatic Flow — PR Gate (Historical Context)
 
 
 <!-- ci pragmatic flow staleness scope note -->
@@ -7,19 +7,14 @@
 
 **Canonical reference:** [GATES_OVERVIEW.md](GATES_OVERVIEW.md) ist SSoT für Gates. Dieses Doc beschreibt PR-Gate-Details.
 
-**Ziel:** Für Branch Protection nur **einen** Required Check: **PR Gate**.  
-- Reine Docs/Workflow-Änderungen: nur Fast-Lane + Smoke (keine volle Py-Matrix).  
-- Code-Änderungen: volle Python-Matrix (3.9/3.10/3.11) + strategy-smoke.
+**Hinweis:** Dieses Dokument beschreibt historischen Pragmatic-Flow-Kontext.
+Für aktuelle Required-Checks-Semantik gilt JSON-SSOT (`config/ci/required_status_checks.json` mit
+`effective_required_contexts = required_contexts - ignored_contexts`).
 
-## Required Check = PR Gate
+## PR Gate im historischen Pragmatic-Flow
 
-In **GitHub → Settings → Branches → Branch protection rules → main → Required status checks** nur eintragen:
-
-| Check-Name | Quelle |
-|------------|--------|
-| **PR Gate** | `.github/workflows/ci.yml` Job `pr-gate` |
-
-Matrix läuft nur bei Code-Änderungen (siehe Pfad-Logik). Lint Gate, Docs Gates, CI Health Gate laufen weiter in eigenen Workflows, sind aber nicht als required eingetragen (nur PR Gate).
+PR Gate war ein aggregierender CI-Check im damaligen Flow.
+Aktuelle Required/ignored-Kontexte werden ausschließlich über JSON-SSOT gepflegt.
 
 ## Pfad-Logik (paths-filter)
 
@@ -58,7 +53,7 @@ CI → "Run workflow" → Input **force_matrix** (boolean): bei `true` wird `run
 
 ## Konfiguration
 
-- `config/ci/required_status_checks.json`: `required_contexts: ["PR Gate"]`.
+- `config/ci/required_status_checks.json`: SSOT für required/ignored contexts.
 - Hygiene-Validator: `scripts&#47;ci/validate_required_checks_hygiene.py`.
 - Inventar: `docs/ops/ci_pragmatic_flow_inventory.md`.
 

--- a/docs/ops/ci_pragmatic_flow_pr_body.md
+++ b/docs/ops/ci_pragmatic_flow_pr_body.md
@@ -9,7 +9,8 @@
 
 ## Motivation
 
-Ein einziger Required Check (PR Gate) für Branch Protection; bei Docs/Grafana/Workflow-only PRs läuft nur Fast-Lane (keine volle Py-Matrix). Reduziert Wartezeit und vereinheitlicht Merge-Gate.
+Historischer Pragmatic-Flow-Kontext: bei Docs/Grafana/Workflow-only PRs lief nur Fast-Lane (keine volle Py-Matrix), bei Code-Änderungen die volle Matrix.
+Für aktuelle Required-Checks-Verträge ist JSON-SSOT maßgeblich (`config/ci/required_status_checks.json`, effective required contexts).
 
 ## Pragmatischer CI-Flow
 
@@ -25,17 +26,18 @@ Ein einziger Required Check (PR Gate) für Branch Protection; bei Docs/Grafana/W
 | `.github&#47;workflows&#47;...` | false | Fast-Lane + workflow checks |
 | `src&#47;...`, `tests&#47;...`, `scripts&#47;...`, `pyproject.toml`, `uv.lock`, `requirements.txt` | true | volle Matrix |
 
-## Required Check (Branch Protection)
+## Required Checks (SSOT)
 
-**Einziger required check:** **PR Gate**  
-(Alle anderen Checks laufen weiter, sind aber nicht als required eingetragen.)
+Kanonisch ist `config/ci/required_status_checks.json` mit
+`effective_required_contexts = required_contexts - ignored_contexts`.
 
 ## Änderungen
 
 - `.github/workflows/ci.yml`: changes (run_fast, run_matrix, docs_only, workflow_only, force_matrix), Fast-Lane, PR Gate (umbenannt von Meta-Gate), workflow_dispatch mit `force_matrix`.
-- `config/ci/required_status_checks.json`: `required_contexts: ["PR Gate"]`.
+- `config/ci/required_status_checks.json`: SSOT für required/ignored contexts.
 - Docs: `docs/ops/ci_pragmatic_flow_meta_gate.md`, `ci_pragmatic_flow_inventory.md`, kurzer Hinweis in `docs/ops/README.md`.
 
 ## Rollout (Branch Protection)
 
-Nach Merge: In GitHub → Settings → Branches → main → Required status checks nur **PR Gate** eintragen (bestehende andere required checks entfernen oder durch PR Gate ersetzen, je nach Policy).
+Branch-Protection-Rollout folgt der JSON-SSOT-Konfiguration und der aktuellen Ruleset-Policy;
+keine separate PR-Gate-only-Anweisung.

--- a/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
+++ b/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -47,6 +48,18 @@ def _parse_args() -> argparse.Namespace:
         "--report-json",
         default="out/ci/pr_head_sha_required_checks_liveness_report.json",
         help="Where to write structured report JSON",
+    )
+    parser.add_argument(
+        "--liveness-wait-seconds",
+        type=int,
+        default=90,
+        help="Bounded wait window for required contexts to appear on head SHA",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=int,
+        default=5,
+        help="Polling interval while waiting for missing required contexts",
     )
     return parser.parse_args()
 
@@ -245,6 +258,21 @@ def _render_summary(rows: List[Dict[str, str]]) -> str:
     return "\n".join(lines)
 
 
+def _collect_head_snapshot(
+    repo: str,
+    head_sha: str,
+    pr_number: int,
+    token: str,
+) -> Tuple[Set[str], Dict[str, str]]:
+    head_runs = _fetch_head_check_runs(repo, head_sha, token)
+    head_statuses = _fetch_head_status_contexts(repo, head_sha, token)
+    rollup_states = _fetch_pr_checks_states(repo, pr_number, token)
+    run_names = {str(r.get("name", "")).strip() for r in head_runs if r.get("name")}
+    status_names = {str(s.get("context", "")).strip() for s in head_statuses if s.get("context")}
+    on_head = run_names | status_names
+    return on_head, rollup_states
+
+
 def _evaluate_rows(
     required_contexts: Sequence[str],
     ignored_contexts: Set[str],
@@ -312,15 +340,35 @@ def main() -> int:
     required_contexts = config_semantics["required_contexts"]
     ignored_contexts = set(config_semantics["ignored_contexts"])
     effective_required_contexts = config_semantics["effective_required_contexts"]
-    head_runs = _fetch_head_check_runs(args.repo, args.head_sha, token)
-    head_statuses = _fetch_head_status_contexts(args.repo, args.head_sha, token)
-    rollup_states = _fetch_pr_checks_states(args.repo, args.pr_number, token)
+    wait_seconds = max(args.liveness_wait_seconds, 0)
+    poll_interval_seconds = max(args.poll_interval_seconds, 1)
+    deadline = time.monotonic() + wait_seconds
+    on_head: Set[str] = set()
+    rollup_states: Dict[str, str] = {}
+    missing = list(effective_required_contexts)
+    waited = False
 
-    run_names = {str(r.get("name", "")).strip() for r in head_runs if r.get("name")}
-    status_names = {str(s.get("context", "")).strip() for s in head_statuses if s.get("context")}
-    on_head = run_names | status_names
-
-    missing = [ctx for ctx in effective_required_contexts if ctx not in on_head]
+    while True:
+        on_head, rollup_states = _collect_head_snapshot(
+            repo=args.repo,
+            head_sha=args.head_sha,
+            pr_number=args.pr_number,
+            token=token,
+        )
+        missing = [ctx for ctx in effective_required_contexts if ctx not in on_head]
+        if not missing:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        waited = True
+        sleep_for = min(poll_interval_seconds, max(remaining, 0))
+        missing_csv = ", ".join(missing)
+        print(
+            f"LIVENESS_GUARD_WAIT: pending required contexts on head SHA: {missing_csv}; "
+            f"retrying in {sleep_for:.1f}s (time left {remaining:.1f}s)"
+        )
+        time.sleep(sleep_for)
 
     prior_commits = _fetch_pr_commits(args.repo, args.pr_number, token)
     prior_shas = [sha for sha in prior_commits if sha != args.head_sha][
@@ -355,6 +403,9 @@ def main() -> int:
                 "required_contexts": effective_required_contexts,
                 "configured_required_contexts": required_contexts,
                 "ignored_contexts": sorted(ignored_contexts),
+                "liveness_wait_seconds": wait_seconds,
+                "poll_interval_seconds": poll_interval_seconds,
+                "waited_for_liveness_window": waited,
                 "rows": rows,
             },
             indent=2,

--- a/tests/ci/test_pr_head_sha_required_checks_liveness_guard.py
+++ b/tests/ci/test_pr_head_sha_required_checks_liveness_guard.py
@@ -40,6 +40,8 @@ def test_ignored_context_on_head_gap_is_non_blocking(
             required_config=str(config_path),
             max_prior_commits=5,
             report_json=str(report_path),
+            liveness_wait_seconds=0,
+            poll_interval_seconds=1,
         ),
     )
     monkeypatch.setattr(
@@ -86,6 +88,8 @@ def test_head_sha_coupling_suspect_stays_fail_closed(
             required_config=str(config_path),
             max_prior_commits=5,
             report_json=str(report_path),
+            liveness_wait_seconds=0,
+            poll_interval_seconds=1,
         ),
     )
     monkeypatch.setattr(guard, "_fetch_head_check_runs", lambda repo, sha, token: [])
@@ -104,3 +108,56 @@ def test_head_sha_coupling_suspect_stays_fail_closed(
     report = json.loads(report_path.read_text(encoding="utf-8"))
     rows = {row["context"]: row for row in report["rows"]}
     assert rows["tests (3.11)"]["classification"] == "HEAD_SHA_COUPLING_SUSPECT"
+
+
+def test_wait_window_allows_late_required_context_on_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "required_status_checks.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "required_contexts": ["tests (3.11)"],
+                "ignored_contexts": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report_path = tmp_path / "report.json"
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr(
+        guard,
+        "_parse_args",
+        lambda: Namespace(
+            repo="acme/repo",
+            pr_number=2701,
+            head_sha="deadbeef",
+            required_config=str(config_path),
+            max_prior_commits=5,
+            report_json=str(report_path),
+            liveness_wait_seconds=10,
+            poll_interval_seconds=2,
+        ),
+    )
+    snapshots = iter(
+        [
+            (set(), {}),
+            ({"tests (3.11)"}, {}),
+        ]
+    )
+    monkeypatch.setattr(
+        guard, "_collect_head_snapshot", lambda repo, head_sha, pr_number, token: next(snapshots)
+    )
+    monkeypatch.setattr(guard, "_fetch_pr_commits", lambda repo, pr_number, token: ["deadbeef"])
+    monkeypatch.setattr(guard, "_prior_sha_presence", lambda repo, prior_shas, contexts, token: {})
+    monkeypatch.setattr(guard.time, "sleep", lambda _: None)
+    monotonic_values = iter([0.0, 0.5, 0.6])
+    monkeypatch.setattr(guard.time, "monotonic", lambda: next(monotonic_values))
+
+    assert guard.main() == 0
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    rows = {row["context"]: row for row in report["rows"]}
+    assert rows["tests (3.11)"]["classification"] == "REPORTED_ON_HEAD_SHA"
+    assert report["waited_for_liveness_window"] is True

--- a/tests/ci/test_required_checks_narrative_retirement.py
+++ b/tests/ci/test_required_checks_narrative_retirement.py
@@ -16,3 +16,25 @@ def test_ops_ci_doc_states_json_ssot_effective_required_contexts() -> None:
     doc_text = Path("docs/ops/CI.md").read_text(encoding="utf-8")
     assert "Required Checks SSOT" in doc_text
     assert "effective_required_contexts = required_contexts - ignored_contexts" in doc_text
+
+
+def test_secondary_ops_docs_do_not_reintroduce_pr_gate_only_narrative() -> None:
+    target_paths = [
+        Path("docs/ops/ci_pragmatic_flow_pr_body.md"),
+        Path("docs/ops/ci_pragmatic_flow_meta_gate.md"),
+        Path("docs/ops/ci_pragmatic_flow_inventory.md"),
+        Path("docs/ops/ci/trigger_runbook.md"),
+    ]
+    banned_fragments = [
+        "Einziger required check",
+        'required_contexts: ["PR Gate"]',
+        'nur "PR Gate" als required',
+        "single required check",
+    ]
+    required_anchor = "config/ci/required_status_checks.json"
+
+    for path in target_paths:
+        text = path.read_text(encoding="utf-8")
+        for banned in banned_fragments:
+            assert banned not in text, f"{path} reintroduced legacy narrative: {banned}"
+        assert required_anchor in text, f"{path} must reference JSON SSOT config"


### PR DESCRIPTION
## Summary
- quarantine or retire remaining legacy required-checks narrative in secondary repo surfaces
- keep JSON SSOT as the only canonical required-checks model
- extend invariants to reduce future narrative re-drift

## Validation
- uv run pytest tests/ci -q
- uv run ruff check scripts/ci tests/ci
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
