### PR TITLE
docs(status): clarify live-track production authority boundary

### DIFF
--- a/docs/PEAK_TRADE_STATUS_OVERVIEW.md
+++ b/docs/PEAK_TRADE_STATUS_OVERVIEW.md
@@ -1053,6 +1053,8 @@ Die Phasen **47–49** haben das System auf ein neues Level gehoben:
 
 ### Live-Track – Alerts & Incident-Handling (Cluster 82–85)
 
+> **Authority- und Scope-Hinweis (Status-Overview):** Die folgenden Statuszeilen (z. B. *Production-Ready*, *2026-ready*, *operative Baseline*) beschreiben **Engineering-, Dokumentations- und Runbook-Reife** bzw. **historischen** Phasenstand in diesem Übersichtsdokument. Sie stellen **kein** operatives Echtgeld-Go, **keine** First-Live- oder PRE_LIVE-Freigabe, **keinen** Signoff, **keine** Evidence, **keinen** Gate-Pass, **keine** Order-, Exchange-, Arming- oder Enablement-Autorität und **kein** Master-V2- oder Double-Play-**Handoff** her. Maßgeblich bleiben **Master V2** / **Double Play** und die kanonischen PRE_LIVE-, Readiness- und Signoff-Verträge. Orientierung (Navigation, kein operatives Go): [Readiness Ladder](ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [PRE_LIVE Navigation Read-Model](ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md), [Authority Recovery Consolidation Index](ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) (Doku-Index, kein Freigabesignal).
+
 **Status:** ✅ Production-Ready v1.1 (inkl. Escalation)  
 **Implementierung:** Q4 2025 – **2026-ready**
 


### PR DESCRIPTION
## Summary
- clarify PEAK_TRADE_STATUS_OVERVIEW live-track Production-Ready / 2026-ready / operative-baseline wording as engineering, documentation, runbook, or historical phase status
- add authority boundaries for live/first-live/PRE_LIVE approval, signoff, evidence, gates, orders, exchange, arming, enablement, Master V2, and Double Play
- link to existing Readiness Ladder, PRE_LIVE Navigation Read-Model, and Authority Recovery Consolidation Index as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/PEAK_TRADE_STATUS_OVERVIEW.md
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no strategy promotion
- no alias/rename change
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)