### PR TITLE
docs(ops): add master v2 first live pre live signoff package index contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_PACKAGE_INDEX_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_PACKAGE_INDEX_CONTRACT_V1.md
@@ -1,0 +1,142 @@
+# MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_PACKAGE_INDEX_CONTRACT_V1
+
+Status: Canonical, additive, docs-only, non-authorizing, fail-closed.
+
+## 1. Purpose
+
+This contract defines the minimum pre-live signoff-package-index surface required before a candidate-specific first-live readiness case may be handed into bounded downstream signoff handling with an explicit package index.
+
+This contract standardizes how the package index is assembled from already established pre-live readiness and signoff surfaces so that downstream handling can locate, interpret, and reconstruct the candidate-specific package on a traceable, evidence-bound, and fail-closed basis.
+
+This contract does not authorize live enablement, does not close gates by assertion, and does not replace operator judgment, higher-authority signoff, or existing fail-closed controls.
+
+## 2. Scope
+
+In scope:
+- candidate-specific signoff-package-index completeness
+- evidence-bound package-index assembly for downstream signoff handling
+- traceable linkage from decision input, verdict input, review-pack, verdict-packet, signoff records, evidence index, and handoff surfaces
+- fail-closed handling for missing, contradictory, stale, partial, or unresolved package-index components
+
+Out of scope:
+- live authorization
+- runtime, workflow, config, or test changes
+- execution approval
+- narrative override without evidence anchors
+
+## 3. Required adjacent surfaces
+
+This contract assumes the presence of and must be read with:
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_OPERATIONAL_SIGNOFF_PROCEDURE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_DRY_RUN_ACCEPTANCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ABORT_ROLLBACK_KILL_SWITCH_READINESS_VERIFICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ESCALATION_EXCEPTION_INTAKE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_RECENCY_SNAPSHOT_COHERENCE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_CONFLICT_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_INPUT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_STALE_EVIDENCE_REVALIDATION_HANDLING_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_CANDIDATE_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_ACCEPTANCE_VERDICT_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_REVIEW_PACK_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EXCEPTION_RESOLUTION_ADJUDICATION_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_STALENESS_DECISION_INPUT_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DECISION_BRIEF_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_REVIEW_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_VERDICT_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_READINESS_DECISION_RECORD_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DISPOSITION_RECORD_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_OUTCOME_REGISTER_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_TRACEABILITY_LEDGER_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_EVIDENCE_INDEX_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_SUBMISSION_BUNDLE_CONTRACT_V1.md`
+
+## 4. Definitions
+
+**Signoff package index**
+A bounded, candidate-specific index capturing the minimum evidence-bound reference set required to navigate the signoff package used for downstream first-live readiness handling.
+
+**Index-complete**
+A state in which all required package-index components are present, traceable, evidence-anchored, and not blocked by unresolved fail-closed conditions.
+
+**Package-index gap**
+Any missing, stale, contradictory, partial, non-traceable, or unresolved component that prevents bounded downstream package navigation.
+
+## 5. Required package-index components
+
+A candidate-specific signoff-package index entry must contain evidence-bound pointers for all of the following components:
+
+1. Candidate identity and scope envelope
+2. Candidate decision-input surface reference
+3. Acceptance-verdict input surface reference
+4. Readiness-review pack surface reference
+5. Readiness-verdict packet surface reference
+6. Signoff-decision brief surface reference
+7. Signoff-review packet surface reference
+8. Signoff-verdict packet surface reference
+9. Signoff-readiness decision-record surface reference
+10. Signoff-disposition record surface reference
+11. Signoff-outcome register surface reference
+12. Signoff-traceability-ledger surface reference
+13. Signoff-evidence-index surface reference
+14. Signoff-handoff-packet surface reference
+15. Signoff-submission-bundle surface reference
+16. Candidate-specific blocker summary reference
+17. Candidate-specific residual-risk summary reference
+18. Explicit non-authorizing boundary reference
+
+If any required component is absent, the package index is not complete.
+
+## 6. Minimum index requirements
+
+For each required component, the index entry must provide:
+- a concrete evidence pointer
+- a candidate-specific status value
+- a clear blocking or non-blocking interpretation basis
+- contradiction, exception, or staleness note where relevant
+- traceability to the upstream canonical artifact
+
+Free-text package-index claims without anchored evidence are non-sufficient.
+
+## 7. Fail-closed rules
+
+The package index must be treated as non-complete if any of the following holds:
+- one or more required components are missing
+- any upstream decision-input, verdict-input, review-pack, readiness-verdict, signoff-brief, signoff-review-packet, signoff-verdict-packet, signoff-readiness decision-record, signoff-disposition record, signoff-outcome register, signoff-traceability-ledger, signoff-evidence-index, signoff-handoff-packet, or signoff-submission-bundle surface remains non-complete
+- any required posture is Unknown, Partial, or Contradicted without closed adjudication
+- stale evidence remains unresolved where it materially affects downstream package navigation
+- residual blocking risk is omitted or weakly evidenced
+- the index language implies approval, enablement, or live release
+
+In all such cases, the required outcome is stop &#47; escalate, not package-index closure by prose.
+
+## 8. Index normalization rules
+
+The index entry must normalize materials so that:
+- candidate-local blockers are explicit
+- upstream evidence references are preserved
+- unresolved ambiguity remains blocking
+- index language is bounded as downstream signoff handling input, not authorization
+- residual risk is explicit, not implied
+- index summaries do not replace underlying evidence anchors
+
+## 9. Downstream consumption boundary
+
+An index-complete candidate may enter bounded downstream signoff handling only. This does not imply approval, activation, enablement, deployment, or live release.
+
+## 10. Operator handling
+
+If the package index is not complete:
+- stop
+- record the blocking package-index gap
+- route via the applicable escalation or exception surface where needed
+- require refreshed, adjudicated, or completed evidence before re-review
+
+If the package index is complete:
+- hand off the bounded package index into the next review step under the operational signoff procedure
+
+## 11. Non-authorizing boundary
+
+This contract defines an evidence-bound signoff-package-index surface only. It cannot unlock live operation, cannot substitute for signoff authority, and cannot transform incomplete or weak evidence into approval by narrative compression.


### PR DESCRIPTION
## Summary
- add `MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_PACKAGE_INDEX_CONTRACT_V1.md`
- define a fail-closed, non-authorizing pre-live signoff-package-index contract for candidate-specific first-live readiness
- anchor the slice to existing Master V2 / First Live operational signoff and pre-live readiness surfaces

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)