### PR TITLE
docs(webui): clarify Market Surface v0 vs Futures read-only dashboard

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -15,3 +15,14 @@
 - `source` — `dummy` (Default, offline) \| `kraken` (öffentliche OHLCV, Netzwerk)
 
 Keine Kopplung an OPS Cockpit (`/ops`). Keine Trading-Aktionen.
+
+## Current surface vs. Futures Read-only Market Dashboard
+
+- **`GET &#47;market`** und **`GET &#47;api&#47;market&#47;ohlcv`** sind **Market Surface v0**: minimale **read-only**‑OHLCV‑Anzeige mit `source=dummy` (offline/synthetisch) oder optional **`source=kraken`** (öffentliche OHLCV, Netzwerk).
+- **Nicht** Ziel dieser Seite ist das vollständige **Futures Read-only Market Dashboard** (F5‑Semantik) — Kanon dort: [Futures Read-only Market Dashboard Contract v0](../ops/specs/FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md).
+- Provenance-/Display‑Pflichtfelder für governanceten Futures‑Kontext: [Futures Market Data Provenance Contract v0](../ops/specs/FUTURES_MARKET_DATA_PROVENANCE_CONTRACT_V0.md).
+- Warnungen zu `env_name`, Exchange‑Labels und **non‑authority**: [Session env_name and exchange surfaces non-authority v0](../ops/specs/SESSION_ENV_NAME_AND_EXCHANGE_SURFACES_NON_AUTHORITY_V0.md).
+- **`dummy`** strikt als **offline/synthetisch** interpretieren — kein Beweis für Markt‑ oder Futures‑Readiness.
+- **`kraken`** hier nur **öffentliche OHLCV‑Darstellung**, **keine** Ableitung von Futures‑Readiness noch von Testnet/Live‑Freigaben.
+
+**Read-only / non-authorizing:** Keine Orders, keine Paper-/Testnet-/Live‑Aktivierung, keine Scope/Capital‑Billigung, kein Bypass von Risk/KillSwitch‑Enforcement, keine Ausführungs‑ oder Strategieautorität. Keine Schlussfolgerung auf Futures‑„Readiness“ oder Provider‑Bereitschaft über diese View hinaus.


### PR DESCRIPTION
## Summary
- clarify that /market and /api/market/ohlcv are the current Market Surface v0
- distinguish current dummy/Kraken OHLCV display from the Futures Read-only Market Dashboard target
- anchor futures dashboard, provenance, and exchange-surface semantics to existing canonical specs
- preserve read-only / non-authorizing dashboard boundaries

## Safety
- docs-only
- one existing WebUI owner file only
- no source changes
- no test changes
- no workflow changes
- no new spec/report/index/handoff/readiness/evidence surface
- no provider/exchange behavior change
- no Paper/Testnet/Live/order path
- no Capital/Scope approval
- no Risk/KillSwitch override
- no strategy authorization

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main

Made with [Cursor](https://cursor.com)