### PR TITLE
docs(ops): add master v2 first live pre live abort rollback kill switch readiness verification contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md
@@ -1,0 +1,155 @@
+# MASTER V2 - First Live Pre-Live Abort Rollback Kill-Switch Readiness Verification Contract v1 (Docs-Only, Non-Authorizing)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+intent: Exactly one additive docs-only single-topic contract for verifiable pre-live readiness checks of abort, rollback, and kill-switch interpretation surfaces before external signoff handoff
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1
+
+## 1) Titel + Status / Intent
+
+Diese Spezifikation materialisiert genau einen operativen, pruefbaren, fail-closed Verifikationsvertrag fuer die Pre-Live-Readiness-Sicht auf Abort-, Rollback- und Kill-Switch-Interpretationsflaechen.
+
+Boundary-Profil:
+
+- docs-only
+- non-authorizing
+- fail-closed
+- safety-first
+- evidence-bound
+
+Diese Spezifikation autorisiert nichts, schliesst kein Gate und erzeugt keine Live-Freischaltung.
+
+## 2) Zweck / Scope / Nicht-Ziele
+
+Zweck:
+
+- ein einheitliches, konservatives Verifikationssurface fuer abort&#47;rollback&#47;kill-switch-Readiness vor externer Entscheidungshandoff-Linie
+- nur pointer-basierte Reuse-Interpretation bestehender kanonischer Artefakte ohne Neudefinition operativer Authority
+- reproduzierbare stop&#47;reject&#47;escalate-Disziplin bei fehlender, partieller, unklarer oder widerspruechlicher Lage
+
+Scope:
+
+- genau ein kandidatenspezifischer Pre-Live-Readiness-Verifikationsvertrag fuer abort&#47;rollback&#47;kill-switch-Relevanz
+- Inputs, Preconditions, Required-Evidence-Pointer, Verifikationsmatrix und fail-closed Regeln
+- Traceability zu bestehenden Master-V2- und First-Live-Artefakten
+
+Nicht-Ziele:
+
+- keine Runtime-, Config-, Workflow-, Script-, Test- oder Code-Aenderung
+- keine Aktivierung, Ausfuehrung oder Simulation von Abort, Rollback oder Kill-Switch
+- kein Approval, kein Gate-Pass, keine Promotion, kein Go-Live und keine lokale Gate-Closure-Behauptung
+- keine neue Prozessfamilie, kein neues Rollenmodell, keine neue Authority-Domaene
+
+## 3) Begriffs- und Boundary-Definitionen
+
+- `candidate_id`: stabiler Kandidatenbezeichner, konsistent ueber alle referenzierten Pointer.
+- `abort-readiness`: dokumentierte Sicht, dass relevante Stop-Ausloeser und zugehoerige Referenzflaechen pointer-basiert identifizierbar sind; keine Aktivierungszusage.
+- `rollback-readiness`: dokumentierte Sicht, dass sichere Rueckfall- und Safe-Fallback-Bezuege eindeutig pointer-bar sind; keine Ausfuehrungszusage.
+- `kill-switch-readiness`: dokumentierte Sicht, dass Fail-Closed-Veto-/Stop-Boundaries pointer-basiert verifizierbar sind; keine Steuerungsberechtigung.
+- `verification`: konservative Nachvollziehbarkeitspruefung der vorhandenen Evidenzlage, nie Entscheidungs- oder Freigabeakt.
+- `fail-closed`: bei `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale&#47;Unknown recency` gilt bindend `stop &#47; reject &#47; escalate`.
+
+Boundary-Lock:
+
+- lokale Verifikation bleibt streng auf Sichtbarkeit, Konsistenz und Traceability begrenzt
+- externe finale Authority bleibt extern und unveraendert
+
+## 4) Inputs / Preconditions / Required Evidence Pointers
+
+Required Inputs (reuse-only, pointer-basiert):
+
+1. [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+2. [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+3. [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+4. [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md)
+5. [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+6. [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+7. [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+8. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+9. [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+
+Preconditions:
+
+- `candidate_id` ist fuer den Verifikationskontext eindeutig und in den referenzierten Surfaces rueckfuehrbar.
+- benoetigte Pointer-Klassen sind sichtbar oder explizit als fehlend&#47;partiell&#47;unklar markiert.
+- Authority-Boundary bleibt explizit non-authorizing.
+- jede Aussage ist evidence-bound und auf mindestens einen kanonischen Pointer rueckfuehrbar.
+
+Required Evidence Pointer Set (mindestens):
+
+- candidate-scoped Pointer auf Evidence-Bundle-Ledger-Zeilen
+- cross-gate Pointer auf L1..L5 Zusammenhangslage
+- incident&#47;safe-fallback Pointer fuer Klassifikationsbezug
+- authority-boundary Pointer fuer Decider-/Veto-Legibility
+- gate-posture Pointer fuer konservative Lesehaltung
+
+## 5) Operativer Kernvertrag - Abort/Rollback/Kill-Switch Readiness Verification Matrix
+
+| verification surface | minimum verifiable pointer condition | required interpretation discipline | allowed local output | fail-closed trigger |
+|---|---|---|---|---|
+| `Abort relevance` | candidate-scoped incident/safe-stop pointer ist explizit verlinkt und source-resolvable | keine lokale Aktivierungsbehauptung; nur Relevanz- und Boundary-Lesung | `abort relevance visible` oder `abort relevance unresolved` | fehlender&#47;partieller&#47;unklarer&#47;widerspruechlicher incident-pointer |
+| `Rollback relevance` | safe-fallback- bzw. rollback-bezogene Pointer sind source-konsistent und candidate-rueckfuehrbar | keine Erfolgsaussage ueber Rueckfallausfuehrung; nur Interpretationssicht | `rollback reference visible` oder `rollback reference unresolved` | fehlender&#47;partieller&#47;unklarer oder stale Bezug |
+| `Kill-switch boundary relevance` | veto/fail-closed Boundary-Pointer und Authority-Pointer sind explizit verlinkt | keine lokale Authority-Erweiterung; unklare Ownership nie upward aufloesen | `kill-switch boundary visible` oder `kill-switch boundary unresolved` | authority-unklar, boundary-unklar, oder contradictions |
+| `Cross-surface consistency` | Candidate-Ledger, Cross-Gate-Index und Gate-Status-Index zeigen keine unaufgeloeste Kernkollision | Nachbarstaerke nicht als Closure nutzen; offene Lage offen lassen | `consistency visible` oder `consistency unresolved` | Divergenz ohne kanonischen Vorranganker |
+| `Signoff-prep admissibility` | Ergebnislage ist traceable und mit non-authorizing Boundary-Note versehen | Vorbereitung nur als Handoff-Material; nie als Gate-Closure | `prep admissible for external review handoff` oder `prep blocked` | fehlende Traceability oder closure-nahe Formulierung |
+
+Verbindliche Matrix-Regel:
+
+- lokale Outputs duerfen nur Sichtbarkeits-/Unresolved-Status sein, niemals Authorisierungssprache
+
+## 6) Fail-Closed Stop / Reject / Escalate-Regeln
+
+Bindende Regeln pro Verifikationssurface:
+
+- `Missing` -> `stop &#47; reject &#47; escalate`
+- `Partial` -> keine Annahme-basierte Ergaenzung, `stop &#47; reject &#47; escalate`
+- `Unknown` -> keine lokale Aufloesung, `stop &#47; reject &#47; escalate`
+- `Contradiction` -> keine Mittelung, keine lokale Priorisierung ohne kanonischen Anker, `stop &#47; reject &#47; escalate`
+- `Stale&#47;Unknown recency` -> nicht als aktuell interpretieren, `stop &#47; reject &#47; escalate`
+
+Escalation-Payload Mindestinhalt:
+
+- `candidate_id`
+- betroffene Verifikationssurface
+- betroffene Pointer-Klasse und Quellreferenz
+- konkreter fail-closed Grund
+- explizite non-authorizing Boundary-Notiz
+
+Globale Stop-Regel:
+
+- sobald ein fail-closed Trigger aktiv ist, endet lokale Verifikation ohne Upward-Interpretation
+
+## 7) Traceability / Cross-References auf bestehende repo-kanonische Ziele
+
+Kernreferenzen:
+
+- [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md)
+
+Traceability-Mindestdisziplin:
+
+- jede lokale Verifikationsaussage ist an mindestens einen Quellpointer gebunden
+- kein Pointer, keine Aussage
+- keine implizite Verdichtung zu Freigabe-, Pass- oder Closure-Behauptung
+
+## 8) Abschluss - Klare Non-Authorizing Boundary
+
+Dieser Contract ist strikt ein verifikationsgebundener Readiness-Nachweisrahmen fuer abort&#47;rollback&#47;kill-switch-Interpretationsflaechen.
+
+Er ist nicht:
+
+- keine Autorisierung
+- kein Gate-Pass
+- keine Promotion
+- kein Go-Live
+- keine Runtime-Steuerung
+
+Lokale Vollstaendigkeit oder Pointer-Vollstaendigkeit dieses Contracts ist niemals gleichbedeutend mit Live-Freigabe.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live readiness verification contract for abort, rollback, and kill-switch posture
- anchor the slice to existing Master V2 / First Live operational signoff, pre-live evidence, and dry-run acceptance surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)