### PR TITLE
docs(p0c): add risk layer wiring snapshot

### DIFF
--- a/docs/risk/RISK_LAYER_ALIGNMENT.md
+++ b/docs/risk/RISK_LAYER_ALIGNMENT.md
@@ -15,6 +15,14 @@ Risk Layer alignment remains downstream of distinct Scope / Capital Envelope sem
 
 ---
 
+## Current wiring snapshot note
+
+This wiring snapshot is docs-only and reflects a read-only audit of current repo shape. The alignment memo remains valuable as planning/provenance and must not be discarded merely because some tree, API, rollout, or scaffold sketches are historical.
+
+Current observed wiring surfaces include `src/risk_layer/risk_gate.py` with `RiskGate` and the package-based `src/risk_layer/kill_switch/` surface, where `KillSwitch` is implemented under `core.py` and exported through `__init__.py`. Imports such as `from src.risk_layer.risk_gate import RiskGate` and `from src.risk_layer.kill_switch import KillSwitch` should be treated as current observed surfaces unless a later audit proves otherwise.
+
+Older tree or API sketches that imply multiple separate top-level gate modules should be read as planning/scaffold until independently verified. Missing or unclear gate surfaces are not dropped; they remain Park / retain or Needs deeper audit items for a later Master-V2-compatible wiring audit. This note changes no code, config, imports, tests, runtime behavior, evidence state, or market-data state, and it does not create Live authorization. Any future wiring alignment must be handled in a separate governed slice after read-only evidence and must preserve Master V2 and Doubleplay boundaries.
+
 ## Executive Summary
 
 Die Risk Layer v1.0 Roadmap wird in das **bestehende Dual-Package-System** integriert:


### PR DESCRIPTION
## Summary
- add a current wiring snapshot note to docs/risk/RISK_LAYER_ALIGNMENT.md
- preserve the alignment memo as valuable planning/provenance while clarifying current observed surfaces
- record observed RiskGate and package-based KillSwitch surfaces without changing code, config, imports, tests, or runtime behavior
- mark older tree/API sketches as planning/scaffold until separately verified
- preserve unresolved wiring items as Park / retain or Needs deeper audit for a later governed slice

## Deep recovery / dependency preservation
- no factual contradiction found against the snapshot note
- RiskGate under src/risk_layer/risk_gate.py is supported by current code
- KillSwitch package shape under src/risk_layer/kill_switch/ is supported by current code
- separate ops gate surface under src/ops/gates/risk_gate.py is retained as a name-collision / glossary concern, not collapsed into RiskGate
- deeper dependency recovery is intentionally read-only and parked for later follow-up so the wiring logic is not lost

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization
- future wiring alignment must be a separate governed slice preserving Master V2 and Doubleplay boundaries

Made with [Cursor](https://cursor.com)