### PR TITLE
docs(ops): add master v2 first live pre live stale evidence revalidation handling contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md
@@ -1,0 +1,163 @@
+# MASTER V2 - First Live Pre-Live Stale Evidence Revalidation Handling Contract v1 (Docs-Only, Non-Authorizing)
+
+status: ACTIVE
+last_updated: 2026-04-20
+owner: Peak_Trade
+intent: Genau ein additiver docs-only Single-Topic-Contract fuer fail-closed, candidate-scoped Stale-Evidence-Quarantine und Revalidation-Handoff in der operativen Pre-Live-Readiness
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1
+
+## 1) Titel + Status / Intent
+
+Diese Spezifikation materialisiert genau eine neue Pre-Live-Readiness-Slice: die konservative Behandlung von `stale` Evidenzlagen vor jedem First-Live-Review-Eingang.
+
+Verbindliche Boundary:
+
+- docs-only
+- non-authorizing
+- fail-closed
+- safety-first
+- evidence-bound
+
+Diese Spezifikation autorisiert nichts, schliesst kein Gate und erteilt keine Live-Freischaltung.
+
+## 2) Zweck / Scope / Nicht-Ziele
+
+Zweck:
+
+- stale Evidenzlagen fruehzeitig in eine reproduzierbare Quarantine-Haltung ueberfuehren
+- lokale Umdeutung von `stale` zu "ausreichend aktuell" explizit verhindern
+- einen klaren Revalidation-Input fuer nachgelagerte externe Entscheidungs- und Review-Pfade bereitstellen
+
+Scope:
+
+- genau ein kandidatenspezifischer Contract fuer Stale-Evidence-Erkennung, Quarantine, Revalidation-Handoff und Review-Zulaessigkeit
+- Required Inputs, Preconditions, Revalidation-Matrix, fail-closed Regeln und Decision-Input-Mindestfelder
+- bindende Sprache fuer `stop / reject / escalate` bei ungeklaerter oder veralteter Evidenzlage
+
+Nicht-Ziele:
+
+- keine Autorisierung, kein Approval, kein Gate-Pass, keine Promotion, kein Go-Live
+- keine Runtime-, Config-, Workflow-, Script-, Test- oder Code-Aenderungen
+- keine Evidenzneuerzeugung, keine Evidenzmutation, keine neue Prozessfamilie
+- keine lokale Priorisierung gegen kanonische Recency-/Conflict-Lage
+
+## 3) Begriffe und Boundary-Definitionen
+
+- `stale evidence`: candidate-scoped Evidenzpointer mit sichtbarer Zeitnaehe, die fuer den betroffenen Readiness-Kontext nicht mehr als aktuell lesbar ist.
+- `quarantine`: bindende lokale Haltung, in der stale Pointer nur noch als blocker-Input gefuehrt werden.
+- `revalidation request`: pointer-basierter Handoff-Input, der externe Klaerung ermoeglicht, ohne lokale Entscheidungserweiterung.
+- `revalidation result posture`: zulaessig sind nur `revalidated_visible` oder `still_unresolved`.
+- `stale critical class`: Pointer-Klasse, deren stale Lage den lokalen Review-Eingang zwingend blockiert.
+
+Boundary-Lock:
+
+- stale Lage wird nie lokal "hochinterpretiert"
+- ohne sichtbaren, kanonisch rueckfuehrbaren Revalidation-Input bleibt die Lage blockiert
+- lokale Vollstaendigkeit in diesem Contract hat niemals Freigabecharakter
+
+## 4) Inputs / Preconditions / Required Pointer Surface
+
+Required Inputs (reuse-only, pointer-basiert):
+
+1. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+2. [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+3. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md)
+4. [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md)
+5. [MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md)
+6. [MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md)
+7. [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+
+Preconditions:
+
+- `candidate_id` ist ueber alle betroffenen Pointer-Surfaces stabil und eindeutig.
+- stale Markierungen sind source-sichtbar und nicht nur textuell behauptet.
+- authority boundary bleibt unveraendert extern; lokal keine Freigabeaussage.
+- jede lokale Bewertung ist auf mindestens einen kanonischen Quellpointer rueckfuehrbar.
+
+Required Pointer Surface (pro stale Befund):
+
+- `candidate_id`
+- `level_or_gate_context` (`L1` bis `L5` oder expliziter Gate-Kontext)
+- `pointer_class`
+- `source_pointer`
+- `observed_recency_state` (`fresh`, `stale`, `unknown`)
+- `stale_criticality` (`critical`, `non_critical`)
+- `quarantine_state` (`active`, `cleared`)
+- `revalidation_request_pointer` (oder explizit `none`)
+- `non_authorizing_boundary_note`
+
+## 5) Operativer Kernvertrag - Stale Handling und Revalidation Matrix
+
+| stale scenario | minimum pointer condition | mandatory local handling | allowed local output | required handoff fields | fail-closed trigger |
+|---|---|---|---|---|---|
+| `Stale in critical class` | stale Pointer in required kritischer Klasse fuer denselben `candidate_id` | sofort Quarantine aktivieren, Review-Eingang blockieren | `stale critical blocked` | `candidate_id`, `pointer_class`, `source_pointer`, `quarantine_reason` | fehlender Quarantine-Eintrag oder closure-nahe Sprache |
+| `Stale with unresolved conflict` | stale plus offene Konfliktlage auf derselben Klasse oder benachbartem Kontext | keine lokale Priorisierung, direkt `stop / reject / escalate` | `stale conflict unresolved` | `conflict_pointer_refs`, `recency_state_map`, `escalation_route_pointer` | jede lokale Konfliktaufloesung ohne Anchor |
+| `Stale with revalidation request absent` | stale Befund ohne revalidation request pointer | keine Weiterleitung in Review-Packet, nur blocker-Status | `revalidation missing` | `missing_request_reason`, `candidate_id`, `affected_levels_or_gates` | Annahme-basierte Weiterfuehrung ohne Request |
+| `Stale with visible revalidation request` | stale Befund plus tracebarer request pointer | Quarantine bleibt aktiv bis externe Rueckmeldung sichtbar ist | `revalidation pending` | `revalidation_request_pointer`, `timestamp_visibility_note`, `authority_boundary_note` | vorzeitige Aufhebung der Quarantine |
+| `Revalidation visible but still stale/unknown` | request und Rueckmeldung sichtbar, recency bleibt `stale` oder `unknown` | Quarantine nicht aufheben, erneute Eskalation | `still unresolved after revalidation` | `revalidation_result_pointer`, `remaining_ambiguity_flags` | Umdeutung in `fresh` ohne Quelle |
+| `Revalidation visible and fresh` | request und Rueckmeldung sichtbar, recency klar `fresh` und konfliktfrei | Quarantine auf `cleared` setzen, nur als Review-Input-Zulaessigkeit markieren | `revalidation visible for review input` | `clearance_pointer`, `freshness_basis_pointer`, `explicit_non_claims_block` | jede Form von Autorisierungs- oder Gate-Pass-Behauptung |
+
+Verbindliche Matrix-Regel:
+
+- Jede stale Lage bleibt blockierend, bis eine pointer-sichtbare Revalidation-Lage vorliegt, die stale/unknown nicht mehr traegt.
+
+## 6) Fail-Closed Stop / Reject / Escalate-Regeln
+
+Bindend fuer jede stale Lage:
+
+- `Missing` -> `stop / reject / escalate`
+- `Partial` -> keine Auffuellung durch Annahme, `stop / reject / escalate`
+- `Unknown` -> keine lokale Aufloesung, `stop / reject / escalate`
+- `Contradiction` -> keine lokale Mittelung/Priorisierung ohne kanonischen Anker, `stop / reject / escalate`
+- `Stale/Unknown recency` in kritischer Klasse -> `stop / reject / escalate`
+
+Globale Stop-Regel:
+
+- Sobald eine fail-closed Bedingung zutrifft, endet die lokale Review-Zulaessigkeitspruefung fuer den betroffenen Candidate ohne Upward-Interpretation.
+
+Escalation-Payload Mindestinhalt:
+
+- `candidate_id`
+- `affected_pointer_class`
+- `source_pointer`
+- `recency_state`
+- `quarantine_state`
+- konkreter fail-closed Grund
+- explizite non-authorizing boundary-notiz
+
+## 7) Decision-Input und Review-Pack Mindestinhalt
+
+Ein gueltiger stale-handling Decision-Input fuer nachgelagerte externe Stellen enthaelt mindestens:
+
+1. candidate-scoped stale inventory (alle betroffenen Pointer-Klassen)
+2. aktive Quarantine-Liste inklusive Blocker-Gruenden
+3. Revalidation-Request-Lage (`present` oder `missing`) mit Pointer-Trace
+4. Revalidation-Result-Posture (`revalidated_visible` oder `still_unresolved`)
+5. expliziten non-authorizing und non-closure language block
+
+Review-Pack-Zulaessigkeit in dieser Slice:
+
+- `zulaessig fuer externen Review-Eingang` nur wenn Quarantine fuer alle kritischen stale Klassen auf `cleared` steht und keine fail-closed Flags offen sind
+- diese Zulaessigkeit ist rein vorbereitend und keine Freigabeentscheidung
+
+## 8) Cross-References und Abschluss-Boundary
+
+Kernreferenzen:
+
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md)
+- [MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md](MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md)
+
+Dieser Contract ist ausschliesslich ein konservativer Stale-Evidence-Revalidation-Rahmen fuer Pre-Live-Readiness.
+
+Er ist nicht:
+
+- keine Autorisierung
+- kein Gate-Pass
+- keine Promotion
+- kein Go-Live
+- keine Runtime-Steuerung

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md
@@ -6,7 +6,7 @@ owner: Peak_Trade
 intent: Genau ein additiver docs-only Single-Topic-Contract fuer fail-closed, candidate-scoped Stale-Evidence-Quarantine und Revalidation-Handoff in der operativen Pre-Live-Readiness
 docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1
 
