### PR TITLE
feat(webui): clarify R&D observability panel v0.5

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -31,6 +31,31 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 | R&amp;D Experiments | HTML-Liste und **`GET &#47;api&#47;r_and_d&#47;experiments`** |
 | OPS CI Health | **`GET &#47;ops&#47;ci-health`** und **`GET &#47;ops&#47;ci-health&#47;status`** (Hub nur GET-Links) |
 
+## R&amp;D Experiments Panel (v0.5)
+
+Das R&amp;D-Panel auf `GET &#47;observability` bleibt eine **statische Erklaer- und Linkflaeche**:
+
+- **`GET &#47;r_and_d&#47;experiments`**
+- **`GET &#47;api&#47;r_and_d&#47;experiments?limit=20`**
+
+Semantik und Grenzen (explizit):
+
+- R&amp;D experiments are research visibility only.
+- The hub does not fetch experiment data.
+- The hub does not promote experiments.
+- The hub does not deploy strategies.
+- The hub does not authorize strategy output.
+- R&amp;D display is not readiness approval.
+- R&amp;D display is not Paper/Testnet/Live/order readiness.
+- R&amp;D display is not trading authority.
+
+Stabile Marker fuer Tests/Vertrag:
+
+- `data-observability-rd-panel=&quot;true&quot;`
+- `data-observability-rd-research-only=&quot;true&quot;`
+- `data-observability-rd-no-deployment=&quot;true&quot;`
+- `data-observability-rd-no-strategy-authority=&quot;true&quot;`
+
 ## Market/Data Provenance Panel (v0.4)
 
 Das Market Surface Panel im Hub bleibt eine **reine Anzeige- und Navigationsflaeche**. Es dient zur Einordnung der Datenherkunft (Provenance), nicht als Readiness- oder Trading-Signal.

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -224,15 +224,27 @@
     class="rounded-xl border border-indigo-900/35 bg-indigo-950/10 px-5 py-4 space-y-3"
     aria-label="R and D experiments — visibility only"
     data-observability-rd-panel="true"
+    data-observability-rd-research-only="true"
+    data-observability-rd-no-deployment="true"
+    data-observability-rd-no-strategy-authority="true"
   >
     <div>
       <h2 class="text-sm font-semibold text-indigo-200/95 tracking-wide uppercase text-[11px]">
         R&amp;D Experiments Panel
       </h2>
       <p class="text-xs text-indigo-100/85 mt-1.5 leading-relaxed">
-        Forschungs-/Experiment-Sichtbarkeit — keine Deploy- oder Produktionsfreigabe über diese Links.
+        R&amp;D experiments are research visibility only.
       </p>
     </div>
+    <ul class="list-disc pl-5 space-y-1.5 text-xs text-indigo-100/90 leading-relaxed">
+      <li>The hub does not fetch experiment data.</li>
+      <li>The hub does not promote experiments.</li>
+      <li>The hub does not deploy strategies.</li>
+      <li>The hub does not authorize strategy output.</li>
+      <li>R&amp;D display is not readiness approval.</li>
+      <li>R&amp;D display is not Paper/Testnet/Live/order readiness.</li>
+      <li>R&amp;D display is not trading authority.</li>
+    </ul>
     <ul class="space-y-2 text-sm">
       <li>
         <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs" href="/r_and_d/experiments">

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -43,6 +43,9 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert 'data-observability-double-play-display-json="true"' in body
     assert 'data-observability-double-play-no-authority="true"' in body
     assert 'data-observability-rd-panel="true"' in body
+    assert 'data-observability-rd-research-only="true"' in body
+    assert 'data-observability-rd-no-deployment="true"' in body
+    assert 'data-observability-rd-no-strategy-authority="true"' in body
     assert 'data-observability-ops-ci-panel="true"' in body
     assert 'data-observability-health-panel="true"' in body
     assert 'data-observability-health-readonly="true"' in body
@@ -76,6 +79,14 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert "no Live/Testnet/order path" in body
     assert "no Capital/Scope approval" in body
     assert "no Risk/KillSwitch override" in body
+    assert "R&amp;D experiments are research visibility only." in body
+    assert "The hub does not fetch experiment data." in body
+    assert "The hub does not promote experiments." in body
+    assert "The hub does not deploy strategies." in body
+    assert "The hub does not authorize strategy output." in body
+    assert "R&amp;D display is not readiness approval." in body
+    assert "R&amp;D display is not Paper/Testnet/Live/order readiness." in body
+    assert "R&amp;D display is not trading authority." in body
 
     assert 'href="/market' in body
     assert "/api/market/ohlcv" in body
@@ -86,6 +97,7 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert "/api/health" in body
     assert "/api/master-v2/double-play/dashboard-display.json" in body
     assert "/r_and_d/experiments" in body
+    assert "/api/r_and_d/experiments?limit=20" in body
     assert "/ops/ci-health/status" in body
 
     assert 'method="POST"' not in body
@@ -130,6 +142,9 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert 'data-observability-double-play-display-json="true"' in txt
     assert 'data-observability-double-play-no-authority="true"' in txt
     assert 'data-observability-rd-panel="true"' in txt
+    assert 'data-observability-rd-research-only="true"' in txt
+    assert 'data-observability-rd-no-deployment="true"' in txt
+    assert 'data-observability-rd-no-strategy-authority="true"' in txt
     assert 'data-observability-ops-ci-panel="true"' in txt
     assert 'data-observability-display-only="true"' in txt
     assert "read-only / display-only" in txt
@@ -156,6 +171,15 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert "no Live/Testnet/order path" in txt
     assert "no Capital/Scope approval" in txt
     assert "no Risk/KillSwitch override" in txt
+    assert "R&amp;D experiments are research visibility only." in txt
+    assert "The hub does not fetch experiment data." in txt
+    assert "The hub does not promote experiments." in txt
+    assert "The hub does not deploy strategies." in txt
+    assert "The hub does not authorize strategy output." in txt
+    assert "R&amp;D display is not readiness approval." in txt
+    assert "R&amp;D display is not Paper/Testnet/Live/order readiness." in txt
+    assert "R&amp;D display is not trading authority." in txt
+    assert "/api/r_and_d/experiments?limit=20" in txt
     assert 'method="POST"' not in txt
     assert "<form" not in txt.lower()
     assert 'type="submit"' not in txt


### PR DESCRIPTION
## Summary
- clarify the Observability Hub R&D panel as research visibility only
- keep existing R&D HTML/API GET links
- add stable data-observability-rd-* markers
- document no experiment fetch from the hub, no promotion, no deployment, no strategy authorization, no readiness approval, and no Paper/Testnet/Live/order readiness
- update Observability Hub v0 docs and tests

## Safety
- WebUI template + tests + docs only
- no src route/backend changes
- no new route
- no experiment API fetch from /observability
- no provider/exchange behavior
- no workflow execution
- no polling
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check tests/webui/test_observability_hub.py
- uv run ruff format --check tests/webui/test_observability_hub.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)