### PR TITLE
docs(specs): link readiness ladder to pre-live navigation read model

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -21,6 +21,10 @@ Companion interpretation layer (read-only, non-authorizing):
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
 
+PRE_LIVE `*_CONTRACT_V1` pack — navigation read model (read-only index, non-authorizing):
+
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) — optional suggested read order for the many adjacent `MASTER_V2_FIRST_LIVE_PRE_LIVE_*_CONTRACT_V1` specifications. It is a **navigation/reading map only**; it does not create a gate, signoff, evidence, live or First-Live enablement, Master V2 handoff, or Double Play authority, and it does not change the substantive meaning of any PRE_LIVE contract or the ladder levels in this file.
+
 Consolidation companion (vocabulary/boundary lock, read-only, non-authorizing):
 
 - `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`


### PR DESCRIPTION
## Summary
- add a non-authorizing readiness-ladder pointer to the PRE_LIVE navigation read model
- clarify the read model is a reviewer/navigation index only
- preserve existing ladder levels, PRE_LIVE contracts, gates, signoff, evidence, and Master V2 / Double Play authority boundaries

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
- no PRE_LIVE contract changes
- no docs/INDEX.md change
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no runtime changes
- no workflow changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)