### PR TITLE
docs(ops): add getting started bounded pilot cheatsheet ref v1

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -298,3 +298,5 @@ Siehe [`docs/CLI_CHEATSHEET.md`](CLI_CHEATSHEET.md)
 ---
 
 **Built with ❤️ and safety-first architecture**
+Bounded Pilot / First-Live navigation: For the operator-navigation-only entry points into the bounded-pilot / first-live docs, start with [CLI_CHEATSHEET.md](CLI_CHEATSHEET.md#bounded-pilot--first-live-navigation). This reference is navigation-only and does not authorize live trading, bypass gates, or change runtime, trading, evidence, approval, or live-entry semantics.
+


### PR DESCRIPTION
## Summary
- Adds a GETTING_STARTED pointer to the CLI cheatsheet's Bounded Pilot / First-Live Navigation box.
- Keeps the reference operator-navigation-only.
- Preserves live authorization, gate, runtime, trading, evidence, approval, and live-entry semantics.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
