### PR TITLE
feat(webui): add double play dashboard display json route v0

### DIFF
--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -184,6 +184,9 @@ from .ops_ci_health_router import (
 from .execution_watch_api_v0 import router as execution_watch_v0_router
 from .execution_watch_api_v0_2 import router as execution_watch_v0_2_router
 from .market_surface import create_market_router
+from .double_play_dashboard_display_json_route_v0 import (
+    router as double_play_dashboard_display_json_v0_router,
+)
 
 
 # Wir gehen davon aus: src/webui/app.py -> src/webui -> src -> REPO_ROOT
@@ -501,6 +504,9 @@ def create_app() -> FastAPI:
 
     # Market Surface v0 — read-only OHLCV (kein OPS-Cockpit-Bezug)
     app.include_router(create_market_router(templates, get_project_status))
+
+    # Master V2 Double Play — read-only dashboard display JSON (pure snapshot; no I/O)
+    app.include_router(double_play_dashboard_display_json_v0_router)
 
     # JSON API Alias für /api/ops/workflows
     @app.get("/api/ops/workflows")

--- a/src/webui/double_play_dashboard_display_json_route_v0.py
+++ b/src/webui/double_play_dashboard_display_json_route_v0.py
@@ -1,0 +1,74 @@
+# src/webui/double_play_dashboard_display_json_route_v0.py
+"""
+Master V2 Double Play — read-only dashboard display JSON route (v0).
+
+GET-only, fixture-backed snapshot from pure `build_dashboard_display_snapshot`.
+No scanner, exchange, session, evidence, or market-data imports.
+
+See docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from trading.master_v2.double_play_dashboard_display import (
+    DoublePlayDashboardDisplaySnapshot,
+    DoublePlayDashboardPanel,
+    build_dashboard_display_snapshot,
+)
+
+router = APIRouter(
+    prefix="/api/master-v2/double-play",
+    tags=["master-v2", "double-play", "dashboard-display-readonly"],
+)
+
+
+def _jsonable_panel(panel: DoublePlayDashboardPanel) -> Dict[str, Any]:
+    st = panel.status
+    status_val = st.value if isinstance(st, Enum) else str(st)
+    return {
+        "name": panel.name,
+        "status": status_val,
+        "summary": panel.summary,
+        "blockers": list(panel.blockers),
+        "missing_inputs": list(panel.missing_inputs),
+        "live_authorization": panel.live_authorization,
+        "is_authority": panel.is_authority,
+        "is_signal": panel.is_signal,
+    }
+
+
+def snapshot_to_jsonable(snap: DoublePlayDashboardDisplaySnapshot) -> Dict[str, Any]:
+    """Convert display snapshot to JSON-serializable dict (enum values as strings)."""
+    overall = snap.overall_status
+    overall_val = overall.value if isinstance(overall, Enum) else str(overall)
+    return {
+        "panels": [_jsonable_panel(p) for p in snap.panels],
+        "overall_status": overall_val,
+        "no_live_banner_visible": snap.no_live_banner_visible,
+        "display_only": snap.display_only,
+        "trading_ready": snap.trading_ready,
+        "testnet_ready": snap.testnet_ready,
+        "live_ready": snap.live_ready,
+        "live_authorization": snap.live_authorization,
+        "warnings": list(snap.warnings),
+    }
+
+
+@router.get("/dashboard-display.json")
+async def get_double_play_dashboard_display_json() -> JSONResponse:
+    """
+    Read-only JSON snapshot of Double Play dashboard display DTO (pure, in-memory).
+
+    All optional pure inputs omitted → DISPLAY_MISSING panels; still display-only / no-live.
+    """
+    snap = build_dashboard_display_snapshot()
+    return JSONResponse(
+        content=snapshot_to_jsonable(snap),
+        headers={"Cache-Control": "no-store"},
+    )

--- a/tests/webui/test_double_play_dashboard_display_json_route.py
+++ b/tests/webui/test_double_play_dashboard_display_json_route.py
@@ -1,0 +1,132 @@
+# tests/webui/test_double_play_dashboard_display_json_route.py
+"""HTTP contract for Master V2 Double Play dashboard display JSON (read-only v0)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+ROUTE_PATH = "/api/master-v2/double-play/dashboard-display.json"
+
+_FORBIDDEN_JSON_KEYS = frozenset(
+    {
+        "start",
+        "stop",
+        "arm",
+        "enable",
+        "allocate",
+        "release",
+        "trade",
+        "fetch",
+        "scan",
+        "select",
+        "promote",
+        "approve",
+        "sign_off",
+        "live",
+    }
+)
+
+
+def _collect_object_keys(obj, out: set[str]) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str):
+                out.add(k)
+            _collect_object_keys(v, out)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_object_keys(item, out)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    from src.webui.app import create_app
+
+    return TestClient(create_app())
+
+
+def test_dashboard_display_json_returns_200(client: TestClient) -> None:
+    r = client.get(ROUTE_PATH)
+    assert r.status_code == 200
+
+
+def test_dashboard_display_json_content_type_and_cache_control(client: TestClient) -> None:
+    r = client.get(ROUTE_PATH)
+    assert "application/json" in (r.headers.get("content-type") or "")
+    assert r.headers.get("cache-control") == "no-store"
+
+
+def test_dashboard_display_json_required_no_live_fields(client: TestClient) -> None:
+    r = client.get(ROUTE_PATH)
+    data = r.json()
+    assert data["display_only"] is True
+    assert data["no_live_banner_visible"] is True
+    assert data["trading_ready"] is False
+    assert data["testnet_ready"] is False
+    assert data["live_ready"] is False
+    assert data["live_authorization"] is False
+
+
+def test_dashboard_display_json_panels_and_warnings(client: TestClient) -> None:
+    r = client.get(ROUTE_PATH)
+    data = r.json()
+    assert "panels" in data
+    assert isinstance(data["panels"], list)
+    assert len(data["panels"]) == 7
+    assert "warnings" in data
+    assert isinstance(data["warnings"], list)
+    assert "overall_status" in data
+
+
+def test_dashboard_display_json_no_forbidden_control_keys(client: TestClient) -> None:
+    r = client.get(ROUTE_PATH)
+    data = r.json()
+    keys: set[str] = set()
+    _collect_object_keys(data, keys)
+    assert keys.isdisjoint(_FORBIDDEN_JSON_KEYS)
+
+
+def test_route_module_import_surface_is_safe() -> None:
+    root = Path(__file__).resolve().parents[2] / "src" / "webui"
+    path = root / "double_play_dashboard_display_json_route_v0.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    banned_roots = frozenset(
+        {
+            "ccxt",
+            "requests",
+            "aiohttp",
+            "httpx",
+            "urllib3",
+            "socket",
+        }
+    )
+    banned_modules = frozenset(
+        {
+            "src.live",
+            "src.live.web",
+            "src.data.kraken",
+            "src.execution",
+            "scripts",
+        }
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                base = n.name.split(".")[0]
+                if base in banned_roots:
+                    raise AssertionError(f"unexpected import: {n.name}")
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mod = node.module
+            if mod in banned_modules or any(mod.startswith(p + ".") for p in banned_modules):
+                raise AssertionError(f"unexpected from-import: {mod}")
+            top = mod.split(".")[0]
+            if top in banned_roots:
+                raise AssertionError(f"unexpected from-import: {mod}")


### PR DESCRIPTION
## Summary
- add read-only JSON route for the Double Play dashboard display DTO
- expose GET /api/master-v2/double-play/dashboard-display.json via the general WebUI app
- return display-only/no-live dashboard snapshot with Cache-Control: no-store
- add focused WebUI route tests for response contract, no-live/readiness flags, panels/warnings, forbidden control keys, and import boundaries
- keep route JSON-only; no template added

## Changed files
- src/webui/double_play_dashboard_display_json_route_v0.py
- src/webui/app.py
- tests/webui/test_double_play_dashboard_display_json_route.py

## Validation
- uv run pytest tests/webui/test_double_play_dashboard_display_json_route.py -q
- uv run ruff check src/webui tests/webui tests
- uv run ruff format --check src/webui tests/webui tests

## Safety
- read-only GET route only
- no POST/PUT/PATCH/DELETE controls
- no WebUI server start
- no Docker
- no scanner execution
- no exchange calls
- no market-data fetches
- no selector execution
- no strategy execution
- no allocation/runtime integration
- no execution/session/orchestrator integration
- no evidence/archive/S3 writes
- no out/cache mutation
- no testnet or Live authorization
- dashboard snapshot live_authorization remains false

Made with [Cursor](https://cursor.com)