### PR TITLE
test(j1): add portfolio local ohlcv csv smoke v1

### DIFF
--- a/tests/test_run_portfolio_backtest_v2_cli.py
+++ b/tests/test_run_portfolio_backtest_v2_cli.py
@@ -33,3 +33,62 @@ def test_parse_args_defaults_timeframe():
     from run_portfolio_backtest_v2 import parse_args
 
     assert parse_args([]).timeframe == "1h"
+
+
+def test_run_portfolio_backtest_v2_accepts_local_csv_source_smoke(tmp_path):
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    import pandas as pd
+
+    repo_root = Path(__file__).resolve().parents[1]
+    config_src = repo_root / "config" / "config.test.toml"
+    assert config_src.exists(), "config/config.test.toml is required for portfolio CLI smoke"
+
+    (tmp_path / "config.toml").write_text(
+        config_src.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    csv_path = tmp_path / "BTC_EUR.csv"
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01T00:00:00Z", periods=80, freq="min"),
+            "open": [100.0 + i for i in range(80)],
+            "high": [101.0 + i for i in range(80)],
+            "low": [99.0 + i for i in range(80)],
+            "close": [100.5 + i for i in range(80)],
+            "volume": [1.0 + (i / 100.0) for i in range(80)],
+        }
+    )
+    frame.to_csv(csv_path, index=False)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "run_portfolio_backtest_v2.py"),
+            "--symbols",
+            "BTC/EUR",
+            "--ohlcv-source",
+            "csv",
+            "--ohlcv-csv",
+            str(csv_path),
+            "--n-bars",
+            "80",
+            "--no-report",
+        ],
+        cwd=tmp_path,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined_output = result.stdout + result.stderr
+    assert "csv" in combined_output.lower()
+    assert "BTC/EUR" in combined_output
+    assert "OHLCV-Quelle" in combined_output
+    assert "--no-report" in combined_output or "nicht geschrieben" in combined_output.lower()
+    assert not (tmp_path / "reports").exists()


### PR DESCRIPTION
## Summary
- Adds a subprocess smoke for `scripts/run_portfolio_backtest_v2.py` using local OHLCV CSV input.
- Runs in a temp working directory with a temp `config.toml`, local CSV input, and `--no-report`.
- Completes J1 local CSV parity across Generate, Evaluate, and Portfolio CLI paths.

## Safety
- Test-only change.
- Local tempfile config/CSV only.
- No live trading, broker/exchange orders, Paper/Shadow/Evidence mutation, repo-root reports, or gate changes.

## Validation
- uv run python -m pytest tests/test_run_portfolio_backtest_v2_cli.py -q
- uv run ruff check tests/test_run_portfolio_backtest_v2_cli.py
- uv run ruff format --check tests/test_run_portfolio_backtest_v2_cli.py
