### PR TITLE
docs(ops): add cross-gate bundle read model section7 ref v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md
@@ -53,6 +53,8 @@ Minimal operator read path for First Live readiness review:
 
 1. Start with framing: [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md).
 2. Load interpretation grammar: [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md).
+Read-model pointer note: For the read-model-local `evidence_pointer` semantics that remain separate from bounded-pilot external metadata-only pointer vocabulary, see [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md §7](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md#7-evidence-pointer-semantics). This note is navigation-only and does not change evidence, gate, approval, runtime, trading, or live-entry semantics.
+
 3. Read compact gate posture: [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md).
 4. Cross-check rendered gate details: [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md).
 5. Validate decision and promotion boundaries: [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md).


### PR DESCRIPTION
## Summary
- Adds a Section 4 Step 2 navigation note from the cross-gate evidence bundle index to the readiness read model §7.
- Clarifies where read-model-local `evidence_pointer` semantics are documented.
- Preserves evidence, gate, approval, runtime, trading, and live-entry semantics.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)