### PR TITLE
docs(ops): sync current focus sweep pipeline v1

### DIFF
--- a/docs/ops/roadmap/CURRENT_FOCUS.md
+++ b/docs/ops/roadmap/CURRENT_FOCUS.md
@@ -22,6 +22,7 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 
 ## Recently landed (truth, docs governance, officers)
 
+- PR #2878: Added CLI cheatsheet discoverability for the unified sweep pipeline (`scripts&#47;run_sweep_pipeline.py --help`), with explicit separation from lower-level grid/preset sweep helpers and NO-LIVE/local-research notes.
 - PR #2876: Added CLI cheatsheet discoverability for the J3 placeholder report generator (`scripts&#47;ops&#47;placeholders&#47;generate_placeholder_reports.py --help`, `--prefix src&#47;`, `.ops_local` output), with NO-LIVE/local-only notes and no broker/exchange-order, Paper/Shadow/Evidence, or gate changes.
 - PR #2874: Added CLI cheatsheet discoverability for the J2 Optuna placeholder surface (`--help` / `--dry-run` on `scripts&#47;run_study_optuna_placeholder.py`), explicitly separate from `scripts&#47;run_optuna_study.py` and NO-LIVE with no broker/exchange-order, Paper/Shadow/Evidence, or gate changes.
 - PR #2868: Added CLI cheatsheet discoverability for the J1 local OHLCV CSV source, including `csv`, `fixture`, `--ohlcv-csv PATH`, `{symbol}` path expansion, and NO-LIVE/local-only notes.
@@ -174,6 +175,7 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 | 2026-04-24 | J1 local CSV follow-up closure (#2868-#2872) | `uv run python -m pytest tests/test_dummy_ohlcv.py tests/test_forward_generate_evaluate_integration_smoke.py -q`; `uv run ruff check tests/test_dummy_ohlcv.py tests/test_forward_generate_evaluate_integration_smoke.py`; `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed` — *Outcome:* J1 local CSV is pausierbar (loader/template tests, Generate/Evaluate subprocess smokes, negative Evaluate validation, runbook/CURRENT_FOCUS and cheatsheet coverage). |
 | 2026-04-24 | J2 Optuna placeholder cheatsheet sync (#2874) | `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed`; docs-only discoverability for placeholder/dry-run surface, NO-LIVE. |
 | 2026-04-24 | J3 placeholder reports cheatsheet sync (#2876) | `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed`; docs-only discoverability for placeholder report generator, NO-LIVE/local-only. |
+| 2026-04-24 | Unified sweep pipeline cheatsheet sync (#2878) | `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed`; docs-only discoverability for `scripts&#47;run_sweep_pipeline.py --help`, NO-LIVE/local-research. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Syncs CURRENT_FOCUS with PR #2878.
- Records CLI cheatsheet discoverability for the unified sweep pipeline.
- Keeps the update docs-only and NO-LIVE/local-research; no broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
