### PR TITLE
docs(master-v2): add bounded pilot l1-l5 pointer runbook crosswalk v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L1_L5_POINTER_RUNBOOK_CROSSWALK_V0.md
+++ b/docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L1_L5_POINTER_RUNBOOK_CROSSWALK_V0.md
@@ -1,0 +1,90 @@
+# MASTER V2 — Bounded Pilot L1–L5 Pointer Runbook Crosswalk v0 (Canonical, Read-Only)
+
+status: ACTIVE
+last_updated: 2026-04-26
+owner: Peak_Trade
+purpose: Docs-only crosswalk mapping bounded-pilot / First-Live L1–L5 pointer expectations to canonical runbooks and specs; discoverability and review-discipline aid only
+docs_token: DOCS_TOKEN_MASTER_V2_BOUNDED_PILOT_L1_L5_POINTER_RUNBOOK_CROSSWALK_V0
+
+## 1) Purpose / status
+
+This document is a **docs-only** **crosswalk**: it connects **expected evidence-pointer roles** (L1–L5) to the **read path** operators and reviewers should use in this repository.
+
+It is **non-authorizing**. It introduces **no** new evidence payload requirements beyond what the cited pointer contracts and gate index already state. It does **not** mutate evidence, registry state, archives, or any runtime surface.
+
+This crosswalk does **not** enable Testnet, Live, bounded-pilot execution, or any trading **authority**. Ambiguity remains **fail-closed** (`NO_TRADE` posture per canonical governance framing).
+
+## 2) Current blocker framing (what this crosswalk helps with)
+
+**Candidate-specific** L1–L5 material is **not** modeled as immutable in-repository objects for a named pilot candidate. The canonical gate index therefore keeps **G4–G8** in **`Partial`** interpretation posture: substantial **mapping** exists, but **closure-relevant proof** for a specific candidate is **operator-held evidence** retained **outside** this repository and referenced with **pointer** discipline.
+
+This crosswalk helps teams:
+
+- keep a **stable read path** from ladder levels to runbooks to **pointer** contracts;
+- apply consistent **operator-held evidence** and **pointer** metadata expectations without pasting payloads into git;
+- perform **cross-gate** readiness reviews without conflating **navigation** with **gate** closure.
+
+**This document does not close G4–G8** and does not change **`Partial`** status in [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md). It does not satisfy Testnet, bounded-pilot, or Live readiness by existence alone.
+
+## 3) L1–L5 pointer crosswalk table
+
+For each ladder level, the **expected evidence-pointer role** is the vocabulary in the cited **pointer** contract (pointer classes and external retention only). **Read first** points to the primary operator-facing sequence; **non-proof** means: presence of links or this crosswalk does not prove any run succeeded or any prerequisite is met.
+
+| Level | Expected evidence-pointer role | Read first (operator / reviewer) | Runbook / spec links (read path) | Non-proof / caution boundary | Remains external or operator-held |
+|---|---|---|---|---|---|
+| **L1** — Dry validation | [L1 pointer classes](MASTER_V2_BOUNDED_PILOT_L1_EVIDENCE_POINTER_CONTRACT_V0.md) (`L1_STEP1_DRILL_CAPTURE`, `L1_STEP2_GO_NO_GO_EVAL_CAPTURE`, `L1_STEP3_EXECUTION_DRY_RUN_LOG`): metadata for **dry-validation** Steps 1–3 captures | [RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md) (Steps 1–3; **E.** Evidence and pointers (L1 discipline)); Phase A ordering in [RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md) §3 | [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) §4 Level 1; [BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md) §3.1 (wording context); gate index [§4.1 L1 pointer record](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md#41-l1-candidate-evidence-pointer-record-g4) | Pointer classes describe **what** may be described externally, not **success** or **acceptable** verdicts. Do not commit drill transcripts, full go/no-go JSON bodies, or dry-run logs to this repo. | All Step 1–3 **captures**; optional Step 4–5 material per dry-validation runbook is outside this v0 L1 pointer table unless extended elsewhere |
+| **L2** — Go / no-go interpretation | [L2 pointer classes](MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md) (`L2_GO_NO_GO_EVAL_SUMMARY_CAPTURE`, `L2_GO_NO_GO_EVAL_JSON_CAPTURE`): external **eval** summary and optional machine-readable handle | [PILOT_GO_NO_GO_CHECKLIST.md](PILOT_GO_NO_GO_CHECKLIST.md); [PILOT_GO_NO_GO_OPERATIONAL_SLICE.md](PILOT_GO_NO_GO_OPERATIONAL_SLICE.md); dry-validation Step 2 in [RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md](../runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md) | Ladder §4 Level 2; entry contract §3 prerequisite **2. Go/No-Go Acceptable** (interpretation vocabulary only); gate index [§4.2 L2 pointer record](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md#42-l2-candidate-verdict-pointer-record-g5) | **Acceptable** verdict **classes** in the entry contract are for **interpretation**, not repository **authorization**. No full `--json` payloads in git. | Operator-held eval captures; cockpit-related material stays **external** per pointer non-claims |
+| **L3** — Entry contract prerequisites | [L3 pointer classes](MASTER_V2_BOUNDED_PILOT_L3_ENTRY_PREREQUISITE_EVIDENCE_POINTER_CONTRACT_V0.md) (`L3_ENTRY_PREREQUISITE_ATTESTATION_SUMMARY`, `L3_ENTRY_PREREQUISITE_SUPPORTING_BUNDLE`): external attestation / bundle **handles** for §3 | [BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md) §3; boundary: [BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md](BOUNDED_REAL_MONEY_PILOT_ENTRY_BOUNDARY_NOTE.md); procedure pointer: [RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md) | Ladder §4 Level 3; gate index [§4.3 L3 pointer record](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md#43-l3-candidate-prerequisite-pointer-record-g6); optional read-only preflight mention in gate index (does not replace per-prerequisite evidence) | L3 pointers do **not** encode per-item pass/fail in this repo. Preflight scripts are **tools**, not **external** signoff. | All §3 confirmation detail; treasury and ops evidence per contract cross-references |
+| **L4** — Candidate session flow | [L4 pointer classes](MASTER_V2_BOUNDED_PILOT_L4_SESSION_FLOW_EVIDENCE_POINTER_CONTRACT_V0.md) (summary, registry/trace bundle, closeout/reconciliation bundle handles) | [RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md](../runbooks/RUNBOOK_BOUNDED_REAL_MONEY_PILOT_CANDIDATE_FLOW.md); [RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md) | Ladder §4 Level 4; entry contract §4 **First Bounded Real-Money Step**; gate index [§4.4 L4 pointer record](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md#44-l4-candidate-session-flow-pointer-record-g7) | Session-flow **read path** does not prove correct handoff, reconciliation, or safe completion. No raw logs or registry JSON in git. | Session logs, registry exports, closeout bodies, **operator-held** only |
+| **L5** — Incident / safe-stop | [L5 pointer classes](MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md) (summary, incident-response bundle, drill/tabletop bundle handles) | Ladder §4 Level 5 incident runbooks: [RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md](../runbooks/RUNBOOK_PILOT_INCIDENT_EXCHANGE_DEGRADED.md), [RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md](../runbooks/RUNBOOK_PILOT_INCIDENT_UNEXPECTED_EXPOSURE.md), [RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md](../runbooks/RUNBOOK_PILOT_INCIDENT_RECONCILIATION_MISMATCH.md), [RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md](../runbooks/RUNBOOK_PILOT_INCIDENT_TRANSFER_AMBIGUITY.md), [RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md](../runbooks/RUNBOOK_PILOT_INCIDENT_SESSION_END_MISMATCH.md), [RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md](../runbooks/RUNBOOK_PILOT_INCIDENT_RESTART_MID_SESSION.md); failure taxonomy: [MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md](MASTER_V2_FAILURE_TAXONOMY_SAFE_FALLBACKS_V1.md) | Entry contract §5; gate index [§4.5 L5 pointer record](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md#45-l5-candidate-incident-pointer-record-g8) | Drill/tabletop **pointers** must not be read as production incident proof unless **EXTERNAL** governance labels them that way outside this repo. This crosswalk does not harden runbook draft status. | Incident tickets, timelines, comms summaries, recovery transcripts — **operator-held** / governance-held only |
+
+**Cross-gate bundle pointer (separate vocabulary):** for candidate-scoped **cross-gate** metadata only, see [MASTER_V2_BOUNDED_PILOT_CROSS_GATE_CANDIDATE_EVIDENCE_BUNDLE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_CROSS_GATE_CANDIDATE_EVIDENCE_BUNDLE_POINTER_CONTRACT_V0.md) and the review order in [MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md](MASTER_V2_FIRST_LIVE_CROSS_GATE_EVIDENCE_BUNDLE_INDEX_V1.md).
+
+## 4) Gate alignment (navigation only)
+
+| Surface | How this crosswalk relates | Explicit non-implication |
+|---|---|---|
+| [Readiness Ladder](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) | Levels L1–L5 are the **structural** columns of §3; this file adds **runbook ↔ pointer** navigation | Ladder visibility ≠ execution permission |
+| [Gate Status Index](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md) | **G4–G8** map to L1–L5 pointer records §4.1–§4.5; **G11** cross-gate bundle visibility remains **Partial** for candidate material | **Partial** / **Verified** in the index ≠ **gate** closure or Live eligibility |
+| [Gate Status Report Surface](MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md) | Report rendering consumes read-model grammar; this crosswalk does not add report rows | Rendered tables are not **external** signoff |
+| [Decision Authority Map](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) | Promotion/readiness visibility is separate from **authoritative** Live **authority**; pointer discipline does not assign **authority** | This crosswalk authorizes nothing |
+| [PRE_LIVE Navigation Read Model](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) | Optional **read-order** context for adjacent PRE_LIVE contracts (evidence, dry run, kill-switch, signoff clusters); use when the review spans formal PRE_LIVE **input**/**signoff** shapes | PRE_LIVE navigation is not a **gate** schedule |
+
+## 5) Review workflow (safe, fail-closed)
+
+1. **Identify candidate scope** — literal **first strictly bounded real-money pilot** label per entry contract §1–2; any extra candidate identifier is **EXTERNAL** unless governance already defined it outside this repo.
+2. **Inspect pointer presence** — for each L1–L5 level, check whether **operator-held evidence** is represented by **opaque** `retrieval_reference` handles and minimal metadata per the level’s pointer contract (not by files in this repository).
+3. **Inspect freshness / provenance / replay claims** — use [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) and read-model **evidence_pointer** semantics in [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md) §7 as **interpretation** aids; artifact presence does not imply end-to-end replayability.
+4. **Verify external / archive references through operator process** — retrieval handles are resolved in **change-control** or governance systems **outside** git; this repo stays free of payloads.
+5. **Record unknowns** — use **OPEN**, **TBD**, or **EXTERNAL** explicitly in review notes when ownership, freshness, or **authority** is unclear.
+6. **Stop / fail-closed** — if evidence is missing, stale, contradictory, or **authority** is unclear, treat as **blocked** for progression interpretation; do not infer **permission** from this crosswalk.
+
+## 6) Non-goals
+
+- No **evidence** creation, ingestion, or validation engine in this slice.
+- No registry, object-store, or archive upload/download semantics added here.
+- No scanner, exchange, provider, runtime, session, Testnet, or Live **enablement**.
+- No **trading** **authority** and no **external** signoff or waiver implied.
+- No new CI gates, code paths, WebUI behavior, workflows, or config changes via this document.
+
+## 7) Safe next steps (only if explicitly requested later)
+
+Potential **separate** slices, each with its own **non-authorizing** charter:
+
+- **Docs-only:** PRE_LIVE cluster **pointer** notes keyed to this crosswalk (navigation only).
+- **Test-only:** a docs-reference or wording guard if a concrete ambiguity is found and scoped.
+- **Read-only tooling:** evidence-index inspection helpers only under an explicit operator objective (no mutation of `out/`, experiments, or stores).
+
+## 8) Cross-references
+
+- [MASTER_V2_BOUNDED_PILOT_L1_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L1_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L2_GO_NO_GO_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_BOUNDED_PILOT_L3_ENTRY_PREREQUISITE_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L3_ENTRY_PREREQUISITE_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_BOUNDED_PILOT_L4_SESSION_FLOW_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L4_SESSION_FLOW_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md](MASTER_V2_BOUNDED_PILOT_L5_INCIDENT_SAFE_STOP_EVIDENCE_POINTER_CONTRACT_V0.md)
+- [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+
+## 9) Non-authorizing constraint
+
+This specification **authorizes nothing**. It is a **read path** and **crosswalk** only.


### PR DESCRIPTION
## Summary

- adds a non-authorizing bounded-pilot / First-Live L1-L5 pointer runbook crosswalk
- maps candidate-specific operator-held evidence pointer expectations to existing runbooks/specs/read paths
- frames missing, stale, contradictory, or unclear evidence as OPEN/TBD/EXTERNAL and fail-closed
- clarifies this does not close G4-G8, create evidence, mutate registries, or authorize Testnet/Live

## Changed docs

- `docs/ops/specs/MASTER_V2_BOUNDED_PILOT_L1_L5_POINTER_RUNBOOK_CROSSWALK_V0.md`

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — ok
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — ok

## Safety

- docs-only slice
- no `src/` changes
- no tests changed
- no WebUI/workflow/config changes
- no scanner/exchange/runtime/session/testnet/live changes
- no evidence, registry, cache, S3, MLflow, experiment-store, `out/`, or session mutation
- non-authorizing crosswalk/read-path only

Made with [Cursor](https://cursor.com)