### PR TITLE
harden(execution): fail closed bounded pilot entry

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;CANARY_LIVE_ENTRY_CRITERIA.md` — Bounded-Pilot fail-closed Handoff (`PT_BOUNDED_PILOT_INVOKED_FROM_GATE`, `PT_LIVE_CONFIRM_TOKEN`), Abgrenzung `--dry-run` ohne Gate-Env, Go/No-Go-Konsistenz `TRADE_READY` vs. `dry_run`; Companion zu `src/execution/live_session.py` / `src/core/environment.py` (Drift-Regeln `execution-layer`, `core-environment`); **keine** zusätzliche Live-Freigabe.
+
 - 2026-04-18 — `docs&#47;ops&#47;registry&#47;TRUTH_BRANCH_PROTECTION.md` auf Single-Writer-Contract präzisiert (`ensure_truth_branch_protection.py --apply` fail-closed blockiert; kanonischer Writer `scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --apply`); dieser Eintrag dokumentiert den verpflichtenden Companion-Nachzug gemäß `truth-branch-protection-canonical`.
 
 - 2026-04-16: `docs&#47;ops&#47;specs&#47;LEVELUP_V0_CANONICAL_SURFACE.md` neu — kanonische Ops-/Spec-Oberfläche für LevelUp v0 (Manifest-/IO-/CLI; keine neue Autorität); Querverweise in `docs&#47;KNOWLEDGE_BASE_INDEX.md`, `docs&#47;ops&#47;README.md`, `docs&#47;ops&#47;RUNBOOK_INDEX.md`; Truth-Map-Abschnitt „Canonical: LevelUp v0“; zunächst ohne `docs_truth_map.yaml`-Regel; keine Runtime-/E2E-Ausweitung.

--- a/docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md
+++ b/docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md
@@ -76,6 +76,8 @@ Vor Start sind **numerische** Obergrenzen definiert und technisch/operativ durch
 - **Confirm-Token** (oder gleichwertiges zweites Kontrollsignal): kein „aus Versehen live“.
 - **Dry-Run / Shadow / Testnet** (je nach Peak_Trade-Setup): **nachweislich** erfolgreich für **dieselbe** Strategie-Version und **dieselbe** Integrationskette **vor** Canary-Live (Evidenz dokumentiert).
 
+**Technischer Bounded-Pilot-Eintritt (Peak_Trade-Repo, fail-closed):** Nach grünem `pilot_go_no_go_eval_v1` startet `scripts&#47;ops&#47;run_bounded_pilot_session.py` die Session nur über einen Subprozess von `scripts&#47;run_execution_session.py --mode bounded_pilot` und setzt dabei `PT_BOUNDED_PILOT_INVOKED_FROM_GATE=1` sowie `PT_LIVE_CONFIRM_TOKEN` auf den kanonischen Wert aus `src&#47;core&#47;environment.py` (gleiche Bedeutung wie `LIVE_CONFIRM_TOKEN`); ohne diese Umgebungsvariablen darf kein echter bounded-pilot-Lauf beginnen (`--dry-run` bleibt ohne sie möglich). Im automatisierten Go/No-Go darf `TRADE_READY` u. a. nicht zusammen mit `policy_state.dry_run == true` oder sonst widersprüchlicher Posture als „grün“ durchgereicht werden.
+
 ### 4. Daten- und Zeit-Sicherheit
 
 - **Live-Marktdaten** sind **aktuell** (kein veralteter Snapshot als Entscheidungsgrundlage).

--- a/scripts/ops/pilot_go_no_go_eval_v1.py
+++ b/scripts/ops/pilot_go_no_go_eval_v1.py
@@ -37,10 +37,13 @@ def _get(payload: dict[str, Any], *keys: str, default: Any = None) -> Any:
 
 
 def _eval_row_1_safety_gates(payload: dict[str, Any]) -> str:
