### PR TITLE
docs(ops): add master v2 first live pre-live signoff delivery receipt contract v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DELIVERY_RECEIPT_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DELIVERY_RECEIPT_CONTRACT_V1.md
@@ -39,7 +39,7 @@ This contract depends on, and must remain consistent with, the following canonic
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_TRACEABILITY_LEDGER_CONTRACT_V1.md`
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_OUTCOME_REGISTER_CONTRACT_V1.md`
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DISPOSITION_RECORD_CONTRACT_V1.md`
-- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DELIVERABLE_MANIFEST_CONTRACT_V1.md`
+- signoff deliverable-manifest contract surface (when materialized in canonical inventory)
 
 ## 4. Delivery receipt intent
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DELIVERY_RECEIPT_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DELIVERY_RECEIPT_CONTRACT_V1.md
@@ -1,0 +1,302 @@
+# MASTER V2 — First Live Pre-Live Signoff Delivery Receipt Contract v1
+
+Status: Canonical
+Type: Contract
+Scope: Pre-Live / First-Live / Signoff Readiness
+Authority: Non-authorizing
+Change mode: Additive / docs-only
+Version: v1
+
+## 1. Purpose
+
+This contract defines the minimum canonical receipt surface that records bounded downstream receipt of a pre-live signoff delivery package for a specific first-live candidate. It exists to confirm that a declared delivery was received as a candidate-specific, evidence-bound package and to preserve fail-closed receipt semantics without introducing any operational authorization, release approval, or live-enablement effect.
+
+## 2. Scope
+
+In scope:
+
+- candidate-specific receipt recording for a delivered pre-live signoff package
+- identity binding between delivered package, manifest, and package index surfaces
+- minimum receipt fields required for downstream handling, audit, and traceability
+- fail-closed handling when receipt evidence is incomplete, stale, conflicting, or ambiguous
+- normalization and boundary rules for downstream consumers
+
+Out of scope:
+
+- any live authorization, arming, enabling, launch approval, or release decision
+- any replacement of verdict, review, adjudication, or disposition surfaces
+- any mutation of upstream evidence, manifests, bundles, ledgers, or registers
+- any operator shortcut that treats delivery receipt as signoff completion
+
+## 3. Upstream canonical dependencies
+
+This contract depends on, and must remain consistent with, the following canonical surfaces:
+
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_SUBMISSION_BUNDLE_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_PACKAGE_INDEX_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_EVIDENCE_INDEX_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_TRACEABILITY_LEDGER_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_OUTCOME_REGISTER_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DISPOSITION_RECORD_CONTRACT_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DELIVERABLE_MANIFEST_CONTRACT_V1.md`
+
+## 4. Delivery receipt intent
+
+The delivery receipt surface is a bounded acknowledgement that a named package instance was received for downstream review, custody, or controlled intake.
+
+It answers only these questions:
+
+- what candidate-specific package was received
+- from which declared upstream package surfaces that package was assembled
+- when receipt was recorded
+- by which bounded downstream recipient role or system receipt surface
+- whether receipt is complete, provisional, disputed, or rejected due to missing or invalid package identity
+
+It does not answer:
+
+- whether the package contents are sufficient for signoff
+- whether the underlying evidence is valid
+- whether a verdict is accepted
+- whether first-live may proceed
+
+## 5. Required receipt components
+
+A conforming delivery receipt must contain, at minimum, the following components:
+
+1. **receipt_id**
+   Stable candidate-specific receipt identifier.
+
+2. **candidate_id**
+   Stable identifier of the first-live candidate to which the receipt applies.
+
+3. **package_identity**
+   Declared package identity sufficient to bind the receipt to the delivered package instance.
+
+4. **submission_bundle_reference**
+   Canonical reference to the submission bundle surface used for the delivered package.
+
+5. **package_index_reference**
+   Canonical reference to the package index surface used for the delivered package.
+
+6. **deliverable_manifest_reference**
+   Canonical reference to the deliverable manifest surface declaring intended delivered components.
+
+7. **receipt_timestamp**
+   Timestamp at which downstream receipt was recorded.
+
+8. **receipt_actor_or_system**
+   Bounded receiving role, desk, function, or system surface that recorded receipt.
+
+9. **receipt_status**
+   Controlled receipt status indicating the state of intake.
+
+10. **integrity_or_completeness_observation**
+    Minimal bounded statement indicating whether the received package aligns with declared package identity and manifest expectations.
+
+11. **exception_or_dispute_reference**
+    Reference field used when receipt is provisional, disputed, or rejected.
+
+12. **non_authorizing_notice**
+    Explicit statement that receipt has no authorization effect.
+
+## 6. Minimum field requirements
+
+### 6.1 Candidate binding
+
+The receipt must bind to exactly one candidate context.
+
+Minimum required fields:
+
+- candidate_id
+- candidate_epoch or equivalent candidate-scoped time marker, if used upstream
+- package_identity
+- receipt_id
+
+If the candidate context cannot be uniquely determined, receipt must fail closed.
+
+### 6.2 Package identity binding
+
+The receipt must bind to a package identity that is consistent with upstream package surfaces.
+
+Minimum accepted identity elements should include enough information to distinguish the received package from any other package instance, for example:
+
+- package_id or package_label
+- package generation timestamp
+- bundle reference
+- package index reference
+- manifest reference
+
+If identity elements conflict, the receipt must not be normalized to “received cleanly”.
+
+### 6.3 Receiver binding
+
+The receipt must identify the receiving side sufficiently for audit and downstream handling.
+
+Minimum accepted receiver fields:
+
+- receiving role, desk, or system name
+- receipt timestamp
+- bounded receipt status
+
+Anonymous or unbound receipt statements are non-conforming.
+
+## 7. Allowed receipt statuses
+
+At minimum, the receipt status vocabulary must support:
+
+- `RECEIVED_COMPLETE`
+- `RECEIVED_PROVISIONAL`
+- `RECEIVED_DISPUTED`
+- `RECEIPT_REJECTED`
+
+Interpretation:
+
+- `RECEIVED_COMPLETE`: receipt recorded and package identity appears consistent with declared package surfaces
+- `RECEIVED_PROVISIONAL`: receipt recorded but one or more completeness or consistency concerns remain open
+- `RECEIVED_DISPUTED`: receipt recorded but identity, integrity, or manifest alignment is actively disputed
+- `RECEIPT_REJECTED`: receipt not accepted as a valid package intake event
+
+No other status may be treated as equivalent to downstream acceptance or signoff readiness.
+
+## 8. Completeness and integrity observation rules
+
+The receipt may record bounded observational statements regarding delivered-package completeness and integrity, but such statements must remain scoped to intake.
+
+Allowed examples include:
+
+- manifest-aligned on receipt
+- one declared component not present on receipt
+- package identity mismatch under investigation
+- receipt blocked pending exception resolution
+
+Not allowed:
+
+- “package approved”
+- “signoff complete”
+- “ready for live”
+- “launch accepted”
+
+Receipt observations must remain descriptive, not authorizing.
+
+## 9. Exception and dispute handling
+
+If receipt is provisional, disputed, or rejected, the receipt must include at least one bounded exception or dispute reference.
+
+Examples of acceptable reference targets:
+
+- exception adjudication record
+- evidence conflict adjudication record
+- stale evidence revalidation handling record
+- intake exception ticket or equivalent bounded downstream record
+
+A receipt with a non-final or disputed status but no linked exception handling surface is non-conforming.
+
+## 10. Fail-closed rules
+
+The delivery receipt must fail closed under any of the following conditions:
+
+- candidate context is missing or ambiguous
+- package identity cannot be bound to submission bundle, package index, and manifest surfaces
+- receipt timestamp is missing
+- receiver identity is absent
+- receipt status is missing or outside controlled vocabulary
+- manifest alignment is asserted without enough declared evidence to support that observation
+- conflicting package identity claims exist
+- receipt text implies approval, authorization, readiness, enablement, or launch permission
+
+When fail-closed is triggered, the package may still be physically present, but the canonical receipt surface must not represent the intake as valid complete receipt.
+
+## 11. Normalization rules
+
+Downstream consumers must normalize this surface using the following rules:
+
+- delivery receipt is an intake acknowledgment only
+- delivery receipt is not equivalent to review completion
+- delivery receipt is not equivalent to verdict acceptance
+- delivery receipt is not equivalent to disposition closure
+- delivery receipt is not equivalent to authorization
+- provisional or disputed receipt must remain visibly non-final
+- rejected receipt must remain non-consumable as completed intake
+
+Consumers must preserve distinction between “delivered”, “received”, “reviewed”, and “approved”.
+
+## 12. Downstream consumption boundary
+
+This surface may be consumed by:
+
+- downstream review intake tracking
+- traceability ledgers
+- package custody or handoff records
+- audit and evidence-chain reconstruction
+- bounded exception handling workflows
+
+This surface must not be consumed as authority for:
+
+- enabling live
+- arming execution
+- changing release status
+- suppressing missing-evidence findings
+- overriding upstream conflicts or staleness findings
+
+## 13. Operator handling
+
+Operators must treat delivery receipt as a narrow, candidate-specific intake record.
+
+Operators must not:
+
+- collapse receipt into signoff
+- infer readiness from package arrival alone
+- bypass unresolved exceptions because a package was received
+- use delivery receipt as substitute for review packet, verdict packet, or disposition record
+
+Where package arrival and canonical receipt diverge, operators must prefer fail-closed canonical receipt semantics.
+
+## 14. Non-authorizing boundary
+
+This contract is strictly non-authorizing.
+
+No conforming delivery receipt created under this contract may be interpreted as:
+
+- permission to proceed to first-live
+- signoff approval
+- release approval
+- authorization to enable or arm any runtime pathway
+- waiver of missing, stale, conflicting, or unresolved evidence
+
+Any downstream interpretation that grants such effect is out of contract.
+
+## 15. Minimal example shape
+
+A minimal conforming shape should include:
+
+- receipt_id
+- candidate_id
+- package_identity
+- submission_bundle_reference
+- package_index_reference
+- deliverable_manifest_reference
+- receipt_timestamp
+- receipt_actor_or_system
+- receipt_status
+- integrity_or_completeness_observation
+- exception_or_dispute_reference (required when non-final)
+- non_authorizing_notice
+
+This shape is illustrative and non-executable.
+
+## 16. Acceptance criteria for this contract surface
+
+This contract surface is acceptable only if it:
+
+- remains additive and docs-only
+- is candidate-specific and evidence-bound
+- preserves a narrow intake-only meaning
+- clearly separates delivered vs received vs reviewed vs approved semantics
+- defines fail-closed handling for ambiguity, incompleteness, and dispute
+- contains an explicit non-authorizing boundary
+- does not introduce any live-enablement semantics
+
+## 17. Canonical summary
+
+The pre-live signoff delivery receipt contract defines the bounded, candidate-specific, non-authorizing intake acknowledgment surface for a delivered signoff package. It records receipt identity, receiver binding, and intake status while preserving strict fail-closed semantics and forbidding any interpretation of receipt as approval, readiness, or authorization.


### PR DESCRIPTION
## Summary
- add MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_DELIVERY_RECEIPT_CONTRACT_V1
- keep the slice docs-only, additive, non-authorizing, fail-closed, and evidence-bound
- define bounded downstream receipt semantics for delivered pre-live signoff packages

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)