### PR TITLE
test(market): add daily outlook help smoke v1

### DIFF
--- a/tests/test_market_sentinel_v0_daily.py
+++ b/tests/test_market_sentinel_v0_daily.py
@@ -631,3 +631,27 @@ class TestCLI:
             module = importlib.util.module_from_spec(spec)
             # Nur prüfen dass Import klappt, nicht ausführen
             assert module is not None
+
+
+def test_generate_market_outlook_daily_help_subprocess_smoke():
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    script = root / "scripts" / "generate_market_outlook_daily.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined_output = result.stdout + result.stderr
+    assert "usage:" in combined_output.lower()
+    assert "--skip-llm" in combined_output
+    assert "--config-path" in combined_output


### PR DESCRIPTION
## Summary
- Adds a subprocess help smoke for `scripts/generate_market_outlook_daily.py --help`.
- Verifies the documented `--skip-llm` and `--config-path` options remain visible.

## Safety
- Test-only change.
- NO-LIVE.
- No LLM/API calls, broker/exchange orders, Paper/Shadow/Evidence mutation, or gate changes.

## Validation
- uv run python -m pytest tests/test_market_sentinel_v0_daily.py -q
- uv run ruff check tests/test_market_sentinel_v0_daily.py
- uv run ruff format --check tests/test_market_sentinel_v0_daily.py
