### PR TITLE
docs(master-v2): add futures class a capability contract v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md
@@ -69,3 +69,7 @@ This **closeout index** does **not** claim or enable:
 - Any future implementation must remain **separate**, **gated**, **read-only** first, and **non-authorizing** until **external** authority surfaces exist outside this **pure display baseline** documentation set.
 
 Peer navigation (outside this **reading order**, **non-authority**): [MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md).
+
+## 7. Peer: Class A spot infrastructure vs Futures Class A (non-authority)
+
+- [MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md](MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md) — **capability contract** and **non-claims** separating **spot** GitHub Actions Class A smoke from **Futures Class A** **prerequisite** work. Does **not** extend the **pure display baseline** proof in §2.

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md
@@ -23,6 +23,7 @@ The following **test anchors** and contracts describe the **pure stack** and **r
 - **Futures Input read model:** [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — data-only snapshot vocabulary.
 - **Dashboard display map:** [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) **§20** — includes **route-independent** **`snapshot_to_jsonable`** **JSON serialization** **test anchors** in `tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py` (**non-authority**).
 - **WebUI read-only JSON route:** [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§8** (producer adapter stack **test anchors**) and **§9** (HTTP **`TestClient`** **authority-invariant** **test anchors** plus the same **route-independent** serialization cross-link).
+- **Futures Class A capability / non-claims (spot vs Perp boundary):** [MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md](MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md) — **non-authorizing**; **spot infrastructure smoke** vs **Futures Class A** **prerequisite** checklist (**no** Double Play **runtime** implication).
 
 Together, these show: adapter + **pure stack** + **JSON serialization** + **read-only** HTTP JSON surface are **test-anchored** and **display-only**; **runtime producer** integration is **not** implied.
 
@@ -72,6 +73,7 @@ Work may **only** move off this **parked** list when **all** of the following ho
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer boundary; **§20** **test anchors**.
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot read model.
+- [MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md](MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md) — **capability contract** / **non-claims** for Class A **spot** probe vs **Futures Class A** prerequisites.
 - [MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md) — **closeout index**; **reading order** for **pure display baseline** (**non-authorizing**).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — **pure stack** inventory.
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — **downstream display** map; **§20** **test anchors**.

--- a/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
@@ -1,0 +1,127 @@
+---
+title: "Master V2 Futures Class A Capability Contract v0"
+status: "DRAFT"
+owner: "ops"
+last_updated: "2026-04-28"
+docs_token: "DOCS_TOKEN_MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0"
+---
+
+# Master V2 Futures Class A Capability Contract v0
+
+## 1. Purpose and status
+
+This file is a **docs-only** **capability contract** with explicit **non-claims**. It records what the **current** Class A Shadow/Paper GitHub Actions probe demonstrates versus what would be required for a **hypothetical** **Futures Class A** bounded probe — **without** granting **non-authorizing** permission to trade, run Testnet or Live, or change operational posture.
+
+This contract:
+
+- is **docs-only** and **non-authorizing**,
+- introduces **no** runtime wiring, code, workflow, or config change by its existence alone,
+- does **not** enable Testnet or Live,
+- does **not** call exchanges, private APIs, AWS, S3, or rclone,
+- does **not** alter the **current** Class A **BTC/EUR** spot-like workflow (`.github/workflows/class-a-shadow-paper-scheduled-probe-v1.yml`).
+
+Operational Class A runs (manual or guarded schedule) remain governed by their **separate** workflow and repository settings; this document **does not** dispatch or start them.
+
+## 2. Current Class A baseline (spot infrastructure smoke)
+
+The **current** Class A probe on **`main`**:
+
+- uses **`workflow_dispatch`** and a **guarded** `schedule` (repository variable gate) on the workflow above,
+- runs a **bounded** paper-mode session via `scripts/run_shadow_paper_session` (typical **BTC/EUR**, **ma_crossover**, short duration, artifact upload),
+- has produced **success** conclusions for **manual** and **scheduled** runs with downloadable artifacts,
+- artifacts include **`meta.json`** and typically **`events.parquet`** (or CSV per logging config), **mode paper**,
+
+and is **useful** as:
+
+- **spot infrastructure smoke** for CI, uv install, public market-data polling, run logging, and artifact chain discipline.
+
+It is **not** a **Futures** or **Perp** proof: the runner and provider path are **spot-oriented** (see §3–§4). **BTC/EUR Class A** artifacts **must not** be read as **Futures Class A prerequisite** satisfaction or as **non-claims** violations pretending they are Perp-ready.
+
+## 3. Capability classification table
+
+Cross-layer labels (read-only assessment; **non-authorizing**):
+
+| Layer | Classification |
+|-------|----------------|
+| Runner (`scripts/run_shadow_paper_session` + Kraken live candle source) | **SPOT_ONLY** |
+| Paper/Shadow execution loop (`ShadowPaperSession` + paper order path) | **FUTURES_ADJACENT_BUT_INCOMPLETE** |
+| WP1B `src/execution/paper` engine | **SPOT_SIM_ONLY** |
+| Master V2 Futures DTO / Producer (`trading.master_v2.double_play_futures_input*`) | **PURE_DTO_READY**; binding to Shadow runner: **RUNTIME_NOT_WIRED** |
+| Provider path used by Class A | **SPOT_PUBLIC_ONLY** |
+
+**pure DTO ready** means the read-model and adapter tests can evaluate **futures-shaped** packets **without** exchange I/O. **runtime not wired** means those surfaces are **not** connected to `run_shadow_paper_session` or the Class A workflow today.
+
+## 4. Futures Class A gap map (top 10)
+
+Before any **Futures Class A** **runtime** probe, these **prerequisites** remain open (order is not a priority ranking):
+
+1. **Instrument / symbol convention** — Perp/Future vs **spot** naming and exchange mapping (not only `BTC/EUR`).
+2. **Futures public market-data feed / market type** — configurable **market type** and correct **public** endpoint (not assumed spot OHLC only).
+3. **Contract size / tick / step** — sizing math for notionals vs contracts.
+4. **Margin and leverage model** — account state beyond **spot** cash + scalar position.
+5. **Funding (perpetuals)** — ingest or proxy rules and PnL semantics if Perp is in scope.
+6. **Liquidation / maintenance margin** — absent from current Shadow paper loop.
+7. **Short semantics** — **spot sell** vs **margin short** / hedge semantics must be explicit.
+8. **Mark / index / last** — futures price references vs single OHLC **close** proxy.
+9. **Futures evidence fields** — `meta.json` / events should record **market_type**, instrument metadata pointers, and derivatives context if claimed.
+10. **Config / safety gates** — prevent **spot/futures** mixups and accidental non-paper modes.
+
+## 5. Non-claims / prohibited interpretations
+
+Readers **must not** treat **BTC/EUR Class A** as proof of:
+
+- **Futures** or **Perp** / **swap** readiness,
+- **margin**, **leverage**, **funding**, or **liquidation** handling,
+- **Master V2 Double Play** operational **runtime** wiring (DTOs may be **pure DTO ready** while **runtime not wired**),
+- **Testnet** or **Live** readiness,
+- **trading authority** or external **approval** to trade,
+- justification to **retarget** the **current** scheduled workflow to **Futures** symbols **immediately** without a **separate** governed slice.
+
+This section is **non-claims** language only; it does not accuse past runs of misuse — it **constrains** future **evidence** interpretation.
+
+## 6. Safe future route
+
+- **Retain** the **current** **spot** Class A workflow as **spot infrastructure smoke** (bounded, paper, public data, artifacts).
+- Keep **next Futures work** in **docs** / **pure-model** / **read-only** lanes first until §4 gaps have **explicit** contracts and tests.
+- Any **first** **Futures Class A** **runtime** candidate should be **separate** from the **spot** workflow (new workflow or gated path), with its own **non-live** / **no-testnet** guards and **evidence schema**.
+- Require, before such a probe: **Futures instrument metadata** contract alignment, **public read-only** provider contract, a **futures paper accounting** model (even if minimal), **risk** gates, and **evidence** fields — none of which are satisfied by **BTC/EUR** Class A alone.
+
+## 7. Minimal prerequisites before Futures Class A runtime (checklist)
+
+A future **Futures Class A** bounded probe should not be scheduled until **at least** the following are specified and reviewed (docs + tests as appropriate):
+
+- **Futures symbol convention** and exchange mapping.
+- **Market type** field and feed selection (future / perpetual / swap vs spot).
+- **Instrument metadata DTO** alignment (peer: futures instrument metadata specs in `docs/ops/specs/`).
+- **Funding / readiness data** policy for Perp, if Perp is in scope.
+- **Margin / leverage** configuration semantics (simulation bounds).
+- **Contract sizing** rules (tick, step, multiplier).
+- **Long/short position model** distinct from **spot** inventory where needed.
+- **Futures risk limits** (exposure, notional caps) in the simulation loop.
+- **Evidence / log fields** for futures context in **`meta.json`** and events.
+- **Explicit non-live / no-testnet** guards and **no private API** default for Class-A-style probes.
+
+## 8. References
+
+**Master V2 / Double Play (pure, non-authority):**
+
+- [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot vocabulary; **data-only**.
+- [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer adapter boundary; **§20** test anchors.
+- [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — **pure stack** vs runtime adjacency.
+- [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — **downstream display** map.
+- [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime producer prerequisites.
+- [MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md) — **pure display baseline** reading order.
+
+**Runtime architecture (context, not permission):**
+
+- [REAL_MARKET_247_RUNTIME_ARCHITECTURE_V1.md](REAL_MARKET_247_RUNTIME_ARCHITECTURE_V1.md) — high-level runtime narrative; **non-authorizing** consumption only.
+
+**Navigation (peer index):**
+
+- [MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) — PRE_LIVE navigation index; **no** implication of First-Live readiness from this contract.
+
+**Test anchors (pure `master_v2`; not Shadow runner integration):**
+
+- `tests&#47;trading&#47;master_v2&#47;test_double_play_futures_input_producer.py`
+- `tests&#47;trading&#47;master_v2&#47;test_double_play_pure_stack_contract.py`
+- `tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py`

--- a/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
@@ -18,7 +18,7 @@ This contract:
 - introduces **no** runtime wiring, code, workflow, or config change by its existence alone,
 - does **not** enable Testnet or Live,
 - does **not** call exchanges, private APIs, AWS, S3, or rclone,
-- does **not** alter the **current** Class A **BTC/EUR** spot-like workflow (`.github/workflows/class-a-shadow-paper-scheduled-probe-v1.yml`).
+- does **not** alter the **current** Class A **BTC/EUR** spot-like workflow (`.github&#47;workflows&#47;class-a-shadow-paper-scheduled-probe-v1.yml`).
 
 Operational Class A runs (manual or guarded schedule) remain governed by their **separate** workflow and repository settings; this document **does not** dispatch or start them.
 
@@ -27,7 +27,7 @@ Operational Class A runs (manual or guarded schedule) remain governed by their *
 The **current** Class A probe on **`main`**:
 
 - uses **`workflow_dispatch`** and a **guarded** `schedule` (repository variable gate) on the workflow above,
-- runs a **bounded** paper-mode session via `scripts/run_shadow_paper_session` (typical **BTC/EUR**, **ma_crossover**, short duration, artifact upload),
+- runs a **bounded** paper-mode session via `scripts&#47;run_shadow_paper_session.py` (typical **BTC/EUR**, **ma_crossover**, short duration, artifact upload),
 - has produced **success** conclusions for **manual** and **scheduled** runs with downloadable artifacts,
 - artifacts include **`meta.json`** and typically **`events.parquet`** (or CSV per logging config), **mode paper**,
 
@@ -43,19 +43,19 @@ Cross-layer labels (read-only assessment; **non-authorizing**):
 
 | Layer | Classification |
 |-------|----------------|
-| Runner (`scripts/run_shadow_paper_session` + Kraken live candle source) | **SPOT_ONLY** |
+| Runner (`scripts&#47;run_shadow_paper_session.py` + Kraken live candle source) | **SPOT_ONLY** |
 | Paper/Shadow execution loop (`ShadowPaperSession` + paper order path) | **FUTURES_ADJACENT_BUT_INCOMPLETE** |
-| WP1B `src/execution/paper` engine | **SPOT_SIM_ONLY** |
+| WP1B `src&#47;execution&#47;paper&#47;engine.py` engine | **SPOT_SIM_ONLY** |
 | Master V2 Futures DTO / Producer (`trading.master_v2.double_play_futures_input*`) | **PURE_DTO_READY**; binding to Shadow runner: **RUNTIME_NOT_WIRED** |
 | Provider path used by Class A | **SPOT_PUBLIC_ONLY** |
 
-**pure DTO ready** means the read-model and adapter tests can evaluate **futures-shaped** packets **without** exchange I/O. **runtime not wired** means those surfaces are **not** connected to `run_shadow_paper_session` or the Class A workflow today.
+**pure DTO ready** means the read-model and adapter tests can evaluate **futures-shaped** packets **without** exchange I/O. **runtime not wired** means those surfaces are **not** connected to `scripts&#47;run_shadow_paper_session.py` or the Class A workflow today.
 
 ## 4. Futures Class A gap map (top 10)
 
 Before any **Futures Class A** **runtime** probe, these **prerequisites** remain open (order is not a priority ranking):
 
-1. **Instrument / symbol convention** — Perp/Future vs **spot** naming and exchange mapping (not only `BTC/EUR`).
+1. **Instrument / symbol convention** — Perp/Future vs **spot** naming and exchange mapping (not only `BTC&#47;EUR`).
 2. **Futures public market-data feed / market type** — configurable **market type** and correct **public** endpoint (not assumed spot OHLC only).
 3. **Contract size / tick / step** — sizing math for notionals vs contracts.
 4. **Margin and leverage model** — account state beyond **spot** cash + scalar position.
@@ -92,7 +92,7 @@ A future **Futures Class A** bounded probe should not be scheduled until **at le
 
 - **Futures symbol convention** and exchange mapping.
 - **Market type** field and feed selection (future / perpetual / swap vs spot).
-- **Instrument metadata DTO** alignment (peer: futures instrument metadata specs in `docs/ops/specs/`).
+- **Instrument metadata DTO** alignment (peer: futures instrument metadata specs in `docs&#47;ops&#47;specs&#47;`).
 - **Funding / readiness data** policy for Perp, if Perp is in scope.
 - **Margin / leverage** configuration semantics (simulation bounds).
 - **Contract sizing** rules (tick, step, multiplier).


### PR DESCRIPTION
## Summary

- adds a non-authorizing Futures Class A capability / non-claims contract
- clarifies that the current BTC/EUR Class A scheduled probe is a spot infrastructure smoke, not Futures/Perp readiness evidence
- records capability classifications: spot-only runner/provider, futures-adjacent but incomplete Paper/Shadow execution, pure DTO ready but runtime not wired
- lists Futures Class A gaps and prerequisites before any Futures runtime probe

## Changed docs

- `docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md`
- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md`
- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md`

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — ok
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — ok

## Safety

- docs-only slice
- no `src/` changes
- no tests changed
- no workflow/config changes
- no Paper/Shadow/Testnet/Live session started
- no exchange/AWS/S3/rclone calls
- no mutation of `live_runs/`, `out/`, reports, evidence, registry, cache, MLflow, or experiment stores
- non-authorizing capability contract only; no Futures runtime execution

Made with [Cursor](https://cursor.com)