### PR TITLE
feat(webui): clarify OPS CI observability panel v0.6

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -29,7 +29,7 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 | Market Surface v0 | Dummy-Links **`GET &#47;market`** und **`GET &#47;api&#47;market&#47;ohlcv`** |
 | Double Play Display | **`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`** (display-only Snapshot/Display-Vertrag, ohne Autorität) |
 | R&amp;D Experiments | HTML-Liste und **`GET &#47;api&#47;r_and_d&#47;experiments`** |
-| OPS CI Health | **`GET &#47;ops&#47;ci-health`** und **`GET &#47;ops&#47;ci-health&#47;status`** (Hub nur GET-Links) |
+| OPS CI Health | **`GET &#47;ops&#47;ci-health`** (dediziertes CI-Dashboard) und **`GET &#47;ops&#47;ci-health&#47;status`** (bevorzugter read-only Status, JSON) — Hub nur GET-Links, v0.6 |
 
 ## R&amp;D Experiments Panel (v0.5)
 
@@ -55,6 +55,31 @@ Stabile Marker fuer Tests/Vertrag:
 - `data-observability-rd-research-only=&quot;true&quot;`
 - `data-observability-rd-no-deployment=&quot;true&quot;`
 - `data-observability-rd-no-strategy-authority=&quot;true&quot;`
+
+## OPS CI Health Panel (v0.6)
+
+Das OPS-CI-Panel auf `GET &#47;observability` bleibt eine **statische Erklaer- und Linkflaeche** zu den bestehenden OPS-CI-**GET**-Oberflaechen:
+
+- **`GET &#47;ops&#47;ci-health`** — HTML-Dashboard (dedizierte CI-Health-Oberflaeche; kann dort eigene Schritte anbieten).
+- **`GET &#47;ops&#47;ci-health&#47;status`** — **bevorzugter read-only Status-Pfad** (JSON-Lesestatus vom Server; der Hub aggregiert nicht und ruft nichts serverseitig ab).
+
+Semantik und Grenzen (explizit):
+
+- The Observability Hub only links to OPS CI GET surfaces.
+- **`GET &#47;ops&#47;ci-health&#47;status`** ist der bevorzugte read-only Status-Pfad.
+- **`GET &#47;ops&#47;ci-health`** kann das dedizierte CI-Dashboard zeigen; der Hub selbst loest nichts aus.
+- The Hub does not trigger workflows.
+- The Hub does not start GitHub Actions.
+- CI status display is not readiness approval.
+- CI status display is not deployment approval.
+- CI status display is not Live&#47;Testnet&#47;order readiness.
+- CI status display is not trading authority.
+
+Stabile Marker fuer Tests/Vertrag (zusaetzlich zu `data-observability-ops-ci-panel`):
+
+- `data-observability-ops-ci-readonly-links=&quot;true&quot;`
+- `data-observability-ops-ci-no-workflow-trigger=&quot;true&quot;`
+- `data-observability-ops-ci-no-approval=&quot;true&quot;`
 
 ## Market/Data Provenance Panel (v0.4)
 
@@ -98,6 +123,9 @@ Stabile Marker fuer Tests/Vertrag:
 - `data-observability-double-play-no-authority`
 - `data-observability-rd-panel`
 - `data-observability-ops-ci-panel`
+- `data-observability-ops-ci-readonly-links`
+- `data-observability-ops-ci-no-workflow-trigger`
+- `data-observability-ops-ci-no-approval`
 - `data-observability-status-summary`
 
 Kein `method=&quot;POST&quot;`, kein `<form>`, kein eingebettetes `fetch(` im Hub-Template.

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -264,6 +264,9 @@
     class="rounded-xl border border-orange-900/35 bg-orange-950/10 px-5 py-4 space-y-3"
     aria-label="OPS CI Health — hub links read-only"
     data-observability-ops-ci-panel="true"
+    data-observability-ops-ci-readonly-links="true"
+    data-observability-ops-ci-no-workflow-trigger="true"
+    data-observability-ops-ci-no-approval="true"
   >
     <div>
       <h2 class="text-sm font-semibold text-orange-200/95 tracking-wide uppercase text-[11px]">
@@ -274,6 +277,22 @@
         an anderer Stelle eigene Schritte anbieten; dieser Hub triggert nichts.
       </p>
     </div>
