### PR TITLE
docs(ops): clarify bounded acceptance index authority boundary

### DIFF
--- a/docs/ops/BOUNDED_ACCEPTANCE_INDEX.md
+++ b/docs/ops/BOUNDED_ACCEPTANCE_INDEX.md
@@ -3,6 +3,8 @@
 ## Purpose
 Single index page for the bounded / acceptance documentation chain. Use this as the entry point for operators and governance.
 
+> **Authority and scope (chain index):** *Operators*, *governance*, *acceptance*, *chain*, and *operationally credible* (including in the [Bottom Line](#bottom-line) below) refer to this page as a **bounded/acceptance documentation chain index** and **review/navigation** surface — not an operational Echtgeld go, not First-Live or PRE_LIVE approval, not signoff, not Evidence, not a current Master V2 enablement **gate pass**, and not order, exchange, arming, or enablement **authority** from reading or following this index. **No** Master V2 or **Double Play** handoff is created from this file alone. **Master V2** / **Double Play** and the canonical PRE_LIVE, Readiness, and signoff **contracts** remain **authoritative**. **Navigation only, not a go:** [Readiness Ladder](specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [PRE_LIVE navigation read model](specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md), [Bounded / acceptance authority frontdoor (P0-D light)](BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md), [Authority recovery consolidation index](AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) (consolidation map, not approval).
+
 ## Documentation Chain
 
 | Layer | Document | Description |


### PR DESCRIPTION
## Summary
- clarify BOUNDED_ACCEPTANCE_INDEX as a bounded/acceptance documentation-chain and review-navigation index, not operational approval
- add authority boundaries for real-money live, first-live/PRE_LIVE release, signoff, evidence, gate pass, orders, exchange, arming, enablement, Master V2, and Double Play
- link to Readiness Ladder, PRE_LIVE Navigation Read-Model, Bounded Acceptance Authority Frontdoor Index, Authority Recovery Consolidation Index, and Bottom Line as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/BOUNDED_ACCEPTANCE_INDEX.md
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no GO_NO_GO_SNAPSHOT.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)