### PR TITLE
docs(ops): add master v2 first live pre live exception resolution adjudication contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1.md
@@ -1,0 +1,125 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live exception-resolution adjudication surface required before a candidate-specific first-live readiness case may treat an exception as bounded, reviewable, and dispositioned for downstream consumption.
+
+This contract standardizes how candidate-specific exceptions are represented, evidenced, adjudicated, and either closed as bounded inputs or left blocking under fail-closed posture.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace higher-authority signoff, operator judgment, or existing fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific exception identification and adjudication posture
+- evidence-bound exception-resolution inputs
+- traceable linkage between exception intake, evidence surfaces, and downstream review inputs
+- fail-closed handling for unresolved, weakly evidenced, stale, contradictory, or partially dispositioned exceptions
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- narrative override without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Exception**
+A candidate-specific deviation, incompleteness, anomaly, or boundary condition requiring explicit bounded intake and adjudication before downstream readiness review may treat it as non-implicit.
+
+**Exception-resolution adjudication**
+The evidence-bound process of determining whether an identified exception remains blocking, becomes bounded with explicit disposition, or requires escalation without closure.
+
+**Adjudication-complete**
+A state in which the exception has a traceable intake basis, evidence anchors, disposition rationale, and explicit blocking or non-blocking posture, with no unresolved fail-closed conditions.
+
+**Exception-resolution gap**
+Any missing, stale, contradictory, partial, non-traceable, or unresolved exception input that prevents adjudication-complete posture.
+
+## 5. Required exception adjudication classes
+
+For each candidate-specific exception, the adjudication surface must contain evidence-bound pointers for all of the following classes:
+
+1. Exception identity and candidate binding
+2. Exception intake source and boundary classification
+3. Affected readiness surfaces
+4. Evidence basis supporting the exception description
+5. Recency and snapshot coherence posture
+6. Conflict posture and adjudication dependencies
+7. Proposed bounded disposition
+8. Residual blocking risk summary
+9. Escalation requirement, if any
+10. Final adjudication state for downstream consumption
+
+If any required class is absent, the exception is not adjudication-complete.
+
+## 6. Minimum adjudication requirements
+
+For each required class, the adjudication surface must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- a clear blocking or non-blocking interpretation basis
+- contradiction, exception, or staleness note where relevant
+- traceability to the upstream canonical artifact
+
+Free-text exception narratives without anchored evidence are non-sufficient.
+
+## 7. Fail-closed rules
+
+The exception must be treated as unresolved and blocking if any of the following holds:
+- one or more required adjudication classes are missing
+- the intake basis is unclear or non-traceable
+- the evidence basis is stale, partial, unknown, or contradictory without closed adjudication
+- snapshot incoherence prevents a stable candidate view
+- the affected readiness surface cannot be bounded
+- the proposed disposition lacks explicit residual-risk treatment
+- escalation is required but remains open without bounded disposition
+
+In all such cases, the required outcome is stop &#47; escalate, not exception closure by prose.
+
+## 8. Adjudication normalization rules
+
+The adjudication surface must normalize exception handling so that:
+- candidate-local impact is explicit
+- upstream evidence references are preserved
+- unresolved ambiguity remains blocking
+- bounded disposition is separated from approval language
+- residual risk is explicit, not implied
+- exception closure cannot be inferred from missing escalation data
+
+## 9. Downstream consumption boundary
+
+An adjudication-complete exception may be consumed as bounded downstream input by candidate decision input, acceptance-verdict input, and readiness-review pack surfaces. This does not imply approval, activation, enablement, deployment, or live release.
+
+## 10. Operator handling
+
+If the exception is not adjudication-complete:
+- stop
+- record the blocking exception-resolution gap
+- route via the applicable escalation path
+- require refreshed, adjudicated, or completed evidence before re-review
+
+If the exception is adjudication-complete:
+- hand off the bounded adjudication result into the relevant downstream readiness surfaces
+
+## 11. Non-authorizing boundary
+
+This contract defines an evidence-bound exception-resolution adjudication surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot transform unresolved exceptions into acceptance by narrative compression.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live exception-resolution adjudication contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)