### PR TITLE
docs(ops): add session review pack contract v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md
@@ -1,0 +1,219 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0
+status: draft
+scope: docs-only, non-authorizing session review pack contract
+last_updated: 2026-04-27
+---
+
+# Master V2 Session Review Pack Contract V0
+
+## 1. Executive Summary
+
+This document defines a docs-only Session Review Pack V0 contract for post-hoc operator and reviewer analysis of a run or session.
+
+The pack is a non-authorizing review bundle shape. It is intended to make evidence, provenance, readiness, handoff, risk, gate, strategy/context, observer, and Learning Loop references easier to collect and review after a run.
+
+This contract does not modify runtime behavior, report behavior, `scripts/report_live_sessions.py`, Evidence Index content, registry behavior, Risk/KillSwitch behavior, Execution/Live Gates, Master V2 / Double Play, strategy behavior, dashboard/cockpit behavior, or AI behavior.
+
+A Session Review Pack is not live authorization, signoff completion, gate passage, strategy readiness, or autonomy readiness.
+
+## 2. Purpose and Non-Goals
+
+Purpose:
+
+- Define a concrete post-hoc review pack shape.
+- Connect existing evidence, provenance, handoff, observer, and Learning Loop surfaces.
+- Prepare a safe future read-only implementation candidate.
+- Improve operator review and auditability without changing behavior.
+
+Non-goals:
+
+- No code changes.
+- No runtime changes.
+- No report implementation changes.
+- No workflow changes.
+- No config changes.
+- No Evidence Index body rewrite.
+- No evidence schema change.
+- No registry behavior change.
+- No live enablement.
+- No signoff claim.
+- No gate-pass claim.
+- No autonomy-readiness claim.
+
+## 3. Session Review Pack Concept
+
+A Session Review Pack is a structured post-hoc review bundle that points to existing surfaces.
+
+It should help answer:
+
+- What session or run is being reviewed?
+- Which mode or environment was involved?
+- Which provenance and replayability references exist?
+- Which evidence references exist?
+- Which readiness, handoff, risk, gate, strategy/context, observer, or Learning Loop references should be reviewed?
+- What did the operator note?
+- Which artifacts should be preserved for later review?
+
+The pack is a review surface. It does not authorize action.
+
+## 4. Pack Contents
+
+| Field | Meaning | Example source surface | Required now? | Not used for |
+| --- | --- | --- | --- | --- |
+| `session_id` | Identifier for the reviewed session or run. | `out&#47;ops&#47;` convention or report output. | Optional until implemented. | Not proof of validity. |
+| `run_timestamp` | Time associated with the reviewed run. | report or artifact metadata. | Optional until implemented. | Not approval. |
+| `mode_or_environment` | Paper, shadow, testnet, bounded pilot, or other mode context where available. | report output or config context. | Optional until implemented. | Not live authorization. |
+| `provenance_reference` | Link or pointer to replayability or provenance context. | [`MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | Recommended. | Not permission to execute. |
+| `evidence_references` | Evidence links or index references. | [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md) | Recommended. | Not signoff completion. |
+| `readiness_summary_reference` | Pointer to readiness summary or verdict surface. | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md) | Optional until implemented. | Not gate passage. |
+| `handoff_reference` | Pointer to handoff packet or operator handoff surface. | [`MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md`](./MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md) | Recommended. | Not external authority completion. |
+| `registry_reference` | Registry or index reference where applicable. | [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) | Optional until implemented. | Not approval. |
+| `operator_notes` | Human review notes or follow-up observations. | operator review process. | Optional. | Not runtime state. |
+| `risk_kill_switch_summary_reference` | Pointer to risk or stop-signal summary where available. | risk/report surface or docs. | Recommended for future implementation. | Not Risk/KillSwitch override. |
+| `execution_gate_summary_reference` | Pointer to execution or gate summary where available. | report or gate summary surface. | Recommended for future implementation. | Not live enablement. |
+| `strategy_context_summary_reference` | Pointer to strategy/context summary where available. | [`MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md`](./MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md) | Optional. | Not strategy readiness. |
+| `dashboard_observer_summary_reference` | Pointer to dashboard, cockpit, report, or observer output. | [`MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md`](./MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md) | Optional. | Not order authority. |
+| `learning_loop_feedback_reference` | Pointer to lessons, priors, unsafe zones, or refinement context. | [`MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md`](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md) | Optional. | Not autonomous execution. |
+| `artifacts_manifest_reference` | Pointer to artifact manifest or retained outputs where available. | `out&#47;ops&#47;` convention or future read-only report. | Optional until implemented. | Not signoff. |
+
+## 5. Existing Surface Mapping
+
+| Existing surface | Anchor | Used by Session Review Pack for | Not used for |
+| --- | --- | --- | --- |
+| Operator triage checklist | [`MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md`](./MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md) | Opening the correct first reference during review. | Approval or live decision. |
+| Operator handoff map | [`MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md`](./MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md) | Understanding handoff and verdict order. | External authority completion. |
+| Observer surface inventory | [`MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md`](./MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md) | Locating dashboard/cockpit/report observer surfaces. | Order authority. |
+| Evidence packet/index navigation | [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md) | Relating evidence index, packet, readiness, handoff, and provenance. | Signoff completion. |
+| KB / Registry / Evidence taxonomy | [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) | Vocabulary for review, learning, registry, and evidence surfaces. | Implementation or approval. |
+| Learning Loop path map | [`MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md`](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md) | Connecting review results to lessons and future refinement. | Current autonomous execution. |
+| Provenance / replayability | [`MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | Traceability and replay context. | Permission to execute. |
+| System dataflow and AI-layer overview | [`MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md`](./MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md) | Understanding system-wide flow and AI boundaries. | AI trade authority. |
+| Evidence Index contract | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_EVIDENCE_INDEX_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_EVIDENCE_INDEX_CONTRACT_V1.md) | Evidence reference navigation. | Signoff completion. |
+| Evidence requirement contract | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md) | Required evidence posture. | Proof of fulfillment by itself. |
+| Readiness verdict packet contract | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md) | Readiness-review structure. | Live authorization. |
+| Handoff packet contract | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md) | Downstream review input. | External authority completion. |
+| Current reporting surface | `scripts/report_live_sessions.py` | Future read-only pack source candidate. | Runtime mutation or approval. |
+
+## 6. Operator Review Checklist
+
+A Session Review Pack should help the operator check:
+
+1. Which session or run is under review?
+2. Which mode or environment was involved?
+3. Which evidence and provenance references exist?
+4. Which readiness or handoff surfaces apply?
+5. Which risk, stop, or gate summaries exist?
+6. Which strategy/context summary is relevant?
+7. Which observer or dashboard summary should be read?
+8. Which Learning Loop lessons or unsafe zones should be recorded?
+9. Which artifacts must be retained for replay or audit?
+10. Which question requires separate authority review?
+
+Stop if the review question asks the pack to approve, authorize, pass gates, establish live readiness, or establish autonomy readiness.
+
+## 7. Relation to Evidence / Registry / Knowledge Base
+
+The Session Review Pack should point to evidence, registry, and Knowledge Base context rather than duplicate it.
+
+Related anchor:
+
+- [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md)
+
+The pack can support post-hoc learning and review. It must not become the approval mechanism.
+
+## 8. Relation to Learning Loop
+
+The Session Review Pack can feed the Learning Loop by preserving:
+
+- observed outcomes;
+- risk and gate behavior;
+- strategy/context notes;
+- evidence and provenance references;
+- operator observations;
+- failure modes;
+- unsafe zones.
+
+Related anchor:
+
+- [`MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md`](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md)
+
+Learning feedback remains non-authorizing and must pass through controlled handoff.
+
+## 9. Relation to Master V2 / Double Play
+
+Master V2 / Double Play remains the protected trading architecture.
+
+Protected source paths:
+
+- `src/trading/master_v2/`
+- `src/ops/double_play/`
+
+A Session Review Pack may reference context related to Master V2 / Double Play. It must not change or reinterpret Bull/Bear specialist logic, state or side-switch semantics, Scope and Capital semantics, or trading behavior.
+
+## 10. Relation to Risk / KillSwitch / Execution Gates
+
+A Session Review Pack may point to risk, stop, gate, execution, or readiness summaries. It must not override them.
+
+Protected source paths:
+
+- `src/risk_layer/`
+- `src/execution/`
+- `src/live/`
+
+Risk/KillSwitch and Execution/Live Gates remain downstream blockers and safety boundaries.
+
+## 11. Authority Boundaries
+
+| Surface | May do | Must not do |
+| --- | --- | --- |
+| Session Review Pack | Collect or point to review references. | Approve or authorize trades. |
+| Evidence reference | Support review. | Complete signoff by itself. |
+| Provenance reference | Support replay and audit. | Grant permission. |
+| Readiness reference | Structure readiness review. | Pass gates by itself. |
+| Handoff reference | Support downstream review. | Complete external authority. |
+| Risk/KillSwitch summary | Explain safety posture. | Override blocking behavior. |
+| Gate summary | Explain gate posture. | Enable live mode by itself. |
+| Strategy/context summary | Explain candidate context. | Establish strategy readiness. |
+| Observer summary | Explain status. | Place or authorize orders. |
+| Learning feedback | Improve future review. | Enable current autonomy. |
+
+## 12. Known Ambiguities
+
+Known ambiguities:
+
+- This contract defines a shape before implementation.
+- Some fields may not have concrete generated sources yet.
+- Some evidence, registry, and observer outputs may be distributed across reports, docs, and `out&#47;ops&#47;` conventions.
+- A future read-only implementation must choose exact source precedence and missing-field behavior.
+- Existing paper test data and runs must remain undisturbed.
+
+## 13. Future Read-Only Implementation Candidate
+
+A future safe implementation candidate could add a read-only `session-review-pack` report mode, likely near existing report surfaces such as `scripts/report_live_sessions.py`.
+
+That future implementation should be:
+
+- additive;
+- read-only;
+- test-backed;
+- fail-closed on missing or malformed inputs;
+- explicit about missing fields;
+- non-authorizing;
+- safe for paper/test data;
+- not modifying live gates;
+- not modifying Master V2 / Double Play;
+- not modifying Risk/KillSwitch behavior.
+
+This document does not implement that mode.
+
+## 14. Validation Notes
+
+Validate this docs-only file with:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+```
+
+Both commands are non-authorizing and do not place trades or call brokers.


### PR DESCRIPTION
## Summary

- Add a docs-only, non-authorizing Session Review Pack V0 contract.
- Define a post-hoc review bundle shape for session/run review across evidence, provenance, readiness, handoff, registry, operator notes, risk/gate summaries, strategy context, observer summaries, learning-loop feedback, and artifact manifests.
- Prepare a future read-only implementation candidate without changing report behavior.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1679 Markdown files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed, all referenced targets exist

## Safety / Authority

- Docs-only change.
- No code, runtime, workflow, config, test, report_live_sessions.py, EVIDENCE_INDEX body, evidence schema, registry behavior, strategy, dashboard, risk, or gate behavior changes.
- No live authorization, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
