### PR TITLE
feat(j1): add local csv ohlcv source v1

### DIFF
--- a/scripts/_shared_forward_args.py
+++ b/scripts/_shared_forward_args.py
@@ -5,7 +5,7 @@ Gemeinsame CLI-Defaults und Argument-Gruppe für Forward-/Portfolio-OHLCV (J1).
 Drei Skripte teilen denselben Parametervertrag für ``--n-bars``/``--bars``,
 ``--ohlcv-source`` und ``--timeframe`` (Kraken; Dummy ignoriert ``timeframe`` intern 1h).
 
-Keine neuen Datenquellen — gemeinsame CLI-Normalisierung; Kraken-Pagination für große ``n-bars`` liegt im Loader.
+Gemeinsame CLI-Normalisierung inkl. lokaler CSV (``--ohlcv-csv``); Kraken-Pagination für große ``n-bars`` liegt im Loader.
 
 NO-LIVE: keine Order-Ausführung; Kraken-Pfad nur öffentliche OHLCV (Stub), siehe Epilog-Helfer unten.
 """
@@ -13,9 +13,11 @@ NO-LIVE: keine Order-Ausführung; Kraken-Pfad nur öffentliche OHLCV (Stub), sie
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from _shared_ohlcv_loader import (
     KRAKEN_OHLCV_MAX_BARS,
+    OHLCV_SOURCE_CSV,
     OHLCV_SOURCE_DUMMY,
     OHLCV_SOURCES,
     normalize_ohlcv_source,
@@ -29,8 +31,21 @@ FORWARD_PIPELINE_OHLCV_SCOPE_EPILOG = """
 Scope (J1, NO-LIVE):
   Kein Live-Handel und keine Order-Ausführung (kein C1-/Execution-Scope).
   OHLCV: Default --ohlcv-source=dummy (offline); kraken = öffentliche REST-OHLCV nur zum
-  Laden von Kursreihen; opt-in, Netzwerk nötig. Kein neuer Anbieter.
+  Laden von Kursreihen; opt-in, Netzwerk nötig. csv/fixture = lokale Datei (--ohlcv-csv), kein Netzwerk.
+  Kein neuer Anbieter.
 """.strip()
+
+
+def validate_forward_ohlcv_cli_args(args: argparse.Namespace) -> None:
+    """Pflicht: --ohlcv-csv bei csv; --ohlcv-csv nur bei csv."""
+    p = getattr(args, "ohlcv_csv", None)
+    src = getattr(args, "ohlcv_source", None)
+    if src == OHLCV_SOURCE_CSV and not p:
+        raise ValueError(
+            "--ohlcv-csv ist erforderlich, wenn --ohlcv-source csv (oder fixture) gesetzt ist."
+        )
+    if p is not None and src != OHLCV_SOURCE_CSV:
+        raise ValueError("--ohlcv-csv ist nur mit --ohlcv-source csv/fixture erlaubt.")
 
 
 def append_forward_ohlcv_scope_epilog(parser: argparse.ArgumentParser) -> None:
@@ -90,9 +105,21 @@ def add_shared_ohlcv_cli_group(
         default=OHLCV_SOURCE_DUMMY,
         metavar="|".join(OHLCV_SOURCES),
         help=(
-            "OHLCV-Quelle: dummy (offline, Default, NO-LIVE) oder kraken (öffentliche REST-OHLCV; "
-            f"Netzwerk nötig; große Fenster: mehrere Abrufe à max. {KRAKEN_OHLCV_MAX_BARS} Bars). "
-            "Groß-/Kleinschreibung egal (wie load_ohlcv). Keine Orders."
+            "OHLCV-Quelle: dummy (offline, Default, NO-LIVE), kraken (öffentliche REST-OHLCV; "
+            f"Netzwerk nötig; große Fenster: mehrere Abrufe à max. {KRAKEN_OHLCV_MAX_BARS} Bars), "
+            "oder csv (Alias fixture; lokale CSV, setzt --ohlcv-csv). "
+            "Groß-/Kleinschreibung egal. Keine Orders."
+        ),
+    )
+    parser.add_argument(
+        "--ohlcv-csv",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Nur bei --ohlcv-source=csv: Pfad zur OHLCV-CSV (Spalten open/high/low/close/volume "
+            "plus timestamp|datetime|date|time oder erste Spalte = Zeit). "
+            "Optional {symbol} im Pfad (BTC/EUR → …/BTC_EUR…). Nur lokal; kein Netzwerk."
         ),
     )
     parser.add_argument(

--- a/scripts/_shared_ohlcv_loader.py
+++ b/scripts/_shared_ohlcv_loader.py
@@ -8,6 +8,7 @@ Gleicher DataFrame-Vertrag für ``generate_forward_signals``, ``evaluate_forward
 - ``DatetimeIndex`` (1h, **UTC**), Spalten open/high/low/close/volume (vgl. ``src.data.REQUIRED_OHLCV_COLUMNS``).
 - Dummy: OHLC-Nachkorrektur zentral; vor Rückgabe ``validate_ohlcv(..., strict=True, require_tz=True)``.
 - Kraken: ``src.data.kraken.fetch_ohlcv_df`` (öffentliche OHLCV, kein Trading; Cache-Pfad via ConfigRegistry).
+- CSV/Fixture: ``source="csv"`` (Alias ``fixture``) — lokale Datei, kein Netzwerk; Pfad über ``ohlcv_csv_path`` (CLI: ``--ohlcv-csv``).
 - Read-only: keine Orders, kein C1-Bezug.
 
 J1 Slice 4: ``source="kraken"`` — bis zu 720 Bars pro **Request** (Kraken/ccxt-Limit), siehe ``KRAKEN_OHLCV_MAX_BARS``.
@@ -23,11 +24,13 @@ CLI-Defaults für ``--n-bars``, ``--timeframe``, ``--ohlcv-source`` (Forward-/Po
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pandas as pd
 
+from src.data import REQUIRED_OHLCV_COLUMNS
 from src.data.contracts import validate_ohlcv
 
 # Kraken Public-OHLCV: ccxt/Kraken begrenzt ``limit`` (hier konservativ wie ``fetch_ohlcv_df``).
@@ -35,20 +38,23 @@ KRAKEN_OHLCV_MAX_BARS = 720
 
 OHLCV_SOURCE_DUMMY = "dummy"
 OHLCV_SOURCE_KRAKEN = "kraken"
-OHLCV_SOURCES = (OHLCV_SOURCE_DUMMY, OHLCV_SOURCE_KRAKEN)
+OHLCV_SOURCE_CSV = "csv"
+OHLCV_SOURCES = (OHLCV_SOURCE_DUMMY, OHLCV_SOURCE_KRAKEN, OHLCV_SOURCE_CSV)
 
 
 def _normalize_ohlcv_source(source: str) -> str:
     """
