### PR TITLE
ci(automation): drop pytest_fast subprocess timeout for GHA outer guard

### DIFF
--- a/scripts/automation/run_offline_daily_suite.py
+++ b/scripts/automation/run_offline_daily_suite.py
@@ -52,10 +52,9 @@ from scripts.run_offline_realtime_ma_crossover import (
 
 logger = logging.getLogger(__name__)
 
-# Subprocess timeout for `job_pytest_fast` (full `pytest -q -x --tb=short` run).
-# Must stay below the GitHub Actions job budget in offline_suites.yml (30m for daily).
-PYTEST_FAST_TIMEOUT_SEC = 600
-
+# `job_pytest_fast` runs `pytest` without an internal `subprocess.run(..., timeout=...)`.
+# The daily-suite GitHub Actions job (`offline_suites.yml`) sets `timeout-minutes: 30`
+# as the outer bounded guard.
 
 # =============================================================================
 # Job Result Model
@@ -119,7 +118,6 @@ def job_pytest_fast(dry_run: bool = False) -> JobResult:
             cwd=project_root,
             capture_output=True,
             text=True,
-            timeout=PYTEST_FAST_TIMEOUT_SEC,
         )
 
         duration = time.perf_counter() - start_time
@@ -144,16 +142,6 @@ def job_pytest_fast(dry_run: bool = False) -> JobResult:
                 extra={"returncode": result.returncode},
                 error_msg=result.stderr[:500] if result.stderr else None,
             )
-
-    except subprocess.TimeoutExpired:
-        duration = time.perf_counter() - start_time
-        logger.error(f"[JOB] {job_name}: TIMEOUT")
-        return JobResult(
-            job_name=job_name,
-            status="failed",
-            duration_sec=duration,
-            error_msg=f"Pytest timeout after {PYTEST_FAST_TIMEOUT_SEC}s",
-        )
 
     except Exception as e:
         duration = time.perf_counter() - start_time

--- a/tests/automation/test_run_offline_daily_suite_timeout_v0.py
+++ b/tests/automation/test_run_offline_daily_suite_timeout_v0.py
@@ -1,18 +1,11 @@
-"""Tests for offline daily suite `job_pytest_fast` timeout wiring (no full pytest run)."""
+"""Tests for offline daily suite `job_pytest_fast` subprocess wiring (no full pytest run)."""
 
 from __future__ import annotations
 
 import subprocess
 from unittest.mock import patch
 
-from scripts.automation.run_offline_daily_suite import (
-    PYTEST_FAST_TIMEOUT_SEC,
-    job_pytest_fast,
-)
-
-
-def test_pytest_fast_timeout_constant_default() -> None:
-    assert PYTEST_FAST_TIMEOUT_SEC == 600
+from scripts.automation.run_offline_daily_suite import job_pytest_fast
 
 
 def test_job_pytest_fast_dry_run_skips_subprocess() -> None:
@@ -22,7 +15,7 @@ def test_job_pytest_fast_dry_run_skips_subprocess() -> None:
     assert result.status == "skipped"
 
 
-def test_job_pytest_fast_passes_expected_cmd_and_timeout() -> None:
+def test_job_pytest_fast_passes_expected_cmd_without_subprocess_timeout() -> None:
     with patch.object(subprocess, "run") as m:
         m.return_value = subprocess.CompletedProcess(
             args=["pytest"],
@@ -33,15 +26,18 @@ def test_job_pytest_fast_passes_expected_cmd_and_timeout() -> None:
         job_pytest_fast(dry_run=False)
     m.assert_called_once()
     assert m.call_args[0][0] == ["pytest", "-q", "-x", "--tb=short"]
-    assert m.call_args.kwargs["timeout"] == PYTEST_FAST_TIMEOUT_SEC
+    assert "timeout" not in m.call_args.kwargs
 
 
-def test_job_pytest_fast_timeout_expired_marks_failed_with_config_seconds() -> None:
+def test_job_pytest_fast_nonzero_return_marks_failed() -> None:
     with patch.object(subprocess, "run") as m:
-        m.side_effect = subprocess.TimeoutExpired(
-            cmd=["pytest", "-q", "-x", "--tb=short"],
-            timeout=PYTEST_FAST_TIMEOUT_SEC,
+        m.return_value = subprocess.CompletedProcess(
+            args=["pytest"],
+            returncode=1,
+            stdout="",
+            stderr="boom",
         )
         result = job_pytest_fast(dry_run=False)
     assert result.status == "failed"
-    assert result.error_msg == f"Pytest timeout after {PYTEST_FAST_TIMEOUT_SEC}s"
+    assert result.extra.get("returncode") == 1
+    assert result.error_msg == "boom"


### PR DESCRIPTION
## Summary
- remove the internal subprocess timeout from offline daily pytest_fast
- rely on the existing offline_suites.yml daily-suite job timeout-minutes: 30 as the outer fail-safe
- keep the pytest command unchanged: pytest -q -x --tb=short
- preserve fail-on-nonzero semantics
- update focused automation tests to assert subprocess.run is called without timeout for pytest_fast

## Safety / authority
- CI/automation-only
- no workflow YAML changes
- no trading runtime changes
- no src/execution changes
- no paper test data changes
- no Master V2 / Double Play runtime changes
- no Scope/Capital, Risk/KillSwitch, or Execution/Live Gate changes
- no live/testnet changes

## Validation
- uv run pytest tests/automation/test_run_offline_daily_suite_timeout_v0.py -q
- uv run ruff check scripts/automation/run_offline_daily_suite.py tests/automation/test_run_offline_daily_suite_timeout_v0.py
- uv run ruff format --check scripts/automation/run_offline_daily_suite.py tests/automation/test_run_offline_daily_suite_timeout_v0.py

Made with [Cursor](https://cursor.com)