### PR TITLE
docs(ops): add first live pre live evidence requirement contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md
@@ -14,7 +14,7 @@ Zweck:
 
 - aus verteilter Artefaktlage eine reproduzierbare, fail-closed Intake-Basis machen
 - Required-Pointer-Klassen pro Level `L1` bis `L5` explizit machen
-- unklare/inkonsistente Lage konservativ als `stop / escalate` behandeln
+- unklare/inkonsistente Lage konservativ als `stop &#47; escalate` behandeln
 
 Diese Spezifikation autorisiert nichts und leitet keine Freigabe ab.
 
@@ -43,7 +43,7 @@ Pointer-Klassen nutzen bestehende Evidenzkonventionen und bleiben Pointer-basier
 
 | level | required pointer classes (candidate-scoped) | minimum intake expectation | fail-closed trigger |
 |---|---|---|---|
-| `L1` | dry-validation sequence pointer; go/no-go verdict pointer; execution dry-run pointer; evidence index anchor pointer | alle vier Pointer-Klassen vorhanden und fuer `candidate_id` eindeutig lesbar | eine Klasse `Missing`, `Partial`, `Unknown`, `Contradiction`, oder `Stale/Unknown recency` |
+| `L1` | dry-validation sequence pointer; go/no-go verdict pointer; execution dry-run pointer; evidence index anchor pointer | alle vier Pointer-Klassen vorhanden und fuer `candidate_id` eindeutig lesbar | eine Klasse `Missing`, `Partial`, `Unknown`, `Contradiction`, oder `Stale&#47;Unknown recency` |
 | `L2` | verdict interpretation pointer; checklist/slice pointer; gate-status surface pointer; candidate ledger row pointer | verdict-bezogene Pointer-Klassen sind konsistent und candidate-scoped | jede inkonsistente oder unvollstaendige verdict-Lage |
 | `L3` | entry-contract prerequisite pointer; boundary-note pointer; pre-entry gate posture pointer; cross-gate index pointer | prerequisite-Lage ist pointer-basiert nachweisbar und ohne offene Kernluecke | fehlende/unklare prerequisite-Pointer oder Widerspruch zwischen Quellen |
 | `L4` | candidate session-flow pointer; live-entry runbook pointer; session outcome pointer; handoff continuity pointer | session-flow-Interpretation fuer denselben Candidate ist pointer-konsistent | unklare Session-Fortschreibung oder nicht aufloesbare Pointer-Divergenz |
