### PR TITLE
feat(webui): add observability status summary v0.2

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -41,8 +41,19 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 - `data-observability-double-play-panel`
 - `data-observability-rd-panel`
 - `data-observability-ops-ci-panel`
+- `data-observability-status-summary`
 
 Kein `method=&quot;POST&quot;`, kein `<form>`, kein eingebettetes `fetch(` im Hub-Template.
+
+## System Status Summary (v0.2)
+
+Auf `GET &#47;observability` gibt es ein kleines, rein visuelles Panel **System Status Snapshot** mit dem Marker `data-observability-status-summary=&quot;true&quot;`.
+
+Das Panel zeigt nur Werte aus dem bereits vorhandenen Template-Kontext `status` (z. B. `version`, `snapshot_commit`, optional `environment`/`mode`). Fehlende Felder werden als `not provided` dargestellt.
+
+Es gibt dabei **kein** Polling, **kein** `fetch(`, **keine** API-Aufrufe aus dem Panel und keine neuen Backend-Pfade.
+
+Wichtig: Das Panel ist rein deklarativ und macht **keine** Aussagen zu Backend-Health-Zertifizierung, Provider-Readiness oder Paper/Testnet/Live/Order-Readiness.
 
 ## Lokale Vorschau
 

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -58,6 +58,52 @@
   </section>
 
   <section
+    class="rounded-xl border border-cyan-900/35 bg-cyan-950/10 px-5 py-4 space-y-3"
+    aria-label="System Status Snapshot — display-only"
+    data-observability-status-summary="true"
+  >
+    <div>
+      <h2 class="text-sm font-semibold text-cyan-200/95 tracking-wide uppercase text-[11px]">
+        System Status Snapshot
+      </h2>
+      <p class="text-xs text-cyan-100/85 mt-1.5 leading-relaxed">
+        Display-only status snapshot. No backend health certification. No provider readiness.
+        No Paper/Testnet/Live/order readiness.
+      </p>
+    </div>
+    <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-xs">
+      <div>
+        <dt class="text-slate-400">Version</dt>
+        <dd class="font-mono text-slate-200">{{ status.version if status and status.version else "not provided" }}</dd>
+      </div>
+      <div>
+        <dt class="text-slate-400">Snapshot Commit</dt>
+        <dd class="font-mono text-slate-200">
+          {{ status.snapshot_commit if status and status.snapshot_commit else "not provided" }}
+        </dd>
+      </div>
+      <div>
+        <dt class="text-slate-400">Environment</dt>
+        <dd class="font-mono text-slate-200">
+          {{
+            status.environment if status and status.environment
+            else (status.env if status and status.env else "not provided")
+          }}
+        </dd>
+      </div>
+      <div>
+        <dt class="text-slate-400">Mode</dt>
+        <dd class="font-mono text-slate-200">
+          {{
+            status.mode if status and status.mode
+            else (status.run_mode if status and status.run_mode else "not provided")
+          }}
+        </dd>
+      </div>
+    </dl>
+  </section>
+
+  <section
     class="rounded-xl border border-emerald-900/40 bg-emerald-950/15 px-5 py-4 space-y-3"
     aria-label="Health Status — display-only"
     data-observability-health-panel="true"

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -34,6 +34,7 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert 'data-observability-display-only="true"' in body
     assert 'data-observability-safety-banner="true"' in body
     assert 'data-observability-boundary-legend="true"' in body
+    assert 'data-observability-status-summary="true"' in body
     assert 'data-observability-market-panel="true"' in body
     assert 'data-observability-double-play-panel="true"' in body
     assert 'data-observability-rd-panel="true"' in body
@@ -43,6 +44,10 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert 'data-observability-health-no-actions="true"' in body
 
     assert "read-only / display-only" in body
+    assert "Display-only status snapshot" in body
+    assert "No backend health certification" in body
+    assert "No provider readiness" in body
+    assert "No Paper/Testnet/Live/order readiness" in body
     assert "Workflows" in body
     assert "Keine Orders" in body
     assert "Testnet" in body and "Live" in body
@@ -66,6 +71,7 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert "<form" not in body.lower()
     assert 'type="submit"' not in body
     assert "fetch(" not in body
+    assert "/api/knowledge" not in body
 
     assert "data-observability-health-project-snapshot=" in body
 
@@ -94,12 +100,17 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert 'data-observability-health-readonly="true"' in txt
     assert 'data-observability-health-no-actions="true"' in txt
     assert 'data-observability-boundary-legend="true"' in txt
+    assert 'data-observability-status-summary="true"' in txt
     assert 'data-observability-market-panel="true"' in txt
     assert 'data-observability-double-play-panel="true"' in txt
     assert 'data-observability-rd-panel="true"' in txt
     assert 'data-observability-ops-ci-panel="true"' in txt
     assert 'data-observability-display-only="true"' in txt
     assert "read-only / display-only" in txt
+    assert "Display-only status snapshot" in txt
+    assert "No backend health certification" in txt
+    assert "No provider readiness" in txt
+    assert "No Paper/Testnet/Live/order readiness" in txt
     assert "Workflows" in txt
     assert "PaperExecutionEngine" in txt
     assert "Workflow-Trigger" in txt


### PR DESCRIPTION
## Summary
- add a display-only System Status Snapshot to GET /observability
- render existing status context only, without new server-side fetches or polling
- add stable data-observability-status-summary marker
- document status-summary semantics and safety boundaries in Observability Hub v0 docs
- extend Observability Hub tests for marker/copy/no-control guarantees

## Safety
- WebUI template + tests + docs only
- no src route/backend changes
- no new route
- no provider/exchange fetches
- no workflow execution
- no polling
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check tests/webui/test_observability_hub.py
- uv run ruff format --check tests/webui/test_observability_hub.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)