### PR TITLE
docs(ops): add external signoff evidence classification replay input signature canonicalization matrix v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_INPUT_SIGNATURE_CANONICALIZATION_MATRIX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_INPUT_SIGNATURE_CANONICALIZATION_MATRIX_V1.md
@@ -1,0 +1,154 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Classification Replay Input Signature Canonicalization Matrix v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing input-signature canonicalization matrix for deterministic replay of external-signoff evidence classification from already materialized artifacts
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_INPUT_SIGNATURE_CANONICALIZATION_MATRIX_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one canonical Replay Input Signature Canonicalization Matrix for External Signoff Evidence Classification in the Packet -> LB_APR_001 handoff path.
+
+It is explicitly docs-only, mapping-only, and non-authorizing.
+
+Purpose boundary:
+
+- define one field-exact canonical input signature surface for deterministic replay classification inputs
+- lock reproducible equality semantics so identical normalized replay inputs are interpreted identically across replay, trace, scenario, and invariant artifacts
+- preserve existing conservative truth/posture behavior without introducing new authority, new states, or new decision logic
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- exactly one canonical input-signature canonicalization matrix over already materialized replay/trace/precedence/invariant/scenario fields
+- deterministic normalization and equality rules for replay-relevant input fields
+- reference-uniqueness constraints for stable replayability
+- conservative missing/ambiguous handling that is downward-only and uses existing posture semantics only
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, runtime enablement, or operational transition
+- any runtime, config, workflow, test, CI, or code change
+- any evidence creation or evidence mutation
+- any new posture states, new authority domains, or new operational roles
+- any rewrite of neighboring canonical specs or 1:1 table rebuild under a new name
+
+This specification does not derive, grant, imply, or simulate authorization.
+
+## 3) Canonical Input Signature Canonicalization Matrix
+
+Deterministic identity lock:
+
+- two replay-input sets are identical if and only if every required canonical signature field below resolves to the same normalized value and every required reference resolves to the same unique canonical target
+- identical normalized inputs + identical normalized references -> same replay interpretation constraints and same final posture output ceiling under existing semantics
+
+Canonical matrix:
+
+| canonical_signature_field | upstream field surface (existing artifacts only) | canonicalization rule (deterministic) | equality rule | conservative rule if missing/ambiguous |
+|---|---|---|---|---|
+| `snapshot_id` | Replay Contract required field | trim outer whitespace; preserve case and token order; reject empty | equal as exact canonical string | mark input signature unresolved; no upward interpretation |
+| `packet_ref` | Replay Contract + Trace Ledger | trim outer whitespace; preserve canonical token text | equal as exact canonical string | treat packet continuity as unresolved; downward-only |
+| `candidate_ref` | Replay Contract + Trace Ledger | trim outer whitespace; preserve canonical token text | equal as exact canonical string | treat candidate continuity as unresolved; downward-only |
+| `classification_trace_ref` | Replay Contract pointer to Trace Ledger record | normalize as one canonical repo-local reference string; trim outer whitespace | equal as exact canonical reference | replay cannot assert stronger posture than conservative floor |
+| `trace_id` | Trace Ledger record key | trim outer whitespace; preserve canonical identifier | equal as exact canonical string | mark replay-trace alignment unresolved; downward-only |
+| `observed_finding` | Trace Ledger `observed_finding` | use existing enum text only; trim outer whitespace; no synonym substitution | equal as exact enum token | resolve to lower justified posture using existing precedence/downgrade semantics |
+| `visible_anchor_classes` | Trace Ledger anchor visibility set | normalize set as sorted unique list of existing anchor classes: `attribution`, `recency`, `candidate-continuity`, `packet-continuity`, `contradiction-or-exception-disclosure` | equal when same normalized sorted unique set | treat missing/contradictory anchor classes as incomplete; downward-only |
+| `attribution_status` | Trace Ledger anchor status | use existing enum tokens only; trim outer whitespace | equal as exact enum token | attribution treated as partial or unverifiable; downward-only |
+| `recency_status` | Trace Ledger anchor status | use existing enum tokens only; trim outer whitespace | equal as exact enum token | recency treated as partial/stale/ambiguous; downward-only |
+| `candidate_continuity_status` | Trace Ledger anchor status | use existing enum tokens only; trim outer whitespace | equal as exact enum token | continuity treated as broken/ambiguous; downward-only |
+| `packet_continuity_status` | Trace Ledger anchor status | use existing enum tokens only; trim outer whitespace | equal as exact enum token | continuity treated as broken/ambiguous; downward-only |
+| `contradiction_exception_disclosure_status` | Trace Ledger anchor status + Truth Precedence priority | use existing enum tokens only; trim outer whitespace | equal as exact enum token | unresolved disclosure integrity remains highest-priority conservative constraint |
+| `applied_precedence_reference` | Replay Contract + Trace Ledger + Truth Precedence Matrix | normalize as one canonical rule reference string; trim outer whitespace | equal as exact canonical reference | precedence unresolved -> conservative cap (default floor when unresolved) |
+| `applied_tie_break_reference` | Replay Contract + Trace Ledger | normalize as canonical reference or explicit `none`; trim outer whitespace; lowercase only for literal `none` | equal as exact canonical reference or exact `none` | if ambiguous, keep lower posture and mark tie unresolved |
+| `applied_downgrade_reference` | Replay Contract + Trace Ledger + Truth Precedence Matrix | normalize as canonical reference or explicit `none`; trim outer whitespace; lowercase only for literal `none` | equal as exact canonical reference or exact `none` | if missing/incoherent, assume active downgrade pressure and resolve downward |
+| `boundary_context_ref` | Replay Contract boundary pointer | normalize as one canonical boundary reference string; trim outer whitespace | equal as exact canonical reference | boundary interpretation remains non-closure and conservative |
+| `required_anchor_visibility_set` | Replay Contract + Anchor profile/binding-linked requirements (as referenced by existing artifacts) | normalize as sorted unique list of required anchor classes defined by existing artifacts | equal when same normalized sorted unique set | any missing required class blocks upward interpretation |
+| `posture_ladder_ref` | Replay Contract pointer to Posture Ladder | normalize as one canonical posture-ladder reference string; trim outer whitespace | equal as exact canonical reference | output constrained to existing posture vocabulary only |
+| `scenario_input_signature` | Scenario Atlas `input_signature` surface | normalize as ordered `key=value` pairs separated by `; `, keys in stable lexical order, values from existing tokens only | equal as exact normalized ordered token string | unresolved keys/values remain unresolved visibility; no upward inference |
+
+Reference-uniqueness rules:
+
+- each canonical `*_ref` field must resolve to one unique existing artifact location in this repo; multi-target resolution is ambiguous
+- if one reference text resolves to multiple plausible targets, treat as ambiguous and resolve downward
+- if trace and replay reference the same semantic field with different normalized reference targets, treat as drift and resolve downward
+- reference uniqueness is a replayability requirement, not an authorization surface
+
+## 4) Deterministic Signature Construction Procedure
+
+Use only inputs already materialized in the neighboring artifacts listed in Section 8.
+
+1. Collect one replay input set by required replay identity fields and linked trace/scenario surfaces (`snapshot_id`, continuity refs, anchor statuses, precedence/downgrade/tie-break refs, boundary/posture refs).
+2. Canonicalize each field exactly by Section 3 rules (trim policy, enum token locks, sorted-set locks, ordered `scenario_input_signature` locks, explicit `none` handling).
+3. Validate each canonical reference for uniqueness and existence against existing artifact surfaces; do not infer missing references.
+4. Construct the canonical input signature as the ordered tuple of all required canonical fields from Section 3.
+5. Compare canonical tuples for equality: all required canonical fields equal + all required references uniquely equal means identical replay inputs.
+6. Emit replay interpretation constraints using existing Truth/Trace/Posture/Invariant/Scenario semantics only; no extra interpretation layer is allowed.
+
+Determinism clause:
+
+- same canonical tuple + same canonical references -> same replay interpretation outcome boundaries and same final posture output under existing semantics
+
+## 5) Missing / Ambiguous Resolution Rules
+
+Binding conservative rules:
+
+- missing or ambiguous input is never resolved toward stronger posture wording
+- missing or ambiguous input is never resolved toward authorization-like interpretation
+- ambiguity is always resolved downward-only within existing posture vocabulary: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+- unresolved contradiction-or-exception disclosure integrity remains precedence-dominant and blocks upward reinterpretation
+
+Deterministic conservative handling:
+
+- missing required identity/reference fields (`snapshot_id`, `packet_ref`, `candidate_ref`, required `*_ref`) -> unresolved input signature with conservative downward outcome
+- ambiguous precedence/tie-break/downgrade references -> keep lower posture and mark unresolved visibility
+- incomplete/contradictory anchor class sets -> treat as incomplete anchors and apply downward cap
+- unresolved scenario signature keys/values -> keep unresolved visibility and do not infer stronger closure language
+
+## 6) Cross-Artifact Consistency Locks
+
+Cross-artifact bindings:
+
+- Replay Contract lock: canonicalized `snapshot_id`, continuity refs, `classification_trace_ref`, precedence/tie-break/downgrade refs, anchor requirement set, boundary/posture refs must remain field-consistent with the Replay Contract schema.
+- Trace Ledger lock: canonicalized trace-linked fields (`trace_id`, `observed_finding`, anchor statuses, applied references) must remain value-consistent with Trace Ledger record semantics.
+- Scenario Atlas lock: canonicalized `scenario_input_signature` must preserve deterministic same-input semantics used by scenario replay/drift vectors.
+- Cross-Artifact Invariant lock: canonicalized inputs must preserve invariant checks for `final_posture_output` ceiling consistency, precedence-reference coherence, downgrade-reference coherence, and replay reproducibility.
+- Truth/Posture lock: canonicalized inputs never bypass existing precedence order or posture ceilings; same normalized inputs must remain bounded by existing truth and posture semantics.
+
+Consistency failure rule:
+
+- any cross-artifact mismatch after canonicalization is treated as drift and resolves conservatively downward; no upward reconciliation is allowed
+
+## 7) Interpretation Locks / Non-Authorization Clauses
+
+Binding interpretation locks:
+
+- this artifact is a canonicalization mapping surface only and not an authorization surface
+- canonical replay-input identity is not approval, not authorization, not gate pass, not promotion, and not go-live
+- deterministic replayability does not grant runtime enablement or operational permission
+
+Language locks:
+
+- internal outputs must stay in existing posture-language and replayability-language surfaces
+- `approved`, `authorized`, `gate passed`, `promoted`, `go-live` are forbidden as internal classification outputs
+- such terms may appear only as externally attributed evidence text or explicit out-of-scope references
+
+## 8) Nearest Existing Repo Artifacts / Cross-References
+
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1.md)
+- [`/docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](/docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [`/docs/ops/specs/MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md`](/docs/ops/specs/MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+
+## 9) Operator Notes
+
+- apply this matrix conservatively: canonicalize first, then classify within existing caps only
+- keep closure language conservative: no closure inflation from partial or ambiguous inputs
+- do not expand interpretation beyond existing Truth/Trace/Posture/Replay/Invariant/Scenario semantics
+- if canonical reference uniqueness fails, treat output as unresolved visibility and resolve downward
+- this artifact rewires existing semantics only; it does not create authority, new states, or new decision paths


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_INPUT_SIGNATURE_CANONICALIZATION_MATRIX_V1.md`
- codify a non-authorizing canonicalization matrix for replay-input signatures on the `Handoff Packet -> LB_APR_001 -> External Signoff` classification stack
- make input identity deterministic across replay contract, trace ledger, truth precedence, posture ladder, invariant rules, and scenario-atlas references

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / mapping-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)