### PR TITLE
feat(sweeps): add opt-in diagnostics export v0

### DIFF
--- a/scripts/run_sweep_strategy.py
+++ b/scripts/run_sweep_strategy.py
@@ -205,6 +205,13 @@ Examples:
         help="CSV-Export der Ergebnisse",
     )
     output_group.add_argument(
+        "--diagnostics-dir",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Optional: Verzeichnis für research-only Diagnostik (JSON pro Parameterkombination)",
+    )
+    output_group.add_argument(
         "--no-registry",
         action="store_true",
         help="Kein Registry-Logging (für Tests)",
@@ -497,6 +504,83 @@ def export_results(summary: SweepSummary, export_path: str) -> None:
     print(f"\nErgebnisse exportiert nach: {export_path}")
 
 
+def _serialize_diagnostic_value(value: Any) -> Any:
+    """Konvertiert typische Backtest-Diagnostik in JSON-sichere Werte."""
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _serialize_diagnostic_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_serialize_diagnostic_value(v) for v in value]
+
+    try:
+        if isinstance(value, pd.DataFrame):
+            return value.reset_index().to_dict(orient="records")
+        if isinstance(value, pd.Series):
+            return value.reset_index().to_dict(orient="records")
+    except Exception:
+        pass
+
+    if hasattr(value, "model_dump"):
+        return _serialize_diagnostic_value(value.model_dump())
+    if hasattr(value, "__dict__"):
+        return _serialize_diagnostic_value(vars(value))
+
+    return str(value)
+
+
+def _extract_backtest_diagnostics(result: Any) -> Dict[str, Any]:
+    """Extrahiert Research-Diagnostik aus einem Backtest-Resultat."""
+    diagnostics: Dict[str, Any] = {}
+    for attr in (
+        "trades",
+        "equity_curve",
+        "drawdown",
+        "drawdown_curve",
+        "positions",
+        "signals",
+        "stats",
+        "metrics",
+    ):
+        if hasattr(result, attr):
+            diagnostics[attr] = _serialize_diagnostic_value(getattr(result, attr))
+    return diagnostics
+
+
+def _write_sweep_diagnostics(
+    diagnostics_dir: Optional[str],
+    combo_index: int,
+    params: Dict[str, Any],
+    stats: Dict[str, Any],
+    success: bool,
+    error: Optional[str],
+    result: Any = None,
+) -> None:
+    """Schreibt optionale, nicht-autorisierende Research-Diagnostik für eine Kombination."""
+    if diagnostics_dir is None:
+        return
+
+    out_dir = Path(diagnostics_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "combo_index": combo_index,
+        "params": _serialize_diagnostic_value(params),
+        "stats": _serialize_diagnostic_value(stats),
+        "success": bool(success),
+        "error": error,
+        "backtest_diagnostics": _extract_backtest_diagnostics(result) if result is not None else {},
+    }
+
+    target = out_dir / f"combo_{combo_index:04d}.json"
+    target.write_text(
+        json.dumps(payload, indent=2, sort_keys=False, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
 # =============================================================================
 # MAIN
 # =============================================================================
@@ -616,10 +700,29 @@ def main(argv: Optional[List[str]] = None) -> int:
             progress_callback=None if args.verbose else progress_callback,
         )
 
+        def diagnostics_callback(
+            combo_index: int,
+            combo_params: Dict[str, Any],
+            combo_stats: Dict[str, Any],
+            combo_success: bool,
+            combo_error: Optional[str],
+            bt_result: Any,
+        ) -> None:
+            _write_sweep_diagnostics(
+                args.diagnostics_dir,
+                combo_index,
+                combo_params,
+                combo_stats,
+                combo_success,
+                combo_error,
+                bt_result,
+            )
+
         summary = engine.run_sweep(
             config=config,
             data=data,
             skip_registry=args.no_registry,
+            diagnostics_callback=diagnostics_callback if args.diagnostics_dir else None,
         )
 
     except Exception as e:

--- a/src/sweeps/engine.py
+++ b/src/sweeps/engine.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 
+from src.backtest.result import BacktestResult
 from src.core.experiments import log_sweep_run, RUN_TYPE_SWEEP
 from src.core.peak_config import PeakConfig, load_config
 from src.core.position_sizing import build_position_sizer_from_config
@@ -347,6 +348,20 @@ class SweepEngine:
         config: SweepConfig,
         data: pd.DataFrame,
         skip_registry: bool = False,
+        *,
+        diagnostics_callback: Optional[
+            Callable[
+                [
+                    int,
+                    Dict[str, Any],
+                    Dict[str, Any],
+                    bool,
+                    Optional[str],
+                    Optional[BacktestResult],
+                ],
+                None,
+            ]
+        ] = None,
     ) -> SweepSummary:
         """
         Führt einen kompletten Hyperparameter-Sweep aus.
@@ -355,6 +370,7 @@ class SweepEngine:
             config: Sweep-Konfiguration
             data: OHLCV-DataFrame für Backtests
             skip_registry: Wenn True, kein Registry-Logging (für Tests)
+            diagnostics_callback: Optional; pro Kombination (1-basiierter Index, params, stats, success, error, result)
 
         Returns:
             SweepSummary mit allen Ergebnissen
@@ -395,7 +411,7 @@ class SweepEngine:
                 print(f"  [{i}/{len(combinations)}] {params}")
 
             try:
-                stats = self._run_single_backtest(
+                stats, bt_result = self._run_single_backtest(
                     data=data,
                     strategy_key=config.strategy_key,
                     params=params,
@@ -424,6 +440,9 @@ class SweepEngine:
                 else:
                     run_id = f"test_{uuid.uuid4().hex[:8]}"
 
+                if diagnostics_callback is not None:
+                    diagnostics_callback(i, params, stats, True, None, bt_result)
+
                 results.append(
                     SweepResult(
                         params=params,
@@ -436,6 +455,9 @@ class SweepEngine:
             except Exception as e:
                 if self.verbose:
                     print(f"    FEHLER: {e}")
+
+                if diagnostics_callback is not None:
+                    diagnostics_callback(i, params, {}, False, str(e), None)
 
                 results.append(
                     SweepResult(
@@ -496,7 +518,7 @@ class SweepEngine:
         strategy_key: str,
         params: Dict[str, Any],
         cfg: PeakConfig,
-    ) -> Dict[str, Any]:
+    ) -> Tuple[Dict[str, Any], BacktestResult]:
         """
         Führt einen einzelnen Backtest mit spezifischen Parametern aus.
 
