### PR TITLE
feat(webui): add Paper Shadow observability placeholder panel

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -15,17 +15,17 @@ Es gibt **kein** eingebettetes Client-Polling auf dieser Hub-HTML, **keine** zus
 - **Kein Workflow-Trigger** von dieser Hub-Seite.
 - **Kein PaperExecutionEngine-Wiring** über diesen Hub.
 - **Knowledge API** wird bewusst **nicht** verlinkt (geschriebene/POST-relevante Flächen gehören nicht in dieses Link-Inventar).
-- **Kein Paper/Shadow-Artifact-Panel** in dieser Phase — kein zusätzlicher Readiness-/Handoff-/Evidence-Narrativ-Anker.
+- **Kein** Paper/Shadow-**Artifact-Render-Panel** (keine eingebettete JSON-/Status-Anzeige, kein serverseitiger Abruf des Summary-Endpunkts beim Laden von **`GET &#47;observability`**).
 
 ## Paper/Shadow Artifact Read-model (v0.8 — docs only)
 
-Paper/Shadow-Artefakt-Anzeige ist im Hub **bewusst nicht** umgesetzt. Ein zukünftiges Panel darf erst folgen, wenn der Vertrag [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) erfüllt ist.
+Paper/Shadow-Artefakt-**Daten** werden auf **`GET &#47;observability`** **nicht** gelesen und der Summary-Endpunkt **nicht** serverseitig aufgerufen. Ein **statisches Placeholder-Panel** verlinkt den env-gated **`GET &#47;api&#47;observability&#47;paper-shadow-summary`** und die zugehörigen **Docs-Pfade** (Runtime-Contract, Summary-Schema) — **ohne** `fetch(`, **ohne** Artefakt-Fetch, **ohne** Readiness- oder Autoritätssemantik.
 
 Operator-lokale Reviews unter **`&#47;tmp`** (z. B. PR-J Shadow+Paper Trend/Semantic Reviews) sind **keine** WebUI-Datenquellen und werden vom Hub **nicht** gelesen. Es gibt auf **`GET &#47;observability`** keine Artefakt-Fetches, kein Polling und keine Readiness-, Freigabe- oder Evidence-Semantik für Paper/Shadow.
 
-**v0.8b — Quellen-Ranking (nur Planung):** Ein Paper/Shadow-Panel bleibt **unverdrahtet**. Die priorisierte Kandidaten-Reihenfolge (Execution-Watch API zuerst, dann u. a. live.web-Snapshot, dedizierter Summary-Endpoint, Repo-Fixture, zuletzt CI-Ingestion) steht ausschließlich im Vertrag [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) unter *Source decision matrix v0.8b*. **Keine** Laufzeit-Quelle ist damit freigegeben.
+**v0.8b — Quellen-Ranking (nur Planung):** Vollständige Paper/Shadow-**Anzeige** aus einem Read-model bleibt **unverdrahtet**, bis der Vertrag [**Paper/Shadow Artifact Read-model v0**](PAPER_SHADOW_ARTIFACT_READ_MODEL_V0.md) erfüllt ist. Die priorisierte Kandidaten-Reihenfolge (Execution-Watch API zuerst, dann u. a. live.web-Snapshot, dedizierter Summary-Endpoint, Repo-Fixture, zuletzt CI-Ingestion) steht ausschließlich dort unter *Source decision matrix v0.8b*. **Keine** zusätzliche Laufzeit-Quellen-Freigabe durch das Placeholder-Panel.
 
-Das dedizierte Summary-Schema [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md) (**`paper_shadow_summary_readmodel_v0`**) hat einen **fixture-only** Builder im Repo (explizites **`bundle_root`**, Tests und **`tests&#47;fixtures&#47;...`**) und einen **serverseitig env-gated** Endpunkt **`GET &#47;api&#47;observability&#47;paper-shadow-summary`** (siehe [**Paper/Shadow Runtime Source Contract v0**](PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md)). **`GET &#47;observability`** hat weiterhin **kein** Paper/Shadow-**Panel**, liest **keine** Artefakte und **ruft diesen API-Pfad nicht** vom Hub-Template aus auf. Die Existenz des Endpunkts begründet **keine** Readiness-, Freigabe- oder Evidence-Autorität.
+Das dedizierte Summary-Schema [**Paper/Shadow Summary Read-model Schema v0**](PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md) (**`paper_shadow_summary_readmodel_v0`**) und [**Paper/Shadow Runtime Source Contract v0**](PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md) beschreiben den env-gated Endpunkt. Die Existenz des Endpunkts und des Placeholder-Panels begründet **keine** Readiness-, Freigabe- oder Evidence-Autorität.
 
 ## Aktuelle Panels (Display-only)
 
