### PR TITLE
feat(experiments): add ohlcv file input v0

### DIFF
--- a/scripts/run_monte_carlo_robustness.py
+++ b/scripts/run_monte_carlo_robustness.py
@@ -51,6 +51,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from src.experiments.dummy_returns_timeline import create_dummy_returns
+from src.experiments.ohlcv_returns_file import load_close_returns_from_ohlcv_parquet
 from src.experiments.monte_carlo import (
     MonteCarloConfig,
     run_monte_carlo_from_returns,
@@ -97,6 +98,7 @@ def load_returns_for_config(
     *,
     use_dummy_data: bool = False,
     dummy_bars: int = 500,
+    shared_returns: Optional[pd.Series] = None,
 ) -> Optional[pd.Series]:
     """
     Lädt Returns für eine Top-N-Konfiguration.
@@ -114,15 +116,21 @@ def load_returns_for_config(
         Aktuell ist dies eine vereinfachte Implementierung. In einer vollständigen
         Implementierung würde man die Equity-Curves aus den Backtest-Result-Objekten
         laden. Für Phase 45 verwenden wir Dummy-Daten oder Approximationen.
+        ``shared_returns`` (aus ``--ohlcv-file``) überschreibt Dummy-/Placeholder-Returns.
     """
+    logger = logging.getLogger(__name__)
+    if shared_returns is not None:
+        logger.info(
+            f"Verwende OHLCV-CLI-Returns (--ohlcv-file) für {config.get('config_id', 'unknown')}"
+        )
+        return shared_returns.copy()
+
     if use_dummy_data:
-        logger = logging.getLogger(__name__)
         logger.info(f"Verwende Dummy-Daten für Config {config.get('config_id', 'unknown')}")
         return create_dummy_returns(dummy_bars)
 
     # NOTE: Siehe docs/TECH_DEBT_BACKLOG.md (Eintrag "Vollständige Monte-Carlo-Robustness-Implementierung")
     # Aktuell: Placeholder - würde hier die Equity-Curve aus dem Experiment-Run laden
-    logger = logging.getLogger(__name__)
     logger.warning(
         f"load_returns_for_config ist noch nicht vollständig implementiert "
         f"für config_id={config.get('config_id', 'unknown')}. "
@@ -215,6 +223,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=500,
         help="Anzahl Bars für Dummy-Daten (default: 500)",
     )
+    parser.add_argument(
+        "--ohlcv-file",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Parquet OHLCV (Spalte 'close'); gemeinsame close-to-close-Returns für alle Configs "
+            "(überschreibt Dummy-Returns)."
+        ),
+    )
 
     parser.add_argument(
         "--experiments-dir",
@@ -254,6 +272,18 @@ def run_from_args(args: argparse.Namespace) -> int:
 
     experiments_dir = Path(args.experiments_dir)
     sweeps_output_dir = Path(args.sweeps_output_dir)
+
+    shared_returns = None  # OHLCV --ohlcv-file
+    if getattr(args, "ohlcv_file", None):
+        ohlcv = Path(args.ohlcv_file).expanduser()
+        if not ohlcv.is_file():
+            logger.error(f"OHLCV-Datei nicht gefunden: {ohlcv}")
+            return 1
+        try:
+            shared_returns = load_close_returns_from_ohlcv_parquet(ohlcv)
+        except Exception as e:
+            logger.error(f"Laden OHLCV/Returns fehlgeschlagen ({ohlcv}): {e}")
+            return 1
 
     # 1. Lade Top-N-Konfigurationen (optional Dummy-Fallback wie run_stress_tests.py)
     logger.info(f"Lade Top-{args.top_n} Konfigurationen für Sweep '{args.sweep_name}'")
@@ -312,6 +342,7 @@ def run_from_args(args: argparse.Namespace) -> int:
             experiments_dir,
             use_dummy_data=args.use_dummy_data,
             dummy_bars=args.dummy_bars,
+            shared_returns=shared_returns,
         )
 
         if returns is None:

