### PR TITLE
feat(ops): add pre-live package status report mode v0

### DIFF
--- a/scripts/report_live_sessions.py
+++ b/scripts/report_live_sessions.py
@@ -73,6 +73,9 @@ Usage:
 
     # Session Review Pack V0 (read-only, non-authorizing post-hoc review bundle; JSON-only in v0):
     python scripts/report_live_sessions.py --session-review-pack --json
+
+    # Pre-Live Package Status V0 (read-only gap signal; stdout JSON-only; registry + bounded-pilot artifacts):
+    python scripts/report_live_sessions.py --pre-live-package-status --json
 """
 
 from __future__ import annotations
@@ -81,7 +84,7 @@ import argparse
 import json
 import logging
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -1820,6 +1823,199 @@ def _run_bounded_pilot_closeout_status_summary(
 
 
 # =============================================================================
+# Pre-Live Package Status V0 (read-only aggregated gap signal; stdout JSON)
+# =============================================================================
+
+PRE_LIVE_PACKAGE_STATUS_AUTHORITY_BOUNDARY = {
+    "live_authorization": False,
+    "bounded_pilot_approval": False,
+    "closeout_approval": False,
+    "gate_passage": False,
+    "strategy_readiness": False,
+    "autonomy_readiness": False,
+    "external_authority_completion": False,
+}
+
+
+def _derive_closeout_lifecycle_label_pre_live(
+    n_open_bounded: int,
+    closeout: dict[str, Any],
+) -> str:
+    """Map bounded-pilot closeout read-model to characterization lifecycle strings."""
+    if n_open_bounded > 0:
+        return "PARTIAL_NON_TERMINAL"
+    summary = closeout.get("closeout_signal_summary")
+    terminalish_codes = {
+        "NO_BOUNDED_PILOT_SESSION_IN_REGISTRY",
+        "REGISTRY_TERMINAL_IN_NEWEST_ARTIFACT",
+    }
+    partialish_codes = {
+        "REGISTRY_ROWS_MISSING_AFTER_SELECTION",
+        "AMBIGUOUS_NEWEST_STARTED_WITH_OLDER_TERMINAL",
+        "REGISTRY_NON_TERMINAL_NEWEST_ONLY",
+        "REGISTRY_STATUS_NON_STANDARD",
+    }
+    if summary in terminalish_codes:
+        return "TERMINAL_CLEAN"
+    if summary in partialish_codes:
+        return "PARTIAL_NON_TERMINAL"
+    return "PARTIAL_NON_TERMINAL"
+
+
+def _compute_pre_live_package_status_semantics_v0(
+    *,
+    open_bounded_pilot_sessions: int,
+    closeout_lifecycle_status: str,
+    evidence_package_complete: bool,
+    blocker_states: dict[str, str],
+    external_decision_present: bool,
+) -> tuple[str, list[str], list[str]]:
+    """
+    Mirrors tests/ops/test_report_live_sessions_pre_live_package_status_v0.py semantics.
+
+    This function does not close blockers automatically; blocker_states is empty in v0 slices.
+    """
+    missing_or_open_items: list[str] = []
+    blockers: list[str] = []
+
+    if open_bounded_pilot_sessions:
+        missing_or_open_items.append("bounded_pilot.open_sessions_present")
+        blockers.append("GLB-018")
+
+    if closeout_lifecycle_status != "TERMINAL_CLEAN":
+        missing_or_open_items.append("closeout_lifecycle.non_terminal_or_partial")
+        blockers.append("GLB-018")
+
+    if not evidence_package_complete:
+        missing_or_open_items.append("evidence_package.incomplete")
+        blockers.append("GLB-003")
+
+    for blocker_id, state in sorted(blocker_states.items()):
+        if state in {"OPEN", "BLOCKED"}:
+            missing_or_open_items.append(f"blockers.{blocker_id}.{state.lower()}")
+            blockers.append(blocker_id)
+
+    unique_blockers = sorted(set(blockers))
+    unique_missing = sorted(set(missing_or_open_items))
+
+    if unique_blockers:
+        status = "BLOCKED"
+    elif not evidence_package_complete:
+        status = "NOT_READY"
+    elif not external_decision_present:
+        status = "READY_FOR_EXTERNAL_REVIEW"
+    else:
+        status = "REVIEW_ONLY"
+
+    return status, unique_missing, unique_blockers
+
+
+def _pre_live_package_status_flag_conflicts(args: argparse.Namespace) -> str | None:
+    """--pre-live-package-status aggregates registry bounded-pilot posture; no readiness/packet run."""
+    if args.session_id is not None:
+        return "--session-id is only for --evidence-pointers"
+    if args.latest_bounded_pilot:
+        return "--latest-bounded-pilot is only for --evidence-pointers"
+    if args.bounded_pilot_only or args.latest_bounded_pilot_open:
+        return "--bounded-pilot-only / --latest-bounded-pilot-open require --open-sessions"
+    if args.run_type is not None:
+        return "--run-type is not compatible with --pre-live-package-status"
+    if args.status is not None:
+        return "--status is not compatible with --pre-live-package-status"
+    if args.limit is not None:
+        return "--limit is not compatible with --pre-live-package-status"
+    if args.summary_only:
+        return "--summary-only is not compatible with --pre-live-package-status"
+    if args.output_dir is not None:
+        return "--output-dir is not compatible with --pre-live-package-status"
+    if args.stdout:
+        return "--stdout is not compatible with --pre-live-package-status"
+    if args.config_path is not None:
+        return "--config-path is not compatible with --pre-live-package-status"
+    if not args.json:
+        return "--pre-live-package-status requires --json (stdout JSON-only v0 slice)"
+    return None
+
+
+def _run_pre_live_package_status(
+    args: argparse.Namespace,
+    logger: logging.Logger,
+) -> int:
+    """Read-only aggregated status JSON; registry + bounded_pilot artifact signals only."""
+    if not args.json:
+        print(
+            "ERR: --pre-live-package-status requires --json",
+            file=sys.stderr,
+        )
+        return 2
+
+    base_dir = _registry_base_dir(args)
+    cwd = Path.cwd()
+    session_focus = _collect_bounded_pilot_session_focus(base_dir=base_dir, cwd=cwd)
+    closeout = _build_bounded_pilot_closeout_analysis(
+        session_focus,
+        base_dir=base_dir,
+        cwd=cwd,
+    )
+
+    open_rows = session_focus["open_bounded_pilot_sessions"]
+    n_open = len(open_rows)
+
+    lifecycle = _derive_closeout_lifecycle_label_pre_live(n_open, closeout)
+
+    # v0 slice: do not imply external authority or evidence automation; blocker_states empty here.
+    status, missing, bloc = _compute_pre_live_package_status_semantics_v0(
+        open_bounded_pilot_sessions=n_open,
+        closeout_lifecycle_status=lifecycle,
+        evidence_package_complete=True,
+        blocker_states={},
+        external_decision_present=False,
+    )
+
+    logger.info(
+        "Pre-Live Package Status V0 read-only posture (status=%s open_bounded=%s)",
+        status,
+        n_open,
+    )
+
+    payload = {
+        "contract": "pre_live_package_status_v0",
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "mode": "pre_live_package_status",
+        "registry_dir": str(base_dir.resolve()),
+        "non_authorizing": True,
+        "json_only": True,
+        "stdout_only": True,
+        "authority_boundary": dict(PRE_LIVE_PACKAGE_STATUS_AUTHORITY_BOUNDARY),
+        "status": status,
+        "open_bounded_pilot_sessions": n_open,
+        "closeout_lifecycle_status": lifecycle,
+        "closeout_signal_summary": closeout.get("closeout_signal_summary"),
+        "primary_session_id": session_focus.get("primary_session_id"),
+        "evidence_package_complete": True,
+        "external_decision_present": False,
+        "disclaimer_slices": (
+            "This JSON is a read-only gap signal combining registry-derived bounded-pilot posture. "
+            "It does not run readiness/preflight/cockpit checks in v0, does not close GLB rows automatically, "
+            "and evidence_package_complete is not asserted by external attestations in this slice."
+        ),
+        "blocker_states": {},
+        "missing_or_open_items": missing,
+        "blockers": bloc,
+        "signals": {
+            "open_bounded_pilot_session_ids": [x["session_id"] for x in open_rows],
+            "closeout_registry_terminal_in_newest": closeout.get(
+                "registry_terminal_in_newest_artifact"
+            ),
+            "closeout_conflict": closeout.get("open_vs_terminal_artifact_conflict"),
+        },
+    }
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+# =============================================================================
 # Session Review Pack V0 (read-only, non-authorizing; docs contract mapping)
 # =============================================================================
 
@@ -2038,7 +2234,7 @@ Beispiele:
             "--bounded-pilot-readiness-summary, --bounded-pilot-closeout-status-summary, "
             "--bounded-pilot-operator-overview, --bounded-pilot-gate-index, "
             "--bounded-pilot-first-live-frontdoor, --bounded-pilot-lifecycle-consistency, "
-            "or --session-review-pack"
+            "--session-review-pack, or --pre-live-package-status"
         ),
     )
     parser.add_argument(
@@ -2134,6 +2330,15 @@ Beispiele:
         ),
     )
     parser.add_argument(
+        "--pre-live-package-status",
+        action="store_true",
+        dest="pre_live_package_status",
+        help=(
+            "Read-only: Pre-Live package status gap summary (bounded_pilot registry + closeout posture; "
+            "use with --json; v0 excludes readiness/preflight/cockpit evaluation)"
+        ),
+    )
+    parser.add_argument(
         "--config-path",
         type=str,
         default=None,
@@ -2168,6 +2373,7 @@ Beispiele:
         + int(bool(args.evidence_pointers))
         + int(bool(args.open_sessions))
         + int(bool(args.session_review_pack))
+        + int(bool(args.pre_live_package_status))
     )
     if _mode_n > 1:
         print(
@@ -2175,10 +2381,18 @@ Beispiele:
             "--bounded-pilot-closeout-status-summary, --bounded-pilot-operator-overview, "
             "--bounded-pilot-gate-index, --bounded-pilot-first-live-frontdoor, "
             "--bounded-pilot-lifecycle-consistency, "
-            "--evidence-pointers, --open-sessions, --session-review-pack",
+            "--evidence-pointers, --open-sessions, --session-review-pack, "
+            "--pre-live-package-status",
             file=sys.stderr,
         )
         return 2
+
+    if args.pre_live_package_status:
+        conflict = _pre_live_package_status_flag_conflicts(args)
+        if conflict is not None:
+            print(f"ERR: {conflict}", file=sys.stderr)
+            return 2
+        return _run_pre_live_package_status(args, logger)
 
     if args.session_review_pack:
         conflict = _session_review_pack_flag_conflicts(args)

--- a/tests/ops/test_report_live_sessions_pre_live_package_status_v0.py
+++ b/tests/ops/test_report_live_sessions_pre_live_package_status_v0.py
@@ -1,20 +1,29 @@
-"""Characterization tests for a future pre-live package status report mode.
+"""Tests for Pre-Live package status report (`--pre-live-package-status --json`).
 
-These tests describe the desired read-only `report_live_sessions.py`
-`--pre-live-package-status --json` surface without implementing or invoking a
-production mode. They do not read real registries, generated reports, or
-artifact directories.
+Synthetic helpers pin intended semantics for `pre_live_package_status_v0`. Integration tests
+invoke `scripts.report_live_sessions.main()` with `--registry-base` pointing at isolated
+directories under ``tmp_path`` (no commits to repo registries).
+
+These tests do not read real production artifact trees in the workspace when running under
+their own ``tmp_path`` registry overlays.
 """
 
 from __future__ import annotations
 
 import json
