### PR TITLE
feat(scripts): add pipeline_cli master_v2 dry delegate

### DIFF
--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -16,7 +16,10 @@ def run(cmd: list[str], env: dict[str, str]) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="pipeline_cli.py",
-        description="Unified pipeline CLI (offline-first): research / live_ops (no-live) / risk",
+        description=(
+            "Unified pipeline CLI (offline-first): research / live_ops (no-live) / risk / "
+            "master_v2 (non-production dry smoke; no live; no orders)"
+        ),
     )
     parser.add_argument("--run-id", default=None, help="Run id for evidence pack directory naming")
     parser.add_argument(
@@ -45,6 +48,19 @@ def main() -> int:
     p_k = sub.add_parser("risk", help="Delegate to scripts/risk_cli.py")
     p_k.add_argument(
         "args", nargs=argparse.REMAINDER, help="Args forwarded to risk_cli.py (prefix with --)"
+    )
+
+    # Master V2 dry smoke (dev-only, non-production)
+    p_m = sub.add_parser(
+        "master_v2",
+        help=(
+            "Delegate to scripts/dev/master_v2_dry_smoke_v1.py (non-production; no live; no orders)"
+        ),
+    )
+    p_m.add_argument(
+        "args",
+        nargs=argparse.REMAINDER,
+        help="Args forwarded to master_v2_dry_smoke_v1.py (e.g. -- --run)",
     )
 
     args = parser.parse_args()
@@ -78,6 +94,19 @@ def main() -> int:
         if getattr(args, "artifacts_dir", None):
             cmd += ["--artifacts-dir", args.artifacts_dir]
         cmd += args.args
+        return run(cmd, env)
+
+    if args.cmd == "master_v2":
+        cmd = [sys.executable, str(ROOT / "scripts" / "dev" / "master_v2_dry_smoke_v1.py")]
+        forwarded = list(args.args)
+        if forwarded and forwarded[0] == "--":
+            forwarded = forwarded[1:]
+        cmd += forwarded
+        src = str(ROOT / "src")
+        if env.get("PYTHONPATH"):
+            env["PYTHONPATH"] = src + os.pathsep + env["PYTHONPATH"]
+        else:
+            env["PYTHONPATH"] = src
         return run(cmd, env)
 
     return 2

--- a/tests/ops/test_pipeline_cli_smoke.py
+++ b/tests/ops/test_pipeline_cli_smoke.py
@@ -1,6 +1,7 @@
 """Smoke test for pipeline_cli delegating to risk_cli (offline-first)."""
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -47,3 +48,26 @@ def test_pipeline_cli_risk_smoke(tmp_path):
     assert data["var"] >= 0
     assert (tmp_path / "smoke_pipeline" / "meta.json").exists()
     assert (tmp_path / "smoke_pipeline" / "results" / "var.json").exists()
+
+
+def test_pipeline_cli_master_v2_dry_smoke_delegate():
+    """Delegates to scripts/dev/master_v2_dry_smoke_v1.py (non-production)."""
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "pipeline_cli.py"),
+        "master_v2",
+        "--",
+        "--run",
+    ]
+    p = subprocess.run(
+        cmd,
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(ROOT / "src")},
+    )
+    assert p.returncode == 0, p.stderr or p.stdout
+    data = json.loads(p.stdout)
+    assert data["ok"] is True
+    assert data.get("wire_path_ok") is True
+    assert data.get("wire_smoke_version") == "v1"


### PR DESCRIPTION
## Summary
Adds a non-production `master_v2` subcommand to `scripts/pipeline_cli.py` that delegates to the existing Master-V2 dry-smoke entrypoint.

## What changed
- extends `scripts/pipeline_cli.py` with a `master_v2` subcommand
- delegates to:
  - `scripts/dev/master_v2_dry_smoke_v1.py`
- supports delegated remainder args such as:
  - `python3 scripts/pipeline_cli.py master_v2 -- --run`
- sets `PYTHONPATH=src` for the subprocess, consistent with existing local usage
- adds a focused smoke test in:
  - `tests/ops/test_pipeline_cli_smoke.py`

## Why this approach
This creates the first small runtime-adjacent, non-production attachment point for the canonical Master-V2 dry flow using the existing unified offline-first CLI surface, without changing trading logic or production-adjacent paths.

## Non-goals
- no live authorization
- no broker/order/execution integration
- no new workflow family
- no changes to `src/trading/master_v2/*`
- no production pipeline wiring

## Validation
- `uv run ruff check scripts tests`
- `uv run ruff format scripts tests`
- `uv run pytest tests/ops/test_pipeline_cli_smoke.py -q`
- manual:
  - `python3 scripts/pipeline_cli.py master_v2 -- --run`

Made with [Cursor](https://cursor.com)