### PR TITLE
ci(hygiene): make strict yaml load fail closed v1

### DIFF
--- a/scripts/ci/validate_required_checks_hygiene.py
+++ b/scripts/ci/validate_required_checks_hygiene.py
@@ -27,7 +27,7 @@ Usage:
 
 Exit Codes:
   0: All required checks are hygiene-compliant
-  2: Hygiene violations found (required checks unreliable)
+  2: Hygiene violations found (required checks unreliable), or strict-mode YAML load errors
 
 Phase: 5D
 Date: 2026-01-12
@@ -67,9 +67,11 @@ class WorkflowAnalyzer:
     def __init__(self, workflow_dir: Path):
         self.workflow_dir = workflow_dir
         self.workflows: List[Dict[str, Any]] = []
+        self.load_errors: List[Tuple[str, str]] = []
 
     def load_workflows(self) -> None:
         """Load and parse all workflow YAML files."""
+        self.load_errors = []
         yaml = _require_yaml()
         patterns = ["*.yml", "*.yaml"]
         workflow_files = []
@@ -89,6 +91,8 @@ class WorkflowAnalyzer:
                             }
                         )
             except Exception as e:
+                msg = f"{type(e).__name__}: {e}"
+                self.load_errors.append((wf_file.name, msg))
                 print(f"WARNING: Failed to parse {wf_file.name}: {e}", file=sys.stderr)
 
     def _expand_matrix_job_names(
@@ -241,6 +245,20 @@ class RequiredChecksValidator:
         """
         self.load_config()
         self.analyzer.load_workflows()
+
+        if self.strict and self.analyzer.load_errors:
+            for fname, err in self.analyzer.load_errors:
+                self.findings.append(
+                    {
+                        "context": f"workflow YAML ({fname})",
+                        "status": "FAIL",
+                        "reason": f"Failed to parse workflow file: {err}",
+                        "remediation": (
+                            f"Fix YAML syntax in {fname} so the hygiene validator can analyze all workflows."
+                        ),
+                    }
+                )
+
         surfaces = self.analyzer.extract_required_check_surfaces()
 
         self.effective_required_contexts = load_effective_required_contexts(self.config_path)
@@ -335,6 +353,8 @@ class RequiredChecksValidator:
             print("All required status checks are produced by always-on PR workflows.")
             print("All required status checks are also available on merge_group.")
             print("No path-filtering detected on required checks.")
+            if self.strict:
+                print("Strict mode: all workflow YAML files parsed successfully.")
             return
 
         print(f"❌ FAILURE: {findings_count} hygiene violation(s) found")
@@ -397,7 +417,7 @@ Examples:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Strict mode (treat warnings as failures)",
+        help="Strict mode: fail if any workflow YAML cannot be parsed (load errors)",
     )
 
     args = parser.parse_args()

--- a/tests/ci/test_required_checks_hygiene.py
+++ b/tests/ci/test_required_checks_hygiene.py
@@ -442,3 +442,53 @@ jobs:
         assert len(validator.findings) == 1
         assert validator.findings[0]["context"] == "parity-check"
         assert "merge_group" in validator.findings[0]["reason"]
+
+
+def test_strict_mode_fails_closed_on_unparseable_workflow_yaml(fixtures_dir):
+    """Strict: invalid YAML in the workflows dir must surface as a hygiene failure."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workflows_dir = Path(tmpdir) / "workflows"
+        workflows_dir.mkdir()
+
+        good_wf = fixtures_dir / "minimal_good.yml"
+        (workflows_dir / "minimal_good.yml").write_text(good_wf.read_text())
+        (workflows_dir / "broken_syntax.yml").write_text(
+            "this: is: not: valid: yaml: structure: [\n"
+        )
+
+        config = fixtures_dir / "test_config_good.json"
+        validator = RequiredChecksValidator(
+            config_path=config,
+            workflow_dir=workflows_dir,
+            strict=True,
+        )
+        success = validator.validate()
+        assert success is False
+        yaml_findings = [f for f in validator.findings if f["context"].startswith("workflow YAML")]
+        assert len(yaml_findings) >= 1
+        assert "broken_syntax.yml" in yaml_findings[0]["context"]
+        assert "Failed to parse" in yaml_findings[0]["reason"]
+
+
+def test_non_strict_keeps_success_when_contexts_ok_despite_unparseable_yaml(fixtures_dir):
+    """Non-strict: parse warnings do not add findings; required contexts may still pass."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workflows_dir = Path(tmpdir) / "workflows"
+        workflows_dir.mkdir()
+
+        good_wf = fixtures_dir / "minimal_good.yml"
+        (workflows_dir / "minimal_good.yml").write_text(good_wf.read_text())
+        (workflows_dir / "broken_syntax.yml").write_text(
+            "this: is: not: valid: yaml: structure: [\n"
+        )
+
+        config = fixtures_dir / "test_config_good.json"
+        validator = RequiredChecksValidator(
+            config_path=config,
+            workflow_dir=workflows_dir,
+            strict=False,
+        )
+        success = validator.validate()
+        assert success is True
+        assert len(validator.findings) == 0
+        assert len(validator.analyzer.load_errors) >= 1


### PR DESCRIPTION
## Summary
Gives `--strict` real fail-closed meaning in the required-checks hygiene validator when workflow YAML files cannot be parsed/loaded.

## What changed
- updates:
  - `scripts/ci/validate_required_checks_hygiene.py`
  - `tests/ci/test_required_checks_hygiene.py`
- `WorkflowAnalyzer` now collects workflow YAML load/parse errors in structured form
- in `strict=True`, `RequiredChecksValidator.validate()` turns these into FAIL findings
- in non-strict mode, load errors remain warnings and do not automatically fail the run
- success reporting in strict mode now also reflects successful workflow parsing

## Why this approach
Previously `--strict` mainly affected display, while broken/unreadable workflow YAML could be warned to stderr and then effectively skipped.
This PR makes strict mode semantically meaningful with the smallest practical fail-closed guard.

## Non-goals
- no new workflow family
- no broad CI redesign
- no production/runtime changes
- no branch-protection policy changes

## Validation
- `python3 scripts/ci/validate_required_checks_hygiene.py --config config/ci/required_status_checks.json --workflows .github/workflows`
- `python3 scripts/ci/validate_required_checks_hygiene.py --config config/ci/required_status_checks.json --workflows .github/workflows --strict`
- `uv run pytest tests/ci/test_required_checks_hygiene.py -q`
- `uv run ruff check scripts tests`

Made with [Cursor](https://cursor.com)