### PR TITLE
feat(webui): Market Surface v0 chart empty/error status

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -78,6 +78,19 @@
     data-chart="market-v0-close-line"
   >
     <h2 class="text-sm font-medium text-slate-200 mb-3">Schlusskurs (Close)</h2>
+    <div
+      id="market-v0-chart-status"
+      role="status"
+      class="text-xs text-slate-400 mb-2 min-h-[1.25rem]"
+      data-market-chart-status="{% if payload.bars_returned == 0 %}empty{% else %}ready{% endif %}"
+      {% if payload.bars_returned == 0 %}data-market-empty-state="true"{% endif %}
+    >
+      {% if payload.bars_returned == 0 %}
+      No OHLCV bars available for this query.
+      {% else %}
+      Chart ready — read-only OHLCV display.
+      {% endif %}
+    </div>
     <div class="relative h-80 w-full">
       <canvas id="chart-market-v0-close"></canvas>
     </div>
@@ -87,71 +100,116 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
   <script>
     (function () {
-      const el = document.getElementById("market-v0-payload");
-      if (!el) return;
-      let payload;
+      function setMarketChartStatus(kind) {
+        var node = document.getElementById("market-v0-chart-status");
+        if (!node) return;
+        var copy = {
+          ready: "Chart ready — read-only OHLCV display.",
+          empty: "No OHLCV bars available for this query.",
+          error:
+            "Chart payload could not be rendered; no trading action is available.",
+        };
+        node.setAttribute("data-market-chart-status", kind);
+        node.removeAttribute("data-market-empty-state");
+        node.removeAttribute("data-market-error-state");
+        if (kind === "empty") {
+          node.setAttribute("data-market-empty-state", "true");
+        }
+        if (kind === "error") {
+          node.setAttribute("data-market-error-state", "true");
+        }
+        node.textContent = copy[kind] || "";
+      }
+
+      var el = document.getElementById("market-v0-payload");
+      if (!el) {
+        setMarketChartStatus("error");
+        return;
+      }
+
+      var payload;
       try {
         payload = JSON.parse(el.textContent || "{}");
       } catch (e) {
+        setMarketChartStatus("error");
         return;
       }
-      const bars = payload.bars || [];
-      if (!bars.length) return;
 
-      const labels = bars.map(function (b) { return b.ts; });
-      const closes = bars.map(function (b) { return b.close; });
+      var bars = payload.bars || [];
+      if (!bars.length) {
+        setMarketChartStatus("empty");
+        return;
+      }
 
-      const canvas = document.getElementById("chart-market-v0-close");
-      if (!canvas || !window.Chart) return;
+      var canvas = document.getElementById("chart-market-v0-close");
+      if (!canvas || !window.Chart) {
+        setMarketChartStatus("error");
+        return;
+      }
 
-      const grid = "rgba(148, 163, 184, 0.15)";
-      const tick = "#94a3b8";
-      const line = "rgba(56, 189, 248, 0.85)";
+      var grid = "rgba(148, 163, 184, 0.15)";
+      var tick = "#94a3b8";
+      var line = "rgba(56, 189, 248, 0.85)";
 
-      new Chart(canvas.getContext("2d"), {
-        type: "line",
-        data: {
-          labels: labels,
-          datasets: [
-            {
-              label: "Close",
-              data: closes,
-              borderColor: line,
-              backgroundColor: "rgba(56, 189, 248, 0.12)",
-              borderWidth: 1.5,
-              fill: true,
-              tension: 0.1,
-              pointRadius: 0,
-            },
-          ],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          interaction: { mode: "index", intersect: false },
-          plugins: {
-            legend: { labels: { color: tick } },
-            tooltip: {
-              callbacks: {
-                label: function (ctx) {
-                  var v = ctx.parsed.y;
-                  return v != null ? "close: " + v.toFixed(2) : "";
+      try {
+        new Chart(canvas.getContext("2d"), {
+          type: "line",
+          data: {
+            labels: bars.map(function (b) {
+              return b.ts;
+            }),
+            datasets: [
+              {
+                label: "Close",
+                data: bars.map(function (b) {
+                  return b.close;
+                }),
+                borderColor: line,
+                backgroundColor: "rgba(56, 189, 248, 0.12)",
+                borderWidth: 1.5,
+                fill: true,
+                tension: 0.1,
+                pointRadius: 0,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: "index", intersect: false },
+            plugins: {
+              legend: { labels: { color: tick } },
+              tooltip: {
+                callbacks: {
+                  label: function (ctx) {
+                    var v = ctx.parsed.y;
+                    return v != null ? "close: " + v.toFixed(2) : "";
+                  },
                 },
               },
             },
-          },
-          scales: {
-            x: {
-              ticks: { color: tick, maxRotation: 45, minRotation: 0, font: { size: 9 } },
-              grid: { color: grid },
+            scales: {
+              x: {
+                ticks: {
+                  color: tick,
+                  maxRotation: 45,
+                  minRotation: 0,
+                  font: { size: 9 },
+                },
+                grid: { color: grid },
+              },
+              y: {
+                ticks: { color: tick },
+                grid: { color: grid },
+              },
             },
-            y: {
-              ticks: { color: tick },
-              grid: { color: grid },
-            },
           },
-        },
-      });
+        });
+      } catch (e2) {
+        setMarketChartStatus("error");
+        return;
+      }
+      setMarketChartStatus("ready");
     })();
   </script>
 </div>

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -82,6 +82,9 @@ class TestMarketSurfaceHtml:
         assert "KillSwitch" in body or "Risk" in body
         assert "chart.js@4.4.1" in body.lower() or "chart.umd.min.js" in body
         assert 'method="POST"' not in body
+        assert 'id="market-v0-chart-status"' in body
+        assert 'data-market-chart-status="ready"' in body
+        assert "Chart ready — read-only OHLCV display." in body
 
     def test_market_html_invalid_timeframe_422(self, client: TestClient) -> None:
         r = client.get("/market", params={"source": "dummy", "timeframe": "bad"})
@@ -104,3 +107,7 @@ def test_market_v0_template_kraken_banner_markers_in_source() -> None:
     assert 'data-market-source-kind="kraken-public-ohlcv-network"' in txt
     assert "Futures" in txt
     assert "read-only · non-authorizing" in txt
+    assert 'id="market-v0-chart-status"' in txt
+    assert "data-market-chart-status" in txt
+    assert "data-market-empty-state" in txt
+    assert "Chart ready — read-only OHLCV display." in txt


### PR DESCRIPTION
## Summary

UI-only polish for **`GET /market`**: a small **`#market-v0-chart-status`** region with stable markers (`data-market-chart-status`, optional `data-market-empty-state` / `data-market-error-state`) and short **read-only / non-authorizing** copy for **ready**, **empty**, and **client error** states.

- Server default text/marker from **`payload.bars_returned`** (0 → empty; else ready).
- Existing inline script sets **empty** / **error** / **ready** after JSON parse and Chart.js init (no new network calls, no router/API changes).

## Tests

- `uv run pytest tests/test_market_surface_api.py`
- `uv run ruff check tests/test_market_surface_api.py`

## Scope

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/test_market_surface_api.py` (static HTML/template assertions only)


Made with [Cursor](https://cursor.com)