+import sys
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Literal
+from unittest.mock import patch
+
+import pytest
+
+from src.experiments.live_session_registry import LiveSessionRecord, register_live_session_run  # noqa: E402
 
 
 CONTRACT = "pre_live_package_status_v0"
-FUTURE_FLAG = "--pre-live-package-status"
+CLI_FLAG = "--pre-live-package-status"
 
 AUTHORITY_FLAGS = {
     "live_authorization": False,
@@ -73,7 +82,7 @@ def build_future_pre_live_package_status_report(
     return {
         "contract": CONTRACT,
         "mode": "pre_live_package_status",
-        "future_flag": FUTURE_FLAG,
+        "future_flag": CLI_FLAG,
         "json_only": True,
         "stdout_only": True,
         "non_authorizing": True,
@@ -98,7 +107,7 @@ def test_future_contract_and_flag_are_explicit() -> None:
 
     assert payload["contract"] == CONTRACT
     assert payload["mode"] == "pre_live_package_status"
-    assert payload["future_flag"] == FUTURE_FLAG
+    assert payload["future_flag"] == CLI_FLAG
     assert payload["json_only"] is True
     assert payload["stdout_only"] is True
     assert_non_authorizing(payload)
@@ -193,10 +202,128 @@ def test_serialized_report_contains_no_unqualified_authority_claims() -> None:
             assert claim not in serialized
 
 
-def test_production_report_live_sessions_parser_does_not_expose_future_flag_yet() -> None:
+def test_production_parser_exposes_pre_live_package_status_flag_in_source() -> None:
     source = Path("scripts/report_live_sessions.py").read_text(encoding="utf-8")
 
-    assert FUTURE_FLAG not in source
+    assert CLI_FLAG in source
+    assert 'dest="pre_live_package_status"' in source
+
+
+def test_pre_live_package_status_requires_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    reg = tmp_path.joinpath("reports", "experiments", "live_sessions")
+    reg.mkdir(parents=True)
+    from scripts.report_live_sessions import main
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "report_live_sessions.py",
+            CLI_FLAG,
+            "--registry-base",
+            str(reg),
+            "--log-level",
+            "ERROR",
+        ],
+    ):
+        assert main() == 2
+
+
+def test_pre_live_package_status_empty_registry_read_only_stdout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No bounded rows: closeout classify → NO_BOUNDED_PILOT; status external-review semantics."""
+    monkeypatch.chdir(tmp_path)
+    reg = tmp_path.joinpath("reports", "experiments", "live_sessions")
+    reg.mkdir(parents=True)
+    from scripts.report_live_sessions import main
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "report_live_sessions.py",
+            CLI_FLAG,
+            "--json",
+            "--registry-base",
+            str(reg),
+            "--log-level",
+            "ERROR",
+        ],
+    ):
+        assert main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["contract"] == CONTRACT
+    assert payload["non_authorizing"] is True
+    assert payload["authority_boundary"] == AUTHORITY_FLAGS
+    assert payload["json_only"] is True
+    assert payload["stdout_only"] is True
+    assert payload["open_bounded_pilot_sessions"] == 0
+    assert payload["status"] == "READY_FOR_EXTERNAL_REVIEW"
+    low = json.dumps(payload, sort_keys=True).lower()
+    assert "live authorization granted" not in low
+
+
+def _bp_rec_started(session_id: str, *, started: datetime | None = None) -> LiveSessionRecord:
+    t0 = started or datetime(2026, 3, 19, 12, 0, 0)
+    return LiveSessionRecord(
+        session_id=session_id,
+        run_id="run_v0",
+        run_type="live_session_live",
+        mode="bounded_pilot",
+        env_name="pilot_env",
+        symbol="BTC/USDT",
+        status="started",
+        started_at=t0,
+        finished_at=None,
+        config={},
+        metrics={},
+        cli_args=[],
+    )
+
+
+def test_pre_live_package_status_blocked_with_open_bounded_pilot_sessions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    reg = tmp_path.joinpath("reports", "experiments", "live_sessions")
+    reg.mkdir(parents=True)
+    t0 = datetime(2026, 3, 19, 15, 14, 0)
+    register_live_session_run(_bp_rec_started("bp_open_one", started=t0), base_dir=reg)
+    register_live_session_run(
+        _bp_rec_started("bp_open_two", started=t0 + timedelta(minutes=1)), base_dir=reg
+    )
+
+    from scripts.report_live_sessions import main
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "report_live_sessions.py",
+            CLI_FLAG,
+            "--json",
+            "--registry-base",
+            str(reg),
+            "--log-level",
+            "ERROR",
+        ],
+    ):
+        assert main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "BLOCKED"
+    assert payload["open_bounded_pilot_sessions"] == 2
+    assert "GLB-018" in payload["blockers"]
+    assert "bounded_pilot.open_sessions_present" in payload["missing_or_open_items"]
 
 
 def test_this_characterization_test_does_not_read_real_artifact_locations() -> None:
@@ -205,7 +332,6 @@ def test_this_characterization_test_does_not_read_real_artifact_locations() -> N
         "/".join(["reports", "experiments", "live_sessions"]),
         "/".join(["out", "ops"]),
         "/".join(["execution_events", "sessions"]),
-        "_".join(["live", "session", "registry"]),
     ]
 
     for fragment in forbidden_fragments:


### PR DESCRIPTION
## Summary

- Add read-only `scripts/report_live_sessions.py --pre-live-package-status --json` mode.
- Emit `pre_live_package_status_v0` JSON to stdout without writing summary files or mutating registry / artifacts.
- Reuse bounded-pilot session focus and closeout analysis surfaces while avoiding readiness/preflight/cockpit checks in this first slice.
- Preserve `non_authorizing: true`, false authority flags, blocker/missing-item reporting, and no live-ready / approval claim.

## Validation

- `uv run pytest tests/ops/test_report_live_sessions_pre_live_package_status_v0.py tests/ops/test_pre_live_package_status_read_model_v0.py -q` — 21 passed
- `uv run pytest tests/ops/test_report_live_sessions_open_sessions.py tests/ops/test_report_live_sessions_lifecycle_consistency.py tests/ops/test_report_live_sessions_pre_live_package_status_v0.py -q` — 31 passed
- `uv run ruff check scripts/report_live_sessions.py tests/ops/test_report_live_sessions_pre_live_package_status_v0.py` — passed
- `uv run ruff format --check scripts/report_live_sessions.py tests/ops/test_report_live_sessions_pre_live_package_status_v0.py` — passed

## Safety / Authority

- Read-only report mode only.
- No workflows, configs, registry JSONs, `out/ops` artifacts, generated artifacts, paper/test data, historical run artifacts, Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gates, dashboard/AI/strategy authority, or live/testnet behavior changes.
- No readiness/preflight/cockpit execution in this slice.
- No live authorization, bounded-pilot approval, closeout approval, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
