### PR TITLE
feat(webui): add Double-Play structured display metadata v2

### DIFF
--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
@@ -169,9 +169,9 @@ A **no-live banner** (or equivalent persistent disclosure) is **required** on an
 
 **Pure stack producer adapter → dashboard (test anchors, read-only, non-authority):** Cross-module tests in `tests/trading/master_v2/test_double_play_pure_stack_contract.py` include **`test_contract_32`–`37`**, summarized in [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) §20. Display semantics exercised there include **`DISPLAY_READY`** (contracts 32 and 37), **`DISPLAY_BLOCKED`** on the futures panel and overall (contracts 33–35), and **`DISPLAY_MISSING`** / overall **`DISPLAY_WARNING`** when no readiness decision exists after an adapter block (contract 36). These are **test anchors** for **pure** behavior only; they do **not** prove WebUI implementation, scanner runs, provider pipelines, market-data fetch, Testnet/Live **readiness**, **trading authority**, or any external sign-off treated as permission to trade or go operational.
 
-**Read-only JSON route (downstream):** `tests&#47;webui&#47;test_double_play_dashboard_display_json_route.py` provides **authority-invariant test coverage** for the **GET** JSON **read-only route** (exact key surfaces, **display-only** flags, forbidden control/runtime-style keys, route-module import guard), documented in [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§9**. It does **not** replace §20 **pure stack** anchors or imply operational **producer** integration.
+**Read-only JSON route (downstream):** `tests&#47;webui&#47;test_double_play_dashboard_display_json_route.py` provides **authority-invariant test coverage** for the **GET** JSON **read-only route** (exact key surfaces, **display-layer v2** metadata, **display-only** flags, forbidden control/runtime-style keys, route-module import guard), documented in [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§9**. It does **not** replace §20 **pure stack** anchors or imply operational **producer** integration.
 
-**Route-independent JSON serialization (test anchors, non-authority):** `tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py` includes **test anchors** that exercise **`snapshot_to_jsonable`** on a **pure dashboard snapshot** **without** HTTP or `TestClient` — the same **JSON serialization** path the **downstream display surface** uses for JSON bodies. Scenarios include a **full-stack** snapshot, a **blocked survival** / **display-blocked** panel path, and an **empty** default snapshot. Assertions include **JSON-native** values, **`json.dumps`** compatibility, exact top-level and per-panel key surfaces aligned with the WebUI JSON route contract, **display-only** semantics (`display_only` true, `no_live_banner_visible` true), **non-authorizing** readiness booleans (`trading_ready`, `testnet_ready`, `live_ready`, and `live_authorization` false at the top level), panel **non-authority** / **non-signal** flags (`live_authorization`, `is_authority`, `is_signal` false), and a recursive forbidden-key scan for order/control/runtime/provider/scanner/exchange/session/credential-like key names, while explicit false **safety** booleans are asserted separately rather than banned by name. These anchors **complement** the WebUI route **test anchors** and **do not replace** [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) **§20** producer-adapter → **pure stack** → dashboard anchors. Boundary: they prove **JSON serialization** and key-surface **invariants** only — not operational **producer** integration, market-data ingestion, WebUI **HTML** or control UI, Testnet or Live **readiness**, execution permission, or external sign-off treated as permission to trade.
+**Route-independent JSON serialization (test anchors, non-authority):** `tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py` includes **test anchors** that exercise **`snapshot_to_jsonable`** on a **pure dashboard snapshot** **without** HTTP or `TestClient` — the same **JSON serialization** path the **downstream display surface** uses for JSON bodies. Scenarios include a **full-stack** snapshot, a **blocked survival** / **display-blocked** panel path, and an **empty** default snapshot. Assertions include **JSON-native** values, **`json.dumps`** compatibility, exact top-level and per-panel key surfaces aligned with the WebUI JSON route contract (including **display-layer v2** **`display_layer_version`**, **`display_snapshot_meta`**, **`ordinal`**, **`panel_group`**, **`severity_rank`**), **display-only** semantics (`display_only` true, `no_live_banner_visible` true), **non-authorizing** readiness booleans (`trading_ready`, `testnet_ready`, `live_ready`, and `live_authorization` false at the top level), panel **non-authority** / **non-signal** flags (`live_authorization`, `is_authority`, `is_signal` false), and a recursive forbidden-key scan for order/control/runtime/provider/scanner/exchange/session/credential-like key names, while explicit false **safety** booleans are asserted separately rather than banned by name. These anchors **complement** the WebUI route **test anchors** and **do not replace** [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) **§20** producer-adapter → **pure stack** → dashboard anchors. Boundary: they prove **JSON serialization** and key-surface **invariants** only — not operational **producer** integration, market-data ingestion, WebUI **HTML** or control UI, Testnet or Live **readiness**, execution permission, or external sign-off treated as permission to trade.
 
 When code exists, future tests may include:
 
@@ -181,24 +181,24 @@ When code exists, future tests may include:
 
 This docs change: run `validate_docs_token_policy`, `verify_docs_reference_targets`, and `pt_docs_gates_snapshot` as for sibling ops specs.
 
-## 21. Structured display metadata v2 planning
+## 21. Structured display metadata v2
 
-**Status:** docs-only envelope — **not** wired to code yet.
+**Status:** **Implemented** in **`src/webui/double_play_dashboard_display_json_route_v0.py`** (**`snapshot_to_jsonable`** + GET JSON route mapper). **Pure** **`DoublePlayDashboardDisplaySnapshot`** dataclasses in **`master_v2`** are unchanged.
 
-**v2** metadata is **only** an optional **presentation layer** atop the existing **`DoublePlayDashboardDisplaySnapshot` → `snapshot_to_jsonable`** serialization. It **does not** alter **`master_v2`** pure decision meanings, evaluator outcomes, composition logic, Scope/Capital runtime, Risk/KillSwitch semantics, or any trading/execution pathway.
+**v2** metadata is an optional **presentation layer** atop **`DoublePlayDashboardDisplaySnapshot` → `snapshot_to_jsonable`** serialization only. It **does not** alter **`master_v2`** pure decision meanings, evaluator outcomes, composition logic, Scope/Capital runtime, Risk/KillSwitch semantics, or any trading/execution pathway.
 
 Purpose:
 
-- Reduce **hardcoded rail mapping** in HTML by carrying **ordinal**, **grouping**, **layer version**, **assembly provenance**, and reproducible **`severity_rank`** in JSON (**still non-authoritative**).
+- Reduce **hardcoded rail mapping** in downstream consumers by carrying **ordinal**, **grouping**, **layer version**, **assembly provenance**, and reproducible **`severity_rank`** in JSON (**still non-authoritative**).
 
-### 21.A Derivation table (planned metadata)
+### 21.A Derivation table (**shipping** mapper)
 
-| Existing source field / signal | Planned metadata | Planned derivation rule | Safety note |
+| Existing source field / signal | Serialized metadata | Derivation rule | Safety note |
 |---|---|---|---|
-| Canonical panel fixture order (`futures_input` → … → `composition`) | `ordinal` | Fixed **0‑based or 1‑based** ladder published with spec | Describes **ordering in the snapshot renderer**, **not** priority to trade |
+| Canonical panel fixture order (`futures_input` → … → `composition`) | `ordinal` | **0‑based** ladder emitted in **`snapshot_to_jsonable`** | Describes **ordering in the snapshot renderer**, **not** priority to trade |
 | Panel `name` key | `panel_group` | Static map: keys → **`input`** / **`state`** / **`scope`** / **`strategy`** / **`capital`** / **`composition`** | Semantic **cluster** for dashboards only |
-| Panel `status` (**`DashboardDisplayStatus`**) | `severity_rank` | Integer ladder (ready 0 … error 40) | **Sorting / UX severity** — **repeat**: **not** operational readiness despite numeric ordering |
-| Server-side display serialization moment | `display_snapshot_meta.assembled_at_iso` | Set when JSON is built for this route/HTML bundle | Assembly clock — **not** market candle time, evidence clock, gate approval |
+| Panel `status` (**`DashboardDisplayStatus`**) | `severity_rank` | Integer ladder (ready **0**, warning **10**, missing **20**, blocked **30**, error **40**) per [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§19** | **Sorting / UX severity** — **not** operational readiness despite numeric ordering |
+| Server-side display serialization moment | `display_snapshot_meta.assembled_at_iso` | Set when JSON dict is assembled for **`snapshot_to_jsonable`** callers | Assembly clock — **not** market candle time, evidence clock, gate approval |
 
 ### 21.B Forbidden / deferred display keys (explicit non-goals)
 
@@ -213,21 +213,21 @@ The following identifiers (and obvious casing variants repurposed as **JSON keys
 
 Operational rule: **`live_authorization` remains false** for this display path (see [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§17 Fail-closed semantics**); dashboards **cannot** resurrect authority via cleverly named sibling flags.
 
-Cross-link canonical **planned additive key list**: [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) §19 (**Structured display contract v2 planning**).
+Cross-link canonical **additive key list**: [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) §19 (**Structured display contract v2**).
 
 ## 22. Implementation staging
 
 1. **Docs** — this display map and cross-links (current slice).
 2. **Fixture pack** (future) — static JSON under `tests/` or `docs` examples only if governed.
 3. **Adapter** (future) — maps allowed inputs to display snapshot; **no** exchange inside `master_v2`.
-4. **WebUI** (future) — new router + template; operator runbook for local only.
+4. **WebUI** — read-only **`GET`** JSON mapper implemented (**structured display metadata v2** in **`snapshot_to_jsonable`**); HTML template consumption remains future work.
 
 ## 23. References
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer boundary: snapshot data must be precomputed **before** read-only display (no fetch in route).
 - [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer → **downstream display** **prerequisites** (**non-authorizing** **parking map**).
 - [MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_DISPLAY_BASELINE_CLOSEOUT_INDEX_V0.md) — **closeout index**; **reading order** for **pure display baseline** (**non-authorizing**).
-- [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) — future WebUI **GET** read-only JSON route boundary for this display DTO (docs-only; no implementation here).
+- [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) — WebUI **GET** read-only JSON route boundary for this display DTO (**§9**, **§19**).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — pure stack inventory and model boundaries.
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_READ_MODEL_V0.md) — Futures Input Snapshot read model.
 - [FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md](FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md) — futures read-only dashboard display contract (F5).

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md
@@ -120,8 +120,8 @@ For the **pure stack** regression story of **`FuturesProducerPacket` → `adapt_
 
 **Coverage (summary):**
 
-- **Exact top-level key surface** — JSON object keys match the serialized snapshot contract only (no extra control fields).
-- **Exact per-panel key surface** — each panel object exposes only the expected display fields.
+- **Exact top-level key surface** — JSON object keys match the serialized snapshot contract only (including **additive display-layer v2** metadata described in §19; no extra control fields).
+- **Exact per-panel key surface** — each panel object exposes only the expected display fields (including **`ordinal`**, **`panel_group`**, **`severity_rank`** from §19.C).
 - **Display-only top-level flags** — `display_only` true, `no_live_banner_visible` true; **`trading_ready`**, **`testnet_ready`**, **`live_ready`**, **`live_authorization`** remain **false** (explicit **safety** booleans, not permission to go operational).
 - **Panel-level flags** — each panel keeps **`live_authorization`**, **`is_authority`**, **`is_signal`** false for the static fixture path.
 - **Forbidden JSON keys** — recursive key scan rejects control / runtime / **provider** / **scanner** / **exchange** / session / credential-like key names in the payload tree (keys that are legitimate DTO safety flags are asserted false separately, not banned by name).
@@ -212,21 +212,21 @@ bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main
 
 **Route module:** `pytest` coverage for the JSON handler is anchored in **§9**; extend tests in future PRs if governance adds fields or routes.
 
-## 19. Structured display contract v2 planning
+## 19. Structured display contract v2
 
-**Status:** planned only — **no** implementation in this docs slice.
+**Status:** **Implemented** — the read-only route and **`snapshot_to_jsonable`** expose **additive display-layer metadata** (**§19.A–§19.C**); **Master-v2 runtime / evaluator semantics** remain unchanged.
 
-This section sketches **additive** JSON keys intended for **`GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json`** in a **later** code PR. Until then, consumers **must** tolerate their **absence**; the existing **exact key surface** asserted in **§9** remains the **canonical shipping** shape until tests and serializers are intentionally updated.
+Older consumers **must** tolerate **presence or absence** of these keys depending on serializer version (current tests assert presence for the shipping route mapper). Existing **authority / display-only booleans** in **§10**, **§16**, **§17** are unchanged.
 
 Design goals:
 
 - **Non-authorizing** structured **display-layer** metadata (labels, grouping, ordinal, reproducible severity rank for UX only).
-- **Additive only**: no renaming or removal of current fields in the same versioning step.
+- **Additive only**: no renaming or removal of prior fields alongside this versioning step.
 - **No control semantics**: optional keys describe **presentation** assembly, not readiness to trade or operate.
 
-### 19.A Planned top-level keys
+### 19.A Top-level keys
 
-| Planned key | Type | Example | Meaning |
+| Key | Type | Example | Meaning |
 |---|---|---|---|
 | `display_layer_version` | string | `v2` | Display-contract/schema layer — **not** runtime, **not** live version marker |
 | `display_snapshot_meta` | object | (see §19.B) | Provenance/time for **this display assembly** |
@@ -239,15 +239,15 @@ Design goals:
 | `source_id` | string | Short, non-secret **label** (fixture id / adapter nickname) — **not** an order, session, or exchange handle |
 | `assembled_at_iso` | ISO-8601 string | **Display assembly timestamp** — **not** a market quotation time, **not** evidence/sign-off timestamp, **not** operational readiness time |
 
-### 19.C Planned per-panel keys
+### 19.C Per-panel keys
 
-| Planned key | Type | Meaning |
+| Key | Type | Meaning |
 |---|---|---|
-| `ordinal` | integer | Stable **display ordering** hint only |
+| `ordinal` | integer | Stable **display ordering** hint only (0-based ladder matching canonical panel fixture order). |
 | `panel_group` | enum-like string | One of: **`input`**, **`state`**, **`scope`**, **`strategy`**, **`capital`**, **`composition`** — **UI grouping** only |
 | `severity_rank` | integer | Derived from **`status`** (**`DashboardDisplayStatus`**) for sort/visual tint only |
 
-Suggested derivation map (presentation-only; **not** operational severity):
+**Shipping mapper** derivation map (presentation-only; **not** operational severity):
 
 ```text
 display_ready   →  0
@@ -263,20 +263,20 @@ See [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOU
 
 ### 19.E Consumer expectations
 
-Implementations MAY emit v2 metadata under this plan; consumers MUST NOT treat absence as permission to bypass **display-only / no-live** disclosures. Existing safety booleans and fail-closed rules in **§10**, **§16**, **§17** survive unchanged.
+The shipping GET JSON mapper **emits v2 metadata** (**§19.A–§19.C**); older clients **must** tolerate **presence or absence** across versions — treat **presence** strictly as display-layer cues. Consumers MUST NOT treat **`severity_rank`** or **`panel_group`** as permission to bypass **display-only / no-live** disclosures. Existing safety booleans and fail-closed rules in **§10**, **§16**, **§17** survive unchanged.
 
 ## 20. Implementation staging
 
-1. **Docs** — this contract + cross-links (current slice).
-2. **Router module** (implemented) — GET JSON handler + `include_router` in `create_app()`; keep **read-only** semantics.
-3. **Tests** — **`TestClient`** **authority-invariant** anchors in **§9**; extend if JSON shape evolves.
+1. **Docs** — this contract + cross-links (maintained with serializers).
+2. **Router module** (implemented) — GET JSON handler + `include_router` in `create_app()`; **`snapshot_to_jsonable`** emits **structured display metadata v2** — keep **read-only** semantics.
+3. **Tests** — **`TestClient`** **authority-invariant** anchors in **§9**; extend if JSON shape evolves beyond **§19**.
 4. **Optional HTML** (future) — template page consuming the same snapshot payload.
 
 ## 21. References
 
 - [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) — producer handoff boundary; **§20** **test anchors** for **`test_contract_32`–`37`** (**non-authority**).
 - [MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_RUNTIME_PRODUCER_DASHBOARD_PREREQUISITE_PARKING_MAP_V0.md) — **parked** runtime-producer → **downstream display** **prerequisites** (**non-authorizing** **parking map**).
-- [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — display panels and DTO vocabulary; **§21** structured display metadata v2 planning (docs-only).
+- [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) — display panels and DTO vocabulary; **§21** structured display metadata v2 (**implemented** in **`snapshot_to_jsonable`** **/** **read-only JSON route** mapper).
 - [MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md](MASTER_V2_DOUBLE_PLAY_PURE_STACK_READINESS_MAP_V0.md) — pure stack inventory vs runtime.
 - [MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md](MASTER_V2_FIRST_LIVE_PRE_LIVE_NAVIGATION_READ_MODEL_V0.md) — PRE_LIVE reading index; peer context only.
 - [FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md](FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md) — style reference for read-only dashboard contracts (different surface).

--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -108,19 +108,21 @@ Die **visual Double‑Play**‑Rail (**Chips**, **Tiles**, **Diagnostics**) ist 
 
 **Route:** **`GET &#47;market&#47;double-play`** (unverändert)
 
-**v1.3** ergänzt **nur Templates/Tests/Docs**: menschenlesbare **Panel‑Titel/Untertitel** und deutschsprachige **„Anzeige: …“**‑Beschriftungen für die **`display_*`**‑Status‑Strings des bestehenden **Double‑Play‑Display‑Snapshots** (**kein** neues Feld im JSON, **keine** Änderung an **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard‑display.json`**, keine Trading‑ oder Runtime‑Logik).
+**v1.3** ergänzt **nur Templates/Tests/Docs**: menschenlesbare **Panel‑Titel/Untertitel** und deutschsprachige **„Anzeige: …“**‑Beschriftungen für die **`display_*`**‑Status‑Strings des bestehenden **Double‑Play‑Display‑Snapshots** (**keine** neue **Trading**/Runtime‑Logik).
+
+**Structured display metadata v2 (JSON):** **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard‑display.json`** enthält zusätzliche **additive** Felder (**`display_layer_version`**, **`display_snapshot_meta`**, pro Panel **`ordinal`**, **`panel_group`**, **`severity_rank`**) wie in [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§19** beschrieben. **`GET`** **`&#47;market&#47;double-play`** (**v1.3**) konsumiert diese JSON‑Felder **nicht**.
 
 - Roh‑ **`display_ready`** **`/`** Panel‑ **`display_*`** werden **nicht** als Handelsbereitschaft dargestellt; **„Anzeige: OK“** bedeutet **„Karte beschriftbar vorhanden im Snapshot“**, **nicht** Order‑Freigabe.
 - **`Bull`**/**`Bear`**/**`Long`**/**`Short`** werden **nicht** aus Panel‑Schlüsseln **abgeleitet** — nur bereits in **`summary`**/**Listen** vorhandene Wörter erscheinen als **übernommener Fließtext**.
 - weiterhin **keine** operative Autorität, **keine** Live/Testnet‑Aktivierung, **keine** Order-/Scope/Capital/Risk‑Override‑Semantik über die neue Copy hinaus.
 
-## Double-Play structured display contract v2 planning
+## Double-Play structured display contract v2 (JSON route)
 
-**Kontext:** Operative Specs planen eine **additive**, **non-authorizing** **Struktur-Schicht** (**`display_layer_version`**, **`display_snapshot_meta`**, pro Panel **`ordinal`**, **`panel_group`**, **`severity_rank`**) für **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard-display.json`** — siehe [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§19** und [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) **§21**.
+Die **additive** Display‑Schicht für **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard‑display.json`** ist in **`snapshot_to_jsonable`** (**`src/webui/double_play_dashboard_display_json_route_v0.py`**) umgesetzt — siehe [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§19** und [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) **§21**.
 
-- **`GET`** **`&#47;market&#47;double-play`** nutzt derzeit **v1.3 Template-Mapping** ohne diese JSON-Felder; geplante **v2**-Metadaten können **später** harte Template-Zuordnung zu **Reihenfolge/Gruppe/Schwere** ersetzen (**separates Implementierungs-PR** nach Spec + Tests).
-- **Keine** geplanten **`active_side`**, **`recommended_side`**, Order-/Session-Handles oder Aktions-Freigaben im beschriebenen **MVP-Umfang**.
-- **Keine** Trading-/UI-Autorität durch die neuen Metadaten; Markt-Surface-Docs bleiben konsistent mit „read-only / display-only“ oben.
+- **`GET`** **`&#47;market&#47;double-play`** nutzt weiterhin **v1.3 Template‑Mapping** ohne Nutzung der neuen JSON‑Strukturfelder; ein **HTML‑Consumer** dieser Metadaten wäre ein **separates** Arbeitspaket.
+- **Keine** **`active_side`**, **`recommended_side`**, Order-/Session‑Handles oder Aktions‑Freigaben im beschriebenen **Scope**.
+- **Keine** Trading-/UI‑Autorität durch die neuen Metadaten; Markt‑Surface‑Docs bleiben konsistent mit „read-only / display-only“ oben.
 
 ## Chart status states
 

--- a/src/webui/double_play_dashboard_display_json_route_v0.py
+++ b/src/webui/double_play_dashboard_display_json_route_v0.py
@@ -10,8 +10,9 @@ See docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
@@ -28,6 +29,7 @@ from trading.master_v2.double_play_composition import (
     compose_double_play_decision,
 )
 from trading.master_v2.double_play_dashboard_display import (
+    DashboardDisplayStatus,
     DoublePlayDashboardDisplaySnapshot,
     DoublePlayDashboardPanel,
     build_dashboard_display_snapshot,
@@ -76,6 +78,36 @@ router = APIRouter(
     prefix="/api/master-v2/double-play",
     tags=["master-v2", "double-play", "dashboard-display-readonly"],
 )
+
+_DISPLAY_JSON_LAYER_VERSION = "v2"
+
+_DISPLAY_PANEL_GROUP: Mapping[str, str] = {
+    "futures_input": "input",
+    "state_transition": "state",
+    "survival_envelope": "scope",
+    "strategy_suitability": "strategy",
+    "capital_slot_ratchet": "capital",
+    "capital_slot_release": "capital",
+    "composition": "composition",
+}
+
+_DISPLAY_SEVERITY_RANK: Mapping[DashboardDisplayStatus, int] = {
+    DashboardDisplayStatus.DISPLAY_READY: 0,
+    DashboardDisplayStatus.DISPLAY_WARNING: 10,
+    DashboardDisplayStatus.DISPLAY_MISSING: 20,
+    DashboardDisplayStatus.DISPLAY_BLOCKED: 30,
+    DashboardDisplayStatus.DISPLAY_ERROR: 40,
+}
+
+
+def _display_severity_rank(status: DashboardDisplayStatus) -> int:
+    return _DISPLAY_SEVERITY_RANK[status]
+
+
+def _assembled_at_iso_utc() -> str:
+    dt = datetime.now(timezone.utc).replace(microsecond=0)
+    return dt.isoformat().replace("+00:00", "Z")
+
 
 _GOOD_LIMITS = StaticHardLimits(
     max_notional=1.0,
@@ -349,9 +381,10 @@ def _build_static_double_play_dashboard_display_snapshot_v0() -> DoublePlayDashb
     )
 
 
-def _jsonable_panel(panel: DoublePlayDashboardPanel) -> Dict[str, Any]:
+def _jsonable_panel(panel: DoublePlayDashboardPanel, ordinal: int) -> Dict[str, Any]:
     st = panel.status
     status_val = st.value if isinstance(st, Enum) else str(st)
+    panel_group = _DISPLAY_PANEL_GROUP.get(panel.name, "unknown")
     return {
         "name": panel.name,
         "status": status_val,
@@ -361,6 +394,9 @@ def _jsonable_panel(panel: DoublePlayDashboardPanel) -> Dict[str, Any]:
         "live_authorization": panel.live_authorization,
         "is_authority": panel.is_authority,
         "is_signal": panel.is_signal,
+        "ordinal": ordinal,
+        "panel_group": panel_group,
+        "severity_rank": _display_severity_rank(st),
     }
 
 
@@ -369,7 +405,13 @@ def snapshot_to_jsonable(snap: DoublePlayDashboardDisplaySnapshot) -> Dict[str, 
     overall = snap.overall_status
     overall_val = overall.value if isinstance(overall, Enum) else str(overall)
     return {
-        "panels": [_jsonable_panel(p) for p in snap.panels],
+        "display_layer_version": _DISPLAY_JSON_LAYER_VERSION,
+        "display_snapshot_meta": {
+            "source_kind": "static_display_v0",
+            "source_id": "webui_dashboard_display_static_v0",
+            "assembled_at_iso": _assembled_at_iso_utc(),
+        },
+        "panels": [_jsonable_panel(p, i) for i, p in enumerate(snap.panels)],
         "overall_status": overall_val,
         "no_live_banner_visible": snap.no_live_banner_visible,
         "display_only": snap.display_only,

--- a/tests/trading/master_v2/test_double_play_dashboard_display.py
+++ b/tests/trading/master_v2/test_double_play_dashboard_display.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import ast
 import json
 from dataclasses import replace
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
@@ -308,6 +309,8 @@ def test_snapshot_invariants_always() -> None:
 
 _EXPECTED_JSON_TOP_LEVEL_KEYS = frozenset(
     {
+        "display_layer_version",
+        "display_snapshot_meta",
         "panels",
         "overall_status",
         "no_live_banner_visible",
@@ -320,6 +323,10 @@ _EXPECTED_JSON_TOP_LEVEL_KEYS = frozenset(
     }
 )
 
+_EXPECTED_JSON_DISPLAY_SNAPSHOT_META_KEYS = frozenset(
+    {"source_kind", "source_id", "assembled_at_iso"}
+)
+
 _EXPECTED_JSON_PANEL_KEYS = frozenset(
     {
         "name",
@@ -330,6 +337,9 @@ _EXPECTED_JSON_PANEL_KEYS = frozenset(
         "live_authorization",
         "is_authority",
         "is_signal",
+        "ordinal",
+        "panel_group",
+        "severity_rank",
     }
 )
 
@@ -413,6 +423,13 @@ def _assert_json_native_values(obj: object) -> None:
 
 def _assert_serialized_dashboard_authority_invariants(data: dict) -> None:
     assert set(data.keys()) == _EXPECTED_JSON_TOP_LEVEL_KEYS
+    assert data["display_layer_version"] == "v2"
+    meta = data["display_snapshot_meta"]
+    assert set(meta.keys()) == _EXPECTED_JSON_DISPLAY_SNAPSHOT_META_KEYS
+    assert isinstance(meta["assembled_at_iso"], str)
+    datetime.fromisoformat(meta["assembled_at_iso"].replace("Z", "+00:00"))
+    assert meta["source_kind"] == "static_display_v0"
+    assert meta["source_id"] == "webui_dashboard_display_static_v0"
     assert data["display_only"] is True
     assert data["no_live_banner_visible"] is True
     assert data["trading_ready"] is False
@@ -451,6 +468,21 @@ def test_snapshot_to_jsonable_full_stack_matches_route_contract() -> None:
     data = snapshot_to_jsonable(snap)
     _assert_serialized_dashboard_authority_invariants(data)
     assert len(data["panels"]) == 7
+    expected_rows = (
+        ("futures_input", "input", 0, 0),
+        ("state_transition", "state", 1, 0),
+        ("survival_envelope", "scope", 2, 0),
+        ("strategy_suitability", "strategy", 3, 0),
+        ("capital_slot_ratchet", "capital", 4, 0),
+        ("capital_slot_release", "capital", 5, 0),
+        ("composition", "composition", 6, 0),
+    )
+    for row, panel in zip(expected_rows, data["panels"]):
+        name, grp, ordinal, rank = row
+        assert panel["name"] == name
+        assert panel["panel_group"] == grp
+        assert panel["ordinal"] == ordinal
+        assert panel["severity_rank"] == rank
 
 
 def test_snapshot_to_jsonable_blocked_survival_still_matches_contract() -> None:
@@ -472,6 +504,9 @@ def test_snapshot_to_jsonable_blocked_survival_still_matches_contract() -> None:
     )
     data = snapshot_to_jsonable(snap)
     _assert_serialized_dashboard_authority_invariants(data)
+    survival_p = next(p for p in data["panels"] if p["name"] == "survival_envelope")
+    assert survival_p["status"] == "display_blocked"
+    assert survival_p["severity_rank"] == 30
 
 
 def test_snapshot_to_jsonable_empty_snapshot_still_matches_contract() -> None:
@@ -479,3 +514,8 @@ def test_snapshot_to_jsonable_empty_snapshot_still_matches_contract() -> None:
     snap = build_dashboard_display_snapshot()
     data = snapshot_to_jsonable(snap)
     _assert_serialized_dashboard_authority_invariants(data)
+    assert data["overall_status"] == "display_warning"
+    for i, p in enumerate(data["panels"]):
+        assert p["status"] == "display_missing"
+        assert p["severity_rank"] == 20
+        assert p["ordinal"] == i

--- a/tests/webui/test_double_play_dashboard_display_json_route.py
+++ b/tests/webui/test_double_play_dashboard_display_json_route.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import ast
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,8 @@ ROUTE_PATH = "/api/master-v2/double-play/dashboard-display.json"
 
 _EXPECTED_TOP_LEVEL_KEYS = frozenset(
     {
+        "display_layer_version",
+        "display_snapshot_meta",
         "panels",
         "overall_status",
         "no_live_banner_visible",
@@ -29,6 +32,10 @@ _EXPECTED_TOP_LEVEL_KEYS = frozenset(
     }
 )
 
+_EXPECTED_DISPLAY_SNAPSHOT_META_KEYS = frozenset(
+    {"source_kind", "source_id", "assembled_at_iso"},
+)
+
 _EXPECTED_PANEL_KEYS = frozenset(
     {
         "name",
@@ -39,6 +46,9 @@ _EXPECTED_PANEL_KEYS = frozenset(
         "live_authorization",
         "is_authority",
         "is_signal",
+        "ordinal",
+        "panel_group",
+        "severity_rank",
     }
 )
 
@@ -127,6 +137,14 @@ def test_dashboard_display_json_top_level_key_surface_is_display_only_contract(
     r = client.get(ROUTE_PATH)
     data = r.json()
     assert set(data.keys()) == _EXPECTED_TOP_LEVEL_KEYS
+    assert data["display_layer_version"] == "v2"
+    meta = data["display_snapshot_meta"]
+    assert set(meta.keys()) == _EXPECTED_DISPLAY_SNAPSHOT_META_KEYS
+    assert meta["source_kind"] == "static_display_v0"
+    assert meta["source_id"] == "webui_dashboard_display_static_v0"
+    assembled = meta["assembled_at_iso"]
+    assert isinstance(assembled, str)
+    datetime.fromisoformat(assembled.replace("Z", "+00:00"))
     assert data["display_only"] is True
     assert data["no_live_banner_visible"] is True
     assert data["trading_ready"] is False
@@ -177,6 +195,28 @@ def test_dashboard_display_json_panel_key_surface_and_no_panel_authority_flags(
         assert panel["is_authority"] is False
         assert panel["is_signal"] is False
         assert panel["status"] == "display_ready"
+        assert isinstance(panel["ordinal"], int)
+        assert isinstance(panel["panel_group"], str)
+        assert panel["severity_rank"] == 0
+
+
+def test_dashboard_display_json_display_layer_panel_order_and_groups(client: TestClient) -> None:
+    r = client.get(ROUTE_PATH)
+    data = r.json()
+    expected = (
+        ("futures_input", "input", 0),
+        ("state_transition", "state", 1),
+        ("survival_envelope", "scope", 2),
+        ("strategy_suitability", "strategy", 3),
+        ("capital_slot_ratchet", "capital", 4),
+        ("capital_slot_release", "capital", 5),
+        ("composition", "composition", 6),
+    )
+    by_name = {p["name"]: p for p in data["panels"]}
+    for name, group, ordinal in expected:
+        p = by_name[name]
+        assert p["panel_group"] == group
+        assert p["ordinal"] == ordinal
 
 
 def test_dashboard_display_json_no_forbidden_control_keys(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- add additive structured metadata v2 to Double-Play dashboard-display JSON
- add top-level display_layer_version and display_snapshot_meta
- add per-panel ordinal, panel_group, and severity_rank
- derive metadata in WebUI JSON serialization without changing Master V2 trading DTOs
- update JSON route and pure display tests for exact key surfaces and metadata values
- sync route/display-map/Market Surface docs from planned to implemented

## Safety
- additive JSON metadata only
- no trading DTO/runtime change
- no strategy logic change
- no Scope/Capital runtime change
- no Risk/KillSwitch runtime change
- no provider/Kraken change
- no template/UI consumption change
- no new route
- no new endpoint
- no client fetch
- no polling
- no POST/form/button/action
- no active_side/recommended_side
- no buy/sell/go/approved fields
- no ready_to_trade field
- no Live/Testnet enabling
- no order/session/exchange handles
- no readiness/evidence/handoff/report/index surface

## Validation
- uv run python -m pytest tests/webui/test_double_play_dashboard_display_json_route.py tests/trading/master_v2/test_double_play_dashboard_display.py -q
- uv run ruff check src/webui/double_play_dashboard_display_json_route_v0.py tests/webui/test_double_play_dashboard_display_json_route.py tests/trading/master_v2/test_double_play_dashboard_display.py
- uv run ruff format --check src/webui/double_play_dashboard_display_json_route_v0.py tests/webui/test_double_play_dashboard_display_json_route.py tests/trading/master_v2/test_double_play_dashboard_display.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

Made with [Cursor](https://cursor.com)