### PR TITLE
docs(p0c): clarify execution risk layer readiness authority

### DIFF
--- a/docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md
+++ b/docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md
@@ -396,3 +396,8 @@ Phase 25 ergänzt den **organisatorischen Layer**:
   - Rollen & Verantwortlichkeiten beschrieben
   - Entscheidungsprozesse dokumentiert
   - Keine Code-Änderungen
+
+## Execution and risk-layer README authority boundary
+
+Module-level README files under `src&#47;execution&#47;` and `src&#47;risk_layer&#47;` may preserve historical or component-level readiness wording for operator context. That wording is not, by itself, Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, or Live permission. Current execution authority remains governed by this overview, current gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement.
+

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-25 — `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` — Abschnitt „Execution and risk-layer README authority boundary“ (Spiegel zu `src&#47;execution&#47;README.md` / `src&#47;risk_layer&#47;README.md`; P0-C Epoch-/Autoritätsgrenze; **keine** Live-Freigabe); paired with `governance-overview-canonical`.
+
 - 2026-04-20 — `scripts&#47;report_live_sessions.py` — read-only `--bounded-pilot-readiness-summary` (Readiness + Operator-Preflight-Packet + Registry-Fokus; keine Autorisierung); Runbook `RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` §4; **keine** Live-Freigabe.
 
 - 2026-04-20 — `scripts&#47;report_live_sessions.py` — read-only `--bounded-pilot-closeout-status-summary` (Registry-Terminalstatus im neuesten JSON pro `session_id` + Pointer; ohne Readiness-/Packet-Lauf); Runbook `RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` §4; **keine** Live-Freigabe.

--- a/src/execution/README.md
+++ b/src/execution/README.md
@@ -1,5 +1,12 @@
 # Execution Module (Full-Featured)
 
+
+## Authority and epoch note
+
+This README may contain historical or component-level `production-ready` / execution wording. Such wording is not, by itself, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, or permission to route orders into any live capital path.
+
+Execution components remain downstream of current Master V2 decision authority, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. Paper, Shadow, and Live references in this README describe environment or integration context only unless a current gate, evidence, and signoff artifact proves promotion. This note is docs-only and changes no runtime behavior.
+
 **Location:** `src/execution/`  
 **Purpose:** Production execution pipeline with full feature set  
 **Status:** Production-ready

--- a/src/risk_layer/README.md
+++ b/src/risk_layer/README.md
@@ -47,7 +47,7 @@ This module provides **operational risk management** for live trading:
 
 ## Key Components
 
-### Kill Switch (`kill_switch/`)
+### Kill Switch (`kill_switch&#47;`)
 
 **Purpose:** Emergency halt mechanism (Layer 4 of Defense-in-Depth)
 
@@ -55,7 +55,7 @@ This module provides **operational risk management** for live trading:
 - `core.py` - KillSwitch class (state machine)
 - `state.py` - State definitions (ACTIVE, KILLED, RECOVERING)
 - `execution_gate.py` - ExecutionGate (blocks orders when killed)
-- `triggers/` - Trigger mechanisms (manual, threshold, watchdog, external)
+- `triggers&#47;` - Trigger mechanisms (manual, threshold, watchdog, external)
 - `persistence.py` - State persistence (survive restarts)
 - `audit.py` - Audit trail
 - `cli.py` - Command-line interface
@@ -101,7 +101,7 @@ python -m src.risk_layer.kill_switch.cli complete-recovery
 
 ---
 
-### Alerting (`alerting/`)
+### Alerting (`alerting&#47;`)
 
 **Purpose:** Risk event notification and dispatch
 
@@ -110,7 +110,7 @@ python -m src.risk_layer.kill_switch.cli complete-recovery
 - `alert_dispatcher.py` - AlertDispatcher (routing)
 - `alert_types.py` - Alert severity and types
 - `alert_event.py` - AlertEvent dataclass
-- `channels/` - Notification channels
+- `channels&#47;` - Notification channels
 
 **Channels:**
 - `slack_channel.py` - Slack notifications
@@ -137,7 +137,7 @@ manager.send_alert(
 
 ---
 
-### VaR Backtesting (`var_backtest/`)
+### VaR Backtesting (`var_backtest&#47;`)
 
 **Purpose:** Validation of VaR models (regulatory compliance)
 

--- a/src/risk_layer/README.md
+++ b/src/risk_layer/README.md
@@ -1,5 +1,12 @@
 # Risk Layer (Live Trading)
 
+
+## Authority and epoch note
+
+This README may contain historical or component-level `PRODUCTION-READY`, gate, kill-switch, integration, and test-evidence wording. Such wording is not, by itself, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, or permission to route orders into any live capital path.
+
+Risk-layer material remains downstream of distinct Scope / Capital Envelope semantics and upstream of Safety / Kill-Switch fail-closed boundaries where applicable. Test counts and integration references are useful provenance, not current readiness proof unless validated by current CI and evidence. This note is docs-only and changes no runtime behavior.
+
 **Location:** `src/risk_layer/`  
 **Purpose:** Operational risk management for live trading  
 **Status:** Production-ready (Layer 4 Defense-in-Depth)


### PR DESCRIPTION
## Summary
- add authority/epoch clarification to src/execution/README.md
- add authority/epoch clarification to src/risk_layer/README.md
- preserve historical component value while preventing production-ready wording from being misread as Master V2, Doubleplay, First-Live, operator, or Live authority

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)