### PR TITLE
docs(ops): add master v2 readiness read model v1

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,6 +20,7 @@
 - Canonical Spec (verbindlich): [docs/ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](ops/specs/CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
 - Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
 - Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
+- Master-V2 Readiness (canonical pair): [Readiness Ladder](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) + [Readiness Read Model v1 (read-only interpretation)](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
 
 ---
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -87,6 +87,7 @@ For scripts and port notes, see the root [`README.md`](../../README.md) section 
 - `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` — Kanonischer operatorischer Eintrittsvertrag für den ersten strikt begrenzten Echtgeldpilot
 - `docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md` — Kanonische First-Session-Sequenz für den ersten strikt begrenzten Echtgeldpilot-Kandidatenfluss
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` — **Bindende kanonische Steuerdatei** für den aktuellen Master-V2-First-Live-Enablement-Clarification-Workstream (Readiness Contract/Ladder)
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` — Kanonisches read-only Interpretations-/Statusmodell v1 für Master-V2-Readiness-Reviews (nicht autorisierend, keine Gate-Closure)
 
 - `docs/ops/specs/BOUNDED_PILOT_CAPS_ENFORCEMENT_POINT.md` — Kanonische Einordnung des aktuellen Caps-Enforcement-Punkts im bounded-pilot-Pfad
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -16,6 +16,10 @@ Canonical path:
 
 No other document has equal canonical priority for this specific workstream.
 
+Companion interpretation layer (read-only, non-authorizing):
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+
 ## 2) Scope and Non-Goals
 
 This document is docs-only steering and mapping guidance:
@@ -105,6 +109,10 @@ Use this file as the single starting point when clarifying:
 - current first-live-enablement readiness level
 - missing prerequisites before bounded real-money candidate entry
 - which canonical spec/runbook has binding wording for a disputed interpretation
+
+For normalized status wording and claim discipline during readiness reviews, apply the companion read model:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
 
 If conflicts appear between supporting docs, this file defines the canonical navigation order for this workstream.
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -1,0 +1,174 @@
+# MASTER V2 — First Live Enablement Readiness Read Model v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Canonical read-only interpretation model for Master V2 First Live Enablement readiness status reviews
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1
+
+## 1) Purpose / Scope
+
+This document defines a canonical, review-friendly read model for interpreting readiness status in the Master V2 First Live Enablement workstream.
+
+Scope:
+
+- define a stable readiness ladder interpretation frame (`L0` to `L5`)
+- define fixed per-level evaluation fields (`status`, `evidence pointer`, `blocker`, `authority-safe interpretation`)
+- define strict claim classes for review wording
+- reduce interpretation drift across status reports and PR reviews
+
+This is a docs-only mapping layer. It does not change runtime behavior, policy enforcement, gate logic, evidence generation, or decision authority.
+
+## 2) Non-Goals
+
+This document does not:
+
+- close any gate
+- authorize live entry, live unlock, or promotion
+- create a runtime read model or telemetry source
+- add dataflow maps or authority maps
+- evaluate factual gate outcomes beyond referenced evidence
+- replace existing canonical contracts/runbooks
+
+## 3) Relationship to Canonical Master V2
+
+Canonical steering for the workstream remains:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
+
+This read model is a companion interpretation layer for that canonical ladder.  
+If wording conflicts arise, the canonical ladder and underlying canonical specs/runbooks win.
+
+## 4) Readiness Read Model Levels
+
+The read model uses six interpretation levels:
+
+| Level | Ladder intent | Minimal interpretation meaning |
+|---|---|---|
+| `L0` | Baseline posture | Governance-first default posture; no implied enablement. |
+| `L1` | Dry validation readiness | Dry/preflight interpretation only; no live implication. |
+| `L2` | Go/No-Go interpretation | Checklist/verdict interpretation surface; still read-only. |
+| `L3` | Entry contract interpretation | Entry contract text interpreted; no gate closure implied. |
+| `L4` | Candidate session flow interpretation | Operator flow interpreted; no execution authorization implied. |
+| `L5` | Incident/safe-stop discipline interpretation | Incident/abort discipline interpreted as mandatory boundary. |
+
+Per-level reporting MUST always include these fields:
+
+- `status`
+- `evidence_pointer`
+- `blocker`
+- `authority_safe_interpretation`
+
+## 5) Status Grammar
+
+Allowed `status` values for this read model:
+
+- `not-assessed`
+- `in-review`
+- `mapped`
+- `blocked`
+- `unknown`
+
+Status semantics:
+
+- `mapped`: interpretation text exists and is linked to canonical sources
+- `blocked`: interpretation exists but is currently constrained by explicit blocker text
+- `in-review`: interpretation draft exists but is not yet review-stable
+- `not-assessed`: no interpretation pass performed yet
+- `unknown`: information is insufficient to classify reliably
+
+This status grammar is interpretation-state only, not runtime-state and not gate-state.
+
+## 6) Claim Discipline
+
+Every readiness statement MUST be tagged with one claim class:
+
+- `repo-evidenced`: claim is directly supported by explicit repo artifact(s)
+- `documented`: claim is documented in canonical docs but not independently verified by this read model
+- `operator-stated` (optional): claim originates from operator statement and is not repo-verified in this context
+- `unverified`: claim is plausible or reported but not verified by cited repo evidence
+- `not-claimed`: no claim is asserted
+
+Claim discipline rules:
+
+- never present `unverified`, `operator-stated`, or `not-claimed` as verified fact
+- do not mix multiple claim classes in one atomic statement
+- if evidence is missing, downgrade to `unverified` or `not-claimed`
+- prefer `repo-evidenced` only with concrete `evidence_pointer` values
+
+## 7) Evidence Pointer Semantics
+
+`evidence_pointer` is a reference to existing repository artifacts only.
+
+Allowed pointer forms (examples):
+
+- canonical doc path (for interpretation provenance), e.g. `docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md`
+- runbook path (for operational wording provenance)
+- script path (for evaluation logic provenance)
+- explicit list when multiple canonical references are required
+
+Rules:
+
+- pointers MUST be concrete and repository-resolvable
+- no generated or hypothetical future path as evidence
+- no telemetry/event stream references introduced by this spec
+
+## 8) Blocker Semantics
+
+`blocker` captures interpretation constraints, not runtime diagnostics.
+
+Allowed blocker forms:
+
+- `none`
+- concise blocker sentence with canonical source reference
+
+Rules:
+
+- blocker text must remain reviewable and source-anchored
+- blocker presence does not imply authority to resolve or override
+- blocker removal requires source-state update outside this read model
+
+## 9) Authority-Safe Interpretation Rules
+
+`authority_safe_interpretation` MUST preserve governance boundaries:
+
+- use wording such as `interpreted as`, `mapped as`, `not authorized by this read model`
+- prohibit wording that implies approval, closure, unlock, or enablement
+- keep decision authority external to this layer
+- when uncertain, default interpretation remains `NO_TRADE`
+
+## 10) Reporting Template / Example Table
+
+Use this template for status reporting:
+
+| level | status | claim_class | evidence_pointer | blocker | authority_safe_interpretation |
+|---|---|---|---|---|---|
+| `L0` | `mapped` | `repo-evidenced` | `docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md` | `none` | Baseline posture interpreted as governance-first and non-authorizing. |
+| `L1` | `in-review` | `documented` | `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md` | Clarification pending on checklist wording. | Dry-readiness language mapped only; no live implication. |
+| `L2` | `not-assessed` | `not-claimed` | `docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md` | `none` | No interpretation claim currently asserted. |
+
+Template notes:
+
+- one row per level (`L0` to `L5`)
+- each row MUST include all required fields
+- include claim class explicitly for each row
+
+## 11) Explicit Non-Authorization Rule
+
+This specification is an interpretation/readiness status read model only.
+
+It MUST NOT be used as:
+
+- gate closure
+- go-live approval
+- live-unlock trigger
+- runtime execution authority
+
+Any such decision remains bound to existing governance, safety, risk, and operator authority sources.
+
+## 12) Open Questions / Future Extensions
+
+Potential future additive work (out of scope for v1):
+
+- optional machine-readable schema for report validation (docs-only)
+- optional cross-reference matrix between ladder levels and canonical source sections


### PR DESCRIPTION
## Summary
- add the canonical Master V2 First Live Enablement Readiness Read Model v1 spec
- link the new read-model surface from the existing readiness ladder and docs frontdoors
- keep the slice docs-only, single-topic, and explicitly non-authorizing

## Scope
- new spec: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
- update: `docs/ops/README.md`
- update: `docs/INDEX.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no gate closure implied

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)