### PR TITLE
docs(backtest): clarify live validation authority boundary

### DIFF
--- a/docs/BACKTEST_ENGINE.md
+++ b/docs/BACKTEST_ENGINE.md
@@ -376,7 +376,9 @@ result.stats = {
 
 ---
 
-## Live-Trading-Validierung
+## Heuristische Post-Backtest-Prüfung (Screening, kein operatives Go)
+
+**Authority-Hinweis:** `validate_for_live_trading` wertet **nur** aggregierte **Backtest-`stats`** anhand fester **Schwellwerte** aus — ein Research- bzw. Screening-Hilfsmittel. Das ist **weder** eine Live-Freigabe **noch** Testnet-, Paper- oder Shadow-Autorisierung, **weder** First-Live-**noch** Master-V2- oder Double-Play-Signoff, **weder** Evidence-**noch** operatives Trading. Es entsteht **keine** Order-, Exchange-, Arming- oder Enablement-Autorität. Operative Nutzung verlangt getrennte, Master-V2-kompatible Governance- und Readiness-Pfade, u. a. [STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md](ops/specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md), [STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md](ops/specs/STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md) und (First-Live-Readiness-Rahmen) [MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md](ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md).
 
 ```python
 from src.backtest.stats import validate_for_live_trading
@@ -384,18 +386,20 @@ from src.backtest.stats import validate_for_live_trading
 passed, warnings = validate_for_live_trading(result.stats)
 
 if passed:
-    print("✅ Strategie für Live-Trading freigegeben")
+    print("Hinweis: Heuristische Mindestkriterien am Backtest erfüllt (kein operatives Go)")
 else:
-    print("❌ Nicht freigegeben:")
+    print("Hinweis: Heuristik am Backtest nicht erfüllt; Details:")
     for warning in warnings:
         print(f"  - {warning}")
 ```
 
-**Kriterien:**
+**Heuristische Mindestfilter (Beispiel-Implementierung, Research-Screening):**
 - Sharpe Ratio >= 1.5
 - Min. 50 Trades
 - Profit Factor >= 1.3
 - Max Drawdown < 30%
+
+Diese Werte sind **keine** verbindlichen Produktions- oder Live-Policy-Limits; sie dienen ausschließlich der schnellen Doku-Illustration der Hilfsfunktion.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify the BACKTEST_ENGINE post-backtest validation section as heuristic screening, not operational live approval
- replace Live-Trading freigegeben wording with neutral screening output
- add an authority boundary note for live/testnet/paper/shadow/first-live/Master-V2/Double-Play usage

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/BACKTEST_ENGINE.md
- no src/ changes
- no tests/ changes
- no config/ changes
- no validate_for_live_trading code change
- no runtime changes
- no strategy execution
- no workflow changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)