### PR TITLE
docs(ops): add cli cheatsheet j1 evaluate csv ref v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -182,6 +182,17 @@ python3 scripts/generate_forward_signals.py --strategy ma_crossover --symbols BT
 python3 scripts/generate_forward_signals.py --strategy ma_crossover --symbols BTC/EUR,ETH/EUR --ohlcv-source fixture --ohlcv-csv 'data/{symbol}.csv'
 ```
 
+Evaluate the generated forward signals with the same local CSV source:
+
+```bash
+python3 scripts/evaluate_forward_signals.py reports/forward/csv_demo_signals.csv --config-path config/config.test.toml --ohlcv-source csv --ohlcv-csv data/BTC_EUR.csv --output-dir reports/forward/evaluation
+```
+
+Evaluate notes:
+- The signal CSV carries `as_of`; choose a generated signal set whose `as_of` leaves an entry bar available in the local OHLCV series.
+- Use the same `--ohlcv-csv` file or `{symbol}` template used during generation when reproducing local CSV runs.
+- Keep `--output-dir` explicit for demos so evaluation artifacts do not land in an unexpected default path.
+
 Notes:
 
 - `csv` and `fixture` use the same local/file-based loader path.


### PR DESCRIPTION
## Summary
- Adds an Evaluate + local CSV example to the CLI cheatsheet J1 Local OHLCV CSV Source block.
- Documents `--config-path`, `--ohlcv-source csv`, `--ohlcv-csv`, explicit `--output-dir`, and the `as_of`/entry-bar caveat.
- Keeps the guidance docs-only and NO-LIVE/local-only.

## Safety
- Docs-only change.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
