### PR TITLE
feat(backtest): add walk-forward candidate presets v0

### DIFF
--- a/scripts/run_walkforward_backtest.py
+++ b/scripts/run_walkforward_backtest.py
@@ -149,7 +149,16 @@ def load_data_from_file(filepath: Path) -> pd.DataFrame:
         raise ValueError(f"Fehlende Spalten: {missing}")
 
     if not isinstance(df.index, pd.DatetimeIndex):
-        raise ValueError("DataFrame muss einen DatetimeIndex haben")
+        if "timestamp" in df.columns:
+            df = df.set_index(pd.to_datetime(df["timestamp"], utc=True))
+            df = df.drop(columns=["timestamp"], errors="ignore")
+        else:
+            raise ValueError(
+                "DataFrame muss einen DatetimeIndex oder eine 'timestamp'-Spalte haben"
+            )
+
+    if not df.index.is_monotonic_increasing:
+        df = df.sort_index()
 
     return df
 

--- a/scripts/run_walkforward_backtest.py
+++ b/scripts/run_walkforward_backtest.py
@@ -31,6 +31,15 @@ Verwendung:
         --use-dummy-data \
         --dummy-bars 1000
 
+    # Explizite Kandidaten (JSON schema walkforward_candidate_presets/v0)
+    python scripts/run_walkforward_backtest.py \
+        --sweep-name my_run_label \
+        --train-window 90d \
+        --test-window 30d \
+        --data-file path/to/ohlcv.parquet \
+        --candidate-presets path/to/presets.json \
+        --output-dir /tmp/wf_out
+
 Output:
     - reports/walkforward/{sweep_name}/{config_id}_walkforward_YYYYMMDD.md
     - reports/walkforward/{sweep_name}/comparison_YYYYMMDD.md (Multi-Config)

--- a/scripts/run_walkforward_backtest.py
+++ b/scripts/run_walkforward_backtest.py
@@ -54,6 +54,7 @@ sys.path.insert(0, str(project_root))
 
 from src.backtest.walkforward import (
     WalkForwardConfig,
+    run_walkforward_for_candidate_presets,
     run_walkforward_for_top_n_from_sweep,
 )
 from src.reporting.walkforward_report import (
@@ -242,6 +243,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fallback-Metrik (default: metric_total_return)",
     )
     parser.add_argument(
+        "--candidate-presets",
+        type=str,
+        default=None,
+        help=(
+            "Optional JSON mit expliziten Kandidaten "
+            "(schema walkforward_candidate_presets/v0). "
+            "Wenn gesetzt, werden diese Kandidaten statt Top-N aus Sweep-Ergebnissen genutzt."
+        ),
+    )
+    parser.add_argument(
         "--output-dir",
         "-o",
         type=str,
@@ -310,17 +321,29 @@ def run_from_args(args: argparse.Namespace) -> int:
         )
 
         # 3. Walk-Forward ausführen
-        logger.info(
-            f"Starte Walk-Forward-Analyse für Top-{args.top_n} aus Sweep: {args.sweep_name}"
-        )
-        results = run_walkforward_for_top_n_from_sweep(
-            sweep_name=args.sweep_name,
-            wf_config=wf_config,
-            top_n=args.top_n,
-            df=df,
-            metric_primary=args.metric_primary,
-            metric_fallback=args.metric_fallback,
-        )
+        if args.candidate_presets:
+            preset_path = Path(args.candidate_presets)
+            logger.info(
+                f"Starte Walk-Forward mit Kandidaten-Presets: {preset_path} (Sweep-Label: {args.sweep_name})"
+            )
+            results = run_walkforward_for_candidate_presets(
+                preset_path,
+                args.sweep_name,
+                wf_config,
+                df=df,
+            )
+        else:
+            logger.info(
+                f"Starte Walk-Forward-Analyse für Top-{args.top_n} aus Sweep: {args.sweep_name}"
+            )
+            results = run_walkforward_for_top_n_from_sweep(
+                sweep_name=args.sweep_name,
+                wf_config=wf_config,
+                top_n=args.top_n,
+                df=df,
+                metric_primary=args.metric_primary,
+                metric_fallback=args.metric_fallback,
+            )
 
         logger.info(f"{len(results)} Walk-Forward-Ergebnisse erzeugt")
 
@@ -363,7 +386,10 @@ def run_from_args(args: argparse.Namespace) -> int:
         print("Walk-Forward Analysis Summary")
         print("=" * 70)
         print(f"Sweep:           {args.sweep_name}")
-        print(f"Top N:           {args.top_n}")
+        if args.candidate_presets:
+            print(f"Mode:            candidate_presets ({args.candidate_presets})")
+        else:
+            print(f"Top N:           {args.top_n}")
         print(f"Train Window:    {wf_config.train_window}")
         print(f"Test Window:     {wf_config.test_window}")
         print(f"Configs Tested:  {len(results)}")

