### PR TITLE
test(ops): add live status report help smoke v1

### DIFF
--- a/tests/ops/test_generate_live_status_report.py
+++ b/tests/ops/test_generate_live_status_report.py
@@ -1,0 +1,22 @@
+def test_generate_live_status_report_help_subprocess_smoke():
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    script = root / "scripts" / "generate_live_status_report.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined_output = result.stdout + result.stderr
+    assert "usage:" in combined_output.lower()
+    assert "live" in combined_output.lower()
+    assert "status" in combined_output.lower()


### PR DESCRIPTION
## Summary
- Adds a subprocess help smoke for `scripts/generate_live_status_report.py --help`.
- Covers the argparse/help contract for the live status report generator without executing report generation.

## Safety
- Test-only change.
- NO-LIVE.
- No broker/exchange orders, no live status generation, no network calls, no Paper/Shadow/Evidence mutation, and no gate changes.

## Validation
- uv run python -m pytest <test-file> -q
- uv run ruff check <test-file>
- uv run ruff format --check <test-file>