@@ -507,7 +529,7 @@ class SweepEngine:
             cfg: Peak-Config
 
         Returns:
-            Stats-Dict mit Backtest-Ergebnissen
+            Tuple aus Stats-Dict und BacktestResult
         """
         # Position-Sizer und Risk-Manager aus Config
         position_sizer = build_position_sizer_from_config(cfg)
@@ -549,7 +571,7 @@ class SweepEngine:
             strategy_params=params,
         )
 
-        return result.stats or {}
+        return result.stats or {}, result
 
     def _find_best_result(
         self,

--- a/tests/test_run_sweep_strategy_diagnostics_export_v0.py
+++ b/tests/test_run_sweep_strategy_diagnostics_export_v0.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""Tests for opt-in --diagnostics-dir on scripts/run_sweep_strategy.py (v0)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class TestSweepDiagnosticsExport:
+    """Research-only JSON per combination when --diagnostics-dir is set."""
+
+    def test_no_diagnostics_when_flag_omitted(self, tmp_path: Path) -> None:
+        diag = tmp_path / "nodiag"
+        diag.mkdir()
+        from scripts.run_sweep_strategy import main
+
+        rc = main(
+            [
+                "--strategy",
+                "ma_crossover",
+                "--param",
+                "fast_window=5",
+                "--param",
+                "slow_window=10",
+                "--bars",
+                "35",
+                "--no-registry",
+                "--max-runs",
+                "1",
+            ]
+        )
+        assert rc == 0
+        assert list(diag.glob("*.json")) == []
+
+    def test_diagnostics_written_with_flag(self, tmp_path: Path) -> None:
+        diag = tmp_path / "diag"
+        from scripts.run_sweep_strategy import main
+
+        rc = main(
+            [
+                "--strategy",
+                "ma_crossover",
+                "--param",
+                "fast_window=5",
+                "--param",
+                "slow_window=10",
+                "--bars",
+                "35",
+                "--no-registry",
+                "--max-runs",
+                "1",
+                "--diagnostics-dir",
+                str(diag),
+            ]
+        )
+        assert rc == 0
+        p = diag / "combo_0001.json"
+        assert p.is_file()
+        payload = json.loads(p.read_text(encoding="utf-8"))
+        assert payload["combo_index"] == 1
+        assert payload["success"] is True
+        assert payload["error"] is None
+        assert payload["params"]["fast_window"] == 5
+        assert payload["params"]["slow_window"] == 10
+        assert isinstance(payload["stats"], dict)
+        assert "total_trades" in payload["stats"] or "sharpe" in payload["stats"]
+        bd = payload["backtest_diagnostics"]
+        assert isinstance(bd, dict)
+        assert "equity_curve" in bd or "trades" in bd
+
+    def test_multiple_combos_deterministic_names(self, tmp_path: Path) -> None:
+        diag = tmp_path / "diag2"
+        from scripts.run_sweep_strategy import main
+
+        rc = main(
+            [
+                "--strategy",
+                "ma_crossover",
+                "--param",
+                "fast_window=5,6",
+                "--param",
+                "slow_window=10",
+                "--bars",
+                "30",
+                "--no-registry",
+                "--max-runs",
+                "2",
+                "--diagnostics-dir",
+                str(diag),
+            ]
+        )
+        assert rc == 0
+        assert (diag / "combo_0001.json").is_file()
+        assert (diag / "combo_0002.json").is_file()


### PR DESCRIPTION
## Summary
- add optional --diagnostics-dir to scripts/run_sweep_strategy.py
- emit per-combination JSON diagnostics when explicitly requested
- preserve default aggregate CSV behavior when diagnostics are omitted
- extend sweep engine callback path to pass BacktestResult to diagnostics
- add focused tests for omitted/present diagnostics export

## Profit relevance
- Stage-2 regime-aware portfolio grid produced 24 successful rows but only 2 aggregate metric signatures
- diagnostics export enables trade/equity-level inspection instead of blind grid expansion

## Safety / authority boundaries
- opt-in research-only diagnostics
- no Live authorization
- no Testnet/Gate changes
- no Master V2 / Double Play core change
- no Risk/KillSwitch change
- no registry mutation when --no-registry is used
- no out/ops mutation
- no strategy promotion or profitability claim

## Validation
- uv run pytest tests/test_run_sweep_strategy_diagnostics_export_v0.py tests/test_sweeps.py -q
- uv run pytest tests -q -k "sweep_strategy or diagnostics or backtest or sweeps"
- uv run ruff check scripts/run_sweep_strategy.py src/sweeps/engine.py tests/test_run_sweep_strategy_diagnostics_export_v0.py
- uv run ruff format --check scripts/run_sweep_strategy.py src/sweeps/engine.py tests/test_run_sweep_strategy_diagnostics_export_v0.py
- /tmp smoke produced non-empty CSV and 24 combo diagnostics under /tmp/peak_trade_sweep_diagnostics_export_pr_smoke_20260429_043436

Made with [Cursor](https://cursor.com)