### PR TITLE
ci: harden required-checks event parity

### DIFF
--- a/.github/workflows/ci-workflow-dispatch-guard.yml
+++ b/.github/workflows/ci-workflow-dispatch-guard.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     # NO paths filter at workflow level (required checks must always run)
+  merge_group:
   push:
     branches: ["main"]
     paths:

--- a/docs/ops/CI.md
+++ b/docs/ops/CI.md
@@ -6,6 +6,8 @@ Peak_Trade uses GitHub Actions for continuous integration. The primary workflow 
 
 **Required Checks SSOT:** Die kanonische Quelle ist `config/ci/required_status_checks.json`.  
 Blocking-Semantik: `effective_required_contexts = required_contexts - ignored_contexts`.
+Event-Parity-Semantik: effective required contexts muessen auf `pull_request` und `merge_group`
+zuverlaessig erzeugt werden.
 
 Hinweis: GitHub Branch-Protection wird separat verwaltet; Live-Settings sind ein Abgleichssignal und nicht die zweite Semantikquelle. Aktueller Stand: `gh api repos/<owner>/<repo>/branches/main/protection`.
 

--- a/scripts/ci/validate_required_checks_hygiene.py
+++ b/scripts/ci/validate_required_checks_hygiene.py
@@ -4,7 +4,7 @@ Required Checks Hygiene Validator
 
 Purpose:
   Validates that all required status checks are reliably produced by
-  always-on PR workflows (no PR-level path filtering).
+  always-on PR workflows and are available on merge_group.
 
 Problem Context (Phase 5C):
   Branch protection "required status checks" can block PRs if the
@@ -15,8 +15,9 @@ Problem Context (Phase 5C):
 Solution:
   This validator ensures that:
   1) Every required context is producible by at least one PR workflow
-  2) No required context relies exclusively on path-filtered workflows
-  3) Findings are audit-stable with clear remediation guidance
+  2) No required context relies exclusively on path-filtered PR workflows
+  3) Every required context is producible by at least one merge_group workflow
+  4) Findings are audit-stable with clear remediation guidance
 
 Usage:
   python scripts/ci/validate_required_checks_hygiene.py \\
@@ -136,9 +137,9 @@ class WorkflowAnalyzer:
             result.append({"job_id": job_id, "job_display": display})
         return result
 
-    def extract_pr_workflows(self) -> List[Dict[str, Any]]:
-        """Extract workflows that trigger on pull_request events."""
-        pr_workflows = []
+    def extract_required_check_surfaces(self) -> List[Dict[str, Any]]:
+        """Extract workflows that trigger on pull_request and/or merge_group."""
+        surfaces = []
 
         for wf in self.workflows:
             content = wf["content"]
@@ -156,16 +157,17 @@ class WorkflowAnalyzer:
             if not isinstance(on_config, dict):
                 continue
 
-            # Check if pull_request trigger exists
-            if "pull_request" not in on_config:
+            has_pr = "pull_request" in on_config
+            has_merge_group = "merge_group" in on_config
+            if not has_pr and not has_merge_group:
                 continue
-
-            pr_config = on_config["pull_request"]
 
             # Determine if PR-level paths filtering is present
             has_pr_paths = False
-            if isinstance(pr_config, dict):
-                has_pr_paths = "paths" in pr_config or "paths-ignore" in pr_config
+            if has_pr:
+                pr_config = on_config["pull_request"]
+                if isinstance(pr_config, dict):
+                    has_pr_paths = "paths" in pr_config or "paths-ignore" in pr_config
 
             # Extract workflow name
             workflow_name = content.get("name", wf["file"].replace(".yml", "").replace(".yaml", ""))
@@ -178,16 +180,18 @@ class WorkflowAnalyzer:
                 if isinstance(job_config, dict):
                     job_list.extend(self._expand_matrix_job_names(job_id, job_config))
 
