### PR TITLE
docs(p0c): frame live testnet status authority

### DIFF
--- a/docs/LIVE_TESTNET_TRACK_STATUS.md
+++ b/docs/LIVE_TESTNET_TRACK_STATUS.md
@@ -7,6 +7,13 @@ Stand: 2025-12-07 (nach Phase 54)
 
 ---
 
+## Einstiegseinordnung
+
+Diese Datei ist eine historische Status- und Navigationsfläche für den Live-/Testnet-Track, keine eigenständige Freigabe- oder Promotionsautorität. Prozentwerte, Statuslabels, Begriffe wie funktional einsatzbereit, live-reif, Testnet/Live und Legenden müssen zusammen mit aktuellem Master V2 / PRE_LIVE / Gate / Evidence / Signoff-Kontext gelesen werden.
+
+Diese Datei erteilt keine Master-V2-Freigabe, keine Doubleplay-Autorität, keine First-Live-Readiness, keine Operator-Autorisierung, keine Produktionsreife und keine Live-Erlaubnis. Jede Live- oder First-Live-Promotion bleibt an aktuelle Gate-/Evidence-/Signoff-Artefakte, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches und staged Execution Enablement gebunden. Dieser docs-only Hinweis ändert kein Laufzeitverhalten und keine Statuswerte.
+
+
 ## 1. Zusammenfassung in Prozent
 
 | Bereich                                     | Status   |


### PR DESCRIPTION
## Summary
- add an Einstiegseinordnung block to docs/LIVE_TESTNET_TRACK_STATUS.md before the percentage summary
- clarify that Live/Testnet track status is historical/navigation context, not standalone readiness or promotion authority
- preserve all percentages, dates, tables, legends, and historical status values
- tie interpretation to Master V2 / PRE_LIVE / gates / evidence / signoff, Scope / Capital Envelope, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main
- bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main

## Safety
- docs-only
- no status value changes
- no date/table/legend changes
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization
