### PR TITLE
docs(risk): clarify stress gate runbook production authority

### DIFF
--- a/docs/risk/STRESS_GATE_RUNBOOK.md
+++ b/docs/risk/STRESS_GATE_RUNBOOK.md
@@ -11,6 +11,8 @@ KillSwitch → VaR Gate → Stress Gate → Order Validation
 
 **Status:** ✅ Production-Ready (P1)
 
+> **Authority- und Scope-Hinweis (Runbook):** *Production-Ready* und *P1* beziehen sich hier auf **Engineering- und Dokumentationsreife** im Stress-Gate-**Risk-Modul**- und **Runbook**-Kontext (Szenarien, Schwellen, Operator-Hinweise), **nicht** auf einen operativen Echtgeld-Go, eine First-Live- oder PRE_LIVE-Freigabe, Signoff, Evidence, Gate-Pass im Sinne der enablement-**Vertragsketten** oder Order-, Exchange-, Arming- oder Enablement-**Autorität**. Dieses Runbook begründet **keinen** Master-V2- oder Double-Play-**Handoff**. **Master V2** / **Double Play** und die kanonischen PRE_LIVE-, Readiness- und Signoff-**Verträge** bleiben maßgeblich. **Nur** Navigation, kein Go: [Readiness Ladder](../ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [PRE_LIVE Navigation Read-Model](../ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md), [Authority Recovery Consolidation Index](../ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) (Doku-Index, kein Freigabesignal).
+
 ---
 
 ## Quick Reference


### PR DESCRIPTION
## Summary
- clarify STRESS_GATE_RUNBOOK Production-Ready / P1 wording as engineering and documentation maturity in the stress-gate risk-module/runbook context
- add authority boundaries for real-money live, first-live/PRE_LIVE release, signoff, evidence, enablement contract gates, orders, exchange, arming, enablement, Master V2, and Double Play
- link to existing Readiness Ladder, PRE_LIVE Navigation Read-Model, and Authority Recovery Consolidation Index as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/risk/STRESS_GATE_RUNBOOK.md
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no strategy promotion
- no alias/rename change
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)