### PR TITLE
docs(strategy): clarify dev guide production authority status

### DIFF
--- a/docs/STRATEGY_DEV_GUIDE.md
+++ b/docs/STRATEGY_DEV_GUIDE.md
@@ -511,7 +511,9 @@ _STRATEGY_REGISTRY: Dict[str, StrategySpec] = {
 
 #### Beispiele
 
-**Production-Ready Strategie:**
+**Authority-Hinweis (Registry-Beispiele in diesem Guide):** Didaktische **Doku-/Code-Beispiele** zum `StrategySpec`-Layout; Bezeichnungen wie (informell) *Production-Ready* oder *Live* beziehen sich **nicht** auf operatives Echtgeld-Go, **keine** Testnet-, Paper- oder Shadow-Readiness im Governance-Sinn, **kein** Gate, kein Signoff, **keine** Evidence und **keine** Order-, Exchange-, Arming- oder Enablement-Autorität. **Keine** Strategy-Promotion; Master-V2- bzw. Double-Play-Handoff entsteht **nicht** aus diesen Snippets. Technische `is_live_ready`/`tier`-Semantik bleibt **Code-/Loader**-Kontext; maßgeblich für Integrations- und Tiering-Grenzen: [STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md](ops/specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md), [STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md](ops/specs/STRATEGY_REGISTRY_TIERING_DUAL_SOURCE_CONTRACT_V1.md), [STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md](ops/specs/STRATEGY_REGISTRY_TIERING_MV2_RECONCILIATION_TABLE_V0.md). Konsolidierte Navigations-Read-Modelle: [AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md](ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md).
+
+**Doku- / Katalog-Beispiel (informell: „Production-Ready“; siehe Authority-Hinweis):**
 ```python
 "ma_crossover": StrategySpec(
     key="ma_crossover",


### PR DESCRIPTION
## Summary
- clarify STRATEGY_DEV_GUIDE registry/Production-Ready examples as documentation/catalog context, not operational approval
- add authority boundaries for live/testnet/paper/shadow readiness, governance readiness, gates, signoff, evidence, orders, arming, promotion, Master V2, and Double Play
- preserve the Python example behavior while changing only surrounding documentation labels and authority wording

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/STRATEGY_DEV_GUIDE.md
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no docs/PEAK_TRADE_OVERVIEW.md change
- no docs/STRATEGY_LAYER_VNEXT.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no strategy promotion
- no alias/rename change
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)