### PR TITLE
docs(observability): add Paper Shadow runtime source contract v0

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -25,7 +25,7 @@ Operator-lokale Reviews unter **`&#47;tmp`** (z. B. PR-J Shadow+Paper Trend/Sema
 
 **v0.8b — Quellen-Ranking (nur Planung):** Ein Paper/Shadow-Panel bleibt **unverdrahtet**. Die priorisierte Kandidaten-Reihenfolge (Execution-Watch API zuerst, dann u. a. live.web-Snapshot, dedizierter Summary-Endpoint, Repo-Fixture, zuletzt CI-Ingestion) steht ausschließlich im Vertrag [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) unter *Source decision matrix v0.8b*. **Keine** Laufzeit-Quelle ist damit freigegeben.
 
-Das dedizierte Summary-Schema [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md) (**`paper_shadow_summary_readmodel_v0`**) hat einen **fixture-only** Builder im Repo (explizites **`bundle_root`**, Tests und **`tests&#47;fixtures&#47;...`**); es gibt weiterhin **keinen** freigegebenen **Observability-`GET`** und **kein** Panel **`GET &#47;observability`**. **`GET &#47;observability`** liest weiterhin **keine** Paper/Shadow-Artefakte.
+Das dedizierte Summary-Schema [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md) (**`paper_shadow_summary_readmodel_v0`**) hat einen **fixture-only** Builder im Repo (explizites **`bundle_root`**, Tests und **`tests&#47;fixtures&#47;...`**); es gibt weiterhin **keinen** freigegebenen **Observability-`GET`** und **kein** Panel **`GET &#47;observability`**. **`GET &#47;observability`** liest weiterhin **keine** Paper/Shadow-Artefakte. Die **rein dokumentierte** Laufzeit-Quellen-Grenze liegt in [**Paper/Shadow Runtime Source Contract v0**](PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md) (**noch** kein Endpoint, **keine** Hub-Verdrahtung).
 
 ## Aktuelle Panels (Display-only)
 

--- a/docs/webui/observability/PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md
+++ b/docs/webui/observability/PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md
@@ -171,6 +171,7 @@ Before adding a hub panel or route:
 5. **Docs update** to [**OBSERVABILITY_HUB_V0**](OBSERVABILITY_HUB_V0.md) panel table and non-goals.
 6. **Drift&#47;token policy** pass for new docs paths.
 7. **Fixture&#47;input path rules** — documented in [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md) (*Appendix: fixture and input path rules v0*). A **fixture-only** builder and curated **test** fixtures **exist** in-repo (see that document’s **Implementation status**). They are **not** an approved **runtime** or **hub** operator data plane; **no** **`GET &#47;observability`** wiring and **no** canonical operator **`GET`** for live bundle truth until items **1–2** and reviews **3–6** are satisfied. **No** **`&#47;tmp`** runtime source and **no** **GitHub Actions** artifact fetch **from the WebUI** without a **separate** approved design (unchanged).
+8. **Runtime source contract** — before mounting any **server-side** **`GET`** that reads a **`bundle_root`**, adopt [**Paper/Shadow Runtime Source Contract v0**](PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md) (server-side configuration only; **no** browser-supplied path; **no** **`&#47;tmp`** default). **No** implementation is implied by that document alone.
 
 ## 12. Stop conditions
 
@@ -185,4 +186,5 @@ Stop and **do not** add UI if:
 
 - [**Observability Hub v0**](OBSERVABILITY_HUB_V0.md) — current hub scope; **no** Paper/Shadow artifact panel today.
 - [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md) — normative JSON shape for **`paper_shadow_summary_readmodel_v0`** (Candidate C); fixture-only builder **shipped** (see Implementation status there); **no** hub **`GET`** approved here.
+- [**Paper/Shadow Runtime Source Contract v0**](PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md) — planning-only **runtime source** boundary for a future read-only **`GET`**; **no** route or config shipped by this doc alone.
 - [**Market Surface v0**](../MARKET_SURFACE_V0.md) — example of read-only display boundaries (orthogonal domain).

--- a/docs/webui/observability/PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md
+++ b/docs/webui/observability/PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md
@@ -1,0 +1,140 @@
+# Paper/Shadow Runtime Source Contract v0 (docs only)
+
+## 1. Purpose
+
+This document defines a **docs-only runtime source contract** for any **future** server-side exposure of **`paper_shadow_summary_readmodel_v0`** (e.g. a single read-only **`GET`**). It does **not** register a route, read files at runtime, or change application configuration.
+
+It locks **who may configure the source**, **which source modes are allowed**, and **which behaviors remain forbidden** before implementation work is approved.
+
+## 2. Non-authority note
+
+Nothing here grants **execution**, **orders**, **Live&#47;Testnet** activation, **Capital&#47;Scope** approval, **Risk&#47;KillSwitch** override, **strategy authorization**, **readiness** certification, **promotion**, **deployment** approval, or **paper&#47;shadow** “go” semantics.
+
+Any future **`GET`** remains **display-only** and **non-authorizing**. Numeric fields stay **source-bound counts** or **opaque snapshot** values — never performance endorsement.
+
+## 3. Relationship to adjacent contracts
+
+| Document | Role |
+|----------|------|
+| [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md) | **Normative JSON shape** for **`paper_shadow_summary_readmodel_v0`**; **Implementation status** lists the **fixture-only** builder. |
+| [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) | Parent **hub / observability** contract; §11 prerequisites and **forbidden** display semantics. |
+| **Fixture-only builder** ([`src/webui/paper_shadow_summary_readmodel_v0/`](../../../src/webui/paper_shadow_summary_readmodel_v0/) — code path illustrative) | **Offline** materialization for **explicit `bundle_root`** (tests, scripts, operator-invoked tools). **Not** the same as an approved **runtime** WebUI source until this contract + §11 gates are satisfied. |
+
+**This contract** governs the **runtime configuration boundary** (server-side only). **It does not** replace the schema doc or the artifact read-model; **it narrows** how a future handler may obtain **`bundle_root`**.
+
+## 4. Direct decisions (planning)
+
+- **No endpoint is implemented** under this document alone; naming below is **placeholder only**.
+- **Preferred first runtime source mode** (when implemented): **explicit local bundle directory**, known only to the **server** via **configuration or environment** set by the **source owner** — **no** per-request path from the browser, **no** **`&#47;tmp`** default.
+- **Fixture&#47;dev** exposure, if ever allowed, is **explicitly gated** (separate mode; never the implied production truth).
+
+## 5. Source owner model
+
+- **Owner:** the team or role responsible for **Operator WebUI &#47; Observability runtime** configuration (server process that would host the future **`GET`**).
+- **Operator &#47; user &#47; browser** MUST **not** supply a **filesystem path** (query, header, path segment, or body) that maps directly to **`bundle_root`**.
+- **Configuration** of the bundle location (or mode = disabled &#47; dev fixture) is **server-side only**, **auditable**, and **documented** per deployment; no “pick any directory” escape hatch.
+
+## 6. Allowed future source modes
+
+Modes are **planning labels**; at most **one** active mode per deployment should be documented.
+
+| Mode | Meaning |
+|------|---------|
+| **Disabled &#47; no source** | Future **`GET`** (if mounted) returns **unavailable** per §10 — handler MUST NOT silently invent bundle paths. |
+| **Fixture &#47; dev (gated)** | Reads only an **approved** repo-relative or server-allowlisted fixture tree; enabled **only** when an **explicit** server flag &#47; environment gate is set; MUST NOT be enabled by default in production-like environments. |
+| **Explicit local bundle root** | **`bundle_root`** is a single directory on the server host, set only via **config &#47; environment** by the **source owner**; same **mechanical** bundle shape as schema **Appendix A.3**. |
+| **Ingestion cache (future)** | Stable **server-local** cache populated by a **separate** ingestion &#47; promotion process; **this contract does not** design that pipeline — only acknowledges it as a **later** mode requiring its own security review. |
+
+## 7. Forbidden source modes
+
+The following MUST **not** be used (now or without a **new** governed contract revision):
+
+- **Query**, **path**, or **header** parameters that carry an **arbitrary filesystem path** for **`bundle_root`**.
+- **Browser-supplied** or **user-supplied** path strings.
+- **Implicit default** to **`&#47;tmp`**, “latest smoke”, or any **hidden** directory guessing.
+- **GitHub Actions** artifact **download** or **fetch** in the **request path** of the WebUI **`GET`**.
+- **Network** I/O, **polling**, or **workflow execution** inside the handler to “refresh” bundles.
+- **Recursive scan** of the host filesystem outside the **single** configured **`bundle_root`** (scan rules remain those of the **fixture builder**: only governed paths under that root; see schema appendix).
+
+## 8. Proposed future endpoint placeholder (unimplemented)
+
+**Naming only** — not registered in code by this document:
+
+- **`GET &#47;api&#47;observability&#47;paper-shadow-summary`**
+
+Rules when implemented:
+
+- **`GET`** only; **no** **`POST`**, **no** mutation semantics.
+- **No** query parameter that supplies **`bundle_root`** or a subpath override for untrusted path selection.
+
+The real path MAY change under governance but MUST remain **one** documented read-only **`GET`** consistent with [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md) §7 placeholder intent.
+
+## 9. Request &#47; response semantics
+
+When a handler exists and the **runtime source mode** is not **disabled**:
+
+- **Method:** **`GET`** only.
+- **Request body:** none (no body).
+- **User-provided path:** none (see §5).
+- **Success body (HTTP 200):** a JSON object conforming to **`paper_shadow_summary_readmodel_v0`** (i.e. **`schema_version`**, **`generated_at_utc`**, presence fields, **`stale`**, **`warnings`**, **`errors`**, etc.). **Partial** bundles and parse issues surface as **`warnings`** &#47; **`errors`** inside the **200** body — not as hidden success.
+- **Unavailable source (disabled &#47; unconfigured):** see §10 — **explicit** machine-readable response; **no** silent fallback to **`&#47;tmp`**, repo fixture, or synthetic “all true”.
+
+## 10. HTTP status guidance
+
+| Situation | Status | Rationale |
+|-----------|--------|-----------|
+| Handler ran; bundle read &#47; builder completed (including domain **`warnings`** &#47; **`errors`**) | **200** | **Read-model** is the success carrier; trust caveats live in **`stale`**, **`warnings`**, **`errors`**. |
+| Runtime source **disabled** or **not configured** (no valid server-side **`bundle_root`**, or mode = off) | **503 Service Unavailable** | Distinguishes **misconfiguration &#47; intentional off** from a successful scan; avoids emitting a **full** read-model that pretends a bundle was read. Response: small JSON object, e.g. `{"error":"runtime_source_unavailable","reason":"disabled"|"unconfigured"}` with JSON response headers (e.g. **Content-Type:** `application&#47;json`; shape MAY be refined at implementation; MUST stay non-authorizing and MUST NOT echo secrets). |
+| Route not mounted or feature not shipped | **404** **or** omission from OpenAPI | Deployment choice; if the route is registered but permanently off, prefer **503** with **`reason`**. |
+| Unexpected handler failure (bug, uncaught exception) | **500** | Operator incident; not a domain **`errors`** list inside read-model. |
+
+**503** is preferred over **200** with a fabricated read-model when **no** bundle was evaluated, so consumers do not misread **presence booleans** as meaningful.
+
+## 11. Security &#47; safety constraints
+
+- **No** secrets (tokens, Basic auth, artifact download credentials) in **URLs**, **logs**, or **responses**.
+- **No** exposure of raw artifact file contents in logs; **safe metadata only** (e.g. configured mode, high-level error codes).
+- **No** **WebUI** **GitHub Artifact API** from browser clients for this read-model chain.
+- **Path traversal:** server MUST resolve and constrain reads to the configured root (same spirit as builder **`bundle_root`** discipline).
+
+## 12. Stale &#47; snapshot ownership
+
+- **`generated_at_utc`** and **`snapshot_time_utc`** in the read-model are defined by the **schema**; the **handler** does not reinterpret them as **freshness guarantees**.
+- **`stale: true`** and **`stale_reason`** remain **mandatory** conservative defaults unless a **separate** governance decision documents otherwise (default expectation: **offline &#47; bundle scan** remains **non-operator-truth**).
+
+## 13. Logging &#47; audit notes
+
+- Log **mode** (disabled, dev-fixture, local-bundle, future-cache), **request id** if available, and **outcome** (success, 503 reason).
+- **Do not** log **full paths** if they contain sensitive host layouts; prefer hashed or redacted identifiers if required by ops policy.
+- **Do not** log **artifact JSON** bodies or **index** contents.
+
+## 14. Future tests required (when implemented)
+
+1. **Contract tests:** **`GET`** only; no accepted path query; **503** when unconfigured.
+2. **Response shape:** **200** body validates required **`paper_shadow_summary_readmodel.v0`** keys for happy path (test bundle under temp dir + server-side test config).
+3. **Hub &#47; template** (if linked): markers and **no** `fetch(` to GitHub; **no** readiness copy (aligned with artifact read-model §10).
+4. **Regression:** presence **`true`** in JSON still implies **no** approval semantics in UI copy.
+
+## 15. Stop conditions
+
+Do **not** implement the **`GET`** if:
+
+- Source **owner** and **configuration** story are undefined.
+- The only story is **`&#47;tmp`** mirrors without an approved staging contract.
+- Stakeholders treat **`workflow_run_id`** or **`source_commit`** as **approval**.
+- **Readiness**, **handoff**, or **promotion** language would attach to the panel or **`GET`**.
+
+## 16. Future implementation phases (ordered)
+
+1. **Adopt** this contract in implementation specs + code review checklist.
+2. **Mount** read-only **`GET`** (name per §8) with **explicit local bundle** mode only (or **disabled** by default).
+3. **Optional** gated dev-fixture mode for UI development (never default prod).
+4. **Later:** ingestion-backed cache mode + **Observability Hub** link **only** as **`GET`** target (no hub-side artifact read).
+
+Each phase requires **security &#47; copy** review per [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) §11.
+
+## 17. References
+
+- [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md)
+- [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md)
+- [**Observability Hub v0**](OBSERVABILITY_HUB_V0.md)

--- a/docs/webui/observability/PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md
+++ b/docs/webui/observability/PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md
@@ -51,6 +51,12 @@ The schema is now backed by a **fixture-only**, stdlib **builder** (offline; exp
 
 **Implementation notes (non-normative):** The builder may support an explicit stamp override type (`PaperShadowPathPolicyV0`) and deterministic `generated_at_utc` for tests via environment variable. These are **not** a public HTTP contract.
 
+### Runtime source boundary (planning)
+
+- WebUI **runtime** bundle configuration and **forbidden** source modes for any future **`GET`** are governed by [**Paper/Shadow Runtime Source Contract v0**](PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md).
+- **This schema** does **not**, by itself, approve an **endpoint** or **runtime** source.
+- The **fixture-only builder** remains **separate** from an approved **runtime** source until that contract and [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) §11 gates are satisfied.
+
 ## 7. Future endpoint placeholder (unimplemented)
 
 A **possible** future read-only route namespace ( **not** registered; **no** implementation today ):
@@ -287,6 +293,7 @@ The builder MUST NOT emit summary semantics that imply:
 
 ## 19. References
 
+- [**Paper/Shadow Runtime Source Contract v0**](PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md) — planning-only **runtime source** boundary for a future **`GET`** (server-side config; no browser path).
 - [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) — parent contract, §7–§8, source matrix v0.8b.
 - [**Observability Hub v0**](OBSERVABILITY_HUB_V0.md) — hub boundaries; no wired Paper/Shadow panel today.
 - [**Market Surface v0**](../MARKET_SURFACE_V0.md) — orthogonal read-only display precedent.


### PR DESCRIPTION
## Summary
- add docs-only Paper/Shadow runtime source contract v0
- define future source-owner model, allowed/forbidden source modes, request/response semantics, HTTP status guidance, security constraints, stale/snapshot ownership, logging notes, tests, stop conditions, and implementation phases
- document preferred future runtime candidate as server-side explicit local bundle
- update schema, artifact read-model, and Observability Hub docs with contract references

## Safety
- docs-only
- no src changes
- no tests changed
- no templates changed
- no scripts/workflows changed
- no config implementation
- no env var implementation
- no endpoint implementation
- no router
- no UI panel
- no runtime reader
- no artifact fetch
- no GitHub Actions integration
- no /tmp runtime source
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no dashboard authority semantics
- no new readiness/evidence/report/index/handoff surface

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)