### PR TITLE
docs(ops): add master v2 first live authority handoff packet contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md
@@ -1,0 +1,116 @@
+# MASTER V2 — First Live Authority Handoff Packet Contract v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing contract for first-live handoff packet composition at the external final-authorization boundary
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 packet contract for the First Live handoff edge.
+
+Purpose boundary:
+
+- standardize what a compact handoff packet must contain at the review-to-authorization boundary
+- preserve visibility, continuity, and contradiction surfacing across already materialized Master V2 review surfaces
+- keep the handoff packet strictly non-authorizing and interpretation-safe
+
+This packet is a transfer format for external final-authorization review intake. It is not a release, approval, pass, or promotion event.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- canonical minimum sections for one first-live handoff packet
+- source-surface boundaries for what packet statements may draw from
+- integrity visibility requirements at handoff time: completeness, recency, contradiction, and authority-boundary visibility
+- minimal operator assembly and review flow for repeatable packet quality
+
+Out of scope:
+
+- promotion decisions
+- gate-pass assertions
+- authority substitution
+- runtime control or orchestration
+- policy rewrites or governance-chain changes
+- evidence artifact generation or mutation
+- replacement of deep artifact inspection
+
+## 3) Canonical Handoff Packet Contract Table
+
+| packet section | required content | source surfaces it may draw from | boundary risk if omitted | what this section can state | what this section cannot state | current clarity |
+|---|---|---|---|---|---|---|
+| candidate identity and continuity | canonical candidate identifier, continuity note across `L1` to `L5`, explicit identity drift flag if present | [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md), [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | identity ambiguity and continuity blind spots at handoff boundary | that one candidate view is consistently referenceable or explicitly inconsistent | that candidate continuity equals readiness approval, gate pass, or live authorization | partial |
+| reviewed artifact set | compact list of reviewed canonical surfaces and evidence anchors used for packet condensation | [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md), [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md), [registry/INDEX.md](../registry/INDEX.md) | missing traceability and unverifiable review basis | that packet statements are anchored to known repo surfaces | that listed artifacts are complete, sufficient, or authority-approved by listing alone | partial to strong for discoverability |
+| summarized gate-state visibility | conservative snapshot of visible gate posture, with unresolved gate ambiguity explicitly named | [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md), [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | hidden gate ambiguity and accidental status inflation | that current gate interpretation visibility is compactly summarized | that any gate is passed, closed, or authorized for transition | strong for visibility, non-authorizing by design |
+| summarized evidence coverage | level and gate coverage summary, explicit missing coverage list, explicit recency visibility note | [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md), [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md), [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | unbounded completeness assumptions and stale-context invisibility | that evidence visibility and recency visibility are explicitly bounded | that visible coverage proves closure, causality completeness, or permission | partial |
+| unresolved ambiguities and contradictions | explicit unresolved ambiguity list, contradiction list, and owner-to-resolve remains external note | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md), [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md), [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md) | silent contradiction carry-over and unsafe interpretation closure | that unresolved contradictions are present and must remain unresolved in packet language | that contradiction presence is acceptable for progression, waived, or externally resolved | partial |
+| escalation triggers encountered | explicit trigger list encountered during condensation: authority ambiguity, evidence insufficiency, stale candidate view, contradiction, non-reconcilable gate interpretation | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md), [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | trigger invisibility and delayed escalation at final boundary | that escalation conditions are explicitly surfaced for external authority review intake | that triggers are resolved internally by packet construction | partial |
+| explicit non-claims and out-of-scope statements | standardized non-claims block covering no promotion decision, no gate pass, no authority substitution, no runtime control, no deep-inspection replacement | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md), [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | interpretation inflation and authority-boundary erosion | that packet language is constrained to non-authorizing mapping claims | that packet itself grants any transition, permission, or authorization | strong for boundary intent |
+| authority-boundary statement | explicit sentence that external final authorization remains outside packet scope and unchanged by packet contents | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | authority confusion and implicit delegation drift | that packet is an intake handoff artifact at a boundary | that packet records final authority decision outcome | partial with explicit external dependency |
+
+## 4) Minimal Packet Assembly / Review Flow
+
+Minimal operator path:
+
+1. Read sequence and boundary posture first: [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md).
+2. Build candidate identity and reviewed artifact set using candidate and cross-gate indexes: [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md).
+3. Condense conservative gate-state and evidence coverage visibility from existing read-model and index surfaces: [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md).
+4. Record unresolved ambiguities, contradictions, and escalation triggers without closure inflation.
+5. Attach explicit non-claims and authority-boundary statement, then route packet to external final authorization channel.
+
+Minimal review checks before handoff:
+
+- completeness visibility: every mandatory packet section is present
+- recency visibility: each evidence statement includes discoverable freshness context from source surfaces
+- contradiction visibility: unresolved contradictions are explicit and not smoothed away
+- authority-boundary visibility: non-authorizing boundary remains explicit in final packet text
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This packet contract is explicitly not:
+
+- a promotion decision
+- a gate pass
+- an authority substitute
+- a runtime controller
+- a substitute for deep artifact inspection
+
+Binding interpretation locks:
+
+- packet completeness is not permission
+- packet clarity is not authorization
+- packet evidence coverage is not closure proof
+- packet handoff is not transition execution
+- unresolved ambiguity remains unresolved until external authority resolves it
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary nearby anchors:
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/INDEX.md](../registry/INDEX.md)
+- [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+
+External final-authorization context anchor:
+
+- [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md)
+
+## 7) Operator Notes
+
+- Build this packet only after review condensation reaches the external authority boundary.
+- Keep packet language compact, source-anchored, and non-authorizing.
+- Prefer explicit unresolved statements over inferred closure language.
+- If completeness, recency, contradiction, or authority-boundary visibility is weak, mark partial clarity and escalate.
+- Do not treat packet preparation as permission to proceed.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1 as a docs-only / mapping-only / non-authorizing spec
- define the canonical handoff packet format at the boundary to external final authority in the first-live context
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)