### PR TITLE
ci: add branch-protection reconciliation v1

### DIFF
--- a/docs/ops/BRANCH_PROTECTION_REQUIRED_CHECKS.md
+++ b/docs/ops/BRANCH_PROTECTION_REQUIRED_CHECKS.md
@@ -67,18 +67,23 @@ gh api -H "Accept: application/vnd.github+json" \
 
 ---
 
-## Automated Drift Guard (JSON-SSOT vs Live)
+## Automated Reconciliation Check (JSON-SSOT vs Live)
 
 ### What is it?
 
-The **Required Checks Drift Guard** verifies that JSON-SSOT effective required contexts
-(`config/ci/required_status_checks.json`) match live branch protection on GitHub.
+Der kanonische Reconciliation-Pfad vergleicht JSON-SSOT effective required contexts
+(`config/ci/required_status_checks.json`) deterministisch mit der live branch protection.
 
 ### How to Use
 
 **Quick check:**
 ```bash
-scripts/ops/verify_required_checks_drift.sh
+scripts/ops/reconcile_required_checks_branch_protection.py --check
+```
+
+**Apply (schreibend, fail-closed):**
+```bash
+scripts/ops/reconcile_required_checks_branch_protection.py --apply
 ```
 
 **Integrated check (part of ops_doctor):**
@@ -88,9 +93,9 @@ ops_center.sh doctor
 
 ### Exit Codes
 
-- `0` = No drift (JSON-SSOT effective required contexts match live)
-- `1` = Drift detected (hard fail)
-- `2` = Drift detected (warn-only mode)
+- `0` = Match (JSON-SSOT effective required contexts match live)
+- `1` = Drift oder unsicherer Zustand (hard fail, fail-closed)
+- `2` = Drift in warn-only Wrapper-Mode (`verify_required_checks_drift.sh --warn-only`)
 
 ### Interpreting Results
 
@@ -103,7 +108,7 @@ ops_center.sh doctor
 **Action Required:**
 1. Review the diff output
 2. Update JSON SSOT if intended required semantics changed
-3. Or adjust branch protection if live settings drifted
+3. Oder den kanonischen apply-Pfad ausfuehren
 
 ### Troubleshooting
 

--- a/docs/ops/REQUIRED_CHECKS_DRIFT_GUARD_v1_OPERATOR_NOTES.md
+++ b/docs/ops/REQUIRED_CHECKS_DRIFT_GUARD_v1_OPERATOR_NOTES.md
@@ -13,18 +13,25 @@
 
 ## 📦 What Was Delivered
 
-### 1. Core Script: `verify_required_checks_drift.sh`
-- **Location:** `scripts/ops/verify_required_checks_drift.sh`
-- **Purpose:** Verifies Branch Protection Required Checks (JSON-SSOT vs live)
+### 1. Canonical Reconciliation Script: `reconcile_required_checks_branch_protection.py`
+- **Location:** `scripts/ops/reconcile_required_checks_branch_protection.py`
+- **Purpose:** Deterministic check/apply reconciliation (JSON-SSOT -> live)
 - **Features:**
-  - Delegates execution to canonical engine: `scripts/ci/required_checks_drift_detector.py`
+  - `--check` and `--apply` modes
+  - JSON-SSOT only: `config/ci/required_status_checks.json`
+  - Fail-closed on drift, invalid config, or live API uncertainty
+  - Deterministic required-context set (no wildcard heuristics)
+
+### 2. Ops Wrapper: `verify_required_checks_drift.sh`
+- **Location:** `scripts/ops/verify_required_checks_drift.sh`
+- **Purpose:** Thin wrapper for canonical `--check` reconciliation
+- **Features:**
+  - Delegates execution to canonical engine: `scripts/ops/reconcile_required_checks_branch_protection.py`
   - Loads effective required contexts from `config/ci/required_status_checks.json`
-  - Fetches live checks via `gh` CLI
-  - Compares and reports drift (missing/extra checks)
   - Supports `--warn-only` mode (exit 2 instead of 1)
   - CLI flags: `--owner`, `--repo`, `--branch`, `--required-config`, `--warn-only`
 
