### PR TITLE
docs(ops): connect master v2 bridge to gate fill vocabulary v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -81,6 +81,26 @@ Non-authorization lock for this bridge link:
 - no gate closure is asserted or implied
 - no live authorization or runtime authority is granted
 
+## 3.3) Canonical Bridge v1 ↔ Vocabulary/Boundary Lock v1 (Connection Clarification)
+
+Role split for drift-resistant reading is explicit and non-overlapping:
+
+- `Canonical Bridge v1` (on the readiness ladder surface) is the canonical relationship, reading-order, and navigation clarification across readiness surfaces
+- `Gate-Fill Vocabulary &#47; Boundary Lock v1` is the canonical terminology, forbidden-equality, and boundary-rule lock for gate-fill semantics
+- this read model remains the interpretation grammar layer consumed by the report surface
+
+How later additive single-gate fills must stay aligned with both surfaces:
+
+- use bridge logic for placement and reader navigation path across ladder/read-model/report-surface
+- use vocabulary lock rules for term meaning, dangerous-confusion prevention, and boundary-safe wording
+- keep fill substance additive and one-gate scoped on the report surface
+
+Explicit non-implication lock for this connection clarification:
+
+- no new gate fill is introduced
+- no gate closure is asserted or implied
+- no live authorization, live unlock, or runtime authority is granted
+
 ## 4) Readiness Read Model Levels
 
 The read model uses six interpretation levels:

--- a/docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md
+++ b/docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md
@@ -43,6 +43,24 @@ Companion canonical interpretation/rendering layers:
 
 This vocabulary lock is subordinate to canonical steering and does not overrule underlying contracts/runbooks.
 
+## 3.1) Connection to Canonical Bridge v1 (Role Boundary Clarification)
+
+For this workstream, `Canonical Bridge v1` is carried by the readiness-ladder surface and remains the canonical navigation/relationship clarification between readiness surfaces:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` (bridge + reader order anchor)
+
+This vocabulary lock is complementary and narrower in role:
+
+- lock term meaning for gate-fill semantics
+- lock forbidden equalities and dangerous confusions
+- lock boundary-safe wording so interpretation artifacts are not misread as authority outcomes
+
+Co-use rule for future additive single-gate fills:
+
+- navigation/placement must follow bridge reader-order logic
+- term and boundary discipline must follow this vocabulary lock
+- neither surface implies gate closure or live authorization
+
 ## 4) Canonical Terms
 
 The following meanings are locked for Master V2 gate-fill semantics:
@@ -125,6 +143,12 @@ Minimal canonical links required for this vocabulary lock:
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+
+Bridge/vocabulary discoverability lock:
+
+- canonical bridge/reader-order clarification is read from the readiness ladder surface
+- canonical terminology/forbidden-equality/boundary lock is read from this vocabulary surface
+- additive single-gate fills must preserve both simultaneously (bridge placement + vocabulary boundary discipline)
 
 Existing additive single-gate fills are consumed through the gate-status report surface sections:
 


### PR DESCRIPTION
## Summary
- connect the Master V2 readiness canonical bridge to the gate-fill vocabulary / boundary lock surface
- clarify how navigation/reading-order guidance and terminology/boundary discipline work together
- keep the slice docs-only, single-topic, and explicitly non-authorizing

## Scope
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
- update: `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no new gate fill content added
- no gate closure implied

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)