### PR TITLE
docs(ops): harden bounded real money pilot candidate flow v1

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md
@@ -1,147 +1,98 @@
-# RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW
+# RUNBOOK — Bounded Real-Money Pilot: Candidate Flow
 
-status: DRAFT
-last_updated: 2026-04-20
+status: OPERATOR-READY
+last_updated: 2026-04-23
 owner: Peak_Trade
-purpose: Canonical first-session sequence for the first strictly bounded real-money pilot candidate flow
+purpose: Canonical operator sequence for the first strictly bounded real-money pilot candidate session—preconditions, bounded posture, ordered steps, abort discipline, and closeout orientation—without authorizing broad live trading or replacing dry validation, go/no-go, or incident procedures
 docs_token: DOCS_TOKEN_RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW
 
-## 1. Goal
+## Non-authorization (read first)
 
-This runbook defines the canonical operator sequence for the **first strictly bounded real-money pilot candidate session**.
+This runbook is an **operator aid** only. It does **not**:
 
-It does **not** authorize broad live trading.
-It defines one tightly bounded, explicitly operator-supervised first-session flow.
+- authorize broad live trading, permanent rollout, or any gate closure;
+- replace [Dry validation](RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md), [Live entry](RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md), [Go/No-Go checklist](../specs/PILOT_GO_NO_GO_CHECKLIST.md) / eval tooling, or org kill-switch procedures;
+- prove safety from read-only CLI output or in-repo documentation alone.
 
