### PR TITLE
docs(ops): clarify local bounded secret launcher authority

### DIFF
--- a/docs/ops/runbooks/LOCAL_BOUNDED_SECRET_LAUNCHER_RUNBOOK.md
+++ b/docs/ops/runbooks/LOCAL_BOUNDED_SECRET_LAUNCHER_RUNBOOK.md
@@ -3,6 +3,10 @@
 ## Purpose
 Operator workflow for bounded/acceptance sessions without repeated manual secret copy-paste.
 
+> **Authority and scope**  
+> This file is a **local** **bounded** **secret** **launcher** **operator** **runbook** and **review / operator navigation** for the `.bounded_pilot.env` + bounded secret launcher path. Wording about *secret* **source**, `KRAKEN`, `.bounded_pilot.env`, *launcher*, *bounded*, *trial*, *run*, or *local* **ops** is **not** an automatic **operational authorization** — it does **not** grant real-money go, any **live** / first-live / `PRE_LIVE` release, **signoff**, **evidence**, or a **gate pass** in the current **Master V2** enablement sense. **Secret** and **credential** steps are **local**, **technical**, and *fails closed* by design; they do **not** substitute for a governed signoff. This runbook confers **no** order, exchange, arming, routing, or enablement authority, and it does **not** create a **Master V2** or **Double Play** handoff. **Master V2 / Double Play** and the canonical **PRE_LIVE** / readiness / signoff contracts remain the governing authority.  
+> Optional pointers: [`../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`](../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) · [`../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md`](../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) · [`../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md`](../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md) · [`../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md`](../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md)
+
 ## Secret Source
 Expected local non-git env file:
 - `.bounded_pilot.env`


### PR DESCRIPTION
## Summary
- clarify LOCAL_BOUNDED_SECRET_LAUNCHER_RUNBOOK as local bounded/secret/launcher review and operator navigation, not operational approval
- add authority boundaries for secret source, KRAKEN, .bounded_pilot.env, launcher, bounded, trial, run, local ops, real-money live, first-live/PRE_LIVE release, signoff, evidence, gate pass, orders, routing, exchange, arming, enablement, Master V2, and Double Play
- preserve Secret Source, Guardrails, Dry Check, and Setup content unchanged while linking to canonical readiness/frontdoor navigation as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/runbooks/LOCAL_BOUNDED_SECRET_LAUNCHER_RUNBOOK.md
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md change
- no NEXT_BOUNDED_TRIAL_PREFLIGHT_CHECKLIST.md change
- no ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md change
- no BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md change
- no BOUNDED_ACCEPTANCE_OPERATOR_VERIFY_CHECKLIST.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no P0-D complete claim
- no Master V2 / Double Play authority change
