### PR TITLE
docs(ops): add session review pack evidence provenance precedence v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md
+++ b/docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md
@@ -1,0 +1,146 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0
+status: draft
+scope: docs-only, non-authorizing Session Review Pack evidence / provenance precedence
+last_updated: 2026-04-27
+---
+
+# Master V2 Session Review Pack Evidence / Provenance Precedence V0
+
+## 1. Executive Summary
+
+This document defines a **future-facing**, **docs-only** precedence model for how a later Session Review Pack implementation may rank **evidence**, **provenance**, **registry**, **artifact**, **operator**, **observer**, **Learning Loop**, and **AI-summary** source classes when binding a pack to multiple references.
+
+It does **not** implement source binding, change `scripts/report_live_sessions.py`, change the [Session Review Pack V0](MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md) contract output, bind real session data, modify Evidence Index **body** content, alter registry **behavior**, alter provenance **behavior**, or change runtime **behavior**. It is a **precedence** and **review-context** map only.
+
+The model is **non-authorizing** and supports post-hoc review and auditability. It does **not** imply live authorization, signoff completion, gate passage, strategy readiness, autonomy readiness, or external authority completion.
+
+## 2. Purpose and Non-Goals
+
+**Purpose**
+
+- Define conservative **source-class** precedence for **future** Session Review Pack binding.
+- Make future **conflicts** explicit (`unresolved` / `needs_review`) instead of silently resolved.
+- Keep evidence, provenance, registry, operator notes, observer summaries, Learning Loop feedback, and AI summaries in **review** boundaries.
+
+**Non-goals**
+
+- No code, test, workflow, or config change.
+- No report implementation change to `scripts/report_live_sessions.py` Session Review Pack v0 static JSON.
+- No Evidence Index **body** rewrite, no evidence schema change.
+- No registry or provenance **runtime** change.
+- No real session binding, no artifact-manifest binding, no dashboard/cockpit **authority** or **display** change.
+- No live enablement, no signoff claim, no gate-pass claim, no strategy- or autonomy-readiness claim.
+
+## 3. Source Classes
+
+A future Session Review Pack may reference several **source classes** (see precedence in §4).
+
+| Source class | Meaning | Example surfaces | Review use |
+| --- | --- | --- | --- |
+| Runtime artifact / session-scoped artifact | Concrete artifact tied to a run or session. | `out&#47;ops&#47;` convention, future artifact manifest reference | Session-specific observation. |
+| Provenance / replayability reference | Traceability and replay context. | [`MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | Reproducibility and audit. |
+| Evidence Index / evidence requirement reference | Evidence **navigation** and expected posture. | [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md), [`MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_EVIDENCE_INDEX_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_EVIDENCE_INDEX_CONTRACT_V1.md), [`MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md) | **Navigation**, not machine truth. |
+| Registry reference | Indexed operational or evidence cross-reference. | [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) | Discovery, not approval. |
+| Readiness / handoff packet reference | Readiness and handoff review surfaces. | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md), [`MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md) | Review posture, **not** live authorization. |
+| Operator note | Human annotation. | operator review, future `operator_notes` field | **Review context** only, not authority. |
+| Dashboard / observer summary | Display or observer summary. | [`MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md`](./MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md) | Explanation and navigation, **not** order authority. |
+| Learning Loop feedback | Lessons, priors, unsafe zones, refinement. | [`MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md`](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md) | Learning context, **not** current autonomous execution. |
+| AI summary if present | Advisory text or ranking. | context in [`MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md`](./MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md) | **Advisory** only, **not** trade approval. |
+
+## 4. Precedence Model
+
+| Rank | Source class | Example surfaces | Use as | Conflict rule | Not used for |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | Runtime artifact / session-scoped artifact | `out&#47;ops&#47;` convention, future manifest pointer | **Primary** session-specific observation. | If missing, mark `needs_review`; do not infer **gate pass** or success. | Not permission to execute. |
+| 2 | Provenance / replayability | [`MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | **Primary** traceability context. | If inconsistent with (1), mark `unresolved`; do not auto-pick. | Not **signoff** or **approved** in the positive sense. |
+| 3 | Evidence Index / evidence requirement | Navigation map, Evidence Index / Requirement contracts | Evidence **navigation** and expected posture. | If referenced but absent, `needs_review`. | Not signoff complete; Evidence Index is **not** truth by itself. |
+| 4 | Registry reference | [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) | Discovery and cross-link. | If registry conflicts with (1), `unresolved`. | Not **authority** or **externally authorized** in the enablement sense. |
+| 5 | Readiness / handoff packet | Readiness Verdict, Handoff Packet contracts | Handoff and readiness **review** context. | If posture conflicts with lower ranks, `needs_review`. | **Not** live authorization, **not** gate passed as a claim. |
+| 6 | Operator note | future operator field | Human review context. | If conflicts with (1)–(2), **preserve** both, mark `needs_review`. | **Not** machine authority. |
+| 7 | Dashboard / observer summary | observer inventory | Explanation / navigation. | If conflicts with (1)–(2), `unresolved`. | **Not** order authority. |
+| 8 | Learning Loop feedback | Learning Loop map | Future refinement context. | If conflicts with evidence trail, `needs_review`. | **Not** current autonomy readiness. |
+| 9 | AI summary if present | AI-layer overview | **Advisory** explanation only. | If conflicts with any prior rank, `needs_review`; **never** prefer AI over artifacts. | **Not** live-ready, **not** strategy ready, **not** **approved** in the positive sense. |
+
+**Conservative rules (summary)**
+
+- (1) and (2) do **not** override explicit **blocks** or safety signals elsewhere; on tension, prefer `unresolved` / `needs_review`.
+- Evidence Index and registry are **supporting** and navigational, not a substitute for (1)–(2).
+- Operator notes and AI remain **non-authorizing**; any conflict is **unresolved** or **needs_review**, not silently fixed.
+
+## 5. Conflict Handling
+
+A future binding implementation should **not** silently choose a **winner** when sources disagree.
+
+| State | Meaning | Expected handling |
+| --- | --- | --- |
+| `ok` | Consistent enough to continue human review. | Keep references, continue review. |
+| `missing` | Expected source absent. | Make absence explicit. |
+| `unresolved` | Incompatible sources. | **Preserve** all conflicting pointers; no silent merge. |
+| `needs_review` | Human or downstream triage before interpretation. | **Not** live authorization, **not** signoff, **not** **gate pass**. |
+| `not_applicable` | Irrelevant for this pack instance. | Record if schema allows. |
+
+Conflicts are **not** resolved by **AI** alone, dashboard text alone, **registry** presence alone, or **operator** note alone.
+
+## 6. Missing Source Handling
+
+Missing sources should be explicit, not back-filled from weaker classes.
+
+A future pack should prefer:
+
+```text
+missing source -> explicit missing field or marker -> needs_review
+```
+
+- Do not infer a **production-ready** or **externally authorized** state from a missing (1) or (2).
+- Do not substitute Evidence Index for missing runtime artifacts.
+- Triage: [`MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md`](./MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md).
+
+## 7. Relationship to Session Review Pack V0
+
+- [Session Review Pack contract](MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md) defines the **V0** static JSON **shape**; this precedence doc does **not** change that output.
+- Operator invoke: [`../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md`](../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md) (same repo root notion as `uv run python scripts/report_live_sessions.py` from repo root; script path: `scripts/report_live_sessions.py`).
+- **Future** binding, if any, must keep **non_authorizing** and `authority_boundary` semantics aligned with the contract; this document is a **source-class** design aid, **not** a JSON change.
+
+## 8. Relationship to Evidence / Registry / Knowledge Base
+
+- Evidence and index **navigation**: [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md).
+- Registry and taxonomy: [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md).
+- This precedence model treats Evidence Index as **review navigation**, **not** automatic truth, **not** signoff, **not** **live-ready** by reading alone.
+
+## 9. Relationship to Learning Loop
+
+- Context map: [`MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md`](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md).
+- Learning Loop input is **supporting** and **advisory** for refinement; it does not override (1)–(2) on conflict, and is **not** **autonomy readiness**.
+
+## 10. Relationship to Master V2 / Double Play and Gates
+
+- This document is **governance- and review-facing**; it does **not** restate or replace Master V2 / Double Play trading **logic**, **Risk/KillSwitch**, or **Execution/Live Gates** contracts.
+- **No** work here grants **gate pass** or **live** enablement. Full autonomy remains a **future** target, **not** current authorization.
+- Relevant handoff and operator surfaces: [`MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md`](./MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md).
+
+## 11. Authority Boundaries
+
+- **Not** live authorization, **not** signoff, **not** **gate** passage, **not** **strategy** readiness, **not** **autonomy** readiness, **not** **externally authorized** in the **enablement** sense.
+- **Precedence** and **source class** support **review** and **audit**; they are **not approval**.
+- **AI**-layer content is **advisory** only; see [`MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md`](./MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md) for system positioning.
+
+## 12. Future Binding Guidance
+
+When a **future** implementation proposes to populate Session Review Pack fields:
+
+1. Prefer explicit fields for **(1)–(2)** before treating Index or registry as conclusive.
+2. On any conflict, emit `unresolved` or `needs_review`; **do not** infer **go**.
+3. Keep pack output **read-only** with respect to trading **authority**; dashboard/cockpit **authority** boundaries stay unchanged.
+4. Use this doc as a **future binding candidate**; until then, v0 static JSON in `scripts/report_live_sessions.py` remains as today.
+
+## 13. Validation Notes
+
+- Docs quality gates (from repo root), when changing this file:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+```
+
+- This spec is **docs-only**; it does not require new tests or code paths.


### PR DESCRIPTION
## Summary

- Add a docs-only, non-authorizing evidence / provenance precedence note for future Session Review Pack source binding.
- Define source classes, precedence ranks, conflict handling, missing-source handling, and future binding guidance.
- Preserve Session Review Pack V0 JSON behavior and avoid any evidence index, registry, provenance, report, runtime, or gate behavior changes.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1681 files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed

## Safety / Authority

- Docs-only change.
- No code, runtime, workflow, config, test, report implementation, Session Review Pack JSON contract, EVIDENCE_INDEX body, evidence schema, registry behavior, strategy, dashboard, risk, or gate behavior changes.
- No live authorization, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