-### 2. Ops Center Integration
+### 3. Ops Center Integration
 - **File:** `scripts/ops/ops_center.sh`
 - **Integration Point:** `cmd_doctor()` function
 - **Behavior:**
@@ -33,7 +40,7 @@
   - Displays short diff summary on drift
   - Included in overall doctor exit code
 
-### 3. Documentation Update
+### 4. Documentation Update
 - **File:** `docs/ops/BRANCH_PROTECTION_REQUIRED_CHECKS.md`
 - **New Section:** "Automated Drift Guard"
 - **Content:**
@@ -42,7 +49,7 @@
   - Interpreting WARN vs FAIL
   - Troubleshooting tips
 
-### 4. Smoke Test
+### 5. Smoke Test
 - **Location:** `scripts/ops/tests/test_verify_required_checks_drift.sh`
 - **Coverage:**
   - Bash syntax check

--- a/scripts/ops/check_and_fix_branch_protection.sh
+++ b/scripts/ops/check_and_fix_branch_protection.sh
@@ -14,6 +14,10 @@
 
 set -euo pipefail
 
+echo "This script is deprecated and intentionally disabled."
+echo "Use scripts/ops/reconcile_required_checks_branch_protection.py (--check|--apply) instead."
+exit 2
+
 ORG="${GITHUB_ORG:-rauterfrank-ui}"
 REPO="${GITHUB_REPO:-Peak_Trade}"
 BRANCH="${GITHUB_BRANCH:-main}"

