### PR TITLE
docs(ops): add operator audit flat path index v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_OPERATOR_AUDIT_FLAT_PATH_INDEX_V0.md
+++ b/docs/ops/specs/MASTER_V2_OPERATOR_AUDIT_FLAT_PATH_INDEX_V0.md
@@ -1,0 +1,160 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_OPERATOR_AUDIT_FLAT_PATH_INDEX_V0
+status: draft
+scope: docs-only, non-authorizing operator / audit flat path index
+last_updated: 2026-04-27
+---
+
+# Master V2 Operator / Audit Flat Path Index V0
+
+## 1. Executive Summary
+
+This document is a **non-authorizing** **flat** **path** **index** for **operator**, **reviewer**, and **audit** **review** **surfaces** across the **current** **Master** **V2** **documentation** **chain**.
+
+It is a **navigation** **aid** **only**. It **does** **not** **modify** **runtime** **behavior**, **workflows**, **gates**, **reports**, **tests**, **configs**, **evidence**, **registry** **behavior**, **paper**/**test** **data**, **trading** **logic**, or **any** **Master** **V2** / **Double** **Play** **semantics**.
+
+**Review** **surfaces** are **not** **live** **authorization**, **signoff** **completion**, **gate** **passage**, **strategy** **readiness**, **autonomy** **readiness**, **external** **authority** **completion**, or **approval**.
+
+## 2. Purpose and Non-Goals
+
+**Purpose:**
+
+- **Provide** a **single** **open**-**first** **index** for **current** **review** **surfaces**.
+- **Reduce** **navigation** **friction** **across** **triage**, **handoff**, **evidence**, **Session** **Review** **Pack**, **CI**, **backtest**, **Paper**/**Testnet**, **strategy**, **learning**, **AI**, and **visual** **reference** **surfaces**.
+- **Preserve** **non**-**authorizing** **boundaries** for **all** **review** and **audit** **surfaces**.
+- **Support** **operator**/**audit** **review** **without** **creating** **new** **authority**.
+
+**Non-goals:**
+
+- **No** **code** **changes**, **no** **test** **changes**, **no** **workflow** **changes**, **no** **config** **changes**, **no** **runtime** **changes**, **no** **report** **behavior** **changes**.
+- **No** **evidence** or **registry** **behavior** **changes** **by** **this** **document** **alone**.
+- **No** **paper**/**test** **data** **changes**.
+- **No** **live** **enablement** and **no** **strategy**-**readiness** **claim** **by** **index** **presence** **alone**.
+
+## 3. Flat Path Index
+
+| **Order** | **Open** **this** **file** | **Use** **when** | **Then** **open** | **Not** **used** **for** |
+| ---: | --- | --- | --- | --- |
+| 1 | [`MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md`](./MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md) | **You** **need** **the** **first** **decision** **path**. | **The** **matching** **route** **below**. | **Not** **approval**. |
+| 2 | [`MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md`](./MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md) | **You** **need** **evidence**/**readiness**/**verdict**/**handoff** **order**. | **Evidence** **or** **readiness** **packet** **surfaces**. | **Not** **external** **authority** **completion**. |
+| 3 | [`MASTER_V2_VISUAL_LEARNING_EVIDENCE_REFERENCE_CHAIN_POINTER_V0.md`](./MASTER_V2_VISUAL_LEARNING_EVIDENCE_REFERENCE_CHAIN_POINTER_V0.md) | **You** **need** **the** **broader** **visual**/**learning**/**evidence** **reading** **chain**. | **The** **referenced** **family** **doc**. | **Not** **runtime** **source** **of** **truth**. |
+| 4 | [`MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md`](./MASTER_V2_DASHBOARD_COCKPIT_OBSERVER_SURFACE_INVENTORY_V0.md) | **You** **need** **observer**/**dashboard**/**report** **surface** **context**. | **Session** **Review** **Pack** **or** **report** **surfaces**. | **Not** **dashboard**/**cockpit** **authority**. |
+| 5 | [`MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md`](./MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md) | **You** **need** **registry**/**evidence**/**provenance** **navigation**. | **Evidence** **Index** **or** **provenance** **surfaces**. | **Not** **signoff** **complete**. |
+| 6 | [`MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md) | **You** **need** **post**-**hoc** **Session** **Review** **Pack** **shape**. | **Invoke** **runbook** **or** **precedence** **spec**. | **Not** **live** **authorization**. |
+| 7 | [`RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md`](../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md) | **You** **need** **the** **read**-**only** **Session** **Review** **Pack** **command**. | **Report** **output** **or** **SRP** **tests**. | **Not** **approval**. |
+| 8 | [`MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md) | **You** **need** **future** **evidence**/**provenance** **binding** **precedence**. | **Synthetic** **precedence** **tests** **if** **reviewing** **behavior**. | **Not** **binding** **as** **authority** **by** **this** **index** **alone**. |
+| 9 | [`MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md`](./MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md) | **You** **need** **CI**/**required**-**checks**/**safety**-**gate** **navigation**. | **CI** **tests** **or** **workflow** **files**. | **Not** **trading** **authority**. |
+| 10 | [`MASTER_V2_BACKTEST_ROBUSTNESS_VALIDATION_SURFACE_INVENTORY_V0.md`](./MASTER_V2_BACKTEST_ROBUSTNESS_VALIDATION_SURFACE_INVENTORY_V0.md) | **You** **need** **backtest**/**statistical** **validation** **surfaces**. | **Backtest** **characterization** **tests**. | **Not** **strategy** **readiness**. |
+| 11 | [`MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md`](./MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md) | **You** **need** **Paper**/**Testnet** **readiness** **review** **surfaces**. | **Paper**/**Testnet** **characterization** **tests**. | **Not** **live** **readiness**. |
+| 12 | [`MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md`](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md) | **You** **need** **learning**-**loop**/**review**-**feedback** **pathing**. | **Registry**/**evidence** **or** **strategy** **surfaces**. | **Not** **current** **autonomous** **execution**. |
+| 13 | [`MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md`](./MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md) | **You** **need** **strategy** **family**/**status**-**lane** **surfaces**. | **Visual** **architecture** **reference**. | **Not** **strategy** **approval**. |
+| 14 | [`MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md`](./MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md) | **You** **need** **system** **dataflow** **or** **AI**-**layer** **context**. | **Visual** **architecture** **reference**. | **Not** **AI** **trade** **authority**. |
+| 15 | [`MASTER_V2_VISUAL_ARCHITECTURE_AND_STRATEGY_REFERENCE_V0.md`](./MASTER_V2_VISUAL_ARCHITECTURE_AND_STRATEGY_REFERENCE_V0.md) | **You** **need** **the** **high**-**level** **visual** **architecture** **reference**. | **Strategy** **or** **dataflow** **docs**. | **Not** **runtime** **behavior** **as** **sole** **authority**. |
+| 16 | [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md) | **You** **need** **vocabulary** for **KB**/**Registry**/**Evidence** **concepts**. | **Registry**/**evidence** **pointer** **index**. | **Not** **implementation** **correctness** **by** **naming** **alone**. |
+
+## 4. Open-First Routes by Question
+
+| **Question** | **Open** **first** | **Then** **open** |
+| --- | --- | --- |
+| "What do I read first?" | [`MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md`](./MASTER_V2_OPERATOR_TRIAGE_OPEN_FIRST_CHECKLIST_V0.md) | **This** **flat** **path** **index**. |
+| "What is the handoff or verdict order?" | [`MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md`](./MASTER_V2_OPERATOR_HANDOFF_SURFACE_MAP_V0.md) | **Evidence** **packet**/**index** **navigation**. |
+| "Where is evidence or registry context?" | [`MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md`](./MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md) | **Evidence**/**registry** **taxonomy**. |
+| "How do I review a session?" | [`MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md) | [`RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md`](../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md). |
+| "Which CI or gate surface matters?" | [`MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md`](./MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md) | **CI** **characterization** **tests**. |
+| "Which backtest/validation surface matters?" | [`MASTER_V2_BACKTEST_ROBUSTNESS_VALIDATION_SURFACE_INVENTORY_V0.md`](./MASTER_V2_BACKTEST_ROBUSTNESS_VALIDATION_SURFACE_INVENTORY_V0.md) | **Backtest** **characterization** **tests**. |
+| "Which Paper/Testnet surface matters?" | [`MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md`](./MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md) | **Paper**/**Testnet** **characterization** **tests**. |
+| "Where does strategy/readiness fit?" | [`MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md`](./MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md) | **Visual** **architecture** **reference**. |
+| "Where does AI fit?" | [`MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md`](./MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md) | **Visual** **architecture** **reference**. |
+| "Can this trade live?" | **Stop** — **out** **of** **scope** **for** **this** **index**. | **Requires** **separate** **governed** **authority** **review** **elsewhere**. |
+
+## 5. Evidence / Registry / Provenance Route
+
+**Use** **(in** **order** **for** **that** **question**)**:**
+
+1. [`MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md`](./MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md)
+2. [`MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md`](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md)
+3. [`MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md`](./MASTER_V2_KB_REGISTRY_EVIDENCE_TAXONOMY_V0.md)
+4. [`MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md`](./MASTER_V2_PROVENANCE_REPLAYABILITY_V1.md)
+
+**This** **route** **supports** **audit** **and** **review**. It **does** **not** **complete** **signoff** **or** **grant** **trading** **permission**.
+
+## 6. Session Review Pack Route
+
+**Use:**
+
+1. [`MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md)
+2. [`RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md`](../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md)
+3. [`MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md`](./MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md)
+
+**Current** v0 **posture** **remains** **read**-**only** **and** **non**-**authorizing** **where** **documented** **in** **those** **sources**. **It** **does** **not** **bind** **real** **session** **data** **as** **the** **sole** **effect** **of** **this** **index**.
+
+## 7. CI / Safety Gate Route
+
+**Use:**
+
+1. [`MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md`](./MASTER_V2_CI_REQUIRED_CHECKS_SAFETY_GATE_POINTER_INDEX_V0.md)
+2. `tests&#47;ci&#47;test_required_checks_safety_gate_surfaces_v0.py`
+
+**CI** and **required**-**checks** **surfaces** are **engineering** **validation** **surfaces**. **They** are **not** **trading** **authority** **or** **live** **authorization**.
+
+## 8. Backtest / Robustness Route
+
+**Use:**
+
+1. [`MASTER_V2_BACKTEST_ROBUSTNESS_VALIDATION_SURFACE_INVENTORY_V0.md`](./MASTER_V2_BACKTEST_ROBUSTNESS_VALIDATION_SURFACE_INVENTORY_V0.md)
+2. `tests&#47;ops&#47;test_backtest_robustness_validation_surface_inventory_v0.py`
+
+**Backtest** and **robustness** **surfaces** are **evidence**, **review**, and **learning** **inputs**. **They** are **not** **strategy** **readiness** **by** **themselves**.
+
+## 9. Paper / Testnet Route
+
+**Use:**
+
+1. [`MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md`](./MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md)
+2. `tests&#47;ops&#47;test_paper_testnet_readiness_gap_map_v0.py`
+
+**Paper**/**Testnet** **review** is **not** **live** **authorization**.
+
+## 10. Strategy / Learning / AI Route
+
+**Use:**
+
+1. [`MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md`](./MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md)
+2. [`MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md`](./MASTER_V2_LEARNING_LOOP_TO_REPO_PATH_MAP_V0.md)
+3. [`MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md`](./MASTER_V2_SYSTEM_DATAFLOW_AND_AI_LAYER_OVERVIEW_V0.md)
+4. [`MASTER_V2_VISUAL_ARCHITECTURE_AND_STRATEGY_REFERENCE_V0.md`](./MASTER_V2_VISUAL_ARCHITECTURE_AND_STRATEGY_REFERENCE_V0.md)
+
+**Strategy**, **Learning** **Loop**, and **AI** **surfaces** **support** **review** and **future** **staged** **autonomy** **planning**. **They** **do** **not** **approve** **strategy** **live** **use** **or** **AI** **trade** **authority**.
+
+## 11. Authority Boundaries
+
+| **Surface** | **May** **(informational)** | **Must** **not** **(by** **this** **index)** |
+| --- | --- | --- |
+| **Triage** **checklist** | **Route** **review**. | **Approve** **action** **or** **orders**. |
+| **Handoff** **map** | **Explain** **review** **order**. | **Complete** **external** **authority** **by** **narrative** **alone**. |
+| **Evidence**/**registry** **index** | **Navigate** **evidence** **and** **registry** **context**. | **Complete** **signoff** **by** **file** **presence** **alone**. |
+| **Session** **Review** **Pack** | **Preserve** **post**-**hoc** **review** **context** **where** **governed**. | **Authorize** **trades** **or** **live** **use**. |
+| **CI**/**safety** **pointer** | **Explain** **engineering** **and** **policy** **gates** **in** **CI**. | **Grant** **trading** **authority**. |
+| **Backtest** **inventory** | **Map** **validation** **and** **robustness** **surfaces**. | **Establish** **strategy** **readiness** **as** **the** **sole** **signal**. |
+| **Paper**/**Testnet** **gap** **map** | **Map** **readiness** **review** **surfaces**. | **Establish** **live** **readiness** **or** **approval**. |
+| **Strategy** **map** | **Explain** **strategy** **surfaces** **in** **repo** **context**. | **Approve** **strategy** **live** **use**. |
+| **AI**/**dataflow** **overview** | **Explain** **AI** **placement** **and** **dataflow** **context**. | **Approve** **AI** **trade** **authority**. |
+
+## 12. Known Ambiguities
+
+- **Some** **surfaces** are **contracts** **or** **pointers** **rather** **than** **generated** **artifacts**.
+- **Some** **test** **surfaces** **characterize** **docs** and **do** **not** **imply** **production** **evidence** **or** **gate** **passage** **in** a **trading** **sense**.
+- **Some** **generated** **outputs** **may** **exist** **outside** **tracked** **paths** and **must** **not** **be** **read** **without** a **scoped** **mandate**.
+- **Some** **future** **workstreams** **require** **explicit** **source** **decisions** **before** **implementation**.
+- **Operator**/**audit** **review** **can** **identify** **questions** but **cannot** **replace** **governed** **authority** **elsewhere**.
+
+## 13. Validation Notes
+
+**Validate** this **docs**-**only** **file** with:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+```
+
+- **read**-**only** **validation** of **documentation** only — **not** a **trading** or **gate** **result**.


### PR DESCRIPTION
## Summary

- Add a docs-only, non-authorizing Operator / Audit Flat Path Index V0.
- Provide a flat open-first navigation surface across triage, handoff, evidence, Session Review Pack, CI, backtest, Paper/Testnet, strategy, learning, AI, and visual reference surfaces.
- Clarify review routes and authority boundaries without changing behavior.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1687 Markdown files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed

## Safety / Authority

- Docs-only change.
- No code, tests, workflows, configs, runtime, report implementation, EVIDENCE_INDEX body, registry behavior, evidence schema, paper/test data, historical run artifacts, risk, gate, strategy, dashboard, AI, or live behavior changes.
- No live authorization, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
