### PR TITLE
feat(webui): add read-only observability hub

### DIFF
--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -51,6 +51,7 @@ HTML Pages:
 - GET /r_and_d/experiments/{run_id} (R&D Experiment Detail - Phase 76 kanonisch)
 - GET /r_and_d/comparison (R&D Multi-Run Comparison - Phase 78)
 - GET /market (Market Surface v0 — read-only OHLCV, Close-Line-Chart)
+- GET /observability (Observability-Hub — read-only Link-/Hinweisleiste, keine neue Autorität)
 
 API Endpoints:
 Live-Track:
@@ -542,6 +543,20 @@ def create_app() -> FastAPI:
             {
                 "status": proj_status,
             },
+        )
+
+    @app.get("/observability", response_class=HTMLResponse)
+    async def observability_hub_page(request: Request) -> Any:
+        """
+        Read-only Observability-Hub — curated links to existing GET surfaces only.
+
+        No POST, no provider/exchange orchestration by this endpoint; navigation layer only.
+        """
+        proj_status = get_project_status()
+        return templates.TemplateResponse(
+            request,
+            "observability_hub.html",
+            {"status": proj_status},
         )
 
     @app.get("/", response_class=HTMLResponse)

--- a/templates/peak_trade_dashboard/base.html
+++ b/templates/peak_trade_dashboard/base.html
@@ -74,6 +74,13 @@
             <a href="/live/alerts" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               🔔 Alerts
             </a>
