### PR TITLE
ci: install ccxt for real market forward smoke

### DIFF
--- a/.github/workflows/real-market-forward-evidence-smoke.yml
+++ b/.github/workflows/real-market-forward-evidence-smoke.yml
@@ -33,6 +33,9 @@ jobs:
           BTC/EUR,2026-01-01T00:00:00Z,1.0
           EOF
 
+      - name: Install Kraken market-data dependency
+        run: uv pip install ccxt
+
       - name: Run read-only Kraken forward evidence smoke
         run: |
           set -euo pipefail


### PR DESCRIPTION
Fixes the workflow_dispatch-only Real Market Forward Evidence Smoke by installing ccxt before the Kraken/historical_real evaluate_forward_signals step. No S3, IAM, rclone, live, testnet, or order behavior changes.

Made with [Cursor](https://cursor.com)