### PR TITLE
docs(ops): sync cli cheatsheet strategy profile contract v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -145,7 +145,7 @@ Use the `strategy-profile` subcommand for local research/inspection of strategy 
 
 ```bash
 python3 scripts/research_cli.py strategy-profile --help
-python3 scripts/research_cli.py strategy-profile ma_crossover
+python3 scripts/research_cli.py strategy-profile --strategy-id ma_crossover
 ```
 
 Notes:


### PR DESCRIPTION
## Summary
- Fixes the CLI cheatsheet strategy-profile example to use the real `--strategy-id` contract.
- Keeps the Research CLI Strategy Profile section otherwise unchanged.
- Does not add additional research_cli subcommands.

## Safety
- Docs-only change.
- NO-LIVE/research-only.
- No broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- python3 scripts/research_cli.py strategy-profile --help
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
