### PR TITLE
docs(ops): add master v2 first live gate status index v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md
@@ -1,0 +1,129 @@
+# MASTER V2 — First Live Gate Status Index v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Canonical docs-only gate status index for Master V2 First Live readiness visibility and auditability
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1
+
+## 1) Executive Summary
+
+This document materializes one compact, canonical gate status index for Master V2 First Live readiness.
+
+It is strictly mapping-only and non-authorizing: it makes gate posture legible and auditable, but it does not grant live permission, does not close gates, and does not change runtime behavior.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one compact gate status index for First Live readiness
+- explicit conservative status assignment per gate (`Unclear`, `Missing`, `Partial`, `Verified`)
+- repository-resolvable evidence pointers, blockers, required authority, and next minimal slice
+
+Out of scope:
+
+- runtime rewiring or implementation changes
+- live authorization decisions
+- gate closure by assertion
+- reuse or rewire inventory updates
+- vocabulary or boundary lock expansion
+- scope implementation work
+
+## 3) Canonical Status Model
+
+Allowed status values for this index:
+
+- `Unclear`: gate intent is visible, but ownership, closure criteria, or evidence linkage is ambiguous
+- `Missing`: no canonical compact artifact for this gate need is currently materialized
+- `Partial`: substantial mapping material exists, but closure-relevant proof or authority linkage remains open
+- `Verified`: gate mapping intent, evidence basis, and boundary wording are explicitly and canonically materialized
+
+Status discipline:
+
+- status is interpretation-state for this index, not runtime-state and not authorization-state
+- adjacent strength must not inflate neighboring status
+- `Verified` in this index is never equal to live authorized
+
+## 4) Compact Gate Index Table
+
+| gate | gate title | current status | evidence present | blocking issue | required authority | next minimal slice |
+|---|---|---|---|---|---|---|
+| G1 | Canonical First Live readiness anchor | `Verified` | yes: [Readiness Ladder](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) | none for mapping visibility | canonical docs stewardship | none for this index slice |
+| G2 | Canonical interpretation grammar availability | `Verified` | yes: [Readiness Read Model](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md) | none for mapping visibility | canonical docs stewardship | none for this index slice |
+| G3 | Canonical report rendering carrier availability | `Verified` | yes: [Gate Status Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | none for mapping visibility | canonical docs stewardship | none for this index slice |
+| G4 | Dry validation readiness posture (L1) | `Partial` | yes: [Ladder](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [Dry Validation Runbook](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md), [Live Entry Runbook](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md) | candidate-scoped dry-validation evidence bundle is not canonically indexed here | governance plus operator decision authority | add one docs-only candidate-scoped L1 evidence pointer record |
+| G5 | Go or no-go interpretation posture (L2) | `Partial` | yes: [Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md), [Go No-Go Checklist](PILOT_GO_NO_GO_CHECKLIST.md), [Go No-Go Operational Slice](PILOT_GO_NO_GO_OPERATIONAL_SLICE.md) | candidate-scoped verdict evidence is not canonically indexed here | governance plus operator decision authority | add one docs-only candidate-scoped L2 verdict pointer record |
+| G6 | Entry contract interpretation posture (L3) | `Partial` | yes: [Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md), [Entry Contract](BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md), [Entry Boundary Note](BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md) | candidate-scoped prerequisite bundle for entry interpretation is not canonically indexed here | governance plus operator decision authority | add one docs-only L3 prerequisite evidence pointer record |
+| G7 | Candidate session flow interpretation posture (L4) | `Partial` | yes: [Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md), [Candidate Flow Runbook](../runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md), [Live Entry Runbook](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md) | candidate-scoped flow execution bundle is not canonically indexed here | governance plus operator decision authority | add one docs-only L4 session-flow evidence pointer record |
+| G8 | Incident and safe-stop interpretation posture (L5) | `Partial` | yes: [Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md), [Incident Exchange Degraded](../runbooks/RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md), [Incident Unexpected Exposure](../runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md), [Incident Reconciliation Mismatch](../runbooks/RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md) | candidate-scoped incident bundle is not canonically indexed here and incident runbooks remain draft-heavy | governance plus operator decision authority | add one docs-only L5 incident evidence pointer record |
+| G9 | Dataflow consistency for First Live surfaces | `Verified` | yes: [Dataflow Map](MASTER_V2_DATAFLOW_MAP_V1.md), [Ladder](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [Read Model](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md), [Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | none for mapping visibility | canonical docs stewardship | none for this index slice |
+| G10 | Decision authority legibility for closure handoff | `Partial` | yes: [Decision Authority Map](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | final canonical live-authorization actor chain remains external to this index | governance plus operator decision authority | add one focused docs-only authority-gap closure slice |
+| G11 | Compact cross-gate evidence bundle visibility | `Missing` | partial: [Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) contains single-gate fills only | one compact canonical cross-gate bundle index is not yet materialized | governance plus operator decision authority | add one docs-only cross-gate evidence bundle index slice |
+| G12 | Non-authorizing boundary lock for gate reporting | `Verified` | yes: [Ladder](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [Read Model](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md), [Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md), [Decision Authority Map](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | none for mapping visibility | existing canonical governance and safety authorities external to this index | none for this index slice |
+
+## 5) Gate-by-Gate Notes
+
+- G1: Canonical anchor is explicit and active; this index reuses that anchor without redefining steering authority.
+- G2: Interpretation grammar is canonically materialized; this index does not redefine grammar.
+- G3: Reporting carrier is canonically materialized; this index does not alter report schema.
+- G4: L1 has mapped sources, but no compact candidate-scoped evidence pointer row is canonically consolidated in this index.
+- G5: L2 is materially mapped, but no candidate-scoped verdict pointer is canonically consolidated here.
+- G6: L3 contract wording exists, but closure-relevant candidate prerequisite evidence remains open in this index.
+- G7: L4 flow shape exists, but candidate execution evidence bundle is not compactly indexed here.
+- G8: L5 incident boundaries exist, but candidate incident evidence bundle remains open and runbook maturity is uneven.
+- G9: Cross-surface dataflow linkage is explicit; no additional mapping needed for this slice.
+- G10: Authority topology is mapped, but final closure handoff remains partially external and unresolved.
+- G11: Single-gate fills exist, but one compact cross-gate index artifact is not materialized yet.
+- G12: Non-authorizing wording is explicit across canonical surfaces and remains binding for this index.
+
+## 6) Relationship to Existing Master V2 Artifacts
+
+Role split used by this index:
+
+- [Readiness Ladder](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md): canonical framing, reader order, and readiness anchor
+- [Readiness Read Model v1](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md): interpretation grammar and status discipline
+- [Gate Status Report Surface v1](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md): reporting schema and single-gate materializations
+- [Dataflow Map v1](MASTER_V2_DATAFLOW_MAP_V1.md): explicit flow linkage across framing, grammar, and reporting surfaces
+- [Decision Authority Map v1](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md): authority visibility and unresolved handoff nodes
+- [Bounded Real Money Pilot Entry Contract](BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md): canonical entry-boundary contract source
+
+This index only cross-links and reuses those artifacts. It does not modify them.
+
+## 7) Non-Authorizing Constraint
+
+This specification authorizes nothing.
+
+It only exposes gate status posture for review and audit.
+
+Live progression remains separately gated and separately authorized by existing governance, safety, risk, and operator authority sources external to this document.
+
+`Verified` in this index is never equivalent to live authorized.
+
+## 8) Evidence and Closure Criteria
+
+Confirmed by this index:
+
+- one compact canonical visibility surface for 12 First Live gate units is now materialized
+- conservative status posture is explicit, including open and missing areas
+- cross-surface references for framing, grammar, reporting, dataflow, and authority are explicit
+
+Still open:
+
+- candidate-scoped evidence bundle consolidation for L1 to L5 related gates
+- compact cross-gate evidence index as a standalone canonical artifact
+- final closure handoff chain for live authorization remains external
+
+Follow-up slice candidate (separate topic):
+
+- add one docs-only cross-gate evidence bundle index that reuses existing schema and keeps non-authorizing boundaries intact
+
+## 9) Cross-References
+
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md)
+- [PILOT_GO_NO_GO_CHECKLIST.md](PILOT_GO_NO_GO_CHECKLIST.md)
+- [PILOT_GO_NO_GO_OPERATIONAL_SLICE.md](PILOT_GO_NO_GO_OPERATIONAL_SLICE.md)


### PR DESCRIPTION
## Summary
- add canonical docs-only spec `MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1`
- make the First-Live readiness ladder compact and operator-readable as a gate status index
- keep the slice mapping-only and explicitly non-authorizing

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)