### PR TITLE
ci: harden branch-protection required-checks single writer

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-18 — `docs&#47;ops&#47;registry&#47;TRUTH_BRANCH_PROTECTION.md` auf Single-Writer-Contract präzisiert (`ensure_truth_branch_protection.py --apply` fail-closed blockiert; kanonischer Writer `scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --apply`); dieser Eintrag dokumentiert den verpflichtenden Companion-Nachzug gemäß `truth-branch-protection-canonical`.
+
 - 2026-04-16: `docs&#47;ops&#47;specs&#47;LEVELUP_V0_CANONICAL_SURFACE.md` neu — kanonische Ops-/Spec-Oberfläche für LevelUp v0 (Manifest-/IO-/CLI; keine neue Autorität); Querverweise in `docs&#47;KNOWLEDGE_BASE_INDEX.md`, `docs&#47;ops&#47;README.md`, `docs&#47;ops&#47;RUNBOOK_INDEX.md`; Truth-Map-Abschnitt „Canonical: LevelUp v0“; zunächst ohne `docs_truth_map.yaml`-Regel; keine Runtime-/E2E-Ausweitung.
 
 - 2026-04-16: `config&#47;ops&#47;docs_truth_map.yaml` — Regel `levelup-v0-layer` (`src&#47;levelup&#47;` → `docs&#47;ops&#47;specs&#47;LEVELUP_V0_CANONICAL_SURFACE.md`); Truth-Map-Abschnitt „Canonical: LevelUp v0“ + Operator-Stub `levelup-v0-layer` aligned; Drift-Guard wie `forward-run-manifest-helper`; keine neue Autorität.

--- a/docs/ops/registry/TRUTH_BRANCH_PROTECTION.md
+++ b/docs/ops/registry/TRUTH_BRANCH_PROTECTION.md
@@ -10,9 +10,9 @@
 | Modus | Verhalten |
 | --- | --- |
 | `--check` | Nur lesen (`gh api` GET). Exit `0`, wenn beide Kontexte vorhanden sind; sonst `1`. |
-| `--apply` | Fehlende Kontexte in `required_status_checks.contexts` mergen und per PUT setzen (Schreibrechte / Admin nötig). |
+| `--apply` | Deprecated und fail-closed blockiert (Exit `2`). Verwende den kanonischen Writer `scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --apply`. |
 
-**Voraussetzungen:** `gh` installiert und authentifiziert; Token mit Leserecht auf Branch Protection, für `--apply` zusätzlich Schreibrecht.
+**Voraussetzungen:** `gh` installiert und authentifiziert; Token mit Leserecht auf Branch Protection.
 
 **Standard-Repo:** Owner `rauterfrank-ui`, Repo `Peak_Trade`, Branch `main` (über CLI-Flags überschreibbar).
 

--- a/scripts/ops/ensure_truth_branch_protection.py
+++ b/scripts/ops/ensure_truth_branch_protection.py
@@ -2,7 +2,7 @@
 """
 Ensure Truth Gates branch protection — Required status checks on main.
 
-Reads GitHub branch protection via ``gh api`` and verifies (or applies) that the
+Reads GitHub branch protection via ``gh api`` and verifies that the
 stable job names from ``.github/workflows/truth_gates_pr.yml`` are required:
 
   - docs-drift-guard
@@ -10,15 +10,15 @@ stable job names from ``.github/workflows/truth_gates_pr.yml`` are required:
 
 Modes:
   --check   Read-only; exit 0 if both are present, 1 if missing or error.
-  --apply   Merge missing contexts into required status checks (PUT); needs admin.
+  --apply   Deprecated and blocked (fail-closed); use canonical reconciler instead.
 
-Requires: ``gh`` CLI with a token that can read (and for --apply, write) branch
-protection (``repo`` or ``admin`` scope as appropriate).
+Requires: ``gh`` CLI with a token that can read branch protection
+(``repo`` or ``admin`` scope as appropriate).
 
 Exit codes:
-  0 — check passed, or apply succeeded
+  0 — check passed
   1 — missing required checks (check mode), or non-permission failure
-  2 — usage / unexpected error
+  2 — deprecated/blocked mode or usage / unexpected error
 """
 
 from __future__ import annotations
@@ -169,42 +169,23 @@ def run_check(owner: str, repo: str, branch: str) -> int:
     for m in missing:
         print(f"  - {m}")
     print()