--- a/src/backtest/walkforward.py
+++ b/src/backtest/walkforward.py
@@ -858,3 +858,136 @@ def run_walkforward_for_top_n_from_sweep(
     )
 
     return results
+
+
+# =============================================================================
+# EXPLICIT CANDIDATE PRESETS (RESEARCH / NON-LIVE)
+# =============================================================================
+
+WALKFORWARD_CANDIDATE_PRESETS_SCHEMA_V0 = "walkforward_candidate_presets/v0"
+
+
+def _unique_preset_config_id(name: str, used: set[str]) -> str:
+    """Derive a unique filesystem/report-safe config_id for a preset candidate."""
+    safe = _safe_filename(name)
+    candidate_id = safe
+    suffix = 2
+    while candidate_id in used:
+        candidate_id = f"{safe}_{suffix}"
+        suffix += 1
+    used.add(candidate_id)
+    return candidate_id
+
+
+def load_walkforward_candidate_presets(path: Union[str, Path]) -> Tuple[str, List[Dict[str, Any]]]:
+    """
+    Load explicit walk-forward candidate presets from JSON (schema v0).
+
+    Returns:
+        strategy: Strategy key passed to ``load_strategy``.
+        candidates: List of ``{"name": str, "params": dict}`` entries.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(f"Candidate presets file not found: {p}")
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise FileNotFoundError(f"Cannot read candidate presets: {p}") from exc
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in candidate presets {p}: {exc}") from exc
+
+    if not isinstance(doc, dict):
+        raise ValueError(f"Candidate presets root must be a JSON object: {p}")
+
+    schema = doc.get("schema_version")
+    if schema != WALKFORWARD_CANDIDATE_PRESETS_SCHEMA_V0:
+        raise ValueError(
+            f"Unsupported schema_version {schema!r} in {p} "
+            f"(expected {WALKFORWARD_CANDIDATE_PRESETS_SCHEMA_V0!r})"
+        )
+
+    strategy = doc.get("strategy")
+    if not strategy or not isinstance(strategy, str):
+        raise ValueError(f"Candidate presets must include non-empty string 'strategy': {p}")
+
+    raw_list = doc.get("candidates")
+    if not isinstance(raw_list, list) or len(raw_list) == 0:
+        raise ValueError(f"Candidate presets 'candidates' must be a non-empty list: {p}")
+
+    candidates: List[Dict[str, Any]] = []
+    for i, item in enumerate(raw_list):
+        if not isinstance(item, dict):
+            raise ValueError(f"candidates[{i}] must be an object: {p}")
+        cand_name = item.get("name")
+        if not cand_name or not isinstance(cand_name, str):
+            raise ValueError(f"candidates[{i}] must have non-empty string 'name': {p}")
+        params = item.get("params")
+        if not isinstance(params, dict):
+            raise ValueError(f"candidates[{i}] 'params' must be an object: {p}")
+        candidates.append({"name": cand_name, "params": dict(params)})
+
+    return strategy, candidates
+
+
+def run_walkforward_for_candidate_presets(
+    preset_path: Union[str, Path],
+    sweep_name: str,
+    wf_config: WalkForwardConfig,
+    *,
+    df: pd.DataFrame,
+    logger: Optional[logging.Logger] = None,
+) -> List[WalkForwardResult]:
+    """
+    Run walk-forward for each explicit candidate in a JSON preset file.
+
+    ``sweep_name`` is only used for logging and report directory grouping (CLI contract).
+
+    Args:
+        preset_path: Path to JSON (schema ``walkforward_candidate_presets/v0``).
+        sweep_name: Sweep / run label (output layout).
+        wf_config: Window and output settings.
+        df: OHLCV DataFrame (DatetimeIndex).
+        logger: Optional logger.
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    strategy, candidates = load_walkforward_candidate_presets(preset_path)
+    logger.info(
+        f"Walk-forward from candidate presets: {len(candidates)} candidate(s), "
+        f"strategy={strategy!r}, sweep label={sweep_name!r}"
+    )
+
+    used_ids: set[str] = set()
+    results: List[WalkForwardResult] = []
+
+    for i, cand in enumerate(candidates, start=1):
+        name = cand["name"]
+        params = cand["params"]
+        config_id = _unique_preset_config_id(name, used_ids)
+        logger.info(f"Preset candidate {i}/{len(candidates)}: {name!r} → config_id={config_id!r}")
+
+        try:
+            result = run_walkforward_for_config(
+                config_id=config_id,
+                wf_config=wf_config,
+                df=df,
+                strategy_name=strategy,
+                strategy_params=params,
+                logger=logger,
+            )
+            results.append(result)
+        except Exception as exc:  # pragma: no cover - defensive path
+            logger.error(f"Walk-forward failed for preset {name!r} ({config_id}): {exc}")
+            continue
+
+    if len(results) == 0:
+        raise ValueError("No successful walk-forward results from candidate presets")
+
+    logger.info(
+        f"Walk-forward presets finished: {len(results)}/{len(candidates)} candidate(s) successful"
+    )
+    return results

