### PR TITLE
feat(webui): expand observability display panels v0.1

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -61,3 +61,7 @@ Das HTML für **`GET &#47;market`** enthält beim Chart‑Bereich ein Status‑E
 
 - **`data-market-empty-state="true"`** und **`data-market-error-state="true"`** sind **Display/Test‑Anker** wie andere **`data-market-*`**‑Marker.
 - **Keine** Schlussfolgerung auf Backend‑Betriebssicherheit, **Provider‑Readiness**, **Futures‑Readiness**, **Trading‑ oder Strategieautorität** oder **Capital/Scope/Risk/KillSwitch**‑Laufzeit über diese Marker hinaus.
+
+## Verwandte read-only WebUI-Fläche
+
+- [**Observability Hub v0**](observability/OBSERVABILITY_HUB_V0.md) — zentraler Display-/Navigations‑Kontext mit Verweisen u. a. auf diese Market‑Surface‑GET‑Routen; **ohne** zusätzliche Autorität oder Steuerlogik.

--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -1,0 +1,58 @@
+# Observability Hub v0 (`GET &#47;observability`)
+
+## Zweck
+
+Der **Observability Hub** ist eine **read-only / display-only** HTML-Fläche im Operator-WebUI-Prozess. Sie bündelt **Verweise und kurze Einordnungstexte** zu bestehenden **GET-Endpunkten** — ohne neue Autorität, ohne Steuerlogik für Handel, Runner oder Workflows von dieser Seite aus.
+
+Es gibt **kein** eingebettetes Client-Polling auf dieser Hub-HTML, **keine** zusätzliche serverseitige Datenaggregation speziell für den Hub über das bereits an Templates übergebene Projekt-/Snapshot-Stub (`status`), und **keine** POST-Endpunkte oder Formulare auf der Hub-Seite.
+
+## Grenzen und explizites Nicht-Angebot
+
+- **Keine Orders**, keine Ausführung.
+- **Keine Testnet-/Live-Aktivierung** über den Hub.
+- **Keine Capital-/Scope-Freigabe**.
+- **Kein Risk-/KillSwitch-Override**.
+- **Kein Workflow-Trigger** von dieser Hub-Seite.
+- **Kein PaperExecutionEngine-Wiring** über diesen Hub.
+- **Knowledge API** wird bewusst **nicht** verlinkt (geschriebene/POST-relevante Flächen gehören nicht in dieses Link-Inventar).
+- **Kein Paper/Shadow-Artifact-Panel** in dieser Phase — kein zusätzlicher Readiness-/Handoff-/Evidence-Narrativ-Anker.
+
+## Aktuelle Panels (Display-only)
+
+Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness oder Strategie-/Ausführungsfreigabe.
+
+| Panel | Zweck kurz |
+|-------|------------|
+| Einordnung (Amber-Banner) | Top-Level read-only · non-authorizing |
+| Globale Grenz-Legende | Kompakte Wiederholung der Systemgrenze inkl. Workflow/PaperExecutionEngine |
+| Health Status Panel | Links zu **`GET &#47;health`**, **`&#47;health&#47;detailed`**, **`&#47;metrics`**, **`&#47;prometheus`**, **`GET &#47;api&#47;health`** |
+| Market Surface v0 | Dummy-Links **`GET &#47;market`** und **`GET &#47;api&#47;market&#47;ohlcv`** |
+| Double Play Display | **`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`** (Snapshot/Display-Vertrag) |
+| R&amp;D Experiments | HTML-Liste und **`GET &#47;api&#47;r_and_d&#47;experiments`** |
+| OPS CI Health | **`GET &#47;ops&#47;ci-health`** und **`GET &#47;ops&#47;ci-health&#47;status`** (Hub nur GET-Links) |
+
+### Stabile `data-observability-*` Marker (Auszug)
+
+- `data-observability-hub`, `data-observability-readonly`, `data-observability-display-only`
+- `data-observability-safety-banner`
+- `data-observability-boundary-legend`
+- `data-observability-health-panel`, `data-observability-health-readonly`, `data-observability-health-no-actions`
+- `data-observability-market-panel`
+- `data-observability-double-play-panel`
+- `data-observability-rd-panel`
+- `data-observability-ops-ci-panel`
+
+Kein `method=&quot;POST&quot;`, kein `<form>`, kein eingebettetes `fetch(` im Hub-Template.
+
+## Lokale Vorschau
+
+```bash
+uv run python -m uvicorn src.webui.app:app --reload --host 127.0.0.1 --port 8000
+```
+
+Sichere Beispiel-URLs (nach Start):
+
+- `http://127.0.0.1:8000/observability` — entspricht **`GET &#47;observability`**
+- `http://127.0.0.1:8000/market?source=dummy` — entspricht **`GET &#47;market`** mit Dummy-OHLCV
+
+Siehe ergänzend: [**Market Surface v0**](../MARKET_SURFACE_V0.md) zur OHLCV-Read-only-Oberfläche.

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -8,6 +8,7 @@
   data-section="observability-hub-v0"
   data-observability-hub="true"
   data-observability-readonly="true"
