### PR TITLE
docs(ops): add cli cheatsheet market outlook ref v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -160,6 +160,20 @@ python3 scripts/research_cli.py strategy-profile --list-strategies
 - Keep deeper research modes such as walk-forward, Monte Carlo, stress, sweeps, or optimization as separate, explicit follow-up choices.
 - This is NO-LIVE/research-only: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
 
+## Market Outlook / Market Sentinel Daily Outlook
+
+Use the daily market-outlook generator for local operator-facing outlook reports. Start with `--skip-llm` when you want to avoid any LLM/API call:
+
+```bash
+python3 scripts/generate_market_outlook_daily.py --help
+python3 scripts/generate_market_outlook_daily.py --skip-llm --config-path config/market_outlook/daily_market_outlook.yaml --out-dir .ops_local/market_outlook
+```
+
+Notes:
+- `--skip-llm` skips the LLM call only; market data behavior still depends on the selected YAML config and local data paths (see `--data-dir` / defaults in `--help`).
+- Keep runs local and review generated files before sharing them.
+- This is NO-LIVE/operator-discoverability guidance: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
+
 ## 3b. Report-Tools
 
 Es gibt zwei getrennte Report-Flows:


### PR DESCRIPTION
## Summary
- Adds CLI cheatsheet discoverability for the Market Outlook / Market Sentinel daily outlook generator.
- Documents `--help` plus a local `--skip-llm` example using the YAML daily-outlook config and an `.ops_local` output directory.
- Clarifies that `--skip-llm` skips the LLM call only and that market-data behavior remains config/path dependent.

## Safety
- Docs-only change.
- NO-LIVE/operator-discoverability guidance.
- No broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
