### PR TITLE
feat(experiments): add MC robustness dummy fallback v0

### DIFF
--- a/scripts/run_monte_carlo_robustness.py
+++ b/scripts/run_monte_carlo_robustness.py
@@ -60,6 +60,11 @@ from src.experiments.topn_promotion import load_top_n_configs_for_sweep
 from src.reporting.monte_carlo_report import build_monte_carlo_report
 
 
+def _dummy_top_configs(top_n: int) -> list[dict]:
+    """Minimal synthetic Top-N rows for offline/dummy smoke (parity with run_stress_tests.py)."""
+    return [{"config_id": f"dummy_config_{i + 1}", "rank": i + 1} for i in range(top_n)]
+
+
 def setup_logging(verbose: bool = False) -> None:
     """Konfiguriert Logging."""
     level = logging.DEBUG if verbose else logging.INFO
@@ -234,7 +239,7 @@ def run_from_args(args: argparse.Namespace) -> int:
     """
     logger = logging.getLogger(__name__)
 
-    # 1. Lade Top-N-Konfigurationen
+    # 1. Lade Top-N-Konfigurationen (optional Dummy-Fallback wie run_stress_tests.py)
     logger.info(f"Lade Top-{args.top_n} Konfigurationen für Sweep '{args.sweep_name}'")
     try:
         configs = load_top_n_configs_for_sweep(
@@ -245,11 +250,19 @@ def run_from_args(args: argparse.Namespace) -> int:
         )
     except Exception as e:
         logger.error(f"Fehler beim Laden der Top-N-Konfigurationen: {e}")
-        return 1
+        if args.use_dummy_data:
+            logger.info("Erstelle Dummy-Konfigurationen für Tests...")
+            configs = _dummy_top_configs(args.top_n)
+        else:
+            return 1
 
     if not configs:
-        logger.error(f"Keine Konfigurationen gefunden für Sweep '{args.sweep_name}'")
-        return 1
+        if args.use_dummy_data:
+            logger.info("Erstelle Dummy-Konfigurationen für Tests...")
+            configs = _dummy_top_configs(args.top_n)
+        else:
+            logger.error(f"Keine Konfigurationen gefunden für Sweep '{args.sweep_name}'")
+            return 1
 
     logger.info(f"{len(configs)} Konfigurationen geladen")
 

--- a/tests/test_run_monte_carlo_robustness_cli_dummy_fallback_v0.py
+++ b/tests/test_run_monte_carlo_robustness_cli_dummy_fallback_v0.py
@@ -1,0 +1,138 @@
+"""
+CLI: Dummy-Top-N-Fallback für offline Smoke (parity mit run_stress_tests.py).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import scripts.run_monte_carlo_robustness as mc_script
+
+
+@patch("scripts.run_monte_carlo_robustness.load_top_n_configs_for_sweep")
+def test_mc_dummy_fallback_loader_raises_writes_md(mock_load, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    mock_load.side_effect = RuntimeError("no sweep results")
+
+    out = tmp_path / "mc_out"
+    args = mc_script.build_parser().parse_args(
+        [
+            "--sweep-name",
+            "smoke",
+            "--top-n",
+            "1",
+            "--num-runs",
+            "20",
+            "--format",
+            "md",
+            "--output-dir",
+            str(out),
+            "--use-dummy-data",
+            "--dummy-bars",
+            "80",
+        ]
+    )
+
+    rc = mc_script.run_from_args(args)
+    assert rc == 0
+    md_files = list(out.rglob("*.md"))
+    assert md_files, "expected at least one markdown report under output-dir"
+
+
+@patch("scripts.run_monte_carlo_robustness.load_top_n_configs_for_sweep")
+def test_mc_no_dummy_loader_raises_exits_nonzero(mock_load, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    mock_load.side_effect = RuntimeError("no sweep results")
+
+    args = mc_script.build_parser().parse_args(
+        [
+            "--sweep-name",
+            "smoke",
+            "--top-n",
+            "1",
+            "--num-runs",
+            "20",
+            "--format",
+            "md",
+            "--output-dir",
+            str(tmp_path / "mc_out"),
+            "--dummy-bars",
+            "80",
+        ]
+    )
+
+    rc = mc_script.run_from_args(args)
+    assert rc == 1
+
+
+@patch("scripts.run_monte_carlo_robustness.load_top_n_configs_for_sweep")
+def test_mc_dummy_fallback_empty_configs(mock_load, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    mock_load.return_value = []
+
+    out = tmp_path / "mc_empty"
+    args = mc_script.build_parser().parse_args(
+        [
+            "--sweep-name",
+            "smoke",
+            "--top-n",
+            "2",
+            "--num-runs",
+            "15",
+            "--format",
+            "md",
+            "--output-dir",
+            str(out),
+            "--use-dummy-data",
+            "--dummy-bars",
+            "60",
+        ]
+    )
+
+    rc = mc_script.run_from_args(args)
+    assert rc == 0
+    dirs = [p for p in out.iterdir() if p.is_dir()]
+    assert {d.name for d in dirs} >= {"dummy_config_1", "dummy_config_2"}
+
+
+def test_mc_dummy_fallback_no_writes_under_repo_reports(tmp_path, monkeypatch):
+    """Outputs only under tmp_path (caller-provided output-dir); repo reports/ untouched."""
+    marker = project_root / "reports" / "monte_carlo"
+    before = set(marker.rglob("*")) if marker.exists() else set()
+
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / "only_here"
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("no experiments")
+
+    with patch.object(mc_script, "load_top_n_configs_for_sweep", side_effect=_boom):
+        args = mc_script.build_parser().parse_args(
+            [
+                "--sweep-name",
+                "smoke",
+                "--top-n",
+                "1",
+                "--num-runs",
+                "10",
+                "--format",
+                "md",
+                "--output-dir",
+                str(out),
+                "--use-dummy-data",
+                "--dummy-bars",
+                "40",
+            ]
+        )
+        rc = mc_script.run_from_args(args)
+    assert rc == 0
+    assert out.exists()
+    assert list(out.rglob("*.md"))
+
+    after = set(marker.rglob("*")) if marker.exists() else set()
+    assert before == after


### PR DESCRIPTION
## Summary
- add a dummy Top-N config fallback to scripts/run_monte_carlo_robustness.py when --use-dummy-data is set
- preserve fail-closed behavior when --use-dummy-data is not set
- add focused CLI tests for loader exception, empty Top-N list, and no writes under repo reports/

## Safety
- offline/dummy-data only fallback
- no Live authorization
- no strategy logic change
- no Master V2 / Double Play change
- no Risk/KillSwitch change
- no Execution/Gate change
- no registry or out/ops mutation
- no new evidence/readiness/map/handoff surface

## Validation
- uv run pytest tests/test_monte_carlo_robustness.py tests/test_run_monte_carlo_robustness_cli_dummy_fallback_v0.py -q
- uv run pytest tests -q -k "monte_carlo or robustness or stress"
- uv run ruff check scripts/run_monte_carlo_robustness.py tests/test_run_monte_carlo_robustness_cli_dummy_fallback_v0.py
- uv run ruff format --check scripts/run_monte_carlo_robustness.py tests/test_run_monte_carlo_robustness_cli_dummy_fallback_v0.py
- /tmp smoke produced: /tmp/peak_trade_mc_dummy_fallback_smoke_20260428_235341/dummy_config_1/monte_carlo_report.md

Made with [Cursor](https://cursor.com)