### PR TITLE
feat(webui): consume Double-Play structured metadata v2 on market dashboard

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -110,7 +110,7 @@ Die **visual Double‑Play**‑Rail (**Chips**, **Tiles**, **Diagnostics**) ist 
 
 **v1.3** ergänzt **nur Templates/Tests/Docs**: menschenlesbare **Panel‑Titel/Untertitel** und deutschsprachige **„Anzeige: …“**‑Beschriftungen für die **`display_*`**‑Status‑Strings des bestehenden **Double‑Play‑Display‑Snapshots** (**keine** neue **Trading**/Runtime‑Logik).
 
-**Structured display metadata v2 (JSON):** **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard‑display.json`** enthält zusätzliche **additive** Felder (**`display_layer_version`**, **`display_snapshot_meta`**, pro Panel **`ordinal`**, **`panel_group`**, **`severity_rank`**) wie in [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§19** beschrieben. **`GET`** **`&#47;market&#47;double-play`** (**v1.3**) konsumiert diese JSON‑Felder **nicht**.
+**Structured display metadata v2:** **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard‑display.json`** enthält zusätzliche **additive** Felder (**`display_layer_version`**, **`display_snapshot_meta`**, pro Panel **`ordinal`**, **`panel_group`**, **`severity_rank`**) wie in [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§19** beschrieben. Dieselben Werte erreichen **`GET`** **`&#47;market&#47;double-play`** bereits über eingebettetes **`dp_display`** (**SSR** — siehe **[Double‑Play Market Dashboard konsumiert strukturierte Metadaten v2](#double-play-market-dashboard-konsumiert-strukturierte-metadaten-v2)**).
 
 - Roh‑ **`display_ready`** **`/`** Panel‑ **`display_*`** werden **nicht** als Handelsbereitschaft dargestellt; **„Anzeige: OK“** bedeutet **„Karte beschriftbar vorhanden im Snapshot“**, **nicht** Order‑Freigabe.
 - **`Bull`**/**`Bear`**/**`Long`**/**`Short`** werden **nicht** aus Panel‑Schlüsseln **abgeleitet** — nur bereits in **`summary`**/**Listen** vorhandene Wörter erscheinen als **übernommener Fließtext**.
