### PR TITLE
docs(runbooks): clarify phase6 strategy switch authority boundary

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_PHASE6_STRATEGY_SWITCH_SANITY_CHECK_CURSOR_MULTI_AGENT.md
+++ b/docs/ops/runbooks/RUNBOOK_PHASE6_STRATEGY_SWITCH_SANITY_CHECK_CURSOR_MULTI_AGENT.md
@@ -7,6 +7,8 @@
 **Owner:** ops  
 **Risk Level:** MINIMAL (read-only, 3-line code change)
 
+> **Authority- und Scope-Hinweis (Runbook):** *Production-Ready*, *Phase 6* und PR-/Merge-Nähe in diesem Dokument beziehen sich auf **Cursor-Multi-Agent-**/**Docs-**/**Operator-**Runbook-**Kontext** und den **Sanity-Check-**Ablauf für **Strategy-**Switch-**Governance-**Doku **—** **nicht** auf einen operativen Echtgeld-Go, First-Live- oder PRE_LIVE-Freigabe, Signoff, Evidence, Gate-Pass, Order-, Exchange-, Arming- oder Enablement-**Autorität** oder eine **Dokumentations-**/**CI-**Merge-**Freigabe** als generelles **Produkt-Go**. **Kein** Master-V2- oder Double-Play-**Handoff** entsteht aus diesem Runbook. **Master V2** / **Double Play** und die kanonischen PRE_LIVE-, Readiness- und Signoff-**Verträge** bleiben maßgeblich. **Nur** Navigation, kein Go: [Readiness Ladder](../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [PRE_LIVE Navigation Read-Model](../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md), [Authority Recovery Consolidation Index](../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) (Doku-Index, kein Freigabesignal).
+
 ---
 
 ## Executive Summary


### PR DESCRIPTION
## Summary
- clarify RUNBOOK_PHASE6_STRATEGY_SWITCH_SANITY_CHECK_CURSOR_MULTI_AGENT Production-Ready / Phase 6 / PR-merge-adjacent wording as Cursor-Multi-Agent, docs, operator-runbook, and sanity-check context
- add authority boundaries for real-money live, first-live/PRE_LIVE release, signoff, evidence, gate pass, orders, exchange, arming, enablement, product-go, Master V2, and Double Play
- preserve the lower status/next-steps section and all technical runbook content unchanged

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/runbooks/RUNBOOK_PHASE6_STRATEGY_SWITCH_SANITY_CHECK_CURSOR_MULTI_AGENT.md
- no lower status/next-steps section change
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no docs/ops/STRATEGY_SWITCH_SANITY_CHECK.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no strategy promotion
- no alias/rename change
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)