-## 1) Titel + Status / Intent
+## 1) Titel + Status &#47; Intent
 
 Diese Spezifikation materialisiert genau eine neue Pre-Live-Readiness-Slice: die konservative Behandlung von `stale` Evidenzlagen vor jedem First-Live-Review-Eingang.
 
@@ -20,7 +20,7 @@ Verbindliche Boundary:
 
 Diese Spezifikation autorisiert nichts, schliesst kein Gate und erteilt keine Live-Freischaltung.
 
-## 2) Zweck / Scope / Nicht-Ziele
+## 2) Zweck &#47; Scope &#47; Nicht-Ziele
 
 Zweck:
 
@@ -32,7 +32,7 @@ Scope:
 
 - genau ein kandidatenspezifischer Contract fuer Stale-Evidence-Erkennung, Quarantine, Revalidation-Handoff und Review-Zulaessigkeit
 - Required Inputs, Preconditions, Revalidation-Matrix, fail-closed Regeln und Decision-Input-Mindestfelder
-- bindende Sprache fuer `stop / reject / escalate` bei ungeklaerter oder veralteter Evidenzlage
+- bindende Sprache fuer `stop &#47; reject &#47; escalate` bei ungeklaerter oder veralteter Evidenzlage
 
 Nicht-Ziele:
 
