### PR TITLE
test(ops): add formatter policy ci contract coverage v0

### DIFF
--- a/tests/ops/test_check_formatter_policy_ci_enforced_cli_contract_v0.py
+++ b/tests/ops/test_check_formatter_policy_ci_enforced_cli_contract_v0.py
@@ -1,0 +1,57 @@
+"""CLI contract tests for scripts/ops/check_formatter_policy_ci_enforced.sh."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = ROOT / "scripts" / "ops" / "check_formatter_policy_ci_enforced.sh"
+
+_WORKFLOW_REL = Path(".github/workflows/lint_gate.yml")
+_NEEDLE = "scripts/ops/check_no_black_enforcement.sh"
+
+
+def _write_workflow(root: Path, body: str) -> None:
+    wf = root / _WORKFLOW_REL
+    wf.parent.mkdir(parents=True, exist_ok=True)
+    wf.write_text(body, encoding="utf-8")
+
+
+def _run_in(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(_SCRIPT)],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_missing_workflow_exits_1(tmp_path: Path) -> None:
+    p = _run_in(tmp_path)
+    assert p.returncode == 1
+    assert "Workflow not found" in p.stdout
+    assert _WORKFLOW_REL.as_posix() in p.stdout
+    assert p.stderr == ""
+
+
+def test_workflow_without_needle_exits_1(tmp_path: Path) -> None:
+    _write_workflow(tmp_path, "name: lint\njobs: {}\n")
+    p = _run_in(tmp_path)
+    assert p.returncode == 1
+    assert "CI enforcement missing" in p.stdout
+    assert _NEEDLE in p.stdout
+    assert p.stderr == ""
+
+
+def test_workflow_with_needle_exits_0(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        f"name: lint\njobs:\n  x:\n    run: bash {_NEEDLE}\n",
+    )
+    p = _run_in(tmp_path)
+    assert p.returncode == 0
+    assert "PASS" in p.stdout
+    assert _NEEDLE in p.stdout
+    assert p.stderr == ""


### PR DESCRIPTION
## Summary
- add tests-only CLI contract coverage for scripts/ops/check_formatter_policy_ci_enforced.sh
- cover missing workflow, missing CI enforcement needle, and present CI enforcement needle
- keep tests isolated with tmp_path workflow fixtures and absolute script invocation

## Safety
- tests-only
- no changes to scripts/ops/check_formatter_policy_ci_enforced.sh
- no live/testnet behavior
- no Master V2 / Double Play / Scope-Capital / Risk / KillSwitch / Execution Gate changes
- no readiness/evidence/report/index/handoff surface
- no repo workflow/docs or paper test data mutation

## Validation
- uv run pytest tests/ops/test_check_formatter_policy_ci_enforced_cli_contract_v0.py -q
- uv run ruff check tests/ops/test_check_formatter_policy_ci_enforced_cli_contract_v0.py
- uv run ruff format --check tests/ops/test_check_formatter_policy_ci_enforced_cli_contract_v0.py

Made with [Cursor](https://cursor.com)