### PR TITLE
docs(index): link authority recovery consolidation index

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,6 +22,7 @@
 - Claim-Disziplin: Claims nur in den Klassen `repo-evidenced`, `documented`, `unverified`, `not-claimed` formulieren (Abschnitt 6); `unverified` und `not-claimed` nicht als verifizierte Fakten ausgeben; `operator-stated` explizit markieren; keine impliziten E2E-/Runtime-Behauptungen.
 - Master-V2 Readiness (canonical pair): [Readiness Ladder](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) + [Readiness Read Model v1 (read-only interpretation)](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
 - Master-V2 Gate-Status Report Surface v1 (docs-only reporting layer): [Gate-Status Report Surface / Summary Table v1](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
+- Authority Recovery (Navigations-&#47;Konsolidierungsindex, **non-authorizing**): [AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md](ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) — Review- und Re-Onboarding-Navigation zu **bereits gelandeten** Authority-Boundary-Dokumenten (P0-Bereiche u. a.); **weder** Gate **noch** Signoff, **weder** Evidence-Paket **noch** Live-, First-Live-, Master-V2- oder Double-Play-Freigabe; ersetzt **nicht** die kanonischen Verträge oberhalb.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a docs/INDEX.md pointer to AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md
- describe the index as non-authorizing review and re-onboarding navigation
- preserve canonical contract authority and clarify the pointer creates no gate, signoff, evidence, live, first-live, Master V2, or Double Play approval

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/INDEX.md
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no KNOWLEDGE_BASE_INDEX.md change
- no PEAK_TRADE_OVERVIEW.md change
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)