### PR TITLE
feat(master-v2): add double play dashboard display dto v0

### DIFF
--- a/src/trading/master_v2/double_play_dashboard_display.py
+++ b/src/trading/master_v2/double_play_dashboard_display.py
@@ -1,0 +1,426 @@
+# src/trading/master_v2/double_play_dashboard_display.py
+"""
+Pure read-only dashboard display DTO for Master V2 Double Play.
+
+Aggregates already-computed pure decisions into a display-safe snapshot only.
+No WebUI, ASGI web framework imports, I/O, scanner, exchange, sessions, or Live authority.
+See docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+from trading.master_v2.double_play_capital_slot import (
+    CapitalSlotRatchetDecision,
+    CapitalSlotReleaseDecision,
+)
+from trading.master_v2.double_play_composition import (
+    DoublePlayCompositionDecision,
+    DoublePlayCompositionStatus,
+)
+from trading.master_v2.double_play_futures_input import (
+    FuturesInputReadinessDecision,
+    FuturesReadinessStatus,
+)
+from trading.master_v2.double_play_state import TransitionDecision
+from trading.master_v2.double_play_suitability import (
+    SuitabilityClass,
+    SuitabilityProjectionDecision,
+)
+from trading.master_v2.double_play_survival import (
+    SurvivalEnvelopeDecision,
+    SurvivalEnvelopeStatus,
+)
+
+DOUBLE_PLAY_DASHBOARD_DISPLAY_LAYER_VERSION = "v0"
+
+
+class DashboardDisplayStatus(str, Enum):
+    """Overall display health; non-authority."""
+
+    DISPLAY_READY = "display_ready"
+    DISPLAY_WARNING = "display_warning"
+    DISPLAY_BLOCKED = "display_blocked"
+    DISPLAY_MISSING = "display_missing"
+    DISPLAY_ERROR = "display_error"
+
+
+# Per-panel status uses the same vocabulary (display map / brief).
+DashboardPanelStatus = DashboardDisplayStatus
+
+
+@dataclass(frozen=True)
+class DoublePlayDashboardPanel:
+    name: str
+    status: DashboardPanelStatus
+    summary: str
+    blockers: Tuple[str, ...]
+    missing_inputs: Tuple[str, ...]
+    live_authorization: bool = False
+    is_authority: bool = False
+    is_signal: bool = False
+
+
+@dataclass(frozen=True)
+class DoublePlayDashboardDisplaySnapshot:
+    panels: Tuple[DoublePlayDashboardPanel, ...]
+    overall_status: DashboardDisplayStatus
+    no_live_banner_visible: bool = True
+    display_only: bool = True
+    trading_ready: bool = False
+    testnet_ready: bool = False
+    live_ready: bool = False
+    live_authorization: bool = False
+    warnings: Tuple[str, ...] = ()
+
+
+def _panel(
+    name: str,
+    status: DashboardPanelStatus,
+    summary: str,
+    *,
+    blockers: Tuple[str, ...] = (),
+    missing: Tuple[str, ...] = (),
+) -> DoublePlayDashboardPanel:
+    return DoublePlayDashboardPanel(
+        name=name,
+        status=status,
+        summary=summary,
+        blockers=blockers,
+        missing_inputs=missing,
+        live_authorization=False,
+        is_authority=False,
+        is_signal=False,
+    )
+
+
+def _severity_rank(s: DashboardDisplayStatus) -> int:
+    return {
+        DashboardDisplayStatus.DISPLAY_ERROR: 4,
+        DashboardDisplayStatus.DISPLAY_BLOCKED: 3,
+        DashboardDisplayStatus.DISPLAY_WARNING: 2,
+        DashboardDisplayStatus.DISPLAY_MISSING: 1,
+        DashboardDisplayStatus.DISPLAY_READY: 0,
+    }[s]
+
+
+def _max_severity(a: DashboardDisplayStatus, b: DashboardDisplayStatus) -> DashboardDisplayStatus:
+    return a if _severity_rank(a) >= _severity_rank(b) else b
+
+
+def _collect_input_live_warnings(
+    *,
+    futures_input: Optional[FuturesInputReadinessDecision],
+    transition: Optional[TransitionDecision],
+    survival: Optional[SurvivalEnvelopeDecision],
+    suitability: Optional[SuitabilityProjectionDecision],
+    capital_slot_ratchet: Optional[CapitalSlotRatchetDecision],
+    capital_slot_release: Optional[CapitalSlotReleaseDecision],
+    composition: Optional[DoublePlayCompositionDecision],
+) -> Tuple[str, ...]:
+    w: list[str] = []
+    if futures_input is not None and futures_input.live_authorization:
+        w.append("futures_input reported live_authorization; ignored for display")
+    if transition is not None and transition.live_authorization_granted:
+        w.append("transition reported live_authorization_granted; ignored for display")
+    if survival is not None and survival.live_authorization:
+        w.append("survival reported live_authorization; ignored for display")
+    if suitability is not None:
+        if suitability.live_authorization:
+            w.append("suitability reported live_authorization; ignored for display")
+        if suitability.projection.live_authorization:
+            w.append("suitability.projection reported live_authorization; ignored for display")
+    if capital_slot_ratchet is not None and capital_slot_ratchet.live_authorization:
+        w.append("capital_slot_ratchet reported live_authorization; ignored for display")
+    if capital_slot_release is not None and capital_slot_release.live_authorization:
+        w.append("capital_slot_release reported live_authorization; ignored for display")
+    if composition is not None and composition.live_authorization:
+        w.append("composition reported live_authorization; ignored for display")
+    return tuple(w)
+
+
+def _panel_futures_input(d: Optional[FuturesInputReadinessDecision]) -> DoublePlayDashboardPanel:
+    if d is None:
+        return _panel(
+            "futures_input",
+            DashboardPanelStatus.DISPLAY_MISSING,
+            "No futures input readiness decision supplied (display-only gap).",
+        )
+    if d.status is FuturesReadinessStatus.BLOCKED:
+        return _panel(
+            "futures_input",
+            DashboardPanelStatus.DISPLAY_BLOCKED,
+            "Futures input readiness is blocked (data-only).",
+            blockers=tuple(str(x) for x in d.block_reasons),
+            missing=d.missing_inputs,
+        )
+    return _panel(
+        "futures_input",
+        DashboardPanelStatus.DISPLAY_READY,
+        "Futures input readiness is data-ready (not trading permission).",
+    )
+
+
+def _panel_transition(d: Optional[TransitionDecision]) -> DoublePlayDashboardPanel:
+    if d is None:
+        return _panel(
+            "state_transition",
+            DashboardPanelStatus.DISPLAY_MISSING,
+            "No transition decision supplied (display-only gap).",
+        )
+    if d.live_authorization_granted:
+        return _panel(
+            "state_transition",
+            DashboardPanelStatus.DISPLAY_ERROR,
+            "Transition carried live_authorization_granted; display treats as error state.",
+            blockers=("live_authorization_granted_true",),
+        )
+    if not d.allowed:
+        return _panel(
+            "state_transition",
+            DashboardPanelStatus.DISPLAY_WARNING,
+            f"Transition not allowed: {d.reason_code}",
+            blockers=(d.reason_code,),
+        )
+    return _panel(
+        "state_transition",
+        DashboardPanelStatus.DISPLAY_READY,
+        f"Transition allowed (model label): {d.reason_code}",
+    )
+
+
+def _panel_survival(d: Optional[SurvivalEnvelopeDecision]) -> DoublePlayDashboardPanel:
+    if d is None:
+        return _panel(
+            "survival_envelope",
+            DashboardPanelStatus.DISPLAY_MISSING,
+            "No survival envelope decision supplied (display-only gap).",
+        )
+    if d.status is SurvivalEnvelopeStatus.BLOCKED or not d.pre_authorization_eligible:
+        return _panel(
+            "survival_envelope",
+            DashboardPanelStatus.DISPLAY_BLOCKED,
+            "Survival envelope blocked or not pre-authorization eligible (data-only).",
+            blockers=tuple(str(x) for x in d.block_reasons),
+        )
+    return _panel(
+        "survival_envelope",
+        DashboardPanelStatus.DISPLAY_READY,
+        "Survival envelope OK (model label only).",
+    )
+
+
+def _panel_suitability(d: Optional[SuitabilityProjectionDecision]) -> DoublePlayDashboardPanel:
+    if d is None:
+        return _panel(
+            "strategy_suitability",
+            DashboardPanelStatus.DISPLAY_MISSING,
+            "No suitability projection supplied (display-only gap).",
+        )
+    if d.live_authorization or d.projection.live_authorization:
+        return _panel(
+            "strategy_suitability",
+            DashboardPanelStatus.DISPLAY_ERROR,
+            "Suitability carried live_authorization; display treats as error state.",
+            blockers=("live_authorization_true",),
+        )
+    proj = d.projection
+    if proj.suitability_class is SuitabilityClass.UNKNOWN_SUITABILITY:
+        return _panel(
+            "strategy_suitability",
+            DashboardPanelStatus.DISPLAY_BLOCKED,
+            "Suitability unknown (fail-closed display).",
+            blockers=tuple(str(x) for x in proj.block_reasons),
+            missing=proj.missing_inputs,
+        )
+    if proj.block_reasons:
+        return _panel(
+            "strategy_suitability",
+            DashboardPanelStatus.DISPLAY_WARNING,
+            "Suitability has block reasons (metadata only).",
+            blockers=tuple(str(x) for x in proj.block_reasons),
+            missing=proj.missing_inputs,
+        )
+    return _panel(
+        "strategy_suitability",
+        DashboardPanelStatus.DISPLAY_READY,
+        "Suitability projection present (not strategy activation).",
+    )
+
+
+def _panel_ratchet(d: Optional[CapitalSlotRatchetDecision]) -> DoublePlayDashboardPanel:
+    if d is None:
+        return _panel(
+            "capital_slot_ratchet",
+            DashboardPanelStatus.DISPLAY_MISSING,
+            "No capital slot ratchet decision supplied (display-only gap).",
+        )
+    if d.live_authorization:
+        return _panel(
+            "capital_slot_ratchet",
+            DashboardPanelStatus.DISPLAY_ERROR,
+            "Ratchet decision reported live_authorization; display error.",
+            blockers=("live_authorization_true",),
+        )
+    if d.block_reasons:
+        return _panel(
+            "capital_slot_ratchet",
+            DashboardPanelStatus.DISPLAY_BLOCKED,
+            "Capital slot ratchet blocked (data-only).",
+            blockers=tuple(str(x) for x in d.block_reasons),
+        )
+    return _panel(
+        "capital_slot_ratchet",
+        DashboardPanelStatus.DISPLAY_READY,
+        "Capital slot ratchet decision present (no allocation).",
+    )
+
+
+def _panel_release(d: Optional[CapitalSlotReleaseDecision]) -> DoublePlayDashboardPanel:
+    if d is None:
+        return _panel(
+            "capital_slot_release",
+            DashboardPanelStatus.DISPLAY_MISSING,
+            "No capital slot release decision supplied (display-only gap).",
+        )
+    if d.live_authorization:
+        return _panel(
+            "capital_slot_release",
+            DashboardPanelStatus.DISPLAY_ERROR,
+            "Release decision reported live_authorization; display error.",
+            blockers=("live_authorization_true",),
+        )
+    if d.block_reasons:
+        return _panel(
+            "capital_slot_release",
+            DashboardPanelStatus.DISPLAY_BLOCKED,
+            "Capital slot release path blocked (data-only).",
+            blockers=tuple(str(x) for x in d.block_reasons),
+        )
+    if d.released:
+        return _panel(
+            "capital_slot_release",
+            DashboardPanelStatus.DISPLAY_WARNING,
+            "Capital slot released (data-only label; does not perform release here).",
+        )
+    return _panel(
+        "capital_slot_release",
+        DashboardPanelStatus.DISPLAY_READY,
+        "Capital slot active (release decision present; data-only).",
+    )
+
+
+def _panel_composition(d: Optional[DoublePlayCompositionDecision]) -> DoublePlayDashboardPanel:
+    if d is None:
+        return _panel(
+            "composition",
+            DashboardPanelStatus.DISPLAY_MISSING,
+            "No composition decision supplied (display-only gap).",
+        )
+    if d.live_authorization:
+        return _panel(
+            "composition",
+            DashboardPanelStatus.DISPLAY_ERROR,
+            "Composition reported live_authorization; display error.",
+            blockers=("live_authorization_true",),
+        )
+    st = d.status
+    if st is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY:
+        return _panel(
+            "composition",
+            DashboardPanelStatus.DISPLAY_READY,
+            "Composition: ELIGIBLE_MODEL_ONLY — data-only; not trading-ready.",
+            blockers=tuple(str(x) for x in d.block_reasons),
+        )
+    if st in (DoublePlayCompositionStatus.KILL_ALL, DoublePlayCompositionStatus.CHOP_GUARD):
+        return _panel(
+            "composition",
+            DashboardPanelStatus.DISPLAY_BLOCKED,
+            f"Composition status {st.value} (display-only).",
+            blockers=tuple(str(x) for x in d.block_reasons),
+        )
+    if st is DoublePlayCompositionStatus.BLOCKED:
+        return _panel(
+            "composition",
+            DashboardPanelStatus.DISPLAY_BLOCKED,
+            "Composition blocked (data-only).",
+            blockers=tuple(str(x) for x in d.block_reasons),
+        )
+    if st is DoublePlayCompositionStatus.OBSERVE_ONLY:
+        return _panel(
+            "composition",
+            DashboardPanelStatus.DISPLAY_WARNING,
+            "Composition observe-only (data-only).",
+            blockers=tuple(str(x) for x in d.block_reasons),
+        )
+    return _panel(
+        "composition",
+        DashboardPanelStatus.DISPLAY_WARNING,
+        d.reason,
+        blockers=tuple(str(x) for x in d.block_reasons),
+    )
+
+
+def build_dashboard_display_snapshot(
+    *,
+    futures_input: Optional[FuturesInputReadinessDecision] = None,
+    transition: Optional[TransitionDecision] = None,
+    survival: Optional[SurvivalEnvelopeDecision] = None,
+    suitability: Optional[SuitabilityProjectionDecision] = None,
+    capital_slot_ratchet: Optional[CapitalSlotRatchetDecision] = None,
+    capital_slot_release: Optional[CapitalSlotReleaseDecision] = None,
+    composition: Optional[DoublePlayCompositionDecision] = None,
+) -> DoublePlayDashboardDisplaySnapshot:
+    """
+    Build a display-only snapshot from pure decisions. Never authorizes Live or trading.
+
+    Missing optional inputs produce DISPLAY_MISSING panels. Contradictory live flags on
+    inputs yield DISPLAY_ERROR on the affected panel and warning strings on the snapshot.
+    """
+    input_live = _collect_input_live_warnings(
+        futures_input=futures_input,
+        transition=transition,
+        survival=survival,
+        suitability=suitability,
+        capital_slot_ratchet=capital_slot_ratchet,
+        capital_slot_release=capital_slot_release,
+        composition=composition,
+    )
+
+    panels = (
+        _panel_futures_input(futures_input),
+        _panel_transition(transition),
+        _panel_survival(survival),
+        _panel_suitability(suitability),
+        _panel_ratchet(capital_slot_ratchet),
+        _panel_release(capital_slot_release),
+        _panel_composition(composition),
+    )
+
+    overall = DashboardDisplayStatus.DISPLAY_READY
+    for p in panels:
+        if p.status is DashboardPanelStatus.DISPLAY_MISSING:
+            overall = _max_severity(overall, DashboardDisplayStatus.DISPLAY_WARNING)
+        else:
+            overall = _max_severity(overall, p.status)
+
+    extra: list[str] = list(input_live)
+    if any(p.status is DashboardPanelStatus.DISPLAY_MISSING for p in panels):
+        extra.append("one_or_more_panels_missing_optional_pure_inputs")
+
+    warnings = tuple(dict.fromkeys(extra))
+
+    return DoublePlayDashboardDisplaySnapshot(
+        panels=panels,
+        overall_status=overall,
+        no_live_banner_visible=True,
+        display_only=True,
+        trading_ready=False,
+        testnet_ready=False,
+        live_ready=False,
+        live_authorization=False,
+        warnings=warnings,
+    )

--- a/tests/trading/master_v2/test_double_play_dashboard_display.py
+++ b/tests/trading/master_v2/test_double_play_dashboard_display.py
@@ -1,0 +1,300 @@
+# tests/trading/master_v2/test_double_play_dashboard_display.py
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from enum import Enum
+from pathlib import Path
+
+from trading.master_v2.double_play_capital_slot import (
+    CapitalSlotConfig,
+    CapitalSlotState,
+    evaluate_capital_slot_ratchet,
+    evaluate_capital_slot_release,
+)
+from trading.master_v2.double_play_composition import (
+    DoublePlayCompositionInput,
+    RequestedSide,
+    compose_double_play_decision,
+)
+from trading.master_v2.double_play_dashboard_display import (
+    DOUBLE_PLAY_DASHBOARD_DISPLAY_LAYER_VERSION,
+    DashboardDisplayStatus,
+    build_dashboard_display_snapshot,
+)
+from trading.master_v2.double_play_futures_input import evaluate_futures_input_snapshot
+from trading.master_v2.double_play_state import ScopeEvent, SideState
+from trading.master_v2.double_play_suitability import (
+    SideCompatibility,
+    StrategyMetadata,
+)
+from trading.master_v2.double_play_survival import (
+    SurvivalEnvelopeDecision,
+    SurvivalEnvelopeStatus,
+)
+
+from tests.trading.master_v2.test_double_play_futures_input import _snapshot as _fi_snapshot
+from tests.trading.master_v2.test_double_play_pure_stack_contract import (
+    _env_ok,
+    _suit_in,
+    _suit_allows_from_envelope,
+    evaluate_survival_envelope,
+    project_strategy_suitability,
+)
+from trading.master_v2.double_play_state import RuntimeScopeState, transition_state
+from trading.master_v2.double_play_state import DynamicScopeRules, RuntimeEnvelope, StaticHardLimits
+
+GOOD = StaticHardLimits(
+    max_notional=1.0,
+    max_leverage=1.0,
+    max_switches_per_window=100,
+    min_band_width=1.0,
+    max_band_width=100.0,
+)
+GOOD_ENVELOPE = RuntimeEnvelope(static=GOOD, live_authorization=False)
+GOOD_RULES = DynamicScopeRules(
+    min_band_width=1.0,
+    max_band_width=50.0,
+    min_switch_cooldown_ticks=0,
+    max_switches_per_window=1_000_000,
+    volatility_estimate=0.1,
+)
+EMPTY_ST = RuntimeScopeState()
+
+
+def _ts(side: SideState, event: ScopeEvent, st: RuntimeScopeState, now: int = 0):
+    return transition_state(
+        side_state=side,
+        event=event,
+        scope_state=st,
+        rules=GOOD_RULES,
+        envelope=GOOD_ENVELOPE,
+        now_tick=now,
+    )
+
+
+def _full_stack_decisions():
+    s1, st1, _ = _ts(SideState.NEUTRAL_OBSERVE, ScopeEvent.UPSCOPE_CONFIRMED, EMPTY_ST, 0)
+    s2, st2, t2 = _ts(s1, ScopeEvent.UPSCOPE_CONFIRMED, st1, 1)
+    surv = evaluate_survival_envelope(_env_ok())
+    meta = StrategyMetadata(
+        strategy_id="c1",
+        strategy_family="m",
+        declared_side=SideCompatibility.LONG_BULL,
+        explicit_side_evidence=True,
+    )
+    suit = project_strategy_suitability(_suit_in(meta, _suit_allows_from_envelope(surv)))
+    cfg = CapitalSlotConfig(
+        profit_step_pct=0.10,
+        cashflow_lock_fraction=0.30,
+        reinvest_fraction=0.70,
+        allow_auto_top_up=False,
+        live_authorization=False,
+        min_realized_volatility=0.05,
+        min_atr_or_range=0.05,
+        max_time_without_cashflow_step=10_000,
+        min_opportunity_score=0.2,
+    )
+    cs_st = CapitalSlotState(
+        selected_future="BTC-USD-PERP",
+        initial_slot_base=300.0,
+        active_slot_base=300.0,
+        realized_or_settled_slot_equity=340.0,
+        unrealized_pnl=0.0,
+        locked_cashflow=0.0,
+        time_without_cashflow_step=0,
+        realized_volatility=0.5,
+        atr_or_range=0.5,
+        opportunity_score=0.8,
+        survival_allows_slot=True,
+    )
+    rat = evaluate_capital_slot_ratchet(cfg, cs_st)
+    rel = evaluate_capital_slot_release(cfg, cs_st)
+    comp = compose_double_play_decision(
+        DoublePlayCompositionInput(
+            transition=t2,
+            resulting_side_state=s2,
+            survival=surv,
+            suitability=suit,
+            requested_side=RequestedSide.LONG_BULL,
+            capital_slot_ratchet_decision=rat,
+            capital_slot_release_decision=rel,
+        )
+    )
+    fi = evaluate_futures_input_snapshot(_fi_snapshot())
+    return fi, t2, surv, suit, rat, rel, comp
+
+
+def test_layer_version_is_v0() -> None:
+    assert DOUBLE_PLAY_DASHBOARD_DISPLAY_LAYER_VERSION == "v0"
+
+
+def test_builds_snapshot_from_all_pure_decisions() -> None:
+    fi, t2, surv, suit, rat, rel, comp = _full_stack_decisions()
+    snap = build_dashboard_display_snapshot(
+        futures_input=fi,
+        transition=t2,
+        survival=surv,
+        suitability=suit,
+        capital_slot_ratchet=rat,
+        capital_slot_release=rel,
+        composition=comp,
+    )
+    assert len(snap.panels) == 7
+    names = [p.name for p in snap.panels]
+    assert names == [
+        "futures_input",
+        "state_transition",
+        "survival_envelope",
+        "strategy_suitability",
+        "capital_slot_ratchet",
+        "capital_slot_release",
+        "composition",
+    ]
+    assert snap.overall_status is DashboardDisplayStatus.DISPLAY_READY
+    assert snap.no_live_banner_visible
+    assert snap.display_only
+    assert not snap.trading_ready
+    assert not snap.testnet_ready
+    assert not snap.live_ready
+    assert not snap.live_authorization
+    comp_panel = snap.panels[-1]
+    assert "ELIGIBLE_MODEL_ONLY" in comp_panel.summary
+    assert (
+        "not trading" in comp_panel.summary.lower() or "trading-ready" in comp_panel.summary.lower()
+    )
+
+
+def test_missing_optional_panel_is_warning_level() -> None:
+    fi, t2, surv, suit, rat, rel, comp = _full_stack_decisions()
+    snap = build_dashboard_display_snapshot(
+        futures_input=fi,
+        transition=t2,
+        survival=surv,
+        suitability=suit,
+        capital_slot_ratchet=rat,
+        capital_slot_release=rel,
+        composition=None,
+    )
+    assert snap.panels[-1].status is DashboardDisplayStatus.DISPLAY_MISSING
+    assert snap.overall_status is DashboardDisplayStatus.DISPLAY_WARNING
+
+
+def test_blocked_survival_maps_to_blocked_panel() -> None:
+    fi, t2, _, suit, rat, rel, comp = _full_stack_decisions()
+    bad_surv = SurvivalEnvelopeDecision(
+        status=SurvivalEnvelopeStatus.BLOCKED,
+        pre_authorization_eligible=False,
+        block_reasons=(),
+    )
+    snap = build_dashboard_display_snapshot(
+        futures_input=fi,
+        transition=t2,
+        survival=bad_surv,
+        suitability=suit,
+        capital_slot_ratchet=rat,
+        capital_slot_release=rel,
+        composition=comp,
+    )
+    p = snap.panels[2]
+    assert p.name == "survival_envelope"
+    assert p.status is DashboardDisplayStatus.DISPLAY_BLOCKED
+    assert snap.overall_status is DashboardDisplayStatus.DISPLAY_BLOCKED
+
+
+def test_eligible_composition_not_trading_ready_on_snapshot() -> None:
+    _, _, _, _, _, _, comp = _full_stack_decisions()
+    snap = build_dashboard_display_snapshot(composition=comp)
+    assert snap.panels[-1].status is DashboardDisplayStatus.DISPLAY_READY
+    assert not snap.trading_ready
+    assert snap.display_only
+
+
+def test_no_live_banner_always_visible() -> None:
+    snap = build_dashboard_display_snapshot()
+    assert snap.no_live_banner_visible
+
+
+def test_live_authorization_false_despite_malformed_projection_flag() -> None:
+    _, _, _, suit, _, _, _ = _full_stack_decisions()
+    bad_proj = replace(suit.projection, live_authorization=True)
+    bad_suit = replace(suit, projection=bad_proj)
+    snap = build_dashboard_display_snapshot(suitability=bad_suit)
+    assert not snap.live_authorization
+    p = snap.panels[3]
+    assert p.status is DashboardDisplayStatus.DISPLAY_ERROR
+    assert any("suitability.projection" in w for w in snap.warnings)
+
+
+def test_dto_values_are_display_safe_no_callables() -> None:
+    fi, t2, surv, suit, rat, rel, comp = _full_stack_decisions()
+    snap = build_dashboard_display_snapshot(
+        futures_input=fi,
+        transition=t2,
+        survival=surv,
+        suitability=suit,
+        capital_slot_ratchet=rat,
+        capital_slot_release=rel,
+        composition=comp,
+    )
+    assert _is_display_safe(snap)
+
+
+def _is_display_safe(obj: object, *, depth: int = 0) -> bool:
+    if depth > 12:
+        return False
+    if obj is None:
+        return True
+    if isinstance(obj, (str, int, float, bool)):
+        return True
+    if callable(obj):
+        return False
+    if isinstance(obj, tuple):
+        return all(_is_display_safe(x, depth=depth + 1) for x in obj)
+    if isinstance(obj, Enum):
+        return True
+    if hasattr(obj, "__dataclass_fields__"):
+        for name in obj.__dataclass_fields__:
+            if not _is_display_safe(getattr(obj, name), depth=depth + 1):
+                return False
+        return True
+    return False
+
+
+def test_no_forbidden_imports_in_module() -> None:
+    root = Path(__file__).resolve().parent.parent.parent.parent / "src" / "trading" / "master_v2"
+    path = root / "double_play_dashboard_display.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bad = {"fastapi", "uvicorn", "requests", "urllib3", "ccxt", "httpx", "aiohttp", "socket"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                assert n.name.split(".")[0].lower() not in bad
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mod0 = node.module.split(".")[0].lower()
+            assert mod0 not in bad
+            if mod0 == "trading":
+                assert node.module.startswith("trading.master_v2")
+
+
+def test_module_has_no_fastapi_strings() -> None:
+    path = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "src"
+        / "trading"
+        / "master_v2"
+        / "double_play_dashboard_display.py"
+    )
+    text = path.read_text(encoding="utf-8").lower()
+    assert "fastapi" not in text
+    assert "apirouter" not in text
+
+
+def test_snapshot_invariants_always() -> None:
+    snap = build_dashboard_display_snapshot()
+    assert snap.display_only
+    assert not snap.trading_ready
+    assert not snap.testnet_ready
+    assert not snap.live_ready
+    assert not snap.live_authorization
+    assert snap.no_live_banner_visible


### PR DESCRIPTION
## Summary
- add pure read-only Double Play dashboard display DTO/snapshot model v0
- aggregate already-computed pure decisions into display-safe panels
- preserve fixed no-live/no-testnet/no-trading invariants
- represent missing inputs as display warnings/missing panels
- flag malformed upstream live_authorization values without granting authority
- add focused tests and import/string guards against WebUI/FastAPI/scanner/exchange/session/backtest/evidence/network surfaces

## Changed files
- src/trading/master_v2/double_play_dashboard_display.py
- tests/trading/master_v2/test_double_play_dashboard_display.py

## Validation
- uv run pytest tests/trading/master_v2/test_double_play_dashboard_display.py -q
- uv run pytest tests/trading/master_v2/ -q
- uv run ruff check src/trading/master_v2 tests/trading/master_v2
- uv run ruff format --check src/trading/master_v2 tests/trading/master_v2

## Safety
- pure DTO/model + unit tests only
- no WebUI route
- no template
- no FastAPI integration
- no dashboard runtime integration
- no scanner execution
- no exchange calls
- no market-data fetches
- no selector execution
- no strategy execution
- no allocation/runtime integration
- no state-switch/composition changes
- no workflow changes
- no config changes
- no out/evidence/S3/cache mutation
- no testnet or Live authorization
- dashboard snapshot live_authorization remains false

Made with [Cursor](https://cursor.com)