### PR TITLE
docs(ops): add external signoff evidence classification replay contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md
@@ -1,0 +1,156 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Classification Replay Contract v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing replay contract for deterministic reconstruction of external-signoff evidence classification trace output per packet snapshot using already materialized artifacts
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one canonical External Signoff Evidence Classification Replay Contract for the Packet -> LB_APR_001 handoff path.
+
+It is explicitly docs-only, mapping-only, and non-authorizing.
+
+Purpose boundary:
+
+- define one minimal, reproducible replay contract for reconstructing a classification-trace dataset per snapshot
+- bind replayed output to already materialized precedence, posture, anchor, and boundary semantics
+- preserve conservative claim-versus-demonstrated interpretation without introducing new authority, new states, or new decision routes
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one canonical replay input contract with minimal required pointers and allowed source surfaces
+- one deterministic replay procedure for input resolution, precedence or tie-break or downgrade reconstruction, and final posture reproduction
+- consistency locks between applied reference fields and referenced Truth or Anchor or Boundary artifacts
+- conservative replay failure handling for missing or ambiguous inputs inside existing posture vocabulary
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, runtime enablement, or operational transition claim
+- any runtime, config, workflow, test, or code change
+- any evidence creation, evidence mutation, or rewrite of neighboring canonical specs
+- any new posture state, authority domain, role, escalation lane, or independent decision logic
+
+This replay contract does not derive, grant, imply, or simulate authorization.
+
+## 3) Canonical Replay Input Contract
+
+Replay input unit:
+
+- one packet snapshot replay request, resolved only from already materialized neighboring artifacts
+
+Minimal required replay fields:
+
+| field | type | required | allowed source | conservative rule if missing or ambiguous |
+|---|---|---|---|---|
+| snapshot_id | string | yes | existing packet and trace surfaces | mark replay unresolved and cap output conservatively |
+| packet_ref | string | yes | packet handoff traceability surfaces | treat continuity as unresolved |
+| candidate_ref | string | yes | candidate continuity surfaces | treat candidate continuity as unresolved |
+| classification_trace_ref | string | yes | classification trace ledger | replay cannot assert final posture above conservative floor |
+| applied_precedence_reference | string | yes | truth precedence matrix references | precedence resolution becomes unresolved |
+| applied_tie_break_reference | string or `none` | yes | truth precedence matrix or classification trace ledger references | if ambiguous, select lower posture and record unresolved tie |
+| applied_downgrade_reference | string or `none` | yes | truth precedence matrix or classification trace ledger references | if missing, assume downgrade may apply and resolve downward |
+| required_anchor_visibility_set | set | yes | anchor profile and anchor binding matrix | any missing required class is unresolved |
+| boundary_context_ref | string | yes | signoff evidence boundary matrix | boundary posture cannot be treated as demonstrated |
+| posture_ladder_ref | string | yes | posture ladder | final posture must remain inside existing ladder states |
+
+Allowed replay source artifacts (canonical set only):
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md`
+- `docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`
+- `docs/ops/specs/MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md`
+- `docs/ops/registry/DOCS_TRUTH_MAP.md`
+- `docs/ops/EVIDENCE_INDEX.md`
+
+Determinism lock:
+
+- same replay input set -> same `final_posture_output`
+
+## 4) Deterministic Replay Procedure
+
+Use only canonical input contract fields and allowed source artifacts.
+
+1. Resolve replay inputs by `snapshot_id` and confirm all required pointers are present, unique, and source-valid.
+2. Reconstruct anchor visibility and boundary context from anchor profile or anchor binding or boundary matrix references.
+3. Reconstruct precedence outcome using `applied_precedence_reference`; if multiple outcomes seem plausible, apply `applied_tie_break_reference` and choose the lower posture.
+4. Reconstruct mandatory downgrade effect using `applied_downgrade_reference`; if missing or ambiguous, resolve conservatively downward.
+5. Reproduce `final_posture_output` strictly within existing posture ladder vocabulary: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`.
+6. Emit replay output as visibility-only posture interpretation with explicit non-authorization language.
+
+Replay invariance rule:
+
+- for identical resolved inputs and identical references, replay must reproduce identical `final_posture_output`
+
+## 5) Replay Consistency Locks
+
+Reference-integrity locks:
+
+- `classification_trace_ref` must point to a trace record shape aligned with the classification trace ledger schema
+- `applied_precedence_reference` must map to an existing rule surface in the truth precedence matrix
+- `applied_tie_break_reference` and `applied_downgrade_reference` must be either valid existing references or explicit `none`
+- anchor-related replay fields must be consistent with required anchor classes from the anchor profile and anchor binding matrix
+- boundary interpretation must remain consistent with the signoff evidence boundary matrix
+- replay vocabulary and non-claim wording must remain consistent with vocab boundary locks
+
+Consistency resolution rule:
+
+- any reference mismatch, unresolved pointer, or cross-artifact inconsistency forces conservative posture reproduction, never upward reinterpretation
+
+## 6) Replay Failure Posture Rules
+
+Replay failure principles:
+
+- no new posture labels are allowed
+- no missing or ambiguous input may be resolved toward stronger posture language
+- unresolved replay inputs remain explicitly unresolved visibility states
+
+Deterministic conservative handling:
+
+- if required identity or continuity inputs are missing or ambiguous, replay cannot output `demonstrated-evidence-visible`
+- if precedence reference cannot be reconstructed, replay must resolve to the lowest justified existing posture
+- if downgrade reference is missing or non-replayable, replay assumes downgrade pressure and resolves downward
+- if anchor visibility set is incomplete or contradictory, replay remains at conservative posture and records unresolved status
+- if boundary context is not reproducible, replay output must stay within non-closure wording
+
+## 7) Interpretation Locks / Language Locks
+
+Binding interpretation locks:
+
+- this artifact is a replay contract for documentary reconstruction, not an authorization surface
+- replay success is not approval
+- replayed demonstrated visibility is not gate pass, not promotion, not go-live, and not runtime enablement
+
+Language locks:
+
+- internal replay outputs must use existing posture vocabulary only: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+- terms such as `approved`, `authorized`, `gate passed`, `promoted`, `go-live` are forbidden as replay outputs
+- such terms may appear only as externally attributed evidence text or explicit out-of-scope references
+- unresolved inputs must be narrated as unresolved visibility, never as implicit closure
+
+## 8) Nearest Existing Repo Artifacts / Cross-References
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+
+## 9) Operator Notes
+
+- apply replay conservatively: reconstruct only what canonical references can reproduce
+- avoid closure inflation: replayed posture visibility is not decision authority
+- do not expand interpretation beyond already materialized Truth or Anchor or Boundary semantics
+- when ambiguity remains, keep lower posture and disclose unresolved inputs explicitly


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md`
- codify a non-authorizing replay contract for reconstructing external-signoff classification-trace outputs per snapshot
- bind replay inputs, reconstruction steps, consistency locks, and conservative replay-failure handling to existing trace / truth / posture / anchor / boundary semantics

## Validation
- `test -f docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / mapping-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)