### PR TITLE
fix(strategies): support regime portfolio component overrides v0

### DIFF
--- a/src/strategies/regime_aware_portfolio.py
+++ b/src/strategies/regime_aware_portfolio.py
@@ -39,6 +39,40 @@ from .base import BaseStrategy, StrategyMetadata
 
 logger = logging.getLogger(__name__)
 
+_FULL_VOL_REGIME_KEY_PREFIX = "strategy.vol_regime_filter."
+_SHORT_VOL_REGIME_KEY_PREFIX = "vol_regime_filter."
+
+
+class _ConfigGetOverlay:
+    """Minimale cfg-Hülle: überschreibt nur explizit gesetzte dotted keys für .get()."""
+
+    __slots__ = ("_base", "_overrides")
+
+    def __init__(self, base: Any, overrides: Dict[str, Any]) -> None:
+        self._base = base
+        self._overrides = overrides
+
+    def get(self, path: str, default: Any = None) -> Any:
+        if path in self._overrides:
+            return self._overrides[path]
+        return self._base.get(path, default)
+
+
+def _extract_vol_regime_filter_cfg_overrides(
+    param_overrides: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Mappt Sweep-keys auf strategy.vol_regime_filter.* Pfade für VolRegimeFilter.from_config."""
+    out: Dict[str, Any] = {}
+    if not param_overrides:
+        return out
+    for k, v in param_overrides.items():
+        if k.startswith(_FULL_VOL_REGIME_KEY_PREFIX):
+            out[k] = v
+        elif k.startswith(_SHORT_VOL_REGIME_KEY_PREFIX):
+            suffix = k[len(_SHORT_VOL_REGIME_KEY_PREFIX) :]
+            out[f"{_FULL_VOL_REGIME_KEY_PREFIX}{suffix}"] = v
+    return out
+
 
 class RegimeAwarePortfolioStrategy(BaseStrategy):
     """
@@ -89,6 +123,7 @@ class RegimeAwarePortfolioStrategy(BaseStrategy):
         signal_threshold: float = 0.3,
         config: Optional[Dict[str, Any]] = None,
         metadata: Optional[StrategyMetadata] = None,
+        regime_component_cfg_overrides: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Initialisiert Regime-Aware Portfolio Strategy.
@@ -128,6 +163,10 @@ class RegimeAwarePortfolioStrategy(BaseStrategy):
         )
 
         super().__init__(config=base_cfg, metadata=meta)
+
+        self._regime_component_cfg_overrides: Dict[str, Any] = dict(
+            regime_component_cfg_overrides or {}
+        )
 
         # Parameter extrahieren
         self.components = list(self.config.get("components", []))
@@ -209,6 +248,8 @@ class RegimeAwarePortfolioStrategy(BaseStrategy):
         risk_off_scale = pick("risk_off_scale", 0.0)
         signal_threshold = pick("signal_threshold", 0.3)
 
+        embedded = _extract_vol_regime_filter_cfg_overrides(po)
+
         return cls(
             components=components,
             base_weights=base_weights,
@@ -218,7 +259,19 @@ class RegimeAwarePortfolioStrategy(BaseStrategy):
             neutral_scale=neutral_scale,
             risk_off_scale=risk_off_scale,
             signal_threshold=signal_threshold,
+            regime_component_cfg_overrides=embedded or None,
         )