-    """Safety Gates: enabled/armed/confirm-token/dry-run explicit?"""
+    """Safety Gates: enabled/armed/confirm-token/dry-run explicit (typed, fail-closed)."""
     ps = _get(payload, "policy_state") or {}
-    if not all(k in ps for k in ("enabled", "armed", "dry_run", "confirm_token_required")):
-        return "UNKNOWN"
+    for key in ("enabled", "armed", "dry_run", "confirm_token_required"):
+        if key not in ps:
+            return "UNKNOWN"
+        if not isinstance(ps[key], bool):
+            return "UNKNOWN"
     return "PASS"
 
 
@@ -53,11 +56,25 @@ def _eval_row_2_kill_switch(payload: dict[str, Any]) -> str:
 
 
 def _eval_row_3_policy_posture(payload: dict[str, Any]) -> str:
-    """Policy Posture: current policy action visible?"""
+    """Policy Posture: action visible and internally consistent (fail-closed for TRADE_READY)."""
     ps = _get(payload, "policy_state") or {}
     action = ps.get("action")
     if action not in ("NO_TRADE", "TRADE_READY"):
         return "UNKNOWN"
+    if action == "NO_TRADE":
+        return "PASS"
+    # TRADE_READY must not be vacuous: require explicit real-order posture signals.
+    if ps.get("kill_switch_active") is True:
+        return "FAIL"
+    if ps.get("blocked") is not False:
+        return "FAIL"
+    if ps.get("enabled") is not True:
+        return "FAIL"
+    if ps.get("armed") is not True:
+        return "FAIL"
+    dry_run = ps.get("dry_run")
+    if dry_run is not False:
+        return "FAIL"
     return "PASS"
 
 

--- a/scripts/ops/run_bounded_pilot_session.py
+++ b/scripts/ops/run_bounded_pilot_session.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -143,7 +144,17 @@ def main() -> int:
         "--position-fraction",
         str(args.position_fraction),
     ]
-    result = subprocess.run(cmd, cwd=repo_root)
+    from src.core.environment import (
+        LIVE_CONFIRM_TOKEN,
+        PT_BOUNDED_PILOT_INVOKED_FROM_GATE,
+        PT_LIVE_CONFIRM_TOKEN_ENV,
+    )
+
+    child_env = os.environ.copy()
+    child_env[PT_BOUNDED_PILOT_INVOKED_FROM_GATE] = "1"
+    child_env[PT_LIVE_CONFIRM_TOKEN_ENV] = LIVE_CONFIRM_TOKEN
+
+    result = subprocess.run(cmd, cwd=repo_root, env=child_env)
     return result.returncode
 
 

--- a/scripts/run_execution_session.py
+++ b/scripts/run_execution_session.py
@@ -295,6 +295,19 @@ WICHTIG: Shadow/Testnet senden keine echten Orders. Modus bounded_pilot kann nac
     args = parser.parse_args()
     _ensure_bounded_pilot_events_enabled(args)
 
+    if args.mode == "bounded_pilot" and not args.dry_run:
+        from src.core.environment import PT_BOUNDED_PILOT_INVOKED_FROM_GATE
+
+        if os.environ.get(PT_BOUNDED_PILOT_INVOKED_FROM_GATE) != "1":
+            print(
+                "ERR: bounded_pilot Ausführung (ohne --dry-run) erfordert "
+                f"{PT_BOUNDED_PILOT_INVOKED_FROM_GATE}=1 nach kanonischem Gate-Handoff "
+                "(z. B. scripts/ops/run_bounded_pilot_session.py). "
+                "Direkter Start verhindert implizite Live-Freischaltung.",
+                file=sys.stderr,
+            )
+            return 1
+
     # Strategy-Liste?
     if args.list_strategies:
         list_available_strategies()

--- a/src/core/environment.py
+++ b/src/core/environment.py
@@ -44,6 +44,11 @@ class TradingEnvironment(str, Enum):
 # Muss explizit in der Config gesetzt werden
 LIVE_CONFIRM_TOKEN = "I_KNOW_WHAT_I_AM_DOING"
 