-## 2. Preconditions
+If there is **any** doubt whether trading is allowed, apply [Entry Contract §5](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#5-abort--rollback--no_trade-criteria): **ambiguity ⇒ `NO_TRADE` / safe stop**.
 
-All of the following must already be true before this runbook is used:
+## A. Purpose and boundaries
 
-- Dry validation completed
-  - `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md`
-- Entry contract accepted
-  - `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md`
-- Pilot go/no-go verdict acceptable
-  - `scripts/ops/pilot_go_no_go_eval_v1.py`
-  - expected verdict: `GO_FOR_NEXT_PHASE_ONLY`
-- Ops Cockpit reviewed
-  - `policy_state`
-  - `operator_state`
-  - `run_state`
-  - `incident_state`
-  - `exposure_state`
-  - `evidence_state`
-  - `dependencies_state`
-  - `stale_state`
-  - `session_end_mismatch_state`
-  - `human_supervision_state`
+**Use this runbook as the primary path when** you are executing the **first strictly bounded real-money pilot candidate session** sequence: preconditions are met, posture is **operator-supervised** and **ambiguity-intolerant**, and you need a **single canonical step order** from final checks through start, observe, abort-if-needed, and closeout orientation.
 
-## 3. Candidate Session Posture
+**This runbook does not:**
 
-The first bounded real-money pilot candidate session must remain:
+- substitute **[Dry validation](RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md)** — dry validation must already be **complete** per your procedure before this flow;
+- redefine **Master V2** promotion or enablement semantics — it is **bounded-pilot operator procedure** only;
+- **imply** L4/L1 or any gate is **passed** or **unblocked** in enablement report surfaces — visibility and docs alignment remain **non-authorizing** (see [Decision authority map](../specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) §4 / §7).
 
-- operator-supervised
-- strictly bounded by configured caps
-- ambiguity-intolerant
-- kill-switch aware
-- treasury-separated
-- evidence-first
+**Prefer specialized paths when:**
 
-Rule: **ambiguity => `NO_TRADE` / safe stop**
+- **Incident or safe-stop** symptoms dominate → primary [Abort triage compass](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md) and the relevant **`RUNBOOK_PILOT_INCIDENT_*.md`** runbook.
+- **End-to-end live entry mechanics** (commands, phases, German Ist-Stand detail) → [Live entry](RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md).
+- **Dry-run / validation sequence** → [Dry validation](RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md) only — **not** this document.
 
-## 4. Step Sequence
+## B. Triggers and entry conditions
 
-### Step 1 — Confirm Entry Preconditions
-Confirm that:
-- dry validation is complete
-- go/no-go verdict is `GO_FOR_NEXT_PHASE_ONLY`
-- `human_supervision_state.status == operator_supervised`
-- no unresolved stale state exists
-- no unresolved session-end mismatch exists
-- no unresolved transfer ambiguity exists
-- kill switch is not active
-- bounded caps are present
-- treasury separation is explicit
+**All of the following must already be true** before starting the candidate session sequence:
 
-### Step 2 — Confirm First-Session Bounds
-Confirm the first candidate session is explicitly bounded:
-- smallest acceptable pilot scope only
-- no broad rollout interpretation
-- no informal cap widening
-- no relaxed operator posture
-- no hidden dependency on missing evidence
+- **Dry validation completed** per [Dry validation](RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md).
+- **[Entry contract](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md)** accepted and boundaries understood ([boundary note](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md)).
+- **Pilot go/no-go** verdict **acceptable** — e.g. `GO_FOR_NEXT_PHASE_ONLY` from `scripts/ops/pilot_go_no_go_eval_v1.py` per your procedure ([operational slice](../specs/PILOT_GO_NO_GO_OPERATIONAL_SLICE.md)).
+- **Ops Cockpit** reviewed for at least: `policy_state`, `operator_state`, `run_state`, `incident_state`, `exposure_state`, `evidence_state`, `dependencies_state`, `stale_state`, `session_end_mismatch_state`, `human_supervision_state` (see [Entry Contract §6](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#6-where-to-look)).
 
-### Step 3 — Start the First Candidate Session
-Run the first bounded real-money candidate session only under explicit operator observation.
+**Fail-closed rule**
 
-**Concrete entry (current repo):** follow **`docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`** — typically  
-`python3 scripts/ops/run_bounded_pilot_session.py` after all gates GREEN (or `python3 scripts/run_execution_session.py --mode bounded_pilot` only if the same preconditions are already verified).
+- If **any** precondition is **unknown** or **not verified**, **do not** start the candidate session — **`NO_TRADE` / safe stop** until clarified or governance directs otherwise **outside** this document.
 
-During start:
-- keep the Ops Cockpit visible
-- keep incident posture visible
-- keep kill-switch posture visible
-- keep bounded caps visible
+## C. Operator sequence (ordered)
 
-### Step 4 — Observe During Session
-During the candidate session, continuously watch:
-- `policy_state`
-- `operator_state`
-- `incident_state`
-- `dependencies_state`
-- `evidence_state`
-- `exposure_state`
-- `stale_state`
+**Required posture throughout:** operator-supervised, **strictly** bounded by configured caps, **ambiguity-intolerant**, kill-switch aware, treasury-separated, evidence-first.
 
-Any operator uncertainty is treated as `NO_TRADE`.
+1. **Confirm entry preconditions:** dry validation **complete**; go/no-go verdict **`GO_FOR_NEXT_PHASE_ONLY`** (or your org’s equivalent **acceptable** verdict); `human_supervision_state.status == operator_supervised`; **no** unresolved `stale_state`; **no** unresolved session-end mismatch; **no** unresolved transfer ambiguity; kill switch **not** active; bounded caps **present**; treasury separation **explicit**.
+2. **Confirm first-session bounds:** smallest acceptable pilot scope only; **no** broad-rollout interpretation; **no** informal cap widening; **no** relaxed operator posture; **no** hidden dependency on missing evidence.
+3. **Start the first candidate session** only under **explicit** operator observation. **Concrete commands:** follow [Live entry](RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md) — typically `python3 scripts/ops/run_bounded_pilot_session.py` after preconditions are verified, or `python3 scripts/run_execution_session.py --mode bounded_pilot` **only if** the **same** preconditions are already verified. During start: keep Ops Cockpit, **incident** posture, kill-switch posture, and bounded caps **visible**.
+4. **Observe during session:** continuously watch `policy_state`, `operator_state`, `incident_state`, `dependencies_state`, `evidence_state`, `exposure_state`, `stale_state`. **Any** operator uncertainty → treat as **`NO_TRADE`**.
+5. **Abort immediately** if **any** holds: kill switch active; policy blocked; dependency posture beyond acceptable bounded tolerance; unresolved stale state; [unexpected exposure](RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md) path; [transfer ambiguity](RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md); [restart mid-session](RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md) without coherent handling; [session-end mismatch](RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md) evident; operator **cannot** determine allowed posture. Use org **kill-switch / safe-stop** per [Kill Switch runbook](../../risk/KILL_SWITCH_RUNBOOK.md); this runbook does not redefine that mechanism.
+6. **Close out and reconcile:** perform required closeout and reconciliation; resolve mismatches before **any** next session; **do not** treat one successful candidate session as **broad** live readiness.
 
-### Step 5 — Abort Immediately If Any Abort Criterion Appears
-Abort immediately if any of the following occurs:
-- kill switch becomes active
-- policy posture becomes blocked
-- dependency posture degrades beyond acceptable bounded pilot tolerance
-- stale state becomes unresolved
-- unexpected exposure appears
-- transfer ambiguity appears
-- restart mid-session occurs without coherent restart handling
-- session-end mismatch becomes evident
-- operator can no longer clearly determine allowed posture
+**Order matters:** **preconditions and bounds** before **start**; **posture** before interpreting success.
 
-### Step 6 — Close Out and Reconcile
-After the candidate session:
-- perform the required closeout and reconciliation steps
-- review any mismatch or ambiguity before any next session is considered
-- do not interpret one successful candidate session as broad live readiness
+## D. Verification and stop conditions
 
-## 5. Required Evidence
+**Suggested checks**
 
-The operator should preserve evidence for:
-- pilot go/no-go result
-- relevant Ops Cockpit state at session start
-- session-level notes / decision rationale
-- incident/mismatch notes, if any
-- session closeout outcome
-- reconciliation outcome
-- Optional docs-only pointer metadata for externally retained session-flow / closeout evidence (bounded pilot L4; no payloads in git): [`../specs/MASTER_V2_BOUNDED_PILOT_L4_SESSION_FLOW_EVIDENCE_POINTER_CONTRACT_V0.md`](../specs/MASTER_V2_BOUNDED_PILOT_L4_SESSION_FLOW_EVIDENCE_POINTER_CONTRACT_V0.md)
+- Re-read [Entry Contract §5](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#5-abort--rollback--no_trade-criteria) when posture slips or signals conflict.
+- If using read-only report/CLI outputs (e.g. via [Compass §8](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md#8-read-only-cli--report-hints-scriptsreport_live_sessionspy)), treat as **hints only**; read **disclaimers**; JSON is **not** proof of safety.
 
-## 6. Related Runbooks / Specs
+**Return toward normal (non-authorizing)**
 
-- `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md`
-- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` (**bounded pilot live entry — Ist-Stand**)
-- `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md` (dry vs first real-money step)
-- `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md`
-- `docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md`
-- `docs/ops/specs/PILOT_GO_NO_GO_OPERATIONAL_SLICE.md`
-- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md`
-- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md`
-- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md`
-- `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md`
+- **No** “broad live ready” or “next phase authorized” from this runbook alone. **Only** governance or explicit org disposition **outside** this repo can authorize expansion beyond this **first** bounded candidate session narrative.
+- **No** second session or **risk-increasing** follow-on while [Entry Contract §5](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#5-abort--rollback--no_trade-criteria) blockers or unresolved closeout/reconciliation remain.
 
-## 7. Non-Goals
+## E. Evidence and pointers (L4 discipline)
 
-This runbook does not:
-- authorize broad live trading
-- replace go/no-go evaluation
-- replace dry validation
-- replace incident runbooks
-- remove operator supervision
+Retain **review-oriented** material **outside** git per [L4 session-flow evidence pointer contract](../specs/MASTER_V2_BOUNDED_PILOT_L4_SESSION_FLOW_EVIDENCE_POINTER_CONTRACT_V0.md): **metadata and opaque handles only** — no full cockpit dumps, secrets, or payloads in the repository.
+
+**Minimum narrative to record externally (conceptual)**
+
+- Go/no-go outcome and **timestamp**; Ops Cockpit snapshot **references** at session start; session notes; incident/mismatch pointers if any; closeout and reconciliation **summary**; **final posture**.
+
+## F. Escalation
+
+Escalate per your **bounded-pilot governance** channel when:
+
+- Preconditions **cannot** be confirmed, or abort criteria **fire** and disposition is **unclear**;
+- Closeout or reconciliation remains **partial** or **ambiguous** after bounded steps.
+
+State **session id** (if any), **UTC window**, and whether posture is **known**, **partially known**, or **unknown**.
+
+## G. Related runbooks and specs
+
+- [Entry Contract](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md); [Entry boundary note](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md)
+- [Live entry](RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md); [Dry validation](RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md)
+- [Go/No-Go checklist](../specs/PILOT_GO_NO_GO_CHECKLIST.md); [Go/No-Go operational slice](../specs/PILOT_GO_NO_GO_OPERATIONAL_SLICE.md)
+- [Abort triage compass](RUNBOOK_BOUNDED_PILOT_INCIDENT_ABORT_TRIAGE_COMPASS.md)
+- [Restart mid-session](RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md); [Session end mismatch](RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md); [Transfer ambiguity](RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md); [Reconciliation mismatch](RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md)
+
+**Design context (non-authorizing):** [Failure taxonomy](../specs/MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md); [Decision authority map](../specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md).


### PR DESCRIPTION
## Summary
Hardens `RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md` from draft-heavy toward a clearer operator-ready structure.

## What changed
- updates:
  - `docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md`
- clarifies:
  - non-authorization / fail-closed posture
  - triggers and entry criteria
  - numbered sequence with preconditions and abort hints
  - verification and stop conditions
  - L4 / evidence pointer discipline
  - escalation without implicit authorization
  - boundaries vs. dry-validation / live-entry / go-no-go / incident documents
  - repo-true related links

## Why this approach
After the recent incident-leaf and L5/G8 consistency work, the bounded real-money pilot candidate flow remained one of the clearest small draft-heavy operational docs with direct readiness/readability leverage.
This PR improves operator clarity without touching product code, Master-V2, or readiness semantics beyond better documentation structure.

## Non-goals
- no trading logic changes
- no live authorization
- no broker/execution integration
- no Master-V2 code-path changes
- no artificial “greenwashing” of readiness state

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)