### PR TITLE
feat(webui): clarify Market provenance observability panel v0.4

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -31,6 +31,36 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 | R&amp;D Experiments | HTML-Liste und **`GET &#47;api&#47;r_and_d&#47;experiments`** |
 | OPS CI Health | **`GET &#47;ops&#47;ci-health`** und **`GET &#47;ops&#47;ci-health&#47;status`** (Hub nur GET-Links) |
 
+## Market/Data Provenance Panel (v0.4)
+
+Das Market Surface Panel im Hub bleibt eine **reine Anzeige- und Navigationsflaeche**. Es dient zur Einordnung der Datenherkunft (Provenance), nicht als Readiness- oder Trading-Signal.
+
+Bestehende GET-Links im Hub:
+
+- **`GET &#47;market?source=dummy&amp;timeframe=1h&amp;limit=30&amp;symbol=BTC%2FUSD`** (HTML-Ansicht)
+- **`GET &#47;api&#47;market&#47;ohlcv?symbol=BTC%2FUSD&amp;timeframe=1h&amp;limit=30&amp;source=dummy`** (JSON-Ansicht)
+
+Bedeutung der Quellenhinweise:
+
+- `source=dummy` bedeutet **offline/synthetic** Darstellungsdaten.
+- `source=kraken` bedeutet optionale **public OHLCV/network display** nur dann, wenn die Market-Route direkt geoeffnet wird.
+- Der Observability Hub selbst **does not fetch OHLCV**.
+- Der Observability Hub selbst **does not call Kraken**.
+
+Readiness-/Autoritaetsgrenze (explizit):
+
+- Market display is not provider readiness.
+- Market display is not Futures readiness.
+- Market display is not Paper/Testnet/Live/order readiness.
+- Market display is not trading authority.
+
+Stabile Marker fuer Tests/Vertrag:
+
+- `data-observability-market-panel=&quot;true&quot;`
+- `data-observability-market-provenance=&quot;true&quot;`
+- `data-observability-market-no-fetch=&quot;true&quot;`
+- `data-observability-market-no-readiness=&quot;true&quot;`
+
 ### Stabile `data-observability-*` Marker (Auszug)
 
 - `data-observability-hub`, `data-observability-readonly`, `data-observability-display-only`

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -145,6 +145,9 @@
     class="rounded-xl border border-sky-900/35 bg-sky-950/10 px-5 py-4 space-y-3"
     aria-label="Market Surface v0 — display-only"
     data-observability-market-panel="true"
+    data-observability-market-provenance="true"
+    data-observability-market-no-fetch="true"
+    data-observability-market-no-readiness="true"
   >
     <div>
       <h2 class="text-sm font-semibold text-sky-200/95 tracking-wide uppercase text-[11px]">
@@ -155,6 +158,18 @@
         ohne Trading-, Live- oder Readiness-Aussage. Keine Ausführung, keine Ordersemantik.
       </p>
     </div>
+    <ul class="list-disc pl-5 space-y-1.5 text-xs text-sky-100/90 leading-relaxed">
+      <li><span class="font-mono">source=dummy</span> is offline/synthetic display data.</li>
+      <li>
+        <span class="font-mono">source=kraken</span> is optional public OHLCV/network display if opened directly.
+      </li>
+      <li>The Observability Hub itself does not fetch OHLCV.</li>
+      <li>The Observability Hub itself does not call Kraken.</li>
+      <li>Market display is not provider readiness.</li>
+      <li>Market display is not Futures readiness.</li>
+      <li>Market display is not Paper/Testnet/Live/order readiness.</li>
+      <li>Market display is not trading authority.</li>
+    </ul>
     <ul class="space-y-2 text-sm text-sky-400">
       <li>
         <a class="underline hover:text-sky-300 font-mono text-xs break-all"

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -36,6 +36,9 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert 'data-observability-boundary-legend="true"' in body
     assert 'data-observability-status-summary="true"' in body
     assert 'data-observability-market-panel="true"' in body
+    assert 'data-observability-market-provenance="true"' in body
+    assert 'data-observability-market-no-fetch="true"' in body
+    assert 'data-observability-market-no-readiness="true"' in body
     assert 'data-observability-double-play-panel="true"' in body
     assert 'data-observability-double-play-display-json="true"' in body
     assert 'data-observability-double-play-no-authority="true"' in body
@@ -50,6 +53,15 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert "No backend health certification" in body
     assert "No provider readiness" in body
     assert "No Paper/Testnet/Live/order readiness" in body
+    assert "source=dummy" in body
+    assert "source=kraken" in body
+    assert "offline/synthetic" in body
+    assert "does not fetch OHLCV" in body
+    assert "does not call Kraken" in body
+    assert "not provider readiness" in body
+    assert "not Futures readiness" in body
+    assert "not Paper/Testnet/Live/order readiness" in body
+    assert "not trading authority" in body
     assert "Workflows" in body
     assert "Keine Orders" in body
     assert "Testnet" in body and "Live" in body
@@ -111,6 +123,9 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert 'data-observability-boundary-legend="true"' in txt
     assert 'data-observability-status-summary="true"' in txt
     assert 'data-observability-market-panel="true"' in txt
+    assert 'data-observability-market-provenance="true"' in txt
+    assert 'data-observability-market-no-fetch="true"' in txt
+    assert 'data-observability-market-no-readiness="true"' in txt
     assert 'data-observability-double-play-panel="true"' in txt
     assert 'data-observability-double-play-display-json="true"' in txt
     assert 'data-observability-double-play-no-authority="true"' in txt
@@ -122,6 +137,15 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert "No backend health certification" in txt
     assert "No provider readiness" in txt
     assert "No Paper/Testnet/Live/order readiness" in txt
+    assert "source=dummy" in txt
+    assert "source=kraken" in txt
+    assert "offline/synthetic" in txt
+    assert "does not fetch OHLCV" in txt
+    assert "does not call Kraken" in txt
+    assert "not provider readiness" in txt
+    assert "not Futures readiness" in txt
+    assert "not Paper/Testnet/Live/order readiness" in txt
+    assert "not trading authority" in txt
     assert "Workflows" in txt
     assert "PaperExecutionEngine" in txt
     assert "Workflow-Trigger" in txt


### PR DESCRIPTION
## Summary
- enhance the Observability Hub Market panel with data provenance boundaries
- clarify source=dummy as offline/synthetic and source=kraken as optional public OHLCV/network display only when opened directly
- state that the hub itself does not fetch OHLCV or call Kraken
- add stable data-observability-market-* markers
- document no provider readiness, no Futures readiness, no Paper/Testnet/Live/order readiness, and no trading authority

## Safety
- WebUI template + tests + docs only
- no src route/backend changes
- no new route
- no provider/exchange behavior
- no Kraken/OHLCV fetch from hub
- no workflow execution
- no polling
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check tests/webui/test_observability_hub.py
- uv run ruff format --check tests/webui/test_observability_hub.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)