### PR TITLE
feat(ops): add operator stop signal snapshot cli

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-20 — `docs&#47;ops&#47;reviews&#47;incident_stop_kill_switch_consistency_review&#47;REVIEW.md` — Companion: read-only `scripts&#47;ops&#47;snapshot_operator_stop_signals.py` (PT_* / incident_stop artifact / kill_switch JSON, Divergenz-Hinweise); **keine** Runtime-Vereinheitlichung; **keine** Live-Freigabe.
+
 - 2026-04-20 — `docs&#47;ops&#47;specs&#47;BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` — Verweis auf kanonischen Preflight `scripts&#47;ops&#47;check_bounded_pilot_readiness.py` (Primary docs / scripts); **read-only**; **keine** Live-Freigabe.
 
 - 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` — Kanonischer Bounded-Pilot-Preflight `scripts&#47;ops&#47;check_bounded_pilot_readiness.py` (bündelt `check_live_readiness` live + `pilot_go_no_go_eval_v1`); Runbook-Phase B; Companion zu `scripts&#47;ops&#47;run_bounded_pilot_session.py`; **read-only**, **keine** Session, **keine** zusätzliche Live-Freigabe.

--- a/docs/ops/reviews/incident_stop_kill_switch_consistency_review/REVIEW.md
+++ b/docs/ops/reviews/incident_stop_kill_switch_consistency_review/REVIEW.md
@@ -101,6 +101,7 @@ Current posture:
 2. state clearly which surface is operator-authoritative for stop status today
 3. keep incident-stop and kill-switch expectations conservative until alignment is tighter
 4. do not imply full stop-signal unification while RiskHook kill-switch integration remains future work
+5. use read-only tooling for side-by-side visibility: `scripts&#47;ops&#47;snapshot_operator_stop_signals.py` prints process `PT_*` stop-related env, the latest `out&#47;ops&#47;incident_stop_*` state file (if any), and `data&#47;kill_switch&#47;state.json` with explicit `consistency_notes` when signals diverge — **no** state mutation, **no** runtime-path unification
 
 ## Preferred Next Slice
 - `ops_suite_incident_state_real_signal_alignment`

