### PR TITLE
docs(webui): Market Surface v0 chart status states

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -44,3 +44,13 @@ Stabile `data-*`‑Marker (Anker für Anzeige und automatisierte Tests — **kei
 - `kraken-public-ohlcv-network`
 
 Banner‑Inhalt fasst u. a.: keine Orders, kein Testnet/Live, keine Capital/Scope‑Freigabe, kein Risk-/KillSwitch‑Bypass — rein erklärend; **kein** Gate, **keine** Strategie- oder Ausführungsfreigabe.
+
+## Chart status states
+
+Das HTML für **`GET &#47;market`** enthält beim Chart‑Bereich ein Status‑Element **`#market-v0-chart-status`** (read‑only‑Formulierung, **non‑authorizing**).
+
+- **`data-market-chart-status`** kann mindestens **`ready`**, **`empty`** und **`error`** sein (**`error`** = Client-/Renderfehler; **kein** OPS‑„Health‑Gate“).
+- **Server‑Default:** abgeleitet von **`payload.bars_returned`** — **`empty`**, wenn **keine** Bars zurückgegeben werden; sonst **`ready`**.
+- **Client (Chart.js‑Bootstrap)** kann **`empty`** setzen, wenn nach JSON‑Parse keine Bars vorliegen; **`error`**, wenn JSON‑Parse oder Chart‑Initialisierung fehlschlägt; **`ready`**, nach erfolgreicher Darstellung.
+- **`data-market-empty-state="true"`** und **`data-market-error-state="true"`** sind **Display/Test‑Anker** wie andere **`data-market-*`**‑Marker.
+- **Keine** Schlussfolgerung auf Backend‑Betriebssicherheit, **Provider‑Readiness**, **Futures‑Readiness**, **Trading‑ oder Strategieautorität** oder **Capital/Scope/Risk/KillSwitch**‑Laufzeit über diese Marker hinaus.


### PR DESCRIPTION
## Summary

Minimal **docs-only** follow-up to **#3198**: extend `docs/webui/MARKET_SURFACE_V0.md` with **Chart status states** for **`GET &#47;market`** — `#market-v0-chart-status`, `data-market-chart-status` (`ready` / `empty` / client `error`), server default from `bars_returned`, client Chart.js transitions, and optional `data-market-empty-state` / `data-market-error-state` as display/test anchors only (no authority/readiness semantics).

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`

## Scope

- `docs/webui/MARKET_SURFACE_V0.md` only.


Made with [Cursor](https://cursor.com)