### PR TITLE
docs(ops): add master v2 dataflow map v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md
+++ b/docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md
@@ -106,8 +106,8 @@ Surface categories used in this map:
 - `Ladder -> Read Model` framing-to-grammar role split is explicit.
 - `Read Model -> Report Surface` grammar-to-rendering coupling is explicit.
 - `Report Surface -> Single-Gate Fill carriers` bounded one-gate materialization pattern is explicit.
-- `Vocabulary Lock -> Report/Fill wording` boundary/forbidden-equality constraints are explicit.
-- `Reuse/Rewire Inventory -> next higher-order slice targets` preparation intent is explicit.
+- `Vocabulary Lock -> Report&#47;Fill wording` boundary/forbidden-equality constraints are explicit.
+- `Reuse&#47;Rewire Inventory -> next higher-order slice targets` preparation intent is explicit.
 
 ### 6.2 Implicit transitions (documented-only linkage)
 
@@ -154,5 +154,5 @@ Any closure, unlock, or live-authorization decision remains external to this map
 ## 9) Open Questions / Future Extensions
 
 - Should a compact canonical cross-gate evidence-bundle index be added later to reduce documented-only aggregation drift?
-- Should the later decision-authority slice reuse this table schema (`stage/block`, `input`, `transformation`, `output`, `consumer`, `clarity`) for review continuity?
+- Should the later decision-authority slice reuse this table schema (`stage&#47;block`, `input`, `transformation`, `output`, `consumer`, `clarity`) for review continuity?
 - Is one additional minimal discoverability pointer needed in a frontdoor index, or is canonical reader-path usage sufficient?

--- a/docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md
+++ b/docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md
@@ -1,0 +1,158 @@
+# MASTER V2 — Dataflow Map v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Canonical docs-only, evidence-based dataflow mapping across Master V2 readiness framing, read-model grammar, report surface, and support surfaces
+docs_token: DOCS_TOKEN_MASTER_V2_DATAFLOW_MAP_V1
+
+## 1) Purpose / Scope
+
+This specification defines one canonical, read-only, evidence-based dataflow map for the existing Master V2 First Live Enablement readiness landscape.
+
+Scope:
+
+- map where relevant inputs originate
+- map which canonical surface receives which information
+- map how information is transformed, interpreted, forwarded, or referenced
+- classify artifacts as evidence pointers, reporting carriers, or interpretation carriers
+- classify transition clarity as `explicit`, `implicit`, `unclear`, or `missing`
+- provide structural handoff points for later decision-authority mapping work, without performing that work here
+
+This slice is docs-only, mapping-only, and non-authorizing.
+
+## 2) Non-Goals
+
+This specification does not:
+
+- close any gate
+- add or modify any single-gate fill substance
+- authorize live unlock, live entry, promotion, or runtime behavior
+- define runtime architecture or telemetry/evidence generation pipelines
+- mutate paper/shadow/live evidence data
+- replace canonical ladder, read-model, report-surface, vocabulary-lock, or reuse/rewire surfaces
+- provide a decision-authority map
+
+## 3) Relationship to Canonical Master V2 Surfaces
+
+Canonical framing and navigation anchor:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
+
+Canonical interpretation grammar:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
+
+Canonical report/rendering carrier and existing single-gate fills:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+
+Canonical vocabulary/boundary lock:
+
+- `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`
+
+Canonical reuse/rewire inventory:
+
+- `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md`
+
+Relationship rule:
+
+- this dataflow map is subordinate to the above surfaces and maps their flow roles only
+- if wording conflicts arise, canonical source surfaces win
+
+## 4) Mapping Method / Evidence Discipline
+
+Method:
+
+1. Start from canonical reader path (`Ladder -> Read Model -> Report Surface -> Single-Gate Fill Sections`).
+2. Classify each step as input reception, interpretation/mapping, reporting/rendering, or support constraint.
+3. Record only repository-resolvable evidence pointers.
+4. Mark transition clarity as `explicit`, `implicit`, `unclear`, or `missing`.
+
+Evidence discipline:
+
+- only explicit repository artifacts are used as evidence pointers
+- `operator-stated` content is never upgraded to `repo-evidenced` by this map
+- documented relationships without explicit handoff contracts are marked `implicit` or `unclear`
+- absent handoff contracts are marked `missing`
+- mapping does not infer authority from interpretation/reporting flow
+
+Surface categories used in this map:
+
+- readiness framing surfaces
+- read-model grammar surfaces
+- report surface / reporting outputs
+- single-gate fill carriers
+- bridge / vocabulary / inventory support surfaces
+
+## 5) Dataflow Map by Stage / Block
+
+| stage / block | surface category | input artifact(s) | received information | transformation / interpretation step | forwarded / referenced output | downstream consumer(s) | evidence pointer(s) | transition clarity |
+|---|---|---|---|---|---|---|---|---|
+| A1: Canonical framing anchor | readiness framing surfaces | `MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` | master framing, canonical reader order, bridge role boundaries, L0-L5 readiness framing | normalize navigation order and framing constraints for companion surfaces | canonical reader path and boundary framing reused by read-model/report consumers | read-model reviewers, report-surface authors, gate-fill authors | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` | `explicit` |
+| A2: Bridge connection handoff | bridge / vocabulary / inventory support surfaces | ladder bridge clauses + read-model bridge clauses + report-surface connection clarification | relationship split between framing, grammar, and rendering roles | map bridge relationship into non-overlapping surface responsibilities | stable cross-surface handoff contract for interpretation/reporting | review flows across ladder/read-model/report-surface | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` | `explicit` |
+| B1: Grammar intake | read-model grammar surfaces | ladder framing + read-model canonical grammar source | level semantics (`L0..L5`), status grammar, claim classes, evidence-pointer semantics, blocker semantics, authority-safe interpretation rules | convert framing intent into interpretation grammar fields and allowed values | reusable interpretation grammar consumed by report surface and additive single-gate fills | report-surface schema, additive fill sections, review PRs | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` | `explicit` |
+| C1: Reporting schema rendering | report surface / reporting outputs | read-model grammar + ladder level labels | status rows, evidence-pointer slots, blocker slots, required-authority slots, next-slice slots | render grammar into summary table contract and per-gate detail contract without changing semantics | report output schema and five additive single-gate fill carriers | readiness status reviews, additive mapping slices | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` | `explicit` |
+| C2: Single-gate fill materialization | single-gate fill carriers | report-surface fill sections (First to Fifth) + canonical gate/runbook/script pointers | one-gate scoped interpretation snapshots, evidence-pointer bundles, blockers, required authority domains | instantiate schema per single gate with claim discipline and non-authorization wording | additive gate-level interpretation carriers; no closure artifacts | reviewers comparing gate-level interpretation deltas | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` | `explicit` |
+| D1: Vocabulary boundary enforcement | bridge / vocabulary / inventory support surfaces | vocabulary/boundary lock surface + read-model claim discipline | term definitions, forbidden equalities, boundary-safe phrasing constraints | constrain wording and prevent semantic drift across map/report/fill artifacts | guarded interpretation language (`Gate Fill != Gate Closure`, etc.) reused by report/fill docs | report/fill authors and reviewers | `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` | `explicit` |
+| D2: Reuse/rewire preparation handoff | bridge / vocabulary / inventory support surfaces | reuse/rewire inventory table + canonical surfaces | reusable blocks, minimally rewirable blocks, documented-only/partial areas, identified missing higher-order artifacts | map where future slices should attach without redefining current semantics | preparation pointers for dataflow/authority follow-up slices | future docs-only mapping slices | `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md` | `explicit` |
+| E1: Evidence provenance to closure inference | cross-surface transition | evidence pointers from read-model/report/fills | pointer provenance exists, but closure sufficiency criteria are external | none in current canonical surfaces (no closure engine in this map scope) | potential interpretation by reviewers; no canonical closure output in this layer | external authority domains only | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md` | `implicit` |
+| E2: Decision-authority consolidation handoff | cross-surface transition | required-authority fields + non-authorization clauses across ladder/read-model/report/vocabulary | authority remains external and named as required, but not consolidated as a map | none in this slice by design | future decision-authority mapping input set | future decision-authority slice only | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`; `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md` | `missing` |
+
+## 6) Explicit vs Implicit vs Unclear vs Missing Transitions
+
+### 6.1 Explicit transitions (repo-evidenced)
+
+- `Ladder -> Read Model` framing-to-grammar role split is explicit.
+- `Read Model -> Report Surface` grammar-to-rendering coupling is explicit.
+- `Report Surface -> Single-Gate Fill carriers` bounded one-gate materialization pattern is explicit.
+- `Vocabulary Lock -> Report/Fill wording` boundary/forbidden-equality constraints are explicit.
+- `Reuse/Rewire Inventory -> next higher-order slice targets` preparation intent is explicit.
+
+### 6.2 Implicit transitions (documented-only linkage)
+
+- `Evidence pointer presence -> closure-readiness interpretation` is documented as non-authorizing and externally constrained, but no explicit closure handoff contract exists in these surfaces.
+
+### 6.3 Unclear transitions (partial/ambiguous in current surfaces)
+
+- cross-surface, normalized method for aggregating candidate-scoped evidence bundles across multiple gates is only partially visible through isolated single-gate fill sections and not yet a dedicated canonical cross-gate carrier.
+
+### 6.4 Missing transitions (intentionally not yet materialized)
+
+- consolidated decision-authority map transition from `required_authority` fields to a canonical authority-node graph is missing and explicitly out of scope for this slice.
+- explicit canonical transition from interpretation/report outputs to any closure artifact remains absent in this docs-only mapping set.
+
+## 7) Implications for Later Decision-Authority Work
+
+This map prepares (but does not implement) later authority mapping by identifying stable upstream inputs:
+
+- `required_authority` fields on report surface rows/details
+- non-authorization clauses across ladder/read-model/report/vocabulary surfaces
+- single-gate fill blockers and open-items phrasing
+- reuse/rewire inventory identification of missing authority-map artifact
+
+Recommended next authority-oriented slice boundary:
+
+- consume existing `required_authority` and non-authorization clauses as immutable inputs
+- produce one docs-only authority-node mapping artifact
+- avoid any runtime or policy/risk/governance semantic changes
+
+## 8) Explicit Non-Authorization Rule
+
+This specification is strictly mapping-only and non-authorizing.
+
+It MUST NOT be used as:
+
+- gate closure artifact
+- live authorization artifact
+- live-unlock trigger
+- runtime architecture decision record
+- implementation authority for policy-core, risk-core, governance-core, or execution behavior
+
+Any closure, unlock, or live-authorization decision remains external to this map and bound to existing authoritative sources.
+
+## 9) Open Questions / Future Extensions
+
+- Should a compact canonical cross-gate evidence-bundle index be added later to reduce documented-only aggregation drift?
+- Should the later decision-authority slice reuse this table schema (`stage/block`, `input`, `transformation`, `output`, `consumer`, `clarity`) for review continuity?
+- Is one additional minimal discoverability pointer needed in a frontdoor index, or is canonical reader-path usage sufficient?


### PR DESCRIPTION
## Summary
- add the canonical Master V2 Dataflow Map v1 spec
- map explicit, implicit, unclear, and missing dataflow transitions across the existing Master V2 readiness surfaces
- keep the slice docs-only, single-topic, evidence-based, and explicitly non-authorizing

## Scope
- new spec: `docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md`

## Constraints honored
- docs-only
- no runtime / risk-core / policy-core changes
- no Paper / Shadow / Evidence mutation
- no live unlock
- no new gate fill content added
- no gate closure implied
- no decision-authority inference beyond documented flow roles

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)