### PR TITLE
docs(ops): update authority recovery index for bounded acceptance

### DIFF
--- a/docs/ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md
+++ b/docs/ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md
@@ -2,7 +2,7 @@
 title: "Authority Recovery Consolidation Index v0"
 status: "DRAFT"
 owner: "ops"
-last_updated: "2026-04-24"
+last_updated: "2026-04-25"
 docs_token: "DOCS_TOKEN_AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0"
 ---
 
@@ -10,7 +10,7 @@ docs_token: "DOCS_TOKEN_AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0"
 
 ## 1) Title
 
-This document is a **consolidation index** for **docs-only** authority-boundary and misread-guard work delivered under the **P0-A / P0-B / P0-C / P0-E** labels in the `Peak_Trade` documentation track. It is **not** a completion certificate, go decision, or evidence pack.
+This document is a **consolidation index** for **docs-only** authority-boundary and misread-guard work delivered under the **P0-A / P0-B / P0-C / P0-D (partial) / P0-E** labels in the `Peak_Trade` documentation track. It is **not** a completion certificate, go decision, or evidence pack.
 
 ## 2) Purpose
 
@@ -62,6 +62,11 @@ The following process characteristics are **preserved** as **intent** (not a pro
 | P0-C | [../shadow/SHADOW_PIPELINE_PHASE2_OPERATOR_RUNBOOK.md](../shadow/SHADOW_PIPELINE_PHASE2_OPERATOR_RUNBOOK.md) | Shadow / Dev **Phase 2** operator runbook *Production-Ready* as **Shadow/Dev operator-runbook** documentation maturity (pipeline tick → OHLCV → quality) | Operational real-money go, First-Live / PRE_LIVE approval, signoff, evidence, gate pass, order / exchange / arming / enablement authority, **Master V2** handoff, or **Double Play** proof |
 | P0-C | [../risk/STRESS_GATE_RUNBOOK.md](../risk/STRESS_GATE_RUNBOOK.md) | **Stress Gate** *Production-Ready* / *P1* as **risk-module / operator-runbook** **engineering and documentation** maturity (scenarios, thresholds, operator guidance) | Operational real-money go, First-Live / PRE_LIVE approval, signoff, evidence, gate pass, order / exchange / arming / enablement authority, **Master V2** handoff, or **Double Play** proof |
 | P0-C | [runbooks/RUNBOOK_PHASE6_STRATEGY_SWITCH_SANITY_CHECK_CURSOR_MULTI_AGENT.md](runbooks/RUNBOOK_PHASE6_STRATEGY_SWITCH_SANITY_CHECK_CURSOR_MULTI_AGENT.md) | **Phase 6** (Governance) *Production-Ready* / **Cursor** **Multi-Agent** / **PR-** and **merge-adjacent** runbook as **docs / operator** **governance** **sanity-check** **runbook** maturity (live strategy-switch check workflow) | A **stand-alone** **PR** / **CI** / **doc** / **governance** / **merge** workflow as an **operational** real-money or **product-level** go; First-Live / PRE_LIVE approval, signoff, evidence, gate pass, order / exchange / arming / enablement authority, **Master V2** handoff, or **Double Play** proof |
+| **P0-D — Bounded / Acceptance (landed, partial)** | [BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md](BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md) | P0-D **frontdoor** / inventory **read-model** for bounded/acceptance/go–no-go/**first_live**-shaped **doc surfaces** (navigation map, not a gate) | A **consolidation index** row or **frontdoor** list as **operational** Echtgeld go, **PRE_LIVE** / First-Live approval, signoff, **Evidence**, gate pass, order/exchange/arming/enablement authority, **Master V2** handoff, or **Double Play** proof |
+| P0-D | [reviews/bounded_acceptance_go_no_go_snapshot/GO_NO_GO_SNAPSHOT.md](reviews/bounded_acceptance_go_no_go_snapshot/GO_NO_GO_SNAPSHOT.md) | *Proven Now* / *Allowed Now* / go–no-go **snapshot** as **review labels** and **docs** snapshot context | **Snapshot** / **list** as current **trading** authorization, **product** go, signoff, **Evidence**, or gate pass |
+| P0-D | [BOUNDED_ACCEPTANCE_INDEX.md](BOUNDED_ACCEPTANCE_INDEX.md) | *Operators* / *governance* / *operationally credible* on the **documentation chain** index | **Chain index** or **credible** wording as unbounded **live** go or **Master V2** / **Double Play** handoff |
+| P0-D | [reviews/bounded_acceptance_index_page/INDEX.md](reviews/bounded_acceptance_index_page/INDEX.md) | *Single entrypoint* / *Current Position* / **operational interpretation** on the **review hub** | **Entrypoint** / **operational** framing as org **signoff** or **override** of **Master V2** / **Double Play** |
+| P0-D | [reviews/bounded_acceptance_start_here_page/START_HERE.md](reviews/bounded_acceptance_start_here_page/START_HERE.md) | *Default re-entry* / *operator* / *run path* on the **start-here** page | **Re-entry** / *operator-ready* as routing, **arm**, or **enablement** **authority** from navigation alone |
 | **P0-E — PRE_LIVE navigation** | [specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) | Many **PRE_LIVE** contract filenames; read order | Gate closure, signoff, evidence, or **read order** = go |
 | P0-E | [specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) + pointer to nav read model in-file | L0–L5 steering vs. **PRE_LIVE** pack map | Ladder or map **alone** = enablement **done** |
 | **Anchors (governance, not “done”)** | [specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md](specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md) | Master V2 integration framing | **Automatic** strategy promotion from doc presence |
@@ -85,7 +90,7 @@ The following process characteristics are **preserved** as **intent** (not a pro
 
 The following are **candidates only** — **not** scheduled, **not** approved work here:
 
-- **P0-D — Bounded / Acceptance / First-Live** authority: only as a **narrow** docs read-model or a **single** boundary note when scope is **explicit** (no broad Sammel-audit in one PR).
+- **P0-D — Bounded / Acceptance / First-Live** authority: **landed in-repo (partial):** the **P0-D** table rows above (frontdoor, **GO_NO_GO** snapshot, **bounded** chain **index**, **review** hub **index** page, **START_HERE**) record **docs-only** authority-boundary work already merged; that is **not** a claim that **P0-D** is **complete** or that every bounded/acceptance surface is bounded. **Still open as single-topic candidates** where misread is concrete: e.g. operator runbooks, checklists, and review surfaces not yet in the table — each as a **narrow** docs read-model or **single** boundary note when scope is **explicit** (no broad Sammel-audit in one PR).
 - **Further P0-C wording:** only **single** files or **tight** clusters with a **concrete** misread (e.g. remaining legacy *production-ready* in clearly scoped docs).
 - **Entry links** (e.g. from high-traffic `docs/INDEX.md` or entry pages): only when a pointer is **clearly** orphaned and **link risk** (dead discovery) is **higher** than review noise.
 - **Code / TOML / registry** changes: only under a **separate** explicit **implementation** or **wiring** audit with tests — **out of scope** for this consolidation index as authority.


### PR DESCRIPTION
## Summary
- update the Authority Recovery Consolidation Index with landed P0-D bounded/acceptance authority-boundary work
- add non-authorizing index rows for the bounded/acceptance frontdoor, GO_NO_GO snapshot, bounded acceptance index, review hub, and START_HERE
- clarify P0-D is partially landed and not complete; remaining bounded/acceptance docs stay future one-file/one-PR candidates

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no GO_NO_GO_SNAPSHOT.md change
- no BOUNDED_ACCEPTANCE_INDEX.md change
- no bounded_acceptance_index_page/INDEX.md change
- no START_HERE.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no P0-D complete claim
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)