### PR TITLE
feat(sweeps): merge base config into sweep parameter sets v0

### DIFF
--- a/scripts/run_sweep_strategy.py
+++ b/scripts/run_sweep_strategy.py
@@ -237,15 +237,48 @@ Examples:
 # =============================================================================
 
 
+def _coerce_param_grid_lists(raw: Dict[str, Any]) -> Dict[str, List[Any]]:
+    """Normalisiert ein Roh-Grid: Jeder Wert ist eine nicht-leere Liste."""
+    out: Dict[str, List[Any]] = {}
+    for key, values in raw.items():
+        if isinstance(values, list):
+            if len(values) == 0:
+                raise ValueError(f"Parameter '{key}' hat keine Werte")
+            out[key] = values
+        else:
+            out[key] = [values]
+    return out
+
+
+def _merge_base_config_into_grid(
+    base_config: Dict[str, Any], grid: Dict[str, Any]
+) -> Dict[str, List[Any]]:
+    """
+    Vereinigt [base_config] mit [grid]: Basis-Keys werden zu Ein-Wert-Sweep-Dimensionen;
+    Grid-Keys überschreiben bei Namenskollision.
+
+    So bleibt expand_parameter_grid / SweepEngine unverändert nutzbar.
+    """
+    merged: Dict[str, List[Any]] = {}
+    for k, v in base_config.items():
+        merged[k] = [v]
+    for k, v in grid.items():
+        merged[k] = v if isinstance(v, list) else [v]
+    return merged
+
+
 def load_parameter_grid(grid_arg: str) -> Dict[str, List[Any]]:
     """
     Lädt ein Parameter-Grid aus TOML-Datei, JSON-Datei oder JSON-String.
+
+    TOML mit optionaler [base_config]- und [grid]-Sektion: beide werden zu einem
+    gemeinsamen param_grid zusammengeführt (Grid gewinnt bei Schlüsselkollision).
 
     Args:
         grid_arg: Pfad zu TOML/JSON-Datei oder JSON-String
 
     Returns:
-        Parameter-Grid als Dict
+        Parameter-Grid als Dict[str, List[Any]]
     """
     grid_path = Path(grid_arg)
 
@@ -258,19 +291,31 @@ def load_parameter_grid(grid_arg: str) -> Dict[str, List[Any]]:
                 import tomli as tomllib
             with grid_path.open("rb") as f:
                 data = tomllib.load(f)
-            # Erwarte "grid" Sektion oder Top-Level
-            return data.get("grid", data)
-        elif grid_path.suffix == ".json":
+            if "grid" in data:
+                grid_section = data["grid"]
+                if not isinstance(grid_section, dict):
+                    raise ValueError("[grid] muss eine TOML-Tabelle sein")
+                base_section = dict(data.get("base_config", {}))
+                return _merge_base_config_into_grid(base_section, grid_section)
+            return _coerce_param_grid_lists(data)
+        if grid_path.suffix == ".json":
             with grid_path.open("r", encoding="utf-8") as f:
-                return json.load(f)
-        else:
-            raise ValueError(f"Unbekanntes Dateiformat: {grid_path.suffix}")
+                loaded = json.load(f)
+            if not isinstance(loaded, dict):
+                raise ValueError("JSON-Grid muss ein Objekt sein")
+            return _coerce_param_grid_lists(loaded)
+        raise ValueError(f"Unbekanntes Dateiformat: {grid_path.suffix}")
 
     # Versuche als JSON-String zu parsen
     try:
-        return json.loads(grid_arg)
+        loaded = json.loads(grid_arg)
     except json.JSONDecodeError as e:
-        raise ValueError(f"Konnte Grid nicht laden. Weder gültige Datei noch JSON-String: {e}")
+        raise ValueError(
+            f"Konnte Grid nicht laden. Weder gültige Datei noch JSON-String: {e}"
+        ) from e
+    if not isinstance(loaded, dict):
+        raise ValueError("JSON-Grid muss ein Objekt sein")
+    return _coerce_param_grid_lists(loaded)
 
 
 def parse_cli_params(params: List[str]) -> Dict[str, List[Any]]:

--- a/src/strategies/regime_aware_portfolio.py
+++ b/src/strategies/regime_aware_portfolio.py
@@ -180,6 +180,7 @@ class RegimeAwarePortfolioStrategy(BaseStrategy):
         cls,
         cfg: Any,
         section: str = "portfolio.regime_aware_breakout_rsi",
