### PR TITLE
docs(ops): post-2905 release rubric evidence snapshot (NO-LIVE)

### DIFF
--- a/docs/ops/evidence/EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24_POST_2905.md
+++ b/docs/ops/evidence/EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24_POST_2905.md
@@ -1,0 +1,111 @@
+---
+id: EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24_POST_2905
+title: Release Operator Verify Go/No-Go Rubric Evidence Note — main snapshot (post-#2905)
+status: DRAFT
+date: 2026-04-24
+repo_ref: main@a02f04d7409b
+scope: NO-LIVE operator-readiness snapshot
+---
+
+# Release Operator Verify Go/No-Go Rubric Evidence Note — main snapshot (post-#2905)
+
+## 1. Purpose
+
+This evidence note records a **NO-LIVE** operator-readiness snapshot for the current `main` branch **after** the merged NO-LIVE doc/test slices **#2898–#2905**, against the release checklist and Go/No-Go rubric. It is a **formal review anchor** for the **current** tree; it does **not** supplant the earlier same-day note for the prior SHA, which remains a historical record.
+
+Canonical rubric:
+
+- [RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md](../release/runbooks/RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md)
+
+Finish-plan reference:
+
+- [FINISH_PLAN.md — PR 8](../roadmap/FINISH_PLAN.md#pr-8-release-checklist-gono-go-rubric-docs-only)
+
+Current-focus reference:
+
+- [CURRENT_FOCUS.md](../roadmap/CURRENT_FOCUS.md)
+
+Prior snapshot (same day, earlier `main`):
+
+- [EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24.md](EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24.md) — `main@0ed0cb0d4455`
+
+## 2. Snapshot identity
+
+- Branch: `main`
+- Git SHA: `a02f04d7409b62fd68267b21b6b319c9eaa4176d` (authoritative: run `git rev-parse HEAD` on the reviewed commit)
+- Recorded date: `2026-04-24`
+- Recorded mode: `NO-LIVE`
+- Evidence type: docs-only operator-readiness note
+- Live authorization: **not granted**
+- Broker/exchange orders: **not allowed**
+- Paper/Shadow/Evidence **runtime** mutation: **not in scope of this review**
+- Master-V2 expansion: **not in scope**
+- Required-checks hygiene changes: **not in scope**
+
+## 3. NO-LIVE scope merged since prior snapshot (`0ed0cb0` → `a02f04d`)
+
+The following Merged-PR list is a **reconciliation index** for operator sign-off: it is **not** a per-PR re-audit. All items are understood as **docs-only and/or test-only** NO-LIVE work unless a runbook says otherwise (none do here).
+
+| PR | Short description (NO-LIVE) |
+|----|------------------------------|
+| #2898 | Release/operator verify alignment and evidence hooks for rubric (docs; review-only) |
+| #2899 | C1 execution boundary operator runbook (NO-LIVE) |
+| #2900 | F3 learning/promotion v2 triage runbook (NO-LIVE) |
+| #2901 | Cross-links between operator boundary runbooks and related anchors (docs) |
+| #2902 | J1 portfolio/forward OHLCV metadata parity in tests/CLI (test-only) |
+| #2903 | Market outlook CLI cheatsheet discoverability (docs) |
+| #2904 | Market outlook `generate_market_outlook_daily.py` help subprocess smoke (test) |
+| #2905 | Infostream `infostream_run_cycle.py` help subprocess smoke + CLI cheatsheet (test + docs) |
+
+## 4. Rubric interpretation
+
+The release checklist and Go/No-Go rubric may use words such as `Go`, `No-Go`, `Ready`, or `Blocked` as rubric outcomes.
+
+For this note, those terms mean **operator-readiness classification only**. They do not authorize live trading, broker/exchange orders, testnet operations, paper mutations, shadow mutations, or **runtime** evidence mutation.
+
+Any rubric row involving broker/testnet/live-like activity is interpreted as **blocked for execution** unless a separate approved workflow explicitly authorizes that action.
+
+## 5. Checklist mapping
+
+| Rubric area | Snapshot interpretation | Status |
+|-------------|------------------------|--------|
+| Documentation surface | Release rubric, finish-plan PR 8 reference, CURRENT_FOCUS, and this evidence note are present as review anchors. | Review-only |
+| Operator readiness | This note re-anchors post-#2905 `main` for operator review. | Review-only |
+| Go/No-Go classification | No operational `Go` is granted by this note. | No-live |
+| Broker/testnet/live actions | Not executed and not authorized. | Blocked |
+| Evidence mutation | This note is an evidence **document**; it does not execute evidence pipelines or mutate live evidence state. | Not performed (runtime) |
+| Required checks | Docs validation for this slice; see §7. | Recorded |
+
+## 6. Expected validation for this evidence-note slice
+
+Run these checks before merge:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+bash scripts/ops/pt_docs_gates_snapshot.sh --changed
+```
+
+Optional (only if you need parity with [RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md](../release/runbooks/RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md) §4.4):
+
+```bash
+python3 scripts/ops/ensure_truth_branch_protection.py --check
+```
+
+## 7. Local validation (recorded 2026-04-24, pre-merge)
+
+| Check | Result | Command / note |
+|-------|--------|----------------|
+| Docs token policy | PASS | `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — all tracked `docs&#47;**&#47;*.md` scanned. |
+| Reference targets | PASS | `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — all references resolve. |
+| Docs gates snapshot | PASS (full tracked scope) | `uv run python scripts/ops/validate_docs_token_policy.py` + `verify_docs_reference_targets` as above; for PR, run `pt_docs_gates_snapshot.sh --changed` against the PR base. |
+| Truth branch protection (optional) | Not run | `python3 scripts/ops/ensure_truth_branch_protection.py --check` — optional per [RELEASE_CHECKLIST…](../release/runbooks/RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md) §4.4. |
+
+**No** value in the table (once filled) constitutes a live, broker, or testnet **Go**.
+
+---
+
+## 8. Change discipline
+
+- Do not use this note to imply production readiness, live unlock, or automatic `Go` from rubric language alone.
+- This note **does** establish a **current** `main` anchor after **#2905** for NO-LIVE operator review; the prior note for `0ed0cb0` remains valid as a **time-sliced** record for that SHA.


### PR DESCRIPTION
## Summary
- Adds a new NO-LIVE operator-readiness / Go–No-Go rubric evidence note for `main` at commit `a02f04d7409b62fd68267b21b6b319c9eaa4176d` (post-#2905), superseding the review **anchor** relative to the earlier same-day note at `0ed0cb0`.
- Reconciles merged NO-LIVE work #2898–#2905 in a **review-only** table (not a per-PR re-audit).
- Preserves the prior `EV_…_2026_04_24.md` file as a historical time-slice.

## Safety
- **Docs-only.**
- **NO-LIVE;** no live authorization, no broker/exchange orders, no Paper/Shadow/Evidence **runtime** mutation, no Master-V2, no required-checks-hygiene changes.
- `pt_docs_gates_snapshot --changed` to be run in CI; local pre-commit: `validate_docs_token_policy` + `verify_docs_reference_targets` both PASS (recorded in §7).

## Related
- Prior snapshot: `docs/ops/evidence/EV_RELEASE_OPERATOR_VERIFY_GO_NO_GO_RUBRIC_MAIN_2026_04_24.md`
- Rubric: `docs/ops/release/runbooks/RELEASE_CHECKLIST_AND_GO_NO_GO_RUBRIC.md`

Made with [Cursor](https://cursor.com)