### PR TITLE
docs(webui): Market Surface v0 German chart status copy

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -52,5 +52,12 @@ Das HTML für **`GET &#47;market`** enthält beim Chart‑Bereich ein Status‑E
 - **`data-market-chart-status`** kann mindestens **`ready`**, **`empty`** und **`error`** sein (**`error`** = Client-/Renderfehler; **kein** OPS‑„Health‑Gate“).
 - **Server‑Default:** abgeleitet von **`payload.bars_returned`** — **`empty`**, wenn **keine** Bars zurückgegeben werden; sonst **`ready`**.
 - **Client (Chart.js‑Bootstrap)** kann **`empty`** setzen, wenn nach JSON‑Parse keine Bars vorliegen; **`error`**, wenn JSON‑Parse oder Chart‑Initialisierung fehlschlägt; **`ready`**, nach erfolgreicher Darstellung.
+
+**Sichtbare UI‑Copy (Stand #3200, deutsch)** — nur **Darstellung**, **keine** Marker‑Semantik‑Änderung; **kein** Schluss auf Backend‑Health, **Provider‑Readiness**, **Futures‑Readiness** oder **Trading-/Strategieautorität**:
+
+- **`ready`:** `Chart bereit — read-only OHLCV-Anzeige.`
+- **`empty`:** `Keine OHLCV-Bars für diese Abfrage verfügbar.`
+- **`error`:** `Chart-Daten konnten nicht gerendert werden; keine Trading-Aktion verfügbar.`
+
 - **`data-market-empty-state="true"`** und **`data-market-error-state="true"`** sind **Display/Test‑Anker** wie andere **`data-market-*`**‑Marker.
 - **Keine** Schlussfolgerung auf Backend‑Betriebssicherheit, **Provider‑Readiness**, **Futures‑Readiness**, **Trading‑ oder Strategieautorität** oder **Capital/Scope/Risk/KillSwitch**‑Laufzeit über diese Marker hinaus.


### PR DESCRIPTION
## Summary

Docs-only alignment after **#3200**: **`docs/webui/MARKET_SURFACE_V0.md`** **Chart status states** now records the canonical **German** visible strings for **`ready` / `empty` / `error`**, explicitly as **UI copy only** (no marker-semantics change; no backend/provider/futures/trading-authority implication).

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`

## Scope

- `docs/webui/MARKET_SURFACE_V0.md` only.


Made with [Cursor](https://cursor.com)