### PR TITLE
ci: add merge-group required-checks liveness guard

### DIFF
--- a/.github/workflows/pr-head-sha-required-checks-liveness-guard.yml
+++ b/.github/workflows/pr-head-sha-required-checks-liveness-guard.yml
@@ -3,6 +3,7 @@ name: PR Head SHA Required Checks Liveness Guard
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
 
 permissions:
   contents: read
@@ -11,7 +12,7 @@ permissions:
   statuses: read
 
 concurrency:
-  group: pr-head-sha-required-checks-liveness-guard-${{ github.event.pull_request.number }}
+  group: pr-head-sha-required-checks-liveness-guard-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -30,14 +31,30 @@ jobs:
           python-version: "3.11"
 
       - name: Evaluate required-check liveness on PR head SHA
+        if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python scripts/ci/pr_head_sha_required_checks_liveness_guard.py \
+            --subject-kind "pull_request" \
             --repo "${{ github.repository }}" \
             --pr-number "${{ github.event.pull_request.number }}" \
             --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --liveness-wait-seconds 90 \
+            --poll-interval-seconds 5 \
+            --required-config "config/ci/required_status_checks.json"
+
+      - name: Evaluate required-check liveness on merge_group head SHA
+        if: github.event_name == 'merge_group'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/ci/pr_head_sha_required_checks_liveness_guard.py \
+            --subject-kind "merge_group" \
+            --repo "${{ github.repository }}" \
+            --head-sha "${{ github.sha }}" \
             --liveness-wait-seconds 90 \
             --poll-interval-seconds 5 \
             --required-config "config/ci/required_status_checks.json"
@@ -46,7 +63,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pr-head-sha-required-checks-liveness-report
-          path: out/ci/pr_head_sha_required_checks_liveness_report.json
+          name: required-checks-liveness-report
+          path: out/ci/required_checks_liveness_report.json
           if-no-files-found: ignore
           retention-days: 14

--- a/docs/ops/CI.md
+++ b/docs/ops/CI.md
@@ -8,6 +8,8 @@ Peak_Trade uses GitHub Actions for continuous integration. The primary workflow 
 Blocking-Semantik: `effective_required_contexts = required_contexts - ignored_contexts`.
 Event-Parity-Semantik: effective required contexts muessen auf `pull_request` und `merge_group`
 zuverlaessig erzeugt werden.
+Liveness-Semantik: Required-Checks-Liveness wird auf dem jeweiligen Head-SHA fuer
+`pull_request` und `merge_group` fail-closed ausgewertet.
 
 Hinweis: GitHub Branch-Protection wird separat verwaltet; Live-Settings sind ein Abgleichssignal und nicht die zweite Semantikquelle. Aktueller Stand: `gh api repos/<owner>/<repo>/branches/main/protection`.
 

--- a/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
+++ b/scripts/ci/pr_head_sha_required_checks_liveness_guard.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-PR-head-SHA required-checks liveness guard.
+Required-checks liveness guard on head SHA.
 
 Purpose:
-  Make missing required contexts on the current PR head SHA explicit and
+  Make missing required contexts on the current subject head SHA explicit and
   distinguish between:
     - REQUIRED context reported on head SHA
     - REQUIRED context stuck in EXPECTED/WAITING without head check-run
@@ -28,11 +28,17 @@ from required_checks_config import load_required_checks_config
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Guard required-check liveness on the current PR head SHA"
+        description="Guard required-check liveness on the current head SHA"
+    )
+    parser.add_argument(
+        "--subject-kind",
+        choices=["pull_request", "merge_group"],
+        default="pull_request",
+        help="GitHub event subject being evaluated",
     )
     parser.add_argument("--repo", required=True, help="owner/repo")
