### PR TITLE
docs(ops): add master v2 first live pre live readiness review pack contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md
@@ -1,0 +1,120 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live readiness-review pack surface required before a candidate-specific first-live readiness case may be handed into bounded review. It standardizes which artifacts, summaries, and evidence-bound references must be assembled into a review pack so that review can proceed on a traceable and fail-closed basis.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace operator judgment, signoff authority, or existing fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific readiness-review pack completeness
+- evidence-bound assembly of review inputs
+- traceable linkage across existing pre-live readiness surfaces
+- fail-closed handling for missing, stale, contradictory, partial, or unresolved review-pack components
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- narrative override without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Readiness-review pack**  
+A bounded, candidate-specific review assembly containing the minimum evidence-bound materials required for a first-live readiness review step.
+
+**Pack-complete**  
+A state in which all required review-pack components are present, traceable, evidence-anchored, and not blocked by unresolved fail-closed conditions.
+
+**Review-pack gap**  
+Any missing, stale, contradictory, partial, non-traceable, or unresolved component that prevents bounded review.
+
+## 5. Required review-pack components
+
+A candidate readiness-review pack must contain evidence-bound pointers for all of the following components:
+
+1. Candidate identity and scope envelope
+2. Required evidence coverage summary
+3. Dry-run acceptance summary
+4. Abort&#47;rollback&#47;kill-switch readiness summary
+5. Escalation&#47;exception disposition summary
+6. Evidence recency&#47;snapshot coherence summary
+7. Evidence conflict adjudication summary
+8. Candidate decision-input packet reference
+9. Acceptance-verdict input packet reference
+10. Candidate-specific blocker summary
+11. Candidate-specific review recommendation posture
+
+If any required component is absent, the review pack is not complete.
+
+## 6. Minimum pack requirements
+
+For each required component, the pack must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- a clear blocking or non-blocking interpretation basis
+- contradiction, exception, or staleness note where relevant
+- traceability to the upstream canonical artifact
+
+Free-text packaging without anchored evidence is non-sufficient.
+
+## 7. Fail-closed rules
+
+The review pack must be treated as non-complete if any of the following holds:
+- one or more required components are missing
+- any upstream decision-input or verdict-input surface remains non-complete
+- any required posture is Unknown, Partial, or Contradicted without closed adjudication
+- stale evidence remains unresolved
+- snapshot incoherence prevents a stable candidate view
+- an exception or escalation remains open without bounded disposition
+- dry-run acceptance is not established
+- abort&#47;rollback&#47;kill-switch readiness is not established
+
+In all such cases, the required outcome is stop &#47; escalate, not review-pack closure by prose.
+
+## 8. Review-pack normalization rules
+
+The pack must normalize materials so that:
+- candidate-local blockers are explicit
+- upstream evidence references are preserved
+- unresolved ambiguity remains blocking
+- summaries do not replace underlying evidence anchors
+- recommendation posture remains bounded as review input, not approval
+
+## 9. Reviewability boundary
+
+A pack-complete candidate may enter bounded readiness review only. This does not imply approval, activation, enablement, deployment, or live release.
+
+## 10. Operator handling
+
+If the review pack is not complete:
+- stop
+- record the blocking review-pack gap
+- route via the applicable escalation or exception intake surface where needed
+- require refreshed, adjudicated, or completed evidence before re-review
+
+If the review pack is complete:
+- hand off the bounded review pack into the next review step under the operational signoff procedure
+
+## 11. Non-authorizing boundary
+
+This contract defines an evidence-bound readiness-review pack surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot transform incomplete evidence into approval by narrative compression.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live readiness review-pack contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)