### PR TITLE
test(p63): harden online readiness shadow runner contracts

### DIFF
--- a/tests/p63/test_online_readiness_shadow_runner_v1.py
+++ b/tests/p63/test_online_readiness_shadow_runner_v1.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -34,3 +35,39 @@ def test_p63_writes_only_when_outdir(tmp_path: Path) -> None:
         P63RunContextV1(mode="paper", run_id="x", out_dir=tmp_path),
     )
     assert out["meta"]["out_dir"] is not None
+
+
+@pytest.mark.parametrize("bad_mode", ["record", "testnet"])
+def test_p63_blocks_disallowed_modes_other_than_live(bad_mode: str) -> None:
+    """Paper/shadow only; same guard as live (live covered in test_p63_blocks_live_record)."""
+    with pytest.raises(PermissionError) as exc:
+        run_online_readiness_shadow_runner_v1(
+            [0.001] * 200, P63RunContextV1(mode=bad_mode, run_id="x")
+        )
+    assert bad_mode in str(exc.value)
+
+
+def test_p63_output_json_serializable(tmp_path: Path) -> None:
+    """dict-only JSONable boundary (parity with p62 output contract test)."""
+    prices = [0.001] * 200
+    out = run_online_readiness_shadow_runner_v1(
+        prices, P63RunContextV1(mode="paper", run_id="jsonable", out_dir=tmp_path)
+    )
+    assert isinstance(out, dict)
+    json_str = json.dumps(out)
+    assert isinstance(json_str, str)
+    assert "readiness_report" in out
+    assert "shadow_plan" in out
+
+
+def test_p63_top_level_contract_keys() -> None:
+    out = run_online_readiness_shadow_runner_v1(
+        [0.001] * 200, P63RunContextV1(mode="paper", run_id="contract")
+    )
+    assert out["version"] == "p63_shadow_runner_v1"
+    assert "readiness_report" in out
+    assert "shadow_plan" in out
+    assert "switch" in out
+    assert isinstance(out["readiness_report"], dict)
+    assert isinstance(out["shadow_plan"], dict)
+    assert isinstance(out["switch"], dict)


### PR DESCRIPTION
## Summary
- add p63 online-readiness shadow runner contract tests for disallowed modes beyond live
- assert p63 runner output stays JSON-serializable in allowed mode
- assert top-level p63 contract keys and core dict-shaped sections remain stable

## Validation
- uv run pytest tests/p63/test_online_readiness_shadow_runner_v1.py -q
- uv run pytest tests/p63/ -q
- uv run pytest tests/p62/ tests/p63/ -q
- uv run ruff check tests/p63/test_online_readiness_shadow_runner_v1.py
- uv run ruff format --check tests/p63/test_online_readiness_shadow_runner_v1.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- test-only
- changed only tests/p63/test_online_readiness_shadow_runner_v1.py
- no product code changes
- no docs changes
- no p62 changes
- no P6/aiops changes
- no config changes
- no registry.py changes
- no TOML changes
- no workflow changes
- no runtime changes
- no real out/ changes
- tmp_path-only test artifacts
- no paper/shadow/testnet/live/evidence mutation
- no live unlock
- no gate/signoff/readiness decision
- no Master V2 / Double Play authority change
