### PR TITLE
test(optuna): harden single objective integration determinism

### DIFF
--- a/tests/test_optuna_integration.py
+++ b/tests/test_optuna_integration.py
@@ -307,8 +307,11 @@ def test_single_objective_study_integration():
         x = trial.suggest_float("x", -10, 10)
         return (x - 2) ** 2  # Minimize (x-2)^2, optimal at x=2
 
-    # Create study
-    study = optuna.create_study(direction="minimize")
+    # Use a seeded sampler to avoid flaky behavior across CI runs.
+    study = optuna.create_study(
+        direction="minimize",
+        sampler=optuna.samplers.RandomSampler(seed=0),
+    )
 
     # Run optimization
     study.optimize(objective, n_trials=20, show_progress_bar=False)


### PR DESCRIPTION
## Summary
- harden tests/test_optuna_integration.py::test_single_objective_study_integration against stochastic CI failures
- use aSeeded Optuna RandomSampler(seed=0) for deterministic trial selection
- preserve the existing integration behavior and best_value assertion

## Context
- PR #3173 had an unrelated Python 3.9 CI failure in this test:
  tests/test_optuna_integration.py::test_single_objective_study_integration
- The failed job reran green, but the failure showed the test could miss the < 1.0 threshold with the unseeded/default sampler

## Safety
- tests-only
- no production/source changes
- no ops script changes
- no live/testnet behavior
- no Master V2 / Double Play / Scope-Capital / Risk / KillSwitch / Execution Gate changes
- no readiness/evidence/report/index/handoff surface
- no paper test data mutation

## Validation
- uv run pytest tests/test_optuna_integration.py::test_single_objective_study_integration -q -rs
  - local result: skipped because Optuna is not installed in the local uv environment
- uv run pytest tests/test_optuna_integration.py -q -rs
  - local result: 1 passed, 22 skipped
- uv run ruff check tests/test_optuna_integration.py
- uv run ruff format --check tests/test_optuna_integration.py

Made with [Cursor](https://cursor.com)