### PR TITLE
docs(ops): add master v2 reuse rewire inventory v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md
+++ b/docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md
@@ -1,0 +1,149 @@
+# MASTER V2 — Reuse / Rewire Inventory v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Evidence-based reuse/rewire inventory for existing Master V2 First Live Enablement readiness surfaces
+docs_token: DOCS_TOKEN_MASTER_V2_REUSE_REWIRE_INVENTORY_V1
+
+## 1) Purpose / Scope
+
+This spec defines a strictly read-only, evidence-based inventory of the current Master V2 readiness landscape with a reuse-first and rewire-first posture.
+
+Scope:
+
+- identify what already exists and is reusable as-is
+- identify what can be rewired with minimal adaptation (no parallel rebuild)
+- identify what is documented-only, partial, or unclear
+- isolate genuinely missing inventory/mapping pieces
+- prepare structurally for later higher-order slices (dataflow/decision-authority), without implementing them
+
+This document is mapping-only and non-authorizing.
+
+## 2) Non-Goals
+
+This inventory does not:
+
+- close any gate
+- add any new gate fill
+- authorize live unlock, live entry, or promotion
+- define runtime architecture, runtime dataflow, or execution behavior
+- mutate paper/shadow/live evidence data
+- change policy-core, risk-core, governance-core, or safety logic
+- implement telemetry/evidence generators
+
+## 3) Relationship to Canonical Master V2 Surfaces
+
+Canonical anchor and bridge/reader-order source:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
+
+Canonical interpretation grammar:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+
+Canonical report/rendering + existing single-gate fills:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+
+Canonical vocabulary/boundary lock for gate-fill semantics:
+
+- `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`
+
+This inventory is subordinate to all above surfaces and only maps reuse/rewire opportunity across them.
+
+## 4) Inventory Method / Evidence Discipline
+
+Method:
+
+1. start from canonical Master V2 reader path (ladder -> read model -> report surface -> additive single-gate fills)
+2. classify each block into reusable, minimally rewirable, documented-only/partial/unclear, and genuinely missing
+3. keep each statement repo-resolvable via explicit artifact pointers
+
+Evidence discipline:
+
+- only repository artifacts are treated as evidence pointers
+- operator-stated content is never upgraded to repo-evidenced in this inventory
+- uncertain areas remain explicitly marked as `documented-only`, `partial`, or `unclear`
+- conservative boundary remains: ambiguity -> no authorization inference
+
+## 5) Reuse / Rewire Inventory by Block
+
+### 5.1 Readiness Surfaces
+
+| block / area | existing repo artifacts | reusable as-is | rewirable with minimal adaptation | documented-only / partial / unclear | genuinely missing | notes / evidence pointers |
+|---|---|---|---|---|---|---|
+| canonical steering + bridge + reader order | canonical ladder with explicit bridge and reader order | yes: ladder remains canonical anchor and navigation winner | yes: can rewire discoverability by adding targeted cross-reference hooks in future docs-only slices | no major ambiguity in role split text | no new steering surface required | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` |
+| interpretation grammar surface | read model with status grammar, claim discipline, evidence pointer semantics, blocker semantics | yes: grammar can be reused unchanged for all future mapping/report slices | yes: future mapping slices can rewire to read-model fields instead of redefining status semantics | partial for higher-order mapping templates (dataflow/authority map templates are out of scope in v1) | no new interpretation grammar required | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` |
+| report/rendering surface | gate-status report table/detail contract plus five additive single-gate fills | yes: table/detail schema and non-authorization language reusable as-is | yes: can rewire additional inventory/mapping slices onto same schema without semantic expansion | partial where candidate-scoped bundles are intentionally not asserted in current fills | no new report surface required for inventory v1 | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` |
+
+### 5.2 Gate-Fill Semantics
+
+| block / area | existing repo artifacts | reusable as-is | rewirable with minimal adaptation | documented-only / partial / unclear | genuinely missing | notes / evidence pointers |
+|---|---|---|---|---|---|---|
+| gate-fill vocabulary and forbidden equalities | explicit canonical term lock and dangerous-confusion guards | yes: term lock and forbidden equalities can be reused unchanged | yes: future slices can rewire wording review checklists to this lock | no major ambiguity in semantic boundary text | no new vocabulary baseline required | `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md` |
+| single-gate fill pattern (one gate per additive slice) | five repo-evidenced single-gate fills on report surface | yes: one-gate additive pattern is reusable and review-friendly | yes: future slices can rewire missing-evidence slot conventions while preserving one-gate scope | partial by design: fills stay non-closure and non-authorization; candidate-scoped evidence bundles often open | missing is not additional fill now; missing is only mapping-level cross-gate inventory view (this spec) | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` |
+| claim discipline in gate-fill wording | read model claim classes and downgrade rules | yes: claim-class rules reusable as-is | yes: can rewire PR review checks to enforce one-claim-class-per-atomic-statement | unclear only where future reviewers omit explicit claim tags (process risk, not semantic gap) | optional future lint/check aid for claim tagging (docs/process) | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` |
+
+### 5.3 Mapping / Bridge Surfaces
+
+| block / area | existing repo artifacts | reusable as-is | rewirable with minimal adaptation | documented-only / partial / unclear | genuinely missing | notes / evidence pointers |
+|---|---|---|---|---|---|---|
+| canonical bridge between Master V2, ladder, read model, report surface | explicit bridge and connection clarifications are embedded in canonical surfaces | yes: existing bridge text is sufficient as navigation baseline | yes: can rewire later inventories to same reader path without adding a parallel bridge | partial discoverability outside canonical reader path may remain for occasional readers | no new bridge semantics required in this slice | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` |
+| bridge-to-vocabulary coupling | explicit connection between bridge role and vocabulary lock role | yes: role split text can be reused directly | yes: future mapping slices can rewire review checklists to require both bridge placement and vocabulary compliance | no major ambiguity in role split wording | no additional coupling spec required for v1 inventory | `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` |
+| master-v2 to report-surface connection | explicit connection clarification in ladder/report/read-model surfaces | yes: connection and non-implication lock reusable | yes: future slices can rewire to these connection clauses instead of inventing new linkage text | partial only for next-level operationalization artifacts, intentionally out of scope | no new connection semantics required | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` |
+
+### 5.4 Prospective Next Higher-Order Work (Preparation-Only)
+
+| block / area | existing repo artifacts | reusable as-is | rewirable with minimal adaptation | documented-only / partial / unclear | genuinely missing | notes / evidence pointers |
+|---|---|---|---|---|---|---|
+| dataflow mapping preparation | read-model evidence pointer semantics and report surface row/detail schema | yes: reuse evidence-pointer and field schema as stable input vocabulary | yes: rewire by adding a docs-only dataflow map that references existing fields without changing semantics | currently documented only as interpretation pointers, not full source-to-decision flow | canonical cross-surface dataflow map (docs-only) | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` |
+| decision-authority mapping preparation | required-authority field and non-authorization clauses already exist | yes: authority boundary language reusable as-is | yes: rewire by mapping decision nodes to existing authority-safe wording and required-authority field | partial: authority ownership is referenced but not consolidated as a single map artifact | canonical decision-authority map surface (docs-only) | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` |
+| cross-gate inventory maintenance | five single-gate fills plus canonical ladder levels | yes: gate labels (`L0` to `L5`) and single-gate pattern reusable | yes: rewire by maintaining one canonical cross-gate inventory table instead of parallel notes | partial visibility if readers inspect only per-gate sections | this canonical inventory file is the missing artifact now materialized in v1 | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md` |
+
+## 6) Genuinely Missing / Unclear Areas
+
+Genuinely missing (for later slices, not implemented here):
+
+- canonical docs-only cross-surface dataflow map (source -> interpretation field -> report surface cell -> decision touchpoint)
+- canonical docs-only decision-authority map that consolidates authority domains referenced across readiness surfaces
+- optional claim-discipline review aid (lint/checklist) to reduce accidental claim-class drift in future additive docs slices
+
+Unclear or partial (kept explicit, non-upgraded):
+
+- candidate-scoped evidence bundles are intentionally open in multiple existing single-gate fills
+- discoverability can degrade if readers skip canonical reader order and consume isolated sections
+- higher-order mapping work is prepared structurally but not yet consolidated in dedicated artifacts
+
+## 7) Implications for Next Higher-Order Slices
+
+This inventory suggests a minimal, low-drift sequence for later work:
+
+1. Dataflow Map Slice (docs-only): reuse read-model/report fields as nodes, map provenance paths end-to-end.
+2. Decision-Authority Map Slice (docs-only): consolidate required-authority anchors and authority boundaries without changing authority.
+3. Optional Review Hygiene Slice (docs/process-only): lightweight claim-class and pointer-consistency checklist.
+
+Guardrails for all above:
+
+- reuse existing canonical semantics; do not redefine them
+- rewire through existing reader path and schema surfaces
+- keep single-topic scope and non-authorizing wording
+
+## 8) Explicit Non-Authorization Rule
+
+This inventory is strictly read-only, mapping-only, and non-authorizing.
+
+It MUST NOT be used as:
+
+- gate closure artifact
+- live authorization artifact
+- runtime architecture decision record
+- implementation mandate for risk/policy/governance/runtime behavior
+
+Any closure, unlock, promotion, or execution authority remains outside this document and bound to existing authoritative sources.
+
+## 9) Open Questions / Future Extensions
+
+- Should one minimal canonical frontdoor pointer to this inventory be added later for discoverability, or is canonical-reader-path usage sufficient?
+- Should future higher-order map slices share one common table schema derived from read-model/report fields?
+- Is a docs-only, non-blocking review checklist for claim-class hygiene needed to reduce interpretation drift further?


### PR DESCRIPTION
## Summary
- add the canonical Master V2 Reuse / Rewire Inventory v1 spec
- document what is reusable as-is, what is minimally rewirable, what remains documented-only / partial / unclear, and what is genuinely missing
- keep the slice docs-only, single-topic, evidence-based, and explicitly non-authorizing

## Scope
- new spec: `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no new gate fill content added
- no gate closure implied

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)