### PR TITLE
docs(ops): add master v2 first live authority handoff packet to lb apr 001 signoff evidence boundary matrix v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md
@@ -1,0 +1,119 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 Signoff Evidence Boundary Matrix v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing boundary matrix for distinguishing LB_APR_001 template completion from externally evidenced signoff
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 boundary matrix for the First Live authority handoff edge between internal packet mapping and external signoff evidence.
+
+Purpose boundary:
+
+- make one compact, canonical boundary view between "LB_APR_001 template populated" and "external signoff evidence actually demonstrated"
+- prevent false confidence where packet quality, template completeness, or review readiness are misread as authorization proof
+- preserve authority-boundary visibility and evidence-of-signoff visibility without granting any transition, gate-pass, or approval outcome
+
+This matrix is a boundary and interpretation aid only. It does not authorize, approve, enable, or substitute external authority.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- canonical boundary mapping for observable handoff states and transitions around LB_APR_001 usage
+- explicit distinction between template completion evidence and approval proof evidence
+- explicit wording discipline for allowed versus non-allowed claims at each boundary edge
+- compact operator check path for distinguishing "template filled" from "external signoff demonstrated"
+
+Out of scope:
+
+- promotion decisions
+- gate-pass decisions
+- authority substitution
+- runtime control, runtime orchestration, or runtime policy behavior
+- evidence artifact generation or mutation
+- edits to LB_APR_001 template semantics
+- replacement of deep artifact inspection
+
+## 3) Signoff Evidence Boundary Matrix
+
+| observable state or transition | what is actually evidenced | what is not yet evidenced | common false inference risk | acceptable wording | required additional signoff evidence signal | nearest repo anchors | current clarity |
+|---|---|---|---|---|---|---|---|
+| internal handoff packet prepared | a packet exists with structured handoff sections and boundary notes | that external intake occurred, that external reviewer accepted scope, or that signoff exists | packet existence is misread as "already approved path" | "internal handoff packet prepared for external review intake" | explicit external intake acknowledgment tied to the packet | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md) | partial |
+| internal packet prepared -> LB_APR_001 fields populated | template fields are populated from mapped packet inputs with visible carry-over boundaries | that field population reflects external approval judgment, that unresolved contradictions were externally accepted | template completion is misread as authorization proof | "LB_APR_001 fields populated from internal packet mapping; no signoff claim implied" | externally attributable signoff evidence artifact or signed response reference | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md), [LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md) | strong for mapping, non-authorizing by design |
+| LB_APR_001 fields populated -> review-ready external packet | an externally shareable packet draft is assembled with explicit non-claims and unresolved items | that external authority reviewed, endorsed, or finalized any decision | review-ready packaging is misread as "approved unless contested" | "review-ready external packet assembled; authorization remains external and unresolved" | external review event evidence with identifiable reviewer authority context | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md), [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md) | partial to strong for review readiness only |
+| review-ready external packet -> external signoff evidence claimed | a claim statement exists that signoff evidence exists or was received | that the claimed evidence is authentic, in-scope, complete, and anchored to this candidate and packet continuity | claim presence is misread as demonstrated evidence | "external signoff evidence is claimed and pending verification against canonical anchors" | verifiable, candidate-scoped, packet-continuous external signoff evidence anchor | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) | partial |
+| external signoff evidence claimed -> external signoff evidence actually demonstrated | external signoff evidence is verified as attributable, candidate-continuous, packet-continuous, and scope-consistent | no additional authorization is created by this matrix itself; no runtime transition is enacted by documentation state alone | verified evidence visibility is misread as automatic gate execution or runtime permission | "external signoff evidence demonstrated for this candidate and packet continuity scope; transition authority remains outside this matrix" | demonstrated chain: external authority identity + scoped signoff evidence + continuity alignment + contradiction disposition visibility | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md), [registry/INDEX.md](../registry/INDEX.md), [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md) | partial with explicit external dependency |
+| any transition with contradiction or omission carry-over | contradictions, omissions, staleness, or unresolved ambiguity are explicitly visible as unresolved carry-over risk | that unresolved items are acceptable, waived, or closed for authorization | silence on unresolved gaps is misread as closure | "unresolved contradiction or omission carry-over remains open and blocks closure claims in this matrix view" | explicit external disposition evidence for each unresolved contradiction or omission | [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md), [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md), [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md) | partial |
+
+Boundary visibility intent made explicit by the matrix:
+
+- authority-boundary visibility: where documentation stops and external authority evidence must begin
+- evidence-of-signoff visibility: claim versus demonstrated evidence state is separated per transition
+- template-completion versus approval-proof distinction: population is transport; proof requires external evidence signals
+- contradiction and omission carry-over risk: unresolved items remain unresolved until externally evidenced disposition exists
+- candidate continuity and packet continuity limits: continuity helps scoping and replayability, but does not imply approval
+
+## 4) Minimal Boundary Review Flow
+
+Minimal operator path to distinguish "template filled" from "external signoff evidenced":
+
+1. Confirm internal handoff packet is prepared and source-anchored with explicit non-claims.
+2. Confirm LB_APR_001 field population was done through canonical mapping, not claim inflation.
+3. Confirm the packet is only review-ready, not decision-ready, and wording remains non-authorizing.
+4. If signoff evidence is claimed, require a candidate-scoped and packet-continuous external anchor before any stronger wording.
+5. Verify evidence-of-signoff signals are attributable to external authority context and are not merely internal restatements.
+6. Keep contradiction and omission carry-over visible; do not permit closure language without external disposition evidence.
+7. Classify final state conservatively:
+   - template-only state: template populated and/or review-ready without demonstrated external signoff evidence
+   - externally evidenced state: claim upgraded only after verifiable external signoff evidence is demonstrated
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This matrix is explicitly not:
+
+- a promotion decision
+- a gate pass
+- an authority substitute
+- a runtime controller
+- a substitute for deep artifact inspection
+
+Binding interpretation locks:
+
+- template population is not approval proof
+- review readiness is not signoff evidence
+- signoff claim text is not signoff demonstration
+- continuity evidence is not authorization evidence
+- demonstrated signoff evidence in docs is not runtime transition execution by itself
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary nearby anchors:
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/INDEX.md](../registry/INDEX.md)
+- [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+
+External template anchor:
+
+- [LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md)
+
+## 7) Operator Notes
+
+- Keep operator wording conservative: "prepared", "populated", "review-ready", "claimed", "demonstrated", never "approved" unless externally evidenced and anchored.
+- If evidence cannot be traced to external authority context, keep state at claim-level or template-only.
+- When ambiguity exists, downgrade clarity and escalate rather than infer closure.
+- Use this matrix to prevent false confidence, not to advance state transitions.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1 as a docs-only / mapping-only / non-authorizing spec
- define the canonical boundary between a populated LB_APR_001 artifact and actual externally evidenced signoff
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)