### PR TITLE
docs(p0c): clarify risk layer alignment authority

### DIFF
--- a/docs/risk/RISK_LAYER_ALIGNMENT.md
+++ b/docs/risk/RISK_LAYER_ALIGNMENT.md
@@ -1,5 +1,14 @@
 # Risk Layer v1.0 - Repository Alignment Decision
 
+
+## Authority and epoch note
+
+This document preserves historical and component-level Risk Layer alignment, dual-package, configuration, API-sketch, rollout, migration, and RiskGate integration context. Terms such as FINAL, READY FOR IMPLEMENTATION, Production Readiness, Live Trading, rollout, scaffold, placeholder, or API sketch are not, by themselves, current Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, system certification, production readiness, or permission to route orders into any live capital path.
+
+The alignment logic is valuable and must be preserved for later read-only wiring / architecture audits. This note does not validate every path, import, placeholder, scaffold, API sketch, or rollout claim as current repo truth. Any future code, config, test, import, or API alignment must be handled in a separate governed slice after read-only evidence.
+
+Risk Layer alignment remains downstream of distinct Scope / Capital Envelope semantics and upstream of Safety / Kill-Switch fail-closed boundaries where applicable. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This note is docs-only and changes no runtime behavior.
+
 **Agent:** A0 (Architect & Repo Alignment)  
 **Datum:** 2025-12-28  
 **Status:** FINAL


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/risk/RISK_LAYER_ALIGNMENT.md
- preserve the dual-package / configuration / API-sketch / rollout / migration / RiskGate alignment value
- clarify that FINAL, READY FOR IMPLEMENTATION, Production Readiness, Live Trading, scaffold, placeholder, rollout, or API-sketch wording is not standalone Master V2, Doubleplay, First-Live, operator, system-certification, production-readiness, or Live authority
- explicitly preserve wiring/alignment material for a separate read-only architecture audit rather than editing code, config, imports, paths, or APIs in this slice

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization
- alignment/wiring value preserved for separate audit

Made with [Cursor](https://cursor.com)