### PR TITLE
docs(p0c): clarify VAR gate runbook authority

### DIFF
--- a/docs/risk/VAR_GATE_RUNBOOK.md
+++ b/docs/risk/VAR_GATE_RUNBOOK.md
@@ -1,5 +1,12 @@
 # VaR Gate Runbook
 
+
+## Authority and epoch note
+
+This runbook preserves historical and component-level VAR gate / RiskGate operator context. Phrases such as allowing trades, gate pass/fail, `BLOCK` / `WARN`, TOML defaults, operational deployment, or live-gate behavior are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, or permission to route orders into any live capital path.
+
+VAR Gate checks can support risk enforcement and promotion discussions, but they are not a standalone promotion gate and do not replace the full staged enablement chain. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 ## Overview
 
 The **VaR Gate** is a portfolio-level risk control that evaluates Value-at-Risk (VaR) against configured thresholds before allowing trades.


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/VAR_GATE_RUNBOOK.md
- preserve the VAR Gate / RiskGate operator value while clarifying it is not standalone Master V2, Doubleplay, First-Live, operator, or Live authority
- clarify that VAR Gate checks can support risk enforcement and promotion discussions but do not replace current gates, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches, or staged Execution Enablement

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)