### PR TITLE
docs(ops): add cli cheatsheet j3 placeholder reports v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -216,6 +216,20 @@ Notes:
 - Use it for CLI discoverability and orchestration checks before any real Optuna study path is selected.
 - This is NO-LIVE: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
 
+## J3 Placeholder Reports
+
+Use the J3 placeholder report generator to exercise local report-output plumbing without touching live, paper, shadow, or evidence paths:
+
+```bash
+python3 scripts/ops/placeholders/generate_placeholder_reports.py --help
+python3 scripts/ops/placeholders/generate_placeholder_reports.py --prefix src/ --output-dir .ops_local/j3_placeholder_reports
+```
+
+Notes:
+- Keep output under `.ops_local` or another explicitly local scratch directory.
+- `--prefix` limits the scan to repo-relative paths (repeatable); e.g. `src/` or `docs/ops/`.
+- This is NO-LIVE/local-only: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
+
 ## 5. Forward-Signals (Out-of-Sample)
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a CLI cheatsheet block for the J3 placeholder report generator.
- Documents `scripts/ops/placeholders/generate_placeholder_reports.py --help`, `--prefix` (repo-relative scan scope), and local `.ops_local` output.
- Keeps the guidance docs-only and NO-LIVE/local-only.

## Safety
- Docs-only change.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Note
- The canonical script path is `scripts/ops/placeholders/generate_placeholder_reports.py` (not `scripts/generate_placeholder_reports.py`).
- `--prefix` filters which repo paths are scanned (e.g. `src/`), not output filenames.
