### PR TITLE
docs(p0c): clarify risk layer v1 guide authority

### DIFF
--- a/docs/risk/RISK_LAYER_V1_GUIDE.md
+++ b/docs/risk/RISK_LAYER_V1_GUIDE.md
@@ -1,5 +1,14 @@
 # Risk Layer v1.0 - User Guide
 
+
+## Authority and epoch note
+
+This guide preserves historical and component-level Risk Layer v1.0 usage and configuration context. Terms such as comprehensive, enabled, Traffic-Light scenarios, deployment-style examples, operational readiness, production-readiness, or best-practice language are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, system certification, production readiness, or permission to route orders into any live capital path.
+
+Risk Layer v1 guidance can support risk review, architecture review, configuration review, and safety discussions, but it is not a standalone promotion gate and does not replace the full staged enablement chain. Risk Layer guidance remains downstream of distinct Scope / Capital Envelope semantics and upstream of Safety / Kill-Switch fail-closed boundaries where applicable.
+
+Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Version:** 1.0  
 **Date:** 2025-12-28  
 **Agent:** A6 (Integration & Documentation)


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/RISK_LAYER_V1_GUIDE.md
- preserve Risk Layer v1 usage / config / quickstart / troubleshooting value while clarifying it is not standalone Master V2, Doubleplay, First-Live, operator, system-certification, production-readiness, or Live authority
- clarify that Risk Layer guidance remains downstream of Scope / Capital Envelope and current gates, and upstream of Safety / Kill-Switch fail-closed boundaries where applicable

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)