### PR TITLE
docs(ops): add master v2 first live candidate evidence bundle ledger v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md
@@ -1,0 +1,104 @@
+# MASTER V2 — First Live Candidate Evidence Bundle Ledger v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only candidate-scoped evidence bundle ledger view for Master V2 First Live readiness review orientation
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one compact, candidate-scoped ledger view for Master V2 First Live readiness review across `L1` to `L5`.
+
+Its purpose is review condensation and operator visibility only:
+
+- consolidate which candidate-relevant evidence surfaces are reviewed together per level
+- make nearest spec, registry, pointer, and artifact anchors explicit
+- expose consistency questions without granting any decision authority
+
+This ledger is strictly docs-only, mapping-only, and non-authorizing.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one candidate evidence bundle ledger table for `L1` to `L5`
+- candidate-specific review focus and typical evidence element mapping per level
+- nearest repository entry anchors for each level
+- consistency and interpretation locks for conservative review usage
+
+Out of scope:
+
+- promotion decision making
+- gate pass assertion
+- causal replay proof
+- runtime control, runtime orchestration, or execution enablement
+- evidence artifact generation or mutation
+- policy, config, CI, test, workflow, or code changes
+- redefinition of existing `L1` to `L5` semantics
+
+## 3) Candidate Evidence Bundle Ledger Table
+
+| level | candidate review focus | typical candidate evidence elements | nearest repo anchors | what this can confirm | what this cannot confirm | current clarity |
+|---|---|---|---|---|---|---|
+| `L1` | Dry-validation readiness for one named candidate, with explicit preflight continuity | candidate-scoped dry-validation checklist record, candidate identifier in preflight context, candidate-linked readiness notes, candidate-level blocker wording | [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md); [RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md); [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md); [registry/INDEX.md](../registry/INDEX.md) | that dry-validation review anchors for the candidate are explicit and traversable | that dry-validation is sufficient for live entry authorization | partial |
+| `L2` | Candidate verdict interpretation posture in Go or No-Go review language | candidate-scoped verdict record, checklist interpretation lines, unresolved-governance note for candidate, candidate-specific ambiguity statements | [PILOT_GO_NO_GO_CHECKLIST.md](PILOT_GO_NO_GO_CHECKLIST.md); [PILOT_GO_NO_GO_OPERATIONAL_SLICE.md](PILOT_GO_NO_GO_OPERATIONAL_SLICE.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md); [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md); [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md) | that candidate verdict interpretation is documented in canonical wording boundaries | that a Go phrasing in review text equals a pass or promotion approval | partial |
+| `L3` | Candidate entry-contract completeness visibility, without closure inflation | candidate-scoped prerequisite evidence references, candidate boundary-condition notes, candidate contract-interpretation blockers, continuity to prior-level candidate record | [BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md); [BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md); [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md); [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) | that candidate-specific entry-contract interpretation anchors are visible and reviewable | that contract interpretation mapping closes `L3` or confers entry permission | partial |
+| `L4` | Candidate session-flow traceability for first bounded session review | candidate session-flow run log references, candidate handoff notes across steps, candidate exception-path notes, candidate-level evidence pointer continuity | [RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md](../runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md); [RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md); [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md); [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) | that session-flow interpretation for one candidate can be reviewed end-to-end at docs level | that the candidate session was authorized, complete, or safe by ledger view alone | partial |
+| `L5` | Candidate incident and safe-stop visibility for first-live review context | candidate incident event references, candidate safe-stop handling notes, candidate unresolved incident ambiguity list, candidate continuity marker back to `L1` to `L4` | [RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md](../runbooks/RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md); [RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md](../runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md); [RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md](../runbooks/RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md); [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md); [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | that incident-boundary and safe-stop review anchors are explicit for candidate-focused interpretation | that incident mapping proves causal replay completeness or authorizes continuation | partial with draft-heavy incident dependency |
+
+## 4) Minimal Candidate Review Flow
+
+Minimal read path for one First Live candidate:
+
+1. Start with canonical ladder framing and level intent: [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md).
+2. Load read-model grammar for status, evidence pointer, blocker, and authority-safe wording: [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md).
+3. Read compact gate posture context: [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md).
+4. Read report-surface rendering contract and existing single-gate fills: [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md).
+5. Traverse this ledger level-by-level (`L1` to `L5`) for the same candidate identity.
+6. Cross-check evidence discoverability and recency context from [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md).
+7. Cross-check authority boundaries before interpretation statements: [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md).
+
+## 5) Consistency / Interpretation Locks
+
+Consistency questions this ledger is designed to expose:
+
+- identity and candidate continuity: Is the same candidate identity consistently recognizable across `L1` to `L5` records?
+- evidence coverage: Is each level represented with candidate-relevant evidence references, and are level gaps explicit?
+- evidence freshness and recency visibility: Is recency discoverable from timestamped evidence surfaces and index context, without inventing new recency logic?
+- cross-level contradiction visibility: Do level statements conflict in a way that requires explicit ambiguity marking?
+- unresolved gaps and ambiguities: Are unknowns and unresolved blockers visible as first-class review outcomes?
+
+Binding interpretation locks:
+
+- this ledger is not a promotion decision
+- this ledger is not a gate pass
+- this ledger is not a causal replay proof
+- this ledger is not a runtime controller
+- this ledger is not a substitute for deep artifact inspection
+- mapped presence of evidence pointers is not equivalent to closure, safety, or authorization
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary nearby anchors for this ledger:
+
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/INDEX.md](../registry/INDEX.md)
+- [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+
+## 7) Operator Notes
+
+- Use this ledger as a compact candidate-focused reading and contradiction-detection surface, not as an approval surface.
+- Keep candidate identity tags stable across all referenced level records before drawing any interpretation summary.
+- Treat missing or stale-looking candidate evidence as explicit ambiguity and retain conservative posture.
+- Escalate any cross-level contradiction or unresolved authority question to external governance and operator authority channels.
+- Keep deep artifact inspection mandatory for any substantive readiness claim.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1 as a docs-only / mapping-only / non-authorizing spec
- map the candidate-specific first-live evidence bundle view across L1-L5 as a review ledger
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)