### PR TITLE
feat(master-v2): add double play pure scope state model v0

### DIFF
--- a/src/trading/master_v2/double_play_state.py
+++ b/src/trading/master_v2/double_play_state.py
@@ -1,0 +1,355 @@
+# src/trading/master_v2/double_play_state.py
+"""
+Pure, dependency-light state model for Master V2 Double Play (docs-only target semantics).
+
+No I/O, no exchange, no risk layer wiring. See docs/ops/specs/MASTER_V2_DOUBLE_PLAY_TRADING_LOGIC_MANIFEST_V0.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Tuple
+
+DOUBLE_PLAY_STATE_LAYER_VERSION = "v0"
+
+
+class SideState(str, Enum):
+    """High-level double-play / scope side machine (manifest §4)."""
+
+    NEUTRAL_OBSERVE = "neutral_observe"
+    LONG_ARMED = "long_armed"
+    LONG_ACTIVE = "long_active"
+    LONG_BLOCKED = "long_blocked"
+    SHORT_ARMED = "short_armed"
+    SHORT_ACTIVE = "short_active"
+    SHORT_BLOCKED = "short_blocked"
+    SWITCH_LONG_TO_SHORT_PENDING = "switch_long_to_short_pending"
+    SWITCH_SHORT_TO_LONG_PENDING = "switch_short_to_long_pending"
+    CHOP_GUARD_BLOCK = "chop_guard_block"
+    KILL_ALL = "kill_all"
+
+
+class ScopeEvent(str, Enum):
+    """Scope and safety events (manifest §5, extended with NOOP)."""
+
+    DOWNSCOPE_CANDIDATE = "downscope_candidate"
+    DOWNSCOPE_CONFIRMED = "downscope_confirmed"
+    UPSCOPE_CANDIDATE = "upscope_candidate"
+    UPSCOPE_CONFIRMED = "upscope_confirmed"
+    CHOP_DETECTED = "chop_detected"
+    SCOPE_UNKNOWN = "scope_unknown"
+    KILL_ALL_REQUIRED = "kill_all_required"
+    NOOP = "noop"
+
+
+class ActiveSide(str, Enum):
+    """Which side holds active exposure; manifest invariant: at most one 'active' side."""
+
+    NEUTRAL = "neutral"
+    LONG = "long"
+    SHORT = "short"
+
+
+@dataclass(frozen=True)
+class StaticHardLimits:
+    """Upper bounds; dynamic rules must not widen these (manifest §7.1)."""
+
+    max_notional: float = 0.0
+    max_leverage: float = 0.0
+    max_switches_per_window: int = 0
+    min_band_width: float = 1.0
+    max_band_width: float = 1.0e6
+
+
+@dataclass(frozen=True)
+class RuntimeEnvelope:
+    """Pre-authorized envelope: static limits + policy flags."""
+
+    static: StaticHardLimits
+    live_authorization: bool = False
+
+
+@dataclass(frozen=True)
+class DynamicScopeRules:
+    """Bounded dynamic scope policy (manifest §7.2) — all numeric, no I/O."""
+
+    downscope_band_multiplier: float = 1.0
+    upscope_band_multiplier: float = 1.0
+    min_band_width: float = 0.0
+    max_band_width: float = 1.0e6
+    min_switch_cooldown_ticks: int = 0
+    # Vol proxy for band width in update_dynamic_boundaries; abstract unit.
+    volatility_estimate: float = 1.0
+    # Switches in rolling window (optional enforcement in transition_state)
+    max_switches_per_window: int = 1_000_000
+
+
+@dataclass(frozen=True)
+class RuntimeScopeState:
+    """
+    Hot-path state snapshot: boundaries, anchor, cooldown bookkeeping (manifest §7.3).
+    All mutations happen via ``replace`` in pure functions.
+    """
+
+    anchor_price: float = 0.0
+    current_upscope_boundary: float = 0.0
+    current_downscope_boundary: float = 0.0
+    current_hysteresis_band: float = 0.0
+    last_switch_tick: int = -1_000_000
+    now_tick: int = 0
+    scope_stability_ticks: int = 0
+    switches_in_window: int = 0
+    # Window start for switch counting (simplified: reset every N ticks in caller)
+    window_start_tick: int = 0
+    # Last completed migration to a new ActiveSide (for cooldown)
+    last_completed_side_switch_tick: int = -1_000_000
+    # Chop: cleared via NOOP from CHOP_GUARD in this v0 model
+    chop_latched: bool = False
+
+
+@dataclass(frozen=True)
+class TransitionDecision:
+    """Outcome of ``transition_state``; never authorizes live."""
+
+    allowed: bool
+    reason_code: str
+    live_authorization_granted: bool = False
+
+
+def derive_active_side(side: SideState) -> ActiveSide:
+    if side in (SideState.LONG_ACTIVE,):
+        return ActiveSide.LONG
+    if side in (SideState.SHORT_ACTIVE,):
+        return ActiveSide.SHORT
+    return ActiveSide.NEUTRAL
+
+
+def _both_active_invariant_ok(side: SideState) -> bool:
+    return not (side == SideState.LONG_ACTIVE and side == SideState.SHORT_ACTIVE)
+
+
+def envelope_valid(envelope: RuntimeEnvelope) -> bool:
+    """Fail-closed: invalid envelope blocks transitions."""
+    s = envelope.static
+    if envelope.live_authorization:
+        return False
+    if s.min_band_width <= 0 or s.max_band_width < s.min_band_width:
+        return False
+    if s.max_notional < 0 or s.max_leverage < 0:
+        return False
+    if s.max_switches_per_window < 0:
+        return False
+    return True
+
+
+def rules_valid(rules: DynamicScopeRules) -> bool:
+    if rules.min_band_width < 0 or rules.max_band_width < rules.min_band_width:
+        return False
+    if rules.min_switch_cooldown_ticks < 0:
+        return False
+    if rules.max_switches_per_window < 0:
+        return False
+    return True
+
+
+def _switch_count_ok(rule: DynamicScopeRules, st: RuntimeScopeState) -> bool:
+    if rule.max_switches_per_window <= 0:
+        return True
+    return st.switches_in_window < rule.max_switches_per_window
+
+
+def _cooldown_allows_opposite_switch(
+    *,
+    now_tick: int,
+    st: RuntimeScopeState,
+    rules: DynamicScopeRules,
+) -> bool:
+    if rules.min_switch_cooldown_ticks <= 0:
+        return True
+    return (now_tick - st.last_completed_side_switch_tick) >= rules.min_switch_cooldown_ticks
+
+
+def clamp_band_width(raw: float, rules: DynamicScopeRules, env: RuntimeEnvelope) -> float:
+    lo = max(rules.min_band_width, env.static.min_band_width)
+    hi = min(rules.max_band_width, env.static.max_band_width)
+    if hi < lo:
+        return lo
+    return max(lo, min(hi, raw))
+
+
+def update_dynamic_boundaries(
+    *,
+    mark_price: float,
+    side: ActiveSide,
+    st: RuntimeScopeState,
+    rules: DynamicScopeRules,
+    env: RuntimeEnvelope,
+) -> RuntimeScopeState:
+    """
+    Update trailing anchor and scope boundaries; band width is clamped (manifest §6–7).
+
+    Long: anchor chases new highs; downscope boundary trails below anchor.
+    Short: anchor chases new lows; upscope boundary trails above anchor.
+    """
+    if not envelope_valid(env) or not rules_valid(rules):
+        return st
+    band = clamp_band_width(rules.volatility_estimate * mark_price, rules, env)
+    if side == ActiveSide.LONG:
+        new_anchor = max(st.anchor_price, mark_price) if st.anchor_price > 0 else mark_price
+        down = new_anchor - band
+        up = new_anchor + band  # still bounded; manifest emphasizes downscope side for long
+        return replace(
+            st,
+            anchor_price=new_anchor,
+            current_downscope_boundary=down,
+            current_upscope_boundary=up,
+            current_hysteresis_band=band,
+        )
+    if side == ActiveSide.SHORT:
+        new_anchor = min(st.anchor_price, mark_price) if st.anchor_price > 0 else mark_price
+        up = new_anchor + band
+        down = new_anchor - band
+        return replace(
+            st,
+            anchor_price=new_anchor,
+            current_upscope_boundary=up,
+            current_downscope_boundary=down,
+            current_hysteresis_band=band,
+        )
+    return st
+
+
+def transition_state(
+    *,
+    side_state: SideState,
+    event: ScopeEvent,
+    scope_state: RuntimeScopeState,
+    rules: DynamicScopeRules,
+    envelope: RuntimeEnvelope,
+    now_tick: int,
+) -> Tuple[SideState, RuntimeScopeState, TransitionDecision]:
+    """
+    Single-step state transition. Pure: no I/O, no globals.
+
+    * ``live_authorization`` in envelope must be False; otherwise fail-closed.
+    * KILL_ALL_REQUIRED from any state -> KILL_ALL.
+    * CHOP_DETECTED in armed/pending before activation -> CHOP_GUARD_BLOCK.
+    * Downscope / upscope **confirmed** drive long<->short pipelines (manifest §4).
+    """
+    st = replace(scope_state, now_tick=now_tick)
+
+    if not _both_active_invariant_ok(side_state):
+        return side_state, st, TransitionDecision(False, "INVARIANT_BROKEN_INTERNAL")
+
+    if not envelope_valid(envelope) or not rules_valid(rules):
+        return side_state, st, TransitionDecision(False, "ENVELOPE_OR_RULES_INVALID")
+
+    if side_state == SideState.KILL_ALL and event == ScopeEvent.KILL_ALL_REQUIRED:
+        return side_state, st, TransitionDecision(True, "ALREADY_KILL_ALL")
+    if event == ScopeEvent.KILL_ALL_REQUIRED:
+        st2 = replace(st, last_switch_tick=now_tick)
+        return SideState.KILL_ALL, st2, TransitionDecision(True, "KILL_ALL")
+
+    if side_state == SideState.KILL_ALL:
+        return side_state, st, TransitionDecision(False, "IN_KILL_ALL")
+
+    if event in (ScopeEvent.SCOPE_UNKNOWN,):
+        return side_state, st, TransitionDecision(False, "SCOPE_UNKNOWN_FAIL_CLOSED")
+
+    if event in (ScopeEvent.CHOP_DETECTED,):
+        if side_state in (
+            SideState.SHORT_ARMED,
+            SideState.LONG_ARMED,
+            SideState.SWITCH_LONG_TO_SHORT_PENDING,
+            SideState.SWITCH_SHORT_TO_LONG_PENDING,
+        ):
+            st2 = replace(st, chop_latched=True, last_switch_tick=now_tick)
+            return SideState.CHOP_GUARD_BLOCK, st2, TransitionDecision(True, "CHOP_GUARD")
+        return side_state, st, TransitionDecision(False, "CHOP_IRRELEVANT")
+
+    if side_state == SideState.CHOP_GUARD_BLOCK and event == ScopeEvent.NOOP:
+        st2 = replace(st, chop_latched=False)
+        return SideState.NEUTRAL_OBSERVE, st2, TransitionDecision(True, "CHOP_CLEAR")
+
+    if side_state == SideState.CHOP_GUARD_BLOCK:
+        return side_state, st, TransitionDecision(False, "CHOP_STILL_BLOCKING")
+
+    # Cooldown: block starting a new opposite-direction pipeline from active side
+    if event == ScopeEvent.DOWNSCOPE_CONFIRMED and side_state == SideState.LONG_ACTIVE:
+        if not _cooldown_allows_opposite_switch(now_tick=now_tick, st=st, rules=rules):
+            return side_state, st, TransitionDecision(False, "COOLDOWN_BLOCK")
+        if not _switch_count_ok(rules, st):
+            return side_state, st, TransitionDecision(False, "MAX_SWITCHES")
+        st2 = replace(st, last_switch_tick=now_tick, switches_in_window=st.switches_in_window + 1)
+        return (
+            SideState.SWITCH_LONG_TO_SHORT_PENDING,
+            st2,
+            TransitionDecision(True, "DOWNscope_SWITCH_PENDING"),
+        )
+
+    if (
+        event == ScopeEvent.DOWNSCOPE_CONFIRMED
+        and side_state == SideState.SWITCH_LONG_TO_SHORT_PENDING
+    ):
+        return (
+            SideState.LONG_BLOCKED,
+            st,
+            TransitionDecision(True, "LONG_BLOCKED"),
+        )
+
+    if event == ScopeEvent.DOWNSCOPE_CONFIRMED and side_state == SideState.LONG_BLOCKED:
+        return SideState.SHORT_ARMED, st, TransitionDecision(True, "SHORT_ARMED")
+
+    if event == ScopeEvent.DOWNSCOPE_CONFIRMED and side_state == SideState.SHORT_ARMED:
+        st2 = replace(
+            st,
+            last_completed_side_switch_tick=now_tick,
+            last_switch_tick=now_tick,
+        )
+        return SideState.SHORT_ACTIVE, st2, TransitionDecision(True, "SHORT_ACTIVE")
+
+    if event == ScopeEvent.UPSCOPE_CONFIRMED and side_state == SideState.SHORT_ACTIVE:
+        if not _cooldown_allows_opposite_switch(now_tick=now_tick, st=st, rules=rules):
+            return side_state, st, TransitionDecision(False, "COOLDOWN_BLOCK")
+        if not _switch_count_ok(rules, st):
+            return side_state, st, TransitionDecision(False, "MAX_SWITCHES")
+        st2 = replace(st, last_switch_tick=now_tick, switches_in_window=st.switches_in_window + 1)
+        return (
+            SideState.SWITCH_SHORT_TO_LONG_PENDING,
+            st2,
+            TransitionDecision(True, "UPscope_SWITCH_PENDING"),
+        )
+
+    if (
+        event == ScopeEvent.UPSCOPE_CONFIRMED
+        and side_state == SideState.SWITCH_SHORT_TO_LONG_PENDING
+    ):
+        return SideState.SHORT_BLOCKED, st, TransitionDecision(True, "SHORT_BLOCKED")
+
+    if event == ScopeEvent.UPSCOPE_CONFIRMED and side_state == SideState.SHORT_BLOCKED:
+        return SideState.LONG_ARMED, st, TransitionDecision(True, "LONG_ARMED")
+
+    if event == ScopeEvent.UPSCOPE_CONFIRMED and side_state == SideState.LONG_ARMED:
+        st2 = replace(
+            st,
+            last_completed_side_switch_tick=now_tick,
+            last_switch_tick=now_tick,
+        )
+        return SideState.LONG_ACTIVE, st2, TransitionDecision(True, "LONG_ACTIVE")
+
+    # Neutral start (manifest: neutral -> armed -> active)
+    if event == ScopeEvent.UPSCOPE_CONFIRMED and side_state == SideState.NEUTRAL_OBSERVE:
+        return SideState.LONG_ARMED, st, TransitionDecision(True, "NEUTRAL_TO_LONG_ARMED")
+
+    if event == ScopeEvent.DOWNSCOPE_CONFIRMED and side_state == SideState.NEUTRAL_OBSERVE:
+        return SideState.SHORT_ARMED, st, TransitionDecision(True, "NEUTRAL_TO_SHORT_ARMED")
+
+    if event in (ScopeEvent.DOWNSCOPE_CANDIDATE, ScopeEvent.UPSCOPE_CANDIDATE):
+        st2 = replace(st, scope_stability_ticks=st.scope_stability_ticks + 1)
+        return side_state, st2, TransitionDecision(True, "CANDIDATE_ACK")
+
+    if event == ScopeEvent.NOOP:
+        return side_state, st, TransitionDecision(True, "NOOP")
+
+    return side_state, st, TransitionDecision(False, "NO_TRANSITION")

--- a/tests/trading/master_v2/test_double_play_state.py
+++ b/tests/trading/master_v2/test_double_play_state.py
@@ -1,0 +1,277 @@
+# tests/trading/master_v2/test_double_play_state.py
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.double_play_state import (
+    ActiveSide,
+    DOUBLE_PLAY_STATE_LAYER_VERSION,
+    DynamicScopeRules,
+    RuntimeEnvelope,
+    RuntimeScopeState,
+    ScopeEvent,
+    SideState,
+    StaticHardLimits,
+    TransitionDecision,
+    derive_active_side,
+    envelope_valid,
+    rules_valid,
+    transition_state,
+    update_dynamic_boundaries,
+    clamp_band_width,
+)
+
+GOOD = StaticHardLimits(
+    max_notional=1.0,
+    max_leverage=1.0,
+    max_switches_per_window=100,
+    min_band_width=1.0,
+    max_band_width=100.0,
+)
+GOOD_ENVELOPE = RuntimeEnvelope(static=GOOD, live_authorization=False)
+GOOD_RULES = DynamicScopeRules(
+    min_band_width=1.0,
+    max_band_width=50.0,
+    min_switch_cooldown_ticks=0,
+    max_switches_per_window=1_000_000,
+    volatility_estimate=0.1,
+)
+EMPTY_ST = RuntimeScopeState()
+
+
+def _t(
+    side: SideState,
+    event: ScopeEvent,
+    st: RuntimeScopeState,
+    now: int = 0,
+) -> tuple[SideState, RuntimeScopeState, TransitionDecision]:
+    return transition_state(
+        side_state=side,
+        event=event,
+        scope_state=st,
+        rules=GOOD_RULES,
+        envelope=GOOD_ENVELOPE,
+        now_tick=now,
+    )
+
+
+def test_version_constant():
+    assert DOUBLE_PLAY_STATE_LAYER_VERSION == "v0"
+
+
+def test_both_sides_cannot_both_be_active_invariant_expressed_in_derivation():
+    """Invariant 1: at most one of LONG/SHORT is ActiveSide active."""
+    assert derive_active_side(SideState.LONG_ACTIVE) == ActiveSide.LONG
+    assert derive_active_side(SideState.SHORT_ACTIVE) == ActiveSide.SHORT
+    assert derive_active_side(SideState.LONG_ARMED) == ActiveSide.NEUTRAL
+    assert derive_active_side(SideState.KILL_ALL) == ActiveSide.NEUTRAL
+    for s in SideState:
+        ab = derive_active_side(s) == ActiveSide.LONG
+        be = derive_active_side(s) == ActiveSide.SHORT
+        assert not (ab and be)
+
+
+def test_downscope_pipeline_from_long_active():
+    """Downscope from LONG_ACTIVE moves through pending and blocked to SHORT (tests 2)."""
+    st = EMPTY_ST
+    s, st2, d = _t(SideState.LONG_ACTIVE, ScopeEvent.DOWNSCOPE_CONFIRMED, st, 0)
+    assert s == SideState.SWITCH_LONG_TO_SHORT_PENDING and d.allowed
+    s, st2, d = _t(s, ScopeEvent.DOWNSCOPE_CONFIRMED, st2, 1)
+    assert s == SideState.LONG_BLOCKED and d.allowed
+    s, st2, d = _t(s, ScopeEvent.DOWNSCOPE_CONFIRMED, st2, 2)
+    assert s == SideState.SHORT_ARMED
+    s, st2, d = _t(s, ScopeEvent.DOWNSCOPE_CONFIRMED, st2, 3)
+    assert s == SideState.SHORT_ACTIVE and d.reason_code == "SHORT_ACTIVE"
+
+
+def test_upscope_pipeline_from_short_active():
+    """Upscope from SHORT_ACTIVE moves through pending/ blocked to LONG (test 3)."""
+    st = EMPTY_ST
+    s, st2, d = _t(SideState.SHORT_ACTIVE, ScopeEvent.UPSCOPE_CONFIRMED, st, 0)
+    assert s == SideState.SWITCH_SHORT_TO_LONG_PENDING
+    s, st2, d = _t(s, ScopeEvent.UPSCOPE_CONFIRMED, st2, 1)
+    assert s == SideState.SHORT_BLOCKED
+    s, st2, d = _t(s, ScopeEvent.UPSCOPE_CONFIRMED, st2, 2)
+    assert s == SideState.LONG_ARMED
+    s, st2, d = _t(s, ScopeEvent.UPSCOPE_CONFIRMED, st2, 3)
+    assert s == SideState.LONG_ACTIVE
+
+
+def test_kill_all_overrides_switch():
+    """Test 4: KILL_ALL_REQUIRED from PENDING or ACTIVE -> KILL_ALL."""
+    s, _, d = _t(SideState.SWITCH_LONG_TO_SHORT_PENDING, ScopeEvent.KILL_ALL_REQUIRED, EMPTY_ST, 0)
+    assert s == SideState.KILL_ALL and d.allowed
+    s, _, d = _t(SideState.LONG_ACTIVE, ScopeEvent.KILL_ALL_REQUIRED, EMPTY_ST, 0)
+    assert s == SideState.KILL_ALL
+    s, _, d = _t(SideState.KILL_ALL, ScopeEvent.DOWNSCOPE_CONFIRMED, EMPTY_ST, 0)
+    assert s == SideState.KILL_ALL and not d.allowed
+
+
+def test_chop_blocks_from_short_armed():
+    """Test 5: CHOP on armed blocks activation path."""
+    s, _, d = _t(SideState.SHORT_ARMED, ScopeEvent.CHOP_DETECTED, EMPTY_ST, 0)
+    assert s == SideState.CHOP_GUARD_BLOCK
+    s2, _, d2 = _t(s, ScopeEvent.DOWNSCOPE_CONFIRMED, EMPTY_ST, 1)
+    assert s2 == SideState.CHOP_GUARD_BLOCK and not d2.allowed
+
+
+def test_cooldown_prevents_immediate_reversal():
+    """Test 6: min_switch_cooldown_ticks blocks starting opposite switch too soon after activation."""
+    r = DynamicScopeRules(
+        min_band_width=1.0,
+        max_band_width=50.0,
+        min_switch_cooldown_ticks=5,
+        max_switches_per_window=1_000_000,
+        volatility_estimate=0.1,
+    )
+    # Just landed LONG_ACTIVE: last_completed records entry at tick 10
+    st_long = replace(EMPTY_ST, last_completed_side_switch_tick=10, last_switch_tick=10)
+    s, _, d = transition_state(
+        side_state=SideState.LONG_ACTIVE,
+        event=ScopeEvent.DOWNSCOPE_CONFIRMED,
+        scope_state=st_long,
+        rules=r,
+        envelope=GOOD_ENVELOPE,
+        now_tick=12,  # 12-10 < 5
+    )
+    assert s == SideState.LONG_ACTIVE and d.reason_code == "COOLDOWN_BLOCK"
+    s, _, d = transition_state(
+        side_state=SideState.LONG_ACTIVE,
+        event=ScopeEvent.DOWNSCOPE_CONFIRMED,
+        scope_state=st_long,
+        rules=r,
+        envelope=GOOD_ENVELOPE,
+        now_tick=16,  # 16-10 >= 5
+    )
+    assert s == SideState.SWITCH_LONG_TO_SHORT_PENDING and d.allowed
+
+
+def test_invalid_envelope_fails_closed():
+    """Test 7: bad envelope / live_auth blocks."""
+    bad = RuntimeEnvelope(
+        static=StaticHardLimits(min_band_width=10.0, max_band_width=1.0),
+        live_authorization=False,
+    )
+    s, _, d = transition_state(
+        side_state=SideState.LONG_ACTIVE,
+        event=ScopeEvent.DOWNSCOPE_CONFIRMED,
+        scope_state=EMPTY_ST,
+        rules=GOOD_RULES,
+        envelope=bad,
+        now_tick=0,
+    )
+    assert s == SideState.LONG_ACTIVE and not d.allowed
+    live_env = RuntimeEnvelope(static=GOOD, live_authorization=True)
+    assert not envelope_valid(live_env)
+    s2, _, d2 = transition_state(
+        side_state=SideState.LONG_ACTIVE,
+        event=ScopeEvent.DOWNSCOPE_CONFIRMED,
+        scope_state=EMPTY_ST,
+        rules=GOOD_RULES,
+        envelope=live_env,
+        now_tick=0,
+    )
+    assert s2 == SideState.LONG_ACTIVE and not d2.allowed
+
+
+def test_clamp_dynamic_band():
+    """Test 8: band width clamped to [min, max] across rules + static."""
+    r = DynamicScopeRules(
+        min_band_width=1.0,
+        max_band_width=10.0,
+        min_switch_cooldown_ticks=0,
+        max_switches_per_window=1_000_000,
+        volatility_estimate=1e6,
+    )
+    w = clamp_band_width(1e9, r, GOOD_ENVELOPE)
+    assert w <= 100.0 and w >= 1.0
+
+
+def test_trailing_long_anchor_upward():
+    """Test 9: long anchor ratchets up; downscope boundary follows below anchor."""
+    st = RuntimeScopeState(anchor_price=100.0, now_tick=0)
+    r = DynamicScopeRules(
+        min_band_width=2.0,
+        max_band_width=20.0,
+        min_switch_cooldown_ticks=0,
+        max_switches_per_window=1_000_000,
+        volatility_estimate=0.05,
+    )
+    st2 = update_dynamic_boundaries(
+        mark_price=120.0, side=ActiveSide.LONG, st=st, rules=r, env=GOOD_ENVELOPE
+    )
+    assert st2.anchor_price == 120.0
+    assert st2.current_downscope_boundary < st2.anchor_price
+    assert (st2.anchor_price - st2.current_downscope_boundary) == pytest.approx(
+        st2.current_hysteresis_band
+    )
+
+
+def test_trailing_short_anchor_downward():
+    """Test 10: short anchor ratchets down; upscope boundary follows above."""
+    st = RuntimeScopeState(anchor_price=100.0, now_tick=0)
+    r = DynamicScopeRules(
+        min_band_width=2.0,
+        max_band_width=20.0,
+        min_switch_cooldown_ticks=0,
+        max_switches_per_window=1_000_000,
+        volatility_estimate=0.05,
+    )
+    st2 = update_dynamic_boundaries(
+        mark_price=80.0, side=ActiveSide.SHORT, st=st, rules=r, env=GOOD_ENVELOPE
+    )
+    assert st2.anchor_price == 80.0
+    assert st2.current_upscope_boundary > st2.anchor_price
+
+
+def test_no_transition_grants_live():
+    """Test 11: TransitionDecision always has live_authorization_granted False."""
+    for ev in ScopeEvent:
+        s, _, d = _t(SideState.LONG_ACTIVE, ev, EMPTY_ST, 0)
+        assert d.live_authorization_granted is False
+        s, _, d = _t(SideState.NEUTRAL_OBSERVE, ev, EMPTY_ST, 0)
+        assert d.live_authorization_granted is False
+
+
+def test_pure_module_no_network_side_effect_imports():
+    """Test 12: module uses stdlib + local imports only; transition is referentially transparent."""
+    p = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "src"
+        / "trading"
+        / "master_v2"
+        / "double_play_state.py"
+    )
+    tree = ast.parse(p.read_text(encoding="utf-8"))
+    bad = {"requests", "urllib", "ccxt", "httpx", "socket"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                assert n.name.split(".")[0] not in bad
+        if isinstance(node, ast.ImportFrom):
+            if node.module and node.module.split(".")[0] in bad:
+                raise AssertionError(node.module)
+    a = _t(SideState.LONG_ACTIVE, ScopeEvent.NOOP, EMPTY_ST, 0)
+    b = _t(SideState.LONG_ACTIVE, ScopeEvent.NOOP, EMPTY_ST, 0)
+    assert a == b
+
+
+def test_invalid_rules_fails():
+    r = DynamicScopeRules(
+        min_band_width=20.0,
+        max_band_width=1.0,
+    )
+    assert not rules_valid(r)
+    s, _, d = transition_state(
+        side_state=SideState.LONG_ACTIVE,
+        event=ScopeEvent.DOWNSCOPE_CONFIRMED,
+        scope_state=EMPTY_ST,
+        rules=r,
+        envelope=GOOD_ENVELOPE,
+        now_tick=0,
+    )
+    assert not d.allowed


### PR DESCRIPTION
## Summary
- add pure Master V2 Double Play state/scope model v0
- define SideState, ScopeEvent, ActiveSide, StaticHardLimits, RuntimeEnvelope, DynamicScopeRules, RuntimeScopeState, TransitionDecision
- add pure helpers for envelope/rules validation, band clamping, dynamic boundary updates, active-side derivation, and transition_state
- add focused unit tests for state-switch invariants, Kill-All, Chop Guard, cooldown, envelope fail-closed behavior, dynamic band clamping, trailing boundaries, no-live invariant, and pure/no-network-import constraints

## Changed files
- src/trading/master_v2/double_play_state.py
- tests/trading/master_v2/test_double_play_state.py

## Validation
- uv run pytest tests/trading/master_v2/test_double_play_state.py -q
- uv run ruff check src/trading/master_v2 tests/trading/master_v2
- uv run ruff format --check src/trading/master_v2 tests/trading/master_v2

## Safety
- pure model + unit tests only
- no execution/orchestrator/session changes
- no risk gate / safety guard / kill switch changes
- no exchange adapter changes
- no workflow changes
- no config changes
- no scanner/backtest/market-data/exchange calls
- no out/evidence/S3/cache mutation
- no testnet or Live authorization

Made with [Cursor](https://cursor.com)