### PR TITLE
feat(ops): add forward market data provenance manifest

### DIFF
--- a/scripts/_market_data_provenance.py
+++ b/scripts/_market_data_provenance.py
@@ -1,0 +1,78 @@
+# scripts/_market_data_provenance.py
+"""Reine Metadaten-Hilfen für Marktdaten-Provenance in CLI-Manifesten (NO-LIVE).
+
+v1: Mappt kanonische ``ohlcv_source``-Werte (siehe ``_shared_ohlcv_loader``) auf auditierbare Flags.
+Keine Secrets, keine I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _shared_ohlcv_loader import (
+    OHLCV_SOURCE_CSV,
+    OHLCV_SOURCE_DUMMY,
+    OHLCV_SOURCE_KRAKEN,
+    normalize_ohlcv_source,
+)
+
+
+def build_market_data_provenance_v1(
+    *,
+    ohlcv_source: str,
+    symbols: list[str],
+    timeframe: str,
+    n_bars: int,
+    fetched_at_utc: str,
+    dry_run_execution: bool = True,
+) -> dict[str, Any]:
+    """
+    Baut den Block ``market_data_provenance`` für Forward-Evaluation-Manifeste.
+
+    Semantik (v1):
+    - ``dummy``: synthetische interne Reihe (kein Exchange).
+    - ``kraken``: öffentliche REST-OHLCV (historische Kerzen), kein Order-Trading.
+    - ``csv`` (inkl. normalisiertes ``fixture``): lokale Datei — ``local_file``, kein „live real“-Claim.
+    """
+    src = normalize_ohlcv_source(ohlcv_source)
+
+    if src == OHLCV_SOURCE_DUMMY:
+        source_kind = "synthetic"
+        provider = "dummy"
+        exchange = "none"
+        is_synthetic = True
+        is_fixture = False
+    elif src == OHLCV_SOURCE_KRAKEN:
+        source_kind = "historical_real"
+        provider = "kraken"
+        exchange = "kraken"
+        is_synthetic = False
+        is_fixture = False
+    elif src == OHLCV_SOURCE_CSV:
+        source_kind = "local_file"
+        provider = "csv"
+        exchange = "none"
+        is_synthetic = False
+        is_fixture = True
+    else:  # pragma: no cover — normalize_ohlcv_source wirft bei unbekanntem Wert
+        source_kind = "unknown"
+        provider = "unknown"
+        exchange = "unknown"
+        is_synthetic = False
+        is_fixture = False
+
+    return {
+        "schema_version": "market_data_provenance_v1",
+        "ohlcv_source": src,
+        "source_kind": source_kind,
+        "provider": provider,
+        "exchange": exchange,
+        "symbols": list(symbols),
+        "timeframe": timeframe,
+        "n_bars": int(n_bars),
+        "fetched_at_utc": fetched_at_utc,
+        "is_mock": False,
+        "is_synthetic": is_synthetic,
+        "is_fixture": is_fixture,
+        "dry_run_execution": bool(dry_run_execution),
+    }

--- a/scripts/evaluate_forward_signals.py
+++ b/scripts/evaluate_forward_signals.py
@@ -43,6 +43,7 @@ from _forward_run_manifest import (
     try_git_sha,
     write_forward_run_manifest,
 )
+from _market_data_provenance import build_market_data_provenance_v1
 from src.core.peak_config import load_config
 from src.core.experiments import log_generic_experiment
 
@@ -337,6 +338,14 @@ def main(argv: List[str] | None = None) -> int:
             argv=payload["argv"],
             config_path=str(payload["config_path"]),
             git_sha=payload.get("git_sha"),
+        )
+        payload["market_data_provenance"] = build_market_data_provenance_v1(
+            ohlcv_source=args.ohlcv_source,
+            symbols=symbols_val,
+            timeframe=args.timeframe,
+            n_bars=args.n_bars,
+            fetched_at_utc=payload["generated_at_utc"],
+            dry_run_execution=True,
         )
         write_forward_run_manifest(manifest_path, payload)
 

--- a/tests/test_forward_run_contract.py
+++ b/tests/test_forward_run_contract.py
@@ -103,3 +103,7 @@ def test_evaluate_forward_exits_1_on_empty_signals_csv(tmp_path, cfg_test_path: 
     assert payload.get("generated_at_utc") and isinstance(payload["generated_at_utc"], str)
     assert payload["generated_at_utc"].endswith("Z")
     assert payload["config_path"] == str(cfg_test_path)
+    mdp = payload.get("market_data_provenance")
+    assert mdp and mdp.get("schema_version") == "market_data_provenance_v1"
+    assert mdp.get("source_kind") == "synthetic"
+    assert mdp.get("ohlcv_source") == "dummy"

--- a/tests/test_market_data_provenance_v1.py
+++ b/tests/test_market_data_provenance_v1.py
@@ -1,0 +1,55 @@
+"""Unit-Tests für ``build_market_data_provenance_v1`` (Forward-Manifest-Metadaten)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from _market_data_provenance import build_market_data_provenance_v1  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "source,expect_kind,expect_provider,expect_ex,expect_synth,expect_fix",
+    [
+        ("dummy", "synthetic", "dummy", "none", True, False),
+        ("DUMMY", "synthetic", "dummy", "none", True, False),
+        ("kraken", "historical_real", "kraken", "kraken", False, False),
+        ("csv", "local_file", "csv", "none", False, True),
+        ("fixture", "local_file", "csv", "none", False, True),
+    ],
+)
+def test_build_market_data_provenance_v1_mapping(
+    source: str,
+    expect_kind: str,
+    expect_provider: str,
+    expect_ex: str,
+    expect_synth: bool,
+    expect_fix: bool,
+) -> None:
+    ts = "2026-01-01T00:00:00Z"
+    p = build_market_data_provenance_v1(
+        ohlcv_source=source,
+        symbols=["BTC/EUR"],
+        timeframe="1h",
+        n_bars=200,
+        fetched_at_utc=ts,
+        dry_run_execution=True,
+    )
+    assert p["schema_version"] == "market_data_provenance_v1"
+    assert p["source_kind"] == expect_kind
+    assert p["provider"] == expect_provider
+    assert p["exchange"] == expect_ex
+    assert p["is_synthetic"] is expect_synth
+    assert p["is_fixture"] is expect_fix
+    assert p["is_mock"] is False
+    assert p["dry_run_execution"] is True
+    assert p["symbols"] == ["BTC/EUR"]
+    assert p["timeframe"] == "1h"
+    assert p["n_bars"] == 200
+    assert p["fetched_at_utc"] == ts


### PR DESCRIPTION
Adds additive market_data_provenance v1 metadata to evaluate_forward_signals run manifests. Distinguishes dummy/synthetic, csv/local_file, and kraken/historical_real without changing strategy logic, S3/IAM, rclone, live/order behavior, or Master V2 governance. Includes focused provenance and forward-run contract tests.

Made with [Cursor](https://cursor.com)