### PR TITLE
docs(ops): sync research strategy profile inspect trace v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -149,7 +149,14 @@ python3 scripts/research_cli.py strategy-profile --strategy-id ma_crossover
 ```
 
 Notes:
-- This is a local research/discoverability surface for strategy-profile inspection.
+- List available strategy profiles without selecting one:
+
+```bash
+python3 scripts/research_cli.py strategy-profile --list-strategies
+```
+
+- This is a local research/discoverability surface; `research_cli` does not run the global `artifacts&#47;research` evidence-bootstrap path for `strategy-profile` (other research subcommands still do).
+- With `--strategy-id`, a full run may write profile outputs to the default export paths in `--help` / `--output-dir` (separate from that bootstrap; generated files are not the global `artifacts&#47;research` run folder).
 - Keep deeper research modes such as walk-forward, Monte Carlo, stress, sweeps, or optimization as separate, explicit follow-up choices.
 - This is NO-LIVE/research-only: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
 

--- a/docs/ops/roadmap/CURRENT_FOCUS.md
+++ b/docs/ops/roadmap/CURRENT_FOCUS.md
@@ -2,7 +2,7 @@
 title: "Current focus — operator-maintained (not auto-generated)"
 status: DRAFT
 scope: docs-only (NO-LIVE)
-last_updated: 2026-04-24
+P26-04-24
 ---
 
 # Current focus
@@ -22,6 +22,9 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 
 ## Recently landed (truth, docs governance, officers)
 
+- PR #2892: Added CLI cheatsheet discoverability for `scripts&#47;research_cli.py strategy-profile`, NO-LIVE/research-only.
+- PR #2893: Corrected the strategy-profile cheatsheet example to use the real `--strategy-id ma_crossover` contract.
+- PR #2894: Hardened `strategy-profile` as an inspect/discoverability command without the global `artifacts&#47;research` bootstrap; artifact-producing research commands still bootstrap evidence.
 - PR #2889: Added a Portfolio CLI subprocess smoke for local OHLCV CSV input with temp `config.toml`, local CSV, and `--no-report`; test-only; no repo-root reports; no Paper/Shadow/Evidence mutation; no gate changes.
 - PR #2890: Hardened the Portfolio CLI contract with `--config-path`, explicit `main()` exit codes, `SystemExit(main())`, and subprocess validation for missing CSV/config inputs; J1 local CSV parity is now covered across Generate, Evaluate, and Portfolio paths and is pausierbar.
 - PR #2887: Added a Chat-led J1 Forward Scripts operator quick reference to [CLI_CHEATSHEET.md](../../CLI_CHEATSHEET.md), keeping the existing three-column table shape despite the `dummy|kraken` source text in the row; navigation-only and NO-LIVE.
@@ -187,6 +190,7 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 | 2026-04-24 | Chat-led Forward Demo cheatsheet sync (#2885) | `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed`; docs-only navigation link from Chat-led Demo-Stub row to CLI_CHEATSHEET, NO-LIVE. |
 | 2026-04-24 | Chat-led Forward Scripts cheatsheet sync (#2887) | `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed`; docs-only navigation link from Chat-led Scripts row to CLI_CHEATSHEET, three-column table preserved. |
 | 2026-04-24 | J1 Portfolio local CSV contract closure (#2889-#2890) | `uv run python -m pytest tests/test_run_portfolio_backtest_v2_cli.py -q`; `uv run python -m pytest tests/test_shared_forward_args_cli.py -q`; `uv run ruff check scripts/run_portfolio_backtest_v2.py tests/test_run_portfolio_backtest_v2_cli.py`; `uv run ruff format --check scripts/run_portfolio_backtest_v2.py tests/test_run_portfolio_backtest_v2_cli.py`; `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed`; J1 local CSV pausierbar after Generate/Evaluate/Portfolio coverage and portfolio CLI contract hardening. |
+| 2026-04-24 | Research strategy-profile inspect closure (#2892-#2894) | `python3 scripts/research_cli.py strategy-profile --help`; `uv run python -m pytest tests/test_research_cli.py tests/test_strategy_profile_cli.py -q`; `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`; `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`; `bash scripts/ops/pt_docs_gates_snapshot.sh --changed`; strategy-profile is an inspect/discoverability surface without global `artifacts&#47;research` bootstrap. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Syncs CURRENT_FOCUS with PRs #2892-#2894.
- Adds `strategy-profile --list-strategies` discoverability to the CLI cheatsheet.
- Clarifies that strategy-profile does not use the global `artifacts/research` bootstrap path, while other research subcommands still may.

## Safety
- Docs-only change.
- NO-LIVE/research-only.
- No broker/exchange orders, Paper/Shadow mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
