### PR TITLE
test(paper): keep BTC ETH paper prep outside engine seam

### DIFF
--- a/tests/execution/paper/test_paper_engine_futures_seam_v0.py
+++ b/tests/execution/paper/test_paper_engine_futures_seam_v0.py
@@ -1,6 +1,6 @@
 """Characterization tests: PaperExecutionEngine (WP1B) vs pure Futures Paper Accounting v0.
 
-Non-authorizing: documents current import/runtime boundaries only — no wiring, no source edits.
+Non-authorizing: documents current import/runtime boundaries only — no wiring; no edits to WP1B production modules in this suite.
 See MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0 (WP1B spot-sim vs offline futures kernel).
 """
 
@@ -112,6 +112,39 @@ def test_paper_execution_engine_source_has_no_futures_accounting_type_references
             pytest.fail(f"{_ENGINE_SRC.name}: unexpected Name reference {node.id!r}")
         if isinstance(node, ast.Attribute) and node.attr in _FUTURES_TYPE_NAMES:
             pytest.fail(f"{_ENGINE_SRC.name}: unexpected Attribute {node.attr!r}")
+
+
+def test_paper_execution_engine_source_has_no_um_paper_prep_or_snapshot_wire_tokens_v0() -> None:
+    """BTC/ETH paper-prep charters (Binance UM-style labels / slot language) remain external."""
+
+    forbidden_names = frozenset(
+        {
+            "FuturesPaperAccountingSnapshotV0",
+            "build_futures_paper_accounting_snapshot_v0",
+        }
+    )
+    forbidden_substrings = (
+        "FuturesPaperAccountingSnapshotV0",
+        "build_futures_paper_accounting_snapshot_v0",
+        "futures_accounting",
+        "BTCUSDT",
+        "ETHUSDT",
+        "paper_slot",
+        "max_loss",
+    )
+
+    text = _ENGINE_SRC.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id in forbidden_names:
+            pytest.fail(f"{_ENGINE_SRC.name}: unexpected Name reference {node.id!r}")
+        if isinstance(node, ast.Attribute) and node.attr in forbidden_names:
+            pytest.fail(f"{_ENGINE_SRC.name}: unexpected Attribute {node.attr!r}")
+    for token in forbidden_substrings:
+        assert token not in text, (
+            f"{_ENGINE_SRC.name}: forbidden substring {token!r}; "
+            "offline futures snapshot/kernel + UM worksheet prep stays unwired."
+        )
 
 
 def test_import_engine_and_futures_accounting_modules_without_coupling() -> None:


### PR DESCRIPTION
## Summary
- add a characterization test to keep BTC/ETH paper-prep and Binance-UM-style slot/max-loss vocabulary outside PaperExecutionEngine
- assert the engine remains unwired from FuturesPaperAccountingSnapshotV0 and build_futures_paper_accounting_snapshot_v0
- keep the existing WP1B seam non-authorizing and structural only

## Safety
- tests-only
- one existing test-owner file only
- no production code changes
- no docs changes
- no workflow changes
- no paper test data mutation
- no PaperExecutionEngine wiring
- no runner/workflow execution
- no provider/exchange access
- no Testnet/Live
- no order path
- no new readiness/evidence/report/index/handoff surface

## Context
- Charter: /tmp/peak_trade_btc_eth_futures_paper_prep_slice_charter_20260430T231115Z/BTC_ETH_FUTURES_PAPER_PREP_SLICE_CHARTER.md
- Test-owner discovery: /tmp/peak_trade_btc_eth_paper_prep_test_owner_discovery_20260430T231400Z/TEST_OWNER_DISCOVERY_SUMMARY.md
- Slice brief: /tmp/peak_trade_btc_eth_paper_prep_seam_tests_slice_20260430T231652Z/CURSOR_BTC_ETH_PAPER_PREP_SEAM_TESTS_SLICE_BRIEF.md

## Validation
- uv run pytest tests/execution/paper/test_paper_engine_futures_seam_v0.py -q
- uv run ruff check tests/execution/paper/test_paper_engine_futures_seam_v0.py
- uv run ruff format --check tests/execution/paper/test_paper_engine_futures_seam_v0.py

Made with [Cursor](https://cursor.com)