### PR TITLE
docs(ops): add go-live chain operator navigation links v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_OPERATOR_AUDIT_FLAT_PATH_INDEX_V0.md
+++ b/docs/ops/specs/MASTER_V2_OPERATOR_AUDIT_FLAT_PATH_INDEX_V0.md
@@ -7,6 +7,17 @@ last_updated: 2026-04-27
 
 # Master V2 Operator / Audit Flat Path Index V0
 
+## Master V2 Go-Live planning chain (navigation only)
+
+The following documents provide the current non-authorizing operator navigation path for Go-Live planning:
+
+- [Master V2 Go-Live Roadmap V0](./MASTER_V2_GO_LIVE_ROADMAP_V0.md)
+- [Master V2 First Live Execution Sequence V0](./MASTER_V2_FIRST_LIVE_EXECUTION_SEQUENCE_V0.md)
+- [Runbook: Master V2 First Live Pilot Sequence V0](../runbooks/RUNBOOK_MASTER_V2_FIRST_LIVE_PILOT_SEQUENCE_V0.md)
+- [Master V2 Go-Live Blocker Register V0](./MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md)
+
+This subsection is navigation-only and **non-authorizing**. It is **not** **live** **authorization**. It does not authorize bounded-pilot entry, closeout approval, gate passage, strategy readiness, autonomy readiness, or external signoff.
+
 ## 1. Executive Summary
 
 This document is a **non-authorizing** **flat** **path** **index** for **operator**, **reviewer**, and **audit** **review** **surfaces** across the **current** **Master** **V2** **documentation** **chain**.


### PR DESCRIPTION
## Summary

- Add navigation-only links from the Operator Audit Flat Path Index to the Master V2 Go-Live planning chain.
- Link Roadmap, First Live Execution Sequence, First Live Pilot Sequence Runbook, and Go-Live Blocker Register.
- Preserve non-authorizing wording, including explicit `not live authorization` language.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` — passed, 1700 Markdown files scanned
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` — passed, 9080 references checked
- `uv run pytest tests/ops/test_session_review_pack_source_bound_cli_shape_v0.py tests/ops/test_session_review_pack_source_bound_temp_resolver_v0.py tests/ops/test_session_review_pack_source_bound_payload_builder_v0.py tests/ops/test_session_review_pack_report_contracts_v0.py -q` — 50 passed
- `uv run pytest tests/ops/test_operator_audit_flat_path_index_v0.py -q` — 9 passed

## Safety / Authority

- Docs-only navigation change.
- No code, tests, workflows, configs, runtime behavior, report implementation, registry JSONs, `out/ops` artifacts, generated artifacts, paper/test data, historical run artifacts, Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gates, dashboard/AI/strategy authority, or live/testnet behavior changes.
- No live authorization, bounded-pilot approval, closeout approval, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
