### PR TITLE
docs(ops): document j1 local ohlcv csv source v1

### DIFF
--- a/docs/ops/roadmap/CURRENT_FOCUS.md
+++ b/docs/ops/roadmap/CURRENT_FOCUS.md
@@ -22,6 +22,7 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 
 ## Recently landed (truth, docs governance, officers)
 
+- PR #2865: Added deterministic local OHLCV `csv` source with `fixture` alias for J1 forward/portfolio CLIs; requires `--ohlcv-csv PATH`, supports `{symbol}` path expansion, and remains local/file-based with no live, broker, exchange-order, Paper/Shadow/Evidence, or gate changes.
 - PR #2857: Added a CLI cheatsheet Bounded Pilot / First-Live navigation box; operator-navigation-only, no live authorization or gate bypass.
 - PR #2858: Added a GETTING_STARTED pointer to that CLI cheatsheet navigation box; navigation-only.
 - PR #2859: Aligned Readiness Ladder L3 wording with DRAFT entry-contract / boundary-note maturity; no DRAFT status uplift.
@@ -162,6 +163,7 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 | 2026-04-12 | Post–PR #2297: Stufe J Forward-Demo-Stub + `CURRENT_FOCUS` + Runbook (this file) | PR #2297 merge; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed` |
 | 2026-04-12 | Post–PR #2298: Chat-led §5 J1 Forward Demo + `CURRENT_FOCUS` refresh (this file) | PR #2298 merge; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed` |
 | 2026-04-24 | Post–PRs #2857–#2861: bounded-pilot operator-navigation + DRAFT maturity wording; `CURRENT_FOCUS` refresh (this file) | PR #2857–#2861 merge; `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed` |
+| 2026-04-24 | J1 local OHLCV CSV source (#2865) | `uv run python -m pytest tests/test_dummy_ohlcv.py tests/test_shared_forward_args_cli.py tests/test_forward_generate_evaluate_integration_smoke.py tests/test_run_portfolio_backtest_v2_cli.py`; `uv run ruff check scripts/_shared_ohlcv_loader.py scripts/_shared_forward_args.py scripts/generate_forward_signals.py scripts/evaluate_forward_signals.py scripts/run_portfolio_backtest_v2.py tests/test_dummy_ohlcv.py tests/test_shared_forward_args_cli.py tests/test_forward_generate_evaluate_integration_smoke.py`; `uv run ruff format` (same paths) | Local/file-based only; no live/broker/order/evidence/gate changes. |
 
 ---
 

--- a/docs/ops/runbooks/RUNBOOK_UNIMPLEMENTED_FEATURES_ORDERED.md
+++ b/docs/ops/runbooks/RUNBOOK_UNIMPLEMENTED_FEATURES_ORDERED.md
@@ -150,6 +150,8 @@
 
 ---
 
+J1 local OHLCV note: the forward/portfolio CLI path now has a deterministic local source via `--ohlcv-source csv` plus alias `fixture`; `--ohlcv-csv PATH` is required for those sources. For multi-symbol runs, `PATH` may include `{symbol}` and resolves symbols such as `BTC&#47;EUR` to `BTC_EUR`. This is local/file-based only and does not enable live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.
+
 ## Empfohlene Bearbeitungs-Reihenfolge (hochlevel)
 
 1. **Governance & Safety-Draht** (D1–D3) — wenn Live-nah berührt, nur mit Freigabe.  


### PR DESCRIPTION
## Summary
- Adds CURRENT_FOCUS traceability for PR #2865 and the J1 local OHLCV CSV source.
- Adds a short RUNBOOK_UNIMPLEMENTED_FEATURES_ORDERED note for `--ohlcv-source csv`, `fixture`, `--ohlcv-csv PATH`, and `{symbol}` path expansion.
- Keeps the update docs-only and local/file-based; no live, broker, exchange-order, Paper/Shadow/Evidence, or gate semantics changed.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
