### PR TITLE
docs(ops): add master v2 go-live blocker register v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md
+++ b/docs/ops/specs/MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md
@@ -1,0 +1,176 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0
+status: draft
+scope: docs-only, non-authorizing Master V2 Go-Live blocker register
+last_updated: 2026-04-28
+---
+
+# Master V2 Go-Live Blocker Register V0
+
+## 1. Executive Summary
+
+This document defines a non-authorizing blocker register for Master V2 Go-Live preparation.
+
+It converts the [Master V2 Go-Live Roadmap V0](./MASTER_V2_GO_LIVE_ROADMAP_V0.md), [Master V2 First Live Execution Sequence V0](./MASTER_V2_FIRST_LIVE_EXECUTION_SEQUENCE_V0.md), and [First Live Pilot Sequence Runbook V0](../runbooks/RUNBOOK_MASTER_V2_FIRST_LIVE_PILOT_SEQUENCE_V0.md) into a triage surface.
+
+This register does not mark Peak_Trade as ready for live trading. It does not authorize live execution, bounded-pilot entry, closeout, strategy readiness, autonomy readiness, external authority, or gate passage.
+
+Default posture: blockers are OPEN unless evidence and the correct authority explicitly close or accept them.
+
+## 2. Purpose and Non-Goals
+
+Purpose:
+
+- list Go-Live blocker classes by stage and authority boundary;
+- preserve explicit STOP conditions;
+- prevent accidental “green” claims;
+- make evidence and decision requirements visible;
+- support operator/external review without changing runtime behavior.
+
+Non-goals:
+
+- No live authorization.
+- No live config enablement.
+- No order placement.
+- No registry JSON mutation.
+- No `out&#47;ops` artifact mutation.
+- No closeout mutation.
+- No evidence backfill.
+- No strategy readiness claim.
+- No autonomy readiness claim.
+- No external signoff claim.
+
+## 3. Relationship to Existing Surfaces
+
+Roadmap and sequence:
+
+- [Go-Live Roadmap](./MASTER_V2_GO_LIVE_ROADMAP_V0.md)
+- [First Live Execution Sequence](./MASTER_V2_FIRST_LIVE_EXECUTION_SEQUENCE_V0.md)
+- [First Live Pilot Sequence Runbook](../runbooks/RUNBOOK_MASTER_V2_FIRST_LIVE_PILOT_SEQUENCE_V0.md)
+
+Readiness, gates, and authority:
+
+- [Readiness Ladder](./MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [Gate Status Index](./MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md)
+- [Operator / Audit Flat Path Index](./MASTER_V2_OPERATOR_AUDIT_FLAT_PATH_INDEX_V0.md)
+- [Decision Authority Map](./MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
+- [Promotion State Machine](./MASTER_V2_PROMOTION_STATE_MACHINE_V1.md)
+
+Session review and bounded pilot:
+
+- [Session Review Pack Contract V0](./MASTER_V2_SESSION_REVIEW_PACK_CONTRACT_V0.md)
+- [Source-Bound SRP Report Implementation Plan](./MASTER_V2_SESSION_REVIEW_PACK_SOURCE_BOUND_REPORT_IMPLEMENTATION_PLAN_V0.md)
+- [Bounded Pilot Live Entry Runbook](../runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md)
+
+Relevant focused tests:
+
+- `tests/ops/test_session_review_pack_source_bound_cli_shape_v0.py`
+- `tests/ops/test_session_review_pack_source_bound_temp_resolver_v0.py`
+- `tests/ops/test_session_review_pack_source_bound_payload_builder_v0.py`
+- `tests/ops/test_session_review_pack_report_contracts_v0.py`
+
+## 4. Blocker State Vocabulary
+
+| State | Meaning | Authority implication |
+|---|---|---|
+| OPEN | Known blocker or unresolved review item. | No Go. |
+| BLOCKED | Active blocker prevents progression. | STOP. |
+| DEFERRED | Explicitly postponed by proper owner. | No implicit pass. |
+| ACCEPTED_BY_AUTHORITY | Proper authority accepted risk/gap. | Still not a repo-level approval. |
+| CLOSED | Evidence/decision resolved the blocker. | Only for the stated blocker. |
+
+No state in this table authorizes live trading by itself.
+
+## 5. Blocker Categories
+
+Blockers are grouped as:
+
+1. readiness/gate blockers;
+2. evidence/provenance blockers;
+3. SRP/source-bound review blockers;
+4. risk/kill switch blockers;
+5. scope/capital blockers;
+6. execution/live gate blockers;
+7. operator/external authority blockers;
+8. closeout/post-pilot blockers.
+
+## 6. Blocker Register
+
+| Blocker ID | Stage | Blocker | Required evidence / decision | Owner / authority | Default state | STOP condition |
+|---|---|---|---|---|---|---|
+| GLB-001 | Repo/readiness confirmation | Roadmap or execution-sequence anchor missing. | Valid docs anchors and reference checks. | Repo/operator review | OPEN | Missing canonical anchor. |
+| GLB-002 | Repo/readiness confirmation | Readiness ladder or gate index unavailable. | Readiness and gate surfaces present. | Repo/operator review | OPEN | Gate posture cannot be reviewed. |
+| GLB-003 | Evidence package | Evidence package incomplete or untraceable. | Evidence list, provenance, replayability route. | Evidence owner / operator | OPEN | Missing evidence is treated as passed. |
+| GLB-004 | Evidence package | Registry/session records ambiguous. | Explicit selected session or documented deferral. | Operator | OPEN | Ambiguity blocks review. |
+| GLB-005 | SRP/source-bound review | Static SRP V0 confused with source-bound review. | SRP contract boundaries acknowledged. | Operator / reviewer | OPEN | Static SRP is treated as real-source binding. |
+| GLB-006 | SRP/source-bound review | Source-bound session selection implicit. | Explicit selected `session_id` or STOP. | Operator | BLOCKED | Newest/open-session auto-selection is attempted. |
+| GLB-007 | SRP/source-bound review | Missing event pointer hidden or repaired. | Missing/present state preserved in review. | Evidence owner / operator | OPEN | Artifacts are mutated to look complete. |
+| GLB-008 | Risk/KillSwitch | KillSwitch behavior uncertain. | KillSwitch posture confirmed. | Risk owner / operator | BLOCKED | KillSwitch cannot be explained. |
+| GLB-009 | Risk/KillSwitch | Risk limits unclear. | Risk limit evidence and stop path. | Risk owner | BLOCKED | Live or pilot scope lacks risk boundary. |
+| GLB-010 | Scope/capital | Capital slot or maximum loss boundary unclear. | Bounded capital/scope decision. | Capital/risk owner | BLOCKED | Capital is open-ended. |
+| GLB-011 | Scope/capital | Instrument/scope undefined. | Explicit instrument and pilot scope. | Operator / risk owner | BLOCKED | Pilot scope cannot be stated. |
+| GLB-012 | Execution/live gates | Live gates or arming semantics unclear. | Gate state and preflight semantics. | Execution owner / operator | BLOCKED | Live mode can be armed without clear preflight. |
+| GLB-013 | Execution/live gates | Dry-run/live semantics ambiguous. | Dry-run/live mode evidence. | Execution owner | BLOCKED | Operator cannot explain execution mode. |
+| GLB-014 | Operator/external authority | External/operator Go-No-Go owner unclear. | Named authority route. | External/operator authority | BLOCKED | No proper authority owner. |
+| GLB-015 | Operator/external authority | Repo docs treated as approval. | Explicit non-authorizing statement. | Operator / reviewer | BLOCKED | In-repo doc is used as final approval. |
+| GLB-016 | Bounded pilot preparation | Preflight packet unavailable. | Preflight output and decision record. | Operator | BLOCKED | Preflight cannot be reproduced. |
+| GLB-017 | Bounded pilot preparation | Incident/abort route unclear. | Abort/incident route confirmed. | Operator / incident owner | BLOCKED | Abort path unknown. |
+| GLB-018 | Closeout/post-pilot | Closeout path missing. | Closeout runbook/report posture. | Operator | OPEN | Pilot cannot be reviewed after execution. |
+| GLB-019 | Closeout/post-pilot | Event stream missing or inconsistent. | Missing event posture recorded. | Evidence owner / operator | OPEN | Missing events are ignored. |
+| GLB-020 | Promotion | Promotion would be automatic or PnL-only. | Explicit promotion decision criteria. | Promotion authority | BLOCKED | Promotion bypasses review. |
+
+## 7. No-Green Claim Rule
+
+This register may show that a blocker is OPEN, BLOCKED, DEFERRED, ACCEPTED_BY_AUTHORITY, or CLOSED.
+
+It must not claim:
+
+- Go-Live approved;
+- live trading authorized;
+- bounded pilot approved;
+- all gates passed;
+- strategy ready;
+- autonomy ready;
+- external signoff complete.
+
+A blocker can be CLOSED only for its stated scope. Closing one blocker does not imply readiness for First Live.
+
+## 8. STOP Semantics
+
+STOP applies immediately when:
+
+- any BLOCKED item lacks resolution;
+- evidence is missing and not explicitly accepted by authority;
+- source selection is implicit;
+- KillSwitch or risk posture is unclear;
+- live gate semantics are unclear;
+- external/operator authority is missing;
+- registry or `out&#47;ops` mutation is proposed to satisfy evidence;
+- promotion is automatic or PnL-only.
+
+STOP is a safe state, not a failure.
+
+## 9. Owner / Authority Guidance
+
+Owner labels in this register are role categories, not approvals.
+
+| Owner category | May do | Must not do |
+|---|---|---|
+| Repo/operator review | Confirm docs and report surfaces. | Authorize live trading. |
+| Evidence owner | Explain evidence/provenance. | Patch historical artifacts. |
+| Risk owner | Confirm risk/KillSwitch posture. | Override live gates alone. |
+| Execution owner | Explain execution/preflight semantics. | Arm live without authority. |
+| External/operator authority | Decide Go/No-Go within mandate. | Bypass hard STOP criteria. |
+| Promotion authority | Decide next stage. | Promote automatically from PnL. |
+
+## 10. Validation Notes
+
+Validate this blocker register with:
+
+```bash
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+uv run pytest tests/ops/test_session_review_pack_source_bound_cli_shape_v0.py tests/ops/test_session_review_pack_source_bound_temp_resolver_v0.py tests/ops/test_session_review_pack_source_bound_payload_builder_v0.py tests/ops/test_session_review_pack_report_contracts_v0.py -q
+```
+
+Optional: re-run the same SRP test set after any change to SRP or ops docs inventory tests on `main`.


### PR DESCRIPTION
## Summary

- Add a docs-only Master V2 Go-Live Blocker Register V0.
- Define blocker states, categories, GLB-001 through GLB-020 triage rows, STOP semantics, No-Green-Claim rules, and owner/authority guidance.
- Link the register to the Go-Live Roadmap, First Live Execution Sequence, First Live Pilot Sequence Runbook, readiness/gate surfaces, authority/promotion maps, SRP, and bounded-pilot runbooks.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1700 Markdown files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed
- `uv run pytest tests/ops/test_session_review_pack_source_bound_cli_shape_v0.py tests/ops/test_session_review_pack_source_bound_temp_resolver_v0.py tests/ops/test_session_review_pack_source_bound_payload_builder_v0.py tests/ops/test_session_review_pack_report_contracts_v0.py -q` — 50 passed

## Safety / Authority

- Docs-only change.
- No code, tests, workflows, configs, runtime behavior, report implementation, registry JSONs, `out/ops` artifacts, generated artifacts, paper/test data, historical run artifacts, Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gates, dashboard/AI/strategy authority, or live/testnet behavior changes.
- No live authorization, bounded-pilot approval, closeout approval, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
