### PR TITLE
docs(ops): add master v2 first live pre live signoff readiness decision record contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_READINESS_DECISION_RECORD_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_READINESS_DECISION_RECORD_CONTRACT_V1.md
@@ -1,0 +1,129 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_READINESS_DECISION_RECORD_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live signoff-readiness decision-record surface required before a candidate-specific first-live readiness case may be recorded as a bounded downstream signoff decision artifact.
+
+This contract standardizes how the decision record is assembled from already established pre-live readiness surfaces so that the resulting record remains traceable, evidence-bound, and fail-closed rather than becoming a prose-only claim of closure.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace operator judgment, higher-authority signoff, or existing fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific signoff-readiness decision-record completeness
+- evidence-bound decision-record assembly for downstream signoff consumption
+- traceable linkage from decision input, verdict input, review-pack, readiness-verdict, signoff brief, signoff-review packet, and signoff-verdict packet surfaces
+- fail-closed handling for missing, contradictory, stale, partial, or unresolved decision-record components
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- narrative override without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_STALENESS_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DECISION_BRIEF_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_REVIEW_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_VERDICT_PACKET_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Signoff-readiness decision record**  
+A bounded, candidate-specific record capturing the minimum evidence-bound materials required to preserve a downstream signoff readiness decision posture as a review artifact.
+
+**Record-complete**  
+A state in which all required decision-record components are present, traceable, evidence-anchored, and not blocked by unresolved fail-closed conditions.
+
+**Decision-record gap**  
+Any missing, stale, contradictory, partial, non-traceable, or unresolved component that prevents bounded recording of signoff-readiness posture.
+
+## 5. Required decision-record components
+
+A candidate-specific signoff-readiness decision record must contain evidence-bound pointers for all of the following components:
+
+1. Candidate identity and scope envelope
+2. Candidate decision-input posture
+3. Acceptance-verdict input posture
+4. Readiness-review pack posture
+5. Readiness-verdict packet posture
+6. Signoff-decision brief posture
+7. Signoff-review packet posture
+8. Signoff-verdict packet posture
+9. Candidate-specific blocker summary
+10. Candidate-specific residual-risk summary
+11. Bounded decision-record statement for downstream review consumption
+12. Explicit non-authorizing boundary statement
+
+If any required component is absent, the decision record is not complete.
+
+## 6. Minimum record requirements
+
+For each required component, the record must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- a clear blocking or non-blocking interpretation basis
+- contradiction, exception, or staleness note where relevant
+- traceability to the upstream canonical artifact
+
+Free-text recording without anchored evidence is non-sufficient.
+
+## 7. Fail-closed rules
+
+The decision record must be treated as non-complete if any of the following holds:
+- one or more required components are missing
+- any upstream decision-input, verdict-input, review-pack, readiness-verdict, signoff-brief, signoff-review-packet, or signoff-verdict-packet surface remains non-complete
+- any required posture is Unknown, Partial, or Contradicted without closed adjudication
+- stale evidence remains unresolved where it materially affects the recorded posture
+- residual blocking risk is omitted or weakly evidenced
+- the decision-record statement implies approval, enablement, or live release
+
+In all such cases, the required outcome is stop &#47; escalate, not decision-record closure by prose.
+
+## 8. Record normalization rules
+
+The record must normalize materials so that:
+- candidate-local blockers are explicit
+- upstream evidence references are preserved
+- unresolved ambiguity remains blocking
+- record language is bounded as downstream signoff review input, not authorization
+- residual risk is explicit, not implied
+- summaries do not replace underlying evidence anchors
+
+## 9. Downstream consumption boundary
+
+A record-complete candidate may enter bounded downstream signoff review only. This does not imply approval, activation, enablement, deployment, or live release.
+
+## 10. Operator handling
+
+If the decision record is not complete:
+- stop
+- record the blocking decision-record gap
+- route via the applicable escalation or exception surface where needed
+- require refreshed, adjudicated, or completed evidence before re-review
+
+If the decision record is complete:
+- hand off the bounded decision record into the next review step under the operational signoff procedure
+
+## 11. Non-authorizing boundary
+
+This contract defines an evidence-bound signoff-readiness decision-record surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot transform incomplete or weak evidence into approval by narrative compression.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_READINESS_DECISION_RECORD_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live signoff-readiness decision-record contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)