### PR TITLE
docs(ops): sync current focus j1 local csv followups v1

### DIFF
--- a/docs/ops/roadmap/CURRENT_FOCUS.md
+++ b/docs/ops/roadmap/CURRENT_FOCUS.md
@@ -22,6 +22,11 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 
 ## Recently landed (truth, docs governance, officers)
 
+- PR #2868: Added CLI cheatsheet discoverability for the J1 local OHLCV CSV source, including `csv`, `fixture`, `--ohlcv-csv PATH`, `{symbol}` path expansion, and NO-LIVE/local-only notes.
+- PR #2869: Added a subprocess smoke for `generate_forward_signals.py` with local CSV OHLCV input; test-only, tempfile/local, no live/broker/order/evidence/gate changes.
+- PR #2870: Added a subprocess smoke for `evaluate_forward_signals.py` with local CSV OHLCV input after generated signals; test-only and local-only.
+- PR #2871: Added a negative subprocess validation test for `evaluate_forward_signals.py` when `--ohlcv-source csv` is used without `--ohlcv-csv`.
+- PR #2872: Added Evaluate + local CSV guidance to the CLI cheatsheet, including `--config-path`, `--output-dir`, and the `as_of`/entry-bar caveat.
 - PR #2865: Added deterministic local OHLCV `csv` source with `fixture` alias for J1 forward/portfolio CLIs; requires `--ohlcv-csv PATH`, supports `{symbol}` path expansion, and remains local/file-based with no live, broker, exchange-order, Paper/Shadow/Evidence, or gate changes.
 - PR #2857: Added a CLI cheatsheet Bounded Pilot / First-Live navigation box; operator-navigation-only, no live authorization or gate bypass.
 - PR #2858: Added a GETTING_STARTED pointer to that CLI cheatsheet navigation box; navigation-only.
@@ -164,6 +169,7 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 | 2026-04-12 | Post–PR #2298: Chat-led §5 J1 Forward Demo + `CURRENT_FOCUS` refresh (this file) | PR #2298 merge; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed` |
 | 2026-04-24 | Post–PRs #2857–#2861: bounded-pilot operator-navigation + DRAFT maturity wording; `CURRENT_FOCUS` refresh (this file) | PR #2857–#2861 merge; `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed` |
 | 2026-04-24 | J1 local OHLCV CSV source (#2865) | `uv run python -m pytest tests/test_dummy_ohlcv.py tests/test_shared_forward_args_cli.py tests/test_forward_generate_evaluate_integration_smoke.py tests/test_run_portfolio_backtest_v2_cli.py`; `uv run ruff check scripts/_shared_ohlcv_loader.py scripts/_shared_forward_args.py scripts/generate_forward_signals.py scripts/evaluate_forward_signals.py scripts/run_portfolio_backtest_v2.py tests/test_dummy_ohlcv.py tests/test_shared_forward_args_cli.py tests/test_forward_generate_evaluate_integration_smoke.py`; `uv run ruff format` (same paths) | Local/file-based only; no live/broker/order/evidence/gate changes. |
+| 2026-04-24 | J1 local CSV follow-up closure (#2868-#2872) | `uv run python -m pytest tests/test_dummy_ohlcv.py tests/test_forward_generate_evaluate_integration_smoke.py -q`; `uv run ruff check tests/test_dummy_ohlcv.py tests/test_forward_generate_evaluate_integration_smoke.py`; `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed` — *Outcome:* J1 local CSV is pausierbar (loader/template tests, Generate/Evaluate subprocess smokes, negative Evaluate validation, runbook/CURRENT_FOCUS and cheatsheet coverage). |
 
 ---
 


### PR DESCRIPTION
## Summary
- Syncs CURRENT_FOCUS with the J1 local CSV follow-up sequence #2868-#2872.
- Records CLI cheatsheet discoverability, Generate/Evaluate subprocess smokes, negative Evaluate validation, and Evaluate cheatsheet guidance.
- Adds a Last verification table row documenting the closure checks and pausierbar posture.

## Safety
- Docs-only change.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
