### PR TITLE
feat(webui): add observability health status panel

### DIFF
--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -38,6 +38,44 @@
     </p>
   </header>
 
+  <section
+    class="rounded-xl border border-emerald-900/40 bg-emerald-950/15 px-5 py-4 space-y-3"
+    aria-label="Health Status — display-only"
+    data-observability-health-panel="true"
+    data-observability-health-readonly="true"
+    data-observability-health-no-actions="true"
+  >
+    <div>
+      <h2 class="text-sm font-semibold text-emerald-200/95 tracking-wide uppercase text-[11px]">
+        Health Status Panel
+      </h2>
+      <p class="text-xs text-emerald-100/85 mt-1.5 leading-relaxed">
+        read-only / display-only — keine Steuerbuttons, keine Formulare auf dieser Hub-Seite.
+        Dieses Panel löst keine Health-Checks oder Workflows aus, aktiviert weder Live noch Testnet und keine Orders,
+        und erlaubt keinen Risk- oder KillSwitch-Override.
+        Nutze die Links, um bestehende JSON-/Text-Endpunkte im Browser oder per Client abzufragen
+        (Polling oder Automatisierung gehört hierher nicht).
+      </p>
+    </div>
+    {% if status %}
+    <p class="text-xs text-slate-400 font-mono border border-slate-800/80 rounded-lg px-3 py-2 bg-slate-950/40"
+       data-observability-health-project-snapshot="{{ status.version }} {{ status.snapshot_commit }}">
+      Projekt-/Dashboard-Kontext (wie übrige Seiten — kein Gesundheitssignal):
+      {{ status.version }} · {{ status.snapshot_commit }}
+    </p>
+    {% endif %}
+    <div>
+      <h3 class="text-xs font-medium text-slate-300 mb-2">Bestehende Health-GET-Endpunkte</h3>
+      <ul class="space-y-2 text-sm text-sky-400 font-mono text-xs">
+        <li><a class="underline hover:text-sky-300" href="/health">GET /health</a></li>
+        <li><a class="underline hover:text-sky-300" href="/health/detailed">GET /health/detailed</a></li>
+        <li><a class="underline hover:text-sky-300" href="/health/metrics">GET /health/metrics</a></li>
+        <li><a class="underline hover:text-sky-300" href="/health/prometheus">GET /health/prometheus</a></li>
+        <li><a class="underline hover:text-sky-300" href="/api/health">GET /api/health</a> <span class="text-slate-500 font-sans text-xs">(minimaler Alias)</span></li>
+      </ul>
+    </div>
+  </section>
+
   <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="Market Surface v0">
     <h2 class="text-sm font-semibold text-slate-200 mb-3">Market Surface v0 (read-only OHLCV)</h2>
     <ul class="space-y-2 text-sm text-sky-400">
@@ -52,17 +90,6 @@
           GET /api/market/ohlcv</a>
         — JSON (Dummy).
       </li>
-    </ul>
-  </section>
-
-  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="Health">
-    <h2 class="text-sm font-semibold text-slate-200 mb-3">Health &amp; Metriken (GET)</h2>
-    <ul class="space-y-2 text-sm text-sky-400 font-mono text-xs">
-      <li><a class="underline hover:text-sky-300" href="/health">GET /health</a></li>
-      <li><a class="underline hover:text-sky-300" href="/health/detailed">GET /health/detailed</a></li>
-      <li><a class="underline hover:text-sky-300" href="/health/metrics">GET /health/metrics</a></li>
-      <li><a class="underline hover:text-sky-300" href="/health/prometheus">GET /health/prometheus</a></li>
-      <li><a class="underline hover:text-sky-300" href="/api/health">GET /api/health</a> <span class="text-slate-500 font-sans text-xs">(minimaler Alias)</span></li>
     </ul>
   </section>
 

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -32,17 +32,29 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert 'data-observability-hub="true"' in body
     assert 'data-observability-readonly="true"' in body
     assert 'data-observability-safety-banner="true"' in body
-    assert "Keine Orders" in body
-    assert "Testnet" in body or "Live" in body
-    assert "Capital" in body or "Scope" in body
+    assert 'data-observability-health-panel="true"' in body
+    assert 'data-observability-health-readonly="true"' in body
+    assert 'data-observability-health-no-actions="true"' in body
+    assert "read-only / display-only" in body
+    assert "Workflows" in body
+    assert "Live" in body and "Testnet" in body and "Orders" in body
     assert "KillSwitch" in body or "Risk" in body
+    assert "Keine Orders" in body
+    assert "Capital" in body or "Scope" in body
     assert 'href="/market' in body
     assert "/api/market/ohlcv" in body
     assert "/health/detailed" in body
+    assert 'href="/health"' in body
+    assert "/health/metrics" in body
+    assert "/health/prometheus" in body
+    assert "/api/health" in body
     assert "/api/master-v2/double-play/dashboard-display.json" in body
     assert "/r_and_d/experiments" in body
     assert "/ops/ci-health/status" in body
     assert 'method="POST"' not in body
+    assert "<form" not in body.lower()
+    assert 'type="submit"' not in body
+    assert "data-observability-health-project-snapshot=" in body
 
 
 def test_observability_hub_template_knowledge_exclusion_banner() -> None:
@@ -55,3 +67,19 @@ def test_observability_hub_template_knowledge_exclusion_banner() -> None:
     txt = tmpl.read_text(encoding="utf-8")
     assert "Knowledge API" in txt
     assert "/api/knowledge" not in txt
+
+
+def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
+    tmpl = (
+        Path(__file__).resolve().parents[2]
+        / "templates"
+        / "peak_trade_dashboard"
+        / "observability_hub.html"
+    )
+    txt = tmpl.read_text(encoding="utf-8")
+    assert 'data-observability-health-panel="true"' in txt
+    assert 'data-observability-health-readonly="true"' in txt
+    assert 'data-observability-health-no-actions="true"' in txt
+    assert "read-only / display-only" in txt
+    assert "Workflows" in txt
+    assert 'method="POST"' not in txt


### PR DESCRIPTION
## Summary
- add a display-only Health Status panel to GET /observability
- group existing Health GET links in the panel
- add stable observability health data markers
- state that the panel triggers no workflows/checks, enables no Live/Testnet/orders, and overrides no Risk/KillSwitch
- keep src/webui/app.py unchanged

## Safety
- template + tests only
- no backend behavior change
- no new route
- no provider/exchange behavior
- no workflow execution
- no health polling loop
- no Paper/Testnet/Live/order behavior
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check tests/webui/test_observability_hub.py
- uv run ruff format --check tests/webui/test_observability_hub.py
- git diff --check

Made with [Cursor](https://cursor.com)