@@ -120,9 +120,21 @@ Die **visual Double‑Play**‑Rail (**Chips**, **Tiles**, **Diagnostics**) ist 
 
 Die **additive** Display‑Schicht für **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard‑display.json`** ist in **`snapshot_to_jsonable`** (**`src/webui/double_play_dashboard_display_json_route_v0.py`**) umgesetzt — siehe [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§19** und [MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md](../ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md) **§21**.
 
-- **`GET`** **`&#47;market&#47;double-play`** nutzt weiterhin **v1.3 Template‑Mapping** ohne Nutzung der neuen JSON‑Strukturfelder; ein **HTML‑Consumer** dieser Metadaten wäre ein **separates** Arbeitspaket.
+- **`GET`** **`&#47;market&#47;double-play`** zeigt dieselben strukturierten v2‑Metadaten **sichtbar**, soweit sie bereits im SSR‑**`dp_display`** enthalten sind — Details unter **[Double‑Play Market Dashboard konsumiert strukturierte Metadaten v2](#double-play-market-dashboard-konsumiert-strukturierte-metadaten-v2)** (Templates/Tests/Docs‑Schicht **ohne** neue Backend‑Keys).
 - **Keine** **`active_side`**, **`recommended_side`**, Order-/Session‑Handles oder Aktions‑Freigaben im beschriebenen **Scope**.
 - **Keine** Trading-/UI‑Autorität durch die neuen Metadaten; Markt‑Surface‑Docs bleiben konsistent mit „read-only / display-only“ oben.
+
+## Double-Play Market Dashboard konsumiert strukturierte Metadaten v2
+
+**Route:** **`GET &#47;market&#47;double-play`** (SSR unverändert).
+
+Diese Dokumentations‑Schicht beschreibt die **sichtbare** Aufbereitung von **bereits vorhandenen** strukturierten Metadaten v2 (**`display_layer_version`**, **`display_snapshot_meta`**, pro Panel **`ordinal`**, **`panel_group`**, **`severity_rank`**) aus dem eingebetteten **`dp_display`** (**gleicher Aufbau wie** **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard‑display.json`**, weiterhin **in‑process** ohne Client‑Fetch).
+
+- **Keine** Backend‑ oder API‑Erweiterung in diesem Template-/Docs-/Test‑Schritt; **keine** neuen JSON‑Felder und **keine** neue Route.
+- **`assembled_at_iso`** und **`display_snapshot_meta`** sind **Display‑Assembly/provenance**, **nicht** Kurszeit, Evidence‑Zeit oder Operational‑Readiness.
+- **`severity_rank`** ist **Anzeige-/Sortier‑Skala** (**Styling/Ordnung**), **kein** Handels‑ oder Freigabe‑Signal.
+- **`panel_group`** ist eine **UI‑Kategorie**/Clusterbezeichnung (**keine** operative Autorität, **kein** Scope/Capital/Risk‑Bypass).
+- weiterhin **kein** `fetch()`, **kein** Polling, **keine** Formulare oder POST‑Aktionen durch diese Seite.
 
 ## Chart status states
 

--- a/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
+++ b/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
@@ -630,6 +630,7 @@
       data-double-play-display-ssr-v1="true"
       data-double-play-market-visual-panels-v1-2="true"
       data-double-play-market-field-mapping-v1-3="true"
+      data-double-play-market-ui-consumes-v2-metadata="true"
     >
       {% set _dp_snap_status = {
         'display_ready': {'lab': 'Anzeige: OK', 'hint': 'Karteninhalt vorhanden · keine Trading-Freigabe'},
@@ -667,6 +668,25 @@
         Display-only Snapshot — keine Operational-Freigabe.
         <a href="{{ double_play_json_url }}" class="text-sky-400 underline underline-offset-2 font-mono break-all block mt-2" data-double-play-market-display-json-link="true">{{ double_play_json_url }}</a>
       </p>
+
+      <div
+        class="rounded-lg border border-slate-800/90 bg-slate-950/70 px-3 py-2.5 mb-3 space-y-1 font-mono text-[10px] text-slate-300"
+        data-double-play-market-display-snapshot-meta="true"
+      >
+        <p class="text-[9px] uppercase tracking-wide text-slate-500 m-0 font-sans font-semibold">
+          Structured display metadata (SSR)
+        </p>
+        <p class="m-0" data-double-play-market-display-layer-version="true">
+          Display layer: {{ dp_display.display_layer_version }}
+        </p>
+        <p class="m-0">Source kind: {{ dp_display.display_snapshot_meta.source_kind }}</p>
+        <p class="m-0">Source id: {{ dp_display.display_snapshot_meta.source_id }}</p>
+        <p class="m-0">Assembled: {{ dp_display.display_snapshot_meta.assembled_at_iso }}</p>
+        <p class="m-0 text-slate-400 font-sans text-[10px] leading-snug">Display metadata only</p>
+        <p class="m-0 text-slate-500 font-sans text-[9px] leading-snug">
+          Assembly timestamp, not market/evidence/readiness time
+        </p>
+      </div>
 
       <div class="grid gap-2 mb-3">
         <div class="rounded-lg border border-emerald-900/35 bg-emerald-950/15 px-3 py-2.5" data-double-play-overall-snapshot-pack="true" data-double-play-overall-display-status="{{ dp_display.overall_status }}">
@@ -734,6 +754,28 @@
             <h3 class="text-xs font-bold text-slate-50 m-0 tracking-tight leading-tight max-w-[18rem] break-words font-sans" data-double-play-market-panel-human-title="true">{{ _hum.title }}</h3>
             <p class="text-[10px] text-slate-500 m-0 leading-snug">{{ _hum.subtitle }}</p>
           </div>
+          <div class="mt-1 flex flex-wrap gap-1.5 text-[10px] text-slate-400">
+            <span
+              class="rounded border border-slate-800/90 bg-black/45 px-1.5 py-0.5 font-mono text-slate-300"
+              data-double-play-market-panel-ordinal="true"
+            >Ordinal: {{ panel.ordinal }}</span>
+            <span
+              class="rounded border border-slate-800/90 bg-black/45 px-1.5 py-0.5 font-mono text-slate-300"
+              data-double-play-market-panel-group="true"
+            >Group: {{ panel.panel_group }}</span>
+            <span
+              class="rounded border border-slate-800/90 bg-black/45 px-1.5 py-0.5 font-mono text-slate-300"
+              data-double-play-market-severity-rank="true"
+            >Severity rank: {{ panel.severity_rank }}</span>
+          </div>
+          {% if loop.first %}
+          <p class="m-0 mt-1.5 text-[9px] text-slate-500 leading-snug font-sans">
+            Severity rank is display ordering metadata, not trading readiness
+          </p>
+          <p class="m-0 text-[9px] text-slate-500 leading-snug font-sans">
+            Panel group is a display category
+          </p>
+          {% endif %}
           <div class="flex items-start justify-between gap-2 mb-2 flex-wrap">
             <span class="rounded-md border border-slate-700/85 bg-black/65 px-2 py-1 text-[11px] font-semibold text-sky-100/95" data-double-play-market-display-status-label="true">{{ _sl.lab }}</span>
             <span class="rounded-md border border-slate-800/85 bg-black/45 px-2 py-1 text-[9px] text-slate-500 font-mono shrink-0">{{ _sl.hint }}</span>

--- a/tests/webui/test_double_play_market_dashboard_v0.py
+++ b/tests/webui/test_double_play_market_dashboard_v0.py
@@ -204,6 +204,61 @@ def test_double_play_market_dashboard_v1_3_field_mapping_rail(client: TestClient
     assert "setinterval" not in lower
 
 
+def test_double_play_market_dashboard_consumes_structured_metadata_v2(client: TestClient) -> None:
+    """Rail surfaces display-layer v2 metadata from SSR dp_display (no new backend keys)."""
+    r = client.get("/market/double-play")
+    assert r.status_code == 200
+    body = r.text
+
+    assert 'data-double-play-market-ui-consumes-v2-metadata="true"' in body
+    assert 'data-double-play-market-display-layer-version="true"' in body
+    assert 'data-double-play-market-display-snapshot-meta="true"' in body
+    assert 'data-double-play-market-panel-ordinal="true"' in body
+    assert 'data-double-play-market-panel-group="true"' in body
+    assert 'data-double-play-market-severity-rank="true"' in body
+
+    assert "Display layer:" in body
+    assert "Source kind:" in body
+    assert "Source id:" in body
+    assert "Assembled:" in body
+    assert "Display metadata only" in body
+    assert "Assembly timestamp, not market/evidence/readiness time" in body
+    assert "Severity rank is display ordering metadata, not trading readiness" in body
+    assert "Panel group is a display category" in body
+
+    assert "Display layer: v2" in body
+    assert "static_display_v0" in body
+    assert "webui_dashboard_display_static_v0" in body
+
+    assert "Group: input" in body
+    assert "Group: state" in body
+    assert "Group: scope" in body
+    assert "Group: strategy" in body
+    assert "Group: capital" in body
+    assert "Group: composition" in body
+    assert "Severity rank: 0" in body
+    assert "Ordinal: 0" in body
+
+    lower_keys = body.lower()
+    assert "recommended_side" not in lower_keys
+    assert "active_side" not in lower_keys
+    assert "ready_to_trade" not in lower_keys
+
+    assert "fetch(" not in body
+    assert "setinterval" not in body.lower()
+    assert "<form" not in body.lower()
+    assert 'method="post"' not in body.lower()
+    assert "<button" not in body.lower()
+    assert 'type="submit"' not in body.lower()
+
+    forbidden = ("BUY", "SELL", "GO", "APPROVED", "ACTIVE TRADE")
+    for w in forbidden:
+        assert w not in body
+
+    lower = body.lower()
+    assert "live_authorization" not in lower
+
+
 def test_double_play_market_dashboard_bad_timeframe_422(client: TestClient) -> None:
     r = client.get("/market/double-play", params={"timeframe": "bogus"})
     assert r.status_code == 422


### PR DESCRIPTION
## Summary
- renders Double-Play structured display metadata v2 on `/market/double-play`
- shows display layer, display snapshot metadata, source kind/id, assembly timestamp, and panel ordinal/group/severity-rank
- updates the Market Surface docs to describe the UI consumption boundary

## Safety / Authority
- backend unchanged
- no client fetch or polling
- no POST/forms/buttons/action controls
- no order/execution/exchange-handle semantics
- no live/testnet activation
- no readiness/authority claim
- no recommended_side/active_side/buy/sell/go/approved/ready_to_trade semantics
- `panel_group` and `severity_rank` are display-only grouping/ordering metadata

## Validation
- `uv run pytest tests/webui/test_double_play_market_dashboard_v0.py -q` → 5 passed
- `uv run ruff check tests/webui/test_double_play_market_dashboard_v0.py` → OK
- `uv run ruff format --check tests/webui/test_double_play_market_dashboard_v0.py` → OK
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs` → OK
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs` → OK
- `git diff --check` → OK

## Notes
- Ruff is intentionally not run on the Jinja/HTML template because Ruff interprets `.html` as Python and reports invalid syntax.
- PR-readiness reviewed in `/tmp/peak_trade_double_play_market_ui_v2_pr_readiness/CURSOR_ORCHESTRATOR_PR_READINESS.md`.

Made with [Cursor](https://cursor.com)