### PR TITLE
feat(ops): add bounded pilot closeout triage hints v0

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md
@@ -129,7 +129,7 @@ These commands are **read-only**; they **do not** unlock live trading or assert 
 | Evidence pointers for one session or latest bounded pilot | `python scripts/report_live_sessions.py --evidence-pointers --session-id <id>` / `--evidence-pointers --latest-bounded-pilot [--json]` |
 | Open registry rows (`started`) | `python scripts/report_live_sessions.py --open-sessions [--bounded-pilot-only] [--latest-bounded-pilot-open] [--json]` |
 | Readiness + preflight packet + registry focus | `python scripts/report_live_sessions.py --bounded-pilot-readiness-summary [--json]` |
-| Closeout / terminal registry signals | `python scripts/report_live_sessions.py --bounded-pilot-closeout-status-summary [--json]` |
+| Closeout / terminal registry signals + derived `abort_triage_hints` (JSON) | `python scripts/report_live_sessions.py --bounded-pilot-closeout-status-summary [--json]` — top-level `abort_triage_hints`; same derivation discipline as lifecycle (read-only; not authorization) |
 | Combined operator snapshot | `python scripts/report_live_sessions.py --bounded-pilot-operator-overview [--json]` |
 | Compact gate / enablement index block | `python scripts/report_live_sessions.py --bounded-pilot-gate-index [--json]` |
 | Frontdoor + canonical subcommand hints | `python scripts/report_live_sessions.py --bounded-pilot-first-live-frontdoor [--json]` |

--- a/scripts/report_live_sessions.py
+++ b/scripts/report_live_sessions.py
@@ -49,7 +49,8 @@ Usage:
     python scripts/report_live_sessions.py --bounded-pilot-readiness-summary
     python scripts/report_live_sessions.py --bounded-pilot-readiness-summary --json
 
-    # Bounded-pilot closeout / final registry status + pointers (read-only; no readiness run):
+    # Bounded-pilot closeout / final registry status + pointers (read-only; no readiness run;
+    # JSON includes abort_triage_hints derived via same lifecycle consistency rules — not authorization):
     python scripts/report_live_sessions.py --bounded-pilot-closeout-status-summary
     python scripts/report_live_sessions.py --bounded-pilot-closeout-status-summary --json
 
@@ -1732,6 +1733,11 @@ def _run_bounded_pilot_closeout_status_summary(
         base_dir=base_dir,
         cwd=cwd,
     )
+    lifecycle_for_hints = _build_bounded_pilot_lifecycle_consistency_block(
+        session_focus,
+        closeout,
+    )
+    abort_triage_hints = lifecycle_for_hints["abort_triage_hints"]
 
     payload: dict[str, Any] = {
         "contract": "report_live_sessions.bounded_pilot_closeout_status_summary",
@@ -1742,6 +1748,7 @@ def _run_bounded_pilot_closeout_status_summary(
             "that a process is or is not running."
         ),
         "registry_dir": str(base_dir),
+        "abort_triage_hints": abort_triage_hints,
         "session_focus": session_focus,
         "closeout": closeout,
     }
