### PR TITLE
ci: retire legacy required checks drift detector

### DIFF
--- a/docs/ops/ci_ops_wave26_review/inventory.tsv
+++ b/docs/ops/ci_ops_wave26_review/inventory.tsv
@@ -37,7 +37,7 @@ path	area	kind	current_role_guess	operational_risk_if_changed	initial_bucket
 .github/workflows/docs-token-policy-gate.yml	ci	workflow	Docs token policy (duplicate ref)	HIGH	KEEP_AS_IS
 config/ci/required_status_checks.json	ci	config	Required contexts; branch protection contract	CRITICAL	KEEP_AS_IS
 scripts/ci/validate_required_checks_hygiene.py	ci	script	Required checks hygiene validator	HIGH	KEEP_AS_IS
-scripts/ci/required_checks_drift_detector.py	ci	script	Required checks drift detector	MEDIUM	KEEP_AS_IS
+scripts/ci/required_checks_drift_detector.py	ci	script	Legacy PR-U entry point (retired/unsupported; canonical is scripts/ops/reconcile_required_checks_branch_protection.py --check)	LOW	KEEP_AS_IS
 scripts/ci/scheduled_guardrails.sh	ci	script	Scheduled workflow guardrails	MEDIUM	KEEP_AS_IS
 scripts/ci/check_docs_diff_guard_section.py	ci	script	Docs diff guard section checker	MEDIUM	KEEP_AS_IS
 scripts/ci/guard_no_tracked_reports.sh	ci	script	Guard no tracked reports	MEDIUM	KEEP_AS_IS

--- a/scripts/ci/required_checks_drift_detector.py
+++ b/scripts/ci/required_checks_drift_detector.py
@@ -1,102 +1,17 @@
-"""Deprecated compatibility wrapper for required checks drift detection."""
+"""Legacy entry point retired; use canonical reconciler directly."""
 
 from __future__ import annotations
 
-import argparse
-import subprocess
-from pathlib import Path
 import sys
 
 
-def _parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(
-        description=(
-            "Deprecated compatibility wrapper. "
-            "Use scripts/ops/reconcile_required_checks_branch_protection.py --check."
-        )
-    )
-    p.add_argument(
-        "--required-config",
-        default="config/ci/required_status_checks.json",
-        help="JSON required checks config path (default: config/ci/required_status_checks.json)",
-    )
-    p.add_argument(
-        "--workflows-dir",
-        default=".github/workflows",
-        help="Deprecated and ignored (kept for backwards compatibility)",
-    )
-    p.add_argument(
-        "--compare-live",
-        action="store_true",
-        default=False,
-        help="Deprecated alias. Live compare is the canonical default check behavior.",
-    )
-    p.add_argument(
-        "--strict-live",
-        action="store_true",
-        default=False,
-        help="Deprecated and ignored (fail-closed is canonical default).",
-    )
-    p.add_argument(
-        "--owner",
-        default="rauterfrank-ui",
-        help="GitHub owner/org for canonical reconciliation check",
-    )
-    p.add_argument(
-        "--repo",
-        default="Peak_Trade",
-        help="GitHub repo for canonical reconciliation check",
-    )
-    p.add_argument(
-        "--branch-pattern",
-        default="main",
-        help="Branch pattern (mapped to --branch for canonical reconciliation check)",
-    )
-    return p.parse_args()
-
-
-def _build_reconciler_cmd(args: argparse.Namespace) -> list[str]:
-    repo_root = Path(__file__).resolve().parents[2]
-    reconciler = repo_root / "scripts" / "ops" / "reconcile_required_checks_branch_protection.py"
-    return [
-        sys.executable,
-        str(reconciler),
-        "--check",
-        "--required-config",
-        args.required_config,
-        "--owner",
-        args.owner,
-        "--repo",
-        args.repo,
-        "--branch",
-        args.branch_pattern,
-    ]
-
-
 def main() -> int:
-    args = _parse_args()
     print(
-        "DEPRECATED: scripts/ci/required_checks_drift_detector.py now redirects to "
-        "scripts/ops/reconcile_required_checks_branch_protection.py --check",
+        "ERROR: scripts/ci/required_checks_drift_detector.py is retired and unsupported. "
+        "Use scripts/ops/reconcile_required_checks_branch_protection.py --check.",
         file=sys.stderr,
     )
