### PR TITLE
docs(ops): add master v2 first live pre live readiness review input packet contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md
@@ -1,0 +1,176 @@
+# MASTER V2 - First Live Pre-Live Readiness Review Input Packet Contract v1 (Docs-Only, Non-Authorizing)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+intent: Genau ein additiver docs-only Single-Topic-Contract fuer operativ pruefbare Pre-Live-Readiness-Review-Input-Packets im First-Live-Kontext
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1
+
+## 1) Titel + Status &#47; Intent
+
+Diese Spezifikation materialisiert genau einen operativen, docs-only Review-Input-Packet-Contract fuer First-Live Pre-Live-Readiness.
+
+Verbindliche Boundary:
+
+- non-authorizing
+- fail-closed
+- safety-first
+- evidence-bound
+
+Diese Spezifikation autorisiert nichts, schliesst kein Gate und erzeugt keine Live-Freischaltung.
+
+## 2) Zweck &#47; Scope &#47; Nicht-Ziele
+
+Zweck:
+
+- Readiness-Review-Input-Packets pro `candidate_id` in eine reproduzierbare, konservative Mindestform bringen
+- verteilte kanonische Evidence- und Gate-Surfaces in eine pruefbare Decision-Input-Lesehaltung binden
+- lokale Closure-Inflation durch explizite non-authorizing und fail-closed Regeln verhindern
+
+Scope:
+
+- genau ein kandidatenspezifischer Contract fuer die Struktur und Pruefbarkeit von Review-Input-Packets
+- Required Inputs, Preconditions, Required Evidence Pointers und eine operative Decision-Input-Checklist
+- verdict-surface nur als Sichtbarkeits- und Unresolved-Surface, niemals als Freigabe-Surface
+
+Nicht-Ziele:
+
+- keine Autorisierung, kein Approval, kein Gate-Pass, keine Promotion, kein Go-Live
+- keine Runtime-, Config-, Workflow-, Script-, Test- oder Code-Aenderungen
+- keine Evidenzerzeugung oder Mutation bestehender Artefakte
+- keine neue Prozessfamilie, keine neue Authority-Domaene, keine lokale Gate-Closure per Behauptung
+
+## 3) Begriffs- und Boundary-Definitionen
+
+- `candidate_id`: stabiler Kandidatenbezeichner, konsistent ueber alle referenzierten kanonischen Pointer.
+- `review input packet`: strukturierte, pointer-basierte Zusammenstellung fuer Readiness-Review-Eingang; keine Entscheidungsausgabe.
+- `required evidence pointer`: explizite Referenz auf bestehende repo-kanonische Quelle; ohne Pointer keine belastbare Aussage.
+- `verdict surface`: lokale Sicht auf `ready for external review input` oder `unresolved`; nie Autorisierungs- oder Closure-Aussage.
+- `fail-closed`: bei `Missing`, `Partial`, `Unknown`, `Contradiction`, `Stale&#47;Unknown recency` gilt bindend `stop &#47; reject &#47; escalate`.
+- `non-authorizing boundary`: lokale Vollstaendigkeit des Packets bleibt rein vorbereitend und nicht freigabeaequivalent.
+
+Boundary-Lock:
+
+- keine upward-Aufloesung von Authority- oder Evidenzunklarheit
+- keine semantische Verdichtung zu impliziter Entscheidung
+- externe finale Entscheidungshoheit bleibt extern
+
+## 4) Inputs &#47; Preconditions &#47; Required Evidence Pointers
+
+Required Inputs (reuse-only, pointer-basiert):
+
+1. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+2. [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+3. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md)
+4. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md)
+5. [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+6. [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+7. [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+8. [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+9. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+10. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+11. [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+12. [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+
+Preconditions:
+
+- `candidate_id` ist eindeutig und in Ledger- sowie Cross-Gate-Surfaces konsistent auffindbar.
+- benoetigte Pointer-Klassen sind sichtbar oder explizit als offen markiert; nichts wird stillschweigend ergaenzt.
+- Authority-Boundary ist explizit non-authorizing und unveraendert.
+- jede lokale Review-Input-Aussage ist mindestens einem kanonischen Quellpointer zugeordnet.
+
+Required Evidence Pointer Set (Mindestklassen):
+
+- candidate identity und candidate continuity pointer
+- required-evidence coverage pointer je betroffenem Level `L1` bis `L5`
+- dry-run acceptance posture pointer
+- recency coherence pointer
+- conflict adjudication posture pointer
+- gate posture pointer
+- authority-boundary pointer
+- handoff traceability pointer
+
+## 5) Operativer Kernvertrag - Review-Input-Packet Decision-Input Matrix und Verdict-Surface
+
+| review packet dimension | required pointer condition | required review discipline | allowed local verdict-surface output | required decision-input field | fail-closed trigger |
+|---|---|---|---|---|---|
+| `Candidate identity integrity` | `candidate_id` ist in Candidate-Ledger und Cross-Gate-Index source-resolvable | keine Kandidatenfusion und keine implizite Uebernahme | `identity visible` oder `identity unresolved` | `candidate_id`, `identity_pointer_set` | fehlende oder widerspruechliche Kandidatenzuordnung |
+| `Evidence requirement coverage` | Required-Pointer-Klassen aus Evidence-Requirement sind sichtbar oder explizit als offen markiert | keine Annahme-basierte Auffuellung | `coverage visible` oder `coverage unresolved` | `required_pointer_classes`, `coverage_gap_flags` | `Missing` oder `Partial` ohne belastbaren Quellanker |
+| `Dry-run acceptance posture` | Dry-run-Lage ist pointer-basiert fuer denselben Candidate nachweisbar | keine Umdeutung von Aufnahmefaehigkeit in Freigabe | `dry-run posture visible` oder `dry-run posture unresolved` | `dry_run_pointer_refs`, `acceptance_boundary_note` | unklare oder widerspruechliche Dry-run-Lage |
+| `Recency and conflict coherence` | Recency- und Konflikt-Posture sind explizit pointer-gebunden | `stale` oder `unknown` nie als aktuell lesen | `coherence visible` oder `coherence unresolved` | `recency_pointer_refs`, `conflict_flags` | `Stale&#47;Unknown recency` oder `Contradiction` |
+| `Gate and authority boundary legibility` | Gate-Status- und Authority-Pointer sind explizit und nachvollziehbar | keine lokale Authority-Substitution | `boundary visible` oder `boundary unresolved` | `gate_posture_refs`, `authority_boundary_statement` | authority-unklar oder gate-unklar |
+| `Handoff traceability readiness` | Packet-Contract und Traceability-Matrix sind fuer den Fall pointer-gebunden | keine closure-nahe Formulierung im Review-Input-Packet | `packet ready for external review input` oder `packet blocked` | `traceability_links`, `explicit_non_claims_block`, `escalation_route_pointer` | fehlende Traceability oder implizite Freigabeaussage |
+
+Verbindliche Matrix-Regel:
+
+- lokale Verdict-Surface-Ausgaben duerfen nur Sichtbarkeit oder Unresolved-Lage ausdruecken; sie duerfen keine Autorisierungs- oder Gate-Closure-Behauptung enthalten.
+
+Decision-Input Surface Mindestinhalt:
+
+- `candidate_id`
+- `affected_levels_or_gates`
+- `pointer_inventory`
+- `coverage_and_ambiguity_flags`
+- `recency_and_conflict_posture`
+- `authority_boundary_statement`
+- `explicit_non_claims_block`
+- `escalation_route_pointer`
+
+## 6) Fail-Closed Stop &#47; Reject &#47; Escalate-Regeln
+
+Bindende Regeln:
+
+- `Missing` -> `stop &#47; reject &#47; escalate`
+- `Partial` -> keine Annahme-basierte Ergaenzung, `stop &#47; reject &#47; escalate`
+- `Unknown` -> keine lokale Aufloesung, `stop &#47; reject &#47; escalate`
+- `Contradiction` -> keine Mittelung oder lokale Priorisierung ohne kanonischen Anker, `stop &#47; reject &#47; escalate`
+- `Stale&#47;Unknown recency` -> nicht als aktuell interpretieren, `stop &#47; reject &#47; escalate`
+
+Escalation-Payload Mindestinhalt:
+
+- `candidate_id`
+- betroffene review packet dimension
+- betroffene pointer-klasse und quellsurface
+- konkreter fail-closed grund
+- explizite non-authorizing boundary-notiz
+
+Globale Stop-Regel:
+
+- sobald ein fail-closed Trigger aktiv ist, endet die lokale Review-Input-Packet-Bewertung ohne Upward-Interpretation.
+
+## 7) Traceability &#47; Cross-References auf bestehende repo-kanonische Ziele
+
+Kernreferenzen:
+
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+- [MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_CANDIDATE_EVIDENCE_BUNDLE_LEDGER_V1.md)
+- [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_PACKET_TRACEABILITY_MATRIX_V1.md)
+- [MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md](MASTER_V2_FIRST_LIVE_AUTHORITY_HANDOFF_BOUNDARY_LEDGER_V1.md)
+- [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+
+Traceability-Mindestdisziplin:
+
+- jede Review-Input- und Decision-Input-Aussage ist an mindestens einen Quellpointer gebunden
+- kein Pointer, keine Aussage
+- keine implizite Verdichtung zu Freigabe-, Pass-, Promotion- oder Go-Live-Behauptung
+
+## 8) Abschluss - Klare non-authorizing Boundary
+
+Dieser Contract ist ausschliesslich ein Review-Input-Packet-Rahmen fuer operative Pre-Live-Readiness-Pruefbarkeit.
+
+Er ist nicht:
+
+- keine Autorisierung
+- kein Gate-Pass
+- keine Promotion
+- kein Go-Live
+- keine Runtime-Steuerung
+
+Lokale Vollstaendigkeit dieses Review-Input-Packets ist niemals gleichbedeutend mit Live-Freischaltung oder Gate-Closure.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live readiness review input packet contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness evidence surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)