### PR TITLE
docs(ops): add stufe j cli cheatsheet navigation ref v1

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_UNIMPLEMENTED_FEATURES_ORDERED.md
+++ b/docs/ops/runbooks/RUNBOOK_UNIMPLEMENTED_FEATURES_ORDERED.md
@@ -151,6 +151,7 @@
 ---
 
 J1 local OHLCV note: the forward/portfolio CLI path now has a deterministic local source via `--ohlcv-source csv` plus alias `fixture`; `--ohlcv-csv PATH` is required for those sources. For multi-symbol runs, `PATH` may include `{symbol}` and resolves symbols such as `BTC&#47;EUR` to `BTC_EUR`. This is local/file-based only and does not enable live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.
+Stufe-J operator navigation: for the current CLI-facing quick references covering J1 local CSV, J2 Optuna placeholder, full Optuna study, J3 placeholder reports, unified sweep pipeline, and the forward dummy pipeline demo, see [CLI_CHEATSHEET.md](../../CLI_CHEATSHEET.md). This link is navigation-only and does not enable live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.
 
 ## Empfohlene Bearbeitungs-Reihenfolge (hochlevel)
 


### PR DESCRIPTION
## Summary
- Adds a Stufe-J navigation note in RUNBOOK_UNIMPLEMENTED_FEATURES_ORDERED.
- Points operators to docs/CLI_CHEATSHEET.md for J1/J2/J3, full Optuna, sweep pipeline, and forward dummy demo quick references.
- Keeps the update docs-only and navigation-only.

## Safety
- Docs-only change.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