+# Bounded-pilot session handoff: set only by scripts/ops/run_bounded_pilot_session.py (subprocess env).
+PT_BOUNDED_PILOT_INVOKED_FROM_GATE = "PT_BOUNDED_PILOT_INVOKED_FROM_GATE"
+# Operator must export the canonical confirm token for bounded_pilot entry (no implicit injection in runner).
+PT_LIVE_CONFIRM_TOKEN_ENV = "PT_LIVE_CONFIRM_TOKEN"
+
 
 @dataclass
 class EnvironmentConfig:

--- a/src/execution/live_session.py
+++ b/src/execution/live_session.py
@@ -240,6 +240,35 @@ class SessionSetupError(Exception):
     pass
 
 
+def require_bounded_pilot_handoff_env() -> str:
+    """
+    Fail-closed: bounded_pilot LiveSessionRunner may only start after canonical gate handoff.
+
+    ``scripts/ops/run_bounded_pilot_session.py`` sets these in the subprocess environment
+    after Go/No-Go is GREEN. Direct ``run_execution_session --mode bounded_pilot`` must
+    not implicitly synthesize confirm/live posture.
+    """
+    from ..core.environment import (
+        LIVE_CONFIRM_TOKEN,
+        PT_BOUNDED_PILOT_INVOKED_FROM_GATE,
+        PT_LIVE_CONFIRM_TOKEN_ENV,
+    )
+
+    if os.environ.get(PT_BOUNDED_PILOT_INVOKED_FROM_GATE) != "1":
+        raise SessionSetupError(
+            "bounded_pilot erfordert PT_BOUNDED_PILOT_INVOKED_FROM_GATE=1 im Prozess-Umfeld "
+            "(nach grünen Gates z. B. über scripts/ops/run_bounded_pilot_session.py). "
+            "Direkter CLI-Start ohne Gate-Handoff ist nicht erlaubt."
+        )
+    confirm = os.environ.get(PT_LIVE_CONFIRM_TOKEN_ENV)
+    if confirm != LIVE_CONFIRM_TOKEN:
+        raise SessionSetupError(
+            f"bounded_pilot erfordert Umgebungsvariable {PT_LIVE_CONFIRM_TOKEN_ENV!r} "
+            f"mit dem kanonischen Governance-Confirm-Token (siehe LIVE_CONFIRM_TOKEN)."
+        )
+    return confirm
+
+
 class SessionRuntimeError(Exception):
     """Exception bei Fehlern während der Session-Ausführung."""
 
@@ -491,11 +520,7 @@ class LiveSessionRunner:
 
         try:
             # Lazy imports um Circular Imports zu vermeiden
-            from ..core.environment import (
-                EnvironmentConfig,
-                LIVE_CONFIRM_TOKEN,
-                TradingEnvironment,
-            )
+            from ..core.environment import EnvironmentConfig, TradingEnvironment
             from ..live.safety import SafetyGuard
             from ..live.risk_limits import LiveRiskLimits
 
@@ -516,13 +541,14 @@ class LiveSessionRunner:
                     testnet_dry_run=True,
                 )
             elif session_config.mode == "bounded_pilot":
+                confirm_token = require_bounded_pilot_handoff_env()
                 env_config = EnvironmentConfig(
                     environment=TradingEnvironment.LIVE,
                     enable_live_trading=True,
                     bounded_pilot_mode=True,
                     live_mode_armed=True,  # Gate 2: bounded_pilot has governance approval
                     live_dry_run_mode=False,  # bounded_pilot: governance-approved actual order path
-                    confirm_token=LIVE_CONFIRM_TOKEN,  # bounded_pilot: operator-confirmed actual submit path
+                    confirm_token=confirm_token,
                     testnet_dry_run=False,
                 )
             else:  # testnet