--- a/tests/test_walkforward_candidate_presets_v0.py
+++ b/tests/test_walkforward_candidate_presets_v0.py
@@ -1,0 +1,211 @@
+"""
+Tests for walk-forward explicit candidate presets (schema v0).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.backtest.walkforward import (
+    WALKFORWARD_CANDIDATE_PRESETS_SCHEMA_V0,
+    WalkForwardConfig,
+    WalkForwardResult,
+    WalkForwardWindowResult,
+    load_walkforward_candidate_presets,
+    run_walkforward_for_candidate_presets,
+)
+from tests.test_walkforward_backtest import create_test_data
+
+
+def _minimal_ma_preset_doc() -> dict:
+    return {
+        "schema_version": WALKFORWARD_CANDIDATE_PRESETS_SCHEMA_V0,
+        "strategy": "ma_crossover",
+        "candidates": [
+            {
+                "name": "preset_a",
+                "params": {
+                    "fast_period": 5,
+                    "slow_period": 20,
+                    "stop_pct": 0.02,
+                },
+            },
+            {
+                "name": "preset_b",
+                "params": {
+                    "fast_period": 12,
+                    "slow_period": 30,
+                    "stop_pct": 0.02,
+                },
+            },
+        ],
+    }
+
+
+class TestLoadWalkforwardCandidatePresets:
+    def test_missing_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "none.json"
+        with pytest.raises(FileNotFoundError, match="not found"):
+            load_walkforward_candidate_presets(p)
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("{not json", encoding="utf-8")
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_walkforward_candidate_presets(p)
+
+    def test_wrong_schema_version(self, tmp_path: Path) -> None:
+        p = tmp_path / "wrong.json"
+        p.write_text(
+            json.dumps({"schema_version": "other", "strategy": "x", "candidates": []}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="Unsupported schema_version"):
+            load_walkforward_candidate_presets(p)
+
+    def test_empty_candidates(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "schema_version": WALKFORWARD_CANDIDATE_PRESETS_SCHEMA_V0,
+                    "strategy": "ma_crossover",
+                    "candidates": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="non-empty list"):
+            load_walkforward_candidate_presets(p)
+
+    def test_load_ok(self, tmp_path: Path) -> None:
+        p = tmp_path / "ok.json"
+        doc = _minimal_ma_preset_doc()
+        p.write_text(json.dumps(doc), encoding="utf-8")
+        strategy, cands = load_walkforward_candidate_presets(p)
+        assert strategy == "ma_crossover"
+        assert len(cands) == 2
+        assert cands[0]["name"] == "preset_a"
+        assert cands[0]["params"]["fast_period"] == 5
+
+
+class TestRunWalkforwardCandidatePresets:
+    def test_duplicate_names_get_unique_config_ids(self, tmp_path: Path) -> None:
+        p = tmp_path / "dup.json"
+        doc = _minimal_ma_preset_doc()
+        doc["candidates"] = [
+            {"name": "same", "params": doc["candidates"][0]["params"]},
+            {"name": "same", "params": doc["candidates"][1]["params"]},
+        ]
+        p.write_text(json.dumps(doc), encoding="utf-8")
+
+        df = create_test_data(n_bars=500, freq="1d")
+        wf = WalkForwardConfig(
+            train_window="90d",
+            test_window="30d",
+            output_dir=tmp_path / "out",
+        )
+        results = run_walkforward_for_candidate_presets(p, "label_sweep", wf, df=df)
+        assert len(results) == 2
+        ids = [r.config_id for r in results]
+        assert ids[0] == "same"
+        assert ids[1] == "same_2"
+
+    def test_preset_names_in_config_id_and_reports_metadata(self, tmp_path: Path) -> None:
+        p = tmp_path / "run.json"
+        p.write_text(json.dumps(_minimal_ma_preset_doc()), encoding="utf-8")
+        df = create_test_data(n_bars=500, freq="1d")
+        wf = WalkForwardConfig(
+            train_window="90d",
+            test_window="30d",
+            output_dir=tmp_path / "out",
+        )
+        results = run_walkforward_for_candidate_presets(p, "wf_test_sweep", wf, df=df)
+        assert len(results) == 2
+        by_id = {r.config_id: r for r in results}
+        assert "preset_a" in by_id
+        assert "preset_b" in by_id
+        assert by_id["preset_a"].strategy_name == "ma_crossover"
+
+
+class TestRunWalkforwardBacktestCliPresetBranch:
+    """CLI uses presets path without calling top-N sweep loader."""
+
+    def test_run_from_args_preset_skips_top_n_sweep(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import scripts.run_walkforward_backtest as rwmod
+
+        wr = WalkForwardWindowResult(
+            window_index=0,
+            train_start=pd.Timestamp("2020-01-01"),
+            train_end=pd.Timestamp("2020-04-01"),
+            test_start=pd.Timestamp("2020-04-01"),
+            test_end=pd.Timestamp("2020-05-01"),
+            metrics={"sharpe": 0.2, "total_return": 0.01},
+        )
+        fake_result = WalkForwardResult(
+            config_id="from_preset",
+            strategy_name="ma_crossover",
+            windows=[wr],
+            aggregate_metrics={
+                "avg_sharpe": 0.2,
+                "avg_return": 0.01,
+                "win_rate_windows": 1.0,
+                "total_windows": 1,
+            },
+        )
+
+        def fail_topn(*_a, **_k):
+            raise AssertionError("run_walkforward_for_top_n_from_sweep must not be used")
+
+        monkeypatch.setattr(rwmod, "run_walkforward_for_top_n_from_sweep", fail_topn)
+
+        def fake_presets(preset_path, sweep_name, wf_config, *, df, logger=None):
+            assert Path(preset_path).is_file()
+            assert sweep_name == "cli_sweep_label"
+            return [fake_result]
+
+        monkeypatch.setattr(rwmod, "run_walkforward_for_candidate_presets", fake_presets)
+
+        preset_file = tmp_path / "c.json"
+        preset_file.write_text(json.dumps(_minimal_ma_preset_doc()), encoding="utf-8")
+        out_dir = tmp_path / "reports"
+
+        code = rwmod.run_from_args(
+            rwmod.build_parser().parse_args(
+                [
+                    "--sweep-name",
+                    "cli_sweep_label",
+                    "--train-window",
+                    "30d",
+                    "--test-window",
+                    "10d",
+                    "--use-dummy-data",
+                    "--dummy-bars",
+                    "120",
+                    "--candidate-presets",
+                    str(preset_file),
+                    "--output-dir",
+                    str(out_dir),
+                ]
+            )
+        )
+        assert code == 0
+
+
+class TestNoRegistryWrites:
+    """Regression: preset loader does not touch registry/out/ops paths."""
+
+    def test_load_only_reads_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "only.json"
+        p.write_text(json.dumps(_minimal_ma_preset_doc()), encoding="utf-8")
+        load_walkforward_candidate_presets(p)
+        assert {f.name for f in tmp_path.iterdir()} == {"only.json"}


### PR DESCRIPTION
## Summary
- add walkforward candidate preset JSON contract v0
- allow `run_walkforward_backtest.py` to consume explicit candidate parameter sets via `--candidate-presets`
- preserve existing sweep/top-N behavior when the flag is omitted
- add focused tests for loader validation, duplicate names, CLI branch, and end-to-end behavior
- add CLI doc/example for candidate presets
- parquet OHLCV with a `timestamp` column is normalized to DatetimeIndex on load

## Profit relevance
- enables direct walk-forward validation of selected Stage-2 regime-aware portfolio candidates (**full param surface must match what the strategy expects**, e.g. portfolio components — same as sweep-assembled configs)
- avoids depending on sweep/top-N report lookup for explicitly selected candidates
- supports comparing named candidates (e.g. best vs weak) once presets mirror sweep-complete params

## Safety / authority boundaries
- non-live research validation only
- no Live authorization
- no Testnet/Gate changes
- no Master V2 / Double Play core change
- no Risk/KillSwitch change
- no registry/out/ops mutation
- no strategy promotion or profitability claim

## Validation
- `uv run pytest tests/test_walkforward_candidate_presets_v0.py -q`
- `uv run pytest tests -q -k "walkforward or candidate_presets or run_walkforward"`
- `uv run ruff check src/backtest/walkforward.py scripts/run_walkforward_backtest.py tests/test_walkforward_candidate_presets_v0.py`
- `uv run ruff format --check src/backtest/walkforward.py scripts/run_walkforward_backtest.py tests/test_walkforward_candidate_presets_v0.py`
- local smoke: `BTC_EUR_1m.parquet` with **1d / 12h** windows (file span ~4d; **90d/30d requires longer history**). Preset strategy **ma_crossover** for end-to-end file writes; **regime_aware_portfolio** needs full component config (otherwise backtest errors e.g. empty components).
- latest smoke dir: `/tmp/peak_trade_walkforward_candidate_presets_pr_smoke_20260429_050639/walkforward_out`

Made with [Cursor](https://cursor.com)