### PR TITLE
docs(p0c): clarify VAR backtest suite authority

### DIFF
--- a/docs/risk/VAR_BACKTEST_SUITE_GUIDE.md
+++ b/docs/risk/VAR_BACKTEST_SUITE_GUIDE.md
@@ -1,6 +1,12 @@
 # VaR Backtest Suite – Operator Guide
 
-**Phases 9A/9B/10** · **Status:** ✅ Live on main
+## Authority and epoch note
+
+This guide preserves historical and component-level VaR backtest suite context. References to suite availability on `main`, production-oriented readiness, or validation status are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, or permission to route orders into any live capital path.
+
+VaR backtest output can support risk review and promotion discussions, but it is not a standalone promotion gate. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. Validation-suite surfaces and risk-layer suite surfaces are documentation and analysis surfaces unless a future governed slice explicitly proves and rewires a canonical authority path. This note is docs-only and changes no runtime behavior.
+
+**Phases 9A/9B/10** · **Status:** ✅ Available on main (repository availability, not live-trading authority)
 
 ---
 

--- a/docs/risk/VAR_BACKTEST_SUITE_QUICKSTART.md
+++ b/docs/risk/VAR_BACKTEST_SUITE_QUICKSTART.md
@@ -1,5 +1,11 @@
 # VaR Backtest Suite – Quick Start Guide
 
+## Authority and epoch note
+
+This quickstart preserves historical and component-level VaR backtest suite usage context. Backtest or validation output is support evidence for risk review, not standalone Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, or permission to route orders into any live capital path.
+
+Validation-suite surfaces and risk-layer suite surfaces are documentation and analysis surfaces unless a future governed slice explicitly proves and rewires a canonical authority path. This note is docs-only and changes no runtime behavior.
+
 **Phase:** 8C + 8D  
 **Feature:** Suite Runner, Report Formatter, Index & Compare Tools  
 **Status:** ✅ Production-Ready  
@@ -18,7 +24,7 @@ Die **VaR Backtest Suite** aggregiert alle VaR-Validierungstests in einem einzig
 
 **Overall Result:** `PASS` wenn alle Tests grün, sonst `FAIL`.
 
-⚠️ **Note:** `src/risk/validation/christoffersen.py` ist aktuell ein **Stub/Placeholder**. Die Christoffersen Tests (IND/CC) liefern dummy-Werte und sind noch nicht vollständig implementiert. Vollständige Implementation folgt in PR #422.
+⚠️ **Note (current implementation):** Christoffersen coverage in the validation suite delegates through `src/risk/validation/christoffersen.py` to the canonical functions in `src.risk_layer.var_backtest.christoffersen_tests` (not a free-standing historical stub; behavior follows that delegation path and tests).
 
 ---
 
@@ -489,4 +495,4 @@ print(f"Breaches: {breaches}, Expected: {expected:.1f}")
 
 **Last Updated:** 2026-01-04  
 **Phase:** 8C + 8D  
-**Status:** ✅ Production-Ready Human: continue
+**Status:** ✅ Production-Ready


### PR DESCRIPTION
## Summary
- clarify VAR backtest suite authority/epoch boundaries in the guide and quickstart
- replace Live-on-main wording with repository availability language, not live-trading authority
- correct Christoffersen wording to reflect delegation through src/risk/validation/christoffersen.py to src.risk_layer.var_backtest.christoffersen_tests
- remove stray Human: continue artifact

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- Christoffersen hard-verify log: /tmp/peak_trade_p0c_var_backtest_christoffersen_hard_verify_v0/CHRISTOFFERSEN_HARD_VERIFY.log

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)