@@ -1102,4 +1128,5 @@ __all__ = [
     "LiveModeNotAllowedError",
     "SessionSetupError",
     "SessionRuntimeError",
+    "require_bounded_pilot_handoff_env",
 ]

--- a/src/execution/live_session.py
+++ b/src/execution/live_session.py
@@ -541,14 +541,14 @@ class LiveSessionRunner:
                     testnet_dry_run=True,
                 )
             elif session_config.mode == "bounded_pilot":
-                confirm_token = require_bounded_pilot_handoff_env()
+                _bp_confirm = require_bounded_pilot_handoff_env()
                 env_config = EnvironmentConfig(
                     environment=TradingEnvironment.LIVE,
                     enable_live_trading=True,
                     bounded_pilot_mode=True,
                     live_mode_armed=True,  # Gate 2: bounded_pilot has governance approval
                     live_dry_run_mode=False,  # bounded_pilot: governance-approved actual order path
-                    confirm_token=confirm_token,
+                    confirm_token=_bp_confirm,
                     testnet_dry_run=False,
                 )
             else:  # testnet

--- a/src/governance/policy_critic/rules.py
+++ b/src/governance/policy_critic/rules.py
@@ -11,6 +11,29 @@ from typing import List, Optional
 from .models import Evidence, Severity, Violation
 
 
+POLICY_CRITIC_TEST_PATH_PREFIX = "tests/governance/policy_critic/"
+
+
+def iter_diff_added_lines(diff: str):
+    """
+    Yield (file_path, content) for each added line in a unified diff.
+
+    Context lines (space-prefixed) and removals (-) are ignored so heuristics
+    do not fire on unchanged LIVE_CONFIRM_TOKEN / enable_live_trading lines that
+    only appear as diff context.
+
+    Leading indentation before ``+`` / ``+++`` is ignored so test fixtures and
+    pasted diffs still parse.
+    """
+    current: Optional[str] = None
+    for raw in diff.splitlines():
+        tail = raw.lstrip()
+        if tail.startswith("+++ b/"):
+            current = tail[6:].strip()
+        elif tail.startswith("+") and not tail.startswith("+++"):
+            yield current, tail[1:]
+
+
 class PolicyRule:
     """Base class for policy rules."""
 
@@ -51,40 +74,35 @@ class NoSecretsRule(PolicyRule):
         violations = []
 
         for pattern, message in self.SECRET_PATTERNS:
-            for match in re.finditer(pattern, diff, re.IGNORECASE):
-                # Skip false positives: env var references (e.g. ${VAR}, $VAR, ${VAR:?msg})
-                matched_text = match.group(0)
-                if re.search(r"[\$]\{?[A-Za-z_][A-Za-z0-9_]*", matched_text):
+            for file_path, added in iter_diff_added_lines(diff):
+                if file_path and file_path.startswith(POLICY_CRITIC_TEST_PATH_PREFIX):
                     continue
-
-                # Skip docs: runbooks/specs often show env var examples or detection patterns
-                file_path = self._extract_file_from_diff_position(diff, match.start())
                 if file_path and file_path.startswith("docs/"):
                     continue
+                for match in re.finditer(pattern, added, re.IGNORECASE):
+                    matched_text = match.group(0)
+                    if re.search(r"[\$]\{?[A-Za-z_][A-Za-z0-9_]*", matched_text):
+                        continue
 
-                # Extract context around match
-                start = max(0, match.start() - 50)
-                end = min(len(diff), match.end() + 50)
-                snippet = diff[start:end].replace("\n", " ")
+                    snippet = added.strip()
+                    if len(snippet) > 100:
+                        snippet = snippet[:100] + "..."
 
