### PR TITLE
docs(ops): sync l2 go no-go pointer runbook refs v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md
@@ -79,7 +79,7 @@ Same minimum discipline as L1 pointers: when recording a pointer **outside** thi
 - **Gate-Status Report Surface:** remains **non-authorizing**; see [`MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) §3.2.
 - **`G10`:** pointer metadata is not final live authorization.
 - **`G11`:** L2-only; not a cross-gate bundle.
-- **L1 contract:** dry-validation Step 2 uses the **same** eval entry point as documented in §4.2; a single external capture may be referenced for **both** L1 Step 2 framing and **L2/G5** framing if governance agrees one object satisfies both review questions — use consistent `retrieval_reference` and clear `artifact_summary` scope.
+- **L1 contract:** dry-validation [**C.** Operator sequence (ordered)](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md#c-operator-sequence-ordered) item **2** (Pilot go/no-go eval) uses the **same** eval entry point as documented in gate index §4.2; a single external capture may be referenced for **both** L1 Step 2 framing and **L2/G5** framing if governance agrees one object satisfies both review questions — use consistent `retrieval_reference` and clear `artifact_summary` scope.
 
 ## 7) Illustrative pointer records (non-binding)
 
@@ -108,4 +108,4 @@ retention_owner: "governance_steward_role"
 
 ## 8) Operator / reviewer use
 
-Align external retention with [`PILOT_GO_NO_GO_CHECKLIST.md`](PILOT_GO_NO_GO_CHECKLIST.md), [`PILOT_GO_NO_GO_OPERATIONAL_SLICE.md`](PILOT_GO_NO_GO_OPERATIONAL_SLICE.md), and runbook ordering in [`RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md`](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md) / [`RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md). Authorization remains external.
+Align external retention with [`PILOT_GO_NO_GO_CHECKLIST.md`](PILOT_GO_NO_GO_CHECKLIST.md), [`PILOT_GO_NO_GO_OPERATIONAL_SLICE.md`](PILOT_GO_NO_GO_OPERATIONAL_SLICE.md), and runbook ordering in [`RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md`](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md) (**sections A–G**; [**C.** Operator sequence (ordered)](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md#c-operator-sequence-ordered), item **2** — Pilot go/no-go eval) / [`RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md). Authorization remains external.


### PR DESCRIPTION
## Summary
Synchronizes stale/generic dry-validation references in `MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md` with the current A–G structure of the hardened dry-validation runbook.

## What changed
- updates:
  - `docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md`
- in §8:
  - aligns the dry-validation reference with the current A–G structure
  - adds the deep link to `#c-operator-sequence-ordered`
  - points to Item 2 / Pilot go-no-go eval
- in §6 (L1 bullet):
  - aligns the same location reference instead of only “Step 2”
- also clarifies the “§4.2” reference as gate-index §4.2 to avoid accidental misreading as this document’s own §4 metadata section

## Why this approach
After the dry-validation runbook was hardened into an A–G structure, the L2 go/no-go evidence pointer contract still referenced it too generically.
This PR fixes that navigation/citation mismatch without changing status semantics, gate interpretation, or the runbook itself.

## Non-goals
- no trading logic changes
- no live authorization
- no broker/execution integration
- no status/non-claim changes
- no edits to the dry-validation runbook itself
- no changes to the already-synced L1/L4 contracts in this PR

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)