### PR TITLE
docs(p0c): clarify VAR backtest guide authority

### DIFF
--- a/docs/risk/VAR_BACKTEST_GUIDE.md
+++ b/docs/risk/VAR_BACKTEST_GUIDE.md
@@ -1,5 +1,12 @@
 # VaR Backtest Guide – Operator Manual
 
+
+## Authority and epoch note
+
+This guide preserves historical and component-level VaR backtest operator context. Phrases such as `production-ready`, deployment, live-gate, or operational readiness are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, or permission to route orders into any live capital path.
+
+VaR backtesting can support risk review, diagnostics, and promotion discussions, but it is not a standalone promotion gate. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Module:** `src/risk_layer/var_backtest/`  
 **Purpose:** Research & Backtesting Only  
 **Status:** ✅ Production Ready (Backtest/Research)


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/VAR_BACKTEST_GUIDE.md
- preserve the Kupiec / CLI / troubleshooting operator-guide value while clarifying it is not standalone Master V2, Doubleplay, First-Live, operator, or Live authority
- clarify that VaR backtesting can support risk review and promotion discussions but remains downstream of current gates, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)