@@ -40,6 +40,7 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 | Double Play Display | **`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`** (display-only Snapshot/Display-Vertrag, ohne Autorität) |
 | R&amp;D Experiments | HTML-Liste und **`GET &#47;api&#47;r_and_d&#47;experiments`** |
 | OPS CI Health | **`GET &#47;ops&#47;ci-health`** (dediziertes CI-Dashboard) und **`GET &#47;ops&#47;ci-health&#47;status`** (bevorzugter read-only Status, JSON) — Hub nur GET-Links, v0.6 |
+| Paper/Shadow Summary (Placeholder v0) | Statischer Link zu **`GET &#47;api&#47;observability&#47;paper-shadow-summary`** + Doc-Pfad-Hinweise; **kein** serverseitiger Aufruf, **kein** Artefakt-Lesen beim Rendern von **`GET &#47;observability`** |
 
 ## Visual/UX consolidation (v0.7)
 
@@ -53,7 +54,7 @@ Stabiler Anzeige-/Test-Anker (nur Darstellung):
 
 - `data-observability-panel-link-block=&quot;true&quot;`
 
-Es gibt **keine** Aenderung an Backend-Routen, Links (`href`), Autoritaetsgrenzen, `fetch(`, Formular-/POST-Semantik oder Panel-Reihenfolge.
+Es gibt **keine** Änderung an Backend-Routen (außer der bestehenden Hub-Route), **Autoritätsgrenzen**, `fetch(`, Formular-/POST-Semantik; die **Panel-Reihenfolge** ergänzt das Placeholder-Panel **nach** OPS CI Health.
 
 ## R&amp;D Experiments Panel (v0.5)
 
@@ -150,10 +151,32 @@ Stabile Marker fuer Tests/Vertrag:
 - `data-observability-ops-ci-readonly-links`
 - `data-observability-ops-ci-no-workflow-trigger`
 - `data-observability-ops-ci-no-approval`
+- `data-observability-paper-shadow-panel`, `data-observability-paper-shadow-readmodel`, `data-observability-paper-shadow-no-readiness`, `data-observability-paper-shadow-no-authority`, `data-observability-paper-shadow-placeholder`
 - `data-observability-status-summary`
 - `data-observability-panel-link-block` (v0.7 — Link-Block-Wrapper, display-only)
 
 Kein `method=&quot;POST&quot;`, kein `<form>`, kein eingebettetes `fetch(` im Hub-Template.
+
+## Paper/Shadow Summary Placeholder Panel (v0.8c — static only)
+
+Statisches Panel auf **`GET &#47;observability`**:
+
+- **`GET &#47;api&#47;observability&#47;paper-shadow-summary`** — nur als **Benutzer-Link**, kein serverseitiger Template-Aufruf.
+- Repo-Pfad-Text: **`docs/webui/observability/PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md`**, **`docs/webui/observability/PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md`** (kein erfundener Docs-HTTP-Endpunkt).
+
+Grenzen:
+
+- **`GET &#47;observability`** **ruft** den Summary-Endpunkt **nicht** auf und **liest** keine Paper/Shadow-Artefakte.
+- **Kein** **`&#47;tmp`**-Runtime-Datenpfad, **kein** GitHub-Actions-Artefakt-Fetch über diesen Hub.
+- **Keine** Readiness-, Freigabe- oder Evidence-Autorität.
+
+Stabile Marker:
+
+- `data-observability-paper-shadow-panel=&quot;true&quot;`
+- `data-observability-paper-shadow-readmodel=&quot;true&quot;`
+- `data-observability-paper-shadow-no-readiness=&quot;true&quot;`
+- `data-observability-paper-shadow-no-authority=&quot;true&quot;`
+- `data-observability-paper-shadow-placeholder=&quot;true&quot;`
 
 ## System Status Summary (v0.2)
 

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -348,6 +348,57 @@
     </div>
   </section>
 
