### PR TITLE
docs: canonicalize PRU drift guard automation surface

### DIFF
--- a/.github/workflows/pru-required-checks-drift-detector.yml
+++ b/.github/workflows/pru-required-checks-drift-detector.yml
@@ -1,4 +1,5 @@
-name: PR-U / Required Checks Drift Detector
+# Legacy filename retained for compatibility/history; canonical PR-U surface is reconciliation check.
+name: PR-U / Required Checks Reconciliation Check
 on:
   pull_request:
     paths:
@@ -10,11 +11,11 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: pru-required-checks-drift-${{ github.ref }}-${{ github.event_name }}
+  group: pru-required-checks-reconcile-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 jobs:
-  drift-detector:
-    name: required-checks-drift
+  required_checks_reconciliation:
+    name: required-checks-reconciliation-check
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/docs/ops/DRIFT_GUARD_QUICK_START.md
+++ b/docs/ops/DRIFT_GUARD_QUICK_START.md
@@ -1,15 +1,23 @@
-# Required Checks Drift Guard — Quick Start
+# Required Checks Drift Guard — Quick Start (Legacy Surface)
 
 Kanonische Quelle: `config/ci/required_status_checks.json` (JSON SSOT).
 
-## 🚀 Deterministischer Entrypoint (Copy/Paste)
+> Status: Die PR-Automation-Surface in diesem Dokument ist legacy und **nicht**
+> der kanonische produktive Operator-Einstieg.
+>
+> **Kanonischer produktiver Entry-Point:**  
+> `scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --check`
+>
+> `scripts/ops/run_required_checks_drift_guard_pr.sh` und
+> `scripts/ops/create_required_checks_drift_guard_pr.sh` bleiben nur als
+> historisch/unterstuetzende Hilfen bestehen.
+
+## 🚀 Kanonischer produktiver Entrypoint (Copy/Paste)
 
 ```bash
-cd ~/Peak_Trade && scripts/ops/run_required_checks_drift_guard_pr.sh --dry-run --offline-only
+cd ~/Peak_Trade && python3 scripts/ops/reconcile_required_checks_branch_protection.py --check
 ```
 
-Der Wrapper nutzt deterministisch den kanonischen Entrypoint
-`scripts/ops/create_required_checks_drift_guard_pr.sh`.
 Das Legacy-Setup-Skript `scripts/ops/setup_drift_guard_pr_workflow.sh` ist deprecated/disabled.
 
 ---

--- a/docs/ops/REQUIRED_CHECKS_DRIFT_GUARD_PR_WORKFLOW.md
+++ b/docs/ops/REQUIRED_CHECKS_DRIFT_GUARD_PR_WORKFLOW.md
@@ -2,6 +2,16 @@
 
 Kanonische Quelle: `config/ci/required_status_checks.json` (JSON SSOT).
 
+> Status: Diese PR-Workflow-Surface ist legacy und nicht der kanonische
+> produktive Operator-Einstieg fuer Required-Checks-Reconciliation.
+>
+> **Kanonischer produktiver Entry-Point:**  
+> `scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --check`
+>
+> Legacy-Hinweis: `scripts/ops/run_required_checks_drift_guard_pr.sh` und
+> `scripts/ops/create_required_checks_drift_guard_pr.sh` sind als historische
+> PR-Automation-Helfer einzuordnen.
+
 Dieses Workflow-Skript erstellt automatisch einen PR für das **Required Checks Drift Guard** Feature und folgt dem gleichen Operator-Pattern wie `create_and_open_merge_log_pr.sh`.
 
 ## Was das Skript macht

