### PR TITLE
docs(ops): add external signoff evidence classification replay completeness traceability matrix v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_COMPLETENESS_TRACEABILITY_MATRIX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_COMPLETENESS_TRACEABILITY_MATRIX_V1.md
@@ -1,0 +1,136 @@
+# MASTER V2 — First Live Authority Handoff Packet to LB_APR_001 External Signoff Evidence Classification Replay Completeness Traceability Matrix v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, mapping-only, non-authorizing replay completeness and traceability matrix for deterministic external-signoff evidence classification coverage from already materialized artifacts
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_COMPLETENESS_TRACEABILITY_MATRIX_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes one canonical Replay Completeness and Traceability Matrix for External Signoff Evidence Classification in the Packet -> LB_APR_001 handoff path.
+
+It is explicitly docs-only, mapping-only, and non-authorizing.
+
+Purpose boundary:
+
+- define one deterministic replay-completeness coverage layer on top of already materialized canonicalization, trace, replay, scenario, invariant, truth, and posture artifacts
+- ensure that identical canonicalized inputs and identical canonical references produce the same replay-completeness class and the same conservative output cap
+- rewire existing semantics only, without introducing new authority, new states, or new decision logic
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- exactly one canonical replay completeness and traceability coverage matrix
+- deterministic classification of replayability completeness into documentary classes only: `fully replayable`, `partially replayable`, `unresolved replayability`
+- deterministic mapping from completeness class to conservative output caps inside existing posture vocabulary only: `template-only`, `signoff-claimed`, `anchor-partial`, `demonstrated-evidence-visible`
+- conservative handling for missing, ambiguous, drift, or mismatch conditions using downward-only resolution
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, runtime enablement, or operational transition
+- any runtime, config, workflow, test, CI, or code change
+- any evidence creation or evidence mutation
+- any new posture state, new authority domain, new role, or new decision route
+- any rewrite, replacement, or 1:1 rebuild of neighboring canonical specifications
+
+This specification does not derive, grant, imply, or simulate authorization.
+
+## 3) Canonical Replay Completeness & Traceability Coverage Matrix
+
+Deterministic class lock:
+
+- completeness class is assigned only from existing canonical fields, existing references, and existing consistency checks
+- same canonicalized input signature plus same canonical references plus same artifact checks always yields the same completeness class and conservative output cap
+
+| completeness_class | canonical input signature state (existing fields only) | reference uniqueness and resolvability | cross-artifact invariants and scenario vectors | deterministic replay-traceability condition | conservative output cap mapping (existing posture vocabulary only) |
+|---|---|---|---|---|---|
+| `fully replayable` | all required canonical signature fields from replay input signature canonicalization are present and normalized | every required `*_ref` resolves to exactly one existing target and remains consistent across replay contract and trace ledger | no unresolved invariant mismatch; scenario vector alignment is reproducible without unresolved drift | replay contract reconstruction reproduces the same trace outcome for identical inputs | cap equals reproduced existing `final_posture_output`, bounded by existing truth precedence and posture ladder ceilings; no upward reinterpretation |
+| `partially replayable` | identity core is canonical and reproducible (`snapshot_id`, `packet_ref`, `candidate_ref`, `classification_trace_ref`), but one or more supporting canonical fields or supporting references are missing, ambiguous, or partially reproducible | at least one supporting reference is missing, ambiguous, or only partially coherent, while identity core remains uniquely resolvable | one or more drift or mismatch vectors are active and resolvable only conservatively under existing invariant and scenario semantics | replay can be reconstructed only with conservative downward interpretation and explicit unresolved visibility | cap is the lower of reproduced existing posture and `anchor-partial`; if existing precedence or downgrade rules enforce a lower cap, lower cap wins |
+| `unresolved replayability` | required canonical identity cannot be fully established from existing canonicalized fields | required reference uniqueness or existence cannot be established deterministically | invariant alignment or scenario alignment is unresolved for required identity path | deterministic replay reconstruction cannot be completed from existing artifacts | cap is `template-only` until required canonical identity and references become replay-resolvable |
+
+Completeness interpretation boundary:
+
+- completeness classes are documentary replayability coverage classes only
+- completeness classes are not authorization states and not operational permissions
+
+## 4) Deterministic Completeness Evaluation Procedure
+
+Use only already materialized neighboring artifacts listed in Section 8.
+
+1. Construct the canonical replay input signature exactly from the Replay Input Signature Canonicalization Matrix fields and normalization rules.
+2. Resolve required references from replay contract and trace ledger surfaces; enforce unique-target resolution for each required `*_ref`.
+3. Validate consistency against cross-artifact invariants and scenario atlas vectors, including replay-trace reproducibility expectations.
+4. Evaluate whether replay reconstruction reproduces the same `final_posture_output` under existing truth-precedence, downgrade, and posture-ladder semantics.
+5. Assign completeness class deterministically from Section 3 matrix criteria only.
+6. Apply the class-bound conservative output cap and emit visibility-only wording with explicit non-authorization boundaries.
+
+Determinism clause:
+
+- identical canonicalized inputs and identical references must resolve to identical completeness class and identical conservative output cap
+
+## 5) Missing / Ambiguous Handling and Conservative Caps
+
+Binding conservative rules:
+
+- missing or ambiguous inputs are never resolved toward stronger wording or stronger posture
+- missing or ambiguous references are never interpreted as implicit support
+- drift or mismatch conditions are resolved downward-only inside existing posture semantics
+- unresolved contradiction-or-exception disclosure integrity remains precedence-dominant and blocks upward reinterpretation
+
+Deterministic conservative handling:
+
+- missing required identity fields or missing required unique references -> `unresolved replayability` with cap `template-only`
+- identity present but supporting fields or supporting references partially replayable -> `partially replayable` with conservative cap from Section 3
+- ambiguity between two plausible outputs -> keep lower output and preserve unresolved visibility
+- any mismatch across replay contract, trace ledger, scenario vectors, and invariant locks -> treat as drift and resolve downward-only
+
+## 6) Cross-Artifact Consistency Locks
+
+Binding locks:
+
+- canonicalized input fields must remain aligned with the Replay Input Signature Canonicalization Matrix field rules
+- completeness classification must remain traceable to replay contract references and trace ledger record semantics
+- invariant consistency checks must remain those already defined by the Cross-Artifact Invariant Matrix, including posture ceiling and reference coherence checks
+- scenario interpretation must remain bounded by the Drift Detection Replay Scenario Atlas vectors
+- truth precedence and posture ceilings remain authoritative caps for any replay-completeness output mapping
+- provenance and vocabulary boundaries remain locked to documented replayability and non-equality constraints
+
+Consistency failure rule:
+
+- any unresolved cross-artifact mismatch is classified conservatively and never resolved upward
+
+## 7) Interpretation Locks / Non-Authorization Clauses
+
+Binding interpretation locks:
+
+- this artifact is a documentary replayability coverage mapping surface only
+- `fully replayable`, `partially replayable`, and `unresolved replayability` are not approval, not authorization, not gate pass, not promotion, and not go-live
+- replay completeness does not grant runtime enablement or operational permission
+
+Language locks:
+
+- internal outputs must stay inside existing posture-language and replayability-language surfaces
+- terms `approved`, `authorized`, `gate passed`, `promoted`, `go-live` are forbidden as internal classification outputs
+- such terms may appear only as externally attributed evidence text or explicit out-of-scope references
+
+## 8) Nearest Existing Repo Artifacts / Cross-References
+
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_INPUT_SIGNATURE_CANONICALIZATION_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_INPUT_SIGNATURE_CANONICALIZATION_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_CONTRACT_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_TRACE_LEDGER_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_CROSS_ARTIFACT_INVARIANT_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_DRIFT_DETECTION_REPLAY_SCENARIO_ATLAS_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_TRUTH_PRECEDENCE_MATRIX_V1.md)
+- [`/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md`](/docs/ops/specs/MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_POSTURE_LADDER_V1.md)
+- [`/docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](/docs/ops/specs/MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+- [`/docs/ops/specs/MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md`](/docs/ops/specs/MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+
+## 9) Operator Notes
+
+- apply this matrix conservatively: canonicalize, resolve references, then classify completeness
+- avoid closure inflation: partial replayability never implies stronger closure wording
+- do not expand interpretation beyond existing truth, posture, trace, replay, invariant, scenario, and canonicalization semantics
+- keep unresolved replayability explicit when required identity or references are missing or ambiguous
+- this artifact rewires existing semantics only and does not create authority, new states, or implicit decision expansion


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TO_LB_APR_001_EXTERNAL_SIGNOFF_EVIDENCE_CLASSIFICATION_REPLAY_COMPLETENESS_TRACEABILITY_MATRIX_V1.md`
- codify a non-authorizing replay completeness and traceability matrix for the `Handoff Packet -> LB_APR_001 -> External Signoff` classification stack
- map canonicalized replay inputs and references to deterministic completeness classes and conservative posture caps

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / mapping-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)