### PR TITLE
docs(ops): add master v2 first live pre live escalation exception intake contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md
@@ -1,0 +1,170 @@
+# MASTER V2 - First Live Pre-Live Escalation Exception Intake Contract v1 (Docs-Only, Non-Authorizing)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+intent: Genau ein additiver docs-only Single-Topic-Contract fuer operative, pruefbare Pre-Live Escalation-Exception-Intake-Readiness vor externer Entscheidungsgrenze
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1
+
+## 1) Titel + Status &#47; Intent
+
+Diese Spezifikation materialisiert genau einen operativen Intake-Contract fuer Pre-Live Escalation Exceptions im First-Live-Kontext.
+
+Boundary-Profil:
+
+- docs-only
+- non-authorizing
+- fail-closed
+- safety-first
+- evidence-bound
+
+Diese Spezifikation autorisiert nichts, schliesst kein Gate und erzeugt keine Live-Freischaltung.
+
+## 2) Zweck &#47; Scope &#47; Nicht-Ziele
+
+Zweck:
+
+- Escalation-Exception-Intake auf eine reproduzierbare, konservative Mindestform bringen
+- nur bestehende kanonische Master-V2- und First-Live-Surfaces als Pointer-Basis nutzen
+- stop&#47;reject&#47;escalate-Disziplin bei unklarer oder widerspruechlicher Lage operationalisieren
+
+Scope:
+
+- genau ein kandidatenspezifischer Intake-Contract fuer Escalation Exceptions in Pre-Live-Readiness
+- Required Inputs, Preconditions, Required Evidence Pointers, Intake-Matrix und Decision-Input-Surface
+- fail-closed Regeln fuer Stop-, Reject- und Escalate-Entscheidungspunkte
+
+Nicht-Ziele:
+
+- keine Autorisierung, kein Approval, kein Gate-Pass, keine Promotion, kein Go-Live
+- keine Runtime-, Config-, Workflow-, Script-, Test- oder Code-Aenderungen
+- keine neue Prozessfamilie, kein neues Rollenmodell, keine neue Authority-Domaene
+- keine lokale Gate-Closure per Behauptung oder impliziter Verdichtung
+
+## 3) Begriffs- und Boundary-Definitionen
+
+- `candidate_id`: stabiler Kandidatenbezeichner, konsistent ueber alle referenzierten Pointer-Surfaces.
+- `escalation exception`: dokumentierte, pointer-gebundene Abweichungslage, die lokale Klarstellung nicht zulaesst und externe Behandlung erfordert.
+- `exception intake`: konservative Aufnahme und Strukturierung bestehender Evidenzpointer; keine Ursachenheilung, keine Entscheidungsfreigabe.
+- `decision-input surface`: verdichtete, traceable Inputs fuer externe Entscheidungshandoff-Linie; niemals lokaler Entscheidungsakt.
+- `fail-closed`: bei `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale&#47;Unknown recency` gilt bindend `stop &#47; reject &#47; escalate`.
+
+Boundary-Lock:
+
+- lokale Outputs bleiben Sichtbarkeits- und Ambiguitaetsaussagen
+- externe finale Authority bleibt extern und unveraendert
+- keine upward-Aufloesung von Authority- oder Evidenzunklarheit
+
+## 4) Inputs &#47; Preconditions &#47; Required Evidence Pointers
+
+Required Inputs (reuse-only, pointer-basiert):
+
+1. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+2. [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+3. [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+4. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+5. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+6. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+7. [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+8. [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+9. [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+10. [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+11. [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+
+Preconditions:
+
+- `candidate_id` ist eindeutig und ueber Candidate-Ledger sowie Cross-Gate-Index rueckfuehrbar.
+- benoetigte Pointer-Klassen sind explizit sichtbar oder explizit als offen markiert.
+- Authority-Boundary ist explizit non-authorizing und bleibt unveraendert.
+- jede Intake-Aussage ist auf mindestens einen kanonischen Quellpointer rueckfuehrbar.
+
+Required Evidence Pointer Set (mindestens):
+
+- candidate-scoped Pointer auf betroffene Ledger- und Cross-Gate-Eintraege
+- gate-posture Pointer fuer konservative Einordnung der Exception-Lage
+- authority-boundary Pointer fuer externe Decider-/Veto-Klarheit
+- incident/safe-fallback Pointer fuer konservative Risikoklassifikation
+- traceability-pointer fuer Handoff-Paket-Section-Zuordnung
+
+## 5) Operativer Kernvertrag - Escalation Exception Intake Matrix und Decision-Input Surface
+
+| intake dimension | required pointer condition | required intake discipline | allowed local output | required decision-input field | fail-closed trigger |
+|---|---|---|---|---|---|
+| `Exception identity` | exception-bezogener Pointer ist candidate-scoped und source-resolvable | keine implizite Zusammenlegung unterschiedlicher Exception-Faelle | `exception identity visible` oder `exception identity unresolved` | `candidate_id`, `exception_pointer`, `source_surface` | fehlende oder widerspruechliche Exception-Identitaet |
+| `Evidence completeness posture` | benoetigte Pointer-Klassen aus Evidence-Requirement und Dry-Run-Acceptance sind sichtbar oder explizit als offen markiert | keine Auffuellung durch Annahme | `coverage visible` oder `coverage unresolved` | `required_pointer_classes`, `missing_or_partial_flags` | `Missing` oder `Partial` ohne belastbaren Quellanker |
+| `Cross-surface consistency` | Candidate-Ledger, Cross-Gate-Index und Gate-Status-Index zeigen keine unaufgeloeste Kernkollision | Nachbarstaerke nie als Closure nutzen | `consistency visible` oder `consistency unresolved` | `consistency_note`, `contradiction_flags` | unaufgeloeste Divergenz oder nicht nachvollziehbarer Vorrang |
+| `Authority boundary legibility` | authority-pointer benennen advisory, authoritative und veto/fail-closed Rolle explizit | keine lokale Authority-Substitution | `authority boundary visible` oder `authority boundary unresolved` | `authority_reference`, `external_handoff_target_note` | authority-unklar oder boundary-unklar |
+| `Escalation payload readiness` | Packet-Traceability-Mapping fuer relevante Sections ist explizit | nur Intake- und Routing-Faehigkeit, nie Freigabeaussage | `payload prep admissible` oder `payload prep blocked` | `escalation_reason`, `traceability_links`, `non_authorizing_note` | fehlende Traceability oder closure-nahe Formulierung |
+
+Verbindliche Matrix-Regel:
+
+- lokale Outputs duerfen ausschliesslich Sichtbarkeits- und Unresolved-Status enthalten, keine Autorisierungsbegriffe
+
+Decision-Input Surface Mindestinhalt:
+
+- `candidate_id`
+- `exception_case_label`
+- `affected_gates_or_levels`
+- `pointer_inventory`
+- `ambiguity_and_contradiction_flags`
+- `authority_boundary_statement`
+- `explicit_non_claims_block`
+- `escalation_route_pointer`
+
+## 6) Fail-Closed Stop &#47; Reject &#47; Escalate-Regeln
+
+Bindende Regeln:
+
+- `Missing` -> `stop &#47; reject &#47; escalate`
+- `Partial` -> keine Annahme-basierte Ergaenzung, `stop &#47; reject &#47; escalate`
+- `Unknown` -> keine lokale Aufloesung, `stop &#47; reject &#47; escalate`
+- `Contradiction` -> keine Mittelung, keine lokale Priorisierung ohne kanonischen Anker, `stop &#47; reject &#47; escalate`
+- `Stale&#47;Unknown recency` -> nicht als aktuell interpretieren, `stop &#47; reject &#47; escalate`
+
+Escalation-Payload Mindestinhalt:
+
+- `candidate_id`
+- betroffene Intake-Dimension
+- betroffene Pointer-Klasse und Quellreferenz
+- konkreter fail-closed Grund
+- explizite non-authorizing Boundary-Notiz
+
+Globale Stop-Regel:
+
+- sobald ein fail-closed Trigger aktiv ist, endet lokale Intake-Bewertung ohne Upward-Interpretation
+
+## 7) Traceability &#47; Cross-References auf bestehende repo-kanonische Ziele
+
+Kernreferenzen:
+
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+
+Traceability-Mindestdisziplin:
+
+- jede lokale Intake- und Decision-Input-Aussage ist an mindestens einen Quellpointer gebunden
+- kein Pointer, keine Aussage
+- keine implizite Verdichtung zu Freigabe-, Pass- oder Closure-Behauptung
+
+## 8) Abschluss - Klare non-authorizing Boundary
+
+Dieser Contract ist strikt ein Intake- und Decision-Input-Rahmen fuer Pre-Live Escalation Exceptions.
+
+Er ist nicht:
+
+- keine Autorisierung
+- kein Gate-Pass
+- keine Promotion
+- kein Go-Live
+- keine Runtime-Steuerung
+
+Lokale Vollstaendigkeit oder Pointer-Vollstaendigkeit dieses Contracts ist niemals gleichbedeutend mit Live-Freigabe.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live escalation and exception intake contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff, pre-live evidence, dry-run acceptance, and abort/rollback/kill-switch readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)