### PR TITLE
test(ops): add testnet orchestrator cli help smoke v1

### DIFF
--- a/tests/ops/test_testnet_orchestrator_cli_help.py
+++ b/tests/ops/test_testnet_orchestrator_cli_help.py
@@ -1,0 +1,23 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_testnet_orchestrator_cli_help_subprocess_smoke():
+    root = Path(__file__).resolve().parents[2]
+    script = root / "scripts" / "testnet_orchestrator_cli.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined_output = result.stdout + result.stderr
+    assert "usage:" in combined_output.lower()
+    assert "testnet" in combined_output.lower()
+    assert "orchestrator" in combined_output.lower()


### PR DESCRIPTION
## Summary
- Adds a subprocess help smoke for `scripts/testnet_orchestrator_cli.py --help`.
- Covers the documented testnet orchestrator CLI discoverability contract from the CLI cheatsheet.

## Safety
- Test-only change.
- NO-LIVE.
- No broker/exchange orders, no testnet run, no network calls, no Paper/Shadow/Evidence mutation, and no gate changes.

## Validation
- uv run python -m pytest tests/ops/test_testnet_orchestrator_cli_help.py -q
- uv run ruff check tests/ops/test_testnet_orchestrator_cli_help.py
- uv run ruff format --check tests/ops/test_testnet_orchestrator_cli_help.py
