### PR TITLE
ops(scripts): add read-only session-review-pack report v0

### DIFF
--- a/scripts/report_live_sessions.py
+++ b/scripts/report_live_sessions.py
@@ -1914,7 +1914,10 @@ def _run_session_review_pack(
 ) -> int:
     """Emit static Session Review Pack V0 JSON (read-only, no registry I/O in v0)."""
     if not args.json:
-        print("ERR: --session-review-pack requires --json (read-only pack output; v0 JSON-only)", file=sys.stderr)
+        print(
+            "ERR: --session-review-pack requires --json (read-only pack output; v0 JSON-only)",
+            file=sys.stderr,
+        )
         return 2
     logger.info("Session Review Pack V0 (read-only, static shape)")
     payload = _build_session_review_pack_v0_payload()

--- a/scripts/report_live_sessions.py
+++ b/scripts/report_live_sessions.py
@@ -70,6 +70,9 @@ Usage:
     # JSON includes abort_triage_hints derived from existing signals only — not authorization):
     python scripts/report_live_sessions.py --bounded-pilot-lifecycle-consistency
     python scripts/report_live_sessions.py --bounded-pilot-lifecycle-consistency --json
+
+    # Session Review Pack V0 (read-only, non-authorizing post-hoc review bundle; JSON-only in v0):
+    python scripts/report_live_sessions.py --session-review-pack --json
 """
 
 from __future__ import annotations
@@ -1817,6 +1820,109 @@ def _run_bounded_pilot_closeout_status_summary(
 
 
 # =============================================================================
+# Session Review Pack V0 (read-only, non-authorizing; docs contract mapping)
+# =============================================================================
+
+
+def _session_review_pack_flag_conflicts(args: argparse.Namespace) -> str | None:
+    """--session-review-pack is a static JSON pack in v0; no registry or report filters."""
+    if args.session_id is not None:
+        return "--session-id is only for --evidence-pointers"
+    if args.latest_bounded_pilot:
+        return "--latest-bounded-pilot is only for --evidence-pointers"
+    if args.bounded_pilot_only or args.latest_bounded_pilot_open:
+        return "--bounded-pilot-only / --latest-bounded-pilot-open require --open-sessions"
+    if args.run_type is not None:
+        return "--run-type is not compatible with --session-review-pack"
+    if args.status is not None:
+        return "--status is not compatible with --session-review-pack"
+    if args.limit is not None:
+        return "--limit is not compatible with --session-review-pack"
+    if args.summary_only:
+        return "--summary-only is not compatible with --session-review-pack"
+    if args.output_dir is not None:
+        return "--output-dir is not compatible with --session-review-pack"
+    if args.stdout:
+        return "--stdout is not compatible with --session-review-pack"
+    if args.config_path is not None:
+        return "--config-path is not compatible with --session-review-pack"
+    if args.registry_base is not None:
+        return "--registry-base is not compatible with --session-review-pack (v0 is static JSON)"
+    if not args.json:
+        return "--session-review-pack requires --json (read-only pack output; v0 JSON-only)"
+    return None
+
+
+def _build_session_review_pack_v0_payload() -> dict[str, Any]:
+    """Build static v0 pack shape; session/reference fields are unpopulated until future slices."""
+    session: dict[str, Any] = {
+        "session_id": None,
+        "run_timestamp": None,
+        "mode_or_environment": None,
+    }
+    references: dict[str, Any] = {
+        "provenance_reference": None,
+        "evidence_references": [],
+        "readiness_summary_reference": None,
+        "handoff_reference": None,
+        "registry_reference": None,
+        "operator_notes": None,
+        "risk_kill_switch_summary_reference": None,
+        "execution_gate_summary_reference": None,
+        "strategy_context_summary_reference": None,
+        "dashboard_observer_summary_reference": None,
+        "learning_loop_feedback_reference": None,
+        "artifacts_manifest_reference": None,
+    }
+    missing: list[str] = []
+    for k, v in session.items():
+        if v is None:
+            missing.append(f"session.{k}")
+    for k, v in references.items():
+        if k == "evidence_references":
+            if not v:
+                missing.append("references.evidence_references")
+        elif v is None:
+            missing.append(f"references.{k}")
+    missing = sorted(missing)
+    return {
+        "contract": "report_live_sessions.session_review_pack_v0",
+        "schema_version": "master_v2/session_review_pack/v0",
+        "non_authorizing": True,
+        "disclaimer": (
+            "Read-only Session Review Pack V0: post-hoc review bundle shape; not live authorization, "
+            "not signoff, not gate pass, not strategy or autonomy readiness."
+        ),
+        "authority_boundary": {
+            "live_authorization": False,
+            "signoff_complete": False,
+            "gate_passed": False,
+            "autonomy_ready": False,
+            "strategy_ready": False,
+        },
+        "mode": "session_review_pack",
+        "session": session,
+        "references": references,
+        "source_contract": "docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md",
+        "missing_fields": missing,
+    }
+
+
+def _run_session_review_pack(
+    args: argparse.Namespace,
+    logger: logging.Logger,
+) -> int:
+    """Emit static Session Review Pack V0 JSON (read-only, no registry I/O in v0)."""
+    if not args.json:
+        print("ERR: --session-review-pack requires --json (read-only pack output; v0 JSON-only)", file=sys.stderr)
+        return 2
+    logger.info("Session Review Pack V0 (read-only, static shape)")
+    payload = _build_session_review_pack_v0_payload()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+# =============================================================================
 # Main Entry Point
 # =============================================================================
 
@@ -1928,7 +2034,8 @@ Beispiele:
             "JSON output for --evidence-pointers, --open-sessions, "
             "--bounded-pilot-readiness-summary, --bounded-pilot-closeout-status-summary, "
             "--bounded-pilot-operator-overview, --bounded-pilot-gate-index, "
-            "--bounded-pilot-first-live-frontdoor, or --bounded-pilot-lifecycle-consistency"
+            "--bounded-pilot-first-live-frontdoor, --bounded-pilot-lifecycle-consistency, "
+            "or --session-review-pack"
         ),
     )
     parser.add_argument(
@@ -2015,6 +2122,15 @@ Beispiele:
         ),
     )
     parser.add_argument(
+        "--session-review-pack",
+        action="store_true",
+        dest="session_review_pack",
+        help=(
+            "Read-only: Session Review Pack V0 (non-authorizing post-hoc review bundle; "
+            "use with --json; see docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md)"
+        ),
+    )
+    parser.add_argument(
         "--config-path",
         type=str,
         default=None,
@@ -2048,6 +2164,7 @@ Beispiele:
         + int(bool(args.bounded_pilot_lifecycle_consistency))
         + int(bool(args.evidence_pointers))
         + int(bool(args.open_sessions))
+        + int(bool(args.session_review_pack))
     )
     if _mode_n > 1:
         print(
@@ -2055,10 +2172,17 @@ Beispiele:
             "--bounded-pilot-closeout-status-summary, --bounded-pilot-operator-overview, "
             "--bounded-pilot-gate-index, --bounded-pilot-first-live-frontdoor, "
             "--bounded-pilot-lifecycle-consistency, "
-            "--evidence-pointers, --open-sessions",
+            "--evidence-pointers, --open-sessions, --session-review-pack",
             file=sys.stderr,
         )
         return 2
+
+    if args.session_review_pack:
+        conflict = _session_review_pack_flag_conflicts(args)
+        if conflict is not None:
+            print(f"ERR: {conflict}", file=sys.stderr)
+            return 2
+        return _run_session_review_pack(args, logger)
 
     if args.bounded_pilot_readiness_summary:
         conflict = _bounded_pilot_readiness_summary_flag_conflicts(args)

--- a/tests/ops/test_session_review_pack_report_contracts_v0.py
+++ b/tests/ops/test_session_review_pack_report_contracts_v0.py
@@ -1,12 +1,12 @@
-"""Characterization tests for future Session Review Pack report contracts.
+"""Characterization tests for Session Review Pack report contracts.
 
-These tests intentionally do not implement a session-review-pack mode. They pin
-the current non-authorizing/read-only posture around existing report surfaces so
-a future additive report can be introduced safely.
+`--session-review-pack` is a read-only, non-authorizing post-hoc review bundle
+(see `docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md`).
 """
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -28,15 +28,16 @@ def run_report_live_sessions(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_report_live_sessions_help_does_not_expose_session_review_pack_mode_yet() -> None:
-    """The Session Review Pack is currently a docs-only contract, not a CLI mode."""
+def test_report_live_sessions_help_exposes_session_review_pack_read_only() -> None:
+    """Help documents the read-only pack mode without authority claims."""
 
     result = run_report_live_sessions("--help")
 
     assert result.returncode == 0, result.stderr
     help_text = result.stdout + result.stderr
 
-    assert "session-review-pack" not in help_text
+    assert "session-review-pack" in help_text
+    assert "Read-only" in help_text or "read-only" in help_text.lower()
     assert "live authorization" not in help_text.lower()
     assert "signoff complete" not in help_text.lower()
     assert "autonomous-ready" not in help_text.lower()
@@ -78,14 +79,37 @@ def test_existing_report_modes_are_not_described_as_authority_surfaces(mode_flag
         assert claim not in lowered
 
 
-def test_unknown_session_review_pack_flag_fails_closed() -> None:
-    """A future mode is not silently accepted before implementation."""
+def test_session_review_pack_requires_json() -> None:
+    """V0 is JSON-only; --session-review-pack without --json fails closed."""
 
     result = run_report_live_sessions("--session-review-pack")
 
     assert result.returncode != 0
     combined = result.stdout + result.stderr
-    assert "session-review-pack" in combined or "unrecognized" in combined.lower()
+    assert "session-review-pack" in combined
+    assert "--json" in combined
+
+
+def test_session_review_pack_json_shape() -> None:
+    """Static v0 pack matches contract-oriented keys and non-authorizing posture."""
+
+    result = run_report_live_sessions("--session-review-pack", "--json")
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["contract"] == "report_live_sessions.session_review_pack_v0"
+    assert data["schema_version"] == "master_v2/session_review_pack/v0"
+    assert data["non_authorizing"] is True
+    assert data["mode"] == "session_review_pack"
+    assert data["source_contract"] == "docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md"
+    ab = data["authority_boundary"]
+    assert ab["live_authorization"] is False
+    assert ab["signoff_complete"] is False
+    assert ab["gate_passed"] is False
+    assert ab["autonomy_ready"] is False
+    assert ab["strategy_ready"] is False
+    assert "session" in data and "references" in data
+    assert isinstance(data["missing_fields"], list)
+    assert "session.session_id" in data["missing_fields"]
 
 
 def test_help_keeps_report_script_read_or_report_oriented() -> None:


### PR DESCRIPTION
## Summary

- Add an additive read-only `--session-review-pack --json` report mode to `scripts/report_live_sessions.py`.
- Emit a static, non-authorizing Session Review Pack V0 JSON object with explicit missing fields and false authority flags.
- Update characterization tests for the new report mode and fail-closed behavior.

## Validation

- `uv run pytest tests/ops/test_session_review_pack_report_contracts_v0.py -q` — 9 passed
- `uv run ruff check scripts/report_live_sessions.py tests/ops/test_session_review_pack_report_contracts_v0.py` — passed

## Safety / Authority

- Read-only reporting change.
- No registry/out/ops I/O in v0.
- No Master V2 / Double Play, Bull/Bear, Scope/Capital, Risk/KillSwitch, Execution/Live Gates, dashboard/cockpit authority, AI authority, strategy live authority, workflow, config, or evidence-index behavior changes.
- No live authorization, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
