### PR TITLE
ci: extend offline daily pytest fast timeout

### DIFF
--- a/scripts/automation/run_offline_daily_suite.py
+++ b/scripts/automation/run_offline_daily_suite.py
@@ -52,6 +52,10 @@ from scripts.run_offline_realtime_ma_crossover import (
 
 logger = logging.getLogger(__name__)
 
+# Subprocess timeout for `job_pytest_fast` (full `pytest -q -x --tb=short` run).
+# Must stay below the GitHub Actions job budget in offline_suites.yml (30m for daily).
+PYTEST_FAST_TIMEOUT_SEC = 600
+
 
 # =============================================================================
 # Job Result Model
@@ -115,7 +119,7 @@ def job_pytest_fast(dry_run: bool = False) -> JobResult:
             cwd=project_root,
             capture_output=True,
             text=True,
-            timeout=120,  # 2 Minuten Timeout
+            timeout=PYTEST_FAST_TIMEOUT_SEC,
         )
 
         duration = time.perf_counter() - start_time
@@ -148,7 +152,7 @@ def job_pytest_fast(dry_run: bool = False) -> JobResult:
             job_name=job_name,
             status="failed",
             duration_sec=duration,
-            error_msg="Pytest timeout after 120s",
+            error_msg=f"Pytest timeout after {PYTEST_FAST_TIMEOUT_SEC}s",
         )
 
     except Exception as e:

--- a/tests/automation/test_run_offline_daily_suite_timeout_v0.py
+++ b/tests/automation/test_run_offline_daily_suite_timeout_v0.py
@@ -1,0 +1,47 @@
+"""Tests for offline daily suite `job_pytest_fast` timeout wiring (no full pytest run)."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from scripts.automation.run_offline_daily_suite import (
+    PYTEST_FAST_TIMEOUT_SEC,
+    job_pytest_fast,
+)
+
+
+def test_pytest_fast_timeout_constant_default() -> None:
+    assert PYTEST_FAST_TIMEOUT_SEC == 600
+
+
+def test_job_pytest_fast_dry_run_skips_subprocess() -> None:
+    with patch.object(subprocess, "run") as m:
+        result = job_pytest_fast(dry_run=True)
+    m.assert_not_called()
+    assert result.status == "skipped"
+
+
+def test_job_pytest_fast_passes_expected_cmd_and_timeout() -> None:
+    with patch.object(subprocess, "run") as m:
+        m.return_value = subprocess.CompletedProcess(
+            args=["pytest"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        job_pytest_fast(dry_run=False)
+    m.assert_called_once()
+    assert m.call_args[0][0] == ["pytest", "-q", "-x", "--tb=short"]
+    assert m.call_args.kwargs["timeout"] == PYTEST_FAST_TIMEOUT_SEC
+
+
+def test_job_pytest_fast_timeout_expired_marks_failed_with_config_seconds() -> None:
+    with patch.object(subprocess, "run") as m:
+        m.side_effect = subprocess.TimeoutExpired(
+            cmd=["pytest", "-q", "-x", "--tb=short"],
+            timeout=PYTEST_FAST_TIMEOUT_SEC,
+        )
+        result = job_pytest_fast(dry_run=False)
+    assert result.status == "failed"
+    assert result.error_msg == f"Pytest timeout after {PYTEST_FAST_TIMEOUT_SEC}s"


### PR DESCRIPTION
## Summary
- replace the inline pytest_fast subprocess timeout with PYTEST_FAST_TIMEOUT_SEC
- increase pytest_fast timeout from 120s to 600s while preserving fail-on-timeout semantics
- keep the pytest command unchanged: pytest -q -x --tb=short
- add focused automation tests for dry-run behavior, timeout propagation, command preservation, and TimeoutExpired failure reporting

## Safety / authority
- CI/automation-only
- no workflow YAML changes
- no trading runtime changes
- no src/execution changes
- no paper test data changes
- no Master V2 / Double Play runtime changes
- no Scope/Capital, Risk/KillSwitch, or Execution/Live Gate changes
- no live/testnet changes

## Validation
- uv run pytest tests/automation/test_run_offline_daily_suite_timeout_v0.py -q
- uv run ruff check scripts/automation/run_offline_daily_suite.py tests/automation/test_run_offline_daily_suite_timeout_v0.py
- uv run ruff format --check scripts/automation/run_offline_daily_suite.py tests/automation/test_run_offline_daily_suite_timeout_v0.py
