### PR TITLE
feat(master-v2): add dry smoke ci hook v1

### DIFF
--- a/.github/workflows/master_v2_dry_smoke.yml
+++ b/.github/workflows/master_v2_dry_smoke.yml
@@ -1,0 +1,46 @@
+# Nicht-produktiver Sichtbarkeits-Check: Master-V2 dry smoke (lokal/dev-inhaltlich
+# derselbe Entrypoint wie in scripts/dev/master_v2_dry_smoke_v1.py --run).
+name: Master V2 Dry Smoke
+
+on:
+  pull_request:
+    paths:
+      - "src/trading/master_v2/**"
+      - "tests/trading/master_v2/**"
+      - "scripts/dev/master_v2_dry_smoke_v1.py"
+      - ".github/workflows/master_v2_dry_smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/trading/master_v2/**"
+      - "tests/trading/master_v2/**"
+      - "scripts/dev/master_v2_dry_smoke_v1.py"
+      - ".github/workflows/master_v2_dry_smoke.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: master-v2-dry-smoke-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dry-smoke:
+    name: Master V2 dry smoke (--run)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run Master V2 dry smoke (opt-in script)
+        run: |
+          uv run python scripts/dev/master_v2_dry_smoke_v1.py --run


### PR DESCRIPTION
## Summary
Adds a small dedicated GitHub Actions workflow for the existing Master-V2 dry smoke path.

## What this does
- introduces a path-based, non-production workflow
- runs:
  - `uv run python scripts/dev/master_v2_dry_smoke_v1.py --run`
- triggers only when Master-V2 relevant paths change, or manually via `workflow_dispatch`

## Why this approach
The canonical Master-V2 dry-flow tree is now on `main`, and the next smallest useful step is explicit regression visibility without touching existing central CI gates or production-adjacent paths.

## Non-goals
- no live authorization
- no broker/order/execution integration
- no production pipeline changes
- no new trading semantics

## Validation
- `uv run ruff check src tests scripts`
- `uv run ruff format src tests scripts`
- `uv run pytest tests/trading/master_v2/ -q`
- manual smoke:
  - `uv run python scripts/dev/master_v2_dry_smoke_v1.py --run`

Made with [Cursor](https://cursor.com)