### PR TITLE
feat(master-v2): add happy raw builder v1

### DIFF
--- a/scripts/dev/master_v2_dry_smoke_v1.py
+++ b/scripts/dev/master_v2_dry_smoke_v1.py
@@ -32,65 +32,15 @@ def _setup_src_path() -> None:
         sys.path.insert(0, s)
 
 
-def _build_happy_raw_wire_smoke_v1() -> dict[str, Any]:
-    """
-    Golder Roh-Input wie in `tests/trading/master_v2/test_input_adapter_v1` (happy path).
-    Reuse der kanonischen Szenario-Matrix, keine zusaetzliche Business-Semantik.
-    """
-    from trading.master_v2.scenario_matrix_v1 import (
-        SCENARIO_HAPPY_LIVE_GATED,
-        get_master_v2_scenario_case_v1,
-    )
-
-    c = get_master_v2_scenario_case_v1(SCENARIO_HAPPY_LIVE_GATED)
-    p = c.packet
-    if (
-        p.universe is None
-        or p.doubleplay is None
-        or p.scope_envelope is None
-        or p.risk_cap is None
-        or p.safety is None
-    ):
-        raise RuntimeError("wire_smoke: happy scenario must include all handoff layers")
-    return {
-        "correlation_id": p.correlation_id,
-        "staged": {
-            "current_stage": p.staged.current_stage.value,
-            "requested_stage": p.staged.requested_stage.value,
-            "safety_decision_allowed": p.staged.safety_decision_allowed,
-            "live_authority_acknowledged": p.staged.live_authority_acknowledged,
-        },
-        "universe": {
-            "layer_version": p.universe.layer_version,
-            "symbols": list(p.universe.symbols),
-        },
-        "doubleplay": {
-            "layer_version": p.doubleplay.layer_version,
-            "resolution": p.doubleplay.resolution,
-        },
-        "scope_envelope": {
-            "layer_version": p.scope_envelope.layer_version,
-            "within_envelope": p.scope_envelope.within_envelope,
-        },
-        "risk_cap": {
-            "layer_version": p.risk_cap.layer_version,
-            "cap_satisfied": p.risk_cap.cap_satisfied,
-        },
-        "safety": {
-            "layer_version": p.safety.layer_version,
-            "safety_decision_allowed": p.safety.safety_decision_allowed,
-        },
-    }
-
-
 def _run_wire_format_smoke_v1() -> None:
     """
     Simuliert Wire: JSON dump/load -> Input-Adapter inkl. Local-Evaluator.
     Fail-closed: wirft, wenn Adapter oder Flow nicht dem Happy-Path entsprechen.
     """
+    from trading.master_v2.happy_raw_input_v1 import build_master_v2_happy_scenario_raw_input_v1
     from trading.master_v2.input_adapter_v1 import adapt_inputs_to_master_v2_flow_v1
 
-    raw = _build_happy_raw_wire_smoke_v1()
+    raw = build_master_v2_happy_scenario_raw_input_v1()
     as_wire = json.loads(json.dumps(raw))
     ar = adapt_inputs_to_master_v2_flow_v1(as_wire, run_evaluator=True, with_snapshot=True)
     if not ar.ok:

