### PR TITLE
test(j1): add local ohlcv csv cli smoke v1

### DIFF
--- a/tests/test_forward_generate_evaluate_integration_smoke.py
+++ b/tests/test_forward_generate_evaluate_integration_smoke.py
@@ -9,6 +9,7 @@ in die Mitte der Serie, während Preisdaten und Loader mit dem Generate-Lauf üb
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict
@@ -188,3 +189,65 @@ def test_generate_then_evaluate_with_captured_ohlcv(tmp_path, monkeypatch):
     df_eval = pd.read_csv(eval_files[0])
     assert not df_eval.empty
     assert "return" in df_eval.columns
+
+
+@pytest.mark.smoke
+@pytest.mark.integration
+def test_generate_forward_signals_accepts_local_csv_source_smoke(tmp_path):
+    """Subprozess-Smoke: Generate-CLI mit --ohlcv-source csv und lokaler CSV (NO-LIVE)."""
+    cfg_path = ROOT / "config" / "config.test.toml"
+    if not cfg_path.is_file():
+        pytest.skip(f"fehlt: {cfg_path}")
+
+    csv_path = tmp_path / "BTC_EUR.csv"
+    n = 60
+    idx = pd.date_range("2024-06-01", periods=n, freq="1h", tz="UTC")
+    pd.DataFrame(
+        {
+            "timestamp": idx.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "open": [100.0 + i * 0.1 for i in range(n)],
+            "high": [101.0 + i * 0.1 for i in range(n)],
+            "low": [99.0 + i * 0.1 for i in range(n)],
+            "close": [100.5 + i * 0.1 for i in range(n)],
+            "volume": [10.0] * n,
+        }
+    ).to_csv(csv_path, index=False)
+
+    out_dir = tmp_path / "forward"
+    run_name = "j1_csv_cli_smoke"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate_forward_signals.py"),
+            "--strategy",
+            "ma_crossover",
+            "--symbols",
+            "BTC/EUR",
+            "--config-path",
+            str(cfg_path),
+            "--output-dir",
+            str(out_dir),
+            "--run-name",
+            run_name,
+            "--n-bars",
+            str(n),
+            "--ohlcv-source",
+            "csv",
+            "--ohlcv-csv",
+            str(csv_path),
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    sig_path = out_dir / f"{run_name}_signals.csv"
+    assert sig_path.is_file()
+    assert sig_path.read_text(encoding="utf-8").strip()
+    combined = result.stdout + result.stderr
+    assert "csv" in combined.lower()
+    assert str(csv_path.resolve()) in combined


### PR DESCRIPTION
## Summary
- Adds a deterministic subprocess smoke test for `scripts/generate_forward_signals.py` using local OHLCV CSV input.
- Exercises `--ohlcv-source csv` and `--ohlcv-csv PATH` through the real CLI (with `--output-dir`, `--run-name`, and `config/config.test.toml`).
- Asserts command success, expected `{run_name}_signals.csv`, and CSV observability in CLI output (`csv=` / resolved path).

## Safety
- Test-only change.
- Local tempfile CSV only.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python -m pytest tests/test_forward_generate_evaluate_integration_smoke.py -q
- uv run ruff check tests/test_forward_generate_evaluate_integration_smoke.py
- uv run ruff format --check tests/test_forward_generate_evaluate_integration_smoke.py
