### PR TITLE
feat(master_v2): add double play futures input model v0

### DIFF
--- a/src/trading/master_v2/double_play_futures_input.py
+++ b/src/trading/master_v2/double_play_futures_input.py
@@ -1,0 +1,274 @@
+# src/trading/master_v2/double_play_futures_input.py
+"""
+Pure Double Play futures input snapshot model: data-only readiness evaluation.
+
+No I/O, scanners, exchanges, market-data fetch, selection, allocation, or Live authority.
+Aligned with docs/ops/specs/MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+DOUBLE_PLAY_FUTURES_INPUT_LAYER_VERSION = "v0"
+
+
+class FuturesMarketType(str, Enum):
+    FUTURES = "futures"
+    PERPETUAL = "perpetual"
+    SWAP = "swap"
+    UNKNOWN = "unknown"
+
+
+class FuturesFreshnessState(str, Enum):
+    FRESH = "fresh"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+class FuturesReadinessStatus(str, Enum):
+    """Data-only readiness label; non-authority."""
+
+    DATA_READY = "data_ready"
+    BLOCKED = "blocked"
+
+
+class FuturesInputBlockReason(str, Enum):
+    INSTRUMENT_METADATA_INCOMPLETE = "instrument_metadata_incomplete"
+    MARKET_DATA_PROVENANCE_INCOMPLETE = "market_data_provenance_incomplete"
+    FRESHNESS_STALE = "freshness_stale"
+    FRESHNESS_UNKNOWN = "freshness_unknown"
+    MARKET_TYPE_UNKNOWN = "market_type_unknown"
+    VOLATILITY_INCOMPLETE = "volatility_incomplete"
+    LIQUIDITY_INCOMPLETE = "liquidity_incomplete"
+    PERPETUAL_FUNDING_INCOMPLETE = "perpetual_funding_incomplete"
+
+
+@dataclass(frozen=True)
+class FuturesCandidateSnapshot:
+    candidate_id: str
+    instrument_id: str
+    symbol: str
+    market_type: FuturesMarketType
+    exchange: str
+    base_currency: str
+    quote_currency: str
+    live_authorization: bool = False
+
+
+@dataclass(frozen=True)
+class FuturesRankingSnapshot:
+    source_universe_size: Optional[int]
+    selected_top_n: Optional[int]
+    rank: Optional[int]
+    score: Optional[float]
+    score_components_complete: bool
+    is_top_n_member: bool
+
+
+@dataclass(frozen=True)
+class FuturesInstrumentMetadataStatus:
+    complete: bool
+    contract_size_known: bool
+    tick_size_known: bool
+    step_size_known: bool
+    min_qty_known: bool
+    min_notional_known: bool
+    margin_asset_known: bool
+    settlement_asset_known: bool
+    leverage_bounds_known: bool
+    missing_fields: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FuturesMarketDataProvenanceStatus:
+    complete: bool
+    freshness_state: FuturesFreshnessState
+    dataset_id: Optional[str]
+    source: Optional[str]
+    mark_available: bool
+    index_available: bool
+    last_available: bool
+    ohlcv_available: bool
+    funding_available: bool
+    open_interest_available: bool
+    missing_fields: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FuturesVolatilityProfile:
+    realized_volatility: Optional[float]
+    atr_or_rolling_range: Optional[float]
+    volatility_regime: Optional[str]
+    dynamic_scope_usable: bool
+
+
+@dataclass(frozen=True)
+class FuturesLiquidityProfile:
+    spread_bps: Optional[float]
+    average_spread_bps: Optional[float]
+    volume: Optional[float]
+    quote_volume: Optional[float]
+    liquidity_regime: Optional[str]
+    spread_quality: Optional[str]
+
+
+@dataclass(frozen=True)
+class FuturesDerivativesProfile:
+    funding_available: bool
+    funding_rate: Optional[float]
+    funding_regime: Optional[str]
+    open_interest_available: bool
+    open_interest: Optional[float]
+    open_interest_regime: Optional[str]
+
+
+@dataclass(frozen=True)
+class FuturesOpportunityProfile:
+    opportunity_score: Optional[float]
+    inactivity_score: Optional[float]
+    movement_above_fee_slippage_breakeven: Optional[bool]
+    chop_risk: Optional[str]
+    candidate_is_inactive: bool
+
+
+@dataclass(frozen=True)
+class FuturesInputSnapshot:
+    candidate: FuturesCandidateSnapshot
+    ranking: FuturesRankingSnapshot
+    instrument: FuturesInstrumentMetadataStatus
+    provenance: FuturesMarketDataProvenanceStatus
+    volatility: FuturesVolatilityProfile
+    liquidity: FuturesLiquidityProfile
+    derivatives: FuturesDerivativesProfile
+    opportunity: FuturesOpportunityProfile
+    dashboard_label: Optional[str] = None
+    ai_summary: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class FuturesInputReadinessDecision:
+    status: FuturesReadinessStatus
+    ready_for_downstream_model_use: bool
+    ready_for_dynamic_scope: bool
+    ready_for_capital_slot: bool
+    ready_for_suitability: bool
+    ready_for_survival_envelope: bool
+    block_reasons: Tuple[FuturesInputBlockReason, ...]
+    missing_inputs: Tuple[str, ...]
+    is_authority: bool = False
+    is_signal: bool = False
+    live_authorization: bool = False
+
+
+def instrument_metadata_complete(status: FuturesInstrumentMetadataStatus) -> bool:
+    return bool(status.complete)
+
+
+def market_data_provenance_complete(status: FuturesMarketDataProvenanceStatus) -> bool:
+    return bool(status.complete)
+
+
+def volatility_profile_complete(profile: FuturesVolatilityProfile) -> bool:
+    return (
+        profile.realized_volatility is not None
+        and profile.atr_or_rolling_range is not None
+        and profile.dynamic_scope_usable
+    )
+
+
+def liquidity_profile_complete(profile: FuturesLiquidityProfile) -> bool:
+    if profile.spread_bps is None:
+        return False
+    return profile.volume is not None or profile.quote_volume is not None
+
+
+def perpetual_derivatives_profile_complete(profile: FuturesDerivativesProfile) -> bool:
+    return profile.funding_available and profile.funding_rate is not None
+
+
+def _perpetual_like(market_type: FuturesMarketType) -> bool:
+    return market_type in (FuturesMarketType.PERPETUAL, FuturesMarketType.SWAP)
+
+
+def evaluate_futures_input_snapshot(
+    snapshot: FuturesInputSnapshot,
+) -> FuturesInputReadinessDecision:
+    """
+    Fail-closed, data-only readiness over a precomputed futures input snapshot.
+
+    Display fields (dashboard_label, ai_summary, ranking context, opportunity scalars)
+    never confer authority. Candidate ``live_authorization`` is ignored.
+    """
+    blocks: list[FuturesInputBlockReason] = []
+    missing: list[str] = []
+
+    if not instrument_metadata_complete(snapshot.instrument):
+        blocks.append(FuturesInputBlockReason.INSTRUMENT_METADATA_INCOMPLETE)
+        missing.extend(list(snapshot.instrument.missing_fields))
+
+    if not market_data_provenance_complete(snapshot.provenance):
+        blocks.append(FuturesInputBlockReason.MARKET_DATA_PROVENANCE_INCOMPLETE)
+        missing.extend(list(snapshot.provenance.missing_fields))
+
+    if snapshot.provenance.freshness_state is FuturesFreshnessState.STALE:
+        blocks.append(FuturesInputBlockReason.FRESHNESS_STALE)
+    elif snapshot.provenance.freshness_state is FuturesFreshnessState.UNKNOWN:
+        blocks.append(FuturesInputBlockReason.FRESHNESS_UNKNOWN)
+
+    if snapshot.candidate.market_type is FuturesMarketType.UNKNOWN:
+        blocks.append(FuturesInputBlockReason.MARKET_TYPE_UNKNOWN)
+
+    downstream_ok = (
+        instrument_metadata_complete(snapshot.instrument)
+        and market_data_provenance_complete(snapshot.provenance)
+        and snapshot.provenance.freshness_state is FuturesFreshnessState.FRESH
+        and snapshot.candidate.market_type is not FuturesMarketType.UNKNOWN
+    )
+
+    vol_ok = volatility_profile_complete(snapshot.volatility)
+    if not vol_ok:
+        blocks.append(FuturesInputBlockReason.VOLATILITY_INCOMPLETE)
+
+    liq_ok = liquidity_profile_complete(snapshot.liquidity)
+    if not liq_ok:
+        blocks.append(FuturesInputBlockReason.LIQUIDITY_INCOMPLETE)
+
+    perp_need = _perpetual_like(snapshot.candidate.market_type)
+    perp_ok = perpetual_derivatives_profile_complete(snapshot.derivatives) if perp_need else True
+    if perp_need and not perp_ok:
+        blocks.append(FuturesInputBlockReason.PERPETUAL_FUNDING_INCOMPLETE)
+
+    ready_downstream = downstream_ok
+    ready_dynamic = downstream_ok and vol_ok
+    ready_capital = downstream_ok and liq_ok and perp_ok
+    ready_suitability = downstream_ok and vol_ok and liq_ok and perp_ok
+    ready_survival = downstream_ok
+
+    unique_blocks = tuple(dict.fromkeys(blocks))
+    unique_missing = tuple(dict.fromkeys(m for m in missing if m))
+
+    all_clear = (
+        ready_downstream
+        and ready_dynamic
+        and ready_capital
+        and ready_suitability
+        and ready_survival
+    )
+    status = FuturesReadinessStatus.DATA_READY if all_clear else FuturesReadinessStatus.BLOCKED
+
+    return FuturesInputReadinessDecision(
+        status=status,
+        ready_for_downstream_model_use=ready_downstream,
+        ready_for_dynamic_scope=ready_dynamic,
+        ready_for_capital_slot=ready_capital,
+        ready_for_suitability=ready_suitability,
+        ready_for_survival_envelope=ready_survival,
+        block_reasons=unique_blocks,
+        missing_inputs=unique_missing,
+        is_authority=False,
+        is_signal=False,
+        live_authorization=False,
+    )

--- a/tests/trading/master_v2/test_double_play_futures_input.py
+++ b/tests/trading/master_v2/test_double_play_futures_input.py
@@ -1,0 +1,337 @@
+# tests/trading/master_v2/test_double_play_futures_input.py
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from trading.master_v2.double_play_futures_input import (
+    DOUBLE_PLAY_FUTURES_INPUT_LAYER_VERSION,
+    FuturesCandidateSnapshot,
+    FuturesDerivativesProfile,
+    FuturesFreshnessState,
+    FuturesInputBlockReason,
+    FuturesInputSnapshot,
+    FuturesInstrumentMetadataStatus,
+    FuturesLiquidityProfile,
+    FuturesMarketDataProvenanceStatus,
+    FuturesMarketType,
+    FuturesOpportunityProfile,
+    FuturesRankingSnapshot,
+    FuturesReadinessStatus,
+    FuturesVolatilityProfile,
+    evaluate_futures_input_snapshot,
+)
+
+
+def _candidate(**overrides: object) -> FuturesCandidateSnapshot:
+    d: dict = {
+        "candidate_id": "c1",
+        "instrument_id": "inst-btc-perp",
+        "symbol": "BTC-USDT-PERP",
+        "market_type": FuturesMarketType.PERPETUAL,
+        "exchange": "example",
+        "base_currency": "BTC",
+        "quote_currency": "USDT",
+        "live_authorization": False,
+    }
+    d.update(overrides)
+    return FuturesCandidateSnapshot(**d)
+
+
+def _ranking(**overrides: object) -> FuturesRankingSnapshot:
+    d: dict = {
+        "source_universe_size": 200,
+        "selected_top_n": 20,
+        "rank": 3,
+        "score": 0.91,
+        "score_components_complete": True,
+        "is_top_n_member": True,
+    }
+    d.update(overrides)
+    return FuturesRankingSnapshot(**d)
+
+
+def _instrument(**overrides: object) -> FuturesInstrumentMetadataStatus:
+    d: dict = {
+        "complete": True,
+        "contract_size_known": True,
+        "tick_size_known": True,
+        "step_size_known": True,
+        "min_qty_known": True,
+        "min_notional_known": True,
+        "margin_asset_known": True,
+        "settlement_asset_known": True,
+        "leverage_bounds_known": True,
+        "missing_fields": (),
+    }
+    d.update(overrides)
+    return FuturesInstrumentMetadataStatus(**d)
+
+
+def _provenance(**overrides: object) -> FuturesMarketDataProvenanceStatus:
+    d: dict = {
+        "complete": True,
+        "freshness_state": FuturesFreshnessState.FRESH,
+        "dataset_id": "ds-1",
+        "source": "fixture",
+        "mark_available": True,
+        "index_available": True,
+        "last_available": True,
+        "ohlcv_available": True,
+        "funding_available": True,
+        "open_interest_available": True,
+        "missing_fields": (),
+    }
+    d.update(overrides)
+    return FuturesMarketDataProvenanceStatus(**d)
+
+
+def _volatility(**overrides: object) -> FuturesVolatilityProfile:
+    d: dict = {
+        "realized_volatility": 0.42,
+        "atr_or_rolling_range": 120.0,
+        "volatility_regime": "medium",
+        "dynamic_scope_usable": True,
+    }
+    d.update(overrides)
+    return FuturesVolatilityProfile(**d)
+
+
+def _liquidity(**overrides: object) -> FuturesLiquidityProfile:
+    d: dict = {
+        "spread_bps": 1.5,
+        "average_spread_bps": 1.8,
+        "volume": 1_000_000.0,
+        "quote_volume": 50_000_000.0,
+        "liquidity_regime": "deep",
+        "spread_quality": "tight",
+    }
+    d.update(overrides)
+    return FuturesLiquidityProfile(**d)
+
+
+def _derivatives(**overrides: object) -> FuturesDerivativesProfile:
+    d: dict = {
+        "funding_available": True,
+        "funding_rate": 0.0001,
+        "funding_regime": "neutral",
+        "open_interest_available": True,
+        "open_interest": 1e9,
+        "open_interest_regime": "high",
+    }
+    d.update(overrides)
+    return FuturesDerivativesProfile(**d)
+
+
+def _opportunity(**overrides: object) -> FuturesOpportunityProfile:
+    d: dict = {
+        "opportunity_score": 0.75,
+        "inactivity_score": 0.1,
+        "movement_above_fee_slippage_breakeven": True,
+        "chop_risk": "low",
+        "candidate_is_inactive": False,
+    }
+    d.update(overrides)
+    return FuturesOpportunityProfile(**d)
+
+
+def _snapshot(**overrides: object) -> FuturesInputSnapshot:
+    parts: dict = {
+        "candidate": _candidate(),
+        "ranking": _ranking(),
+        "instrument": _instrument(),
+        "provenance": _provenance(),
+        "volatility": _volatility(),
+        "liquidity": _liquidity(),
+        "derivatives": _derivatives(),
+        "opportunity": _opportunity(),
+        "dashboard_label": None,
+        "ai_summary": None,
+    }
+    parts.update(overrides)
+    return FuturesInputSnapshot(**parts)
+
+
+def test_layer_version_is_v0() -> None:
+    assert DOUBLE_PLAY_FUTURES_INPUT_LAYER_VERSION == "v0"
+
+
+def test_complete_snapshot_returns_data_only_ready_status() -> None:
+    d = evaluate_futures_input_snapshot(_snapshot())
+    assert d.status is FuturesReadinessStatus.DATA_READY
+    assert d.ready_for_downstream_model_use
+    assert d.ready_for_dynamic_scope
+    assert d.ready_for_capital_slot
+    assert d.ready_for_suitability
+    assert d.ready_for_survival_envelope
+    assert not d.block_reasons
+    assert not d.is_authority
+    assert not d.is_signal
+    assert not d.live_authorization
+
+
+def test_missing_instrument_metadata_fails_closed() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(instrument=_instrument(complete=False, missing_fields=("tick_size",)))
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert not d.ready_for_downstream_model_use
+    assert FuturesInputBlockReason.INSTRUMENT_METADATA_INCOMPLETE in d.block_reasons
+    assert "tick_size" in d.missing_inputs
+
+
+def test_missing_market_data_provenance_fails_closed() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(provenance=_provenance(complete=False, missing_fields=("dataset_id",)))
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert not d.ready_for_downstream_model_use
+    assert FuturesInputBlockReason.MARKET_DATA_PROVENANCE_INCOMPLETE in d.block_reasons
+
+
+def test_stale_freshness_fails_closed() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(provenance=_provenance(freshness_state=FuturesFreshnessState.STALE))
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert FuturesInputBlockReason.FRESHNESS_STALE in d.block_reasons
+    assert not d.ready_for_downstream_model_use
+
+
+def test_unknown_freshness_fails_closed() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(provenance=_provenance(freshness_state=FuturesFreshnessState.UNKNOWN))
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert FuturesInputBlockReason.FRESHNESS_UNKNOWN in d.block_reasons
+
+
+def test_unknown_market_type_fails_closed() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(candidate=_candidate(market_type=FuturesMarketType.UNKNOWN))
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert FuturesInputBlockReason.MARKET_TYPE_UNKNOWN in d.block_reasons
+    assert not d.ready_for_downstream_model_use
+
+
+def test_top20_rank_alone_does_not_authorize_readiness() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(
+            ranking=_ranking(rank=1, is_top_n_member=True, score=0.99),
+            instrument=_instrument(complete=False, missing_fields=("contract_size",)),
+        )
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert not d.ready_for_downstream_model_use
+
+
+def test_missing_volatility_blocks_dynamic_scope() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(
+            volatility=_volatility(
+                realized_volatility=None,
+                atr_or_rolling_range=10.0,
+                dynamic_scope_usable=False,
+            )
+        )
+    )
+    assert not d.ready_for_dynamic_scope
+    assert FuturesInputBlockReason.VOLATILITY_INCOMPLETE in d.block_reasons
+    assert d.ready_for_downstream_model_use
+
+
+def test_missing_spread_liquidity_blocks_capital_slot() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(liquidity=_liquidity(spread_bps=None, volume=1.0, quote_volume=None))
+    )
+    assert not d.ready_for_capital_slot
+    assert FuturesInputBlockReason.LIQUIDITY_INCOMPLETE in d.block_reasons
+
+
+def test_missing_funding_blocks_perpetual_readiness() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(
+            candidate=_candidate(market_type=FuturesMarketType.PERPETUAL),
+            derivatives=_derivatives(funding_available=False, funding_rate=None),
+        )
+    )
+    assert not d.ready_for_capital_slot
+    assert not d.ready_for_suitability
+    assert FuturesInputBlockReason.PERPETUAL_FUNDING_INCOMPLETE in d.block_reasons
+
+
+def test_opportunity_score_is_data_only_does_not_unblock() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(
+            instrument=_instrument(complete=False, missing_fields=("min_notional",)),
+            opportunity=_opportunity(opportunity_score=1.0),
+        )
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert not d.ready_for_downstream_model_use
+
+
+def test_inactivity_context_is_data_only_does_not_unblock() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(
+            provenance=_provenance(complete=False, missing_fields=("source",)),
+            opportunity=_opportunity(inactivity_score=0.0, candidate_is_inactive=False),
+        )
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+
+
+def test_dashboard_label_cannot_authorize_readiness() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(
+            instrument=_instrument(complete=False, missing_fields=("tick_size",)),
+            dashboard_label="LIVE APPROVED — OPERATOR GO",
+        )
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert not d.live_authorization
+
+
+def test_ai_summary_cannot_authorize_readiness() -> None:
+    d = evaluate_futures_input_snapshot(
+        _snapshot(
+            provenance=_provenance(complete=False),
+            ai_summary="Model recommends immediate Testnet enablement.",
+        )
+    )
+    assert d.status is FuturesReadinessStatus.BLOCKED
+    assert not d.is_authority
+
+
+def test_live_authorization_on_candidate_is_ignored_in_decision() -> None:
+    d = evaluate_futures_input_snapshot(_snapshot(candidate=_candidate(live_authorization=True)))
+    assert not d.live_authorization
+
+
+def test_no_forbidden_top_level_imports_in_module() -> None:
+    root = Path(__file__).resolve().parent.parent.parent.parent / "src" / "trading" / "master_v2"
+    path = root / "double_play_futures_input.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bad_roots = {
+        "ccxt",
+        "requests",
+        "urllib3",
+        "httpx",
+        "aiohttp",
+        "socket",
+        "websockets",
+        "boto3",
+        "botocore",
+        "mlflow",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                base = n.name.split(".")[0]
+                assert base not in bad_roots
+                assert base != "trading"
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mod0 = node.module.split(".")[0]
+            assert mod0 not in bad_roots
+            assert mod0 != "trading"


### PR DESCRIPTION
## Summary
- add pure Double Play futures input snapshot model v0
- encode candidate/ranking context, instrument metadata status, market-data provenance status, volatility, liquidity, derivatives, and opportunity profiles
- add fail-closed readiness evaluation for downstream pure-model use
- ensure Top-N/rank, dashboard labels, AI summaries, and candidate live flags do not grant authority
- add focused unit tests and import-boundary guard

## Changed files
- src/trading/master_v2/double_play_futures_input.py
- tests/trading/master_v2/test_double_play_futures_input.py

## Validation
- uv run pytest tests/trading/master_v2/test_double_play_futures_input.py -q
- uv run ruff check src/trading/master_v2 tests/trading/master_v2
- uv run ruff format --check src/trading/master_v2/double_play_futures_input.py tests/trading/master_v2/test_double_play_futures_input.py

## Safety
- pure model + unit tests only
- no scanner execution
- no exchange calls
- no market-data fetches
- no dashboard integration
- no selector execution
- no strategy execution
- no allocation/runtime integration
- no state-switch/composition changes
- no workflow changes
- no config changes
- no out/evidence/S3/cache mutation
- no testnet or Live authorization
- futures input decisions never set live_authorization true

Made with [Cursor](https://cursor.com)