### PR TITLE
docs(ops): consolidate master v2 readiness ladder surfaces v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
@@ -53,12 +53,37 @@ Read model companion:
 
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
 
+Vocabulary/boundary lock companion:
+
+- `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`
+
 Binding coupling rules:
 
 - `Status` values in this report surface MUST reuse the read model status grammar
 - `Evidence Present &#47; Evidence Pointer` MUST follow read model evidence pointer semantics
 - status wording MUST preserve authority-safe interpretation boundaries
 - claim hygiene in status narrative MUST follow read model claim discipline
+
+## 5.1) Canonical Surface Roles (Consolidation v1)
+
+Role boundaries for this surface are intentionally narrow:
+
+- ladder is authoritative for gate/sequence/status framing and navigation intent
+- read model is authoritative for status/claim/evidence/blocker interpretation grammar
+- report surface is authoritative for compact rendering shape only (table + per-gate detail schema)
+- single-gate fills are additive report sections that materialize one gate interpretation scope per slice
+
+Reader order for low-drift interpretation:
+
+1. ladder framing
+2. read-model grammar
+3. report-surface schema
+4. relevant additive single-gate fill section (`First` to `Fourth`)
+
+Consolidation v1 effect on this surface:
+
+- no new single-gate fill is introduced
+- no gate closure is asserted or implied
 
 ## 6) Summary Table Contract
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -21,6 +21,24 @@ Companion interpretation layer (read-only, non-authorizing):
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
 
+Consolidation companion (vocabulary/boundary lock, read-only, non-authorizing):
+
+- `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`
+
+## 1.1) Canonical Surface Roles (Consolidation v1)
+
+For this workstream, role boundaries are intentionally strict:
+
+- `Readiness Ladder`: canonical gate/sequence/status framing and navigation order (`L0` to `L5`)
+- `Readiness Read Model v1`: interpretation grammar (`status`, claim class, evidence pointer, blocker, authority-safe wording)
+- `Gate-Status Report Surface v1`: compact reporting/table/detail rendering contract using read-model semantics
+- `Single-Gate Fills` (rendered on report surface): additive, repo-evidenced interpretation materialization for exactly one gate scope per slice
+
+Consolidation v1 is mapping-only:
+
+- no new gate fill is introduced by this ladder consolidation
+- no gate closure is asserted or implied by this ladder consolidation
+
 ## 2) Scope and Non-Goals
 
 This document is docs-only steering and mapping guidance:
@@ -114,6 +132,10 @@ Use this file as the single starting point when clarifying:
 For normalized status wording and claim discipline during readiness reviews, apply the companion read model:
 
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+
+For compact gate-status rendering and the already materialized single-gate fills, use the canonical report surface:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
 
 If conflicts appear between supporting docs, this file defines the canonical navigation order for this workstream.
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -43,6 +43,24 @@ Companion report surface (docs-only, non-authorizing):
 
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
 
+Vocabulary/boundary lock companion:
+
+- `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`
+
+## 3.1) Canonical Surface Roles (Consolidation v1)
+
+This read model is intentionally limited to interpretation grammar:
+
+- ladder remains canonical for gate/sequence/status framing (`L0` to `L5`)
+- read model remains canonical for status/claim/evidence/blocker interpretation semantics
+- report surface remains canonical for compact rendering (summary table + per-gate details)
+- single-gate fills remain additive report-surface sections and must not be treated as gate closure artifacts
+
+Consolidation v1 effect for this read model is mapping-only:
+
+- no new single-gate fill is introduced here
+- no gate closure is asserted or implied here
+
 ## 4) Readiness Read Model Levels
 
 The read model uses six interpretation levels:


### PR DESCRIPTION
## Summary
- consolidate the canonical Master V2 readiness ladder, readiness read model, and gate status report surface
- reduce terminology, anchor, and cross-link drift across the three readiness/reporting surfaces
- keep the slice docs-only, single-topic, and explicitly non-authorizing

## Scope
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no new gate fill content added
- no gate closure implied

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)