@@ -1798,6 +1805,13 @@ def _run_bounded_pilot_closeout_status_summary(
         lines.append("  Operator notes:")
         for n in co["operator_notes"]:
             lines.append(f"    - {n}")
+    hints = payload.get("abort_triage_hints") or []
+    if hints:
+        lines.append("")
+        lines.append("  Abort triage hints (read-only; not authorization):")
+        for i, h in enumerate(hints):
+            lines.append(f"    hint[{i}].primary_runbook: {h.get('primary_runbook')}")
+            lines.append(f"    hint[{i}].section_5_keywords: {h.get('section_5_keywords')}")
     print("\n".join(lines))
     return 0
 

--- a/tests/ops/test_report_live_sessions_closeout_status_summary.py
+++ b/tests/ops/test_report_live_sessions_closeout_status_summary.py
@@ -74,6 +74,11 @@ def test_closeout_summary_terminal_completed_json(
     data = json.loads(capsys.readouterr().out)
     assert data["contract"] == "report_live_sessions.bounded_pilot_closeout_status_summary"
     assert "disclaimer" in data
+    assert "abort_triage_hints" in data
+    hints = data["abort_triage_hints"]
+    assert len(hints) == 1
+    assert "not live authorization" in hints[0]["disclaimer"].lower()
+    assert hints[0]["primary_runbook"].endswith("RUNBOOK_PILOT_INCIDENT_TELEMETRY_DEGRADED.md")
     co = data["closeout"]
     assert co["primary_session_id"] == "bp_done"
     assert co["closeout_signal_summary"] == "REGISTRY_TERMINAL_IN_NEWEST_ARTIFACT"
@@ -111,6 +116,10 @@ def test_closeout_summary_open_started_non_terminal(
 
     data = json.loads(capsys.readouterr().out)
     assert data["session_focus"]["primary_session_id"] == "bp_open"
+    hints = data["abort_triage_hints"]
+    assert len(hints) == 1
+    assert hints[0]["primary_runbook"].endswith("RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md")
+    assert "stale state is unresolved" in hints[0]["section_5_keywords"]
     co = data["closeout"]
     assert co["closeout_signal_summary"] == "REGISTRY_NON_TERMINAL_NEWEST_ONLY"
     assert co["registry_terminal_in_newest_artifact"] is False
@@ -152,6 +161,10 @@ def test_closeout_summary_conflict_newest_started_older_terminal(
 
     data = json.loads(capsys.readouterr().out)
     co = data["closeout"]
+    hints = data["abort_triage_hints"]
+    assert len(hints) == 1
+    assert hints[0]["primary_runbook"].endswith("RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md")
+    assert "session-end mismatch is unresolved" in hints[0]["section_5_keywords"]
     assert co["primary_session_id"] == sid
     assert co["closeout_signal_summary"] == "AMBIGUOUS_NEWEST_STARTED_WITH_OLDER_TERMINAL"
     assert co["registry_terminal_in_newest_artifact"] is False
@@ -190,6 +203,7 @@ def test_closeout_summary_execution_events_pointer_present(
         assert main() == 0
 
     data = json.loads(capsys.readouterr().out)
+    assert data["abort_triage_hints"] == []
     assert data["closeout"]["execution_events_jsonl_present"] is True
     assert data["closeout"]["pointers"]["execution_events_session_jsonl"]["present"] is True
 
@@ -220,6 +234,9 @@ def test_closeout_summary_empty_registry(
     data = json.loads(capsys.readouterr().out)
     assert data["closeout"]["closeout_signal_summary"] == "NO_BOUNDED_PILOT_SESSION_IN_REGISTRY"
     assert data["closeout"]["primary_session_id"] is None
+    hints = data["abort_triage_hints"]
+    assert len(hints) == 1
+    assert "ABORT_TRIAGE_COMPASS" in hints[0]["primary_runbook"]
 
 
 def test_closeout_summary_text_stable_keywords(
@@ -250,6 +267,7 @@ def test_closeout_summary_text_stable_keywords(
     assert "closeout_signal_summary:" in out
     assert "REGISTRY_TERMINAL_IN_NEWEST_ARTIFACT" in out
     assert "bp_txt" in out
+    assert "abort triage hints" in out.lower()
 
 
 def test_closeout_summary_conflicts_with_readiness(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- add read-only `abort_triage_hints` to bounded pilot closeout status summary output
- reuse the existing lifecycle hint derivation path to keep triage semantics aligned
- extend closeout text/JSON surfaces and Compass CLI table without changing runtime or governance behavior

## Files
- `scripts/report_live_sessions.py`
- `tests/ops/test_report_live_sessions_closeout_status_summary.py`
- `tests/ops/test_report_live_sessions_lifecycle_consistency.py`
- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md`

## Validation
- `uv run ruff format --check scripts/report_live_sessions.py tests/ops/test_report_live_sessions_closeout_status_summary.py tests/ops/test_report_live_sessions_lifecycle_consistency.py`
- `uv run ruff check scripts/report_live_sessions.py tests/ops/test_report_live_sessions_closeout_status_summary.py tests/ops/test_report_live_sessions_lifecycle_consistency.py`
- `uv run pytest tests/ops/test_report_live_sessions_closeout_status_summary.py tests/ops/test_report_live_sessions_lifecycle_consistency.py -q`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Safety
- read-only / non-authorizing hints only
- no changes in `src/`
- no governance / risk / execution behavior changes
- no new pointer / contract family
