### PR TITLE
docs(ops): add master v2 first live authority handoff packet to lb apr 001 external signoff evidence anchor profile v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md
@@ -1,0 +1,122 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Anchor Profile v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing anchor-profile view for external signoff evidence visibility in LB_APR_001 context
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 anchor profile for the First Live authority handoff edge in LB_APR_001 context.
+
+Purpose boundary:
+
+- provide one compact, canonical profile of evidence anchors that make external signoff visibility reviewable
+- close the operator gap between "external signoff claimed" and "external signoff demonstrated"
+- prevent wording drift and false confidence when anchor strength is partial or missing
+
+This profile is an interpretation and evidence-visibility aid only. It does not approve, authorize, pass gates, or enact transitions.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- canonical anchor classes for external signoff evidence visibility
+- anchor-level limits: what each anchor can and cannot evidence
+- common weakness patterns and corresponding false-confidence risks
+- conservative wording discipline when only partial anchors are available
+- minimal operator review path for claim-versus-demonstrated classification
+
+Out of scope:
+
+- promotion decisions
+- gate-pass decisions
+- authority substitution
+- runtime control or runtime state transitions
+- policy relaxation
+- evidence generation or evidence mutation
+- replacement of deep artifact inspection
+
+## 3) External Signoff Evidence Anchor Profile Table
+
+| anchor class | what this anchor can evidence | what this anchor cannot evidence | common weakness pattern | false confidence risk if weak | acceptable wording if only partial | nearest repo anchors | current clarity |
+|---|---|---|---|---|---|---|---|
+| authoritative approval artifact | an external approval artifact exists and states a signoff posture for a stated scope | that approver identity is valid, that authority is genuine, or that all contradictions were resolved | artifact present but status remains draft, conditional, stale, or scope-ambiguous | template completion or artifact presence is misread as active signoff | "external approval artifact is present but signoff demonstration remains partial pending authority and scope verification" | [LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md) | partial |
+| attributable approver evidence | signoff statement is attributable to a named role and identity context | that role claims are independent, currently authorized, or sufficient for transition authority | missing role context, unverifiable identity, or internal restatement without external attribution | any signoff sentence is treated as authoritative despite weak attribution | "signoff is claimed with partial attribution; independent authority verification remains open" | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md) | partial |
+| timestamp and recency anchor | signoff evidence has visible time context and can be checked for freshness at review time | that the evidence is still valid for current candidate state, or that no drift occurred since signoff time | timestamp exists but no recency window, unclear timezone context, or stale signoff reused | stale evidence is interpreted as current authorization | "signoff evidence is time-anchored but recency adequacy is not yet demonstrated for current review context" | [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md), [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) | partial |
+| candidate continuity anchor | signoff evidence can be traced to the same candidate identity and scoped artifact set | that candidate continuity alone implies signoff validity, readiness, or approval closure | candidate identifiers mismatch, scope fields drift, or continuity text is generic | continuity language is mistaken for decision evidence | "candidate continuity is partially visible; signoff demonstration remains incomplete until scope alignment is fully verified" | [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md) | partial to strong for traceability, not authority |
+| packet-to-approval continuity anchor | the handoff packet and external approval references are visibly connected without silent remapping | that continuity guarantees correctness of judgments, authority sufficiency, or contradiction closure | broken reference chain, omitted carry-over caveats, or semantic inflation during transfer | mapping continuity is overread as confirmed signoff | "packet-to-approval continuity is partially demonstrated; external signoff remains at claim-level where links are weak" | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md) | partial |
+| contradiction and exception disclosure anchor | unresolved contradictions, exceptions, and omissions remain explicitly visible to reviewers | that undisclosed contradictions do not exist, or that open exceptions are accepted externally | disclosure is missing, softened, or buried in non-binding notes | silence is interpreted as clean approval state | "contradiction or exception visibility remains partial; no closure claim is allowed" | [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md), [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md), [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md) | partial |
+
+Visibility objectives this profile makes explicit:
+
+- claim versus demonstrated distinction must remain visible
+- identity and authority attribution visibility must remain explicit
+- recency visibility must remain explicit
+- continuity visibility must remain explicit for candidate and packet linkage
+- contradiction and omission visibility must remain explicit
+
+Disallowed wording when evidence is only claimed or partially anchored:
+
+- "approved for transition"
+- "signoff complete"
+- "gate passed"
+- "authorization confirmed"
+
+## 4) Minimal Anchor Review Flow
+
+Minimal operator path for claim-versus-demonstrated classification:
+
+1. Locate the external approval artifact and classify whether it is authoritative, in-scope, and not merely template-complete.
+2. Check whether signoff is attributable to identifiable authority context, not only to internal restatement.
+3. Verify timestamp and recency visibility; classify stale or unbounded recency as partial evidence.
+4. Verify candidate continuity and packet-to-approval continuity; treat link gaps as claim-level evidence only.
+5. Check contradiction, exception, and omission disclosure; block closure wording when disclosure is weak or absent.
+6. Classify final state conservatively:
+   - claim-level: one or more anchor classes missing or weak
+   - demonstrated-level: all anchor classes sufficiently visible with no unresolved contradiction masking
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This anchor profile is explicitly not:
+
+- a promotion decision
+- a gate pass
+- an authority substitute
+- a runtime controller
+- a replacement for deep artifact review
+
+Binding interpretation locks:
+
+- anchor presence is not transition authorization
+- anchor strength is not runtime enablement
+- demonstrated evidence visibility is not policy execution
+- attribution visibility is not authority delegation
+- continuity visibility is not approval validity
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary adjacent anchors:
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+
+Template anchor:
+
+- [LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md)
+
+## 7) Operator Notes
+
+- Keep wording conservative: "claimed", "partially anchored", and "demonstrated only where anchors are sufficient".
+- If any anchor class is weak or missing, keep state at claim-level and escalate.
+- Never convert mapping quality into authorization language.
+- Use this profile to expose boundary and confidence limits, not to grant transitions.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1 as a docs-only / mapping-only / non-authorizing spec
- define the canonical anchor profile for the transition from external signoff claimed to external signoff demonstrated in the LB_APR_001 path
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)