+            <a
+              href="/observability"
+              class="text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              title="Read-only Observability-Hub (Links zu GET-Flächen; keine neue Autorität)."
+            >
+              Observability
+            </a>
             <a href="/r_and_d/experiments" class="text-xs text-slate-400 hover:text-slate-200 transition-colors">
               R&D Experiments
             </a>

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -1,0 +1,129 @@
+<!-- templates/peak_trade_dashboard/observability_hub.html -->
+<!-- Read-only Navigations-/Observability-Hub — keine Datenabfragen, keine Steuerzentrale -->
+{% extends "base.html" %}
+
+{% block content %}
+<div
+  class="space-y-8 max-w-5xl mx-auto"
+  data-section="observability-hub-v0"
+  data-observability-hub="true"
+  data-observability-readonly="true"
+>
+  <section
+    aria-label="Einordnung dieser Seite"
+    class="rounded-xl border border-amber-900/40 bg-amber-950/25 px-4 py-3 text-xs text-amber-100/95"
+    data-observability-safety-banner="true"
+  >
+    <p class="font-semibold text-amber-200/95 tracking-wide uppercase text-[11px] mb-2">
+      Observability-Hub · rein read-only · non-authorizing
+    </p>
+    <ul class="list-disc pl-5 space-y-1.5 leading-relaxed text-amber-100/90">
+      <li>Keine Orders.</li>
+      <li>Keine Live-/Testnet-Aktivierung.</li>
+      <li>Keine Capital-/Scope-Freigabe.</li>
+      <li>Kein Risk-/KillSwitch-Override.</li>
+      <li>
+        Diese Seite enthält keine POSTs und kein eigener Datenabruf gegen Provider oder Exchanges
+        — nur Verweise zu bestehenden GET-/Anzeige-Flächen.
+      </li>
+    </ul>
+  </section>
+
+  <header class="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+    <p class="text-xs uppercase tracking-wide text-slate-500 mb-1">Peak_Trade</p>
+    <h1 class="text-2xl font-bold text-slate-100">Observability-Hub</h1>
+    <p class="text-sm text-slate-400 mt-2 max-w-3xl">
+      Zentrale Link- und Hinweisleiste: bestehende, sichere Lese-Angebote durchklickbar machen —
+      keine neue Autorität, keine Steuerlogik für Handel oder Runner.
+    </p>
+  </header>
+
+  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="Market Surface v0">
+    <h2 class="text-sm font-semibold text-slate-200 mb-3">Market Surface v0 (read-only OHLCV)</h2>
+    <ul class="space-y-2 text-sm text-sky-400">
+      <li>
+        <a class="underline hover:text-sky-300 font-mono text-xs break-all"
+           href="/market?source=dummy&amp;timeframe=1h&amp;limit=30&amp;symbol=BTC%2FUSD">GET /market</a>
+        — HTML-Anzeige (Dummy-Beispielparameter).
+      </li>
+      <li>
+        <a class="underline hover:text-sky-300 font-mono text-xs break-all"
+           href="/api/market/ohlcv?symbol=BTC%2FUSD&amp;timeframe=1h&amp;limit=30&amp;source=dummy">
+          GET /api/market/ohlcv</a>
+        — JSON (Dummy).
+      </li>
+    </ul>
+  </section>
+
+  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="Health">
+    <h2 class="text-sm font-semibold text-slate-200 mb-3">Health &amp; Metriken (GET)</h2>
+    <ul class="space-y-2 text-sm text-sky-400 font-mono text-xs">
+      <li><a class="underline hover:text-sky-300" href="/health">GET /health</a></li>
+      <li><a class="underline hover:text-sky-300" href="/health/detailed">GET /health/detailed</a></li>
+      <li><a class="underline hover:text-sky-300" href="/health/metrics">GET /health/metrics</a></li>
+      <li><a class="underline hover:text-sky-300" href="/health/prometheus">GET /health/prometheus</a></li>
+      <li><a class="underline hover:text-sky-300" href="/api/health">GET /api/health</a> <span class="text-slate-500 font-sans text-xs">(minimaler Alias)</span></li>
+    </ul>
+  </section>
+
+  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="Master V2 Double Play">
+    <h2 class="text-sm font-semibold text-slate-200 mb-3">Master V2 — Double Play (Display-JSON)</h2>
+    <p class="text-xs text-slate-400 mb-2 leading-relaxed">
+      Read-only Snapshot laut Vertrag — reine Darstellungs-/Fixture-Schicht für das Dashboard-Payload,
+      keine Live-Session oder Exchange-Anbindung.
+    </p>
+    <ul class="text-sm">
+      <li>
+        <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs break-all"
+           href="/api/master-v2/double-play/dashboard-display.json">
+          GET /api/master-v2/double-play/dashboard-display.json
+        </a>
+      </li>
+    </ul>
+  </section>
+
+  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="R and D">
+    <h2 class="text-sm font-semibold text-slate-200 mb-3">R&amp;D Experimente (read-only)</h2>
+    <ul class="space-y-2 text-sm">
+      <li>
+        <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs" href="/r_and_d/experiments">
+          GET /r_and_d/experiments
+        </a>
+      </li>
+      <li>
+        <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs break-all"
+           href="/api/r_and_d/experiments?limit=20">
+          GET /api/r_and_d/experiments?limit=20
+        </a>
+      </li>
+    </ul>
+  </section>
+
+  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="OPS CI Health">
+    <h2 class="text-sm font-semibold text-slate-200 mb-3">OPS — CI Health</h2>
+    <p class="text-xs text-slate-400 mb-2 leading-relaxed">
+      Die HTML-Oberfläche kann eigene Buttons für Prüfungsläufe enthalten (POST dort, nicht hier).
+      Für reinen Lesestatus eignet sich der JSON-Status.
+    </p>
+    <ul class="space-y-2 text-sm">
+      <li>
+        <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs" href="/ops/ci-health">
+          GET /ops/ci-health</a>
+        <span class="text-slate-500 text-xs"> — HTML-Dashboard</span>
+      </li>
+      <li>
+        <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs" href="/ops/ci-health/status">
+          GET /ops/ci-health/status</a>
+        <span class="text-slate-500 text-xs"> — JSON (Lesestatus)</span>
+      </li>
+    </ul>
+  </section>
+
+  <section class="rounded-xl border border-slate-800 bg-slate-900/40 p-4 text-xs text-slate-500" aria-label="Hinweise">
+    <p class="leading-relaxed">
+      Knowledge API und andere geschriebene Oberflächen sind absichtlich nicht verlinkt
+      — dieser Hub soll nur bestehende, uneingeschränkte GET-/Angebote sammeln, ohne neue Autorisierung zu suggerieren.
+    </p>
+  </section>
+</div>
+{% endblock %}

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -1,0 +1,57 @@
+"""Observability-Hub (GET /observability) — read-only Link-Schicht ohne POST."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def test_observability_hub_ok_markers(client: TestClient) -> None:
+    r = client.get("/observability")
+    assert r.status_code == 200
+    assert "text/html" in r.headers.get("content-type", "")
+    body = r.text
+    assert 'data-observability-hub="true"' in body
+    assert 'data-observability-readonly="true"' in body
+    assert 'data-observability-safety-banner="true"' in body
+    assert "Keine Orders" in body
+    assert "Testnet" in body or "Live" in body
+    assert "Capital" in body or "Scope" in body
+    assert "KillSwitch" in body or "Risk" in body
+    assert 'href="/market' in body
+    assert "/api/market/ohlcv" in body
+    assert "/health/detailed" in body
+    assert "/api/master-v2/double-play/dashboard-display.json" in body
+    assert "/r_and_d/experiments" in body
+    assert "/ops/ci-health/status" in body
+    assert 'method="POST"' not in body
+
+
+def test_observability_hub_template_knowledge_exclusion_banner() -> None:
+    tmpl = (
+        Path(__file__).resolve().parents[2]
+        / "templates"
+        / "peak_trade_dashboard"
+        / "observability_hub.html"
+    )
+    txt = tmpl.read_text(encoding="utf-8")
+    assert "Knowledge API" in txt
+    assert "/api/knowledge" not in txt


### PR DESCRIPTION
## Summary
- add GET /observability as a read-only WebUI navigation hub
- link existing GET/status surfaces for Market, Health, Double Play display JSON, R&D experiments, and OPS CI Health
- add visible no-orders/no-live/no-capital/no-risk-override safety banner
- keep Knowledge API intentionally unlinked
- add tests for route markers, safety copy, expected links, no POST forms, and no Knowledge link

## Safety
- read-only navigation layer
- no provider/exchange fetches
- no workflow execution
- no PaperExecutionEngine wiring
- no runner/execution path
- no Testnet/Live activation
- no order path
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check src/webui/app.py tests/webui/test_observability_hub.py
- uv run ruff format --check src/webui/app.py tests/webui/test_observability_hub.py
- git diff --check

Made with [Cursor](https://cursor.com)