### PR TITLE
docs(ops): add master v2 first live pre live candidate decision input contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md
@@ -1,0 +1,114 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live candidate decision-input surface required before a candidate-specific first-live readiness decision can be reviewed. It standardizes which decision inputs must be present, internally coherent, and traceable before any candidate can be treated as decision-ready.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace operator judgment, higher-authority signoff, or existing fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific pre-live decision-input completeness
+- evidence-bound decision-input normalization
+- traceable linkage to existing pre-live readiness artifacts
+- fail-closed handling for missing, stale, contradictory, partial, or exception-bound decision inputs
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- override by prose claim without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Candidate decision input**
+A bounded, candidate-specific input that materially affects whether a candidate may be treated as pre-live readiness-reviewable.
+
+**Decision-ready**
+A state in which the required decision-input classes are present, evidence-anchored, mutually non-contradictory or explicitly adjudicated, and not blocked by unresolved fail-closed conditions.
+
+**Decision-input gap**
+Any missing, stale, partial, contradictory, non-traceable, or exception-bound input that prevents decision-ready posture.
+
+## 5. Required decision-input classes
+
+A candidate decision-input packet must contain evidence-bound pointers for all of the following classes:
+
+1. Candidate identity and scope envelope
+2. Required evidence coverage posture across required pre-live classes
+3. Dry-run acceptance posture
+4. Abort&#47;rollback&#47;kill-switch readiness posture
+5. Exception&#47;escalation posture, if any
+6. Evidence recency&#47;snapshot coherence posture
+7. Evidence conflict posture and adjudication status
+8. Consolidated readiness-review input packet reference
+
+If any required class is absent, the candidate is not decision-ready.
+
+## 6. Minimum input requirements
+
+For each required class, the packet must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- snapshot or recency basis where relevant
+- contradiction or exception note where relevant
+- clear traceability to the upstream canonical artifact
+
+Free-text claims without anchored pointers are non-sufficient.
+
+## 7. Fail-closed rules
+
+The candidate must be treated as not decision-ready if any of the following holds:
+- one or more required decision-input classes are missing
+- any required input is marked Unknown, Partial, or Contradicted without closed adjudication
+- stale evidence remains unresolved under the applicable stale-evidence handling surface
+- snapshot incoherence prevents a stable candidate view
+- an exception or escalation remains intake-open without bounded disposition
+- dry-run acceptance is not established
+- abort&#47;rollback&#47;kill-switch readiness is not established
+
+In all such cases, the required outcome is stop &#47; escalate, not interpretive closure.
+
+## 8. Decision-input normalization rules
+
+The packet must normalize inputs so that:
+- statuses are candidate-specific, not portfolio-generic
+- upstream evidence references are preserved, not paraphrase-substituted
+- conflict disposition is reflected explicitly rather than implied
+- unresolved ambiguity is represented as blocking, not softened prose
+- stale evidence is represented using fail-closed posture, not optimistic carry-forward
+
+## 9. Reviewability boundary
+
+A decision-ready candidate under this contract is only review-input complete. That state means the candidate may enter bounded readiness review. It does not imply approval, activation, enablement, or live release.
+
+## 10. Operator handling
+
+If the packet is not decision-ready:
+- stop
+- record the blocking decision-input gap
+- route via the applicable escalation or exception intake surface where needed
+- require refreshed or adjudicated evidence before re-review
+
+If the packet is decision-ready:
+- hand off as bounded decision input into the next review step under the operational signoff procedure
+
+## 11. Non-authorizing boundary
+
+This contract is an evidence-bound input-completeness surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot convert missing or weak evidence into acceptance by narrative compression.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live candidate decision-input contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)