### PR TITLE
feat(webui): add read-only labels banner to Market Surface v0

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -6,10 +6,41 @@
 <div
   class="space-y-6 max-w-6xl mx-auto"
   data-section="market-v0"
+  data-market-surface-v0="true"
+  data-market-readonly="true"
+  data-market-non-authorizing="true"
   data-market-source="{{ query.source }}"
   data-market-bars="{{ payload.bars_returned }}"
   data-market-symbol="{{ query.symbol }}"
 >
+  <section
+    aria-label="Read-only und Datenquelle"
+    class="rounded-xl border border-amber-900/40 bg-amber-950/25 px-4 py-3 text-xs text-amber-100/95"
+    data-market-safety-banner="true"
+    {% if query.source == 'dummy' %}
+    data-market-source-kind="dummy-offline-synthetic"
+    {% elif query.source == 'kraken' %}
+    data-market-source-kind="kraken-public-ohlcv-network"
+    {% endif %}
+  >
+    <p class="font-semibold text-amber-200/95 tracking-wide uppercase text-[11px] mb-1.5">
+      Market Surface v0 · read-only · non-authorizing
+    </p>
+    {% if query.source == 'dummy' %}
+    <p class="leading-relaxed text-amber-100/90">
+      <span class="text-sky-200/95 font-medium">Dummy / Offline / synthetisch</span>
+      — keine Orders, kein Testnet, kein Live, keine Paper-Aktivierung.
+      Keine Capital-/Scope-Freigabe, kein Risk-/KillSwitch-Bypass, keine Ausführungsautorität.
+    </p>
+    {% elif query.source == 'kraken' %}
+    <p class="leading-relaxed text-amber-100/90">
+      <span class="text-sky-200/95 font-medium">Öffentliche OHLCV über Netzwerk (Kraken)</span>
+      — rein anzeigend (read-only), non-authorizing, <strong class="font-medium text-amber-200">kein Nachweis von Futures‑Readiness</strong>.
+      Keine Orders, kein Testnet, kein Live.
+    </p>
+    {% endif %}
+  </section>
+
   <header class="bg-gradient-to-r from-slate-900/80 to-slate-900/40 rounded-2xl border border-slate-800 p-6">
     <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
       <div>
@@ -37,7 +68,7 @@
       <li>symbol={{ query.symbol }}</li>
       <li>timeframe={{ query.timeframe }} (Kraken; Dummy bleibt synthetisch 1h)</li>
       <li>limit={{ query.limit }}</li>
-      <li>source={{ query.source }} — für Live-Daten: <span class="text-sky-400">?source=kraken</span> (Netzwerk)</li>
+      <li>source={{ query.source }} — für Netzwerk-OHLCV: <span class="text-sky-400">?source=kraken</span></li>
     </ul>
   </section>
 

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -65,9 +65,34 @@ class TestMarketSurfaceHtml:
         assert "text/html" in resp.headers.get("content-type", "")
         body = resp.text
         assert 'data-section="market-v0"' in body
+        assert 'data-market-surface-v0="true"' in body
+        assert 'data-market-readonly="true"' in body
+        assert 'data-market-non-authorizing="true"' in body
+        assert 'data-market-source-kind="dummy-offline-synthetic"' in body
+        assert 'data-market-safety-banner="true"' in body
         assert 'data-market-source="dummy"' in body
         assert 'data-market-bars="20"' in body
         assert 'data-chart="market-v0-close-line"' in body
         assert 'id="market-v0-payload"' in body
+        assert "read-only · non-authorizing" in body
+        assert "Keine Orders" in body or "keine Orders" in body
+        assert "Testnet" in body
+        assert "Live" in body
+        assert "Capital" in body or "Scope" in body
+        assert "KillSwitch" in body or "Risk" in body
         assert "chart.js@4.4.1" in body.lower() or "chart.umd.min.js" in body
         assert 'method="POST"' not in body
+
+
+def test_market_v0_template_kraken_banner_markers_in_source() -> None:
+    """Kraken-Pfad ohne Netzwerk: Banner-Zweig muss im Template existieren."""
+    tmpl_path = (
+        Path(__file__).resolve().parents[1]
+        / "templates"
+        / "peak_trade_dashboard"
+        / "market_v0.html"
+    )
+    txt = tmpl_path.read_text(encoding="utf-8")
+    assert 'data-market-source-kind="kraken-public-ohlcv-network"' in txt
+    assert "Futures" in txt
+    assert "read-only · non-authorizing" in txt


### PR DESCRIPTION
## Summary
- add visible read-only / non-authorizing safety banner to Market Surface v0
- label dummy source as offline/synthetic and Kraken source as public network OHLCV
- clarify that the page has no orders, no Testnet/Live, no Capital/Scope approval, and no Risk/KillSwitch override
- add tests for dummy banner markers and Kraken template branch markers

## Safety
- UI/template + tests only
- no backend behavior change
- no source route/data-loader changes
- no workflow changes
- no provider/exchange call in tests
- no Kraken/network test
- no Paper/Testnet/Live/order behavior
- no new route
- no new report/index/handoff/readiness/evidence surface
- no dashboard authority semantics

## Validation
- uv run python -m pytest tests/test_market_surface_api.py -q
- uv run ruff check tests/test_market_surface_api.py
- uv run ruff format --check tests/test_market_surface_api.py
- git diff --check

Made with [Cursor](https://cursor.com)