### PR TITLE
feat(ops): wire operator preflight packet into bounded pilot session entry

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,11 +73,11 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` — Phase B: kanonischer Preflight `check_bounded_pilot_readiness.py`; Entry-Wrapper `run_bounded_pilot_session.py` baut vor Runner-Handoff zusätzlich das read-only Operator-Preflight-Packet (`bounded_pilot_operator_preflight_packet.py`); Ist-Zustand-Tabelle / Phase D; **keine** Live-Freigabe; **keine** neue Gate-Theorie.
+
 - 2026-04-20 — `docs&#47;ops&#47;reviews&#47;incident_stop_kill_switch_consistency_review&#47;REVIEW.md` — Companion: read-only `scripts&#47;ops&#47;snapshot_operator_stop_signals.py` (PT_* / incident_stop artifact / kill_switch JSON, Divergenz-Hinweise); **keine** Runtime-Vereinheitlichung; **keine** Live-Freigabe.
 
 - 2026-04-20 — `docs&#47;ops&#47;specs&#47;BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` — Verweis auf kanonischen Preflight `scripts&#47;ops&#47;check_bounded_pilot_readiness.py` (Primary docs / scripts); **read-only**; **keine** Live-Freigabe.
-
-- 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` — Kanonischer Bounded-Pilot-Preflight `scripts&#47;ops&#47;check_bounded_pilot_readiness.py` (bündelt `check_live_readiness` live + `pilot_go_no_go_eval_v1`); Runbook-Phase B; Companion zu `scripts&#47;ops&#47;run_bounded_pilot_session.py`; **read-only**, **keine** Session, **keine** zusätzliche Live-Freigabe.
 
 - 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;CANARY_LIVE_ENTRY_CRITERIA.md` — Bounded-Pilot fail-closed Handoff (`PT_BOUNDED_PILOT_INVOKED_FROM_GATE`, `PT_LIVE_CONFIRM_TOKEN`), Abgrenzung `--dry-run` ohne Gate-Env, Go/No-Go-Konsistenz `TRADE_READY` vs. `dry_run`; Companion zu `src/execution/live_session.py` / `src/core/environment.py` (Drift-Regeln `execution-layer`, `core-environment`); **keine** zusätzliche Live-Freigabe.
 

--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
@@ -1,7 +1,7 @@
 # RUNBOOK — Bounded Pilot Live Entry (Ist-Zustand Repo)
 
 **status:** ACTIVE  
-**last_updated:** 2026-04-01  
+**last_updated:** 2026-04-20  
 **owner:** Peak_Trade  
 **purpose:** Einheitliche Operator-Anleitung für den **ersten eng begrenzten Real-Money-Pilot** (Bounded Pilot)—abgestimmt auf den **aktuellen Code- und Governance-Stand** im Repository.  
 **docs_token:** DOCS_TOKEN_RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY
@@ -26,7 +26,8 @@ Dieses Runbook beschreibt **end-to-end**, wie ein Operator von **Dry-Validation*
 | Komponente | Stand |
 |------------|--------|
 | Kanonischer Preflight (read-only) | `scripts/ops/check_bounded_pilot_readiness.py` bündelt **`check_live_readiness.py --stage live`** und **`pilot_go_no_go_eval_v1`**; Exit 0 nur bei voller Live-Readiness **und** `GO_FOR_NEXT_PHASE_ONLY`. Startet **keine** Session und setzt **kein** Gate-Handoff-Env. |
-| Entry-Gate + Session-Handoff | `scripts/ops/run_bounded_pilot_session.py` nutzt denselben Preflight-Stack, ruft bei grünen Gates **`run_execution_session.py --mode bounded_pilot`** auf (ohne `--no-invoke`). |
+| Operator-Preflight-Packet (read-only) | `scripts/ops/bounded_pilot_operator_preflight_packet.py` orchestriert Readiness + **Stop-Signal-Snapshot** (`snapshot_operator_stop_signals`) in ein festes JSON; gleiche fail-closed Hartfehler wie im Skript-Docstring. |
+| Entry-Gate + Session-Handoff | `scripts/ops/run_bounded_pilot_session.py` nutzt den Preflight-Stack, baut **unmittelbar vor** Setzen von `PT_BOUNDED_PILOT_INVOKED_FROM_GATE` / Confirm-Token das Operator-Preflight-Packet erneut; bei `packet_ok` ruft es **`run_execution_session.py --mode bounded_pilot`** auf (ohne `--no-invoke`). Bei Packet-Blockade: **kein** Runner-Handoff. `--no-invoke` prüft nur Readiness+Go/No-Go (kein Packet), wie `--help`. |
 | Session-CLI | `scripts/run_execution_session.py` unterstützt `shadow`, `testnet`, **`bounded_pilot`**. |
 | Runner | `LiveSessionRunner` / Konfiguration für `bounded_pilot` in `src/execution/live_session.py` (u. a. `bounded_pilot_mode`, `live_dry_run_mode=False` im Pilot-Kontext). |
 | Governance | Pipeline wählt bei Bounded-Pilot-Kontext den Key **`live_order_execution_bounded_pilot`** (`select_live_order_execution_key`). |
@@ -106,6 +107,14 @@ python3 scripts/check_live_readiness.py --stage live --verbose
 python3 scripts/ops/pilot_go_no_go_eval_v1.py --json
 ```
 
