### PR TITLE
docs(p0c): clarify Kupiec POF roadmap authority

### DIFF
--- a/docs/risk/roadmaps/KUPIEC_POF_BACKTEST_ROADMAP.md
+++ b/docs/risk/roadmaps/KUPIEC_POF_BACKTEST_ROADMAP.md
@@ -1,5 +1,14 @@
 # Kupiec POF Backtest – Implementierungs-Roadmap
 
+
+## Authority and epoch note
+
+This roadmap preserves historical and component-level Kupiec POF backtest planning context. Roadmap status, implementation readiness, production-readiness language, shadow / live mentions, pseudocode, or `is_valid` examples are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, model certification, production readiness, or permission to route orders into any live capital path.
+
+Kupiec POF roadmap material can support risk-validation planning and later implementation review, but it is not a standalone promotion gate. Canonical-path, dependency, or implementation-alignment questions must be handled in a separate governed slice; this note does not rewrite paths, dependencies, code, tests, or architecture.
+
+Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Projekt:** Peak_Trade Risk Layer  
 **Komponente:** VaR Backtesting / Kupiec Proportion of Failures (POF) Test  
 **Erstellt:** 2025-12-27  


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/roadmaps/KUPIEC_POF_BACKTEST_ROADMAP.md
- preserve Kupiec POF roadmap / pseudocode / backlog value while clarifying it is not standalone Master V2, Doubleplay, First-Live, operator, model-certification, production-readiness, or Live authority
- clarify that canonical-path, dependency, or implementation-alignment questions require a separate governed slice

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)