### PR TITLE
docs(ops): align master v2 read model and report surface v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md
@@ -106,6 +106,27 @@ Consolidation v1 effect on this surface:
 - no new single-gate fill is introduced
 - no gate closure is asserted or implied
 
+## 5.2) Read Model ↔ Report Surface Final Alignment v1
+
+Final role split for low-drift review is explicit:
+
+- `Readiness Read Model v1` provides the status/claim/interpretation grammar
+- this report surface renders and instantiates that grammar as summary-table and per-gate output
+- this report surface does not redefine interpretation semantics from the read model
+- this report surface does not set gate closure, approval state, or live authority
+
+Forward constraint for later additive single-gate fills on this surface:
+
+- each fill MUST reuse read-model grammar as-is for status/claim/evidence/blocker interpretation wording
+- each fill MUST remain a bounded report rendering for one gate scope
+- each fill MUST keep authority external and preserve non-authorizing wording
+
+Explicit non-implication lock for this final alignment slice:
+
+- no new gate fill is introduced
+- no gate closure is asserted or implied
+- no live authorization, live unlock, or runtime authority is granted
+
 ## 6) Summary Table Contract
 
 Every gate-status report using this surface MUST include exactly one compact summary table with the following columns:

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -101,6 +101,27 @@ Explicit non-implication lock for this connection clarification:
 - no gate closure is asserted or implied
 - no live authorization, live unlock, or runtime authority is granted
 
+## 3.4) Read Model ↔ Gate-Status Report Surface Final Alignment v1
+
+Final role boundary for this workstream is explicit and binding for review wording:
+
+- this read model is the canonical status/claim/interpretation grammar source
+- the gate-status report surface renders and instantiates that grammar in summary/detail output
+- rendering on the report surface does not set gate closure, decision state, or live authority
+- both surfaces remain docs-only and non-authorizing
+
+Forward lock for later additive single-gate fills:
+
+- later single-gate fills MUST reuse this read-model grammar without redefining status/claim semantics
+- later single-gate fills MUST stay bounded report-surface render materializations for one gate scope
+- later single-gate fills MUST NOT be phrased as closure or authorization artifacts
+
+Explicit non-implication lock for this final alignment slice:
+
+- no new gate fill is introduced
+- no gate closure is asserted or implied
+- no live authorization, live unlock, or runtime authority is granted
+
 ## 4) Readiness Read Model Levels
 
 The read model uses six interpretation levels:


### PR DESCRIPTION
## Summary
- align the Master V2 readiness read model and gate status report surface roles more explicitly
- clarify that the read model provides the status/claim/interpretation grammar while the report surface renders that grammar without setting authorization
- keep the slice docs-only, single-topic, and explicitly non-authorizing

## Scope
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
- update: `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no new gate fill content added
- no gate closure implied

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)