### PR TITLE
docs(ops): add external signoff evidence classification drift detection replay scenario atlas v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1.md
@@ -1,0 +1,125 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Classification Drift Detection Replay Scenario Atlas v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing scenario atlas that rewires existing cross-artifact invariants into deterministic drift-detection and replay vectors for external-signoff evidence classification
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one canonical Drift Detection Replay Scenario Atlas for External Signoff Evidence Classification in the Packet -> LB_APR_001 handoff path.
+
+It is explicitly docs-only, mapping-only, and non-authorizing.
+
+Purpose boundary:
+
+- condense existing invariant, precedence, posture, trace, replay, anchor, boundary, and vocab locks into deterministic scenario vectors
+- make replay and drift classification reproducible for identical input signatures
+- enforce conservative output discipline without introducing new states, new authority, or new decision logic
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one canonical scenario atlas table for deterministic drift and replay edge cases
+- one deterministic evaluation procedure that depends only on already materialized neighboring artifacts
+- one drift-class-to-scenario coverage map for complete mapping of all existing drift classes from the cross-artifact invariant matrix
+- conservative non-claim wording surfaces for each scenario outcome
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, runtime enablement, or transition command
+- any runtime, config, workflow, test, or code change
+- any evidence creation or mutation
+- any new posture state, new authority domain, or new escalation domain
+- any rewrite or replacement of neighboring canonical specs
+
+This specification does not derive, grant, imply, or simulate authorization.
+
+## 3) Canonical Drift & Replay Scenario Atlas Table
+
+Canonical scenario intent:
+
+- this atlas is a condensation and rewiring layer over existing semantics, not a rebuild of neighboring matrices
+- scenarios never resolve above existing precedence and posture caps
+- same input signature and same references must yield the same `final_posture_output`
+
+| scenario_id | scenario_type | input_signature | affected_artifacts | expected_applied_precedence_reference | expected_applied_downgrade_reference | expected_final_posture_output | allowed_conservative_non_claim_wording_surface | replayability_check | forbidden_upward_resolving |
+|---|---|---|---|---|---|---|---|---|---|
+| SCN-DRIFT-001 | precedence-drift | `observed_finding=claim-only`; `applied_precedence_reference` missing or non-existent; anchors partial/ambiguous | truth precedence matrix, trace ledger, replay contract, posture ladder | unresolved precedence reference in truth precedence semantics | mandatory conservative downgrade per precedence-unresolved rule | `template-only` | "precedence reference unresolved; external-signoff evidence is not demonstrated and remains visibility-only" | identical unresolved precedence inputs must replay to identical `template-only` output | never infer stronger posture from lower-priority claim/template signals |
+| SCN-DRIFT-002 | downgrade-drift | downgrade trigger visible (for example continuity gap), but `applied_downgrade_reference=none` | truth precedence matrix, trace ledger, replay contract | continuity/disclosure failure precedence remains binding | active downgrade expected; `none` is invalid when trigger is active | `signoff-claimed` | "downgrade trigger remains active; signoff stays claim-level with unresolved visibility" | same trigger plus missing downgrade reference must replay to same downgraded output | never ignore active downgrade pressure due to wording confidence |
+| SCN-DRIFT-003 | posture-output-drift | trace emits `anchor-partial`, replay emits `demonstrated-evidence-visible` for same resolved inputs | posture ladder, truth precedence matrix, trace ledger, replay contract | same precedence reference must cap both outputs | mismatch forces lower-output selection | `anchor-partial` | "cross-surface output mismatch resolved conservatively; demonstrated posture not retained" | same inputs with same mismatch pattern must always resolve to lower output | never pick stronger posture from conflicting surfaces |
+| SCN-DRIFT-004 | anchor-classification-drift | trace marks `attribution_status=verified-external`, but anchor/boundary surfaces only support partial or missing attribution | trace ledger, anchor profile, anchor binding matrix, boundary matrix | attribution integrity precedence cap | downgrade to attribution-supported floor | `signoff-claimed` | "attribution remains partial or unverifiable; demonstrated evidence posture is not supported" | same anchor evidence set must reproduce same downgraded attribution posture | never compensate weak attribution with other strong anchors |
+| SCN-DRIFT-005 | replay-reproducibility-drift | identical `snapshot_id` and resolved references replay to different outputs across runs | replay contract, trace ledger, provenance replayability, truth precedence matrix | original governing precedence remains reference of record | replay inconsistency triggers conservative downgrade | `template-only` | "replay reproducibility is unresolved; classification remains conservative and non-closure" | same inputs -> same output is mandatory; violation resolves to conservative floor | never reinterpret replay instability as stronger closure |
+| SCN-DRIFT-006 | language-drift | internal output wording uses approval-like decision language while evidence posture is only claim/partial | vocab boundary lock, posture ladder, truth precedence matrix, trace ledger, replay contract | existing precedence cap remains unchanged | language drift may trigger downgrade when phrasing implies stronger closure | `signoff-claimed` | "external signoff is claimed for documented scope; authorization and gate semantics are out of scope" | identical wording drift inputs must normalize to same conservative wording/output | never preserve `approved`/`authorized`/`gate passed` as internal classification output |
+| SCN-DRIFT-007 | claim-vs-demonstrated-boundary-drift | claim text and template completeness present, required anchor classes incomplete, yet output proposed as demonstrated | posture ladder, boundary matrix, truth precedence matrix, trace ledger | claim-only/partial-anchor precedence binding | boundary-enforced downgrade reference required | `anchor-partial` | "evidence is partially anchored; demonstrated evidence is not reached" | same incomplete-anchor signature must replay to identical `anchor-partial` | never promote claim/template completion to demonstrated posture |
+| SCN-DRIFT-008 | contradiction-exception-integrity-drift | `contradiction_exception_disclosure_status` partial/softened/missing with otherwise strong continuity/attribution/recency signals | truth precedence matrix, anchor profile, trace ledger, replay contract | contradiction-or-exception disclosure integrity has highest precedence | mandatory immediate downgrade for unresolved disclosure | `template-only` | "contradiction or exception disclosure remains unresolved; closure wording is prohibited" | same unresolved disclosure signature must replay to same conservative floor | never bypass unresolved disclosure using lower-priority strengths |
+| SCN-CTRL-001 | non-drift-control (demonstrated-consistent) | all required anchor classes visible and replayable; references valid; no active downgrade trigger | posture ladder, truth precedence matrix, trace ledger, replay contract, anchor profile, anchor binding matrix, boundary matrix | valid no-conflict precedence reference | `none` (not triggered) | `demonstrated-evidence-visible` | "external-signoff evidence is demonstrated for documented scope only; not an authorization output" | same complete input set must replay to identical demonstrated output | no upward resolution beyond existing demonstrated cap and non-claim boundary |
+| SCN-CTRL-002 | non-drift-control (claim-only-consistent) | template populated with explicit claim text, but attribution/continuity incomplete and references consistent with caps | posture ladder, truth precedence matrix, trace ledger, replay contract, boundary matrix | continuity/attribution failure precedence reference | active downgrade reference present and coherent | `signoff-claimed` | "external signoff is claimed and pending anchor verification; no approval or gate claim" | same claim-only signature must replay to identical claim-level output | no escalation to `anchor-partial` or higher without required anchor evidence |
+| SCN-CTRL-003 | non-drift-control (template-baseline-consistent) | template population present, no explicit signoff claim anchor, no contradictory reference mismatch | boundary matrix, posture ladder, truth precedence matrix, trace ledger, replay contract | claim-absence precedence reference | `none` (not triggered) | `template-only` | "template population only; no external-signoff claim or demonstrated evidence output" | same claim-absent signature must replay to identical baseline output | no escalation above `template-only` without explicit claim and anchor evidence |
+
+## 4) Deterministic Evaluation Procedure
+
+Use only already materialized neighboring artifacts named in Section 7.
+
+1. Resolve the scenario `input_signature` from trace, replay, precedence, anchor, boundary, and vocab surfaces; do not infer missing inputs.
+2. Validate `applied_precedence_reference` against the truth precedence matrix and enforce its posture ceiling.
+3. Validate `applied_downgrade_reference` against active downgrade conditions; if trigger is active and reference is absent or mismatched, resolve downward.
+4. Validate anchor-class consistency (attribution, recency, candidate continuity, packet continuity, contradiction-or-exception disclosure) against anchor profile, anchor binding, and boundary semantics.
+5. Compare trace and replay outputs for identical inputs; any mismatch is drift and resolves to the lower still-justified posture.
+6. Emit `final_posture_output` and conservative non-claim wording using existing posture vocabulary only.
+
+Determinism lock:
+
+- same inputs + same references -> same scenario outcome
+- unresolved or ambiguous inputs -> conservative downward resolution only
+
+## 5) Drift-Class-to-Scenario Coverage Map
+
+| drift_class (from cross-artifact invariant matrix) | mapped_scenario_id | coverage_note |
+|---|---|---|
+| precedence-drift | SCN-DRIFT-001 | precedence reference missing/invalid/incoherent is covered explicitly |
+| downgrade-drift | SCN-DRIFT-002 | active downgrade trigger with absent/incoherent downgrade reference is covered explicitly |
+| posture-output-drift | SCN-DRIFT-003 | cross-surface `final_posture_output` mismatch is covered explicitly |
+| anchor-classification-drift | SCN-DRIFT-004 | trace anchor overstatement versus anchor/boundary support is covered explicitly |
+| replay-reproducibility-drift | SCN-DRIFT-005 | same-input replay non-reproducibility is covered explicitly |
+| language-drift | SCN-DRIFT-006 | forbidden decision-language drift in internal output is covered explicitly |
+| claim-vs-demonstrated-boundary-drift | SCN-DRIFT-007 | claim/template inflation into demonstrated posture is covered explicitly |
+| contradiction-exception-integrity-drift | SCN-DRIFT-008 | unresolved disclosure integrity with inflated output is covered explicitly |
+
+## 6) Interpretation Locks / Non-Authorization Clauses
+
+Binding locks:
+
+- this atlas is a docs-only mapping surface and not an authorization surface
+- scenario consistency or drift-free replay is not approval, not authorization, not gate pass, not promotion, and not go-live
+- no scenario in this atlas may be used as runtime enablement, transition execution, or operational permission
+- conservative downgrade outcomes are documentary classification controls only
+
+Language locks:
+
+- internal outputs must stay within existing posture vocabulary: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+- `approved`, `authorized`, `gate passed`, `promoted`, `go-live` are forbidden as internal classification outputs
+- such terms may appear only as externally attributed evidence text or explicit out-of-scope references
+
+## 7) Nearest Existing Repo Artifacts / Cross-References
+
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_ANCHOR_PROFILE_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_ANCHOR_BINDING_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_SIGNOFF_EVIDENCE_BOUNDARY_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](/docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [`/docs/ops/specs/MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md`](/docs/ops/specs/MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+
+## 8) Operator Notes
+
+- konservativ anwenden: bei Unklarheit immer die niedrigere bestehende posture wählen
+- kein closure inflation: claim/template/isolierte anchors nie als demonstrierte closure umdeuten
+- keine implizite Entscheidungsausweitung: Atlas-Ausgaben bleiben dokumentarische Klassifikation ohne Autorisierungswirkung
+- drift sichtbar halten: unresolved Zustände explizit benennen, nie stillschweigend normalisieren
+- rewire-over-rebuild einhalten: nur bestehende Semantik verknüpfen, keine neuen Zustände oder Entscheidungswege erzeugen


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1.md`
- codify a non-authorizing drift-detection and replay scenario atlas for the `Handoff Packet -> LB_APR_001 -> External Signoff` classification stack
- translate existing posture / truth-precedence / trace / replay / invariant rules into deterministic scenario vectors without adding new states or authority

## Validation
- `test -f docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1.md`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / mapping-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)