### PR TITLE
docs(webui): Market Surface v0 safety banner + stable markers

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -26,3 +26,21 @@ Keine Kopplung an OPS Cockpit (`/ops`). Keine Trading-Aktionen.
 - **`kraken`** hier nur **öffentliche OHLCV‑Darstellung**, **keine** Ableitung von Futures‑Readiness noch von Testnet/Live‑Freigaben.
 
 **Read-only / non-authorizing:** Keine Orders, keine Paper-/Testnet-/Live‑Aktivierung, keine Scope/Capital‑Billigung, kein Bypass von Risk/KillSwitch‑Enforcement, keine Ausführungs‑ oder Strategieautorität. Keine Schlussfolgerung auf Futures‑„Readiness“ oder Provider‑Bereitschaft über diese View hinaus.
+
+## Safety banner and stable markers
+
+Das HTML-Template für **`GET &#47;market`** rendert oberhalb der Chart-Fläche ein **sichtbares** Safety-Banner (**read-only**, **non-authorizing**) mit Quellen-spezifischem Kurztext (`source=dummy` \| `source=kraken`).
+
+Stabile `data-*`‑Marker (Anker für Anzeige und automatisierte Tests — **keine** neue Autorität, **keine** Readiness):
+
+- `data-market-readonly="true"`
+- `data-market-non-authorizing="true"`
+- `data-market-safety-banner="true"`
+- `data-market-surface-v0="true"`
+
+`data-market-source-kind` unterscheidet aktuell:
+
+- `dummy-offline-synthetic`
+- `kraken-public-ohlcv-network`
+
+Banner‑Inhalt fasst u. a.: keine Orders, kein Testnet/Live, keine Capital/Scope‑Freigabe, kein Risk-/KillSwitch‑Bypass — rein erklärend; **kein** Gate, **keine** Strategie- oder Ausführungsfreigabe.


### PR DESCRIPTION
## Summary

Lane 6 follow-up after **#3195**: minimal **docs-only** sync to `docs/webui/MARKET_SURFACE_V0.md`.

Adds **Safety banner and stable markers** documenting the visible read-only / non-authorizing banner on **`GET &#47;market`** and the stable `data-market-*` template anchors (`readonly`, `non-authorizing`, `safety-banner`, `surface-v0`, `source-kind` values `dummy-offline-synthetic` | `kraken-public-ohlcv-network`).

States explicitly: display/test anchors only; no new authority, readiness, order path, Capital/Scope, Risk/KillSwitch bypass, or strategy authorization.

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` (pass)

## Scope

- **Docs only** (`docs/webui/MARKET_SURFACE_V0.md`). No source, tests, or workflows.