-    Trim + lower case; ``dummy`` / ``kraken`` only (CLI/Programme oft variieren in der Schreibweise).
+    Trim + lower case; ``dummy`` / ``kraken`` / ``csv`` (Alias ``fixture``).
     """
     if not isinstance(source, str):
         raise TypeError(f"OHLCV-Quelle muss str sein, nicht {type(source).__name__}.")
     key = source.strip().lower()
+    if key == "fixture":
+        key = OHLCV_SOURCE_CSV
     if key not in OHLCV_SOURCES:
         raise ValueError(
             f"Unbekannte OHLCV-Quelle {source!r}; erlaubt: {list(OHLCV_SOURCES)} "
-            "(Groß-/Kleinschreibung egal)."
+            "(Groß-/Kleinschreibung egal; fixture → csv)."
         )
     return key
 
@@ -94,6 +100,142 @@ def _warn_kraken_shortfall_if_needed(
         f"(History/Pagination-Ende oder Datenlücke; Pagination={pag})."
     )
     warnings.warn(msg, UserWarning, stacklevel=2)
+
+
+def _warn_csv_shortfall_if_needed(
+    path: Path,
+    n_bars_requested: int,
+    bars_loaded: int,
+) -> None:
+    if bars_loaded >= n_bars_requested:
+        return
+    msg = (
+        f"OHLCV-CSV {path}: nur {bars_loaded} von {n_bars_requested} angeforderten Bars "
+        "(Datei zu kurz)."
+    )
+    warnings.warn(msg, UserWarning, stacklevel=2)
+
+
+def _safe_symbol_token(symbol: str) -> str:
+    return symbol.replace("/", "_").replace("\\", "_").replace(" ", "_")
+
+
+def resolve_ohlcv_csv_path(path_arg: str | Path, symbol: str) -> Path:
+    """
+    Löst ``--ohlcv-csv`` auf. Optional ``{symbol}`` im Pfad (z. B. ``rows/BTC_EUR.csv``).
+    """
+    tpl = str(path_arg)
+    if "{symbol}" in tpl:
+        p = Path(tpl.format(symbol=_safe_symbol_token(symbol)))
+    else:
+        p = Path(tpl)
+    return p.expanduser().resolve(strict=False)
+
+
+def _column_lookup(raw: pd.DataFrame) -> dict[str, str]:
+    return {str(c).strip().lower(): str(c) for c in raw.columns}
+
+
+def _parse_ohlcv_csv(path: Path) -> pd.DataFrame:
+    """
+    Liest eine OHLCV-CSV (lokal), fail-closed: Spalten, Typen, monoton UTC-Index, keine Duplikate.
+
+    Erwartet Spalten ``open``/``high``/``low``/``close``/``volume`` (Groß/Klein egal)
+    und genau eine Zeit-Spalte: ``timestamp``, ``datetime``, ``date``, oder ``time``
+    (numerisch → Unix-Sekunden UTC). Alternativ: erste Spalte ist parsierbares Datum,
+    wenn keine der Zeit-Spalten genannt ist.
+    """
+    try:
+        raw = pd.read_csv(path)
+    except FileNotFoundError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"OHLCV-CSV nicht lesbar ({path}): {exc}") from exc
+
+    if raw.empty:
+        raise ValueError(f"OHLCV-CSV leer: {path}")
+
+    lookup = _column_lookup(raw)
+    missing_ohlc = [c for c in REQUIRED_OHLCV_COLUMNS if c not in lookup]
+    if missing_ohlc:
+        raise ValueError(
+            f"OHLCV-CSV {path}: fehlende Spalten {missing_ohlc}; vorhanden: {sorted(lookup.keys())}"
+        )
+
+    ts_col: str | None = None
+    for key in ("timestamp", "datetime", "date"):
+        if key in lookup:
+            ts_col = lookup[key]
+            break
+
+    index: pd.DatetimeIndex | None = None
+    drop_cols: set[str] = set()
+
+    if ts_col is not None:
+        series = raw[ts_col]
+        if pd.api.types.is_numeric_dtype(series):
+            index = pd.to_datetime(series, unit="s", utc=True)
+        else:
+            index = pd.to_datetime(series, utc=True)
+        drop_cols.add(ts_col)
+    else:
+        if "time" in lookup:
+            tcol = lookup["time"]
+            series = raw[tcol]
+            if pd.api.types.is_numeric_dtype(series):
+                index = pd.to_datetime(series, unit="s", utc=True)
+            else:
+                index = pd.to_datetime(series, utc=True)
+            drop_cols.add(tcol)
+        else:
+            first = raw.columns[0]
+            try:
+                index = pd.to_datetime(raw.iloc[:, 0], utc=True)
+            except Exception as exc:
+                raise ValueError(
+                    f"OHLCV-CSV {path}: keine Zeit-Spalte (timestamp/datetime/date/time) "
+                    f"und erste Spalte nicht als Datum parsierbar."
+                ) from exc
+            drop_cols.add(str(first))
+
+    if index is None or len(index) != len(raw):
+        raise ValueError(f"OHLCV-CSV {path}: Zeit-Index konnte nicht gebildet werden.")
+
+    ohlcv = pd.DataFrame(index=index)
+    for c in REQUIRED_OHLCV_COLUMNS:
+        # Werte positional übernehmen (CSV-Zeilen == Index-Länge); kein Label-Align mit Default-Index.
+        vals = pd.to_numeric(raw[lookup[c]], errors="coerce").to_numpy(dtype=np.float64, copy=True)
+        ohlcv[c] = vals
+    if ohlcv.index.duplicated().any():
+        raise ValueError(f"OHLCV-CSV {path}: doppelte Zeitstempel.")
+    if not ohlcv.index.is_monotonic_increasing:
+        raise ValueError(f"OHLCV-CSV {path}: Zeitstempel sind nicht streng aufsteigend.")
+
+    validate_ohlcv(ohlcv, strict=True, require_tz=True)
+    return ohlcv
+
+
+def load_csv_ohlcv(
+    ohlcv_csv_path: str | Path,
+    symbol: str,
+    n_bars: int = 200,
+) -> pd.DataFrame:
+    """
+    Lokale CSV-OHLCV (J1, NO-LIVE). Nutzt ``resolve_ohlcv_csv_path``; nimmt die letzten ``n_bars`` Zeilen.
+    """
+    if n_bars < 1:
+        raise ValueError("n_bars muss >= 1 sein (CSV-OHLCV).")
+
+    resolved = resolve_ohlcv_csv_path(ohlcv_csv_path, symbol)
+    if not resolved.is_file():
+        raise FileNotFoundError(f"OHLCV-CSV nicht gefunden: {resolved}")
+
+    df = _parse_ohlcv_csv(resolved)
+    if len(df) > n_bars:
+        df = df.iloc[-n_bars:].copy()
+    validate_ohlcv(df, strict=True, require_tz=True)
+    _warn_csv_shortfall_if_needed(resolved, n_bars, len(df))
+    return df
 
 
 def load_dummy_ohlcv(symbol: str, n_bars: int = 200) -> pd.DataFrame:
@@ -265,22 +407,28 @@ def load_ohlcv(
     source: str = OHLCV_SOURCE_DUMMY,
     timeframe: str = "1h",
     use_cache: bool = True,
+    ohlcv_csv_path: str | Path | None = None,
 ) -> pd.DataFrame:
     """
