### PR TITLE
test(ops): harden bounded pilot preflight contracts

### DIFF
--- a/tests/ops/test_bounded_pilot_operator_preflight_packet.py
+++ b/tests/ops/test_bounded_pilot_operator_preflight_packet.py
@@ -187,3 +187,51 @@ def test_main_json_green(monkeypatch: pytest.MonkeyPatch, capsys: pytest.Capture
     out = json.loads(capsys.readouterr().out.strip())
     assert out["contract"] == mod.CONTRACT_ID
     assert out["summary"]["packet_ok"] is True
+
+
+def test_main_json_exit_2_invalid_repo_root_is_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    import scripts.ops.bounded_pilot_operator_preflight_packet as mod
+
+    not_a_dir = tmp_path / "file_instead_of_dir.txt"
+    not_a_dir.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bounded_pilot_operator_preflight_packet",
+            "--json",
+            "--repo-root",
+            str(not_a_dir),
+        ],
+    )
+    assert mod.main() == 2
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["contract"] == mod.CONTRACT_ID
+    assert "not a directory" in str(data.get("error", ""))
+
+
+def test_main_json_exit_2_when_build_packet_raises(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    import scripts.ops.bounded_pilot_operator_preflight_packet as mod
+
+    def _outer_boom(*a, **k):
+        raise RuntimeError("orchestrator outer failure")
+
+    monkeypatch.setattr(mod, "build_operator_preflight_packet", _outer_boom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bounded_pilot_operator_preflight_packet",
+            "--json",
+            "--repo-root",
+            str(ROOT),
+        ],
+    )
+    assert mod.main() == 2
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["contract"] == mod.CONTRACT_ID
+    assert "orchestrator outer failure" in str(data.get("error", ""))

--- a/tests/ops/test_check_bounded_pilot_readiness.py
+++ b/tests/ops/test_check_bounded_pilot_readiness.py
@@ -109,6 +109,55 @@ def test_run_bounded_pilot_readiness_blocks_on_go_no_go(monkeypatch: pytest.Monk
     assert bundle["go_no_go"]["verdict"] == "NO_GO"
 
 
+def test_run_bounded_pilot_readiness_readiness_check_exception_is_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.ops.check_bounded_pilot_readiness as mod
+
+    def _boom(**kw: object) -> object:
+        raise RuntimeError("readiness boom")
+
+    monkeypatch.setattr("scripts.check_live_readiness.run_readiness_checks", _boom)
+
+    ok, bundle = mod.run_bounded_pilot_readiness(
+        ROOT, ROOT / "config" / "config.toml", run_tests=False
+    )
+    assert ok is False
+    assert bundle["contract"] == mod.CONTRACT_ID
+    assert bundle.get("ok") is False
+    assert bundle["blocked_at"] == "live_readiness"
+    assert "readiness evaluation error" in (bundle.get("message") or "")
+    assert "readiness boom" in (bundle.get("message") or "")
+    assert "go_no_go" not in bundle
+
+
+def test_run_bounded_pilot_readiness_blocks_on_cockpit_payload_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.ops.check_bounded_pilot_readiness as mod
+
+    monkeypatch.setattr(
+        "scripts.check_live_readiness.run_readiness_checks",
+        lambda **kw: _passing_readiness_report(),
+    )
+
+    def _no_cockpit(**kw: object) -> object:
+        raise OSError("cockpit down")
+
+    monkeypatch.setattr("src.webui.ops_cockpit.build_ops_cockpit_payload", _no_cockpit)
+    ok, bundle = mod.run_bounded_pilot_readiness(
+        ROOT, ROOT / "config" / "config.toml", run_tests=False
+    )
+    assert ok is False
+    assert bundle["contract"] == mod.CONTRACT_ID
+    assert bundle.get("ok") is False
+    assert bundle["blocked_at"] == "cockpit_payload"
+    assert "failed to build ops cockpit payload" in (bundle.get("message") or "")
+    assert "cockpit down" in (bundle.get("message") or "")
+    assert "go_no_go" not in bundle
+    assert "live_readiness" in bundle  # partial summary for diagnostics
+
+
 def test_main_json_exit_codes(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:
@@ -152,3 +201,25 @@ def test_main_json_exit_codes(
     )
     monkeypatch.setattr(sys, "argv", ["x", "--json", "--repo-root", str(ROOT)])
     assert mod.main() == 1
+
+
+def test_main_json_exit_2_on_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("check_bounded_pilot_readiness", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    def _boom(*a, **k):
+        raise RuntimeError("orchestrated preflight failure")
+
+    monkeypatch.setattr(mod, "run_bounded_pilot_readiness", _boom)
+    monkeypatch.setattr(sys, "argv", ["x", "--json", "--repo-root", str(ROOT)])
+    assert mod.main() == 2
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["contract"] == mod.CONTRACT_ID
+    assert data["ok"] is False
+    assert "orchestrated preflight failure" in str(data.get("error", ""))

--- a/tests/ops/test_pilot_go_no_go_eval_v1.py
+++ b/tests/ops/test_pilot_go_no_go_eval_v1.py
@@ -189,3 +189,34 @@ def test_evaluate_safety_gates_reject_non_bool_fields() -> None:
     }
     result = mod.evaluate(payload)
     assert any(r["row"] == 1 and r["status"] == "UNKNOWN" for r in result["rows"])
+
+
+def test_main_exits_3_when_cockpit_payload_build_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Cockpit build failure is script error: exit 3, stderr, no result JSON (fail-closed)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "pilot_go_no_go_eval_v1",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    def _no_cockpit(**kw) -> object:
+        raise RuntimeError("cockpit down")
+
+    monkeypatch.setattr("src.webui.ops_cockpit.build_ops_cockpit_payload", _no_cockpit)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["pilot_go_no_go_eval_v1", "--json", "--repo-root", str(ROOT)],
+    )
+    assert mod.main() == 3
+    captured = capsys.readouterr()
+    assert "failed to build cockpit payload" in captured.err
+    assert "cockpit down" in captured.err
+    # No eval result JSON (script exits before evaluate / stdout remains empty for this path)
+    assert not captured.out.strip()


### PR DESCRIPTION
## Summary
- add bounded pilot readiness fail-closed tests for run_readiness_checks exceptions, cockpit payload build errors, and main --json exception handling
- add pilot go/no-go CLI exception coverage for cockpit-build failure behavior
- add operator preflight packet CLI failure coverage for invalid repo roots and build exceptions

## Validation
- uv run pytest tests/ops/test_check_bounded_pilot_readiness.py tests/ops/test_pilot_go_no_go_eval_v1.py tests/ops/test_bounded_pilot_operator_preflight_packet.py -q
- uv run ruff check tests/ops/test_check_bounded_pilot_readiness.py tests/ops/test_pilot_go_no_go_eval_v1.py tests/ops/test_bounded_pilot_operator_preflight_packet.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- test-only
- changed only tests/ops/test_check_bounded_pilot_readiness.py
- changed only tests/ops/test_pilot_go_no_go_eval_v1.py
- changed only tests/ops/test_bounded_pilot_operator_preflight_packet.py
- no product code changes
- no docs changes
- no config changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no live unlock
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change
