### PR TITLE
docs(overview): clarify research strategy authority status

### DIFF
--- a/docs/PEAK_TRADE_OVERVIEW.md
+++ b/docs/PEAK_TRADE_OVERVIEW.md
@@ -150,10 +150,12 @@ Alle verfügbaren Strategien sind in der **Strategy Registry** registriert (`src
 
 ### Research-Track Strategien (R&D)
 
+**Authority-Hinweis (Diese Übersicht):** Diese Tabelle ersetzt keine Strategy-Promotion und keine Live-, Testnet-, Paper- oder Shadow-Freigabe. R&D- bzw. Research-Status hier ist **keine** Master-V2- oder Double-Play-Handoff-Autorität. Maßgeblich bleiben die expliziten Master-V2-konformen Verträge und Reconciliation-Read-Models, u. a. [STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md](ops/specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md), [STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md](ops/specs/STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md) und [STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md](ops/specs/STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md). Namens- und Nicht-Autorität für die Armstrong-/ECM-Fläche siehe [STRATEGY_ECM_AND_ARMSTRONG_NAME_SURFACES_NON_AUTHORITY_NOTE_V0.md](ops/specs/STRATEGY_ECM_AND_ARMSTRONG_NAME_SURFACES_NON_AUTHORITY_NOTE_V0.md).
+
 | Key | Beschreibung | Status |
 |-----|-------------|--------|
-| `armstrong_cycle` | Armstrong ECM Cycle Model | ✅ Live-Ready |
-| `el_karoui_vol_model` | El Karoui Stochastic Vol | ✅ Live-Ready |
+| `armstrong_cycle` | Armstrong ECM Cycle Model | 🔬 R&D-Only |
+| `el_karoui_vol_model` | El Karoui Stochastic Vol | 🔬 R&D-Only |
 | `ehlers_cycle_filter` | Ehlers DSP Cycle Filter | 🔬 R&D-Only |
 | `meta_labeling` | López de Prado Meta-Labeling | 🔬 R&D-Only |
 | `bouchaud_microstructure` | Bouchaud Microstructure | 🔬 Skeleton |


### PR DESCRIPTION
## Summary
- change Research-Track strategy rows for armstrong_cycle and el_karoui_vol_model from Live-Ready to R&D-Only
- add an authority note clarifying the overview table does not provide strategy promotion, live/testnet/paper/shadow readiness, or Master V2 / Double Play authority
- link the overview to the existing Strategy/Master-V2 integration and reconciliation specs

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/PEAK_TRADE_OVERVIEW.md
- no src/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no runtime changes
- no strategy execution
- no workflow changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)