### PR TITLE
docs(ops): add master v2 first live authority handoff boundary ledger v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md
@@ -1,0 +1,112 @@
+# MASTER V2 — First Live Authority Handoff Boundary Ledger v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing boundary ledger for first-live handoff from review surfaces to external final authorization
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 boundary ledger for the First Live handoff edge.
+
+Purpose boundary:
+
+- make the handoff boundary between review condensation and external final authorization explicit
+- make escalation signals visible before any authority inflation occurs
+- keep interpretation conservative and strictly non-authorizing
+
+This ledger is for boundary clarity and handoff visibility only. It does not grant promotion, pass a gate, or assign live authorization.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one compact ledger mapping for where canonical review and mapping surfaces end
+- one explicit handoff start boundary to external final authorization
+- one trigger map for common handoff or escalation conditions
+- explicit answerability boundaries for existing Master V2 review surfaces
+
+Out of scope:
+
+- promotion decisions
+- gate pass assertions
+- authority substitution
+- runtime control or orchestration
+- evidence artifact creation or mutation
+- policy softening or authority-chain rewrites
+
+Answerability boundary for this slice:
+
+- answerable inside existing surfaces: what is currently mapped, how status is interpreted, where contradictions or gaps are visible
+- not answerable inside existing surfaces: whether final live authorization exists, whether unresolved ambiguity is acceptable, whether external authority has granted progression
+
+## 3) Authority Handoff Boundary Ledger Table
+
+| review surface | question this surface can answer | question this surface cannot answer | typical handoff trigger | handoff implication | nearest repo anchors | current clarity |
+|---|---|---|---|---|---|---|
+| Review sequence ordering and condensation | What is the conservative reading order and where does review condensation end? | Does completion of sequence steps authorize progression? | stale or incomplete candidate view | sequence completion is downgraded to review artifact only; escalate for external decision | [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md); [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md) | partial to strong for ordering, non-authorizing by design |
+| Gate-status visibility and interpretation posture | What gate posture is visible in a conservative mapping model? | Is any visible status equivalent to pass, closure, or live authorization? | non-reconcilable gate-state interpretation | treat gate-state disagreement as unresolved and hand off to external authority | [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md) | strong for visibility, partial for closure relevance |
+| Cross-gate evidence orientation | Which gate families and evidence bundles should be reviewed together? | Does cross-gate evidence discoverability prove closure or readiness authorization? | evidence insufficiency | keep open state explicit and escalate for external adjudication | [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md); [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) | partial |
+| Candidate-scoped continuity view | Is one candidate view readable across `L1` to `L5` with visible contradictions and gaps? | Is candidate continuity sufficient for final promotion or final live authorization? | unresolved contradiction | unresolved contradiction blocks interpretation closure and triggers external authority handoff | [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md); [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | partial |
+| Authority topology and promotion boundary visibility | Where do advisory, authoritative, and veto boundaries appear in current mapping? | Who has finally authorized this exact First Live progression instance? | authority ambiguity | unresolved actor ambiguity requires explicit external final authorization step | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md); [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md); [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | partial with explicit external boundary |
+| Vocabulary and boundary-lock discipline | Which semantic conflations are forbidden before interpretation or handoff language? | Can vocabulary compliance substitute for authority evidence or final decision evidence? | authority ambiguity | language compliance is retained as safety lock, while authority remains external | [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md); [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md) | repo-evidenced for terminology, partial for authority closure |
+
+## 4) Minimal Review-to-Handoff Flow
+
+Minimal operator path to handoff point:
+
+1. Read sequence and condensation boundary: [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md).
+2. Read gate visibility and read-model interpretation grammar: [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md).
+3. Read cross-gate and candidate continuity surfaces: [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md), [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md).
+4. Read authority and promotion separation boundaries: [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md).
+5. If any handoff trigger remains active, stop interpretation closure and hand off to external final authorization authority.
+
+Logical handoff start point:
+
+- handoff begins after review condensation reaches unresolved authority, contradiction, evidence, freshness, or gate-interpretation ambiguity that cannot be resolved inside the above canonical surfaces
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This ledger is explicitly not:
+
+- a promotion decision
+- a gate pass
+- an authority substitute
+- a runtime controller
+- a substitute for deep artifact inspection
+
+Binding non-authorization locks:
+
+- mapped status is never final authorization
+- mapped evidence discoverability is never closure proof
+- review condensation is never permission
+- unresolved ambiguity remains unresolved until external authority resolves it
+- this ledger records boundary and trigger visibility only
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary anchors:
+
+- [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+
+External final-authorization context anchor:
+
+- [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md)
+
+## 7) Operator Notes
+
+- Use this ledger as a compact handoff boundary map, not as an approval surface.
+- Keep handoff trigger wording explicit in operator notes: authority ambiguity, unresolved contradiction, evidence insufficiency, stale or incomplete candidate view, non-reconcilable gate-state interpretation.
+- If one trigger persists, record handoff and stop any implied closure language.
+- Preserve conservative posture: no transition claim without external final authorization evidence.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1 as a docs-only / mapping-only / non-authorizing spec
- define the canonical handoff boundary between review surfaces and external final authority in the first-live context
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)