### PR TITLE
docs(ops): harden pilot incident unexpected exposure v1

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md
+++ b/docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md
@@ -1,9 +1,9 @@
 # RUNBOOK — Pilot Incident: Unexpected Exposure
 
-status: DRAFT
-last_updated: 2026-04-20
+status: OPERATOR-READY
+last_updated: 2026-04-23
 owner: Peak_Trade
-purpose: Operator response when position or notional exposure is outside the intended bounded pilot envelope, or when exposure relative to caps cannot be established
+purpose: Operator response when position or notional exposure is outside the intended bounded pilot envelope, when exposure grows without an operator-trusted explanation, or when exposure relative to caps cannot be established; fail-closed until classified or governance directs otherwise outside this document
 docs_token: DOCS_TOKEN_RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE
 
 ## Non-authorization (read first)
@@ -18,9 +18,9 @@ If there is **any** doubt whether trading is allowed, apply [Entry Contract §5]
 
 ## A. Purpose and boundaries
 
-**In this context, “unexpected exposure” means:** observed or inferred **position / notional / risk** sits **outside** the **intended bounded pilot envelope**, **grows** without an operator-trusted explanation, or **cannot be reconciled** to configured caps quickly enough to justify continued risk-taking.
+**Use this runbook as the primary path when** cap or envelope surprise is the **dominant** problem: you know or strongly suspect **“too much / wrong shape / unknown size”** relative to the **intended bounded pilot envelope**, not merely that one feed is slow. Symptom routing: [Abort triage compass §5.2](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md#52-exposure-or-cap-surprise).
 
-**Use this runbook when** cap or envelope surprise is the **primary** problem (you know or strongly suspect “too much / wrong shape / unknown size,” not merely that one feed is slow).
+**In this context, “unexpected exposure” means:** observed or inferred **position / notional / risk** sits **outside** that envelope, **grows** without an operator-trusted explanation, or **cannot be reconciled** to configured caps quickly enough to justify continued risk-taking.
 
 **Prefer a different primary path when:**
 
@@ -28,7 +28,10 @@ If there is **any** doubt whether trading is allowed, apply [Entry Contract §5]
 - **Disagreement is narrowly at session end / closeout boundary** → [Session end mismatch](RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md).
 - **Funding / transfer status** is the unknown → [Transfer ambiguity](RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md).
 - **Venue path unhealthy** (timeouts, rejects, unreliable acks) without a cap surprise yet → [Exchange degraded](RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md); **overlap is common** — stabilize venue **and** hold `NO_TRADE` if exposure is unclear.
+- **Observability / evidence continuity** is the main gap **without** a crisp cap/envelope narrative → [Telemetry degraded](RUNBOOK_PILOT_INCIDENT_TELEMETRY_DEGRADED.md); if **exposure** doubt dominates, keep **this** runbook primary.
+- **Process restart / cold local state** mid-session → [Restart mid-session](RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md); return here if **envelope** truth remains the open question after continuity rebuild.
 - **Kill switch already active** as the org-wide control → follow [Kill Switch runbook](../../risk/KILL_SWITCH_RUNBOOK.md) and remain `NO_TRADE`; use this runbook **additionally** if you must **characterize** unexpected exposure for evidence and escalation.
+- **Symptom routing** → [Abort triage compass](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md).
 
 ## B. Triggers and entry conditions
 
@@ -56,24 +59,36 @@ If there is **any** doubt whether trading is allowed, apply [Entry Contract §5]
 - **Transfer not landed** → transfer runbook first.
 - **Only** connectivity / rate-limit noise **without** exposure doubt → exchange degraded first (still `NO_TRADE` if ambiguity exists).
 
-## C. Immediate actions (fail-closed order)
+**Fail-closed rule**
+
+- If **envelope or cap truth** is **unclear** after a bounded check, treat as **`ambiguous`**: **`NO_TRADE`** and **freeze** risk expansion until classification improves or governance directs otherwise **outside** this document.
+
+## C. Immediate actions (ordered)
 
 1. **Stop new risk immediately:** **`NO_TRADE`** and **no deliberate new positions** or size increases. If org procedure requires an explicit **kill-switch / safe-stop** posture, apply it per [Kill Switch runbook](../../risk/KILL_SWITCH_RUNBOOK.md) — this runbook does not redefine that mechanism.
-2. **Freeze the scene:** note **time**, **session id**, **operator**, and **what changed** (last known good envelope vs now). Do **not** “trade through” to fix.
-3. **Snapshot visibility (read-only):** pull bounded-pilot **overview / closeout / lifecycle** JSON **after** posture is safe, not instead of stopping risk — see §E for commands. Read embedded **disclaimers**; JSON is **not** proof of safety.
+2. **Freeze the scene:** note **UTC time**, **session id**, **operator**, and **what changed** (last known good envelope vs now). Do **not** “trade through” to fix.
+3. **Snapshot visibility (read-only):** pull bounded-pilot **overview / closeout / lifecycle** JSON **after** posture is safe, not instead of stopping risk — see §E and [Compass §8](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md#8-read-only-cli--report-hints-scriptsreport_live_sessionspy). Read embedded **disclaimers**; JSON is **not** proof of safety.
 4. **Establish broker-trusted truth:** use the **same broker/exchange channels** your reconciliation discipline already relies on; do **not** trust a single local pane if it disagrees with broker authority for size.
-5. **Classify:** `reconciled_explainable` / `partial` / **`ambiguous`**. If **partial** or **ambiguous**, **remain** `NO_TRADE` and **escalate** — see §G.
+5. **Classify:** **`reconciled_explainable`** / **`partial`** / **`ambiguous`** (see §D). If **`partial`** or **`ambiguous`**, **remain** `NO_TRADE` and **escalate** per §F.
 6. **Record external evidence** per [L5 incident / safe-stop pointer contract](../specs/MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md) (handles **outside** git; **no** log dumps in-repo).
 
-Order matters: **posture before investigation**, **broker truth before “we’re fine”**, **external pointers for review bundles**.
+**Order matters:** **posture before investigation**, **broker truth before “we’re fine”**, **external pointers for review bundles**.
 
-## D. Verification (signal → suspicion → confirmation)
+**Containment reminders:** Do **not** “roll forward” by widening caps or interpreting JSON hints as approval. Do **not** delete or rewrite registry rows to **match** a desired story; if registry and truth disagree, involve [Reconciliation mismatch](RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md) and escalation. **Broker‑protective actions** (flatten, hedge, cancel working orders) follow **org trading policy** and kill-switch playbooks — this runbook **does not** prescribe specific market actions.
 
-**Definitions**
+## D. Verification and classification
+
+**Signal → suspicion → confirmation (lens)**
 
 - **Signal:** UI, alert, metric, or JSON hint that something may be wrong.
 - **Suspicion:** operator judgment that exposure may be **out of envelope** or **unknown**.
 - **Confirmation:** **consistent** story across **cockpit / registry / broker-trusted** views (as applicable) that exposure is **within** envelope **or** **bounded and explained**; or a **governance-accepted** disposition recorded **outside** this repo.
+
+**Classification (operational)**
+
+- **Reconciled explainable:** broker-trusted exposure is **within** the intended pilot envelope **or** the **delta** is **fully explained** by a known, operator-trusted cause **without** residual cap doubt — **still** no authorization from this document to resume.
+- **Partial:** some checks align, but caps, notionals, or margin story **not** fully settled — **cannot** justify the next risk-increasing step.
+- **Ambiguous:** contradictory views, **unknown** net vs envelope, or **cannot** complete verification in bounded time — **unsafe** to extend risk.
 
 **Suggested order**
 
@@ -81,9 +96,21 @@ Order matters: **posture before investigation**, **broker truth before “we’r
 2. Compare **intended caps** (configured caps, pilot plan) to **broker-trusted** position / notional / margin.
 3. Use **read-only** session reports to **correlate** session id, registry row, and closeout/lifecycle hints — not to **override** broker truth.
 4. If **reconciliation** explains the delta **without** cap violation, **hand off** to [Reconciliation mismatch](RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md) as primary narrative; **do not** resume trading while [Entry Contract §5](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#5-abort--rollback--no_trade-criteria) blocks.
-5. If **after** checks exposure is **still** unclear or **out of envelope**, treat as **unresolved** — §G.
+5. If **after** checks exposure is **still** unclear or **out of envelope**, treat as **unresolved** — §F.
 
-## E. Evidence and artifact sources (repo-established only)
+**Suggested checks**
+
+- Re-pull **bounded-pilot** overview / lifecycle / closeout JSON **read-only** after posture is safe — see [Compass §8](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md#8-read-only-cli--report-hints-scriptsreport_live_sessionspy); read **disclaimers**; JSON is **not** proof of safety.
+- If **observability** alone is the gap, pivot triage context to [Telemetry degraded](RUNBOOK_PILOT_INCIDENT_TELEMETRY_DEGRADED.md) while holding **`NO_TRADE`** if exposure is unclear.
+
+**Return toward normal (non-authorizing)**
+
+- **No** “resume trading” from this runbook alone after **`partial`** / **`ambiguous`**. **Only** governance or explicit org disposition **outside** this repo can authorize continuation.
+- **May treat as stabilized for *this incident slice* only** when **all** hold: broker-trusted exposure is **within** envelope **or** **fully explained** and **accepted** under **external** governance (record via **L5** pointers); **no** remaining Entry Contract §5 blockers you are aware of; operator of record can **state** **final classification** and **posture** without contradiction across cockpit, broker, and registry snapshots used.
+- If **`reconciled_explainable`**, posture still follows [Entry Contract §5](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#5-abort--rollback--no_trade-criteria) and [Failure taxonomy §6](../specs/MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md#6-ambiguity-confusion-and-interpretation-risk-map); this runbook does not grant go-ahead.
+- **Do not continue** when you would need to **assume** away ambiguity, or when read-only JSON or gate-index snippets **look green** but **contradict** broker-trusted exposure — visibility is **not** authorization ([Decision authority map §4 / §7](../specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md); [Gate index G8](../specs/MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md) is **not** a substitute for exposure truth).
+
+## E. Evidence and pointers (L5 discipline)
 
 Use **existing** operator surfaces; do **not** invent new artifact types in git.
 
@@ -99,40 +126,36 @@ Use **existing** operator surfaces; do **not** invent new artifact types in git.
 | `python scripts/ops/check_bounded_pilot_readiness.py` | Canonical **read-only** preflight bundle (does **not** replace incident verification) |
 | [L5 pointer contract](../specs/MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md) | **External** evidence handles after stabilization |
 
-## F. Safe retreat, containment, and rollback posture
+Capture review material **outside** git per the L5 contract: **metadata and opaque handles only** — no log dumps, secrets, or raw payloads in the repository.
 
-- **Default containment:** **`NO_TRADE`** and **no new risk** until exposure is **explained** or **governance-accepted** disposition exists **outside** this repository.
-- **Do not** “roll forward” by widening caps or interpreting JSON hints as approval.
-- **Do not** delete or rewrite registry rows to **match** a desired story; if registry and truth disagree, that is **reconciliation / integrity** territory — involve [Reconciliation mismatch](RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md) and escalation.
-- **Broker‑protective actions** (flatten, hedge, cancel working orders) follow **org trading policy** and kill-switch playbooks — this runbook **does not** prescribe specific market actions.
+**Minimum narrative to record externally (conceptual)**
 
-## G. Exit criteria (when to stand down vs stop)
+- **Trigger** (cap/envelope symptom, first observation).
+- **Intended cap / envelope** vs **broker-trusted numbers** (categories only as appropriate).
+- **Cockpit/registry snapshot references** (handles only).
+- **Classification** (`reconciled_explainable` / `partial` / `ambiguous`).
+- **Final posture** and **escalation id / owner** if any.
 
-**May treat as stabilized for *this incident slice* only** when **all** hold:
+## F. Escalation
 
-- Broker-trusted exposure is **within** the **intended pilot envelope**, **or** exposure is **fully explained** and **accepted** under **external** governance (record via **L5** pointers, not free-form logs in git).
-- **No** remaining [Entry Contract §5](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#5-abort--rollback--no_trade-criteria) blockers you are aware of.
-- Operator of record can **state** the **final classification** and **posture** without contradiction across cockpit, broker, and registry snapshots used in the investigation.
-
-**Escalate and remain `NO_TRADE` when:**
+Escalate when **any** holds:
 
 - Exposure is **still unknown**, **out of envelope**, or **classification is partial** after initial checks.
 - **Policy / kill-switch / evidence** posture is degraded such that you cannot **verify** caps.
 
-**Do not continue pilot activity when:**
+**Internal:** pilot owner / governance per bounded-pilot path; state **symptom class**, **UTC window**, **session id**, and whether exposure is **known**, **partially known**, or **unknown**.
 
-- You would need to **assume** away ambiguity to resume.
-- Read-only JSON or gate-index snippets **look green** but **contradict** broker-trusted exposure — visibility is **not** authorization ([Decision authority map §4 / §7](../specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md); [Gate index G8](../specs/MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md) is **not** a substitute for exposure truth).
+**External:** only per org rules; **no** secrets or unnecessary identifiers in unsecured channels.
 
-## H. Cross-links
+## G. Related runbooks
 
-- [§5 Abort triage compass](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md) — symptom routing, CLI table, escalation defaults
-- [Entry Contract §5](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#5-abort--rollback--no_trade-criteria) — abort / `NO_TRADE` criteria
-- [Reconciliation mismatch](RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md), [Session end mismatch](RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md), [Exchange degraded](RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md), [Transfer ambiguity](RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md)
+- [Reconciliation mismatch](RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md)
+- [Session end mismatch](RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md)
+- [Exchange degraded](RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md)
+- [Telemetry degraded](RUNBOOK_PILOT_INCIDENT_TELEMETRY_DEGRADED.md)
+- [Transfer ambiguity](RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md)
+- [Restart mid-session](RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md)
+- [Abort triage compass](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md)
 - [Kill Switch runbook](../../risk/KILL_SWITCH_RUNBOOK.md)
-- [L5 incident / safe-stop evidence pointers](../specs/MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md)
-- [Failure taxonomy (non-authorizing)](../specs/MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md#4-failure-taxonomy-table)
 
-## Evidence checklist (external record)
-
-Capture via **L5** classes only (metadata + external handles): **trigger**, **intended cap / envelope**, **broker-trusted numbers**, **cockpit/registry snapshot references**, **classification** (`reconciled_explainable` / `partial` / `ambiguous`), **final posture**, **escalation id / owner**.
+**Design context (non-authorizing):** [Entry Contract §5](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#5-abort--rollback--no_trade-criteria); [L5 incident / safe-stop evidence pointers](../specs/MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md); [Failure taxonomy](../specs/MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md#4-failure-taxonomy-table).


### PR DESCRIPTION
## Summary
Hardens `RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md` from draft-heavy toward operator-ready.

## What changed
- updates:
  - `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md`
- raises the runbook from `DRAFT` toward `OPERATOR-READY`
- aligns it with the A–G structure used by the recently hardened pilot-incident runbooks
- clarifies:
  - Compass §5.2 as the primary anchor
  - expanded boundaries vs. telemetry / restart / reconciliation / exchange / transfer / session-end / compass routing
  - fail-closed posture in §B
  - numbered immediate actions with Compass §8 and containment hints
  - classification (`reconciled_explainable` / `partial` / `ambiguous`)
  - suggested checks
  - return-to-normal conditions without authorization semantics
  - L5 guidance and minimum narrative expectations
  - escalation
  - related-runbook and design-context pointers

## Why this approach
Within the bounded-pilot incident/runbook track, `RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md` was the last remaining draft-heavy pilot-incident leaf.
This PR brings it to the same operator-ready standard as the rest of the hardened family with a single-file docs-only change.

## Non-goals
- no trading logic changes
- no live authorization
- no broker/execution integration
- no Compass-file correction in this PR
- no broad runbook series refactor

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)