### PR TITLE
docs(ops): clarify bounded run operator runbook authority

### DIFF
--- a/docs/ops/runbooks/ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md
+++ b/docs/ops/runbooks/ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md
@@ -3,6 +3,10 @@
 ## Purpose
 Operator workflow for a conservative acceptance-oriented bounded-pilot run aligned to the acceptance evidence standard.
 
+> **Authority and scope**  
+> This file is an **acceptance- / bounded-run operator runbook** and **review / operator navigation** for a bounded-pilot path. Wording about operators, runs, launches, acceptance, bounded scope, or credentials is **not** an automatic **operational authorization**: it does **not** grant real-money go, any **live** / first-live / `PRE_LIVE` release, **signoff**, **evidence**, or a **gate pass** in the current **Master V2** enablement sense. It confers **no** order, exchange, arming, routing, or enablement authority, and it does **not** create a **Master V2** or **Double Play** handoff. **Master V2 / Double Play** and the canonical **PRE_LIVE** / readiness / signoff contracts remain the governing authority.  
+> Optional pointers: [`../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`](../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) · [`../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md`](../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) · [`../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md`](../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md) · [`../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md`](../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md)
+
 ## Bounded Acceptance Index
 - `docs&#47;ops&#47;reviews&#47;bounded_acceptance_index_page&#47;INDEX.md`
 


### PR DESCRIPTION
## Summary
- clarify ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK as operator/review navigation, not operational approval
- add authority boundaries for real-money live, first-live/PRE_LIVE release, signoff, evidence, gate pass, orders, routing, arming, enablement, Master V2, and Double Play
- preserve existing operator runbook content and commands while linking to the bounded/acceptance frontdoor and canonical readiness navigation as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/runbooks/ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no BOUNDED_ACCEPTANCE_INDEX.md change
- no GO_NO_GO_SNAPSHOT.md change
- no bounded_acceptance_index_page/INDEX.md change
- no START_HERE.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change
