### PR TITLE
docs(ops): add master v2 provenance replayability v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md
+++ b/docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md
@@ -1,0 +1,122 @@
+# MASTER V2 — Provenance Replayability v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-19
+owner: Peak_Trade
+purpose: Canonical docs-only mapping of provenance and replayability surfaces for Master V2
+docs_token: DOCS_TOKEN_MASTER_V2_PROVENANCE_REPLAYABILITY_V1
+
+## 1) Executive Summary
+
+This specification materializes a compact, canonical provenance and replayability view for Master V2.
+
+It is mapping-only and non-authorizing. Its purpose is reconstruction and audit readability, not runtime enablement or live authorization.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- canonical provenance and replayability surface mapping for Master V2
+- evidence-based visibility of what can be reconstructed versus what remains partial
+- boundary clarity between artifact presence, replay intent, and actual replayability support
+
+Out of scope:
+
+- runtime rewiring or implementation changes
+- live authorization
+- replay guarantees by assertion
+- evidence format redesign
+
+## 3) Canonical Provenance Replayability Surface
+
+This slice maps provenance and replayability across these surfaces:
+
+- input data provenance
+- intermediate signal provenance
+- model, strategy, and policy version provenance
+- scope and capital state provenance
+- risk and safety decision provenance
+- promotion and environment-state provenance
+- evidence artifact and registry provenance
+- replay and reconstruction path visibility
+
+## 4) Provenance Replayability Table
+
+| surface | canonical meaning | nearest repo evidence | what is confirmed | what remains unclear | reconstruction value | confidence | ambiguity and gap |
+|---|---|---|---|---|---|---|---|
+| input data provenance | traceability of input-source context used by analysis and decisions | [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | provenance is named as required concept and mapped as evidence-pointer discipline | one compact input-lineage contract for all Master V2 stages is not materialized | medium | partial | evidence pointers exist, but end-to-end source lineage is partial |
+| intermediate signal provenance | traceability of derived signals across directional and gating steps | [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md), [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | directional and stage outputs are mapped with evidence references | one canonical per-stage signal lineage chain is not consolidated | medium | partial | stage linkage exists without one canonical signal registry |
+| model, strategy, and policy version provenance | visibility of versions used in evaluation and governance decisions | [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) | version fields and sign-off anchors are explicitly documented | one Master V2 canonical version-lineage index across decisions is not materialized | high | partial to strong | template support is strong, but cross-surface consolidation is partial |
+| scope and capital state provenance | traceability of scope and capital envelope semantics used in progression decisions | [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md), [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | scope and capital concepts plus authority ambiguity are explicit | canonical transition from scope-state capture to replayable decision state remains partial | medium | partial | semantics are clear, but replay-ready state chain is incomplete |
+| risk and safety decision provenance | evidence trail for risk-cap and safety-veto outcomes | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | veto precedence and limit-enforcement boundaries are strongly documented | one compact replay model connecting denial causes to full decision context is not materialized | high | partial | policy and authority docs are strong; causal replay path is only partial |
+| promotion and environment-state provenance | traceability of promotion stage and environment posture transitions | [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md), [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | promotion-state and live-gated versus live-authorized distinction is explicit | one canonical transition-event ledger across environments is not materialized | medium | partial | stage semantics are clear; event-level replayability remains partial |
+| evidence artifact and registry provenance | existence and structure of evidence artifacts and registry pointers | [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md), [docs/ops/registry/README.md](../registry/README.md) | structured evidence packs and evidence index surfaces exist | one canonical provenance registry for all Master V2 decisions is not materialized | high | partial to strong | artifact presence is strong; unification of registry semantics is incomplete |
+| replay and reconstruction path visibility | ability to replay or reconstruct decision context from available artifacts | [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md), [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md), [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) | replay and provenance are explicitly framed as bounded and non-automatic | full cross-subsystem end-to-end replayability remains not-claimed and partially visible | medium | partial | documented replay intent is stronger than currently consolidated replay support |
+
+## 5) Decision Reconstruction Notes
+
+- Some promotion and gating decisions appear reconstructable at interpretation level via gate status, authority map, and evidence-pack fields.
+- Reconstruction quality is partial where decision chains cross multiple surfaces without a single canonical event ledger.
+- Registry and evidence artifacts provide strong anchors for audit context, especially for policy-version and sign-off snapshots.
+- End-to-end causal replay remains incomplete where cross-surface linkage is documented but not consolidated into one replay contract.
+
+## 6) Relationship to Existing Master V2 Artifacts
+
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md): maps flow paths and identifies implicit and missing transitions relevant to replay boundaries.
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md): maps authority and veto visibility needed for causal reconstruction.
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md): provides compact status surface and evidence-pointer posture for readiness interpretation.
+- [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md): inventories learning and model-evidence surfaces and approval ambiguity.
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md): frames staged progression and transition clarity relevant to replay semantics.
+- [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md): provides structured audit and reconstruction fields.
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md): provides evidence navigation and historical artifact context.
+
+This spec only cross-links these artifacts and does not modify them.
+
+## 7) Ambiguity, Confusion, and Interpretation Risk Map
+
+- evidence artifact presence versus true replayability: stored artifacts do not automatically imply end-to-end replay.
+- audit trail versus causal reconstruction: trace logs may exist while cause-and-effect linkage remains partial.
+- model or policy version visibility versus approval authority: version stamps are not equal to authoritative approval chain completion.
+- registry pointer presence versus full decision replay: pointers improve discoverability but may not contain full replay context.
+- documented replay intent versus visible repo support: intent is explicit, but consolidated replay contract is still incomplete.
+
+## 8) Non-Authorizing Constraint
+
+This specification authorizes nothing.
+
+It only makes provenance and replayability semantics visible.
+
+Clarified mapping in this spec is not equivalent to fully replayable end-to-end state.
+
+Live remains separately gated and separately authorized.
+
+## 9) Evidence and Closure Criteria
+
+Confirmed by this specification:
+
+- a dedicated Master V2 provenance and replayability surface now exists.
+- reconstruction strengths and gaps are explicitly marked with conservative confidence.
+- replayability boundaries are separated from authorization claims.
+
+Still open:
+
+- one canonical cross-surface replay contract that unifies event lineage and authority decisions.
+- one compact canonical transition-event registry across promotion and environment states.
+- one explicit linkage model from evidence-pointer presence to replay completeness criteria.
+
+Potential follow-up slice (separate topic):
+
+- focused replay-contract consolidation slice that unifies lineage fields and decision-linkage semantics without runtime changes.
+
+## 10) Cross-References
+
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md)
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md)
+- [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [docs/ops/registry/README.md](../registry/README.md)


### PR DESCRIPTION
## Summary
- add canonical docs-only spec `MASTER_V2_PROVENANCE_REPLAYABILITY_V1`
- materialize the Master V2 provenance / replayability surface as a compact, operator-readable artifact
- keep the slice mapping-only and explicitly non-authorizing

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)