### PR TITLE
docs(ops): add master v2 first live pre live evidence staleness decision input contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_STALENESS_DECISION_INPUT_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_STALENESS_DECISION_INPUT_CONTRACT_V1.md
@@ -1,0 +1,124 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_STALENESS_DECISION_INPUT_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live evidence-staleness decision-input surface required before a candidate-specific first-live readiness case may treat stale evidence as bounded downstream input.
+
+This contract standardizes how stale evidence is represented, evaluated, and converted into candidate-specific decision input without implying acceptance, approval, or live authorization.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace operator judgment, higher-authority signoff, or existing fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific stale-evidence decision-input completeness
+- evidence-bound staleness posture for downstream review surfaces
+- traceable linkage from stale-evidence handling into decision-input and verdict-input surfaces
+- fail-closed handling for missing, unresolved, weakly evidenced, contradictory, or snapshot-incoherent staleness inputs
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- narrative override without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Stale evidence**  
+Candidate-specific evidence whose recency posture is insufficient for direct downstream use without explicit bounded treatment.
+
+**Staleness decision input**  
+A bounded, evidence-anchored representation of how stale evidence affects candidate-specific downstream readiness interpretation.
+
+**Decision-input complete**  
+A state in which all required staleness decision-input classes are present, traceable, and not blocked by unresolved fail-closed conditions.
+
+**Staleness decision-input gap**  
+Any missing, contradictory, partial, non-traceable, or unresolved input that prevents downstream use of stale-evidence posture.
+
+## 5. Required staleness decision-input classes
+
+A candidate-specific staleness decision-input packet must contain evidence-bound pointers for all of the following classes:
+
+1. Candidate identity and affected evidence binding
+2. Stale-evidence identification basis
+3. Recency and snapshot-coherence posture
+4. Revalidation or refresh posture
+5. Conflict posture, if any
+6. Exception or escalation dependency, if any
+7. Residual blocking-risk summary
+8. Downstream interpretation posture for decision-input consumers
+9. Final bounded staleness decision-input state
+
+If any required class is absent, the staleness decision input is not complete.
+
+## 6. Minimum decision-input requirements
+
+For each required class, the packet must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- a clear blocking or non-blocking interpretation basis
+- contradiction, exception, or staleness note where relevant
+- traceability to the upstream canonical artifact
+
+Free-text reassurance without anchored evidence is non-sufficient.
+
+## 7. Fail-closed rules
+
+The staleness decision input must be treated as unresolved and blocking if any of the following holds:
+- one or more required classes are missing
+- stale-evidence identification is unclear or non-traceable
+- recency or snapshot posture remains incoherent
+- refresh or revalidation posture is missing where required
+- conflict or exception dependencies remain open without bounded disposition
+- residual blocking risk is omitted or weakly evidenced
+- the downstream interpretation posture is implied rather than explicitly bounded
+
+In all such cases, the required outcome is stop &#47; escalate, not stale-evidence compression by prose.
+
+## 8. Normalization rules
+
+The staleness decision-input surface must normalize inputs so that:
+- candidate-local stale-evidence impact is explicit
+- upstream evidence references are preserved
+- unresolved ambiguity remains blocking
+- revalidation posture is represented explicitly, not inferred
+- downstream interpretation remains bounded as decision input, not approval
+
+## 9. Downstream consumption boundary
+
+A complete staleness decision-input packet may be consumed by candidate decision-input, acceptance-verdict input, and readiness-review pack surfaces. This does not imply approval, activation, enablement, deployment, or live release.
+
+## 10. Operator handling
+
+If the staleness decision input is not complete:
+- stop
+- record the blocking staleness decision-input gap
+- route via the applicable stale-evidence, escalation, or exception surface where needed
+- require refreshed, revalidated, adjudicated, or completed evidence before re-review
+
+If the staleness decision input is complete:
+- hand off the bounded staleness decision-input packet into the relevant downstream readiness surfaces
+
+## 11. Non-authorizing boundary
+
+This contract defines an evidence-bound stale-evidence decision-input surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot transform stale evidence into acceptance by narrative compression.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_STALENESS_DECISION_INPUT_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live evidence-staleness decision-input contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)