### PR TITLE
ci: schedule real market forward evidence smoke every six hours

### DIFF
--- a/.github/workflows/real-market-forward-evidence-smoke.yml
+++ b/.github/workflows/real-market-forward-evidence-smoke.yml
@@ -2,9 +2,15 @@ name: Real Market Forward Evidence Smoke
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
 
 permissions:
   contents: read
+
+concurrency:
+  group: real-market-forward-evidence-smoke
+  cancel-in-progress: false
 
 jobs:
   real-market-forward-evidence-smoke:
@@ -118,3 +124,4 @@ jobs:
             out/ops/real_market_forward_evidence_smoke/out_eval/*
             out/ops/real_market_forward_evidence_smoke/summary.json
           if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
Schedules the Real Market Forward Evidence Smoke every six hours while preserving workflow_dispatch. The workflow remains read-only: Kraken/historical_real market_data_provenance_v1 validation and artifact upload only. No S3, IAM, rclone, live, testnet, or order behavior changes.

Made with [Cursor](https://cursor.com)