### PR TITLE
docs(specs): link ECM Armstrong name surfaces to wiring inventory

### DIFF
--- a/docs/ops/specs/STRATEGY_ECM_AND_ARMSTRONG_NAME_SURFACES_NON_AUTHORITY_NOTE_V0.md
+++ b/docs/ops/specs/STRATEGY_ECM_AND_ARMSTRONG_NAME_SURFACES_NON_AUTHORITY_NOTE_V0.md
@@ -85,6 +85,8 @@ This note does not claim that the wiring is correct, incorrect, complete, unused
 
 No code, registry, TOML, or runtime conclusion should be inferred from this note.
 
+For a **read-only** inventory of observed ECM/Armstrong-related naming and wiring surfaces (modules, loader map vs. central registry, config section names, docs pointers), see [STRATEGY_ECM_ARMSTRONG_WIRING_INVENTORY_READ_MODEL_V0.md](STRATEGY_ECM_ARMSTRONG_WIRING_INVENTORY_READ_MODEL_V0.md). That document is a **reading map / inventory only**; it does not authorize an alias, registry or TOML change, loader priority, promotion, live or First-Live enablement, Master V2 handoff, Double Play selection, or any technical wiring outcome, and it does not replace a future separately approved implementation decision.
+
 ## 7) Master V2 / Double Play Boundary
 
 Name alignment is not authority alignment.


### PR DESCRIPTION
## Summary
- add a non-authorizing backlink from the ECM/Armstrong name-surfaces note to the wiring inventory read model
- clarify that the inventory is a read-only map and does not create alias, registry, TOML, runtime, live, Master V2, or Double Play authority
- preserve the existing non-authority boundary and defer any technical wiring decision to a separate explicit audit

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/specs/STRATEGY_ECM_AND_ARMSTRONG_NAME_SURFACES_NON_AUTHORITY_NOTE_V0.md
- no wiring inventory file changes
- no other strategy spec changes
- no docs/INDEX.md change
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no alias/rename/promotion change
- no runtime changes
- no workflow changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)