### PR TITLE
docs(ops): add cli cheatsheet bounded pilot navigation box v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -1,5 +1,15 @@
 # Peak_Trade CLI Cheatsheet
 
+## Bounded Pilot / First-Live Navigation
+
+This cheat-sheet is operator navigation only. It does not authorize live trading, bypass gates, or replace the bounded-pilot contracts/runbooks.
+
+- Entry contract: [BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md)
+- Entry boundary note: [BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md](ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md)
+- Readiness ladder: [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- Readiness read model: [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- Cross-gate bundle index: [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](ops/specs/MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md)
+
 Schnellreferenz für alle CLI-Tools im Peak_Trade Framework.
 
 > **Neu bei Peak_Trade?**


### PR DESCRIPTION
## Summary
- Adds a short Bounded Pilot / First-Live navigation box to the CLI cheatsheet.
- Links the entry contract, boundary note, readiness ladder, readiness read model, and cross-gate bundle index.
- Keeps the section operator-navigation-only; no live authorization, gate bypass, runtime, trading, or evidence semantics changed.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs