### PR TITLE
feat(paper): add bounded futures accounting model v0

### DIFF
--- a/docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md
+++ b/docs/GOVERNANCE_AND_SAFETY_OVERVIEW.md
@@ -39,6 +39,7 @@ Peak_Trade ist aktuell ein **Research-/Backtest-/Paper-/Shadow-System**:
 - **Strategien & Research**: Playground mit `ma_crossover`, `trend_following`, `mean_reversion`, etc.
 - **Analytics & Reporting**: Experiment Explorer, HTML-Reports, Regime-Analyse
 - **Execution**: Paper-/Shadow-Execution (Phase 24), keine echten Orders
+- **Execution-Paper (rein offline):** `src&#47;execution&#47;paper&#47;futures_accounting.py` enthält ein **deterministisches Futures-Paper-Accounting v0** (Notional, lineares Long/Short-PnL, Margin-**Schätzungen**, Funding-/Liquidations-**Platzhalter**) — **ohne** Exchange-I/O, **ohne** Anbindung an WP1B-Runner oder Class-A-Workflow, **nicht** venue-getreu, **keine** Live-/Testnet-Freigabe und **kein** Futures-Class-A- oder Go-Live-Nachweis.
 - **Safety-Status**: Live-/Testnet-Executors sind Stubs, alle echten Order-Pfade blockiert
 
 **NO-LIVE Posture (kanonisch):** Der Repo-Default ist **NO-LIVE** im Sinne der [Stop Rules in `FINISH_PLAN.md`](ops/roadmap/FINISH_PLAN.md#stop-rules-non-negotiable) — **research/backtest first**; keine Live-Order-Platzierung und keine Creds/Secrets in Chats oder Commits. Ergänzend: [`SAFETY_POLICY_TESTNET_AND_LIVE.md`](SAFETY_POLICY_TESTNET_AND_LIVE.md).

--- a/docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md
+++ b/docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md
@@ -40,6 +40,8 @@ Dieses Dokument listet **bewusst nicht implementierte Features** und **bekannte 
 **Referenz:**
 - `src/live/safety.py` – SafetyGuard-Implementierung
 
+- **Offline Futures-Paper-Accounting v0:** `src&#47;execution&#47;paper&#47;futures_accounting.py` — **reines** Hilfsmodul für deterministische Long/Short- und Margin-**Schätzungen** (keine Exchange-Calls, keine Runner-Verdrahtung, keine venue-getreue Liquidation); **keine** Strategieautorität und **kein** Live-/Testnet- oder Futures-Class-A-Readiness-Nachweis.
+
 - `src/execution/live/safety.py` and `src/execution/live/reconcile.py` are a bounded Finish-C3 mock/testability slice for safety-rail and reconcile failure-path coverage; they do **not** represent live approval, exchange enablement, or production-ready live operations.
 
 - Finish-C3 LB-OPE-001 Phase 1 further hardens mock-only invariant-first failure handling in `src/execution/live/safety.py` and `src/execution/live/reconcile.py`; this remains non-live, deny-by-default, and is not evidence of live-approved operations.

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-29 — `src&#47;execution&#47;paper&#47;futures_accounting.py` (Pure-Model v0) mit begleitenden Verweisen in `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` und `docs&#47;PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` — offline/deterministisch, ohne Runner/Exchange; **keine** Live-/Testnet-Freigabe, **kein** Futures-Class-A-Abschluss; erfüllt **governance-overview-canonical** / **known-limitations-canonical** Kaskade.
+
 - 2026-04-25 — `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` — Abschnitt „Execution and risk-layer README authority boundary“ (Spiegel zu `src&#47;execution&#47;README.md` / `src&#47;risk_layer&#47;README.md`; P0-C Epoch-/Autoritätsgrenze; **keine** Live-Freigabe); paired with `governance-overview-canonical`.
 
 - 2026-04-20 — `scripts&#47;report_live_sessions.py` — read-only `--bounded-pilot-readiness-summary` (Readiness + Operator-Preflight-Packet + Registry-Fokus; keine Autorisierung); Runbook `RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md` §4; **keine** Live-Freigabe.

--- a/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
@@ -82,6 +82,7 @@ This section is **non-claims** language only; it does not accuse past runs of mi
 ## 6. Safe future route
 
 - **Retain** the **current** **spot** Class A workflow as **spot infrastructure smoke** (bounded, paper, public data, artifacts).
+- **Offline futures paper accounting v0 (pure-model anchor):** `src&#47;execution&#47;paper&#47;futures_accounting.py` is a **side-effect-free**, **deterministic** kernel for notional, linear long/short PnL, margin **estimates**, funding **placeholder**, and a **conservative** liquidation-proximity label — **not** venue-accurate liquidation, **not** wired to the Class A runner or WP1B hot path, **non-authorizing**, and **does not** close §4–§7 or Futures Class A by itself.
 - Keep **next Futures work** in **docs** / **pure-model** / **read-only** lanes first until §4 gaps have **explicit** contracts and tests.
 - Any **first** **Futures Class A** **runtime** candidate should be **separate** from the **spot** workflow (new workflow or gated path), with its own **non-live** / **no-testnet** guards and **evidence schema**.
 - Require, before such a probe: **Futures instrument metadata** contract alignment, **public read-only** provider contract, a **futures paper accounting** model (even if minimal), **risk** gates, and **evidence** fields — none of which are satisfied by **BTC/EUR** Class A alone.

--- a/src/execution/paper/futures_accounting.py
+++ b/src/execution/paper/futures_accounting.py
@@ -1,0 +1,331 @@
+"""
+Futures paper accounting v0 — pure, offline, side-effect free.
+
+Deterministic primitives for notional, margin estimates, PnL, funding placeholder,
+and conservative liquidation proximity. Not exchange-accurate; not wired to runners.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+from typing import Optional, Tuple, Union
+
+
+class FuturesSide(str, Enum):
+    LONG = "long"
+    SHORT = "short"
+
+
+class LiquidationProximityV0(str, Enum):
+    """Conservative v0 proximity vs maintenance margin — not venue liquidation."""
+
+    SAFE = "safe"
+    WARNING_INSUFFICIENT_BUFFER = "warning_insufficient_buffer"
+    BLOCKED_BELOW_MAINTENANCE = "blocked_below_maintenance"
+
+
+@dataclass(frozen=True)
+class FuturesInstrumentSpec:
+    symbol: str
+    contract_size: Decimal
+    tick_size: Decimal
+    min_qty: Decimal
+    quote_currency: str
+
+
+@dataclass(frozen=True)
+class FuturesMarginSpec:
+    initial_margin_rate: Decimal
+    maintenance_margin_rate: Decimal
+    max_leverage: Decimal
+
+
+@dataclass(frozen=True)
+class FuturesPosition:
+    symbol: str
+    side: FuturesSide
+    qty: Decimal
+    entry_price: Decimal
+    mark_price: Decimal
+    realized_pnl: Decimal
+    funding_pnl: Decimal
+    fees_paid: Decimal = Decimal("0")
+
+
+def _to_decimal(name: str, value: Union[Decimal, float, int, str]) -> Decimal:
+    if isinstance(value, Decimal):
+        d = value
+    else:
+        d = Decimal(str(value))
+    if not d.is_finite():
+        raise ValueError(f"{name} must be finite")
+    return d
+
+
+def validate_futures_accounting_inputs(
+    *,
+    instrument: FuturesInstrumentSpec,
+    margin: FuturesMarginSpec,
+    wallet_equity: Optional[Decimal] = None,
+    position: Optional[FuturesPosition] = None,
+) -> None:
+    """Fail-closed validation for v0 accounting inputs."""
+    if not instrument.symbol.strip():
+        raise ValueError("instrument.symbol must be non-empty")
+    if not instrument.quote_currency.strip():
+        raise ValueError("instrument.quote_currency must be non-empty")
+
+    for label, field in (
+        ("contract_size", instrument.contract_size),
+        ("tick_size", instrument.tick_size),
+        ("min_qty", instrument.min_qty),
+    ):
+        d = _to_decimal(label, field)
+        if d <= 0:
+            raise ValueError(f"instrument.{label} must be > 0")
+
+    imr = _to_decimal("initial_margin_rate", margin.initial_margin_rate)
+    mmr = _to_decimal("maintenance_margin_rate", margin.maintenance_margin_rate)
+    ml = _to_decimal("max_leverage", margin.max_leverage)
+    if imr <= 0 or imr >= 1:
+        raise ValueError("margin.initial_margin_rate must be in (0, 1)")
+    if mmr <= 0 or mmr >= 1:
+        raise ValueError("margin.maintenance_margin_rate must be in (0, 1)")
+    if mmr > imr:
+        raise ValueError("maintenance_margin_rate must not exceed initial_margin_rate")
+    if ml < 1:
+        raise ValueError("margin.max_leverage must be >= 1")
+    # Consistency: margin fractions must support at most max_leverage notional per unit margin.
+    if ml * imr < Decimal("1"):
+        raise ValueError(
+            "inconsistent margin: max_leverage * initial_margin_rate must be >= 1 "
+            "(e.g. 10x leverage needs at least 10% initial margin rate)"
+        )
+
+    if wallet_equity is not None:
+        we = _to_decimal("wallet_equity", wallet_equity)
+        if we < 0:
+            raise ValueError("wallet_equity must be >= 0")
+
+    if position is not None:
+        _validate_position_primitives(
+            qty=position.qty,
+            entry_price=position.entry_price,
+            mark_price=position.mark_price,
+        )
+
+
+def _validate_position_primitives(
+    *,
+    qty: Decimal,
+    entry_price: Decimal,
+    mark_price: Decimal,
+) -> None:
+    q = _to_decimal("qty", qty)
+    ep = _to_decimal("entry_price", entry_price)
+    mp = _to_decimal("mark_price", mark_price)
+    if q <= 0:
+        raise ValueError("qty must be > 0")
+    if ep <= 0 or mp <= 0:
+        raise ValueError("entry_price and mark_price must be > 0")
+
+
+def notional_value(*, mark_price: Decimal, qty: Decimal, contract_size: Decimal) -> Decimal:
+    """Notional in quote currency: |qty| * mark * contract_size (qty magnitude convention: positive)."""
+    mp = _to_decimal("mark_price", mark_price)
+    q = _to_decimal("qty", qty)
+    cs = _to_decimal("contract_size", contract_size)
+    if q <= 0 or mp <= 0 or cs <= 0:
+        raise ValueError("mark_price, qty, contract_size must be > 0")
+    return q * mp * cs
+
+
+def unrealized_pnl(
+    *,
+    side: FuturesSide,
+    entry_price: Decimal,
+    mark_price: Decimal,
+    qty: Decimal,
+    contract_size: Decimal,
+) -> Decimal:
+    """Linear v0: long (mark-entry)*q*cs; short (entry-mark)*q*cs."""
+    _validate_position_primitives(qty=qty, entry_price=entry_price, mark_price=mark_price)
+    cs = _to_decimal("contract_size", contract_size)
+    if cs <= 0:
+        raise ValueError("contract_size must be > 0")
+    q = _to_decimal("qty", qty)
+    ep = _to_decimal("entry_price", entry_price)
+    mp = _to_decimal("mark_price", mark_price)
+    unit = q * cs
+    if side == FuturesSide.LONG:
+        return (mp - ep) * unit
+    return (ep - mp) * unit
+
+
+def initial_margin_required(*, notional: Decimal, initial_margin_rate: Decimal) -> Decimal:
+    n = _to_decimal("notional", notional)
+    r = _to_decimal("initial_margin_rate", initial_margin_rate)
+    if n < 0:
+        raise ValueError("notional must be >= 0")
+    if r <= 0 or r >= 1:
+        raise ValueError("initial_margin_rate must be in (0, 1)")
+    return n * r
+
+
+def maintenance_margin_required(
+    *,
+    notional: Decimal,
+    maintenance_margin_rate: Decimal,
+) -> Decimal:
+    n = _to_decimal("notional", notional)
+    r = _to_decimal("maintenance_margin_rate", maintenance_margin_rate)
+    if n < 0:
+        raise ValueError("notional must be >= 0")
+    if r <= 0 or r >= 1:
+        raise ValueError("maintenance_margin_rate must be in (0, 1)")
+    return n * r
+
+
+def funding_payment_quote(
+    *,
+    side: FuturesSide,
+    notional: Decimal,
+    funding_rate: Decimal,
+) -> Decimal:
+    """
+    Signed quote-currency funding payment for one accrual step.
+
+    funding_rate > 0 means long pays short (long debited, short credited).
+    """
+    n = _to_decimal("notional", notional)
+    fr = _to_decimal("funding_rate", funding_rate)
+    if n < 0:
+        raise ValueError("notional must be >= 0")
+    if side == FuturesSide.LONG:
+        return -fr * n
+    return fr * n
+
+
+def apply_funding_payment(
+    position: FuturesPosition,
+    *,
+    notional: Decimal,
+    funding_rate: Decimal,
+) -> FuturesPosition:
+    """Return a copy with funding_pnl adjusted by funding_payment_quote."""
+    delta = funding_payment_quote(side=position.side, notional=notional, funding_rate=funding_rate)
+    return FuturesPosition(
+        symbol=position.symbol,
+        side=position.side,
+        qty=position.qty,
+        entry_price=position.entry_price,
+        mark_price=position.mark_price,
+        realized_pnl=position.realized_pnl,
+        funding_pnl=position.funding_pnl + delta,
+        fees_paid=position.fees_paid,
+    )
+
+
+def estimate_liquidation_proximity_v0(
+    *,
+    equity: Decimal,
+    maintenance_margin: Decimal,
+    warning_buffer_fraction: Decimal = Decimal("0.05"),
+) -> Tuple[LiquidationProximityV0, Optional[Decimal]]:
+    """
+    Conservative placeholder: compares equity to maintenance margin only.
+
+    Returns (status, buffer_quote) where buffer = equity - maintenance_margin.
+    """
+    eq = _to_decimal("equity", equity)
+    mm = _to_decimal("maintenance_margin", maintenance_margin)
+    wf = _to_decimal("warning_buffer_fraction", warning_buffer_fraction)
+    if mm <= 0:
+        raise ValueError("maintenance_margin must be > 0")
+    if wf < 0 or wf >= 1:
+        raise ValueError("warning_buffer_fraction must be in [0, 1)")
+
+    buffer_ = eq - mm
+    if buffer_ < 0:
+        return LiquidationProximityV0.BLOCKED_BELOW_MAINTENANCE, buffer_
+    if buffer_ < mm * wf:
+        return LiquidationProximityV0.WARNING_INSUFFICIENT_BUFFER, buffer_
+    return LiquidationProximityV0.SAFE, buffer_
+
+
+def realize_pnl_on_close(
+    *,
+    side: FuturesSide,
+    entry_price: Decimal,
+    close_price: Decimal,
+    close_qty: Decimal,
+    contract_size: Decimal,
+    fee_quote: Decimal = Decimal("0"),
+) -> Decimal:
+    """Realized quote PnL for closing `close_qty` at `close_price`, minus fee_quote."""
+    cq = _to_decimal("close_qty", close_qty)
+    if cq <= 0:
+        raise ValueError("close_qty must be > 0")
+    gross = unrealized_pnl(
+        side=side,
+        entry_price=entry_price,
+        mark_price=close_price,
+        qty=cq,
+        contract_size=contract_size,
+    )
+    fee = _to_decimal("fee_quote", fee_quote)
+    if fee < 0:
+        raise ValueError("fee_quote must be >= 0")
+    return gross - fee
+
+
+def reduce_position(
+    position: FuturesPosition,
+    *,
+    contract_size: Decimal,
+    close_qty: Decimal,
+    close_price: Decimal,
+    fee_quote: Decimal = Decimal("0"),
+) -> FuturesPosition:
+    """Partial or full close at close_price; updates qty and realized_pnl."""
+    cq = _to_decimal("close_qty", close_qty)
+    if cq <= 0:
+        raise ValueError("close_qty must be > 0")
+    if cq > position.qty:
+        raise ValueError("close_qty must not exceed open qty")
+    realized_delta = realize_pnl_on_close(
+        side=position.side,
+        entry_price=position.entry_price,
+        close_price=close_price,
+        close_qty=cq,
+        contract_size=contract_size,
+        fee_quote=fee_quote,
+    )
+    new_qty = position.qty - cq
+    return FuturesPosition(
+        symbol=position.symbol,
+        side=position.side,
+        qty=new_qty,
+        entry_price=position.entry_price,
+        mark_price=position.mark_price,
+        realized_pnl=position.realized_pnl + realized_delta,
+        funding_pnl=position.funding_pnl,
+        fees_paid=position.fees_paid + _to_decimal("fee_quote", fee_quote),
+    )
+
+
+def apply_fee_on_notional(
+    *,
+    notional: Decimal,
+    fee_bps: Decimal,
+) -> Decimal:
+    """Optional helper: fee = notional * fee_bps / 10000 (same idiom as PaperBroker)."""
+    n = _to_decimal("notional", notional)
+    bps = _to_decimal("fee_bps", fee_bps)
+    if n < 0:
+        raise ValueError("notional must be >= 0")
+    if bps < 0:
+        raise ValueError("fee_bps must be >= 0")
+    return n * bps / Decimal("10000")

--- a/tests/execution/paper/test_futures_accounting_v0.py
+++ b/tests/execution/paper/test_futures_accounting_v0.py
@@ -1,0 +1,223 @@
+"""Tests for futures paper accounting v0 (pure, offline)."""
+
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from src.execution.paper.futures_accounting import (
+    FuturesInstrumentSpec,
+    FuturesMarginSpec,
+    FuturesPosition,
+    FuturesSide,
+    LiquidationProximityV0,
+    apply_fee_on_notional,
+    apply_funding_payment,
+    estimate_liquidation_proximity_v0,
+    funding_payment_quote,
+    initial_margin_required,
+    maintenance_margin_required,
+    notional_value,
+    reduce_position,
+    unrealized_pnl,
+    validate_futures_accounting_inputs,
+)
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "src" / "execution" / "paper" / "futures_accounting.py"
+)
+
+
+def _spec() -> tuple[FuturesInstrumentSpec, FuturesMarginSpec]:
+    inst = FuturesInstrumentSpec(
+        symbol="PF_XBTUSD",
+        contract_size=Decimal("1"),
+        tick_size=Decimal("0.5"),
+        min_qty=Decimal("0.001"),
+        quote_currency="USD",
+    )
+    margin = FuturesMarginSpec(
+        initial_margin_rate=Decimal("0.1"),
+        maintenance_margin_rate=Decimal("0.05"),
+        max_leverage=Decimal("10"),
+    )
+    return inst, margin
+
+
+def test_unrealized_long_positive_when_mark_above_entry() -> None:
+    pnl = unrealized_pnl(
+        side=FuturesSide.LONG,
+        entry_price=Decimal("100"),
+        mark_price=Decimal("110"),
+        qty=Decimal("2"),
+        contract_size=Decimal("1"),
+    )
+    assert pnl == Decimal("20")
+
+
+def test_unrealized_long_negative_when_mark_below_entry() -> None:
+    pnl = unrealized_pnl(
+        side=FuturesSide.LONG,
+        entry_price=Decimal("100"),
+        mark_price=Decimal("90"),
+        qty=Decimal("1"),
+        contract_size=Decimal("1"),
+    )
+    assert pnl == Decimal("-10")
+
+
+def test_unrealized_short_positive_when_mark_below_entry() -> None:
+    pnl = unrealized_pnl(
+        side=FuturesSide.SHORT,
+        entry_price=Decimal("100"),
+        mark_price=Decimal("90"),
+        qty=Decimal("2"),
+        contract_size=Decimal("1"),
+    )
+    assert pnl == Decimal("20")
+
+
+def test_unrealized_short_negative_when_mark_above_entry() -> None:
+    pnl = unrealized_pnl(
+        side=FuturesSide.SHORT,
+        entry_price=Decimal("100"),
+        mark_price=Decimal("110"),
+        qty=Decimal("1"),
+        contract_size=Decimal("1"),
+    )
+    assert pnl == Decimal("-10")
+
+
+def test_notional_scales_with_contract_size() -> None:
+    n = notional_value(mark_price=Decimal("50"), qty=Decimal("4"), contract_size=Decimal("10"))
+    assert n == Decimal("2000")
+
+
+def test_initial_margin_deterministic() -> None:
+    im = initial_margin_required(notional=Decimal("1000"), initial_margin_rate=Decimal("0.1"))
+    assert im == Decimal("100")
+
+
+def test_maintenance_margin_deterministic() -> None:
+    mm = maintenance_margin_required(
+        notional=Decimal("800"), maintenance_margin_rate=Decimal("0.05")
+    )
+    assert mm == Decimal("40")
+
+
+def test_funding_side_aware() -> None:
+    n = Decimal("10000")
+    rate = Decimal("0.0001")
+    long_pay = funding_payment_quote(side=FuturesSide.LONG, notional=n, funding_rate=rate)
+    short_pay = funding_payment_quote(side=FuturesSide.SHORT, notional=n, funding_rate=rate)
+    assert long_pay == -rate * n
+    assert short_pay == rate * n
+    pos = FuturesPosition(
+        symbol="PF",
+        side=FuturesSide.LONG,
+        qty=Decimal("1"),
+        entry_price=Decimal("100"),
+        mark_price=Decimal("100"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+    )
+    after = apply_funding_payment(pos, notional=n, funding_rate=rate)
+    assert after.funding_pnl == long_pay
+
+
+def test_liquidation_proximity_placeholder() -> None:
+    st, buf = estimate_liquidation_proximity_v0(
+        equity=Decimal("100"),
+        maintenance_margin=Decimal("100"),
+        warning_buffer_fraction=Decimal("0.05"),
+    )
+    assert st == LiquidationProximityV0.WARNING_INSUFFICIENT_BUFFER
+    assert buf == Decimal("0")
+
+    st2, _ = estimate_liquidation_proximity_v0(
+        equity=Decimal("50"),
+        maintenance_margin=Decimal("100"),
+    )
+    assert st2 == LiquidationProximityV0.BLOCKED_BELOW_MAINTENANCE
+
+    st3, _ = estimate_liquidation_proximity_v0(
+        equity=Decimal("200"),
+        maintenance_margin=Decimal("100"),
+    )
+    assert st3 == LiquidationProximityV0.SAFE
+
+
+def test_invalid_inputs_fail_closed() -> None:
+    with pytest.raises(ValueError):
+        notional_value(mark_price=Decimal("-1"), qty=Decimal("1"), contract_size=Decimal("1"))
+    with pytest.raises(ValueError):
+        unrealized_pnl(
+            side=FuturesSide.LONG,
+            entry_price=Decimal("0"),
+            mark_price=Decimal("10"),
+            qty=Decimal("1"),
+            contract_size=Decimal("1"),
+        )
+    inst, margin = _spec()
+    bad_margin = FuturesMarginSpec(
+        initial_margin_rate=Decimal("0.05"),
+        maintenance_margin_rate=Decimal("0.04"),
+        max_leverage=Decimal("10"),
+    )
+    with pytest.raises(ValueError):
+        validate_futures_accounting_inputs(instrument=inst, margin=bad_margin)
+    bad_inst = FuturesInstrumentSpec(
+        symbol="",
+        contract_size=Decimal("1"),
+        tick_size=Decimal("1"),
+        min_qty=Decimal("1"),
+        quote_currency="USD",
+    )
+    with pytest.raises(ValueError):
+        validate_futures_accounting_inputs(instrument=bad_inst, margin=margin)
+
+
+def test_reduce_position_realizes_pnl() -> None:
+    pos = FuturesPosition(
+        symbol="PF",
+        side=FuturesSide.LONG,
+        qty=Decimal("2"),
+        entry_price=Decimal("100"),
+        mark_price=Decimal("110"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+    )
+    new_p = reduce_position(
+        pos,
+        contract_size=Decimal("1"),
+        close_qty=Decimal("1"),
+        close_price=Decimal("120"),
+        fee_quote=Decimal("1"),
+    )
+    assert new_p.qty == Decimal("1")
+    assert new_p.realized_pnl == Decimal("19")
+    assert new_p.fees_paid == Decimal("1")
+
+
+def test_no_forbidden_imports_in_module() -> None:
+    text = _MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    banned = ("master_v2", "live", "ccxt", "requests")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                base = (alias.name or "").split(".")[0]
+                assert base not in banned, alias.name
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module is not None
+            mod = node.module
+            for b in banned:
+                assert b not in mod, mod
+
+
+def test_apply_fee_on_notional_matches_bps_idiom() -> None:
+    fee = apply_fee_on_notional(notional=Decimal("10000"), fee_bps=Decimal("10"))
+    assert fee == Decimal("10")


### PR DESCRIPTION
## Summary
- add a pure, deterministic Futures Paper Accounting v0 kernel under src/execution/paper
- cover long/short PnL, notional with contract size, margin estimates, funding, liquidation proximity placeholder, reduce/close behavior, and fees
- add deterministic tests including AST import guard against live/exchange/Master-V2 authority coupling
- add a bounded non-authorizing docs pointer in the Futures Class-A Capability Contract

## Safety / authority
- pure-model-only
- no runner wiring
- no exchange calls
- no scheduled workflow changes
- no Master V2 / Double Play runtime changes
- no Scope/Capital, Risk/KillSwitch, or Execution/Live Gate changes
- does not close Futures Class-A readiness by itself
- no Testnet/Live approval

## Validation
- uv run pytest tests/execution/paper/test_futures_accounting_v0.py -q
- uv run ruff check src/execution/paper/futures_accounting.py tests/execution/paper/test_futures_accounting_v0.py
- uv run ruff format --check src/execution/paper/futures_accounting.py tests/execution/paper/test_futures_accounting_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)