### PR TITLE
docs(ops): clarify read model pointer vocabulary boundary v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md
@@ -195,6 +195,7 @@ Rules:
 - pointers MUST be concrete and repository-resolvable
 - no generated or hypothetical future path as evidence
 - no telemetry/event stream references introduced by this spec
+Pointer-vocabulary boundary: This read model's in-repo `evidence_pointer` fields describe repo-local evidence references for read-model materialization. They are separate from the bounded-pilot external metadata-only pointer-contract vocabulary summarized in [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md). This boundary note is vocabulary/navigation-only and does not change evidence, gate, approval, runtime, trading, or live-entry semantics.
 
 ## 8) Blocker Semantics
 


### PR DESCRIPTION
## Summary
- Adds a Section 7 boundary note distinguishing read-model in-repo `evidence_pointer` fields from bounded-pilot external metadata-only pointer-contract vocabulary.
- Links the Readiness Ladder summary as the nearest navigation anchor.
- Preserves evidence, gate, approval, runtime, trading, and live-entry semantics.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)