### PR TITLE
docs(p0c): clarify learning promotion loop authority

### DIFF
--- a/docs/LEARNING_PROMOTION_LOOP_INDEX.md
+++ b/docs/LEARNING_PROMOTION_LOOP_INDEX.md
@@ -4,6 +4,12 @@
 **Status:** ✅ Production-Ready  
 **Datum:** 2025-12-11
 
+## Authority and epoch note
+
+This document is a learning/promotion-loop architecture and governance navigation surface, not a standalone promotion authority. `Production-Ready`, `Production-Readiness`, promotion, readiness, registry, or Live-session wording in this document does not, by itself, grant Master V2 approval, Doubleplay authority, PRE_LIFE completion, First-Live readiness, operator authorization, production readiness, experiment authorization, training authorization, or permission to route orders into any live capital path.
+
+Interpret this document together with current gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, staged Execution Enablement, manual-only controls, and the explicit blacklist / P0 / P1 governance in this document. This docs-only note changes no runtime behavior, learning/promotion logic, registry behavior, experiment/training behavior, MLflow behavior, or status/history/checklist content.
+
 ---
 
 ## 🎯 Schnellstart


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/LEARNING_PROMOTION_LOOP_INDEX.md
- clarify that Production-Ready, promotion, readiness, registry, or Live-session wording is not standalone Master V2, Doubleplay, PRE_LIVE, First-Live, operator, production, experiment, training, or Live authority
- preserve the status line, version history, learning paths, checklists, blacklist/P0/P1 governance, and all historical content unchanged

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main
- bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed

## Safety
- docs-only
- no runtime changes
- no training changes
- no MLflow changes
- no workflow changes
- no config changes
- no test changes
- no evidence/cache/market-data mutation
- no Live authorization
