### PR TITLE
docs(ops): embed canonical master v2 readiness ladder

### DIFF
--- a/docs/RUNBOOK_TO_FINISH_MASTER.md
+++ b/docs/RUNBOOK_TO_FINISH_MASTER.md
@@ -1,5 +1,8 @@
 # RUNBOOK — Peak_Trade „bis Finish“ (Master Runbook)
 
+> **Canonical-Note (aktueller Clarification-Workstream):** Die bindende kanonische Steuerdatei fuer **Master V2 + First Live Enablement Readiness Contract/Ladder** ist `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`.  
+> Dieses Runbook bleibt eine operative Companion-Flaeche und ist fuer diesen Workstream nicht der kanonische Winner.
+
 **Ziel:** Dieses Runbook führt dich vom aktuellen **docs-only Branch-Stand** (untracked Files + 1× EOF-Newline) bis zu einem klar definierten „Finish“-Zustand – inkl. PR‑Lieferung, DoD‑Verifikationen für D2/D3/D4 und optionalen (governance‑locked) Finish‑C / Option‑B Tracks.
 
 **Geltungsbereich:** Standardmäßig **docs-only** (kein Code‑Change, keine Live‑Aktivierung).  

--- a/docs/WORKFLOW_FRONTDOOR.md
+++ b/docs/WORKFLOW_FRONTDOOR.md
@@ -85,6 +85,7 @@
 - [Live Operational Runbooks](./LIVE_OPERATIONAL_RUNBOOKS.md) – 12+ runbooks for live operations and incident handling
 - [Runbooks Landscape 2026-Ready](./runbooks/RUNBOOKS_LANDSCAPE_2026_READY.md) – Comprehensive runbook catalog and quick-reference matrix
 - [Ops README](./ops/README.md) – Complete ops tools and documentation index
