### PR TITLE
feat(experiments): add configurable experiments dir v0

### DIFF
--- a/scripts/run_monte_carlo_robustness.py
+++ b/scripts/run_monte_carlo_robustness.py
@@ -216,6 +216,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Anzahl Bars für Dummy-Daten (default: 500)",
     )
 
+    parser.add_argument(
+        "--experiments-dir",
+        type=str,
+        default="reports/experiments",
+        help="Basisverzeichnis für Sweep-/Experiment-Artefakte (default: reports/experiments)",
+    )
+    parser.add_argument(
+        "--sweeps-output-dir",
+        type=str,
+        default="reports/sweeps",
+        help="Verzeichnis für Top-N-TOML-/Sweep-Metadaten (default: reports/sweeps)",
+    )
+
     # Weitere Optionen
     parser.add_argument(
         "--verbose",
@@ -239,14 +252,17 @@ def run_from_args(args: argparse.Namespace) -> int:
     """
     logger = logging.getLogger(__name__)
 
+    experiments_dir = Path(args.experiments_dir)
+    sweeps_output_dir = Path(args.sweeps_output_dir)
+
     # 1. Lade Top-N-Konfigurationen (optional Dummy-Fallback wie run_stress_tests.py)
     logger.info(f"Lade Top-{args.top_n} Konfigurationen für Sweep '{args.sweep_name}'")
     try:
         configs = load_top_n_configs_for_sweep(
             args.sweep_name,
             n=args.top_n,
-            experiments_dir=Path("reports/experiments"),
-            output_path=Path("reports/sweeps"),
+            experiments_dir=experiments_dir,
+            output_path=sweeps_output_dir,
         )
     except Exception as e:
         logger.error(f"Fehler beim Laden der Top-N-Konfigurationen: {e}")
@@ -293,7 +309,7 @@ def run_from_args(args: argparse.Namespace) -> int:
         # Lade Returns
         returns = load_returns_for_config(
             config,
-            Path("reports/experiments"),
+            experiments_dir,
             use_dummy_data=args.use_dummy_data,
             dummy_bars=args.dummy_bars,
         )

--- a/scripts/run_stress_tests.py
+++ b/scripts/run_stress_tests.py
@@ -180,6 +180,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Anzahl Bars für Dummy-Daten (default: 500)",
     )
     parser.add_argument(
+        "--experiments-dir",
+        type=str,
+        default="reports/experiments",
+        help="Basisverzeichnis für Sweep-/Experiment-Artefakte (default: reports/experiments)",
+    )
+    parser.add_argument(
+        "--sweeps-output-dir",
+        type=str,
+        default="reports/sweeps",
+        help="Verzeichnis für Top-N-TOML-/Sweep-Metadaten (default: reports/sweeps)",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -216,13 +228,15 @@ def run_from_args(args: argparse.Namespace) -> int:
 
         # 3. Lade Top-N-Konfigurationen
         logger.info(f"Lade Top-{args.top_n} Konfigurationen für Sweep '{args.sweep_name}'...")
-        experiments_dir = Path("reports/experiments")
+        experiments_dir = Path(args.experiments_dir)
+        sweeps_output_dir = Path(args.sweeps_output_dir)
 
         try:
             top_configs = load_top_n_configs_for_sweep(
                 sweep_name=args.sweep_name,
                 n=args.top_n,
                 experiments_dir=experiments_dir,
+                output_path=sweeps_output_dir,
             )
         except Exception as e:
             logger.error(f"Fehler beim Laden der Top-N-Konfigurationen: {e}")

--- a/tests/test_runner_experiments_dir_cli_v0.py
+++ b/tests/test_runner_experiments_dir_cli_v0.py
@@ -1,0 +1,111 @@
+"""
+CLI: --experiments-dir / --sweeps-output-dir für MC- und Stress-Runner.
+
+Read-only Bezugspfad-Anpassung; keine Produktions-Evidence durch diese Tests allein.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import scripts.run_monte_carlo_robustness as mc_script
+import scripts.run_stress_tests as stress_script
+
+
+def test_monte_carlo_passes_custom_experiments_and_sweeps_dirs(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    captured = {}
+
+    def _fake_loader(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["kwargs"] = kwargs
+        return [{"config_id": "only", "rank": 1}]
+
+    with patch.object(mc_script, "load_top_n_configs_for_sweep", side_effect=_fake_loader):
+        with patch.object(mc_script, "load_returns_for_config", return_value=_series()):
+            with patch.object(mc_script, "run_monte_carlo_from_returns") as mc_run:
+                with patch.object(mc_script, "build_monte_carlo_report"):
+                    mc_run.return_value = MagicMock()
+                    parser = mc_script.build_parser()
+                    args = parser.parse_args(
+                        [
+                            "--sweep-name",
+                            "smoke_sweep",
+                            "--top-n",
+                            "1",
+                            "--num-runs",
+                            "5",
+                            "--format",
+                            "md",
+                            "--experiments-dir",
+                            str(tmp_path / "exp"),
+                            "--sweeps-output-dir",
+                            str(tmp_path / "swp"),
+                            "--use-dummy-data",
+                            "--output-dir",
+                            str(tmp_path / "out"),
+                        ]
+                    )
+                    rc = mc_script.run_from_args(args)
+
+    assert rc == 0
+    assert captured["kwargs"]["experiments_dir"] == tmp_path / "exp"
+    assert captured["kwargs"]["output_path"] == tmp_path / "swp"
+
+
+def test_stress_passes_custom_experiments_and_sweeps_dirs(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    captured = {}
+
+    def _fake_loader(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["kwargs"] = kwargs
+        return [{"config_id": "only", "rank": 1}]
+
+    with patch.object(stress_script, "load_top_n_configs_for_sweep", side_effect=_fake_loader):
+        with patch.object(stress_script, "load_returns_for_top_config") as lr:
+            lr.return_value = _series()
+            with patch.object(stress_script, "run_stress_test_suite") as suite_run:
+                with patch.object(stress_script, "build_stress_test_report") as brep:
+                    suite_run.return_value = MagicMock()
+                    brep.return_value = {}
+                    parser = stress_script.build_parser()
+                    args = parser.parse_args(
+                        [
+                            "--sweep-name",
+                            "smoke_sweep",
+                            "--config",
+                            "config/config.toml",
+                            "--top-n",
+                            "1",
+                            "--scenarios",
+                            "single_crash_bar",
+                            "--format",
+                            "md",
+                            "--experiments-dir",
+                            str(tmp_path / "exp2"),
+                            "--sweeps-output-dir",
+                            str(tmp_path / "swp2"),
+                            "--output-dir",
+                            str(tmp_path / "stre"),
+                            "--use-dummy-data",
+                        ]
+                    )
+                    rc = stress_script.run_from_args(args)
+
+    assert rc == 0
+    assert captured["kwargs"]["experiments_dir"] == tmp_path / "exp2"
+    assert captured["kwargs"]["output_path"] == tmp_path / "swp2"
+    lr_kwargs = lr.call_args[1]
+    assert lr_kwargs["experiments_dir"] == tmp_path / "exp2"
+
+
+def _series():  # type: ignore[no-untyped-def]
+    import pandas as pd
+
+    return pd.Series([0.01, -0.005, 0.002])


### PR DESCRIPTION
## Summary
- add --experiments-dir and --sweeps-output-dir to MC robustness and stress CLIs
- preserve defaults to reports/experiments and reports/sweeps
- allow /tmp fixture-based offline/dummy smokes without writing repo reports/
- add narrow CLI tests for path propagation

## Safety
- no Live authorization
- no strategy logic change
- no Master V2 / Double Play change
- no Risk/KillSwitch change
- no Execution/Gate change
- no registry or out/ops mutation
- no canonical evidence/readiness/map/handoff surface

## Validation
- uv run pytest tests/test_runner_experiments_dir_cli_v0.py tests/test_run_monte_carlo_robustness_cli_dummy_fallback_v0.py -q
- uv run ruff check scripts/run_monte_carlo_robustness.py scripts/run_stress_tests.py tests/test_runner_experiments_dir_cli_v0.py
- uv run ruff format --check scripts/run_monte_carlo_robustness.py scripts/run_stress_tests.py tests/test_runner_experiments_dir_cli_v0.py
- /tmp smoke produced:
  - /tmp/peak_trade_experiments_dir_patch_smoke_20260429_002935/mc/dummy_config_1/monte_carlo_report.md
  - /tmp/peak_trade_experiments_dir_patch_smoke_20260429_002935/stress/test_sweep/config_1/stress_test_report.md

Made with [Cursor](https://cursor.com)