### PR TITLE
docs(ops): align bounded pilot l3 draft anchor wording v1

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md
@@ -37,7 +37,7 @@ If there is **any** doubt whether trading is allowed, apply [Entry Contract §5]
 **All of the following must already be true** before starting the candidate session sequence:
 
 - **Dry validation completed** per [Dry validation](RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md).
-- **[Entry contract](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md)** accepted and boundaries understood ([boundary note](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md)).
+- **[Entry contract](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md)** and [boundary note](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md) reviewed as repo-local **DRAFT** anchors; boundaries acknowledged for this candidate sequence only (not approval, not gate bypass).
 - **Pilot go/no-go** verdict **acceptable** — e.g. `GO_FOR_NEXT_PHASE_ONLY` from `scripts/ops/pilot_go_no_go_eval_v1.py` per your procedure ([operational slice](../specs/PILOT_GO_NO_GO_OPERATIONAL_SLICE.md)).
 - **Ops Cockpit** reviewed for at least: `policy_state`, `operator_state`, `run_state`, `incident_state`, `exposure_state`, `evidence_state`, `dependencies_state`, `stale_state`, `session_end_mismatch_state`, `human_supervision_state` (see [Entry Contract §6](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md#6-where-to-look)).
 

--- a/docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md
+++ b/docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md
@@ -3,12 +3,14 @@
 status: DRAFT
 last_updated: 2026-03-13
 owner: Peak_Trade
-purpose: Canonical operator-facing entry contract for the first strictly bounded real-money pilot
+purpose: Draft operator-facing entry contract anchor for the first strictly bounded real-money pilot
 docs_token: DOCS_TOKEN_BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT
 
 ## 1. Goal
 
-This document defines the single operator-facing contract for entering the first strictly bounded real-money pilot.
+This document defines the draft operator-facing contract anchor for entering the first strictly bounded real-money pilot.
+
+Draft-maturity note: This contract is a repo-local **DRAFT** anchor for candidate-scoped review. It does not by itself approve bounded real-money execution, bypass gates, or change runtime, trading, evidence, approval, or live-entry semantics.
 
 It does **not** authorize broad live trading.
 It defines the minimal bounded entry posture under explicit operator supervision.
@@ -140,6 +142,6 @@ This document does not:
 
 ## 8. Exit Condition For This Contract
 
-This contract remains the canonical operator reference for the **first strictly bounded real-money pilot**.
+This contract remains the operator-facing **DRAFT** reference anchor for the **first strictly bounded real-money pilot**.
 Operational steps (dry validation → gates → session handoff) are detailed in  
 `docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`; future automation layers may extend but do not replace Entry Contract obligations or abort criteria.


### PR DESCRIPTION
## Summary
- Aligns bounded-pilot L3 wording with DRAFT maturity of the entry contract and candidate-flow references.
- Reframes strong canonical/accepted language as draft-anchor / candidate-scoped review language.
- Preserves gate, runtime, trading, evidence, approval, and live-entry semantics.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