-    print("Hinweis: --apply ergänzt die Kontexte (Admin-Rechte nötig).")
+    print(
+        "Hinweis: Apply erfolgt nur noch kanonisch über "
+        "scripts/ops/reconcile_required_checks_branch_protection.py --apply."
+    )
     return 1
 
 
-def run_apply(owner: str, repo: str, branch: str) -> int:
-    code, data, err = fetch_protection(owner, repo, branch)
-    if code != 0 or data is None:
-        print(f"❌ Branch protection konnte nicht gelesen werden: {err}", file=sys.stderr)
-        return 1
-
-    existing = collect_context_names(data)
-    merged = sorted(set(existing) | set(TRUTH_REQUIRED))
-    missing_before = missing_truth_checks(existing)
-
-    print("Vorher — Required contexts:", len(existing))
-    if missing_before:
-        print("Fehlend:", ", ".join(missing_before))
-    else:
-        print("Keine Truth-Gate-Kontexte fehlten; nichts zu tun.")
-        return 0
-
-    put_body = build_put_body(data, merged)
-    path = f"repos/{owner}/{repo}/branches/{branch}/protection"
-    pcode, pout, perr = _gh_api("PUT", path, body=put_body)
-    if pcode != 0:
-        print("❌ PUT branch protection fehlgeschlagen.", file=sys.stderr)
-        print(perr or pout or "", file=sys.stderr)
-        print(
-            "Typische Ursache: fehlende Admin-/repo-Rechte für gh auth token.",
-            file=sys.stderr,
-        )
-        return 1
-
-    print("✅ Branch protection aktualisiert (required_status_checks.contexts ergänzt).")
-    print("Neue Kontext-Anzahl:", len(merged))
-    return 0
+def run_apply(_owner: str, _repo: str, _branch: str) -> int:
+    print(
+        "❌ --apply ist deprecated und absichtlich deaktiviert (fail-closed).",
+        file=sys.stderr,
+    )
+    print(
+        "Nutze stattdessen scripts/ops/reconcile_required_checks_branch_protection.py --apply.",
+        file=sys.stderr,
+    )
+    return 2
 
 
 def main() -> int:
@@ -223,7 +204,7 @@ def main() -> int:
     mode.add_argument(
         "--apply",
         action="store_true",
-        help="Fehlende Truth-Checks zur Required-Liste hinzufügen (schreibend).",
+        help="Deprecated/blocked. Use reconcile_required_checks_branch_protection.py --apply.",
     )
     args = parser.parse_args()
 

--- a/tests/ci/test_required_checks_narrative_retirement.py
+++ b/tests/ci/test_required_checks_narrative_retirement.py
@@ -133,7 +133,7 @@ def test_truth_branch_protection_apply_path_is_blocked() -> None:
     script = Path("scripts/ops/ensure_truth_branch_protection.py").read_text(encoding="utf-8")
     assert "deprecated und absichtlich deaktiviert" in script
     assert "reconcile_required_checks_branch_protection.py --apply" in script
-    assert "_gh_api(\"PUT\"" not in script
+    assert '_gh_api("PUT"' not in script
 
 
 def test_single_writer_contract_for_branch_protection_required_checks() -> None:
@@ -142,5 +142,5 @@ def test_single_writer_contract_for_branch_protection_required_checks() -> None:
     )
     truth_script = Path("scripts/ops/ensure_truth_branch_protection.py").read_text(encoding="utf-8")
     assert 'path = f"repos/{owner}/{repo}/branches/{branch}/protection"' in canonical_writer
-    assert "_gh_api(\"PUT\"" in canonical_writer
-    assert "_gh_api(\"PUT\"" not in truth_script
+    assert '_gh_api("PUT"' in canonical_writer
+    assert '_gh_api("PUT"' not in truth_script

--- a/tests/ci/test_required_checks_narrative_retirement.py
+++ b/tests/ci/test_required_checks_narrative_retirement.py
@@ -127,3 +127,20 @@ def test_legacy_branch_protection_fixer_is_hard_disabled() -> None:
     assert "deprecated and intentionally disabled" in script
     assert "exit 2" in script
     assert "reconcile_required_checks_branch_protection.py" in script
