### PR TITLE
docs(ops): add repo-evidenced l5 incident safe-stop gate fill v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
@@ -242,7 +242,32 @@ Per-gate detail (single-gate scope):
 - `required_authority`: Governance/operator authority remains external; this report surface has no closure or live-unlock authority.
 - `next_minimal_slice`: Add one minimal canonical docs-only hook that records the latest repository-resolvable candidate-scoped L4 flow evidence pointers using this surface schema, without touching runtime, policy-core, or risk-core.
 
-## 15) Open Questions / Future Extensions
+## 15) Fourth Additive Single-Gate Fill (Repo-Evidenced, Non-Authorizing)
+
+This section materializes exactly one additional real gate fill for review use:
+
+- gate in scope: `L5 Incident&#47;Safe-Stop Discipline Interpretation`
+- claim discipline: `repo-evidenced` pointers only
+- authority posture: interpretation-only, non-authorizing
+- closure posture: no gate-closure assertion
+
+Summary table (single-gate scope):
+
+| Gate | Status | Evidence Present &#47; Evidence Pointer | Blocking Issue | Required Authority | Next Minimal Slice |
+|---|---|---|---|---|---|
+| `L5 Incident&#47;Safe-Stop Discipline Interpretation` | `blocked` | `yes: docs&#47;ops&#47;runbooks&#47;RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md; docs&#47;ops&#47;runbooks&#47;RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md; docs&#47;ops&#47;runbooks&#47;RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md; docs&#47;ops&#47;runbooks&#47;RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md; docs&#47;ops&#47;runbooks&#47;RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md; docs&#47;ops&#47;runbooks&#47;RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md; docs&#47;ops&#47;specs&#47;BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` | Incident/safe-stop discipline wording is present, but this slice does not assert a candidate-scoped incident evidence bundle and the referenced pilot incident runbooks are currently `status: DRAFT`. | Governance and operator decision authority outside this report surface. | Add one docs-only canonical pointer slot for the latest candidate-scoped L5 incident/safe-stop evidence bundle (trigger, classification, operator escalation, final posture), without adding authorization semantics. |
+
+Per-gate detail (single-gate scope):
+
+- `gate_name`: `L5 Incident&#47;Safe-Stop Discipline Interpretation`
+- `current_status`: `blocked`
+- `evidence_used_or_pointer`: `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md`; `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md`; `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md`; `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md`; `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md`; `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md`; `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md`
+- `what_remains_open`: Candidate-scoped repository evidence showing an executed L5 incident/safe-stop discipline path (trigger, classification result, escalation outcome, and final posture) is not asserted in this additive slice; therefore interpretation remains partial.
+- `blocking_condition`: Canonical incident runbooks require conservative freeze/`NO_TRADE` or safe-stop posture under ambiguity, and the entry contract makes abort/`NO_TRADE` criteria explicit (`ambiguity => NO_TRADE &#47; safe stop`); however, referenced pilot incident runbooks remain `status: DRAFT` and no candidate-scoped L5 evidence bundle is asserted here.
+- `required_authority`: Governance/operator authority remains external; this report surface has no closure or live-unlock authority.
+- `next_minimal_slice`: Add one minimal canonical docs-only hook that records a repository-resolvable candidate-scoped L5 incident/safe-stop evidence pointer set under this surface schema, without touching runtime, policy-core, or risk-core.
+
+## 16) Open Questions / Future Extensions
 
 Potential additive follow-ups (out of scope for v1):
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -216,7 +216,22 @@ Read-model alignment for that instantiation:
 - blocker semantics: source-anchored interpretation constraint only
 - authority-safe interpretation: decision authority remains external
 
-## 15) Open Questions / Future Extensions
+## 15) Fourth Additive Instantiation Note (Single-Gate, Non-Authorizing)
+
+The fourth real, additive gate instantiation under this read model is intentionally single-gate and docs-only:
+
+- gate in scope: `L5 Incident&#47;Safe-Stop Discipline Interpretation`
+- rendered on canonical report surface: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` (section `Fourth Additive Single-Gate Fill`)
+- interpretation status there remains non-authorizing and must not be read as gate closure
+
+Read-model alignment for that instantiation:
+
+- status grammar: uses allowed values from this spec
+- evidence pointers: repository-resolvable canonical paths only
+- blocker semantics: source-anchored interpretation constraint only
+- authority-safe interpretation: decision authority remains external
+
+## 16) Open Questions / Future Extensions
 
 Potential future additive work (out of scope for v1):
 


### PR DESCRIPTION
## Summary
- add the fourth repo-evidenced single-gate fill for L5 Incident/Safe-Stop Discipline Interpretation
- update the canonical gate-status report surface and readiness read model to carry this bounded, non-authorizing gate content
- keep the slice docs-only, single-topic, and strictly limited to repo-evidenced statements

## Scope
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no automatic gate closure
- no claims beyond repo-evidenced support

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)