--- a/scripts/ops/reconcile_required_checks_branch_protection.py
+++ b/scripts/ops/reconcile_required_checks_branch_protection.py
@@ -94,7 +94,9 @@ def build_put_body(get_data: dict[str, Any], required_contexts: list[str]) -> di
         body["required_pull_request_reviews"] = {
             "dismiss_stale_reviews": bool(reviews.get("dismiss_stale_reviews", False)),
             "require_code_owner_reviews": bool(reviews.get("require_code_owner_reviews", False)),
-            "required_approving_review_count": int(reviews.get("required_approving_review_count", 0)),
+            "required_approving_review_count": int(
+                reviews.get("required_approving_review_count", 0)
+            ),
         }
         if "require_last_push_approval" in reviews:
             body["required_pull_request_reviews"]["require_last_push_approval"] = bool(

--- a/scripts/ops/reconcile_required_checks_branch_protection.py
+++ b/scripts/ops/reconcile_required_checks_branch_protection.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Reconcile required checks branch protection from JSON SSOT (check/apply)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "scripts" / "ci"))
+
+from required_checks_config import load_effective_required_contexts  # noqa: E402
+
+DEFAULT_OWNER = "rauterfrank-ui"
+DEFAULT_REPO = "Peak_Trade"
+DEFAULT_BRANCH = "main"
+DEFAULT_REQUIRED_CONFIG = "config/ci/required_status_checks.json"
+
+
+def _gh_api(method: str, path: str, *, body: dict[str, Any] | None = None) -> tuple[int, str, str]:
+    cmd = ["gh", "api", "-H", "Accept: application/vnd.github+json"]
+    if method.upper() != "GET":
+        cmd.extend(["-X", method.upper()])
+    cmd.append(path)
+    payload = None
+    if body is not None:
+        cmd.extend(["--input", "-"])
+        payload = json.dumps(body)
+    proc = subprocess.run(cmd, input=payload, capture_output=True, text=True)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def fetch_protection(owner: str, repo: str, branch: str) -> tuple[int, dict[str, Any] | None, str]:
+    path = f"repos/{owner}/{repo}/branches/{branch}/protection"
+    code, out, err = _gh_api("GET", path)
+    if code != 0:
+        return code, None, (err or out or "").strip()
+    try:
+        return 0, json.loads(out), ""
+    except json.JSONDecodeError as exc:
+        return 2, None, str(exc)
+
+
+def load_required_contexts(config_path: str | Path) -> list[str]:
+    contexts = load_effective_required_contexts(config_path)
+    normalized = [str(ctx).strip() for ctx in contexts if str(ctx).strip()]
+    if not normalized:
+        raise RuntimeError("effective_required_contexts is empty; fail-closed")
+    return normalized
+
+
+def collect_live_contexts(data: dict[str, Any]) -> list[str]:
+    rsc = data.get("required_status_checks") or {}
+    names: set[str] = set()
+    for ctx in rsc.get("contexts") or []:
+        if ctx:
+            names.add(str(ctx))
+    for item in rsc.get("checks") or []:
+        context = item.get("context") if isinstance(item, dict) else None
+        if context:
+            names.add(str(context))
+    return sorted(names)
+
+
+def diff_contexts(required: list[str], live: list[str]) -> tuple[list[str], list[str]]:
+    req_set = set(required)
+    live_set = set(live)
+    missing_in_live = sorted(req_set - live_set)
+    extra_in_live = sorted(live_set - req_set)
+    return missing_in_live, extra_in_live
+
+
+def build_put_body(get_data: dict[str, Any], required_contexts: list[str]) -> dict[str, Any]:
+    rsc = get_data.get("required_status_checks") or {}
+    body: dict[str, Any] = {
+        "required_status_checks": {
+            "strict": bool(rsc.get("strict", False)),
+            "contexts": required_contexts,
+        }
+    }
+
+    enforce_admins = get_data.get("enforce_admins")
+    if isinstance(enforce_admins, dict) and "enabled" in enforce_admins:
+        body["enforce_admins"] = bool(enforce_admins["enabled"])
+    else:
+        body["enforce_admins"] = None
+
+    reviews = get_data.get("required_pull_request_reviews")
+    if isinstance(reviews, dict):
+        body["required_pull_request_reviews"] = {
+            "dismiss_stale_reviews": bool(reviews.get("dismiss_stale_reviews", False)),
+            "require_code_owner_reviews": bool(reviews.get("require_code_owner_reviews", False)),
+            "required_approving_review_count": int(reviews.get("required_approving_review_count", 0)),
+        }
+        if "require_last_push_approval" in reviews:
+            body["required_pull_request_reviews"]["require_last_push_approval"] = bool(
+                reviews["require_last_push_approval"]
+            )
+    else:
+        body["required_pull_request_reviews"] = None
+
+    body["restrictions"] = None
+    for key in (
+        "required_linear_history",
+        "allow_force_pushes",
+        "allow_deletions",
+        "block_creations",
+        "required_conversation_resolution",
+        "lock_branch",
+        "allow_fork_syncing",
+    ):
+        value = get_data.get(key)
+        if isinstance(value, dict) and "enabled" in value:
+            body[key] = bool(value["enabled"])
+        elif value is None:
+            body[key] = None
+
+    required_signatures = get_data.get("required_signatures")
+    if isinstance(required_signatures, dict) and "enabled" in required_signatures:
+        body["required_signatures"] = bool(required_signatures["enabled"])
+
+    return body
+
+
+def _print_diff(required: list[str], live: list[str]) -> tuple[list[str], list[str]]:
+    missing_in_live, extra_in_live = diff_contexts(required, live)
+    if missing_in_live or extra_in_live:
+        print("RECONCILE_DIFF:")
+        if missing_in_live:
+            print("missing_in_live:")
+            for item in missing_in_live:
+                print("-", item)
+        if extra_in_live:
+            print("extra_in_live:")
+            for item in extra_in_live:
+                print("-", item)
+    return missing_in_live, extra_in_live
+
+
+def run_check(owner: str, repo: str, branch: str, required_config: str) -> int:
+    try:
+        required = load_required_contexts(required_config)
+    except Exception as exc:
+        print(f"❌ Invalid JSON SSOT required contexts: {exc}", file=sys.stderr)
+        return 1
+
+    code, data, err = fetch_protection(owner, repo, branch)
+    if code != 0 or data is None:
+        print(f"❌ Failed to fetch branch protection: {err}", file=sys.stderr)
+        return 1
+
+    live = collect_live_contexts(data)
+    missing_in_live, extra_in_live = _print_diff(required, live)
+    if missing_in_live or extra_in_live:
+        return 1
+    print("RECONCILE_OK")
+    return 0
+
+
+def run_apply(owner: str, repo: str, branch: str, required_config: str) -> int:
+    try:
+        required = load_required_contexts(required_config)
+    except Exception as exc:
+        print(f"❌ Invalid JSON SSOT required contexts: {exc}", file=sys.stderr)
+        return 1
+
+    code, data, err = fetch_protection(owner, repo, branch)
+    if code != 0 or data is None:
+        print(f"❌ Failed to fetch branch protection: {err}", file=sys.stderr)
+        return 1
+
+    live = collect_live_contexts(data)
+    missing_in_live, extra_in_live = _print_diff(required, live)
+    if not missing_in_live and not extra_in_live:
+        print("RECONCILE_APPLY_NOOP")
+        return 0
+
+    put_body = build_put_body(data, required)
+    path = f"repos/{owner}/{repo}/branches/{branch}/protection"
+    pcode, pout, perr = _gh_api("PUT", path, body=put_body)
+    if pcode != 0:
+        print("❌ Failed to apply branch protection reconciliation", file=sys.stderr)
+        print(perr or pout or "", file=sys.stderr)
+        return 1
+    print("RECONCILE_APPLY_OK")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reconcile required checks branch protection from JSON SSOT (check/apply)."
+    )
+    parser.add_argument("--owner", default=DEFAULT_OWNER)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--required-config", default=DEFAULT_REQUIRED_CONFIG)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        if args.check:
+            return run_check(args.owner, args.repo, args.branch, args.required_config)
+        return run_apply(args.owner, args.repo, args.branch, args.required_config)
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/verify_required_checks_drift.sh
+++ b/scripts/ops/verify_required_checks_drift.sh
@@ -3,8 +3,8 @@
 # verify_required_checks_drift.sh
 #
 # Purpose:
