### PR TITLE
docs(ops): add entry contract l3 prerequisite pointer ref v1

### DIFF
--- a/docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md
+++ b/docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md
@@ -65,6 +65,8 @@ The operator must confirm all of the following before entry:
    - `guard_state.treasury_separation == enforced`
    - See `docs&#47;ops&#47;specs&#47;TREASURY_BALANCE_SEPARATION_SPEC.md`
 
+Pointer note: For the external-metadata-only pointer vocabulary around L3 entry prerequisites, see [MASTER_V2_BOUNDED_PILOT_L3_ENTRY_PREREQUISITE_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L3_ENTRY_PREREQUISITE_EVIDENCE_POINTER_CONTRACT_V0.md). This note is non-authorizing and does not change gate, approval, runtime, trading, or live-entry semantics.
+
 ## 4. First Bounded Real-Money Step
 
 The first bounded real-money step is defined as:


### PR DESCRIPTION
## Summary
- Adds a short non-authorizing pointer note in the bounded pilot entry contract Section 3.
- Links the L3 entry prerequisite pointer-contract spec from the contract itself.
- Preserves gate, approval, runtime, trading, and live-entry semantics.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)