### PR TITLE
docs(p0c): frame narrative readiness authority

### DIFF
--- a/docs/GO_NO_GO_2026_LIVE_ALERTS_CLUSTER_82_85.md
+++ b/docs/GO_NO_GO_2026_LIVE_ALERTS_CLUSTER_82_85.md
@@ -1,5 +1,12 @@
 # Go/No-Go 2026 – Live Alerts & Escalation (Cluster 82–85)
 
+
+## Authority and epoch note
+
+This document preserves the historical Cluster 82–85 alert / Go-No-Go context. Its alert, go/no-go, live, deployment, or readiness wording is scoped to that cluster context and is not, by itself, current Master V2 approval, Doubleplay authority, PRE_LIVE completion, First-Live readiness, operator authorization, production readiness, or permission to route orders into any live capital path.
+
+This document is not a general live-trading authorization and is not a substitute for current candidate-specific gate, evidence, and signoff artifacts. Any live or first-live promotion remains governed by current gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This docs-only note changes no runtime behavior and changes no alert thresholds, tables, dates, or historical claims.
+
 **Datum:** 2025-12-09  
 **Status:** ✅ Freigegeben für 2026-Betrieb  
 **Verantwortlich:** Doku-Governance-Lead

--- a/docs/LIVE_DEPLOYMENT_PLAYBOOK.md
+++ b/docs/LIVE_DEPLOYMENT_PLAYBOOK.md
@@ -1,5 +1,12 @@
 # Peak_Trade – Live-Deployment-Playbook
 
+
+## Authority and epoch note
+
+This playbook preserves historical and operational deployment context. Deployment, live, go/no-go, checklist, production-ready, complete, or readiness wording is not, by itself, current Master V2 approval, Doubleplay authority, PRE_LIVE completion, First-Live readiness, operator authorization, production readiness, or permission to route orders into any live capital path.
+
+Any live or first-live promotion remains governed by current candidate-specific gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This docs-only note changes no runtime behavior and changes no checklist items, status values, tables, dates, or historical claims.
+
 > **Phase:** 39 – Live-Deployment-Playbook & Ops-Runbooks
 > **Version:** v1.1
 > **Zweck:** Stufenplan für den Weg von Research zu Live-Trading

--- a/docs/LIVE_READINESS_CHECKLISTS.md
+++ b/docs/LIVE_READINESS_CHECKLISTS.md
@@ -1,5 +1,12 @@
 # Peak_Trade – Live-Readiness-Checklisten
 
+
+## Authority and epoch note
+
+This checklist document preserves historical and operational readiness context. Checklist completion, live, go/no-go, deployment, production-ready, complete, or readiness wording is not, by itself, current Master V2 approval, Doubleplay authority, PRE_LIVE completion, First-Live readiness, operator authorization, production readiness, or permission to route orders into any live capital path.
+
+Any live or first-live promotion remains governed by current candidate-specific gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This docs-only note changes no runtime behavior and changes no checklist items, status values, tables, dates, or historical claims.
+
 > **Status:** Phase 39 – Live-Deployment-Playbook & Ops-Runbooks
 > **Version:** v1.1
 > **Scope:** Checklisten für Stufen-Übergänge, keine Aktivierung

--- a/docs/PEAK_TRADE_COMPLETE_OVERVIEW_2025-12-07.md
+++ b/docs/PEAK_TRADE_COMPLETE_OVERVIEW_2025-12-07.md
@@ -1,5 +1,12 @@
 # Peak_Trade – Vollständige Projektdokumentation
 
+
+## Authority and epoch note
+
+This document preserves historical, narrative, and status overview context. Production-ready, complete, success, deployment, live, go/no-go, checklist, phase, percentage, or readiness wording is not, by itself, current Master V2 approval, Doubleplay authority, PRE_LIVE completion, First-Live readiness, operator authorization, production readiness, or permission to route orders into any live capital path.
+
+Interpret this document together with current gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This docs-only note changes no runtime behavior and changes no status values, tables, dates, or historical claims.
+
 > **Stand:** 2025-12-07  
 > **Version:** v1.0 Research + Testnet-ready  
 > **Tests:** 1870 Tests (1376+ passed in 39 Phasen)  

--- a/docs/PEAK_TRADE_V1_OVERVIEW_FULL.md
+++ b/docs/PEAK_TRADE_V1_OVERVIEW_FULL.md
@@ -1,5 +1,12 @@
 # Peak_Trade v1.0 – Vollständige Übersicht & Rollen-Guide
 
+
+## Authority and epoch note
+
+This document preserves historical, narrative, and status overview context. Production-ready, complete, success, deployment, live, go/no-go, checklist, phase, percentage, or readiness wording is not, by itself, current Master V2 approval, Doubleplay authority, PRE_LIVE completion, First-Live readiness, operator authorization, production readiness, or permission to route orders into any live capital path.
+
+Interpret this document together with current gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This docs-only note changes no runtime behavior and changes no status values, tables, dates, or historical claims.
+
 > **Status:** Phase 63 – v1.0 Gesamtübersicht & Rollen-Guide
 > **Zielgruppe:** Entwickler:innen, die bereits GETTING_STARTED gelesen haben und verstehen wollen, wie alles zusammenhängt
 

--- a/docs/features/psychology/PSYCHOLOGY_HEURISTICS_README.md
+++ b/docs/features/psychology/PSYCHOLOGY_HEURISTICS_README.md
@@ -1,5 +1,12 @@
 # 🧠 Psychologie-Heuristik-System – Quick Start
 
+
+## Authority and epoch note
+
+This document preserves historical and component-level trading psychology context. Psychology readiness, production-ready, complete, success, operational, or readiness wording is not, by itself, current Master V2 approval, Doubleplay authority, PRE_LIVE completion, First-Live readiness, operator authorization, production readiness, or permission to route orders into any live capital path.
+
+Psychology material can support operator discipline and review, but it is not a standalone promotion gate. Any live or first-live promotion remains governed by current gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, and staged Execution Enablement. This docs-only note changes no runtime behavior and changes no checklist items, tables, dates, or historical claims.
+
 **Status:** ✅ Production-Ready  
 **Version:** 1.0  
 **Tests:** 47/47 passing ✅


### PR DESCRIPTION
## Summary
- add entry authority/epoch framing to high-risk narrative, alert, deployment, readiness, and psychology docs
- clarify that production-ready, complete, deployment, live, go/no-go, checklist, and readiness wording is not standalone Master V2, Doubleplay, PRE_LIVE, First-Live, operator, production, or Live authority
- preserve all historical values, percentages, dates, tables, alert thresholds, checklist contents, and narrative context
- use docs/features/psychology/PSYCHOLOGY_HEURISTICS_README.md as the existing psychology target because docs/psychology/README.md does not exist

## Changed files
- docs/PEAK_TRADE_V1_OVERVIEW_FULL.md
- docs/PEAK_TRADE_COMPLETE_OVERVIEW_2025-12-07.md
- docs/GO_NO_GO_2026_LIVE_ALERTS_CLUSTER_82_85.md
- docs/LIVE_DEPLOYMENT_PLAYBOOK.md
- docs/LIVE_READINESS_CHECKLISTS.md
- docs/features/psychology/PSYCHOLOGY_HEURISTICS_README.md

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main
- bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main

## Safety
- docs-only
- no percentage changes
- no date changes
- no table changes
- no checklist-line changes
- no alert-threshold changes
- no runtime changes
- no workflow changes
- no registry changes
- no TOML/config changes
- no test changes
- no Paper/Shadow/Evidence/out/S3 mutation
- no market-data mutation
- no Live authorization
