### PR TITLE
docs(master-v2): plan Double-Play structured display contract v2

### DIFF
--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
@@ -2,7 +2,7 @@
 title: "Master V2 Double Play Pure Stack Dashboard Display Map v0"
 status: "DRAFT"
 owner: "ops"
-last_updated: "2026-04-28"
+last_updated: "2026-05-02"
 docs_token: "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0"
 ---
 
@@ -181,14 +181,48 @@ When code exists, future tests may include:
 
 This docs change: run `validate_docs_token_policy`, `verify_docs_reference_targets`, and `pt_docs_gates_snapshot` as for sibling ops specs.
 
-## 21. Implementation staging
+## 21. Structured display metadata v2 planning
+
+**Status:** docs-only envelope — **not** wired to code yet.
+
+**v2** metadata is **only** an optional **presentation layer** atop the existing **`DoublePlayDashboardDisplaySnapshot` → `snapshot_to_jsonable`** serialization. It **does not** alter **`master_v2`** pure decision meanings, evaluator outcomes, composition logic, Scope/Capital runtime, Risk/KillSwitch semantics, or any trading/execution pathway.
+
+Purpose:
+
+- Reduce **hardcoded rail mapping** in HTML by carrying **ordinal**, **grouping**, **layer version**, **assembly provenance**, and reproducible **`severity_rank`** in JSON (**still non-authoritative**).
+
+### 21.A Derivation table (planned metadata)
+
+| Existing source field / signal | Planned metadata | Planned derivation rule | Safety note |
+|---|---|---|---|
+| Canonical panel fixture order (`futures_input` → … → `composition`) | `ordinal` | Fixed **0‑based or 1‑based** ladder published with spec | Describes **ordering in the snapshot renderer**, **not** priority to trade |
+| Panel `name` key | `panel_group` | Static map: keys → **`input`** / **`state`** / **`scope`** / **`strategy`** / **`capital`** / **`composition`** | Semantic **cluster** for dashboards only |
+| Panel `status` (**`DashboardDisplayStatus`**) | `severity_rank` | Integer ladder (ready 0 … error 40) | **Sorting / UX severity** — **repeat**: **not** operational readiness despite numeric ordering |
+| Server-side display serialization moment | `display_snapshot_meta.assembled_at_iso` | Set when JSON is built for this route/HTML bundle | Assembly clock — **not** market candle time, evidence clock, gate approval |
+
+### 21.B Forbidden / deferred display keys (explicit non-goals)
+
+The following identifiers (and obvious casing variants repurposed as **JSON keys**) are **rejected or deferred indefinitely** until a **separate** governed contract proves they remain non-authorizing:
+
+- `recommended_side`, `active_side`, `target_position`, `order_intent`, `trade_signal`
+- `buy`, `sell`, `go`, `approved`, `ready_to_trade`
+- `enable_live`, `enable_testnet`
+- `risk_override`, `killswitch_override`
+- `scope_approval`, `capital_approval`
+- Order / session / live execution **handles**, exchange API keys, webhook secrets, credential blobs
+
+Operational rule: **`live_authorization` remains false** for this display path (see [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§17 Fail-closed semantics**); dashboards **cannot** resurrect authority via cleverly named sibling flags.
+
+Cross-link canonical **planned additive key list**: [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) §19 (**Structured display contract v2 planning**).
+
+## 22. Implementation staging
 
 1. **Docs** — this display map and cross-links (current slice).
 2. **Fixture pack** (future) — static JSON under `tests/` or `docs` examples only if governed.
 3. **Adapter** (future) — maps allowed inputs to display snapshot; **no** exchange inside `master_v2`.
 4. **WebUI** (future) — new router + template; operator runbook for local only.
 
-## 22. References
+## 23. References
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer boundary: snapshot data must be precomputed **before** read-only display (no fetch in route).
 - [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer → **downstream display** **prerequisites** (**non-authorizing** **parking map**).

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md
@@ -2,7 +2,7 @@
 title: "Master V2 Double Play WebUI Read-only Route Contract v0"
 status: "DRAFT"
 owner: "ops"
-last_updated: "2026-04-27"
+last_updated: "2026-05-02"
 docs_token: "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0"
 ---
 
@@ -212,18 +212,71 @@ bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main
 
 **Route module:** `pytest` coverage for the JSON handler is anchored in **§9**; extend tests in future PRs if governance adds fields or routes.
 
-## 19. Implementation staging
+## 19. Structured display contract v2 planning
+
+**Status:** planned only — **no** implementation in this docs slice.
+
+This section sketches **additive** JSON keys intended for **`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`** in a **later** code PR. Until then, consumers **must** tolerate their **absence**; the existing **exact key surface** asserted in **§9** remains the **canonical shipping** shape until tests and serializers are intentionally updated.
+
+Design goals:
+
+- **Non-authorizing** structured **display-layer** metadata (labels, grouping, ordinal, reproducible severity rank for UX only).
+- **Additive only**: no renaming or removal of current fields in the same versioning step.
+- **No control semantics**: optional keys describe **presentation** assembly, not readiness to trade or operate.
+
+### 19.A Planned top-level keys
+
+| Planned key | Type | Example | Meaning |
+|---|---|---|---|
+| `display_layer_version` | string | `v2` | Display-contract/schema layer — **not** runtime, **not** live version marker |
+| `display_snapshot_meta` | object | (see §19.B) | Provenance/time for **this display assembly** |
+
+### 19.B `display_snapshot_meta` fields
+
+| Field | Type | Guidance |
+|---|---|---|
+| `source_kind` | enum-like string | Examples only: **`fixture_v0`**, **`static_display_v0`**, **`adapter_snapshot_v0`** — describes **construction class**, not scanner/exchange invocation |
+| `source_id` | string | Short, non-secret **label** (fixture id / adapter nickname) — **not** an order, session, or exchange handle |
+| `assembled_at_iso` | ISO-8601 string | **Display assembly timestamp** — **not** a market quotation time, **not** evidence/sign-off timestamp, **not** operational readiness time |
+
+### 19.C Planned per-panel keys
+
+| Planned key | Type | Meaning |
+|---|---|---|
+| `ordinal` | integer | Stable **display ordering** hint only |
+| `panel_group` | enum-like string | One of: **`input`**, **`state`**, **`scope`**, **`strategy`**, **`capital`**, **`composition`** — **UI grouping** only |
+| `severity_rank` | integer | Derived from **`status`** (**`DashboardDisplayStatus`**) for sort/visual tint only |
+
+Suggested derivation map (presentation-only; **not** operational severity):
+
+```text
+display_ready   →  0
+display_warning → 10
+display_missing → 20
+display_blocked → 30
+display_error   → 40
+```
+
+### 19.D Rejected deferred fields / claims (explicit non-goals)
+
+See [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) **§21.B** (*Forbidden / deferred display keys*). This route **must not** introduce actionable trading, side recommendation, readiness promotion, overrides, or control handles via these or any sister keys.
+
+### 19.E Consumer expectations
+
+Implementations MAY emit v2 metadata under this plan; consumers MUST NOT treat absence as permission to bypass **display-only / no-live** disclosures. Existing safety booleans and fail-closed rules in **§10**, **§16**, **§17** survive unchanged.
+
+## 20. Implementation staging
 
 1. **Docs** — this contract + cross-links (current slice).
 2. **Router module** (implemented) — GET JSON handler + `include_router` in `create_app()`; keep **read-only** semantics.
 3. **Tests** — **`TestClient`** **authority-invariant** anchors in **§9**; extend if JSON shape evolves.
 4. **Optional HTML** (future) — template page consuming the same snapshot payload.
 
-## 20. References
+## 21. References
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer handoff boundary; **§20** **test anchors** for **`test_contract_32`–`37`** (**non-authority**).
 - [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer → **downstream display** **prerequisites** (**non-authorizing** **parking map**).
-- [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — display panels and DTO vocabulary (docs-only).
+- [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — display panels and DTO vocabulary; **§21** structured display metadata v2 planning (docs-only).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — pure stack inventory vs runtime.
 - [MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) — PRE_LIVE reading index; peer context only.
 - [FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md](FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md) — style reference for read-only dashboard contracts (different surface).

--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -114,6 +114,14 @@ Die **visual Double‑Play**‑Rail (**Chips**, **Tiles**, **Diagnostics**) ist 
 - **`Bull`**/**`Bear`**/**`Long`**/**`Short`** werden **nicht** aus Panel‑Schlüsseln **abgeleitet** — nur bereits in **`summary`**/**Listen** vorhandene Wörter erscheinen als **übernommener Fließtext**.
 - weiterhin **keine** operative Autorität, **keine** Live/Testnet‑Aktivierung, **keine** Order-/Scope/Capital/Risk‑Override‑Semantik über die neue Copy hinaus.
 
+## Double-Play structured display contract v2 planning
+
+**Kontext:** Operative Specs planen eine **additive**, **non-authorizing** **Struktur-Schicht** (**`display_layer_version`**, **`display_snapshot_meta`**, pro Panel **`ordinal`**, **`panel_group`**, **`severity_rank`**) für **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard-display.json`** — siehe [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§19** und [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) **§21**.
+
+- **`GET`** **`&#47;market&#47;double-play`** nutzt derzeit **v1.3 Template-Mapping** ohne diese JSON-Felder; geplante **v2**-Metadaten können **später** harte Template-Zuordnung zu **Reihenfolge/Gruppe/Schwere** ersetzen (**separates Implementierungs-PR** nach Spec + Tests).
+- **Keine** geplanten **`active_side`**, **`recommended_side`**, Order-/Session-Handles oder Aktions-Freigaben im beschriebenen **MVP-Umfang**.
+- **Keine** Trading-/UI-Autorität durch die neuen Metadaten; Markt-Surface-Docs bleiben konsistent mit „read-only / display-only“ oben.
+
 ## Chart status states
 
 Das HTML für **`GET &#47;market`** enthält beim Chart‑Bereich ein Status‑Element **`#market-v0-chart-status`** (read‑only‑Formulierung, **non‑authorizing**).


### PR DESCRIPTION
## Summary
- document planned additive structured display metadata for Double-Play dashboard-display JSON
- define planned top-level display_layer_version and display_snapshot_meta
- define planned per-panel ordinal, panel_group, and severity_rank
- document derivation from existing display serialization/panel order/status
- explicitly reject/defer authority-like fields such as recommended_side, trade_signal, ready_to_trade, overrides, and handles
- update Market Surface docs to reference the planned v2 metadata contract

## Safety
- docs-only
- no src changes
- no tests changed
- no templates changed
- no scripts/workflows changed
- no JSON route changes
- no DTO changes
- no UI consumption changes
- no backend helper changes
- no trading/execution changes
- no Double-Play runtime changes
- no Scope/Capital approval
- no Risk/KillSwitch override
- no strategy authority
- no side-switch authority
- no Live/Testnet/order behavior
- no provider/Kraken changes
- no PaperExecutionEngine wiring
- no readiness/evidence/handoff/report/index surface

## Validation
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)