+  <section
+    class="rounded-xl border border-rose-900/35 bg-rose-950/10 px-5 py-4 space-y-4"
+    aria-label="Paper Shadow summary API — placeholder links only"
+    data-observability-paper-shadow-panel="true"
+    data-observability-paper-shadow-readmodel="true"
+    data-observability-paper-shadow-no-readiness="true"
+    data-observability-paper-shadow-no-authority="true"
+    data-observability-paper-shadow-placeholder="true"
+  >
+    <div class="space-y-1.5">
+      <h2 class="text-sm font-semibold text-rose-200/95 tracking-wide uppercase text-[11px]">
+        Paper/Shadow Summary API — Placeholder
+      </h2>
+      <p class="text-xs text-rose-100/85 leading-relaxed">
+        A read-only Paper/Shadow summary <span class="font-mono">GET</span> exists and is <strong>env-gated</strong>
+        on the server. This panel is static navigation only.
+      </p>
+    </div>
+    <ul class="list-disc pl-5 space-y-1.5 text-xs text-rose-100/90 leading-relaxed">
+      <li><span class="font-mono">GET /observability</span> does not call that endpoint server-side.</li>
+      <li>The Observability Hub does not read Paper/Shadow artifacts.</li>
+      <li>No <span class="font-mono">/tmp</span> runtime source and no GitHub Actions artifact fetch from this page.</li>
+      <li>This placeholder is not readiness approval.</li>
+      <li>Not Paper/Testnet/Live/order readiness.</li>
+      <li>Not trading, execution, or strategy authority.</li>
+    </ul>
+    <div
+      class="rounded-lg border border-slate-800/50 bg-slate-950/30 px-3 py-3 space-y-2"
+      data-observability-panel-link-block="true"
+    >
+      <h3 class="text-xs font-medium text-slate-400 uppercase tracking-wide text-[11px]">
+        GET-Ziele und Doc-Pfade
+      </h3>
+      <ul class="space-y-2 text-sm">
+        <li>
+          <a
+            class="text-sky-400 underline hover:text-sky-300 font-mono text-xs break-all"
+            href="/api/observability/paper-shadow-summary"
+          >GET /api/observability/paper-shadow-summary</a>
+          <span class="text-slate-500 text-xs"> — JSON (env-gated; may return 503)</span>
+        </li>
+        <li>
+          <span class="text-slate-300 font-mono text-xs">docs/webui/observability/PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md</span>
+        </li>
+        <li>
+          <span class="text-slate-300 font-mono text-xs">docs/webui/observability/PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md</span>
+        </li>
+      </ul>
+    </div>
+  </section>
+
   <section class="rounded-xl border border-slate-800 bg-slate-900/40 px-5 py-4 text-xs text-slate-500" aria-label="Hinweise">
     <p class="leading-relaxed">
       Knowledge API und andere geschriebene Oberflächen sind absichtlich nicht verlinkt

--- a/tests/webui/test_observability_hub.py
+++ b/tests/webui/test_observability_hub.py
@@ -53,6 +53,11 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert 'data-observability-health-panel="true"' in body
     assert 'data-observability-health-readonly="true"' in body
     assert 'data-observability-health-no-actions="true"' in body
+    assert 'data-observability-paper-shadow-panel="true"' in body
+    assert 'data-observability-paper-shadow-readmodel="true"' in body
+    assert 'data-observability-paper-shadow-no-readiness="true"' in body
+    assert 'data-observability-paper-shadow-no-authority="true"' in body
+    assert 'data-observability-paper-shadow-placeholder="true"' in body
 
     assert "read-only / display-only" in body
     assert "Display-only status snapshot" in body
@@ -114,15 +119,27 @@ def test_observability_hub_ok_markers(client: TestClient) -> None:
     assert "CI status display is not Live/Testnet/order readiness." in body
     assert "CI status display is not trading authority." in body
 
