### PR TITLE
feat(ops): add bounded pilot execution cli preflight packet parity

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` — Phase D.3: direkter `run_execution_session.py --mode bounded_pilot` (non-dry-run) führt dasselbe Operator-Preflight-Packet nach Handoff-Env aus (Defense-in-Depth); **keine** Live-Freigabe.
+
 - 2026-04-20 — `docs&#47;ops&#47;runbooks&#47;RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` — Phase B: kanonischer Preflight `check_bounded_pilot_readiness.py`; Entry-Wrapper `run_bounded_pilot_session.py` baut vor Runner-Handoff zusätzlich das read-only Operator-Preflight-Packet (`bounded_pilot_operator_preflight_packet.py`); Ist-Zustand-Tabelle / Phase D; **keine** Live-Freigabe; **keine** neue Gate-Theorie.
 
 - 2026-04-20 — `docs&#47;ops&#47;reviews&#47;incident_stop_kill_switch_consistency_review&#47;REVIEW.md` — Companion: read-only `scripts&#47;ops&#47;snapshot_operator_stop_signals.py` (PT_* / incident_stop artifact / kill_switch JSON, Divergenz-Hinweise); **keine** Runtime-Vereinheitlichung; **keine** Live-Freigabe.

--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
@@ -137,7 +137,7 @@ Vor **Session-Start ohne `--no-invoke`** wird dieses Packet im Entry-Wrapper int
    **Hinweis:** Default ist **extrem klein** steps/sizing im Wrapper-Docstring; Cap an eure Pilot-Tabelle anpassen, aber **immer innerhalb** der konfigurierten `live_risk`-Grenzen.
 
 3. **Alternativ (Operator kontrolliert den Aufruf selbst):**  
-   Nach Gate-Logik manuell:  
+   Nach Gate-Logik manuell (inkl. kanonischem Handoff-Env und **demselben** read-only Operator-Preflight-Packet wie im Wrapper — `run_execution_session.py` baut es im **non-dry-run**-Pfad nach dem Handoff-Bit erneut, fail-closed):  
    `python3 scripts/run_execution_session.py --mode bounded_pilot --strategy <key> --steps <n> ...`  
    Nur nutzen, wenn dieselben Vorbedingungen wie oben erfüllt sind und der Go/No-Go **GO_FOR_NEXT_PHASE_ONLY** ist.
 

--- a/scripts/run_execution_session.py
+++ b/scripts/run_execution_session.py
@@ -121,6 +121,54 @@ def _ensure_bounded_pilot_events_enabled(args: argparse.Namespace) -> None:
         os.environ["PT_EXEC_EVENTS_ENABLED"] = "true"
 
 
+def _bounded_pilot_non_dry_run_preflight_packet_ok(repo_root: Path, config_file: str) -> int:
+    """
+    Defense-in-depth: same operator preflight packet as ``run_bounded_pilot_session`` / CLI.
+
+    Read-only; reuses ``build_operator_preflight_packet`` semantics (no new gate rules).
+
+    Returns:
+        0 if packet_ok and orchestration succeeded; 1 if blocked; 2 on orchestration error.
+    """
+    try:
+        from scripts.ops.bounded_pilot_operator_preflight_packet import (
+            build_operator_preflight_packet,
+        )
+        from scripts.ops.check_bounded_pilot_readiness import (
+            resolve_bounded_pilot_config_path,
+        )
+
+        cfg = Path(config_file)
+        config_path = resolve_bounded_pilot_config_path(
+            repo_root,
+            cfg if cfg.is_absolute() else repo_root / cfg,
+        )
+        packet, packet_code = build_operator_preflight_packet(
+            repo_root,
+            config_path,
+            run_tests=False,
+        )
+    except Exception as e:
+        print(
+            f"ERR: bounded_pilot operator preflight packet failed: {e}",
+            file=sys.stderr,
+        )
+        return 2
+
+    summary = packet.get("summary") or {}
+    packet_ok = bool(summary.get("packet_ok"))
+    if packet_code == 2 or not packet_ok:
+        print(
+            "ERR: bounded_pilot Ausführung abgebrochen — Operator-Preflight-Packet nicht GREEN "
+            "(fail-closed; gleiche Semantik wie scripts/ops/bounded_pilot_operator_preflight_packet.py).",
+            file=sys.stderr,
+        )
+        for b in summary.get("blocked") or []:
+            print(f"  [packet] {b}", file=sys.stderr)
+        return 2 if packet_code == 2 else 1
+    return 0
+
+
 # =============================================================================
 # Main Entry Point
 # =============================================================================
