### PR TITLE
test(ops): add markdown links cli contract coverage v0

### DIFF
--- a/tests/ops/test_check_markdown_links_cli_contract_v0.py
+++ b/tests/ops/test_check_markdown_links_cli_contract_v0.py
@@ -1,0 +1,103 @@
+"""CLI contract tests for scripts/ops/check_markdown_links.py (v0)."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ops" / "check_markdown_links.py"
+
+
+def _run_cli(root: Path, *paths: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(root),
+            "--paths",
+            *paths,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_exit_0_when_no_broken_internal_links(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+    (docs / "guide.md").write_text(
+        "# Guide\n\nSee [section](#details).\n\n## Details\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    p = _run_cli(tmp_path, "docs/guide.md")
+
+    assert p.returncode == 0
+    assert "✅ Markdown link check: OK (no broken internal links found)" in p.stdout
+    assert p.stderr == ""
+
+
+def test_cli_exit_1_when_target_file_missing(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+    (docs / "broken_file.md").write_text(
+        "# Broken\n\nMissing [target](./does-not-exist.md).\n",
+        encoding="utf-8",
+    )
+
+    p = _run_cli(tmp_path, "docs/broken_file.md")
+
+    assert p.returncode == 1
+    assert "❌ Markdown link check: BROKEN LINKS FOUND" in p.stdout
+    assert re.search(
+        r"^- docs/broken_file\.md: \(\./does-not-exist\.md\) -> target file does not exist: \./does-not-exist\.md$",
+        p.stdout,
+        flags=re.MULTILINE,
+    )
+    assert "Total broken links: 1" in p.stdout
+    assert p.stderr == ""
+
+
+def test_cli_exit_1_when_cross_file_anchor_missing(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+    (docs / "source.md").write_text(
+        "# Source\n\nJump to [missing anchor](target.md#nope).\n",
+        encoding="utf-8",
+    )
+    (docs / "target.md").write_text("# Target\n\nText.\n", encoding="utf-8")
+
+    p = _run_cli(tmp_path, "docs")
+
+    assert p.returncode == 1
+    assert "❌ Markdown link check: BROKEN LINKS FOUND" in p.stdout
+    assert re.search(
+        r"^- docs/source\.md: \(target\.md#nope\) -> anchor '#nope' not found in docs/target\.md$",
+        p.stdout,
+        flags=re.MULTILINE,
+    )
+    assert "Total broken links: 1" in p.stdout
+    assert p.stderr == ""
+
+
+def test_cli_ignores_external_and_contact_links(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+    (docs / "external_only.md").write_text(
+        "# External\n\n"
+        "[web](https://example.com)\n"
+        "[mail](mailto:ops@example.com)\n"
+        "[phone](tel:+490000000)\n",
+        encoding="utf-8",
+    )
+
+    p = _run_cli(tmp_path, "docs/external_only.md")
+
+    assert p.returncode == 0
+    assert "✅ Markdown link check: OK (no broken internal links found)" in p.stdout
+    assert p.stderr == ""


### PR DESCRIPTION
## Summary
- add tests-only CLI contract coverage for scripts/ops/check_markdown_links.py
- cover valid internal links, missing linked file, missing cross-file anchor, and ignored external links
- invoke the CLI through subprocess with explicit --root and --paths fixtures

## Safety
- tests-only
- no changes to scripts/ops/check_markdown_links.py
- no live/testnet behavior
- no Master V2 / Double Play / Scope-Capital / Risk / KillSwitch / Execution Gate changes
- no readiness/evidence/report/index/handoff surface
- no repo docs/workflows or paper test data mutation

## Validation
- uv run pytest tests/ops/test_check_markdown_links_cli_contract_v0.py -q
- uv run ruff check tests/ops/test_check_markdown_links_cli_contract_v0.py
- uv run ruff format --check tests/ops/test_check_markdown_links_cli_contract_v0.py

Made with [Cursor](https://cursor.com)