### PR TITLE
docs(ops): add master v2 learning ai autonomy inventory v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md
+++ b/docs/ops/specs/MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md
@@ -1,0 +1,116 @@
+# MASTER V2 — Learning AI Autonomy Inventory v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Canonical docs-only inventory of learning, AI, and autonomy surfaces for Master V2 clarification
+docs_token: DOCS_TOKEN_MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1
+
+## 1) Executive Summary
+
+This specification materializes a compact, repo-evidenced inventory of learning, AI, and autonomy surfaces adjacent to Master V2.
+
+It is mapping-only and non-authorizing. Its purpose is readability and auditability of boundaries and gaps, not runtime enablement.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- repo-visible learning, AI, autonomy, evidence, and approval surfaces
+- explicit distinction between advisory behavior, authoritative decisions, and veto boundaries
+- explicit marking of unclear or partial materialization
+
+Out of scope:
+
+- runtime rewiring or implementation changes
+- live authorization
+- model release by assertion
+- online-learning activation
+
+## 3) Canonical Inventory Categories
+
+This inventory uses the following canonical categories:
+
+- learning triggers
+- training loops
+- offline learning and retraining
+- online learning and adaptation
+- knowledge base and memory-like layer
+- AI-layer orchestration
+- model orchestration and routing
+- approval logic for updated models
+- decision authority for model and policy changes
+- feedback loops from outcomes to learning
+- evidence, audit, and replay trail for learning and model changes
+
+## 4) Inventory Table
+
+| category | canonical meaning | nearest repo evidence | what is confirmed | what remains unclear | authority visibility | confidence | ambiguity and gap |
+|---|---|---|---|---|---|---|---|
+| learning triggers | events that should start learning-related review or retraining flow | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md) | trigger-like governance conditions and re-entry guardrails are documented | one compact canonical trigger registry for Master V2 is not materialized | partial | partial | trigger semantics are distributed across governance and decision notes |
+| training loops | closed-loop training process definitions and control boundaries | [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | closed self-learning loops are explicitly disallowed in current guardrails | one canonical training-loop contract for Master V2 is not materialized | unclear | partial | boundary is mostly defined by prohibitions, not by one positive loop contract |
+| offline learning and retraining | bounded offline model improvement outside live hot path | [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | offline-only direction is explicit in multiple documents | canonical retraining lifecycle with approval checkpoints is not consolidated | partial | partial | retraining semantics exist, but lifecycle ownership remains distributed |
+| online learning and adaptation | live-time adaptation that affects behavior | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md) | online-learning influence on live behavior is explicitly blocked | approved exception path is intentionally absent | clear for prohibition | high | prohibition is strong, but no positive allowed path is specified |
+| knowledge base and memory-like layer | documented knowledge surfaces used for context and review continuity | [KNOWLEDGE_BASE_INDEX.md](../../KNOWLEDGE_BASE_INDEX.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | a broad knowledge index and canonical vocabulary layer exist | one Master V2-specific memory contract tied to authority boundaries is not materialized | partial | partial | knowledge indexing exists without one consolidated Master V2 memory contract |
+| AI-layer orchestration | AI coordination layer above execution and risk hot path | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | AI orchestration is documented as advisory and non-execution authority | one compact Master V2 orchestration capability map is not materialized | partial | partial | role boundaries are explicit but spread across governance and vocabulary docs |
+| model orchestration and routing | proposer, fallback, critic model assignment and separation of duties | [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | proposer and critic separation plus model-assignment fields are documented | canonical runtime-routing contract for Master V2 remains outside this inventory | partial | partial | template fields are clear but do not assert one authoritative runtime router |
+| approval logic for updated models | process and sign-off requirements before stronger autonomy states | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md) | evidence pack and sign-off obligations are explicit | one compact model-update approval state machine is not materialized | partial | partial | approval requirements exist without one canonical state-machine artifact |
+| decision authority for model and policy changes | who can approve, veto, or stop changes | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | decision-authority map marks learning/model/policy chain as missing or partial | single consolidated authoritative approval chain remains open | unclear to partial | partial | authority topology is visible, but consolidation is still missing |
+| feedback loops from outcomes to learning | how outcomes inform future learning or policy updates | [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | read-only and offline-first feedback intent is explicit | canonical bounded feedback protocol is not materialized | unclear | partial | distributed references, no single Master V2 feedback contract |
+| evidence, audit, and replay trail for learning and model changes | artifacts proving what changed, why, and under which authority | [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | evidence, replay, provenance, and sign-off fields are strongly documented | one compact Master V2 learning-change evidence index is not materialized | partial to strong | partial to high | evidence primitives are strong; consolidation as one index remains open |
+
+## 5) Advisory, Authoritative, and Approval Boundary Notes
+
+- Advisory AI behavior: documented as analysis and recommendation support, not final execution authority.
+- Authoritative trading decisions: remain external to AI orchestration and remain bounded by governance, risk, and safety layers.
+- Approval authority for model or policy changes: requires explicit governance-oriented evidence and sign-off, but one consolidated canonical chain remains incomplete.
+- Veto and fail-closed boundaries: governance and safety veto posture is explicit and dominates advisory outputs.
+
+## 6) Ambiguity, Confusion, and Interpretation Risk Map
+
+- advisory AI versus authoritative execution decisioning: advisory wording can be misread as approval if authority tags are omitted.
+- learning loops versus runtime decision loops: learning-oriented updates can be confused with live decision-path logic if boundary language is weak.
+- model orchestration versus strategy selection: model routing and strategy switching remain distinct and must not be collapsed.
+- offline retraining versus online adaptation: offline allowance exists, online adaptation in live influence remains prohibited.
+- evidence and registry artifacts versus actual learning authority: rich artifacts do not automatically prove consolidated authority ownership.
+
+## 7) Non-Authorizing Constraint
+
+This specification authorizes nothing.
+
+It only inventories the currently visible learning, AI, and autonomy surfaces and their boundary posture.
+
+Unclear and partial areas remain explicitly marked as unclear and partial.
+
+Live remains separately gated and separately authorized.
+
+## 8) Evidence and Closure Criteria
+
+Confirmed by this specification:
+
+- one dedicated Master V2 learning, AI, and autonomy inventory surface now exists
+- advisory, authority, and veto boundary distinctions are explicitly readable
+- evidence and provenance primitives are mapped with conservative confidence labeling
+
+Still open:
+
+- a consolidated approval-chain map for model and policy updates
+- a compact Master V2 promotion and state-machine artifact for autonomy transitions
+- one consolidated learning-change evidence index tied to explicit authority nodes
+
+Potential next follow-up slice (separate topic):
+
+- a dedicated promotion and state-machine clarification slice focused on transition and approval semantics
+
+## 9) Cross-References
+
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
+- [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md)
+- [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md)
+- [POLICY_CRITIC_STATUS.md](../../governance/POLICY_CRITIC_STATUS.md)
+- [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md)
+- [KNOWLEDGE_BASE_INDEX.md](../../KNOWLEDGE_BASE_INDEX.md)


### PR DESCRIPTION
## Summary
- add canonical docs-only spec `MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1`
- inventory the visible Learning / AI / autonomy surface and its approval-boundary ambiguity
- keep the slice mapping-only and explicitly non-authorizing

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)