-#   Thin ops wrapper around the canonical CI drift engine:
-#   scripts/ci/required_checks_drift_detector.py
+#   Thin ops wrapper around the canonical branch-protection reconciliation check:
+#   scripts/ops/reconcile_required_checks_branch_protection.py
 #
 # Usage:
 #   verify_required_checks_drift.sh [options]
@@ -44,7 +44,7 @@ REQUIRED_CONFIG="config/ci/required_status_checks.json"
 WARN_ONLY=0
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-DETECTOR="$REPO_ROOT/scripts/ci/required_checks_drift_detector.py"
+RECONCILER="$REPO_ROOT/scripts/ops/reconcile_required_checks_branch_protection.py"
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Help
@@ -52,11 +52,11 @@ DETECTOR="$REPO_ROOT/scripts/ci/required_checks_drift_detector.py"
 show_help() {
   cat <<'HELP'
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🧭 Required Checks Drift Guard (Single Engine)
+🧭 Required Checks Drift Guard (Reconciliation Check)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Ops wrapper around the canonical CI drift detector:
-  scripts/ci/required_checks_drift_detector.py
-Compares JSON SSOT effective required contexts to live branch protection.
+Ops wrapper around the canonical branch-protection reconciler:
+  scripts/ops/reconcile_required_checks_branch_protection.py
+Runs deterministic JSON-SSOT check against live branch protection.
 
 USAGE:
   verify_required_checks_drift.sh [options]
@@ -94,7 +94,7 @@ CANONICAL SOURCE:
   config/ci/required_status_checks.json
 
 CANONICAL ENGINE:
-  scripts/ci/required_checks_drift_detector.py
+  scripts/ops/reconcile_required_checks_branch_protection.py
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 HELP
 }
@@ -173,8 +173,8 @@ preflight_check() {
     errors=$((errors + 1))
   fi
 
-  if [[ ! -f "$DETECTOR" ]]; then
-    echo "❌ Required drift detector not found: $DETECTOR"
+  if [[ ! -f "$RECONCILER" ]]; then
+    echo "❌ Required reconciler not found: $RECONCILER"
     errors=$((errors + 1))
   fi
 
@@ -193,47 +193,34 @@ main() {
   preflight_check
 
   local output=""
-  local detector_status=0
+  local reconcile_status=0
 
   output="$(
-    python3 "$DETECTOR" \
+    python3 "$RECONCILER" \
+      --check \
       --required-config "$REQUIRED_CONFIG" \
-      --compare-live \
-      --strict-live \
       --owner "$OWNER" \
       --repo "$REPO" \
-      --branch-pattern "$BRANCH" 2>&1
-  )" || detector_status=$?
+      --branch "$BRANCH" 2>&1
+  )" || reconcile_status=$?
 
   if [[ -n "$output" ]]; then
     echo "$output"
   fi
 