-    Einheitlicher Einstieg: Dummy (Default) oder Kraken.
+    Einheitlicher Einstieg: Dummy (Default), Kraken oder lokale CSV.
 
     Args:
         symbol: Trading-Paar (z.B. ``BTC/EUR``).
         n_bars: Gewünschte Bar-Anzahl (Kraken: mehrere Abrufe bei ``n_bars`` > ``KRAKEN_OHLCV_MAX_BARS``).
-        source: ``dummy`` | ``kraken`` (Groß-/Kleinschreibung wird normalisiert).
-        timeframe: Nur Kraken; Default ``1h`` (wie Forward-Pipeline).
+        source: ``dummy`` | ``kraken`` | ``csv`` (Alias ``fixture``; Groß-/Kleinschreibung wird normalisiert).
+        timeframe: Nur Kraken; Default ``1h`` (wie Forward-Pipeline). CSV/Dummy: nur Meta/CLI-Konsistenz.
         use_cache: Nur Kraken — Parquet-Cache in ``fetch_ohlcv_df``.
+        ohlcv_csv_path: Pfad zur CSV bei ``source=csv`` (Pfad kann ``{symbol}`` enthalten).
     """
     src = _normalize_ohlcv_source(source)
     if src == OHLCV_SOURCE_DUMMY:
         return load_dummy_ohlcv(symbol, n_bars=n_bars)
     if src == OHLCV_SOURCE_KRAKEN:
         return load_kraken_ohlcv(symbol, n_bars=n_bars, timeframe=timeframe, use_cache=use_cache)
+    if src == OHLCV_SOURCE_CSV:
+        if not ohlcv_csv_path:
+            raise ValueError("OHLCV-Quelle csv erfordert ohlcv_csv_path (CLI: --ohlcv-csv).")
+        return load_csv_ohlcv(ohlcv_csv_path, symbol, n_bars=n_bars)
     raise AssertionError("unreachable")
 
 
@@ -291,11 +439,13 @@ def load_ohlcv_with_meta(
     source: str = OHLCV_SOURCE_DUMMY,
     timeframe: str = "1h",
     use_cache: bool = True,
+    ohlcv_csv_path: str | Path | None = None,
 ) -> tuple[pd.DataFrame, dict[str, Any]]:
     """
     Wie ``load_ohlcv``, zusätzlich deterministisches Observability-Dict (J1):
     symbol, Quelle, Timeframe, angeforderte/effektive Bar-Anzahl, Kraken-Pagination-Flag,
