### PR TITLE
docs(p0c): clarify Christoffersen guide authority

### DIFF
--- a/docs/risk/CHRISTOFFERSEN_TESTS_GUIDE.md
+++ b/docs/risk/CHRISTOFFERSEN_TESTS_GUIDE.md
@@ -1,5 +1,12 @@
 # Christoffersen Independence & Conditional Coverage Tests
 
+
+## Authority and epoch note
+
+This guide preserves historical and component-level Christoffersen validation context. Phrases such as `fully validated`, regulatory, operations, production, or deployment context are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, regulatory certification, or permission to route orders into any live capital path.
+
+Christoffersen tests can support VaR model review, independence / conditional-coverage diagnostics, and risk validation discussions, but they are not a standalone promotion gate. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Status:** Phase 8B Complete  
 **Date:** 2025-12-28  
 **Module:** `src.risk_layer.var_backtest.christoffersen_tests`


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/CHRISTOFFERSEN_TESTS_GUIDE.md
- preserve Christoffersen independence / conditional-coverage value while clarifying it is not standalone Master V2, Doubleplay, First-Live, operator, regulatory, or Live authority
- clarify that Christoffersen tests can support VaR/risk review but remain downstream of current gates, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)