### PR TITLE
docs(ops): add master v2 first live pre live signoff verdict packet contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_VERDICT_PACKET_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_VERDICT_PACKET_CONTRACT_V1.md
@@ -1,0 +1,130 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_VERDICT_PACKET_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live signoff-verdict packet surface required before a candidate-specific first-live readiness case may be handed into bounded final signoff review as a verdict-shaped packet.
+
+This contract standardizes how the signoff-verdict packet is assembled from already established pre-live readiness surfaces so that downstream signoff review receives a traceable, evidence-bound, and fail-closed verdict packet rather than an implied approval narrative.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace operator judgment, higher-authority signoff, or existing fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific signoff-verdict packet completeness
+- evidence-bound verdict packet assembly for downstream signoff review
+- traceable linkage from decision input, verdict input, review-pack, readiness-verdict, signoff-decision brief, signoff-review packet, exception, and staleness surfaces
+- fail-closed handling for missing, contradictory, stale, partial, or unresolved signoff-verdict packet components
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- narrative override without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_STALENESS_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DECISION_BRIEF_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_REVIEW_PACKET_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Signoff-verdict packet**  
+A bounded, candidate-specific packet that assembles the minimum evidence-bound materials required to present a signoff-oriented readiness verdict for downstream review consumption.
+
+**Verdict-packet complete**  
+A state in which all required signoff-verdict packet components are present, traceable, evidence-anchored, and not blocked by unresolved fail-closed conditions.
+
+**Verdict-packet gap**  
+Any missing, stale, contradictory, partial, non-traceable, or unresolved component that prevents bounded signoff-verdict presentation.
+
+## 5. Required signoff-verdict packet components
+
+A candidate-specific signoff-verdict packet must contain evidence-bound pointers for all of the following components:
+
+1. Candidate identity and scope envelope
+2. Candidate decision-input posture
+3. Acceptance-verdict input posture
+4. Readiness-review pack posture
+5. Readiness-verdict packet posture
+6. Signoff-decision brief posture
+7. Signoff-review packet posture
+8. Exception-resolution adjudication posture, if any
+9. Evidence-staleness decision-input posture, if any
+10. Candidate-specific blocker summary
+11. Candidate-specific residual-risk summary
+12. Bounded signoff-verdict statement for review consumption
+13. Explicit non-authorizing boundary statement
+
+If any required component is absent, the signoff-verdict packet is not complete.
+
+## 6. Minimum packet requirements
+
+For each required component, the packet must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- a clear blocking or non-blocking interpretation basis
+- contradiction, exception, or staleness note where relevant
+- traceability to the upstream canonical artifact
+
+Free-text verdict language without anchored evidence is non-sufficient.
+
+## 7. Fail-closed rules
+
+The signoff-verdict packet must be treated as non-complete if any of the following holds:
+- one or more required components are missing
+- any upstream decision-input, verdict-input, review-pack, readiness-verdict, signoff-brief, or signoff-review-packet surface remains non-complete
+- any required posture is Unknown, Partial, or Contradicted without closed adjudication
+- stale evidence remains unresolved where it materially affects signoff-verdict interpretation
+- exception handling remains open without bounded adjudication
+- residual blocking risk is omitted or weakly evidenced
+- the signoff-verdict statement implies approval, enablement, or live release
+
+In all such cases, the required outcome is stop &#47; escalate, not signoff-verdict closure by prose.
+
+## 8. Packet normalization rules
+
+The packet must normalize materials so that:
+- candidate-local blockers are explicit
+- upstream evidence references are preserved
+- unresolved ambiguity remains blocking
+- verdict language is bounded as signoff review input, not authorization
+- residual risk is explicit, not implied
+- summaries do not replace underlying evidence anchors
+
+## 9. Downstream consumption boundary
+
+A verdict-packet complete candidate may enter bounded downstream signoff review only. This does not imply approval, activation, enablement, deployment, or live release.
+
+## 10. Operator handling
+
+If the signoff-verdict packet is not complete:
+- stop
+- record the blocking verdict-packet gap
+- route via the applicable escalation or exception surface where needed
+- require refreshed, adjudicated, or completed evidence before re-review
+
+If the signoff-verdict packet is complete:
+- hand off the bounded verdict packet into the next review step under the operational signoff procedure
+
+## 11. Non-authorizing boundary
+
+This contract defines an evidence-bound signoff-verdict packet surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot transform incomplete or weak evidence into approval by narrative compression.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_VERDICT_PACKET_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live signoff-verdict packet contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)