### PR TITLE
feat(ops): add paper testnet readiness status report v0

### DIFF
--- a/scripts/ops/report_paper_testnet_readiness_status.py
+++ b/scripts/ops/report_paper_testnet_readiness_status.py
@@ -1,0 +1,122 @@
+"""Emit a read-only Paper/Testnet readiness status report.
+
+This CLI is intentionally conservative: unless explicit evidence flags are
+provided, the report remains BLOCKED. It does not read or mutate paper/testnet
+artifacts, registries, out/ops data, execution state, or live state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Literal
+
+
+CONTRACT = "paper_testnet_readiness_status_v0"
+
+Status = Literal["BLOCKED", "READY_FOR_REVIEW", "REVIEW_ONLY"]
+
+AUTHORITY_FLAGS = {
+    "live_authorization": False,
+    "bounded_pilot_approval": False,
+    "closeout_approval": False,
+    "gate_passage": False,
+    "strategy_readiness": False,
+    "autonomy_readiness": False,
+    "external_authority_completion": False,
+}
+
+
+def build_status(
+    *,
+    paper_evidence_present: bool,
+    paper_robustness_present: bool,
+    paper_stress_present: bool,
+    testnet_evidence_present: bool,
+    testnet_robustness_present: bool,
+    testnet_stress_present: bool,
+    external_review_decision_present: bool,
+) -> dict[str, Any]:
+    blockers: list[str] = []
+    missing_or_open_items: list[str] = []
+
+    if not paper_evidence_present:
+        blockers.append("paper.evidence_missing")
+        missing_or_open_items.append("paper.evidence_missing")
+    if not paper_robustness_present:
+        blockers.append("paper.robustness_missing")
+        missing_or_open_items.append("paper.robustness_missing")
+    if not paper_stress_present:
+        blockers.append("paper.stress_missing")
+        missing_or_open_items.append("paper.stress_missing")
+
+    if not testnet_evidence_present:
+        blockers.append("testnet.evidence_missing")
+        missing_or_open_items.append("testnet.evidence_missing")
+    if not testnet_robustness_present:
+        blockers.append("testnet.robustness_missing")
+        missing_or_open_items.append("testnet.robustness_missing")
+    if not testnet_stress_present:
+        blockers.append("testnet.stress_missing")
+        missing_or_open_items.append("testnet.stress_missing")
+
+    if blockers:
+        status: Status = "BLOCKED"
+    elif not external_review_decision_present:
+        status = "READY_FOR_REVIEW"
+    else:
+        status = "REVIEW_ONLY"
+
+    return {
+        "contract": CONTRACT,
+        "non_authorizing": True,
+        "status": status,
+        "paper": {
+            "evidence_present": paper_evidence_present,
+            "robustness_present": paper_robustness_present,
+            "stress_present": paper_stress_present,
+        },
+        "testnet": {
+            "evidence_present": testnet_evidence_present,
+            "robustness_present": testnet_robustness_present,
+            "stress_present": testnet_stress_present,
+        },
+        "blockers": sorted(set(blockers)),
+        "missing_or_open_items": sorted(set(missing_or_open_items)),
+        "external_review_decision_present": external_review_decision_present,
+        "authority_boundary": dict(AUTHORITY_FLAGS),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Emit read-only Paper/Testnet readiness status JSON."
+    )
+    parser.add_argument("--json", action="store_true", required=True, help="Emit JSON to stdout.")
+    parser.add_argument("--paper-evidence-present", action="store_true")
+    parser.add_argument("--paper-robustness-present", action="store_true")
+    parser.add_argument("--paper-stress-present", action="store_true")
+    parser.add_argument("--testnet-evidence-present", action="store_true")
+    parser.add_argument("--testnet-robustness-present", action="store_true")
+    parser.add_argument("--testnet-stress-present", action="store_true")
+    parser.add_argument("--external-review-decision-present", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_status(
+        paper_evidence_present=args.paper_evidence_present,
+        paper_robustness_present=args.paper_robustness_present,
+        paper_stress_present=args.paper_stress_present,
+        testnet_evidence_present=args.testnet_evidence_present,
+        testnet_robustness_present=args.testnet_robustness_present,
+        testnet_stress_present=args.testnet_stress_present,
+        external_review_decision_present=args.external_review_decision_present,
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
+++ b/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
@@ -1,0 +1,162 @@
+"""CLI tests for the Paper/Testnet readiness status report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+SCRIPT = Path("scripts/ops/report_paper_testnet_readiness_status.py")
+
+AUTHORITY_FLAGS = {
+    "live_authorization": False,
+    "bounded_pilot_approval": False,
+    "closeout_approval": False,
+    "gate_passage": False,
+    "strategy_readiness": False,
+    "autonomy_readiness": False,
+    "external_authority_completion": False,
+}
+
+
+def run_report(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def parse_payload(proc: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    return json.loads(proc.stdout)
+
+
+def assert_non_authorizing(payload: dict[str, object]) -> None:
+    assert payload["non_authorizing"] is True
+    assert payload["authority_boundary"] == AUTHORITY_FLAGS
+
+
+def test_default_invocation_is_blocked_with_missing_paper_and_testnet_items() -> None:
+    proc = run_report()
+    payload = parse_payload(proc)
+
+    assert proc.returncode == 0
+    assert payload["contract"] == "paper_testnet_readiness_status_v0"
+    assert payload["status"] == "BLOCKED"
+    assert payload["blockers"] == [
+        "paper.evidence_missing",
+        "paper.robustness_missing",
+        "paper.stress_missing",
+        "testnet.evidence_missing",
+        "testnet.robustness_missing",
+        "testnet.stress_missing",
+    ]
+    assert_non_authorizing(payload)
+
+
+def test_complete_paper_only_still_blocks_on_testnet() -> None:
+    proc = run_report(
+        "--paper-evidence-present",
+        "--paper-robustness-present",
+        "--paper-stress-present",
+    )
+    payload = parse_payload(proc)
+
+    assert payload["status"] == "BLOCKED"
+    assert payload["paper"] == {
+        "evidence_present": True,
+        "robustness_present": True,
+        "stress_present": True,
+    }
+    assert payload["testnet"] == {
+        "evidence_present": False,
+        "robustness_present": False,
+        "stress_present": False,
+    }
+    assert payload["blockers"] == [
+        "testnet.evidence_missing",
+        "testnet.robustness_missing",
+        "testnet.stress_missing",
+    ]
+    assert_non_authorizing(payload)
+
+
+def test_complete_paper_and_testnet_without_external_decision_is_ready_for_review() -> None:
+    proc = run_report(
+        "--paper-evidence-present",
+        "--paper-robustness-present",
+        "--paper-stress-present",
+        "--testnet-evidence-present",
+        "--testnet-robustness-present",
+        "--testnet-stress-present",
+    )
+    payload = parse_payload(proc)
+
+    assert payload["status"] == "READY_FOR_REVIEW"
+    assert payload["blockers"] == []
+    assert payload["missing_or_open_items"] == []
+    assert payload["external_review_decision_present"] is False
+    assert_non_authorizing(payload)
+
+
+def test_complete_paper_and_testnet_with_external_decision_is_review_only() -> None:
+    proc = run_report(
+        "--paper-evidence-present",
+        "--paper-robustness-present",
+        "--paper-stress-present",
+        "--testnet-evidence-present",
+        "--testnet-robustness-present",
+        "--testnet-stress-present",
+        "--external-review-decision-present",
+    )
+    payload = parse_payload(proc)
+
+    assert payload["status"] == "REVIEW_ONLY"
+    assert payload["external_review_decision_present"] is True
+    assert_non_authorizing(payload)
+
+
+def test_output_contains_no_unqualified_authority_claims() -> None:
+    proc = run_report(
+        "--paper-evidence-present",
+        "--paper-robustness-present",
+        "--paper-stress-present",
+        "--testnet-evidence-present",
+        "--testnet-robustness-present",
+        "--testnet-stress-present",
+        "--external-review-decision-present",
+    )
+
+    forbidden_claims = [
+        "live authorization granted",
+        "bounded pilot approved",
+        "closeout approved",
+        "signoff complete",
+        "gate passed",
+        "strategy ready",
+        "autonomy ready",
+        "externally authorized",
+        "approved for live",
+        "trade approved",
+        "live ready",
+    ]
+
+    serialized = proc.stdout.lower()
+    for claim in forbidden_claims:
+        assert claim not in serialized
+
+
+def test_this_cli_test_does_not_read_real_artifact_locations() -> None:
+    source_text = Path(__file__).read_text(encoding="utf-8")
+    forbidden_fragments = [
+        "/".join(["reports", "experiments", "live_sessions"]),
+        "/".join(["out", "ops"]),
+        "/".join(["execution_events", "sessions"]),
+        "_".join(["paper", "testnet", "artifact"]),
+    ]
+
+    for fragment in forbidden_fragments:
+        assert fragment not in source_text


### PR DESCRIPTION
## Summary

- Add read-only `scripts/ops/report_paper_testnet_readiness_status.py --json` CLI.
- Emit `paper_testnet_readiness_status_v0` JSON with separate Paper and Testnet evidence sections.
- Default conservatively to `BLOCKED` unless explicit Paper/Testnet evidence, robustness, and stress flags are supplied.
- Preserve `non_authorizing: true`, false authority flags, and no live-ready / approval / gate-pass claims.

## Validation

- `uv run pytest tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py tests/ops/test_paper_testnet_readiness_status_contract_v0.py -q` — 15 passed
- `uv run pytest tests/ops/test_paper_testnet_readiness_gap_map_v0.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py -q` — 15 passed
- `uv run ruff check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py` — passed
- `uv run ruff format --check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py` — passed
- `uv run python scripts/ops/report_paper_testnet_readiness_status.py --json` — returns conservative `BLOCKED` with missing Paper/Testnet evidence flags

## Safety / Authority

- Read-only status report only.
- No workflows, configs, registry JSONs, `out/ops` artifacts, generated artifacts, paper/testnet/live data, historical run artifacts, Master V2 / Double Play, Risk/KillSwitch, Execution/Live Gates, dashboard/AI/strategy authority, GLB-018 decision materials, or live/testnet behavior changes.
- No live authorization, bounded-pilot approval, closeout approval, signoff-complete, strategy-ready, autonomous-ready, externally-authorized, live-ready, or gate-pass claim.
