### PR TITLE
docs(ops): add external signoff evidence classification trace ledger v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md
@@ -1,0 +1,148 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Classification Trace Ledger v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing classification-trace ledger for deterministic external-signoff evidence posture output in the Packet -> LB_APR_001 handoff path
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one canonical External Signoff Evidence Classification Trace Ledger for the Packet -> LB_APR_001 handoff path.
+
+It is explicitly docs-only, mapping-only, and non-authorizing.
+
+Purpose boundary:
+
+- define one deterministic classification-trace surface that binds final posture output back to already-established precedence, anchor, boundary, and downgrade findings
+- preserve reproducible claim-versus-demonstrated interpretation for identical evidence inputs
+- prevent wording and closure inflation without introducing new authority, new decision routes, or new result vocabulary
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one canonical classification-trace schema for external-signoff evidence in the handoff packet context
+- deterministic input-to-output mapping for observed findings, applied precedence rules, applied tie-break and downgrade references, and final posture output
+- mandatory trace fields for anchor visibility, attribution, recency, candidate continuity, packet continuity, contradiction or exception disclosure, and conservative non-claim wording
+- minimal trace recording flow using only already materialized neighboring artifacts
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, runtime enablement, or transition command
+- any runtime, config, workflow, test, or code change
+- any evidence generation, evidence mutation, or semantic rewrite of neighboring canonical specs
+- any new authority domain, new role, new escalation lane, or replacement of existing canonical matrices
+
+This spec does not derive, grant, imply, or simulate authorization.
+
+## 3) External Signoff Evidence Classification Trace Ledger
+
+Determinism lock:
+
+- same inputs -> same classification trace output
+- missing, stale, ambiguous, or non-replayable inputs are treated as unresolved and therefore downgraded
+- no new posture states are introduced; only existing states are allowed: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+
+Canonical ledger schema (single record per reviewed packet snapshot):
+
+| ledger field | required value type | allowed values or source posture | deterministic mapping intent |
+|---|---|---|---|
+| trace_id | string | repo-local unique trace key | identifies one reproducible classification record |
+| packet_ref | string | packet identifier from existing handoff surfaces | binds trace to one packet snapshot |
+| candidate_ref | string | candidate identifier from existing continuity surfaces | binds trace to one candidate continuity scope |
+| observed_finding | enum-text | `contradiction-or-exception-gap` / `continuity-gap` / `attribution-gap` / `recency-gap` / `claim-only` / `all-required-anchors-visible` | canonical observed result prior to precedence resolution |
+| visible_anchor_classes | set | `attribution`, `recency`, `candidate-continuity`, `packet-continuity`, `contradiction-or-exception-disclosure` | explicit visibility state by required anchor class |
+| attribution_status | enum | `verified-external` / `partial` / `missing-or-unverifiable` | anchor-profile aligned attribution posture |
+| recency_status | enum | `bounded-current` / `partial-or-ambiguous` / `stale-or-missing` | recency anchor posture for reviewed scope |
+| candidate_continuity_status | enum | `continuous` / `partial-or-ambiguous` / `broken-or-missing` | candidate continuity posture |
+| packet_continuity_status | enum | `continuous` / `partial-or-ambiguous` / `broken-or-missing` | packet-to-LB_APR_001 continuity posture |
+| contradiction_exception_disclosure_status | enum | `explicit-and-replayable` / `partial-or-softened` / `missing-or-unreplayable` | contradiction or exception disclosure posture |
+| applied_precedence_reference | string | reference to Truth Precedence Matrix rule used | records highest-precedence active rule |
+| applied_tie_break_reference | string | reference to tie-break rule used or `none` | records conservative tie handling |
+| applied_downgrade_reference | string | reference to downgrade trigger used or `none` | records posture cap or downgrade cause |
+| final_posture_output | enum | `template-only` / `signoff-claimed` / `anchor-partial` / `demonstrated-evidence-visible` | final deterministic posture result |
+| conservative_non_claim_wording_surface | string | visibility-only statement with explicit non-claims | prevents approval and authorization drift |
+
+Deterministic classification binding table:
+
+| observed finding pattern | precedence binding | tie-break or downgrade binding | final posture output | conservative non-claim wording surface |
+|---|---|---|---|---|
+| contradiction or exception disclosure is missing, softened, or unreplayable | highest precedence failure (disclosure integrity first) | mandatory downgrade to lowest justified posture | `template-only` | external-signoff evidence is not demonstrated; contradiction or exception disclosure remains unresolved |
+| candidate continuity or packet continuity is broken or ambiguous | continuity precedence binding | downgrade cap applies regardless of lower-layer strengths | `signoff-claimed` | signoff is claimed; continuity evidence remains insufficient for demonstrated posture |
+| attribution is missing or unverifiable as external evidence | attribution precedence binding | downgrade cap applies regardless of recency strength | `signoff-claimed` | signoff attribution remains partial or unverifiable; authorization is not claimed |
+| attribution is present but recency is stale, ambiguous, or unbounded | recency precedence binding | downgrade cap applies below demonstrated posture | `anchor-partial` | evidence is partially anchored; recency adequacy is unresolved |
+| claim exists with mixed partial anchors and no higher-precedence hard fail | partial aggregate binding | conservative tie-break chooses lower state | `anchor-partial` | external-signoff evidence is partially anchored; demonstrated evidence is not yet supported |
+| all required anchor classes are visible and replayable with no active contradiction or exception gap | no active precedence conflict | no active downgrade | `demonstrated-evidence-visible` | external-signoff evidence is demonstrated for documented scope only; this is not an authorization output |
+| template fields are populated but no explicit signoff claim anchor exists | claim-absence binding | downgrade to baseline state | `template-only` | template population only; no external-signoff claim or demonstrated evidence output |
+
+## 4) Downgrade and Tie-Break Trace Rules
+
+Binding rules for classification trace recording:
+
+1. Highest-precedence failing condition always dominates lower-precedence strengths.
+2. If two outcomes are plausible from the same evidence set, select the lower posture state and record the tie-break reference.
+3. If replayability of the deciding evidence cannot be reproduced from existing artifacts, classify to `template-only`.
+4. Contradiction or exception uncertainty is never resolved toward stronger language.
+5. Continuity ambiguity (candidate or packet) always blocks `demonstrated-evidence-visible`.
+6. Attribution ambiguity always blocks `demonstrated-evidence-visible`.
+7. Recency ambiguity always blocks `demonstrated-evidence-visible`.
+8. Language drift toward approval or authorization terms triggers immediate downgrade and wording correction.
+
+Trace rule lock:
+
+- tie-break and downgrade logic in this ledger is derived only from existing Truth Precedence, Posture Ladder, and Boundary Matrix semantics
+- uncertainty is always resolved conservatively and never upward
+
+## 5) Minimal Trace Recording Flow
+
+Use only already materialized neighboring artifacts as input.
+
+1. Collect the current external-signoff evidence posture context and observed findings from boundary, anchor, and route surfaces.
+2. Classify anchor visibility statuses: attribution, recency, candidate continuity, packet continuity, contradiction or exception disclosure.
+3. Apply precedence order and record the first active precedence condition in `applied_precedence_reference`.
+4. If ambiguity or competing interpretations exist, apply conservative tie-break and record `applied_tie_break_reference`.
+5. Apply mandatory downgrade caps, record `applied_downgrade_reference`, and emit the lowest still-justified `final_posture_output`.
+6. Record one conservative non-claim wording surface that states visibility posture only and explicitly excludes authorization semantics.
+
+Reproducibility clause:
+
+- repeating this flow with identical inputs produces the same classification-trace record and the same final posture output
+
+## 6) Interpretation Locks / Language Locks
+
+Binding interpretation locks:
+
+- this ledger is a documentary traceability surface, not an authorization surface
+- trace completeness is not approval
+- demonstrated evidence visibility is not gate pass, not promotion, not go-live, and not runtime enablement
+- no section in this ledger creates new authority or new decision routes
+
+Language locks:
+
+- internal outputs must remain posture-language only: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+- `approved`, `authorized`, `gate passed`, `promoted`, `go-live`, and equivalent decision terms are forbidden as internal outputs
+- such terms may appear only as externally attributed evidence text or explicit out-of-scope references
+- uncertainty must be narrated as unresolved visibility, never as implicit closure
+
+## 7) Nearest Existing Repo Artifacts / Cross-References
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_REVIEW_ROUTE_COMPASS_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+
+## 8) Operator Notes
+
+- apply classification output conservatively and record only what evidence visibly supports
+- keep claim versus demonstrated distinction explicit in every trace record
+- do not inflate closure language from template completeness, isolated anchors, or partial continuity
+- do not extend this ledger into implicit decision authority, runtime permission, or gate semantics
+- when ambiguity persists, keep the lower posture and disclose unresolved state explicitly


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md`
- codify a non-authorizing classification-trace ledger for the `Handoff Packet -> LB_APR_001 -> External Signoff` path
- bind final posture outputs deterministically to existing precedence, anchor, boundary, and downgrade findings

## Validation
- `test -f docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / mapping-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)