### PR TITLE
ci(marketsentinel): skip LLM on scheduled daily outlook runs

### DIFF
--- a/.github/workflows/market_outlook_automation.yml
+++ b/.github/workflows/market_outlook_automation.yml
@@ -48,9 +48,19 @@ jobs:
       - name: Run MarketSentinel v0 – Daily Market Outlook
         run: |
           mkdir -p reports/market_outlook
-          python scripts/generate_market_outlook_daily.py \
-            --config-path config/market_outlook/daily_market_outlook.yaml \
-            --out-dir reports/market_outlook/
+          # Scheduled runs: degrade to placeholder (--skip-llm) so cron does not require
+          # PT_AI_* gates / policy chain for outbound LLM. Manual dispatch unchanged.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "::notice title=MarketSentinel::Scheduled run uses --skip-llm (placeholder report)."
+            python scripts/generate_market_outlook_daily.py \
+              --config-path config/market_outlook/daily_market_outlook.yaml \
+              --out-dir reports/market_outlook/ \
+              --skip-llm
+          else
+            python scripts/generate_market_outlook_daily.py \
+              --config-path config/market_outlook/daily_market_outlook.yaml \
+              --out-dir reports/market_outlook/
+          fi
 
       - name: Upload daily market outlook reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- make scheduled MarketSentinel daily outlook runs use the existing --skip-llm placeholder path
- keep manual workflow_dispatch behavior unchanged so explicit manual runs can still exercise the LLM path subject to AI gates/policy
- avoid setting PT_AI_MODELS_ENABLED or PT_PAPERTRAIL_READY in CI just to make the schedule green

## Context
- OPENAI_API_KEY is now present and injected
- the previous manual run moved past missing secret and failed on create_model_client hard gates
- scheduled runs should not require outbound LLM governance gates unless explicitly enabled by a larger governance decision

## Safety
- ops/reporting workflow only
- no Master V2 / Double Play runtime changes
- no Scope-Capital / Risk / KillSwitch / Execution Gate changes
- no exchange/provider changes
- no PaperExecutionEngine or runner wiring
- no new readiness/evidence/report/index/handoff surface
- no secrets committed or printed

## Validation
- python3 YAML safe_load check on .github/workflows/market_outlook_automation.yml
- rg check confirms --skip-llm schedule branch and no PT_AI_* gate envs added

Made with [Cursor](https://cursor.com)