### PR TITLE
docs(ops): add live entry pointer contract links v1

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
@@ -45,6 +45,9 @@ Alle Punkte müssen **vor** dem ersten Aufruf mit echten Orders erfüllt sein.
 - `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` — Entry Contract (Pilot-Haltung).
 - `docs/ops/specs/PILOT_GO_NO_GO_CHECKLIST.md` — Checklistenbasis für Go/No-Go.
 - Optional: `docs/ops/runbooks/live_pilot_execution_plan.md` — übergeordneter Plan (PRBI, Ops-Status, Export-Smokes).
+- `docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L1_EVIDENCE_POINTER_CONTRACT_V0.md` — Evidence-Pointer-Disziplin L1 (Dry-Validation-Bezug; extern, ohne Payloads in Git).
+- `docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md` — Evidence-Pointer-Disziplin L2 (Go/No-Go; extern, ohne Payloads in Git).
+- `docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L3_ENTRY_PREREQUISITE_EVIDENCE_POINTER_CONTRACT_V0.md` — Evidence-Pointer-Disziplin L3 (Entry Contract §3 Prerequisites; extern, ohne Payloads in Git).
 
 ### 2.2 Konfiguration & Kapital-Grenzen
 
@@ -89,6 +92,8 @@ Alle Punkte müssen **vor** dem ersten Aufruf mit echten Orders erfüllt sein.
    Erwartung: Readiness + Go/No-Go **und** Operator-Preflight-Packet **GREEN**, **kein** Handoff / keine Session.
 
 Detaillierte Einordnung: `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md` (Schritt 5 dort ist historisch; Gate-only = `--no-invoke` hier in Phase A.4).
+
+Zum Zuordnen **extern** gehaltener Nachweise aus dieser Phase: die L1–L3 Pointer-Contract-Specs in §2.1 — **ohne** zusätzliche Gate-, Readiness- oder Freigabeaussage (siehe Non-Claims in den Specs).
 
 ### Phase B — Readiness (empfohlen)
 


### PR DESCRIPTION
## Summary
Adds the nearest L1/L2/L3 pointer-contract links to `RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` so reviewers/operators can navigate evidence-/pointer-discipline references more directly.

## What changed
- updates:
  - `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`
- in §2.1:
  - adds canonical references to the L1 / L2 / L3 evidence-pointer specs
- at the end of §3 Phase A:
  - adds a short reminder pointing back to the same specs in §2.1
  - explicitly states that these references do not add gate/readiness/authorization semantics and remain subject to the specs’ non-claims

## Why this approach
The live-entry runbook already references the surrounding entry/go-no-go flow, but it still made operators/reviewers take a longer path to the actual pointer-discipline specs.
This PR improves repo-true navigation without changing workflow semantics.

## Non-goals
- no trading logic changes
- no live authorization
- no broker/execution integration
- no gate/readiness changes
- no pointer-contract content changes
- no changes outside this single runbook

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)