### PR TITLE
docs(ops): add master v2 readiness canonical bridge v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -39,6 +39,30 @@ Consolidation v1 is mapping-only:
 - no new gate fill is introduced by this ladder consolidation
 - no gate closure is asserted or implied by this ladder consolidation
 
+## 1.2) Canonical Bridge v1 (Master V2 ↔ Readiness Surfaces)
+
+This bridge clarifies how canonical surfaces connect for this workstream without introducing new gate substance:
+
+- `Master V2 (this ladder surface)`: overarching target framing and canonical readiness navigation anchor
+- `Readiness Ladder`: canonical gate sequence and readiness framing (`L0` to `L5`)
+- `Readiness Read Model v1`: canonical interpretation grammar for status/claim/evidence/blocker semantics
+- `Gate-Status Report Surface v1`: canonical reporting schema that renders read-model-aligned gate status
+- `Single-Gate Fills`: bounded, additive, repo-evidenced population of individual gate interpretations rendered on the report surface
+
+Reader order for low-drift interpretation and review:
+
+1. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` (Master framing + ladder intent)
+2. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` (interpretation grammar)
+3. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` (report schema)
+4. relevant single-gate fill section(s) on the report surface (`First` to `Fourth`)
+
+Bridge boundary note (explicit):
+
+- this bridge is docs-only and mapping-only
+- this bridge does not add any new single-gate fill
+- this bridge does not assert or imply gate closure
+- this bridge does not authorize live unlock, live entry, or runtime behavior
+
 ## 2) Scope and Non-Goals
 
 This document is docs-only steering and mapping guidance:

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -61,6 +61,26 @@ Consolidation v1 effect for this read model is mapping-only:
 - no new single-gate fill is introduced here
 - no gate closure is asserted or implied here
 
+## 3.2) Canonical Bridge Link (Read Model → Report Surface)
+
+For this workstream, the bridge between interpretation grammar and reporting output is strict:
+
+- this read model defines the allowed interpretation grammar (`status`, claim class, `evidence_pointer`, `blocker`, authority-safe wording)
+- the report surface consumes this grammar as rendering schema and does not redefine semantics
+- additive single-gate fills remain bounded report-surface materializations of individual gate interpretation scopes
+
+Cross-link path for stable navigation:
+
+1. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
+2. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` (this file)
+3. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+
+Non-authorization lock for this bridge link:
+
+- no new single-gate fill is introduced by this clarification
+- no gate closure is asserted or implied
+- no live authorization or runtime authority is granted
+
 ## 4) Readiness Read Model Levels
 
 The read model uses six interpretation levels:


### PR DESCRIPTION
## Summary
- add a canonical bridge clarification between Master V2 readiness framing surfaces
- clarify the relationship and reading order between the readiness ladder and readiness read model
- keep the slice docs-only, single-topic, and explicitly non-authorizing

## Scope
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no new gate fill content added
- no gate closure implied

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)