### PR TITLE
docs(ops): add srp started open session linkage plan v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_STARTED_OPEN_SESSION_LINKAGE_PLAN_V0.md
+++ b/docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_STARTED_OPEN_SESSION_LINKAGE_PLAN_V0.md
@@ -1,0 +1,168 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_SESSION_REVIEW_PACK_STARTED_OPEN_SESSION_LINKAGE_PLAN_V0
+status: draft
+scope: docs-only, non-authorizing Session Review Pack started/open session linkage plan
+last_updated: 2026-04-27
+---
+
+# Master V2 Session Review Pack Started / Open Session Linkage Plan V0
+
+## 1. Executive Summary
+
+This document defines a planning-only linkage model between started/open bounded-pilot session review surfaces and the Session Review Pack V0.
+
+The current Session Review Pack V0 remains static/template-like, read-only, and non-authorizing. Started/open bounded-pilot sessions are review signals. They do not imply closeout approval, live authorization, signoff completion, gate passage, strategy readiness, autonomy readiness, or external authority completion.
+
+This document does not bind real sessions, read or mutate historical artifacts, edit registry JSONs, edit `out&#47;ops` artifacts, infer PnL, or change report behavior.
+
+## 2. Purpose and Non-Goals
+
+Purpose:
+
+- Describe how started/open bounded-pilot session information could later become Session Review Pack input.
+- Define source classes before any implementation binding.
+- Preserve missing/present execution-event pointer semantics.
+- Keep operator review separate from closeout, readiness, and authority.
+- Provide a safe next step toward synthetic fixture tests.
+
+Non-goals:
+
+- No code changes.
+- No report behavior changes.
+- No registry JSON changes.
+- No `out&#47;ops` artifact changes.
+- No generated artifact normalization.
+- No real session binding.
+- No closeout action.
+- No PnL inference.
+- No live, paper, testnet, or bounded-pilot execution.
+- No live authorization.
+- No strategy readiness or autonomy readiness claim.
+
+## 3. Current SRP V0 Posture
+
+Primary anchors:
+
+- [Session Review Pack Contract](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md)
+- [Session Review Pack Evidence / Provenance Precedence](./MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md)
+- [Session Review Pack Invoke Runbook](../runbooks/RUNBOOK_SESSION_REVIEW_PACK_INVOKE_V0.md)
+
+Session Review Pack V0 currently provides a read-only JSON surface. It is intentionally conservative and does not bind actual started/open session records.
+
+Current tests:
+
+- `tests&#47;ops&#47;test_session_review_pack_report_contracts_v0.py`
+- `tests&#47;ops&#47;test_session_review_pack_precedence_synthetic_v0.py`
+
+## 4. Started/Open Session Inputs
+
+Started/open bounded-pilot sessions are visible through read-only report modes and operator review runbooks.
+
+Related anchors:
+
+- [Started Bounded-Pilot Session Review Runbook](../runbooks/RUNBOOK_STARTED_BOUNDED_PILOT_SESSION_REVIEW_V0.md)
+- [Operator / Audit Flat Path Index](./MASTER_V2_OPERATOR_AUDIT_FLAT_PATH_INDEX_V0.md)
+- [Paper / Testnet Readiness Gap Map](./MASTER_V2_PAPER_TESTNET_READINESS_GAP_MAP_V0.md)
+- [Registry / Evidence Surface Pointer Index](./MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md)
+
+Relevant existing test:
+
+- `tests&#47;ops&#47;test_report_live_sessions_started_bounded_pilot_open_sessions_v0.py`
+
+Started/open session inputs can include:
+
+| Input | Meaning | Not used for |
+| --- | --- | --- |
+| Registry session record | A bounded-pilot session record exists in the registry. | Not closeout approval. |
+| Status `started` | Registry state is non-terminal. | Not live readiness. |
+| Scoped execution-events pointer | Expected path for session-scoped event history. | Not proof of correctness. |
+| Closeout summary state | Read-only closeout posture. | Not signoff. |
+| Lifecycle consistency state | Read-only lifecycle posture. | Not gate passage. |
+| Operator review note | Human review context. | Not external authority completion. |
+
+## 5. Source Classes for Later Synthetic Mapping
+
+Future synthetic mapping should model source classes before any real binding.
+
+| Source class | Example future field | Missing behavior | Authority boundary |
+| --- | --- | --- | --- |
+| `registry_session_record` | `session.session_id`, `session.status` | Missing means no session-backed SRP linkage. | Not approval. |
+| `scoped_execution_events_present_true` | `references.execution_events_session_jsonl.present=true` | N/A. | Not proof of correct trading. |
+| `scoped_execution_events_present_false` | `references.execution_events_session_jsonl.present=false` | Preserve as review signal. | Not permission to recreate artifacts. |
+| `closeout_summary_state` | `references.closeout_summary.status` | Missing remains explicit. | Not closeout approval. |
+| `lifecycle_consistency_state` | `references.lifecycle_consistency.status` | Missing remains explicit. | Not gate passage. |
+| `operator_review_runbook` | `references.operator_review_runbook` | Missing remains explicit. | Not external authority. |
+
+## 6. Missing / Present Event Pointer Semantics
+
+`execution_events_session_jsonl.present` must remain a pointer/state signal.
+
+| State | Meaning | SRP treatment |
+| --- | --- | --- |
+| `present: true` | A scoped event file exists at the expected path. | Link as evidence/reference candidate only. |
+| `present: false` | No scoped event file exists at the expected path. | Preserve as missing/needs-review field. |
+| unknown / omitted | The source was not evaluated. | Treat as missing; do not infer absence or correctness. |
+
+Do not recreate, normalize, delete, or patch historical event files as part of SRP linkage.
+
+## 7. Authority Boundaries
+
+| Surface | May do | Must not do |
+| --- | --- | --- |
+| Session Review Pack | Preserve review context. | Authorize trades. |
+| Started/open registry record | Signal non-terminal state. | Close the session. |
+| Execution-events pointer | Indicate expected artifact presence. | Prove correctness or PnL. |
+| Closeout summary | Explain read-only closeout posture. | Approve closeout. |
+| Lifecycle consistency | Explain lifecycle posture. | Pass gates. |
+| Operator runbook | Guide review. | Mutate artifacts. |
+| Future synthetic tests | Pin mapping semantics. | Bind real sessions. |
+
+## 8. Recommended Next Slice
+
+The next implementation step, if selected, should be tests-only and synthetic:
+
+- create synthetic registry records;
+- create synthetic scoped execution event pointers for both present and missing cases;
+- map those synthetic source classes into a Session Review Pack-like structure;
+- assert missing fields remain explicit;
+- assert all authority boundaries remain false/non-authorizing.
+
+Do not bind real registry entries or `out&#47;ops` artifacts in that next slice.
+
+Possible branch:
+
+`test/srp-started-open-session-linkage-synthetic-v0`
+
+Possible commit:
+
+`test(ops): add srp started open session linkage synthetic tests v0`
+
+## 9. Out of Scope
+
+Out of scope:
+
+- real session binding;
+- artifact-manifest binding;
+- registry JSON edits;
+- `out&#47;ops` artifact edits;
+- closeout mutation;
+- PnL inference;
+- report implementation changes;
+- workflow/config changes;
+- live/testnet/paper execution;
+- Master V2 / Double Play changes;
+- Risk/KillSwitch changes;
+- Execution/Live Gate changes;
+- dashboard/cockpit authority;
+- AI trading authority;
+- strategy live authority.
+
+## 10. Validation Notes
+
+Validate this docs-only plan with:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+uv run pytest tests/ops/test_report_live_sessions_started_bounded_pilot_open_sessions_v0.py tests/ops/test_session_review_pack_report_contracts_v0.py tests/ops/test_session_review_pack_precedence_synthetic_v0.py -q
+```


### PR DESCRIPTION
## Summary

- Add a docs-only Session Review Pack started/open session linkage plan.
- Define future source classes for started/open bounded-pilot sessions, scoped execution-events present/missing pointers, closeout summary, lifecycle consistency, and operator review context.
- Clarify that the next implementation step should be synthetic tests only, not real session binding.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1689 Markdown files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed, 8952 references checked
- `uv run pytest tests/ops/test_report_live_sessions_started_bounded_pilot_open_sessions_v0.py tests/ops/test_session_review_pack_report_contracts_v0.py tests/ops/test_session_review_pack_precedence_synthetic_v0.py -q` — 35 passed

## Safety / Authority

- Docs-only change.
- No code, tests, workflows, configs, runtime behavior, report implementation, registry JSONs, `out/ops` artifacts, paper/test data, historical run artifacts, Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gates, dashboard/AI/strategy authority, or live/testnet behavior changes.
- No real session binding, closeout approval, live authorization, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