-    parser.add_argument("--pr-number", required=True, type=int, help="PR number")
-    parser.add_argument("--head-sha", required=True, help="Current PR head SHA")
+    parser.add_argument("--pr-number", type=int, help="PR number (required for pull_request)")
+    parser.add_argument("--head-sha", required=True, help="Current subject head SHA")
     parser.add_argument(
         "--required-config",
         default="config/ci/required_status_checks.json",
@@ -46,7 +52,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--report-json",
-        default="out/ci/pr_head_sha_required_checks_liveness_report.json",
+        default="out/ci/required_checks_liveness_report.json",
         help="Where to write structured report JSON",
     )
     parser.add_argument(
@@ -248,7 +254,7 @@ def _prior_sha_presence(
 
 def _render_summary(rows: List[Dict[str, str]]) -> str:
     lines = []
-    lines.append("# PR Head SHA Required Checks Liveness Guard")
+    lines.append("# Required Checks Liveness Guard")
     lines.append("")
     lines.append("| required context | classification | detail |")
     lines.append("|---|---|---|")
@@ -261,12 +267,14 @@ def _render_summary(rows: List[Dict[str, str]]) -> str:
 def _collect_head_snapshot(
     repo: str,
     head_sha: str,
-    pr_number: int,
+    pr_number: Optional[int],
     token: str,
 ) -> Tuple[Set[str], Dict[str, str]]:
     head_runs = _fetch_head_check_runs(repo, head_sha, token)
     head_statuses = _fetch_head_status_contexts(repo, head_sha, token)
-    rollup_states = _fetch_pr_checks_states(repo, pr_number, token)
+    rollup_states: Dict[str, str] = {}
+    if pr_number is not None:
+        rollup_states = _fetch_pr_checks_states(repo, pr_number, token)
     run_names = {str(r.get("name", "")).strip() for r in head_runs if r.get("name")}
     status_names = {str(s.get("context", "")).strip() for s in head_statuses if s.get("context")}
     on_head = run_names | status_names
@@ -336,6 +344,10 @@ def main() -> int:
         print("ERROR: GITHUB_TOKEN or GH_TOKEN is required", file=sys.stderr)
         return 2
 
+    if args.subject_kind == "pull_request" and args.pr_number is None:
+        print("ERROR: --pr-number is required when --subject-kind=pull_request", file=sys.stderr)
+        return 2
+
     config_semantics = load_required_checks_config(args.required_config)
     required_contexts = config_semantics["required_contexts"]
     ignored_contexts = set(config_semantics["ignored_contexts"])
@@ -370,11 +382,13 @@ def main() -> int:
         )
         time.sleep(sleep_for)
 
-    prior_commits = _fetch_pr_commits(args.repo, args.pr_number, token)
-    prior_shas = [sha for sha in prior_commits if sha != args.head_sha][
-        : max(args.max_prior_commits, 0)
-    ]
-    prior_seen = _prior_sha_presence(args.repo, prior_shas, missing, token)
+    prior_seen: Dict[str, Optional[str]] = {}
+    if args.subject_kind == "pull_request" and args.pr_number is not None:
+        prior_commits = _fetch_pr_commits(args.repo, args.pr_number, token)
+        prior_shas = [sha for sha in prior_commits if sha != args.head_sha][
+            : max(args.max_prior_commits, 0)
+        ]
+        prior_seen = _prior_sha_presence(args.repo, prior_shas, missing, token)
 
     rows, has_liveness_gap = _evaluate_rows(
         required_contexts=required_contexts,
@@ -397,6 +411,7 @@ def main() -> int:
     report_path.write_text(
         json.dumps(
             {
+                "subject_kind": args.subject_kind,
                 "repo": args.repo,
                 "pr_number": args.pr_number,
                 "head_sha": args.head_sha,
@@ -416,11 +431,9 @@ def main() -> int:
     )
 
     if has_liveness_gap:
-        print(
-            "LIVENESS_GUARD_FAIL: missing required contexts on current PR head SHA", file=sys.stderr
-        )
+        print("LIVENESS_GUARD_FAIL: missing required contexts on current head SHA", file=sys.stderr)
         return 2
-    print("LIVENESS_GUARD_OK: all required contexts are reported on current PR head SHA")
+    print("LIVENESS_GUARD_OK: all required contexts are reported on current head SHA")
     return 0
 
 

--- a/tests/ci/test_pr_head_sha_required_checks_liveness_guard.py
+++ b/tests/ci/test_pr_head_sha_required_checks_liveness_guard.py
@@ -275,5 +275,5 @@ def test_liveness_workflow_includes_merge_group_path() -> None:
         encoding="utf-8"
     )
     assert "merge_group:" in workflow
-    assert "--subject-kind \"merge_group\"" in workflow
-    assert "--head-sha \"${{ github.sha }}\"" in workflow
+    assert '--subject-kind "merge_group"' in workflow
+    assert '--head-sha "${{ github.sha }}"' in workflow

--- a/tests/ci/test_pr_head_sha_required_checks_liveness_guard.py
+++ b/tests/ci/test_pr_head_sha_required_checks_liveness_guard.py
@@ -34,6 +34,7 @@ def test_ignored_context_on_head_gap_is_non_blocking(
         guard,
         "_parse_args",
         lambda: Namespace(
+            subject_kind="pull_request",
             repo="acme/repo",
             pr_number=2701,
             head_sha="deadbeef",
@@ -82,6 +83,7 @@ def test_head_sha_coupling_suspect_stays_fail_closed(
         guard,
         "_parse_args",
         lambda: Namespace(
+            subject_kind="pull_request",
             repo="acme/repo",
             pr_number=2701,
             head_sha="deadbeef",
@@ -131,6 +133,7 @@ def test_wait_window_allows_late_required_context_on_head(
         guard,
         "_parse_args",
         lambda: Namespace(
+            subject_kind="pull_request",
             repo="acme/repo",
             pr_number=2701,
             head_sha="deadbeef",
@@ -161,3 +164,116 @@ def test_wait_window_allows_late_required_context_on_head(
     rows = {row["context"]: row for row in report["rows"]}
     assert rows["tests (3.11)"]["classification"] == "REPORTED_ON_HEAD_SHA"
     assert report["waited_for_liveness_window"] is True
+
+
+def test_merge_group_missing_context_is_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "required_status_checks.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "required_contexts": ["tests (3.11)"],
+                "ignored_contexts": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report_path = tmp_path / "report.json"
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr(
+        guard,
+        "_parse_args",
+        lambda: Namespace(
+            subject_kind="merge_group",
+            repo="acme/repo",
+            pr_number=None,
+            head_sha="deadbeef",
+            required_config=str(config_path),
+            max_prior_commits=5,
+            report_json=str(report_path),
+            liveness_wait_seconds=0,
+            poll_interval_seconds=1,
+        ),
+    )
+    monkeypatch.setattr(guard, "_fetch_head_check_runs", lambda repo, sha, token: [])
+    monkeypatch.setattr(guard, "_fetch_head_status_contexts", lambda repo, sha, token: [])
+
+    def _no_pr_rollup(*args, **kwargs):
+        raise AssertionError("merge_group must not call PR rollup fetch")
+
+    def _no_pr_commits(*args, **kwargs):
+        raise AssertionError("merge_group must not call PR commits fetch")
+
+    monkeypatch.setattr(guard, "_fetch_pr_checks_states", _no_pr_rollup)
+    monkeypatch.setattr(guard, "_fetch_pr_commits", _no_pr_commits)
+
+    assert guard.main() == 2
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    rows = {row["context"]: row for row in report["rows"]}
+    assert report["subject_kind"] == "merge_group"
+    assert rows["tests (3.11)"]["classification"] == "MISSING_ON_HEAD_SHA"
+
+
+def test_merge_group_wait_window_allows_late_required_context_on_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "required_status_checks.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "required_contexts": ["tests (3.11)"],
+                "ignored_contexts": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report_path = tmp_path / "report.json"
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr(
+        guard,
+        "_parse_args",
+        lambda: Namespace(
+            subject_kind="merge_group",
+            repo="acme/repo",
+            pr_number=None,
+            head_sha="deadbeef",
+            required_config=str(config_path),
+            max_prior_commits=5,
+            report_json=str(report_path),
+            liveness_wait_seconds=10,
+            poll_interval_seconds=2,
+        ),
+    )
+    snapshots = iter(
+        [
+            (set(), {}),
+            ({"tests (3.11)"}, {}),
+        ]
+    )
+    monkeypatch.setattr(
+        guard, "_collect_head_snapshot", lambda repo, head_sha, pr_number, token: next(snapshots)
+    )
+    monkeypatch.setattr(guard.time, "sleep", lambda _: None)
+    monotonic_values = iter([0.0, 0.5, 0.6])
+    monkeypatch.setattr(guard.time, "monotonic", lambda: next(monotonic_values))
+
+    assert guard.main() == 0
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    rows = {row["context"]: row for row in report["rows"]}
+    assert report["subject_kind"] == "merge_group"
+    assert rows["tests (3.11)"]["classification"] == "REPORTED_ON_HEAD_SHA"
+    assert report["waited_for_liveness_window"] is True
+
+
+def test_liveness_workflow_includes_merge_group_path() -> None:
+    workflow = Path(".github/workflows/pr-head-sha-required-checks-liveness-guard.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "merge_group:" in workflow
+    assert "--subject-kind \"merge_group\"" in workflow
+    assert "--head-sha \"${{ github.sha }}\"" in workflow


### PR DESCRIPTION
## Summary
- add merge_group required-checks liveness guard parity on top of the existing JSON-SSOT-based liveness stack
- reuse the shared engine/path rather than introducing a parallel implementation
- extend tests and invariants for merge_group liveness behavior

## Validation
- uv run pytest tests/ci -q
- uv run ruff check scripts/ci tests/ci
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
