### PR TITLE
docs(ops): add master v2 first live authority handoff packet to lb apr 001 external signoff anchor binding matrix v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md
@@ -1,0 +1,117 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Anchor Binding Matrix v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing matrix for binding external signoff anchor classes to LB_APR_001 target fields with explicit claim-only versus demonstrated-capable boundaries
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one dedicated Master V2 binding matrix view for the First Live authority handoff edge in LB_APR_001 context.
+
+Purpose boundary:
+
+- provide one compact canonical anchor-to-field binding matrix between external signoff anchor classes and LB_APR_001 target fields or sections
+- keep claim-only versus demonstrated-capable interpretation explicit per binding
+- reduce wording drift, semantic mismatch, and false-confidence inflation when anchor quality is weak
+- preserve visibility of authority attribution, recency, candidate continuity, packet-to-approval continuity, and contradiction or exception disclosure
+
+This matrix is an interpretation aid only. It does not authorize, approve, enable, pass gates, or execute transitions.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- external signoff anchor classes as source-side inputs, aligned to established anchor-profile semantics
+- LB_APR_001 target fields or sections as target-side binding destinations
+- per-binding constraints for intent, claim-only versus demonstrated-capable boundary, wording caution, semantic mismatch risk, and false-confidence risk
+- compact operator review flow to classify whether a specific anchor only fills a field or can support stronger demonstrated visibility
+
+Out of scope:
+
+- promotion decisions
+- gate-pass decisions
+- authority substitution
+- runtime control or runtime policy execution
+- evidence generation or evidence mutation
+- LB_APR_001 template semantics rewrite
+- replacement of deep artifact inspection
+
+## 3) External Signoff Anchor Binding Matrix
+
+| external signoff anchor class | LB_APR_001 target field or section | allowed binding intent | claim-only vs demonstrated-capable boundary | wording caution | semantic mismatch risk | false confidence risk if weak | what this binding can preserve | what this binding cannot establish | current clarity |
+|---|---|---|---|---|---|---|---|---|---|
+| authoritative approval artifact | section 7 review outcome context and section 8 sign-off context | carry external approval artifact identity and stated signoff posture into review visibility context | claim-only if artifact is draft, conditional, stale, scope-ambiguous, or not externally attributable; demonstrated-capable only when artifact is externally attributable, in-scope, and continuity-aligned | avoid verbs such as approved, granted, passed, confirmed when only artifact presence is visible | template completion and artifact presence can be misread as active signoff state | weak artifact can be mistaken as final authorization evidence | signoff-claim visibility and artifact traceability | signoff validity, authority sufficiency, or transition permission | partial |
+| attributable approver evidence | section 2 responsibilities and section 8 sign-off by fields | bind visible approver identity context and role attribution to signoff statements | claim-only if attribution is internal restatement, role-only without identity, or unverifiable; demonstrated-capable when attributable to identifiable external authority context | use attributable, claimed, pending verification for weak attribution; avoid authorized by unless evidence is external and verifiable | role labels in template can be interpreted as proven independent authority | weak attribution can be overread as delegated authority closure | authority-attribution visibility | independent authority proof, delegation legality, or approval closure | partial |
+| timestamp and recency anchor | section 1 metadata timestamps, section 7 review date, section 8 sign-off date | bind time and recency context to signoff evidence posture | claim-only if timestamp exists without bounded recency adequacy or timezone clarity; demonstrated-capable only when recency is bounded and coherent with candidate scope and packet state | describe as time-anchored or recency-visible, not currently valid unless recency adequacy is evidenced | timestamp population can be read as freshness guarantee | stale anchors can be interpreted as current authority evidence | recency visibility and replayability context | ongoing validity, drift absence, or active approval currency | partial |
+| candidate continuity anchor | section 3 scope fields and section 10 optional pointers | bind candidate identity and scope continuity between packet and external artifact | claim-only if candidate identifiers, scope elements, or version references are incomplete or mismatched; demonstrated-capable when candidate identity and scope continuity are consistently evidenced | use continuity-visible and scope-aligned wording; avoid approved candidate phrasing | continuity metadata can be interpreted as approval readiness | continuity-only signals can be mistaken for decision evidence | candidate continuity visibility | readiness, acceptance, or signoff legitimacy | partial to strong for continuity, not authority |
+| packet-to-approval continuity anchor | section 6 binding repo references and section 10 optional pointers | bind packet source chain into external approval context without silent remapping | claim-only when links are weak, missing, or semantically inflated; demonstrated-capable when packet-to-approval linkage remains explicit, consistent, and contradiction-aware | keep transfer wording non-decisional; avoid translated as approved by mapping | mapping continuity can be mistaken for judgment correctness | weak linkage can create false closure confidence | packet-to-approval continuity visibility and traceability | external judgment quality, approval decision correctness, or authority transfer | partial |
+| contradiction and exception disclosure anchor | section 7 conditions and unresolved points, section 9 explicit non-statements | bind unresolved contradictions, exceptions, omissions, and non-claims into visible external review context | claim-only if unresolved disclosures are missing, softened, or buried; demonstrated-capable when unresolved items are explicit and disposition evidence is visible | keep unresolved wording explicit; avoid accepted, closed, or waived without external disposition evidence | softened exception language can hide unresolved blockers | silence can be misread as contradiction-free approval state | contradiction and exception disclosure visibility | contradiction resolution, waiver approval, or closure status | partial |
+
+Visibility dimensions the matrix must keep explicit:
+
+- authority attribution visibility: attributable approver evidence row
+- recency visibility: timestamp and recency anchor row
+- candidate continuity visibility: candidate continuity anchor row
+- packet-to-approval continuity visibility: packet-to-approval continuity anchor row
+- contradiction and exception disclosure visibility: contradiction and exception disclosure anchor row
+
+## 4) Minimal Binding Review Flow
+
+Minimal operator path to classify whether an anchor class only fills a field or can support stronger demonstrated visibility:
+
+1. Select one binding row and confirm source anchor class and LB_APR_001 target field match the matrix.
+2. Check allowed binding intent and copy only visibility-safe content into the target field.
+3. Apply claim-only versus demonstrated-capable boundary checks for attribution, recency, continuity, and contradiction disclosure.
+4. If any boundary check is weak or unresolved, keep wording at claim-level and mark the binding as partial.
+5. Apply wording caution and semantic mismatch checks; remove decision-like language inflation.
+6. Record false-confidence risk posture for weak anchors before finalizing review wording.
+7. Classify final per-binding posture conservatively:
+   - field-filled only: target field populated but support remains claim-only
+   - supportable visibility: demonstrated-capable conditions met for that binding only
+
+## 5) Interpretation Locks / Non-Authorization Clauses
+
+This binding matrix is explicitly not:
+
+- a promotion decision
+- a gate pass
+- an authority substitute
+- a runtime controller
+- a replacement for deep artifact inspection
+
+Binding interpretation locks:
+
+- binding quality is not authorization
+- demonstrated-capable visibility is not transition execution
+- source-to-target continuity is not approval validity
+- attribution visibility is not delegated authority
+- contradiction disclosure visibility is not contradiction closure
+
+## 6) Nearest Existing Repo Artifacts / Cross-References
+
+Primary nearby anchors:
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/INDEX.md](../registry/INDEX.md)
+
+External template anchor:
+
+- [LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md](../templates/LB_APR_001_EXTERNAL_APPROVAL_ARTIFACT_TEMPLATE.md)
+
+## 7) Operator Notes
+
+- Keep binding language conservative: claimed, partially anchored, demonstrated-capable only where boundary checks pass.
+- When any anchor class is weak, preserve visibility but block closure wording.
+- Never convert matrix quality into approval, pass, or enablement language.
+- Escalate semantic mismatch or contradiction ambiguity instead of normalizing away uncertainty.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1 as a docs-only / mapping-only / non-authorizing spec
- define the canonical binding matrix between external signoff anchor classes and LB_APR_001 target fields, including the claim-vs-demonstrated boundary
- keep scope to a single new spec file

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)