### PR TITLE
docs(ops): add master v2 first live operator review sequence compass v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md
@@ -1,0 +1,116 @@
+# MASTER V2 — First Live Operator Review Sequence Compass v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing one-pass review sequence compass for Master V2 First Live operator orientation
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 sequence compass for First Live operator review.
+
+Purpose boundary:
+
+- define one canonical one-pass reading sequence across already materialized Master V2 slices
+- define the primary review question per station and compact condensation intent
+- keep interpretation conservative and non-authorizing
+
+This compass supports review ordering and review condensation only. It does not grant promotion, pass any gate, or authorize live transition.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one canonical sequence for first-pass operator reading across existing Master V2 artifacts
+- station-wise mapping of question, ordering rationale, escalation signal, and confirmation boundary
+- explicit non-authorization locks for first-live review context
+
+Out of scope:
+
+- promotion decisions
+- gate-pass assertions
+- causal replay proof assertions
+- runtime control or orchestration
+- evidence artifact creation or mutation
+- policy or authority-chain rewrites
+
+## 3) Operator Review Sequence Compass Table
+
+| sequence step | master-v2 artifact | primary operator question | why this comes here | typical escalation signal | what this step can confirm | what this step cannot confirm | current clarity |
+|---|---|---|---|---|---|---|---|
+| 1 | [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md) | Which terms must remain non-equivalent before any first-live interpretation begins? | Sequence starts at boundary and meaning to prevent term collapse before authority or status reading. | Review text implies term collapse such as visibility equals permission. | Canonical vocabulary boundaries and forbidden equalities are explicit. | Any gate closure, transition permission, or live authorization. | repo-evidenced |
+| 2 | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | Which roles are advisory, authoritative, or veto, and where are gaps still open? | After meaning lock, authority topology is read before status summaries so role boundaries stay explicit. | Claimed decider is not canonically evidenced, or advisory output is treated as final authority. | Role separation and major authority ambiguity nodes are visible. | Final live authorization chain completion. | partial |
+| 3 | [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md) | Is scope and capital interpretation kept separate from downstream caps? | Scope and capital are reviewed before promotion and gate posture to avoid downstream-cap overreach in interpretation. | Scope semantics are collapsed into generic risk-cap checks. | Upstream versus downstream semantic layering for scope and capital. | Candidate readiness approval or deployability permission. | partial |
+| 4 | [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md) | Which stage boundary is being interpreted, and where is live-authorization separation enforced? | Promotion semantics follow scope semantics so stage transition language is read with capital-boundary context. | `live-gated` is read as `live-authorized` or transition wording implies permission. | Canonical stage labels and transition ambiguity boundaries. | Promotion approval or authorization grant. | partial |
+| 5 | [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md) | What is the conservative current posture per gate unit in first-live context? | Status index is read after authority and promotion framing so status is interpreted as visibility state only. | `Verified` is interpreted as pass, closure, or authorization. | Compact gate posture and open or missing areas are visible. | Gate pass or live unlock. | partial to strong for visibility |
+| 6 | [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md) | Are gate families reviewable together with stable evidence anchors? | After gate posture, cross-gate bundle orientation condenses where to read across families without changing decisions. | Cross-gate visibility is treated as closure proof. | Cross-gate reading anchors and bundle orientation are explicit. | Candidate-specific pass verdict or transition permission. | partial |
+| 7 | [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | How far does provenance and replayability support reconstruction, and where does it stop? | Evidence continuity is reviewed after gate mapping so replay claims stay bounded and non-inflated. | Evidence pointer presence is treated as full causal replay proof. | Provenance surfaces and replayability limits are explicit. | Deterministic end-to-end causal replay proof. | partial |
+| 8 | [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md) | Which failure and safe-fallback signals should stop or downgrade interpretation? | Safe-fallback reading follows replayability so ambiguity and fail-closed retreat signals are explicit before candidate condensation. | Fail-closed, rollback, or unresolved safety signals are downplayed. | Failure classes, fallback posture, and retreat implications. | Authorization to continue despite unresolved blockers. | partial with strong safety boundary clarity |
+| 9 | [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md) | For one candidate, is `L1` to `L5` evidence continuity readable without contradiction inflation? | Candidate ledger comes last to condense all prior constraints into candidate-specific view. | Candidate identity drift, cross-level contradiction, or stale evidence context. | Candidate-focused review condensation and contradiction visibility. | Promotion decision, gate pass, or runtime readiness authorization. | partial |
+
+## 4) Minimal One-Pass Review Flow
+
+Minimal first-live operator read:
+
+1. Lock vocabulary boundary at step 1.
+2. Lock authority interpretation at step 2.
+3. Lock scope and capital interpretation at step 3.
+4. Read stage-transition posture at step 4.
+5. Read gate posture and cross-gate bundle orientation at steps 5 and 6.
+6. Read provenance and replay limits at step 7.
+7. Read failure and safe-fallback stop signals at step 8.
+8. Condense candidate-specific `L1` to `L5` view at step 9.
+
+Minimal one-pass output for operator notes:
+
+- concise station-by-station interpretation summary
+- explicit open ambiguities
+- explicit escalation items
+- explicit reminder that no authorization is granted by this flow
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This compass is explicitly not:
+
+- a promotion decision
+- a gate pass
+- a causal replay proof
+- a runtime controller
+- a substitute for deep artifact inspection
+
+Binding locks:
+
+- sequence completion is not authorization
+- station clarity is not permission
+- evidence discoverability is not closure proof
+- candidate-ledger readability is not live-readiness approval
+- unresolved ambiguity must remain unresolved unless anchored by existing canonical artifacts
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary sequence anchors:
+
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md)
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+
+Supporting context anchors:
+
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
+
+## 7) Operator Notes
+
+- Use this compass as a one-pass reading order and condensation aid only.
+- Escalate when any station implies permission, closure, or causal proof without canonical anchor.
+- Keep unresolved authority gaps, replay gaps, and candidate contradictions explicit in the final operator review note.
+- If ambiguity remains after step 9, retain conservative posture and stop interpretation escalation.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1 as a docs-only / mapping-only / non-authorizing spec
- define a canonical one-pass operator review order across the existing master-v2 slice family
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)