### PR TITLE
docs(master-v2): add pure display baseline closeout index v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md
@@ -1,0 +1,71 @@
+---
+title: "Master V2 Double Play Pure Display Baseline Closeout Index v0"
+status: "DRAFT"
+owner: "ops"
+last_updated: "2026-04-28"
+docs_token: "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0"
+---
+
+# Master V2 Double Play Pure Display Baseline Closeout Index v0
+
+## 1. Purpose and status
+
+This file is a **docs-only** **closeout index**. It gives reviewers and operators a **safe reading order** for the **pure display baseline** that is already **test-anchored** and **doc-anchored** **today** — **without** claiming **readiness**, **approval**, **no runtime enablement** reversal, or trading **authority**.
+
+It introduces **no** WebUI, provider, scanner, exchange, session, Paper, Shadow, Testnet, or Live behavior change. It does **not** implement code, routes, or market-data **ingestion**.
+
+## 2. What is currently proven (summary only)
+
+At a high level, the following are exercised **in-repo** as **pure** or **read-only downstream display** surfaces (details and boundaries live in the linked contracts):
+
+- **Pure Producer Adapter** — positive path and fail-closed paths (**§20** in [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md); **`test_contract_32`–`37`**).
+- **Futures Input Read Model** — snapshot vocabulary and fail-closed / **non-authorizing** semantics ([MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md)).
+- **Pure stack readiness** — **pure** `master_v2` module inventory vs runtime adjacency ([MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md)).
+- **Dashboard Display DTO** — **display-only** / **no-live** presentation boundaries ([MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) **§20**).
+- **Route-independent JSON serialization** — **`snapshot_to_jsonable`** **test anchors** **without** HTTP (`tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py`, summarized in the Display Map **§20**).
+- **WebUI read-only JSON route** — **`TestClient`** **authority-invariant** **test anchors** ([MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§8**–**§9**).
+- **Runtime Producer parking** — **hypothetical** operational **prerequisites** remain **parked** ([MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md)).
+
+This section **summarizes** only; it does **not** add new proof obligations.
+
+## 3. Reading order / index
+
+Recommended **reading order** for the **pure display baseline** (logical flow from producer handoff through **downstream display**):
+
+1. [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer boundary and **§20** **test anchors**.
+2. [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot read model.
+3. [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — **pure stack** inventory.
+4. [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — dashboard display map (**§20** **test anchors**).
+5. [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) — **read-only** JSON route (**§8**–**§9**).
+6. [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer **prerequisites** (**non-authorizing** **parking map**).
+
+## 4. Test anchor inventory
+
+Relevant **test anchors** (non-exhaustive listing; see contracts for exact assertions):
+
+- `tests&#47;trading&#47;master_v2&#47;test_double_play_pure_stack_contract.py` — cross-module **`test_contract_32`–`37`** (producer adapter → **pure stack** → dashboard display).
+- `tests&#47;trading&#47;master_v2&#47;test_double_play_futures_input_producer.py` — adapter-focused coverage (peer to **§20**).
+- `tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py` — dashboard DTO and **route-independent** **`snapshot_to_jsonable`** **JSON serialization** **test anchors** (requires FastAPI import path for the mapper).
+- `tests&#47;webui&#47;test_double_play_dashboard_display_json_route.py` — WebUI JSON route **authority-invariant** **test anchors** (`TestClient`).
+
+These **test anchors** do **not** prove operational runtime integration, HTML/control UI, or execution permission.
+
+## 5. Explicit non-proofs / non-goals
+
+This **closeout index** does **not** claim or enable:
+
+- scanner **runtime**,
+- exchange calls or market-data **ingestion** implementation,
+- provider injection into **`master_v2`**,
+- WebUI **HTML** or control UI,
+- session **runtime**,
+- Paper, Shadow, Testnet, or Live **enablement**,
+- trading **authority**,
+- external sign-off treated as execution permission.
+
+## 6. Safe next-step posture
+
+- **Retain** hypothetical **runtime producer** work as **parked**; use only the **prerequisite** list and reopening triggers in [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) to discuss next docs or code slices.
+- Any future implementation must remain **separate**, **gated**, **read-only** first, and **non-authorizing** until **external** authority surfaces exist outside this **pure display baseline** documentation set.
+
+Peer navigation (outside this **reading order**, **non-authority**): [MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md).

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
@@ -2,7 +2,7 @@
 title: "Master V2 Double Play Pure Stack Dashboard Display Map v0"
 status: "DRAFT"
 owner: "ops"
-last_updated: "2026-04-27"
+last_updated: "2026-04-28"
 docs_token: "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0"
 ---
 
@@ -192,6 +192,7 @@ This docs change: run `validate_docs_token_policy`, `verify_docs_reference_targe
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer boundary: snapshot data must be precomputed **before** read-only display (no fetch in route).
 - [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer → **downstream display** **prerequisites** (**non-authorizing** **parking map**).
+- [MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md) — **closeout index**; **reading order** for **pure display baseline** (**non-authorizing**).
 - [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) — future WebUI **GET** read-only JSON route boundary for this display DTO (docs-only; no implementation here).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — pure stack inventory and model boundaries.
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot read model.

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md
@@ -2,7 +2,7 @@
 title: "Master V2 Double Play Runtime Producer Dashboard Prerequisite Parking Map v0"
 status: "DRAFT"
 owner: "ops"
-last_updated: "2026-04-27"
+last_updated: "2026-04-28"
 docs_token: "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0"
 ---
 
@@ -72,6 +72,7 @@ Work may **only** move off this **parked** list when **all** of the following ho
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer boundary; **§20** **test anchors**.
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot read model.
+- [MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md) — **closeout index**; **reading order** for **pure display baseline** (**non-authorizing**).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — **pure stack** inventory.
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — **downstream display** map; **§20** **test anchors**.
 - [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) — **read-only** JSON route; **§8**–**§9** **test anchors**.


### PR DESCRIPTION
## Summary

- adds a non-authorizing closeout index for the Master V2 Double Play pure display baseline
- provides a safe reading order across Producer Adapter, Futures Input Read Model, Pure Stack Readiness, Dashboard Display DTO, WebUI JSON route, and Runtime Producer Parking Map
- inventories the current test anchors while explicitly preserving non-proofs and parked runtime-producer posture

## Changed docs

- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md`
- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md`
- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md`

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — ok
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — ok

## Safety

- docs-only slice
- no `src/` changes
- no tests changed
- no WebUI route/provider/static fixture/workflow behavior changes
- no scanner/exchange/runtime/session/testnet/live changes
- no `out/`, evidence, cache, S3, registry, experiment-store, or session mutation
- closeout index only; no runtime enablement or authority claim

Made with [Cursor](https://cursor.com)