### PR TITLE
docs(ops): add repo-evidenced l3 entry contract gate fill v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
@@ -192,7 +192,32 @@ Per-gate detail (single-gate scope):
 - `required_authority`: Governance/operator authority remains external; this report surface has no closure or live-unlock authority.
 - `next_minimal_slice`: Add one minimal canonical doc hook that records the latest candidate-scoped verdict pointer for `L2` using this surface schema, without touching runtime, policy-core, or risk-core.
 
-## 13) Open Questions / Future Extensions
+## 13) Second Additive Single-Gate Fill (Repo-Evidenced, Non-Authorizing)
+
+This section materializes exactly one additional real gate fill for review use:
+
+- gate in scope: `L3 Entry Contract Interpretation`
+- claim discipline: `repo-evidenced` pointers only
+- authority posture: interpretation-only, non-authorizing
+- closure posture: no gate-closure assertion
+
+Summary table (single-gate scope):
+
+| Gate | Status | Evidence Present &#47; Evidence Pointer | Blocking Issue | Required Authority | Next Minimal Slice |
+|---|---|---|---|---|---|
+| `L3 Entry Contract Interpretation` | `blocked` | `yes: docs&#47;ops&#47;specs&#47;BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md; docs&#47;ops&#47;specs&#47;BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md; docs&#47;ops&#47;runbooks&#47;RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md; scripts&#47;ops&#47;pilot_go_no_go_eval_v1.py` | Entry contract wording requires an acceptable pilot verdict (`GO_FOR_NEXT_PHASE_ONLY`) and explicit pre-entry posture checks, while this docs-only slice does not assert a candidate-scoped prerequisite evidence bundle. | Governance and operator decision authority outside this report surface. | Add one docs-only canonical pointer slot for the latest candidate-scoped pre-entry evidence bundle used to interpret `L3` contract prerequisites, without adding authorization semantics. |
+
+Per-gate detail (single-gate scope):
+
+- `gate_name`: `L3 Entry Contract Interpretation`
+- `current_status`: `blocked`
+- `evidence_used_or_pointer`: `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md`; `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md`; `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`; `scripts/ops/pilot_go_no_go_eval_v1.py`
+- `what_remains_open`: Candidate-scoped proof that all contract prerequisites are satisfied (including acceptable verdict posture and explicit pre-entry checks) is missing from this additive slice, so closure cannot be inferred.
+- `blocking_condition`: Contract prerequisites explicitly require acceptable Go/No-Go (`GO_FOR_NEXT_PHASE_ONLY`) and keep ambiguity posture conservative (`NO_TRADE`); missing candidate-scoped prerequisite evidence keeps interpretation blocked.
+- `required_authority`: Governance/operator authority remains external; this report surface has no closure or live-unlock authority.
+- `next_minimal_slice`: Add one minimal canonical docs-only hook that records a repository-resolvable candidate-scoped prerequisite evidence pointer set for `L3` interpretation (verdict artifact + pre-entry posture snapshot references), without touching runtime, policy-core, or risk-core.
+
+## 14) Open Questions / Future Extensions
 
 Potential additive follow-ups (out of scope for v1):
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -186,7 +186,22 @@ Read-model alignment for that instantiation:
 - blocker semantics: source-anchored interpretation constraint only
 - authority-safe interpretation: decision authority remains external
 
-## 13) Open Questions / Future Extensions
+## 13) Second Additive Instantiation Note (Single-Gate, Non-Authorizing)
+
+The second real, additive gate instantiation under this read model is intentionally single-gate and docs-only:
+
+- gate in scope: `L3 Entry Contract Interpretation`
+- rendered on canonical report surface: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` (section `Second Additive Single-Gate Fill`)
+- interpretation status there remains non-authorizing and must not be read as gate closure
+
+Read-model alignment for that instantiation:
+
+- status grammar: uses allowed values from this spec
+- evidence pointers: repository-resolvable canonical paths only
+- blocker semantics: source-anchored interpretation constraint only
+- authority-safe interpretation: decision authority remains external
+
+## 14) Open Questions / Future Extensions
 
 Potential future additive work (out of scope for v1):
 


### PR DESCRIPTION
## Summary
- add the second repo-evidenced single-gate fill for L3 Entry Contract Interpretation
- update the canonical gate-status report surface and readiness read model to carry this bounded, non-authorizing gate content
- keep the slice docs-only, single-topic, and strictly limited to repo-evidenced statements

## Scope
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no automatic gate closure
- no claims beyond repo-evidenced support

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)