### PR TITLE
docs(shadow): clarify phase2 runbook production authority boundary

### DIFF
--- a/docs/shadow/SHADOW_PIPELINE_PHASE2_OPERATOR_RUNBOOK.md
+++ b/docs/shadow/SHADOW_PIPELINE_PHASE2_OPERATOR_RUNBOOK.md
@@ -4,6 +4,8 @@
 **Status:** Production-Ready (Shadow/Dev contexts only)  
 **Owner:** Peak_Trade Ops Team
 
+> **Authority and scope (non-authorizing):** *Production-Ready* in this runbook means **Shadow/Dev operator-runbook** documentation maturity for the described pipeline. It is **not** an operational real-money go, a First-Live or PRE_LIVE release, a signoff, evidence, a gate pass, or order / exchange / arming / enablement authority. This document does **not** create a **Master V2** or **Double Play** handoff. **Master V2** and **Double Play** remain the top trading and selection frames, together with the canonical PRE_LIVE / Readiness / Signoff contracts. Navigation only (not a go): [Readiness Ladder](../ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [PRE_LIVE navigation read model](../ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md), [Authority Recovery Consolidation Index](../ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) (doc index, not an approval).
+
 ---
 
 ## Purpose


### PR DESCRIPTION
## Summary
- clarify SHADOW_PIPELINE_PHASE2_OPERATOR_RUNBOOK Production-Ready wording as Shadow/Dev operator-runbook documentation maturity
- add authority boundaries for real-money live, first-live/PRE_LIVE release, signoff, evidence, gate pass, orders, exchange, arming, enablement, Master V2, and Double Play
- link to existing Readiness Ladder, PRE_LIVE Navigation Read-Model, and Authority Recovery Consolidation Index as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/shadow/SHADOW_PIPELINE_PHASE2_OPERATOR_RUNBOOK.md
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no strategy promotion
- no alias/rename change
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)