+
+
+def test_truth_branch_protection_apply_path_is_blocked() -> None:
+    script = Path("scripts/ops/ensure_truth_branch_protection.py").read_text(encoding="utf-8")
+    assert "deprecated und absichtlich deaktiviert" in script
+    assert "reconcile_required_checks_branch_protection.py --apply" in script
+    assert "_gh_api(\"PUT\"" not in script
+
+
+def test_single_writer_contract_for_branch_protection_required_checks() -> None:
+    canonical_writer = Path("scripts/ops/reconcile_required_checks_branch_protection.py").read_text(
+        encoding="utf-8"
+    )
+    truth_script = Path("scripts/ops/ensure_truth_branch_protection.py").read_text(encoding="utf-8")
+    assert 'path = f"repos/{owner}/{repo}/branches/{branch}/protection"' in canonical_writer
+    assert "_gh_api(\"PUT\"" in canonical_writer
+    assert "_gh_api(\"PUT\"" not in truth_script

--- a/tests/ops/test_ensure_truth_branch_protection.py
+++ b/tests/ops/test_ensure_truth_branch_protection.py
@@ -94,65 +94,12 @@ def test_run_check_exits_1_when_missing(capsys):
     assert "repo-truth-claims" in out
 
 
-def test_run_apply_noop_when_already_complete(capsys):
-    sample = {
-        "required_status_checks": {
-            "strict": False,
-            "contexts": ["docs-drift-guard", "repo-truth-claims"],
-            "checks": [],
-        },
-        "enforce_admins": {"enabled": False},
-        "required_pull_request_reviews": {
-            "dismiss_stale_reviews": False,
-            "require_code_owner_reviews": False,
-            "required_approving_review_count": 0,
-        },
-    }
-
-    def fake_fetch(*_a, **_k):
-        return 0, sample, ""
-
-    with patch.object(et, "fetch_protection", fake_fetch):
-        assert et.run_apply("o", "r", "main") == 0
-    assert "nichts zu tun" in capsys.readouterr().out
-
-
-def test_run_apply_calls_put_when_missing():
-    sample = {
-        "required_status_checks": {
-            "strict": False,
-            "contexts": ["Lint Gate"],
-            "checks": [],
-        },
-        "enforce_admins": {"enabled": True},
-        "required_pull_request_reviews": {
-            "dismiss_stale_reviews": False,
-            "require_code_owner_reviews": False,
-            "required_approving_review_count": 0,
-        },
-        "required_linear_history": {"enabled": False},
-        "allow_force_pushes": {"enabled": False},
-        "allow_deletions": {"enabled": False},
-        "block_creations": {"enabled": False},
-        "required_conversation_resolution": {"enabled": False},
-        "lock_branch": {"enabled": False},
-        "allow_fork_syncing": {"enabled": False},
-        "required_signatures": {"enabled": False},
-    }
-    put_calls: list[dict] = []
-
-    def fake_gh_api(method: str, path: str, *, body=None):
-        if method == "PUT":
-            put_calls.append(body or {})
-            return 0, "{}", ""
-        raise AssertionError(method)
-
-    with patch.object(et, "fetch_protection", lambda *a, **k: (0, sample, "")):
-        with patch.object(et, "_gh_api", fake_gh_api):
-            assert et.run_apply("o", "r", "main") == 0
-    assert len(put_calls) == 1
-    ctxs = put_calls[0]["required_status_checks"]["contexts"]
-    assert "docs-drift-guard" in ctxs and "repo-truth-claims" in ctxs
+def test_run_apply_is_blocked_fail_closed(capsys):
+    with patch.object(et, "fetch_protection", side_effect=AssertionError("must not be called")):
+        assert et.run_apply("o", "r", "main") == 2
+    err = capsys.readouterr().err
+    assert "deprecated und absichtlich deaktiviert" in err
+    assert "reconcile_required_checks_branch_protection.py --apply" in err
 
 
 def test_main_check_integration():
@@ -170,3 +117,11 @@ def test_main_check_integration():
     with patch.object(sys, "argv", argv):
         with patch.object(et, "fetch_protection", fake_fetch):
             assert et.main() == 0
+
+
+def test_main_apply_integration_blocked(capsys):
+    argv = ["ensure_truth_branch_protection.py", "--apply"]
+    with patch.object(sys, "argv", argv):
+        assert et.main() == 2
+    err = capsys.readouterr().err
+    assert "deprecated und absichtlich deaktiviert" in err


### PR DESCRIPTION
## Summary
- harden a single canonical writer for branch-protection required checks
- retire, disable, or make read-only any residual parallel write surfaces
- extend invariants to reduce future writer-path drift

## Validation
- uv run pytest tests/ci -q
- uv run ruff check scripts/ci tests/ci
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
