### PR TITLE
docs(ops): add first live execution sequence v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_FIRST_LIVE_EXECUTION_SEQUENCE_V0.md
+++ b/docs/ops/specs/MASTER_V2_FIRST_LIVE_EXECUTION_SEQUENCE_V0.md
@@ -1,0 +1,343 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_FIRST_LIVE_EXECUTION_SEQUENCE_V0
+status: draft
+scope: docs-only, non-authorizing Master V2 First Live execution sequence
+last_updated: 2026-04-28
+---
+
+# Master V2 First Live Execution Sequence V0
+
+## 1. Executive Summary
+
+This document defines a concrete, ordered, non-authorizing First Live execution sequence.
+
+It translates the staged [Master V2 Go-Live Roadmap V0](./MASTER_V2_GO_LIVE_ROADMAP_V0.md) into an operator-facing sequence of review and decision steps. It does not authorize live trading, enable live configuration, arm live mode, approve bounded-pilot entry, approve closeout, or grant strategy/autonomy readiness.
+
+Every step is fail-closed. Advancement requires explicit operator or external decision where applicable.
+
+## 2. Purpose and Non-Goals
+
+Purpose:
+
+- define the read/review order for First Live preparation;
+- make evidence, SRP, readiness, gate, and bounded-pilot handoffs explicit;
+- preserve Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gate boundaries;
+- define step-level entry and exit criteria;
+- define hard STOP conditions before any bounded real-money activity.
+
+Non-goals:
+
+- No live authorization.
+- No live config enablement.
+- No order placement.
+- No dry-run bypass.
+- No strategy readiness claim.
+- No autonomy readiness claim.
+- No external authority completion claim.
+- No registry JSON or `out&#47;ops` artifact mutation.
+- No real-session binding implementation.
+- No closeout mutation.
+
+## 3. Relationship to the Go-Live Roadmap and Other Surfaces
+
+**Relationship to the Go-Live Roadmap:** This execution sequence is a **companion** to [Master V2 Go-Live Roadmap V0](./MASTER_V2_GO_LIVE_ROADMAP_V0.md). The roadmap states **stages**; this document states an **ordered sequence of review and decision activities** that align with those stages. This sequence does not replace, extend, or re-rank the roadmap’s non-goals. If anything here appears to conflict with the roadmap, **the roadmap wins**.
+
+**Other readiness, review, and handoff anchors:**
+
+Primary roadmap and readiness anchors:
+
+- [Master V2 Go-Live Roadmap V0](./MASTER_V2_GO_LIVE_ROADMAP_V0.md)
+- [First Live Readiness Ladder](./MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [First Live Readiness Read Model](./MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md)
+- [First Live Gate Status Index](./MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [Operator / Audit Flat Path Index](./MASTER_V2_OPERATOR_AUDIT_FLAT_PATH_INDEX_V0.md)
+- [Promotion State Machine](./MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+- [Decision Authority Map](./MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+
+Session review anchors:
+
+- [Session Review Pack Contract V0](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md)
+- [Source-Bound SRP Report Implementation Plan](./MASTER_V2_SESSION_REVIEW_PACK_SOURCE_BOUND_REPORT_IMPLEMENTATION_PLAN_V0.md)
+- [Source-Bound SRP Report CLI Integration Test Plan](./MASTER_V2_SESSION_REVIEW_PACK_SOURCE_BOUND_REPORT_CLI_INTEGRATION_TEST_PLAN_V0.md)
+
+Bounded-pilot anchors:
+
+- [Bounded Pilot Live Entry Runbook](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md)
+- [Started Bounded-Pilot Session Review Runbook](../runbooks/RUNBOOK_STARTED_BOUNDED_PILOT_SESSION_REVIEW_V0.md)
+
+Relevant tests:
+
+- `tests/ops/test_session_review_pack_source_bound_cli_shape_v0.py`
+- `tests/ops/test_session_review_pack_source_bound_temp_resolver_v0.py`
+- `tests/ops/test_session_review_pack_source_bound_payload_builder_v0.py`
+- `tests/ops/test_session_review_pack_report_contracts_v0.py`
+
+## 4. Sequence Overview
+
+| Step | Name | Decision posture |
+|---|---|---|
+| 1 | Confirm repo/readiness surfaces | Read-only confirmation |
+| 2 | Collect evidence / PRE_LIVE package | Review package preparation |
+| 3 | Select session for SRP/source-bound review | Explicit operator selection only |
+| 4 | Review gates/readiness/blockers | Go/No-Go preparation |
+| 5 | External/operator Go/No-Go decision | Authority required |
+| 6 | Bounded pilot preparation | No execution yet |
+| 7 | Preflight / kill criteria confirmation | Fail-closed gate |
+| 8 | Bounded pilot execution handoff | Requires separate authority |
+| 9 | Closeout / post-pilot review | Review only |
+| 10 | Promotion or STOP | Explicit decision only |
+
+## 5. Step 1 — Confirm Repo / Readiness Surfaces
+
+### Entry Criteria
+
+- Repo is on `main`.
+- Working tree is clean.
+- Readiness and roadmap docs are present.
+- Docs reference and token checks are available.
+
+### Exit Criteria
+
+- Roadmap, Ladder, Gate Index, Read Model, SRP, and bounded-pilot runbook anchors are present.
+- Missing docs are recorded as blockers.
+- No implementation change is made during confirmation.
+
+### Hard STOP
+
+- Missing canonical readiness anchor.
+- Broken doc references.
+- Unclear repo branch or dirty working tree.
+- Any attempt to treat this confirmation as live approval.
+
+## 6. Step 2 — Collect Evidence / PRE_LIVE Package
+
+### Entry Criteria
+
+- Readiness surfaces are present.
+- Evidence sources are known.
+- PRE_LIVE package expectations are identified.
+
+### Exit Criteria
+
+- Evidence inputs are listed.
+- Missing evidence is explicit.
+- No missing evidence is treated as passed.
+- Evidence package remains review-only.
+
+### Hard STOP
+
+- Evidence cannot be traced.
+- Registry/session records are ambiguous.
+- Artifact pointers are missing without review posture.
+- Evidence package is described as approval.
+
+## 7. Step 3 — Select Session for SRP / Source-Bound Review
+
+### Entry Criteria
+
+- Session review is required.
+- Candidate sessions are known.
+- Source-bound SRP semantics are understood.
+
+### Exit Criteria
+
+- A session is selected explicitly by an operator decision.
+- Static SRP V0 remains unchanged.
+- Missing/present event-pointer state remains visible.
+- No automatic newest/open-session primacy is used.
+
+### Hard STOP
+
+- No explicit selected session.
+- Multiple candidates are auto-selected.
+- `out&#47;ops` artifacts are mutated.
+- Session selection is treated as closeout approval.
+
+## 8. Step 4 — Review Gates / Readiness / Blockers
+
+### Entry Criteria
+
+- Evidence package exists or missing evidence is explicit.
+- SRP/source-bound review state is known or deferred with reason.
+- Readiness surfaces are available.
+
+### Exit Criteria
+
+- Gate posture is summarized.
+- Blockers are listed.
+- Authority owner is known for the next decision.
+- No in-repo check is represented as external approval.
+
+### Hard STOP
+
+- Gate state is unclear.
+- Risk/KillSwitch posture is unclear.
+- Capital/scope boundaries are unclear.
+- Dashboard, AI, or strategy surfaces are treated as authority.
+
+## 9. Step 5 — External / Operator Go-No-Go Decision
+
+### Entry Criteria
+
+- Evidence package is ready for decision.
+- Blockers and hard stops are visible.
+- Decision authority is known.
+
+### Exit Criteria
+
+- Go, No-Go, or STOP decision is recorded by the proper authority.
+- Any Go decision is scoped and bounded.
+- No code or doc alone is treated as sufficient authority.
+
+### Hard STOP
+
+- External authority missing.
+- Decision owner unclear.
+- Go criteria are not bounded.
+- Decision bypasses Master V2 / Risk / Execution gates.
+
+## 10. Step 6 — Bounded Pilot Preparation
+
+### Entry Criteria
+
+- Go decision exists for bounded preparation.
+- Scope, capital, instrument, and kill criteria are explicit.
+- Bounded-pilot runbook is available.
+
+### Exit Criteria
+
+- Preflight inputs are known.
+- Expected artifacts are known.
+- Abort/incident path is known.
+- Execution remains unstarted until separate preflight passes.
+
+### Hard STOP
+
+- Live mode or capital scope unclear.
+- KillSwitch uncertainty.
+- Missing preflight packet.
+- Unknown closeout path.
+
+## 11. Step 7 — Preflight / Kill Criteria Confirmation
+
+### Entry Criteria
+
+- Bounded pilot preparation is complete.
+- Operator has the required preflight context.
+- Kill criteria are visible and understood.
+
+### Exit Criteria
+
+- Preflight is pass/fail.
+- Any failure blocks progression.
+- A pass is still not broad live authorization.
+
+### Hard STOP
+
+- Preflight cannot be reproduced.
+- Kill criteria are ambiguous.
+- Incident/abort handling is unclear.
+- Dry-run/live semantics are unclear.
+
+## 12. Step 8 — Bounded Pilot Execution Handoff
+
+### Entry Criteria
+
+- Proper bounded authority exists.
+- Preflight passes.
+- Scope/capital/kill limits are explicit.
+- Operator handoff is complete.
+
+### Exit Criteria
+
+- Execution handoff is recorded.
+- Expected evidence collection is known.
+- Closeout/post-pilot review route is known.
+- No promotion is automatic.
+
+### Hard STOP
+
+- Any mismatch between authority and execution mode.
+- Unexpected live exposure.
+- Missing evidence capture.
+- KillSwitch alert or uncertainty.
+
+## 13. Step 9 — Closeout / Post-Pilot Review
+
+### Entry Criteria
+
+- Pilot session produced artifacts or a failure/abort signal.
+- Registry, execution events, and closeout posture are reviewable.
+- Operator notes are available.
+
+### Exit Criteria
+
+- Session review is complete or blockers are explicit.
+- PnL is not used as sole promotion criterion.
+- Missing artifacts remain visible.
+- Promotion decision is deferred to proper authority.
+
+### Hard STOP
+
+- Missing closeout.
+- Unreviewed reject/fill/execution anomaly.
+- Missing event stream.
+- Inconsistent lifecycle posture.
+- Artifact mutation pressure.
+
+## 14. Step 10 — Promotion or STOP
+
+### Entry Criteria
+
+- Post-pilot review is complete.
+- Risk, scope, capital, and evidence criteria are reviewed.
+- Decision authority is known.
+
+### Exit Criteria
+
+- Promotion, repeat pilot, rollback, or STOP is explicitly recorded.
+- Any next scope remains bounded.
+- Master V2 / Double Play remains protected.
+
+### Hard STOP
+
+- Automatic promotion.
+- PnL-only decision.
+- Unresolved risk or kill switch questions.
+- Missing external decision.
+
+## 15. Authority Boundaries
+
+| Surface | May do | Must not do |
+|---|---|---|
+| Execution sequence | Order review and decisions. | Authorize live trading. |
+| Roadmap | Define staged path. | Bypass gates. |
+| SRP/source-bound review | Review selected session evidence. | Approve closeout or live. |
+| Readiness/gate surfaces | Summarize posture. | Grant external approval. |
+| Bounded-pilot runbook | Guide process. | Override KillSwitch/Risk. |
+| Operator decision | Select next step within authority. | Rewrite evidence or artifacts. |
+
+## 16. No-Live-Authorization Statement
+
+This document does not authorize live trading, testnet trading, arming live mode, increasing capital, selecting strategy candidates, accepting missing evidence, closing sessions, modifying registry or `out&#47;ops` artifacts, or bypassing Risk, KillSwitch, Execution, or live gates. It is **sequencing and review guidance only**. External and operator decisions remain the only path to any bounded or live activity, and only under separate, explicit authority.
+
+## 17. Next Suggested Docs
+
+After this execution sequence, use this order:
+
+1. `RUNBOOK_MASTER_V2_FIRST_LIVE_PILOT_SEQUENCE_V0.md` (place under `docs/ops/runbooks/` when created)
+2. `MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md` (place under `docs/ops/specs/` when created)
+
+Both should remain non-authorizing unless a separate, explicit authority process says otherwise.
+
+## 18. Validation Notes
+
+Validate this execution sequence with:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+uv run pytest tests/ops/test_session_review_pack_source_bound_cli_shape_v0.py tests/ops/test_session_review_pack_source_bound_temp_resolver_v0.py tests/ops/test_session_review_pack_source_bound_payload_builder_v0.py tests/ops/test_session_review_pack_report_contracts_v0.py -q
+```
+
+Optional: add further ops characterization tests in `tests/ops/` as the repo evolves; those tests do not authorize live behavior.


### PR DESCRIPTION
## Summary

- Add a docs-only Master V2 First Live Execution Sequence V0.
- Translate the Go-Live Roadmap into an ordered ten-step sequence from repo/readiness confirmation through evidence package, SRP/source-bound review, gate/blocker review, external/operator Go-No-Go, bounded pilot preparation, preflight, execution handoff, closeout review, and promotion-or-STOP.
- Document entry/exit criteria, hard STOP criteria, authority boundaries, no-live-authorization language, and follow-up docs.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1698 Markdown files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed
- `uv run pytest tests/ops/test_session_review_pack_source_bound_cli_shape_v0.py tests/ops/test_session_review_pack_source_bound_temp_resolver_v0.py tests/ops/test_session_review_pack_source_bound_payload_builder_v0.py tests/ops/test_session_review_pack_report_contracts_v0.py -q` — 50 passed

## Safety / Authority

- Docs-only change.
- No code, tests, workflows, configs, runtime behavior, report implementation, registry JSONs, `out/ops` artifacts, generated artifacts, paper/test data, historical run artifacts, Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gates, dashboard/AI/strategy authority, or live/testnet behavior changes.
- No live authorization, bounded-pilot approval, closeout approval, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
