### PR TITLE
docs(ops): add cli cheatsheet forward dummy demo ref v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -256,6 +256,19 @@ python3 scripts/run_forward_signals.py \
 
 ---
 
+## Forward Dummy Pipeline Demo
+
+Use the forward dummy pipeline demo for local operator-orchestration checks without touching live, paper, shadow, or evidence paths:
+
+```bash
+bash scripts/dev/run_forward_dummy_pipeline_demo.sh
+```
+
+Notes:
+- This is a local demo-shell path for the forward dummy pipeline, not a live or paper execution path.
+- Use it after reading the Forward-Signals and J1 local OHLCV notes in this cheatsheet when you need a quick operator-facing demo reference.
+- This is NO-LIVE/local-only: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
+
 ## 6. Live-Workflows
 
 ### Order-Preview


### PR DESCRIPTION
## Summary
- Adds CLI cheatsheet discoverability for `scripts/dev/run_forward_dummy_pipeline_demo.sh`.
- Places the demo near Forward/J1 guidance and frames it as a local operator-orchestration reference.
- Keeps the guidance docs-only and NO-LIVE/local-only.

## Safety
- Docs-only change.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
