### PR TITLE
ci(class-a): add guarded schedule option for shadow paper probe v1

### DIFF
--- a/.github/workflows/class-a-shadow-paper-scheduled-probe-v1.yml
+++ b/.github/workflows/class-a-shadow-paper-scheduled-probe-v1.yml
@@ -2,9 +2,14 @@ name: Class A Shadow Paper Scheduled Probe v1
 
 on:
   workflow_dispatch:
-  # v1: schedule deliberately off. Enable only after ops review, e.g.:
-  # schedule:
-  #   - cron: "0 6 * * 1"
+  schedule:
+    # ~4 runs/day, minute 17 avoids top-of-hour congestion.
+    # Inactive for scheduled runs until repo variable is set (see job `if:`):
+    # Settings → Secrets and variables → Actions → Variables:
+    #   CLASS_A_SHADOW_PAPER_SCHEDULE_ENABLED = true
+    # Manual workflow_dispatch always runs; schedule events still appear in the
+    # Actions UI but skip the job when the variable is absent or not 'true'.
+    - cron: "17 */6 * * *"
 
 permissions:
   contents: read
@@ -18,6 +23,9 @@ jobs:
     name: class-a-shadow-paper-probe
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Same guard pattern as prj-scheduled-shadow-paper-features-smoke: manual
+    # dispatch always; cron only when CLASS_A_SHADOW_PAPER_SCHEDULE_ENABLED is 'true'.
+    if: ${{ vars.CLASS_A_SHADOW_PAPER_SCHEDULE_ENABLED == 'true' || github.event_name == 'workflow_dispatch' }}
 
     env:
       PEAK_TRADE_LIVE_ENABLED: "false"


### PR DESCRIPTION
## Summary

- adds a guarded Class A Shadow/Paper schedule option to the existing probe workflow
- keeps `workflow_dispatch` available for manual operator runs
- adds low-frequency cron `17 */6 * * *`
- scheduled runs execute the probe only when repository variable `CLASS_A_SHADOW_PAPER_SCHEDULE_ENABLED` is set to `true`
- manual dispatch remains allowed regardless of the variable

## Changed workflow

- `.github/workflows/class-a-shadow-paper-scheduled-probe-v1.yml`

## Validation

- YAML parsed successfully
- safety grep reviewed: no unsafe live/testnet/export env assignment found
- no workflow dispatch performed
- no Paper/Shadow/Testnet/Live session started from this implementation step

## Safety

- workflow-only slice
- no `src/` changes
- no tests changed
- no docs/config changes
- no AWS/rclone/S3 export
- no Testnet/Live enablement
- no daemon / no unbounded runtime
- scheduled probe remains gated by `CLASS_A_SHADOW_PAPER_SCHEDULE_ENABLED == true`

Made with [Cursor](https://cursor.com)