### PR TITLE
feat(webui): add Paper Shadow summary API v0

### DIFF
--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -81,6 +81,9 @@ System:
 
 Market Surface v0 (read-only):
 - GET /api/market/ohlcv (JSON — öffentliche OHLCV oder Dummy)
+
+Paper/Shadow summary read-model v0 (read-only, server-configured bundle only):
+- GET /api/observability/paper-shadow-summary
 """
 
 from __future__ import annotations
@@ -184,6 +187,7 @@ from .ops_ci_health_router import (
 
 from .execution_watch_api_v0 import router as execution_watch_v0_router
 from .execution_watch_api_v0_2 import router as execution_watch_v0_2_router
+from .paper_shadow_summary_api_v0 import router as paper_shadow_summary_api_v0_router
 from .market_surface import create_market_router
 from .double_play_dashboard_display_json_route_v0 import (
     router as double_play_dashboard_display_json_v0_router,
@@ -502,6 +506,9 @@ def create_app() -> FastAPI:
     app.include_router(execution_watch_v0_router)
     # Execution Watch Dashboard v0.2 — watch-only (read-only APIs)
     app.include_router(execution_watch_v0_2_router)
+
+    # Paper/Shadow Summary read-model v0 — read-only JSON (server-side bundle root only)
+    app.include_router(paper_shadow_summary_api_v0_router)
 
     # Market Surface v0 — read-only OHLCV (kein OPS-Cockpit-Bezug)
     app.include_router(create_market_router(templates, get_project_status))

--- a/src/webui/paper_shadow_summary_api_v0.py
+++ b/src/webui/paper_shadow_summary_api_v0.py
@@ -1,0 +1,100 @@
+"""Paper/Shadow Summary API v0 — read-only GET for `paper_shadow_summary_readmodel_v0` (server-configured bundle only)."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from .paper_shadow_summary_readmodel_v0 import (
+    SCHEMA_VERSION,
+    build_paper_shadow_summary_readmodel_v0,
+    to_json_dict,
+)
+
+_ENV_ENABLED = "PEAK_TRADE_PAPER_SHADOW_SUMMARY_ENABLED"
+_ENV_BUNDLE_ROOT = "PEAK_TRADE_PAPER_SHADOW_SUMMARY_BUNDLE_ROOT"
+_FIXED_GEN_ENV = "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
+
+router = APIRouter(prefix="/api/observability", tags=["paper-shadow-summary-v0"])
+
+
+def _generated_at_utc_iso() -> str:
+    fixed = os.environ.get(_FIXED_GEN_ENV)
+    if fixed:
+        return fixed
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _enabled_explicitly_on() -> bool:
+    raw = os.environ.get(_ENV_ENABLED)
+    return raw is not None and raw.strip() == "1"
+
+
+def _resolved_bundle_root_or_none() -> Path | None:
+    raw = os.environ.get(_ENV_BUNDLE_ROOT)
+    if raw is None or not str(raw).strip():
+        return None
+    p = Path(raw).expanduser()
+    try:
+        p = p.resolve(strict=True)
+    except OSError:
+        return None
+    if not p.is_dir():
+        return None
+    return p
+
+
+def _diagnostic_envelope(
+    *,
+    runtime_source_status: Literal["disabled", "unconfigured"],
+    warning_code: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": _generated_at_utc_iso(),
+        "source_kind": "disabled",
+        "stale": True,
+        "warnings": [warning_code],
+        "errors": ["runtime_source_unavailable"],
+        "runtime_source_status": runtime_source_status,
+    }
+
+
+@router.get("/paper-shadow-summary")
+async def get_paper_shadow_summary() -> JSONResponse:
+    if not _enabled_explicitly_on():
+        return JSONResponse(
+            status_code=503,
+            content=_diagnostic_envelope(
+                runtime_source_status="disabled",
+                warning_code="paper_shadow_summary_source_disabled",
+            ),
+        )
+
+    bundle_root = _resolved_bundle_root_or_none()
+    if bundle_root is None:
+        return JSONResponse(
+            status_code=503,
+            content=_diagnostic_envelope(
+                runtime_source_status="unconfigured",
+                warning_code="paper_shadow_summary_bundle_root_unconfigured",
+            ),
+        )
+
+    try:
+        model = build_paper_shadow_summary_readmodel_v0(bundle_root)
+    except ValueError:
+        return JSONResponse(
+            status_code=503,
+            content=_diagnostic_envelope(
+                runtime_source_status="unconfigured",
+                warning_code="paper_shadow_summary_bundle_root_unconfigured",
+            ),
+        )
+
+    return JSONResponse(content=to_json_dict(model))