+- [Master V2 First Live Enablement Readiness Ladder (canonical)](./ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) – Bindende kanonische Steuerdatei fuer den aktuellen Clarification-Workstream
 - [Tech-Debt Top-3 ROI bis Finish Runbook](./ops/runbooks/RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md) – 3 kleine PRs (C/B/E) bis Finish, Cursor Multi-Agent, NO-LIVE
 - [RUNBOOK_BRANCH_CLEANUP_RECOVERY.md](./ops/runbooks/RUNBOOK_BRANCH_CLEANUP_RECOVERY.md) – Branch cleanup recovery (tags + bundles)
 - [Execution Watch Dashboard v0.2 Runbook](./ops/runbooks/RUNBOOK_EXECUTION_WATCH_DEMO_STACK.md) – Start/verify the read-only execution watch dashboard

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -86,6 +86,7 @@ For scripts and port notes, see the root [`README.md`](../../README.md) section 
 
 - `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` — Kanonischer operatorischer Eintrittsvertrag für den ersten strikt begrenzten Echtgeldpilot
 - `docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md` — Kanonische First-Session-Sequenz für den ersten strikt begrenzten Echtgeldpilot-Kandidatenfluss
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` — **Bindende kanonische Steuerdatei** für den aktuellen Master-V2-First-Live-Enablement-Clarification-Workstream (Readiness Contract/Ladder)
 
 - `docs/ops/specs/BOUNDED_PILOT_CAPS_ENFORCEMENT_POINT.md` — Kanonische Einordnung des aktuellen Caps-Enforcement-Punkts im bounded-pilot-Pfad
 

--- a/docs/ops/runbooks/README.md
+++ b/docs/ops/runbooks/README.md
@@ -56,6 +56,7 @@ Runbooks for AI autonomy workflows and control center operations:
 
 Runbooks for specific phase implementations and workflows:
 
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) — **Bindende kanonische Steuerdatei** fuer den aktuellen Master-V2-First-Live-Enablement-Clarification-Workstream (Specs-Surface, kein Ausfuehrungs-Runbook)
 - [RUNBOOK_TO_FINISH_MASTER.md](RUNBOOK_TO_FINISH_MASTER.md) — Master: docs-only Branch → PR → D2/D3/D4 DoD → SSoT „Finish“-Definition (NO‑LIVE)
 - [RUNBOOK_CURSOR_MA_P4C_P6_P7CORE_P5B_2026-02-19.md](RUNBOOK_CURSOR_MA_P4C_P6_P7CORE_P5B_2026-02-19.md) — Cursor Multi-Agent: P4C (L2 Market Outlook) → P6 (Shadow) → P7 Core (Paper) → P5B (Evidence CI)
 - [RUNBOOK_FINISH_A_MVP.md](RUNBOOK_FINISH_A_MVP.md) — Finish Level A (MVP): Backtest → Artifacts → Report → Watch‑Only Dashboard (Cursor Multi‑Agent, NO‑LIVE)

--- a/docs/ops/runbooks/RUNBOOK_TO_FINISH_MASTER.md
+++ b/docs/ops/runbooks/RUNBOOK_TO_FINISH_MASTER.md
@@ -1,5 +1,8 @@
 # RUNBOOK — Peak_Trade „bis Finish“ (Master Runbook)
 
+> **Canonical-Note (aktueller Clarification-Workstream):** Die bindende kanonische Steuerdatei fuer **Master V2 + First Live Enablement Readiness Contract/Ladder** ist `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`.  
+> Dieses Runbook bleibt eine operative Companion-Flaeche und ist fuer diesen Workstream nicht der kanonische Winner.
+
 **Ziel:** Dieses Runbook führt dich vom aktuellen **docs-only Branch-Stand** (untracked Files + 1× EOF-Newline) bis zu einem klar definierten „Finish“-Zustand – inkl. PR‑Lieferung, DoD‑Verifikationen für D2/D3/D4 und optionalen (governance‑locked) Finish‑C / Option‑B Tracks.
 
 **Geltungsbereich:** Standardmäßig **docs-only** (kein Code‑Change, keine Live‑Aktivierung).  

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -1,0 +1,118 @@
+# MASTER V2 — First Live Enablement Readiness Ladder (Canonical)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Canonical steering file for the Master V2 clarification workstream, including First Live Enablement readiness contract ladder
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER
+
+## 1) Canonical Binding (Current Clarification Workstream)
+
+For the current **Master V2 + First Live Enablement** clarification workstream, this file is the **single binding canonical steering document** in the repository.
+
+Canonical path:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
+
+No other document has equal canonical priority for this specific workstream.
+
+## 2) Scope and Non-Goals
+
+This document is docs-only steering and mapping guidance:
+
+- no runtime changes
+- no CI/test policy changes
+- no live/paper/shadow evidence mutation
+- no governance lock softening
+- no direct execution authority
+
+Rule: ambiguity remains `NO_TRADE`.
+
+## 3) Master V2 Core Substance (Consolidated)
+
+The Master V2 baseline remains:
+
+- docs-first and governance-first operation
+- explicit NO-LIVE default posture unless independently unlocked by existing governance gates
+- explicit operator-supervised progression for bounded pilot contexts
+- single-source steering for "what is required before first bounded real-money entry"
+
+Existing operational runbook content (including D2/D3/D4-oriented finish/readiness workflow mechanics) remains available as companion material:
+
+- `docs/ops/runbooks/RUNBOOK_TO_FINISH_MASTER.md`
+- `docs/RUNBOOK_TO_FINISH_MASTER.md`
+
+For this workstream, those runbooks are **supporting** and not the canonical steering winner.
+
+## 4) First Live Enablement Readiness Contract Ladder (Mapped to Existing Canonical Docs)
+
+This ladder does not introduce new domain logic; it consolidates already existing canonical docs into one navigation/decision surface.
+
+### Level 0 — Baseline Posture (NO-LIVE Default)
+
+Interpretation baseline and authority boundaries:
+
+- `docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md`
+- `docs/SAFETY_POLICY_TESTNET_AND_LIVE.md`
+- `docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md`
+
+### Level 1 — Dry Validation Readiness
+
+Dry validation sequence and gate-preflight posture:
+
+- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md`
+- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` (Phase A and gate posture)
+
+### Level 2 — Go/No-Go Interpretation
+
+Canonical checklist and verdict semantics:
+
+- `docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md`
+- `docs/ops/specs/PILOT_GO_NO_GO_OPERATIONAL_SLICE.md`
+- `scripts/ops/pilot_go_no_go_eval_v1.py`
+
+### Level 3 — First Live Enablement Entry Contract
+
+Binding operator-facing entry contract for first strictly bounded real-money pilot:
+
+- `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md`
+- `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md`
+- `docs/ops/specs/BOUNDED_PILOT_LIVE_ENTRY_GAP_NOTE.md` (historical gap context only)
+
+### Level 4 — First Candidate Session Flow (Operator Execution Surface)
+
+Canonical first-session sequence and operative invocation path:
+
+- `docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md`
+- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`
+- `scripts/ops/run_bounded_pilot_session.py`
+
+### Level 5 — Incident, Abort, and Safe-Stop Discipline
+
+During first-live-enablement progression, incident handling and safe-stop discipline remain mandatory:
+
+- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md`
+- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md`
+- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md`
+- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md`
+- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md`
+- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md`
+
+## 5) How to Use This File
+
+Use this file as the single starting point when clarifying:
+
+- current first-live-enablement readiness level
+- missing prerequisites before bounded real-money candidate entry
+- which canonical spec/runbook has binding wording for a disputed interpretation
+
+If conflicts appear between supporting docs, this file defines the canonical navigation order for this workstream.
+
+## 6) Companion and De-Emphasized Surfaces
+
+The following are retained for operational continuity but are not canonical steering winners for this clarification workstream:
+
+- `docs/ops/runbooks/RUNBOOK_TO_FINISH_MASTER.md`
+- `docs/RUNBOOK_TO_FINISH_MASTER.md`
+
+They should point readers back to this file for canonical workstream steering.


### PR DESCRIPTION
## Summary
- embed the canonical Master V2 first-live-enablement readiness ladder at a single repo-native specs path
- add minimal frontdoor and ops links so Cursor can discover the canonical document from repo navigation
- de-emphasize older non-canonical master/runbook briefing surfaces for this clarification workstream

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)