-    ``kraken_bars_shortfall`` (nur Kraken: ``True`` wenn ``bars_loaded < n_bars_requested``).
+    ``kraken_bars_shortfall`` (nur Kraken: ``True`` wenn ``bars_loaded < n_bars_requested``),
+    bei CSV: ``ohlcv_csv_resolved``, ``csv_bars_shortfall``.
     """
     src = _normalize_ohlcv_source(source)
     if src == OHLCV_SOURCE_DUMMY:
@@ -308,6 +458,8 @@ def load_ohlcv_with_meta(
             "bars_loaded": int(len(df)),
             "kraken_pagination_used": None,
             "kraken_bars_shortfall": None,
+            "ohlcv_csv_resolved": None,
+            "csv_bars_shortfall": None,
         }
         return df, meta
     if src == OHLCV_SOURCE_KRAKEN:
@@ -324,6 +476,27 @@ def load_ohlcv_with_meta(
             "bars_loaded": loaded,
             "kraken_pagination_used": pagination_used,
             "kraken_bars_shortfall": shortfall,
+            "ohlcv_csv_resolved": None,
+            "csv_bars_shortfall": None,
+        }
+        return df, meta
+    if src == OHLCV_SOURCE_CSV:
+        if not ohlcv_csv_path:
+            raise ValueError("OHLCV-Quelle csv erfordert ohlcv_csv_path (CLI: --ohlcv-csv).")
+        resolved = resolve_ohlcv_csv_path(ohlcv_csv_path, symbol)
+        df = load_csv_ohlcv(ohlcv_csv_path, symbol, n_bars=n_bars)
+        loaded = int(len(df))
+        shortfall = loaded < n_bars
+        meta = {
+            "symbol": symbol,
+            "ohlcv_source": OHLCV_SOURCE_CSV,
+            "timeframe": timeframe,
+            "n_bars_requested": n_bars,
+            "bars_loaded": loaded,
+            "kraken_pagination_used": None,
+            "kraken_bars_shortfall": None,
+            "ohlcv_csv_resolved": str(resolved),
+            "csv_bars_shortfall": shortfall,
         }
         return df, meta
     raise AssertionError("unreachable")

--- a/scripts/evaluate_forward_signals.py
+++ b/scripts/evaluate_forward_signals.py
@@ -31,7 +31,11 @@ sys.path.insert(0, str(_scripts))
 
 import pandas as pd
 
-from _shared_forward_args import add_shared_ohlcv_cli_group, append_forward_ohlcv_scope_epilog
+from _shared_forward_args import (
+    add_shared_ohlcv_cli_group,
+    append_forward_ohlcv_scope_epilog,
+    validate_forward_ohlcv_cli_args,
+)
 from _shared_ohlcv_loader import OHLCV_SOURCE_DUMMY, load_ohlcv_with_meta
 from _forward_run_manifest import (
     compute_deterministic_run_id,
@@ -124,11 +128,15 @@ def _print_ohlcv_load_observability(meta: Dict[str, Any], *, run_id: str | None 
     else:
         sf_s = "ja" if sf else "nein"
     tail = f"Kraken-Shortfall={sf_s}" + (f" | run_id={run_id}" if run_id else "")
+    csv_bit = ""
+    cr = meta.get("ohlcv_csv_resolved")
+    if cr:
+        csv_bit = f" | csv={cr}"
     print(
         f"  📡 OHLCV-Load: {meta['symbol']} | Quelle={meta['ohlcv_source']} | "
         f"TF={meta['timeframe']} | n_bars={meta['n_bars_requested']} | "
         f"geladen={meta['bars_loaded']} | Kraken-Pagination={pag_s} | "
-        f"{tail}"
+        f"{tail}{csv_bit}"
     )
 
 
@@ -140,6 +148,7 @@ def evaluate_signals_for_symbol(
     *,
     ohlcv_source: str = OHLCV_SOURCE_DUMMY,
     timeframe: str = "1h",
+    ohlcv_csv_path: Path | str | None = None,
 ) -> tuple[pd.DataFrame, Dict[str, Any]]:
     """
     Evaluierung der Signale für ein Symbol.
