### PR TITLE
docs(ops): add master v2 first live authority handoff packet traceability matrix v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md
@@ -1,0 +1,123 @@
+# MASTER V2 — First Live Authority Handoff Packet Traceability Matrix v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing traceability and quality matrix for first-live authority handoff packet sections
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 traceability matrix for the First Live authority handoff packet.
+
+Purpose boundary:
+
+- provide a compact, section-accurate matrix view for packet traceability and quality review
+- make completeness, recency, contradiction, authority-boundary, and candidate-continuity visibility explicit
+- keep packet assessment non-authorizing, interpretation-safe, and strictly mapping-only
+
+This matrix is a review aid for packet quality and anchor visibility. It is not a promotion, pass, or authorization surface.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- packet-section traceability mapping to existing canonical repo surfaces
+- minimum traceability expectations per packet section
+- section-level quality question framing
+- section-level integrity and boundary risk visibility when traceability is weak
+- explicit confirm-versus-non-confirm boundaries for matrix usage
+
+Out of scope:
+
+- promotion decisions
+- gate-pass decisions
+- authority substitution
+- runtime control or orchestration
+- policy relaxation or governance rewrites
+- evidence artifact creation or mutation
+- replacement of deep artifact inspection
+
+## 3) Handoff Packet Traceability Matrix
+
+| packet section | allowed source surfaces | minimum traceability expectation | primary quality question | typical integrity risk if weak | what this can confirm | what this cannot confirm | current clarity |
+|---|---|---|---|---|---|---|---|
+| candidate identity and continuity | [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md), [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | candidate identifier and continuity statement are explicitly anchored across `L1` to `L5`; identity drift is called out when present | Is candidate continuity visible without contradiction smoothing? | candidate continuity visibility collapse; identity drift hidden behind summary language | candidate continuity visibility state for the packet snapshot | readiness approval, promotion fitness, or live authorization | partial |
+| reviewed artifact set | [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md), [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md), [registry/INDEX.md](../registry/INDEX.md) | each packet claim references discoverable review surfaces and evidence anchors | Is each packet claim traceable to canonical source surfaces? | incomplete coverage appears complete; unverifiable condensation basis | completeness visibility of cited review basis | sufficiency, closure, or authority acceptance of listed artifacts | partial to strong for discoverability |
+| summarized gate-state visibility | [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md), [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | conservative gate posture summary includes unresolved interpretation ambiguity when present | Is gate posture presented as visibility state rather than pass language? | gate interpretation inflation; implicit gate-pass phrasing at boundary | conservative gate-state visibility for handoff context | pass decision, closure decision, or authorization decision | strong for visibility, non-authorizing by design |
+| summarized evidence coverage | [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md), [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md), [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | coverage summary states what is present, what is missing, and how freshness is visible from anchors | Are completeness and recency visibility explicit and bounded? | stale evidence context, invisible missing coverage, false freshness assumptions | bounded completeness visibility and recency visibility | causal completeness proof, adequacy proof, or authorization basis | partial |
+| unresolved ambiguities and contradictions | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md), [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md), [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md) | unresolved ambiguity and contradiction lists are explicit; no synthetic closure language | Are contradictions visible as unresolved, not normalized away? | contradiction visibility loss and unsafe interpretation closure | contradiction visibility and unresolved-state posture | contradiction resolution, risk acceptance, or permission to proceed | partial |
+| escalation triggers encountered | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md), [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | active triggers are listed with source anchors and left unresolved when unresolved | Are trigger conditions visible before external boundary handoff? | delayed escalation and hidden authority ambiguity | trigger visibility for boundary routing context | trigger clearance, waiver, or internally granted continuation | partial |
+| explicit non-claims and out-of-scope statements | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md), [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | packet includes explicit non-claims for promotion, gate pass, authority substitution, runtime control, and deep inspection replacement | Is authority-boundary wording explicit and free from implied approval semantics? | authority-boundary erosion through implicit claims | authority-boundary visibility and interpretation lock intent | external approval evidence, transition execution authority, or runtime control | strong for boundary intent |
+| authority-boundary statement | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | packet contains one explicit statement that final authorization remains external to this matrix and packet | Is the authority boundary explicit, stable, and non-transferable in packet language? | implicit delegation drift and authority confusion | boundary visibility that packet review is intake-only | existence of external approval outcome | partial with explicit external dependency |
+
+Visibility lenses this matrix should make explicit at section level:
+
+- completeness visibility
+- recency visibility
+- contradiction visibility
+- authority-boundary visibility
+- candidate continuity visibility
+
+## 4) Minimal Matrix Review Flow
+
+Minimal operator path for reviewing one prepared handoff packet against this matrix:
+
+1. Open packet sections and map each section to one row in the matrix.
+2. Verify allowed source surfaces are used and linkable for each row.
+3. Check minimum traceability expectation is met per section, including visible missing items.
+4. Ask the primary quality question per row and document concise findings.
+5. Record any weak-traceability risks exactly as unresolved integrity or boundary risks.
+6. Confirm non-claims and authority-boundary statement are explicit and unchanged.
+7. Emit one compact review note that states visibility posture only, then route to external authority channel.
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This matrix is explicitly not:
+
+- a promotion decision
+- a gate pass
+- an authority substitute
+- a runtime controller
+- a replacement for deep artifact inspection
+
+Binding interpretation locks:
+
+- traceability completeness is not permission
+- clarity is not approval
+- coverage visibility is not closure proof
+- contradiction logging is not contradiction resolution
+- matrix usage is not authorization transfer
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary packet and boundary anchors:
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/INDEX.md](../registry/INDEX.md)
+- [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+
+External final-authorization context anchor:
+
+- [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md)
+
+## 7) Operator Notes
+
+- Keep matrix use compact, section-first, and source-anchored.
+- Prefer explicit partial clarity over implied completeness.
+- Record uncertainty as unresolved visibility, never as inferred closure.
+- Stop at mapping and quality posture; do not convert matrix output into decision language.
+- If authority-boundary wording becomes ambiguous, downgrade clarity and escalate.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1 as a docs-only / mapping-only / non-authorizing spec
- define the canonical section-level traceability and quality matrix for the first-live authority handoff packet
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)