### PR TITLE
docs(ops): add master v2 gate fill vocabulary boundary lock v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md
+++ b/docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md
@@ -1,0 +1,156 @@
+# MASTER V2 — Gate-Fill Vocabulary / Boundary Lock v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Canonical vocabulary and boundary lock for Master V2 First Live Enablement gate-fill semantics
+docs_token: DOCS_TOKEN_MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1
+
+## 1) Purpose / Scope
+
+This specification defines the canonical vocabulary and boundary rules for interpreting Master V2 First Live Enablement gate-fill semantics in a review-safe, drift-resistant way.
+
+Scope:
+
+- lock meaning boundaries across gate-status reporting and single-gate fills
+- define canonical term meanings and explicit non-equivalences
+- stabilize claim and status wording for additive docs-only slices
+- keep authority, closure, and live-authorization semantics strictly external
+
+This spec is mapping-only and non-authorizing.
+
+## 2) Non-Goals
+
+This specification does not:
+
+- close any gate
+- authorize live entry, live unlock, or promotion
+- create runtime measurements, telemetry, or executable controls
+- add a new gate fill or expand existing gate-fill substance
+- replace canonical governance, risk, safety, or operator authority sources
+- perform repo-wide terminology reform outside Master V2 gate-fill semantics
+
+## 3) Relationship to Canonical Master V2 Surfaces
+
+Canonical steering/briefing posture for this workstream remains:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
+
+Companion canonical interpretation/rendering layers:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+
+This vocabulary lock is subordinate to canonical steering and does not overrule underlying contracts/runbooks.
+
+## 4) Canonical Terms
+
+The following meanings are locked for Master V2 gate-fill semantics:
+
+- `Gate Status Report Surface`: docs-only rendering surface for compact gate-status output; interpretation/reporting only.
+- `Readiness Read Model`: docs-only interpretation model that defines status grammar, claim discipline, and evidence-pointer semantics.
+- `Single-Gate Fill`: additive docs-only materialization for exactly one gate interpretation scope in one slice.
+- `repo-evidenced`: claim class backed by explicit repository-resolvable artifact pointers.
+- `documented`: claim class documented in canonical docs but not independently verified by this layer.
+- `unverified`: claim class without sufficient repository evidence in this context.
+- `not-claimed`: explicit statement that no claim is being asserted.
+- `current status`: interpretation-state value under read-model grammar; not runtime or authorization state.
+- `evidence pointer`: concrete repository path reference used for provenance, not closure proof.
+- `blocker` / `blocking condition`: source-anchored interpretation constraint text; not executable enforcement.
+- `required authority`: external authority domain required for closure/decision, never granted by this docs layer.
+- `next minimal slice`: smallest additive single-topic docs-only clarification step.
+- `gate closure`: formal closure outcome outside this vocabulary spec and outside report/read-model surfaces.
+- `live authorization`: explicit approval to enable live behavior; always external to this spec.
+- `non-authorizing`: cannot grant closure, unlock, or operational authority.
+- `interpretation-only`: maps and explains canonical wording without changing system behavior or authority state.
+
+## 5) Forbidden Equalities / Dangerous Confusions
+
+The following equalities are explicitly forbidden:
+
+- `Gate Fill != Gate Closure`
+- `repo-evidenced != verified for authorization`
+- `Report Surface != authoritative readiness decision`
+- `Read Model != runtime state measurement`
+- `required authority != granted authority`
+- `blocker text != executable control`
+
+Additional confusion guards:
+
+- `current status != go-live readiness verdict`
+- `documented != repo-evidenced`
+- `evidence pointer != evidence sufficiency for closure`
+- `next minimal slice != closure commitment`
+
+## 6) Boundary Rules
+
+Boundary rules across canonical surfaces:
+
+- `Master V2 briefing` boundary: for this workstream, canonical briefing/steering is carried by the readiness ladder surface at `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`.
+- `Readiness Ladder` boundary: canonical navigation and intent source for `L0` to `L5`; wins in steering conflicts.
+- `Readiness Read Model v1` boundary: interpretation grammar and claim discipline layer; read-only and non-authorizing.
+- `Gate Status Report Surface v1` boundary: report rendering contract; consumes read-model semantics; non-authorizing.
+- `Additive Single-Gate Fills` boundary: one-gate interpretation instantiations rendered on the report surface; they map evidence pointers and blockers but do not claim closure.
+
+Operational boundary lock:
+
+- no surface in this set grants authority by itself
+- authority decisions remain external to governance/safety/risk/operator authority sources
+- ambiguity posture remains conservative (`NO_TRADE`) unless explicitly resolved by authoritative sources outside this spec
+
+## 7) Claim / Status Grammar Alignment
+
+This lock aligns to read-model semantics and keeps usage stable:
+
+- allowed status values remain those defined in `MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+- claim classes in gate-fill wording must use read-model classes (`repo-evidenced`, `documented`, `unverified`, `not-claimed`, optional `operator-stated`)
+- each atomic statement should carry exactly one claim class
+- unknown or missing evidence must downgrade claim strength, never upgrade it
+- interpretation status may be `mapped` or `blocked` without implying closure
+
+## 8) Authority-Safe Interpretation Notes
+
+Authority-safe wording rules for reviews and additive slices:
+
+- prefer wording such as `interpreted as`, `mapped as`, `not authorized by this layer`
+- prohibit wording that implies approval, unlock, closure, or enablement
+- keep `required authority` explicit whenever closure-like language might be inferred
+- treat blocker text as explanatory boundary, not as control logic
+- retain separation between interpretation artifacts and operational authority outcomes
+
+## 9) Minimal Cross-Link Contract
+
+Minimal canonical links required for this vocabulary lock:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+
+Existing additive single-gate fills are consumed through the gate-status report surface sections:
+
+- `First Additive Single-Gate Fill`
+- `Second Additive Single-Gate Fill`
+- `Third Additive Single-Gate Fill`
+- `Fourth Additive Single-Gate Fill`
+
+No broader frontdoor rewiring is required in this slice.
+
+## 10) Explicit Non-Authorization Rule
+
+This specification is strictly docs-only, interpretation-only, and non-authorizing.
+
+It MUST NOT be used as:
+
+- gate closure artifact
+- live authorization artifact
+- live-unlock trigger
+- runtime control or enforcement source
+
+Any closure or authorization outcome remains outside this specification and bound to existing authoritative governance/safety/risk/operator mechanisms.
+
+## 11) Open Questions / Future Extensions
+
+Potential additive follow-ups (out of scope for v1):
+
+- optional lintable glossary schema for term usage consistency in future gate-fill slices
+- optional compact confusion-check checklist for PR review templates


### PR DESCRIPTION
## Summary
- add the canonical Master V2 Gate Fill Vocabulary / Boundary Lock v1 spec
- stabilize terminology and boundary rules around report surface, read model, single-gate fills, claim grammar, and non-authorizing semantics
- keep the slice docs-only, single-topic, and explicitly non-authorizing

## Scope
- new spec: `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no gate closure implied
- no new gate fill content added

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)