### PR TITLE
docs(ops): clarify bounded acceptance verify checklist authority

### DIFF
--- a/docs/ops/runbooks/BOUNDED_ACCEPTANCE_OPERATOR_VERIFY_CHECKLIST.md
+++ b/docs/ops/runbooks/BOUNDED_ACCEPTANCE_OPERATOR_VERIFY_CHECKLIST.md
@@ -3,6 +3,10 @@
 ## Purpose
 Short pass/fail verification checklist for bounded / acceptance runs.
 
+> **Authority and scope**  
+> This file is a **bounded / acceptance operator verify checklist** and **review / operator navigation** for local pass/fail checks around a bounded/acceptance run. Wording about *pass* / *fail*, *go/no-go*, *checklist*, *evidence*, *closeout*, *acceptance*, *bounded* scope, or similar **decision language** is **not** an automatic **operational authorization** — it does **not** grant real-money go, any **live** / first-live / `PRE_LIVE` release, **signoff**, **evidence**, or a **gate pass** in the current **Master V2** enablement sense. It confers **no** order, exchange, arming, routing, or enablement authority, and it does **not** create a **Master V2** or **Double Play** handoff. **Master V2 / Double Play** and the canonical **PRE_LIVE** / readiness / signoff contracts remain the governing authority.  
+> Optional pointers: [`../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`](../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) · [`../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md`](../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) · [`../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md`](../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md) · [`../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md`](../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md)
+
 ## Usage
 Use this checklist:
 - immediately before a bounded / acceptance run


### PR DESCRIPTION
## Summary
- clarify BOUNDED_ACCEPTANCE_OPERATOR_VERIFY_CHECKLIST as operator/review navigation, not operational approval
- add authority boundaries for pass/fail, go-no-go, evidence, closeout, real-money live, first-live/PRE_LIVE release, signoff, gate pass, orders, routing, exchange, arming, enablement, Master V2, and Double Play
- preserve existing checklist content and steps while linking to the bounded/acceptance frontdoor and canonical readiness navigation as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/runbooks/BOUNDED_ACCEPTANCE_OPERATOR_VERIFY_CHECKLIST.md
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md change
- no ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md change
- no BOUNDED_ACCEPTANCE_INDEX.md change
- no GO_NO_GO_SNAPSHOT.md change
- no bounded_acceptance_index_page/INDEX.md change
- no START_HERE.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no P0-D complete claim
- no Master V2 / Double Play authority change
