### PR TITLE
feat(webui): add Double-Play market dashboard v0 shell

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -5,6 +5,7 @@
 | Methode | Pfad | Beschreibung |
 |---------|------|----------------|
 | GET | `/market` | HTML: Close-Line-Chart (Chart.js), Parameter per Query |
+| GET | `/market/double-play` | HTML: statische read-only Kompositions-Hülle (Links zu Market + Double-Play display JSON; **kein** Fetch) |
 | GET | `/api/market/ohlcv` | JSON: OHLCV-Bars (`open`/`high`/`low`/`close`/`volume`, Zeit `ts`) |
 
 ## Query-Parameter (beide Endpunkte)
@@ -65,6 +66,16 @@ Banner‑Inhalt fasst u. a.: keine Orders, kein Testnet/Live, keine Capital/Sc
 - **Keine** lokale Chart.js‑Vendor‑ oder Static‑Asset‑Einbindung; **GET &#47;api&#47;market&#47;ohlcv** bleibt unverändert.
 - **Keine** Double‑Play‑Komposition oder Trading‑/Risk‑/Capital‑Interpretation durch diese Diagnosemarker.
 - **v1.2** kann einen **lokalen Chart.js‑Fallback** planen, falls CDN‑Blocking **evidenziert** ist.
+
+## Double-Play Market Dashboard v0
+
+**Route:** **`GET &#47;market&#47;double-play`**
+
+Statische **read-only**‑Kompositions‑Hülle (Templates/HTML): verlinkt die **pure Market Surface** (**`GET &#47;market`**, **`GET &#47;api&#47;market&#47;ohlcv`**) sowie das bestehende **Double‑Play‑Display‑JSON** (**`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`**) als **navigation only**.
+
+- **Kein** automatischer Fetch, **keine** Client‑Polling‑Logik durch diese Seite, **keine** serverseitige JSON‑Aggregation hier.
+- **`GET &#47;market`** bleibt die Chart‑/Marktdaten‑Fläche; **`dashboard‑display.json`** bleibt **display‑only** (keine Orders, **keine** Strategie-/Side‑Schalt‑Autorität, **keine** Scope/Capital‑Billigung, **kein** Risk/KillSwitch‑Override, **kein** Live/Testnet‑Activate).
+- Eine spätere dynamische Komposition gehört in einen **eigenen** Read‑model‑/Kontrakt‑Slice.
 
 ## Chart status states
 

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -51,6 +51,7 @@ HTML Pages:
 - GET /r_and_d/experiments/{run_id} (R&D Experiment Detail - Phase 76 kanonisch)
 - GET /r_and_d/comparison (R&D Multi-Run Comparison - Phase 78)
 - GET /market (Market Surface v0 — read-only OHLCV, Close-Line-Chart)
+- GET /market/double-play (Double-Play Market Dashboard v0 — statische Links, kein Fetch)
 - GET /observability (Observability-Hub — read-only Link-/Hinweisleiste, keine neue Autorität)
 
 API Endpoints:
@@ -378,7 +379,15 @@ def load_strategy_tiering(include_research: bool = False) -> Dict[str, Any]:
     }
 
 
+
 templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+
+# Double-Play Market Dashboard v0 — static URL examples (no runtime I/O)
+_DP_MARKET_V0_DEMO_URL = "/market?source=dummy&symbol=BTC/EUR&timeframe=1d&limit=120"
+_DP_MARKET_V0_API_URL = "/api/market/ohlcv?source=dummy&symbol=BTC/EUR&timeframe=1d&limit=120"
+_DP_MARKET_V0_DEMO_HREF = "/market?source=dummy&symbol=BTC%2FEUR&timeframe=1d&limit=120"
+_DP_MARKET_V0_API_HREF = "/api/market/ohlcv?source=dummy&symbol=BTC%2FEUR&timeframe=1d&limit=120"
+_DP_DOUBLE_PLAY_DISPLAY_JSON_URL = "/api/master-v2/double-play/dashboard-display.json"
 
 
 def load_live_sessions(limit: int = 10) -> Dict[str, Any]:
@@ -564,6 +573,27 @@ def create_app() -> FastAPI:
             request,
             "observability_hub.html",
             {"status": proj_status},
+        )
+
+    @app.get("/market/double-play", response_class=HTMLResponse)
+    async def double_play_market_dashboard_v0_page(request: Request) -> Any:
+        """
+        Double-Play Market Dashboard v0 — static read-only shell.
+
+        Links only; no HTTP calls to Market or Double-Play JSON endpoints; no client fetch wired here.
+        """
+        proj_status = get_project_status()
+        return templates.TemplateResponse(
+            request,
+            "double_play_market_dashboard_v0.html",
+            {
+                "status": proj_status,
+                "market_demo_url": _DP_MARKET_V0_DEMO_URL,
+                "market_api_url": _DP_MARKET_V0_API_URL,
+                "market_demo_href": _DP_MARKET_V0_DEMO_HREF,
+                "market_api_href": _DP_MARKET_V0_API_HREF,
+                "double_play_json_url": _DP_DOUBLE_PLAY_DISPLAY_JSON_URL,
+            },
         )
 
     @app.get("/", response_class=HTMLResponse)

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -379,7 +379,6 @@ def load_strategy_tiering(include_research: bool = False) -> Dict[str, Any]:
     }
 
 
-
 templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 
 # Double-Play Market Dashboard v0 — static URL examples (no runtime I/O)

--- a/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
+++ b/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
@@ -1,0 +1,103 @@
+<!-- templates/peak_trade_dashboard/double_play_market_dashboard_v0.html -->
+<!-- Double-Play Market Dashboard v0 — static read-only shell; no fetch; no aggregation -->
+{% extends "base.html" %}
+
+{% block content %}
+<div
+  class="space-y-6 max-w-6xl mx-auto px-4 py-8"
+  data-double-play-market-dashboard-v0="true"
+  data-double-play-market-readonly="true"
+  data-double-play-market-no-live="true"
+  data-double-play-market-no-orders="true"
+  data-double-play-market-no-authority="true"
+  data-double-play-market-no-fetch="true"
+>
+  <header class="rounded-2xl border border-slate-800 bg-gradient-to-r from-slate-900/90 to-slate-900/40 p-6">
+    <p class="text-xs uppercase tracking-wide text-slate-500 mb-1">PeakTrade Dashboard</p>
+    <h1 class="text-2xl font-bold text-slate-100">Double-Play Market Dashboard v0</h1>
+    <p class="text-sm text-slate-400 mt-2">
+      Static read-only composition shell
+    </p>
+    <p class="mt-3 text-[11px] text-slate-500 leading-relaxed max-w-3xl">
+      Market Surface remains the chart surface · Double-Play display JSON remains display-only
+    </p>
+    <div class="mt-4 flex flex-wrap gap-2">
+      <a href="/" class="text-xs px-3 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300">Dashboard</a>
+      <a href="/market" class="text-xs px-3 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300">Market Surface</a>
+      <a href="/observability" class="text-xs px-3 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300">Observability</a>
+    </div>
+  </header>
+
+  <section
+    aria-label="Safety boundaries"
+    class="rounded-xl border border-amber-900/50 bg-amber-950/20 px-4 py-3 text-xs text-amber-100/95"
+    data-double-play-market-safety="true"
+  >
+    <p class="font-semibold text-amber-200 uppercase tracking-wide text-[11px] mb-2">Read-only / non-authority</p>
+    <ul class="m-0 pl-5 space-y-1 list-disc marker:text-amber-500">
+      <li>No orders</li>
+      <li>No Live/Testnet action</li>
+      <li>No strategy authority</li>
+      <li>No side-switch authority</li>
+      <li>No Scope/Capital approval</li>
+      <li>No Risk/KillSwitch override</li>
+      <li>No automatic fetch</li>
+      <li>No server-side JSON aggregation</li>
+    </ul>
+  </section>
+
+  <section
+    aria-label="Market Surface links"
+    class="rounded-xl border border-slate-800 bg-slate-900/60 p-5"
+    data-double-play-market-market-link="true"
+  >
+    <h2 class="text-sm font-medium text-slate-200 mb-3">Market chart surface</h2>
+    <p class="text-xs text-slate-400 mb-3">
+      Open the pure Market Surface (OHLCV close-line chart); this page does not embed or prefetch it.
+    </p>
+    <p class="text-xs mb-4">
+      <a
+        href="{{ market_demo_href }}"
+        class="text-sky-400 hover:text-sky-300 underline underline-offset-2 font-mono break-all"
+      >Demo: Market Surface</a>
+    </p>
+    <p class="text-xs mb-4">
+      <a
+        href="{{ market_api_href }}"
+        class="text-sky-400 hover:text-sky-300 underline underline-offset-2 font-mono break-all"
+      >Demo: Market OHLCV JSON</a>
+    </p>
+    <pre class="text-[11px] text-slate-500 whitespace-pre-wrap break-all font-mono bg-slate-950/60 rounded-lg border border-slate-800 p-3" aria-hidden="true">{{ market_demo_url }}</pre>
+    <pre class="text-[11px] text-slate-500 whitespace-pre-wrap break-all font-mono bg-slate-950/60 rounded-lg border border-slate-800 p-3 mt-2" aria-hidden="true">{{ market_api_url }}</pre>
+  </section>
+
+  <section
+    aria-label="Double-Play display JSON link"
+    class="rounded-xl border border-slate-800 bg-slate-900/60 p-5"
+    data-double-play-market-display-json-link="true"
+  >
+    <h2 class="text-sm font-medium text-slate-200 mb-3">Double-Play display snapshot (JSON)</h2>
+    <p class="text-xs text-slate-400 mb-3">
+      Display-only contract surface — not Live/Testnet or execution authority. Follow existing Double-Play docs; this hub does not call the endpoint server-side or in the browser.
+    </p>
+    <p class="text-xs">
+      <a
+        href="{{ double_play_json_url }}"
+        class="text-sky-400 hover:text-sky-300 underline underline-offset-2 font-mono break-all"
+      >GET {{ double_play_json_url }}</a>
+    </p>
+    <pre class="text-[11px] text-slate-500 whitespace-pre-wrap break-all font-mono bg-slate-950/60 rounded-lg border border-slate-800 p-3 mt-3">{{ double_play_json_url }}</pre>
+  </section>
+
+  <section
+    class="rounded-xl border border-dashed border-slate-700 bg-slate-950/40 p-4 text-xs text-slate-400"
+    data-double-play-market-future-note="true"
+  >
+    <p class="font-medium text-slate-300 mb-2">Composition status</p>
+    <ul class="m-0 pl-5 space-y-1 list-disc marker:text-slate-600">
+      <li>This v0 shell only links outward; no inlined Double-Play state.</li>
+      <li>A future slice may introduce a contracted read-model or client fetch policy.</li>
+    </ul>
+  </section>
+</div>
+{% endblock %}

--- a/tests/webui/test_double_play_market_dashboard_v0.py
+++ b/tests/webui/test_double_play_market_dashboard_v0.py
@@ -1,0 +1,67 @@
+"""Double-Play Market Dashboard v0 (GET /market/double-play) — static shell, no POST/fetch."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def test_double_play_market_dashboard_v0_ok(client: TestClient) -> None:
+    r = client.get("/market/double-play")
+    assert r.status_code == 200
+    assert "text/html" in r.headers.get("content-type", "")
+    body = r.text
+    lower = body.lower()
+
+    assert 'data-double-play-market-dashboard-v0="true"' in body
+    assert 'data-double-play-market-readonly="true"' in body
+    assert 'data-double-play-market-no-live="true"' in body
+    assert 'data-double-play-market-no-orders="true"' in body
+    assert 'data-double-play-market-no-authority="true"' in body
+    assert 'data-double-play-market-no-fetch="true"' in body
+    assert 'data-double-play-market-display-json-link="true"' in body
+    assert 'data-double-play-market-market-link="true"' in body
+
+    assert "Double-Play Market Dashboard v0" in body
+    assert "Static read-only composition shell" in body
+    assert "No orders" in body
+    assert "No Live/Testnet action" in body
+    assert "No strategy authority" in body
+    assert "No side-switch authority" in body
+    assert "No Scope/Capital approval" in body
+    assert "No Risk/KillSwitch override" in body
+    assert "No automatic fetch" in body
+    assert "No server-side JSON aggregation" in body
+    assert "Market Surface remains the chart surface" in body
+    assert "Double-Play display JSON remains display-only" in body
+
+    assert "/market?source=dummy&amp;symbol=BTC/EUR&amp;timeframe=1d&amp;limit=120" in body
+    assert (
+        "/api/market/ohlcv?source=dummy&amp;symbol=BTC/EUR&amp;timeframe=1d&amp;limit=120" in body
+    )
+    assert "/api/master-v2/double-play/dashboard-display.json" in body
+
+    assert "<form" not in lower
+    assert 'method="post"' not in lower
+    assert "<button" not in lower
+    assert 'type="submit"' not in lower
+    assert "fetch(" not in body
+    assert "live_authorization" not in lower


### PR DESCRIPTION
## Summary
- add static read-only GET /market/double-play composition shell
- link to Market Surface demo, OHLCV API, and Double-Play display JSON
- add stable data-double-play-market-* markers and safety copy
- document the route in Market Surface docs
- add focused WebUI route/template tests

## Safety
- static template + route + tests + docs only
- no server-side calls to Market or Double-Play JSON endpoints
- no client-side fetch
- no polling
- no POST/form/button/action
- no trading/execution changes
- no Double-Play runtime changes
- no Scope/Capital approval
- no Risk/KillSwitch override
- no strategy authority
- no side-switch authority
- no Live/Testnet/order behavior
- no provider/Kraken changes
- no PaperExecutionEngine wiring
- no readiness/evidence/handoff/report/index surface

## Validation
- uv run python -m pytest tests/webui/test_double_play_market_dashboard_v0.py -q
- uv run ruff check tests/webui/test_double_play_market_dashboard_v0.py
- uv run ruff format --check tests/webui/test_double_play_market_dashboard_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)