### PR TITLE
docs(specs): crosslink gate status and pre live navigation

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md
@@ -20,6 +20,7 @@ Companion interpretation layer (read-only, non-authorizing):
 
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`
 - `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`
+- `docs/ops/specs/MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md` — compact G1–G12 gate-status **mapping** index; read-only visibility companion, **not** live authorization, gate closure, or operator signoff
 
 PRE_LIVE `*_CONTRACT_V1` pack — navigation read model (read-only index, non-authorizing):
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md
@@ -1,7 +1,7 @@
 # MASTER V2 — First Live Gate Status Index v1 (Canonical, Read-Only)
 
 status: ACTIVE
-last_updated: 2026-04-20
+last_updated: 2026-04-25
 owner: Peak_Trade
 purpose: Canonical docs-only gate status index for Master V2 First Live readiness visibility and auditability
 docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1
@@ -28,6 +28,10 @@ Out of scope:
 - reuse or rewire inventory updates
 - vocabulary or boundary lock expansion
 - scope implementation work
+
+## 2.1) Related navigation (companion, non-authority)
+
+For **suggested read order** and cluster grouping of the `MASTER_V2_FIRST_LIVE_PRE_LIVE_*_CONTRACT_V1.md` filename set, see [`MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md`](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md). That document is a **navigation and read-order read model only**; it is **not** a gate schedule, not signoff, not evidence, not a live or First-Live go, and it does not change the meaning of any contract in this index.
 
 ## 3) Canonical Status Model
 

--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md
@@ -2,7 +2,7 @@
 title: "Master V2 First Live PRE_LIVE Navigation Read Model v0"
 status: "DRAFT"
 owner: "ops"
-last_updated: "2026-04-24"
+last_updated: "2026-04-25"
 docs_token: "DOCS_TOKEN_MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0"
 ---
 
@@ -45,6 +45,8 @@ Read **context** (optional but useful) **before** or **alongside** the PRE_LIVE 
 | C0 | [STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md](STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md) | Strategy / MV2 **boundary** and vocabulary | Live go, Double Play, registry as sole authority |
 | C1 | [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) | **Canonical** L0–L5 enablement **steering** for the clarification workstream | A finished ladder state, green gates, or live enablement |
 | C2 | [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md) | Interpretation grammar for readiness claims (companion) | Evidence, signoff, or gate completion |
+| C3 | [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md) | **Compact** G1–G12 gate-status **mapping** index (read-only visibility) | Gate closure, live authorization, or operator signoff |
+| C4 | [MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | Docs-only **report/table rendering** carrier aligned with the read model (companion) | A rendered status row as a governance decision, evidence, or go |
 
 **Suggested first pass — PRE_LIVE contract cluster (order is a reading aid, not a mandate):**
 


### PR DESCRIPTION
## Summary
- add PRE_LIVE Navigation Read Model companion entries for Gate Status Index and Gate Status Report Surface
- add Gate Status Index related-navigation pointer back to PRE_LIVE Navigation Read Model
- add Readiness Ladder companion interpretation pointer to Gate Status Index

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Safety
- docs-only
- changed only three Master V2 / First-Live spec docs
- no Report Surface change
- no docs/INDEX.md change
- no KNOWLEDGE_BASE_INDEX.md change
- no AUTHORITY_RECOVERY change
- no runbook changes
- no src/ changes
- no tests/ changes
- no workflows changed
- no registry.py changes
- no TOML changes
- no config changes
- no runtime changes
- no out/ changes
- no paper/shadow/testnet/live/evidence mutation
- no gate closure claim
- no signoff claim
- no evidence claim
- no live-go claim
- no Master V2 / Double Play authority change

Made with [Cursor](https://cursor.com)