### PR TITLE
docs(ops): clarify bounded acceptance cheat sheet authority

### DIFF
--- a/docs/ops/runbooks/BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md
+++ b/docs/ops/runbooks/BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md
@@ -3,6 +3,10 @@
 ## Purpose
 Ultra-compact operator reference for bounded / acceptance runs.
 
+> **Authority and scope**  
+> This file is a **bounded / acceptance operator cheat sheet** and **review / operator navigation** for quick local reference. Wording about *operator*, *go/no-go*, *checklist*, *pass*, *acceptance*, *bounded* scope, or similar **decision language** is **not** an automatic **operational authorization** — it does **not** grant real-money go, any **live** / first-live / `PRE_LIVE` release, **signoff**, **evidence**, or a **gate pass** in the current **Master V2** enablement sense. It confers **no** order, exchange, arming, routing, or enablement authority, and it does **not** create a **Master V2** or **Double Play** handoff. **Master V2 / Double Play** and the canonical **PRE_LIVE** / readiness / signoff contracts remain the governing authority.  
+> Optional pointers: [`../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`](../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) · [`../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md`](../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) · [`../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md`](../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md) · [`../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md`](../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md)
+
 ## Bounded Acceptance Index
 - `docs&#47;ops&#47;reviews&#47;bounded_acceptance_index_page&#47;INDEX.md`
 


### PR DESCRIPTION
## Summary
- clarify BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET as operator/review navigation, not operational approval
- add authority boundaries for real-money live, first-live/PRE_LIVE release, signoff, evidence, gate pass, orders, routing, exchange, arming, enablement, Master V2, and Double Play
- preserve existing cheat-sheet content and commands while linking to the bounded/acceptance frontdoor and canonical readiness navigation as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/runbooks/BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md change
- no BOUNDED_ACCEPTANCE_VERIFY_CHECKLIST.md change
- no BOUNDED_ACCEPTANCE_INDEX.md change
- no GO_NO_GO_SNAPSHOT.md change
- no bounded_acceptance_index_page/INDEX.md change
- no START_HERE.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)