### PR TITLE
docs(p0c): clarify Kupiec POF theory authority

### DIFF
--- a/docs/risk/KUPIEC_POF_THEORY.md
+++ b/docs/risk/KUPIEC_POF_THEORY.md
@@ -1,5 +1,12 @@
 # Kupiec POF Test – Theoretischer Hintergrund
 
+
+## Authority and epoch note
+
+This guide preserves historical and component-level Kupiec POF theory context. Statistical terms such as H0 acceptance, exception-rate fit, Basel traffic-light interpretation, green / yellow / red zones, valid VaR model, or theory-backed validation are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, model certification, regulatory approval, or permission to route orders into any live capital path.
+
+Kupiec POF theory can support VaR / risk review and model-quality discussions, but it is not a standalone promotion gate. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Autor:** Peak_Trade Risk Team  
 **Datum:** 2024-12-27  
 **Zweck:** Theoretische Grundlagen für VaR Backtesting


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/KUPIEC_POF_THEORY.md
- preserve Kupiec POF theory / H0 / Basel-style interpretation value while clarifying it is not standalone Master V2, Doubleplay, First-Live, operator, model-certification, regulatory, or Live authority
- clarify that Kupiec POF theory can support VaR/risk review but remains downstream of current gates, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)