### PR TITLE
docs(ops): add source-bound srp registry evidence linkage plan v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_SOURCE_BOUND_REGISTRY_EVIDENCE_LINKAGE_PLAN_V0.md
+++ b/docs/ops/specs/MASTER_V2_SESSION_REVIEW_PACK_SOURCE_BOUND_REGISTRY_EVIDENCE_LINKAGE_PLAN_V0.md
@@ -1,0 +1,160 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_SESSION_REVIEW_PACK_SOURCE_BOUND_REGISTRY_EVIDENCE_LINKAGE_PLAN_V0
+status: draft
+scope: docs-only, non-authorizing source-bound Session Review Pack registry/evidence linkage plan
+last_updated: 2026-04-27
+---
+
+# Master V2 Session Review Pack Source-Bound Registry / Evidence Linkage Plan V0
+
+## 1. Executive Summary
+
+This document defines a Registry / Evidence linkage plan for a future source-bound Session Review Pack mode.
+
+It is docs-only and non-authorizing. It does not implement source binding, read real registry entries, read real `out&#47;ops` artifacts, mutate evidence indexes, close sessions, infer PnL, grant live authorization, pass gates, establish strategy readiness, establish autonomy readiness, or complete external authority.
+
+The purpose is to define safe pointer classes before any report implementation.
+
+## 2. Purpose and Non-Goals
+
+Purpose:
+
+- define source-bound SRP registry/evidence pointer classes;
+- preserve source-bound explicit selector semantics;
+- keep registry/evidence references as pointers, not authority;
+- preserve missing/present event-pointer semantics;
+- align with evidence/provenance precedence before implementation;
+- define boundaries for future report planning.
+
+Non-goals:
+
+- No code changes.
+- No test changes.
+- No report implementation.
+- No CLI/parser implementation.
+- No registry JSON edits.
+- No evidence index edits.
+- No `out&#47;ops` artifact edits.
+- No real session binding.
+- No closeout action.
+- No live, paper, testnet, or bounded-pilot execution.
+
+## 3. Relationship to Source-Bound SRP Planning
+
+This plan builds on:
+
+- [Source-Bound SRP Mode Implementation Brief](./MASTER_V2_SESSION_REVIEW_PACK_SOURCE_BOUND_MODE_IMPLEMENTATION_BRIEF_V0.md)
+- [Source-Bound SRP CLI/API Test Plan](./MASTER_V2_SESSION_REVIEW_PACK_SOURCE_BOUND_CLI_API_TEST_PLAN_V0.md)
+- [SRP Real-Binding Accepted Decision](./MASTER_V2_SESSION_REVIEW_PACK_REAL_BINDING_ACCEPTED_DECISION_V0.md)
+- [SRP Evidence / Provenance Precedence](./MASTER_V2_SESSION_REVIEW_PACK_EVIDENCE_PROVENANCE_PRECEDENCE_V0.md)
+- [Registry / Evidence Surface Pointer Index](./MASTER_V2_REGISTRY_EVIDENCE_SURFACE_POINTER_INDEX_V0.md)
+- [Evidence Packet and Index Navigation Map](./MASTER_V2_EVIDENCE_PACKET_AND_INDEX_NAVIGATION_MAP_V0.md)
+- [Started Bounded-Pilot Session Review Runbook](../runbooks/RUNBOOK_STARTED_BOUNDED_PILOT_SESSION_REVIEW_V0.md)
+
+Relevant tests:
+
+- `tests&#47;ops&#47;test_session_review_pack_source_bound_cli_shape_v0.py`
+- `tests&#47;ops&#47;test_session_review_pack_source_bound_session_id_shape_v0.py`
+- `tests&#47;ops&#47;test_session_review_pack_report_contracts_v0.py`
+
+## 4. Source Classes
+
+Future source-bound SRP may model these pointer classes:
+
+| Source class | Meaning | Not used for |
+| --- | --- | --- |
+| `registry_session_record` | Explicitly selected session record metadata. | Not PnL proof or live readiness. |
+| `scoped_execution_events_pointer` | Expected session-scoped execution-events path and present/missing state. | Not proof of correct trading. |
+| `registry_evidence_index_pointer` | Pointer into registry/evidence navigation surfaces. | Not approval or signoff. |
+| `closeout_summary_reference` | Read-only closeout posture reference. | Not closeout approval. |
+| `lifecycle_consistency_reference` | Read-only lifecycle posture reference. | Not gate passage. |
+| `operator_review_runbook` | Human review route. | Not external authority completion. |
+
+## 5. Evidence / Provenance Precedence
+
+Future source-bound SRP should follow precedence rules already defined for SRP evidence/provenance.
+
+Precedence principles:
+
+1. explicit operator source selector first;
+2. registry session record as selected source metadata;
+3. session-scoped execution-events pointer as artifact reference candidate or missing-field signal;
+4. closeout/lifecycle reports as read-only posture references;
+5. evidence/registry indexes as navigation surfaces only;
+6. operator review notes/runbooks as human process context;
+7. no dashboard, AI, strategy, or live-execution authority from these pointers.
+
+If two sources conflict, the source-bound SRP should preserve conflict/missing state rather than silently choosing a favorable interpretation.
+
+## 6. Missing / Present Semantics
+
+| Pointer state | Required handling |
+| --- | --- |
+| registry record missing | Fail closed for source-bound binding. |
+| selected session not unique | Fail closed; no automatic primacy. |
+| scoped events `present=true` | Reference candidate only. |
+| scoped events `present=false` | Explicit missing/needs-review field. |
+| scoped events unknown | Explicit missing/needs-review field. |
+| closeout state unavailable | Missing/needs-review field. |
+| lifecycle state unavailable | Missing/needs-review field. |
+| evidence pointer unavailable | Missing/needs-review field. |
+
+Missing fields must remain explicit in output. Do not regenerate or repair historical artifacts as part of this linkage.
+
+## 7. Registry / Evidence Linkage Shape
+
+Future output may include a linkage section shaped conceptually like:
+
+```json
+{
+  "registry_evidence_linkage": {
+    "registry_session_record": {
+      "source_class": "registry_session_record",
+      "selection": "explicit_session_id",
+      "present": true
+    },
+    "execution_events_session_jsonl": {
+      "source_class": "scoped_execution_events_pointer",
+      "present": false,
+      "review_state": "needs_review"
+    },
+    "evidence_navigation": {
+      "source_class": "registry_evidence_index_pointer",
+      "review_state": "reference_candidate"
+    }
+  }
+}
+```
+
+The example is **illustrative** only. Field names, nesting, and review-state vocabulary are subject to a future report contract. This plan does not freeze JSON schema.
+
+## 8. No Artifact Mutation
+
+This linkage model is read-only in intent: planned pointers reference registry surfaces and known artifact paths. Implementations must not rewrite registry JSON, evidence indices, or `out&#47;ops` trees as a side effect of building a Session Review Pack. Normalization, backfill, or “repair” of missing history is out of scope for source-bound SRP and conflicts with the fail-closed and explicit-missing semantics above.
+
+## 9. No Real Binding Yet
+
+This document does not authorize binding a report to a live or historical session. Until an explicit, reviewed implementation and tests exist, operators should use existing static SRP paths and the runbook for human review, not an automated bind.
+
+## 10. Authority Boundaries
+
+- **Registry and evidence pointers** are navigation and context only; they do not substitute for kill-switch, risk, execution, or live gates.
+- **Operator review runbook** and session review process remain human-executed; this plan does not automate signoff.
+- **Master V2 / Double Play** and other product authorities are unchanged: no dashboard, strategy, or AI authority is derived from pointer linkage.
+- **Closeout and lifecycle** references, when present, are posture information only, not permission to act.
+
+## 11. Recommended Next Step
+
+**Report implementation planning** (separate, docs-first outline of how a future `report_live_sessions` mode would assemble the above pointers) is appropriate only **after** this linkage plan and the related source-bound brief/test-plan chain are stable. Do not implement report code from this document alone.
+
+## 12. STOP Conditions
+
+Stop further linkage or implementation work when any of the following would be required to proceed without violating this plan’s non-goals:
+
+- editing real registry or evidence JSON for test convenience;
+- mutating `out&#47;ops` or historical run artifacts;
+- inferring PnL, live readiness, or strategy readiness from pointers alone;
+- binding real production sessions before explicit test and code review;
+- conflating this linkage section with live authorization, gate passage, or external authority.
+
+When in doubt, keep outputs explicit about missing/needs-review state and stay fail-closed.


### PR DESCRIPTION
## Summary

- Add a docs-only Registry/Evidence linkage plan for future source-bound Session Review Pack sources.
- Define pointer/source classes for registry session records, scoped execution-events pointers, evidence index pointers, closeout/lifecycle references, and operator review runbooks.
- Clarify evidence/provenance precedence, missing/present semantics, no-artifact-mutation rules, authority boundaries, and STOP conditions.
- Preserve source-bound SRP as planning-only; no real binding or report implementation in this slice.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1693 Markdown files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed, 8982 references checked
- `uv run pytest tests/ops/test_session_review_pack_source_bound_cli_shape_v0.py tests/ops/test_session_review_pack_source_bound_session_id_shape_v0.py tests/ops/test_session_review_pack_report_contracts_v0.py -q` — 45 passed

## Safety / Authority

- Docs-only change.
- No code, tests, workflows, configs, runtime behavior, report implementation, registry JSONs, `out/ops` artifacts, generated artifacts, paper/test data, historical run artifacts, Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gates, dashboard/AI/strategy authority, or live/testnet behavior changes.
- No real session binding, closeout approval, live authorization, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
