### PR TITLE
docs(ops): add bounded acceptance authority frontdoor index v0

### DIFF
--- a/docs/ops/BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md
+++ b/docs/ops/BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md
@@ -1,0 +1,94 @@
+# Bounded / Acceptance Authority Frontdoor Index (v0)
+
+## Purpose
+
+This document is a **P0-D light** **navigation and read-model frontdoor** for **Bounded / Acceptance / First-Live–adjacent** documentation. It exists so reviewers can:
+
+- see **which existing files** discuss bounded runs, acceptance language, go/no-go snapshots, and First-Live–shaped contracts **before** editing any of them;
+- read that language as **epochal, operator-narrative, or contract-shaped text** unless a **separate** authoritative Master V2 / Double Play / PRE_LIVE signoff path says otherwise;
+- plan **small, one-file / one-PR** follow-ups without treating this index as a gate, signoff, or completion claim.
+
+This file **does not** change, replace, or subsume [BOUNDED_ACCEPTANCE_INDEX.md](BOUNDED_ACCEPTANCE_INDEX.md). That index remains the functional chain index. This file adds an **authority-boundary lens** only.
+
+## Non-authority boundary
+
+- **Not a gate.** This index does not pass, fail, waive, or block any bounded run, launch, or live path.
+- **Not a signoff.** It is not Evidence, not a verdict packet, not a readiness ladder rung completion, and not an operator approval record.
+- **Not a live / First-Live / bounded-live / Master V2 / Double Play authorization.** Reading or following links here does **not** constitute operational go, product go, or trading enablement.
+- **Not a status of P0-D work.** Nothing here claims that P0-D is “done,” that any path is “approved,” “complete,” “live-ready,” “gate-passed,” or “signoff-complete.”
+
+Canonical trading / enablement logic remains **Master V2 / Double Play** as defined elsewhere in repo docs; this file does not extend or override that.
+
+## Why this frontdoor exists
+
+Older and current **Bounded / Acceptance / go–no-go / “operationally credible”** wording appears in multiple operational Markdown files in this repository. That language is often **legitimate for narrative, checklists, or historical closeouts** but is **easy to skim as** a present-tense authorization. This frontdoor:
+
+- centralizes **safe reading rules** and **Master V2 boundary** pointers;
+- lists **inventory** with “what to watch for” and “what the file still does not authorize”;
+- supports a **safe future audit path** (one file, one PR) without mixing mass edits with index churn.
+
+## Suggested read order / inventory table
+
+Read **Master V2 anchors first** (see **Master V2 / Double Play boundary** below), then use the table **in order** for bounded/acceptance entry points. Inventory links below are **repo-relative** to this file’s directory (`docs` / `ops` under the repo root).
+
+| Area | Existing file | Authority-risk wording to watch (skim hazard) | What it does not authorize |
+|------|---------------|-----------------------------------------------|----------------------------|
+| Master V2 — readiness | [specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) | Ladder rungs, “readiness” language | Trading go, bounded-live go, or bypass of Master V2 contracts |
+| Master V2 — gate status surface | [specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | Gate, status, report | A live or First-Live decision; surface is **read-model**, not execution enablement by itself |
+| Master V2 — PRE_LIVE navigation | [specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) | Navigation, packets, signoff-shaped titles | Operational approval; **navigation only** where so stated |
+| PRE_LIVE — verdict packet (contract) | [specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md](specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md) | Verdict, packet, contract | Automatic real-money or bounded-live authorization from reading the contract shape |
+| PRE_LIVE — signoff package index (contract) | [specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_PACKAGE_INDEX_CONTRACT_V1.md](specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_PACKAGE_INDEX_CONTRACT_V1.md) | Signoff, package | A completed or current signoff unless a **separate** governed record says so |
+| Recovery / misread index | [AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md](AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) | P0-C / P0-D / “do not misread as” columns | Any gate, Evidence, or live approval; **consolidation map only** |
+| Bounded chain index | [BOUNDED_ACCEPTANCE_INDEX.md](BOUNDED_ACCEPTANCE_INDEX.md) | “operationally credible,” “operators,” “governance” | Open-ended live readiness or unbounded trading authorization (see that file’s own bottom line) |
+| Start here (review) | [reviews/bounded_acceptance_start_here_page/START_HERE.md](reviews/bounded_acceptance_start_here_page/START_HERE.md) | Entry, “start,” operator path | A single canonical approval to run money; follow contract links |
+| Index page (review) | [reviews/bounded_acceptance_index_page/INDEX.md](reviews/bounded_acceptance_index_page/INDEX.md) | “Single entrypoint,” “go / no-go snapshot,” “operational interpretation” | Present-tense org signoff or Master V2 override |
+| Go/No-Go snapshot (review) | [reviews/bounded_acceptance_go_no_go_snapshot/GO_NO_GO_SNAPSHOT.md](reviews/bounded_acceptance_go_no_go_snapshot/GO_NO_GO_SNAPSHOT.md) | “Allowed Now,” “Not Allowed Now,” phase-style labels | Today’s trading authority; snapshot may be **historical or narrative** unless explicitly bound to a current record |
+| Operator cheat sheet | [runbooks/BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md](runbooks/BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md) | “Go/No-Go confirmed,” “Allowed,” contracts | Automatic enablement of execution or keys |
+| Operator verify checklist | [runbooks/BOUNDED_ACCEPTANCE_OPERATOR_VERIFY_CHECKLIST.md](runbooks/BOUNDED_ACCEPTANCE_OPERATOR_VERIFY_CHECKLIST.md) | “Go / No-Go confirmed,” “ready for closeout,” “evidence” | Signoff completion or gate pass as a **document checklist alone** |
+| Acceptance-oriented operator runbook | [runbooks/ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md](runbooks/ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md) | Runbook flow, “confirmed,” Kraken/credentials mentions in context | Unbounded live trading or Master V2 / Double Play handoff by reading the runbook |
+| Entry contract (anchor) | [specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md) | Entry, pilot, real money in name | By itself, no proof that **this** workspace run is currently within that contract without current evidence |
+
+**Note:** Other files under `docs&#47;ops&#47;` whose paths suggest **bounded**, **acceptance**, **go_no_go**, or **first_live** (evidence closeouts, reviews, pilot contracts) exist. They are **not** listed exhaustively here; treat them as **inventory candidates** for future **one-file** reviews using the same rules.
+
+## Master V2 / Double Play boundary
+
+- **Master V2 / Double Play** trading and risk logic is **canonical** for how live and pilot semantics are meant to be interpreted in this repository’s **authoritative** docs.
+- Bounded and acceptance docs may describe **pilots, trials, checklists, or historical closeouts**. They must **not** be read as replacing, superseding, or **parallel-authorizing** Master V2 / Double Play.
+- If bounded language and Master V2 language **conflict**, **Master V2 / Double Play** wins for **authorization meaning**; bounded docs may still be valid as **history, narrative, or contract drafts** when labeled as such.
+
+Quick anchor links (same as the first rows of the inventory table):
+
+- [specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md)
+- [specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md)
+
+## Bounded / Acceptance / First-Live safe reading rules
+
+- Treat **dates, closeout IDs, and “trial” labels** as **epochal** unless a current, explicitly referenced record ties them to **now**.
+- Treat **“go / no-go,” “allowed,” “ready,” “credible,”** and **“confirmed”** as **documentation or checklist language** until bound to a **governed** Master V2 / PRE_LIVE / operator record outside this index.
+- **Evidence filenames and pointers** are **provenance**, not automatic proof of current authority.
+- **Entry contracts** describe **rules and boundaries**; they do not, by themselves, show that a run **today** satisfies all preconditions.
+
+## Safe future audit path
+
+- Prefer **one bounded/acceptance file per PR** when tightening authority wording.
+- **Do not** mix broad wording edits across many files with **index** updates (this file, [AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md](AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md), [docs/INDEX.md](../INDEX.md), [docs/KNOWLEDGE_BASE_INDEX.md](../KNOWLEDGE_BASE_INDEX.md)) **unless** the change set is explicitly scoped and justified — those index updates are **separate slices** by policy.
+- After a file-level edit, consider whether a **single** follow-up row belongs in the Authority Recovery index in a **dedicated** PR.
+
+## Explicit non-scope
+
+This v0 frontdoor file does **not**:
+
+- modify any existing document other than itself;
+- change `src/`, `tests/`, `config/`, `registry.py`, TOML, workflows, or runtime behavior;
+- mutate Paper, Shadow, testnet, Live, Evidence, or `out/` artifacts;
+- record a gate decision, signoff, readiness verdict, or Master V2 / Double Play logic change.
+
+## Validation note
+
+Before relying on links in this file, run:
+
+- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
+- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
+
+Link targets were checked to exist at introduction time; if a path moves, update this file in a **docs-only** maintenance PR.


### PR DESCRIPTION
## Summary
- add a P0-D bounded/acceptance authority frontdoor index as a non-authorizing read model
- provide reviewer navigation for bounded, acceptance, go/no-go, first-live, PRE_LIVE, readiness, and signoff-related docs
- preserve the one-file/one-PR safe continuation rule for future bounded/acceptance wording work

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- adds only docs/ops/BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md
- no existing bounded/acceptance/first-live docs changed
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)