### PR TITLE
feat(ops): add glb018 decision packet validator cli v0

### DIFF
--- a/scripts/ops/validate_glb018_operator_decision_packet.py
+++ b/scripts/ops/validate_glb018_operator_decision_packet.py
@@ -1,0 +1,150 @@
+"""Validate a local GLB-018 operator decision packet.
+
+This CLI is read-only. It validates an explicitly supplied JSON file and emits a
+non-authorizing validation payload. It does not read registries, read artifacts,
+mutate files, close sessions, or authorize live trading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+VALIDATOR_CONTRACT = "glb018_decision_packet_validator_v0"
+INPUT_CONTRACT = "operator_glb018_decision_packet_v0"
+
+ALLOWED_DECISIONS = {
+    "review_with_events",
+    "evidence_missing_review",
+    "defer_by_authority",
+    "closeout_path_required",
+    "stop",
+}
+
+EXPECTED_DECISION_COUNTS = {
+    "closeout_path_required": 2,
+    "evidence_missing_review": 3,
+}
+
+AUTHORITY_FLAGS = {
+    "live_authorization": False,
+    "bounded_pilot_approval": False,
+    "closeout_approval": False,
+    "gate_passage": False,
+    "strategy_readiness": False,
+    "autonomy_readiness": False,
+    "external_authority_completion": False,
+}
+
+
+def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if packet.get("contract") != INPUT_CONTRACT:
+        errors.append("invalid_input_contract")
+
+    if packet.get("non_authorizing") is not True:
+        errors.append("non_authorizing_required")
+
+    if packet.get("authority_boundary") != AUTHORITY_FLAGS:
+        errors.append("authority_boundary_must_be_all_false")
+
+    rows = packet.get("session_decisions")
+    if not isinstance(rows, list):
+        rows = []
+        errors.append("session_decisions_must_be_list")
+
+    if len(rows) != 5:
+        errors.append("expected_exactly_5_session_decisions")
+
+    seen: set[str] = set()
+    actual_counts: dict[str, int] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            errors.append("session_decision_row_must_be_object")
+            continue
+
+        session_id = row.get("session_id")
+        decision = row.get("operator_decision")
+
+        if not session_id:
+            errors.append("missing_session_id")
+        elif session_id in seen:
+            errors.append("duplicate_session_id")
+        else:
+            seen.add(session_id)
+
+        if decision not in ALLOWED_DECISIONS:
+            errors.append("invalid_operator_decision")
+        else:
+            actual_counts[decision] = actual_counts.get(decision, 0) + 1
+
+    if actual_counts != EXPECTED_DECISION_COUNTS:
+        errors.append("unexpected_decision_counts")
+
+    if packet.get("decision_counts") != EXPECTED_DECISION_COUNTS:
+        errors.append("reported_decision_counts_mismatch")
+
+    return {
+        "contract": VALIDATOR_CONTRACT,
+        "input_contract": packet.get("contract"),
+        "ok": not errors,
+        "errors": sorted(set(errors)),
+        "warnings": warnings,
+        "non_authorizing": True,
+        "authority_boundary": dict(AUTHORITY_FLAGS),
+    }
+
+
+def load_packet(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        packet = json.load(fh)
+    if not isinstance(packet, dict):
+        raise ValueError("packet JSON root must be an object")
+    return packet
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a local GLB-018 operator decision packet."
+    )
+    parser.add_argument(
+        "--packet",
+        required=True,
+        type=Path,
+        help="Path to operator_glb018_decision_packet_v0 JSON.",
+    )
+    parser.add_argument("--json", action="store_true", required=True, help="Emit JSON to stdout.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        packet = load_packet(args.packet)
+    except Exception as exc:
+        result = {
+            "contract": VALIDATOR_CONTRACT,
+            "input_contract": None,
+            "ok": False,
+            "errors": ["packet_read_or_parse_failed"],
+            "warnings": [f"{type(exc).__name__}: {exc}"],
+            "non_authorizing": True,
+            "authority_boundary": dict(AUTHORITY_FLAGS),
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 2
+
+    result = validate_packet(packet)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_glb018_decision_packet_validator_cli_v0.py
+++ b/tests/ops/test_glb018_decision_packet_validator_cli_v0.py
@@ -1,0 +1,172 @@
+"""CLI tests for the GLB-018 operator decision packet validator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/ops/validate_glb018_operator_decision_packet.py")
+
+AUTHORITY_FLAGS = {
+    "live_authorization": False,
+    "bounded_pilot_approval": False,
+    "closeout_approval": False,
+    "gate_passage": False,
+    "strategy_readiness": False,
+    "autonomy_readiness": False,
+    "external_authority_completion": False,
+}
+
+
+def canonical_packet() -> dict[str, object]:
+    rows = [
+        {
+            "session_id": "session_20260319_152033_bounded_pilot_8e5f2c",
+            "operator_decision": "closeout_path_required",
+        },
+        {
+            "session_id": "session_20260319_151416_bounded_pilot_579507",
+            "operator_decision": "closeout_path_required",
+        },
+        {
+            "session_id": "session_20260318_154852_bounded_pilot_979b86",
+            "operator_decision": "evidence_missing_review",
+        },
+        {
+            "session_id": "session_20260318_122341_bounded_pilot_02c8eb",
+            "operator_decision": "evidence_missing_review",
+        },
+        {
+            "session_id": "session_20260318_122123_bounded_pilot_8c7be9",
+            "operator_decision": "evidence_missing_review",
+        },
+    ]
+    return {
+        "contract": "operator_glb018_decision_packet_v0",
+        "non_authorizing": True,
+        "session_decisions": rows,
+        "decision_counts": {
+            "closeout_path_required": 2,
+            "evidence_missing_review": 3,
+        },
+        "operator_decision_required": True,
+        "authority_boundary": dict(AUTHORITY_FLAGS),
+    }
+
+
+def write_packet(tmp_path: Path, packet: dict[str, object]) -> Path:
+    path = tmp_path / "packet.json"
+    path.write_text(json.dumps(packet, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def run_validator(packet_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--packet", str(packet_path), "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def parse_stdout(proc: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    return json.loads(proc.stdout)
+
+
+def test_valid_packet_exits_zero_and_emits_ok_json(tmp_path: Path) -> None:
+    proc = run_validator(write_packet(tmp_path, canonical_packet()))
+    payload = parse_stdout(proc)
+
+    assert proc.returncode == 0
+    assert payload["contract"] == "glb018_decision_packet_validator_v0"
+    assert payload["input_contract"] == "operator_glb018_decision_packet_v0"
+    assert payload["ok"] is True
+    assert payload["errors"] == []
+    assert payload["non_authorizing"] is True
+    assert payload["authority_boundary"] == AUTHORITY_FLAGS
+
+
+def test_invalid_decision_exits_one(tmp_path: Path) -> None:
+    packet = canonical_packet()
+    rows = packet["session_decisions"]
+    assert isinstance(rows, list)
+    rows[0]["operator_decision"] = "approve_live"
+
+    proc = run_validator(write_packet(tmp_path, packet))
+    payload = parse_stdout(proc)
+
+    assert proc.returncode == 1
+    assert payload["ok"] is False
+    assert "invalid_operator_decision" in payload["errors"]
+
+
+def test_malformed_json_exits_two(tmp_path: Path) -> None:
+    path = tmp_path / "packet.json"
+    path.write_text("{not-json", encoding="utf-8")
+
+    proc = run_validator(path)
+    payload = parse_stdout(proc)
+
+    assert proc.returncode == 2
+    assert payload["ok"] is False
+    assert payload["errors"] == ["packet_read_or_parse_failed"]
+    assert payload["non_authorizing"] is True
+    assert payload["authority_boundary"] == AUTHORITY_FLAGS
+
+
+def test_missing_packet_exits_two(tmp_path: Path) -> None:
+    proc = run_validator(tmp_path / "missing.json")
+    payload = parse_stdout(proc)
+
+    assert proc.returncode == 2
+    assert payload["ok"] is False
+    assert payload["errors"] == ["packet_read_or_parse_failed"]
+    assert payload["non_authorizing"] is True
+
+
+def test_true_authority_flag_exits_one(tmp_path: Path) -> None:
+    packet = canonical_packet()
+    packet["authority_boundary"] = {**AUTHORITY_FLAGS, "live_authorization": True}
+
+    proc = run_validator(write_packet(tmp_path, packet))
+    payload = parse_stdout(proc)
+
+    assert proc.returncode == 1
+    assert "authority_boundary_must_be_all_false" in payload["errors"]
+
+
+def test_output_contains_no_unqualified_authority_claims(tmp_path: Path) -> None:
+    proc = run_validator(write_packet(tmp_path, canonical_packet()))
+    serialized = proc.stdout.lower()
+
+    forbidden_claims = [
+        "live authorization granted",
+        "bounded pilot approved",
+        "closeout approved",
+        "signoff complete",
+        "gate passed",
+        "strategy ready",
+        "autonomy ready",
+        "externally authorized",
+        "approved for live",
+        "trade approved",
+    ]
+
+    for claim in forbidden_claims:
+        assert claim not in serialized
+
+
+def test_this_cli_test_does_not_read_real_artifact_locations() -> None:
+    source_text = Path(__file__).read_text(encoding="utf-8")
+    forbidden_fragments = [
+        "/".join(["reports", "experiments", "live_sessions"]),
+        "/".join(["out", "ops"]),
+        "/".join(["execution_events", "sessions"]),
+        "_".join(["live", "session", "registry"]),
+    ]
+
+    for fragment in forbidden_fragments:
+        assert fragment not in source_text


### PR DESCRIPTION
## Summary

- Add read-only `scripts/ops/validate_glb018_operator_decision_packet.py` validator CLI.
- Validate an explicit local `operator_glb018_decision_packet_v0` JSON path and emit `glb018_decision_packet_validator_v0` JSON to stdout.
- Preserve fail-closed exit codes: `0` valid, `1` validation errors, `2` unreadable/invalid input.
- Validate contract, `non_authorizing`, false authority flags, exactly 5 session decisions, no duplicate session IDs, allowed decisions only, and expected 2/3 decision counts.

## Validation

- `uv run pytest tests/ops/test_glb018_decision_packet_validator_cli_v0.py tests/ops/test_glb018_decision_packet_validator_contract_v0.py -q` — 19 passed
- `uv run ruff check scripts/ops/validate_glb018_operator_decision_packet.py tests/ops/test_glb018_decision_packet_validator_cli_v0.py` — passed
- `uv run ruff format --check scripts/ops/validate_glb018_operator_decision_packet.py tests/ops/test_glb018_decision_packet_validator_cli_v0.py` — passed
- `uv run python scripts/ops/validate_glb018_operator_decision_packet.py --packet /tmp/peak_trade_glb018_decision_matrix_draft_v0/GLB018_OPERATOR_DECISION_PACKET_V0.json --json` — returned `ok: true`

## Safety / Authority

- Read-only validator only.
- No workflows, configs, registry JSONs, `out/ops` artifacts, generated artifacts, paper/test data, historical run artifacts, Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gates, dashboard/AI/strategy authority, or live/testnet behavior changes.
- No session closeout, live authorization, bounded-pilot approval, closeout approval, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, or gate-pass claim.
