### PR TITLE
docs(ops): add external signoff evidence classification cross artifact invariant matrix v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md
@@ -1,0 +1,130 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Classification Cross-Artifact Invariant Matrix v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing cross-artifact invariant matrix that locks 1:1 consistency expectations for external-signoff evidence classification across posture, truth-precedence, trace, and replay artifacts
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one canonical Cross-Artifact Invariant Matrix for External Signoff Evidence Classification in the Packet -> LB_APR_001 handoff path.
+
+It is explicitly docs-only, mapping-only, and non-authorizing.
+
+Purpose boundary:
+
+- lock 1:1 cross-artifact consistency for the same classification statement across posture, truth-precedence, trace, and replay surfaces
+- define deterministic drift detection for document-level mismatches without introducing new states or new decision logic
+- enforce conservative downgrade outcomes when artifacts diverge in wording, references, or classification ceilings
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one canonical cross-artifact invariant matrix for existing external-signoff evidence classification semantics
+- consistency constraints for `final_posture_output`, `applied_precedence_reference`, `applied_downgrade_reference`, classification-trace consistency, and replay reproducibility
+- deterministic mismatch handling using existing posture vocabulary only: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+- conservative drift handling with explicit unresolved visibility when references cannot be aligned
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, runtime enablement, or transition command
+- any runtime, config, workflow, test, or code change
+- any evidence creation, mutation, or semantic rewrite of neighboring specs
+- any new posture state, new authority domain, new role, new registry mechanics, or new event-ledger model
+
+This spec does not derive, grant, imply, or simulate authorization.
+
+## 3) Cross-Artifact Invariant Matrix
+
+Canonical rule form (binding for all rows):
+
+- if mismatch then conservative downgrade
+- never upward resolution
+
+| invariant_id | affected_artifacts | consistency_rule | allowed_posture_caps | drift_signal | conservative_resolution_or_downgrade_outcome |
+|---|---|---|---|---|---|
+| INV-001-final-posture-identity | Posture Ladder + Truth Precedence Matrix + Classification Trace Ledger + Classification Replay Contract | For identical resolved inputs, the emitted `final_posture_output` must be identical across trace and replay and must not exceed the maximal allowed posture from truth precedence or posture ladder constraints. | `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible` (existing vocabulary only) | Trace and replay outputs differ, or one output exceeds the precedence ceiling. | Apply lower of conflicting outputs; if ceiling cannot be reproduced, downgrade to lowest still-justified posture, defaulting to `template-only` when unresolved. |
+| INV-002-precedence-reference-coherence | Truth Precedence Matrix + Classification Trace Ledger + Classification Replay Contract | `applied_precedence_reference` must resolve to an existing precedence rule and must be consistent with the observed finding pattern recorded in trace and replay reconstruction. | cap derived only from referenced precedence rule; never above its defined ceiling | Missing, non-existent, or semantically mismatched precedence reference. | Mark precedence as unresolved and downgrade conservatively to the lowest posture justified by reproducible evidence; never infer stronger posture from lower-priority signals. |
+| INV-003-downgrade-reference-coherence | Truth Precedence Matrix + Classification Trace Ledger + Classification Replay Contract | `applied_downgrade_reference` must exist (or be explicit `none`) and must align with active downgrade conditions visible in trace and replay inputs. | posture capped at or below downgrade rule outcome from existing matrix semantics | Downgrade trigger is active but reference is absent/`none`, or reference exists without visible trigger. | Treat mismatch as active downgrade pressure; force downward resolution and record unresolved visibility rather than closure wording. |
+| INV-004-trace-anchor-class-consistency | Classification Trace Ledger + Anchor Profile + Anchor Binding Matrix + Signoff Evidence Boundary Matrix | Trace anchor statuses for attribution, recency, candidate continuity, packet continuity, and contradiction-or-exception disclosure must be semantically consistent with existing anchor and boundary semantics. | no cap lifting from anchor inconsistency; caps remain conservative per existing rules | Any anchor class marked stronger in trace than supported by anchor/boundary surfaces. | Reclassify anchor status downward to supported level and downgrade `final_posture_output` accordingly; no upward reconciliation allowed. |
+| INV-005-replay-trace-reproducibility | Classification Replay Contract + Classification Trace Ledger + Provenance Replayability | Replay of identical resolved inputs must reproduce the same classification posture and reference surfaces as trace output, within documented replayability boundaries. | replay output cannot exceed trace output or precedence ceiling | Same input set yields different replay posture or non-reproducible references. | Resolve to lower posture, annotate unresolved replayability visibility, and keep conservative non-claim wording. |
+| INV-006-claim-vs-demonstrated-boundary-lock | Posture Ladder + Signoff Evidence Boundary Matrix + Truth Precedence Matrix + Classification Trace Ledger | Claim-level signals and demonstrated-level signals must remain separated: claim presence, template population, or isolated partial anchors must never be emitted as demonstrated evidence. | claim-level caps: max `signoff-claimed` or `anchor-partial` unless all required anchor classes are visible and conflict-free | Language or output promotes claim-level evidence to demonstrated-level output without required anchor completeness. | Enforce boundary downgrade to claim-consistent posture and replace inflated closure language with explicit non-claims. |
+| INV-007-language-and-non-authorization-lock | Posture Ladder + Truth Precedence Matrix + Classification Trace Ledger + Classification Replay Contract + Vocab Boundary Lock | Internal outputs must remain posture-language only; terms such as approved, authorized, gate passed, promoted, go-live are forbidden as internal classification outputs. | no posture elevation from wording strength; conservative cap remains binding | Decision-language appears as internal output instead of externally attributed evidence text or out-of-scope note. | Treat as drift, downgrade if needed, and normalize output to visibility-only posture wording with explicit non-authorization clause. |
+| INV-008-contradiction-exception-integrity-priority | Truth Precedence Matrix + Anchor Profile + Classification Trace Ledger + Classification Replay Contract | Contradiction-or-exception disclosure integrity remains highest-priority classification guardrail; unresolved disclosure gaps cannot be bypassed by strong lower-priority anchors. | at most `signoff-claimed` or lower when disclosure is unresolved; `template-only` when disclosure is missing/softened/unreplayable | Unresolved contradiction/exception state coexists with stronger final posture output. | Apply immediate conservative downgrade per existing precedence semantics; never resolve upward based on continuity, attribution, recency, or claim strength. |
+
+Explicit cross-artifact field lock:
+
+- `final_posture_output` must match across trace and replay for the same resolved inputs and remain within posture/precedence caps.
+- `applied_precedence_reference` must point to the governing truth rule that explains the posture ceiling.
+- `applied_downgrade_reference` must explain any cap or downward move; missing references are treated conservatively.
+- classification trace consistency requires anchor-class statuses and observed finding patterns to remain aligned with existing anchor and boundary semantics.
+- replay reproducibility requires same inputs -> same posture output and same reference interpretation; unresolved replayability enforces conservative downgrade.
+
+## 4) Deterministic Consistency Check Flow
+
+Use only already materialized neighboring artifacts.
+
+1. Resolve one classification snapshot from trace and replay inputs, including `final_posture_output`, `applied_precedence_reference`, and `applied_downgrade_reference`.
+2. Validate precedence binding first: confirm the referenced precedence rule exists and that the emitted posture does not exceed its allowed ceiling.
+3. Validate downgrade binding next: confirm active downgrade conditions and references are consistent; if not, apply conservative downgrade.
+4. Validate trace anchor statuses against existing anchor profile, anchor binding, and boundary semantics for attribution, recency, candidate continuity, packet continuity, and contradiction-or-exception disclosure.
+5. Compare trace and replay outputs for identical resolved inputs; any mismatch is drift and must resolve downward.
+6. Emit final consistency result using posture-language only and explicit non-authorization non-claims.
+
+Determinism lock:
+
+- same inputs and same references -> same consistency outcome
+- missing or ambiguous reference -> unresolved visibility and conservative downward resolution
+
+## 5) Drift Classes and Conservative Resolution Rules
+
+| drift_class | definition | mandatory_conservative_rule | forbidden_resolution |
+|---|---|---|---|
+| precedence-drift | precedence reference missing, invalid, or not aligned with observed finding | downgrade to lowest posture justified by reproducible evidence; default `template-only` when unresolved | inferring higher posture from lower-priority strength |
+| downgrade-drift | downgrade condition active but downgrade reference absent/inconsistent | treat downgrade pressure as active and resolve downward immediately | ignoring downgrade due to wording confidence |
+| posture-output-drift | output mismatch across posture/precedence/trace/replay surfaces | choose lower output and enforce cap consistency | selecting stronger wording or stronger posture |
+| anchor-classification-drift | trace anchor statuses overstate anchor or boundary support | reclassify anchors downward and cap posture accordingly | compensating one weak anchor with another strong anchor |
+| replay-reproducibility-drift | replay cannot reproduce trace references or output from same inputs | keep unresolved visibility explicit and downgrade conservatively | replay-side upward reinterpretation |
+| language-drift | internal outputs use decision-language instead of posture-language | normalize to non-authorizing visibility wording; downgrade if language implied stronger closure | preserving approval-like phrasing as internal output |
+
+Binding resolution principle:
+
+- inconsistency is never resolved toward stronger posture language
+- only conservative caps, downgrades, or unresolved visibility are allowed
+
+## 6) Interpretation Locks / Non-Authorization Clauses
+
+Binding interpretation locks:
+
+- this artifact is a documentation consistency matrix, not an authorization surface
+- consistency between artifacts is not approval, not authorization, not gate pass, not promotion, and not go-live
+- drift-free mapping does not grant runtime enablement or operational permission
+- conservative downgrade outcomes are documentary classification controls only
+
+Language locks:
+
+- terms such as `approved`, `authorized`, `gate passed`, `promoted`, `go-live` are forbidden as internal classification outputs
+- such terms may appear only as externally attributed evidence text or explicit out-of-scope references
+- internal outputs must remain within existing posture vocabulary and explicit non-claims
+
+## 7) Nearest Existing Repo Artifacts / Cross-References
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+- [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+
+## 8) Operator Notes
+
+- apply this matrix conservatively and precedence-first; when uncertain, classify lower
+- do not inflate closure from template completeness, claim strength, or isolated anchors
+- keep `final_posture_output`, `applied_precedence_reference`, and `applied_downgrade_reference` explicitly aligned across trace and replay outputs
+- keep unresolved visibility explicit; do not silently normalize inconsistencies
+- this artifact rewires existing semantics only; it does not create new authority, new states, or new decision pathways


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md`
- codify a non-authorizing cross-artifact invariant matrix for the `Handoff Packet -> LB_APR_001 -> External Signoff` classification stack
- make drift detection and conservative resolution explicit across posture, truth-precedence, classification-trace, and classification-replay artifacts

## Validation
- `test -f docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / mapping-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)