### PR TITLE
feat(execution): add futures paper accounting snapshot dto v0

### DIFF
--- a/docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md
+++ b/docs/PEAK_TRADE_V1_KNOWN_LIMITATIONS.md
@@ -40,7 +40,7 @@ Dieses Dokument listet **bewusst nicht implementierte Features** und **bekannte 
 **Referenz:**
 - `src/live/safety.py` – SafetyGuard-Implementierung
 
-- **Offline Futures-Paper-Accounting v0:** `src&#47;execution&#47;paper&#47;futures_accounting.py` — **reines** Hilfsmodul für deterministische Long/Short- und Margin-**Schätzungen** (keine Exchange-Calls, keine Runner-Verdrahtung, keine venue-getreue Liquidation); **keine** Strategieautorität und **kein** Live-/Testnet- oder Futures-Class-A-Readiness-Nachweis.
+- **Offline Futures-Paper-Accounting v0:** `src&#47;execution&#47;paper&#47;futures_accounting.py` — **reines** Hilfsmodul für deterministische Long/Short- und Margin-**Schätzungen** (keine Exchange-Calls, keine Runner-Verdrahtung, keine venue-getreue Liquidation); **`FuturesPaperAccountingSnapshotV0`** bündelt dieselben Kernel-Größen offline (**ohne** `PaperExecutionEngine`, **ohne** Class-A-Runner/Workflow); **keine** Strategieautorität und **kein** Live-/Testnet- oder Futures-Class-A-Readiness-Nachweis.
 
 - `src/execution/live/safety.py` and `src/execution/live/reconcile.py` are a bounded Finish-C3 mock/testability slice for safety-rail and reconcile failure-path coverage; they do **not** represent live approval, exchange enablement, or production-ready live operations.
 

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-04-30 — `src&#47;execution&#47;paper&#47;futures_accounting.py`: **`FuturesPaperAccountingSnapshotV0`** + `build_futures_paper_accounting_snapshot_v0` (rein/offline, ohne WP1B&#47;Runner&#47;Provider); begleitend `docs&#47;ops&#47;specs&#47;MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md` §7.3, `docs&#47;PEAK_TRADE_V1_KNOWN_LIMITATIONS.md`, `tests&#47;execution&#47;paper&#47;test_futures_accounting_snapshot_dto_v0.py`; **keine** Live-&#47;Testnet-Freigabe; **RUNTIME_NOT_WIRED**.
+
 - 2026-04-29 — `src&#47;execution&#47;paper&#47;futures_accounting.py` (Pure-Model v0) mit begleitenden Verweisen in `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` und `docs&#47;PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` — offline/deterministisch, ohne Runner/Exchange; **keine** Live-/Testnet-Freigabe, **kein** Futures-Class-A-Abschluss; erfüllt **governance-overview-canonical** / **known-limitations-canonical** Kaskade.
 
 - 2026-04-25 — `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` — Abschnitt „Execution and risk-layer README authority boundary“ (Spiegel zu `src&#47;execution&#47;README.md` / `src&#47;risk_layer&#47;README.md`; P0-C Epoch-/Autoritätsgrenze; **keine** Live-Freigabe); paired with `governance-overview-canonical`.

--- a/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
@@ -2,7 +2,7 @@
 title: "Master V2 Futures Class A Capability Contract v0"
 status: "DRAFT"
 owner: "ops"
-last_updated: "2026-04-29"
+last_updated: "2026-04-30"
 docs_token: "DOCS_TOKEN_MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0"
 ---
 
@@ -122,7 +122,9 @@ Outputs already expressible from the v0 API surface (still **not** wired to WP1B
 - Fees (`apply_fee_on_notional` or explicit `fee_quote` on close paths).
 - Liquidation proximity v0 (`estimate_liquidation_proximity_v0`).
 
-Whether a **stable snapshot DTO** wraps these values is a **separate** design decision for a future slice; this contract **does not** mandate one.
+**Snapshot DTO v0 (pure/offline, `RUNTIME_NOT_WIRED`):** `FuturesPaperAccountingSnapshotV0` and `build_futures_paper_accounting_snapshot_v0` in `src&#47;execution&#47;paper&#47;futures_accounting.py` bundle the primitives above into one frozen read-model for deterministic, side-effect-free use. The DTO is **not** wired to `PaperExecutionEngine`, Class A runners, workflows, providers, Live, or Testnet; it is **non-authorizing** and **does not** imply venue accuracy, Futures Class A completion, or gate passage. §7.4 **wiring** preconditions remain **not started** until an explicit future approval and mark-price discipline are satisfied.
+
+Characterization: `tests&#47;execution&#47;paper&#47;test_futures_accounting_snapshot_dto_v0.py`.
 
 ### 7.4 Preconditions before any wiring
 

--- a/src/execution/paper/futures_accounting.py
+++ b/src/execution/paper/futures_accounting.py
@@ -54,6 +54,112 @@ class FuturesPosition:
     fees_paid: Decimal = Decimal("0")
 
 
+FUTURES_PAPER_ACCOUNTING_SNAPSHOT_SCHEMA_V0 = "futures_paper_accounting/snapshot/v0"
+
+
+@dataclass(frozen=True)
+class FuturesPaperAccountingSnapshotV0:
+    """
+    Pure read-model bundle over the v0 accounting kernel.
+
+    Not venue-accurate; not wired to engines, runners, or providers; non-authorizing.
+    """
+
+    schema_version: str
+    symbol: str
+    side: FuturesSide
+    quantity: Decimal
+    entry_price: Decimal
+    mark_price: Decimal
+    notional: Decimal
+    initial_margin_required: Decimal
+    maintenance_margin_required: Decimal
+    unrealized_pnl: Decimal
+    realized_pnl: Decimal
+    fees_paid: Decimal
+    funding_paid: Decimal
+    liquidation_proximity: Optional[LiquidationProximityV0]
+
+
+def build_futures_paper_accounting_snapshot_v0(
+    *,
+    instrument: FuturesInstrumentSpec,
+    margin: FuturesMarginSpec,
+    position: FuturesPosition,
+    mark_price: Union[Decimal, float, int, str],
+    equity: Optional[Decimal] = None,
+    warning_buffer_fraction: Union[Decimal, float, int, str] = Decimal("0.05"),
+) -> FuturesPaperAccountingSnapshotV0:
+    """
+    Build a deterministic snapshot at ``mark_price`` without mutating ``position``.
+
+    ``mark_price`` may differ from ``position.mark_price`` (e.g. fresh mark-to-market).
+    ``equity`` optional: when omitted, ``liquidation_proximity`` is ``None``.
+    """
+    mp = _to_decimal("mark_price", mark_price)
+    if position.symbol != instrument.symbol:
+        raise ValueError("position.symbol must match instrument.symbol")
+
+    pos_for_validation = FuturesPosition(
+        symbol=position.symbol,
+        side=position.side,
+        qty=position.qty,
+        entry_price=position.entry_price,
+        mark_price=mp,
+        realized_pnl=position.realized_pnl,
+        funding_pnl=position.funding_pnl,
+        fees_paid=position.fees_paid,
+    )
+    validate_futures_accounting_inputs(
+        instrument=instrument,
+        margin=margin,
+        wallet_equity=equity,
+        position=pos_for_validation,
+    )
+    qty = position.qty
+    cs = instrument.contract_size
+    n = notional_value(mark_price=mp, qty=qty, contract_size=cs)
+    im = initial_margin_required(notional=n, initial_margin_rate=margin.initial_margin_rate)
+    mm = maintenance_margin_required(
+        notional=n, maintenance_margin_rate=margin.maintenance_margin_rate
+    )
+    upnl = unrealized_pnl(
+        side=position.side,
+        entry_price=position.entry_price,
+        mark_price=mp,
+        qty=qty,
+        contract_size=cs,
+    )
+
+    liq: Optional[LiquidationProximityV0]
+    if equity is None:
+        liq = None
+    else:
+        st, _ = estimate_liquidation_proximity_v0(
+            equity=equity,
+            maintenance_margin=mm,
+            warning_buffer_fraction=warning_buffer_fraction,
+        )
+        liq = st
+
+    return FuturesPaperAccountingSnapshotV0(
+        schema_version=FUTURES_PAPER_ACCOUNTING_SNAPSHOT_SCHEMA_V0,
+        symbol=instrument.symbol,
+        side=position.side,
+        quantity=qty,
+        entry_price=position.entry_price,
+        mark_price=mp,
+        notional=n,
+        initial_margin_required=im,
+        maintenance_margin_required=mm,
+        unrealized_pnl=upnl,
+        realized_pnl=position.realized_pnl,
+        fees_paid=position.fees_paid,
+        funding_paid=position.funding_pnl,
+        liquidation_proximity=liq,
+    )
+
+
 def _to_decimal(name: str, value: Union[Decimal, float, int, str]) -> Decimal:
     if isinstance(value, Decimal):
         d = value

--- a/tests/execution/paper/test_futures_accounting_snapshot_dto_v0.py
+++ b/tests/execution/paper/test_futures_accounting_snapshot_dto_v0.py
@@ -1,0 +1,315 @@
+"""Tests for FuturesPaperAccountingSnapshotV0 and pure builder (offline kernel only)."""
+
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from src.execution.paper.futures_accounting import (
+    FUTURES_PAPER_ACCOUNTING_SNAPSHOT_SCHEMA_V0,
+    FuturesInstrumentSpec,
+    FuturesMarginSpec,
+    FuturesPosition,
+    FuturesSide,
+    LiquidationProximityV0,
+    build_futures_paper_accounting_snapshot_v0,
+)
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "src" / "execution" / "paper" / "futures_accounting.py"
+)
+
+
+def _inst_margin() -> tuple[FuturesInstrumentSpec, FuturesMarginSpec]:
+    inst = FuturesInstrumentSpec(
+        symbol="PF_XBTUSD",
+        contract_size=Decimal("1"),
+        tick_size=Decimal("0.5"),
+        min_qty=Decimal("0.001"),
+        quote_currency="USD",
+    )
+    margin = FuturesMarginSpec(
+        initial_margin_rate=Decimal("0.1"),
+        maintenance_margin_rate=Decimal("0.05"),
+        max_leverage=Decimal("10"),
+    )
+    return inst, margin
+
+
+def test_snapshot_long_deterministic_gold() -> None:
+    inst, margin = _inst_margin()
+    pos = FuturesPosition(
+        symbol="PF_XBTUSD",
+        side=FuturesSide.LONG,
+        qty=Decimal("2"),
+        entry_price=Decimal("100"),
+        mark_price=Decimal("100"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+        fees_paid=Decimal("0"),
+    )
+    snap = build_futures_paper_accounting_snapshot_v0(
+        instrument=inst,
+        margin=margin,
+        position=pos,
+        mark_price=Decimal("110"),
+        equity=None,
+    )
+    assert snap.schema_version == FUTURES_PAPER_ACCOUNTING_SNAPSHOT_SCHEMA_V0
+    assert snap.symbol == "PF_XBTUSD"
+    assert snap.side == FuturesSide.LONG
+    assert snap.quantity == Decimal("2")
+    assert snap.entry_price == Decimal("100")
+    assert snap.mark_price == Decimal("110")
+    assert snap.notional == Decimal("220")
+    assert snap.initial_margin_required == Decimal("22")
+    assert snap.maintenance_margin_required == Decimal("11")
+    assert snap.unrealized_pnl == Decimal("20")
+    assert snap.realized_pnl == Decimal("0")
+    assert snap.fees_paid == Decimal("0")
+    assert snap.funding_paid == Decimal("0")
+    assert snap.liquidation_proximity is None
+
+
+def test_snapshot_short_deterministic_gold() -> None:
+    inst, margin = _inst_margin()
+    pos = FuturesPosition(
+        symbol="PF_XBTUSD",
+        side=FuturesSide.SHORT,
+        qty=Decimal("1"),
+        entry_price=Decimal("100"),
+        mark_price=Decimal("100"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+        fees_paid=Decimal("0"),
+    )
+    snap = build_futures_paper_accounting_snapshot_v0(
+        instrument=inst,
+        margin=margin,
+        position=pos,
+        mark_price=Decimal("90"),
+        equity=None,
+    )
+    assert snap.notional == Decimal("90")
+    assert snap.initial_margin_required == Decimal("9")
+    assert snap.maintenance_margin_required == Decimal("4.5")
+    assert snap.unrealized_pnl == Decimal("10")
+
+
+def test_equity_none_leaves_liquidation_proximity_none() -> None:
+    inst, margin = _inst_margin()
+    pos = FuturesPosition(
+        symbol="PF_XBTUSD",
+        side=FuturesSide.LONG,
+        qty=Decimal("1"),
+        entry_price=Decimal("1"),
+        mark_price=Decimal("1"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+    )
+    snap = build_futures_paper_accounting_snapshot_v0(
+        instrument=inst,
+        margin=margin,
+        position=pos,
+        mark_price=Decimal("1"),
+        equity=None,
+    )
+    assert snap.liquidation_proximity is None
+
+
+def test_equity_populates_liquidation_proximity() -> None:
+    inst, margin = _inst_margin()
+    pos = FuturesPosition(
+        symbol="PF_XBTUSD",
+        side=FuturesSide.LONG,
+        qty=Decimal("2"),
+        entry_price=Decimal("100"),
+        mark_price=Decimal("100"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+    )
+    snap = build_futures_paper_accounting_snapshot_v0(
+        instrument=inst,
+        margin=margin,
+        position=pos,
+        mark_price=Decimal("110"),
+        equity=Decimal("200"),
+    )
+    assert snap.liquidation_proximity == LiquidationProximityV0.SAFE
+
+    snap_warn = build_futures_paper_accounting_snapshot_v0(
+        instrument=inst,
+        margin=margin,
+        position=pos,
+        mark_price=Decimal("110"),
+        equity=Decimal("11"),
+    )
+    assert snap_warn.liquidation_proximity == LiquidationProximityV0.WARNING_INSUFFICIENT_BUFFER
+
+
+def test_validation_failures_propagate() -> None:
+    inst, margin = _inst_margin()
+    bad_inst = FuturesInstrumentSpec(
+        symbol="",
+        contract_size=Decimal("1"),
+        tick_size=Decimal("1"),
+        min_qty=Decimal("1"),
+        quote_currency="USD",
+    )
+    pos = FuturesPosition(
+        symbol="",
+        side=FuturesSide.LONG,
+        qty=Decimal("1"),
+        entry_price=Decimal("1"),
+        mark_price=Decimal("1"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+    )
+    with pytest.raises(ValueError, match="instrument.symbol"):
+        build_futures_paper_accounting_snapshot_v0(
+            instrument=bad_inst,
+            margin=margin,
+            position=pos,
+            mark_price=Decimal("1"),
+        )
+
+    bad_margin = FuturesMarginSpec(
+        initial_margin_rate=Decimal("0.1"),
+        maintenance_margin_rate=Decimal("0.11"),
+        max_leverage=Decimal("10"),
+    )
+    pos_ok = FuturesPosition(
+        symbol="PF_XBTUSD",
+        side=FuturesSide.LONG,
+        qty=Decimal("1"),
+        entry_price=Decimal("100"),
+        mark_price=Decimal("100"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+    )
+    with pytest.raises(ValueError, match="maintenance_margin_rate must not exceed"):
+        build_futures_paper_accounting_snapshot_v0(
+            instrument=inst,
+            margin=bad_margin,
+            position=pos_ok,
+            mark_price=Decimal("100"),
+        )
+
+
+def test_symbol_mismatch_raises() -> None:
+    inst, margin = _inst_margin()
+    pos = FuturesPosition(
+        symbol="OTHER",
+        side=FuturesSide.LONG,
+        qty=Decimal("1"),
+        entry_price=Decimal("100"),
+        mark_price=Decimal("100"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("0"),
+    )
+    with pytest.raises(ValueError, match="position.symbol must match"):
+        build_futures_paper_accounting_snapshot_v0(
+            instrument=inst,
+            margin=margin,
+            position=pos,
+            mark_price=Decimal("100"),
+        )
+
+
+def test_snapshot_does_not_mutate_position() -> None:
+    inst, margin = _inst_margin()
+    pos = FuturesPosition(
+        symbol="PF_XBTUSD",
+        side=FuturesSide.LONG,
+        qty=Decimal("2"),
+        entry_price=Decimal("100"),
+        mark_price=Decimal("100"),
+        realized_pnl=Decimal("3"),
+        funding_pnl=Decimal("-1"),
+        fees_paid=Decimal("2"),
+    )
+    before = (
+        pos.symbol,
+        pos.side,
+        pos.qty,
+        pos.entry_price,
+        pos.mark_price,
+        pos.realized_pnl,
+        pos.funding_pnl,
+        pos.fees_paid,
+    )
+    build_futures_paper_accounting_snapshot_v0(
+        instrument=inst,
+        margin=margin,
+        position=pos,
+        mark_price=Decimal("150"),
+        equity=None,
+    )
+    after = (
+        pos.symbol,
+        pos.side,
+        pos.qty,
+        pos.entry_price,
+        pos.mark_price,
+        pos.realized_pnl,
+        pos.funding_pnl,
+        pos.fees_paid,
+    )
+    assert before == after
+
+
+def test_futures_accounting_module_imports_remain_stdlib_only() -> None:
+    allowed_roots = frozenset({"__future__", "dataclasses", "decimal", "enum", "typing"})
+    text = _MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    banned_substrings = (
+        "master_v2",
+        "ccxt",
+        "requests",
+        "urllib",
+        "socket",
+        "paper.engine",
+        "paper.broker",
+        "paper.journal",
+        "PaperExecutionEngine",
+        "PaperBroker",
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                mod = alias.name or ""
+                assert mod.split(".")[0] not in ("src", "execution"), mod
+                for b in banned_substrings:
+                    assert b not in mod, mod
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module is not None
+            mod = node.module
+            root = mod.split(".")[0]
+            assert root in allowed_roots, f"unexpected import {mod!r}"
+            for b in banned_substrings:
+                assert b not in mod, mod
+
+
+def test_funding_paid_reflects_position_funding_pnl() -> None:
+    inst, margin = _inst_margin()
+    pos = FuturesPosition(
+        symbol="PF_XBTUSD",
+        side=FuturesSide.LONG,
+        qty=Decimal("1"),
+        entry_price=Decimal("50"),
+        mark_price=Decimal("50"),
+        realized_pnl=Decimal("0"),
+        funding_pnl=Decimal("-12.5"),
+        fees_paid=Decimal("0"),
+    )
+    snap = build_futures_paper_accounting_snapshot_v0(
+        instrument=inst,
+        margin=margin,
+        position=pos,
+        mark_price=Decimal("50"),
+        equity=None,
+    )
+    assert snap.funding_paid == Decimal("-12.5")


### PR DESCRIPTION
## Summary
- add pure/offline FuturesPaperAccountingSnapshotV0 and builder in futures_accounting.py
- derive snapshot values from existing deterministic futures accounting helpers
- add focused tests for long/short values, equity/no-equity liquidation proximity, validation propagation, immutability, symbol mismatch, and seam safety
- update Futures Class-A capability docs and required execution-layer truth-map companions

## Safety
- additive pure model/builder only
- no PaperExecutionEngine wiring
- no runner/workflow/provider changes
- no exchange/order path
- no live/testnet enablement
- no Master V2 / Double Play runtime changes
- no Scope-Capital / Risk / KillSwitch / Execution Gate changes
- no paper test data mutation
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run pytest tests/execution/paper/test_futures_accounting_snapshot_dto_v0.py -q
- uv run pytest tests/execution/paper/test_futures_accounting_v0.py tests/execution/paper/test_futures_accounting_invariants_v0.py tests/execution/paper/test_paper_engine_futures_seam_v0.py -q
- uv run ruff check src/execution/paper/futures_accounting.py tests/execution/paper/test_futures_accounting_snapshot_dto_v0.py
- uv run ruff format --check src/execution/paper/futures_accounting.py tests/execution/paper/test_futures_accounting_snapshot_dto_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)