@@ -154,8 +163,9 @@ def evaluate_signals_for_symbol(
 
     Args:
         n_bars: Länge der OHLCV-Preisreihe (``load_ohlcv_with_meta``).
-        ohlcv_source: ``dummy`` | ``kraken`` (mit ``generate_forward_signals`` abstimmen).
+        ohlcv_source: ``dummy`` | ``kraken`` | ``csv`` (mit ``generate_forward_signals`` abstimmen).
         timeframe: Kraken-Timeframe; Dummy siehe Loader.
+        ohlcv_csv_path: CSV-Pfad bei ``csv``.
 
     Returns:
         (Evaluations-DataFrame, Observability-Dict für Loader/J1).
@@ -165,6 +175,7 @@ def evaluate_signals_for_symbol(
         n_bars=n_bars,
         source=ohlcv_source,
         timeframe=timeframe,
+        ohlcv_csv_path=ohlcv_csv_path,
     )
     if data.empty:
         raise ValueError(f"Keine Preisdaten für Symbol {symbol}.")
@@ -354,6 +365,13 @@ def main(argv: List[str] | None = None) -> int:
         return 1
 
     try:
+        validate_forward_ohlcv_cli_args(args)
+    except ValueError as e:
+        print(f"\n❌ {e}", file=sys.stderr)
+        write_manifest(1, error=str(e))
+        return 1
+
+    try:
         df_sig = load_signal_df(sig_path)
     except (ValueError, FileNotFoundError) as e:
         print(f"\n❌ {e}", file=sys.stderr)
@@ -401,6 +419,7 @@ def main(argv: List[str] | None = None) -> int:
                 n_bars=n_bars,
                 ohlcv_source=args.ohlcv_source,
                 timeframe=args.timeframe,
+                ohlcv_csv_path=args.ohlcv_csv,
             )
             ohlcv_load_by_symbol[symbol] = ohlcv_meta
             _print_ohlcv_load_observability(ohlcv_meta, run_id=deterministic_run_id)

--- a/scripts/generate_forward_signals.py
+++ b/scripts/generate_forward_signals.py
@@ -42,7 +42,11 @@ from src.analytics.risk_monitor import (
     aggregate_strategy_risk,
 )
 from src.analytics.filter_flow import SelectionPolicy, build_strategy_selection
