### PR TITLE
docs(ops): add master v2 first live pre live evidence conflict adjudication contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md
@@ -1,0 +1,195 @@
+# MASTER V2 - First Live Pre-Live Evidence Conflict Adjudication Contract v1 (Docs-Only, Non-Authorizing)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+intent: Genau ein additiver docs-only Single-Topic-Contract fuer operative, pruefbare Evidence-Conflict-Adjudication-Readiness in der Pre-Live-Lage
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1
+
+## 1) Titel + Status &#47; Intent
+
+Diese Spezifikation materialisiert genau eine additive Single-Topic-Slice fuer First-Live-Pre-Live-Readiness: die konservative, evidence-bound Adjudication widerspruechlicher Evidenzlagen.
+
+Verbindliche Boundary:
+
+- docs-only
+- non-authorizing
+- fail-closed
+- safety-first
+- evidence-bound
+
+Diese Spezifikation autorisiert nichts, schliesst kein Gate und erteilt keine Live-Freischaltung.
+
+## 2) Zweck &#47; Scope &#47; Nicht-Ziele
+
+Zweck:
+
+- einen reproduzierbaren Adjudication-Rahmen fuer Evidence-Konfliktlagen bereitstellen
+- lokale Behauptungsauflosung verhindern und nur pointer-gebundene Entscheidungsinputs zulassen
+- stop &#47; reject &#47; escalate-Disziplin bei Konflikten verbindlich operationalisieren
+
+Scope:
+
+- genau ein kandidatenspezifischer Contract fuer Conflict-Adjudication in der Pre-Live-Readiness
+- Required Inputs, Preconditions, Conflict-Matrix, Adjudication-Regeln, Review-Pack-Mindestinhalt und Decision-Input-Surface
+- explizite fail-closed Trigger fuer `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale&#47;Unknown recency`
+
+Nicht-Ziele:
+
+- keine Autorisierung, kein Approval, kein Gate-Pass, keine Promotion, kein Go-Live
+- keine Runtime-, Config-, Workflow-, Script-, Test- oder Code-Aenderungen
+- keine Evidenzneuerzeugung, keine Evidenzmutation, keine neue Prozessfamilie, keine neue Authority-Domaene
+- keine Gate-Closure oder Gate-Fuellung per sprachlicher Verdichtung
+
+## 3) Begriffs- und Boundary-Definitionen
+
+- `evidence_conflict`: unaufgeloeste, pointer-sichtbare Divergenz zwischen zwei oder mehr kanonischen Evidence-Quellen fuer dieselbe `candidate_id`.
+- `adjudication`: konservative, nachvollziehbare Einordnung einer Konfliktlage als `resolvable_with_anchor` oder `unresolved_fail_closed` ohne lokale Autorisierungswirkung.
+- `canonical_anchor`: explizit benannter Quellanker in bestehenden repo-kanonischen Artefakten, der fuer Konfliktinterpretation zulaessig ist.
+- `decision_input_surface`: strukturierter, traceable Handoff-Input fuer externe Entscheidungslinien; niemals lokale Freigabeentscheidung.
+- `conflict_state`: zulaessige Klassifikation `none_visible`, `anchor_resolvable`, `unresolved_fail_closed`.
+
+Boundary-Lock:
+
+- ohne kanonischen Anchor keine lokale Konfliktauflosung
+- lokale Outputs bleiben auf Sichtbarkeit, Klassifikation und Eskalationsbedarf beschraenkt
+- Authority- und Freigabegraenzen bleiben unveraendert extern
+
+## 4) Inputs &#47; Preconditions &#47; Required Evidence Pointers
+
+Required Inputs (reuse-only, pointer-basiert):
+
+1. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+2. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md)
+3. [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+4. [MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md)
+5. [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+6. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+7. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+8. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+9. [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+10. [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+11. [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+12. [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+13. [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+14. [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+
+Preconditions:
+
+- `candidate_id` ist ueber alle relevanten Pointer-Surfaces stabil und eindeutig.
+- Konfliktbehauptungen sind immer an mindestens zwei konkrete Quellpointer gebunden.
+- Prioritaets- oder Vorrangregeln sind nur zulaessig, wenn ein kanonischer Anchor explizit benannt ist.
+- jede Aussage im Contract ist pointer-traceable; ohne Pointer keine Aussage.
+
+Required Evidence Pointer Set (pro Konfliktfall):
+
+- `candidate_id`
+- `level_or_gate_context`
+- `conflicting_source_pointers` (mindestens zwei)
+- `conflict_dimension` (z. B. status, verdict, recency, boundary)
+- `canonical_anchor_pointer` oder explizit `none`
+- `recency_visibility` (`fresh`, `stale`, `unknown`)
+- `authority_boundary_pointer`
+- `traceability_pointer`
+
+## 5) Operativer Kernvertrag: Conflict-Adjudication-Matrix, Checklist, Review-Pack und Decision-Input Surface
+
+### 5.1 Conflict-Adjudication-Matrix
+
+| conflict dimension | minimum pointer condition | adjudication rule | allowed local output | required decision-input fields | fail-closed trigger |
+|---|---|---|---|---|---|
+| `Status conflict` | mindestens zwei statusbezogene Quellenpointer fuer dieselbe `candidate_id` | nur per kanonischem Anchor klassifizieren, sonst `unresolved_fail_closed` | `status conflict visible`, `anchor_resolvable`, oder `unresolved_fail_closed` | `candidate_id`, `status_sources`, `anchor_note`, `conflict_state` | fehlender Anchor oder widerspruechlicher Anchor |
+| `Verdict conflict` | verdict-nahe Pointer aus mindestens zwei kanonischen Surfaces | keine Mittelung, keine lokale Priorisierung ohne Anchor | `verdict conflict visible` oder `unresolved_fail_closed` | `verdict_sources`, `contradiction_note`, `escalation_reason` | unaufgeloeste Verdict-Kollision |
+| `Recency conflict` | recency-Sichtbarkeit je Quelle explizit | `stale` oder `unknown` nie als aktuell interpretieren | `recency conflict visible` oder `unresolved_fail_closed` | `recency_map`, `staleness_flags`, `requested_external_adjudication_context` | `Stale&#47;Unknown recency` in konfliktkritischer Quelle |
+| `Authority-boundary conflict` | authority-pointer und boundary-pointer sind vorhanden | keine lokale Authority-Substitution, nur externe Eskalationsadressierung | `boundary conflict visible` oder `unresolved_fail_closed` | `authority_boundary_statement`, `external_handoff_target_note` | boundary-unklar, veto-unklar oder authority-unklar |
+| `Traceability conflict` | Konfliktkette ist in Handoff-Traceability matrix-faehig abbildbar | ohne vollstaendige Traceability kein lokales Weiterfuehren | `traceability admissible` oder `traceability blocked` | `traceability_links`, `packet_section_refs`, `non_authorizing_note` | fehlende Traceability oder closure-nahe Formulierung |
+
+### 5.2 Operative Checklist (bindend)
+
+1. Konfliktfall ist candidate-scoped und pointer-gebunden.
+2. Konfliktdimension ist explizit klassifiziert.
+3. kanonischer Anchor ist vorhanden oder explizit als `none` markiert.
+4. recency-Sichtbarkeit ist pro Konfliktquelle benannt.
+5. authority-boundary bleibt explizit non-authorizing.
+6. jede lokale Ausgabe ist rein deskriptiv und nicht autorisierend.
+7. bei `unresolved_fail_closed` erfolgt sofort `stop &#47; reject &#47; escalate`.
+
+### 5.3 Review-Pack Mindestinhalt
+
+Ein gueltiger Review-Pack fuer diese Slice enthaelt mindestens:
+
+1. Konfliktinventar je `candidate_id` mit Quellenpointer-Paaren
+2. Adjudication-Klassifikation je Konfliktfall (`anchor_resolvable` oder `unresolved_fail_closed`)
+3. Anchor-Nachweis oder explizites `none` pro Konfliktfall
+4. fail-closed Triggerliste inklusive Eskalationsgrund
+5. Decision-Input Surface in non-authorizing Sprache
+
+### 5.4 Decision-Input Surface Mindestfelder
+
+- `candidate_id`
+- `conflict_case_label`
+- `conflict_dimension`
+- `conflicting_source_pointers`
+- `canonical_anchor_pointer_or_none`
+- `adjudication_classification`
+- `ambiguity_and_contradiction_flags`
+- `authority_boundary_statement`
+- `explicit_non_claims_block`
+- `escalation_route_pointer`
+
+## 6) Fail-Closed Stop &#47; Reject &#47; Escalate-Regeln
+
+Bindende Trigger:
+
+- `Missing` -> `reject`, sofort `stop &#47; escalate`
+- `Partial` -> `reject`, keine Auffuellung per Annahme, `stop &#47; escalate`
+- `Unknown` -> `reject`, keine lokale Aufloesung, `stop &#47; escalate`
+- `Contradiction` -> `reject`, keine Mittelung, keine lokale Priorisierung ohne kanonischen Anchor, `stop &#47; escalate`
+- `Stale&#47;Unknown recency` -> `reject`, nicht als aktuell interpretieren, `stop &#47; escalate`
+
+Globale Regel:
+
+- ein einzelner unresolved fail-closed Konfliktfall beendet die lokale Adjudication-Linie fuer den betroffenen Fall.
+
+Escalation-Payload Mindestinhalt:
+
+- `candidate_id`
+- `conflict_dimension`
+- `conflicting_source_pointers`
+- `canonical_anchor_pointer_or_none`
+- `fail_closed_reason`
+- `authority_boundary_pointer`
+- `non_authorizing_boundary_note`
+
+## 7) Traceability &#47; Cross-References auf bestehende repo-kanonische Ziele
+
+Kernreferenzen:
+
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md](MASTER_V2_VOCAB_BOUNDARY_LOCK_V1.md)
+- [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md)
+
+Traceability-Regeln:
+
+- jede Konfliktklassifikation ist an konkrete Quellpointer und, falls vorhanden, an genau einen kanonischen Anchor gebunden.
+- kein Anchor und kein eindeutiger Konfliktstatus bedeutet zwingend `unresolved_fail_closed`.
+- pointer-Praesenz oder lokale Vollstaendigkeit erzeugen niemals Freigabe- oder Closure-Befugnis.
+
+## 8) Abschluss - Klare non-authorizing Boundary
+
+Dieser Contract ist ausschliesslich ein operativer, pruefbarer Konflikt-Adjudication-Rahmen fuer Pre-Live-Readiness als Decision-Input Surface.
+
+Er ist keine Autorisierung, kein Gate-Pass, keine Promotion, kein Go-Live und keine Runtime-Steuerung.
+
+Lokale Konfliktklassifikation, Anchor-Verweis oder Review-Pack-Vollstaendigkeit sind niemals gleichbedeutend mit Live-Freischaltung.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live contract for evidence conflict adjudication across candidate-specific first-live readiness inputs
- anchor the slice to existing Master V2 / First Live operational signoff, pre-live evidence, dry-run acceptance, abort/rollback/kill-switch readiness, escalation/exception intake, and evidence recency/snapshot coherence surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)