### PR TITLE
feat(master-v2): add double play suitability projection model v0

### DIFF
--- a/src/trading/master_v2/double_play_suitability.py
+++ b/src/trading/master_v2/double_play_suitability.py
@@ -1,0 +1,384 @@
+# src/trading/master_v2/double_play_suitability.py
+"""
+Pure Master V2 Double Play strategy suitability projection (metadata only).
+
+No I/O, no strategy execution, no registry, no exchange, no live authority.
+See docs/ops/specs/MASTER_V2_DOUBLE_PLAY_STRATEGY_SUITABILITY_PROJECTION_CONTRACT_V0.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+DOUBLE_PLAY_SUITABILITY_LAYER_VERSION = "v0"
+
+
+class SuitabilityClass(str, Enum):
+    LONG_ONLY_CANDIDATE = "long_only_candidate"
+    SHORT_ONLY_CANDIDATE = "short_only_candidate"
+    BOTH_SIDES_CANDIDATE = "both_sides_candidate"
+    NEUTRAL_RANGE_CANDIDATE = "neutral_range_candidate"
+    DISABLED_FOR_CANDIDATE = "disabled_for_candidate"
+    UNKNOWN_SUITABILITY = "unknown_suitability"
+
+
+class SideCompatibility(str, Enum):
+    LONG_BULL = "long_bull"
+    SHORT_BEAR = "short_bear"
+    BOTH = "both"
+    NEUTRAL_RANGE = "neutral_range"
+    UNKNOWN = "unknown"
+
+
+class SuitabilityBlockReason(str, Enum):
+    """Model-level block codes; not execution or registry authority."""
+
+    STRATEGY_DISABLED = "strategy_disabled"
+    METADATA_BLOCKER = "metadata_blocker"
+    INSTRUMENT_INTELLIGENCE_INCOMPLETE = "instrument_intelligence_incomplete"
+    SURVIVAL_ENVELOPE_BLOCKED = "survival_envelope_blocked"
+    INSUFFICIENT_EXPLICIT_EVIDENCE = "insufficient_explicit_evidence"
+    DECLARED_SIDE_INCOMPLETE = "declared_side_incomplete"
+
+
+@dataclass(frozen=True)
+class StrategyMetadata:
+    """Opaque strategy identity and non-authoritative display/context fields."""
+
+    strategy_id: str
+    strategy_family: str | None
+    declared_side: SideCompatibility
+    explicit_side_evidence: bool
+    registry_label: str | None = None
+    name_surface: str | None = None
+    ecm_or_armstrong_surface: str | None = None
+    dashboard_label: str | None = None
+    ai_summary: str | None = None
+    disabled: bool = False
+    blockers: tuple[SuitabilityBlockReason, ...] = ()
+
+
+@dataclass(frozen=True)
+class InstrumentIntelligenceSummary:
+    """Presence flags for required Instrument Intelligence dimensions."""
+
+    volatility_profile_present: bool
+    liquidity_profile_present: bool
+    spread_profile_present: bool
+    funding_profile_present: bool
+    freshness_profile_present: bool
+    risk_warnings_present: bool = False
+    missing_data_warnings_present: bool = False
+
+
+@dataclass(frozen=True)
+class SuitabilityProjectionInput:
+    strategy: StrategyMetadata
+    instrument: InstrumentIntelligenceSummary | None
+    survival_envelope_allows: bool
+    survival_block_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class StrategySuitabilityProjection:
+    strategy_id: str
+    strategy_family: str | None
+    suitability_class: SuitabilityClass
+    side_compatibility: SideCompatibility
+    eligible_for_long_bull_pool: bool
+    eligible_for_short_bear_pool: bool
+    eligible_for_neutral_pool: bool
+    block_reasons: tuple[SuitabilityBlockReason, ...]
+    missing_inputs: tuple[str, ...]
+    reason: str
+    is_signal: bool = False
+    is_authority: bool = False
+    live_authorization: bool = False
+
+
+@dataclass(frozen=True)
+class SuitabilityProjectionDecision:
+    projection: StrategySuitabilityProjection
+    can_enter_any_candidate_pool: bool
+    can_enter_long_bull_pool: bool
+    can_enter_short_bear_pool: bool
+    can_enter_neutral_pool: bool
+    live_authorization: bool = False
+
+
+def metadata_has_authoritative_side_evidence(meta: StrategyMetadata) -> bool:
+    """
+    True when explicit_side_evidence is set and declared_side is not UNKNOWN
+    in a way that can support directional or neutral range classification
+    (still not trading authority).
+    """
+
+    if not meta.explicit_side_evidence:
+        return False
+    return meta.declared_side != SideCompatibility.UNKNOWN
+
+
+def instrument_intelligence_complete(
+    inst: InstrumentIntelligenceSummary | None,
+) -> bool:
+    if inst is None:
+        return False
+    return all(
+        (
+            inst.volatility_profile_present,
+            inst.liquidity_profile_present,
+            inst.spread_profile_present,
+            inst.funding_profile_present,
+            inst.freshness_profile_present,
+        )
+    )
+
+
+def survival_allows_projection(inp: SuitabilityProjectionInput) -> bool:
+    return bool(inp.survival_envelope_allows)
+
+
+def _pool_flags_for_class(
+    cls: SuitabilityClass,
+) -> tuple[bool, bool, bool]:
+    """(long_bull, short_bear, neutral) eligibility from suitability class only."""
+
+    if cls == SuitabilityClass.LONG_ONLY_CANDIDATE:
+        return (True, False, False)
+    if cls == SuitabilityClass.SHORT_ONLY_CANDIDATE:
+        return (False, True, False)
+    if cls == SuitabilityClass.BOTH_SIDES_CANDIDATE:
+        return (True, True, False)
+    if cls == SuitabilityClass.NEUTRAL_RANGE_CANDIDATE:
+        return (False, False, True)
+    return (False, False, False)
+
+
+def _classify_from_declared_and_evidence(
+    meta: StrategyMetadata,
+) -> tuple[SuitabilityClass, SideCompatibility, str] | None:
+    """
+    Returns (class, side_compatibility, reason) or None if caller should emit UNKNOWN
+    (after gates, or immediately for inconsistent metadata).
+    """
+
+    d = meta.declared_side
+    ex = meta.explicit_side_evidence
+
+    if d == SideCompatibility.UNKNOWN and not ex:
+        return None
+
+    if d == SideCompatibility.LONG_BULL and ex:
+        return (
+            SuitabilityClass.LONG_ONLY_CANDIDATE,
+            SideCompatibility.LONG_BULL,
+            "Long/Bull only candidate with explicit side evidence.",
+        )
+    if d == SideCompatibility.SHORT_BEAR and ex:
+        return (
+            SuitabilityClass.SHORT_ONLY_CANDIDATE,
+            SideCompatibility.SHORT_BEAR,
+            "Short/Bear only candidate with explicit side evidence.",
+        )
+    if d == SideCompatibility.BOTH and ex:
+        return (
+            SuitabilityClass.BOTH_SIDES_CANDIDATE,
+            SideCompatibility.BOTH,
+            "Both-side candidate with explicit both-side evidence.",
+        )
+    if d == SideCompatibility.BOTH and not ex:
+        return (
+            SuitabilityClass.UNKNOWN_SUITABILITY,
+            SideCompatibility.UNKNOWN,
+            "Both-side metadata requires explicit both-side evidence; fail closed.",
+        )
+    if d == SideCompatibility.NEUTRAL_RANGE and ex:
+        return (
+            SuitabilityClass.NEUTRAL_RANGE_CANDIDATE,
+            SideCompatibility.NEUTRAL_RANGE,
+            "Neutral/range candidate with explicit context evidence.",
+        )
+    if d in (SideCompatibility.LONG_BULL, SideCompatibility.SHORT_BEAR) and not ex:
+        return (
+            SuitabilityClass.UNKNOWN_SUITABILITY,
+            SideCompatibility.UNKNOWN,
+            "Directional declared side without explicit side evidence; fail closed.",
+        )
+    if d == SideCompatibility.NEUTRAL_RANGE and not ex:
+        return (
+            SuitabilityClass.UNKNOWN_SUITABILITY,
+            SideCompatibility.UNKNOWN,
+            "Neutral/range without explicit context evidence; fail closed.",
+        )
+    if d == SideCompatibility.UNKNOWN and ex:
+        return (
+            SuitabilityClass.UNKNOWN_SUITABILITY,
+            SideCompatibility.UNKNOWN,
+            "Declared side unknown even with explicit flag; cannot classify.",
+        )
+    return None
+
+
+def project_strategy_suitability(
+    inp: SuitabilityProjectionInput,
+) -> SuitabilityProjectionDecision:
+    """
+    Fail-closed suitability projection. ``live_authorization`` is always false.
+    Not a signal; not Master V2, Testnet, or Live authority.
+    """
+
+    meta = inp.strategy
+    miss: list[str] = []
+    br: list[SuitabilityBlockReason] = list(meta.blockers)
+
+    if meta.disabled:
+        br.append(SuitabilityBlockReason.STRATEGY_DISABLED)
+        p = _unknown_projection(
+            meta,
+            SuitabilityClass.DISABLED_FOR_CANDIDATE,
+            SideCompatibility.UNKNOWN,
+            tuple(dict.fromkeys(br)),
+            ("strategy.disabled",),
+            "Strategy marked disabled; no candidate pools.",
+        )
+        return _decision_from_projection(p, allow_any=False)
+
+    if meta.blockers:
+        br2 = list(dict.fromkeys(list(meta.blockers) + [SuitabilityBlockReason.METADATA_BLOCKER]))
+        p = _unknown_projection(
+            meta,
+            SuitabilityClass.DISABLED_FOR_CANDIDATE,
+            SideCompatibility.UNKNOWN,
+            tuple(br2),
+            (f"metadata_blockers={len(meta.blockers)}",),
+            "Metadata-reported blockers; disabled for candidate class.",
+        )
+        return _decision_from_projection(p, allow_any=False)
+
+    if not instrument_intelligence_complete(inp.instrument):
+        br.append(SuitabilityBlockReason.INSTRUMENT_INTELLIGENCE_INCOMPLETE)
+        miss.append("instrument_intelligence")
+        p = _unknown_projection(
+            meta,
+            SuitabilityClass.UNKNOWN_SUITABILITY,
+            SideCompatibility.UNKNOWN,
+            tuple(dict.fromkeys(br)),
+            tuple(miss) if miss else ("instrument_intelligence",),
+            "Instrument Intelligence incomplete or missing; unknown suitability (fail closed).",
+        )
+        return _decision_from_projection(p, allow_any=False)
+
+    if not survival_allows_projection(inp):
+        br.append(SuitabilityBlockReason.SURVIVAL_ENVELOPE_BLOCKED)
+        for r in inp.survival_block_reasons:
+            miss.append(f"survival:{r}")
+        p = _unknown_projection(
+            meta,
+            SuitabilityClass.UNKNOWN_SUITABILITY,
+            SideCompatibility.UNKNOWN,
+            tuple(dict.fromkeys(br)),
+            tuple(miss) if miss else ("survival_envelope",),
+            "Survival envelope blocks suitability projection consumption; no pools.",
+        )
+        return _decision_from_projection(p, allow_any=False)
+
+    if not meta.explicit_side_evidence and meta.declared_side == SideCompatibility.UNKNOWN:
+        br.append(SuitabilityBlockReason.INSUFFICIENT_EXPLICIT_EVIDENCE)
+        p = _unknown_projection(
+            meta,
+            SuitabilityClass.UNKNOWN_SUITABILITY,
+            SideCompatibility.UNKNOWN,
+            tuple(dict.fromkeys(br)),
+            ("explicit_side_evidence,declared_side",),
+            "Registry, name, ECM/Armstrong, dashboard, or AI text alone cannot grant "
+            "suitability; unknown (fail closed).",
+        )
+        return _decision_from_projection(p, allow_any=False)
+
+    classified = _classify_from_declared_and_evidence(meta)
+    if classified is None:
+        br.append(SuitabilityBlockReason.DECLARED_SIDE_INCOMPLETE)
+        p = _unknown_projection(
+            meta,
+            SuitabilityClass.UNKNOWN_SUITABILITY,
+            SideCompatibility.UNKNOWN,
+            tuple(dict.fromkeys(br)),
+            ("declared_side",),
+            "Could not classify from declared side and evidence.",
+        )
+        return _decision_from_projection(p, allow_any=False)
+    scls, sside, sreason = classified
+    if scls == SuitabilityClass.UNKNOWN_SUITABILITY:
+        br.append(SuitabilityBlockReason.INSUFFICIENT_EXPLICIT_EVIDENCE)
+        p = _unknown_projection(
+            meta,
+            scls,
+            sside,
+            tuple(dict.fromkeys(br)),
+            ("side_evidence",),
+            sreason,
+        )
+        return _decision_from_projection(p, allow_any=False)
+
+    lg, sg, ng = _pool_flags_for_class(scls)
+    block_t = tuple(dict.fromkeys(br)) if br else ()
+    p = StrategySuitabilityProjection(
+        strategy_id=meta.strategy_id,
+        strategy_family=meta.strategy_family,
+        suitability_class=scls,
+        side_compatibility=sside,
+        eligible_for_long_bull_pool=lg,
+        eligible_for_short_bear_pool=sg,
+        eligible_for_neutral_pool=ng,
+        block_reasons=block_t,
+        missing_inputs=(),
+        reason=sreason,
+        is_signal=False,
+        is_authority=False,
+        live_authorization=False,
+    )
+    return _decision_from_projection(
+        p,
+        allow_any=lg or sg or ng,
+    )
+
+
+def _unknown_projection(
+    meta: StrategyMetadata,
+    suitability_class: SuitabilityClass,
+    side: SideCompatibility,
+    block_reasons: tuple[SuitabilityBlockReason, ...],
+    missing: tuple[str, ...],
+    reason: str,
+) -> StrategySuitabilityProjection:
+    return StrategySuitabilityProjection(
+        strategy_id=meta.strategy_id,
+        strategy_family=meta.strategy_family,
+        suitability_class=suitability_class,
+        side_compatibility=side,
+        eligible_for_long_bull_pool=False,
+        eligible_for_short_bear_pool=False,
+        eligible_for_neutral_pool=False,
+        block_reasons=block_reasons,
+        missing_inputs=missing,
+        reason=reason,
+        is_signal=False,
+        is_authority=False,
+        live_authorization=False,
+    )
+
+
+def _decision_from_projection(
+    p: StrategySuitabilityProjection,
+    *,
+    allow_any: bool,
+) -> SuitabilityProjectionDecision:
+    return SuitabilityProjectionDecision(
+        projection=p,
+        can_enter_any_candidate_pool=bool(allow_any),
+        can_enter_long_bull_pool=p.eligible_for_long_bull_pool,
+        can_enter_short_bear_pool=p.eligible_for_short_bear_pool,
+        can_enter_neutral_pool=p.eligible_for_neutral_pool,
+        live_authorization=False,
+    )

--- a/tests/trading/master_v2/test_double_play_suitability.py
+++ b/tests/trading/master_v2/test_double_play_suitability.py
@@ -1,0 +1,287 @@
+# tests/trading/master_v2/test_double_play_suitability.py
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from trading.master_v2.double_play_suitability import (
+    DOUBLE_PLAY_SUITABILITY_LAYER_VERSION,
+    InstrumentIntelligenceSummary,
+    SideCompatibility,
+    StrategyMetadata,
+    SuitabilityBlockReason,
+    SuitabilityClass,
+    SuitabilityProjectionInput,
+    instrument_intelligence_complete,
+    metadata_has_authoritative_side_evidence,
+    project_strategy_suitability,
+    survival_allows_projection,
+)
+
+
+def _ii_all_present() -> InstrumentIntelligenceSummary:
+    return InstrumentIntelligenceSummary(
+        volatility_profile_present=True,
+        liquidity_profile_present=True,
+        spread_profile_present=True,
+        funding_profile_present=True,
+        freshness_profile_present=True,
+    )
+
+
+def _ii_incomplete() -> InstrumentIntelligenceSummary:
+    return InstrumentIntelligenceSummary(
+        volatility_profile_present=True,
+        liquidity_profile_present=False,
+        spread_profile_present=True,
+        funding_profile_present=True,
+        freshness_profile_present=True,
+    )
+
+
+def _base_meta(**kwargs: object) -> StrategyMetadata:
+    defaults: dict = {
+        "strategy_id": "sid",
+        "strategy_family": "trend",
+        "declared_side": SideCompatibility.UNKNOWN,
+        "explicit_side_evidence": False,
+        "registry_label": None,
+        "name_surface": None,
+        "ecm_or_armstrong_surface": None,
+        "dashboard_label": None,
+        "ai_summary": None,
+        "disabled": False,
+        "blockers": (),
+    }
+    defaults.update(kwargs)
+    return StrategyMetadata(**defaults)  # type: ignore[arg-type]
+
+
+def _inp(
+    meta: StrategyMetadata,
+    inst: InstrumentIntelligenceSummary | None = None,
+    surv: bool = True,
+    reasons: tuple[str, ...] = (),
+) -> SuitabilityProjectionInput:
+    return SuitabilityProjectionInput(
+        strategy=meta,
+        instrument=inst,
+        survival_envelope_allows=surv,
+        survival_block_reasons=reasons,
+    )
+
+
+def test_1_registry_name_only_is_unknown() -> None:
+    m = _base_meta(
+        registry_label="ma_crossover",
+        name_surface="MA Cross",
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+    assert d.can_enter_long_bull_pool is False
+    assert d.projection.live_authorization is False
+
+
+def test_2_ecm_or_armstrong_name_surface_cannot_grant() -> None:
+    m = _base_meta(ecm_or_armstrong_surface="armstrong_cycle", registry_label="r")
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+    assert SuitabilityBlockReason.INSUFFICIENT_EXPLICIT_EVIDENCE in d.projection.block_reasons
+
+
+def test_3_long_only_with_explicit_goes_to_long_bull() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.LONG_ONLY_CANDIDATE
+    assert d.projection.eligible_for_long_bull_pool is True
+    assert d.projection.eligible_for_short_bear_pool is False
+    assert d.projection.eligible_for_neutral_pool is False
+    assert d.projection.is_signal is False
+    assert d.projection.is_authority is False
+
+
+def test_4_short_only_with_explicit_goes_to_short_bear() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.SHORT_BEAR,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.SHORT_ONLY_CANDIDATE
+    assert d.projection.eligible_for_short_bear_pool is True
+    assert d.projection.eligible_for_long_bull_pool is False
+
+
+def test_5_both_sides_needs_explicit_evidence() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.BOTH,
+        explicit_side_evidence=False,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+    assert d.can_enter_any_candidate_pool is False
+    assert "Both-side" in d.projection.reason or "evidence" in d.projection.reason
+
+
+def test_6_neutral_range_not_directional() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.NEUTRAL_RANGE,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.NEUTRAL_RANGE_CANDIDATE
+    assert d.projection.eligible_for_neutral_pool is True
+    assert d.projection.eligible_for_long_bull_pool is False
+    assert d.projection.eligible_for_short_bear_pool is False
+
+
+def test_7_disabled_is_disabled_for_candidate() -> None:
+    m = _base_meta(
+        disabled=True, declared_side=SideCompatibility.LONG_BULL, explicit_side_evidence=True
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.DISABLED_FOR_CANDIDATE
+    assert d.can_enter_any_candidate_pool is False
+    assert SuitabilityBlockReason.STRATEGY_DISABLED in d.projection.block_reasons
+
+
+def test_8_metadata_blockers_is_disabled() -> None:
+    m = _base_meta(
+        blockers=(SuitabilityBlockReason.INSUFFICIENT_EXPLICIT_EVIDENCE,),
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.DISABLED_FOR_CANDIDATE
+    assert d.can_enter_long_bull_pool is False
+
+
+def test_9_declared_side_unknown_is_unknown_even_if_explicit() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.UNKNOWN,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+    assert d.can_enter_any_candidate_pool is False
+
+
+def test_10_instrument_incomplete_is_unknown() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_incomplete(), True))
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+    assert d.projection.missing_inputs
+
+
+def test_11_instrument_none_is_unknown() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(
+        SuitabilityProjectionInput(
+            strategy=m,
+            instrument=None,
+            survival_envelope_allows=True,
+        )
+    )
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+    assert SuitabilityBlockReason.INSTRUMENT_INTELLIGENCE_INCOMPLETE in d.projection.block_reasons
+
+
+def test_12_survival_blocks_pools() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), False, ("path_survival",)))
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+    assert d.projection.eligible_for_long_bull_pool is False
+    assert SuitabilityBlockReason.SURVIVAL_ENVELOPE_BLOCKED in d.projection.block_reasons
+
+
+def test_13_ai_summary_alone_cannot_grant() -> None:
+    m = _base_meta(ai_summary="Bullish narrative from AI.")
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+
+
+def test_14_dashboard_label_alone_cannot_grant() -> None:
+    m = _base_meta(dashboard_label="ELIGIBLE")
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY
+
+
+def test_15_never_live_authorization() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.BOTH,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.live_authorization is False
+    assert d.live_authorization is False
+
+
+def test_16_both_sides_both_pools() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.BOTH,
+        explicit_side_evidence=True,
+    )
+    d = project_strategy_suitability(_inp(m, _ii_all_present(), True))
+    assert d.projection.suitability_class is SuitabilityClass.BOTH_SIDES_CANDIDATE
+    assert d.projection.eligible_for_long_bull_pool is True
+    assert d.projection.eligible_for_short_bear_pool is True
+    assert d.projection.eligible_for_neutral_pool is False
+
+
+def test_17_layer_version_constant() -> None:
+    assert DOUBLE_PLAY_SUITABILITY_LAYER_VERSION == "v0"
+
+
+def test_18_helper_survival_allows() -> None:
+    m = _base_meta(
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    i = _inp(m, _ii_all_present(), True)
+    assert survival_allows_projection(i) is True
+    assert instrument_intelligence_complete(_ii_all_present()) is True
+    assert instrument_intelligence_complete(None) is False
+    assert (
+        metadata_has_authoritative_side_evidence(
+            _base_meta(
+                declared_side=SideCompatibility.LONG_BULL,
+                explicit_side_evidence=True,
+            )
+        )
+        is True
+    )
+    assert (
+        metadata_has_authoritative_side_evidence(
+            _base_meta(explicit_side_evidence=False, declared_side=SideCompatibility.UNKNOWN)
+        )
+        is False
+    )
+
+
+def test_19_no_network_imports_in_module() -> None:
+    p = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "src"
+        / "trading"
+        / "master_v2"
+        / "double_play_suitability.py"
+    )
+    tree = ast.parse(p.read_text(encoding="utf-8"))
+    bad = {"requests", "urllib3", "ccxt", "httpx", "socket", "aiohttp"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                assert n.name.split(".")[0] not in bad
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in bad


### PR DESCRIPTION
## Summary
- add pure Double Play strategy suitability projection model v0
- encode suitability classes, side compatibility, strategy metadata, instrument intelligence summary, blockers, survival-envelope blocker passthrough, and no-authority/no-live invariants
- add focused unit tests for registry/name-only surfaces, ECM/Armstrong surfaces, Long/Short/Both/Neutral projections, Disabled and Unknown handling, missing instrument data, survival blockers, AI/dashboard-only inputs, no-live invariant, and pure import boundaries
- keep double_play_state.py, double_play_survival.py, and package exports unchanged

## Changed files
- src/trading/master_v2/double_play_suitability.py
- tests/trading/master_v2/test_double_play_suitability.py

## Validation
- uv run pytest tests/trading/master_v2/test_double_play_suitability.py -q
- uv run ruff check src/trading/master_v2 tests/trading/master_v2
- uv run ruff format --check src/trading/master_v2 tests/trading/master_v2

## Safety
- pure model + unit tests only
- no strategy execution
- no strategy registry mutation/wiring
- no runtime composition
- no state-switch integration
- no survival-envelope evaluation changes
- no risk gate / safety guard / kill switch changes
- no exchange adapter changes
- no workflow changes
- no config changes
- no scanner/backtest/market-data/exchange calls
- no out/evidence/S3/cache mutation
- no testnet or Live authorization
- projection live_authorization is always false

Made with [Cursor](https://cursor.com)