-from _shared_forward_args import add_shared_ohlcv_cli_group, append_forward_ohlcv_scope_epilog
+from _shared_forward_args import (
+    add_shared_ohlcv_cli_group,
+    append_forward_ohlcv_scope_epilog,
+    validate_forward_ohlcv_cli_args,
+)
 from _shared_ohlcv_loader import OHLCV_SOURCE_DUMMY, load_ohlcv_with_meta
 from _forward_run_manifest import (
     compute_deterministic_run_id,
@@ -128,11 +132,15 @@ def _print_ohlcv_load_observability(meta: Dict[str, Any], *, run_id: str | None 
     else:
         sf_s = "ja" if sf else "nein"
     tail = f"Kraken-Shortfall={sf_s}" + (f" | run_id={run_id}" if run_id else "")
+    csv_bit = ""
+    cr = meta.get("ohlcv_csv_resolved")
+    if cr:
+        csv_bit = f" | csv={cr}"
     print(
         f"  📡 OHLCV-Load: {meta['symbol']} | Quelle={meta['ohlcv_source']} | "
         f"TF={meta['timeframe']} | n_bars={meta['n_bars_requested']} | "
         f"geladen={meta['bars_loaded']} | Kraken-Pagination={pag_s} | "
-        f"{tail}"
+        f"{tail}{csv_bit}"
     )
 
 
@@ -142,22 +150,31 @@ def load_data_for_symbol(
     *,
     ohlcv_source: str = OHLCV_SOURCE_DUMMY,
     timeframe: str = "1h",
+    ohlcv_csv_path: Path | str | None = None,
 ) -> tuple[pd.DataFrame, Dict[str, Any]]:
     """
     Lädt Daten für ein bestimmtes Symbol.
 
     J1 Slice 1–3: Dummy; J1 Slice 4: optional Kraken über ``load_ohlcv_with_meta`` (gleicher Vertrag).
+    J1 CSV: ``ohlcv_source=csv`` + ``ohlcv_csv_path``.
 
     Args:
         symbol: Trading-Pair (z.B. "BTC/EUR")
         n_bars: Anzahl Bars
-        ohlcv_source: ``dummy`` | ``kraken`` (CLI: ``--ohlcv-source``).
+        ohlcv_source: ``dummy`` | ``kraken`` | ``csv`` (CLI: ``--ohlcv-source``).
         timeframe: Kraken-Timeframe; Dummy bleibt 1h-synthetisch (siehe Loader).
+        ohlcv_csv_path: Pfad zur CSV bei ``csv``.
 
     Returns:
         (DataFrame mit OHLCV-Daten, Observability-Dict für Loader/J1)
     """
-    return load_ohlcv_with_meta(symbol, n_bars=n_bars, source=ohlcv_source, timeframe=timeframe)
+    return load_ohlcv_with_meta(
+        symbol,
+        n_bars=n_bars,
+        source=ohlcv_source,
+        timeframe=timeframe,
+        ohlcv_csv_path=ohlcv_csv_path,
+    )
 
 
 def determine_universe(cfg: Any, symbols_arg: str | None) -> List[str]:
@@ -215,6 +232,11 @@ def enforce_strategy_selection(cfg: PeakConfig, strategy_key: str) -> None:
 
 def main(argv: List[str] | None = None) -> int:
     args = parse_args(argv)
+    try:
+        validate_forward_ohlcv_cli_args(args)
+    except ValueError as e:
+        print(f"\n❌ {e}", file=sys.stderr)
+        return 1
     out_dir = Path(args.output_dir)
     strategy_key = args.strategy
     run_name: str | None = None
@@ -308,6 +330,7 @@ def main(argv: List[str] | None = None) -> int:
                 n_bars=args.n_bars,
                 ohlcv_source=args.ohlcv_source,
                 timeframe=args.timeframe,
+                ohlcv_csv_path=args.ohlcv_csv,
             )
             ohlcv_load_by_symbol[symbol] = ohlcv_meta
             _print_ohlcv_load_observability(ohlcv_meta, run_id=deterministic_run_id)

--- a/scripts/run_portfolio_backtest_v2.py
+++ b/scripts/run_portfolio_backtest_v2.py
@@ -42,6 +42,7 @@ from _shared_forward_args import (
     add_shared_ohlcv_cli_group,
     append_forward_ohlcv_scope_epilog,
     parse_symbols_cli_arg,
+    validate_forward_ohlcv_cli_args,
 )
 from _shared_ohlcv_loader import OHLCV_SOURCE_DUMMY, load_ohlcv
 from src.core.peak_config import load_config, PeakConfig
@@ -137,21 +138,29 @@ def load_data_for_symbol(
     *,
     ohlcv_source: str = OHLCV_SOURCE_DUMMY,
     timeframe: str = "1h",
+    ohlcv_csv_path: Path | str | None = None,
 ) -> pd.DataFrame:
     """
-    Lädt Marktdaten für ein Symbol (J1: ``load_ohlcv`` — dummy oder Kraken; ``cfg`` derzeit ungenutzt).
+    Lädt Marktdaten für ein Symbol (J1: ``load_ohlcv`` — dummy, Kraken oder CSV; ``cfg`` derzeit ungenutzt).
 
     Args:
         cfg: PeakConfig-Objekt
         symbol: Trading-Pair (z.B. "BTC/EUR")
         n_bars: Anzahl Bars
-        ohlcv_source: ``dummy`` | ``kraken``
+        ohlcv_source: ``dummy`` | ``kraken`` | ``csv``
         timeframe: Kraken-Timeframe; Dummy siehe Loader.
+        ohlcv_csv_path: CSV-Pfad bei ``csv``.
 
     Returns:
         DataFrame mit OHLCV-Daten (DatetimeIndex)
     """
-    return load_ohlcv(symbol, n_bars=n_bars, source=ohlcv_source, timeframe=timeframe)
+    return load_ohlcv(
+        symbol,
+        n_bars=n_bars,
+        source=ohlcv_source,
+        timeframe=timeframe,
+        ohlcv_csv_path=ohlcv_csv_path,
+    )
 
 
 def get_portfolio_definition(
@@ -218,6 +227,7 @@ def run_single_symbol_backtest(
     *,
     ohlcv_source: str = OHLCV_SOURCE_DUMMY,
     timeframe: str = "1h",
+    ohlcv_csv_path: Path | str | None = None,
 ) -> BacktestResult:
     """
     Führt einen einzelnen Backtest für ein Symbol durch.
@@ -238,6 +248,7 @@ def run_single_symbol_backtest(
         n_bars=n_bars,
         ohlcv_source=ohlcv_source,
         timeframe=timeframe,
+        ohlcv_csv_path=ohlcv_csv_path,
     )
 
     # Strategie erstellen
@@ -410,6 +421,11 @@ def main(argv: List[str] | None = None) -> None:
     if args.bars < 1:
         print("\n❌ FEHLER: --bars / --n-bars muss >= 1 sein.")
         return
+    try:
+        validate_forward_ohlcv_cli_args(args)
+    except ValueError as e:
+        print(f"\n❌ FEHLER: {e}")
+        return
 
     print("\n🚀 Peak_Trade Multi-Asset Portfolio Backtest")
     print("=" * 70)
@@ -476,6 +492,7 @@ def main(argv: List[str] | None = None) -> None:
                 n_bars=args.bars,
                 ohlcv_source=args.ohlcv_source,
                 timeframe=args.timeframe,
+                ohlcv_csv_path=args.ohlcv_csv,
             )
         except Exception as e:
             print(f"  ❌ FEHLER: {e}")

--- a/tests/test_dummy_ohlcv.py
+++ b/tests/test_dummy_ohlcv.py
@@ -14,12 +14,16 @@ if str(_scripts) not in sys.path:
     sys.path.insert(0, str(_scripts))
 
 from _shared_ohlcv_loader import (  # noqa: E402
+    OHLCV_SOURCE_CSV,
     OHLCV_SOURCE_DUMMY,
     OHLCV_SOURCE_KRAKEN,
+    load_csv_ohlcv,
     load_dummy_ohlcv,
     load_kraken_ohlcv,
     load_ohlcv,
     load_ohlcv_with_meta,
+    normalize_ohlcv_source,
+    resolve_ohlcv_csv_path,
 )
 
 
@@ -55,6 +59,8 @@ def test_load_ohlcv_with_meta_dummy():
     assert meta["bars_loaded"] == 42
     assert meta["kraken_pagination_used"] is None
     assert meta["kraken_bars_shortfall"] is None
+    assert meta["ohlcv_csv_resolved"] is None
+    assert meta["csv_bars_shortfall"] is None
 
 
 def test_load_ohlcv_with_meta_kraken_single_request():
@@ -76,6 +82,8 @@ def test_load_ohlcv_with_meta_kraken_single_request():
     assert len(df) == 10
     assert meta["kraken_pagination_used"] is False
     assert meta["kraken_bars_shortfall"] is False
+    assert meta["ohlcv_csv_resolved"] is None
+    assert meta["csv_bars_shortfall"] is None
 
 
 def test_load_ohlcv_with_meta_kraken_pagination_flag():
@@ -115,6 +123,8 @@ def test_load_ohlcv_with_meta_kraken_pagination_flag():
     assert len(df) == 1000
     assert meta["kraken_pagination_used"] is True
     assert meta["kraken_bars_shortfall"] is False
+    assert meta["ohlcv_csv_resolved"] is None
+    assert meta["csv_bars_shortfall"] is None
 
 
 def test_load_ohlcv_with_meta_kraken_shortfall_warning_and_meta():
@@ -140,6 +150,8 @@ def test_load_ohlcv_with_meta_kraken_shortfall_warning_and_meta():
     assert meta["bars_loaded"] == 12
     assert meta["kraken_bars_shortfall"] is True
     assert meta["kraken_pagination_used"] is False
+    assert meta["ohlcv_csv_resolved"] is None
+    assert meta["csv_bars_shortfall"] is None
 
 
 def test_load_ohlcv_unknown_source():
@@ -264,3 +276,115 @@ def test_timeframe_to_timedelta_invalid():
 
     with pytest.raises(ValueError, match="nicht unterstützt"):
         _timeframe_to_timedelta("2w")
+
+
+def _write_minimal_ohlcv_csv(path: Path, n: int = 30) -> None:
+    idx = pd.date_range("2024-06-01", periods=n, freq="1h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "timestamp": idx.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "open": [100.0 + i * 0.1 for i in range(n)],
+            "high": [101.0 + i * 0.1 for i in range(n)],
+            "low": [99.0 + i * 0.1 for i in range(n)],
+            "close": [100.5 + i * 0.1 for i in range(n)],
+            "volume": [10.0] * n,
+        }
+    )
+    df.to_csv(path, index=False)
+
+
+def test_load_csv_ohlcv_respects_n_bars_tail(tmp_path):
+    p = tmp_path / "s.csv"
+    _write_minimal_ohlcv_csv(p, n=50)
+    df = load_csv_ohlcv(p, "BTC/EUR", n_bars=20)
+    assert len(df) == 20
+    assert list(df.columns) == REQUIRED_OHLCV_COLUMNS
+
+
+def test_load_ohlcv_with_meta_csv(tmp_path):
+    p = tmp_path / "s.csv"
+    _write_minimal_ohlcv_csv(p, n=25)
+    df, meta = load_ohlcv_with_meta(
+        "BTC/EUR",
+        n_bars=10,
+        source=OHLCV_SOURCE_CSV,
+        timeframe="1h",
+        ohlcv_csv_path=p,
+    )
+    assert len(df) == 10
+    assert meta["ohlcv_source"] == OHLCV_SOURCE_CSV
+    assert meta["bars_loaded"] == 10
+    assert meta["n_bars_requested"] == 10
+    assert meta["csv_bars_shortfall"] is False
+    assert meta["ohlcv_csv_resolved"] == str(p.resolve())
+
+
+def test_load_ohlcv_csv_shortfall_warns(tmp_path):
+    p = tmp_path / "s.csv"
+    _write_minimal_ohlcv_csv(p, n=5)
+    with pytest.warns(UserWarning, match="nur 5"):
+        df, meta = load_ohlcv_with_meta(
+            "ETH/EUR",
+            n_bars=100,
+            source=OHLCV_SOURCE_CSV,
+            ohlcv_csv_path=p,
+        )
+    assert len(df) == 5
+    assert meta["csv_bars_shortfall"] is True
+
+
+def test_load_csv_duplicate_timestamp_fails(tmp_path):
+    p = tmp_path / "bad.csv"
+    idx = pd.date_range("2024-06-01", periods=5, freq="1h", tz="UTC")
+    ts = list(idx.strftime("%Y-%m-%dT%H:%M:%S%z"))
+    ts[2] = ts[1]
+    pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": [1.0] * 5,
+            "high": [2.0] * 5,
+            "low": [0.5] * 5,
+            "close": [1.5] * 5,
+            "volume": [1.0] * 5,
+        }
+    ).to_csv(p, index=False)
+    with pytest.raises(ValueError, match="doppelte"):
+        load_csv_ohlcv(p, "BTC/EUR", n_bars=10)
+
+
+def test_load_csv_high_lt_low_fails(tmp_path):
+    p = tmp_path / "bad2.csv"
+    idx = pd.date_range("2024-06-01", periods=3, freq="1h", tz="UTC")
+    pd.DataFrame(
+        {
+            "timestamp": idx.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "open": [10.0, 10.0, 10.0],
+            "high": [9.0, 10.0, 10.0],
+            "low": [10.0, 9.0, 9.0],
+            "close": [10.0, 10.0, 10.0],
+            "volume": [1.0, 1.0, 1.0],
+        }
+    ).to_csv(p, index=False)
+    from src.data.contracts import DataContractError
+
+    with pytest.raises(DataContractError, match="high < low"):
+        load_csv_ohlcv(p, "BTC/EUR", n_bars=10)
+
+
+def test_resolve_ohlcv_csv_path_symbol_placeholder(tmp_path):
+    sub = tmp_path / "data"
+    sub.mkdir()
+    target = sub / "BTC_EUR.csv"
+    target.write_text("x", encoding="utf-8")
+    resolved = resolve_ohlcv_csv_path(str(tmp_path / "data" / "{symbol}.csv"), "BTC/EUR")
+    assert resolved == target.resolve()
+
+
+def test_normalize_fixture_alias_is_csv():
+    assert normalize_ohlcv_source("fixture") == OHLCV_SOURCE_CSV
+    assert normalize_ohlcv_source("FiXtUrE") == OHLCV_SOURCE_CSV
+
+
+def test_load_ohlcv_csv_requires_path():
+    with pytest.raises(ValueError, match="ohlcv_csv_path"):
+        load_ohlcv("BTC/EUR", source=OHLCV_SOURCE_CSV, n_bars=10)

--- a/tests/test_forward_generate_evaluate_integration_smoke.py
+++ b/tests/test_forward_generate_evaluate_integration_smoke.py
@@ -58,6 +58,8 @@ def test_csv_roundtrip_as_of_iso_utc_aligns_with_price_index(tmp_path, monkeypat
         "bars_loaded": len(df_price),
         "kraken_pagination_used": None,
         "kraken_bars_shortfall": None,
+        "ohlcv_csv_resolved": None,
+        "csv_bars_shortfall": None,
     }
     monkeypatch.setattr(
         "evaluate_forward_signals.load_ohlcv_with_meta",
@@ -99,6 +101,8 @@ def test_generate_then_evaluate_with_captured_ohlcv(tmp_path, monkeypatch):
             "bars_loaded": len(df),
             "kraken_pagination_used": None,
             "kraken_bars_shortfall": None,
+            "ohlcv_csv_resolved": None,
+            "csv_bars_shortfall": None,
         }
         return df, meta
 
@@ -154,6 +158,8 @@ def test_generate_then_evaluate_with_captured_ohlcv(tmp_path, monkeypatch):
             "bars_loaded": len(df),
             "kraken_pagination_used": None,
             "kraken_bars_shortfall": None,
+            "ohlcv_csv_resolved": None,
+            "csv_bars_shortfall": None,
         }
         return df, meta
 

--- a/tests/test_shared_forward_args_cli.py
+++ b/tests/test_shared_forward_args_cli.py
@@ -16,7 +16,9 @@ from _shared_forward_args import (  # noqa: E402
     DEFAULT_OHLCV_TIMEFRAME,
     OHLCV_TIMEFRAME_CHOICES,
     parse_symbols_cli_arg,
+    validate_forward_ohlcv_cli_args,
 )
+from _shared_ohlcv_loader import OHLCV_SOURCE_CSV  # noqa: E402
 
 
 def test_parse_symbols_cli_arg():
@@ -101,3 +103,26 @@ def test_forward_pipeline_scripts_help_contains_j1_no_live_scope():
         assert "NO-LIVE" in out
         assert "keine Order" in out or "Keine Orders" in out
         assert "--ohlcv-source" in out
+        assert "--ohlcv-csv" in out
+
+
+def test_parse_args_ohlcv_csv_default_none():
+    from run_portfolio_backtest_v2 import parse_args
+
+    assert parse_args([]).ohlcv_csv is None
+
+
+def test_validate_forward_ohlcv_cli_csv_requires_path():
+    import argparse
+
+    args = argparse.Namespace(ohlcv_source=OHLCV_SOURCE_CSV, ohlcv_csv=None)
+    with pytest.raises(ValueError, match="--ohlcv-csv"):
+        validate_forward_ohlcv_cli_args(args)
+
+
+def test_validate_forward_ohlcv_cli_csv_path_only_with_csv(tmp_path):
+    import argparse
+
+    args = argparse.Namespace(ohlcv_source="dummy", ohlcv_csv=tmp_path / "x.csv")
+    with pytest.raises(ValueError, match="nur mit"):
+        validate_forward_ohlcv_cli_args(args)


### PR DESCRIPTION
## Summary
- Adds a deterministic local OHLCV CSV source for J1 forward/portfolio workflows.
- Supports `--ohlcv-source csv` and alias `fixture`, with required `--ohlcv-csv PATH`.
- Validates CSV schema/time ordering and preserves existing dummy/kraken behavior.
- Adds resolved CSV metadata and shortfall metadata for observability.

## Safety
- Local/file-based only; no network requirement.
- No live trading, broker, exchange order, Paper/Shadow/Evidence, or gate changes.
- Existing dummy/kraken paths remain intact.

## Validation
- `uv run python -m pytest tests/test_dummy_ohlcv.py tests/test_shared_forward_args_cli.py tests/test_forward_generate_evaluate_integration_smoke.py tests/test_run_portfolio_backtest_v2_cli.py`
- `uv run ruff check scripts/_shared_ohlcv_loader.py scripts/_shared_forward_args.py scripts/generate_forward_signals.py scripts/evaluate_forward_signals.py scripts/run_portfolio_backtest_v2.py tests/test_dummy_ohlcv.py tests/test_shared_forward_args_cli.py tests/test_forward_generate_evaluate_integration_smoke.py`
- `uv run ruff format` (same paths as above)
