### PR TITLE
feat(master-v2): add wire smoke v1

### DIFF
--- a/scripts/dev/master_v2_dry_smoke_v1.py
+++ b/scripts/dev/master_v2_dry_smoke_v1.py
@@ -3,7 +3,9 @@
 Nicht-produktiver, opt-in Master-V2-Dry-Smoke (v1).
 
 Fuehrt die kanonische Scenario-Matrix gegen den lokalen Evaluator aus
-(`local_evaluator_scenarios_v1`). Kein Live, kein Paper, keine Broker-Logik.
+(`local_evaluator_scenarios_v1`) und prueft zusaetzlich einen minimalen
+Wire-Format-Pfad: JSON-Roundtrip -> `adapt_inputs_to_master_v2_flow_v1` mit
+lokalem Evaluator. Kein Live, kein Paper, keine Broker-Logik.
 
 Verwendung (explizit):
   PYTHONPATH=src python scripts/dev/master_v2_dry_smoke_v1.py --run
@@ -30,9 +32,79 @@ def _setup_src_path() -> None:
         sys.path.insert(0, s)
 
 
+def _build_happy_raw_wire_smoke_v1() -> dict[str, Any]:
+    """
+    Golder Roh-Input wie in `tests/trading/master_v2/test_input_adapter_v1` (happy path).
+    Reuse der kanonischen Szenario-Matrix, keine zusaetzliche Business-Semantik.
+    """
+    from trading.master_v2.scenario_matrix_v1 import (
+        SCENARIO_HAPPY_LIVE_GATED,
+        get_master_v2_scenario_case_v1,
+    )
+
+    c = get_master_v2_scenario_case_v1(SCENARIO_HAPPY_LIVE_GATED)
+    p = c.packet
+    if (
+        p.universe is None
+        or p.doubleplay is None
+        or p.scope_envelope is None
+        or p.risk_cap is None
+        or p.safety is None
+    ):
+        raise RuntimeError("wire_smoke: happy scenario must include all handoff layers")
+    return {
+        "correlation_id": p.correlation_id,
+        "staged": {
+            "current_stage": p.staged.current_stage.value,
+            "requested_stage": p.staged.requested_stage.value,
+            "safety_decision_allowed": p.staged.safety_decision_allowed,
+            "live_authority_acknowledged": p.staged.live_authority_acknowledged,
+        },
+        "universe": {
+            "layer_version": p.universe.layer_version,
+            "symbols": list(p.universe.symbols),
+        },
+        "doubleplay": {
+            "layer_version": p.doubleplay.layer_version,
+            "resolution": p.doubleplay.resolution,
+        },
+        "scope_envelope": {
+            "layer_version": p.scope_envelope.layer_version,
+            "within_envelope": p.scope_envelope.within_envelope,
+        },
+        "risk_cap": {
+            "layer_version": p.risk_cap.layer_version,
+            "cap_satisfied": p.risk_cap.cap_satisfied,
+        },
+        "safety": {
+            "layer_version": p.safety.layer_version,
+            "safety_decision_allowed": p.safety.safety_decision_allowed,
+        },
+    }
+
+
+def _run_wire_format_smoke_v1() -> None:
+    """
+    Simuliert Wire: JSON dump/load -> Input-Adapter inkl. Local-Evaluator.
+    Fail-closed: wirft, wenn Adapter oder Flow nicht dem Happy-Path entsprechen.
+    """
+    from trading.master_v2.input_adapter_v1 import adapt_inputs_to_master_v2_flow_v1
+
+    raw = _build_happy_raw_wire_smoke_v1()
+    as_wire = json.loads(json.dumps(raw))
+    ar = adapt_inputs_to_master_v2_flow_v1(as_wire, run_evaluator=True, with_snapshot=True)
+    if not ar.ok:
+        raise RuntimeError(f"wire_smoke: adapter rejected: {ar.rejection_reason!r}")
+    if ar.local_flow is None:
+        raise RuntimeError("wire_smoke: expected local_flow when run_evaluator=True")
+    if not ar.local_flow.flow_ok:
+        raise RuntimeError(f"wire_smoke: local flow not ok: {ar.local_flow.rejection_reason!r}")
+
+
 def run_master_v2_dry_smoke_v1() -> dict[str, Any]:
     """
     Laeuft die volle Szenario-Matrix gegen den Local-Flow-Evaluator; wirft bei Drift.
+    Dann: minimaler Wire-Format-Smoke (JSON -> Adapter -> Local Evaluator).
     Reine In-Memory-Contracts, kein I/O.
     """
     from trading.master_v2.local_evaluator_scenarios_v1 import (
@@ -45,17 +117,22 @@ def run_master_v2_dry_smoke_v1() -> dict[str, Any]:
     results = run_master_v2_scenario_matrix_v1()
     for name, r in results.items():
         assert_master_v2_scenario_harness_outcome_v1(m[name], r)
+    _run_wire_format_smoke_v1()
     return {
         "ok": True,
         "dry_smoke_adapter_version": "v1",
         "scenario_count": len(results),
         "scenarios": sorted(results.keys()),
+        "wire_path_ok": True,
+        "wire_smoke_version": "v1",
     }
 
 
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(
-        description="Master V2: opt-in dry smoke (Scenario-Matrix x Local Evaluator).",
+        description=(
+            "Master V2: opt-in dry smoke (Scenario-Matrix + minimaler Wire-Format / Adapter)."
+        ),
     )
     p.add_argument(
         "--run",

--- a/tests/trading/master_v2/test_dry_smoke_dev_script_v1.py
+++ b/tests/trading/master_v2/test_dry_smoke_dev_script_v1.py
@@ -31,6 +31,8 @@ def test_run_dry_smoke_in_memory() -> None:
     assert out["ok"] is True
     assert out["scenario_count"] == 5
     assert "happy_live_gated" in out["scenarios"]
+    assert out["wire_path_ok"] is True
+    assert out["wire_smoke_version"] == "v1"
 
 
 def test_main_no_run_is_noop(capsys) -> None:
@@ -47,6 +49,8 @@ def test_main_run_ok(capsys) -> None:
     out = json.loads(capsys.readouterr().out)
     assert out["ok"] is True
     assert out["scenario_count"] == 5
+    assert out["wire_path_ok"] is True
+    assert out["wire_smoke_version"] == "v1"
 
 
 def test_subprocess_invocation_repo_root() -> None:
@@ -65,3 +69,5 @@ def test_subprocess_invocation_repo_root() -> None:
     assert r.returncode == 0, (r.stdout, r.stderr)
     o = json.loads(r.stdout)
     assert o["ok"] is True
+    assert o["wire_path_ok"] is True
+    assert o["wire_smoke_version"] == "v1"


### PR DESCRIPTION
## Summary
Extends the existing Master-V2 dry smoke entrypoint with a small wire-format smoke path.

## What changed
- keeps the existing scenario-matrix dry smoke
- adds a wire-format smoke using the same happy-path raw input shape as the adapter tests
- runs:
  - JSON dump/load
  - `adapt_inputs_to_master_v2_flow_v1(..., run_evaluator=True, with_snapshot=True)`
- surfaces:
  - `wire_path_ok`
  - `wire_smoke_version`

## Why this approach
The dedicated Master-V2 dry smoke workflow already covers the scenario/evaluator path.
This small addition makes the JSON-/adapter-/wire path explicitly regressions-visible too, without adding a new workflow or touching production-adjacent paths.

## Non-goals
- no live authorization
- no broker/order/execution integration
- no new workflow family
- no production pipeline changes
- no new trading semantics

## Validation
- `uv run ruff check src tests scripts`
- `uv run ruff format src tests scripts`
- `uv run pytest tests/trading/master_v2/ -q`
- manual smoke:
  - `uv run python scripts/dev/master_v2_dry_smoke_v1.py --run`

Made with [Cursor](https://cursor.com)