### PR TITLE
docs(ops): clarify go no go snapshot authority boundary

### DIFF
--- a/docs/ops/reviews/bounded_acceptance_go_no_go_snapshot/GO_NO_GO_SNAPSHOT.md
+++ b/docs/ops/reviews/bounded_acceptance_go_no_go_snapshot/GO_NO_GO_SNAPSHOT.md
@@ -3,6 +3,8 @@
 ## Purpose
 Compact decision snapshot for bounded / acceptance: what is allowed now vs what is not allowed now.
 
+> **Authority and scope (review snapshot):** *Proven Now*, *Allowed Now*, *Not Allowed Now*, *Go/No-Go*, and similar wording in this file are **review labels** for a **bounded/acceptance documentation snapshot** — not an operational Echtgeld go, not First-Live or PRE_LIVE approval, not signoff, not Evidence, not a current Master V2 enablement **gate pass**, and not order, exchange, arming, or enablement **authority** by reading this page. **No** Master V2 or **Double Play** handoff is created from this snapshot alone. **Master V2** / **Double Play** and the canonical PRE_LIVE, Readiness, and signoff **contracts** remain **authoritative** for what counts as enablement. **Navigation only, not a go:** [Readiness Ladder](../../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [PRE_LIVE navigation read model](../../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md), [Bounded / acceptance authority frontdoor (P0-D light)](../../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md), [Authority recovery consolidation index](../../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) (consolidation map, not approval).
+
 ## Proven Now
 - Real exchange connectivity through the bounded path
 - Session-scoped execution-event evidence capture


### PR DESCRIPTION
## Summary
- clarify GO_NO_GO_SNAPSHOT Proven Now / Allowed Now / GO-NO-GO wording as bounded-acceptance review/snapshot labels, not operational approval
- add authority boundaries for real-money live, first-live/PRE_LIVE release, signoff, evidence, gate pass, orders, exchange, arming, enablement, Master V2, and Double Play
- link to Readiness Ladder, PRE_LIVE Navigation Read-Model, Bounded Acceptance Authority Frontdoor Index, and Authority Recovery Consolidation Index as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/reviews/bounded_acceptance_go_no_go_snapshot/GO_NO_GO_SNAPSHOT.md
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)