### PR TITLE
docs(p0c): clarify duration diagnostic guide authority

### DIFF
--- a/docs/risk/DURATION_DIAGNOSTIC_GUIDE.md
+++ b/docs/risk/DURATION_DIAGNOSTIC_GUIDE.md
@@ -1,5 +1,12 @@
 # Duration-Based Independence Diagnostic Guide
 
+
+## Authority and epoch note
+
+This guide preserves historical and component-level duration-diagnostic context. Duration diagnostics can support VaR / risk review, independence analysis, and model-quality discussions, but they are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, a primary production rejection gate, or permission to route orders into any live capital path.
+
+Duration diagnostics do not replace Christoffersen / Kupiec validation, current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, or staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Phase 9A Implementation**  
 **Status:** ✅ Optional Diagnostic (NOT a primary gate)  
 **Purpose:** Supplementary evidence for VaR violation independence


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/DURATION_DIAGNOSTIC_GUIDE.md
- preserve duration-diagnostic value while clarifying it is not standalone Master V2, Doubleplay, First-Live, operator, primary production-rejection, or Live authority
- clarify that duration diagnostics can support VaR/risk review but do not replace Christoffersen/Kupiec validation, current gates, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches, or staged Execution Enablement

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)