--- a/src/trading/master_v2/happy_raw_input_v1.py
+++ b/src/trading/master_v2/happy_raw_input_v1.py
@@ -1,0 +1,59 @@
+# src/trading/master_v2/happy_raw_input_v1.py
+"""
+Kanonische Roh-Input-Struktur (v1) fuer den Happy-Pfad aus `SCENARIO_HAPPY_LIVE_GATED`.
+
+Nur Mapping aus der Szenario-Matrix — keine Handelslogik. Verwendet von
+Input-/Debug-Tests und dem opt-in Dev-Dry-Smoke.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .scenario_matrix_v1 import SCENARIO_HAPPY_LIVE_GATED, get_master_v2_scenario_case_v1
+
+
+def build_master_v2_happy_scenario_raw_input_v1() -> dict[str, Any]:
+    """
+    Baut die flache JSON-affine Struktur, die `adapt_inputs_to_master_v2_flow_v1` fuer
+    den voll befuellten happy_live_gated-Fall erwartet.
+    """
+    c = get_master_v2_scenario_case_v1(SCENARIO_HAPPY_LIVE_GATED)
+    p = c.packet
+    if (
+        p.universe is None
+        or p.doubleplay is None
+        or p.scope_envelope is None
+        or p.risk_cap is None
+        or p.safety is None
+    ):
+        raise ValueError("happy scenario must include all handoff layers for wire raw input")
+    return {
+        "correlation_id": p.correlation_id,
+        "staged": {
+            "current_stage": p.staged.current_stage.value,
+            "requested_stage": p.staged.requested_stage.value,
+            "safety_decision_allowed": p.staged.safety_decision_allowed,
+            "live_authority_acknowledged": p.staged.live_authority_acknowledged,
+        },
+        "universe": {
+            "layer_version": p.universe.layer_version,
+            "symbols": list(p.universe.symbols),
+        },
+        "doubleplay": {
+            "layer_version": p.doubleplay.layer_version,
+            "resolution": p.doubleplay.resolution,
+        },
+        "scope_envelope": {
+            "layer_version": p.scope_envelope.layer_version,
+            "within_envelope": p.scope_envelope.within_envelope,
+        },
+        "risk_cap": {
+            "layer_version": p.risk_cap.layer_version,
+            "cap_satisfied": p.risk_cap.cap_satisfied,
+        },
+        "safety": {
+            "layer_version": p.safety.layer_version,
+            "safety_decision_allowed": p.safety.safety_decision_allowed,
+        },
+    }

--- a/tests/trading/master_v2/test_input_adapter_v1.py
+++ b/tests/trading/master_v2/test_input_adapter_v1.py
@@ -1,6 +1,7 @@
 # tests/trading/master_v2/test_input_adapter_v1.py
 from __future__ import annotations
 
+from trading.master_v2.happy_raw_input_v1 import build_master_v2_happy_scenario_raw_input_v1
 from trading.master_v2.input_adapter_v1 import (
     INPUT_ADAPTER_LAYER_VERSION,
     adapt_inputs_to_master_v2_flow_v1,
@@ -17,48 +18,9 @@ def test_adapter_version() -> None:
     assert INPUT_ADAPTER_LAYER_VERSION == "v1"
 
 
-def _happy_raw() -> dict:
-    c = get_master_v2_scenario_case_v1(SCENARIO_HAPPY_LIVE_GATED)
-    p = c.packet
-    assert p.universe is not None
-    assert p.doubleplay is not None
-    assert p.scope_envelope is not None
-    assert p.risk_cap is not None
-    assert p.safety is not None
-    return {
-        "correlation_id": p.correlation_id,
-        "staged": {
-            "current_stage": p.staged.current_stage.value,
-            "requested_stage": p.staged.requested_stage.value,
-            "safety_decision_allowed": p.staged.safety_decision_allowed,
-            "live_authority_acknowledged": p.staged.live_authority_acknowledged,
-        },
-        "universe": {
-            "layer_version": p.universe.layer_version,
-            "symbols": list(p.universe.symbols),
-        },
-        "doubleplay": {
-            "layer_version": p.doubleplay.layer_version,
-            "resolution": p.doubleplay.resolution,
-        },
-        "scope_envelope": {
-            "layer_version": p.scope_envelope.layer_version,
-            "within_envelope": p.scope_envelope.within_envelope,
-        },
-        "risk_cap": {
-            "layer_version": p.risk_cap.layer_version,
-            "cap_satisfied": p.risk_cap.cap_satisfied,
-        },
-        "safety": {
-            "layer_version": p.safety.layer_version,
-            "safety_decision_allowed": p.safety.safety_decision_allowed,
-        },
-    }
-
-
 def test_adapt_happy_matches_scenario_packet() -> None:
     c = get_master_v2_scenario_case_v1(SCENARIO_HAPPY_LIVE_GATED)
-    r = adapt_inputs_to_master_v2_flow_v1(_happy_raw())
+    r = adapt_inputs_to_master_v2_flow_v1(build_master_v2_happy_scenario_raw_input_v1())
     assert r.ok is True
     assert r.rejection_reason is None
     assert r.packet == c.packet
@@ -66,7 +28,9 @@ def test_adapt_happy_matches_scenario_packet() -> None:
 
 
 def test_adapt_with_evaluator() -> None:
-    r = adapt_inputs_to_master_v2_flow_v1(_happy_raw(), run_evaluator=True)
+    r = adapt_inputs_to_master_v2_flow_v1(
+        build_master_v2_happy_scenario_raw_input_v1(), run_evaluator=True
+    )
     assert r.ok and r.local_flow is not None
     assert r.local_flow is not None
     assert r.local_flow.flow_ok is True
@@ -93,7 +57,7 @@ def test_optional_layers_minimal_raw() -> None:
 
 
 def test_reject_bad_stage() -> None:
-    raw = _happy_raw()
+    raw = build_master_v2_happy_scenario_raw_input_v1()
     raw["staged"] = {
         "current_stage": "not_a_stage",
         "requested_stage": "live_gated",
@@ -119,13 +83,13 @@ def test_reject_missing_correlation() -> None:
 
 
 def test_reject_null_handoff() -> None:
-    raw = _happy_raw()
+    raw = build_master_v2_happy_scenario_raw_input_v1()
     raw["universe"] = None  # type: ignore[assignment]
     r = adapt_inputs_to_master_v2_flow_v1(raw)
     assert r.ok is False
 
 
 def test_iter_unexpected_keys() -> None:
-    raw = _happy_raw()
+    raw = build_master_v2_happy_scenario_raw_input_v1()
     raw["extra_field"] = 1
     assert "extra_field" in iter_unexpected_top_level_keys(raw)

--- a/tests/trading/master_v2/test_local_debug_cli_v1.py
+++ b/tests/trading/master_v2/test_local_debug_cli_v1.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from trading.master_v2.happy_raw_input_v1 import build_master_v2_happy_scenario_raw_input_v1
 from trading.master_v2.input_adapter_v1 import adapt_inputs_to_master_v2_flow_v1
 from trading.master_v2.local_debug_cli_v1 import (
     LOCAL_DEBUG_CLI_LAYER_VERSION,
@@ -12,45 +13,6 @@ from trading.master_v2.local_debug_cli_v1 import (
     master_v2_debug_result_to_dict,
     run_master_v2_local_debug_cli_v1,
 )
-from trading.master_v2.scenario_matrix_v1 import (
-    SCENARIO_HAPPY_LIVE_GATED,
-    get_master_v2_scenario_case_v1,
-)
-
-
-def _happy_raw() -> dict:
-    c = get_master_v2_scenario_case_v1(SCENARIO_HAPPY_LIVE_GATED)
-    p = c.packet
-    assert p.universe and p.doubleplay and p.scope_envelope and p.risk_cap and p.safety
-    return {
-        "correlation_id": p.correlation_id,
-        "staged": {
-            "current_stage": p.staged.current_stage.value,
-            "requested_stage": p.staged.requested_stage.value,
-            "safety_decision_allowed": p.staged.safety_decision_allowed,
-            "live_authority_acknowledged": p.staged.live_authority_acknowledged,
-        },
-        "universe": {
-            "layer_version": p.universe.layer_version,
-            "symbols": list(p.universe.symbols),
-        },
-        "doubleplay": {
-            "layer_version": p.doubleplay.layer_version,
-            "resolution": p.doubleplay.resolution,
-        },
-        "scope_envelope": {
-            "layer_version": p.scope_envelope.layer_version,
-            "within_envelope": p.scope_envelope.within_envelope,
-        },
-        "risk_cap": {
-            "layer_version": p.risk_cap.layer_version,
-            "cap_satisfied": p.risk_cap.cap_satisfied,
-        },
-        "safety": {
-            "layer_version": p.safety.layer_version,
-            "safety_decision_allowed": p.safety.safety_decision_allowed,
-        },
-    }
 
 
 def test_debug_cli_version() -> None:
@@ -59,7 +21,9 @@ def test_debug_cli_version() -> None:
 
 def test_run_happy_json_text() -> None:
     out = run_master_v2_local_debug_cli_v1(
-        json_text=json.dumps(_happy_raw()), run_evaluator=True, with_snapshot=True
+        json_text=json.dumps(build_master_v2_happy_scenario_raw_input_v1()),
+        run_evaluator=True,
+        with_snapshot=True,
     )
     assert out["debug_cli_version"] == "v1"
     assert out["adapter_ok"] is True
@@ -72,7 +36,9 @@ def test_run_happy_json_text() -> None:
 
 def test_run_no_evaluator() -> None:
     out = run_master_v2_local_debug_cli_v1(
-        json_text=json.dumps(_happy_raw()), run_evaluator=False, with_snapshot=True
+        json_text=json.dumps(build_master_v2_happy_scenario_raw_input_v1()),
+        run_evaluator=False,
+        with_snapshot=True,
     )
     assert out["adapter_ok"] is True
     assert out["flow_ok"] is None
@@ -104,14 +70,14 @@ def test_master_v2_debug_result_to_dict_adapter_fail() -> None:
 
 def test_file_input(tmp_path) -> None:
     p = tmp_path / "in.json"
-    p.write_text(json.dumps(_happy_raw()), encoding="utf-8")
+    p.write_text(json.dumps(build_master_v2_happy_scenario_raw_input_v1()), encoding="utf-8")
     out = run_master_v2_local_debug_cli_v1(input_path=p)
     assert out["adapter_ok"] and out["flow_ok"] is True
 
 
 def test_main_exit_ok(tmp_path, capsys) -> None:
     p = tmp_path / "x.json"
-    p.write_text(json.dumps(_happy_raw()), encoding="utf-8")
+    p.write_text(json.dumps(build_master_v2_happy_scenario_raw_input_v1()), encoding="utf-8")
     code = main(["-f", str(p)])
     assert code == 0
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary
Adds a single canonical happy-raw input builder for the Master-V2 dry-flow tooling and tests.

## What changed
- introduces:
  - `src/trading/master_v2/happy_raw_input_v1.py`
  - `build_master_v2_happy_scenario_raw_input_v1()`
- updates:
  - `scripts/dev/master_v2_dry_smoke_v1.py`
  - `tests/trading/master_v2/test_input_adapter_v1.py`
  - `tests/trading/master_v2/test_local_debug_cli_v1.py`

## Why this approach
The same “happy raw” input shape had been duplicated across the dry-smoke script and multiple tests.
This created a small but real drift surface in exactly the area the wire-smoke path is meant to protect.
This PR reduces that duplication without changing semantics.

## Non-goals
- no new trading logic
- no workflow changes
- no live authorization
- no broker/order/execution integration
- no production pipeline changes

## Validation
- `uv run ruff check src tests scripts`
- `uv run ruff format src tests scripts`
- `uv run pytest tests/trading/master_v2/ -q`
- manual smoke:
  - `uv run python scripts/dev/master_v2_dry_smoke_v1.py --run`

Made with [Cursor](https://cursor.com)