### PR TITLE
docs(strategies): clarify overview epoch and authority boundaries v1

### DIFF
--- a/docs/strategies_overview.md
+++ b/docs/strategies_overview.md
@@ -1,6 +1,21 @@
-# Peak_Trade Strategien-Übersicht
+# Peak_Trade Strategien-Übersicht (historische Beispielauswahl)
 
-## 🎯 Alle 6 Strategien im Detail
+## Authority and Coverage Note
+
+This document is a historical and example-oriented strategy overview. It is not the complete current strategy registry, not a live-readiness source, not a Master V2 authority source, and not a Double Play authority source.
+
+For current strategy-authority interpretation, use the dedicated governance and reconciliation documents:
+
+- [`STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md`](ops/specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md)
+- [`STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md`](ops/specs/STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md)
+- [`STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md`](ops/specs/STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md)
+- [`STRATEGY_REGISTRY_SOURCE_COMMENT_DISCORD_NON_AUTHORITY_NOTE_V0.md`](ops/specs/STRATEGY_REGISTRY_SOURCE_COMMENT_DISCORD_NON_AUTHORITY_NOTE_V0.md)
+
+The strategy registry, tiering configuration, and Master V2 documentation remain separate authority surfaces. A strategy appearing in this overview does not imply production readiness, live readiness, promotion approval, or Double Play selection authority.
+
+Known follow-up audit topics include historical naming and epoch drift around ECM/Armstrong-style cycle references and TOML-only surfaces such as `vol_breakout`. Those topics are not resolved by this overview note.
+
+## 🎯 Beispielhafte Darstellung: sechs Strategien
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that docs/strategies_overview.md is a historical/example-oriented strategy overview, not the complete current registry
- add authority and coverage note linking to Strategy/MV2/Reconciliation specs
- neutralize the six-strategy heading and keep ECM/Armstrong plus vol_breakout as follow-up audit topics

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no registry changes
- no TOML changes
- no runtime changes
- no strategy execution
- no out/ changes
- no live/paper/shadow/evidence mutation