@@ -59,7 +59,7 @@ Minimales Intake-Template (nur Struktur/Felder/Pointer, ohne Runtime- oder Workf
 | `level` | genau ein Level `L1` bis `L5` pro Intake-Zeile |
 | `pointer_set` | strukturierte Menge required pointer classes fuer das jeweilige Level |
 | `recency_visibility` | sichtbare Zeitnaehe der Pointer-Lage (`fresh`, `stale`, `unknown`) nur als Interpretationssignal |
-| `ambiguity_flags` | explizite Marker fuer `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale/Unknown recency` |
+| `ambiguity_flags` | explizite Marker fuer `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale&#47;Unknown recency` |
 | `authority_boundary_note` | expliziter Hinweis, dass Intake keine Autorisierung/Freigabe impliziert |
 
 Bindende Form:
@@ -72,11 +72,11 @@ Bindende Form:
 
 Fuer jede Required-Pointer-Klasse und jedes Level gelten dieselben konservativen Regeln:
 
-- `Missing` -> sofort `stop / escalate`
-- `Partial` -> kein Auffuellen per Annahme; `stop / escalate`
-- `Unknown` -> keine lokale Aufloesung; `stop / escalate`
-- `Contradiction` -> kein Mittelwert/Upward-Resolve; `stop / escalate`
-- `Stale or Unknown recency` -> nicht als aktuell interpretieren; `stop / escalate`
+- `Missing` -> sofort `stop &#47; escalate`
+- `Partial` -> kein Auffuellen per Annahme; `stop &#47; escalate`
+- `Unknown` -> keine lokale Aufloesung; `stop &#47; escalate`
+- `Contradiction` -> kein Mittelwert/Upward-Resolve; `stop &#47; escalate`
+- `Stale or Unknown recency` -> nicht als aktuell interpretieren; `stop &#47; escalate`
 
 Globale Bindung:
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md
@@ -1,0 +1,141 @@
+# MASTER V2 — First Live Pre-Live Evidence Requirement Contract v1 (Docs-Only, Non-Authorizing)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+purpose: Canonical docs-only, non-authorizing Mindestvertrag fuer kandidatenspezifische Pre-Live-Evidence-Intake- und Handoff-Pruefung ueber L1 bis L5
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1
+
+## 1) Title / Status / Purpose
+
+Diese Spezifikation materialisiert genau einen verbindlichen, docs-only, non-authorizing Mindest-Evidence-Vertrag fuer kandidatenspezifische Pre-Live-Readiness-Intake/Handoff-Pruefung.
+
+Zweck:
+
+- aus verteilter Artefaktlage eine reproduzierbare, fail-closed Intake-Basis machen
+- Required-Pointer-Klassen pro Level `L1` bis `L5` explizit machen
+- unklare/inkonsistente Lage konservativ als `stop / escalate` behandeln
+
+Diese Spezifikation autorisiert nichts und leitet keine Freigabe ab.
+
+## 2) Scope and Non-Goals
+
+In scope:
+
+- genau ein Mindestvertrag fuer kandidatenspezifische Pre-Live-Evidence-Intake/Handoff-Pruefung
+- Required-Pointer-Klassen pro Level `L1` bis `L5`
+- fail-closed Interpretationsregeln fuer `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale or Unknown recency`
+- minimale Integration in Operational-Signoff-Prozedur-Schritte `S1`, `S2`, `S5`
+- explizite Verknuepfung zu Candidate-Ledger und Cross-Gate-Index
+
+Out of scope:
+
+- jede Form von Approval, Autorisierung, Gate-Pass, Promotion, Go-Live oder Runtime-Enablement
+- Runtime-, Config-, Workflow-, Test-, CI- oder Code-Aenderungen
+- neue Evidenzerzeugung oder Mutation bestehender Evidenz
+- neue Rollen, neue Authority-Domaenen oder neue Prozessfamilien
+
+Diese Spezifikation erzeugt keine Autoritaet und keine implizite Gate-Closure.
+
+## 3) Pre-Live Evidence Requirement Matrix (L1..L5)
+
+Pointer-Klassen nutzen bestehende Evidenzkonventionen und bleiben Pointer-basiert (keine neue Runtime-Semantik, kein Tabellen-Rebuild bestehender Artefakte).
+
+| level | required pointer classes (candidate-scoped) | minimum intake expectation | fail-closed trigger |
+|---|---|---|---|
+| `L1` | dry-validation sequence pointer; go/no-go verdict pointer; execution dry-run pointer; evidence index anchor pointer | alle vier Pointer-Klassen vorhanden und fuer `candidate_id` eindeutig lesbar | eine Klasse `Missing`, `Partial`, `Unknown`, `Contradiction`, oder `Stale/Unknown recency` |
+| `L2` | verdict interpretation pointer; checklist/slice pointer; gate-status surface pointer; candidate ledger row pointer | verdict-bezogene Pointer-Klassen sind konsistent und candidate-scoped | jede inkonsistente oder unvollstaendige verdict-Lage |
+| `L3` | entry-contract prerequisite pointer; boundary-note pointer; pre-entry gate posture pointer; cross-gate index pointer | prerequisite-Lage ist pointer-basiert nachweisbar und ohne offene Kernluecke | fehlende/unklare prerequisite-Pointer oder Widerspruch zwischen Quellen |
+| `L4` | candidate session-flow pointer; live-entry runbook pointer; session outcome pointer; handoff continuity pointer | session-flow-Interpretation fuer denselben Candidate ist pointer-konsistent | unklare Session-Fortschreibung oder nicht aufloesbare Pointer-Divergenz |
+| `L5` | incident/safe-stop pointer; incident classification pointer; escalation path pointer; final posture pointer | incident/safe-stop Lage ist candidate-scoped und konservativ nachvollziehbar | unklare Incident-Lage, fehlende Eskalationssicht, oder Recency-Unklarheit |
+
+## 4) Candidate-Scoped Intake Contract
+
+Minimales Intake-Template (nur Struktur/Felder/Pointer, ohne Runtime- oder Workflow-Aenderung):
+
+| field | required content |
+|---|---|
+| `candidate_id` | eindeutiger Candidate-Bezeichner, konsistent ueber `L1` bis `L5` |
+| `level` | genau ein Level `L1` bis `L5` pro Intake-Zeile |
+| `pointer_set` | strukturierte Menge required pointer classes fuer das jeweilige Level |
+| `recency_visibility` | sichtbare Zeitnaehe der Pointer-Lage (`fresh`, `stale`, `unknown`) nur als Interpretationssignal |
+| `ambiguity_flags` | explizite Marker fuer `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale/Unknown recency` |
+| `authority_boundary_note` | expliziter Hinweis, dass Intake keine Autorisierung/Freigabe impliziert |
+
+Bindende Form:
+
+- intake ist nur pointer-basiert und referenzierend
+- intake ersetzt keine Artefaktpruefung im Ursprung
+- intake erweitert keine Entscheidungsbefugnis
+
+## 5) Fail-Closed Interpretation Rules
+
+Fuer jede Required-Pointer-Klasse und jedes Level gelten dieselben konservativen Regeln:
+
+- `Missing` -> sofort `stop / escalate`
+- `Partial` -> kein Auffuellen per Annahme; `stop / escalate`
+- `Unknown` -> keine lokale Aufloesung; `stop / escalate`
+- `Contradiction` -> kein Mittelwert/Upward-Resolve; `stop / escalate`
+- `Stale or Unknown recency` -> nicht als aktuell interpretieren; `stop / escalate`
+
+Globale Bindung:
+
+- nie upward aufloesen
+- nie aus Nachbarstaerke Closure ableiten
+- bei unklarer/ungenuegender Lage immer konservativ stoppen und eskalieren
+
+## 6) Minimal Review Flow Integration
+
+Diese Integration baut keine neue Prozessfamilie, sondern verankert den Contract minimal in bestehender Operational-Signoff-Prozedur:
+
+- `S1 (Evidence Intake)`: Candidate-Scoped Intake Contract wird pro Level `L1..L5` mit Required-Pointer-Klassen ausgefuellt; jede Fail-Closed-Flag stoppt den Intake-Pfad.
+- `S2 (Gate Posture Read)`: Gate-Lesehaltung nutzt nur Intake-Pointerlage und konservative Statusinterpretation; keine Closure-Inflation aus Pointer-Praesenz.
+- `S5 (Signoff Prep)`: Handoff-Paket uebernimmt Intake-Resultate inkl. Ambiguity-Flags und Authority-Boundary-Note; kein interner Output darf Autorisierung oder Gate-Abschluss behaupten.
+
+## 7) Interpretation Locks / Non-Authorization Clauses
+
+Dieser Contract ist strikt non-authorizing.
+
+Bindende Locks:
+
+- lokale Outputs duerfen nicht als `approved`, `authorized`, `gate passed`, `promoted`, oder `go-live enabled` formuliert werden
+- solche Begriffe sind hier nur als verboten, extern attribuiert oder out-of-scope zulaessig
+- Pointer-Vollstaendigkeit ist keine Freigabe und keine implizite Entscheidungserweiterung
+- fehlende/partielle/unklare/widerspruechliche/stale Lage bleibt offen und eskalationspflichtig
+
+## 8) Nearest Existing Repo Artifacts / Cross-References
+
+- [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
+- [BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md)
+- [RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md)
+- [RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md)
+- [EVIDENCE_SCHEMA.md](../EVIDENCE_SCHEMA.md)
+- [EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md)
+
+Contract-Verknuepfung:
+
+- Candidate-Ledger liefert candidate-scoped Ledger-Orientierung fuer Intake
+- Cross-Gate-Index liefert level-uebergreifende Pointer-Buendel-Orientierung
+- beide bleiben nicht-autorisierende Mapping-Surfaces
+
+## 9) Acceptance Criteria for Contract Completeness
+
+Der Contract gilt als dokumentenintern vollstaendig, wenn:
+
+- fuer jedes Level `L1` bis `L5` explizite Required-Pointer-Klassen benannt sind
+- Candidate-Scoped Intake-Template alle Mindestfelder enthaelt (`candidate_id`, `level`, `pointer_set`, `recency_visibility`, `ambiguity_flags`, `authority_boundary_note`)
+- fail-closed Regeln fuer `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale or Unknown recency` explizit und bindend sind
+- `S1`, `S2`, `S5` Integration explizit und minimal ist
+- Non-Authorization-Klauseln jede interne Freigabe-/Pass-/Promotion-/Go-Live-Interpretation ausschliessen
+- Cross-References auf die geforderten Nachbarartefakte vorhanden sind
+
+## 10) Operator Notes
+
+- konservativ anwenden: bei Zweifel nicht interpretativ aufwerten
+- keine closure inflation: Pointer-Praesenz ist keine Entscheidungsfreigabe
+- keine implizite Entscheidungsausweitung durch Formulierung
+- stop/escalate diszipliniert und reproduzierbar halten


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
- codify a docs-only, non-authorizing pre-live evidence requirement contract for candidate-scoped first-live readiness intake
- define level-specific required pointer classes, fail-closed interpretation rules, and minimal intake structure for `L1..L5` without changing runtime behavior

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Risk
- low
- docs-only / non-authorizing
- no runtime / config / workflow / test / code changes

Made with [Cursor](https://cursor.com)