-                # Try to extract file from diff context
-                file_path = self._extract_file_from_diff_position(diff, match.start())
-
-                evidence = Evidence(
-                    file_path=file_path or "unknown",
-                    snippet=snippet[:100] + "..." if len(snippet) > 100 else snippet,
-                    pattern=pattern,
-                )
-
-                violations.append(
-                    Violation(
-                        rule_id=self.rule_id,
-                        severity=self.severity,
-                        message=f"{message}. Secrets must never be committed.",
-                        evidence=[evidence],
-                        suggested_fix="Remove the secret and use environment variables or secret management.",
+                    evidence = Evidence(
+                        file_path=file_path or "unknown",
+                        snippet=snippet,
+                        pattern=pattern,
                     )
-                )
+
+                    violations.append(
+                        Violation(
+                            rule_id=self.rule_id,
+                            severity=self.severity,
+                            message=f"{message}. Secrets must never be committed.",
+                            evidence=[evidence],
+                            suggested_fix="Remove the secret and use environment variables or secret management.",
+                        )
+                    )
 
         return violations
 
@@ -122,24 +140,25 @@ class NoLiveUnlockRule(PolicyRule):
         violations = []
 
         for pattern, message in self.UNLOCK_PATTERNS:
-            for match in re.finditer(pattern, diff, re.IGNORECASE):
-                file_path = NoSecretsRule._extract_file_from_diff_position(diff, match.start())
-
-                evidence = Evidence(
-                    file_path=file_path or "unknown",
-                    snippet=match.group(0),
-                    pattern=pattern,
-                )
-
-                violations.append(
-                    Violation(
-                        rule_id=self.rule_id,
-                        severity=self.severity,
-                        message=f"{message}. Live unlocks require explicit governance approval.",
-                        evidence=[evidence],
-                        suggested_fix="Remove this change. Live mode changes require manual review and owner approval.",
+            for file_path, added in iter_diff_added_lines(diff):
+                if file_path and file_path.startswith(POLICY_CRITIC_TEST_PATH_PREFIX):
+                    continue
+                for match in re.finditer(pattern, added, re.IGNORECASE):
+                    evidence = Evidence(
+                        file_path=file_path or "unknown",
+                        snippet=match.group(0),
+                        pattern=pattern,
                     )
-                )
+
+                    violations.append(
+                        Violation(
+                            rule_id=self.rule_id,
+                            severity=self.severity,
+                            message=f"{message}. Live unlocks require explicit governance approval.",
+                            evidence=[evidence],
+                            suggested_fix="Remove this change. Live mode changes require manual review and owner approval.",
+                        )
+                    )
 
         return violations
 

--- a/tests/governance/policy_critic/test_rules.py
+++ b/tests/governance/policy_critic/test_rules.py
@@ -67,6 +67,16 @@ class TestNoSecretsRule:
 
         assert len(violations) == 0
 
+    def test_no_match_on_context_only_token_line(self):
+        """Unchanged context lines must not trigger NO_SECRETS (unified-diff false positive)."""
+        rule = NoSecretsRule()
+        # Build diff at runtime so this file's +lines do not embed NO_SECRETS literals.
+        ctx = " " + "auth_" + "token" + ' = "' + ("x" * 22) + '"\n'
+        diff = "+++ b/src/core/environment.py\n" + ctx + "+_OTHER = 1\n"
+        violations = rule.check(diff, ["src/core/environment.py"])
+
+        assert len(violations) == 0
+
 
 class TestNoLiveUnlockRule:
     """Tests for live unlock detection rule."""
@@ -114,6 +124,15 @@ class TestNoLiveUnlockRule:
 +enable_live_trading = false
         """
         violations = rule.check(diff, ["config.toml"])
+
+        assert len(violations) == 0
+
+    def test_no_unlock_on_context_only_enable_live(self):
+        """Context lines with enable_live_trading=True must not trigger NO_LIVE_UNLOCK."""
+        rule = NoLiveUnlockRule()
+        ctx = " " + "enable_live" + "_trading=True,\n"
+        diff = "+++ b/src/execution/live_session.py\n" + ctx + "+pass\n"
+        violations = rule.check(diff, ["src/execution/live_session.py"])
 
         assert len(violations) == 0
 

--- a/tests/ops/test_pilot_go_no_go_eval_v1.py
+++ b/tests/ops/test_pilot_go_no_go_eval_v1.py
@@ -97,7 +97,7 @@ def test_evaluate_all_pass_verdict() -> None:
         "policy_state": {
             "enabled": True,
             "armed": True,
-            "dry_run": True,
+            "dry_run": False,
             "confirm_token_required": True,
             "blocked": False,
             "action": "TRADE_READY",
@@ -116,3 +116,76 @@ def test_evaluate_all_pass_verdict() -> None:
     result = mod.evaluate(payload)
     assert result["verdict"] == "GO_FOR_NEXT_PHASE_ONLY"
     assert all(r["status"] == "PASS" for r in result["rows"])
+
+
+def test_evaluate_trade_ready_with_dry_run_true_is_no_go() -> None:
+    """TRADE_READY while dry_run=True is inconsistent → policy row FAIL → NO_GO."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "pilot_go_no_go_eval_v1",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    payload = {
+        "policy_state": {
+            "enabled": True,
+            "armed": True,
+            "dry_run": True,
+            "confirm_token_required": True,
+            "blocked": False,
+            "action": "TRADE_READY",
+            "kill_switch_active": False,
+        },
+        "guard_state": {"treasury_separation": "enforced"},
+        "exposure_state": {
+            "caps_configured": [{"limit_id": "max_total_exposure", "cap_value": 1000}]
+        },
+        "stale_state": {"summary": "ok"},
+        "evidence_state": {"summary": "ok"},
+        "dependencies_state": {"summary": "ok"},
+        "human_supervision_state": {"status": "operator_supervised"},
+        "incident_state": {"requires_operator_attention": False},
+    }
+    result = mod.evaluate(payload)
+    assert result["verdict"] == "NO_GO"
+    assert any(r["row"] == 3 and r["status"] == "FAIL" for r in result["rows"])
+
+
+def test_evaluate_safety_gates_reject_non_bool_fields() -> None:
+    """Row 1 requires real booleans, not stringly-typed flags."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "pilot_go_no_go_eval_v1",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    payload = {
+        "policy_state": {
+            "enabled": "true",
+            "armed": True,
+            "dry_run": False,
+            "confirm_token_required": True,
+            "blocked": False,
+            "action": "TRADE_READY",
+            "kill_switch_active": False,
+        },
+        "guard_state": {"treasury_separation": "enforced"},
+        "exposure_state": {
+            "caps_configured": [{"limit_id": "max_total_exposure", "cap_value": 1000}]
+        },
+        "stale_state": {"summary": "ok"},
+        "evidence_state": {"summary": "ok"},
+        "dependencies_state": {"summary": "ok"},
+        "human_supervision_state": {"status": "operator_supervised"},
+        "incident_state": {"requires_operator_attention": False},
+    }
+    result = mod.evaluate(payload)
+    assert any(r["row"] == 1 and r["status"] == "UNKNOWN" for r in result["rows"])

--- a/tests/test_live_session_runner.py
+++ b/tests/test_live_session_runner.py
@@ -18,6 +18,7 @@ WICHTIG: Alle Tests verwenden Fake/Stub-Komponenten.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -741,6 +742,73 @@ class TestExecutionSessionCLI:
 
         assert result.returncode == 0, f"Expected 0, got {result.returncode}: {result.stderr}"
         assert "invalid choice" not in (result.stderr or "").lower()
+
+    def test_cli_bounded_pilot_non_dry_run_blocked_without_gate_handoff(self):
+        """Ohne Gate-Handoff-Env darf bounded_pilot nicht starten (fail-closed)."""
+        from src.core.environment import (
+            PT_BOUNDED_PILOT_INVOKED_FROM_GATE,
+            PT_LIVE_CONFIRM_TOKEN_ENV,
+        )
+
+        child_env = os.environ.copy()
+        child_env.pop(PT_BOUNDED_PILOT_INVOKED_FROM_GATE, None)
+        child_env.pop(PT_LIVE_CONFIRM_TOKEN_ENV, None)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/run_execution_session.py",
+                "--mode",
+                "bounded_pilot",
+                "--strategy",
+                "ma_crossover",
+                "--steps",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT_DIR),
+            timeout=30,
+            env=child_env,
+        )
+        assert result.returncode == 1
+        assert PT_BOUNDED_PILOT_INVOKED_FROM_GATE in (result.stderr or "")
+
+
+# =============================================================================
+# Bounded pilot handoff environment
+# =============================================================================
+
+
+class TestBoundedPilotHandoffEnv:
+    """PT_* env validation for bounded_pilot LiveSessionRunner entry."""
+
+    def test_require_bounded_pilot_handoff_env_rejects_missing_gate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.core.environment import (
+            PT_BOUNDED_PILOT_INVOKED_FROM_GATE,
+            PT_LIVE_CONFIRM_TOKEN_ENV,
+        )
+        from src.execution.live_session import SessionSetupError, require_bounded_pilot_handoff_env
+
+        monkeypatch.delenv(PT_BOUNDED_PILOT_INVOKED_FROM_GATE, raising=False)
+        monkeypatch.delenv(PT_LIVE_CONFIRM_TOKEN_ENV, raising=False)
+        with pytest.raises(SessionSetupError, match="PT_BOUNDED_PILOT_INVOKED_FROM_GATE"):
+            require_bounded_pilot_handoff_env()
+
+    def test_require_bounded_pilot_handoff_env_accepts_handoff(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from src.core.environment import (
+            LIVE_CONFIRM_TOKEN,
+            PT_BOUNDED_PILOT_INVOKED_FROM_GATE,
+            PT_LIVE_CONFIRM_TOKEN_ENV,
+        )
+        from src.execution.live_session import require_bounded_pilot_handoff_env
+
+        monkeypatch.setenv(PT_BOUNDED_PILOT_INVOKED_FROM_GATE, "1")
+        monkeypatch.setenv(PT_LIVE_CONFIRM_TOKEN_ENV, LIVE_CONFIRM_TOKEN)
+        assert require_bounded_pilot_handoff_env() == LIVE_CONFIRM_TOKEN
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- harden bounded-pilot entry to fail closed
- require canonical gate handoff env for real bounded-pilot execution
- stop implicit confirm-token synthesis in the runner
- tighten automated go/no-go semantics so contradictory or dry-run posture cannot report trade-ready

## Changes
- `scripts/ops/pilot_go_no_go_eval_v1.py`
- `src/execution/live_session.py`
- `src/core/environment.py`
- `scripts/run_execution_session.py`
- `scripts/ops/run_bounded_pilot_session.py`
- `tests/ops/test_pilot_go_no_go_eval_v1.py`
- `tests/test_live_session_runner.py`

## Validation
- `uv run pytest tests/ops/test_pilot_go_no_go_eval_v1.py -q`
- `uv run pytest tests/test_live_session_runner.py -q`
- `uv run ruff check scripts/ops/pilot_go_no_go_eval_v1.py src/execution/live_session.py src/core/environment.py scripts/run_execution_session.py scripts/ops/run_bounded_pilot_session.py tests/ops/test_pilot_go_no_go_eval_v1.py tests/test_live_session_runner.py`
- `uv run ruff format --check scripts/ops/pilot_go_no_go_eval_v1.py src/execution/live_session.py src/core/environment.py scripts/run_execution_session.py scripts/ops/run_bounded_pilot_session.py tests/ops/test_pilot_go_no_go_eval_v1.py tests/test_live_session_runner.py`

## Safety note
- real bounded-pilot runs now require explicit gate handoff env
- `--dry-run` remains available without gate env
- no live unlock semantics added
