### PR TITLE
docs(ops): clarify bounded acceptance review packet authority

### DIFF
--- a/docs/ops/reviews/bounded_acceptance_review_packet/REVIEW_PACKET.md
+++ b/docs/ops/reviews/bounded_acceptance_review_packet/REVIEW_PACKET.md
@@ -3,6 +3,12 @@
 ## Purpose
 Compact review packet for bounded / acceptance status, evidence position, operator path, and governance framing.
 
+## Authority and scope (review packet; P0-D partial)
+
+> This file is a **bounded / acceptance** **review packet** — **navigation**, **read-model**, and **handover** context for adjacent docs. Phrases such as **what is proven**, **what is allowed now**, **delivery**, **exec**, **handover**, **review packet**, **evidence**, or **allowed** describe **documentation** and **review** semantics unless a **separate** governed record says otherwise; they are **not** automatic **operational** real-money go, **bounded-live** / unrestricted-**live** / **First-Live** / **PRE_LIVE** approval, **signoff**, **Evidence** as authority, **gate** pass in the current **Master V2** enablement sense, **order** / **routing** / **exchange** / **arming** / **enablement** authority, **Master V2** handoff, or **Double Play** proof. **Master V2** / **Double Play** and the canonical **PRE_LIVE**, **readiness**, and **signoff** **contracts** remain **authoritative**.
+
+**Navigation (non-authorizing):** [Readiness Ladder](../../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) · [PRE_LIVE navigation read model](../../specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) · [Bounded / acceptance authority frontdoor](../../BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md) · [Authority recovery consolidation index](../../AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md).
+
 ## Canonical Entry
 - start here:
   `docs&#47;ops&#47;reviews&#47;bounded_acceptance_start_here_page&#47;START_HERE.md`


### PR DESCRIPTION
## Summary
- clarify bounded_acceptance_review_packet/REVIEW_PACKET.md as review/read-model/handover navigation, not operational approval
- add authority boundaries for what-is-proven / allowed-now / delivery / exec / handover / review-packet / evidence wording, real-money live, bounded-live, unrestricted-live, first-live/PRE_LIVE release, signoff, gate pass, orders, routing, exchange, arming, enablement, Master V2, and Double Play
- preserve existing review-packet content unchanged while linking to canonical readiness/frontdoor navigation as navigation only

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only docs/ops/reviews/bounded_acceptance_review_packet/REVIEW_PACKET.md
- no AUTHORITY_RECOVERY_CONSOLIDATION_INDEX_V0.md change
- no BOUNDED_ACCEPTANCE_AUTHORITY_FRONTDOOR_INDEX_V0.md change
- no BOUNDED_ACCEPTANCE_INDEX.md change
- no ACCEPTANCE_EVIDENCE_STANDARD.md change
- no docs/INDEX.md change
- no docs/KNOWLEDGE_BASE_INDEX.md change
- no other docs changed
- no src/ changes
- no tests/ changes
- no config/ changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate/signoff/readiness decision
- no P0-D complete claim
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)