+**Vollständiges Operator-Packet (Readiness + Stop-Signale, read-only):**
+
+```bash
+python3 scripts/ops/bounded_pilot_operator_preflight_packet.py --repo-root . --json
+```
+
+Vor **Session-Start ohne `--no-invoke`** wird dieses Packet im Entry-Wrapper intern nochmals gebaut; ein eigener Aufruf bleibt für Logs/Artefakte sinnvoll.
+
 ### Phase C — Erweiterter Ops-Check (optional, laut live_pilot_execution_plan)
 
 - `scripts/ops/ops_status.sh` (Repo-Root) → Exit 0
@@ -124,6 +133,7 @@ python3 scripts/ops/pilot_go_no_go_eval_v1.py --json
    python3 scripts/ops/run_bounded_pilot_session.py
    ```  
    Optionen siehe `--help` (u. a. `--steps`, `--position-fraction`, `--json`).  
+   Unmittelbar vor dem Handoff an den Runner prüft der Wrapper das **Operator-Preflight-Packet** (fail-closed bei Stop-Signal-**error**-Status wie im Packet definiert).  
    **Hinweis:** Default ist **extrem klein** steps/sizing im Wrapper-Docstring; Cap an eure Pilot-Tabelle anpassen, aber **immer innerhalb** der konfigurierten `live_risk`-Grenzen.
 
 3. **Alternativ (Operator kontrolliert den Aufruf selbst):**  

--- a/scripts/ops/run_bounded_pilot_session.py
+++ b/scripts/ops/run_bounded_pilot_session.py
@@ -3,13 +3,15 @@
 Bounded Pilot Entry Gate Wrapper — Pre-Entry-Checks + Session Handoff.
 
 Read-only gate for the first strictly bounded real-money pilot.
-Runs Pre-Entry-Checks (go/no-go, cockpit, config). On Gates GREEN, invokes
-run_execution_session --mode bounded_pilot (Slice 4 handoff).
+Runs Pre-Entry-Checks (go/no-go, cockpit, config). On Gates GREEN, runs the
+read-only operator preflight packet (readiness + stop-signal snapshot) once more
+immediately before handoff; on packet_ok, invokes run_execution_session --mode
+bounded_pilot (Slice 4 handoff).
 
 Exit codes:
-  0 — All gates GREEN; session completed successfully (or delegated to runner)
-  1 — One or more gates RED; entry not permitted (or runner failed)
-  2 — Script error (e.g. cockpit build failed)
+  0 — All gates GREEN; operator preflight packet GREEN; session completed successfully (or delegated to runner)
+  1 — One or more gates RED; entry not permitted; or operator preflight packet blocked before handoff (or runner failed)
+  2 — Script error (e.g. cockpit build failed; operator preflight packet orchestration error)
 
 Usage:
   python3 scripts/ops/run_bounded_pilot_session.py
@@ -149,6 +151,66 @@ def main() -> int:
         else:
             print(f"ERR: {err}", file=sys.stderr)
         return 2
+
+    try:
+        from scripts.ops.bounded_pilot_operator_preflight_packet import (
+            build_operator_preflight_packet,
+        )
+
+        packet, packet_code = build_operator_preflight_packet(
+            repo_root,
+            config_path,
+            run_tests=False,
+        )
+    except Exception as e:
+        print(f"ERR: operator preflight packet failed: {e}", file=sys.stderr)
+        return 2
+
+    summary = packet.get("summary") or {}
+    packet_ok = bool(summary.get("packet_ok"))
+    if packet_code == 2 or not packet_ok:
+        blocked_at = "operator_preflight_packet"
+        if packet_code == 2:
+            if args.json:
+                out = {
+                    "contract": "run_bounded_pilot_session",
+                    "verdict": verdict,
+                    "entry_permitted": False,
+                    "message": "operator preflight packet orchestration error (fail-closed before handoff)",
+                    "blocked_at": blocked_at,
+                    "bounded_pilot_readiness": readiness_bundle,
+                    "operator_preflight_packet": packet,
+                }
+                print(json.dumps(out, indent=2))
+            else:
+                print(
+                    "GATES_RED: operator preflight packet failed before handoff",
+                    file=sys.stderr,
+                )
+                for b in summary.get("blocked") or []:
+                    print(f"  [packet] {b}", file=sys.stderr)
+                print("Entry not permitted. Fix blockers before retrying.", file=sys.stderr)
+            return 2
+        if args.json:
+            out = {
+                "contract": "run_bounded_pilot_session",
+                "verdict": verdict,
+                "entry_permitted": False,
+                "message": "operator preflight packet not GREEN (fail-closed before handoff)",
+                "blocked_at": blocked_at,
+                "bounded_pilot_readiness": readiness_bundle,
+                "operator_preflight_packet": packet,
+            }
+            print(json.dumps(out, indent=2))
+        else:
+            print(
+                "GATES_RED: operator preflight packet blocked session handoff",
+                file=sys.stderr,
+            )
+            for b in summary.get("blocked") or []:
+                print(f"  [packet] {b}", file=sys.stderr)
+            print("Entry not permitted. Fix blockers before retrying.", file=sys.stderr)
+        return 1
 
     cmd = [
         sys.executable,

--- a/tests/ops/test_run_bounded_pilot_session.py
+++ b/tests/ops/test_run_bounded_pilot_session.py
@@ -1,5 +1,6 @@
 """Tests for scripts/ops/run_bounded_pilot_session.py — Bounded Pilot Entry Gate."""
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -9,6 +10,41 @@ import pytest
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT = ROOT / "scripts" / "ops" / "run_bounded_pilot_session.py"
+
+
+def _load_session_module():
+    spec = importlib.util.spec_from_file_location("run_bounded_pilot_session", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _green_readiness_bundle() -> dict:
+    return {
+        "contract": "bounded_pilot_readiness_v1",
+        "ok": True,
+        "blocked_at": None,
+        "message": "ok",
+        "go_no_go": {
+            "contract": "pilot_go_no_go_eval_v1",
+            "verdict": "GO_FOR_NEXT_PHASE_ONLY",
+            "rows": [],
+        },
+    }
+
+
+def _green_operator_packet() -> dict:
+    return {
+        "contract": "bounded_pilot_operator_preflight_packet_v1",
+        "summary": {
+            "readiness_ok": True,
+            "stop_snapshot_ok": True,
+            "packet_ok": True,
+            "blocked": [],
+            "notes": [],
+        },
+    }
 
 
 def test_script_exists() -> None:
@@ -59,14 +95,148 @@ def test_script_json_output() -> None:
 
 def test_main_importable() -> None:
     """main() can be imported and returns int."""
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location(
-        "run_bounded_pilot_session",
-        SCRIPT,
-    )
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    mod = _load_session_module()
     assert hasattr(mod, "main")
     assert callable(mod.main)
+
+
+def test_invoke_skips_subprocess_when_operator_preflight_packet_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = _load_session_module()
+    monkeypatch.setattr(
+        "scripts.ops.check_bounded_pilot_readiness.run_bounded_pilot_readiness",
+        lambda *a, **k: (True, _green_readiness_bundle()),
+    )
+
+    def _bad_packet(*a, **k):
+        return (
+            {
+                "contract": "bounded_pilot_operator_preflight_packet_v1",
+                "summary": {
+                    "readiness_ok": True,
+                    "stop_snapshot_ok": False,
+                    "packet_ok": False,
+                    "blocked": [
+                        "stop_signal_snapshot.kill_switch_file: error (invalid json)",
+                    ],
+                    "notes": [],
+                },
+            },
+            1,
+        )
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        _bad_packet,
+    )
+
+    def _no_subprocess(*a, **k):
+        raise AssertionError("subprocess.run must not be called when packet blocks")
+
+    monkeypatch.setattr(subprocess, "run", _no_subprocess)
+    monkeypatch.setattr(sys, "argv", ["run_bounded_pilot_session", "--repo-root", str(ROOT)])
+    assert mod.main() == 1
+
+
+def test_invoke_runs_subprocess_when_operator_preflight_packet_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = _load_session_module()
+    monkeypatch.setattr(
+        "scripts.ops.check_bounded_pilot_readiness.run_bounded_pilot_readiness",
+        lambda *a, **k: (True, _green_readiness_bundle()),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        lambda *a, **k: (_green_operator_packet(), 0),
+    )
+    calls: list = []
+
+    def _fake_run(*a, **k):
+        calls.append(1)
+        return subprocess.CompletedProcess(args=a[0] if a else [], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr(sys, "argv", ["run_bounded_pilot_session", "--repo-root", str(ROOT)])
+    assert mod.main() == 0
+    assert calls == [1]
+
+
+def test_invoke_returns_2_when_operator_preflight_packet_orchestrator_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = _load_session_module()
+    monkeypatch.setattr(
+        "scripts.ops.check_bounded_pilot_readiness.run_bounded_pilot_readiness",
+        lambda *a, **k: (True, _green_readiness_bundle()),
+    )
+
+    def _broken_packet(*a, **k):
+        return (
+            {
+                "contract": "bounded_pilot_operator_preflight_packet_v1",
+                "summary": {
+                    "readiness_ok": True,
+                    "stop_snapshot_ok": False,
+                    "packet_ok": False,
+                    "blocked": ["stop_signal_snapshot: exception (boom)"],
+                    "notes": [],
+                },
+                "stop_signal_snapshot": {"orchestrator_error": "boom"},
+            },
+            2,
+        )
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        _broken_packet,
+    )
+
+    def _no_subprocess(*a, **k):
+        raise AssertionError("subprocess.run must not be called")
+
+    monkeypatch.setattr(subprocess, "run", _no_subprocess)
+    monkeypatch.setattr(sys, "argv", ["run_bounded_pilot_session", "--repo-root", str(ROOT)])
+    assert mod.main() == 2
+
+
+def test_invoke_json_shows_operator_preflight_packet_when_blocked(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    mod = _load_session_module()
+    monkeypatch.setattr(
+        "scripts.ops.check_bounded_pilot_readiness.run_bounded_pilot_readiness",
+        lambda *a, **k: (True, _green_readiness_bundle()),
+    )
+    bad = {
+        "contract": "bounded_pilot_operator_preflight_packet_v1",
+        "summary": {
+            "readiness_ok": True,
+            "stop_snapshot_ok": False,
+            "packet_ok": False,
+            "blocked": ["stop_signal_snapshot.incident_stop_artifact: error (e)"],
+            "notes": [],
+        },
+    }
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        lambda *a, **k: (bad, 1),
+    )
+
+    def _no_subprocess(*a, **k):
+        raise AssertionError("subprocess.run must not be called")
+
+    monkeypatch.setattr(subprocess, "run", _no_subprocess)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run_bounded_pilot_session", "--repo-root", str(ROOT), "--json"],
+    )
+    assert mod.main() == 1
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["entry_permitted"] is False
+    assert data["blocked_at"] == "operator_preflight_packet"
+    blocked_txt = " ".join(data["operator_preflight_packet"]["summary"]["blocked"])
+    assert "incident_stop_artifact" in blocked_txt


### PR DESCRIPTION
## Summary
- wire the existing bounded-pilot operator preflight packet into the session entry wrapper before runner handoff
- block runner handoff when the packet reports packet errors or packet_ok=false
- keep `--no-invoke` unchanged on the readiness-only path
- add minimal companion runbook/truth-map updates

## Changes
- `scripts/ops/run_bounded_pilot_session.py`
- `tests/ops/test_run_bounded_pilot_session.py`
- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`

## Validation
- `uv run pytest tests/ops/test_run_bounded_pilot_session.py tests/ops/test_bounded_pilot_operator_preflight_packet.py -q`
- `uv run ruff check scripts/ops/run_bounded_pilot_session.py tests/ops/test_run_bounded_pilot_session.py scripts/ops/bounded_pilot_operator_preflight_packet.py tests/ops/test_bounded_pilot_operator_preflight_packet.py`
- `uv run ruff format --check scripts/ops/run_bounded_pilot_session.py tests/ops/test_run_bounded_pilot_session.py scripts/ops/bounded_pilot_operator_preflight_packet.py tests/ops/test_bounded_pilot_operator_preflight_packet.py`
- `uv run pytest tests/ops/test_validate_docs_token_policy_smoke.py tests/ops/test_docs_reference_targets_baseline.py -q`

## Safety note
- no new gate logic added
- fail-closed before runner handoff
- no state mutation
- no live unlock semantics added
