### PR TITLE
docs(p0c): clarify VAR validation guide live authority

### DIFF
--- a/docs/risk/VAR_VALIDATION_OPERATOR_GUIDE.md
+++ b/docs/risk/VAR_VALIDATION_OPERATOR_GUIDE.md
@@ -1,5 +1,12 @@
 # VaR Validation - Operator Guide
 
+
+## Authority and epoch note
+
+This guide preserves historical and component-level VAR validation operator context. Phrases such as `production-ready`, `merged to main`, `live deployment`, `live trading`, or `promoting to live` are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, or permission to route orders into any live capital path.
+
+VAR validation can support risk review and promotion discussions, but it is not a standalone promotion gate. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Version:** 1.0  
 **Date:** 2025-12-28  
 **Status:** ✅ Production-Ready (Phase 2 merged to main)


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/VAR_VALIDATION_OPERATOR_GUIDE.md
- preserve the VAR validation operator-guide value while clarifying that production/live wording is not current Master V2, Doubleplay, First-Live, operator, or Live authority
- clarify that VAR validation can support risk review but is not a standalone promotion gate

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)