### PR TITLE
docs(master-v2): clarify Double Play WebUI contract coherence v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md
@@ -34,6 +34,10 @@ This file is **non-authorizing**. It does not:
 
 **Displaying a decision does not authorize it.** **`live_authorization` remains false** in all pure-stack semantics; the dashboard must not override that with UI copy or badges.
 
+### 2.1 Document status vs shipped test/code anchors
+
+Frontmatter **`status: DRAFT`** marks this display map as an **evolving contract lens**. It does **not** deny that the read-only JSON mapper and **`snapshot_to_jsonable`** hooks documented in **§20–§21** already exist. **§21 “Implemented”** refers **only** to **presentation-layer JSON metadata v2** atop **`DoublePlayDashboardDisplaySnapshot`** — **not** Live/Testnet readiness, **not** gate closure, **not** Risk/KillSwitch/execution authority, and **not** runtime producer wiring.
+
 ## 3. Scope
 
 **In scope:**
@@ -127,6 +131,8 @@ Future implementations should use a **versioned display snapshot** (conceptual n
 - includes explicit `live_authorization: false` (or omits any live flag; never `true` from this path)
 - never embeds raw exchange credentials or unfettered OHLCV payloads as mandatory fields for Double Play v0
 
+The **shipping** pure display DTO uses the concrete dataclass **`DoublePlayDashboardDisplaySnapshot`** and builder **`build_dashboard_display_snapshot`** in `src&#47;trading&#47;master_v2&#47;double_play_dashboard_display.py` — same role as this section’s conceptual snapshot, **not** a second authority surface or a parallel DTO family.
+
 Pure modules remain **I/O-free**; snapshot **assembly** for the dashboard belongs **outside** `master_v2` when implemented.
 
 ## 15. Route boundary
@@ -173,9 +179,11 @@ A **no-live banner** (or equivalent persistent disclosure) is **required** on an
 
 **Route-independent JSON serialization (test anchors, non-authority):** `tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py` includes **test anchors** that exercise **`snapshot_to_jsonable`** on a **pure dashboard snapshot** **without** HTTP or `TestClient` — the same **JSON serialization** path the **downstream display surface** uses for JSON bodies. Scenarios include a **full-stack** snapshot, a **blocked survival** / **display-blocked** panel path, and an **empty** default snapshot. Assertions include **JSON-native** values, **`json.dumps`** compatibility, exact top-level and per-panel key surfaces aligned with the WebUI JSON route contract (including **display-layer v2** **`display_layer_version`**, **`display_snapshot_meta`**, **`ordinal`**, **`panel_group`**, **`severity_rank`**), **display-only** semantics (`display_only` true, `no_live_banner_visible` true), **non-authorizing** readiness booleans (`trading_ready`, `testnet_ready`, `live_ready`, and `live_authorization` false at the top level), panel **non-authority** / **non-signal** flags (`live_authorization`, `is_authority`, `is_signal` false), and a recursive forbidden-key scan for order/control/runtime/provider/scanner/exchange/session/credential-like key names, while explicit false **safety** booleans are asserted separately rather than banned by name. These anchors **complement** the WebUI route **test anchors** and **do not replace** [MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_FUTURES_INPUT_PRODUCER_CONTRACT_V0.md) **§20** producer-adapter → **pure stack** → dashboard anchors. Boundary: they prove **JSON serialization** and key-surface **invariants** only — not operational **producer** integration, market-data ingestion, WebUI **HTML** or control UI, Testnet or Live **readiness**, execution permission, or external sign-off treated as permission to trade.
 
+**Forbidden-key frozensets:** the WebUI route test and this module-local test each carry a `_FORBIDDEN_JSON_KEYS` set; the master_v2 variant is a **superset for extra conservatism** in the serialization path (see also [MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md](MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md) **§9**). Neither list is documented here as a standalone denylist contract.
+
 When code exists, future tests may include:
 
-- optional JSON schema layering for **DoublePlayPureStackDisplaySnapshotV0** (partially overlapped by the **route-independent** **JSON serialization** **test anchors** above)
+- optional JSON schema layering for **DoublePlayPureStackDisplaySnapshotV0** (historical conceptual label; concrete type **`DoublePlayDashboardDisplaySnapshot`** — partially overlapped by the **route-independent** **JSON serialization** **test anchors** above)
 - WebUI route tests asserting **no** POST side effects on read-only Double Play endpoints
 - invariant: snapshot JSON never contains `live_authorization: true` for this path
 

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md
@@ -10,7 +10,7 @@ docs_token: "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0"
 
 ## 1. Purpose
 
-This contract defines the **future** boundary for a **read-only** WebUI HTTP route that **displays** the Master V2 / Double Play **Dashboard Display DTO** (`DoublePlayDashboardDisplaySnapshot` from `build_dashboard_display_snapshot`), without granting **control authority**, trading permission, or Live/Testnet enablement.
+This contract defines the **normative read-only** WebUI HTTP route boundary that **displays** the Master V2 / Double Play **Dashboard Display DTO** (`DoublePlayDashboardDisplaySnapshot` from `build_dashboard_display_snapshot`), without granting **control authority**, trading permission, or Live/Testnet enablement. **§9** and **§19** reference **already landed** repo tests and the **display-layer v2** JSON mapper as **anchors**; other sections may still describe forward-looking staging where marked.
 
 It exists to prevent confusion between:
 
@@ -34,12 +34,16 @@ This file is **non-authorizing**. It does not:
 
 **Displaying a snapshot does not authorize it.** Responses must preserve **display-only** semantics: **`live_authorization` remains false**, **`display_only` true**, **`no_live_banner_visible` true**, and **`trading_ready` / `testnet_ready` / `live_ready` false** for the v0 fixture-backed path described here.
 
+### 2.1 Document status vs shipped test/code anchors
+
+Frontmatter **`status: DRAFT`** marks this file as an **evolving contract lens** (wording and boundaries may change in follow-up PRs). It does **not** deny that the read-only route module, `snapshot_to_jsonable`, and the tests named in **§9** already exist in the repository. Where **§19** states **Implemented**, it refers **only** to **structured display metadata v2** in the JSON mapper — **not** Live or Testnet readiness, **not** PRE_LIVE or First-Live closure, **not** substitution for Risk/KillSwitch/execution gates, and **not** operational Master V2 runtime producer wiring.
+
 ## 3. Scope
 
 **In scope (this contract):**
 
 - target application and **attachment pattern** (`create_app()` on the general WebUI)
-- **HTTP shape** for a future v0 route (GET-only, read-only)
+- **HTTP shape** for the v0 route (GET-only, read-only)
 - **DTO source strategy** for v0 (pure fixtures; no runtime producer requirement)
 - **JSON response boundary** and caching guidance
 - **forbidden imports** and operational boundaries
@@ -126,6 +130,8 @@ For the **pure stack** regression story of **`FuturesProducerPacket` → `adapt_
 - **Panel-level flags** — each panel keeps **`live_authorization`**, **`is_authority`**, **`is_signal`** false for the static fixture path.
 - **Forbidden JSON keys** — recursive key scan rejects control / runtime / **provider** / **scanner** / **exchange** / session / credential-like key names in the payload tree (keys that are legitimate DTO safety flags are asserted false separately, not banned by name).
 - **Route-module AST guard** — static parse of `double_play_dashboard_display_json_route_v0.py` forbids imports from scanner / **exchange** / session / **backtest** / network-style roots (e.g. `ccxt`, `requests`, `subprocess`, `src.exchange`) outside the allowed **`trading.master_v2`** surface.
+
+**Forbidden-key frozensets (two anchors, same intent):** `tests&#47;webui&#47;test_double_play_dashboard_display_json_route.py` and `tests&#47;trading&#47;master_v2&#47;test_double_play_dashboard_display.py` each define a `_FORBIDDEN_JSON_KEYS` frozenset used in a recursive payload key scan; the master_v2 test module includes a few **additional** conservative tokens (e.g. `producer`, `action`). Treat these as **module-local regression anchors** for the same **non-authority** goal — not as competing normative lists, not as an exhaustive denylist outside those tests, and **not** as a reason to duplicate a third list in documentation.
 
 ## 10. JSON response boundary
 


### PR DESCRIPTION
## Summary

- Clarifies DRAFT/contract-lens wording versus already-landed Display v2 anchors.
- Clarifies the conceptual snapshot language against the concrete `DoublePlayDashboardDisplaySnapshot` / display builder / JSON route surface.
- Documents the two existing forbidden-key frozensets as context-specific regression anchors without adding a new parallel canonical list.
- Keeps the WebUI route/display-map semantics strictly read-only and non-authorizing.

## Scope

Docs-only:

- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md`
- `docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md`

No changes to:

- `src/**`
- `templates/**`
- `tests/**`
- Master V2 / Double Play runtime
- Scope/Capital
- Risk/KillSwitch
- Execution gates
- Paper/Testnet/Live paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Notes

`DOCS_TRUTH_MAP.md` was not changed because `config/ops/docs_truth_map.yaml` has no rule requiring a Truth-Map companion update for these Double Play spec paths.

Made with [Cursor](https://cursor.com)