### PR TITLE
feat(scripts): guard pipeline_cli master_v2 run mode v1

### DIFF
--- a/scripts/pipeline_cli.py
+++ b/scripts/pipeline_cli.py
@@ -101,6 +101,13 @@ def main() -> int:
         forwarded = list(args.args)
         if forwarded and forwarded[0] == "--":
             forwarded = forwarded[1:]
+        if "--run" not in forwarded and "--help" not in forwarded and "-h" not in forwarded:
+            print(
+                "pipeline_cli master_v2: missing --run (dry smoke not executed). "
+                "Use: python3 scripts/pipeline_cli.py master_v2 -- --run",
+                file=sys.stderr,
+            )
+            return 2
         cmd += forwarded
         src = str(ROOT / "src")
         if env.get("PYTHONPATH"):

--- a/tests/ops/test_pipeline_cli_smoke.py
+++ b/tests/ops/test_pipeline_cli_smoke.py
@@ -71,3 +71,18 @@ def test_pipeline_cli_master_v2_dry_smoke_delegate():
     assert data["ok"] is True
     assert data.get("wire_path_ok") is True
     assert data.get("wire_smoke_version") == "v1"
+
+
+def test_pipeline_cli_master_v2_run_guard_without_run():
+    """Fail-closed when --run is omitted so automation does not see a false success."""
+    cmd = [sys.executable, str(ROOT / "scripts" / "pipeline_cli.py"), "master_v2"]
+    p = subprocess.run(
+        cmd,
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(ROOT / "src")},
+    )
+    assert p.returncode == 2, p.stderr or p.stdout
+    assert "master_v2" in p.stderr
+    assert "-- --run" in p.stderr


### PR DESCRIPTION
## Summary
Adds a small fail-closed run guard for `pipeline_cli master_v2` so the command no longer exits successfully when no actual dry-smoke run was requested.

## What changed
- updates `scripts/pipeline_cli.py`
- updates `tests/ops/test_pipeline_cli_smoke.py`

## Behavior
- `python3 scripts/pipeline_cli.py master_v2`
  - now fails closed
  - prints a short hint to stderr
  - exits with non-zero status (2)
- `python3 scripts/pipeline_cli.py master_v2 -- --run`
  - unchanged
  - still delegates to the existing dry-smoke entrypoint
- `python3 scripts/pipeline_cli.py master_v2 -- --help`
  - unchanged
  - still allowed

## Why this approach
The success path was already solid.
The concrete remaining usability/automation gap was the no-arg path: it delegated to the child script, which exited 0 and printed non-JSON text even though no dry-smoke run actually happened.
This PR fixes that with the smallest possible guard at the `pipeline_cli` boundary.

## Non-goals
- no new trading logic
- no workflow changes
- no changes to `src/trading/master_v2/*`
- no production pipeline changes
- no live/execution integration

## Validation
- `uv run ruff check scripts tests`
- `uv run ruff format scripts tests`
- `uv run pytest tests/ops/test_pipeline_cli_smoke.py -q`
- manual:
  - `python3 scripts/pipeline_cli.py master_v2`
  - `python3 scripts/pipeline_cli.py master_v2 -- --run`
  - `python3 scripts/pipeline_cli.py master_v2 -- --help`

Made with [Cursor](https://cursor.com)