### PR TITLE
feat(webui): clarify Double Play observability panel v0.3

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -27,7 +27,7 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 | Globale Grenz-Legende | Kompakte Wiederholung der Systemgrenze inkl. Workflow/PaperExecutionEngine |
 | Health Status Panel | Links zu **`GET &#47;health`**, **`&#47;health&#47;detailed`**, **`&#47;metrics`**, **`&#47;prometheus`**, **`GET &#47;api&#47;health`** |
 | Market Surface v0 | Dummy-Links **`GET &#47;market`** und **`GET &#47;api&#47;market&#47;ohlcv`** |
-| Double Play Display | **`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`** (Snapshot/Display-Vertrag) |
+| Double Play Display | **`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`** (display-only Snapshot/Display-Vertrag, ohne Autorität) |
 | R&amp;D Experiments | HTML-Liste und **`GET &#47;api&#47;r_and_d&#47;experiments`** |
 | OPS CI Health | **`GET &#47;ops&#47;ci-health`** und **`GET &#47;ops&#47;ci-health&#47;status`** (Hub nur GET-Links) |
 
@@ -39,6 +39,8 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 - `data-observability-health-panel`, `data-observability-health-readonly`, `data-observability-health-no-actions`
 - `data-observability-market-panel`
 - `data-observability-double-play-panel`
+- `data-observability-double-play-display-json`
+- `data-observability-double-play-no-authority`
 - `data-observability-rd-panel`
 - `data-observability-ops-ci-panel`
 - `data-observability-status-summary`
@@ -54,6 +56,28 @@ Das Panel zeigt nur Werte aus dem bereits vorhandenen Template-Kontext `status` 
 Es gibt dabei **kein** Polling, **kein** `fetch(`, **keine** API-Aufrufe aus dem Panel und keine neuen Backend-Pfade.
 
 Wichtig: Das Panel ist rein deklarativ und macht **keine** Aussagen zu Backend-Health-Zertifizierung, Provider-Readiness oder Paper/Testnet/Live/Order-Readiness.
+
+## Double Play Display JSON (v0.3)
+
+Das Double-Play-Panel auf `GET &#47;observability` bleibt eine reine Erklaer- und Linkflaeche zu:
+
+- **`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`**
+
+Die sichtbare Einordnung ist explizit:
+
+- `Display JSON only`
+- `pure snapshot&#47;display contract`
+- `no execution authority`
+- `no strategy authorization`
+- `no Live&#47;Testnet&#47;order path`
+- `no Capital&#47;Scope approval`
+- `no Risk&#47;KillSwitch override`
+
+Damit gilt fuer v0.3 weiterhin:
+
+- kein Polling und kein `fetch(` im Hub
+- keine Formular- oder POST-Semantik
+- keine Ausfuehrungs-/Strategie-Freigabe, keine Readiness- oder Override-Autoritaet
 
 ## Lokale Vorschau
 

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -174,6 +174,8 @@
     class="rounded-xl border border-violet-900/35 bg-violet-950/10 px-5 py-4 space-y-3"
     aria-label="Double Play Display JSON — display-only"
     data-observability-double-play-panel="true"
+    data-observability-double-play-display-json="true"
+    data-observability-double-play-no-authority="true"
   >
     <div>
       <h2 class="text-sm font-semibold text-violet-200/95 tracking-wide uppercase text-[11px]">
@@ -184,6 +186,15 @@
         keine Ausführungsautorität.
       </p>
     </div>
+    <ul class="list-disc pl-5 space-y-1.5 text-xs text-violet-100/90 leading-relaxed">
+      <li>Display JSON only</li>
+      <li>pure snapshot/display contract</li>
+      <li>no execution authority</li>
+      <li>no strategy authorization</li>
+      <li>no Live/Testnet/order path</li>
+      <li>no Capital/Scope approval</li>
+      <li>no Risk/KillSwitch override</li>
+    </ul>
     <ul class="text-sm">
       <li>
         <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs break-all"

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -37,6 +37,8 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert 'data-observability-status-summary="true"' in body
     assert 'data-observability-market-panel="true"' in body
     assert 'data-observability-double-play-panel="true"' in body
+    assert 'data-observability-double-play-display-json="true"' in body
+    assert 'data-observability-double-play-no-authority="true"' in body
     assert 'data-observability-rd-panel="true"' in body
     assert 'data-observability-ops-ci-panel="true"' in body
     assert 'data-observability-health-panel="true"' in body
@@ -55,6 +57,13 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert "Risk" in body and "KillSwitch" in body
     assert "Workflow-Trigger" in body
     assert "PaperExecutionEngine" in body
+    assert "Display JSON only" in body
+    assert "pure snapshot/display contract" in body
+    assert "no execution authority" in body
+    assert "no strategy authorization" in body
+    assert "no Live/Testnet/order path" in body
+    assert "no Capital/Scope approval" in body
+    assert "no Risk/KillSwitch override" in body
 
     assert 'href="/market' in body
     assert "/api/market/ohlcv" in body
@@ -103,6 +112,8 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert 'data-observability-status-summary="true"' in txt
     assert 'data-observability-market-panel="true"' in txt
     assert 'data-observability-double-play-panel="true"' in txt
+    assert 'data-observability-double-play-display-json="true"' in txt
+    assert 'data-observability-double-play-no-authority="true"' in txt
     assert 'data-observability-rd-panel="true"' in txt
     assert 'data-observability-ops-ci-panel="true"' in txt
     assert 'data-observability-display-only="true"' in txt
@@ -114,8 +125,16 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert "Workflows" in txt
     assert "PaperExecutionEngine" in txt
     assert "Workflow-Trigger" in txt
+    assert "Display JSON only" in txt
+    assert "pure snapshot/display contract" in txt
+    assert "no execution authority" in txt
+    assert "no strategy authorization" in txt
+    assert "no Live/Testnet/order path" in txt
+    assert "no Capital/Scope approval" in txt
+    assert "no Risk/KillSwitch override" in txt
     assert 'method="POST"' not in txt
     assert "<form" not in txt.lower()
+    assert 'type="submit"' not in txt
     assert "fetch(" not in txt
 
 


### PR DESCRIPTION
## Summary
- clarify the Observability Hub Double Play panel as display JSON only
- keep the existing /api/master-v2/double-play/dashboard-display.json link
- add stable data-observability-double-play-* markers
- document no execution authority, no strategy authorization, no Live/Testnet/order path, no Capital/Scope approval, and no Risk/KillSwitch override
- update Observability Hub v0 docs and tests

## Safety
- WebUI template + tests + docs only
- no src route/backend changes
- no new route
- no provider/exchange behavior
- no workflow execution
- no polling
- no JSON fetch from /observability
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check tests/webui/test_observability_hub.py
- uv run ruff format --check tests/webui/test_observability_hub.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)