### PR TITLE
feat(ops): add class a spot paper snapshot report v0

### DIFF
--- a/scripts/ops/report_class_a_spot_paper_snapshot_v0.py
+++ b/scripts/ops/report_class_a_spot_paper_snapshot_v0.py
@@ -1,0 +1,313 @@
+"""Read-only Class-A Spot/Paper scheduled workflow snapshot report (v0).
+
+Summarizes `gh run list` JSON for the Class-A shadow/paper scheduled probe workflow.
+No network I/O unless ``--gh`` is used. No mutations, no artifact downloads.
+
+This report is infrastructure-smoke evidence only: it is not Futures/Perp readiness,
+not Testnet/Live approval, and does not authorize execution wiring or gate bypass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+CONTRACT = "class_a_spot_paper_snapshot_report_v0"
+DEFAULT_WORKFLOW = "class-a-shadow-paper-scheduled-probe-v1.yml"
+GH_JSON_FIELDS = (
+    "databaseId,status,conclusion,event,createdAt,updatedAt,headBranch,headSha,url"
+)
+
+
+def normalize_run_record(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return a minimal dict with string values for known keys (best-effort)."""
+    out: dict[str, Any] = {}
+    for key in (
+        "databaseId",
+        "status",
+        "conclusion",
+        "event",
+        "createdAt",
+        "updatedAt",
+        "headBranch",
+        "headSha",
+        "url",
+    ):
+        val = raw.get(key)
+        if val is None:
+            out[key] = None
+        elif isinstance(val, (str, int, bool)):
+            out[key] = val
+        else:
+            out[key] = str(val)
+    return out
+
+
+def summarize_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Pure summary counters and caveats from normalized or raw gh run records."""
+    total = len(runs)
+    completed = 0
+    completed_success = 0
+    completed_skipped = 0
+    completed_failure = 0
+    completed_cancelled = 0
+    completed_other = 0
+    not_completed = 0
+    schedule_rows = 0
+
+    for raw in runs:
+        r = raw if "databaseId" in raw else normalize_run_record(raw)
+        status = (r.get("status") or "").strip().lower()
+        conclusion = r.get("conclusion")
+        conclusion_l = (
+            conclusion.strip().lower() if isinstance(conclusion, str) else None
+        )
+        event = (r.get("event") or "").strip().lower()
+        if event == "schedule":
+            schedule_rows += 1
+
+        if status != "completed":
+            not_completed += 1
+            continue
+
+        completed += 1
+        if conclusion_l == "success":
+            completed_success += 1
+        elif conclusion_l == "skipped":
+            completed_skipped += 1
+        elif conclusion_l == "failure":
+            completed_failure += 1
+        elif conclusion_l == "cancelled":
+            completed_cancelled += 1
+        else:
+            completed_other += 1
+
+    caveats: list[str] = [
+        "Class-A Spot/Paper scheduled workflow visibility is infrastructure-smoke only.",
+        "This is not Futures/Perp readiness and not Testnet/Live approval.",
+        "Schedule success does not imply PaperExecutionEngine or Futures wiring.",
+        "Do not treat 'skipped' conclusions as successful probes without reading that run's logs.",
+    ]
+    if completed_skipped:
+        caveats.append(
+            "At least one completed run has conclusion 'skipped'; review URLs before inferring health."
+        )
+    if completed_failure or completed_cancelled:
+        caveats.append(
+            "Non-success conclusions appear in the sample; treat the window as not uniformly green."
+        )
+    if not_completed:
+        caveats.append(
+            "Some runs are not completed in this sample; conclusions apply only to listed rows."
+        )
+
+    return {
+        "run_count": total,
+        "schedule_event_rows": schedule_rows,
+        "completed_total": completed,
+        "completed_success": completed_success,
+        "completed_skipped": completed_skipped,
+        "completed_failure": completed_failure,
+        "completed_cancelled": completed_cancelled,
+        "completed_other_conclusion": completed_other,
+        "not_completed": not_completed,
+        "caveats": caveats,
+    }
+
+
+def build_json_payload(
+    *,
+    workflow: str,
+    runs: list[dict[str, Any]],
+    summary: dict[str, Any],
+) -> dict[str, Any]:
+    normalized = [normalize_run_record(r) if isinstance(r, dict) else {} for r in runs]
+    return {
+        "contract": CONTRACT,
+        "non_authorizing": True,
+        "read_only": True,
+        "workflow_file": workflow,
+        "summary": summary,
+        "runs": normalized,
+    }
+
+
+def render_markdown(
+    *,
+    workflow: str,
+    runs: list[dict[str, Any]],
+    summary: dict[str, Any],
+) -> str:
+    lines: list[str] = [
+        "# Class-A Spot/Paper workflow snapshot (read-only)",
+        "",
+        f"- **Contract:** `{CONTRACT}`",
+        f"- **Workflow file:** `{workflow}`",
+        f"- **Runs in sample:** {summary['run_count']}",
+        "",
+        "## Interpretation boundaries",
+        "",
+        "- Infrastructure-smoke / scheduled probe visibility only.",
+        "- **Not** Futures or perpetual readiness.",
+        "- **Not** Testnet or Live approval.",
+        "- **Not** evidence of PaperExecutionEngine ↔ Futures accounting wiring.",
+        "- Does **not** bypass Master V2 / Double Play, Scope/Capital, Risk/KillSwitch, or execution gates.",
+        "",
+        "## Summary counts",
+        "",
+        f"- Schedule-tagged rows (event=`schedule`): **{summary['schedule_event_rows']}**",
+        f"- Completed + conclusion **success**: **{summary['completed_success']}**",
+        f"- Completed + conclusion **skipped**: **{summary['completed_skipped']}**",
+        f"- Completed + **failure** / **cancelled**: **{summary['completed_failure']}** / "
+        f"**{summary['completed_cancelled']}**",
+        f"- Completed + other/unknown conclusion: **{summary['completed_other_conclusion']}**",
+        f"- Not **completed** in this sample: **{summary['not_completed']}**",
+        "",
+        "## Caveats",
+        "",
+    ]
+    for c in summary["caveats"]:
+        lines.append(f"- {c}")
+    lines.extend(["", "## Recent runs (newest first as provided)", "", "| databaseId | status | conclusion | event | createdAt |", "| --- | --- | --- | --- | --- |"])
+    for raw in runs:
+        r = normalize_run_record(raw) if isinstance(raw, dict) else {}
+        lines.append(
+            "| {id} | {st} | {co} | {ev} | {cr} |".format(
+                id=r.get("databaseId", ""),
+                st=r.get("status", ""),
+                co=r.get("conclusion", ""),
+                ev=r.get("event", ""),
+                cr=r.get("createdAt", ""),
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def coerce_run_list(data: Any) -> list[dict[str, Any]]:
+    if not isinstance(data, list):
+        raise ValueError("Expected a JSON array of run objects")
+    out: list[dict[str, Any]] = []
+    for i, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ValueError(f"Run at index {i} is not a JSON object")
+        out.append(item)
+    return out
+
+
+def load_runs_from_json_stream(stream: TextIO) -> list[dict[str, Any]]:
+    return coerce_run_list(json.load(stream))
+
+
+def fetch_runs_via_gh(*, workflow: str, limit: int) -> list[dict[str, Any]]:
+    proc = subprocess.run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            workflow,
+            "--limit",
+            str(limit),
+            "--json",
+            GH_JSON_FIELDS,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(f"gh run list failed (exit {proc.returncode}): {err}")
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"gh output was not valid JSON: {e}") from e
+    return coerce_run_list(data)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Summarize Class-A Spot/Paper scheduled workflow runs from gh JSON "
+            "(stdin, file, or optional gh subprocess)."
+        ),
+        epilog=(
+            "Example (stdin): "
+            "gh run list --workflow class-a-shadow-paper-scheduled-probe-v1.yml "
+            f"--limit 12 --json {GH_JSON_FIELDS} | "
+            "uv run python scripts/ops/report_class_a_spot_paper_snapshot_v0.py "
+            "--stdin-json"
+        ),
+    )
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--stdin-json",
+        action="store_true",
+        help="Read gh run list JSON array from stdin",
+    )
+    src.add_argument(
+        "--input-file",
+        type=Path,
+        metavar="PATH",
+        help="Read gh run list JSON array from a file",
+    )
+    src.add_argument(
+        "--gh",
+        action="store_true",
+        help=f"Run gh run list locally (workflow default: {DEFAULT_WORKFLOW})",
+    )
+    p.add_argument(
+        "--workflow",
+        default=DEFAULT_WORKFLOW,
+        help=f"Workflow YAML name for --gh (default: {DEFAULT_WORKFLOW})",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=12,
+        help="Limit for --gh (default: 12)",
+    )
+    p.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit JSON instead of Markdown (default is Markdown)",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.gh:
+            runs = fetch_runs_via_gh(workflow=args.workflow, limit=args.limit)
+        elif args.stdin_json:
+            runs = load_runs_from_json_stream(sys.stdin)
+        elif args.input_file is not None:
+            with args.input_file.open(encoding="utf-8") as f:
+                runs = load_runs_from_json_stream(f)
+        else:  # pragma: no cover — argparse requires one source
+            raise ValueError("No input source (internal error)")
+    except (ValueError, OSError, RuntimeError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    summary = summarize_runs(runs)
+    if args.emit_json:
+        payload = build_json_payload(workflow=args.workflow, runs=runs, summary=summary)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            render_markdown(workflow=args.workflow, runs=runs, summary=summary),
+            end="",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/report_class_a_spot_paper_snapshot_v0.py
+++ b/scripts/ops/report_class_a_spot_paper_snapshot_v0.py
@@ -18,9 +18,7 @@ from typing import Any, TextIO
 
 CONTRACT = "class_a_spot_paper_snapshot_report_v0"
 DEFAULT_WORKFLOW = "class-a-shadow-paper-scheduled-probe-v1.yml"
-GH_JSON_FIELDS = (
-    "databaseId,status,conclusion,event,createdAt,updatedAt,headBranch,headSha,url"
-)
+GH_JSON_FIELDS = "databaseId,status,conclusion,event,createdAt,updatedAt,headBranch,headSha,url"
 
 
 def normalize_run_record(raw: dict[str, Any]) -> dict[str, Any]:
@@ -63,9 +61,7 @@ def summarize_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
         r = raw if "databaseId" in raw else normalize_run_record(raw)
         status = (r.get("status") or "").strip().lower()
         conclusion = r.get("conclusion")
-        conclusion_l = (
-            conclusion.strip().lower() if isinstance(conclusion, str) else None
-        )
+        conclusion_l = conclusion.strip().lower() if isinstance(conclusion, str) else None
         event = (r.get("event") or "").strip().lower()
         if event == "schedule":
             schedule_rows += 1
@@ -172,7 +168,15 @@ def render_markdown(
     ]
     for c in summary["caveats"]:
         lines.append(f"- {c}")
-    lines.extend(["", "## Recent runs (newest first as provided)", "", "| databaseId | status | conclusion | event | createdAt |", "| --- | --- | --- | --- | --- |"])
+    lines.extend(
+        [
+            "",
+            "## Recent runs (newest first as provided)",
+            "",
+            "| databaseId | status | conclusion | event | createdAt |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
     for raw in runs:
         r = normalize_run_record(raw) if isinstance(raw, dict) else {}
         lines.append(

--- a/tests/ops/test_report_class_a_spot_paper_snapshot_v0.py
+++ b/tests/ops/test_report_class_a_spot_paper_snapshot_v0.py
@@ -54,9 +54,9 @@ def test_summarize_runs_counts_skipped_separately() -> None:
     assert summary["completed_success"] == 1
     assert summary["completed_skipped"] == 1
     assert summary["schedule_event_rows"] == 2
-    assert any(
-        "skipped" in c.lower() for c in summary["caveats"]
-    ), "expected explicit skipped caveat"
+    assert any("skipped" in c.lower() for c in summary["caveats"]), (
+        "expected explicit skipped caveat"
+    )
 
 
 def test_coerce_run_list_rejects_non_list() -> None:

--- a/tests/ops/test_report_class_a_spot_paper_snapshot_v0.py
+++ b/tests/ops/test_report_class_a_spot_paper_snapshot_v0.py
@@ -1,0 +1,168 @@
+"""Tests for scripts/ops/report_class_a_spot_paper_snapshot_v0.py (read-only)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPT = Path("scripts/ops/report_class_a_spot_paper_snapshot_v0.py")
+
+from scripts.ops.report_class_a_spot_paper_snapshot_v0 import (  # noqa: E402
+    build_json_payload,
+    coerce_run_list,
+    fetch_runs_via_gh,
+    render_markdown,
+    summarize_runs,
+)
+
+
+def _sample_runs() -> list[dict[str, object]]:
+    return [
+        {
+            "databaseId": 1,
+            "status": "completed",
+            "conclusion": "success",
+            "event": "schedule",
+            "createdAt": "2026-04-29T18:00:00Z",
+            "updatedAt": "2026-04-29T18:05:00Z",
+            "headBranch": "main",
+            "headSha": "abc",
+            "url": "https://example.com/1",
+        },
+        {
+            "databaseId": 2,
+            "status": "completed",
+            "conclusion": "skipped",
+            "event": "schedule",
+            "createdAt": "2026-04-28T12:00:00Z",
+            "updatedAt": "2026-04-28T12:01:00Z",
+            "headBranch": "main",
+            "headSha": "def",
+            "url": "https://example.com/2",
+        },
+    ]
+
+
+def test_summarize_runs_counts_skipped_separately() -> None:
+    summary = summarize_runs(_sample_runs())
+    assert summary["run_count"] == 2
+    assert summary["completed_success"] == 1
+    assert summary["completed_skipped"] == 1
+    assert summary["schedule_event_rows"] == 2
+    assert any(
+        "skipped" in c.lower() for c in summary["caveats"]
+    ), "expected explicit skipped caveat"
+
+
+def test_coerce_run_list_rejects_non_list() -> None:
+    with pytest.raises(ValueError, match="array"):
+        coerce_run_list({})
+
+
+def test_coerce_run_list_rejects_non_object_elements() -> None:
+    with pytest.raises(ValueError, match="index 0"):
+        coerce_run_list([1])
+
+
+def test_build_json_payload_has_contract_and_non_authorizing() -> None:
+    runs = _sample_runs()
+    summary = summarize_runs(runs)
+    payload = build_json_payload(
+        workflow="class-a-shadow-paper-scheduled-probe-v1.yml",
+        runs=runs,
+        summary=summary,
+    )
+    assert payload["contract"] == "class_a_spot_paper_snapshot_report_v0"
+    assert payload["non_authorizing"] is True
+    assert payload["read_only"] is True
+    assert len(payload["runs"]) == 2
+
+
+def test_render_markdown_includes_boundary_language() -> None:
+    runs = _sample_runs()
+    summary = summarize_runs(runs)
+    md = render_markdown(
+        workflow="class-a-shadow-paper-scheduled-probe-v1.yml",
+        runs=runs,
+        summary=summary,
+    )
+    lowered = md.lower()
+    assert "infrastructure-smoke" in lowered
+    assert "not futures" in lowered or "futures" in md.lower()
+    assert "251" not in md  # no hard-coded real run ids in fixture
+
+
+def test_cli_stdin_json_markdown_rc0() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--stdin-json"],
+        input=json.dumps(_sample_runs()),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "Class-A Spot/Paper" in proc.stdout
+    assert proc.stderr == ""
+
+
+def test_cli_stdin_json_emit_json() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--stdin-json", "--json"],
+        input=json.dumps(_sample_runs()),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["summary"]["completed_skipped"] == 1
+
+
+def test_cli_input_file(tmp_path: Path) -> None:
+    p = tmp_path / "runs.json"
+    p.write_text(json.dumps(_sample_runs()), encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--input-file", str(p), "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["summary"]["run_count"] == 2
+
+
+def test_fetch_runs_via_gh_parses_stdout() -> None:
+    with patch.object(subprocess, "run") as m:
+        m.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(_sample_runs()),
+            stderr="",
+        )
+        runs = fetch_runs_via_gh(
+            workflow="class-a-shadow-paper-scheduled-probe-v1.yml",
+            limit=5,
+        )
+    assert len(runs) == 2
+    assert m.call_args is not None
+    cmd = m.call_args[0][0]
+    assert cmd[0] == "gh"
+    assert "--limit" in cmd
+    assert "5" in cmd
+
+
+def test_fetch_runs_via_gh_nonzero_raises() -> None:
+    with patch.object(subprocess, "run") as m:
+        m.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="auth failed",
+        )
+        with pytest.raises(RuntimeError, match="gh run list failed"):
+            fetch_runs_via_gh(workflow="wf.yml", limit=1)


### PR DESCRIPTION
## Summary
- add a read-only Class-A Spot/Paper operational snapshot report
- parse gh run list JSON from stdin/file, with optional isolated --gh mode
- emit conservative Markdown or JSON output
- count skipped runs separately and never treat skipped as success
- include explicit non-claims: Spot/Paper infrastructure-smoke only, no Futures/Perp readiness, no Testnet/Live approval, no Master V2 / Risk / Gate bypass

## Safety / authority
- read-only ops/report surface
- no src/execution changes
- no workflow changes
- no PaperExecutionEngine/Futures wiring
- no exchange calls in default stdin/file mode
- no Master V2 / Double Play runtime changes
- no Scope/Capital, Risk/KillSwitch, or Execution/Live Gate changes
- no Testnet/Live approval

## Validation
- uv run pytest tests/ops/test_report_class_a_spot_paper_snapshot_v0.py -q
- uv run ruff check scripts/ops/report_class_a_spot_paper_snapshot_v0.py tests/ops/test_report_class_a_spot_paper_snapshot_v0.py
- uv run ruff format --check scripts/ops/report_class_a_spot_paper_snapshot_v0.py tests/ops/test_report_class_a_spot_paper_snapshot_v0.py