+
+    def _merge_vol_regime_filter_cfg_overrides(self) -> Dict[str, Any]:
+        """from_config-Overrides plus Einträge in self.config (z. B. nach Sweep-Engine setattr)."""
+        merged: Dict[str, Any] = dict(self._regime_component_cfg_overrides)
+        for k, v in self.config.items():
+            if k.startswith(_FULL_VOL_REGIME_KEY_PREFIX):
+                merged.setdefault(k, v)
+            elif k.startswith(_SHORT_VOL_REGIME_KEY_PREFIX):
+                suffix = k[len(_SHORT_VOL_REGIME_KEY_PREFIX) :]
+                merged.setdefault(f"{_FULL_VOL_REGIME_KEY_PREFIX}{suffix}", v)
+        return merged
 
     def _load_strategies(self, data: pd.DataFrame) -> None:
         """
@@ -230,7 +283,7 @@ class RegimeAwarePortfolioStrategy(BaseStrategy):
         if self._component_strategies:
             return  # Bereits geladen
 
-        from .registry import create_strategy_from_config
+        from .registry import create_strategy_from_config, get_strategy_spec
         from ..core.peak_config import load_config
 
         cfg = load_config()
@@ -246,7 +299,17 @@ class RegimeAwarePortfolioStrategy(BaseStrategy):
 
         # Lade Regime-Strategie
         try:
-            self._regime_strategy = create_strategy_from_config(self.regime_strategy_name, cfg)
+            overrides = self._merge_vol_regime_filter_cfg_overrides()
+            if self.regime_strategy_name == "vol_regime_filter" and overrides:
+                from .vol_regime_filter import VolRegimeFilter
+
+                spec = get_strategy_spec("vol_regime_filter")
+                cfg_ov = _ConfigGetOverlay(cfg, overrides)
+                self._regime_strategy = VolRegimeFilter.from_config(
+                    cfg_ov, section=spec.config_section
+                )
+            else:
+                self._regime_strategy = create_strategy_from_config(self.regime_strategy_name, cfg)
             # Prüfe ob Regime-Mode aktiviert ist
             if (
                 hasattr(self._regime_strategy, "regime_mode")

--- a/tests/test_regime_aware_portfolio_component_overrides_v0.py
+++ b/tests/test_regime_aware_portfolio_component_overrides_v0.py
@@ -1,0 +1,96 @@
+# tests/test_regime_aware_portfolio_component_overrides_v0.py
+"""RegimeAwarePortfolioStrategy: nested vol_regime_filter config overrides (research v0)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.core.peak_config import load_config
+from src.strategies.registry import get_strategy_spec
+from src.strategies.regime_aware_portfolio import RegimeAwarePortfolioStrategy
+from src.strategies.vol_regime_filter import VolRegimeFilter
+
+
+def _minimal_ohlcv(n: int = 120) -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    close = pd.Series(50000.0, index=idx) + pd.Series(range(n), index=idx) * 0.1
+    df = pd.DataFrame(
+        {
+            "open": close.shift(1).fillna(close.iloc[0]),
+            "high": close * 1.001,
+            "low": close * 0.999,
+            "close": close,
+            "volume": 100.0,
+        },
+        index=idx,
+    )
+    return df
+
+
+@pytest.fixture
+def cfg():
+    return load_config()
+
+
+@pytest.fixture
+def portfolio_section() -> str:
+    return "portfolio.regime_aware_breakout_rsi"
+
+
+class TestRegimePortfolioComponentOverrides:
+    def test_default_vol_regime_filter_regime_mode_from_config(
+        self, cfg, portfolio_section: str
+    ) -> None:
+        spec = get_strategy_spec("vol_regime_filter")
+        expected_regime_mode = VolRegimeFilter.from_config(
+            cfg, section=spec.config_section
+        ).regime_mode
+        strat = RegimeAwarePortfolioStrategy.from_config(
+            cfg, section=portfolio_section, param_overrides={}
+        )
+        df = _minimal_ohlcv()
+        strat.generate_signals(df)
+        assert strat._regime_strategy is not None
+        assert strat._regime_strategy.regime_mode is expected_regime_mode
+
+    def test_override_short_key_reaches_embedded_vol_regime_filter(
+        self, cfg, portfolio_section: str
+    ) -> None:
+        strat = RegimeAwarePortfolioStrategy.from_config(
+            cfg,
+            section=portfolio_section,
+            param_overrides={"vol_regime_filter.regime_mode": True},
+        )
+        df = _minimal_ohlcv()
+        strat.generate_signals(df)
+        assert getattr(strat._regime_strategy, "regime_mode", None) is True
+
+    def test_override_full_strategy_key_reaches_embedded_vol_regime_filter(
+        self, cfg, portfolio_section: str
+    ) -> None:
+        strat = RegimeAwarePortfolioStrategy.from_config(
+            cfg,
+            section=portfolio_section,
+            param_overrides={"strategy.vol_regime_filter.regime_mode": True},
+        )
+        df = _minimal_ohlcv()
+        strat.generate_signals(df)
+        assert getattr(strat._regime_strategy, "regime_mode", None) is True
+
+    def test_portfolio_level_overrides_still_apply(self, cfg, portfolio_section: str) -> None:
+        strat = RegimeAwarePortfolioStrategy.from_config(
+            cfg,
+            section=portfolio_section,
+            param_overrides={"neutral_scale": 0.37},
+        )
+        assert strat.neutral_scale == pytest.approx(0.37)
+
+    def test_config_dict_nested_keys_after_engine_merge(self, cfg, portfolio_section: str) -> None:
+        strat = RegimeAwarePortfolioStrategy.from_config(
+            cfg, section=portfolio_section, param_overrides={}
+        )
+        strat.config["vol_regime_filter.regime_mode"] = True
+        df = _minimal_ohlcv()
+        strat.generate_signals(df)
+        assert getattr(strat._regime_strategy, "regime_mode", None) is True


### PR DESCRIPTION
## Summary
- add narrow component override support for RegimeAwarePortfolioStrategy.from_config
- allow vol_regime_filter.regime_mode and strategy.vol_regime_filter.regime_mode overrides to reach the embedded vol_regime_filter component
- preserve existing behavior when no nested override is supplied
- add focused tests for default behavior and both override key conventions

## Profit relevance
- resolves a blocker found during real-OHLCV regime-aware portfolio research
- lets the reduced regime-aware portfolio sweep test intended vol_regime_filter regime-mode semantics before expanding the grid

## Safety / authority boundaries
- non-live research configuration path only
- no Live authorization
- no Testnet/Gate changes
- no Master V2 / Double Play core change
- no Risk/KillSwitch change
- no registry/out/ops mutation
- no strategy promotion or profitability claim

## Validation
- uv run pytest tests -q -k "regime_aware_portfolio or vol_regime_filter or sweep_strategy"
- uv run ruff check src/strategies/regime_aware_portfolio.py tests/test_regime_aware_portfolio_component_overrides_v0.py
- uv run ruff format --check src/strategies/regime_aware_portfolio.py tests/test_regime_aware_portfolio_component_overrides_v0.py
- /tmp smoke produced non-empty CSV under /tmp/peak_trade_component_override_pr_smoke_20260429_035507/export/sweep_result.csv
- warning check printed above from /tmp/peak_trade_component_override_pr_smoke_20260429_035507/logs/stderr.log

Made with [Cursor](https://cursor.com)