-  case "$detector_status" in
+  case "$reconcile_status" in
     0)
       echo "✅ Required Checks: No Drift"
       ;;
-    3)
-      # Drift in live compare.
+    1)
+      # Drift or hard error (fail-closed).
       if [[ $WARN_ONLY -eq 1 ]]; then
         exit 2
       fi
-      exit 1
-      ;;
-    2)
-      # Missing workflow-producing contexts is also drift and should fail-closed.
-      if [[ $WARN_ONLY -eq 1 ]]; then
-        exit 2
-      fi
-      exit 1
-      ;;
-    4)
-      # Strict live compare failure is treated as hard failure after preflight.
-      echo "❌ Live compare failed in canonical drift detector"
       exit 1
       ;;
     *)
-      echo "❌ Drift detector failed unexpectedly (exit $detector_status)"
+      echo "❌ Reconciliation check failed unexpectedly (exit $reconcile_status)"
       exit 1
       ;;
   esac

--- a/tests/ci/test_required_checks_branch_protection_reconciliation.py
+++ b/tests/ci/test_required_checks_branch_protection_reconciliation.py
@@ -61,9 +61,13 @@ def test_run_check_fail_closed_on_diff(tmp_path: Path, capsys) -> None:
 
 def test_run_check_fail_closed_on_empty_effective_required(tmp_path: Path) -> None:
     cfg = tmp_path / "required_status_checks.json"
-    cfg.write_text('{"required_contexts":["IGNORED"],"ignored_contexts":["IGNORED"]}\n', encoding="utf-8")
+    cfg.write_text(
+        '{"required_contexts":["IGNORED"],"ignored_contexts":["IGNORED"]}\n', encoding="utf-8"
+    )
 
-    with patch.object(reconcile, "fetch_protection", side_effect=AssertionError("must not be called")):
+    with patch.object(
+        reconcile, "fetch_protection", side_effect=AssertionError("must not be called")
+    ):
         assert reconcile.run_check("o", "r", "main", str(cfg)) == 1
 
 

