### PR TITLE
docs(ops): add cli cheatsheet research strategy profile v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -139,6 +139,20 @@ Notes:
 - Start with `--help` and choose the concrete research/dry-run mode explicitly; do not infer live readiness from sweep output.
 - This is NO-LIVE/local-research guidance: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
 
+## Research CLI Strategy Profile
+
+Use the `strategy-profile` subcommand for local research/inspection of strategy metadata before choosing a deeper research path:
+
+```bash
+python3 scripts/research_cli.py strategy-profile --help
+python3 scripts/research_cli.py strategy-profile ma_crossover
+```
+
+Notes:
+- This is a local research/discoverability surface for strategy-profile inspection.
+- Keep deeper research modes such as walk-forward, Monte Carlo, stress, sweeps, or optimization as separate, explicit follow-up choices.
+- This is NO-LIVE/research-only: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
+
 ## 3b. Report-Tools
 
 Es gibt zwei getrennte Report-Flows:


### PR DESCRIPTION
## Summary
- Adds CLI cheatsheet discoverability for `scripts/research_cli.py strategy-profile`.
- Documents `--help` and a minimal `ma_crossover` example.
- Keeps deeper research modes as separate explicit choices.

## Safety
- Docs-only change.
- NO-LIVE/research-only.
- No broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- python3 scripts/research_cli.py strategy-profile --help
- uv run python -m pytest tests/test_strategy_profile_cli.py tests/test_research_cli.py -q
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
