### PR TITLE
feat(j1): add portfolio ohlcv loader metadata parity v1

### DIFF
--- a/scripts/run_portfolio_backtest_v2.py
+++ b/scripts/run_portfolio_backtest_v2.py
@@ -44,7 +44,7 @@ from _shared_forward_args import (
     parse_symbols_cli_arg,
     validate_forward_ohlcv_cli_args,
 )
-from _shared_ohlcv_loader import OHLCV_SOURCE_DUMMY, load_ohlcv
+from _shared_ohlcv_loader import OHLCV_SOURCE_DUMMY, load_ohlcv_with_meta
 from src.core.peak_config import load_config, PeakConfig
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
@@ -144,9 +144,9 @@ def load_data_for_symbol(
     ohlcv_source: str = OHLCV_SOURCE_DUMMY,
     timeframe: str = "1h",
     ohlcv_csv_path: Path | str | None = None,
-) -> pd.DataFrame:
+) -> Tuple[pd.DataFrame, Dict[str, Any]]:
     """
-    Lädt Marktdaten für ein Symbol (J1: ``load_ohlcv`` — dummy, Kraken oder CSV; ``cfg`` derzeit ungenutzt).
+    Lädt Marktdaten für ein Symbol (J1: ``load_ohlcv_with_meta`` — dummy, Kraken oder CSV; ``cfg`` derzeit ungenutzt).
 
     Args:
         cfg: PeakConfig-Objekt
@@ -157,9 +157,9 @@ def load_data_for_symbol(
         ohlcv_csv_path: CSV-Pfad bei ``csv``.
 
     Returns:
-        DataFrame mit OHLCV-Daten (DatetimeIndex)
+        (DataFrame mit OHLCV-Daten, Loader-Observability-Meta — gleicher Vertrag wie Forward-Skripte)
     """
-    return load_ohlcv(
+    return load_ohlcv_with_meta(
         symbol,
         n_bars=n_bars,
         source=ohlcv_source,
@@ -246,8 +246,8 @@ def run_single_symbol_backtest(
     Returns:
         BacktestResult mit allen Metriken
     """
-    # Daten laden
-    data = load_data_for_symbol(
+    # Daten laden (J1: gleicher Meta-Vertrag wie generate/evaluate_forward_signals)
+    data, ohlcv_meta = load_data_for_symbol(
         cfg,
         symbol,
         n_bars=n_bars,
@@ -282,6 +282,7 @@ def run_single_symbol_backtest(
     result.metadata.setdefault("symbol", symbol)
     result.metadata.setdefault("strategy_key", strategy_key)
     result.metadata.setdefault("name", f"{symbol} – {strategy_key}")
+    result.metadata["ohlcv_load"] = ohlcv_meta
 
     return result
 
@@ -555,6 +556,9 @@ def main(argv: List[str] | None = None) -> int:
         "symbols_regimes": {
             symbol: res.metadata.get("regime_distribution", {})
             for symbol, res in symbol_results.items()
+        },
+        "ohlcv_load_by_symbol": {
+            sym: res.metadata.get("ohlcv_load", {}) for sym, res in symbol_results.items()
         },
     }
 

--- a/tests/test_run_portfolio_backtest_v2_cli.py
+++ b/tests/test_run_portfolio_backtest_v2_cli.py
@@ -162,3 +162,62 @@ def test_run_portfolio_backtest_v2_accepts_local_csv_source_smoke(tmp_path):
     assert "OHLCV-Quelle" in combined_output
     assert "--no-report" in combined_output or "nicht geschrieben" in combined_output.lower()
     assert not (tmp_path / "reports").exists()
+
+
+def test_portfolio_backtest_ohlcv_load_meta_parity_kraken_shortfall(monkeypatch):
+    """
+    J1: Loader-Meta (z. B. kraken_bars_shortfall) muss wie bei Evaluate in Result- und
+    Aggregat-Metadaten erscheinen; kein Netz: nur load_dummy_ohlcv + synthetische Meta.
+    """
+    from src.core.peak_config import load_config
+
+    import run_portfolio_backtest_v2 as mod
+
+    repo_root = Path(__file__).resolve().parents[1]
+    cfg = load_config(str(repo_root / "config" / "config.test.toml"))
+
+    from _shared_ohlcv_loader import load_dummy_ohlcv
+
+    def _fake_with_meta(
+        symbol: str,
+        n_bars: int = 200,
+        *,
+        source: str = "dummy",
+        timeframe: str = "1h",
+        ohlcv_csv_path=None,
+        use_cache: bool = True,
+    ):
+        df = load_dummy_ohlcv(symbol, n_bars=n_bars)
+        meta = {
+            "symbol": symbol,
+            "ohlcv_source": "kraken",
+            "timeframe": timeframe,
+            "n_bars_requested": n_bars,
+            "bars_loaded": len(df),
+            "kraken_pagination_used": False,
+            "kraken_bars_shortfall": True,
+            "ohlcv_csv_resolved": None,
+            "csv_bars_shortfall": None,
+        }
+        return df, meta
+
+    monkeypatch.setattr(mod, "load_ohlcv_with_meta", _fake_with_meta)
+
+    res = mod.run_single_symbol_backtest(
+        cfg=cfg,
+        symbol="BTC/EUR",
+        strategy_key="ma_crossover",
+        n_bars=60,
+        ohlcv_source="dummy",
+        timeframe="1h",
+        ohlcv_csv_path=None,
+    )
+
+    ohlcv_load = res.metadata.get("ohlcv_load", {})
+    assert ohlcv_load.get("kraken_bars_shortfall") is True
+    assert ohlcv_load.get("symbol") == "BTC/EUR"
+
+    ohlcv_by_sym = {
+        "BTC/EUR": res.metadata.get("ohlcv_load", {}),
+    }
+    assert ohlcv_by_sym["BTC/EUR"].get("kraken_bars_shortfall") is True


### PR DESCRIPTION
## Summary
- Switches portfolio OHLCV loading to `load_ohlcv_with_meta`.
- Stores per-symbol loader metadata in each backtest result as `metadata["ohlcv_load"]`.
- Adds aggregate `ohlcv_load_by_symbol` metadata for portfolio-level visibility.
- Adds a no-network monkeypatch test covering loader metadata propagation, including a shortfall field.

## Safety
- NO-LIVE.
- No broker/exchange orders.
- No Paper/Shadow/Evidence mutation.
- No `out/` mutation.
- No new data sources.
- No Generate/Evaluate or shared loader changes.

## Validation
- uv run python -m pytest tests/test_run_portfolio_backtest_v2_cli.py -q
- uv run python -m pytest tests/test_dummy_ohlcv.py -q
- uv run ruff check scripts/run_portfolio_backtest_v2.py tests/test_run_portfolio_backtest_v2_cli.py
- uv run ruff format --check scripts/run_portfolio_backtest_v2.py tests/test_run_portfolio_backtest_v2_cli.py
