### PR TITLE
docs(ops): add cli cheatsheet j2 optuna placeholder v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -202,6 +202,20 @@ Notes:
 
 ---
 
+## J2 Optuna Placeholder
+
+Use the J2 placeholder to exercise the study CLI surface without running real optimization or live trading:
+
+```bash
+python3 scripts/run_study_optuna_placeholder.py --help
+python3 scripts/run_study_optuna_placeholder.py --dry-run
+```
+
+Notes:
+- This is a placeholder/dry-run surface only; it is separate from `scripts/run_optuna_study.py`.
+- Use it for CLI discoverability and orchestration checks before any real Optuna study path is selected.
+- This is NO-LIVE: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
+
 ## 5. Forward-Signals (Out-of-Sample)
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a CLI cheatsheet block for the J2 Optuna placeholder surface.
- Documents `scripts/run_study_optuna_placeholder.py --help` and `--dry-run`.
- Clarifies that this is separate from the real `scripts/run_optuna_study.py` path and remains NO-LIVE.

## Safety
- Docs-only change.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
