### PR TITLE
docs(ops): add readiness ladder pointer vocabulary links v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -166,6 +166,16 @@ During first-live-enablement progression, incident handling and safe-stop discip
 - `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md`
 - `docs/ops/runbooks/RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md`
 
+### Pointer-contract vocabulary (bounded pilot, external metadata only)
+
+These docs-only contracts supply **vocabulary** for describing **externally retained** bounded-pilot evidence with pointers and metadata **outside** this repository. They do **not** replace human judgment, close any gate, or authorize live entry; see each contract’s non-claims.
+
+- [MASTER_V2_BOUNDED_PILOT_L1_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L1_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_BOUNDED_PILOT_L3_ENTRY_PREREQUISITE_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L3_ENTRY_PREREQUISITE_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_BOUNDED_PILOT_L4_SESSION_FLOW_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L4_SESSION_FLOW_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md)
+
 ## 5) How to Use This File
 
 Use this file as the single starting point when clarifying:


### PR DESCRIPTION
## Summary
Adds a small pointer-contract vocabulary subsection to `MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` so reviewers can jump directly to the bounded-pilot L1–L5 pointer-contract specs.

## What changed
- updates:
  - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`
- after §4 “Level 5” and before “## 5) How to Use This File”, adds:
  - `Pointer-contract vocabulary (bounded pilot, external metadata only)`
- includes:
  - a short note that these specs support external metadata / pointer discipline and do not imply gate closure or authorization
  - five markdown links to the L1–L5 bounded-pilot pointer-contract specs
- leaves the level lists and the surrounding readiness semantics unchanged

## Why this approach
The readiness ladder is a primary review entrypoint, but until now it did not provide a direct jump to the bounded-pilot pointer-contract vocabulary layer.
This PR adds that navigation path without changing status, readiness interpretation, or workflow semantics.

## Non-goals
- no trading logic changes
- no live authorization
- no broker/execution integration
- no gate/readiness changes
- no pointer-contract content changes
- no runbook changes

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)