+  data-observability-display-only="true"
 >
   <section
     aria-label="Einordnung dieser Seite"
@@ -37,6 +38,24 @@
       keine neue Autorität, keine Steuerlogik für Handel oder Runner.
     </p>
   </header>
+
+  <section
+    class="rounded-xl border border-slate-700/80 bg-slate-900/45 px-4 py-3 text-xs text-slate-300"
+    aria-label="Globale Systemgrenze"
+    data-observability-boundary-legend="true"
+  >
+    <p class="font-semibold text-slate-200 tracking-wide uppercase text-[11px] mb-2">
+      Globale Grenz-Legende (display-only)
+    </p>
+    <ul class="list-disc pl-5 space-y-1 leading-relaxed text-slate-400">
+      <li>Keine Orders.</li>
+      <li>Keine Testnet-/Live-Aktivierung.</li>
+      <li>Keine Capital-/Scope-Freigabe.</li>
+      <li>Kein Risk-/KillSwitch-Override.</li>
+      <li>Kein Workflow-Trigger von dieser Hub-Seite.</li>
+      <li>Kein PaperExecutionEngine-Wiring über diesen Hub.</li>
+    </ul>
+  </section>
 
   <section
     class="rounded-xl border border-emerald-900/40 bg-emerald-950/15 px-5 py-4 space-y-3"
@@ -76,8 +95,20 @@
     </div>
   </section>
 
-  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="Market Surface v0">
-    <h2 class="text-sm font-semibold text-slate-200 mb-3">Market Surface v0 (read-only OHLCV)</h2>
+  <section
+    class="rounded-xl border border-sky-900/35 bg-sky-950/10 px-5 py-4 space-y-3"
+    aria-label="Market Surface v0 — display-only"
+    data-observability-market-panel="true"
+  >
+    <div>
+      <h2 class="text-sm font-semibold text-sky-200/95 tracking-wide uppercase text-[11px]">
+        Market Surface v0 Panel
+      </h2>
+      <p class="text-xs text-sky-100/80 mt-1.5 leading-relaxed">
+        read-only OHLCV — Dummy/Offline nur informativ; optional öffentliche OHLCV ebenfalls nur Anzeige
+        ohne Trading-, Live- oder Readiness-Aussage. Keine Ausführung, keine Ordersemantik.
+      </p>
+    </div>
     <ul class="space-y-2 text-sm text-sky-400">
       <li>
         <a class="underline hover:text-sky-300 font-mono text-xs break-all"
@@ -93,12 +124,20 @@
     </ul>
   </section>
 
-  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="Master V2 Double Play">
-    <h2 class="text-sm font-semibold text-slate-200 mb-3">Master V2 — Double Play (Display-JSON)</h2>
-    <p class="text-xs text-slate-400 mb-2 leading-relaxed">
-      Read-only Snapshot laut Vertrag — reine Darstellungs-/Fixture-Schicht für das Dashboard-Payload,
-      keine Live-Session oder Exchange-Anbindung.
-    </p>
+  <section
+    class="rounded-xl border border-violet-900/35 bg-violet-950/10 px-5 py-4 space-y-3"
+    aria-label="Double Play Display JSON — display-only"
+    data-observability-double-play-panel="true"
+  >
+    <div>
+      <h2 class="text-sm font-semibold text-violet-200/95 tracking-wide uppercase text-[11px]">
+        Double Play Display Panel
+      </h2>
+      <p class="text-xs text-violet-100/85 mt-1.5 leading-relaxed">
+        Reiner Snapshot/Display-Vertrag für Dashboard-Payload — keine Session, keine Exchange-Anbindung,
+        keine Ausführungsautorität.
+      </p>
+    </div>
     <ul class="text-sm">
       <li>
         <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs break-all"
@@ -109,8 +148,19 @@
     </ul>
   </section>
 
-  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="R and D">
-    <h2 class="text-sm font-semibold text-slate-200 mb-3">R&amp;D Experimente (read-only)</h2>
+  <section
+    class="rounded-xl border border-indigo-900/35 bg-indigo-950/10 px-5 py-4 space-y-3"
+    aria-label="R and D experiments — visibility only"
+    data-observability-rd-panel="true"
+  >
+    <div>
+      <h2 class="text-sm font-semibold text-indigo-200/95 tracking-wide uppercase text-[11px]">
+        R&amp;D Experiments Panel
+      </h2>
+      <p class="text-xs text-indigo-100/85 mt-1.5 leading-relaxed">
+        Forschungs-/Experiment-Sichtbarkeit — keine Deploy- oder Produktionsfreigabe über diese Links.
+      </p>
+    </div>
     <ul class="space-y-2 text-sm">
       <li>
         <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs" href="/r_and_d/experiments">
@@ -126,12 +176,20 @@
     </ul>
   </section>
 
