### PR TITLE
feat(ops): add canonical bounded pilot readiness entrypoint

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,10 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-20 — `docs&#47;ops&#47;specs&#47;BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` — Verweis auf kanonischen Preflight `scripts&#47;ops&#47;check_bounded_pilot_readiness.py` (Primary docs / scripts); **read-only**; **keine** Live-Freigabe.
+
+- 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` — Kanonischer Bounded-Pilot-Preflight `scripts&#47;ops&#47;check_bounded_pilot_readiness.py` (bündelt `check_live_readiness` live + `pilot_go_no_go_eval_v1`); Runbook-Phase B; Companion zu `scripts&#47;ops&#47;run_bounded_pilot_session.py`; **read-only**, **keine** Session, **keine** zusätzliche Live-Freigabe.
+
 - 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;CANARY_LIVE_ENTRY_CRITERIA.md` — Bounded-Pilot fail-closed Handoff (`PT_BOUNDED_PILOT_INVOKED_FROM_GATE`, `PT_LIVE_CONFIRM_TOKEN`), Abgrenzung `--dry-run` ohne Gate-Env, Go/No-Go-Konsistenz `TRADE_READY` vs. `dry_run`; Companion zu `src/execution/live_session.py` / `src/core/environment.py` (Drift-Regeln `execution-layer`, `core-environment`); **keine** zusätzliche Live-Freigabe.
 
 - 2026-04-18 — `docs&#47;ops&#47;registry&#47;TRUTH_BRANCH_PROTECTION.md` auf Single-Writer-Contract präzisiert (`ensure_truth_branch_protection.py --apply` fail-closed blockiert; kanonischer Writer `scripts&#47;ops&#47;reconcile_required_checks_branch_protection.py --apply`); dieser Eintrag dokumentiert den verpflichtenden Companion-Nachzug gemäß `truth-branch-protection-canonical`.

--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
@@ -25,7 +25,8 @@ Dieses Runbook beschreibt **end-to-end**, wie ein Operator von **Dry-Validation*
 
 | Komponente | Stand |
 |------------|--------|
-| Entry-Gate + Session-Handoff | `scripts/ops/run_bounded_pilot_session.py` ruft bei grünen Gates **`run_execution_session.py --mode bounded_pilot`** auf (ohne `--no-invoke`). |
+| Kanonischer Preflight (read-only) | `scripts/ops/check_bounded_pilot_readiness.py` bündelt **`check_live_readiness.py --stage live`** und **`pilot_go_no_go_eval_v1`**; Exit 0 nur bei voller Live-Readiness **und** `GO_FOR_NEXT_PHASE_ONLY`. Startet **keine** Session und setzt **kein** Gate-Handoff-Env. |
+| Entry-Gate + Session-Handoff | `scripts/ops/run_bounded_pilot_session.py` nutzt denselben Preflight-Stack, ruft bei grünen Gates **`run_execution_session.py --mode bounded_pilot`** auf (ohne `--no-invoke`). |
 | Session-CLI | `scripts/run_execution_session.py` unterstützt `shadow`, `testnet`, **`bounded_pilot`**. |
 | Runner | `LiveSessionRunner` / Konfiguration für `bounded_pilot` in `src/execution/live_session.py` (u. a. `bounded_pilot_mode`, `live_dry_run_mode=False` im Pilot-Kontext). |
 | Governance | Pipeline wählt bei Bounded-Pilot-Kontext den Key **`live_order_execution_bounded_pilot`** (`select_live_order_execution_key`). |
@@ -88,13 +89,22 @@ Alle Punkte müssen **vor** dem ersten Aufruf mit echten Orders erfüllt sein.
 
 Detaillierte Einordnung: `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md` (Schritt 5 dort ist historisch; Gate-only = `--no-invoke` hier in Phase A.4).
 
-### Phase B — Readiness-Skript (empfohlen)
+### Phase B — Readiness (empfohlen)
+
+**Kanonischer Bounded-Pilot-Preflight (ein Aufruf, technisch + Go/No-Go):**
+
+```bash
+python3 scripts/ops/check_bounded_pilot_readiness.py --repo-root . --json
+```
+
+Erwartung: Exit **0** und `ok: true` nur wenn Live-Readiness **und** Cockpit-Verdict `GO_FOR_NEXT_PHASE_ONLY`. Bei Fehlern: **kein** Pilot.
+
+**Alternativ einzeln (Debugging):**
 
 ```bash
 python3 scripts/check_live_readiness.py --stage live --verbose
+python3 scripts/ops/pilot_go_no_go_eval_v1.py --json
 ```