-    if args.workflows_dir != ".github/workflows":
-        print("NOTE: --workflows-dir is deprecated and ignored.", file=sys.stderr)
-    if args.compare_live:
-        print(
-            "NOTE: --compare-live is deprecated; live compare is canonical default.",
-            file=sys.stderr,
-        )
-    if args.strict_live:
-        print(
-            "NOTE: --strict-live is deprecated and ignored (fail-closed default).", file=sys.stderr
-        )
-
-    cmd = _build_reconciler_cmd(args)
-    result = subprocess.run(cmd, check=False, cwd=Path(__file__).resolve().parents[2])
-    if result.returncode == 0:
-        return 0
-    return 1
+    return 2
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_pru_required_checks_drift_detector.py
+++ b/tests/ci/test_pru_required_checks_drift_detector.py
@@ -1,10 +1,10 @@
-"""Invariants for PR-U drift engine cutover to canonical reconciler."""
+"""Invariants for canonical PR-U required-checks reconciliation path."""
 
 from __future__ import annotations
 
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 
 def test_pru_workflow_calls_canonical_reconciler_check() -> None:
@@ -18,21 +18,21 @@ def test_pru_workflow_calls_canonical_reconciler_check() -> None:
     assert "GH_TOKEN: ${{ github.token }}" in workflow
 
 
-def test_legacy_drift_detector_is_redirect_only() -> None:
+def test_legacy_drift_detector_is_hard_retired() -> None:
     script = Path("scripts/ci/required_checks_drift_detector.py").read_text(encoding="utf-8")
-    assert "DEPRECATED:" in script
-    assert "reconcile_required_checks_branch_protection.py --check" in script
-    assert "yaml.safe_load" not in script
-    assert "load_effective_required_contexts" not in script
+    assert "retired and unsupported" in script
+    assert "return 2" in script
+    assert "subprocess.run(" not in script
 
 
-def test_legacy_drift_detector_help_mentions_deprecation() -> None:
+def test_legacy_drift_detector_exit_code_is_nonzero_and_points_to_canonical() -> None:
     r = subprocess.run(
-        [sys.executable, "scripts/ci/required_checks_drift_detector.py", "--help"],
+        [sys.executable, "scripts/ci/required_checks_drift_detector.py"],
         capture_output=True,
         text=True,
         cwd=Path(__file__).resolve().parent.parent.parent,
         check=False,
     )
-    assert r.returncode == 0
-    assert "Deprecated compatibility wrapper" in r.stdout
+    assert r.returncode == 2
+    assert "retired and unsupported" in r.stderr
+    assert "reconcile_required_checks_branch_protection.py --check" in r.stderr

--- a/tests/ci/test_prw_live_compare_flag_noop.py
+++ b/tests/ci/test_prw_live_compare_flag_noop.py
@@ -1,4 +1,4 @@
-"""Compatibility tests for legacy --compare-live flag on redirect wrapper."""
+"""Guardrail tests for retired legacy drift detector arguments."""
 
 from __future__ import annotations
 
@@ -7,9 +7,7 @@ import sys
 from pathlib import Path
 
 
-def test_compare_live_flag_is_accepted_and_fails_closed_without_gh(monkeypatch: object) -> None:
-    """Legacy --compare-live remains accepted, but canonical check is fail-closed."""
-    monkeypatch.setenv("PATH", "")
+def test_compare_live_flag_is_no_longer_supported() -> None:
     r = subprocess.run(
         [
             sys.executable,
@@ -20,6 +18,5 @@ def test_compare_live_flag_is_accepted_and_fails_closed_without_gh(monkeypatch: 
         text=True,
         cwd=Path(__file__).resolve().parent.parent.parent,
     )
-    assert r.returncode == 1
-    assert "DEPRECATED:" in r.stderr
-    assert "--compare-live is deprecated" in r.stderr
+    assert r.returncode == 2
+    assert "retired and unsupported" in r.stderr


### PR DESCRIPTION
## Summary
- retire the legacy/unsupported compatibility path around `scripts/ci/required_checks_drift_detector.py`
- keep `scripts/ops/reconcile_required_checks_branch_protection.py --check` as the sole canonical productive path
- update CI tests/docs inventory to reflect the retired legacy state

## Validation
- uv run pytest tests/ci -q
- uv run ruff check scripts/ci tests/ci
- uv run ruff format --check scripts/ci tests/ci
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)