@@ -307,6 +355,10 @@ WICHTIG: Shadow/Testnet senden keine echten Orders. Modus bounded_pilot kann nac
                 file=sys.stderr,
             )
             return 1
+
+        preflight_rc = _bounded_pilot_non_dry_run_preflight_packet_ok(PROJECT_ROOT, args.config)
+        if preflight_rc != 0:
+            return preflight_rc
 
     # Strategy-Liste?
     if args.list_strategies:

--- a/tests/ops/test_run_execution_session_bounded_pilot_preflight.py
+++ b/tests/ops/test_run_execution_session_bounded_pilot_preflight.py
@@ -1,0 +1,267 @@
+"""Tests for bounded_pilot non-dry-run operator preflight packet parity in run_execution_session CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "scripts" / "run_execution_session.py"
+
+
+def _load_mod():
+    spec = importlib.util.spec_from_file_location("run_execution_session_cli", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _green_packet() -> tuple[dict, int]:
+    return (
+        {
+            "contract": "bounded_pilot_operator_preflight_packet_v1",
+            "summary": {
+                "readiness_ok": True,
+                "stop_snapshot_ok": True,
+                "packet_ok": True,
+                "blocked": [],
+                "notes": [],
+            },
+        },
+        0,
+    )
+
+
+def test_preflight_packet_ok_returns_0(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        lambda *a, **k: _green_packet(),
+    )
+    assert mod._bounded_pilot_non_dry_run_preflight_packet_ok(ROOT, "config/config.toml") == 0
+
+
+def test_preflight_packet_blocked_returns_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+
+    def _bad(*a, **k):
+        return (
+            {
+                "contract": "bounded_pilot_operator_preflight_packet_v1",
+                "summary": {
+                    "readiness_ok": True,
+                    "stop_snapshot_ok": False,
+                    "packet_ok": False,
+                    "blocked": ["stop_signal_snapshot.kill_switch_file: error (x)"],
+                    "notes": [],
+                },
+            },
+            1,
+        )
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        _bad,
+    )
+    assert mod._bounded_pilot_non_dry_run_preflight_packet_ok(ROOT, "config/config.toml") == 1
+
+
+def test_preflight_packet_orchestrator_error_returns_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+
+    def _broken(*a, **k):
+        return (
+            {
+                "contract": "bounded_pilot_operator_preflight_packet_v1",
+                "summary": {
+                    "packet_ok": False,
+                    "blocked": ["stop_signal_snapshot: exception (boom)"],
+                },
+            },
+            2,
+        )
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        _broken,
+    )
+    assert mod._bounded_pilot_non_dry_run_preflight_packet_ok(ROOT, "config/config.toml") == 2
+
+
+def test_preflight_packet_build_raises_returns_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+
+    def _raise(*a, **k):
+        raise RuntimeError("packet boom")
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        _raise,
+    )
+    assert mod._bounded_pilot_non_dry_run_preflight_packet_ok(ROOT, "config/config.toml") == 2
+
+
+def test_main_non_dry_run_returns_1_when_preflight_packet_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.core.environment import (
+        LIVE_CONFIRM_TOKEN,
+        PT_BOUNDED_PILOT_INVOKED_FROM_GATE,
+        PT_LIVE_CONFIRM_TOKEN_ENV,
+    )
+
+    mod = _load_mod()
+    monkeypatch.setenv(PT_BOUNDED_PILOT_INVOKED_FROM_GATE, "1")
+    monkeypatch.setenv(PT_LIVE_CONFIRM_TOKEN_ENV, LIVE_CONFIRM_TOKEN)
+
+    def _bad(*a, **k):
+        return (
+            {
+                "contract": "bounded_pilot_operator_preflight_packet_v1",
+                "summary": {
+                    "packet_ok": False,
+                    "blocked": ["stop_signal_snapshot.kill_switch_file: error (e)"],
+                },
+            },
+            1,
+        )
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        _bad,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_execution_session",
+            "--mode",
+            "bounded_pilot",
+            "--strategy",
+            "ma_crossover",
+            "--steps",
+            "1",
+        ],
+    )
+    assert mod.main() == 1
+
+
+def test_main_non_dry_run_reaches_downstream_after_preflight_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preflight GREEN then existing main path runs (fail later at load_config)."""
+    from src.core.environment import (
+        LIVE_CONFIRM_TOKEN,
+        PT_BOUNDED_PILOT_INVOKED_FROM_GATE,
+        PT_LIVE_CONFIRM_TOKEN_ENV,
+    )
+
+    mod = _load_mod()
+    monkeypatch.setenv(PT_BOUNDED_PILOT_INVOKED_FROM_GATE, "1")
+    monkeypatch.setenv(PT_LIVE_CONFIRM_TOKEN_ENV, LIVE_CONFIRM_TOKEN)
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        lambda *a, **k: _green_packet(),
+    )
+
+    def _after_preflight(_p):
+        raise RuntimeError("after_preflight_marker")
+
+    monkeypatch.setattr("src.core.peak_config.load_config", _after_preflight)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_execution_session",
+            "--mode",
+            "bounded_pilot",
+            "--strategy",
+            "ma_crossover",
+            "--steps",
+            "1",
+        ],
+    )
+    assert mod.main() == 1
+
+
+def test_main_non_dry_run_returns_2_when_preflight_orchestrator_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.core.environment import (
+        LIVE_CONFIRM_TOKEN,
+        PT_BOUNDED_PILOT_INVOKED_FROM_GATE,
+        PT_LIVE_CONFIRM_TOKEN_ENV,
+    )
+
+    mod = _load_mod()
+    monkeypatch.setenv(PT_BOUNDED_PILOT_INVOKED_FROM_GATE, "1")
+    monkeypatch.setenv(PT_LIVE_CONFIRM_TOKEN_ENV, LIVE_CONFIRM_TOKEN)
+
+    def _broken(*a, **k):
+        return (
+            {
+                "contract": "bounded_pilot_operator_preflight_packet_v1",
+                "summary": {
+                    "packet_ok": False,
+                    "blocked": ["stop_signal_snapshot: exception (boom)"],
+                },
+            },
+            2,
+        )
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        _broken,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_execution_session",
+            "--mode",
+            "bounded_pilot",
+            "--strategy",
+            "ma_crossover",
+            "--steps",
+            "1",
+        ],
+    )
+    assert mod.main() == 2
+
+
+def test_bounded_pilot_dry_run_skips_preflight_in_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dry-run must not invoke preflight packet helper (abgrenzung)."""
+    mod = _load_mod()
+    called: list = []
+
+    def _should_not_run(*a, **k):
+        called.append(True)
+        return _green_packet()
+
+    monkeypatch.setattr(
+        "scripts.ops.bounded_pilot_operator_preflight_packet.build_operator_preflight_packet",
+        _should_not_run,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_execution_session",
+            "--mode",
+            "bounded_pilot",
+            "--strategy",
+            "ma_crossover",
+            "--steps",
+            "1",
+            "--dry-run",
+        ],
+    )
+    rc = mod.main()
+    assert rc == 0
+    assert called == []


### PR DESCRIPTION
## Summary
- add preflight-packet parity to the direct non-dry-run bounded-pilot execution CLI path
- reuse the existing operator preflight packet after the existing handoff-env check
- fail closed before session start when packet_ok=false or packet orchestration errors
- add minimal companion runbook/truth-map updates

## Changes
- `scripts/run_execution_session.py`
- `tests/ops/test_run_execution_session_bounded_pilot_preflight.py`
- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`

## Validation
- `uv run pytest tests/ops/test_run_execution_session_bounded_pilot_preflight.py tests/test_live_session_runner.py -q`
- `uv run ruff check scripts/run_execution_session.py tests/ops/test_run_execution_session_bounded_pilot_preflight.py`
- `uv run ruff format --check scripts/run_execution_session.py tests/ops/test_run_execution_session_bounded_pilot_preflight.py`
- `uv run pytest tests/ops/test_validate_docs_token_policy_smoke.py tests/ops/test_docs_reference_targets_baseline.py -q`

## Safety note
- no new gate logic added
- fail-closed before session start
- no state mutation
- no live unlock semantics added
