### PR TITLE
docs(ops): correct pilot incident compass draft note v1

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md
@@ -1,7 +1,7 @@
 # RUNBOOK — Bounded Pilot Incident / §5 Abort Triage Compass v0
 
 status: DRAFT
-last_updated: 2026-04-20
+last_updated: 2026-04-23
 owner: Peak_Trade
 purpose: Single canonical orientation surface mapping symptoms and Entry Contract §5 abort posture to pilot incident runbooks, L5 evidence-pointer discipline, and read-only registry/report CLIs (bounded pilot)
 docs_token: DOCS_TOKEN_RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS
@@ -108,7 +108,7 @@ Process or operator continuity interrupted mid-session; need disciplined re-entr
 | [Telemetry degraded](RUNBOOK_PILOT_INCIDENT_TELEMETRY_DEGRADED.md) | `DOCS_TOKEN_RUNBOOK_PILOT_INCIDENT_TELEMETRY_DEGRADED` |
 | [Restart mid-session](RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md) | `DOCS_TOKEN_RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION` |
 
-All listed runbooks remain **operator aids**; several are still **DRAFT** in their headers. This compass **does not** upgrade their maturity.
+All indexed **`RUNBOOK_PILOT_INCIDENT_*.md`** runbooks use **`OPERATOR-READY`** in their headers and remain **operator aids** only — **not** live authorization. **This compass** remains **`status: DRAFT`** and **does not** supersede the [Entry contract](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md), governance, or external sign-off.
 
 ## 7) L5 pointer / evidence expectations (external only)
 


### PR DESCRIPTION
## Summary
Corrects the outdated draft-status note in `RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md` now that all indexed pilot-incident leaf runbooks are operator-ready.

## What changed
- updates:
  - `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md`
- removes the stale statement that several indexed pilot-incident runbooks are still `DRAFT`
- replaces it with a precise note that:
  - all indexed `RUNBOOK_PILOT_INCIDENT_*.md` leaf runbooks now have `OPERATOR-READY` headers
  - they remain operator aids only and do not imply live authorization
  - this Compass document itself still remains `status: DRAFT`
  - the Compass does not replace entry-contract / governance / external sign-off controls
- updates `last_updated` to `2026-04-23`

## Why this approach
After the recent hardening work across the pilot-incident leaf runbooks, the Compass still contained a factually outdated note about several leaves remaining draft.
This PR makes the smallest possible docs-only correction without broadening scope or implicitly upgrading the Compass itself.

## Non-goals
- no trading logic changes
- no live authorization
- no broker/execution integration
- no broad Compass refactor
- no changes to the separate enablement/L5 report-surface documents

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)