### PR TITLE
feat(webui): Market Surface v0 German chart status copy

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -86,9 +86,9 @@
       {% if payload.bars_returned == 0 %}data-market-empty-state="true"{% endif %}
     >
       {% if payload.bars_returned == 0 %}
-      No OHLCV bars available for this query.
+      Keine OHLCV-Bars für diese Abfrage verfügbar.
       {% else %}
-      Chart ready — read-only OHLCV display.
+      Chart bereit — read-only OHLCV-Anzeige.
       {% endif %}
     </div>
     <div class="relative h-80 w-full">
@@ -104,10 +104,10 @@
         var node = document.getElementById("market-v0-chart-status");
         if (!node) return;
         var copy = {
-          ready: "Chart ready — read-only OHLCV display.",
-          empty: "No OHLCV bars available for this query.",
+          ready: "Chart bereit — read-only OHLCV-Anzeige.",
+          empty: "Keine OHLCV-Bars für diese Abfrage verfügbar.",
           error:
-            "Chart payload could not be rendered; no trading action is available.",
+            "Chart-Daten konnten nicht gerendert werden; keine Trading-Aktion verfügbar.",
         };
         node.setAttribute("data-market-chart-status", kind);
         node.removeAttribute("data-market-empty-state");

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -84,7 +84,7 @@ class TestMarketSurfaceHtml:
         assert 'method="POST"' not in body
         assert 'id="market-v0-chart-status"' in body
         assert 'data-market-chart-status="ready"' in body
-        assert "Chart ready — read-only OHLCV display." in body
+        assert "Chart bereit — read-only OHLCV-Anzeige." in body
 
     def test_market_html_invalid_timeframe_422(self, client: TestClient) -> None:
         r = client.get("/market", params={"source": "dummy", "timeframe": "bad"})
@@ -110,4 +110,6 @@ def test_market_v0_template_kraken_banner_markers_in_source() -> None:
     assert 'id="market-v0-chart-status"' in txt
     assert "data-market-chart-status" in txt
     assert "data-market-empty-state" in txt
-    assert "Chart ready — read-only OHLCV display." in txt
+    assert "Chart bereit — read-only OHLCV-Anzeige." in txt
+    assert "Keine OHLCV-Bars für diese Abfrage verfügbar." in txt
+    assert "Chart-Daten konnten nicht gerendert werden; keine Trading-Aktion verfügbar." in txt


### PR DESCRIPTION
## Summary

UI-only polish: chart status messages on **`GET /market`** are now **German** and consistent with the rest of Market Surface v0 (`#market-v0-chart-status`): ready / empty / error copy only; **`data-market-chart-status`** and related markers unchanged; no Chart.js option or router changes.

## Tests

- `uv run pytest tests/test_market_surface_api.py`
- `uv run ruff check tests/test_market_surface_api.py`

## Scope

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/test_market_surface_api.py`


Made with [Cursor](https://cursor.com)