### PR TITLE
fix(strategies): apply vol regime overrides in legacy signals path v0

### DIFF
--- a/src/strategies/regime_aware_portfolio.py
+++ b/src/strategies/regime_aware_portfolio.py
@@ -508,5 +508,9 @@ def generate_signals(df: pd.DataFrame, params: Dict) -> pd.Series:
         "signal_threshold": params.get("signal_threshold", 0.3),
     }
 
-    strategy = RegimeAwarePortfolioStrategy(config=config)
+    embedded = _extract_vol_regime_filter_cfg_overrides(params)
+    strategy = RegimeAwarePortfolioStrategy(
+        config=config,
+        regime_component_cfg_overrides=embedded or None,
+    )
     return strategy.generate_signals(df)

--- a/tests/test_regime_aware_portfolio_component_overrides_v0.py
+++ b/tests/test_regime_aware_portfolio_component_overrides_v0.py
@@ -3,12 +3,17 @@
 
 from __future__ import annotations
 
+import logging
+
 import pandas as pd
 import pytest
 
 from src.core.peak_config import load_config
 from src.strategies.registry import get_strategy_spec
-from src.strategies.regime_aware_portfolio import RegimeAwarePortfolioStrategy
+from src.strategies.regime_aware_portfolio import (
+    RegimeAwarePortfolioStrategy,
+    generate_signals as regime_aware_generate_signals,
+)
 from src.strategies.vol_regime_filter import VolRegimeFilter
 
 
@@ -94,3 +99,26 @@ class TestRegimePortfolioComponentOverrides:
         df = _minimal_ohlcv()
         strat.generate_signals(df)
         assert getattr(strat._regime_strategy, "regime_mode", None) is True
+
+    def test_legacy_generate_signals_applies_vol_regime_overrides(
+        self, cfg, portfolio_section: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Walk-forward / load_strategy path uses module generate_signals(df, params)."""
+        base = RegimeAwarePortfolioStrategy.from_config(
+            cfg, section=portfolio_section, param_overrides={}
+        )
+        params = {
+            "components": base.components,
+            "base_weights": base.base_weights,
+            "regime_strategy": base.regime_strategy_name,
+            "mode": base.mode,
+            "risk_on_scale": base.risk_on_scale,
+            "neutral_scale": base.neutral_scale,
+            "risk_off_scale": base.risk_off_scale,
+            "signal_threshold": base.signal_threshold,
+            "strategy.vol_regime_filter.regime_mode": True,
+        }
+        df = _minimal_ohlcv()
+        with caplog.at_level(logging.WARNING, logger="src.strategies.regime_aware_portfolio"):
+            regime_aware_generate_signals(df, params)
+        assert not any("regime_mode=False" in rec.message for rec in caplog.records), caplog.text


### PR DESCRIPTION
## Summary
- apply vol_regime_filter nested overrides in the legacy regime_aware_portfolio generate_signals path
- align walk-forward candidate preset behavior with Stage-2 sweep semantics
- preserve existing behavior when no override is supplied
- add focused regression coverage for removing the regime_mode=False warning

## Profit relevance
- walk-forward candidate presets now evaluate the same intended regime-mode semantics as the Stage-2 sweep
- prevents interpreting walk-forward results from a mismatched filter-mode component path

## Safety / authority boundaries
- non-live research path alignment only
- no Live authorization
- no Testnet/Gate changes
- no Master V2 / Double Play core change
- no Risk/KillSwitch change
- no registry/out/ops mutation
- no strategy promotion or profitability claim

## Validation
- uv run pytest tests/test_regime_aware_portfolio_component_overrides_v0.py tests/test_walkforward_candidate_presets_v0.py -q
- uv run pytest tests -q -k "walkforward or candidate_presets or regime_aware_portfolio"
- uv run ruff check src/strategies/regime_aware_portfolio.py tests/test_regime_aware_portfolio_component_overrides_v0.py tests/test_walkforward_candidate_presets_v0.py
- uv run ruff format --check src/strategies/regime_aware_portfolio.py tests/test_regime_aware_portfolio_component_overrides_v0.py tests/test_walkforward_candidate_presets_v0.py
- /tmp walk-forward smoke removed regime_mode=False warning under /tmp/peak_trade_walkforward_component_override_bridge_pr_smoke_20260429_053215

Made with [Cursor](https://cursor.com)