### PR TITLE
docs(ops): add external signoff evidence posture ladder v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md
@@ -1,0 +1,116 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Posture Ladder v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing posture ladder that aggregates external-signoff evidence boundaries for the Packet -> LB_APR_001 handoff path
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one canonical External Signoff Evidence Posture Ladder for the Packet -> LB_APR_001 handoff path.
+
+It is explicitly docs-only, mapping-only, and non-authorizing.
+
+Purpose boundary:
+
+- aggregate existing boundary, anchor-profile, anchor-binding, route, and field-map semantics into one conservative posture-classification surface
+- keep claim-versus-demonstrated interpretation explicit and reproducible
+- prevent authorization inflation from template completion, wording strength, or partial anchor visibility
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one documentary posture ladder for external-signoff evidence visibility
+- one conservative classification frame for claim-level versus demonstrated-level posture assignment
+- aggregation rules for anchor classes: attribution, recency, candidate continuity, packet continuity, contradiction or exception disclosure
+- downgrade discipline for ambiguity, drift, staleness, or disclosure gaps
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, or runtime decision
+- any runtime, config, workflow, test, or code change
+- any evidence creation, mutation, or semantic rewrite of LB_APR_001
+- any new authority domain, new decision path, or replacement of existing canonical artifacts
+
+This spec does not derive or grant authorization.
+
+## 3) External Signoff Evidence Posture Ladder
+
+| posture state | claim vs demonstrated boundary | entry conditions (all documentary) | downgrade triggers | common misinterpretation | allowed wording | explicit non-claims | can show | cannot show |
+|---|---|---|---|---|---|---|---|---|
+| template-only | claim absent; demonstrated absent | packet exists and LB_APR_001 fields may be populated, but no external-signoff claim anchor is visible | any hidden contradiction, missing provenance context, or mapping drift keeps/returns state here | "template completed means approved" | "template populated for external review context; no signoff claim demonstrated" | no approval, no authorization, no gate-pass, no transition enablement | mapping completion visibility and boundary-aware preparation | external signoff existence, authority validity, or decision closure |
+| signoff-claimed | claim present; demonstrated not established | explicit signoff claim text exists and references external review intent, but one or more required anchor classes are missing or unverified | unverifiable attribution, stale/ambiguous recency, candidate mismatch, packet-chain gap, missing contradiction disclosure | "claim text means signoff completed" | "external signoff is claimed and pending anchor verification" | no approval confirmation, no authorization claim, no gate-pass claim | that a claim exists and is in-scope for review | that claim is authentic, sufficient, current, or authoritative |
+| anchor-partial | claim present; demonstrated partial only | at least one required anchor class is visible, but aggregate anchor sufficiency is incomplete across attribution/recency/continuity/disclosure | any regression in already-visible anchors, unresolved contradiction expansion, recency expiry, or continuity break | "some anchors mean effectively approved" | "external signoff evidence is partially anchored; demonstrated posture not yet reached" | no closure claim, no authority transfer, no runtime permission implication | partial anchor visibility with explicit gaps | full demonstrated evidence posture or authorization outcome |
+| demonstrated-evidence-visible | claim present; demonstrated documentary visibility achieved | all required anchor classes are visibly satisfied in aggregate: attribution, recency, candidate continuity, packet continuity, contradiction or exception disclosure | any later contradiction, exception, staleness, identity dispute, continuity break, or provenance inconsistency downgrades posture | "demonstrated evidence means gate passed and authorized" | "external signoff evidence is demonstrated for documented scope; authorization remains external to this ladder" | still no gate pass, no runtime transition execution, no autonomous authorization | reproducible documentary demonstration of external-signoff evidence posture | operational authorization decision, gate execution, or live enablement command |
+
+Aggregation rules over anchor classes (conservative, documentary only):
+
+- attribution: external signoff evidence must be attributable to identifiable external authority context
+- recency: evidence time context must be visible and non-stale for the reviewed candidate scope
+- candidate continuity: evidence must bind to the same candidate identity and scope context
+- packet continuity: packet-to-LB_APR_001 chain must remain explicit without silent remapping
+- contradiction or exception disclosure: unresolved contradictions, omissions, and exceptions must remain visible, not softened
+
+## 4) State Transition and Downgrade Rules
+
+This section defines documentary classification transitions only, not an operational state machine.
+
+Allowed documentary progression (if conditions are met): `template-only -> signoff-claimed -> anchor-partial -> demonstrated-evidence-visible`.
+
+Documentary downgrade rules:
+
+- downgrade immediately when any required anchor class becomes missing, unverifiable, stale, contradictory, or continuity-broken
+- downgrade when wording drifts from visibility language to decision language
+- downgrade when contradiction or exception disclosure is removed, softened, or made implicit
+- downgrade when provenance or replayability trace becomes non-reproducible from existing artifacts
+- when uncertain, classify to the lower posture state
+
+## 5) Minimal Classification Review Flow
+
+Minimal, reproducible review path using only already-materialized neighboring artifacts:
+
+1. Start from boundary semantics and field-transfer semantics; classify whether posture is at most `template-only`.
+2. Check if a signoff claim is explicitly present and in-scope; if yes, move to provisional `signoff-claimed`.
+3. Evaluate required anchor classes in aggregate (attribution, recency, candidate continuity, packet continuity, contradiction or exception disclosure).
+4. If one or more anchor classes are incomplete, classify `anchor-partial`; if all are sufficient and reproducible, classify `demonstrated-evidence-visible`.
+5. Apply downgrade checks; if any downgrade trigger is present, move to the lowest still-justified posture.
+6. Record final posture with conservative wording and explicit non-claims.
+
+## 6) Interpretation Locks / Non-Authorization Clauses
+
+Binding interpretation locks:
+
+- this ladder is a documentary classifier, not an authorization surface
+- claim visibility is never equivalent to approval
+- anchor sufficiency visibility is never equivalent to gate pass
+- demonstrated evidence visibility is never equivalent to runtime transition execution
+- continuity visibility is never equivalent to delegated authority
+
+Language boundary locks:
+
+- terms such as `approved`, `authorized`, and `gate passed` are forbidden as internal posture outputs
+- such terms may appear only as externally attributed quotations/evidence text or as explicit out-of-scope examples
+- internal outputs must remain in posture-language only: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+
+## 7) Nearest Existing Repo Artifacts / Cross-References
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_FIELD_MAP_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+- [registry/INDEX.md](../registry/INDEX.md)
+
+## 8) Operator Notes
+
+- keep classification conservative: if evidence quality is ambiguous, classify lower
+- avoid drift by reusing anchor semantics from boundary, anchor-profile, and binding artifacts; do not invent new authority semantics
+- keep claim-versus-demonstrated distinction explicit in every posture record
+- treat this ladder as additive re-wiring of existing semantics, not as a new decision mechanism
+- prevent authorization inflation by preserving explicit non-claims in every review output


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md`
- codify a non-authorizing external-signoff evidence posture ladder for the `Handoff Packet -> LB_APR_001` path
- aggregate existing boundary / anchor-profile / anchor-binding semantics into a reproducible documentation-only classification surface

## Validation
- `test -f docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / mapping-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)