### PR TITLE
docs(ops): add first live operational signoff procedure v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md
@@ -1,0 +1,270 @@
+# MASTER V2 — First Live Operational Signoff Procedure v1 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only operational-runbook-only non-authorizing verification-bound step procedure for First Live signoff preparation and external decision handoff
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1
+
+## 1) Title / Status / Purpose
+
+This specification materializes exactly one operational signoff procedure for Master V2 First Live readiness.
+
+Boundary profile of this artifact:
+
+- docs-only
+- operational-runbook-only
+- non-authorizing
+- verification-bound
+
+Purpose boundary:
+
+- convert existing canonical readiness, evidence, and authority surfaces into one auditable step path (`S0` to `S6`)
+- reduce review drift from distributed signoff sequencing and inconsistent evidence-intake order
+- enforce conservative `stop / escalate` behavior when evidence or authority posture is `Missing`, `Partial`, or `Unknown`
+
+This procedure is an operational review and handoff surface only. It does not grant authorization, does not pass gates, and does not enable runtime actions.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- one compact operational signoff procedure (`S0` to `S6`) for First Live readiness review
+- required inputs and required outputs per step using pointer-based references
+- conservative blocker handling (`blocking`, `non-blocking`, `unknown`) with explicit stop/escalate rules
+- authority-boundary mapping from already materialized canonical authority artifacts
+
+Out of scope:
+
+- any authorization, approval, gate pass, promotion, go-live, or runtime enablement action
+- runtime, config, workflow, test, CI, or code changes
+- generation or mutation of evidence artifacts
+- creation of new authority domains, new decision roles, or redefinition of canonical vocabulary
+- rewriting neighboring specs
+
+This specification does not derive authorization. External final decision authority remains external to this file.
+
+## 3) Roles and Responsibility Boundaries
+
+Role boundaries are reused from canonical maps; no implicit role expansion is allowed.
+
+- advisory: may prepare interpretation notes and evidence pointers but cannot decide authorization outcome
+- authoritative: must be explicitly evidenced in existing authority maps; if unclear, treat as unresolved
+- veto / fail-closed: blocks progression when safety, kill-switch, or unresolved ambiguity conditions apply
+
+Boundary anchors:
+
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+
+Hard boundary rule:
+
+- unknown authority ownership is never resolved upward by local interpretation; it must be marked unresolved and escalated externally
+
+## 4) Operational Signoff Procedure (S0..S6)
+
+### S0 — Preflight
+
+Intent:
+
+- lock interpretation boundaries before evidence intake
+
+Execution:
+
+1. Confirm canonical reader order and review sequence anchor.
+2. Confirm that this procedure is non-authorizing and verification-bound.
+3. Confirm candidate identity label and review scope label are present.
+
+Stop/Escalate condition:
+
+- if scope, candidate identity, or non-authorizing framing is unclear, stop and escalate.
+
+### S1 — Evidence Intake
+
+Intent:
+
+- collect pointer-based evidence references in one consistent intake order.
+
+Execution:
+
+1. Intake candidate-scoped pointers from evidence bundle ledger.
+2. Intake cross-gate bundle pointers for `L1` to `L5` continuity.
+3. Record missing pointer classes without synthesizing replacement evidence.
+
+Stop/Escalate condition:
+
+- if evidence class is `Missing`, `Partial`, or `Unknown` for required intake rows, stop and escalate.
+
+### S2 — Gate Posture Read
+
+Intent:
+
+- read conservative gate posture without closure inflation.
+
+Execution:
+
+1. Read gate statuses from the gate status index.
+2. Apply conservative interpretation semantics from existing read-model posture.
+3. Preserve `Verified` as visibility-state only, never authorization-state.
+
+Stop/Escalate condition:
+
+- if any gate posture interpretation is non-reconcilable or unknown, stop and escalate.
+
+### S3 — Authority Check
+
+Intent:
+
+- confirm role boundaries and unresolved authority nodes before signoff preparation.
+
+Execution:
+
+1. Map advisory vs authoritative vs veto/fail-closed roles from authority map.
+2. Verify no local statement upgrades advisory input into authority outcome.
+3. Mark unresolved authority chains explicitly.
+
+Stop/Escalate condition:
+
+- if authoritative decider is partial/unclear/unknown for required boundary points, stop and escalate.
+
+### S4 — Incident / Abort / Kill-Switch Check
+
+Intent:
+
+- verify stop-surface visibility for failure, rollback semantics, and safety veto boundaries.
+
+Execution:
+
+1. Cross-check failure taxonomy and safe fallback classes.
+2. Cross-check abort/rollback/kill-switch reference surfaces for applicability.
+3. Preserve fail-closed posture when incident interpretation is ambiguous.
+
+Stop/Escalate condition:
+
+- if incident class, abort path, or kill-switch boundary is unknown or contradictory, stop and escalate.
+
+### S5 — Signoff Prep
+
+Intent:
+
+- prepare a compact, pointer-anchored, non-authorizing signoff packet for review handoff readiness.
+
+Execution:
+
+1. Assemble step outputs (`S0` to `S4`) into one traceable review condensation note.
+2. Include unresolved ambiguity list and blocker classification.
+3. Include explicit non-claims block (no approval / no authorization / no gate pass / no promotion / no go-live).
+
+Stop/Escalate condition:
+
+- if prep text implies closure, permission, or decision authority, stop and rewrite conservatively; if unresolved, escalate.
+
+### S6 — Escalation / External Decision Handoff
+
+Intent:
+
+- hand off unresolved or decision-bound material to external final authority channel without local authorization claims.
+
+Execution:
+
+1. Route prepared packet according to authority handoff boundary and packet contract.
+2. Mark all unresolved `Missing`, `Partial`, `Unknown`, and authority-unclear items as active escalation payload.
+3. End local procedure at handoff boundary.
+
+Stop/Escalate condition:
+
+- if external authority target is undefined or handoff payload is incomplete, stop and escalate within governance channel.
+
+## 5) Required Inputs and Outputs by Step
+
+| step | required inputs (pointer-based) | required outputs (pointer-based) |
+|---|---|---|
+| `S0` | [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md), [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) | preflight boundary check note; candidate/scope label pointer; non-authorizing framing confirmation |
+| `S1` | [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md) | evidence intake register pointer set; missing/partial/unknown intake rows |
+| `S2` | [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md), [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) | conservative gate posture read note; explicit unresolved gate interpretations |
+| `S3` | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md) | role-boundary check note; authority-unclear escalation list |
+| `S4` | [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md), [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md) | incident/abort/kill-switch boundary check note; fail-closed applicability markers |
+| `S5` | outputs from `S0` to `S4`; [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md) | non-authorizing signoff-prep packet draft with unresolved ambiguities and blocker classes |
+| `S6` | `S5` packet draft; [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md), [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md) | external decision handoff record pointer; explicit local-stop marker at handoff boundary |
+
+Pointer discipline:
+
+- required outputs are traceability pointers and review notes only
+- required outputs are not runtime directives and not authorization claims
+
+## 6) Blocker Matrix
+
+| condition class | interpretation | operator action | escalation rule |
+|---|---|---|---|
+| `blocking` | clear blocker with explicit canonical anchor | stop current step and preserve blocker text unchanged | escalate with blocker anchor and affected step id |
+| `non-blocking` | bounded issue that does not invalidate current step interpretation | continue with explicit note and no closure inflation | escalate later only if it impacts authority/evidence boundary in downstream step |
+| `unknown` | unresolved condition, unclear evidence posture, or unclear authority ownership | immediate stop (no local resolution) | immediate escalate; unresolved `unknown` never converts to non-blocking locally |
+| `missing` | required evidence/authority pointer absent | immediate stop | immediate escalate with missing pointer class |
+| `partial` | required evidence/authority pointer incomplete for decision-bound interpretation | stop for decision-bound path; continue only as unresolved review note | escalate as unresolved partial before handoff closure language |
+
+Binding matrix rule:
+
+- `unknown => stop / escalate` is mandatory for all steps `S0` to `S6`
+
+## 7) Abort / Rollback / Kill-Switch Reference Surface
+
+This section is reference-only and check-only. It is not an activation guide.
+
+Primary stop-surface anchors:
+
+- [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md)
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
+
+Operational use boundary:
+
+- read these surfaces to verify whether stop/fail-closed semantics are implicated
+- do not treat this procedure as a command surface for abort, rollback, kill-switch, or live activation
+
+## 8) Interpretation Locks / Non-Authorization Clauses
+
+This specification is explicitly not:
+
+- an approval artifact
+- an authorization artifact
+- a gate-pass artifact
+- a promotion artifact
+- a go-live artifact
+- a runtime control artifact
+
+Binding locks:
+
+- terms such as `approved`, `authorized`, `gate passed`, `promoted`, and `go-live` are out-of-scope for local declaration in this procedure
+- those terms may only appear as prohibited local claims, externally attributed outcomes, or escalation payload context
+- local completion of `S0` to `S6` is never equivalent to permission
+- unresolved `Missing`, `Partial`, or `Unknown` posture cannot be interpreted upward into closure
+- no silent authority assumptions are permitted
+
+## 9) Nearest Existing Repo Artifacts / Cross-References
+
+Required nearest anchors:
+
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md)
+
+Directly relevant additional anchors:
+
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md)
+- [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
+
+## 10) Operator Notes
+
+- Apply this procedure conservatively: unresolved items remain unresolved until external authority disposition.
+- Avoid closure inflation: visibility, mapping quality, or packet completeness are never decision outcomes.
+- Preserve strict intake order (`S0` to `S6`) to reduce sequencing drift and evidence-handoff inconsistency.
+- Do not expand local decision scope by wording shortcuts or implied authority transfer.
+- If ambiguity persists after `S6` prep, keep explicit stop posture and route escalation only.

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md
@@ -21,7 +21,7 @@ Purpose boundary:
 
 - convert existing canonical readiness, evidence, and authority surfaces into one auditable step path (`S0` to `S6`)
 - reduce review drift from distributed signoff sequencing and inconsistent evidence-intake order
-- enforce conservative `stop / escalate` behavior when evidence or authority posture is `Missing`, `Partial`, or `Unknown`
+- enforce conservative `stop &#47; escalate` behavior when evidence or authority posture is `Missing`, `Partial`, or `Unknown`
 
 This procedure is an operational review and handoff surface only. It does not grant authorization, does not pass gates, and does not enable runtime actions.
 
@@ -205,7 +205,7 @@ Pointer discipline:
 
 Binding matrix rule:
 
-- `unknown => stop / escalate` is mandatory for all steps `S0` to `S6`
+- `unknown => stop &#47; escalate` is mandatory for all steps `S0` to `S6`
 
 ## 7) Abort / Rollback / Kill-Switch Reference Surface
 


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
- codify a docs-only, operational-runbook-only, non-authorizing, verification-bound operational signoff procedure for first-live readiness
- consolidate signoff steps, evidence intake, blocker handling, and escalation boundaries from existing canonical artifacts into one readable operator path

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / operational-runbook-only / non-authorizing / verification-bound
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)