### PR TITLE
feat(master-v2): add double play survival envelope model v0

### DIFF
--- a/src/trading/master_v2/double_play_survival.py
+++ b/src/trading/master_v2/double_play_survival.py
@@ -1,0 +1,268 @@
+# src/trading/master_v2/double_play_survival.py
+"""
+Pure Double Play Survival Envelope model (docs-only target semantics).
+
+Encodes arithmetic completeness, sequence metrics, and fail-closed evaluation per
+docs/ops/specs/MASTER_V2_DOUBLE_PLAY_ARITHMETIC_SEQUENCE_SURVIVAL_CONTRACT_V0.md.
+No I/O, no exchange, no execution, no risk wiring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+DOUBLE_PLAY_SURVIVAL_LAYER_VERSION = "v0"
+
+
+class SurvivalBlockReason(str, Enum):
+    """Why pre-authorization is blocked (model status only, non-authority)."""
+
+    INCOMPLETE_FINGERPRINT = "incomplete_fingerprint"
+    MISSING_FUNDING_FOR_PERP = "missing_funding_for_perpetual"
+    MISSING_LIQUIDATION_MODEL = "missing_liquidation_model"
+    INCOMPLETE_SEQUENCE_METRICS = "incomplete_sequence_metrics"
+    PATH_SURVIVAL_TOO_LOW = "path_survival_too_low"
+    EARLY_LOSS_TOO_HIGH = "early_loss_toxicity_too_high"
+    MARGIN_BUFFER_AT_RISK_TOO_LOW = "margin_buffer_at_risk_99_too_low"
+    SEQUENCE_FRAGILITY_TOO_HIGH = "sequence_fragility_too_high"
+    LIQUIDATION_NEAR_MISS_TOO_HIGH = "liquidation_near_miss_too_high"
+    GOVERNANCE_BREACH_TOO_HIGH = "governance_breach_frequency_too_high"
+    CHOP_SWITCH_SURVIVAL_TOO_LOW = "chop_switch_survival_too_low"
+    LONG_LEVERAGE_TOO_HIGH = "long_leverage_too_high"
+    SHORT_LEVERAGE_TOO_HIGH = "short_leverage_too_high"
+    LONG_LIQUIDATION_BUFFER_TOO_LOW = "long_liquidation_buffer_too_low"
+    SHORT_LIQUIDATION_BUFFER_TOO_LOW = "short_liquidation_buffer_too_low"
+    LONG_ADVERSE_FILL_LOSS_TOO_HIGH = "long_adverse_fill_loss_too_high"
+    SHORT_ADVERSE_FILL_LOSS_TOO_HIGH = "short_adverse_fill_loss_too_high"
+
+
+class SurvivalEnvelopeStatus(str, Enum):
+    """Coarse result of ``evaluate_survival_envelope``."""
+
+    OK = "ok"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class ArithmeticFingerprint:
+    """Component completeness for the futures Arithmetic Kernel (contract §6)."""
+
+    contract_spec_complete: bool = False
+    fee_model_complete: bool = False
+    slippage_model_complete: bool = False
+    funding_model_complete: bool = False
+    margin_model_complete: bool = False
+    liquidation_model_complete: bool = False
+    rounding_model_complete: bool = False
+
+
+@dataclass(frozen=True)
+class LayerArithmeticStatus:
+    """Per-side arithmetic fingerprint numbers (long/bull or short/bear)."""
+
+    max_effective_leverage: float
+    min_liquidation_buffer: float
+    fee_breakeven_bps: float
+    expected_adverse_fill_loss: float
+    funding_cost_profile: str
+    is_perpetual: bool
+
+
+@dataclass(frozen=True)
+class SequenceSurvivalMetrics:
+    """
+    Path / sequence survival inputs (all optional: ``None`` = missing for fail-closed).
+    """
+
+    path_survival_ratio: Optional[float] = None
+    early_loss_toxicity: Optional[float] = None
+    margin_buffer_at_risk_99: Optional[float] = None
+    sequence_fragility_index: Optional[float] = None
+    liquidation_near_miss_rate: Optional[float] = None
+    governance_breach_frequency: Optional[float] = None
+    chop_switch_survival_score: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class StateSwitchSurvivalLimits:
+    """
+    Pre-arm thresholds. ``live_authorization`` must not grant Live; evaluation
+    still returns ``live_authorization`` false on the decision.
+    """
+
+    min_path_survival_ratio: float
+    max_early_loss_toxicity: float
+    min_margin_buffer_at_risk_99: float
+    max_sequence_fragility_index: float
+    max_liquidation_near_miss_rate: float
+    max_governance_breach_frequency: float
+    min_chop_switch_survival_score: float
+    max_effective_leverage: float
+    min_liquidation_buffer: float
+    max_adverse_fill_loss: float
+    live_authorization: bool = False
+
+
+@dataclass(frozen=True)
+class DoublePlaySurvivalEnvelope:
+    """Bundle passed to :func:`evaluate_survival_envelope`."""
+
+    fingerprint: ArithmeticFingerprint
+    long_layer: LayerArithmeticStatus
+    short_layer: LayerArithmeticStatus
+    sequence: SequenceSurvivalMetrics
+    limits: StateSwitchSurvivalLimits
+
+
+@dataclass(frozen=True)
+class SurvivalEnvelopeDecision:
+    """
+    Outcome: ``pre_authorization_eligible`` is model-level status only, not execution
+    or session permission. ``live_authorization`` is always false.
+    """
+
+    status: SurvivalEnvelopeStatus
+    pre_authorization_eligible: bool
+    block_reasons: Tuple[SurvivalBlockReason, ...]
+    live_authorization: bool = False
+
+
+def core_fingerprint_complete(fp: ArithmeticFingerprint) -> bool:
+    """Contract, fee, slippage, margin, rounding (funding/liquidation checked separately)."""
+
+    return all(
+        (
+            fp.contract_spec_complete,
+            fp.fee_model_complete,
+            fp.slippage_model_complete,
+            fp.margin_model_complete,
+            fp.rounding_model_complete,
+        )
+    )
+
+
+def arithmetic_complete(fp: ArithmeticFingerprint) -> bool:
+    """All seven fields true — used for a fully 'green' fingerprint (e.g. test 15)."""
+
+    return (
+        core_fingerprint_complete(fp)
+        and fp.funding_model_complete
+        and fp.liquidation_model_complete
+    )
+
+
+def layer_arithmetic_complete(
+    long_layer: LayerArithmeticStatus,
+    short_layer: LayerArithmeticStatus,
+) -> bool:
+    """Both layers present with finite numeric fields (structural sanity)."""
+    for layer in (long_layer, short_layer):
+        for x in (
+            layer.max_effective_leverage,
+            layer.min_liquidation_buffer,
+            layer.fee_breakeven_bps,
+            layer.expected_adverse_fill_loss,
+        ):
+            if x != x:  # NaN
+                return False
+    return True
+
+
+def sequence_metrics_complete(seq: SequenceSurvivalMetrics) -> bool:
+    return all(
+        (
+            seq.path_survival_ratio is not None,
+            seq.early_loss_toxicity is not None,
+            seq.margin_buffer_at_risk_99 is not None,
+            seq.sequence_fragility_index is not None,
+            seq.liquidation_near_miss_rate is not None,
+            seq.governance_breach_frequency is not None,
+            seq.chop_switch_survival_score is not None,
+        )
+    )
+
+
+def evaluate_survival_envelope(
+    envelope: DoublePlaySurvivalEnvelope,
+) -> SurvivalEnvelopeDecision:
+    """
+    Fail-closed evaluation. Never authorizes live; never returns live_authorization
+    on the decision (always ``False``) even if ``limits.live_authorization`` is true.
+    """
+    r: list[SurvivalBlockReason] = []
+    fp = envelope.fingerprint
+    lo = envelope.long_layer
+    sh = envelope.short_layer
+    seq = envelope.sequence
+    lim = envelope.limits
+
+    if (lo.is_perpetual or sh.is_perpetual) and not fp.funding_model_complete:
+        r.append(SurvivalBlockReason.MISSING_FUNDING_FOR_PERP)
+    if not fp.liquidation_model_complete:
+        r.append(SurvivalBlockReason.MISSING_LIQUIDATION_MODEL)
+    if not core_fingerprint_complete(fp):
+        r.append(SurvivalBlockReason.INCOMPLETE_FINGERPRINT)
+    if not sequence_metrics_complete(seq):
+        r.append(SurvivalBlockReason.INCOMPLETE_SEQUENCE_METRICS)
+
+    if r:
+        return SurvivalEnvelopeDecision(
+            status=SurvivalEnvelopeStatus.BLOCKED,
+            pre_authorization_eligible=False,
+            block_reasons=tuple(r),
+            live_authorization=False,
+        )
+
+    # Sequence threshold checks (all metrics known)
+    assert seq.path_survival_ratio is not None
+    if seq.path_survival_ratio < lim.min_path_survival_ratio:
+        r.append(SurvivalBlockReason.PATH_SURVIVAL_TOO_LOW)
+    assert seq.early_loss_toxicity is not None
+    if seq.early_loss_toxicity > lim.max_early_loss_toxicity:
+        r.append(SurvivalBlockReason.EARLY_LOSS_TOO_HIGH)
+    assert seq.margin_buffer_at_risk_99 is not None
+    if seq.margin_buffer_at_risk_99 < lim.min_margin_buffer_at_risk_99:
+        r.append(SurvivalBlockReason.MARGIN_BUFFER_AT_RISK_TOO_LOW)
+    assert seq.sequence_fragility_index is not None
+    if seq.sequence_fragility_index > lim.max_sequence_fragility_index:
+        r.append(SurvivalBlockReason.SEQUENCE_FRAGILITY_TOO_HIGH)
+    assert seq.liquidation_near_miss_rate is not None
+    if seq.liquidation_near_miss_rate > lim.max_liquidation_near_miss_rate:
+        r.append(SurvivalBlockReason.LIQUIDATION_NEAR_MISS_TOO_HIGH)
+    assert seq.governance_breach_frequency is not None
+    if seq.governance_breach_frequency > lim.max_governance_breach_frequency:
+        r.append(SurvivalBlockReason.GOVERNANCE_BREACH_TOO_HIGH)
+    assert seq.chop_switch_survival_score is not None
+    if seq.chop_switch_survival_score < lim.min_chop_switch_survival_score:
+        r.append(SurvivalBlockReason.CHOP_SWITCH_SURVIVAL_TOO_LOW)
+
+    # Layer limits
+    if lo.max_effective_leverage > lim.max_effective_leverage:
+        r.append(SurvivalBlockReason.LONG_LEVERAGE_TOO_HIGH)
+    if sh.max_effective_leverage > lim.max_effective_leverage:
+        r.append(SurvivalBlockReason.SHORT_LEVERAGE_TOO_HIGH)
+    if lo.min_liquidation_buffer < lim.min_liquidation_buffer:
+        r.append(SurvivalBlockReason.LONG_LIQUIDATION_BUFFER_TOO_LOW)
+    if sh.min_liquidation_buffer < lim.min_liquidation_buffer:
+        r.append(SurvivalBlockReason.SHORT_LIQUIDATION_BUFFER_TOO_LOW)
+    if lo.expected_adverse_fill_loss > lim.max_adverse_fill_loss:
+        r.append(SurvivalBlockReason.LONG_ADVERSE_FILL_LOSS_TOO_HIGH)
+    if sh.expected_adverse_fill_loss > lim.max_adverse_fill_loss:
+        r.append(SurvivalBlockReason.SHORT_ADVERSE_FILL_LOSS_TOO_HIGH)
+
+    if r:
+        return SurvivalEnvelopeDecision(
+            status=SurvivalEnvelopeStatus.BLOCKED,
+            pre_authorization_eligible=False,
+            block_reasons=tuple(r),
+            live_authorization=False,
+        )
+
+    return SurvivalEnvelopeDecision(
+        status=SurvivalEnvelopeStatus.OK,
+        pre_authorization_eligible=True,
+        block_reasons=(),
+        live_authorization=False,
+    )

--- a/tests/trading/master_v2/test_double_play_survival.py
+++ b/tests/trading/master_v2/test_double_play_survival.py
@@ -1,0 +1,239 @@
+# tests/trading/master_v2/test_double_play_survival.py
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+from trading.master_v2.double_play_survival import (
+    DOUBLE_PLAY_SURVIVAL_LAYER_VERSION,
+    ArithmeticFingerprint,
+    DoublePlaySurvivalEnvelope,
+    LayerArithmeticStatus,
+    SequenceSurvivalMetrics,
+    StateSwitchSurvivalLimits,
+    SurvivalBlockReason,
+    SurvivalEnvelopeStatus,
+    arithmetic_complete,
+    evaluate_survival_envelope,
+)
+
+GOOD_LIM = StateSwitchSurvivalLimits(
+    min_path_survival_ratio=0.5,
+    max_early_loss_toxicity=0.9,
+    min_margin_buffer_at_risk_99=0.1,
+    max_sequence_fragility_index=0.5,
+    max_liquidation_near_miss_rate=0.2,
+    max_governance_breach_frequency=0.05,
+    min_chop_switch_survival_score=0.4,
+    max_effective_leverage=20.0,
+    min_liquidation_buffer=0.05,
+    max_adverse_fill_loss=0.15,
+    live_authorization=False,
+)
+
+
+def _layer() -> LayerArithmeticStatus:
+    return LayerArithmeticStatus(
+        max_effective_leverage=10.0,
+        min_liquidation_buffer=0.1,
+        fee_breakeven_bps=2.0,
+        expected_adverse_fill_loss=0.05,
+        funding_cost_profile="flat",
+        is_perpetual=True,
+    )
+
+
+def _fp_ok() -> ArithmeticFingerprint:
+    return ArithmeticFingerprint(
+        contract_spec_complete=True,
+        fee_model_complete=True,
+        slippage_model_complete=True,
+        funding_model_complete=True,
+        margin_model_complete=True,
+        liquidation_model_complete=True,
+        rounding_model_complete=True,
+    )
+
+
+def _seq_ok() -> SequenceSurvivalMetrics:
+    return SequenceSurvivalMetrics(
+        path_survival_ratio=0.8,
+        early_loss_toxicity=0.2,
+        margin_buffer_at_risk_99=0.2,
+        sequence_fragility_index=0.2,
+        liquidation_near_miss_rate=0.05,
+        governance_breach_frequency=0.01,
+        chop_switch_survival_score=0.7,
+    )
+
+
+def _env(
+    fp: ArithmeticFingerprint,
+    long_layer: LayerArithmeticStatus | None = None,
+    short_layer: LayerArithmeticStatus | None = None,
+    seq: SequenceSurvivalMetrics | None = None,
+    lim: StateSwitchSurvivalLimits | None = None,
+) -> DoublePlaySurvivalEnvelope:
+    return DoublePlaySurvivalEnvelope(
+        fingerprint=fp,
+        long_layer=long_layer or _layer(),
+        short_layer=short_layer or _layer(),
+        sequence=seq or _seq_ok(),
+        limits=lim or GOOD_LIM,
+    )
+
+
+def test_version():
+    assert DOUBLE_PLAY_SURVIVAL_LAYER_VERSION == "v0"
+
+
+def test_1_incomplete_fingerprint_blocks():
+    fp = replace(
+        _fp_ok(),
+        contract_spec_complete=False,
+    )
+    d = evaluate_survival_envelope(_env(fp))
+    assert d.status == SurvivalEnvelopeStatus.BLOCKED
+    assert SurvivalBlockReason.INCOMPLETE_FINGERPRINT in d.block_reasons
+    assert not d.pre_authorization_eligible
+
+
+def test_2_missing_funding_for_perp_blocks():
+    fp = replace(_fp_ok(), funding_model_complete=False)
+    d = evaluate_survival_envelope(_env(fp))
+    assert SurvivalBlockReason.MISSING_FUNDING_FOR_PERP in d.block_reasons
+    l = LayerArithmeticStatus(10, 0.1, 2, 0.05, "x", is_perpetual=False)
+    d2 = evaluate_survival_envelope(
+        _env(
+            replace(_fp_ok(), funding_model_complete=False),
+            long_layer=l,
+            short_layer=l,
+        )
+    )
+    assert SurvivalBlockReason.MISSING_FUNDING_FOR_PERP not in d2.block_reasons
+
+
+def test_3_missing_liquidation_model_blocks():
+    fp = replace(_fp_ok(), liquidation_model_complete=False)
+    d = evaluate_survival_envelope(_env(fp))
+    assert SurvivalBlockReason.MISSING_LIQUIDATION_MODEL in d.block_reasons
+
+
+def test_4_missing_sequence_metrics_blocks():
+    fp = _fp_ok()
+    seq = SequenceSurvivalMetrics(path_survival_ratio=0.5, early_loss_toxicity=None)
+    d = evaluate_survival_envelope(_env(fp, seq=seq))
+    assert SurvivalBlockReason.INCOMPLETE_SEQUENCE_METRICS in d.block_reasons
+
+
+def test_5_path_survival_too_low():
+    seq = replace(_seq_ok(), path_survival_ratio=0.1)
+    d = evaluate_survival_envelope(_env(_fp_ok(), seq=seq))
+    assert SurvivalBlockReason.PATH_SURVIVAL_TOO_LOW in d.block_reasons
+
+
+def test_6_early_loss_too_high():
+    seq = replace(_seq_ok(), early_loss_toxicity=1.0)
+    d = evaluate_survival_envelope(_env(_fp_ok(), seq=seq))
+    assert SurvivalBlockReason.EARLY_LOSS_TOO_HIGH in d.block_reasons
+
+
+def test_7_margin_buffer_at_risk_too_low():
+    seq = replace(_seq_ok(), margin_buffer_at_risk_99=0.01)
+    d = evaluate_survival_envelope(_env(_fp_ok(), seq=seq))
+    assert SurvivalBlockReason.MARGIN_BUFFER_AT_RISK_TOO_LOW in d.block_reasons
+
+
+def test_8_liquidation_near_miss_too_high():
+    seq = replace(_seq_ok(), liquidation_near_miss_rate=0.9)
+    d = evaluate_survival_envelope(_env(_fp_ok(), seq=seq))
+    assert SurvivalBlockReason.LIQUIDATION_NEAR_MISS_TOO_HIGH in d.block_reasons
+
+
+def test_9_governance_breach_too_high():
+    seq = replace(_seq_ok(), governance_breach_frequency=0.2)
+    d = evaluate_survival_envelope(_env(_fp_ok(), seq=seq))
+    assert SurvivalBlockReason.GOVERNANCE_BREACH_TOO_HIGH in d.block_reasons
+
+
+def test_10_sequence_fragility_too_high():
+    seq = replace(_seq_ok(), sequence_fragility_index=0.9)
+    d = evaluate_survival_envelope(_env(_fp_ok(), seq=seq))
+    assert SurvivalBlockReason.SEQUENCE_FRAGILITY_TOO_HIGH in d.block_reasons
+
+
+def test_11_chop_switch_survival_too_low():
+    seq = replace(_seq_ok(), chop_switch_survival_score=0.1)
+    d = evaluate_survival_envelope(_env(_fp_ok(), seq=seq))
+    assert SurvivalBlockReason.CHOP_SWITCH_SURVIVAL_TOO_LOW in d.block_reasons
+
+
+def test_12_leverage_too_high():
+    lo = LayerArithmeticStatus(50.0, 0.1, 2, 0.05, "f", True)
+    d = evaluate_survival_envelope(_env(_fp_ok(), long_layer=lo))
+    assert SurvivalBlockReason.LONG_LEVERAGE_TOO_HIGH in d.block_reasons
+    sh = LayerArithmeticStatus(50.0, 0.1, 2, 0.05, "f", True)
+    d2 = evaluate_survival_envelope(_env(_fp_ok(), short_layer=sh))
+    assert SurvivalBlockReason.SHORT_LEVERAGE_TOO_HIGH in d2.block_reasons
+
+
+def test_13_liquidation_buffer_too_low():
+    lo = LayerArithmeticStatus(10.0, 0.01, 2, 0.05, "f", True)
+    d = evaluate_survival_envelope(_env(_fp_ok(), long_layer=lo))
+    assert SurvivalBlockReason.LONG_LIQUIDATION_BUFFER_TOO_LOW in d.block_reasons
+    sh = LayerArithmeticStatus(10.0, 0.01, 2, 0.05, "f", True)
+    d2 = evaluate_survival_envelope(_env(_fp_ok(), short_layer=sh))
+    assert SurvivalBlockReason.SHORT_LIQUIDATION_BUFFER_TOO_LOW in d2.block_reasons
+
+
+def test_14_adverse_fill_too_high():
+    lo = LayerArithmeticStatus(10.0, 0.1, 2, 0.3, "f", True)
+    d = evaluate_survival_envelope(_env(_fp_ok(), long_layer=lo))
+    assert SurvivalBlockReason.LONG_ADVERSE_FILL_LOSS_TOO_HIGH in d.block_reasons
+
+
+def test_15_valid_complete_allows_model_pre_auth_only():
+    d = evaluate_survival_envelope(_env(_fp_ok()))
+    assert d.status == SurvivalEnvelopeStatus.OK
+    assert d.pre_authorization_eligible is True
+    assert d.block_reasons == ()
+    assert d.live_authorization is False
+    assert arithmetic_complete(_fp_ok())
+
+
+def test_16_limits_live_auth_true_still_decision_false():
+    lim = StateSwitchSurvivalLimits(
+        min_path_survival_ratio=0.5,
+        max_early_loss_toxicity=0.9,
+        min_margin_buffer_at_risk_99=0.1,
+        max_sequence_fragility_index=0.5,
+        max_liquidation_near_miss_rate=0.2,
+        max_governance_breach_frequency=0.05,
+        min_chop_switch_survival_score=0.4,
+        max_effective_leverage=20.0,
+        min_liquidation_buffer=0.05,
+        max_adverse_fill_loss=0.15,
+        live_authorization=True,
+    )
+    d = evaluate_survival_envelope(_env(_fp_ok(), lim=lim))
+    assert d.live_authorization is False
+    assert d.pre_authorization_eligible is True
+
+
+def test_17_no_network_imports_in_module():
+    p = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "src"
+        / "trading"
+        / "master_v2"
+        / "double_play_survival.py"
+    )
+    tree = ast.parse(p.read_text(encoding="utf-8"))
+    bad = {"requests", "urllib3", "ccxt", "httpx", "socket", "aiohttp"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                assert n.name.split(".")[0] not in bad
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in bad


### PR DESCRIPTION
## Summary
- add pure Double Play Survival Envelope model v0
- encode arithmetic completeness/status, side-specific arithmetic readiness, sequence survival metrics, state-switch survival limits, and fail-closed envelope evaluation
- add focused tests for missing arithmetic/funding/liquidation/sequence metrics, threshold breaches, valid pre-authorization status, no-live invariant, and pure import boundaries
- keep double_play_state.py and package exports unchanged

## Changed files
- src/trading/master_v2/double_play_survival.py
- tests/trading/master_v2/test_double_play_survival.py

## Validation
- uv run pytest tests/trading/master_v2/test_double_play_survival.py -q
- uv run ruff check src/trading/master_v2 tests/trading/master_v2
- uv run ruff format --check src/trading/master_v2 tests/trading/master_v2

## Safety
- pure model + unit tests only
- no execution/orchestrator/session changes
- no risk gate / safety guard / kill switch changes
- no exchange adapter changes
- no workflow changes
- no config changes
- no scanner/backtest/market-data/exchange calls
- no out/evidence/S3/cache mutation
- no testnet or Live authorization
- SurvivalEnvelopeDecision.live_authorization is always false

Made with [Cursor](https://cursor.com)