### PR TITLE
docs(master-v2): add runtime producer dashboard prerequisite parking map v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md
@@ -2,7 +2,7 @@
 title: "Master V2 Double Play Futures Input Producer Contract v0"
 status: "DRAFT"
 owner: "ops"
-last_updated: "2026-04-26"
+last_updated: "2026-04-27"
 docs_token: "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0"
 ---
 
@@ -270,6 +270,7 @@ If supported:
 
 ## 23. References
 
+- [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer → **downstream display** **prerequisites** (**non-authorizing** **parking map**).
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot vocabulary and non-authority.
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — pure stack inventory; producer stays outside `master_v2`.
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — read-only display boundaries.

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
@@ -191,6 +191,7 @@ This docs change: run `validate_docs_token_policy`, `verify_docs_reference_targe
 ## 22. References
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer boundary: snapshot data must be precomputed **before** read-only display (no fetch in route).
+- [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer → **downstream display** **prerequisites** (**non-authorizing** **parking map**).
 - [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) — future WebUI **GET** read-only JSON route boundary for this display DTO (docs-only; no implementation here).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — pure stack inventory and model boundaries.
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot read model.

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md
@@ -1,0 +1,81 @@
+---
+title: "Master V2 Double Play Runtime Producer Dashboard Prerequisite Parking Map v0"
+status: "DRAFT"
+owner: "ops"
+last_updated: "2026-04-27"
+docs_token: "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0"
+---
+
+# Master V2 Double Play Runtime Producer Dashboard Prerequisite Parking Map v0
+
+## 1. Purpose and status
+
+This file is a **docs-only** **parking map**. It lists **prerequisite** topics that would need **separate**, explicit governance before any **hypothetical** future **runtime producer** could feed a **downstream display** path. It assumes **no** runtime enablement, maintains a **non-authorizing** posture, and introduces **no** change to WebUI, provider, or static fixture behavior described in peer contracts.
+
+It does **not** implement code, routes, scanners, exchanges, sessions, or market-data **ingestion**. It does **not** grant Double Play authority, execution permission, Testnet or Live permission, or external sign-off treated as permission to trade.
+
+## 2. Current proven baseline (parked context)
+
+The following **test anchors** and contracts describe the **pure stack** and **read-only downstream display** story **today**; they remain the authority for what is already exercised **without** operational runtime integration:
+
+- **Producer adapter (pure):** positive path and fail-closed paths in `tests&#47;trading&#47;master_v2&#47;test_double_play_pure_stack_contract.py` (**`test_contract_32`–`37`**) and adapter-focused tests in `tests&#47;trading&#47;master_v2&#47;test_double_play_futures_input_producer.py`, summarized in [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) **§20** (**non-authority**).
+- **Pure stack inventory:** [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — **pure** `master_v2` modules vs runtime adjacency.
+- **Futures Input read model:** [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — data-only snapshot vocabulary.
+- **Dashboard display map:** [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) **§20** — includes **route-independent** **`snapshot_to_jsonable`** **JSON serialization** **test anchors** in `tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py` (**non-authority**).
+- **WebUI read-only JSON route:** [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§8** (producer adapter stack **test anchors**) and **§9** (HTTP **`TestClient`** **authority-invariant** **test anchors** plus the same **route-independent** serialization cross-link).
+
+Together, these show: adapter + **pure stack** + **JSON serialization** + **read-only** HTTP JSON surface are **test-anchored** and **display-only**; **runtime producer** integration is **not** implied.
+
+## 3. Parked runtime-producer prerequisites
+
+The following **prerequisite** topics stay **parked** until each is covered by its **own** governed contract or runbook slice (this map does **not** create those contracts):
+
+- **Explicit runtime producer source contract** — who may emit packets, allowed sources, and explicit **non-authority** disclaimers.
+- **Deterministic packet boundary** — stable shapes, versioning, and rejection rules before adapter entry.
+- **Market-data source governance** — lineage, allowed feeds, and stale-data policy (docs/process; **no** ingestion here).
+- **Instrument metadata completeness** — alignment with instrument metadata contracts and fail-closed display semantics.
+- **Provenance and freshness evidence** — what “fresh enough” means as **data** labels, not execution permission.
+- **Derivatives completeness** — perpetual/swap funding and related gaps handled per existing fail-closed patterns.
+- **Liquidity/volatility quality thresholds** — as **read-model** gates only, not selector or execution **authority**.
+- **No runtime handles across the adapter boundary** — honest **display gap** when blocked (see producer **§20** anchors).
+- **No provider/scanner objects in dashboard payloads** — **JSON serialization** and route tests forbid control/runtime-style keys; payloads stay **self-describing display data** only.
+- **Read-only observation posture** — any future operational discussion starts from **observation** and **labels**, not shadow/Testnet/Live **enablement** from this map.
+- **Audit/replay artifact policy** — how evidence is stored and cited under separate ops governance.
+- **Failure and stale-data behavior** — prefer fail-closed labels; **never** fabricate permission flags on error paths (peer WebUI contract guidance).
+- **Operator runbook boundaries** — who may start processes and under which **separate** procedures (not defined here).
+- **Separate authority surface** — any future permission to trade or run sessions remains **outside** this **pure stack** and **downstream display** documentation set.
+
+## 4. Explicit non-goals
+
+This **parking map** does **not** authorize or plan:
+
+- scanner **runtime**,
+- exchange calls or market-data **ingestion** implementation,
+- WebUI **HTML** or control UI,
+- provider injection into **`master_v2`**,
+- session **runtime**,
+- Paper, Shadow, Testnet, or Live **enablement**,
+- trading **authority**,
+- external sign-off treated as execution permission.
+
+## 5. Minimal future reopening triggers
+
+Work may **only** move off this **parked** list when **all** of the following hold (still **non-authorizing** until separate governance explicitly says otherwise):
+
+1. A **separate** source-governance / producer contract set exists for operational inputs (peer: [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md)).
+2. A **separate** **read-only** runtime fixture or provider contract exists where network touch is explicit and bounded.
+3. Evidence and provenance requirements are explicit (peer provenance/metadata specs referenced from the producer contract).
+4. **No-live** / **no-control** JSON payload rules remain enforced (**display-only** flags and **non-authorizing** booleans).
+5. [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) and related **readiness** indices can **consume** evidence as **data** without this map implying execution permission.
+
+## 6. References
+
+- [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer boundary; **§20** **test anchors**.
+- [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot read model.
+- [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — **pure stack** inventory.
+- [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — **downstream display** map; **§20** **test anchors**.
+- [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) — **read-only** JSON route; **§8**–**§9** **test anchors**.
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) — **readiness** ladder (**read-only** consumption context for reopening triggers).
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) — PRE_LIVE navigation index; peer context only.
+- [FUTURES_INSTRUMENT_METADATA_CONTRACT_V0.md](FUTURES_INSTRUMENT_METADATA_CONTRACT_V0.md) — instrument metadata (**prerequisite** context).
+- [FUTURES_MARKET_DATA_PROVENANCE_CONTRACT_V0.md](FUTURES_MARKET_DATA_PROVENANCE_CONTRACT_V0.md) — market-data provenance (**prerequisite** context).

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md
@@ -222,6 +222,7 @@ bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main
 ## 20. References
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer handoff boundary; **§20** **test anchors** for **`test_contract_32`–`37`** (**non-authority**).
+- [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer → **downstream display** **prerequisites** (**non-authorizing** **parking map**).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — display panels and DTO vocabulary (docs-only).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — pure stack inventory vs runtime.
 - [MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) — PRE_LIVE reading index; peer context only.


### PR DESCRIPTION
## Summary

- adds a non-authorizing parking map for hypothetical future Runtime Producer → Dashboard prerequisites
- documents the current proven baseline across producer adapter tests, pure stack/dashboard anchors, route-independent serialization, and WebUI JSON route authority-invariant tests
- lists parked prerequisites and reopening triggers without enabling runtime/provider/scanner/exchange/session/testnet/live behavior

## Changed docs

- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md`
- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md`
- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md`
- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md`

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — ok
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — ok

## Safety

- docs-only slice
- no `src/` changes
- no tests changed
- no WebUI route/provider/static fixture/workflow behavior changes
- no scanner/exchange/runtime/session/testnet/live changes
- no `out/`, evidence, cache, S3, registry, experiment-store, or session mutation
- parking/prerequisite map only; no runtime enablement or authority claim

Made with [Cursor](https://cursor.com)