### PR TITLE
docs(ops): add paper testnet readiness gap map v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md
@@ -1,0 +1,172 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0
+status: draft
+scope: docs-only, non-authorizing Paper / Testnet readiness gap map
+last_updated: 2026-04-27
+---
+
+# Master V2 Paper / Testnet Readiness Gap Map V0
+
+## 1. Executive Summary
+
+This document maps repo-visible Paper, Shadow, Testnet, bounded pilot, readiness, gate, runbook, report, and evidence surfaces.
+
+It is a **docs-only** **read-only** **gap** **map**. **Paper**/**Testnet** **readiness** **surfaces** are **review** **inputs**, **not** **live** **authorization**. They **do** **not** **imply** **signoff** **completion**, **gate** **passage**, **strategy** **readiness**, **autonomy** **readiness**, **external** **authority** **completion**, or **permission** to **trade** **live**.
+
+This document does **not** **modify** **paper**/**test** **data**, **testnet** **behavior**, **workflows**, **live** **gates**, **execution** **gates**, **Risk**/**KillSwitch**, **configs**, **runtime** **behavior**, **reports**, **registry** **behavior**, **evidence** **schema** **behavior**, or **Master** **V2** / **Double** **Play** **semantics**.
+
+## 2. Purpose and Non-Goals
+
+**Purpose:**
+
+- **Make** **Paper**/**Testnet** **readiness** **surfaces** **discoverable**.
+- **Separate** **readiness** **review** from **live** **authority**.
+- **Identify** **repo**-**visible** **gaps** **without** **reading** **real** **paper**/**test** **data** or **historical** **run** **artifacts**.
+- **Provide** a **safe** **starting** **point** for **future** **read**-**only** **review** **hardening**.
+
+**Non-goals:**
+
+- **No** **code** **changes**, **no** **test** **changes**, **no** **workflow** **changes**, **no** **config** **changes**, **no** **runtime** **changes**, **no** **report** **behavior** **changes**.
+- **No** **paper**/**test** **data** **changes**.
+- **No** **live** **enablement** and **no** **strategy**-**readiness** **claim** **by** **map** **presence** **alone**.
+
+## 3. Inventory Method
+
+This **gap** **map** is **based** on **repo** **path** and **term** **inspection** **across**:
+
+- `docs&#47;`
+- `scripts&#47;`
+- `tests&#47;`
+- `.github&#47;workflows&#47;`
+- `config&#47;`
+- `src&#47;live&#47;`
+- `src&#47;execution&#47;`
+- `src&#47;risk_layer&#47;`
+
+**Search** **terms** **included** **paper**, **testnet**, **shadow**, **bounded** **pilot**, **readiness**, **go**/**no**-**go**, **gate**, **live** **gate**, **kill** **switch**, **operator**, **session**, **report**, **evidence**, **handoff**, **runbook**, and **dry**-**run**.
+
+This **inventory** is **conservative**. A **listed** **surface** is **review**-**relevant**; it is **not** **evidence** of **readiness**, **signoff**, or **live** **authorization** **by** **itself**.
+
+## 4. Paper / Shadow Surfaces
+
+| Surface | Path | Type | Observes / supports | Consumer | Not used for |
+| --- | --- | --- | --- | --- | --- |
+| **Paper** / **shadow** **workflow** **surfaces** | `.github&#47;workflows&#47;` | **Workflow** **area** | **Scheduled**/**manual** **paper**, **shadow**, or **probe** **posture** **where** **present**. | **operator** / **CI** **reviewer** | **Not** **live** **authorization**. |
+| **Paper**/**session** **report** **surfaces** | `scripts&#47;report_live_sessions.py` | **Read**-**only** **report** **script** | **Session** and **operator** **report** **surfaces** **where** **exposed**. | **operator** / **reviewer** | **Not** **trading** **authority**. |
+| **Paper**-**related** **tests** | `tests&#47;` | **Tests** | **Behavior** and **guard** **expectations** for **paper**/**shadow** **surfaces**. | **CI** / **developer** | **Not** **production** **approval** **as** **the** **sole** **signal**. |
+| **Paper** **output** **conventions** | `out&#47;ops&#47;` | **Generated**-**output** **convention** | **Possible** **generated** **review** **outputs** **where** **documented**. | **reviewer** / **operator** | **Not** **signoff** **complete**. |
+
+## 5. Testnet / Bounded Pilot Surfaces
+
+| Surface | Path | Type | Observes / supports | Consumer | Not used for |
+| --- | --- | --- | --- | --- | --- |
+| **Bounded** **pilot** **runbooks** | `docs&#47;ops&#47;runbooks&#47;` | **Runbook** **area** | **Operator** **guidance** and **procedural** **context**. | **operator** | **Not** **approval** **as** **narrative** **alone**. |
+| **Bounded** **pilot** **specs** | `docs&#47;ops&#47;specs&#47;` | **Spec** **area** | **Entry** **contracts**, **readiness**, **evidence**, and **handoff** **boundaries**. | **reviewer** / **operator** | **Not** **live** **enablement**. |
+| **Bounded** **pilot** **report** **modes** | `scripts&#47;report_live_sessions.py` | **Report** **script** | **Operator** **overview**, **readiness**, **closeout**, and **gate**-**related** **read** **models** **where** **available**. | **operator** / **reviewer** | **Not** **gate** **passage** **in** a **trading** **authorization** **sense**. |
+| **Testnet**/**config** **surfaces** | `config&#47;` | **Config** **area** | **Configuration** **context** **where** **present**. | **developer** / **reviewer** | **Not** **authority** **by** **file** **presence** **alone**. |
+| **Testnet**/**bounded**-**pilot** **tests** | `tests&#47;` | **Tests** | **Guard** and **read**-**model** **expectations**. | **CI** / **developer** | **Not** **external** **authority** **completion**. |
+
+## 6. Readiness / Go-No-Go / Gate Surfaces
+
+| Surface | Path | Type | Observes / supports | Consumer | Not used for |
+| --- | --- | --- | --- | --- | --- |
+| **Operator** **triage** **checklist** | [`MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md`](./MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md) | **Triage** **spec** | **Open**-**first** **review** **path**. | **operator** / **reviewer** | **Not** **approval**. |
+| **Operator** **handoff** **surface** **map** | [`MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md`](./MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md) | **Handoff** **map** | **Evidence**/**readiness**/**verdict**/**handoff** **order**. | **operator** / **reviewer** | **Not** **external** **authority** **completion**. |
+| **Observer** **surface** **inventory** | [`MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md`](./MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md) | **Observer** **inventory** | **Dashboard**/**cockpit**/**report** **observer** **surfaces**. | **operator** / **reviewer** | **Not** **order** **authority**. |
+| **CI** **safety** **gate** **pointer** **index** | [`MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md`](./MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md) | **CI** **pointer** **spec** | **CI**, **docs**, **policy**, and **required**-**check** **gate** **surfaces**. | **developer** / **reviewer** | **Not** **live** **authority** **or** **trading** **permission**. |
+| **Readiness** **verdict** **contracts** | `docs&#47;ops&#47;specs&#47;` | **Contract** **area** | **Readiness** **review** **structure** **where** **present**. | **reviewer** / **operator** | **Not** **live** **authorization**. |
+
+## 7. Risk / KillSwitch / Execution Gate Relevance
+
+**Relevant** **protected** **areas** (**review**-**relevant** **only**; **this** **map** **does** **not** **assert** **behavior**):
+
+- `src&#47;risk_layer&#47;`
+- `src&#47;execution&#47;`
+- `src&#47;live&#47;`
+
+**Paper**/**Testnet** **readiness** **can** **observe** or **report** on **risk**, **stop**, **execution**, or **gate** **posture**. It **must** **not** **override** **Risk**/**KillSwitch** or **Execution**/**Live** **Gates**.
+
+**Any** **future** **slice** **must** **preserve**:
+
+- **fail**-**closed** **posture** **where** **governed**;
+- **confirm**-**token** **boundaries** **where** **governed**;
+- **dry**-**run** **semantics** **where** **governed**;
+- **no**-**touch** **behavior** for **Master** **V2** / **Double** **Play**;
+- **explicit** **separation** **between** **readiness** **review** and **live** **authorization**.
+
+## 8. Evidence / Registry / Session Review Pack Relevance
+
+**Related** **anchors:**
+
+- [`MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md`](./MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md)
+- [`MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md)
+- [`MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md)
+- [`RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md`](../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md)
+- [`MASTER_V2_BACKTEST_ROBUSTNESS_VALIDATION_SURFACE_INVENTORY_V0.md`](./MASTER_V2_BACKTEST_ROBUSTNESS_VALIDATION_SURFACE_INVENTORY_V0.md)
+
+**Paper**/**Testnet** **runs** **can** **eventually** **produce** **evidence**, **provenance**, **review**-**pack**, or **artifact** **references** **in** **separate** **governed** **slices**. This **map** **does** **not** **bind** **those** **sources** and **does** **not** **read** **historical** **paper**/**test** **artifacts**.
+
+## 9. CI / Workflow / Report Surfaces
+
+| Surface | Path | Type | Observes / supports | Consumer | Not used for |
+| --- | --- | --- | --- | --- | --- |
+| **Workflow** **surfaces** | `.github&#47;workflows&#47;` | **Workflow** **area** | **CI**, **schedule**, **dispatch**, **probe**, and **gate**-**related** **automation**. | **developer** / **operator** | **Not** **live** **authorization**. |
+| **Required**-**checks** **pointer** | [`MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md`](./MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md) | **Pointer** **spec** | **Required**-**check** and **safety**-**gate** **navigation**. | **developer** / **reviewer** | **Not** **trading** **authority**. |
+| **Report** **script** | `scripts&#47;report_live_sessions.py` | **Report** **script** | **Existing** **read**-**only** **session**/**report** **modes**. | **operator** / **reviewer** | **Not** **runtime** **mutation**. |
+| **Session** **Review** **Pack** **JSON** (v0) | `scripts&#47;report_live_sessions.py --session-review-pack --json` | **Read**-**only** **JSON** **mode** (see script help) | **Post**-**hoc** **review** **template** **(static** **v0** **where** **documented**). | **operator** / **reviewer** | **Not** **live** **enablement** **or** **registry** **binding** **by** **this** **map** **alone**. |
+
+## 10. Visible Gaps from Repo-Only Review
+
+**Repo**-**visible** **gaps** **without** **reading** **real** **paper**/**test** **data**:
+
+| **Gap** | **Meaning** | **Safe** **next** **posture** |
+| --- | --- | --- |
+| **No** **single** **Paper**/**Testnet** **open**-**first** **surface** | **Review** **surfaces** are **distributed** **across** **specs**, **runbooks**, **reports**, **workflows**, and **tests**. | **Docs**-**only** or **tests**-**only** **characterization** **follow**-**on**. |
+| **Source** **binding** **intentionally** **absent** for **Session** **Review** **Pack** v0 in parts of the repo | **Template**-like **or** **static** **pack** **shapes** **where** **documented** **may** **not** **attach** to **a** **single** **live** **source** **in** v0. | **Bind** **only** **after** an **explicit** **source** **mandate**. |
+| **Artifact** **manifest** **linkage** **not** **selected** | **Generated**-**output** **precedence** is **not** **implemented** **as** **a** **first**-**class** **authoritative** **binding** **here**. | **Use** **synthetic** **fixtures** **before** **real** **data**. |
+| **Dashboard**/**cockpit** **authority** **risk** | **Observer** **display** **can** **be** **misread** as **order** **authority** **or** **readiness** **if** **not** **guarded** **in** **operator** **training**. | **Keep** **read**-**only** and **non**-**authorizing** **narrative**. |
+| **Paper**/**test** **data** **protection** | **Existing** **runs** **must** **remain** **undisturbed** **in** **this** **slice**. | **Avoid** **reading** or **rewriting** **historical** **artifacts** **as** part of **this** **file**'s **purpose**. |
+
+## 11. Authority Boundaries
+
+| **Surface** | **May** **(informational)** | **Must** **not** **(by** **this** **map**)** |
+| --- | --- | --- |
+| **Paper** **run** | **Provide** **lower**-**risk** **operational** **evidence** **in** **review** | **Authorize** **live** **trading** |
+| **Testnet** **run** | **Provide** **venue**/**integration** **evidence** **in** **review** | **Complete** **signoff** **by** **itself** |
+| **Shadow** **run** | **Provide** **observational** **behavior** **in** **review** | **Place** or **authorize** **orders** |
+| **Bounded** **pilot** **surface** | **Structure** **guarded** **review** | **Bypass** **gates** |
+| **Readiness** **summary** | **Summarize** **review** **posture** | **Pass** **gates** **by** **itself** |
+| **CI**/**workflow** **result** | **Validate** **engineering** **and** **policy** **posture** **in** **CI** | **Grant** **trading** **authority** **as** **the** **sole** **signal** |
+| **Report**/**read**-**model** | **Explain** **status** **where** **exposed** | **Mutate** **runtime** **authority** **by** **display** **alone** |
+| **Session** **Review** **Pack** (where static template) | **Preserve** **post**-**hoc** **review** **context** **in** **governed** **modes** | **Establish** **live** **readiness** **or** **external** **approval** **alone** |
+
+## 12. Safe Follow-Up Candidates
+
+**Safe** **follow**-**up** **candidates:**
+
+1. **Tests**-**only** **characterization** of **Paper**/**Testnet** **readiness** **gap**-**map** **anchors**.
+2. **Docs**-**only** **operator**/**audit** **flat** **path** **index** for **current** **review** **surfaces**.
+3. **Read**-**only** **report** **shape** **review** **using** **synthetic** **fixtures** **only**.
+4. **Session** **Review** **Pack** **source**-**binding** **plan** **only** **after** a **concrete** **source** is **chosen**.
+5. **Paper**/**Testnet** **readiness** **open**-**first** **runbook** **only** **if** **operator** **review** **needs** **it** **in** a **separate** **slice**.
+
+**Avoid** **as** **premature** **follow**-**ons** **in** the **same** **intent** as **this** **map**:
+
+- **Reading** or **modifying** **historical** **paper**/**test** **artifacts** **as** **unscoped** **inputs**;
+- **Changing** **paper**/**testnet** **workflows** **without** **governance** **elsewhere**;
+- **Changing** **Risk**/**KillSwitch**;
+- **Changing** **Execution**/**Live** **Gates**;
+- **Binding** **Session** **Review** **Pack** to **real** **session** **data** **without** **mandate**;
+- **Dashboard**/**cockpit** **authority** **changes**;
+- **Live** **enablement**.
+
+## 13. Validation Notes
+
+**Validate** this **docs**-**only** **file** with:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+```
+
+- **read**-**only** **validation** of **documentation** only — **not** a **trading** or **gate** **result**.


### PR DESCRIPTION
## Summary

- Add a docs-only, non-authorizing Paper / Testnet Readiness Gap Map V0.
- Map Paper, Shadow, Testnet, bounded pilot, readiness, gates, workflows, reports, Evidence, Registry, Session Review Pack, and Backtest/Robustness relevance.
- Clarify visible repo-only gaps and authority boundaries without changing behavior.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1685 Markdown files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed

## Safety / Authority

- Docs-only change.
- No code, tests, workflows, configs, runtime, report implementation, EVIDENCE_INDEX body, registry behavior, evidence schema, paper/test data, historical run artifacts, risk, gate, execution, or live behavior changes.
- No live authorization, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
