### PR TITLE
test(webui): enforce ops cockpit non-authority preamble v1

### DIFF
--- a/src/webui/ops_cockpit.py
+++ b/src/webui/ops_cockpit.py
@@ -3316,6 +3316,12 @@ def _render_operator_summary_preamble() -> str:
         "Read-only snapshot from local artifacts and the <code>GET /api/ops-cockpit</code> "
         "payload shape. <strong>Not an approval, not an unlock,</strong> not a substitute for "
         "your governance process.</p>"
+        '<p class="operator-summary-master-v2-non-authority">'
+        "This OPS Cockpit view is read-only and non-authorizing. "
+        "It does not grant live, testnet, paper, shadow, execution, promotion, or evidence authority. "
+        "Canonical authority remains in the Master V2 decision-authority chain and related runbooks. "
+        "Double Play semantics are displayed only as read-only observations and are not controlled by the cockpit."
+        "</p>"
         "</section>"
     )
 

--- a/tests/webui/test_ops_cockpit.py
+++ b/tests/webui/test_ops_cockpit.py
@@ -2674,3 +2674,13 @@ def test_ops_cockpit_workflow_officer_report_contains_operator_rollup_label(tmp_
     assert ctx["present"] is True
     line = str(ctx.get("operator_snapshot_line") or "")
     assert "total=1" in line
+
+
+def test_ops_cockpit_preamble_is_master_v2_non_authorizing(ops_client: TestClient) -> None:
+    response = ops_client.get("/ops")
+    assert response.status_code == 200
+    body = response.text
+    assert "read-only and non-authorizing" in body
+    assert "Master V2 decision-authority chain" in body
+    assert "Double Play semantics" in body
+    assert "not controlled by the cockpit" in body


### PR DESCRIPTION
## Summary
- Aligns the OPS Cockpit operator-summary preamble with the Master V2 non-authority contract.
- Explicitly states that the cockpit does not grant live, testnet, paper, shadow, execution, promotion, or evidence authority.
- Adds a WebUI regression test for the Master V2 / Double Play non-authority wording.

## Safety
- Read-only UI wording + test coverage only.
- No trading logic, no broker/exchange orders, no runtime control path, no Paper/Shadow/Evidence mutation, no gate changes.
- Preserves the OPS Cockpit as observation/navigation, not authority.

## Validation
- uv run python -m pytest tests/webui/test_ops_cockpit.py -q
- uv run ruff check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py
- uv run ruff format --check src/webui/ops_cockpit.py tests/webui/test_ops_cockpit.py
