### PR TITLE
docs(ops): add master v2 first live pre live dry run acceptance contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md
@@ -1,0 +1,119 @@
+# MASTER V2 - First Live Pre-Live Dry-Run Acceptance Contract v1 (Docs-Only, Non-Authorizing)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+intent: Minimaler, pruefbarer, fail-closed Acceptance-Nachweisrahmen fuer kandidatenspezifische Pre-Live-Dry-Run-Ergebnislage zwischen Evidence-Requirement-Contract und Operational-Signoff-Procedure
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1
+
+## 1) Titel, Status, Intent
+
+Diese Spezifikation materialisiert genau einen docs-only Acceptance-Contract fuer die kandidatenspezifische Pre-Live-Dry-Run-Ergebnislage.
+
+Verbindliche Boundary:
+
+- non-authorizing
+- fail-closed
+- safety-first
+- evidence-bound
+
+Diese Spezifikation autorisiert nichts, schliesst kein Gate und erteilt keine Live-Freischaltung.
+
+## 2) Zweck, Scope, Nicht-Ziele
+
+Zweck:
+
+- Dry-Run-Ergebnislage pro `candidate_id` in einen minimalen, reproduzierbaren Acceptance-Rahmen ueberfuehren
+- nur pointer-basierte, vorhandene Evidenzflaechen in eine konservative Ergebnislesehaltung binden
+- die Bruecke zwischen Evidence-Requirement-Contract und Operational-Signoff-Procedure explizit machen
+
+Scope:
+
+- genau ein kandidatenspezifischer Acceptance-Rahmen fuer Pre-Live-Dry-Run
+- Required Inputs, Preconditions, Acceptance-Kriterien, fail-closed Ablehnungsregeln
+- Evidence-, Pointer- und Traceability-Pflichten fuer pruefbare Nachvollziehbarkeit
+
+Nicht-Ziele:
+
+- keine Autorisierung, kein Approval, kein Gate-Pass, keine Promotion, keine Go-Live-Ableitung
+- keine Runtime-, Config-, Workflow-, Script-, Test- oder Code-Aenderung
+- keine Evidenzerzeugung, keine Evidenzmutation, keine neue Prozessfamilie
+
+## 3) Begriffs- und Boundary-Definitionen
+
+- `candidate_id`: stabiler Kandidatenbezeichner, der ueber alle referenzierten Pointer konsistent bleibt.
+- `dry-run-result-lage`: konservative Sicht auf vorhandene, kandidatenspezifische Dry-Run-Evidenzpointer; keine Wirkbehauptung.
+- `acceptance` in diesem Contract: nur Aufnahmefaehigkeit der Evidenzlage fuer nachgelagerte Signoff-Vorbereitung, nie Freigabe.
+- `fail-closed`: bei `Missing`, `Partial`, `Unknown`, `Contradiction` oder `Stale&#47;Unknown recency` wird nicht lokal aufgeloest, sondern `stop &#47; escalate`.
+- `evidence-bound`: Aussagen sind nur zulaessig, wenn ein kanonischer Repository-Pointer explizit genannt ist.
+
+## 4) Required Inputs und Preconditions
+
+Required Inputs (alle pointer-basiert, candidate-scoped):
+
+1. Intake-Lage gemaess [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+2. Kandidatenorientierung gemaess [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+3. Cross-Gate-Pointerkontext gemaess [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+4. Konservative Gate-Leseflaeche gemaess [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+
+Preconditions:
+
+- `candidate_id` ist eindeutig und ueber alle Required Inputs konsistent referenzierbar.
+- Required-Pointer-Klassen fuer Dry-Run-Lage sind explizit sichtbar; fehlende Klassen bleiben explizit fehlend.
+- Authority-Boundary bleibt unveraendert und extern.
+- keine lokale Sprache, die Abschluss, Freigabe oder Autorisierung behauptet.
+
+## 5) Acceptance-Kriterien fuer Dry-Run-Ergebnislage
+
+Die Dry-Run-Ergebnislage ist nur dann als "acceptance-ready fuer Signoff-Preparation" zu klassifizieren, wenn alle folgenden Punkte gleichzeitig erfuellt sind:
+
+1. **Pointer-Vollstaendigkeit im Rahmen**: Alle im Evidence-Requirement-Contract fuer den Candidate benoetigten Dry-Run-relevanten Pointer-Klassen sind vorhanden oder als blocker explizit markiert; nichts wird implizit ergaenzt.
+2. **Konsistenz**: Keine unaufgeloeste Widerspruchslage zwischen Candidate-Ledger, Cross-Gate-Index und Gate-Status-Index.
+3. **Recency-Sichtbarkeit**: Zeitnaehe ist aus Pointerlage sichtbar; `stale` oder `unknown` wird nie als aktuell umgedeutet.
+4. **Authority-Schutz**: Kein Acceptance-Text enthaelt lokale Autorisierungs- oder Closure-Behauptung.
+5. **Traceability**: Jede Acceptance-Aussage ist auf mindestens einen kanonischen Repository-Pointer rueckfuehrbar.
+
+Acceptance-ready bedeutet hier ausschliesslich: geeignet fuer naechsten nicht-autorisierenden Signoff-Prozedur-Schritt, nicht geeignet fuer Live-Freischaltung.
+
+## 6) Fail-Closed Ablehnungs-, Stop- und Escalate-Regeln
+
+Bindende Regeln:
+
+- `Missing` -> sofort `reject`, `stop &#47; escalate`
+- `Partial` -> kein Auffuellen durch Annahme, `reject`, `stop &#47; escalate`
+- `Unknown` -> keine lokale Aufloesung, `reject`, `stop &#47; escalate`
+- `Contradiction` -> keine Mittelung oder Priorisierung ohne kanonischen Anker, `reject`, `stop &#47; escalate`
+- `Stale&#47;Unknown recency` -> nicht akzeptieren, `stop &#47; escalate`
+
+Globale Stop-Regel:
+
+- Sobald eine fail-closed Bedingung zutrifft, endet die lokale Acceptance-Bewertung ohne Upward-Interpretation.
+
+Escalate-Regel:
+
+- Escalation-Payload muss `candidate_id`, betroffene Pointer-Klasse, betroffene Source-Referenz und fail-closed Grund explizit enthalten.
+
+## 7) Evidence-, Pointer- und Traceability-Anforderungen
+
+Verbindliche Nachweisform:
+
+- nur Repository-Pointer auf bestehende kanonische Ziele
+- jede Ergebniszeile enthaelt `candidate_id`, source-pointer, interpretation-note, ambiguity-flag
+- interpretationsfreie Trennung zwischen beobachteter Evidenzlage und offener Ambiguitaet
+
+Traceability-Mindestregeln:
+
+- von jeder Acceptance-Aussage muss ein Ruecksprung auf den Quell-Pointer moeglich sein
+- keine Aussage ohne referenzierten Quellanker
+- keine stillschweigende Verdichtung mehrerer Quellen zu einer impliziten Freigabeaussage
+
+## 8) Cross-References (bestehende kanonische Ziele)
+
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md](MASTER_V2_FIRST_LIVE_OPERATOR_REVIEW_SEQUENCE_COMPASS_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live dry-run acceptance contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live evidence and signoff surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)