### PR TITLE
fix(sweeps): support parquet data-file input v0

### DIFF
--- a/scripts/run_sweep_strategy.py
+++ b/scripts/run_sweep_strategy.py
@@ -139,7 +139,7 @@ Examples:
     data_group.add_argument(
         "--data-file",
         type=str,
-        help="Pfad zur CSV-Datei mit OHLCV-Daten (optional, sonst Dummy-Daten)",
+        help="Pfad zur CSV- oder Parquet-Datei mit OHLCV-Daten (optional, sonst Dummy-Daten)",
     )
     data_group.add_argument(
         "--symbol",
@@ -405,7 +405,7 @@ def load_ohlcv_data(
     n_bars: int,
     verbose: bool = False,
 ) -> pd.DataFrame:
-    """Lädt OHLCV-Daten aus CSV oder generiert Dummy-Daten."""
+    """Lädt OHLCV-Daten aus CSV/Parquet oder generiert Dummy-Daten."""
     if data_file:
         from src.data import DataNormalizer, CsvLoader, KrakenCsvLoader
 
@@ -415,6 +415,15 @@ def load_ohlcv_data(
 
         if verbose:
             print(f"  Lade Daten aus: {data_file}")
+
+        suffix = path.suffix.lower()
+        if suffix in {".parquet", ".pq"}:
+            df = pd.read_parquet(path)
+            df.columns = df.columns.str.lower()
+            if not isinstance(df.index, pd.DatetimeIndex) and "timestamp" in df.columns:
+                df = df.set_index(pd.DatetimeIndex(pd.to_datetime(df.pop("timestamp"), utc=True)))
+            normalizer = DataNormalizer()
+            return normalizer.normalize(df)
 
         if "kraken" in str(path).lower():
             loader = KrakenCsvLoader()


### PR DESCRIPTION
## Summary
- support .parquet/.pq files in scripts/run_sweep_strategy.py --data-file
- preserve CSV behavior
- set timestamp column as DatetimeIndex before normalization when present
- update --data-file help text

## Profit relevance
- unblocks reduced regime_aware_portfolio research sweeps on larger BTC/EUR OHLCV parquet input
- avoids forcing parquet-to-csv conversion outside the CLI

## Safety / authority boundaries
- non-live research input only
- no Live authorization
- no Testnet/Gate changes
- no Master V2 / Double Play core change
- no Risk/KillSwitch change
- no registry mutation when --no-registry is used
- no out/ops mutation

## Validation
- uv run pytest tests -q -k "sweep_strategy or data_file or ohlcv or regime_aware_portfolio"
- uv run ruff check scripts/run_sweep_strategy.py tests
- uv run ruff format --check scripts/run_sweep_strategy.py tests
- /tmp smoke produced non-empty CSV under /tmp/peak_trade_sweep_strategy_parquet_data_file_pr_smoke_20260429_031350/export/sweep_result.csv

Made with [Cursor](https://cursor.com)