+        param_overrides: Optional[Dict[str, Any]] = None,
     ) -> "RegimeAwarePortfolioStrategy":
         """
         Fabrikmethode für Core-Config.
@@ -187,21 +188,26 @@ class RegimeAwarePortfolioStrategy(BaseStrategy):
         Args:
             cfg: Config-Objekt (PeakConfig)
             section: Dotted-Path zum Config-Abschnitt
+            param_overrides: Sweep-Parameter; überschreiben Werte aus cfg (z. B. [base_config] aus TOML)
 
         Returns:
             RegimeAwarePortfolioStrategy-Instanz
         """
-        # Lazy import
-        from .registry import create_strategy_from_config
+        po = param_overrides or {}
 
-        components = cfg.get(f"{section}.components", [])
-        base_weights = cfg.get(f"{section}.base_weights", {})
-        regime_strategy = cfg.get(f"{section}.regime_strategy", None)
-        mode = cfg.get(f"{section}.mode", "scale")
-        risk_on_scale = cfg.get(f"{section}.risk_on_scale", 1.0)
-        neutral_scale = cfg.get(f"{section}.neutral_scale", 0.5)
-        risk_off_scale = cfg.get(f"{section}.risk_off_scale", 0.0)
-        signal_threshold = cfg.get(f"{section}.signal_threshold", 0.3)
+        def pick(key: str, default: Any) -> Any:
+            if key in po:
+                return po[key]
+            return cfg.get(f"{section}.{key}", default)
+
+        components = pick("components", [])
+        base_weights = pick("base_weights", {})
+        regime_strategy = pick("regime_strategy", None)
+        mode = pick("mode", "scale")
+        risk_on_scale = pick("risk_on_scale", 1.0)
+        neutral_scale = pick("neutral_scale", 0.5)
+        risk_off_scale = pick("risk_off_scale", 0.0)
+        signal_threshold = pick("signal_threshold", 0.3)
 
         return cls(
             components=components,

--- a/src/sweeps/engine.py
+++ b/src/sweeps/engine.py
@@ -513,8 +513,18 @@ class SweepEngine:
         position_sizer = build_position_sizer_from_config(cfg)
         risk_manager = build_risk_manager_from_config(cfg, section="risk_management")
 
-        # Strategie erstellen
-        strategy = create_strategy_from_config(strategy_key, cfg)
+        # Strategie erstellen (Sweep-Parameter müssen vor __init__/validate gelten)
+        if strategy_key == "regime_aware_portfolio":
+            from src.strategies.regime_aware_portfolio import RegimeAwarePortfolioStrategy
+
+            spec_ra = get_strategy_spec(strategy_key)
+            strategy = RegimeAwarePortfolioStrategy.from_config(
+                cfg,
+                section=spec_ra.config_section,
+                param_overrides=params,
+            )
+        else:
+            strategy = create_strategy_from_config(strategy_key, cfg)
 
         # Parameter auf Strategie anwenden
         for key, value in params.items():

--- a/tests/test_run_sweep_strategy_base_config_merge_v0.py
+++ b/tests/test_run_sweep_strategy_base_config_merge_v0.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""Tests for run_sweep_strategy.py [base_config] + [grid] TOML merge (v0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestLoadParameterGridBaseConfigMerge:
+    """load_parameter_grid merges [base_config] into sweep dimensions."""
+
+    def test_base_config_and_grid_merged(self, tmp_path: Path) -> None:
+        path = tmp_path / "merge.toml"
+        path.write_text(
+            """
+[base_config]
+components = ["breakout", "rsi_reversion"]
+base_weights = { breakout = 0.6, rsi_reversion = 0.4 }
+regime_strategy = "vol_regime_filter"
+
+[grid]
+neutral_scale = [0.4, 0.5]
+risk_on_scale = [1.0]
+""",
+            encoding="utf-8",
+        )
+        from scripts.run_sweep_strategy import expand_parameter_grid, load_parameter_grid
+
+        grid = load_parameter_grid(str(path))
+        assert grid["components"] == [["breakout", "rsi_reversion"]]
+        assert grid["regime_strategy"] == ["vol_regime_filter"]
+        assert grid["neutral_scale"] == [0.4, 0.5]
+        combos = expand_parameter_grid(grid)
+        assert len(combos) == 2
+        for c in combos:
+            assert c["components"] == ["breakout", "rsi_reversion"]
+            assert c["regime_strategy"] == "vol_regime_filter"
+
+    def test_grid_overrides_base_config_on_collision(self, tmp_path: Path) -> None:
+        path = tmp_path / "override.toml"
+        path.write_text(
+            """
+[base_config]
+overlap = 1
+only_base = true
+
+[grid]
+overlap = [2, 3]
+""",
+            encoding="utf-8",
+        )
+        from scripts.run_sweep_strategy import expand_parameter_grid, load_parameter_grid
+
+        grid = load_parameter_grid(str(path))
+        assert grid["overlap"] == [2, 3]
+        assert grid["only_base"] == [True]
+        combos = expand_parameter_grid(grid)
+        assert len(combos) == 2
+        assert combos[0]["overlap"] == 2
+        assert combos[1]["overlap"] == 3
+
+    def test_grid_only_toml_unchanged_semantics(self, tmp_path: Path) -> None:
+        path = tmp_path / "grid_only.toml"
+        path.write_text(
+            """
+[grid]
+a = [1, 2]
+b = [10]
+""",
+            encoding="utf-8",
+        )
+        from scripts.run_sweep_strategy import expand_parameter_grid, load_parameter_grid
+
+        grid = load_parameter_grid(str(path))
+        assert sorted(grid.keys()) == ["a", "b"]
+        assert expand_parameter_grid(grid) == [
+            {"a": 1, "b": 10},
+            {"a": 2, "b": 10},
+        ]
+
+    def test_top_level_toml_keys_without_grid_section(self, tmp_path: Path) -> None:
+        path = tmp_path / "top_level.toml"
+        path.write_text(
+            """
+x = [1, 2]
+y = [3]
+""",
+            encoding="utf-8",
+        )
+        from scripts.run_sweep_strategy import expand_parameter_grid, load_parameter_grid
+
+        grid = load_parameter_grid(str(path))
+        assert expand_parameter_grid(grid) == [{"x": 1, "y": 3}, {"x": 2, "y": 3}]
+
+    def test_regime_aware_portfolio_dry_run_lists_components(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "regime_smoke.toml"
+        path.write_text(
+            """
+[base_config]
+components = ["breakout", "rsi_reversion"]
+base_weights = { breakout = 0.6, rsi_reversion = 0.4 }
+regime_strategy = "vol_regime_filter"
+
+[grid]
+neutral_scale = [0.4, 0.5]
+risk_on_scale = [1.0]
+risk_off_scale = [0.0]
+mode = ["scale"]
+signal_threshold = [0.25]
+vol_metric = ["atr"]
+low_vol_threshold = [0.5]
+high_vol_threshold = [1.5]
+""",
+            encoding="utf-8",
+        )
+        from scripts.run_sweep_strategy import main
+
+        rc = main(
+            [
+                "--strategy",
+                "regime_aware_portfolio",
+                "--grid",
+                str(path),
+                "--dry-run",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "'components'" in out or "components" in out


### PR DESCRIPTION
## Summary
- merge TOML [base_config] into each [grid] parameter set in scripts/run_sweep_strategy.py
- preserve grid override semantics on key collisions
- keep grid-only and top-level TOML behavior compatible
- allow regime_aware_portfolio sweeps to receive components before validation
- add focused tests for base_config merge behavior and dry-run compatibility

## Profit relevance
- unblocks evaluation of regime_aware_portfolio sweep configs
- fixes the observed failure: components darf nicht leer sein
- enables bounded non-live research sweeps under /tmp

## Safety / authority boundaries
- no Live authorization
- no Testnet/Gate changes
- no Master V2 / Double Play core change
- no Risk/KillSwitch change
- no registry mutation when --no-registry is used
- no out/ops mutation
- strategy remains candidate/context only, not trade authority

## Validation
- uv run pytest tests/test_run_sweep_strategy_base_config_merge_v0.py -q
- uv run pytest tests -q -k "sweep_strategy or parameter_grid or regime_aware_portfolio or sweeps"
- uv run ruff check scripts/run_sweep_strategy.py src/strategies/regime_aware_portfolio.py src/sweeps/engine.py tests/test_run_sweep_strategy_base_config_merge_v0.py
- uv run ruff format --check scripts/run_sweep_strategy.py src/strategies/regime_aware_portfolio.py src/sweeps/engine.py tests/test_run_sweep_strategy_base_config_merge_v0.py
- /tmp smoke produced successful reduced sweep CSV under /tmp/peak_trade_base_config_merge_pr_smoke_20260429_021355/sweep_result.csv

Made with [Cursor](https://cursor.com)