### PR TITLE
feat(master-v2): add double play capital slot model v0

### DIFF
--- a/src/trading/master_v2/double_play_capital_slot.py
+++ b/src/trading/master_v2/double_play_capital_slot.py
@@ -1,0 +1,248 @@
+# src/trading/master_v2/double_play_capital_slot.py
+"""
+Pure Double Play capital slot model: ratchet, release, loss-following base.
+
+Data-only; no I/O, allocation, execution, exchange, or Live authority.
+Aligned with docs/ops/specs/MASTER_V2_DOUBLE_PLAY_CAPITAL_SLOT_RATCHET_RELEASE_CONTRACT_V0.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+DOUBLE_PLAY_CAPITAL_SLOT_LAYER_VERSION = "v0"
+
+_SPLIT_EPS = 1e-9
+
+
+class CapitalSlotStatus(str, Enum):
+    """Per-future capital slot lifecycle (model labels only, non-authority)."""
+
+    ACTIVE = "active"
+    RELEASED = "released"
+
+
+class CapitalSlotReleaseReason(str, Enum):
+    INACTIVITY = "inactivity"
+    OPPORTUNITY_COST = "opportunity_cost"
+
+
+class CapitalSlotBlockReason(str, Enum):
+    """Why ratchet pre-authorization is blocked; fail closed."""
+
+    CONFIG_LIVE_AUTHORIZATION_CONTRADICTION = "config_live_authorization_contradiction"
+    INVALID_CASHFLOW_SPLIT = "invalid_cashflow_split"
+    SURVIVAL_NOT_ALLOWED = "survival_not_allowed"
+    MISSING_REALIZED_SETTLED_BASIS = "missing_realized_settled_basis"
+
+
+@dataclass(frozen=True)
+class CapitalSlotConfig:
+    profit_step_pct: float
+    cashflow_lock_fraction: float
+    reinvest_fraction: float
+    allow_auto_top_up: bool
+    live_authorization: bool
+    min_realized_volatility: float
+    min_atr_or_range: float
+    max_time_without_cashflow_step: int
+    min_opportunity_score: float
+
+
+@dataclass(frozen=True)
+class CapitalSlotState:
+    selected_future: str
+    initial_slot_base: float
+    active_slot_base: float
+    """Realized or settled slot equity; None = unknown -> ratchet fail closed."""
+    realized_or_settled_slot_equity: Optional[float]
+    unrealized_pnl: float
+    locked_cashflow: float
+    time_without_cashflow_step: int
+    realized_volatility: float
+    atr_or_range: float
+    opportunity_score: float
+    survival_allows_slot: bool
+
+
+@dataclass(frozen=True)
+class CapitalSlotRatchetDecision:
+    status: CapitalSlotStatus
+    ratchet_target: float
+    can_ratchet: bool
+    block_reasons: Tuple[CapitalSlotBlockReason, ...]
+    reason: str
+    live_authorization: bool
+    new_active_slot_base: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class CapitalSlotReleaseDecision:
+    status: CapitalSlotStatus
+    released: bool
+    release_reason: Optional[CapitalSlotReleaseReason]
+    block_reasons: Tuple[CapitalSlotBlockReason, ...]
+    reason: str
+    live_authorization: bool
+    authorizes_new_future_selection: bool
+    authorizes_new_trade: bool
+
+
+def calculate_ratchet_target(
+    active_slot_base: float, profit_step_pct: float, *, locked_cashflow: float = 0.0
+) -> float:
+    base = max(0.0, active_slot_base - locked_cashflow)
+    return base * (1.0 + profit_step_pct)
+
+
+def cashflow_split_valid(
+    lock_fraction: float, reinvest_fraction: float, *, eps: float = _SPLIT_EPS
+) -> bool:
+    if lock_fraction < 0 or reinvest_fraction < 0 or lock_fraction > 1.0 or reinvest_fraction > 1.0:
+        return False
+    return abs(lock_fraction + reinvest_fraction - 1.0) <= eps
+
+
+def apply_loss_following_base(prior_active: float, realized_settled_slot_equity: float) -> float:
+    """
+    After realized loss, the active slot base follows realized/settled equity downward.
+
+    This does not top up from reserve or toward ``initial_slot_base``.
+    """
+    return min(prior_active, realized_settled_slot_equity)
+
+
+def evaluate_capital_slot_ratchet(
+    config: CapitalSlotConfig, state: CapitalSlotState
+) -> CapitalSlotRatchetDecision:
+    """
+    Ratchet: target = effective_base * (1 + profit_step_pct) with
+    effective_base = max(0, active_slot_base - locked_cashflow).
+
+    - Eligibility for stepping uses **only** ``realized_or_settled_slot_equity`` vs target;
+      ``unrealized_pnl`` is not used for the comparison (v0 contract).
+    - Survival disallows pre-authorization when ``survival_allows_slot`` is False.
+    - Invalid lock/reinvest split blocks ratchet.
+    - This layer never pulls missing equity from a reserve: ``new_active_slot_base`` is
+      always the observed settled slot equity when a step is allowed, independent of
+      ``allow_auto_top_up`` (v0: field reserved for later governance; no reserve top-up).
+    - Output ``live_authorization`` is always false.
+    """
+    if config.live_authorization:
+        return CapitalSlotRatchetDecision(
+            status=CapitalSlotStatus.ACTIVE,
+            ratchet_target=0.0,
+            can_ratchet=False,
+            block_reasons=(CapitalSlotBlockReason.CONFIG_LIVE_AUTHORIZATION_CONTRADICTION,),
+            reason="live_authorization in config is never accepted in this model; fail closed.",
+            live_authorization=False,
+        )
+    if not cashflow_split_valid(config.cashflow_lock_fraction, config.reinvest_fraction):
+        return CapitalSlotRatchetDecision(
+            status=CapitalSlotStatus.ACTIVE,
+            ratchet_target=0.0,
+            can_ratchet=False,
+            block_reasons=(CapitalSlotBlockReason.INVALID_CASHFLOW_SPLIT,),
+            reason="Lock/reinvest split must be explicit, in [0,1], and sum to 1.",
+            live_authorization=False,
+        )
+    t = calculate_ratchet_target(
+        state.active_slot_base, config.profit_step_pct, locked_cashflow=state.locked_cashflow
+    )
+    if not state.survival_allows_slot:
+        return CapitalSlotRatchetDecision(
+            status=CapitalSlotStatus.ACTIVE,
+            ratchet_target=t,
+            can_ratchet=False,
+            block_reasons=(CapitalSlotBlockReason.SURVIVAL_NOT_ALLOWED,),
+            reason="Survival envelope disallows slot pre-authorization / ratchet.",
+            live_authorization=False,
+        )
+    if state.realized_or_settled_slot_equity is None:
+        return CapitalSlotRatchetDecision(
+            status=CapitalSlotStatus.ACTIVE,
+            ratchet_target=t,
+            can_ratchet=False,
+            block_reasons=(CapitalSlotBlockReason.MISSING_REALIZED_SETTLED_BASIS,),
+            reason="Realized/settled slot equity is unknown; fail closed.",
+            live_authorization=False,
+        )
+    r = state.realized_or_settled_slot_equity
+    if r + 1e-12 < t:
+        return CapitalSlotRatchetDecision(
+            status=CapitalSlotStatus.ACTIVE,
+            ratchet_target=t,
+            can_ratchet=False,
+            block_reasons=(),
+            reason="Realized/settled slot equity has not reached ratchet target (unrealized PnL ignored for this check).",
+            live_authorization=False,
+        )
+    return CapitalSlotRatchetDecision(
+        status=CapitalSlotStatus.ACTIVE,
+        ratchet_target=t,
+        can_ratchet=True,
+        block_reasons=(),
+        reason="Settled slot equity meets ratchet target; new active base follows settled equity (data-only, no reserve top-up).",
+        live_authorization=False,
+        new_active_slot_base=r,
+    )
+
+
+def evaluate_capital_slot_release(
+    config: CapitalSlotConfig, state: CapitalSlotState
+) -> CapitalSlotReleaseDecision:
+    """
+    Data-only inactivity or opportunity-cost release. Does not select a new future or trade.
+    """
+    if config.live_authorization:
+        return CapitalSlotReleaseDecision(
+            status=CapitalSlotStatus.ACTIVE,
+            released=False,
+            release_reason=None,
+            block_reasons=(CapitalSlotBlockReason.CONFIG_LIVE_AUTHORIZATION_CONTRADICTION,),
+            reason="Config live_authorization is invalid for this model.",
+            live_authorization=False,
+            authorizes_new_future_selection=False,
+            authorizes_new_trade=False,
+        )
+    tmax = config.max_time_without_cashflow_step
+    time_breach = tmax > 0 and state.time_without_cashflow_step > tmax
+    low_movement = (
+        state.realized_volatility < config.min_realized_volatility
+        and state.atr_or_range < config.min_atr_or_range
+    )
+    inactivity = time_breach or low_movement
+    if inactivity:
+        return CapitalSlotReleaseDecision(
+            status=CapitalSlotStatus.RELEASED,
+            released=True,
+            release_reason=CapitalSlotReleaseReason.INACTIVITY,
+            block_reasons=(),
+            reason="Inactivity / low movement or stale cashflow step (data-only).",
+            live_authorization=False,
+            authorizes_new_future_selection=False,
+            authorizes_new_trade=False,
+        )
+    if state.opportunity_score < config.min_opportunity_score:
+        return CapitalSlotReleaseDecision(
+            status=CapitalSlotStatus.RELEASED,
+            released=True,
+            release_reason=CapitalSlotReleaseReason.OPPORTUNITY_COST,
+            block_reasons=(),
+            reason="Opportunity score below threshold (data-only).",
+            live_authorization=False,
+            authorizes_new_future_selection=False,
+            authorizes_new_trade=False,
+        )
+    return CapitalSlotReleaseDecision(
+        status=CapitalSlotStatus.ACTIVE,
+        released=False,
+        release_reason=None,
+        block_reasons=(),
+        reason="No inactivity or opportunity release conditions met.",
+        live_authorization=False,
+        authorizes_new_future_selection=False,
+        authorizes_new_trade=False,
+    )

--- a/tests/trading/master_v2/test_double_play_capital_slot.py
+++ b/tests/trading/master_v2/test_double_play_capital_slot.py
@@ -1,0 +1,185 @@
+# tests/trading/master_v2/test_double_play_capital_slot.py
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from trading.master_v2.double_play_capital_slot import (
+    DOUBLE_PLAY_CAPITAL_SLOT_LAYER_VERSION,
+    CapitalSlotBlockReason,
+    CapitalSlotConfig,
+    CapitalSlotReleaseReason,
+    CapitalSlotState,
+    CapitalSlotStatus,
+    apply_loss_following_base,
+    calculate_ratchet_target,
+    cashflow_split_valid,
+    evaluate_capital_slot_ratchet,
+    evaluate_capital_slot_release,
+)
+
+
+def _cfg(**overrides: object) -> CapitalSlotConfig:
+    d: dict = {
+        "profit_step_pct": 0.10,
+        "cashflow_lock_fraction": 0.30,
+        "reinvest_fraction": 0.70,
+        "allow_auto_top_up": False,
+        "live_authorization": False,
+        "min_realized_volatility": 0.05,
+        "min_atr_or_range": 0.05,
+        "max_time_without_cashflow_step": 10_000,
+        "min_opportunity_score": 0.2,
+    }
+    d.update(overrides)
+    return CapitalSlotConfig(**d)
+
+
+def _st(**overrides: object) -> CapitalSlotState:
+    d: dict = {
+        "selected_future": "BTC-USD-PERP",
+        "initial_slot_base": 300.0,
+        "active_slot_base": 300.0,
+        "realized_or_settled_slot_equity": 300.0,
+        "unrealized_pnl": 0.0,
+        "locked_cashflow": 0.0,
+        "time_without_cashflow_step": 0,
+        "realized_volatility": 0.5,
+        "atr_or_range": 0.5,
+        "opportunity_score": 0.8,
+        "survival_allows_slot": True,
+    }
+    d.update(overrides)
+    return CapitalSlotState(**d)
+
+
+def test_layer_version_is_v0() -> None:
+    assert DOUBLE_PLAY_CAPITAL_SLOT_LAYER_VERSION == "v0"
+
+
+def test_ratchet_target_from_active_base() -> None:
+    assert calculate_ratchet_target(300.0, 0.10) == 330.0
+    assert calculate_ratchet_target(270.0, 0.10) == 297.0
+
+
+def test_reset_requires_realized_settled_equity() -> None:
+    cfg = _cfg()
+    st = _st(realized_or_settled_slot_equity=340.0)
+    d = evaluate_capital_slot_ratchet(cfg, st)
+    assert d.can_ratchet
+    assert d.ratchet_target == 330.0
+    assert d.new_active_slot_base == 340.0
+
+    st2 = _st(realized_or_settled_slot_equity=320.0)
+    d2 = evaluate_capital_slot_ratchet(cfg, st2)
+    assert not d2.can_ratchet
+    assert d2.ratchet_target == 330.0
+
+
+def test_unrealized_pnl_alone_cannot_satisfy_ratchet() -> None:
+    cfg = _cfg()
+    st = _st(realized_or_settled_slot_equity=200.0, unrealized_pnl=1_000_000.0)
+    d = evaluate_capital_slot_ratchet(cfg, st)
+    assert not d.can_ratchet
+    assert d.ratchet_target == 330.0
+
+
+def test_losses_reduce_active_base_via_loss_following() -> None:
+    assert apply_loss_following_base(300.0, 270.0) == 270.0
+
+
+def test_losses_do_not_trigger_auto_top_up_in_apply() -> None:
+    out = apply_loss_following_base(300.0, 270.0)
+    assert out < 300.0
+    assert out == 270.0
+
+
+def test_reduced_base_defines_next_target() -> None:
+    assert calculate_ratchet_target(270.0, 0.10) == 297.0
+
+
+def test_cashflow_split_explicit_and_valid() -> None:
+    assert cashflow_split_valid(0.3, 0.7)
+    assert not cashflow_split_valid(0.5, 0.4)
+
+
+def test_locked_cashflow_not_in_ratchet_basis() -> None:
+    t = calculate_ratchet_target(300.0, 0.10, locked_cashflow=50.0)
+    assert t == 250.0 * 1.1
+
+
+def test_invalid_split_blocks_ratchet() -> None:
+    cfg = _cfg(cashflow_lock_fraction=0.5, reinvest_fraction=0.4)
+    d = evaluate_capital_slot_ratchet(cfg, _st())
+    assert not d.can_ratchet
+    assert CapitalSlotBlockReason.INVALID_CASHFLOW_SPLIT in d.block_reasons
+
+
+def test_inactivity_release_low_movement() -> None:
+    cfg = _cfg()
+    st = _st(realized_volatility=0.01, atr_or_range=0.01)
+    rel = evaluate_capital_slot_release(cfg, st)
+    assert rel.released
+    assert rel.release_reason is CapitalSlotReleaseReason.INACTIVITY
+    assert rel.status is CapitalSlotStatus.RELEASED
+    assert not rel.authorizes_new_future_selection
+    assert not rel.authorizes_new_trade
+
+
+def test_opportunity_cost_release() -> None:
+    cfg = _cfg()
+    st = _st(opportunity_score=0.05)
+    rel = evaluate_capital_slot_release(cfg, st)
+    assert rel.released
+    assert rel.release_reason is CapitalSlotReleaseReason.OPPORTUNITY_COST
+
+
+def test_release_does_not_authorize_new_future_or_trade() -> None:
+    cfg = _cfg()
+    st = _st(opportunity_score=0.05)
+    rel = evaluate_capital_slot_release(cfg, st)
+    assert not rel.authorizes_new_future_selection
+    assert not rel.authorizes_new_trade
+    assert not rel.live_authorization
+
+
+def test_survival_blocker_prevents_ratchet() -> None:
+    cfg = _cfg()
+    st = _st(realized_or_settled_slot_equity=400.0, survival_allows_slot=False)
+    d = evaluate_capital_slot_ratchet(cfg, st)
+    assert not d.can_ratchet
+    assert CapitalSlotBlockReason.SURVIVAL_NOT_ALLOWED in d.block_reasons
+
+
+def test_live_authorization_false_on_decisions() -> None:
+    cfg = _cfg()
+    st = _st()
+    assert not evaluate_capital_slot_ratchet(cfg, st).live_authorization
+    assert not evaluate_capital_slot_release(cfg, st).live_authorization
+
+
+def test_config_live_authorization_true_fail_closed() -> None:
+    cfg = _cfg(live_authorization=True)
+    st = _st()
+    dr = evaluate_capital_slot_ratchet(cfg, st)
+    dl = evaluate_capital_slot_release(cfg, st)
+    assert CapitalSlotBlockReason.CONFIG_LIVE_AUTHORIZATION_CONTRADICTION in dr.block_reasons
+    assert CapitalSlotBlockReason.CONFIG_LIVE_AUTHORIZATION_CONTRADICTION in dl.block_reasons
+    assert not dr.live_authorization
+    assert not dl.live_authorization
+
+
+def test_no_forbidden_top_level_imports_in_module() -> None:
+    root = Path(__file__).resolve().parent.parent.parent.parent / "src" / "trading" / "master_v2"
+    path = root / "double_play_capital_slot.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bad = {"requests", "urllib3", "ccxt", "httpx", "socket", "aiohttp"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                assert n.name.split(".")[0] not in bad
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mod0 = node.module.split(".")[0]
+            if mod0 == "trading":
+                continue
+            assert mod0 not in bad

--- a/tests/trading/master_v2/test_double_play_pure_stack_contract.py
+++ b/tests/trading/master_v2/test_double_play_pure_stack_contract.py
@@ -420,6 +420,7 @@ def test_contract_9_ast_no_bad_imports_in_pure_modules() -> None:
         "double_play_survival.py",
         "double_play_suitability.py",
         "double_play_composition.py",
+        "double_play_capital_slot.py",
     )
     bad = {"requests", "urllib3", "ccxt", "httpx", "socket", "aiohttp"}
     for name in files:


### PR DESCRIPTION
## Summary
- add pure Double Play capital-slot model v0
- encode conservative ratchet target calculation, realized/settled reset basis, loss-following base, no auto top-up, cashflow lock/reinvest validation, inactivity release, opportunity-cost release, survival-block passthrough, and no-live invariants
- add focused unit tests for ratchet/reset/loss/release/no-live semantics and import boundaries
- include the capital-slot module in the pure-stack AST import guard
- keep package exports unchanged

## Changed files
- src/trading/master_v2/double_play_capital_slot.py
- tests/trading/master_v2/test_double_play_capital_slot.py
- tests/trading/master_v2/test_double_play_pure_stack_contract.py

## Validation
- uv run pytest tests/trading/master_v2/test_double_play_capital_slot.py -q
- uv run pytest tests/trading/master_v2/ -q
- uv run ruff check src/trading/master_v2 tests/trading/master_v2
- uv run ruff format --check src/trading/master_v2 tests/trading/master_v2

## Safety
- pure model + unit tests only
- no allocation runtime
- no strategy execution
- no strategy registry mutation/wiring
- no runtime integration
- no state-switch integration
- no survival-envelope evaluation changes
- no risk gate / safety guard / kill switch changes
- no exchange adapter changes
- no workflow changes
- no config changes
- no scanner/backtest/market-data/exchange calls
- no out/evidence/S3/cache mutation
- no testnet or Live authorization
- capital-slot decisions never set live_authorization true
