### PR TITLE
docs(ops): add release operator verify rubric evidence note v1

### DIFF
--- a/docs/ops/evidence/EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24.md
+++ b/docs/ops/evidence/EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24.md
@@ -1,0 +1,85 @@
+---
+id: EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24
+title: Release Operator Verify Go/No-Go Rubric Evidence Note — main snapshot
+status: DRAFT
+date: 2026-04-24
+repo_ref: main@0ed0cb0d4455
+scope: NO-LIVE operator-readiness snapshot
+---
+
+# Release Operator Verify Go/No-Go Rubric Evidence Note — main snapshot
+
+## 1. Purpose
+
+This evidence note records a **NO-LIVE** operator-readiness snapshot for the current `main` branch against the release checklist and Go/No-Go rubric.
+
+Canonical rubric:
+
+- [RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md](../release/runbooks/RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md)
+
+Finish-plan reference:
+
+- [FINISH_PLAN.md — PR 8](../roadmap/FINISH_PLAN.md#pr-8-release-checklist-gono-go-rubric-docs-only)
+
+Current-focus reference:
+
+- [CURRENT_FOCUS.md](../roadmap/CURRENT_FOCUS.md)
+
+## 2. Snapshot identity
+
+- Branch: `main`
+- Git SHA: `0ed0cb0d445521d4659413b51efc5b5a47a9f192`
+- Recorded date: `2026-04-24`
+- Recorded mode: `NO-LIVE`
+- Evidence type: docs-only operator-readiness note
+- Live authorization: **not granted**
+- Broker/exchange orders: **not allowed**
+- Paper/Shadow/Evidence mutation: **not performed**
+- Master-V2 expansion: **not in scope**
+- Required-checks hygiene changes: **not in scope**
+
+## 3. Rubric interpretation
+
+The release checklist and Go/No-Go rubric may use words such as `Go`, `No-Go`, `Ready`, or `Blocked` as rubric outcomes.
+
+For this note, those terms mean **operator-readiness classification only**. They do not authorize live trading, broker/exchange orders, testnet operations, paper mutations, shadow mutations, or evidence mutation.
+
+Any rubric row involving broker/testnet/live-like activity is interpreted as **blocked for execution** unless a separate approved workflow explicitly authorizes that action.
+
+## 4. Checklist mapping
+
+| Rubric area | Snapshot interpretation | Status |
+|---|---|---|
+| Documentation surface | Release rubric, finish-plan PR 8 reference, and CURRENT_FOCUS are present as review anchors. | Review-only |
+| Operator readiness | This note provides a candidate snapshot for operator review. | Review-only |
+| Go/No-Go classification | No operational `Go` is granted by this note. | No-live |
+| Broker/testnet/live actions | Not executed and not authorized. | Blocked |
+| Evidence mutation | No out-of-band evidence generation is performed by this note. | Not performed |
+| Required checks | Docs validation for this slice recorded in §6 (token policy, reference targets, snapshot helper). | Recorded |
+
+## 5. Expected validation for this evidence-note slice
+
+Run these checks before PR:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+bash scripts/ops/pt_docs_gates_snapshot.sh --changed
+```
+
+Optional (only if you need parity with [RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md](../release/runbooks/RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md) §4.4):
+
+```bash
+python3 scripts/ops/ensure_truth_branch_protection.py --check
+```
+
+## 6. Local validation (recorded)
+
+| Check | Result | Command / note |
+|-------|--------|----------------|
+| Docs token policy | PASS | `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — all tracked `docs&#47;**&#47;*.md` scanned (2026-04-24). |
+| Reference targets | PASS | `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` (2026-04-24). |
+| Docs gates snapshot | PASS | `bash scripts/ops/pt_docs_gates_snapshot.sh --changed` — all three gates PASS in changed mode vs `origin&#47;main` (2026-04-24). |
+| Truth branch protection (optional) | Not run | `python3 scripts/ops/ensure_truth_branch_protection.py --check` — run locally with GitHub API access if required. |
+
+**No** value in this table constitutes a live, broker, or testnet **Go**.


### PR DESCRIPTION
## Summary
- Adds a NO-LIVE release/operator-verify evidence note for the current main snapshot.
- Maps the release checklist / Go-No-Go rubric to review-only operator-readiness language.
- Clarifies that rubric outcomes do not authorize live trading, broker/testnet actions, evidence mutation, or gate bypass.

## Safety
- Docs-only change.
- NO-LIVE operator-readiness snapshot.
- No broker/exchange orders, Paper/Shadow/Evidence mutation, Master-V2 expansion, or required-checks hygiene change.
- Optional branch-protection truth check was not run locally because GitHub API credentials were unavailable/insufficient.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