+    <ul class="list-disc pl-5 space-y-1.5 text-xs text-orange-100/90 leading-relaxed">
+      <li>The Observability Hub only links to OPS CI GET surfaces.</li>
+      <li>
+        <span class="font-mono">GET /ops/ci-health/status</span> is the preferred read-only status path.
+      </li>
+      <li>
+        <span class="font-mono">GET /ops/ci-health</span> may show the dedicated CI dashboard, but the Hub itself
+        triggers nothing.
+      </li>
+      <li>The Hub does not trigger workflows.</li>
+      <li>The Hub does not start GitHub Actions.</li>
+      <li>CI status display is not readiness approval.</li>
+      <li>CI status display is not deployment approval.</li>
+      <li>CI status display is not Live/Testnet/order readiness.</li>
+      <li>CI status display is not trading authority.</li>
+    </ul>
     <ul class="space-y-2 text-sm">
       <li>
         <a class="text-sky-400 underline hover:text-sky-300 font-mono text-xs" href="/ops/ci-health">

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -47,6 +47,9 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert 'data-observability-rd-no-deployment="true"' in body
     assert 'data-observability-rd-no-strategy-authority="true"' in body
     assert 'data-observability-ops-ci-panel="true"' in body
+    assert 'data-observability-ops-ci-readonly-links="true"' in body
+    assert 'data-observability-ops-ci-no-workflow-trigger="true"' in body
+    assert 'data-observability-ops-ci-no-approval="true"' in body
     assert 'data-observability-health-panel="true"' in body
     assert 'data-observability-health-readonly="true"' in body
     assert 'data-observability-health-no-actions="true"' in body
@@ -98,7 +101,18 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert "/api/master-v2/double-play/dashboard-display.json" in body
     assert "/r_and_d/experiments" in body
     assert "/api/r_and_d/experiments?limit=20" in body
+    assert 'href="/ops/ci-health"' in body
     assert "/ops/ci-health/status" in body
+
+    assert "The Observability Hub only links to OPS CI GET surfaces." in body
+    assert "is the preferred read-only status path." in body
+    assert "may show the dedicated CI dashboard, but the Hub itself" in body
+    assert "The Hub does not trigger workflows." in body
+    assert "The Hub does not start GitHub Actions." in body
+    assert "CI status display is not readiness approval." in body
+    assert "CI status display is not deployment approval." in body
+    assert "CI status display is not Live/Testnet/order readiness." in body
+    assert "CI status display is not trading authority." in body
 
     assert 'method="POST"' not in body
     assert "<form" not in body.lower()
@@ -146,6 +160,9 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert 'data-observability-rd-no-deployment="true"' in txt
     assert 'data-observability-rd-no-strategy-authority="true"' in txt
     assert 'data-observability-ops-ci-panel="true"' in txt
+    assert 'data-observability-ops-ci-readonly-links="true"' in txt
+    assert 'data-observability-ops-ci-no-workflow-trigger="true"' in txt
+    assert 'data-observability-ops-ci-no-approval="true"' in txt
     assert 'data-observability-display-only="true"' in txt
     assert "read-only / display-only" in txt
     assert "Display-only status snapshot" in txt
@@ -180,6 +197,9 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert "R&amp;D display is not Paper/Testnet/Live/order readiness." in txt
     assert "R&amp;D display is not trading authority." in txt
     assert "/api/r_and_d/experiments?limit=20" in txt
+    assert "The Observability Hub only links to OPS CI GET surfaces." in txt
+    assert "The Hub does not start GitHub Actions." in txt
+    assert "CI status display is not deployment approval." in txt
     assert 'method="POST"' not in txt
     assert "<form" not in txt.lower()
     assert 'type="submit"' not in txt


### PR DESCRIPTION
## Summary
- clarify the Observability Hub OPS CI panel as read-only GET links only
- identify /ops/ci-health/status as the preferred read-only status path
- state that the hub does not trigger workflows or GitHub Actions
- add stable data-observability-ops-ci-* markers
- document no readiness approval, no deployment approval, no Live/Testnet/order readiness, and no trading authority
- update Observability Hub v0 docs and tests

## Safety
- WebUI template + tests + docs only
- no src route/backend changes
- no OPS router/template changes
- no workflow/GitHub Actions changes
- no workflow execution
- no polling
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check tests/webui/test_observability_hub.py
- uv run ruff format --check tests/webui/test_observability_hub.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)