+    assert "env-gated" in body
+    assert "does not call that endpoint server-side." in body
+    assert "does not read Paper/Shadow artifacts." in body
+    assert "/api/observability/paper-shadow-summary" in body
+    assert "PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md" in body
+    assert "PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md" in body
+    assert "This placeholder is not readiness approval." in body
+    assert "Not Paper/Testnet/Live/order readiness." in body
+    assert "Not trading, execution, or strategy authority." in body
+    assert "no GitHub Actions artifact fetch" in body
+
     assert 'method="POST"' not in body
     assert "<form" not in body.lower()
     assert 'type="submit"' not in body
+    assert "<button" not in body.lower()
     assert "fetch(" not in body
     assert "/api/knowledge" not in body
 
     assert "data-observability-health-project-snapshot=" in body
 
-    assert body.count('data-observability-panel-link-block="true"') == 5
+    assert body.count('data-observability-panel-link-block="true"') == 6
     assert "GET-Ziele" in body
 
 
@@ -167,6 +184,11 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert 'data-observability-ops-ci-no-workflow-trigger="true"' in txt
     assert 'data-observability-ops-ci-no-approval="true"' in txt
     assert 'data-observability-display-only="true"' in txt
+    assert 'data-observability-paper-shadow-panel="true"' in txt
+    assert 'data-observability-paper-shadow-readmodel="true"' in txt
+    assert 'data-observability-paper-shadow-no-readiness="true"' in txt
+    assert 'data-observability-paper-shadow-no-authority="true"' in txt
+    assert 'data-observability-paper-shadow-placeholder="true"' in txt
     assert "read-only / display-only" in txt
     assert "Display-only status snapshot" in txt
     assert "No backend health certification" in txt
@@ -203,11 +225,19 @@ def test_observability_hub_template_health_panel_markers_and_no_post() -> None:
     assert "The Observability Hub only links to OPS CI GET surfaces." in txt
     assert "The Hub does not start GitHub Actions." in txt
     assert "CI status display is not deployment approval." in txt
-    assert txt.count('data-observability-panel-link-block="true"') == 5
+    assert "env-gated" in txt
+    assert "does not call that endpoint server-side." in txt
+    assert "does not read Paper/Shadow artifacts." in txt
+    assert "/api/observability/paper-shadow-summary" in txt
+    assert "PAPER_SHADOW_RUNTIME_SOURCE_CONTRACT_V0.md" in txt
+    assert "PAPER_SHADOW_SUMMARY_READ_MODEL_SCHEMA_V0.md" in txt
+    assert "This placeholder is not readiness approval." in txt
+    assert txt.count('data-observability-panel-link-block="true"') == 6
     assert "GET-Ziele" in txt
     assert 'method="POST"' not in txt
     assert "<form" not in txt.lower()
     assert 'type="submit"' not in txt
+    assert "<button" not in txt.lower()
     assert "fetch(" not in txt
 
 
@@ -226,3 +256,5 @@ def test_observability_hub_doc_exists_and_tokens() -> None:
     assert "GET &#47;observability" in t
     assert "data-observability-" in t
     assert "Paper/Shadow" in t.lower() or "Paper" in t
+    assert "data-observability-paper-shadow-placeholder" in t
+    assert "paper-shadow-summary" in t


### PR DESCRIPTION
## Summary
- add a static Paper/Shadow placeholder panel to the Observability Hub
- expose the env-gated GET /api/observability/paper-shadow-summary as a link only
- link to the runtime source contract and summary schema repo paths
- add stable data-observability-paper-shadow-* markers
- document that GET /observability does not call the endpoint and does not read Paper/Shadow artifacts

## Safety
- static template/tests/docs only
- no src changes
- no endpoint changes
- no server-side call from GET /observability
- no client-side fetch
- no POST/form/button
- no artifact read
- no runtime reader change
- no GitHub Actions integration
- no /tmp runtime source
- no PaperExecutionEngine wiring
- no Paper/Testnet/Live/order behavior
- no Capital/Scope approval
- no Risk/KillSwitch override
- no readiness/evidence/handoff/report/index surface
- no strategy/trading authority

## Validation
- uv run python -m pytest tests/webui/test_observability_hub.py -q
- uv run ruff check tests/webui/test_observability_hub.py
- uv run ruff format --check tests/webui/test_observability_hub.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)