### PR TITLE
docs(p0c): clarify MLflow setup authority

### DIFF
--- a/docs/MLFLOW_SETUP_GUIDE.md
+++ b/docs/MLFLOW_SETUP_GUIDE.md
@@ -4,6 +4,15 @@
 **Audience**: Research Team, Strategy Developers  
 **Status**: Production-Ready (Phase 2)
 
+
+## Authority and epoch note
+
+This document is an MLflow setup, experiment-tracking, and backend-configuration guide, not a standalone promotion or production authority. `Production-Ready`, tracking, backend, model registry, artifact store, experiment registry, promotion, readiness, or deployment wording in this document does not, by itself, grant Master V2 approval, Doubleplay authority, PRE_LIFE completion, First-Live readiness, operator authorization, production readiness, experiment authorization, training authorization, model-promotion authorization, or permission to route orders into any live capital path.
+
+MLflow setup may create or use local or server-backed tracking stores, artifact stores, registry metadata, or experiment records depending on the executed commands. This docs-only note itself runs nothing and changes no storage behavior. Interpret MLflow material together with current gate/evidence/signoff artifacts, Scope / Capital Envelope boundaries, Risk / Exposure Caps, Safety / Kill-Switches, staged Execution Enablement, and manual governance controls.
+
+This note changes no runtime behavior, MLflow behavior, experiment/training behavior, registry behavior, artifact-store behavior, or setup commands.
+
 ---
 
 ## Quick Start (5 Minuten)
@@ -135,7 +144,7 @@ tracker.log_artifact("equity_curve.png", artifact_path="plots/")
 tracker.log_artifact("backtest_report.txt", artifact_path="reports/")
 ```
 
-**Best Practice**: Strukturierte Artifact-Pfade (`plots/`, `reports/`, `models/`).
+**Best Practice**: Strukturierte Artifact-Pfade (`plots&#47;`, `reports&#47;`, `models&#47;`).
 
 ### Tags
 
@@ -446,7 +455,7 @@ finally:
 
 1. Runs nach Metrik sortieren (z.B. "sharpe_ratio")
 2. Filter nutzen: `metrics.sharpe_ratio > 1.5`
-3. Tags filtern: `tags.market = "BTC/EUR"`
+3. Tags filtern: `tags.market = "BTC&#47;EUR"`
 
 ### Artifacts anzeigen
 


### PR DESCRIPTION
## Summary
- add an authority/epoch note to docs/MLFLOW_SETUP_GUIDE.md
- clarify that Production-Ready, MLflow tracking/backend/model-registry/artifact-store/experiment-registry wording is not standalone Master V2, Doubleplay, PRE_LIVE, First-Live, operator, production, experiment, training, model-promotion, or Live authority
- preserve setup steps, backend descriptions, status/history, and all existing MLflow content
- fix existing docs-token-policy issues in the touched file by encoding illustrative slash tokens

## Changed file
- docs/MLFLOW_SETUP_GUIDE.md

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- bash scripts/ops/pt_docs_gates_snapshot.sh --changed
- uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main
- bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main

## Safety
- docs-only
- no runtime changes
- no training changes
- no MLflow server changes
- no workflow changes
- no config changes
- no test changes
- no MLflow-store mutation
- no evidence/cache/market-data mutation
- no Live authorization
