### PR TITLE
docs(ops): clarify next bounded trial preflight authority

### DIFF
--- a/docs/ops/runbooks/NEXT_BOUNDED_TRIAL_PREFLIGHT_CHECKLIST.md
+++ b/docs/ops/runbooks/NEXT_BOUNDED_TRIAL_PREFLIGHT_CHECKLIST.md
@@ -12,6 +12,10 @@ This checklist defines the minimum read-only preflight needed before starting th
 
 It is intended to preserve paper-test stability, ensure a quiet runtime surface, and make the intended run goal explicit before any operator starts a new bounded trial or acceptance-oriented step.
 
+> **Authority and scope**  
+> This file is a **read-only** **next** **bounded**-**trial** **preflight** **checklist** and **operator / review navigation**; terms such as *preflight*, *trial*, *checklist*, *evidence*, *closeout*, *pass* / *fail*, *ready*, or *read-only* are **not** by themselves **operational** **approvals** or a substitute for the governing enablement path. The checklist does **not** grant real-money go, any **live** / bounded-live / first-live / `PRE_LIVE` release, **signoff**, **evidence** as a verdict, or a **gate pass** in the current **Master V2** enablement sense, and it confers **no** order, exchange, arming, routing, or enablement authority. Working through or completing this document does **not** create a **Master V2** or **Double Play** handoff. **Master V2 / Double Play** and the canonical **PRE_LIVE** / readiness / signoff contracts remain the governing **authority**. References to **Trial-5** closeouts, session paths, and **evidence** are **epochal** **read-only** **context**; they do **not** prove **current** approval for **today**’s run by narrative alone.  
+> Optional pointers: [`../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`](../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) · [`../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md`](../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) · [`../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md`](../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md) · [`../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md`](../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md)
+
 ## Preconditions
 - repository baseline is clean
 - no unintended runtime processes are active


### PR DESCRIPTION
## Summary
- clarify NEXT_BOUNDED_TRIAL_PREFLIGHT_CHECKLIST as read-only bounded-trial preflight review/operator navigation, not operational approval
- add authority boundaries for preflight, trial, checklist, evidence, closeout, pass/fail, ready, read-only, real-money live, bounded-live, first-live/PRE_LIVE release, signoff, gate pass, orders, routing, exchange, arming, enablement, Master V2, and Double Play
- preserve existing preflight content while linking to canonical readiness/frontdoor navigation as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/runbooks/NEXT_BOUNDED_TRIAL_PREFLIGHT_CHECKLIST.md
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no LOCAL_BOUNDED_SECRET_LAUNCHER_RUNBOOK.md change
- no ACCEPTANCE_ORIENTED_BOUNDED_RUN_OPERATOR_RUNBOOK.md change
- no BOUNDED_ACCEPTANCE_OPERATOR_CHEAT_SHEET.md change
- no BOUNDED_ACCEPTANCE_OPERATOR_VERIFY_CHECKLIST.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no P0-D complete claim
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)