### PR TITLE
docs(cli): add master v2 pipeline entrypoint discoverability v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -548,6 +548,27 @@ python3 scripts/preview_live_orders.py \
 
 Die Developer-Guides erklären typische Erweiterungen Schritt für Schritt, inkl. CLI-Beispiele für Tests und Integration.
 
+**Pipeline CLI (offline-first) — Master V2 dry smoke (non-production):**
+
+- Einheitlicher Einstieg über [`scripts/pipeline_cli.py`](../scripts/pipeline_cli.py) (Subcommand `master_v2`). **Nicht produktiv** — kein Live, **keine** Orders, **kein** Broker; delegiert ausschließlich an den opt-in-Dry-Smoke-Entry [`scripts/dev/master_v2_dry_smoke_v1.py`](../scripts/dev/master_v2_dry_smoke_v1.py).
+- Trockenlauf (JSON mit `ok` / `wire_path_ok` u. a. auf stdout):
+
+```bash
+python3 scripts/pipeline_cli.py master_v2 -- --run
+```
+
+- Alternative: Dry-Skript **direkt** (repo root, `PYTHONPATH=src` setzen, wie in Dev-Tests; oder `uv run python …`):
+
+```bash
+PYTHONPATH=src python3 scripts/dev/master_v2_dry_smoke_v1.py --run
+```
+
+- Optional, schmaler **JSON-Dryflow** (Adapter + optional Evaluator) aus dem `trading`-Paket — ebenfalls lokal, nicht produktiv:
+
+```bash
+PYTHONPATH=src python3 -m trading.master_v2.local_debug_cli_v1 --help
+```
+
 ---
 
 ## Siehe auch


### PR DESCRIPTION
## Summary
Adds discoverability for the non-production Master-V2 pipeline entrypoint to the existing CLI cheatsheet.

## What changed
- updates `docs/CLI_CHEATSHEET.md`
- adds a small “For developers” style entry for:
  - `pipeline_cli master_v2 -- --run`
- clarifies:
  - non-production
  - no live / no orders
  - delegation to the existing dry-smoke entrypoint
- includes optional reference to the direct dry-smoke / local debug CLI usage

## Why this approach
After adding the non-production `pipeline_cli master_v2` delegate, the highest-leverage follow-up is simple discoverability in the existing CLI docs, without further expanding the technical surface.

## Non-goals
- no new trading logic
- no workflow changes
- no runtime changes
- no production integration

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)