### PR TITLE
test(ops): add infostream help smoke and cheatsheet v1

### DIFF
--- a/docs/CLI_CHEATSHEET.md
+++ b/docs/CLI_CHEATSHEET.md
@@ -174,6 +174,21 @@ Notes:
 - Keep runs local and review generated files before sharing them.
 - This is NO-LIVE/operator-discoverability guidance: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
 
+## Infostream Cycle
+
+Use the Infostream cycle CLI only as an explicit operator action. Start with `--help`, then prefer `--dry-run` and `--skip-ai` while inspecting the local path:
+
+```bash
+python3 scripts/infostream_run_cycle.py --help
+python3 scripts/infostream_run_cycle.py --dry-run --skip-ai --project-root .
+```
+
+Notes:
+- `--dry-run` is the default safe entrypoint for operator discovery.
+- `--skip-ai` avoids the AI/LLM step; it does not convert the command into an approval or delivery action.
+- The delivery contract is documented separately in [INFOSTREAM_DELIVERY_CONTRACT.md](ops/INFOSTREAM_DELIVERY_CONTRACT.md).
+- This is NO-LIVE/operator-discoverability guidance: no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.
+
 ## 3b. Report-Tools
 
 Es gibt zwei getrennte Report-Flows:

--- a/tests/meta/test_infostream_basic.py
+++ b/tests/meta/test_infostream_basic.py
@@ -730,3 +730,28 @@ class TestIntegration:
         log_content = log_path.read_text()
         assert "# InfoStream Learning Log" in log_content
         assert "INF-" in log_content
+
+
+def test_infostream_run_cycle_help_subprocess_smoke():
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    script = root / "scripts" / "infostream_run_cycle.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined_output = result.stdout + result.stderr
+    assert "usage:" in combined_output.lower()
+    assert "--dry-run" in combined_output
+    assert "--skip-ai" in combined_output
+    assert "--project-root" in combined_output


### PR DESCRIPTION
## Summary
- Adds a subprocess help smoke for `scripts/infostream_run_cycle.py --help`.
- Adds CLI cheatsheet discoverability for Infostream cycle usage with `--dry-run`, `--skip-ai`, and `--project-root`.
- Links the separate Infostream delivery contract from the cheatsheet.

## Safety
- Test/docs-only change.
- NO-LIVE/operator-discoverability guidance.
- No real Infostream cycle run, no AI/LLM call, no network calls, no broker/exchange orders, no Paper/Shadow/Evidence mutation, and no gate changes.

## Validation
- uv run python -m pytest tests/meta/test_infostream_basic.py -q
- uv run ruff check tests/meta/test_infostream_basic.py
- uv run ruff format --check tests/meta/test_infostream_basic.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
