### PR TITLE
docs(ops): align bounded pilot l3 maturity wording v1

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -141,9 +141,10 @@ Canonical checklist and verdict semantics:
 
 ### Level 3 — First Live Enablement Entry Contract
 
-Binding operator-facing entry contract for first strictly bounded real-money pilot:
+Draft operator-facing entry contract anchor for first strictly bounded real-money pilot:
 
 - `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md`
+  Non-authorization note: These L3 entry-contract anchors remain review/navigation anchors while their source specs are marked DRAFT; they do not approve live entry, bypass gates, or change runtime, trading, evidence, approval, or live-entry semantics.
 - `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md`
 - `docs/ops/specs/BOUNDED_PILOT_LIVE_ENTRY_GAP_NOTE.md` (historical gap context only)
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -144,9 +144,10 @@ Canonical checklist and verdict semantics:
 Draft operator-facing entry contract anchor for first strictly bounded real-money pilot:
 
 - `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md`
-  Non-authorization note: These L3 entry-contract anchors remain review/navigation anchors while their source specs are marked DRAFT; they do not approve live entry, bypass gates, or change runtime, trading, evidence, approval, or live-entry semantics.
 - `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md`
 - `docs/ops/specs/BOUNDED_PILOT_LIVE_ENTRY_GAP_NOTE.md` (historical gap context only)
+
+Non-authorization note: These L3 entry-contract anchors remain review/navigation anchors while their source specs are marked DRAFT; they do not approve live entry, bypass gates, or change runtime, trading, evidence, approval, or live-entry semantics.
 
 ### Level 4 — First Candidate Session Flow (Operator Execution Surface)
 


### PR DESCRIPTION
## Summary
- Aligns Readiness Ladder Level 3 wording with the DRAFT maturity of the bounded-pilot entry contract and boundary note specs.
- Replaces binding-style language with a draft anchor framing.
- Adds a short non-authorization note clarifying that these anchors do not approve live entry, bypass gates, or change runtime/trading/evidence semantics.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
