### PR TITLE
test(risk): add risk cli help smoke v1

### DIFF
--- a/tests/risk/test_risk_cli_smoke.py
+++ b/tests/risk/test_risk_cli_smoke.py
@@ -31,3 +31,19 @@ def test_risk_cli_var_smoke(tmp_path):
     assert "var" in j and j["var"] >= 0.0
     assert (tmp_path / run_id / "meta.json").exists()
     assert (tmp_path / run_id / "results" / "var.json").exists()
+
+
+def test_risk_cli_help_subprocess_smoke():
+    root = Path(__file__).resolve().parent.parent.parent
+    result = subprocess.run(
+        [sys.executable, str(root / "scripts" / "risk_cli.py"), "--help"],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    combined_output = result.stdout + result.stderr
+    assert "usage:" in combined_output.lower()
+    assert "risk" in combined_output.lower()


### PR DESCRIPTION
## Summary
- Adds a subprocess smoke test for `scripts/risk_cli.py --help`.
- Covers the top-level risk CLI discoverability contract.

## Safety
- Test-only change.
- NO-LIVE.
- No broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python -m pytest tests/risk/test_risk_cli_smoke.py -q
- uv run ruff check tests/risk/test_risk_cli_smoke.py
- uv run ruff format --check tests/risk/test_risk_cli_smoke.py