--- a/scripts/run_stress_tests.py
+++ b/scripts/run_stress_tests.py
@@ -52,7 +52,7 @@ import numpy as np
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from src.experiments.dummy_returns_timeline import create_dummy_returns
+from src.experiments.ohlcv_returns_file import load_close_returns_from_ohlcv_parquet
 from src.experiments.stress_tests import (
     StressScenarioConfig,
     StressTestSuiteResult,
@@ -180,6 +180,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Anzahl Bars für Dummy-Daten (default: 500)",
     )
     parser.add_argument(
+        "--ohlcv-file",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Parquet OHLCV (Spalte 'close'); gemeinsame close-to-close-Returns für jeden Stress-Lauf "
+            "(überschreibt Dummy-Returns)."
+        ),
+    )
+    parser.add_argument(
         "--experiments-dir",
         type=str,
         default="reports/experiments",
@@ -230,6 +240,18 @@ def run_from_args(args: argparse.Namespace) -> int:
         logger.info(f"Lade Top-{args.top_n} Konfigurationen für Sweep '{args.sweep_name}'...")
         experiments_dir = Path(args.experiments_dir)
         sweeps_output_dir = Path(args.sweeps_output_dir)
+
+        shared_returns = None
+        if getattr(args, "ohlcv_file", None):
+            ohlcv = Path(args.ohlcv_file).expanduser()
+            if not ohlcv.is_file():
+                logger.error(f"OHLCV-Datei nicht gefunden: {ohlcv}")
+                return 1
+            try:
+                shared_returns = load_close_returns_from_ohlcv_parquet(ohlcv)
+            except Exception as e:
+                logger.error(f"Laden OHLCV/Returns fehlgeschlagen ({ohlcv}): {e}")
+                return 1
 
         try:
             top_configs = load_top_n_configs_for_sweep(
@@ -288,6 +310,7 @@ def run_from_args(args: argparse.Namespace) -> int:
                 experiments_dir=experiments_dir,
                 use_dummy_data=args.use_dummy_data,
                 dummy_bars=args.dummy_bars,
+                shared_returns=shared_returns,
             )
 
             if returns is None:

--- a/src/experiments/ohlcv_returns_file.py
+++ b/src/experiments/ohlcv_returns_file.py
@@ -1,0 +1,53 @@
+"""Load close-to-close returns from an OHLCV Parquet file (read-only, offline CLIs)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def load_close_returns_from_ohlcv_parquet(path: Path | str) -> pd.Series:
+    """Build simple close-to-close return series from a Parquet OHLCV artifact.
+
+    Expects column ``close``. Rows must carry a datetime index (`DatetimeIndex`) or a
+    ``timestamp`` column. Index timezone is normalized to UTC when datetime-like.
+
+    Raises:
+        FileNotFoundError: path missing
+        ValueError: empty frame, missing ``close``, or insufficient valid rows
+    """
+    p = Path(path).expanduser()
+    if not p.is_file():
+        raise FileNotFoundError(f"OHLCV parquet not found: {p}")
+
+    df = pd.read_parquet(p).sort_index()
+    if df.empty:
+        raise ValueError(f"OHLCV parquet empty: {p}")
+    if "close" not in df.columns:
+        raise ValueError(f"OHLCV parquet missing 'close' column: {p}")
+
+    if isinstance(df.index, pd.DatetimeIndex):
+        ix = pd.DatetimeIndex(df.index)
+    elif "timestamp" in df.columns:
+        ix = pd.to_datetime(df["timestamp"], utc=True, errors="raise")
+    else:
+        raise ValueError(f"OHLCV parquet must use DatetimeIndex or include 'timestamp' column: {p}")
+
+    s_close = pd.Series(pd.to_numeric(df["close"], errors="raise").to_numpy(dtype=float), index=ix)
+    if s_close.index.duplicated().any():
+        s_close = s_close[~s_close.index.duplicated(keep="last")]
+    s_close = s_close.sort_index()
+
+    if isinstance(s_close.index, pd.DatetimeIndex):
+        if s_close.index.tz is None:
+            s_close.index = s_close.index.tz_localize("UTC")
+        else:
+            s_close.index = s_close.index.tz_convert("UTC")
+
+    rets = s_close.astype(float).pct_change().dropna()
+    if len(rets) < 2:
+        raise ValueError(f"Insufficient close observations after pct_change for OHLCV: {p}")
+
+    rets.name = "returns"
+    return rets

--- a/src/experiments/stress_tests.py
+++ b/src/experiments/stress_tests.py
@@ -364,6 +364,7 @@ def load_returns_for_top_config(
     *,
     use_dummy_data: bool = False,
     dummy_bars: int = 500,
+    shared_returns: Optional[pd.Series] = None,
 ) -> pd.Series:
     """
     Lädt Returns für eine Top-N-Konfiguration aus einem Sweep.
@@ -374,6 +375,7 @@ def load_returns_for_top_config(
         experiments_dir: Verzeichnis mit Experiment-Ergebnissen
         use_dummy_data: Wenn True, werden Dummy-Daten verwendet
         dummy_bars: Anzahl Bars für Dummy-Daten
+        shared_returns: Optional preloaded returns (CLI ``--ohlcv-file``), overrides Dummy
 
     Returns:
         Returns-Serie oder None
@@ -383,6 +385,10 @@ def load_returns_for_top_config(
         Implementierung würde man die Equity-Curves aus den Backtest-Result-Objekten
         laden. Für Phase 46 verwenden wir Dummy-Daten oder Approximationen.
     """
+    if shared_returns is not None:
+        logger.info("Verwende Returns aus OHLCV-CLI (--ohlcv-file)")
+        return shared_returns.copy()
+
     if use_dummy_data:
         logger.info(f"Verwende Dummy-Daten für Config Rank {config_rank}")
         np.random.seed(42 + config_rank)

--- a/tests/test_runner_ohlcv_file_cli_v0.py
+++ b/tests/test_runner_ohlcv_file_cli_v0.py
@@ -1,0 +1,112 @@
+"""
+CLI --ohlcv-file für MC- und Stress-Runner (narrow propagation und Loader-Sanity).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import scripts.run_monte_carlo_robustness as mc_script
+import scripts.run_stress_tests as stress_script
+from src.experiments import ohlcv_returns_file
+
+
+def test_monte_carlo_passes_shared_returns_from_ohlcv(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    pqf = tmp_path / "tiny.parquet"
+    idx = pd.date_range("2024-01-01", periods=20, tz="UTC", freq="min")
+    pd.DataFrame({"close": np.linspace(100.0, 119.0, 20)}, index=idx).to_parquet(pqf)
+
+    with patch.object(
+        mc_script, "load_top_n_configs_for_sweep", return_value=[{"config_id": "one", "rank": 1}]
+    ):
+        with patch.object(mc_script, "run_monte_carlo_from_returns") as mc_run:
+            with patch.object(mc_script, "build_monte_carlo_report"):
+                mc_run.return_value = MagicMock()
+                parser = mc_script.build_parser()
+                args = parser.parse_args(
+                    [
+                        "--sweep-name",
+                        "smoke_sweep",
+                        "--top-n",
+                        "1",
+                        "--num-runs",
+                        "5",
+                        "--format",
+                        "md",
+                        "--ohlcv-file",
+                        str(pqf),
+                        "--output-dir",
+                        str(tmp_path / "out"),
+                    ]
+                )
+                rc = mc_script.run_from_args(args)
+
+    assert rc == 0
+    fed = mc_run.call_args[0][0]
+    assert isinstance(fed, pd.Series)
+    assert len(fed) == 19
+
+
+def test_stress_passes_shared_returns_kwarg(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    pqf = tmp_path / "tiny2.parquet"
+    idx = pd.date_range("2024-06-01", periods=12, tz="UTC", freq="min")
+    pd.DataFrame({"close": np.linspace(50.0, 55.0, 12)}, index=idx).to_parquet(pqf)
+
+    with patch.object(
+        stress_script,
+        "load_top_n_configs_for_sweep",
+        return_value=[{"config_id": "one", "rank": 1}],
+    ):
+        with patch.object(stress_script, "run_stress_test_suite") as suite_run:
+            with patch.object(stress_script, "build_stress_test_report") as brep:
+                suite_run.return_value = MagicMock()
+                brep.return_value = {}
+                parser = stress_script.build_parser()
+                args = parser.parse_args(
+                    [
+                        "--sweep-name",
+                        "smoke_sweep",
+                        "--config",
+                        "config/config.toml",
+                        "--top-n",
+                        "1",
+                        "--scenarios",
+                        "single_crash_bar",
+                        "--format",
+                        "md",
+                        "--ohlcv-file",
+                        str(pqf),
+                        "--output-dir",
+                        str(tmp_path / "sout"),
+                    ]
+                )
+                rc = stress_script.run_from_args(args)
+
+    assert rc == 0
+    baseline_returns = suite_run.call_args[0][0]
+    assert len(baseline_returns) == 11
+
+
+def test_loader_missing_close_column(tmp_path) -> None:
+    p = tmp_path / "noclose.parquet"
+    pd.DataFrame({"open": [1.0]}, index=pd.DatetimeIndex(["2020-01-01"], tz="UTC")).to_parquet(p)
+    with pytest.raises(ValueError):
+        ohlcv_returns_file.load_close_returns_from_ohlcv_parquet(p)
+
+
+def test_loader_raises_missing_file(tmp_path) -> None:
+    with pytest.raises(FileNotFoundError):
+        ohlcv_returns_file.load_close_returns_from_ohlcv_parquet(tmp_path / "none.parquet")


### PR DESCRIPTION
## Summary
- add --ohlcv-file support to MC robustness and stress CLIs
- add shared OHLCV close-to-close returns loader for parquet input
- wire stress runner shared_returns path so OHLCV-derived returns are used consistently
- add focused CLI/loader tests

## Safety
- no Live authorization
- no strategy logic change
- no Master V2 / Double Play change
- no Risk/KillSwitch change
- no Execution/Gate change
- no registry or out/ops mutation
- no canonical evidence/readiness/map/handoff surface
- --returns-file intentionally not implemented in this slice

## Validation
- uv run pytest tests/test_runner_ohlcv_file_cli_v0.py tests/experiments/test_equity_loader.py tests/test_stress_tests.py -q
- uv run ruff check src/experiments/ohlcv_returns_file.py src/experiments/stress_tests.py scripts/run_monte_carlo_robustness.py scripts/run_stress_tests.py tests/test_runner_ohlcv_file_cli_v0.py
- uv run ruff format --check src/experiments/ohlcv_returns_file.py src/experiments/stress_tests.py scripts/run_monte_carlo_robustness.py scripts/run_stress_tests.py tests/test_runner_ohlcv_file_cli_v0.py
- /tmp smoke produced:
  - /tmp/peak_trade_ohlcv_file_adapter_smoke_20260429_005649/mc/dummy_config_1/monte_carlo_report.md
  - /tmp/peak_trade_ohlcv_file_adapter_smoke_20260429_005649/stress/test_sweep/config_1/stress_test_report.md

Made with [Cursor](https://cursor.com)