@@ -55,7 +55,7 @@ Boundary-Lock:
 - ohne sichtbaren, kanonisch rueckfuehrbaren Revalidation-Input bleibt die Lage blockiert
 - lokale Vollstaendigkeit in diesem Contract hat niemals Freigabecharakter
 
-## 4) Inputs / Preconditions / Required Pointer Surface
+## 4) Inputs &#47; Preconditions &#47; Required Pointer Surface
 
 Required Inputs (reuse-only, pointer-basiert):
 
@@ -91,25 +91,25 @@ Required Pointer Surface (pro stale Befund):
 | stale scenario | minimum pointer condition | mandatory local handling | allowed local output | required handoff fields | fail-closed trigger |
 |---|---|---|---|---|---|
 | `Stale in critical class` | stale Pointer in required kritischer Klasse fuer denselben `candidate_id` | sofort Quarantine aktivieren, Review-Eingang blockieren | `stale critical blocked` | `candidate_id`, `pointer_class`, `source_pointer`, `quarantine_reason` | fehlender Quarantine-Eintrag oder closure-nahe Sprache |
-| `Stale with unresolved conflict` | stale plus offene Konfliktlage auf derselben Klasse oder benachbartem Kontext | keine lokale Priorisierung, direkt `stop / reject / escalate` | `stale conflict unresolved` | `conflict_pointer_refs`, `recency_state_map`, `escalation_route_pointer` | jede lokale Konfliktaufloesung ohne Anchor |
+| `Stale with unresolved conflict` | stale plus offene Konfliktlage auf derselben Klasse oder benachbartem Kontext | keine lokale Priorisierung, direkt `stop &#47; reject &#47; escalate` | `stale conflict unresolved` | `conflict_pointer_refs`, `recency_state_map`, `escalation_route_pointer` | jede lokale Konfliktaufloesung ohne Anchor |
 | `Stale with revalidation request absent` | stale Befund ohne revalidation request pointer | keine Weiterleitung in Review-Packet, nur blocker-Status | `revalidation missing` | `missing_request_reason`, `candidate_id`, `affected_levels_or_gates` | Annahme-basierte Weiterfuehrung ohne Request |
 | `Stale with visible revalidation request` | stale Befund plus tracebarer request pointer | Quarantine bleibt aktiv bis externe Rueckmeldung sichtbar ist | `revalidation pending` | `revalidation_request_pointer`, `timestamp_visibility_note`, `authority_boundary_note` | vorzeitige Aufhebung der Quarantine |
