### PR TITLE
docs(ops): add master v2 first live pre live signoff traceability ledger contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_TRACEABILITY_LEDGER_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_TRACEABILITY_LEDGER_CONTRACT_V1.md
@@ -1,0 +1,135 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_TRACEABILITY_LEDGER_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live signoff-traceability-ledger surface required before a candidate-specific first-live readiness case may be preserved as a bounded downstream traceability artifact.
+
+This contract standardizes how signoff-linked pre-live readiness surfaces are traceably bound so that downstream review can reconstruct the candidate-specific path from decision inputs through signoff outcomes on an evidence-bound and fail-closed basis.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace operator judgment, higher-authority signoff, or existing fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific signoff traceability-ledger completeness
+- evidence-bound linkage across already established pre-live readiness and signoff surfaces
+- durable traceability from upstream decision inputs to downstream signoff outcomes
+- fail-closed handling for missing, contradictory, stale, partial, or unresolved traceability links
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- narrative override without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_STALENESS_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DECISION_BRIEF_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_REVIEW_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_VERDICT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_READINESS_DECISION_RECORD_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DISPOSITION_RECORD_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_OUTCOME_REGISTER_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Signoff traceability ledger**
+A bounded, candidate-specific artifact capturing the minimum evidence-bound link set required to trace downstream signoff materials back to upstream pre-live readiness surfaces.
+
+**Ledger-complete**
+A state in which all required traceability-ledger components are present, traceable, evidence-anchored, and not blocked by unresolved fail-closed conditions.
+
+**Traceability gap**
+Any missing, stale, contradictory, partial, non-traceable, or unresolved link that prevents bounded reconstruction of the candidate-specific signoff path.
+
+## 5. Required traceability-ledger components
+
+A candidate-specific signoff-traceability ledger entry must contain evidence-bound pointers for all of the following components:
+
+1. Candidate identity and scope envelope
+2. Candidate decision-input posture
+3. Acceptance-verdict input posture
+4. Readiness-review pack posture
+5. Readiness-verdict packet posture
+6. Signoff-decision brief posture
+7. Signoff-review packet posture
+8. Signoff-verdict packet posture
+9. Signoff-readiness decision-record posture
+10. Signoff-disposition record posture
+11. Signoff-outcome register posture
+12. Candidate-specific blocker summary
+13. Candidate-specific residual-risk summary
+14. Bounded traceability statement for downstream review consumption
+15. Explicit non-authorizing boundary statement
+
+If any required component is absent, the traceability-ledger entry is not complete.
+
+## 6. Minimum ledger requirements
+
+For each required component, the ledger entry must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- a clear blocking or non-blocking interpretation basis
+- contradiction, exception, or staleness note where relevant
+- traceability to the upstream canonical artifact
+
+Free-text linkage claims without anchored evidence are non-sufficient.
+
+## 7. Fail-closed rules
+
+The traceability-ledger entry must be treated as non-complete if any of the following holds:
+- one or more required components are missing
+- any upstream decision-input, verdict-input, review-pack, readiness-verdict, signoff-brief, signoff-review-packet, signoff-verdict-packet, signoff-readiness decision-record, signoff-disposition record, or signoff-outcome register surface remains non-complete
+- any required posture is Unknown, Partial, or Contradicted without closed adjudication
+- stale evidence remains unresolved where it materially affects traceability
+- residual blocking risk is omitted or weakly evidenced
+- the traceability statement implies approval, enablement, or live release
+
+In all such cases, the required outcome is stop &#47; escalate, not traceability closure by prose.
+
+## 8. Ledger normalization rules
+
+The ledger entry must normalize materials so that:
+- candidate-local blockers are explicit
+- upstream evidence references are preserved
+- unresolved ambiguity remains blocking
+- linkage language is bounded as downstream signoff review input, not authorization
+- residual risk is explicit, not implied
+- summaries do not replace underlying evidence anchors
+
+## 9. Downstream consumption boundary
+
+A ledger-complete candidate may enter bounded downstream signoff review only. This does not imply approval, activation, enablement, deployment, or live release.
+
+## 10. Operator handling
+
+If the traceability-ledger entry is not complete:
+- stop
+- record the blocking traceability gap
+- route via the applicable escalation or exception surface where needed
+- require refreshed, adjudicated, or completed evidence before re-review
+
+If the traceability-ledger entry is complete:
+- hand off the bounded traceability-ledger entry into the next review step under the operational signoff procedure
+
+## 11. Non-authorizing boundary
+
+This contract defines an evidence-bound signoff-traceability-ledger surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot transform incomplete or weak evidence into approval by narrative compression.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_TRACEABILITY_LEDGER_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live signoff-traceability-ledger contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)