### PR TITLE
docs(ops): add cli cheatsheet sweep pipeline ref v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -126,6 +126,19 @@ python3 scripts/run_sweep.py \
 
 ---
 
+### Unified sweep pipeline
+
+Use the unified sweep pipeline entry point for CLI discoverability and local/research orchestration checks:
+
+```bash
+python3 scripts/run_sweep_pipeline.py --help
+```
+
+Notes:
+- This is separate from the lower-level `scripts/run_sweep.py` grid sweep helpers and from `research_cli.py sweep` / `scripts/run_strategy_sweep.py` preset-oriented flows.
+- Start with `--help` and choose the concrete research/dry-run mode explicitly; do not infer live readiness from sweep output.
+- This is NO-LIVE/local-research guidance: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
+
 ## 3b. Report-Tools
 
 Es gibt zwei getrennte Report-Flows:


### PR DESCRIPTION
## Summary
- Adds CLI cheatsheet discoverability for `scripts/run_sweep_pipeline.py`.
- Places the entry under the existing sweep section and distinguishes it from lower-level grid/preset sweep helpers.
- Keeps the guidance docs-only and NO-LIVE/local-research.

## Safety
- Docs-only change.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