--- a/tests/ci/test_required_checks_branch_protection_reconciliation.py
+++ b/tests/ci/test_required_checks_branch_protection_reconciliation.py
@@ -1,0 +1,104 @@
+"""Tests for JSON-SSOT required-checks branch-protection reconciliation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "scripts" / "ops"))
+
+import reconcile_required_checks_branch_protection as reconcile  # noqa: E402
+
+
+def _sample_protection(contexts: list[str]) -> dict:
+    return {
+        "required_status_checks": {
+            "strict": False,
+            "contexts": contexts,
+            "checks": [],
+        },
+        "enforce_admins": {"enabled": True},
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": False,
+            "require_code_owner_reviews": False,
+            "required_approving_review_count": 1,
+        },
+    }
+
+
+def test_run_check_ok_when_live_matches_effective_required(tmp_path: Path) -> None:
+    cfg = tmp_path / "required_status_checks.json"
+    cfg.write_text(
+        '{"required_contexts":["Lint Gate","IGNORED"],"ignored_contexts":["IGNORED"]}\n',
+        encoding="utf-8",
+    )
+
+    with patch.object(
+        reconcile,
+        "fetch_protection",
+        lambda *_a, **_k: (0, _sample_protection(["Lint Gate"]), ""),
+    ):
+        assert reconcile.run_check("o", "r", "main", str(cfg)) == 0
+
+
+def test_run_check_fail_closed_on_diff(tmp_path: Path, capsys) -> None:
+    cfg = tmp_path / "required_status_checks.json"
+    cfg.write_text('{"required_contexts":["Lint Gate","audit"]}\n', encoding="utf-8")
+
+    with patch.object(
+        reconcile,
+        "fetch_protection",
+        lambda *_a, **_k: (0, _sample_protection(["Lint Gate"]), ""),
+    ):
+        assert reconcile.run_check("o", "r", "main", str(cfg)) == 1
+
+    output = capsys.readouterr().out
+    assert "missing_in_live:" in output
+    assert "- audit" in output
+
+
+def test_run_check_fail_closed_on_empty_effective_required(tmp_path: Path) -> None:
+    cfg = tmp_path / "required_status_checks.json"
+    cfg.write_text('{"required_contexts":["IGNORED"],"ignored_contexts":["IGNORED"]}\n', encoding="utf-8")
+
+    with patch.object(reconcile, "fetch_protection", side_effect=AssertionError("must not be called")):
+        assert reconcile.run_check("o", "r", "main", str(cfg)) == 1
+
+
+def test_run_apply_overwrites_live_to_ssot_contexts(tmp_path: Path) -> None:
+    cfg = tmp_path / "required_status_checks.json"
+    cfg.write_text('{"required_contexts":["Lint Gate","audit"]}\n', encoding="utf-8")
+
+    put_payloads: list[dict] = []
+
+    def fake_gh_api(method: str, path: str, *, body=None):
+        if method == "PUT":
+            put_payloads.append(body or {})
+            return 0, "{}", ""
+        raise AssertionError(path)
+
+    with patch.object(
+        reconcile,
+        "fetch_protection",
+        lambda *_a, **_k: (0, _sample_protection(["Lint Gate", "legacy-extra"]), ""),
+    ):
+        with patch.object(reconcile, "_gh_api", fake_gh_api):
+            assert reconcile.run_apply("o", "r", "main", str(cfg)) == 0
+
+    assert len(put_payloads) == 1
+    assert put_payloads[0]["required_status_checks"]["contexts"] == ["Lint Gate", "audit"]
+
+
+def test_run_apply_fail_closed_when_put_fails(tmp_path: Path) -> None:
+    cfg = tmp_path / "required_status_checks.json"
+    cfg.write_text('{"required_contexts":["Lint Gate","audit"]}\n', encoding="utf-8")
+
+    with patch.object(
+        reconcile,
+        "fetch_protection",
+        lambda *_a, **_k: (0, _sample_protection(["Lint Gate"]), ""),
+    ):
+        with patch.object(reconcile, "_gh_api", lambda *_a, **_k: (1, "", "permission denied")):
+            assert reconcile.run_apply("o", "r", "main", str(cfg)) == 1

--- a/tests/ci/test_required_checks_narrative_retirement.py
+++ b/tests/ci/test_required_checks_narrative_retirement.py
@@ -45,7 +45,7 @@ def test_secondary_ops_docs_do_not_reintroduce_pr_gate_only_narrative() -> None:
 def test_ops_required_checks_drift_guard_uses_json_ssot_as_source() -> None:
     script_text = Path("scripts/ops/verify_required_checks_drift.sh").read_text(encoding="utf-8")
     assert "config/ci/required_status_checks.json" in script_text
-    assert "scripts/ci/required_checks_drift_detector.py" in script_text
+    assert "scripts/ops/reconcile_required_checks_branch_protection.py" in script_text
 
 
 def test_required_checks_docs_do_not_reintroduce_doc_as_source_narrative() -> None:
@@ -120,3 +120,10 @@ def test_verify_required_checks_drift_no_legacy_doc_flag_path() -> None:
 def test_ci_pr_gate_sanity_script_no_pr_gate_only_contract() -> None:
     script = Path("scripts/ops/ci_pr_gate_sanity.sh").read_text(encoding="utf-8")
     assert 'required_contexts == ["PR Gate"]' not in script
+
+
+def test_legacy_branch_protection_fixer_is_hard_disabled() -> None:
+    script = Path("scripts/ops/check_and_fix_branch_protection.sh").read_text(encoding="utf-8")
+    assert "deprecated and intentionally disabled" in script
+    assert "exit 2" in script
+    assert "reconcile_required_checks_branch_protection.py" in script


### PR DESCRIPTION
## Summary
- add deterministic branch-protection reconciliation v1 for required checks from JSON SSOT to live surface
- introduce clear check/apply operator paths with fail-closed behavior
- extend tests and invariants to reduce future reconciliation drift

## Validation
- uv run pytest tests/ci -q
- uv run ruff check scripts/ci tests/ci
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
