### PR TITLE
ci(mcp-smoke): bump setup-node action major

### DIFF
--- a/.github/workflows/mcp_smoke_preflight.yml
+++ b/.github/workflows/mcp_smoke_preflight.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
## Summary
- update MCP Smoke Preflight workflow from actions/setup-node@v4 to @v6
- keep node-version pinned to "20"
- leave workflow triggers, commands, env, secrets, permissions, and MCP smoke logic unchanged

## Safety
- workflow-only
- one workflow file only
- no source changes
- no test changes
- no docs changes
- no .nvmrc change
- no promptfoo changes
- no secrets/permissions/env changes
- no trigger/schedule changes
- no trading/Paper/Testnet/Live/order path

## Validation
- yaml.safe_load for .github/workflows/mcp_smoke_preflight.yml
- git diff --check

Made with [Cursor](https://cursor.com)