### PR TITLE
test(ops): add rollback report cli contract coverage v0

### DIFF
--- a/tests/ops/test_generate_rollback_report_cli_contract_v0.py
+++ b/tests/ops/test_generate_rollback_report_cli_contract_v0.py
@@ -1,0 +1,45 @@
+"""CLI contract tests for scripts/ops/generate_rollback_report.py (placeholder stub)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = ROOT / "scripts" / "ops" / "generate_rollback_report.py"
+
+_EXPECTED_LINE_1 = "Placeholder stub: scripts/ops/generate_rollback_report.py is not implemented."
+_EXPECTED_LINE_2 = "This file exists only to satisfy documentation reference targets."
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("generate_rollback_report", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_cli_exits_2_with_placeholder_stdout(capsys) -> None:
+    mod = _load_module()
+    assert mod.main() == 2
+    out = capsys.readouterr().out
+    assert _EXPECTED_LINE_1 in out
+    assert _EXPECTED_LINE_2 in out
+    assert capsys.readouterr().err == ""
+
+
+def test_cli_subprocess_contract() -> None:
+    p = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert p.returncode == 2
+    assert _EXPECTED_LINE_1 in p.stdout
+    assert _EXPECTED_LINE_2 in p.stdout
+    assert p.stderr == ""


### PR DESCRIPTION
## Summary
- add tests-only CLI contract coverage for scripts/ops/generate_rollback_report.py
- lock current placeholder behavior via direct main() invocation and subprocess execution
- assert exit code 2, expected placeholder stdout, and empty stderr

Safety
- tests-only
- no changes to scripts/ops/generate_rollback_report.py
- no live/testnet behavior
- no Master V2 / Double Play / Scope-Capital / Risk / KillSwitch / Execution Gate changes
- no readiness/evidence/report/index/handoff surface
- no repo docs, rollback artifacts, or paper test data mutation

## Validation
- uv run pytest tests/ops/test_generate_rollback_report_cli_contract_v0.py -q
- uv run ruff check tests/ops/test_generate_rollback_report_cli_contract_v0.py
- uv run ruff format --check tests/ops/test_generate_rollback_report_cli_contract_v0.py

Made with [Cursor](https://cursor.com)