### PR TITLE
docs(p0c): frame status overview readiness authority

### DIFF
--- a/docs/PEAK_TRADE_STATUS_OVERVIEW.md
+++ b/docs/PEAK_TRADE_STATUS_OVERVIEW.md
@@ -1,5 +1,12 @@
 # Peak_Trade – Projekt-Status Overview (Phasen 1–86)
 
+
+## Entry framing note
+
+This overview is a historical/status navigation surface, not a standalone readiness or promotion authority. Status percentages, phase labels, completion wording, and production/readiness language must be interpreted together with the current Master V2 / PRE_LIVE / gate / evidence / signoff sections.
+
+This overview does not grant Master V2 approval, Doubleplay authority, First-Live readiness, operator authorization, production readiness, or permission to route orders into any live capital path. Any live or first-live promotion remains governed by current gate, evidence, and signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This docs-only note changes no runtime behavior and changes no status values.
+
 Dieses Dokument beschreibt den aktuellen Gesamtstatus von **Peak_Trade**
 (Phasen **1–86**, inkl. Research-/Portfolio-Track und Live-/Testnet-Track).
 


### PR DESCRIPTION
## Summary
- add an entry framing note to docs/PEAK_TRADE_STATUS_OVERVIEW.md
- clarify that the status overview is a historical/status navigation surface, not standalone readiness or promotion authority
- preserve all status values, phase labels, percentages, tables, and historical context
- tie interpretation to Master V2 / PRE_LIVE / gates / evidence / signoff, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main
- bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main

## Safety
- docs-only
- no status value changes
- no table changes
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization
