### PR TITLE
feat(webui): add Market Surface v1 visual shell

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -45,6 +45,17 @@ Stabile `data-*`‑Marker (Anker für Anzeige und automatisierte Tests — **kei
 
 Banner‑Inhalt fasst u. a.: keine Orders, kein Testnet/Live, keine Capital/Scope‑Freigabe, kein Risk-/KillSwitch‑Bypass — rein erklärend; **kein** Gate, **keine** Strategie- oder Ausführungsfreigabe.
 
+## Market Surface v1 visual framing
+
+**v1** ist eine **rein visuelle Dashboard‑Rahmenfläche** auf **`GET &#47;market`** (Templates/Tests/Docs nur): zusätzliche `data‑market‑v1‑*`‑Marker, Kontext-/Stat‑Karten aus **bereits vorhandenen** Payload‑Feldern (`source`, `symbol`, `timeframe`, `bars_returned`, SSR‑Chart‑Hint), englisches **Read‑only / no‑authority**‑Band sowie ein **referenzierender** Link auf **`GET &#47;api&#47;market&#47;ohlcv`** (gleiche Query wie die Seite, **navigation only**).
+
+- **Keine** Backend‑, Provider‑ oder API‑Änderungen; **`GET &#47;api&#47;market&#47;ohlcv`** bleibt unverändert.
+- **Keine** Double‑Play‑Zusammenführung, **keine** Trading‑/Strategieautorität.
+- **Keine** Orders, **kein** Live-/Testnet‑Steuerbezug aus der UI heraus.
+- **Kein** Risk-/KillSwitch‑Override.
+- Die **Chart‑Semantik** (ready/empty/error, Chart.js‑Bootstrap wie in **Chart status states**) bleibt bestehen — v1 rahmt nur ein.
+- Ein **späteres** Arbeitspaket kann **Double‑Play Market Dashboard v0** (read‑only‑Kompositionsvertrag) **separat** planen — nicht Teil von v1.
+
 ## Chart status states
 
 Das HTML für **`GET &#47;market`** enthält beim Chart‑Bereich ein Status‑Element **`#market-v0-chart-status`** (read‑only‑Formulierung, **non‑authorizing**).

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -1,5 +1,5 @@
 <!-- templates/peak_trade_dashboard/market_v0.html -->
-<!-- Market Surface v0 — read-only, Close-Line-Chart (Chart.js) -->
+<!-- Market Surface v0 — read-only, Close-Line-Chart (Chart.js); v1 dashboard shell framing -->
 {% extends "base.html" %}
 
 {% block content %}
@@ -7,12 +7,27 @@
   class="space-y-6 max-w-6xl mx-auto"
   data-section="market-v0"
   data-market-surface-v0="true"
+  data-market-v1-dashboard-shell="true"
   data-market-readonly="true"
   data-market-non-authorizing="true"
   data-market-source="{{ query.source }}"
   data-market-bars="{{ payload.bars_returned }}"
   data-market-symbol="{{ query.symbol }}"
 >
+  <section
+    aria-label="Read-only market constraints"
+    class="rounded-xl border border-slate-700/60 bg-slate-900/50 px-4 py-3 text-xs text-slate-300"
+    data-market-v1-readonly-banner="true"
+  >
+    <ul class="m-0 p-0 list-none grid gap-x-4 gap-y-1 sm:grid-cols-2 lg:grid-cols-5">
+      <li>Read-only market display</li>
+      <li>No orders</li>
+      <li>No strategy authority</li>
+      <li>No Live/Testnet action</li>
+      <li>No Risk/KillSwitch override</li>
+    </ul>
+  </section>
+
   <section
     aria-label="Read-only und Datenquelle"
     class="rounded-xl border border-amber-900/40 bg-amber-950/25 px-4 py-3 text-xs text-amber-100/95"
@@ -45,7 +60,7 @@
     <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
       <div>
         <p class="text-xs uppercase tracking-wide text-slate-500 mb-1">Market Surface</p>
-        <h1 class="text-2xl font-bold text-slate-100">v0 · Read-only OHLCV</h1>
+        <h1 class="text-2xl font-bold text-slate-100">v1 Shell · PeakTrade Dashboard (read-only)</h1>
         <p class="text-sm text-slate-400 mt-2 max-w-2xl">
           READ-ONLY · Keine Orders · Öffentliche OHLCV (Kraken) oder offline Dummy-Daten.
           Chart: Schlusskurs-Linie (V0 — bewusst minimal, kein Candlestick-Plugin).
@@ -62,19 +77,83 @@
     </div>
   </header>
 
-  <section aria-label="Parameter" class="bg-slate-900/60 rounded-xl border border-slate-800 p-4 text-xs text-slate-400">
-    <p class="font-medium text-slate-300 mb-2">Aktuelle Abfrage</p>
-    <ul class="font-mono space-y-1">
-      <li>symbol={{ query.symbol }}</li>
-      <li>timeframe={{ query.timeframe }} (Kraken; Dummy bleibt synthetisch 1h)</li>
-      <li>limit={{ query.limit }}</li>
-      <li>source={{ query.source }} — für Netzwerk-OHLCV: <span class="text-sky-400">?source=kraken</span></li>
-    </ul>
+  <section
+    aria-label="Market query context"
+    class="bg-slate-900/70 rounded-xl border border-slate-800 p-4"
+    data-market-v1-context="true"
+  >
+    <h2 class="text-sm font-medium text-slate-200 mb-3">PeakTrade Market Dashboard · context</h2>
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 text-xs">
+      <div
+        class="rounded-lg border border-slate-800/90 bg-slate-950/50 px-3 py-2"
+        data-market-v1-stat-card="true"
+      >
+        <span class="text-slate-500 block mb-1">Source</span>
+        <span class="font-mono text-sky-300/95">{{ query.source }}</span>
+      </div>
+      <div
+        class="rounded-lg border border-slate-800/90 bg-slate-950/50 px-3 py-2"
+        data-market-v1-stat-card="true"
+      >
+        <span class="text-slate-500 block mb-1">Symbol</span>
+        <span class="font-mono text-slate-200">{{ query.symbol }}</span>
+      </div>
+      <div
+        class="rounded-lg border border-slate-800/90 bg-slate-950/50 px-3 py-2"
+        data-market-v1-stat-card="true"
+      >
+        <span class="text-slate-500 block mb-1">Timeframe</span>
+        <span class="font-mono text-slate-200">{{ query.timeframe }}</span>
+      </div>
+      <div
+        class="rounded-lg border border-slate-800/90 bg-slate-950/50 px-3 py-2"
+        data-market-v1-stat-card="true"
+      >
+        <span class="text-slate-500 block mb-1">Limit</span>
+        <span class="font-mono text-slate-200">{{ query.limit }}</span>
+      </div>
+      <div
+        class="rounded-lg border border-slate-800/90 bg-slate-950/50 px-3 py-2"
+        data-market-v1-stat-card="true"
+      >
+        <span class="text-slate-500 block mb-1">Bars returned</span>
+        <span class="font-mono text-slate-200">{{ payload.bars_returned }}</span>
+      </div>
+      <div
+        class="rounded-lg border border-slate-800/90 bg-slate-950/50 px-3 py-2"
+        data-market-v1-stat-card="true"
+      >
+        <span class="text-slate-500 block mb-1">Chart hint (SSR)</span>
+        <span
+          class="font-mono {% if payload.bars_returned == 0 %}text-amber-300/95{% else %}text-emerald-300/95{% endif %}"
+        >
+          {% if payload.bars_returned == 0 %}empty{% else %}ready{% endif %}
+        </span>
+      </div>
+    </div>
+    <p class="mt-3 text-[11px] text-slate-500 leading-relaxed">
+      Kraken verwendet timeframe; Dummy bleibt synthetisch 1h —
+      öffentliche Netzwerk-OHLCV: <span class="text-sky-400 font-mono">?source=kraken</span>
+    </p>
+  </section>
+
+  <section
+    aria-label="OHLCV API reference"
+    class="rounded-lg border border-dashed border-slate-700/70 bg-slate-950/40 px-4 py-3 text-xs text-slate-400"
+    data-market-v1-api-reference="true"
+  >
+    <p class="font-medium text-slate-300 mb-1">Read-only JSON (gleiche Query wie diese Seite)</p>
+    <p class="font-mono leading-relaxed break-all">
+      <a
+        href="/api/market/ohlcv?source={{ query.source }}&amp;symbol={{ query.symbol | replace('/', '%2F') }}&amp;timeframe={{ query.timeframe }}&amp;limit={{ query.limit }}"
+        class="text-sky-400 hover:text-sky-300 underline underline-offset-2"
+      >/api/market/ohlcv</a>
+    </p>
   </section>
 
   <section
     aria-label="Close-Preis"
-    class="bg-slate-900/60 rounded-xl border border-slate-800 p-4"
+    class="bg-slate-900/60 rounded-xl border border-slate-800 ring-1 ring-slate-700/50 shadow-lg shadow-black/20 p-4"
     data-chart="market-v0-close-line"
   >
     <h2 class="text-sm font-medium text-slate-200 mb-3">Schlusskurs (Close)</h2>

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -66,6 +66,11 @@ class TestMarketSurfaceHtml:
         body = resp.text
         assert 'data-section="market-v0"' in body
         assert 'data-market-surface-v0="true"' in body
+        assert 'data-market-v1-dashboard-shell="true"' in body
+        assert 'data-market-v1-context="true"' in body
+        assert 'data-market-v1-readonly-banner="true"' in body
+        assert body.count('data-market-v1-stat-card="true"') >= 6
+        assert 'data-market-v1-api-reference="true"' in body
         assert 'data-market-readonly="true"' in body
         assert 'data-market-non-authorizing="true"' in body
         assert 'data-market-source-kind="dummy-offline-synthetic"' in body
@@ -75,12 +80,24 @@ class TestMarketSurfaceHtml:
         assert 'data-chart="market-v0-close-line"' in body
         assert 'id="market-v0-payload"' in body
         assert "read-only · non-authorizing" in body
+        assert "Read-only market display" in body
+        assert "No orders" in body
+        assert "No strategy authority" in body
+        assert "No Live/Testnet action" in body
+        assert "No Risk/KillSwitch override" in body
+        assert "/api/market/ohlcv" in body
         assert "Keine Orders" in body or "keine Orders" in body
         assert "Testnet" in body
         assert "Live" in body
         assert "Capital" in body or "Scope" in body
         assert "KillSwitch" in body or "Risk" in body
         assert "chart.js@4.4.1" in body.lower() or "chart.umd.min.js" in body
+        lower = body.lower()
+        assert "<form" not in lower
+        assert 'method="post"' not in lower
+        assert "<button" not in lower
+        assert 'type="submit"' not in lower
+        assert "fetch(" not in body
         assert 'method="POST"' not in body
         assert 'id="market-v0-chart-status"' in body
         assert 'data-market-chart-status="ready"' in body
@@ -105,6 +122,12 @@ def test_market_v0_template_kraken_banner_markers_in_source() -> None:
     )
     txt = tmpl_path.read_text(encoding="utf-8")
     assert 'data-market-source-kind="kraken-public-ohlcv-network"' in txt
+    assert 'data-market-v1-dashboard-shell="true"' in txt
+    assert 'data-market-v1-readonly-banner="true"' in txt
+    assert 'data-market-v1-context="true"' in txt
+    assert 'data-market-v1-api-reference="true"' in txt
+    assert txt.count('data-market-v1-stat-card="true"') >= 6
+    assert "Read-only market display" in txt
     assert "Futures" in txt
     assert "read-only · non-authorizing" in txt
     assert 'id="market-v0-chart-status"' in txt


### PR DESCRIPTION
## Summary
- add Market Surface v1 visual/dashboard framing to /market
- add read-only safety banner, market context cards, and API reference block
- preserve existing Market Surface v0 chart/status behavior
- update tests for v1 markers, safety copy, API reference, and no action controls
- document v1 as template/tests/docs-only visual framing

## Safety
- template/tests/docs only
- no src/webui/app.py changes
- no backend/API/provider changes
- no Kraken/provider behavior changes
- no Double-Play composition
- no new route
- no new endpoint
- no POST/form/button
- no live/testnet/order behavior
- no strategy authority
- no Capital/Scope approval
- no Risk/KillSwitch override
- no PaperExecutionEngine wiring
- no hidden fetch behavior

## Validation
- uv run python -m pytest tests/test_market_surface_api.py -q
- uv run ruff check tests/test_market_surface_api.py
- uv run ruff format --check tests/test_market_surface_api.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)