### PR TITLE
docs(ops): add master v2 first live authority handoff packet to lb apr 001 field map v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md
@@ -1,0 +1,123 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 Field Map v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing field-map bridge from internal first-live authority handoff packet to external LB_APR_001 approval artifact template
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 field-map view for the First Live authority handoff boundary.
+
+Purpose boundary:
+
+- define one compact, canonical mapping bridge from internal handoff packet sections and fields to external LB_APR_001 template target fields
+- preserve boundary clarity so mapping output is readable as transfer context, not as decision evidence
+- preserve authority-boundary visibility, traceability continuity, candidate continuity, contradiction carry-over risk, and non-claim posture across the mapping step
+
+This field map is a transfer aid between internal and external documentation surfaces. It does not grant authorization, pass any gate, or substitute final external authority.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- mapping relation between internal packet sections and external LB_APR_001 target fields
+- per-mapping constraints for allowed carry-over, wording normalization caution, semantic mismatch risk, and omission risk
+- explicit visibility posture for what mapping can preserve versus what mapping cannot establish
+- minimal operator path for filling one external LB_APR_001 artifact from one prepared handoff packet
+
+Out of scope:
+
+- promotion decisions
+- gate-pass decisions
+- authority substitution
+- runtime control, runtime orchestration, or runtime policy behavior
+- creation or mutation of evidence artifacts
+- changes to LB_APR_001 template semantics
+- replacement of deep artifact review
+
+## 3) Packet-to-LB_APR_001 Field Mapping Table
+
+| internal packet section or field | external LB_APR_001 target field | allowed carry-over | normalization caution | semantic boundary risk | what this mapping can preserve | what this mapping cannot establish | current clarity |
+|---|---|---|---|---|---|---|---|
+| candidate identity and continuity | section 1 metadata: release reference context, creation timestamp context; section 10 optional pointer context | candidate identifier, packet timestamp context, continuity note across reviewed packet scope | do not normalize continuity language into validity window claims (`valid from`, `valid until`) unless externally set; keep continuity wording as visibility only | continuity can be misread as approval readiness; metadata fields can be over-read as effective authorization period | candidate continuity visibility and packet snapshot identity | approval lifecycle state, effective authorization window, or release legitimacy | partial |
+| reviewed artifact set | section 6 binding repo references; section 10 optional pointers | compact, source-anchored artifact list and pointer set from packet | preserve repository anchor wording; avoid rewriting references into compliance claims | reference presence can be misread as sufficiency proof; pointer density can hide missing critical anchors | traceability continuity from packet to external artifact | completeness guarantee, review sufficiency, or authority acceptance of listed references | partial to strong for discoverability |
+| summarized gate-state visibility | section 4 gating and safety framework; section 7 review result (visibility wording only) | conservative gate posture summary and unresolved interpretation markers | never rewrite visibility statements into pass language such as `enabled`, `armed`, `approved`, or `fulfilled` | mapping to review-result area can implicitly inflate posture to decision outcome | gate posture visibility at handoff moment | gate pass, gate closure, or transition eligibility | strong for visibility, non-authorizing by design |
+| summarized evidence coverage | section 5 risk and operating conditions; section 6 binding repo references | bounded statement of what coverage is visible, what is missing, and freshness context | keep wording explicit about "visible coverage" versus "proven closure"; do not compress missing-coverage notes | omission of freshness or gaps can create false completeness reading | bounded completeness and recency visibility | causal completeness proof, adequacy proof, or go-live permission | partial |
+| unresolved ambiguities and contradictions | section 7 review result: conditions and open points; section 9 explicit non-statements | unresolved ambiguity list and contradiction list with explicit unresolved posture | retain unresolved wording; do not normalize to "accepted risk" or "closed item" without external decision evidence | contradiction carry-over can be hidden when reformulated as generic risks | contradiction visibility and unresolved-state continuity | contradiction resolution, waiver, or approved exception | partial |
+| escalation triggers encountered | section 7 review result: conditions and evidence fields; section 10 optional pointer to escalation system | explicit trigger list (authority ambiguity, evidence insufficiency, stale context, non-reconcilable interpretation) | do not convert trigger listing into "mitigated" unless external artifact contains explicit approved disposition | trigger text can be mistaken as already handled if phrasing is softened | escalation context continuity into external review lane | trigger closure, remediation completion, or proceed decision | partial |
+| explicit non-claims and out-of-scope statements | section 9 explicit non-statements | non-claim block covering no promotion decision, no gate pass, no authority substitution, no runtime control, no deep-inspection replacement | preserve "not a decision" grammar verbatim; avoid positive reformulations that imply latent approval | non-claim erosion if shortened into generic disclaimer text | non-claim preservation and authority-boundary visibility | any positive authorization inference | strong |
+| authority-boundary statement | section 0 applicability note; section 8 sign-off boundary context | explicit statement that final authorization remains external to this packet-to-template mapping step | do not prefill sign-off fields or status transitions from packet language | mapping can be misused as authority substitute when external sign-off fields appear adjacent | clear boundary separation between internal mapping and external authorization act | sign-off existence, sign-off validity, or approval state transition | partial with explicit external dependency |
+
+Boundary and omission interpretation notes:
+
+- omission risk is highest where unresolved ambiguity, contradiction, and trigger visibility are dropped during wording compression
+- contradiction carry-over risk must be kept visible as unresolved when unresolved in packet sources
+- candidate continuity and traceability continuity are preservation goals, not approval indicators
+
+## 4) Minimal Mapping / Review Flow
+
+Minimal operator path to fill one external LB_APR_001 artifact from one prepared packet:
+
+1. Open packet contract and packet traceability matrix; confirm all mandatory packet sections are present and source-anchored.
+2. Open LB_APR_001 external template and map each target section using the table above, row by row.
+3. Copy only allowed carry-over content for each row; keep unresolved and missing items explicitly visible.
+4. Apply normalization caution checks: remove decision-like verbs and avoid rewriting visibility language into approval language.
+5. Perform boundary check before finalizing draft: ensure non-claims and authority-boundary statement remain explicit.
+6. Mark unresolved contradictions, omissions, and active triggers in the external artifact review area without closure inflation.
+7. Route to external authorization channel; do not treat completed mapping as gate pass or approval state change.
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This field map is explicitly not:
+
+- a promotion decision
+- a gate pass
+- an authority substitute
+- a runtime controller
+- a replacement for deep artifact inspection
+
+Binding interpretation locks:
+
+- mapped carry-over is not approval evidence
+- wording normalization is not risk acceptance
+- traceability continuity is not sufficiency proof
+- candidate continuity is not readiness approval
+- contradiction visibility is not contradiction resolution
+- external template population is not sign-off
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary packet and boundary anchors:
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/INDEX.md](../registry/INDEX.md)
+
+External target anchor:
+
+- [LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md)
+
+Related external-field clarification anchors:
+
+- [LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md](../LB_APR_001_ACCOUNT_TYPE_FIELD_MAPPING.md)
+- [LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md](../LB_APR_001_STRATEGY_VERSION_FIELD_MAPPING.md)
+
+## 7) Operator Notes
+
+- Keep this field map compact and source-anchored; if a statement cannot be traced to packet inputs, do not carry it over.
+- Prefer explicit "unresolved" wording over inferred closure wording.
+- Keep non-claims visible in every external draft so authority-boundary erosion is detectable.
+- If a mapping row has high semantic mismatch risk, mark clarity as partial and escalate instead of normalizing aggressively.
+- Treat this document as a mapping bridge only; external authorization remains a separate action outside this spec.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1 as a docs-only / mapping-only / non-authorizing spec
- define the canonical field-mapping bridge from the internal first-live authority handoff packet to the external LB_APR_001 approval artifact template
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)