-            pr_workflows.append(
+            surfaces.append(
                 {
                     "file": wf["file"],
                     "workflow_name": workflow_name,
+                    "has_pull_request": has_pr,
+                    "has_merge_group": has_merge_group,
                     "has_pr_paths": has_pr_paths,
                     "jobs": job_list,
                 }
             )
 
-        return pr_workflows
+        return surfaces
 
     def generate_check_candidates(self, workflow: Dict[str, Any], job: Dict[str, Any]) -> List[str]:
         """
@@ -237,19 +241,19 @@ class RequiredChecksValidator:
         """
         self.load_config()
         self.analyzer.load_workflows()
-        pr_workflows = self.analyzer.extract_pr_workflows()
+        surfaces = self.analyzer.extract_required_check_surfaces()
 
         self.effective_required_contexts = load_effective_required_contexts(self.config_path)
         for context in self.effective_required_contexts:
-            self._validate_context(context, pr_workflows)
+            self._validate_context(context, surfaces)
 
         return len(self.findings) == 0
 
-    def _validate_context(self, context: str, pr_workflows: List[Dict[str, Any]]) -> None:
+    def _validate_context(self, context: str, surfaces: List[Dict[str, Any]]) -> None:
         """Validate a single required context."""
         # Find all matching workflows/jobs
         matches = []
-        for wf in pr_workflows:
+        for wf in surfaces:
             for job in wf["jobs"]:
                 candidates = self.analyzer.generate_check_candidates(wf, job)
                 if context in candidates:
@@ -258,11 +262,16 @@ class RequiredChecksValidator:
                             "workflow_file": wf["file"],
                             "workflow_name": wf["workflow_name"],
                             "job_display": job["job_display"],
+                            "has_pull_request": wf["has_pull_request"],
+                            "has_merge_group": wf["has_merge_group"],
                             "has_pr_paths": wf["has_pr_paths"],
                         }
                     )
 
-        if not matches:
+        pr_matches = [m for m in matches if m["has_pull_request"]]
+        merge_group_matches = [m for m in matches if m["has_merge_group"]]
+
+        if not pr_matches:
             # FAIL: Required context not produced by any PR workflow
             self.findings.append(
                 {
@@ -275,7 +284,7 @@ class RequiredChecksValidator:
             return
 
         # Check if all matches are path-filtered
-        always_on_matches = [m for m in matches if not m["has_pr_paths"]]
+        always_on_matches = [m for m in pr_matches if not m["has_pr_paths"]]
 
         if not always_on_matches:
             # FAIL: Context only produced by path-filtered workflows
@@ -287,6 +296,18 @@ class RequiredChecksValidator:
                     "reason": "Required context only produced by path-filtered workflows",
                     "remediation": f"Remove PR-level 'paths' filter from workflow '{example['workflow_file']}' "
                     f"and use internal change detection (dorny/paths-filter) instead",
+                }
+            )
+            return
+
+        if not merge_group_matches:
+            # FAIL: Required context not produced on merge_group event
+            self.findings.append(
+                {
+                    "context": context,
+                    "status": "FAIL",
+                    "reason": "Required context not produced by any merge_group workflow",
+                    "remediation": f"Add merge_group trigger to a workflow/job producing '{context}'",
                 }
             )
             return
@@ -312,6 +333,7 @@ class RequiredChecksValidator:
             print(f"✅ SUCCESS: All {required_count} required checks are hygiene-compliant")
             print()
             print("All required status checks are produced by always-on PR workflows.")
+            print("All required status checks are also available on merge_group.")
             print("No path-filtering detected on required checks.")
             return
 

--- a/tests/ci/test_required_checks_hygiene.py
+++ b/tests/ci/test_required_checks_hygiene.py
@@ -6,9 +6,10 @@ Purpose:
   path-filtered required checks and missing required contexts.
 
 Test Coverage:
-  - PASS: Required context produced by always-on workflow
+  - PASS: Required context produced by always-on workflow with merge_group parity
   - FAIL: Required context only produced by path-filtered workflow
   - FAIL: Required context not produced by any workflow
