### PR TITLE
docs(p0c): clarify Kupiec POF canonical path authority

### DIFF
--- a/docs/risk/KUPIEC_POF_CANONICAL_PATH.md
+++ b/docs/risk/KUPIEC_POF_CANONICAL_PATH.md
@@ -1,5 +1,12 @@
 # Kupiec POF: Canonical Import Path Guide
 
+
+## Authority and epoch note
+
+This guide preserves historical and component-level Kupiec POF canonical-path context. Phrases such as active status, canonical path, valid model, migration complete, or test success are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, model certification, or permission to route orders into any live capital path.
+
+Kupiec POF can support VaR / risk review and model-quality discussions, but it is not a standalone promotion gate. Canonical import guidance does not collapse validation-suite and risk-layer surfaces into a single trading-authority path. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Version:** Phase 8A (2025-12-28)  
 **Status:** ✅ Active
 


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/KUPIEC_POF_CANONICAL_PATH.md
- preserve canonical Kupiec POF import / migration / API / test guidance while clarifying it is not standalone Master V2, Doubleplay, First-Live, operator, model-certification, or Live authority
- clarify that canonical import guidance does not collapse validation-suite and risk-layer surfaces into a single trading-authority path

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)