### PR TITLE
docs(ops): connect master v2 to gate status report surface v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
@@ -39,6 +39,27 @@ Canonical steering remains:
 This report surface is subordinate and interpretive.  
 If wording conflicts appear, canonical ladder and underlying canonical specs/runbooks win.
 
+## 3.1) Master V2 Connection Clarification v1 (Bridge / Ladder / Read Model / Report Surface)
+
+Canonical role split for this direct connection is explicit:
+
+- `Master V2 &#47; Canonical Bridge v1 &#47; Readiness Ladder`: navigation anchor, relationship framing, and reader order
+- `Readiness Read Model v1`: status/claim/evidence/blocker interpretation grammar
+- `Gate-Status Report Surface v1` (this file): rendering/status output contract that consumes read-model grammar
+
+Canonical reader path for low-drift review:
+
+1. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` (includes Canonical Bridge v1)
+2. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+3. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+4. relevant additive single-gate fill section(s) on this report surface (`First` to `Fourth`)
+
+Explicit non-implication lock for this connection clarification:
+
+- no new gate fill is introduced by this clarification
+- no gate closure is asserted or implied
+- no live authorization, live unlock, or runtime authority is granted
+
 ## 4) Relationship to Readiness Ladder
 
 Gate-status rows must map to ladder framing and remain review-only:

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -63,6 +63,27 @@ Bridge boundary note (explicit):
 - this bridge does not assert or imply gate closure
 - this bridge does not authorize live unlock, live entry, or runtime behavior
 
+## 1.3) Master V2 ↔ Gate-Status Report Surface Connection Clarification v1
+
+This clarification makes the canonical connection explicit for review and low-drift reading:
+
+- `Master V2 &#47; Bridge &#47; Ladder` define navigation, relationship boundaries, and reader order
+- `Readiness Read Model v1` defines status/claim/evidence/blocker interpretation grammar
+- `Gate-Status Report Surface v1` defines rendering/output contract and consumes read-model grammar without redefining authority
+
+Canonical entry and reader path for this connection:
+
+1. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` (Master V2 anchor, including Canonical Bridge v1 in this file)
+2. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` (interpretation grammar)
+3. `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` (report/status output contract)
+4. relevant additive single-gate fill section(s) on the report surface (`First` to `Fourth`)
+
+Non-implication lock for this connection clarification:
+
+- no new gate fill is introduced
+- no gate closure is asserted or implied
+- no live authorization, live unlock, or runtime authority is granted
+
 ## 2) Scope and Non-Goals
 
 This document is docs-only steering and mapping guidance:


### PR DESCRIPTION
## Summary
- connect the Master V2 readiness framing surfaces directly to the Gate Status Report Surface v1
- clarify how the ladder/bridge framing relates to the reporting/status output contract
- keep the slice docs-only, single-topic, and explicitly non-authorizing

## Scope
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no new gate fill content added
- no gate closure implied

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)