--- a/docs/ops/RUNBOOK_INDEX.md
+++ b/docs/ops/RUNBOOK_INDEX.md
@@ -52,7 +52,7 @@ Policy-Dokumente für illustrative Pfade und Workflow-Konventionen (relevant fü
 | `scripts&#47;ci&#47;validate_required_checks_hygiene.py` | [RUNBOOK_PHASE5E_REQUIRED_CHECKS_HYGIENE_GATE](runbooks/RUNBOOK_PHASE5E_REQUIRED_CHECKS_HYGIENE_GATE_OPERATIONS.md) |
 | `scripts&#47;ops&#47;validate_docs_token_policy.py` | [RUNBOOK_DOCS_TOKEN_POLICY_GATE_OPERATOR](runbooks/RUNBOOK_DOCS_TOKEN_POLICY_GATE_OPERATOR.md), [GATES_OVERVIEW](GATES_OVERVIEW.md) |
 | `scripts&#47;ops&#47;verify_docs_reference_targets.sh` | [RUNBOOK_DOCS_REFERENCE_TARGETS_GATE_OPERATOR](runbooks/RUNBOOK_DOCS_REFERENCE_TARGETS_GATE_OPERATOR.md), [GATES_OVERVIEW](GATES_OVERVIEW.md) |
-| `scripts&#47;ops&#47;create_required_checks_drift_guard_pr.sh` | [RUNBOOK_PHASE5E_REQUIRED_CHECKS_HYGIENE_GATE](runbooks/RUNBOOK_PHASE5E_REQUIRED_CHECKS_HYGIENE_GATE_OPERATIONS.md) |
+| `scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --check` | [RUNBOOK_PHASE5E_REQUIRED_CHECKS_HYGIENE_GATE](runbooks/RUNBOOK_PHASE5E_REQUIRED_CHECKS_HYGIENE_GATE_OPERATIONS.md) |
 
 **Weitere Scripts:** [WORKFLOW_SCRIPTS.md](WORKFLOW_SCRIPTS.md), [OPS_SCRIPT_TEMPLATE_GUIDE.md](OPS_SCRIPT_TEMPLATE_GUIDE.md)
 

--- a/docs/ops/ci_ops_wave26_review/inventory.tsv
+++ b/docs/ops/ci_ops_wave26_review/inventory.tsv
@@ -15,7 +15,7 @@ path	area	kind	current_role_guess	operational_risk_if_changed	initial_bucket
 .github/workflows/evidence_pack_gate.yml	ci	workflow	Evidence pack validation	MEDIUM	KEEP_AS_IS
 .github/workflows/audit.yml	ci	workflow	Audit workflow	MEDIUM	KEEP_AS_IS
 .github/workflows/test_health.yml	ci	workflow	Test health profile	MEDIUM	KEEP_AS_IS
-.github/workflows/pru-required-checks-drift-detector.yml	ci	workflow	Required checks drift detector (scheduled)	MEDIUM	KEEP_AS_IS
+.github/workflows/pru-required-checks-drift-detector.yml	ci	workflow	PR-U required checks reconciliation check (legacy filename; canonical runtime calls scripts/ops/reconcile_required_checks_branch_protection.py --check)	MEDIUM	KEEP_AS_IS
 .github/workflows/ci-scheduled-paper-and-export-smoke.yml	ci	workflow	Scheduled paper + export smoke	MEDIUM	KEEP_AS_IS
 .github/workflows/ci-export-pack-download-verify.yml	ci	workflow	Export pack download/verify	MEDIUM	KEEP_AS_IS
 .github/workflows/prj-scheduled-shadow-paper-features-smoke.yml	ci	workflow	Scheduled PR-J features smoke	MEDIUM	KEEP_AS_IS
@@ -47,7 +47,7 @@ scripts/ops/verify_docs_reference_targets.sh	ci	script	Docs reference targets ve
 scripts/ops/docs_diff_guard.sh	ci	script	Docs diff guard	MEDIUM	KEEP_AS_IS
 scripts/ops/check_merge_log_hygiene.py	ci	script	Merge log hygiene checker	MEDIUM	KEEP_AS_IS
 scripts/ops/check_requirements_synced_with_uv.sh	ci	script	Deps sync checker	MEDIUM	KEEP_AS_IS
-scripts/ops/create_required_checks_drift_guard_pr.sh	ci	script	Create drift guard PR	LOW	WORKFLOW_HYGIENE_CANDIDATE
+scripts/ops/create_required_checks_drift_guard_pr.sh	ci	script	Legacy PR automation helper (non-canonical operator surface; canonical productive path is scripts/ops/reconcile_required_checks_branch_protection.py --check)	LOW	WORKFLOW_HYGIENE_CANDIDATE
 scripts/ops/ci_pr_checks_retrigger_v1.sh	ci	script	CI PR checks retrigger	LOW	KEEP_AS_IS
 scripts/ops/ci_trigger_required_checks.sh	ci	script	CI trigger required checks	LOW	KEEP_AS_IS
 scripts/ops/p46_required_checks_snapshot.sh	ci	script	Required checks snapshot	LOW	KEEP_AS_IS

--- a/docs/ops/runbooks/live_pilot_kickoff.md
+++ b/docs/ops/runbooks/live_pilot_kickoff.md
@@ -35,7 +35,7 @@ Preflight (local)
 - Ensure main is clean and synced.
 - Run: ./scripts/ops/ops_status.sh
 - Confirm YAML parse OK for PR-K/PR-O.
-- Confirm drift detector DRIFT_OK.
+- Confirm PR-U required-checks reconciliation check is OK (`scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --check`).
 
 Evidence Pull (local)
 - Use the dashboard fetcher to pull latest artifacts:
@@ -58,7 +58,7 @@ LIVE_PILOT Caps (recommended defaults)
 - Hard stop conditions:
   - Any execution error => immediate stop.
   - Any policy critic gate triggers => stop.
-  - Any drift detector mismatch => stop.
+  - Any required-checks reconciliation mismatch => stop.
   - Any stability gate fail => stop.
 - Rollback: revert to NO_TRADE and disable/arm gates.
 

--- a/tests/ci/test_pru_required_checks_drift_detector.py
+++ b/tests/ci/test_pru_required_checks_drift_detector.py
@@ -11,6 +11,8 @@ def test_pru_workflow_calls_canonical_reconciler_check() -> None:
     workflow = Path(".github/workflows/pru-required-checks-drift-detector.yml").read_text(
         encoding="utf-8"
     )
+    assert "PR-U / Required Checks Reconciliation Check" in workflow
+    assert "required-checks-reconciliation-check" in workflow
     assert "scripts/ops/reconcile_required_checks_branch_protection.py" in workflow
     assert "--check" in workflow
     assert "config/ci/required_status_checks.json" in workflow

--- a/tests/ci/test_required_checks_narrative_retirement.py
+++ b/tests/ci/test_required_checks_narrative_retirement.py
@@ -82,6 +82,8 @@ def test_secondary_drift_guard_docs_remain_json_ssot_only() -> None:
     required_anchors = [
         "config/ci/required_status_checks.json",
         "JSON SSOT",
+        "scripts/ops/reconcile_required_checks_branch_protection.py --check",
+        "legacy",
     ]
 
     for path in target_paths:

--- a/tests/ci/test_required_checks_narrative_retirement.py
+++ b/tests/ci/test_required_checks_narrative_retirement.py
@@ -82,7 +82,6 @@ def test_secondary_drift_guard_docs_remain_json_ssot_only() -> None:
     required_anchors = [
         "config/ci/required_status_checks.json",
         "JSON SSOT",
-        "scripts/ops/reconcile_required_checks_branch_protection.py --check",
         "legacy",
     ]
 
@@ -92,6 +91,10 @@ def test_secondary_drift_guard_docs_remain_json_ssot_only() -> None:
             assert banned not in text, f"{path} reintroduced legacy drift narrative: {banned}"
         for anchor in required_anchors:
             assert anchor in text, f"{path} must include JSON-SSOT anchor: {anchor}"
+        assert (
+            "scripts/ops/reconcile_required_checks_branch_protection.py --check" in text
+            or "scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --check" in text
+        ), f"{path} must include canonical reconciler --check anchor (escaped or unescaped)"
 
 
 def test_secondary_ops_helper_does_not_reintroduce_legacy_drift_flags() -> None:


### PR DESCRIPTION
## Summary
- canonicalize the PRU drift-guard automation surface across workflow/docs/runbooks/tests
- make the retired or unsupported detector surface explicit and keep the operator-facing canonical entry point consistent
- update narrative and inventory references to reduce remaining ambiguity

## Validation
- uv run pytest tests/ci -q
- uv run ruff check scripts/ci scripts/ops tests/ci
- uv run ruff format --check scripts/ci scripts/ops tests/ci
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)