### PR TITLE
docs(webui): rank Paper Shadow observability read-model sources

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -23,6 +23,8 @@ Paper/Shadow-Artefakt-Anzeige ist im Hub **bewusst nicht** umgesetzt. Ein zukün
 
 Operator-lokale Reviews unter **`&#47;tmp`** (z. B. PR-J Shadow+Paper Trend/Semantic Reviews) sind **keine** WebUI-Datenquellen und werden vom Hub **nicht** gelesen. Es gibt auf **`GET &#47;observability`** keine Artefakt-Fetches, kein Polling und keine Readiness-, Freigabe- oder Evidence-Semantik für Paper/Shadow.
 
+**v0.8b — Quellen-Ranking (nur Planung):** Ein Paper/Shadow-Panel bleibt **unverdrahtet**. Die priorisierte Kandidaten-Reihenfolge (Execution-Watch API zuerst, dann u. a. live.web-Snapshot, dedizierter Summary-Endpoint, Repo-Fixture, zuletzt CI-Ingestion) steht ausschließlich im Vertrag [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) unter *Source decision matrix v0.8b*. **Keine** Laufzeit-Quelle ist damit freigegeben.
+
 ## Aktuelle Panels (Display-only)
 
 Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness oder Strategie-/Ausführungsfreigabe.

--- a/docs/webui/observability/PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md
+++ b/docs/webui/observability/PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md
@@ -36,6 +36,75 @@ Reviews under **`&#47;tmp`** are **external** to the operator WebUI process. The
 
 Until one option is implemented and documented, **no** Paper/Shadow hub panel.
 
