### PR TITLE
docs(p0c): link risk surface glossary from risk README

### DIFF
--- a/docs/risk/README.md
+++ b/docs/risk/README.md
@@ -10,6 +10,10 @@ Diese **Risk-Layer**-Dokumentation ersetzt **keine** Master-V2-konforme Governan
 
 ---
 
+## Risk surface glossary
+
+See [Risk Surfaces Glossary v0](RISK_SURFACES_GLOSSARY_V0.md) for the non-authoritative, docs-only glossary distinguishing risk, gate, safety, diagnostic, evidence, and promotion surfaces. It preserves Master V2 / Doubleplay boundaries by separating Scope / Capital Envelope from Risk / Exposure Caps and by distinguishing RiskGate, ops gates, live gates, execution risk hooks, KillSwitch, diagnostics, and staged Execution Enablement. The glossary changes no runtime behavior and grants no Live authorization.
+
 ## Documentation Index
 
 ### Implementation Guides


### PR DESCRIPTION
## Summary
- add a central docs/risk/README.md crosslink to docs/risk/RISK_SURFACES_GLOSSARY_V0.md
- make the risk README point future agents to the non-authoritative glossary before collapsing risk, gate, safety, diagnostic, evidence, and promotion surfaces
- preserve Master V2 / Doubleplay boundaries, including Scope / Capital Envelope vs Risk / Exposure Caps
- clarify that the glossary changes no runtime behavior and grants no Live authorization

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main

## Safety
- docs-only
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization

Made with [Cursor](https://cursor.com)