### PR TITLE
docs(overview): clarify production strategy authority status

### DIFF
--- a/docs/PEAK_TRADE_OVERVIEW.md
+++ b/docs/PEAK_TRADE_OVERVIEW.md
@@ -135,7 +135,9 @@ daily_loss_limit = 0.05
 
 Alle verfügbaren Strategien sind in der **Strategy Registry** registriert (`src&#47;strategies&#47;registry.py`).
 
-### Production-Ready Strategien
+### Historische / engineering-orientierte Strategieübersicht (Katalog, kein operatives Go)
+
+**Authority-Hinweis (Diese Tabelle):** Katalog- und **Registry-Übersicht** im Dokumentationskontext; früher „Production-Ready“ benannte Keys sind **keine** Zusage operativer Echtgeld-Live-Freigabe, **keine** Testnet-, Paper- oder Shadow-Readiness, **kein** Gate, kein Signoff, **keine** Evidence und **keine** Order-, Exchange-, Arming- oder Enablement-Autorität. **Keine** Strategy-Promotion; Master-V2- bzw. Double-Play-Handoff entsteht **nicht** aus dieser Tabelle. Maßgeblich: [STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md](ops/specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md), [STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md](ops/specs/STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md), [STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md](ops/specs/STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md). Konsolidierte Review-Navigation zu Authority-Work: [AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md](ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md).
 
 | Key | Beschreibung | Config Section |
 |-----|-------------|----------------|


### PR DESCRIPTION
## Summary
- clarify the former Production-Ready strategy overview as a historical/engineering-oriented catalog, not operational approval
- add authority boundaries for live/testnet/paper/shadow readiness, gates, signoff, evidence, orders, exchange, arming, enablement, promotion, Master V2, and Double Play
- link to existing Strategy/Master-V2 authority contracts and the Authority Recovery Consolidation Index

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/PEAK_TRADE_OVERVIEW.md
- no docs/INDEX.md change
- no KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no strategy promotion
- no alias/rename change
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)