-  <section class="rounded-xl border border-slate-800 bg-slate-900/50 p-5" aria-label="OPS CI Health">
-    <h2 class="text-sm font-semibold text-slate-200 mb-3">OPS — CI Health</h2>
-    <p class="text-xs text-slate-400 mb-2 leading-relaxed">
-      Die HTML-Oberfläche kann eigene Buttons für Prüfungsläufe enthalten (POST dort, nicht hier).
-      Für reinen Lesestatus eignet sich der JSON-Status.
-    </p>
+  <section
+    class="rounded-xl border border-orange-900/35 bg-orange-950/10 px-5 py-4 space-y-3"
+    aria-label="OPS CI Health — hub links read-only"
+    data-observability-ops-ci-panel="true"
+  >
+    <div>
+      <h2 class="text-sm font-semibold text-orange-200/95 tracking-wide uppercase text-[11px]">
+        OPS — CI Health Panel
+      </h2>
+      <p class="text-xs text-orange-100/85 mt-1.5 leading-relaxed">
+        Nur Navigations-Verweise hier — löst keine Prüfluft aus. Die HTML-Oberfläche unter „CI Health“ kann
+        an anderer Stelle eigene Schritte anbieten; dieser Hub triggert nichts.
+      </p>
+    </div>
     <ul class="space-y-2 text-sm">
       <li>
         <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs" href="/ops/ci-health">

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -31,16 +31,26 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     body = r.text
     assert 'data-observability-hub="true"' in body
     assert 'data-observability-readonly="true"' in body
+    assert 'data-observability-display-only="true"' in body
     assert 'data-observability-safety-banner="true"' in body
+    assert 'data-observability-boundary-legend="true"' in body
+    assert 'data-observability-market-panel="true"' in body
+    assert 'data-observability-double-play-panel="true"' in body
+    assert 'data-observability-rd-panel="true"' in body
+    assert 'data-observability-ops-ci-panel="true"' in body
     assert 'data-observability-health-panel="true"' in body
     assert 'data-observability-health-readonly="true"' in body
     assert 'data-observability-health-no-actions="true"' in body
+
     assert "read-only / display-only" in body
     assert "Workflows" in body
-    assert "Live" in body and "Testnet" in body and "Orders" in body
-    assert "KillSwitch" in body or "Risk" in body
     assert "Keine Orders" in body
-    assert "Capital" in body or "Scope" in body
+    assert "Testnet" in body and "Live" in body
+    assert "Capital" in body and "Scope" in body
+    assert "Risk" in body and "KillSwitch" in body
+    assert "Workflow-Trigger" in body
+    assert "PaperExecutionEngine" in body
+
     assert 'href="/market' in body
     assert "/api/market/ohlcv" in body
     assert "/health/detailed" in body
@@ -51,9 +61,12 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert "/api/master-v2/double-play/dashboard-display.json" in body
     assert "/r_and_d/experiments" in body
     assert "/ops/ci-health/status" in body
+
     assert 'method="POST"' not in body
     assert "<form" not in body.lower()
     assert 'type="submit"' not in body
+    assert "fetch(" not in body
+
     assert "data-observability-health-project-snapshot=" in body
 
 
@@ -80,6 +93,33 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert 'data-observability-health-panel="true"' in txt
     assert 'data-observability-health-readonly="true"' in txt
     assert 'data-observability-health-no-actions="true"' in txt
+    assert 'data-observability-boundary-legend="true"' in txt
+    assert 'data-observability-market-panel="true"' in txt
+    assert 'data-observability-double-play-panel="true"' in txt
+    assert 'data-observability-rd-panel="true"' in txt
+    assert 'data-observability-ops-ci-panel="true"' in txt
+    assert 'data-observability-display-only="true"' in txt
     assert "read-only / display-only" in txt
     assert "Workflows" in txt
+    assert "PaperExecutionEngine" in txt
+    assert "Workflow-Trigger" in txt
     assert 'method="POST"' not in txt
+    assert "<form" not in txt.lower()
+    assert "fetch(" not in txt
+
+
+def test_observability_hub_doc_exists_and_tokens() -> None:
+    doc = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "webui"
+        / "observability"
+        / "OBSERVABILITY_HUB_V0.md"
+    )
+    assert doc.exists()
+    t = doc.read_text(encoding="utf-8")
+    assert "PaperExecutionEngine" in t
+    assert "`/api/knowledge`" not in t
+    assert "GET &#47;observability" in t
+    assert "data-observability-" in t
+    assert "Paper/Shadow" in t.lower() or "Paper" in t


### PR DESCRIPTION
## Summary
- expand GET /observability into a display-only v0.1 hub with consistent panel cards
- add Market, Double Play, R&D, OPS CI, Health, and boundary legend display sections
- add stable data-observability-* markers for panel/test anchors
- document Observability Hub v0 and link it from Market Surface v0 docs
- preserve no POST/forms/fetch scripts and no control semantics

## Safety
- WebUI template + tests + docs only
- no src route/backend changes
- no provider/exchange fetches
- no workflow execution
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check tests/webui/test_observability_hub.py
- uv run ruff format --check tests/webui/test_observability_hub.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)