### PR TITLE
docs(ops): add cli cheatsheet optuna study ref v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -229,6 +229,19 @@ Notes:
 - Use it for CLI discoverability and orchestration checks before any real Optuna study path is selected.
 - This is NO-LIVE: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
 
+## Optuna Study CLI
+
+Use the full Optuna study CLI only after intentionally leaving the J2 placeholder/dry-run surface:
+
+```bash
+python3 scripts/run_optuna_study.py --help
+```
+
+Notes:
+- This is separate from the J2 placeholder `scripts/run_study_optuna_placeholder.py` surface.
+- Start with `--help`; select any real study configuration explicitly and keep the run in research/dry-run scope unless a separate approved workflow says otherwise.
+- This cheatsheet entry is NO-LIVE/research guidance: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
+
 ## J3 Placeholder Reports
 
 Use the J3 placeholder report generator to exercise local report-output plumbing without touching live, paper, shadow, or evidence paths:


### PR DESCRIPTION
## Summary
- Adds CLI cheatsheet discoverability for the full `scripts/run_optuna_study.py` CLI.
- Places it next to the J2 placeholder guidance and clearly separates real study entry from the placeholder/dry-run surface.
- Keeps the guidance docs-only and NO-LIVE/research-scoped.

## Safety
- Docs-only change.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
