### PR TITLE
docs(ops): clarify bounded acceptance start here authority

### DIFF
--- a/docs/ops/reviews/bounded_acceptance_start_here_page/START_HERE.md
+++ b/docs/ops/reviews/bounded_acceptance_start_here_page/START_HERE.md
@@ -3,6 +3,8 @@
 ## Purpose
 Default re-entry point for future bounded / acceptance work.
 
+> **Authority and scope (start / re-entry):** *Default re-entry*, *operator*, *run path*, *acceptance*, and the [Bottom Line](#bottom-line) below use **bounded/acceptance documentation and review navigation** language — not an operational Echtgeld go, not First-Live or PRE_LIVE approval, not signoff, not Evidence, not a current Master V2 enablement **gate pass**, and not order, exchange, arming, or enablement **authority** from this page. **No** Master V2 or **Double Play** handoff is created from this start-here document. **Master V2** / **Double Play** and the canonical PRE_LIVE, Readiness, and signoff **contracts** remain **authoritative**. **Navigation only, not a go:** [Readiness Ladder](../../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md), [PRE_LIVE navigation read model](../../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md), [Bounded / acceptance authority frontdoor (P0-D light)](../../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md), [Authority recovery consolidation index](../../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md) (consolidation map, not approval).
+
 ## Read This First
 - quick operator path:
   `docs&#47;ops&#47;runbooks&#47;BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md`
@@ -31,5 +33,7 @@ Default re-entry point for future bounded / acceptance work.
 
 ## Bottom Line
 Bounded / acceptance is documented, standardized, operator-ready, and governance-bounded.
+
+*Operator-ready* here means **convenient operator-facing documentation**, not order routing, arming, or a present-tense trading or Master V2/Double Play enablement decision.
 
 It is not blanket live authorization.


### PR DESCRIPTION
## Summary
- clarify bounded_acceptance_start_here_page/START_HERE.md as bounded/acceptance start, re-entry, and review navigation, not operational approval
- add authority boundaries for real-money live, first-live/PRE_LIVE release, signoff, evidence, gate pass, orders, routing, arming, enablement, Master V2, and Double Play
- lightly clarify Bottom Line operator-ready wording as operator-facing documentation rather than order/routing/arming/enablement decision authority

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/reviews/bounded_acceptance_start_here_page/START_HERE.md
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no BOUNDED_ACCEPTANCE_INDEX.md change
- no GO_NO_GO_SNAPSHOT.md change
- no bounded_acceptance_index_page/INDEX.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)