--- a/tests/webui/test_paper_shadow_summary_api_v0.py
+++ b/tests/webui/test_paper_shadow_summary_api_v0.py
@@ -1,0 +1,109 @@
+"""Paper/Shadow Summary API v0 — GET /api/observability/paper-shadow-summary (read-only, env-gated)."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.paper_shadow_summary_readmodel_v0 import SCHEMA_VERSION
+
+pytestmark = pytest.mark.web
+
+FIXTURES = project_root / "tests" / "fixtures" / "paper_shadow_summary_readmodel_v0"
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.delenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_BUNDLE_ROOT", raising=False)
+    return TestClient(create_app())
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_BUNDLE_ROOT", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _fixed_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "PEAK_TRADE_FIXED_GENERATED_AT_UTC",
+        "2026-05-02T12:00:00+00:00",
+    )
+
+
+def test_summary_disabled_when_env_unset(client: TestClient) -> None:
+    r = client.get("/api/observability/paper-shadow-summary")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["runtime_source_status"] == "disabled"
+    assert "paper_shadow_summary_source_disabled" in body["warnings"]
+    assert body["errors"] == ["runtime_source_unavailable"]
+    assert body["schema_version"] == SCHEMA_VERSION
+    assert body["generated_at_utc"] == "2026-05-02T12:00:00+00:00"
+
+
+def test_summary_disabled_when_enabled_not_one(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_ENABLED", "0")
+    r = client.get("/api/observability/paper-shadow-summary")
+    assert r.status_code == 503
+    assert r.json()["runtime_source_status"] == "disabled"
+
+
+def test_summary_unconfigured_when_enabled_without_root(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_ENABLED", "1")
+    monkeypatch.delenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_BUNDLE_ROOT", raising=False)
+    r = client.get("/api/observability/paper-shadow-summary")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["runtime_source_status"] == "unconfigured"
+    assert "paper_shadow_summary_bundle_root_unconfigured" in body["warnings"]
+
+
+def test_summary_unconfigured_when_root_missing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_ENABLED", "1")
+    missing = tmp_path / "no_such_bundle"
+    monkeypatch.setenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_BUNDLE_ROOT", str(missing))
+    r = client.get("/api/observability/paper-shadow-summary")
+    assert r.status_code == 503
+    assert r.json()["runtime_source_status"] == "unconfigured"
+
+
+def test_summary_200_complete_minimal_bundle(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_env(monkeypatch)
+    bundle = tmp_path / "bundle"
+    shutil.copytree(FIXTURES / "complete_minimal", bundle)
+    monkeypatch.setenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_PAPER_SHADOW_SUMMARY_BUNDLE_ROOT", str(bundle))
+    r = client.get("/api/observability/paper-shadow-summary")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["schema_version"] == SCHEMA_VERSION
+    assert body["stale"] is True
+    assert body["manifest_present"] is True
+    assert body["paper_fills_present"] is True
+    assert body["artifact_count"] == 10
+    assert body["paper_fill_count"] == 2
+    assert "runtime_source_status" not in body


### PR DESCRIPTION
## Summary
- add read-only GET /api/observability/paper-shadow-summary
- wire the Paper/Shadow summary API router into the WebUI app
- return 503 diagnostic envelopes when disabled or unconfigured
- return paper_shadow_summary_readmodel_v0 JSON via the existing fixture-only builder when explicitly enabled with a server-side bundle root
- add TestClient coverage for disabled, unconfigured, and configured fixture behavior

## Safety
- GET-only endpoint
- no POST
- no UI panel
- no browser-supplied path
- no query filesystem path
- no default /tmp source
- no network calls
- no GitHub Actions artifact fetch
- no workflow execution
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no readiness/evidence/handoff/report/index surface
- no strategy authorization
- no PnL/performance endorsement

## Validation
- uv run python -m pytest tests/webui/test_paper_shadow_summary_api_v0.py tests/webui/test_paper_shadow_summary_readmodel_v0.py -q
- uv run ruff check src/webui/paper_shadow_summary_api_v0.py tests/webui/test_paper_shadow_summary_api_v0.py src/webui/app.py
- uv run ruff format --check src/webui/paper_shadow_summary_api_v0.py tests/webui/test_paper_shadow_summary_api_v0.py src/webui/app.py
- git diff --check

Made with [Cursor](https://cursor.com)