### PR TITLE
docs(ops): add operator handoff surface map v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md
@@ -1,0 +1,131 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0
+status: draft
+scope: docs-only, non-authorizing operator handoff surface map
+last_updated: 2026-04-27
+---
+
+# Master V2 Operator Handoff Surface Map V0
+
+## 1. Executive Summary
+
+This document maps the **operator reading order** across evidence, readiness, verdict, handoff, provenance, runbook, and review surfaces. It is a **navigation** and **order map** only. It does **not** replace any referenced spec or runbook, does **not** modify runtime behavior, and does **not** imply **live authorization**, **signoff** complete, **gate** pass, **approval**, or **autonomy** readiness. Full autonomy is a **future operating target** in other docs, not a current authorization state established here.
+
+Use this map when an operator or reviewer must understand **which surface to read first** and **what each surface is for** on the path from evidence and readiness toward handoff, verdict, and runbook context.
+
+## 2. Purpose and Non-Goals
+
+**Purpose:**
+
+- Clarify **reading order** and “used for / not used for” boundaries between **readiness**, **verdict packet**, **handoff packet**, **evidence index**, and **runbook** usage.
+- Reduce confusion between evidence navigation, readiness review, verdict packet shape, and downstream handoff input.
+- Keep operator and review surfaces explicitly **non-authorizing** in-repo.
+
+**Non-goals:**
+
+- No code, test, workflow, or config change.
+- No runbook rewrite; no new runtime procedure.
+- No edit to the **body** of [../EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md).
+- No claim of **signoff** complete, **gate** passed, **live-ready**, **production-ready**, **externally authorized**, or **autonomous-ready** from this file alone.
+- **Not** a replacement for [../EVIDENCE_SCHEMA.md](../EVIDENCE_SCHEMA.md) or execution or live-gate code.
+
+## 3. Operator Reading Order
+
+| Order | Surface | Anchor | Use when | Not used for |
+| ---: | --- | --- | --- | --- |
+| 1 | Reference-chain pointer | [`MASTER_V2_VISUAL_LEARNING_EVIDENCE_REFERENCE_CHAIN_POINTER_V0.md`](./MASTER_V2_VISUAL_LEARNING_EVIDENCE_REFERENCE_CHAIN_POINTER_V0.md) | You need the staged visual / learning / evidence reference order before deep-diving. | **Not** runtime authority; **not** a **gate** result. |
+| 2 | Evidence requirement | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md) | You need the expected evidence posture for a pre-live / first-live slice. | **Not** proof that evidence **exists**; **not** **approval**. |
+| 3 | Evidence index (contract) | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_EVIDENCE_INDEX_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_EVIDENCE_INDEX_CONTRACT_V1.md) | You need the index-shaped **contract** next to the [catalog](../EVIDENCE_INDEX.md). | **Not** **signoff** **complete**; **not** **live** **authorization**. |
+| 4 | Evidence packet / index navigation | [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md) | You need how packet, index, readiness, and handoff surfaces relate for review. | **Not** **approval**; **not** **external** authority completion in-repo only. |
+| 4a | KB / Registry / Evidence taxonomy (optional) | [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) | You need shared vocabulary for registry, evidence, and learning layers. | **Not** **trade** permission; **not** an auto-approval path. |
+| 4b | Learning Loop path map (optional) | [`MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md`](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md) | You need the learning path **vs** this operator handoff reading line. | **Not** **autonomous** **execution**; **not** current **autonomy** **readiness** as **authorization**. |
+| 5 | Readiness verdict packet | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md) | You need a structured **verdict** / **readiness** **review** surface (packet **shape**). | **Not** **live** **authorization** by file **alone**; **not** **externally** **authorized** here. |
+| 6 | Handoff packet | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md) | You need a structured **downstream** **handoff** **input** for the next step. | **Handoff** is **not** **signoff** by itself; **not** a green light for live. |
+| 7 | Provenance / replayability | [`MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | You need **traceability** and **replay** **expectations** for defensibility. | **Not** **permission** to **execute**; **not** a go-live toggle. |
+| 8 | Runbooks (index) | [`../runbooks/README.md`](../runbooks/README.md) | You need **operator** procedure context beyond spec navigation. | **Not** **automatic** **approval**; **not** **live** **enablement** from reading. |
+
+**Catalog note:** the live [../EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md) is typically used **with** rows 3 and 4, not as a substitute for those contracts.
+
+## 4. Surface Map: Evidence → Readiness → Verdict → Handoff → Runbook
+
+The intended **information navigation** sequence (for “where to read”, not a runtime job graph) is:
+
+```text
+evidence requirement
+  -> evidence index (contract) and / or EVIDENCE_INDEX catalog
+  -> evidence packet / index navigation map
+  [optional: KB taxonomy, Learning Loop map for vocabulary / learning]
+  -> readiness verdict packet
+  -> handoff packet
+  -> provenance / replayability
+  -> runbook / operator or external review
+```
+
+This is **not** a pipeline that **authorizes** trading. Order execution, live arms, and gate closure live in `src/execution/`, `src/live/`, `src/risk_layer/`, and **operator** process and **externally defined** steps—not in this file.
+
+## 5. Surface Roles
+
+| Surface | Role | Producer / owner (if inferable) | Consumer | Boundary |
+| --- | --- | --- | --- | --- |
+| **Evidence requirement** | Defines expected **evidence** **posture** for a pre-live slice in-repo. | Docs / governance slices (as published). | Operator and internal review readers. | **Not** a **permit** to **trade**. |
+| **Evidence index** | **Catalog** of **evidence** **reference** **rows**; see [../EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md). | Operator-maintained rows in normal practice. | Operator and review stakeholders. | **Inclusion** is **not** **signoff** **complete**; **not** that a **gate** **passed** because a **row** **exists**. |
+| **Readiness verdict packet** | **Readiness** / **verdict** **narrative** **shape** (packet **contract**). | Pre-live governance slices (as published). | Operator and staged readiness review. | **Not** **live-ready**; **not** **production-ready** from file presence alone. |
+| **Handoff packet** | **Structured** **input** to **downstream** **review** (including **potentially** **external** **steps**). | Pre-live governance slices (as published). | Next-stage review or external process (as defined **outside** this **repo** where it applies). | **Not** **externally** **authorized** in-repo only; **not** **approval** **alone**. |
+| **Provenance / replayability** | **Trace** and **replay** **expectations** for audit and defensibility. | Governance and ops spec families (as published). | Operator, review, and audit readers. | **Traceability** is **not** **order** **authorization**. |
+| **Runbook** | Procedural **operator** **steps**; entry via [../runbooks/README.md](../runbooks/README.md) and linked runbooks. | **Ops** (per [runbook index](../runbooks/README.md)). | On-call and change operators. | **Reading** a **runbook** does **not** **imply** **gate** pass or **live** **enablement** by itself. |
+| **Operator review** | In-repo or process **review** of **readiness** / **verdict** / **handoff** **inputs** (non-authorizing here). | Operator or org process (out of scope for this file to define). | Operator and internal stakeholders. | This spec does **not** name a formal signoff **outcome**. |
+| **External review** | Out-of-repo or governed **downstream** **decision** (where it applies). | External or governed bodies (not defined here). | The named process (outside this file). | **Not** **established** or **implied** by this map alone. |
+
+## 6. What Each Surface Is Not
+
+| Surface | **Not** |
+| --- | --- |
+| Reference pointer | A **source** of order **authority**; a **result** of **any** **gate** |
+| Evidence requirement | **Guarantee** that **all** **artifacts** **exist**; **formal** **signoff** |
+| Evidence index | **Approval**; “done” because **rows** **exist** in a file list **alone** |
+| Evidence navigation map | **Rewriting** the index **body**; **substitute** for [EVIDENCE_SCHEMA](../EVIDENCE_SCHEMA.md) text |
+| Readiness verdict packet | **Live** **authorization**; **autonomy** **readiness** as a current **permit** |
+| Handoff packet | **Complete** **external** **signoff**; in-repo-only **authority** |
+| Provenance / replayability | **Execution** **permit**; **bypass** of Master V2 / Double Play / **risks** / **gates** |
+| Runbook | Self-executing **approval**; **bypass** of **live** **gate** code |
+
+## 7. Relationship to Reference Chain Pointer
+
+The [Reference Chain Pointer](./MASTER_V2_VISUAL_LEARNING_EVIDENCE_REFERENCE_CHAIN_POINTER_V0.md) is the broader “**which** **spec** to open **first**” guide for the visual, learning, and evidence stack. **This** document is the **narrower** line for “evidence / readiness → verdict → handoff → provenance / runbook” reading when staged pre-live **contracts** are in scope.
+
+Read the **Pointer** first (row 1 in **section** **3**); use this map when the main question is **operator** path for **verdict** / **handoff** / **runbook**, not system-wide **visual** placement **alone**. This file does **not** **override** the **Pointer**; it **complements** it. The Pointer’s “**Known** **ambiguities**” (if **present**) and **this** file’s **section** **11** can be read **together** for **overlapping** **questions**.
+
+## 8. Relationship to Evidence Packet / Index Navigation Map
+
+The [Evidence Packet and Index Navigation Map](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md) **explains** how **evidence** **index**, **evidence** **requirement**, **readiness** and **handoff** **shapes**, and **provenance** **relate**. This **operator** **handoff** **map** **adds** an ordered “read this then this” **ladder** for staged pre-live **review** when **connecting** to [../runbooks/README.md](../runbooks/README.md). **Neither** file **replaces** [../EVIDENCE_INDEX.md](../EVIDENCE_INDEX.md); both **treat** the **index** as a **review** and **linking** **surface**, **not** an **approval** **seal**.
+
+## 9. Relationship to Risk, Gates, and Master V2 / Double Play
+
+**Master** **V2** and **Double** **Play**, **Bull** / **Bear** **specialist** **logic**, **Scope** / **Capital**, **Risk** / **KillSwitch**, and **Execution** / **Live** **Gates** **remain** the **downstream** **technical** and **governance** **boundaries** **stated** in code and **governance** **docs**—**not** **relaxed** or **replaced** by this **map**. This **document** is a **navigation** **aid** **only**; it does **not** **assign** **gate** pass or **imply** that **readiness** or **verdict** **shapes** **satisfy** any **particular** **operator**-**defined** or **externally**-**defined** **criterion**. **Double** **Play**-relevant runbooks (for **example** [double_play_specialists.md](../runbooks/double_play_specialists.md)) are **operator** **procedure**, **not** a **substitute** for **live** **gate** code.
+
+## 10. Safe Use Checklist
+
+- Treat every row in **section** **3** as one **reading** **suggestion**, **not** a milestone “complete” **state**.
+- Re-read the **relevant** runbook(s) before any action that **affects** **funds** or **orders**.
+- If a word **implies** **approval**, **gate** pass, or **external** **authorization**, **verify** the **claim** in the **correct** **authoritative** process (outside this file if **needed**), not **here**.
+- **Do** **not** **infer** **autonomy** **readiness** from this **map**; full **autonomy** is a **future** **operating** **target** in other **docs**, not a **permit** **stated** **here**.
+- **Prefer** the [Reference Chain Pointer](./MASTER_V2_VISUAL_LEARNING_EVIDENCE_REFERENCE_CHAIN_POINTER_V0.md) and the **evidence** **navigation** **map** before **adding** new ad-hoc “where do I look” **prose** in unrelated **docs**.
+
+## 11. Known Ambiguities
+
+- Multiple “readiness” or “**packet**” file names exist (for **example** **review**-**shaped** **vs** **verdict** **contract**); this map names the **verdict** and **handoff** **contracts** in **section** **3** but does **not** merge all first-live **families** into one **row**.
+- “**Authority** **handoff**” **vs** “pre-live signoff handoff” **packets** are **related** by **naming**; use the **linked** **contract** **titles** and this **map** in **tandem**, **not** as **interchangeable** **files**.
+- **Runbook** **coverage** is **broad**; [../runbooks/README.md](../runbooks/README.md) is the **stable** **entry**, **not** every **edge** **procedure** in one line.
+- This file is **draft**; if a **staged** process **publishes** a **definitive** **external** **order**, that process (when it **exists**) **takes** **precedence** over this **nav** **ladder** for that process.
+- This map may **not** line up with every audit milestone **naming**; it serves in-repo **evidence** / **readiness** / **verdict** / **handoff** / runbook **reading** **only**.
+
+## 12. Validation Notes
+
+When this file or its neighbors **change**, run (from **repo** **root**):
+
+```text
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+```
+
+This map is governed by the same no-fictitious-path and markdown-link discipline as other `MASTER_V2_*.md` spec files in this **directory**. A passing docs **gate** on this file does **not** mean **readiness**, **signoff**, or **live** **authorization**.


### PR DESCRIPTION
## Summary

- Add a docs-only, non-authorizing operator handoff surface map.
- Clarify reading/order relationships across evidence requirements, evidence index, readiness verdict packets, handoff packets, provenance, runbooks, and operator/external review surfaces.
- Preserve Master V2 / Double Play, Scope/Capital, Risk/KillSwitch, Execution/Live Gates, AI, dashboard, strategy, evidence, handoff, and autonomy authority boundaries.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed

## Safety / Authority

- Docs-only change.
- No code, runtime, workflow, config, test, evidence schema, EVIDENCE_INDEX body, registry behavior, runbook behavior, strategy, dashboard, risk, or gate behavior changes.
- No live authorization, signoff-complete, autonomous-ready, externally-authorized, or gate-pass claim.
