### PR TITLE
docs(ops): add evidence packet index navigation map v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md
@@ -1,0 +1,131 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0
+status: draft
+scope: docs-only, non-authorizing evidence packet and index navigation map
+last_updated: 2026-04-27
+---
+
+# Master V2 Evidence Packet and Index Navigation Map V0
+
+## 1. Executive Summary
+
+This document maps how **evidence indexes**, **evidence requirements**, **readiness**-shaped packets, **handoff** packets, **provenance**, the **KB** or **registry** or **evidence** taxonomy, and the **Learning Loop** path map relate as **navigation** and **review** surfaces.
+
+It is intentionally small and **non-authorizing**. It does **not** rewrite the [Evidence Index](../EVIDENCE_INDEX.md) body, does **not** define a new evidence **schema**, does **not** **approve** readiness, does **not** **complete** **signoff**, does **not** enable live trading, and does **not** assert **autonomy** **readiness** or that the system is **autonomous-ready**.
+
+**Evidence** can **support** review, replayability, learning, and **evidence-informed** staged processes. **Evidence** does **not** by itself bypass Master V2 or Double Play, Scope or Capital, Risk or KillSwitch, Execution or Live Gates, operator review, or **external** decision processes.
+
+## 2. Purpose and Non-Goals
+
+**Purpose:**
+
+- Provide a compact **navigation** map for evidence **index** and **packet**-shaped concepts.
+- Clarify which existing specs act as **evidence**, **readiness**, **handoff**, **provenance**, or **taxonomy** anchors.
+- Support the Learning Loop and KB or registry taxonomy **without** changing behavior.
+- Keep evidence surfaces clearly **non-authorizing** **review** surfaces.
+
+**Non-goals:**
+
+- No code, test, or workflow change.
+- No evidence **schema** implementation change.
+- **No** edit to the **body** of [../EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) in the same work as this file (this document is add-only context).
+- No readiness or gate **status** change in code or config.
+- No **signoff** **complete** claim, no **gate** **passed** claim, no **live** **authorization** claim, no **externally** **authorized** claim by this file alone.
+- No live enablement.
+- **Not** a replacement for [../EVIDENCE_SCHEMA.md](../EVIDENCE_SCHEMA.md).
+
+## 3. Navigation Model
+
+The intended **information** **navigation** model is:
+
+```text
+Evidence requirement or evidence artifact
+  -> Evidence Index or packet-shaped contract
+  -> readiness or handoff review surface
+  -> provenance or replayability context
+  -> operator or external review (process-defined)
+  -> (no automatic trading or gate closure implied here)
+```
+
+This is **not** a runtime pipeline diagram. It is a **where to look** map for **review** and **traceability** only. Order execution, live arm semantics, and gate closure remain in `src/execution/`, `src/live/`, `src/risk_layer/`, and **operator** process—not in this file.
+
+## 4. Evidence Index vs Evidence Packet vs Readiness Packet vs Handoff Packet
+
+| Concept | What it is (informational) | Typical anchor | **Not** implied |
+| --- | --- | --- | --- |
+| **Evidence Index** | Operator-facing **catalog** of evidence reference rows | [../EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) | **Not** **approval**; **not** that a **gate** **passed** because a row exists |
+| **Evidence** | Artifact or record supporting a **claim** for review | [../EVIDENCE_SCHEMA.md](../EVIDENCE_SCHEMA.md); generated or checked-in evidence under `docs/ops/` | **Not** automatic **signoff** **complete** |
+| **Evidence requirement (contract)** | **Shape** and expectations for what evidence may mean in a first-live or signoff **slice** | [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](./MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md) | **Not** a permit to trade |
+| **Readiness verdict packet (contract)** | **Packet** **shape** for **readiness** narrative in that slice | [MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md](./MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md) | **Not** **live-ready** or **production-ready** by file presence |
+| **Handoff packet (contract)** | **Structured** **input** to the next review or **external** step | [MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md) | **Handoff** is **not** **signoff** by itself; **not** **externally** **authorized** in-repo only |
+| **Provenance** or **replayability** | **Trace** and **replay** expectations for defensibility | [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | Traceability is **not** **permission** |
+
+**Packet** in this table means **docs contract** and **process** **shape** unless a **separate** runtime type exists; this map does not invent runtime types.
+
+## 5. Example Navigation Rows
+
+Illustrative rows only; **not** exhaustive of all contracts in the tree.
+
+| Role | Existing anchor | Used for | **Not** used for |
+| --- | --- | --- | --- |
+| Evidence Index | [../EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) | Browsing and linking to evidence **records** for **operator** and **review** | **Not** **signoff** **complete**; **not** **approval**; **not** a **gate** **passed** by catalog presence |
+| Evidence Requirement | [MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md](./MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md) | **Defining** what “evidence” may mean in that **slice** for **consistency** in review | **Not** a substitute for process outside the repo; **not** order **authorization** |
+| Readiness Verdict Packet | [MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md](./MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md) | **Shaping** **readiness** **narrative** and **verdict** **inputs** for **review** | **Not** **live** **authorization**; **not** **autonomy** **readiness** |
+| Handoff Packet | [MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md) | **Handoff** **input** to a **downstream** **review** or **external** process | **Not** **externally** **authorized** by packet existence alone; **not** a **green** **light** for live |
+| Provenance and Replayability | [MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | **Audit**, **defensibility**, and **replay** **expectations** | **Not** **permission**; **not** a **go** **live** **toggle** |
+| KB or Registry or Evidence Taxonomy | [MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) | **Shared** **vocabulary** for **learning** and **evidence** **layers** | **Not** a **knowledge** **base** that **authorizes** trades; **not** an **auto**-**approval** path |
+| Learning Loop path map | [MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md) | **Where** **learning** **steps** touch the repo; **separate** from the trading path | **Not** an **execution** or **autonomous** **trading** **loop** by itself |
+| Visual architecture and strategy reference | [MASTER_V2_VISUAL_ARCHITECTURE_AND_STRATEGY_REFERENCE_V0.md](./MASTER_V2_VISUAL_ARCHITECTURE_AND_STRATEGY_REFERENCE_V0.md) · [MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md](./MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md) | **Planning** and **posture** for **visuals** and **strategy** **families** | **Not** runtime **authority**; **not** **live** **readiness** from a diagram |
+
+## 6. Relationship to Learning Loop
+
+[MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md) names **path** **hints** for hypothesis through **evidence** and **refinement**. **This** map focuses on **index** and **packet**-shaped **navigation** for **evidence** **review**; together they **support** the Learning Loop as **non-authorizing** **learning** **input**, not as **live** **authority**.
+
+## 7. Relationship to KB, Registry, and Evidence Taxonomy
+
+[MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) defines **terms** (Knowledge Base, registry, **evidence** **index** row, **handoff** **packet** posture). **This** file adds a **small** “**where** to click next” view for **index** and **first-live**-style **packet** **contracts** without **redefining** those **terms**.
+
+## 8. Relationship to Master V2 and Double Play
+
+[MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md](./MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md) and the Double Play **manifest** (e.g. [MASTER_V2_DOUBLE_PLAY_TRADING_LOGIC_MANIFEST_V0.md](./MASTER_V2_DOUBLE_PLAY_TRADING_LOGIC_MANIFEST_V0.md)) stay the **governance** **boundary** for **trading** **semantics**. **Evidence** **indexes** and **packets** are **inputs** to **operator** and **staged** **processes**; they do **not** **override** Master V2 or Double Play, **Risk** or **KillSwitch**, or **execution** and **live** **gates** without **separate** **wiring** and **governance** described elsewhere.
+
+## 9. Authority Boundaries
+
+| Surface | **May** (informational) | **Must not** (by this map) |
+| --- | --- | --- |
+| Index and schema | help **find** and **read** **evidence** **records** | **imply** **approval** from **inclusion** |
+| **Packet** **contracts** | **shape** **handoff** and **readiness** **artifacts** for **review** | **substitute** for **operator** or **external** **decision** |
+| Provenance | support **audit** and **replay** | **stand in** for **live** **eligibility** |
+| Learning and taxonomy | clarify **vocabulary** and **paths** | **grant** **autonomy** or **trading** **authority** |
+
+**AI**-layer and **orchestration** **outputs** remain **advisory** per the **dataflow** overview; **this** file does not **authorize** them to **place** **orders** or **arm** **live**.
+
+## 10. Known Ambiguities
+
+- **First-live** and **signoff** **contract** **families** are **large**; this map **samples** a **few** **anchors** only.
+- The **EVIDENCE_INDEX** may **list** more **kinds** of **entries** over time; **this** file does **not** **enumerate** every **EV-** id.
+- **Packet** can mean **docs** **contract** **shape** or a **concrete** **file** in an **out** **tree**; disambiguation is by **context** in each **contract**, not in this **navigation** **row** set alone.
+- A **row** in the **index** is a **record** of a **claim**; it is **not** **independent** **proof** of **external** **signoff** **complete**.
+
+## 11. Safe Follow-Up Candidates
+
+- **Tight** **cross-link** when new **readiness** or **handoff** **contracts** land (small **mechanical** **docs** **PRs**).
+- **Observer-only** double-play or WebUI **JSON** **map** (separate spec).
+- **Read-only** **script** to **list** spec **files** by **prefix** (separate **slice**; **touches** **code** and **tests**).
+- **Deeper** **matrix** of **EV-** id **patterns** to **contract** (must **not** **rewrite** the **index** **body** in bulk **without** **operator** **agreement**).
+
+## 12. Validation Notes
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+```
+
+**Related** **anchor** **specs** (non-exhaustive):
+
+- [MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md)
+- [MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md)
+- [MASTER_V2_VISUAL_ARCHITECTURE_AND_STRATEGY_REFERENCE_V0.md](./MASTER_V2_VISUAL_ARCHITECTURE_AND_STRATEGY_REFERENCE_V0.md)
+- [MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md](./MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md)
+
+**Inline** **references** to `src/`, `config/`, and `out&#47;ops&#47;` (where used in **runbooks**) are **citations** only.


### PR DESCRIPTION
## Summary

- Add a docs-only, non-authorizing evidence packet / index navigation map.
- Clarify how evidence index, evidence requirement, readiness verdict packet, handoff packet, provenance, KB taxonomy, Learning Loop map, and visual references relate.
- Preserve Master V2 / Double Play, Scope/Capital, Risk/KillSwitch, Execution/Live Gates, AI, dashboard, strategy, evidence, and autonomy authority boundaries.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1674 files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed, all referenced targets exist

## Safety / Authority

- Docs-only change.
- No code, runtime, workflow, config, test, evidence schema, EVIDENCE_INDEX body, registry behavior, strategy, dashboard, risk, or gate behavior changes.
- No live authorization, signoff-complete, autonomous-ready, externally-authorized, or gate-pass claim.
