### PR TITLE
docs(ops): add master v2 first live cross gate evidence bundle index v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md
@@ -1,0 +1,111 @@
+# MASTER V2 — First Live Cross-Gate Evidence Bundle Index v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only cross-gate evidence bundle index for Master V2 First Live visibility and review orientation
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one compact, Master V2-specific cross-gate evidence bundle index for First Live readiness reviews.
+
+Its purpose is visibility and review orientation only:
+
+- map which First Live gate families must be reviewed together
+- map typical evidence bundle elements per gate family
+- map nearest repository anchors for deterministic reading paths
+
+This index is strictly docs-only, mapping-only, and non-authorizing.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one compact cross-gate index table for First Live review
+- conservative, source-anchored mapping from gate families to evidence bundle elements
+- minimal operator reading order for repeatable review
+- explicit interpretation locks that prevent authorization inflation
+
+Out of scope:
+
+- promotion decision making
+- gate pass assertion
+- live unlock or runtime control
+- evidence artifact generation
+- policy, runtime, config, CI, workflow, test, or code changes
+
+## 3) Cross-Gate Evidence Bundle Index Table
+
+| gate family | review question | typical evidence bundle elements | nearest repo anchors | what this can confirm | what this cannot confirm | current clarity |
+|---|---|---|---|---|---|---|
+| readiness framing and gate-status visibility | Are `L1` to `L5` interpretations visible in one conservative, reviewable posture? | readiness level status wording, evidence pointers, blocker wording, authority-safe interpretation text | [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md); [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md) | that a canonical read path and status grammar exist for First Live interpretation | that any gate is closed, passed, or authorized for live transition | strong for visibility, partial for closure evidence |
+| go-no-go and entry-contract prerequisites | Are verdict semantics and entry prerequisites aligned without semantic drift? | go-no-go checklist interpretation, operational verdict wording, entry-contract prerequisite pointers, boundary-note constraints | [PILOT_GO_NO_GO_CHECKLIST.md](PILOT_GO_NO_GO_CHECKLIST.md); [PILOT_GO_NO_GO_OPERATIONAL_SLICE.md](PILOT_GO_NO_GO_OPERATIONAL_SLICE.md); [BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md); [BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md) | that prerequisite and verdict wording is canonically documented and cross-linkable | that a candidate-specific verdict is acceptable for promotion or live entry | partial |
+| candidate session flow interpretation | Is the first candidate session flow review path explicit and source-anchored? | candidate-flow runbook interpretation, live-entry runbook path, session wrapper pointer, closeout and reconciliation interpretation hooks | [RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md](../runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md); [RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | that the review path for session-flow interpretation is explicit | that runtime execution is approved, complete, or safe by this index alone | partial |
+| incident and safe-stop discipline | Is fail-closed incident discipline represented in the same review bundle as readiness and flow? | incident runbook pointers, safe-stop posture wording, ambiguity-to-no-trade interpretation, escalation path references | [RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md](../runbooks/RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md); [RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md](../runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md); [RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md](../runbooks/RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md); [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md) | that incident and safe-stop interpretation anchors exist and are review-coupled to First Live posture | that incident readiness is complete for a specific candidate session | partial with draft-heavy dependencies |
+| authority and promotion boundary | Are authority boundaries and promotion interpretation explicitly separated from authorization? | authority-role separation, veto precedence, promotion-state boundary wording, external authority handoff notes | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md); [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md); [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md) | that decision-authority and promotion-visibility boundaries are explicitly documented | that promotion is approved or that live authorization exists | partial |
+| provenance and replayability continuity | Is evidence provenance continuity visible across gate families without over-claiming causality? | evidence-pointer continuity, source lineage notes, version provenance notes, replayability constraint statements | [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md); [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md); [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) | that provenance and replayability constraints are explicitly surfaced in First Live review context | that full causal replay or deterministic end-to-end reconstruction is proven | partial |
+| vocabulary and interpretation boundary lock | Are high-risk term conflations prevented during cross-gate review? | boundary-lock terms, non-equality constraints, authority-safe wording constraints, confusion-risk markers | [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md); [MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md](MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md); [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | that the review language can remain drift-resistant and non-authorizing | that terminology discipline alone resolves missing evidence or authority gaps | repo-evidenced for language lock, partial for closure impact |
+
+## 4) Minimal Review Order
+
+Minimal operator read path for First Live readiness review:
+
+1. Start with framing: [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md).
+2. Load interpretation grammar: [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md).
+3. Read compact gate posture: [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md).
+4. Cross-check rendered gate details: [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md).
+5. Validate decision and promotion boundaries: [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md).
+6. Validate provenance constraints: [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md).
+7. Apply vocabulary lock before any interpretation statement: [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md).
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This index is explicitly not:
+
+- a promotion decision
+- a gate pass
+- a causal replay proof
+- a runtime controller
+
+Binding interpretation locks:
+
+- cross-gate visibility is not equivalent to transition permission
+- evidence pointer presence is not equivalent to closure proof
+- mapped readiness posture is not equivalent to live authorization
+- authority references remain external and unchanged by this index
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Nearest anchor artifacts for this index:
+
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md](MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md)
+- [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/INDEX.md](../registry/INDEX.md)
+- [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+
+## 7) Operator Notes
+
+Current clarity and ambiguity notes:
+
+- The major visibility gap named in the gate-status index for compact cross-gate evidence view is now covered as a dedicated mapping surface.
+- Candidate-scoped evidence bundle consolidation remains outside this slice and stays unresolved.
+- Final live authorization chain remains external to this index and unchanged.
+- Replayability remains partial for causal reconstruction and must not be over-claimed.
+- Incident discipline anchors exist, but maturity is uneven where incident runbooks remain draft-heavy.
+
+Operator use boundary:
+
+- Use this document as a navigation and cross-reading index only.
+- Keep all promotion, pass, and authorization decisions in their external authority sources.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1 as a docs-only / mapping-only / non-authorizing spec
- map the first-live cross-gate evidence bundle surface as an index and review aid
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)