-
-Erwartung: relevante Checks **bestanden** (u. a. Risk-Limits, Live-Risk-Config, API-Keys). Bei Fehlern: **kein** Pilot.
 
 ### Phase C — Erweiterter Ops-Check (optional, laut live_pilot_execution_plan)
 

--- a/docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md
+++ b/docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md
@@ -115,6 +115,7 @@ Primary operator evidence:
 
 Primary docs / scripts:
 
+- `scripts&#47;ops&#47;check_bounded_pilot_readiness.py` — Canonical read-only preflight: bundles live-stage `check_live_readiness` + `pilot_go_no_go_eval_v1`; does not start a session
 - `scripts&#47;ops&#47;run_bounded_pilot_session.py` — Pre-Entry-Checks gate; with default args invokes bounded pilot session (see `RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`); use `--no-invoke` for gates only
 - `docs&#47;ops&#47;runbooks&#47;RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md`
 - `docs&#47;ops&#47;specs&#47;PILOT_GO_NO_GO_CHECKLIST.md`

--- a/scripts/ops/check_bounded_pilot_readiness.py
+++ b/scripts/ops/check_bounded_pilot_readiness.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Canonical bounded-pilot readiness / preflight (read-only).
+
+Bundles:
+- `scripts/check_live_readiness.py` — stage `live` technical checks (config, risk, exchange, API env)
+- `scripts/ops/pilot_go_no_go_eval_v1.py` — Ops Cockpit Go/No-Go rows
+
+Does not invoke a session, does not set handoff env, does not authorize live trading.
+Fail-closed: any failed live-readiness check or non-GO verdict blocks.
+
+Exit codes:
+  0 — preflight GREEN (live readiness + GO_FOR_NEXT_PHASE_ONLY)
+  1 — blocked (readiness or go/no-go)
+  2 — script error (e.g. cockpit build failure)
+
+Reference: docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+CONTRACT_ID = "bounded_pilot_readiness_v1"
+
+
+def resolve_bounded_pilot_config_path(repo_root: Path, explicit: Path | None) -> Path:
+    if explicit is not None:
+        return explicit
+    env_path = os.environ.get("PEAK_TRADE_CONFIG_PATH")
+    if env_path:
+        return Path(env_path)
+    return repo_root / "config" / "config.toml"
+
+
+def _readiness_summary(report: Any) -> dict[str, Any]:
+    from scripts.check_live_readiness import ReadinessReport
+
+    assert isinstance(report, ReadinessReport)
+    return {
+        "stage": report.stage,
+        "all_passed": report.all_passed,
+        "passed_count": report.passed_count,
+        "failed_count": report.failed_count,
+        "failed_checks": [
+            {"name": c.name, "message": c.message, "details": c.details}
+            for c in report.checks
+            if not c.passed
+        ],
+        "warning_count": report.warning_count,
+    }
+
+
+def run_bounded_pilot_readiness(
+    repo_root: Path,
+    config_path: Path,
+    *,
+    run_tests: bool = False,
+) -> tuple[bool, dict[str, Any]]:
+    """
+    Run live-stage readiness checks, then pilot go/no-go eval.
+
+    Returns:
+        (ok, bundle) where bundle is JSON-serializable and includes `contract`.
+    """
+    from scripts.check_live_readiness import run_readiness_checks
+    from scripts.ops.pilot_go_no_go_eval_v1 import evaluate
+    from src.webui.ops_cockpit import build_ops_cockpit_payload
+
+    bundle: dict[str, Any] = {"contract": CONTRACT_ID}
+
+    try:
+        readiness_report = run_readiness_checks(
+            stage="live",
+            config_path=config_path,
+            run_tests=run_tests,
+        )
+    except Exception as e:
+        bundle["ok"] = False
+        bundle["blocked_at"] = "live_readiness"
+        bundle["message"] = f"live readiness evaluation error: {e}"
+        return False, bundle
+
+    bundle["live_readiness"] = _readiness_summary(readiness_report)
+    if not readiness_report.all_passed:
+        bundle["ok"] = False
+        bundle["blocked_at"] = "live_readiness"
+        bundle["message"] = f"live readiness failed ({readiness_report.failed_count} check(s))"
+        return False, bundle
+
+    try:
+        payload = build_ops_cockpit_payload(repo_root=repo_root)
+    except Exception as e:
+        bundle["ok"] = False
+        bundle["blocked_at"] = "cockpit_payload"
+        bundle["message"] = f"failed to build ops cockpit payload: {e}"
+        return False, bundle
+
+    go_no_go = evaluate(payload)
+    bundle["go_no_go"] = go_no_go
+    verdict = go_no_go.get("verdict")
+    if verdict != "GO_FOR_NEXT_PHASE_ONLY":
+        bundle["ok"] = False
+        bundle["blocked_at"] = "go_no_go"
+        bundle["message"] = f"go/no-go not GREEN: verdict={verdict}"
+        return False, bundle
+
+    bundle["ok"] = True
+    bundle["blocked_at"] = None
+    bundle["message"] = "bounded_pilot preflight GREEN: live readiness + GO_FOR_NEXT_PHASE_ONLY"
+    return True, bundle
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Canonical bounded-pilot preflight: live readiness + pilot go/no-go "
+            "(read-only, no session invoke)"
+        )
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit full result as JSON on stdout",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repo root (default: inferred from script location)",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Config path (default: PEAK_TRADE_CONFIG_PATH or config/config.toml)",
+    )
+    parser.add_argument(
+        "--run-tests",
+        action="store_true",
+        help="Pass through to live readiness: run baseline pytest (slow)",
+    )
+    args = parser.parse_args()
+    repo_root = args.repo_root or (_REPO_ROOT if _REPO_ROOT.exists() else Path.cwd())
+    config_path = resolve_bounded_pilot_config_path(repo_root, args.config)
+
+    try:
+        ok, bundle = run_bounded_pilot_readiness(
+            repo_root,
+            config_path,
+            run_tests=args.run_tests,
+        )
+    except Exception as e:
+        err = {"contract": CONTRACT_ID, "ok": False, "error": str(e)}
+        if args.json:
+            print(json.dumps(err, indent=2))
+        else:
+            print(f"ERR: {e}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(bundle, indent=2))
+    else:
+        print(bundle.get("message", ""))
+        if not ok:
+            blocked = bundle.get("blocked_at")
+            if blocked == "live_readiness":
+                lr = bundle.get("live_readiness") or {}
+                for fc in lr.get("failed_checks") or []:
+                    print(f"  [readiness] {fc.get('name')}: {fc.get('message')}", file=sys.stderr)
+            elif blocked == "go_no_go":
+                gng = bundle.get("go_no_go") or {}
+                for r in gng.get("rows") or []:
+                    if r.get("status") != "PASS":
+                        print(
+                            f"  [go/no-go] Row {r.get('row')} {r.get('area')}: {r.get('status')}",
+                            file=sys.stderr,
+                        )
+            print("Preflight not GREEN. Do not invoke bounded pilot.", file=sys.stderr)
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/run_bounded_pilot_session.py
+++ b/scripts/ops/run_bounded_pilot_session.py
@@ -76,32 +76,49 @@ def main() -> int:
     repo_root = args.repo_root or (_REPO_ROOT if _REPO_ROOT.exists() else Path.cwd())
 
     try:
-        from scripts.ops.pilot_go_no_go_eval_v1 import evaluate
-        from src.webui.ops_cockpit import build_ops_cockpit_payload
+        from scripts.ops.check_bounded_pilot_readiness import (
+            resolve_bounded_pilot_config_path,
+            run_bounded_pilot_readiness,
+        )
 
-        payload = build_ops_cockpit_payload(repo_root=repo_root)
+        config_path = resolve_bounded_pilot_config_path(repo_root, None)
+        ok, readiness_bundle = run_bounded_pilot_readiness(repo_root, config_path, run_tests=False)
     except Exception as e:
-        print(f"ERR: failed to build cockpit payload: {e}", file=sys.stderr)
+        print(f"ERR: bounded pilot preflight failed: {e}", file=sys.stderr)
         return 2
 
-    result = evaluate(payload)
-    verdict = result["verdict"]
+    result = readiness_bundle.get("go_no_go") or {}
+    verdict = result.get("verdict")
 
-    if verdict != "GO_FOR_NEXT_PHASE_ONLY":
+    if not ok:
+        blocked = readiness_bundle.get("blocked_at")
         if args.json:
             out = {
                 "contract": "run_bounded_pilot_session",
                 "verdict": verdict,
                 "entry_permitted": False,
-                "message": f"Gates not satisfied: verdict={verdict}",
-                "go_no_go": result,
+                "message": readiness_bundle.get("message", "Gates not satisfied"),
+                "blocked_at": blocked,
+                "bounded_pilot_readiness": readiness_bundle,
             }
             print(json.dumps(out, indent=2))
         else:
-            print(f"GATES_RED: verdict={verdict}", file=sys.stderr)
-            for r in result["rows"]:
-                if r["status"] != "PASS":
-                    print(f"  Row {r['row']} {r['area']}: {r['status']}", file=sys.stderr)
+            if blocked == "live_readiness":
+                print("GATES_RED: live readiness failed", file=sys.stderr)
+                lr = readiness_bundle.get("live_readiness") or {}
+                for fc in lr.get("failed_checks") or []:
+                    print(
+                        f"  [readiness] {fc.get('name')}: {fc.get('message')}",
+                        file=sys.stderr,
+                    )
+            else:
+                print(f"GATES_RED: verdict={verdict}", file=sys.stderr)
+                for r in result.get("rows") or []:
+                    if r["status"] != "PASS":
+                        print(
+                            f"  Row {r['row']} {r['area']}: {r['status']}",
+                            file=sys.stderr,
+                        )
             print("Entry not permitted. Fix blockers before retrying.", file=sys.stderr)
         return 1
 
@@ -112,10 +129,11 @@ def main() -> int:
         if args.json:
             out = {
                 "contract": "run_bounded_pilot_session",
-                "verdict": verdict,
+                "verdict": result.get("verdict"),
                 "entry_permitted": True,
                 "message": msg,
                 "go_no_go": result,
+                "bounded_pilot_readiness": readiness_bundle,
             }
             print(json.dumps(out, indent=2))
         else:

--- a/tests/ops/test_check_bounded_pilot_readiness.py
+++ b/tests/ops/test_check_bounded_pilot_readiness.py
@@ -1,0 +1,154 @@
+"""Tests for scripts/ops/check_bounded_pilot_readiness.py — canonical bounded-pilot preflight."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "scripts" / "ops" / "check_bounded_pilot_readiness.py"
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file()
+
+
+def _passing_readiness_report() -> object:
+    from scripts.check_live_readiness import CheckResult, ReadinessReport
+
+    return ReadinessReport(
+        stage="live",
+        checks=[CheckResult("stub", True, "ok")],
+        warnings=[],
+    )
+
+
+def test_run_bounded_pilot_readiness_green(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.ops.check_bounded_pilot_readiness as mod
+
+    monkeypatch.setattr(
+        "scripts.check_live_readiness.run_readiness_checks",
+        lambda **kw: _passing_readiness_report(),
+    )
+    monkeypatch.setattr(
+        "src.webui.ops_cockpit.build_ops_cockpit_payload",
+        lambda **kw: {"repo_root": str(ROOT)},
+    )
+
+    def _go(payload: dict) -> dict:
+        return {
+            "contract": "pilot_go_no_go_eval_v1",
+            "verdict": "GO_FOR_NEXT_PHASE_ONLY",
+            "rows": [{"row": 1, "area": "Safety Gates", "status": "PASS"}],
+        }
+
+    monkeypatch.setattr(
+        "scripts.ops.pilot_go_no_go_eval_v1.evaluate",
+        _go,
+    )
+
+    ok, bundle = mod.run_bounded_pilot_readiness(
+        ROOT, ROOT / "config" / "config.toml", run_tests=False
+    )
+    assert ok is True
+    assert bundle["contract"] == mod.CONTRACT_ID
+    assert bundle["go_no_go"]["verdict"] == "GO_FOR_NEXT_PHASE_ONLY"
+    assert bundle["live_readiness"]["all_passed"] is True
+
+
+def test_run_bounded_pilot_readiness_blocks_on_readiness(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.ops.check_bounded_pilot_readiness as mod
+    from scripts.check_live_readiness import CheckResult, ReadinessReport
+
+    bad = ReadinessReport(
+        stage="live",
+        checks=[
+            CheckResult("API-Credentials", False, "Live-API-Keys fehlen"),
+        ],
+        warnings=[],
+    )
+    monkeypatch.setattr(
+        "scripts.check_live_readiness.run_readiness_checks",
+        lambda **kw: bad,
+    )
+
+    ok, bundle = mod.run_bounded_pilot_readiness(
+        ROOT, ROOT / "config" / "config.toml", run_tests=False
+    )
+    assert ok is False
+    assert bundle["blocked_at"] == "live_readiness"
+    assert "go_no_go" not in bundle
+
+
+def test_run_bounded_pilot_readiness_blocks_on_go_no_go(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.ops.check_bounded_pilot_readiness as mod
+
+    monkeypatch.setattr(
+        "scripts.check_live_readiness.run_readiness_checks",
+        lambda **kw: _passing_readiness_report(),
+    )
+    monkeypatch.setattr(
+        "src.webui.ops_cockpit.build_ops_cockpit_payload",
+        lambda **kw: {},
+    )
+    monkeypatch.setattr(
+        "scripts.ops.pilot_go_no_go_eval_v1.evaluate",
+        lambda payload: {
+            "contract": "pilot_go_no_go_eval_v1",
+            "verdict": "NO_GO",
+            "rows": [{"row": 6, "area": "Treasury Separation", "status": "FAIL"}],
+        },
+    )
+
+    ok, bundle = mod.run_bounded_pilot_readiness(
+        ROOT, ROOT / "config" / "config.toml", run_tests=False
+    )
+    assert ok is False
+    assert bundle["blocked_at"] == "go_no_go"
+    assert bundle["go_no_go"]["verdict"] == "NO_GO"
+
+
+def test_main_json_exit_codes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("check_bounded_pilot_readiness", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    monkeypatch.setattr(
+        "scripts.check_live_readiness.run_readiness_checks",
+        lambda **kw: _passing_readiness_report(),
+    )
+    monkeypatch.setattr(
+        "src.webui.ops_cockpit.build_ops_cockpit_payload",
+        lambda **kw: {},
+    )
+    monkeypatch.setattr(
+        "scripts.ops.pilot_go_no_go_eval_v1.evaluate",
+        lambda payload: {
+            "contract": "pilot_go_no_go_eval_v1",
+            "verdict": "GO_FOR_NEXT_PHASE_ONLY",
+            "rows": [],
+        },
+    )
+
+    monkeypatch.setattr(sys, "argv", ["x", "--json", "--repo-root", str(ROOT)])
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    data = json.loads(out.strip())
+    assert data["ok"] is True
+
+    monkeypatch.setattr(
+        "scripts.ops.pilot_go_no_go_eval_v1.evaluate",
+        lambda payload: {
+            "contract": "pilot_go_no_go_eval_v1",
+            "verdict": "CONDITIONAL",
+            "rows": [{"row": 1, "area": "Safety Gates", "status": "UNKNOWN"}],
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["x", "--json", "--repo-root", str(ROOT)])
+    assert mod.main() == 1

--- a/tests/ops/test_run_bounded_pilot_session.py
+++ b/tests/ops/test_run_bounded_pilot_session.py
@@ -46,8 +46,15 @@ def test_script_json_output() -> None:
     assert data["contract"] == "run_bounded_pilot_session"
     assert "entry_permitted" in data
     assert "verdict" in data
-    assert "go_no_go" in data
-    assert data["go_no_go"]["contract"] == "pilot_go_no_go_eval_v1"
+    assert "bounded_pilot_readiness" in data
+    br = data["bounded_pilot_readiness"]
+    assert br.get("contract") == "bounded_pilot_readiness_v1"
+    if data["entry_permitted"]:
+        assert data["go_no_go"]["contract"] == "pilot_go_no_go_eval_v1"
+    else:
+        assert data.get("blocked_at") == br.get("blocked_at")
+        if br.get("go_no_go"):
+            assert br["go_no_go"]["contract"] == "pilot_go_no_go_eval_v1"
 
 
 def test_main_importable() -> None:


### PR DESCRIPTION
## Summary
- add a canonical read-only bounded-pilot readiness/preflight entrypoint
- bundle technical live-readiness and ops-cockpit go/no-go into one fail-closed operator path
- reuse the same readiness logic from `run_bounded_pilot_session.py`
- add focused tests and minimal companion docs updates

## Changes
- `scripts/ops/check_bounded_pilot_readiness.py`
- `scripts/ops/run_bounded_pilot_session.py`
- `tests/ops/test_check_bounded_pilot_readiness.py`
- `tests/ops/test_run_bounded_pilot_session.py`
- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`
- `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`

## Validation
- `uv run pytest tests/ops/test_check_bounded_pilot_readiness.py tests/ops/test_run_bounded_pilot_session.py -q`
- `uv run ruff check scripts/ops/check_bounded_pilot_readiness.py scripts/ops/run_bounded_pilot_session.py tests/ops/test_check_bounded_pilot_readiness.py tests/ops/test_run_bounded_pilot_session.py`
- `uv run ruff format --check scripts/ops/check_bounded_pilot_readiness.py scripts/ops/run_bounded_pilot_session.py tests/ops/test_check_bounded_pilot_readiness.py tests/ops/test_run_bounded_pilot_session.py`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `uv run python scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety note
- entrypoint is read-only and non-authorizing
- exit 0 only on fully green bounded-pilot readiness
- no live unlock semantics added