+  - FAIL: Required context missing merge_group producer
 
 Phase: 5D
 Date: 2026-01-12
@@ -218,6 +219,7 @@ def test_validator_handles_multiple_workflows():
 name: Always On Workflow
 on:
   pull_request:
+  merge_group:
 jobs:
   my-check:
     name: my-check
@@ -233,6 +235,7 @@ name: Path Filtered Workflow
 on:
   pull_request:
     paths: [".github/workflows/**"]
+  merge_group:
 jobs:
   my-check:
     name: my-check
@@ -393,3 +396,49 @@ def test_report_counts_only_effective_required_contexts(fixtures_dir, capsys):
         validator.print_report()
         captured = capsys.readouterr()
         assert "All 1 required checks are hygiene-compliant" in captured.out
+
+
+def test_fail_when_required_context_missing_merge_group_surface():
+    """
+    Test FAIL case: Required context exists for PR but not for merge_group.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workflows_dir = Path(tmpdir) / "workflows"
+        workflows_dir.mkdir()
+
+        wf = workflows_dir / "pr_only.yml"
+        wf.write_text(
+            """
+name: PR Only Workflow
+on:
+  pull_request:
+jobs:
+  parity-check:
+    name: parity-check
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"
+""".strip()
+        )
+
+        config_path = Path(tmpdir) / "test_config.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0.0",
+                    "required_contexts": ["parity-check"],
+                    "ignored_contexts": [],
+                }
+            )
+        )
+
+        validator = RequiredChecksValidator(
+            config_path=config_path,
+            workflow_dir=workflows_dir,
+            strict=False,
+        )
+        success = validator.validate()
+        assert success is False
+        assert len(validator.findings) == 1
+        assert validator.findings[0]["context"] == "parity-check"
+        assert "merge_group" in validator.findings[0]["reason"]

--- a/tests/ci/test_required_checks_narrative_retirement.py
+++ b/tests/ci/test_required_checks_narrative_retirement.py
@@ -16,6 +16,8 @@ def test_ops_ci_doc_states_json_ssot_effective_required_contexts() -> None:
     doc_text = Path("docs/ops/CI.md").read_text(encoding="utf-8")
     assert "Required Checks SSOT" in doc_text
     assert "effective_required_contexts = required_contexts - ignored_contexts" in doc_text
+    assert "pull_request" in doc_text
+    assert "merge_group" in doc_text
 
 
 def test_secondary_ops_docs_do_not_reintroduce_pr_gate_only_narrative() -> None:

--- a/tests/fixtures/required_checks_hygiene/bad_path_filtered_required.yml
+++ b/tests/fixtures/required_checks_hygiene/bad_path_filtered_required.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/**"
+  merge_group:
   push:
     branches: [main]
 

--- a/tests/fixtures/required_checks_hygiene/good_with_internal_filter.yml
+++ b/tests/fixtures/required_checks_hygiene/good_with_internal_filter.yml
@@ -3,6 +3,7 @@ name: Good With Internal Filter
 on:
   pull_request:
     # NO paths filter at workflow level
+  merge_group:
   push:
     branches: [main]
 

--- a/tests/fixtures/required_checks_hygiene/matrix_job.yml
+++ b/tests/fixtures/required_checks_hygiene/matrix_job.yml
@@ -1,6 +1,7 @@
 name: Matrix Workflow
 on:
   pull_request:
+  merge_group:
 jobs:
   tests:
     name: tests (${{ matrix.python-version }})

--- a/tests/fixtures/required_checks_hygiene/minimal_good.yml
+++ b/tests/fixtures/required_checks_hygiene/minimal_good.yml
@@ -3,6 +3,7 @@ name: Minimal Good Workflow
 on:
   pull_request:
     # NO paths filter - always runs on PR
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- harden required-checks event parity across relevant CI event surfaces
- close remaining merge_group gaps in effective required-context generation and validation
- extend tests and invariants to reduce future event-surface drift

## Validation
- uv run pytest tests/ci -q
- uv run ruff check scripts/ci tests/ci
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
