### PR TITLE
docs(ops): add master v2 gate status report surface v1

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,6 +21,7 @@
 - Normative Kurzregel: `Governance > Safety&#47;Kill-Switch > Risk&#47;Exposure Caps`; `Switch-Gate` und `AI Orchestrator` sind Control-Orchestration/advisory, aber keine finale Execution Authority.
 - Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
 - Master-V2 Readiness (canonical pair): [Readiness Ladder](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) + [Readiness Read Model v1 (read-only interpretation)](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- Master-V2 Gate-Status Report Surface v1 (docs-only reporting layer): [Gate-Status Report Surface / Summary Table v1](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
 
 ---
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -88,6 +88,7 @@ For scripts and port notes, see the root [`README.md`](../../README.md) section 
 - `docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md` — Kanonische First-Session-Sequenz für den ersten strikt begrenzten Echtgeldpilot-Kandidatenfluss
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` — **Bindende kanonische Steuerdatei** für den aktuellen Master-V2-First-Live-Enablement-Clarification-Workstream (Readiness Contract/Ladder)
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` — Kanonisches read-only Interpretations-/Statusmodell v1 für Master-V2-Readiness-Reviews (nicht autorisierend, keine Gate-Closure)
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` — Kanonische docs-only Report-Surface v1 für standardisierte Gate-Status-Tabellen und Per-Gate-Detailformate (read-only, non-authorizing)
 
 - `docs/ops/specs/BOUNDED_PILOT_CAPS_ENFORCEMENT_POINT.md` — Kanonische Einordnung des aktuellen Caps-Enforcement-Punkts im bounded-pilot-Pfad
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
@@ -1,0 +1,176 @@
+# MASTER V2 — First Live Enablement Gate-Status Report Surface / Summary Table v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Canonical docs-only reporting surface for compact, review-friendly Master V2 readiness gate status output
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1
+
+## 1) Purpose / Scope
+
+This specification defines a canonical, docs-only report surface for Master V2 First Live Enablement readiness-gate status reviews.
+
+Scope:
+
+- standardize one compact summary table format for gate-status reporting
+- standardize one per-gate detail format for deeper review context
+- bind report fields to the existing Readiness Read Model v1 interpretation semantics
+- reduce wording drift and report-shape drift across reviews and PRs
+
+This specification is mapping/reporting only. It does not evaluate runtime state, create new evidence, or grant authority.
+
+## 2) Non-Goals
+
+This specification does not:
+
+- close any readiness gate
+- authorize go-live, live unlock, or promotion
+- create a runtime read model, telemetry source, or new data source
+- perform repo-wide factual gate inventory or backfill
+- replace canonical gate contracts/runbooks
+- change policy-core, risk-core, governance-core, or execution semantics
+
+## 3) Relationship to Canonical Master V2
+
+Canonical steering remains:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
+
+This report surface is subordinate and interpretive.  
+If wording conflicts appear, canonical ladder and underlying canonical specs/runbooks win.
+
+## 4) Relationship to Readiness Ladder
+
+Gate-status rows must map to ladder framing and remain review-only:
+
+- ladder provides canonical navigation and level intent (`L0` to `L5`)
+- report surface provides standardized status rendering for review output
+- report rows must not reinterpret level intent beyond ladder wording
+
+## 5) Relationship to Readiness Read Model v1
+
+Read model companion:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+
+Binding coupling rules:
+
+- `Status` values in this report surface MUST reuse the read model status grammar
+- `Evidence Present / Evidence Pointer` MUST follow read model evidence pointer semantics
+- status wording MUST preserve authority-safe interpretation boundaries
+- claim hygiene in status narrative MUST follow read model claim discipline
+
+## 6) Summary Table Contract
+
+Every gate-status report using this surface MUST include exactly one compact summary table with the following columns:
+
+| Gate | Status | Evidence Present / Evidence Pointer | Blocking Issue | Required Authority | Next Minimal Slice |
+|---|---|---|---|---|---|
+
+Column contract:
+
+- `Gate`: canonical gate/level name (for example `L0 Baseline Posture`, `L3 Entry Contract Interpretation`)
+- `Status`: one read-model status value (`not-assessed`, `in-review`, `mapped`, `blocked`, `unknown`)
+- `Evidence Present / Evidence Pointer`: `yes/no` signal plus concrete repo path pointer(s); no hypothetical references
+- `Blocking Issue`: `none` or concise blocker sentence anchored to canonical wording/evidence
+- `Required Authority`: explicit authority domain required for closure/decision outside this report
+- `Next Minimal Slice`: smallest additive, single-topic docs-first next step for clarification
+
+Formatting rules:
+
+- one row per gate included in the report scope
+- do not omit columns
+- avoid compound claims in a single cell when they cross claim classes
+- keep wording interpretation-only and non-authorizing
+
+## 7) Per-Gate Detail Contract
+
+In addition to the summary table, each gate MUST use the following detail schema:
+
+- `gate_name`
+- `current_status`
+- `evidence_used_or_pointer`
+- `what_remains_open`
+- `blocking_condition`
+- `required_authority`
+- `next_minimal_slice`
+
+Field rules:
+
+- `gate_name`: must match summary-table gate label
+- `current_status`: must match summary-table `Status` and read-model grammar
+- `evidence_used_or_pointer`: concrete repository pointers only
+- `what_remains_open`: concise interpretation gap statement; no closure claim
+- `blocking_condition`: `none` or source-anchored blocker sentence
+- `required_authority`: explicit external authority owner/domain; never this report surface
+- `next_minimal_slice`: smallest reviewable additive docs slice
+
+## 8) Evidence Pointer Handling
+
+Evidence pointers in this report surface are provenance links, not proof of gate closure.
+
+Allowed forms:
+
+- canonical docs paths
+- canonical runbook paths
+- canonical script paths (interpretation provenance only)
+- explicit short list when multiple pointers are needed
+
+Rules:
+
+- pointers must resolve to existing repo artifacts
+- no generated future artifacts as evidence
+- no telemetry/event-stream introduction by this spec
+- if evidence is missing, mark explicitly in `Evidence Present / Evidence Pointer` and keep status non-authorizing
+
+## 9) Status / Claim Hygiene
+
+Hygiene rules for report text:
+
+- treat `Status` as interpretation-state only, never execution-state or approval-state
+- never phrase `mapped` as gate-complete or live-ready
+- downgrade uncertain statements to non-assertive wording and mark open items explicitly
+- keep claim wording source-anchored and review-friendly
+- default to conservative interpretation when ambiguity remains
+
+## 10) Explicit Non-Authorization Rule
+
+This report surface is strictly read-only, interpretation-only, and non-authorizing.
+
+A report rendered with this format MUST NOT be interpreted as:
+
+- gate closure
+- live authorization
+- promotion approval
+- runtime enablement trigger
+
+Any such decisions remain outside this document and bound to canonical governance/safety/risk/operator authority sources.
+
+## 11) Illustrative Example (Non-Authoritative)
+
+The example below is illustrative template content only and does not assert factual gate outcomes.
+
+Summary table example:
+
+| Gate | Status | Evidence Present / Evidence Pointer | Blocking Issue | Required Authority | Next Minimal Slice |
+|---|---|---|---|---|---|
+| `L2 Go/No-Go Interpretation` | `in-review` | `yes: docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md` | Clarification pending on row-to-evidence mapping language. | Governance and operator decision authority outside report surface. | Add one docs-only mapping note clarifying row-level evidence pointer style. |
+| `L3 Entry Contract Interpretation` | `mapped` | `yes: docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` | `none` | Live-entry authority remains external and unchanged. | Add one compact review checklist for interpretation consistency only. |
+
+Per-gate detail example:
+
+- `gate_name`: `L2 Go/No-Go Interpretation`
+- `current_status`: `in-review`
+- `evidence_used_or_pointer`: `docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md`
+- `what_remains_open`: Clarify wording for checklist row to evidence-pointer linkage.
+- `blocking_condition`: Clarification pending on canonical row interpretation wording.
+- `required_authority`: Governance/operator authority outside this report layer.
+- `next_minimal_slice`: Add one docs-only mapping clarification note for row-level pointer phrasing.
+
+## 12) Open Questions / Future Extensions
+
+Potential additive follow-ups (out of scope for v1):
+
+- optional machine-readable schema for report linting (docs-only)
+- optional canonical gate label registry for stricter naming consistency
+- optional minimal rendering examples for different review contexts

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
@@ -56,7 +56,7 @@ Read model companion:
 Binding coupling rules:
 
 - `Status` values in this report surface MUST reuse the read model status grammar
-- `Evidence Present / Evidence Pointer` MUST follow read model evidence pointer semantics
+- `Evidence Present &#47; Evidence Pointer` MUST follow read model evidence pointer semantics
 - status wording MUST preserve authority-safe interpretation boundaries
 - claim hygiene in status narrative MUST follow read model claim discipline
 
@@ -64,14 +64,14 @@ Binding coupling rules:
 
 Every gate-status report using this surface MUST include exactly one compact summary table with the following columns:
 
-| Gate | Status | Evidence Present / Evidence Pointer | Blocking Issue | Required Authority | Next Minimal Slice |
+| Gate | Status | Evidence Present &#47; Evidence Pointer | Blocking Issue | Required Authority | Next Minimal Slice |
 |---|---|---|---|---|---|
 
 Column contract:
 
 - `Gate`: canonical gate/level name (for example `L0 Baseline Posture`, `L3 Entry Contract Interpretation`)
 - `Status`: one read-model status value (`not-assessed`, `in-review`, `mapped`, `blocked`, `unknown`)
-- `Evidence Present / Evidence Pointer`: `yes/no` signal plus concrete repo path pointer(s); no hypothetical references
+- `Evidence Present &#47; Evidence Pointer`: `yes&#47;no` signal plus concrete repo path pointer(s); no hypothetical references
 - `Blocking Issue`: `none` or concise blocker sentence anchored to canonical wording/evidence
 - `Required Authority`: explicit authority domain required for closure/decision outside this report
 - `Next Minimal Slice`: smallest additive, single-topic docs-first next step for clarification
@@ -121,7 +121,7 @@ Rules:
 - pointers must resolve to existing repo artifacts
 - no generated future artifacts as evidence
 - no telemetry/event-stream introduction by this spec
-- if evidence is missing, mark explicitly in `Evidence Present / Evidence Pointer` and keep status non-authorizing
+- if evidence is missing, mark explicitly in `Evidence Present &#47; Evidence Pointer` and keep status non-authorizing
 
 ## 9) Status / Claim Hygiene
 
@@ -152,14 +152,14 @@ The example below is illustrative template content only and does not assert fact
 
 Summary table example:
 
-| Gate | Status | Evidence Present / Evidence Pointer | Blocking Issue | Required Authority | Next Minimal Slice |
+| Gate | Status | Evidence Present &#47; Evidence Pointer | Blocking Issue | Required Authority | Next Minimal Slice |
 |---|---|---|---|---|---|
-| `L2 Go/No-Go Interpretation` | `in-review` | `yes: docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md` | Clarification pending on row-to-evidence mapping language. | Governance and operator decision authority outside report surface. | Add one docs-only mapping note clarifying row-level evidence pointer style. |
-| `L3 Entry Contract Interpretation` | `mapped` | `yes: docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` | `none` | Live-entry authority remains external and unchanged. | Add one compact review checklist for interpretation consistency only. |
+| `L2 Go&#47;No-Go Interpretation` | `in-review` | `yes: docs&#47;ops&#47;specs&#47;PILOT_GO_NO_GO_CHECKLIST.md` | Clarification pending on row-to-evidence mapping language. | Governance and operator decision authority outside report surface. | Add one docs-only mapping note clarifying row-level evidence pointer style. |
+| `L3 Entry Contract Interpretation` | `mapped` | `yes: docs&#47;ops&#47;specs&#47;BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` | `none` | Live-entry authority remains external and unchanged. | Add one compact review checklist for interpretation consistency only. |
 
 Per-gate detail example:
 
-- `gate_name`: `L2 Go/No-Go Interpretation`
+- `gate_name`: `L2 Go&#47;No-Go Interpretation`
 - `current_status`: `in-review`
 - `evidence_used_or_pointer`: `docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md`
 - `what_remains_open`: Clarify wording for checklist row to evidence-pointer linkage.

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -19,6 +19,7 @@ No other document has equal canonical priority for this specific workstream.
 Companion interpretation layer (read-only, non-authorizing):
 
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
 
 ## 2) Scope and Non-Goals
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -39,6 +39,10 @@ Canonical steering for the workstream remains:
 This read model is a companion interpretation layer for that canonical ladder.  
 If wording conflicts arise, the canonical ladder and underlying canonical specs/runbooks win.
 
+Companion report surface (docs-only, non-authorizing):
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+
 ## 4) Readiness Read Model Levels
 
 The read model uses six interpretation levels:


### PR DESCRIPTION
## Summary
- add the canonical Master V2 First Live Enablement Gate Status Report Surface v1 spec
- link the new report-surface contract from the readiness ladder, readiness read model, and docs frontdoors
- keep the slice docs-only, single-topic, non-authorizing, and template-oriented

## Scope
- new spec: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
- update: `docs/ops/README.md`
- update: `docs/INDEX.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no gate closure implied
- no authoritative readiness assessment claimed

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)