### PR TITLE
feat(master-v2): gate composition with capital slot decisions v0

### DIFF
--- a/src/trading/master_v2/double_play_composition.py
+++ b/src/trading/master_v2/double_play_composition.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
+from trading.master_v2.double_play_capital_slot import (
+    CapitalSlotRatchetDecision,
+    CapitalSlotReleaseDecision,
+)
 from trading.master_v2.double_play_state import SideState, TransitionDecision
 from trading.master_v2.double_play_survival import SurvivalEnvelopeDecision, SurvivalEnvelopeStatus
 from trading.master_v2.double_play_suitability import (
@@ -40,6 +45,8 @@ class DoublePlayCompositionBlockReason(str, Enum):
     STATE_CHOP_GUARD = "state_chop_guard"
     STATE_NOT_ACTIVE_OR_ARMED = "state_not_active_or_armed"
     LIVE_NOT_AUTHORIZED = "live_not_authorized"
+    CAPITAL_SLOT_RATCHET_BLOCKED = "capital_slot_ratchet_blocked"
+    CAPITAL_SLOT_RELEASED = "capital_slot_released"
 
 
 class RequestedSide(str, Enum):
@@ -55,6 +62,9 @@ class DoublePlayCompositionInput:
 
     ``resulting_side_state`` must be the first return value from
     ``transition_state`` (same step as ``transition``).
+
+    Optional capital-slot decisions are data-only gating inputs; omit both for
+    backward-compatible composition without capital-slot context.
     """
 
     transition: TransitionDecision
@@ -62,6 +72,8 @@ class DoublePlayCompositionInput:
     survival: SurvivalEnvelopeDecision
     suitability: SuitabilityProjectionDecision
     requested_side: RequestedSide
+    capital_slot_ratchet_decision: Optional[CapitalSlotRatchetDecision] = None
+    capital_slot_release_decision: Optional[CapitalSlotReleaseDecision] = None
 
 
 @dataclass(frozen=True)
@@ -88,11 +100,16 @@ def compose_double_play_decision(
     proj = suit.projection
     req = inp.requested_side
 
+    rat = inp.capital_slot_ratchet_decision
+    rel = inp.capital_slot_release_decision
+
     if (
         tr.live_authorization_granted
         or suit.live_authorization
         or proj.live_authorization
         or surv.live_authorization
+        or (rat is not None and rat.live_authorization)
+        or (rel is not None and rel.live_authorization)
     ):
         return DoublePlayCompositionDecision(
             status=DoublePlayCompositionStatus.BLOCKED,
@@ -182,6 +199,30 @@ def compose_double_play_decision(
             status=DoublePlayCompositionStatus.OBSERVE_ONLY,
             block_reasons=(),
             reason="Neutral observe path; model-level observe only.",
+            live_authorization=False,
+        )
+
+    if rel is not None and rel.released:
+        if req in (RequestedSide.LONG_BULL, RequestedSide.SHORT_BEAR):
+            return DoublePlayCompositionDecision(
+                status=DoublePlayCompositionStatus.BLOCKED,
+                block_reasons=(DoublePlayCompositionBlockReason.CAPITAL_SLOT_RELEASED,),
+                reason="Capital slot released (inactivity or opportunity cost); no directional model eligibility.",
+                live_authorization=False,
+            )
+        if req == RequestedSide.NEUTRAL_OBSERVE:
+            return DoublePlayCompositionDecision(
+                status=DoublePlayCompositionStatus.OBSERVE_ONLY,
+                block_reasons=(),
+                reason="Capital slot released; neutral observe only (model-level).",
+                live_authorization=False,
+            )
+
+    if rat is not None and rat.block_reasons:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.CAPITAL_SLOT_RATCHET_BLOCKED,),
+            reason="Capital slot ratchet pre-authorization blocked.",
             live_authorization=False,
         )
 

--- a/tests/trading/master_v2/test_double_play_composition.py
+++ b/tests/trading/master_v2/test_double_play_composition.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from typing import Optional
 
+from trading.master_v2.double_play_capital_slot import (
+    CapitalSlotBlockReason,
+    CapitalSlotRatchetDecision,
+    CapitalSlotReleaseDecision,
+    CapitalSlotReleaseReason,
+    CapitalSlotStatus,
+)
 from trading.master_v2.double_play_composition import (
     DOUBLE_PLAY_COMPOSITION_LAYER_VERSION,
     DoublePlayCompositionBlockReason,
@@ -81,6 +89,8 @@ def _compose(
     surv: SurvivalEnvelopeDecision,
     suit: SuitabilityProjectionDecision,
     req: RequestedSide,
+    capital_slot_ratchet_decision: Optional[CapitalSlotRatchetDecision] = None,
+    capital_slot_release_decision: Optional[CapitalSlotReleaseDecision] = None,
 ):
     return compose_double_play_decision(
         DoublePlayCompositionInput(
@@ -89,6 +99,8 @@ def _compose(
             survival=surv,
             suitability=suit,
             requested_side=req,
+            capital_slot_ratchet_decision=capital_slot_ratchet_decision,
+            capital_slot_release_decision=capital_slot_release_decision,
         )
     )
 
@@ -358,6 +370,196 @@ def test_neutral_observe_blocks_directional_request() -> None:
 
 def test_layer_version() -> None:
     assert DOUBLE_PLAY_COMPOSITION_LAYER_VERSION == "v0"
+
+
+def test_15_long_eligible_with_allowed_capital_slot_ratchet_no_release() -> None:
+    rat = CapitalSlotRatchetDecision(
+        status=CapitalSlotStatus.ACTIVE,
+        ratchet_target=330.0,
+        can_ratchet=True,
+        block_reasons=(),
+        reason="ok",
+        live_authorization=False,
+        new_active_slot_base=340.0,
+    )
+    d = _compose(
+        transition=TransitionDecision(True, "X", False),
+        state=SideState.LONG_ACTIVE,
+        surv=_surv_ok(),
+        suit=_suit(
+            sclass=SuitabilityClass.LONG_ONLY_CANDIDATE,
+            can_long=True,
+            can_short=False,
+            can_neutral=False,
+        ),
+        req=RequestedSide.LONG_BULL,
+        capital_slot_ratchet_decision=rat,
+        capital_slot_release_decision=None,
+    )
+    assert d.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
+
+
+def test_16_short_eligible_with_allowed_capital_slot_ratchet_no_release() -> None:
+    rat = CapitalSlotRatchetDecision(
+        status=CapitalSlotStatus.ACTIVE,
+        ratchet_target=330.0,
+        can_ratchet=True,
+        block_reasons=(),
+        reason="ok",
+        live_authorization=False,
+        new_active_slot_base=340.0,
+    )
+    d = _compose(
+        transition=TransitionDecision(True, "X", False),
+        state=SideState.SHORT_ACTIVE,
+        surv=_surv_ok(),
+        suit=_suit(
+            sclass=SuitabilityClass.SHORT_ONLY_CANDIDATE,
+            can_long=False,
+            can_short=True,
+            can_neutral=False,
+            side_c=SideCompatibility.SHORT_BEAR,
+        ),
+        req=RequestedSide.SHORT_BEAR,
+        capital_slot_ratchet_decision=rat,
+    )
+    assert d.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
+
+
+def test_17_capital_slot_ratchet_blocked_blocks_composition() -> None:
+    rat = CapitalSlotRatchetDecision(
+        status=CapitalSlotStatus.ACTIVE,
+        ratchet_target=330.0,
+        can_ratchet=False,
+        block_reasons=(CapitalSlotBlockReason.SURVIVAL_NOT_ALLOWED,),
+        reason="survival",
+        live_authorization=False,
+    )
+    d = _compose(
+        transition=TransitionDecision(True, "X", False),
+        state=SideState.LONG_ACTIVE,
+        surv=_surv_ok(),
+        suit=_suit(
+            sclass=SuitabilityClass.LONG_ONLY_CANDIDATE,
+            can_long=True,
+            can_short=False,
+            can_neutral=False,
+        ),
+        req=RequestedSide.LONG_BULL,
+        capital_slot_ratchet_decision=rat,
+    )
+    assert d.status is DoublePlayCompositionStatus.BLOCKED
+    assert DoublePlayCompositionBlockReason.CAPITAL_SLOT_RATCHET_BLOCKED in d.block_reasons
+
+
+def test_18_inactivity_release_blocks_directional_composition() -> None:
+    rel = CapitalSlotReleaseDecision(
+        status=CapitalSlotStatus.RELEASED,
+        released=True,
+        release_reason=CapitalSlotReleaseReason.INACTIVITY,
+        block_reasons=(),
+        reason="inactivity",
+        live_authorization=False,
+        authorizes_new_future_selection=False,
+        authorizes_new_trade=False,
+    )
+    d = _compose(
+        transition=TransitionDecision(True, "X", False),
+        state=SideState.LONG_ACTIVE,
+        surv=_surv_ok(),
+        suit=_suit(
+            sclass=SuitabilityClass.LONG_ONLY_CANDIDATE,
+            can_long=True,
+            can_short=False,
+            can_neutral=False,
+        ),
+        req=RequestedSide.LONG_BULL,
+        capital_slot_release_decision=rel,
+    )
+    assert d.status is DoublePlayCompositionStatus.BLOCKED
+    assert DoublePlayCompositionBlockReason.CAPITAL_SLOT_RELEASED in d.block_reasons
+
+
+def test_19_opportunity_release_observe_only_for_neutral_request() -> None:
+    rel = CapitalSlotReleaseDecision(
+        status=CapitalSlotStatus.RELEASED,
+        released=True,
+        release_reason=CapitalSlotReleaseReason.OPPORTUNITY_COST,
+        block_reasons=(),
+        reason="opp",
+        live_authorization=False,
+        authorizes_new_future_selection=False,
+        authorizes_new_trade=False,
+    )
+    d = _compose(
+        transition=TransitionDecision(True, "X", False),
+        state=SideState.LONG_ACTIVE,
+        surv=_surv_ok(),
+        suit=_suit(
+            sclass=SuitabilityClass.NEUTRAL_RANGE_CANDIDATE,
+            can_long=False,
+            can_short=False,
+            can_neutral=True,
+            side_c=SideCompatibility.NEUTRAL_RANGE,
+        ),
+        req=RequestedSide.NEUTRAL_OBSERVE,
+        capital_slot_release_decision=rel,
+    )
+    assert d.status is DoublePlayCompositionStatus.OBSERVE_ONLY
+
+
+def test_20_opportunity_release_blocks_directional() -> None:
+    rel = CapitalSlotReleaseDecision(
+        status=CapitalSlotStatus.RELEASED,
+        released=True,
+        release_reason=CapitalSlotReleaseReason.OPPORTUNITY_COST,
+        block_reasons=(),
+        reason="opp",
+        live_authorization=False,
+        authorizes_new_future_selection=False,
+        authorizes_new_trade=False,
+    )
+    d = _compose(
+        transition=TransitionDecision(True, "X", False),
+        state=SideState.LONG_ACTIVE,
+        surv=_surv_ok(),
+        suit=_suit(
+            sclass=SuitabilityClass.LONG_ONLY_CANDIDATE,
+            can_long=True,
+            can_short=False,
+            can_neutral=False,
+        ),
+        req=RequestedSide.LONG_BULL,
+        capital_slot_release_decision=rel,
+    )
+    assert d.status is DoublePlayCompositionStatus.BLOCKED
+    assert DoublePlayCompositionBlockReason.CAPITAL_SLOT_RELEASED in d.block_reasons
+
+
+def test_21_capital_slot_live_authorization_blocks_composition() -> None:
+    rat = CapitalSlotRatchetDecision(
+        status=CapitalSlotStatus.ACTIVE,
+        ratchet_target=0.0,
+        can_ratchet=False,
+        block_reasons=(),
+        reason="bad",
+        live_authorization=True,
+    )
+    d = _compose(
+        transition=TransitionDecision(True, "X", False),
+        state=SideState.LONG_ACTIVE,
+        surv=_surv_ok(),
+        suit=_suit(
+            sclass=SuitabilityClass.LONG_ONLY_CANDIDATE,
+            can_long=True,
+            can_short=False,
+            can_neutral=False,
+        ),
+        req=RequestedSide.LONG_BULL,
+        capital_slot_ratchet_decision=rat,
+    )
+    assert d.status is DoublePlayCompositionStatus.BLOCKED
+    assert DoublePlayCompositionBlockReason.LIVE_NOT_AUTHORIZED in d.block_reasons
 
 
 def test_live_flag_on_subdecision_blocks() -> None:

--- a/tests/trading/master_v2/test_double_play_pure_stack_contract.py
+++ b/tests/trading/master_v2/test_double_play_pure_stack_contract.py
@@ -21,6 +21,7 @@ from trading.master_v2.double_play_capital_slot import (
     evaluate_capital_slot_release,
 )
 from trading.master_v2.double_play_composition import (
+    DoublePlayCompositionBlockReason,
     DoublePlayCompositionInput,
     DoublePlayCompositionStatus,
     RequestedSide,
@@ -440,17 +441,6 @@ def test_contract_10_long_bull_stack_with_capital_slot_ratchet_context_eligible_
         explicit_side_evidence=True,
     )
     suit = project_strategy_suitability(_suit_in(meta, _suit_allows_from_envelope(surv)))
-    comp = compose_double_play_decision(
-        DoublePlayCompositionInput(
-            transition=t2,
-            resulting_side_state=s2,
-            survival=surv,
-            suitability=suit,
-            requested_side=RequestedSide.LONG_BULL,
-        )
-    )
-    assert comp.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
-
     cfg = _cs_cfg_ok()
     cs_st = _cs_state_ok(future="ETH-USD-PERP", realized=340.0, survival_allows_slot=True)
     rat = evaluate_capital_slot_ratchet(cfg, cs_st)
@@ -464,6 +454,19 @@ def test_contract_10_long_bull_stack_with_capital_slot_ratchet_context_eligible_
     assert not rel.live_authorization
     assert not rel.authorizes_new_future_selection
     assert not rel.authorizes_new_trade
+
+    comp = compose_double_play_decision(
+        DoublePlayCompositionInput(
+            transition=t2,
+            resulting_side_state=s2,
+            survival=surv,
+            suitability=suit,
+            requested_side=RequestedSide.LONG_BULL,
+            capital_slot_ratchet_decision=rat,
+            capital_slot_release_decision=rel,
+        )
+    )
+    assert comp.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
     assert not comp.live_authorization
 
 
@@ -482,17 +485,6 @@ def test_contract_11_short_bear_stack_with_capital_slot_ratchet_context_eligible
         explicit_side_evidence=True,
     )
     suit = project_strategy_suitability(_suit_in(meta, _suit_allows_from_envelope(surv)))
-    comp = compose_double_play_decision(
-        DoublePlayCompositionInput(
-            transition=t2,
-            resulting_side_state=s2,
-            survival=surv,
-            suitability=suit,
-            requested_side=RequestedSide.SHORT_BEAR,
-        )
-    )
-    assert comp.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
-
     cfg = _cs_cfg_ok()
     cs_st = _cs_state_ok(future="SOL-USD-PERP", realized=340.0, survival_allows_slot=True)
     rat = evaluate_capital_slot_ratchet(cfg, cs_st)
@@ -502,6 +494,19 @@ def test_contract_11_short_bear_stack_with_capital_slot_ratchet_context_eligible
     assert not rat.live_authorization
     assert not rel.live_authorization
     assert not rel.authorizes_new_trade
+
+    comp = compose_double_play_decision(
+        DoublePlayCompositionInput(
+            transition=t2,
+            resulting_side_state=s2,
+            survival=surv,
+            suitability=suit,
+            requested_side=RequestedSide.SHORT_BEAR,
+            capital_slot_ratchet_decision=rat,
+            capital_slot_release_decision=rel,
+        )
+    )
+    assert comp.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
 
 
 def test_contract_12_capital_slot_survival_blocks_ratchet_without_trade_or_release_authority() -> (
@@ -534,6 +539,19 @@ def test_contract_12_capital_slot_survival_blocks_ratchet_without_trade_or_relea
     assert not rat.can_ratchet
     assert CapitalSlotBlockReason.SURVIVAL_NOT_ALLOWED in rat.block_reasons
     assert not rat.live_authorization
+
+    comp_cs = compose_double_play_decision(
+        DoublePlayCompositionInput(
+            transition=t2,
+            resulting_side_state=s2,
+            survival=surv,
+            suitability=suit,
+            requested_side=RequestedSide.LONG_BULL,
+            capital_slot_ratchet_decision=rat,
+        )
+    )
+    assert comp_cs.status is DoublePlayCompositionStatus.BLOCKED
+    assert DoublePlayCompositionBlockReason.CAPITAL_SLOT_RATCHET_BLOCKED in comp_cs.block_reasons
 
     rel_ok = evaluate_capital_slot_release(cfg, cs_st)
     assert not rel_ok.authorizes_new_trade
@@ -587,6 +605,10 @@ def test_contract_15_live_authorization_false_all_layers_including_capital_slot(
         explicit_side_evidence=True,
     )
     suit = project_strategy_suitability(_suit_in(meta, _suit_allows_from_envelope(surv)))
+    cfg = _cs_cfg_ok()
+    cs_st = _cs_state_ok()
+    rat = evaluate_capital_slot_ratchet(cfg, cs_st)
+    rel = evaluate_capital_slot_release(cfg, cs_st)
     comp = compose_double_play_decision(
         DoublePlayCompositionInput(
             transition=t2,
@@ -594,12 +616,10 @@ def test_contract_15_live_authorization_false_all_layers_including_capital_slot(
             survival=surv,
             suitability=suit,
             requested_side=RequestedSide.LONG_BULL,
+            capital_slot_ratchet_decision=rat,
+            capital_slot_release_decision=rel,
         )
     )
-    cfg = _cs_cfg_ok()
-    cs_st = _cs_state_ok()
-    rat = evaluate_capital_slot_ratchet(cfg, cs_st)
-    rel = evaluate_capital_slot_release(cfg, cs_st)
 
     assert not t2.live_authorization_granted
     assert not surv.live_authorization
@@ -609,6 +629,78 @@ def test_contract_15_live_authorization_false_all_layers_including_capital_slot(
     assert not rat.live_authorization
     assert not rel.live_authorization
     assert GOOD_ENVELOPE.live_authorization is False
+    assert comp.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
+
+
+def test_contract_16_pure_stack_blocked_when_capital_slot_inactivity_released() -> None:
+    s1, st1, _ = _ts(SideState.NEUTRAL_OBSERVE, ScopeEvent.UPSCOPE_CONFIRMED, EMPTY_ST, 0)
+    s2, st2, t2 = _ts(s1, ScopeEvent.UPSCOPE_CONFIRMED, st1, 1)
+    assert s2 == SideState.LONG_ACTIVE
+
+    surv = evaluate_survival_envelope(_env_ok())
+    meta = StrategyMetadata(
+        strategy_id="cs-inact",
+        strategy_family="m",
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    suit = project_strategy_suitability(_suit_in(meta, _suit_allows_from_envelope(surv)))
+
+    cfg = _cs_cfg_ok()
+    cs_st = replace(
+        _cs_state_ok(),
+        realized_volatility=0.01,
+        atr_or_range=0.01,
+    )
+    rel = evaluate_capital_slot_release(cfg, cs_st)
+    assert rel.released
+
+    comp = compose_double_play_decision(
+        DoublePlayCompositionInput(
+            transition=t2,
+            resulting_side_state=s2,
+            survival=surv,
+            suitability=suit,
+            requested_side=RequestedSide.LONG_BULL,
+            capital_slot_release_decision=rel,
+        )
+    )
+    assert comp.status is DoublePlayCompositionStatus.BLOCKED
+    assert DoublePlayCompositionBlockReason.CAPITAL_SLOT_RELEASED in comp.block_reasons
+
+
+def test_contract_17_pure_stack_blocked_when_capital_slot_opportunity_released() -> None:
+    s1, st1, _ = _ts(SideState.NEUTRAL_OBSERVE, ScopeEvent.UPSCOPE_CONFIRMED, EMPTY_ST, 0)
+    s2, st2, t2 = _ts(s1, ScopeEvent.UPSCOPE_CONFIRMED, st1, 1)
+    assert s2 == SideState.LONG_ACTIVE
+
+    surv = evaluate_survival_envelope(_env_ok())
+    meta = StrategyMetadata(
+        strategy_id="cs-opp",
+        strategy_family="m",
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    suit = project_strategy_suitability(_suit_in(meta, _suit_allows_from_envelope(surv)))
+
+    cfg = _cs_cfg_ok()
+    cs_st = replace(_cs_state_ok(), opportunity_score=0.05)
+    rel = evaluate_capital_slot_release(cfg, cs_st)
+    assert rel.released
+    assert rel.release_reason is CapitalSlotReleaseReason.OPPORTUNITY_COST
+
+    comp = compose_double_play_decision(
+        DoublePlayCompositionInput(
+            transition=t2,
+            resulting_side_state=s2,
+            survival=surv,
+            suitability=suit,
+            requested_side=RequestedSide.LONG_BULL,
+            capital_slot_release_decision=rel,
+        )
+    )
+    assert comp.status is DoublePlayCompositionStatus.BLOCKED
+    assert DoublePlayCompositionBlockReason.CAPITAL_SLOT_RELEASED in comp.block_reasons
 
 
 def _forbidden_toplevels() -> frozenset[str]:


### PR DESCRIPTION
## Summary
- extend pure Double Play composition input with optional capital-slot ratchet/release decisions
- add capital-slot gating reasons for blocked ratchet and released slot
- block composition when ratchet is blocked or capital slot is released for Long/Short requests
- preserve observe-only behavior for released slot with neutral request
- reject erroneous capital-slot live_authorization flags
- keep composition output live_authorization false

## Changed files
- src/trading/master_v2/double_play_composition.py
- tests/trading/master_v2/test_double_play_composition.py
- tests/trading/master_v2/test_double_play_pure_stack_contract.py

## Validation
- uv run pytest tests/trading/master_v2/test_double_play_composition.py tests/trading/master_v2/test_double_play_pure_stack_contract.py -q
- uv run pytest tests/trading/master_v2/ -q
- uv run ruff check src/trading/master_v2 tests/trading/master_v2
- uv run ruff format --check src/trading/master_v2 tests/trading/master_v2

## Safety
- pure model extension + unit tests only
- no allocation runtime
- no strategy execution
- no strategy registry mutation/wiring
- no selector execution
- no runtime integration
- no execution/orchestrator/session changes
- no risk gate / safety guard / kill switch changes
- no exchange adapter changes
- no workflow changes
- no config changes
- no scanner/backtest/market-data/exchange calls
- no out/evidence/S3/cache mutation
- no testnet or Live authorization
- composition live_authorization remains false
