### PR TITLE
docs(ops): add external signoff evidence truth precedence matrix v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md
@@ -1,0 +1,147 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Truth Precedence Matrix v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing truth and precedence matrix for deterministic external-signoff evidence posture classification in the Packet -> LB_APR_001 handoff path
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one canonical External Signoff Evidence Truth Precedence Matrix for the Packet -> LB_APR_001 handoff path.
+
+It is explicitly docs-only, mapping-only, and non-authorizing.
+
+Purpose boundary:
+
+- define deterministic truth precedence when external-signoff evidence signals are conflicting, incomplete, stale, or continuity-broken
+- keep posture classification reproducible across repeated reviews with identical inputs
+- preserve conservative claim-versus-demonstrated interpretation without introducing decision authority
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one canonical precedence order across existing external-signoff evidence anchors and boundary semantics
+- deterministic conflict and tie-break resolution for ambiguity, staleness, continuity breaks, and disclosure gaps
+- posture ceiling mapping from evidence state to maximal allowed posture output
+- mandatory downgrade rules that prevent wording or inference inflation
+- minimal deterministic review flow using only already materialized neighboring artifacts
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, runtime enablement, or transition command
+- any runtime, config, workflow, test, or code change
+- any evidence generation or evidence mutation
+- any new authority domain, new role, or replacement of existing canonical matrices
+
+This spec does not derive, grant, imply, or simulate authorization.
+
+## 3) External Signoff Evidence Truth Precedence Matrix
+
+Precedence order (highest truth-binding first, conservative by default):
+
+1. contradiction or exception disclosure integrity
+2. continuity integrity (candidate continuity and packet continuity)
+3. attribution integrity (externally attributable authority context)
+4. recency integrity (time context and non-stale scope fit)
+5. signoff claim presence
+6. template or field population presence
+
+Interpretation rule:
+
+- stronger lower-priority signals never override weaker or failing higher-priority signals
+- uncertainty resolves downward to the most conservative posture
+
+| observed evidence state (from existing artifacts) | precedence interpretation | maximal allowed posture state | mandatory wording posture |
+|---|---|---|---|
+| contradiction or exception disclosure missing, softened, or non-reproducible | highest-precedence failure; closure truth blocked | template-only | external-signoff evidence not demonstrated; unresolved disclosure integrity gap remains |
+| explicit contradiction unresolved or exception unresolved without disposition evidence | highest-precedence unresolved conflict | signoff-claimed | signoff is claimed; contradiction or exception disposition remains open |
+| candidate continuity or packet continuity broken, mismatched, or ambiguous | continuity precedence failure | signoff-claimed | signoff claim exists but continuity evidence is insufficient for demonstrated posture |
+| attribution unverified, internally restated only, or externally non-attributable | attribution precedence failure | signoff-claimed | attribution remains partial; demonstrated evidence posture not supported |
+| attribution present but recency stale, unbounded, or scope-ambiguous | recency precedence failure under otherwise partial strength | anchor-partial | evidence is partially anchored; recency adequacy remains unresolved |
+| claim present with mixed partial anchors and no hard contradiction breach | partial aggregate with no top-precedence hard fail | anchor-partial | external-signoff evidence is partially anchored; demonstrated posture not reached |
+| all required anchor classes visible and reproducible with no unresolved contradiction or exception disclosure gap | no precedence conflict active | demonstrated-evidence-visible | external-signoff evidence is demonstrated for documented scope only |
+| template populated without explicit signoff claim anchor | claim absent | template-only | template population only; no signoff claim or demonstrated evidence output |
+
+Posture ceiling lock:
+
+- `template-only` is the default ceiling whenever precedence cannot be established deterministically
+- `signoff-claimed` is the ceiling for contradiction, continuity, or attribution integrity failures
+- `anchor-partial` is the ceiling for recency insufficiency or mixed partial anchors without top-precedence breach
+- `demonstrated-evidence-visible` requires all required anchor classes and no active downgrade trigger
+
+## 4) Conflict / Tie-Break and Mandatory Downgrade Rules
+
+Deterministic conflict and tie-break rules:
+
+1. Highest-precedence failure wins over all lower-precedence strengths.
+2. If two interpretations are both plausible, choose the lower posture.
+3. If reviewer certainty cannot be reproduced from artifacts, classify to `template-only`.
+4. Contradiction or exception disclosure uncertainty is never resolved in favor of stronger posture language.
+5. Continuity ambiguity (candidate or packet) blocks demonstrated posture regardless of claim strength.
+6. Attribution ambiguity blocks demonstrated posture regardless of continuity strength.
+7. Recency ambiguity blocks demonstrated posture even when attribution and continuity appear strong.
+
+Mandatory downgrade rules (always apply):
+
+- downgrade immediately when contradiction or exception disclosure is absent, softened, or non-replayable
+- downgrade immediately when candidate continuity or packet continuity is broken or ambiguous
+- downgrade immediately when attribution cannot be externally validated from existing evidence surfaces
+- downgrade immediately when recency is stale, unbounded, timezone-ambiguous, or scope-misaligned
+- downgrade immediately when a previously visible anchor regresses or becomes unverifiable
+- downgrade immediately when output wording drifts into approval or authorization language
+
+## 5) Minimal Deterministic Classification Flow
+
+Use only already materialized neighboring artifacts as inputs.
+
+1. Start at signoff-evidence boundary semantics and current posture ladder state.
+2. Check contradiction or exception disclosure integrity first; if failing, cap posture per matrix and stop upward movement.
+3. Check continuity integrity (candidate then packet); if failing or ambiguous, cap at `signoff-claimed`.
+4. Check attribution integrity; if not externally attributable, cap at `signoff-claimed`.
+5. Check recency integrity; if stale or ambiguous, cap at `anchor-partial`.
+6. Confirm explicit signoff claim anchor; if absent, cap at `template-only`.
+7. Apply downgrade rules once more; final output is the lowest still-justified posture ceiling.
+8. Record posture using visibility-only wording and explicit non-claims.
+
+Determinism lock:
+
+- same inputs -> same maximal allowed posture state
+- missing input is treated as unresolved, not as implied support
+
+## 6) Interpretation Locks / Language Locks
+
+Binding interpretation locks:
+
+- this matrix is a documentary truth-order surface, not an authorization surface
+- claim presence is never equivalent to approval
+- demonstrated evidence visibility is never equivalent to gate pass, runtime permission, or transition command
+- precedence resolution is conservative and downgrade-first
+
+Language locks:
+
+- internal outputs must remain posture-language only: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+- terms `approved`, `authorized`, `gate passed`, `promoted`, `go-live`, and equivalent decision language are forbidden as internal outputs
+- such terms may appear only as externally attributed evidence text or explicit out-of-scope references
+- uncertainty must never be narrated as implicit closure
+
+## 7) Nearest Existing Repo Artifacts / Cross-References
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+
+## 8) Operator Notes
+
+- apply this matrix conservatively: precedence-first, downgrade-first, visibility-only outputs
+- do not infer stronger posture from wording strength, template completeness, or isolated anchors
+- when ambiguity persists, escalate as documentary caution only; no new operational route is created by this spec
+- keep claim-versus-demonstrated distinction explicit in every classification record
+- reuse neighboring canonical semantics as-is; this artifact rewires precedence, it does not rebuild authority meaning


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md`
- codify a non-authorizing truth / precedence layer for external-signoff evidence on the `Handoff Packet -> LB_APR_001` path
- make posture classification deterministic under conflict, ambiguity, staleness, continuity breaks, and missing contradiction disclosure

## Validation
- `test -f docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / mapping-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)