--- a/scripts/ops/snapshot_operator_stop_signals.py
+++ b/scripts/ops/snapshot_operator_stop_signals.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Read-only operator snapshot of adjacent stop / abort signals.
+
+Surfaces side-by-side (no runtime unification):
+- process environment: PT_INCIDENT_STOP, PT_FORCE_NO_TRADE, PT_ENABLED, PT_ARMED
+- latest ``out/ops/incident_stop_*/incident_stop_state.env`` artifact (if any)
+- ``data/kill_switch/state.json`` (same active rule as ops cockpit: state in KILLED, RECOVERING)
+
+Does not write state, does not change kill switch, does not authorize live trading.
+
+Exit codes:
+  0 — snapshot emitted
+  2 — invalid arguments or unreadable repo root
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+CONTRACT_ID = "operator_stop_signal_snapshot_v1"
+
+# Aligned with ``scripts/ops/incident_stop_now.sh`` and cockpit incident_state PT_* fields.
+PT_STOP_KEYS = (
+    "PT_INCIDENT_STOP",
+    "PT_FORCE_NO_TRADE",
+    "PT_ENABLED",
+    "PT_ARMED",
+)
+
+
+def _truthy_env(val: Optional[str]) -> bool:
+    if val is None:
+        return False
+    s = str(val).strip()
+    return s not in ("", "0", "false", "False", "no", "NO")
+
+
+def _snapshot_process_pt() -> Dict[str, Any]:
+    return {k: os.environ.get(k) for k in PT_STOP_KEYS}
+
+
+def _find_latest_incident_stop_state_file(repo_root: Path) -> Optional[Path]:
+    """Mirror discovery order in ``ops_cockpit._detect_incident_stop`` (newest dir first)."""
+    out_ops = repo_root / "out" / "ops"
+    if not out_ops.is_dir():
+        return None
+    for d in sorted(out_ops.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if d.is_dir() and d.name.startswith("incident_stop_"):
+            candidate = d / "incident_stop_state.env"
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def _parse_incident_stop_env_file(path: Path, repo_root: Path) -> Dict[str, Any]:
+    rel = None
+    try:
+        rel = str(path.relative_to(repo_root.resolve()))
+    except ValueError:
+        rel = str(path)
+    out: Dict[str, Any] = {
+        "status": "ok",
+        "path": rel,
+        "parsed": None,
+        "error": None,
+    }
+    try:
+        parsed: Dict[str, str] = {}
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                k, v = line.split("=", 1)
+                parsed[k.strip()] = v.strip()
+        out["parsed"] = parsed
+    except OSError as e:
+        out["status"] = "error"
+        out["error"] = str(e)
+    except UnicodeDecodeError as e:
+        out["status"] = "error"
+        out["error"] = str(e)
+    return out
+
+
+def _read_kill_switch(repo_root: Path) -> Dict[str, Any]:
+    path = repo_root / "data" / "kill_switch" / "state.json"
+    try:
+        rel = str(path.relative_to(repo_root.resolve()))
+    except ValueError:
+        rel = "data/kill_switch/state.json"
+    if not path.is_file():
+        return {
+            "status": "unavailable",
+            "path": rel,
+            "kill_switch_active": None,
+            "state": None,
+        }
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        state_raw = data.get("state", "")
+        state_u = str(state_raw).upper()
+        active = state_u in ("KILLED", "RECOVERING")
+        return {
+            "status": "ok",
+            "path": rel,
+            "kill_switch_active": active,
+            "state": state_raw,
+        }
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+        return {
+            "status": "error",
+            "path": rel,
+            "kill_switch_active": None,
+            "state": None,
+            "error": str(e),
+        }
+
+
+def _build_consistency_notes(
+    pt_env: Dict[str, Any],
+    artifact: Dict[str, Any],
+    ks: Dict[str, Any],
+) -> List[str]:
+    notes: List[str] = []
+    env_fnt = _truthy_env(pt_env.get("PT_FORCE_NO_TRADE"))
+    ks_active = ks.get("kill_switch_active")
+    if ks_active is False and env_fnt:
+        notes.append(
+            "divergence: kill_switch_active is false but PT_FORCE_NO_TRADE is set in process env"
+        )
+    if ks_active is True and not env_fnt and not _truthy_env(pt_env.get("PT_INCIDENT_STOP")):
+        notes.append(
+            "divergence: kill_switch_active is true but PT_FORCE_NO_TRADE / PT_INCIDENT_STOP not set in process env"
+        )
+
+    if artifact.get("status") == "ok" and isinstance(artifact.get("parsed"), dict):
+        ap = artifact["parsed"]
+        art_fnt = _truthy_env(ap.get("PT_FORCE_NO_TRADE"))
+        if art_fnt and not env_fnt:
+            notes.append(
+                "artifact_vs_process: latest incident_stop_state.env sets PT_FORCE_NO_TRADE "
+                "but current process env does not (shell may not have sourced that file)"
+            )
+
+    if artifact.get("status") == "error":
+        notes.append(f"incident_stop_artifact: {artifact.get('error', 'read/parse error')}")
+
+    if ks.get("status") == "error":
+        notes.append(f"kill_switch_file: {ks.get('error', 'read error')}")
+
+    return notes
+
+
+def build_stop_signal_snapshot(repo_root: Path) -> Dict[str, Any]:
+    root = repo_root.resolve()
+    pt_env = _snapshot_process_pt()
+    latest_sf = _find_latest_incident_stop_state_file(root)
+    if latest_sf is None:
+        artifact: Dict[str, Any] = {
+            "status": "none",
+            "path": None,
+            "parsed": None,
+            "error": None,
+        }
+    else:
+        artifact = _parse_incident_stop_env_file(latest_sf, root)
+    ks = _read_kill_switch(root)
+    notes = _build_consistency_notes(pt_env, artifact, ks)
+
+    ks_a = ks.get("kill_switch_active")
+    env_fnt = _truthy_env(pt_env.get("PT_FORCE_NO_TRADE"))
+    summary_parts = [
+        f"kill_switch_active={ks_a}",
+        f"env_PT_FORCE_NO_TRADE={env_fnt}",
+    ]
+    if artifact.get("status") == "ok":
+        summary_parts.append("incident_stop_artifact=present")
+    elif artifact.get("status") == "none":
+        summary_parts.append("incident_stop_artifact=none")
+    else:
+        summary_parts.append(f"incident_stop_artifact={artifact.get('status')}")
+    if notes:
+        summary_parts.append("consistency_notes=see_json")
+
+    return {
+        "contract": CONTRACT_ID,
+        "repo_root": str(root),
+        "process_environment_pt": pt_env,
+        "incident_stop_artifact": artifact,
+        "kill_switch_file": ks,
+        "consistency_notes": notes,
+        "summary": "; ".join(summary_parts),
+    }
+
+
+def _print_text(snapshot: Dict[str, Any]) -> None:
+    print(snapshot.get("summary", ""))
+    print("--- process PT_* ---")
+    for k, v in snapshot["process_environment_pt"].items():
+        print(f"  {k}={v!r}")
+    art = snapshot["incident_stop_artifact"]
+    print("--- incident_stop artifact ---")
+    print(f"  status={art.get('status')} path={art.get('path')}")
+    if art.get("parsed"):
+        for k, v in art["parsed"].items():
+            print(f"    {k}={v!r}")
+    if art.get("error"):
+        print(f"  error={art['error']}", file=sys.stderr)
+    ks = snapshot["kill_switch_file"]
+    print("--- kill_switch state.json ---")
+    print(
+        f"  status={ks.get('status')} kill_switch_active={ks.get('kill_switch_active')} "
+        f"state={ks.get('state')!r}"
+    )
+    if ks.get("error"):
+        print(f"  error={ks['error']}", file=sys.stderr)
+    notes = snapshot.get("consistency_notes") or []
+    if notes:
+        print("--- consistency_notes ---")
+        for n in notes:
+            print(f"  - {n}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only snapshot of operator stop signals (PT_* env, incident_stop artifact, kill_switch JSON)."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: inferred from script location)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit full snapshot as JSON",
+    )
+    args = parser.parse_args()
+    repo_root = args.repo_root or _REPO_ROOT
+    if not repo_root.is_dir():
+        print(f"ERR: repo root not a directory: {repo_root}", file=sys.stderr)
+        return 2
+    try:
+        snapshot = build_stop_signal_snapshot(repo_root)
+    except Exception as e:
+        print(f"ERR: {e}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(snapshot, indent=2))
+    else:
+        _print_text(snapshot)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_snapshot_operator_stop_signals.py
+++ b/tests/ops/test_snapshot_operator_stop_signals.py
@@ -1,0 +1,109 @@
+"""Tests for scripts/ops/snapshot_operator_stop_signals.py — read-only stop signal snapshot."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "scripts" / "ops" / "snapshot_operator_stop_signals.py"
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file()
+
+
+def test_build_snapshot_missing_all_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    for k in mod.PT_STOP_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    snap = mod.build_stop_signal_snapshot(tmp_path)
+    assert snap["contract"] == mod.CONTRACT_ID
+    assert snap["kill_switch_file"]["status"] == "unavailable"
+    assert snap["incident_stop_artifact"]["status"] == "none"
+    assert snap["kill_switch_file"]["kill_switch_active"] is None
+
+
+def test_kill_switch_active_and_env_divergence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    ks_dir = tmp_path / "data" / "kill_switch"
+    ks_dir.mkdir(parents=True)
+    (ks_dir / "state.json").write_text('{"state": "idle"}\n', encoding="utf-8")
+    monkeypatch.setenv("PT_FORCE_NO_TRADE", "1")
+    monkeypatch.delenv("PT_INCIDENT_STOP", raising=False)
+
+    snap = mod.build_stop_signal_snapshot(tmp_path)
+    assert snap["kill_switch_file"]["kill_switch_active"] is False
+    notes = snap["consistency_notes"]
+    assert any("divergence: kill_switch_active is false" in n for n in notes)
+
+
+def test_kill_switch_active_true_without_pt_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    for k in mod.PT_STOP_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    ks_dir = tmp_path / "data" / "kill_switch"
+    ks_dir.mkdir(parents=True)
+    (ks_dir / "state.json").write_text('{"state": "KILLED"}\n', encoding="utf-8")
+
+    snap = mod.build_stop_signal_snapshot(tmp_path)
+    assert snap["kill_switch_file"]["kill_switch_active"] is True
+    assert any("divergence: kill_switch_active is true" in n for n in snap["consistency_notes"])
+
+
+def test_incident_artifact_vs_process_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    for k in mod.PT_STOP_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    inc_dir = tmp_path / "out" / "ops" / "incident_stop_20990101T000000Z_test"
+    inc_dir.mkdir(parents=True)
+    (inc_dir / "incident_stop_state.env").write_text(
+        "PT_FORCE_NO_TRADE=1\nPT_ENABLED=0\nPT_ARMED=0\n",
+        encoding="utf-8",
+    )
+
+    snap = mod.build_stop_signal_snapshot(tmp_path)
+    assert snap["incident_stop_artifact"]["status"] == "ok"
+    assert any("artifact_vs_process" in n for n in snap["consistency_notes"])
+
+
+def test_kill_switch_invalid_json(tmp_path: Path) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    ks_dir = tmp_path / "data" / "kill_switch"
+    ks_dir.mkdir(parents=True)
+    (ks_dir / "state.json").write_text("not-json", encoding="utf-8")
+
+    snap = mod.build_stop_signal_snapshot(tmp_path)
+    assert snap["kill_switch_file"]["status"] == "error"
+    assert any("kill_switch_file:" in n for n in snap["consistency_notes"])
+
+
+def test_main_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("snapshot_operator_stop_signals", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    for k in mod.PT_STOP_KEYS:
+        monkeypatch.delenv(k, raising=False)
+
+    monkeypatch.setattr(sys, "argv", ["x", "--json", "--repo-root", str(tmp_path)])
+    assert mod.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["contract"] == mod.CONTRACT_ID

--- a/tests/test_optuna_integration.py
+++ b/tests/test_optuna_integration.py
@@ -453,17 +453,19 @@ def test_failed_trial_handling():
     """Test that failed trials are handled gracefully."""
 
     def objective(trial):
-        # Deterministic failure so the suite is not flaky (random x∈[0,10] can all be ≤5).
+        # Trial 0 fails deterministically; later trials must always complete (no TPE flake
+        # where every suggest_float lands in a "fail" branch after an early failure).
         if trial.number == 0:
             raise ValueError("Simulated failure")
-        x = trial.suggest_float("x", 0, 10)
-        if x > 5:
-            raise ValueError("Simulated failure")
+        x = trial.suggest_float("x", 0.0, 4.0)
         return x
 
-    study = optuna.create_study(direction="minimize")
+    study = optuna.create_study(
+        direction="minimize",
+        sampler=optuna.samplers.RandomSampler(seed=0),
+    )
 
-    # Run optimization (trial 0 fails; others may fail or complete)
+    # Run optimization (trial 0 fails; others complete)
     study.optimize(objective, n_trials=10, show_progress_bar=False, catch=(ValueError,))
 
     # Check that some trials failed


### PR DESCRIPTION
## Summary
- add a read-only operator CLI to snapshot stop-signal sources side by side
- show process PT_* signals, latest incident-stop artifact state, and kill-switch file state together
- surface divergences via consistency notes instead of hiding them
- keep the slice read-only and non-authorizing

## Changes
- `scripts/ops/snapshot_operator_stop_signals.py`
- `tests/ops/test_snapshot_operator_stop_signals.py`
- `docs/ops/reviews/incident_stop_kill_switch_consistency_review/REVIEW.md`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`

## Validation
- `uv run pytest tests/ops/test_snapshot_operator_stop_signals.py -q`
- `uv run ruff check scripts/ops/snapshot_operator_stop_signals.py tests/ops/test_snapshot_operator_stop_signals.py`
- `uv run ruff format --check scripts/ops/snapshot_operator_stop_signals.py tests/ops/test_snapshot_operator_stop_signals.py`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `uv run python scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety note
- read-only snapshot only
- no state mutation
- no runtime-path unification
- no live unlock semantics added