-| `Revalidation visible but still stale/unknown` | request und Rueckmeldung sichtbar, recency bleibt `stale` oder `unknown` | Quarantine nicht aufheben, erneute Eskalation | `still unresolved after revalidation` | `revalidation_result_pointer`, `remaining_ambiguity_flags` | Umdeutung in `fresh` ohne Quelle |
+| `Revalidation visible but still stale&#47;unknown` | request und Rueckmeldung sichtbar, recency bleibt `stale` oder `unknown` | Quarantine nicht aufheben, erneute Eskalation | `still unresolved after revalidation` | `revalidation_result_pointer`, `remaining_ambiguity_flags` | Umdeutung in `fresh` ohne Quelle |
 | `Revalidation visible and fresh` | request und Rueckmeldung sichtbar, recency klar `fresh` und konfliktfrei | Quarantine auf `cleared` setzen, nur als Review-Input-Zulaessigkeit markieren | `revalidation visible for review input` | `clearance_pointer`, `freshness_basis_pointer`, `explicit_non_claims_block` | jede Form von Autorisierungs- oder Gate-Pass-Behauptung |
 
 Verbindliche Matrix-Regel:
 
-- Jede stale Lage bleibt blockierend, bis eine pointer-sichtbare Revalidation-Lage vorliegt, die stale/unknown nicht mehr traegt.
+- Jede stale Lage bleibt blockierend, bis eine pointer-sichtbare Revalidation-Lage vorliegt, die stale&#47;unknown nicht mehr traegt.
 
-## 6) Fail-Closed Stop / Reject / Escalate-Regeln
+## 6) Fail-Closed Stop &#47; Reject &#47; Escalate-Regeln
 
 Bindend fuer jede stale Lage:
 
-- `Missing` -> `stop / reject / escalate`
-- `Partial` -> keine Auffuellung durch Annahme, `stop / reject / escalate`
-- `Unknown` -> keine lokale Aufloesung, `stop / reject / escalate`
-- `Contradiction` -> keine lokale Mittelung/Priorisierung ohne kanonischen Anker, `stop / reject / escalate`
-- `Stale/Unknown recency` in kritischer Klasse -> `stop / reject / escalate`
+- `Missing` -> `stop &#47; reject &#47; escalate`
+- `Partial` -> keine Auffuellung durch Annahme, `stop &#47; reject &#47; escalate`
+- `Unknown` -> keine lokale Aufloesung, `stop &#47; reject &#47; escalate`
+- `Contradiction` -> keine lokale Mittelung/Priorisierung ohne kanonischen Anker, `stop &#47; reject &#47; escalate`
+- `Stale&#47;Unknown recency` in kritischer Klasse -> `stop &#47; reject &#47; escalate`
 
 Globale Stop-Regel:
 


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live readiness slice for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)