### PR TITLE
docs(ops): add registry evidence surface pointer index v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md
+++ b/docs/ops/specs/MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md
@@ -1,0 +1,180 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0
+status: draft
+scope: docs-only, non-authorizing Registry / Evidence surface pointer index
+last_updated: 2026-04-27
+---
+
+# Master V2 Registry / Evidence Surface Pointer Index V0
+
+## 1. Executive Summary
+
+This document is a concise pointer index for Registry, Evidence, Provenance, Readiness/Verdict/Handoff, Session Review Pack, and related test/report surfaces.
+
+It is a **navigation** **surface** only. Registry and Evidence surfaces support **review**, **auditability**, **learning**, **replayability**, and **operator** **understanding**. They are **not** **live** **authorization**, **not** **signoff** **completion**, **not** **gate** **passage**, **not** **strategy** readiness, **not** **autonomy** readiness, and **not** **external** **authority** **completion**.
+
+This document **does** **not** modify the [Evidence Index](../EVIDENCE_INDEX.md) **body**, **registry** **behavior**, **evidence** **schema** **behavior**, **report** **implementations**, Session Review Pack JSON **behavior**, **runtime** **behavior**, or any Master V2 / Double Play **semantics**.
+
+## 2. Purpose and Non-Goals
+
+**Purpose:**
+
+- Provide a stable **reading** **map** for **registry** and **evidence**-related surfaces.
+- Clarify which surfaces are **contracts**, **indexes**, **tests**, **reports**, **runbooks**, or **future** **binding** references.
+- Preserve **non-authorizing** **boundaries** around **evidence**, **provenance**, and Session Review Pack surfaces.
+- Support **future** **review** **without** **binding** to **real** **session**, **registry**, **artifact**, **paper**, or **live** **data**.
+
+**Non-goals:**
+
+- **No** **code** changes.
+- **No** **test** changes.
+- **No** **workflow** changes.
+- **No** **config** changes.
+- **No** Evidence Index **body** **change**.
+- **No** **evidence** **schema** **change**.
+- **No** **registry** **behavior** **change**.
+- **No** **report** **behavior** **change**.
+- **No** **real** **session** **binding**.
+- **No** **artifact**-manifest **binding**.
+- **No** **live** **enablement**.
+- **No** **signoff** **claim**.
+- **No** **gate**-**pass** **claim**.
+- **No** **strategy**-**readiness** **claim**.
+- **No** **autonomy**-**readiness** **claim**.
+
+## 3. Pointer Table
+
+| Surface | Path | Type | Read when | Consumer | Not used for |
+| --- | --- | --- | --- | --- | --- |
+| Ops Evidence Index | [`../EVIDENCE_INDEX.md`](../EVIDENCE_INDEX.md) | Evidence index / catalog | You need ops **evidence** **navigation**. | reviewer / operator | **Not** **signoff** **completion**. |
+| Audit Evidence Index | [`../../audit/EVIDENCE_INDEX.md`](../../audit/EVIDENCE_INDEX.md) | Audit **evidence** **catalog** | You need audit-oriented **evidence** references. | reviewer / audit | **Not** **external** **authority** **completion**. |
+| Ops Evidence Directory | [`../evidence/`](../evidence/) | Evidence **directory** | You need **evidence** **artifacts** or **evidence** docs. | reviewer / operator | **Not** **approval**. |
+| Ops Registry Directory | [`../registry/`](../registry/) | Registry **directory** | You need **registry** / index surfaces. | reviewer / report reader | **Not** **readiness** **proof**. |
+| KB / Registry / Evidence Taxonomy | [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) | Vocabulary spec | You need definitions of **registry** / **evidence** / report / read-model terms. | docs/review users | **Not** **implementation**. |
+| Evidence Packet / Index Navigation Map | [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md) | **Navigation** spec | You need packet / index / readiness / handoff relationships. | operator / reviewer | **Not** **signoff**. |
+| Provenance / Replayability | [`MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md) | Provenance spec | You need **replayability** and **traceability** context. | reviewer / audit | **Not** **permission** to execute. |
+| Session Review Pack Contract | [`MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md) | Review-pack **contract** | You need Session Review Pack field **shape**. | operator / future tooling | **Not** **live** **authorization**. |
+| Session Review Pack Precedence | [`MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md) | Future source **precedence** spec | You need **future** **binding** source **precedence**. | future implementation planner | **Not** **binding** today. |
+| Session Review Pack Invoke Runbook | [`../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md`](../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md) | Runbook | You need the **read-only** **invocation** command. | operator / reviewer | **Not** **approval**. |
+| Report Live Sessions Script | `scripts&#47;report_live_sessions.py` | **Read-only** report script | You need existing report / read-model CLI surfaces. | operator / CI / reviewer | **Not** **trading** **authority**. |
+| Session Review Pack JSON Tests | `tests&#47;ops&#47;test_session_review_pack_report_contracts_v0.py` | Test surface | You need JSON **contract** and drift-guard **behavior**. | developer / CI | **Not** **production** **approval**. |
+| Session Review Pack Precedence Synthetic Tests | `tests&#47;ops&#47;test_session_review_pack_precedence_synthetic_v0.py` | Test surface | You need **synthetic** **precedence** **behavior**. | developer / CI | **Not** **real** **data** **binding**. |
+| Registry Verification Script | `scripts&#47;ops&#47;verify_from_registry.sh` | Verification helper | You need **registry** **verification** context. | operator / developer | **Not** **live** **authority**. |
+| Evidence Requirement Contract | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md) | Evidence **requirement** **contract** | You need expected **evidence** **posture**. | reviewer / operator | **Not** **proof** of **fulfillment**. |
+| Readiness Verdict Packet Contract | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md) | Readiness packet **contract** | You need **readiness**-**review** structure. | reviewer / handoff consumer | **Not** **live** **authorization**. |
+| Handoff Packet Contract | [`MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md) | Handoff **contract** | You need **downstream** handoff **structure**. | reviewer / external process | **Not** **external** **authority** **completion**. |
+
+## 4. Registry Surfaces
+
+**Registry** surfaces are **discovery** and **cross-reference** aids.
+
+**Primary** **anchors:**
+
+- [`../registry/`](../registry/)
+- [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md)
+- `scripts&#47;ops&#47;verify_from_registry.sh`
+
+**Registry** **presence** means a **surface** is **indexed**, **discoverable**, or **reviewable**. It **does** **not** **prove** **readiness**, **validity**, **signoff** **completion**, or **live** **authorization**.
+
+## 5. Evidence Surfaces
+
+**Evidence** **surfaces** **include** **indexes**, **requirements**, **docs**, **artifacts**, **schemas**, and related **contracts**.
+
+**Primary** **anchors:**
+
+- [`../EVIDENCE_INDEX.md`](../EVIDENCE_INDEX.md)
+- [`../../audit/EVIDENCE_INDEX.md`](../../audit/EVIDENCE_INDEX.md)
+- [`../evidence/`](../evidence/)
+- [`MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_EVIDENCE_REQUIREMENT_CONTRACT_V1.md)
+- [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md)
+
+**Evidence** **supports** **review**. It **must** **not** be **read** as **approval** by **existence** **alone**.
+
+## 6. Provenance / Replayability Surfaces
+
+**Primary** **anchor:**
+
+- [`MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+
+**Provenance** and **replayability** support **audit** and **reproduction**. They **do** **not** **grant** **permission** to **execute** or **override** **gates**.
+
+## 7. Readiness / Verdict / Handoff Surfaces
+
+**Primary** **anchors:**
+
+- [`MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_READINESS_VERDICT_PACKET_CONTRACT_V1.md)
+- [`MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md`](./MASTER_V2_FIRST_LIVE_PRE_LIVE_SIGNOFF_HANDOFF_PACKET_CONTRACT_V1.md)
+- [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md)
+
+These **surfaces** **structure** **review** and **handoff**. They **do** **not** **complete** **signoff** or **external** **authority** **by** **themselves**.
+
+## 8. Session Review Pack Surfaces
+
+**Session** **Review** **Pack** V0 **surfaces:**
+
+- [`MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md)
+- [`MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md)
+- [`../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md`](../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md)
+- `scripts&#47;report_live_sessions.py`
+- `tests&#47;ops&#47;test_session_review_pack_report_contracts_v0.py`
+- `tests&#47;ops&#47;test_session_review_pack_precedence_synthetic_v0.py`
+
+**Current** V0 **behavior** **remains** **read-only** and **non-authorizing**. It **emits** a **template**-like JSON **report** and **does** **not** **bind** **real** **session** **data** (per **runbook** and **contract** **discipline**).
+
+## 9. Test / Validation Surfaces
+
+**Test** **surfaces** **protect** **contract** and **boundary** **behavior:**
+
+- `tests&#47;ops&#47;test_session_review_pack_report_contracts_v0.py`
+- `tests&#47;ops&#47;test_session_review_pack_precedence_synthetic_v0.py`
+- `tests&#47;ci&#47;test_required_checks_safety_gate_surfaces_v0.py`
+
+**Tests** are **validation** **surfaces**. They **do** **not** **authorize** **runtime** **behavior** **by** **themselves**.
+
+## 10. Safe Binding Candidate Notes
+
+**Safe** **future** **binding** **candidates** should be **treated** in this **order:**
+
+| Candidate | Source class | Why useful | Risk | Required tests | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| **Synthetic** **precedence** **fixture** | synthetic source class | Keeps **precedence** **rules** **stable** **without** **real** **data**. | **Low** | **unit** **tests** **only** | **Already** **covered** as **baseline**. |
+| **Explicit** **session-id** **input** | session **identifier** | **Improves** **operator** **review** UX. | **Medium** **without** **source** **decision** | CLI **fail-closed** **tests** | **Wait** for **source** **mandate**. |
+| **Registry** **reference** **binding** | **registry** | **Improves** **discoverability**. | **Medium** (source **precedence** + **fixture** **safety**) | **synthetic** **registry** **fixtures** | **Later**. |
+| **Artifact** **manifest** **reference** | **runtime** **artifact** | **Strong** **audit** **value**. | **Higher** **without** **manifest** **source** **agreement** | **synthetic** **manifest** **fixtures** | **Later**. |
+| **Dashboard** / **observer** **display** | **observer** | **Useful** for **review** **visibility**. | **High** **authority**-**misread** **risk** | UI / **read-only** **tests** | **Later** with **strict** **scope**. |
+
+**Do** **not** **bind** to **real** **paper** or **live** **data** **without** a **separate**, **scoped** **approval** **and** **review** **process** **outside** this **file**.
+
+## 11. Authority Boundaries
+
+| Surface | **May** (informational) | **Must** **not** (by this **index**) |
+| --- | --- | --- |
+| **Registry** | **Index** and **cross**-**reference** | **Approve** **readiness** |
+| **Evidence** **Index** | **Navigate** **evidence** | **Complete** **signoff** |
+| **Evidence** **Requirement** | **Describe** **expected** **evidence** | **Prove** **fulfillment** **alone** |
+| **Provenance** | **Support** **replay** and **audit** | **Grant** **permission** |
+| **Readiness** **Packet** | **Structure** **review** | **Authorize** **live** **execution** |
+| **Handoff** **Packet** | **Support** **downstream** **review** | **Complete** **external** **authority** |
+| **Session** **Review** **Pack** | **Collect** **review** **references** | **Authorize** **trades** |
+| **Tests** | **Validate** **expected** **behavior** | **Serve** as **production** **approval** **alone** |
+| **Dashboard** / **Observer** | **Explain** **status** (when present) | **Place** or **authorize** **orders** |
+| **AI** **Summary** | **Summarize** or **explain** (when present) | **Approve** **trades** |
+
+## 12. Known Ambiguities
+
+- Some **surfaces** are **contracts** **rather** than **generated** **artifacts**.
+- Some **evidence** **indexes** are **navigation** **surfaces** and **may** **not** **imply** **artifact** **presence** **everywhere** they **link**.
+- Some **registry** **surfaces** are **docs**-**level** **rather** than **runtime**-**backed**.
+- Session Review Pack V0 **does** **not** **yet** **bind** **real** **session** **data** (see **runbook**).
+- **Future** **binding** **requires** **explicit** **source** **precedence**, **fixture** **design**, and **no**-**touch** **governance** **review**.
+
+## 13. Validation Notes
+
+**Validate** this **docs**-**only** **file** with:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+```
+
+- **read-only** **validation** of **documentation** only — **not** a **trading** or **gate** **result**.


### PR DESCRIPTION
## Summary

- Add a docs-only, non-authorizing Registry / Evidence surface pointer index.
- Map Registry, Evidence, Provenance, Readiness/Verdict/Handoff, Session Review Pack, report, and test surfaces.
- Clarify safe future binding candidates and authority boundaries without changing any behavior.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed

## Safety / Authority

- Docs-only change.
- No code, tests, workflows, configs, runtime, report implementation, EVIDENCE_INDEX body, evidence schema, registry behavior, strategy, dashboard, risk, gate, paper/test data, or historical run artifact changes.
- No real session binding for Session Review Pack V0.
- No live authorization, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
