### PR TITLE
docs(ops): add master v2 first live authority handoff packet to lb apr 001 review route compass v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md
@@ -1,0 +1,108 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 Review Route Compass v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing review-route compass from internal handoff packet surfaces to external LB_APR_001 review surface
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 review-route compass for the First Live authority handoff edge to LB_APR_001.
+
+Purpose boundary:
+
+- define one compact, canonical read order across existing handoff and bridge artifacts
+- keep boundary clarity explicit between internal review condensation and external review surface usage
+- preserve non-authorizing interpretation posture across the full handoff-to-template path
+
+This compass is a route and interpretation aid only. It does not approve, promote, pass a gate, or transfer authority.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one ordered review route across already materialized handoff boundary, packet, traceability, field-map, and signoff-boundary artifacts
+- one station-by-station question model for operator review clarity
+- one escalation-signal posture for unresolved ambiguity visibility
+- one minimal one-pass read flow for handoff packet to LB_APR_001 review continuity
+
+Out of scope:
+
+- promotion decisions
+- gate-pass decisions
+- authority substitution
+- runtime control or runtime orchestration
+- policy relaxation or authority-chain rewrites
+- replacement of deep artifact inspection
+- evidence creation or evidence mutation
+
+## 3) Review Route Compass Table
+
+| sequence step | artifact | primary operator question | why this comes here | typical escalation signal | what this step can confirm | what this step cannot confirm | current clarity |
+|---|---|---|---|---|---|---|---|
+| 1 | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md) | Where does review condensation end and external authority boundary begin? | Boundary first prevents authority inflation before reading packet detail. | authority ambiguity, non-reconcilable gate interpretation, unresolved contradiction | boundary location, non-authorization posture, handoff trigger visibility | promotion, gate pass, or final external authorization outcome | partial to strong for boundary posture |
+| 2 | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md) | Is packet structure complete and bounded for handoff intake? | Packet structure follows boundary so section claims stay non-authorizing by contract. | missing mandatory section, silent contradiction carry-over, unclear non-claims block | required packet section model, section-level non-claims, authority-boundary sentence intent | that packet completeness equals approval readiness or authorization | partial to strong for structure |
+| 3 | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md) | Are packet sections traceable to canonical source surfaces with explicit integrity posture? | Section-level traceability is reviewed after packet structure to verify claims are source-anchored. | weak traceability, missing freshness context, contradiction visibility loss | section-level completeness visibility, recency visibility, contradiction visibility, boundary wording discipline | sufficiency proof, closure proof, or transition permission | partial |
+| 4 | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md) | How are internal packet statements mapped into LB_APR_001 fields without semantic inflation? | Internal condensation must be stable before bridging to external field surface. | normalization into decision language, omission of unresolved items, carry-over distortion | allowed carry-over boundaries, mapping cautions, external-field transfer posture | external approval, signoff existence, or decision finality | strong for mapping, non-authorizing by design |
+| 5 | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md) | Is there a clear separation between template population, signoff claim, and signoff evidence demonstration? | Signoff-evidence boundary is last because it interprets the post-bridge external review state. | signoff claim without verifiable external evidence, unresolved omission carry-over, candidate continuity mismatch | distinction between template-complete versus externally evidenced signoff posture | runtime transition execution, gate execution, or authority transfer by documentation state | partial with explicit external dependency |
+
+## 4) Minimal End-to-End Review Flow
+
+Minimal one-pass operator read for the handoff-to-LB_APR_001 path:
+
+1. Read boundary ledger first to lock interpretation posture and identify active handoff triggers.
+2. Read packet contract to verify required section shape and explicit non-claims are present.
+3. Read packet traceability matrix row by row to confirm each section remains source-anchored and integrity-visible.
+4. Read packet-to-LB_APR_001 field map and verify transfer language stays visibility-only, not decision-like.
+5. Read signoff-evidence boundary matrix to classify current state conservatively:
+   - template-populated or review-ready state
+   - signoff-claimed state
+   - externally evidenced signoff state (only when externally verifiable evidence anchor is available)
+6. If any unresolved ambiguity, contradiction, evidence insufficiency, staleness, or authority ambiguity remains visible, stop closure language and escalate to external authority channel.
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This compass is explicitly not:
+
+- a promotion decision
+- a gate pass
+- an authority substitute
+- a runtime controller
+- a substitute for deep artifact inspection
+
+Binding interpretation locks:
+
+- route completion is not authorization
+- packet quality visibility is not approval proof
+- traceability strength is not closure proof
+- field-map completion is not signoff
+- signoff claim is not signoff evidence demonstration
+- unresolved ambiguity remains unresolved until externally evidenced disposition exists
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary route anchors:
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+
+Nearest bridge target anchor:
+
+- [LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md)
+
+Nearest registry and evidence orientation anchors:
+
+- [registry/DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+
+## 7) Operator Notes
+
+- Use this compass as an ordering aid and boundary lock, never as an approval surface.
+- Keep station outputs short and evidence-anchored: one question, one bounded answer, one explicit unresolved note when needed.
+- Prefer explicit partial clarity over inferred closure when station evidence is weak.
+- Escalate immediately when wording drifts toward decision semantics (`approved`, `passed`, `authorized`) without external evidence anchor.
+- Keep interpretation conservative: mapping continuity is useful for review routing, not for granting transitions.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1 as a docs-only / mapping-only / non-authorizing spec
- define the canonical end-to-end review route across the existing handoff artifacts up to the LB_APR_001 review surface
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)