+## Source decision matrix v0.8b
+
+This section records a **docs-only planning ranking** of candidate sources for a **future** Paper/Shadow read-model (candidates **B → A → C → D → E**; **not** alphabetical A–E). It **does not** approve any runtime source, implement a read-model, or relax §5–§8 gates.
+
+For hub context, see [**Observability Hub v0**](OBSERVABILITY_HUB_V0.md).
+
+### Rank 1 — Candidate B: WebUI Execution-Watch API
+
+| Field | Detail |
+|--------|--------|
+| **Rank** | 1 — preferred **first** candidate for planning and field-mapping work |
+| **Existing owner/surface** | Router module `src/webui/execution_watch_api_v0_2.py` — read-only **GET** list/detail/events (e.g. **`GET &#47;api&#47;execution&#47;runs`**, **`GET &#47;api&#47;execution&#47;runs&#47;{run_id}`**, events sub-path). Same WebUI process family as **`GET &#47;observability`**. |
+| **Why ranked here** | Already **watch-only / read-only** in code intent; strong **testability** (fixture/query overrides); **no** separate app boundary when linking from the hub; clearest near-term **GET** inventory to document. |
+| **Allowed future use** | Documented **field mapping** from Execution-Watch JSON to allowed §7 **display-only** facts; **companion links** to those GETs from the hub (when separately approved), with explicit **source-bound** and **stale/snapshot** copy. |
+| **Blockers before UI** | **No** hub panel until: named **owner**, stable **schema/version** for the mapped subset, **stale** semantics and **non-readiness** copy review, and **no** hub-side **aggregation** beyond the written contract. Still **not** automatically the Paper/Shadow read-model until explicitly mapped and approved. |
+| **Risk notes** | The word **execution** can suggest **authority** or **readiness**; copy and schema must stay **non-authorizing**. Payload may not match **PR-J bundle** shape without further design (**candidate C**). |
+
+### Rank 2 — Candidate A: live.web / run snapshot
+
+| Field | Detail |
+|--------|--------|
+| **Rank** | 2 |
+| **Existing owner/surface** | **`src/live/web/app.py`** (and related live web models) — **`GET &#47;runs`**, **`GET &#47;runs&#47;{run_id}&#47;snapshot`**, etc. **Separate** operator web surface from the main Observability WebUI. |
+| **Why ranked here** | Mature **run/snapshot** semantics; useful **operator** mental model; **file-backed** run metadata aligns with **snapshot** narrative in §9. |
+| **Allowed future use** | **Companion** links or documented **cross-surface** read-model references — **not** silent merge into **`GET &#47;observability`** data plane; any future mapping must state **which process** serves the GET and **no authority** over paper/shadow **go**. |
+| **Blockers before UI** | Explicit **owner** and **boundary** (separate host/port or path); **schema version** for snapshot fields used; **stale/snapshot** and **no-readiness** copy; security/ops review if cross-origin or credential boundaries apply. |
+| **Risk notes** | **Second app** — easy to **confuse** with “hub truth”; must **not** imply Observability **aggregated** this data. Snapshot may reflect **execution** metrics — still **not** performance endorsement (§8). |
+
+### Rank 3 — Candidate C: future dedicated Paper/Shadow summary endpoint
+
+| Field | Detail |
+|--------|--------|
+| **Rank** | 3 — **target architecture** slot, not an existing GET today |
+| **Existing owner/surface** | **None** yet; would be a **new** read-only **`GET`** (or equivalent server contract) designed for **bundle presence** / **manifest**-class fields (§7). |
+| **Why ranked here** | **Cleanest** eventual fit for **PR-J / smoke bundle** shaped **presence** facts without overloading Execution-Watch or live snapshot fields; aligns with **single canonical** read-model story. |
+| **Allowed future use** | **Canonical** display-only JSON (or file) with **schema version**, **generated_at**, **source label**, and **only** §7-safe fields; hub consumes **only** that contract. |
+| **Blockers before UI** | **Design + implementation** (larger than wiring B/A); **owner**; **security review**; **tests**; **docs** change control; explicit **no GitHub from browser** if ingestion backs the endpoint. |
+| **Risk notes** | **Scope creep** into **readiness/evidence** language — contract and copy must stay §2 / §8 clean. |
+
+### Rank 4 — Candidate D: repo-local fixture / read-model file
+
+| Field | Detail |
+|--------|--------|
+| **Rank** | 4 |
+| **Existing owner/surface** | **Versioned repo paths** only if explicitly chosen (fixtures, examples); no default **canonical** path in this contract. |
+| **Why ranked here** | **Excellent** for **tests** and **documentation examples**; **poor** as **live operator** truth; §6 already **gates** repo-local read-models. |
+| **Allowed future use** | **CI/unit** fixtures, golden files, or **approved** static read-model snapshots — **never** as disguised **evidence** or **readiness** surface; must be **labeled** stale/example. |
+| **Blockers before UI** | **Explicit approval** per §6; **no** panel that implies **repo file** == **production** artifact state; drift and **token policy** for paths. |
+| **Risk notes** | **Fake readiness** — checked-in JSON can look like **sign-off**; **forbidden** framing per §8. |
+
+### Rank 5 — Candidate E: CI artifact ingestion
+
+| Field | Detail |
+|--------|--------|
+| **Rank** | 5 — **last**; highest integration and governance cost |
+| **Existing owner/surface** | **No** approved WebUI or hub **GET** that surfaces GitHub Actions artifacts today; PR-J and CI semantics live under **separate** ops/CI docs, not hub runtime. |
+| **Why ranked here** | Requires **provenance**, retention, **no secrets** in client, and **no** WebUI **GitHub Artifact API** without §6/§8 **separate design**; weakest **off-network** test story for the browser path. |
+| **Allowed future use** | Only via a **backend** read-model (or operator pipeline) that **proxies** and **strips** secrets — **never** hidden hub **`fetch`** to CI; browser sees only an **approved** **`GET`**. |
+| **Blockers before UI** | **Security review**; **no** token in browser; **no** **silent** polling; **ingestion** SLO and **stale** semantics; alignment with **RUNBOOK**-class CI authority boundaries (CI **not** hub authority). |
+| **Risk notes** | **Highest** risk of **“green CI”** being read as **readiness**; **network/auth** coupling; violates hard boundaries if implemented as **WebUI-direct** artifact pull. |
+
+### Planning-only disclaimer (v0.8b)
+
+- This **ranking** is a **planning decision only**.
+- It **does not** approve any source for **runtime** hub display.
+- It **does not** implement a read-model, route, or artifact fetch.
+- It **does not** make **`&#47;tmp`**, **GitHub Actions** artifacts, or **PR-J** packs **WebUI runtime** data sources.
+- The **Observability Hub** must remain **without** a wired Paper/Shadow panel until **one** source path is **separately** approved, **mapped** to §7 fields, and documented under §11.
+
 ## 7. Allowed future display fields (examples)
 
 When a read-model exists, a **display-only** panel may surface **non-endorsement** facts, for example:


### PR DESCRIPTION
## Summary
- add v0.8b source decision matrix to the Paper/Shadow Observability read-model contract
- rank Execution-Watch API, live.web run snapshot, future dedicated endpoint, repo-local fixture/read-model, and CI Artifact Ingestion
- document that the ranking is planning-only and does not approve any runtime source
- update Observability Hub v0 docs with the Paper/Shadow source-ranking status

## Safety
- docs-only
- no template changes
- no test changes
- no src/backend changes
- no route changes
- no artifact fetch
- no GitHub Actions integration
- no /tmp runtime source
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)