### PR TITLE
docs(master-v2): pointer to futures snapshot JSONability test in Class-A contract §7.3

### DIFF
--- a/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md
@@ -126,6 +126,8 @@ Outputs already expressible from the v0 API surface (still **not** wired to WP1B
 
 Characterization: `tests&#47;execution&#47;paper&#47;test_futures_accounting_snapshot_dto_v0.py`.
 
+**JSONability (tests-only, test-local mapping):** `tests&#47;execution&#47;paper&#47;test_futures_accounting_snapshot_jsonability_v0.py` defines an explicit, **test-local** conversion of the snapshot DTO to JSON-safe primitives (`Decimal` → string, enums → `.value`, `liquidation_proximity` → a small primitive dict or `null`) and asserts `json.dumps` / `json.loads` round-trip for a deterministic gold payload. This is **not** a production JSON API; **not** a report, registry, readiness, evidence, index, or handoff surface; **not** `PaperExecutionEngine`, runner, provider, Live, or Testnet wiring.
+
 ### 7.4 Preconditions before any wiring
 
 Before any change under `src&#47;execution&#47;` that connects WP1B to Futures Accounting v0:


### PR DESCRIPTION
## Summary
- add the PR #3183 JSONability characterization test pointer to the canonical Futures Class-A capability contract §7.3
- clarify that the JSON-safe mapping is test-local only
- restate that this is not a production JSON API, report/registry/readiness/evidence/index/handoff surface, or PaperExecutionEngine/runner/provider/Live/Testnet wiring

## Safety
- docs-only
- no source changes
- no test changes
- no workflow changes
- no production JSON/report surface
- no PaperExecutionEngine wiring
- no runner/provider/live/testnet behavior
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)