### PR TITLE
docs(strategy): clarify registry production authority status

### DIFF
--- a/docs/STRATEGY_LAYER_VNEXT.md
+++ b/docs/STRATEGY_LAYER_VNEXT.md
@@ -186,9 +186,11 @@ class BaseStrategy(ABC):
 
 ### Strategie-Registry
 
+**Authority-Hinweis (Dieser Abschnitt):** vNext-**Doku-/Katalog-Überblick** über die Registry-Ausrichtung; Begriffe wie (historisch) *Production-Ready* sind **kein** Echtgeld-Live-Go, **keine** Testnet-, Paper- oder Shadow-Readiness, **kein** Gate, kein Signoff, **keine** Evidence und **keine** Order-, Exchange-, Arming- oder Enablement-Autorität. **Keine** Strategy-Promotion; Master-V2- bzw. Double-Play-Handoff entsteht **nicht** aus diesem Text. Maßgeblich: [STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md](ops/specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md), [STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md](ops/specs/STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md), [STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md](ops/specs/STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md). Konsolidierte Navigations-Read-Modelle: [AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md](ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md).
+
 Derzeit registriert in `src/strategies/__init__.py`:
 
-- **Production-Ready**: `ma_crossover`, `momentum_1h`, `rsi_strategy`, `bollinger_bands`, `macd`
+- **Doku- / Katalog-Label (informell: „Production-Ready“; siehe Authority-Hinweis):** `ma_crossover`, `momentum_1h`, `rsi_strategy`, `bollinger_bands`, `macd`
 - **Research Track**: `trend_following`, `mean_reversion`, `vol_breakout`, `breakout`, etc.
 - **Theory/R&D Only**: `armstrong_cycle`, `el_karoui_vol_model`, `ehlers_cycle_filter`, `meta_labeling`
 


### PR DESCRIPTION
## Summary
- clarify Strategy Layer vNext registry/Production-Ready wording as documentation/catalog context, not operational approval
- add authority boundaries for live/testnet/paper/shadow readiness, gates, signoff, evidence, orders, arming, promotion, Master V2, and Double Play
- link to existing Strategy/Master-V2 authority contracts and the Authority Recovery Consolidation Index

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/STRATEGY_LAYER_VNEXT.md
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no docs/PEAK_TRADE_OVERVIEW.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no strategy promotion
- no alias/rename change
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)