### PR TITLE
feat(master-v2): add futures input producer adapter v0

### DIFF
--- a/src/trading/master_v2/double_play_futures_input_producer.py
+++ b/src/trading/master_v2/double_play_futures_input_producer.py
@@ -1,0 +1,332 @@
+# src/trading/master_v2/double_play_futures_input_producer.py
+"""
+Pure Double Play futures input producer adapter: static packet -> FuturesInputSnapshot.
+
+No scanners, exchanges, registry/evidence writers, sessions, or Live authority.
+Aligned with docs/ops/specs/MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+from trading.master_v2.double_play_futures_input import (
+    FuturesCandidateSnapshot,
+    FuturesDerivativesProfile,
+    FuturesInputReadinessDecision,
+    FuturesInputSnapshot,
+    FuturesInstrumentMetadataStatus,
+    FuturesLiquidityProfile,
+    FuturesMarketDataProvenanceStatus,
+    FuturesMarketType,
+    FuturesOpportunityProfile,
+    FuturesRankingSnapshot,
+    FuturesFreshnessState,
+    FuturesVolatilityProfile,
+    evaluate_futures_input_snapshot,
+)
+
+DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_LAYER_VERSION = "v0"
+
+
+class FuturesProducerAdapterStatus(str, Enum):
+    OK = "ok"
+    BLOCKED = "blocked"
+
+
+class FuturesProducerAdapterBlockReason(str, Enum):
+    """Adapter-level block before or instead of snapshot consumption."""
+
+    RUNTIME_HANDLE_DETECTED = "runtime_handle_detected"
+
+
+@dataclass(frozen=True)
+class FuturesProducerCandidate:
+    candidate_id: str
+    instrument_id: str
+    symbol: str
+    market_type: FuturesMarketType
+    exchange: str
+    base_currency: str
+    quote_currency: str
+    live_authorization: bool = False
+
+
+@dataclass(frozen=True)
+class FuturesProducerRanking:
+    source_universe_size: Optional[int]
+    selected_top_n: Optional[int]
+    rank: Optional[int]
+    score: Optional[float]
+    score_components_complete: bool
+    is_top_n_member: bool
+
+
+@dataclass(frozen=True)
+class FuturesProducerInstrumentMetadata:
+    complete: bool
+    contract_size_known: bool
+    tick_size_known: bool
+    step_size_known: bool
+    min_qty_known: bool
+    min_notional_known: bool
+    margin_asset_known: bool
+    settlement_asset_known: bool
+    leverage_bounds_known: bool
+    missing_fields: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FuturesProducerMarketDataProvenance:
+    complete: bool
+    freshness_state: FuturesFreshnessState
+    dataset_id: Optional[str]
+    source: Optional[str]
+    mark_available: bool
+    index_available: bool
+    last_available: bool
+    ohlcv_available: bool
+    funding_available: bool
+    open_interest_available: bool
+    missing_fields: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FuturesProducerVolatility:
+    realized_volatility: Optional[float]
+    atr_or_rolling_range: Optional[float]
+    volatility_regime: Optional[str]
+    dynamic_scope_usable: bool
+
+
+@dataclass(frozen=True)
+class FuturesProducerLiquidity:
+    spread_bps: Optional[float]
+    average_spread_bps: Optional[float]
+    volume: Optional[float]
+    quote_volume: Optional[float]
+    liquidity_regime: Optional[str]
+    spread_quality: Optional[str]
+
+
+@dataclass(frozen=True)
+class FuturesProducerDerivatives:
+    funding_available: bool
+    funding_rate: Optional[float]
+    funding_regime: Optional[str]
+    open_interest_available: bool
+    open_interest: Optional[float]
+    open_interest_regime: Optional[str]
+
+
+@dataclass(frozen=True)
+class FuturesProducerOpportunity:
+    opportunity_score: Optional[float]
+    inactivity_score: Optional[float]
+    movement_above_fee_slippage_breakeven: Optional[bool]
+    chop_risk: Optional[str]
+    candidate_is_inactive: bool
+
+
+@dataclass(frozen=True)
+class FuturesProducerPacket:
+    candidate: FuturesProducerCandidate
+    ranking: FuturesProducerRanking
+    instrument: FuturesProducerInstrumentMetadata
+    provenance: FuturesProducerMarketDataProvenance
+    volatility: FuturesProducerVolatility
+    liquidity: FuturesProducerLiquidity
+    derivatives: FuturesProducerDerivatives
+    opportunity: FuturesProducerOpportunity
+    dashboard_label: Optional[str] = None
+    ai_summary: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class FuturesProducerAdapterDecision:
+    adapter_status: FuturesProducerAdapterStatus
+    adapter_block_reasons: Tuple[FuturesProducerAdapterBlockReason, ...]
+    snapshot: Optional[FuturesInputSnapshot]
+    readiness: Optional[FuturesInputReadinessDecision]
+
+
+def producer_packet_has_runtime_handles(obj: object, *, _seen: set[int] | None = None) -> bool:
+    """
+    Return True if ``obj`` embeds a non-data value (potential runtime handle).
+
+    Allowed: ``None``, primitives, ``FuturesMarketType``, ``FuturesFreshnessState``,
+    tuples of allowed values, and frozen dataclasses composed only of allowed values.
+    """
+    if _seen is None:
+        _seen = set()
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return False
+    if isinstance(obj, (FuturesMarketType, FuturesFreshnessState)):
+        return False
+    oid = id(obj)
+    if oid in _seen:
+        return False
+    if isinstance(obj, tuple):
+        _seen.add(oid)
+        return any(producer_packet_has_runtime_handles(item, _seen=_seen) for item in obj)
+    fields = getattr(obj, "__dataclass_fields__", None)
+    if fields is not None:
+        _seen.add(oid)
+        for f in fields.values():
+            if producer_packet_has_runtime_handles(getattr(obj, f.name), _seen=_seen):
+                return True
+        return False
+    return True
+
+
+def producer_packet_complete_enough_for_snapshot(packet: FuturesProducerPacket) -> bool:
+    """True when the packet is safe static data and can be mapped to a snapshot structurally."""
+    return not producer_packet_has_runtime_handles(packet)
+
+
+def _to_candidate(p: FuturesProducerCandidate) -> FuturesCandidateSnapshot:
+    return FuturesCandidateSnapshot(
+        candidate_id=p.candidate_id,
+        instrument_id=p.instrument_id,
+        symbol=p.symbol,
+        market_type=p.market_type,
+        exchange=p.exchange,
+        base_currency=p.base_currency,
+        quote_currency=p.quote_currency,
+        live_authorization=False,
+    )
+
+
+def _to_ranking(p: FuturesProducerRanking) -> FuturesRankingSnapshot:
+    return FuturesRankingSnapshot(
+        source_universe_size=p.source_universe_size,
+        selected_top_n=p.selected_top_n,
+        rank=p.rank,
+        score=p.score,
+        score_components_complete=p.score_components_complete,
+        is_top_n_member=p.is_top_n_member,
+    )
+
+
+def _to_instrument(p: FuturesProducerInstrumentMetadata) -> FuturesInstrumentMetadataStatus:
+    return FuturesInstrumentMetadataStatus(
+        complete=p.complete,
+        contract_size_known=p.contract_size_known,
+        tick_size_known=p.tick_size_known,
+        step_size_known=p.step_size_known,
+        min_qty_known=p.min_qty_known,
+        min_notional_known=p.min_notional_known,
+        margin_asset_known=p.margin_asset_known,
+        settlement_asset_known=p.settlement_asset_known,
+        leverage_bounds_known=p.leverage_bounds_known,
+        missing_fields=p.missing_fields,
+    )
+
+
+def _to_provenance(p: FuturesProducerMarketDataProvenance) -> FuturesMarketDataProvenanceStatus:
+    return FuturesMarketDataProvenanceStatus(
+        complete=p.complete,
+        freshness_state=p.freshness_state,
+        dataset_id=p.dataset_id,
+        source=p.source,
+        mark_available=p.mark_available,
+        index_available=p.index_available,
+        last_available=p.last_available,
+        ohlcv_available=p.ohlcv_available,
+        funding_available=p.funding_available,
+        open_interest_available=p.open_interest_available,
+        missing_fields=p.missing_fields,
+    )
+
+
+def _to_volatility(p: FuturesProducerVolatility) -> FuturesVolatilityProfile:
+    return FuturesVolatilityProfile(
+        realized_volatility=p.realized_volatility,
+        atr_or_rolling_range=p.atr_or_rolling_range,
+        volatility_regime=p.volatility_regime,
+        dynamic_scope_usable=p.dynamic_scope_usable,
+    )
+
+
+def _to_liquidity(p: FuturesProducerLiquidity) -> FuturesLiquidityProfile:
+    return FuturesLiquidityProfile(
+        spread_bps=p.spread_bps,
+        average_spread_bps=p.average_spread_bps,
+        volume=p.volume,
+        quote_volume=p.quote_volume,
+        liquidity_regime=p.liquidity_regime,
+        spread_quality=p.spread_quality,
+    )
+
+
+def _to_derivatives(p: FuturesProducerDerivatives) -> FuturesDerivativesProfile:
+    return FuturesDerivativesProfile(
+        funding_available=p.funding_available,
+        funding_rate=p.funding_rate,
+        funding_regime=p.funding_regime,
+        open_interest_available=p.open_interest_available,
+        open_interest=p.open_interest,
+        open_interest_regime=p.open_interest_regime,
+    )
+
+
+def _to_opportunity(p: FuturesProducerOpportunity) -> FuturesOpportunityProfile:
+    return FuturesOpportunityProfile(
+        opportunity_score=p.opportunity_score,
+        inactivity_score=p.inactivity_score,
+        movement_above_fee_slippage_breakeven=p.movement_above_fee_slippage_breakeven,
+        chop_risk=p.chop_risk,
+        candidate_is_inactive=p.candidate_is_inactive,
+    )
+
+
+def producer_packet_to_snapshot(packet: FuturesProducerPacket) -> FuturesInputSnapshot:
+    """
+    Map a static producer packet to ``FuturesInputSnapshot``.
+
+    ``live_authorization`` on the producer candidate is ignored and forced to False
+    on the snapshot. Raises ``ValueError`` if runtime handles are detected.
+    """
+    if producer_packet_has_runtime_handles(packet):
+        msg = "producer packet contains runtime handles or disallowed values"
+        raise ValueError(msg)
+    return FuturesInputSnapshot(
+        candidate=_to_candidate(packet.candidate),
+        ranking=_to_ranking(packet.ranking),
+        instrument=_to_instrument(packet.instrument),
+        provenance=_to_provenance(packet.provenance),
+        volatility=_to_volatility(packet.volatility),
+        liquidity=_to_liquidity(packet.liquidity),
+        derivatives=_to_derivatives(packet.derivatives),
+        opportunity=_to_opportunity(packet.opportunity),
+        dashboard_label=packet.dashboard_label,
+        ai_summary=packet.ai_summary,
+    )
+
+
+def adapt_producer_packet_to_futures_input_snapshot(
+    packet: FuturesProducerPacket,
+) -> FuturesProducerAdapterDecision:
+    """
+    Adapt a static producer packet to a ``FuturesInputSnapshot`` and evaluate readiness.
+
+    Returns a ``FuturesProducerAdapterDecision`` with optional ``snapshot`` and ``readiness``.
+    When runtime handles are detected, ``adapter_status`` is ``BLOCKED`` and both are None.
+    """
+    if producer_packet_has_runtime_handles(packet):
+        return FuturesProducerAdapterDecision(
+            adapter_status=FuturesProducerAdapterStatus.BLOCKED,
+            adapter_block_reasons=(FuturesProducerAdapterBlockReason.RUNTIME_HANDLE_DETECTED,),
+            snapshot=None,
+            readiness=None,
+        )
+    snapshot = producer_packet_to_snapshot(packet)
+    readiness = evaluate_futures_input_snapshot(snapshot)
+    return FuturesProducerAdapterDecision(
+        adapter_status=FuturesProducerAdapterStatus.OK,
+        adapter_block_reasons=(),
+        snapshot=snapshot,
+        readiness=readiness,
+    )

--- a/tests/trading/master_v2/test_double_play_futures_input_producer.py
+++ b/tests/trading/master_v2/test_double_play_futures_input_producer.py
@@ -1,0 +1,428 @@
+# tests/trading/master_v2/test_double_play_futures_input_producer.py
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.double_play_futures_input import (
+    FuturesFreshnessState,
+    FuturesInputBlockReason,
+    FuturesInputReadinessDecision,
+    FuturesInputSnapshot,
+    FuturesMarketType,
+    FuturesReadinessStatus,
+)
+from trading.master_v2.double_play_futures_input_producer import (
+    DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_LAYER_VERSION,
+    FuturesProducerAdapterBlockReason,
+    FuturesProducerAdapterStatus,
+    FuturesProducerCandidate,
+    FuturesProducerDerivatives,
+    FuturesProducerLiquidity,
+    FuturesProducerMarketDataProvenance,
+    FuturesProducerOpportunity,
+    FuturesProducerPacket,
+    FuturesProducerRanking,
+    FuturesProducerInstrumentMetadata,
+    FuturesProducerVolatility,
+    adapt_producer_packet_to_futures_input_snapshot,
+    producer_packet_has_runtime_handles,
+    producer_packet_to_snapshot,
+    producer_packet_complete_enough_for_snapshot,
+)
+from trading.master_v2 import double_play_futures_input as _fi
+from trading.master_v2 import double_play_futures_input_producer as _producer
+
+
+def _pcand(**overrides: object) -> FuturesProducerCandidate:
+    d: dict = {
+        "candidate_id": "producer-packet-c1",
+        "instrument_id": "inst-btc-perp",
+        "symbol": "BTC-USDT-PERP",
+        "market_type": FuturesMarketType.PERPETUAL,
+        "exchange": "example",
+        "base_currency": "BTC",
+        "quote_currency": "USDT",
+        "live_authorization": False,
+    }
+    d.update(overrides)
+    return FuturesProducerCandidate(**d)
+
+
+def _prank(**overrides: object) -> FuturesProducerRanking:
+    d: dict = {
+        "source_universe_size": 200,
+        "selected_top_n": 20,
+        "rank": 3,
+        "score": 0.91,
+        "score_components_complete": True,
+        "is_top_n_member": True,
+    }
+    d.update(overrides)
+    return FuturesProducerRanking(**d)
+
+
+def _pinst(**overrides: object) -> FuturesProducerInstrumentMetadata:
+    d: dict = {
+        "complete": True,
+        "contract_size_known": True,
+        "tick_size_known": True,
+        "step_size_known": True,
+        "min_qty_known": True,
+        "min_notional_known": True,
+        "margin_asset_known": True,
+        "settlement_asset_known": True,
+        "leverage_bounds_known": True,
+        "missing_fields": (),
+    }
+    d.update(overrides)
+    return FuturesProducerInstrumentMetadata(**d)
+
+
+def _pprov(**overrides: object) -> FuturesProducerMarketDataProvenance:
+    d: dict = {
+        "complete": True,
+        "freshness_state": FuturesFreshnessState.FRESH,
+        "dataset_id": "ds-producer-packet-1",
+        "source": "fixture",
+        "mark_available": True,
+        "index_available": True,
+        "last_available": True,
+        "ohlcv_available": True,
+        "funding_available": True,
+        "open_interest_available": True,
+        "missing_fields": (),
+    }
+    d.update(overrides)
+    return FuturesProducerMarketDataProvenance(**d)
+
+
+def _pvol(**overrides: object) -> FuturesProducerVolatility:
+    d: dict = {
+        "realized_volatility": 0.42,
+        "atr_or_rolling_range": 120.0,
+        "volatility_regime": "medium",
+        "dynamic_scope_usable": True,
+    }
+    d.update(overrides)
+    return FuturesProducerVolatility(**d)
+
+
+def _pliq(**overrides: object) -> FuturesProducerLiquidity:
+    d: dict = {
+        "spread_bps": 1.5,
+        "average_spread_bps": 1.8,
+        "volume": 1_000_000.0,
+        "quote_volume": 50_000_000.0,
+        "liquidity_regime": "deep",
+        "spread_quality": "tight",
+    }
+    d.update(overrides)
+    return FuturesProducerLiquidity(**d)
+
+
+def _pder(**overrides: object) -> FuturesProducerDerivatives:
+    d: dict = {
+        "funding_available": True,
+        "funding_rate": 0.0001,
+        "funding_regime": "neutral",
+        "open_interest_available": True,
+        "open_interest": 1e9,
+        "open_interest_regime": "high",
+    }
+    d.update(overrides)
+    return FuturesProducerDerivatives(**d)
+
+
+def _popp(**overrides: object) -> FuturesProducerOpportunity:
+    d: dict = {
+        "opportunity_score": 0.75,
+        "inactivity_score": 0.1,
+        "movement_above_fee_slippage_breakeven": True,
+        "chop_risk": "low",
+        "candidate_is_inactive": False,
+    }
+    d.update(overrides)
+    return FuturesProducerOpportunity(**d)
+
+
+def _ppacket(**overrides: object) -> FuturesProducerPacket:
+    parts: dict = {
+        "candidate": _pcand(),
+        "ranking": _prank(),
+        "instrument": _pinst(),
+        "provenance": _pprov(),
+        "volatility": _pvol(),
+        "liquidity": _pliq(),
+        "derivatives": _pder(),
+        "opportunity": _popp(),
+        "dashboard_label": "producer_adapter_fixture",
+        "ai_summary": None,
+    }
+    parts.update(overrides)
+    return FuturesProducerPacket(**parts)
+
+
+def _assert_adapter_output_data_only(
+    snap: FuturesInputSnapshot,
+    readiness: FuturesInputReadinessDecision,
+    *,
+    _seen: set[int] | None = None,
+) -> None:
+    if _seen is None:
+        _seen = set()
+    for obj in (snap, readiness):
+        _walk_data_only(obj, _seen=_seen)
+
+
+def _walk_data_only(obj: object, *, _seen: set[int]) -> None:
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return
+    if isinstance(obj, (FuturesMarketType, FuturesFreshnessState, FuturesReadinessStatus)):
+        return
+    if isinstance(obj, (FuturesInputBlockReason, FuturesProducerAdapterBlockReason)):
+        return
+    oid = id(obj)
+    if oid in _seen:
+        return
+    if isinstance(obj, tuple):
+        _seen.add(oid)
+        for item in obj:
+            _walk_data_only(item, _seen=_seen)
+        return
+    fields = getattr(obj, "__dataclass_fields__", None)
+    if fields is not None:
+        _seen.add(oid)
+        for f in fields.values():
+            _walk_data_only(getattr(obj, f.name), _seen=_seen)
+        return
+    raise AssertionError(f"disallowed value in adapter output: {type(obj)!r}")
+
+
+def test_producer_layer_version_v0() -> None:
+    assert DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_LAYER_VERSION == "v0"
+
+
+def test_complete_packet_maps_and_is_data_ready() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(_ppacket())
+    assert dec.adapter_status is FuturesProducerAdapterStatus.OK
+    assert dec.snapshot is not None
+    assert dec.readiness is not None
+    assert dec.readiness.status is FuturesReadinessStatus.DATA_READY
+    assert dec.readiness.ready_for_downstream_model_use
+    assert dec.readiness.ready_for_dynamic_scope
+    assert dec.readiness.ready_for_capital_slot
+    assert not dec.readiness.live_authorization
+
+
+def test_missing_instrument_metadata_fails_closed() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(
+        _ppacket(instrument=_pinst(complete=False, missing_fields=("tick_size",)))
+    )
+    assert dec.readiness is not None
+    assert dec.readiness.status is FuturesReadinessStatus.BLOCKED
+    assert not dec.readiness.ready_for_downstream_model_use
+    assert FuturesInputBlockReason.INSTRUMENT_METADATA_INCOMPLETE in dec.readiness.block_reasons
+
+
+def test_missing_provenance_fails_closed() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(
+        _ppacket(provenance=_pprov(complete=False, missing_fields=("dataset_id",)))
+    )
+    assert dec.readiness is not None
+    assert dec.readiness.status is FuturesReadinessStatus.BLOCKED
+    assert FuturesInputBlockReason.MARKET_DATA_PROVENANCE_INCOMPLETE in dec.readiness.block_reasons
+
+
+def test_rank_only_packet_fails_closed() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(
+        _ppacket(
+            ranking=_prank(
+                rank=2, score=0.95, is_top_n_member=True, score_components_complete=False
+            ),
+            instrument=_pinst(complete=False, missing_fields=("tick_size", "contract_size")),
+            provenance=_pprov(complete=False, missing_fields=("dataset_id", "source")),
+            volatility=_pvol(
+                realized_volatility=None, atr_or_rolling_range=None, dynamic_scope_usable=False
+            ),
+            liquidity=_pliq(spread_bps=None, volume=None, quote_volume=None),
+            derivatives=_pder(funding_available=False, funding_rate=None),
+        )
+    )
+    assert dec.readiness is not None
+    assert dec.readiness.status is FuturesReadinessStatus.BLOCKED
+    assert not dec.readiness.ready_for_downstream_model_use
+
+
+def test_generic_market_scan_like_packet_fails_closed() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(
+        _ppacket(
+            candidate=_pcand(
+                candidate_id="market-scan-run-opaque-id",
+                instrument_id="",
+                symbol="BTC/EUR",
+                market_type=FuturesMarketType.UNKNOWN,
+                exchange="kraken",
+            ),
+            ranking=_prank(
+                source_universe_size=50,
+                selected_top_n=20,
+                rank=7,
+                score=1.15,
+                score_components_complete=False,
+                is_top_n_member=True,
+            ),
+            instrument=_pinst(
+                complete=False,
+                contract_size_known=False,
+                tick_size_known=False,
+                step_size_known=False,
+                min_qty_known=False,
+                min_notional_known=False,
+                margin_asset_known=False,
+                settlement_asset_known=False,
+                leverage_bounds_known=False,
+                missing_fields=("instrument_metadata",),
+            ),
+            provenance=_pprov(
+                complete=False,
+                freshness_state=FuturesFreshnessState.UNKNOWN,
+                dataset_id=None,
+                source=None,
+                mark_available=False,
+                index_available=False,
+                last_available=False,
+                ohlcv_available=False,
+                funding_available=False,
+                open_interest_available=False,
+                missing_fields=("provenance",),
+            ),
+            volatility=_pvol(
+                realized_volatility=None,
+                atr_or_rolling_range=None,
+                dynamic_scope_usable=False,
+            ),
+            liquidity=_pliq(spread_bps=None, volume=None, quote_volume=None),
+            derivatives=_pder(
+                funding_available=False,
+                funding_rate=None,
+                open_interest_available=False,
+                open_interest=None,
+            ),
+            opportunity=_popp(opportunity_score=1.15, inactivity_score=None),
+        )
+    )
+    assert dec.readiness is not None
+    assert dec.readiness.status is FuturesReadinessStatus.BLOCKED
+    assert not dec.readiness.ready_for_capital_slot
+    assert FuturesInputBlockReason.MARKET_TYPE_UNKNOWN in dec.readiness.block_reasons
+
+
+@pytest.mark.parametrize("market_type", [FuturesMarketType.PERPETUAL, FuturesMarketType.SWAP])
+def test_perpetual_like_missing_funding_fails_closed(market_type: FuturesMarketType) -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(
+        _ppacket(
+            candidate=_pcand(market_type=market_type),
+            derivatives=_pder(funding_available=False, funding_rate=None),
+        )
+    )
+    assert dec.readiness is not None
+    assert FuturesInputBlockReason.PERPETUAL_FUNDING_INCOMPLETE in dec.readiness.block_reasons
+    assert not dec.readiness.ready_for_capital_slot
+
+
+def test_missing_liquidity_spread_blocks_capital_slot() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(
+        _ppacket(liquidity=_pliq(spread_bps=None, volume=100.0, quote_volume=None))
+    )
+    assert dec.readiness is not None
+    assert not dec.readiness.ready_for_capital_slot
+    assert FuturesInputBlockReason.LIQUIDITY_INCOMPLETE in dec.readiness.block_reasons
+
+
+def test_missing_volatility_blocks_dynamic_scope() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(
+        _ppacket(
+            volatility=_pvol(
+                realized_volatility=None,
+                atr_or_rolling_range=10.0,
+                dynamic_scope_usable=False,
+            )
+        )
+    )
+    assert dec.readiness is not None
+    assert not dec.readiness.ready_for_dynamic_scope
+    assert FuturesInputBlockReason.VOLATILITY_INCOMPLETE in dec.readiness.block_reasons
+
+
+def test_adapter_output_has_no_runtime_handles() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(_ppacket())
+    assert dec.snapshot is not None
+    assert dec.readiness is not None
+    _assert_adapter_output_data_only(dec.snapshot, dec.readiness)
+
+
+def test_live_authorization_on_packet_is_stripped() -> None:
+    dec = adapt_producer_packet_to_futures_input_snapshot(
+        _ppacket(candidate=_pcand(live_authorization=True))
+    )
+    assert dec.snapshot is not None
+    assert dec.snapshot.candidate.live_authorization is False
+    assert dec.readiness is not None
+    assert not dec.readiness.live_authorization
+
+
+def test_runtime_handle_in_packet_blocks_adapter() -> None:
+    bad = _ppacket(dashboard_label=object())  # type: ignore[arg-type]
+    assert producer_packet_has_runtime_handles(bad)
+    dec = adapt_producer_packet_to_futures_input_snapshot(bad)
+    assert dec.adapter_status is FuturesProducerAdapterStatus.BLOCKED
+    assert FuturesProducerAdapterBlockReason.RUNTIME_HANDLE_DETECTED in dec.adapter_block_reasons
+    assert dec.snapshot is None
+    assert dec.readiness is None
+
+
+def test_producer_packet_to_snapshot_rejects_handles() -> None:
+    bad = _ppacket(dashboard_label=object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="runtime handles"):
+        producer_packet_to_snapshot(bad)
+
+
+def test_producer_packet_complete_enough_for_snapshot() -> None:
+    p = _ppacket()
+    assert producer_packet_complete_enough_for_snapshot(p)
+    assert not producer_packet_has_runtime_handles(p)
+
+
+def test_producer_module_imports_exclude_operational_surfaces() -> None:
+    path = Path(_producer.__file__).resolve()
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    banned_roots = frozenset(
+        {
+            "ccxt",
+            "requests",
+            "urllib",
+            "http",
+            "socket",
+            "subprocess",
+            "scripts",
+            "src",
+        }
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                assert root not in banned_roots, alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".", 1)[0]
+            assert root not in banned_roots, node.module
+            assert not node.module.startswith("scripts."), node.module
+            assert not node.module.startswith("src.exchange"), node.module
+
+
+def test_producer_reuses_canonical_futures_input_types() -> None:
+    assert FuturesMarketType is _fi.FuturesMarketType
+    assert FuturesFreshnessState is _fi.FuturesFreshnessState


### PR DESCRIPTION
## Summary
- add pure Double Play futures input producer adapter v0
- transform static producer packet DTOs into canonical FuturesInputSnapshot objects
- reuse canonical futures input enums/DTOs from double_play_futures_input.py
- call evaluate_futures_input_snapshot as the canonical readiness evaluator
- fail closed for runtime handles and incomplete producer packets
- ensure producer candidate live_authorization never propagates as authority
- add focused unit tests and import-boundary guards

## Changed files
- src/trading/master_v2/double_play_futures_input_producer.py
- tests/trading/master_v2/test_double_play_futures_input_producer.py

## Validation
- uv run pytest tests/trading/master_v2/test_double_play_futures_input_producer.py -q
- uv run pytest tests/trading/master_v2/test_double_play_futures_producer_packet_contract.py tests/trading/master_v2/test_double_play_futures_input.py -q
- uv run ruff check src/trading/master_v2 tests/trading/master_v2
- uv run ruff format --check src/trading/master_v2 tests/trading/master_v2

## Safety
- pure adapter model + unit tests only
- no scanner execution
- no exchange calls
- no market-data fetches
- no selector execution
- no strategy execution
- no registry writes
- no experiment logging
- no dashboard route changes
- no runtime integration
- no allocation/runtime integration
- no workflow/config changes
- no out/evidence/S3/cache mutation
- no testnet or Live authorization
