### PR TITLE
docs(ops): add master v2 first live pre live acceptance verdict input contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md
@@ -1,0 +1,117 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live acceptance-verdict input surface required before a candidate-specific first-live readiness verdict can be prepared for bounded review. It standardizes which verdict inputs must be present, evidence-anchored, and internally coherent before an acceptance-shaped conclusion may be formed as review input.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace higher-authority signoff, operator judgment, or fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific acceptance-verdict input completeness
+- evidence-bound verdict-input normalization
+- traceable linkage from candidate decision input to verdict input
+- fail-closed handling for missing, stale, contradictory, partial, or unresolved verdict inputs
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- narrative override without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Acceptance-verdict input**  
+A bounded, candidate-specific input used to prepare a reviewable acceptance-shaped verdict surface without implying authorization.
+
+**Verdict-input complete**  
+A state in which all required verdict-input classes are present, traceable, evidence-anchored, and not blocked by unresolved fail-closed conditions.
+
+**Acceptance-verdict gap**  
+Any missing, stale, contradictory, partial, non-traceable, or unresolved verdict input that prevents bounded verdict preparation.
+
+## 5. Required verdict-input classes
+
+A candidate acceptance-verdict input packet must contain evidence-bound pointers for all of the following classes:
+
+1. Candidate decision-input posture
+2. Required evidence coverage posture
+3. Dry-run acceptance posture
+4. Abort&#47;rollback&#47;kill-switch readiness posture
+5. Exception&#47;escalation disposition posture
+6. Evidence recency&#47;snapshot coherence posture
+7. Evidence conflict adjudication posture
+8. Candidate-specific blocking-gaps summary
+9. Bounded recommendation posture for review consumption
+
+If any required class is absent, the verdict input is not complete.
+
+## 6. Minimum verdict-input requirements
+
+For each required class, the packet must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- a clear blocking or non-blocking interpretation basis
+- contradiction, exception, or staleness note where relevant
+- traceability to the upstream canonical artifact
+
+Free-text optimism without anchored evidence is non-sufficient.
+
+## 7. Fail-closed rules
+
+The verdict input must be treated as non-complete if any of the following holds:
+- one or more required verdict-input classes are missing
+- any upstream candidate decision input remains non-ready
+- any required posture is Unknown, Partial, or Contradicted without closed adjudication
+- stale evidence remains unresolved
+- snapshot incoherence prevents a stable candidate view
+- an exception or escalation remains open without bounded disposition
+- dry-run acceptance is not established
+- abort&#47;rollback&#47;kill-switch readiness is not established
+
+In all such cases, the required outcome is stop &#47; escalate, not acceptance-shaped compression.
+
+## 8. Verdict-input normalization rules
+
+The packet must normalize inputs so that:
+- candidate-local blockers are explicit
+- upstream evidence references are preserved
+- unresolved ambiguity remains blocking
+- acceptance-shaped language is prohibited unless every required input class is verdict-complete
+- the recommendation posture remains bounded as review input, not approval
+
+## 9. Reviewability boundary
+
+A verdict-input complete candidate may enter bounded verdict review only. This does not imply approval, activation, enablement, deployment, or live release.
+
+## 10. Operator handling
+
+If the verdict input is not complete:
+- stop
+- record the blocking verdict-input gap
+- route via the applicable escalation or exception intake surface where needed
+- require refreshed, adjudicated, or completed evidence before re-review
+
+If the verdict input is complete:
+- hand off the bounded verdict-input packet into the next review step under the operational signoff procedure
+
+## 11. Non-authorizing boundary
+
+This contract defines an evidence-bound acceptance-verdict input surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot transform incomplete evidence into acceptance by prose.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live acceptance-verdict input contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)