### PR TITLE
test(ops): harden observability readmodel contracts v0

### DIFF
--- a/tests/webui/test_market_depth_readmodel_v0.py
+++ b/tests/webui/test_market_depth_readmodel_v0.py
@@ -88,3 +88,101 @@ def test_market_depth_readmodel_module_has_no_runtime_provider_imports() -> None
 
     for token in forbidden_tokens:
         assert token not in source
+
+
+_EXPECTED_TOP_LEVEL_KEYS = frozenset(
+    {
+        "readmodel_id",
+        "symbol",
+        "source",
+        "limit",
+        "generated_at_iso",
+        "runtime_source_status",
+        "stale",
+        "stale_reason",
+        "depth",
+    }
+)
+
+_FORBIDDEN_JSON_KEYS = frozenset(
+    {
+        "live_authorization",
+        "live_ready",
+        "testnet_ready",
+        "trading_ready",
+        "execute",
+        "execution",
+        "order",
+        "orders",
+        "approve",
+        "approved",
+        "promote",
+        "sign_off",
+        "enable_live",
+        "confirm_token",
+    }
+)
+
+
+def _collect_object_keys(obj: object, out: set[str]) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str):
+                out.add(k)
+            _collect_object_keys(v, out)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_object_keys(item, out)
+
+
+def test_market_depth_readmodel_rejects_missing_depth_json(tmp_path: Path) -> None:
+    empty_root = tmp_path / "bundle"
+    empty_root.mkdir()
+    with pytest.raises(MarketDepthReadmodelError, match="missing depth fixture"):
+        build_market_depth_readmodel_v0(bundle_root=empty_root)
+
+
+def test_market_depth_readmodel_rejects_invalid_depth_json(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "depth.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(MarketDepthReadmodelError, match="malformed depth fixture JSON"):
+        build_market_depth_readmodel_v0(bundle_root=root)
+
+
+def test_market_depth_readmodel_stable_top_level_keys_and_no_authority_keys() -> None:
+    payload = to_json_dict(
+        build_market_depth_readmodel_v0(
+            bundle_root=FIXTURE_ROOT / "complete_minimal",
+            generated_at_iso="2026-05-02T16:00:00Z",
+        )
+    )
+    assert set(payload.keys()) == _EXPECTED_TOP_LEVEL_KEYS
+    depth_keys = set(payload["depth"].keys())
+    assert depth_keys == frozenset({"bids", "asks", "levels_returned", "level_limit"})
+    collected: set[str] = set()
+    _collect_object_keys(payload, collected)
+    assert collected.isdisjoint(_FORBIDDEN_JSON_KEYS)
+
+
+def test_market_depth_empty_sides_remain_sorted_and_json_native(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    root.mkdir()
+    fixture = {
+        "symbol": "ETH/EUR",
+        "source": "dummy",
+        "limit": 5,
+        "bids": [],
+        "asks": [],
+    }
+    (root / "depth.json").write_text(json.dumps(fixture), encoding="utf-8")
+    payload = to_json_dict(
+        build_market_depth_readmodel_v0(
+            bundle_root=root,
+            generated_at_iso="2026-05-02T17:00:00Z",
+        )
+    )
+    assert payload["depth"]["bids"] == []
+    assert payload["depth"]["asks"] == []
+    assert payload["depth"]["levels_returned"] == {"bids": 0, "asks": 0}
+    assert json.loads(json.dumps(payload)) == payload

--- a/tests/webui/test_paper_shadow_summary_readmodel_v0.py
+++ b/tests/webui/test_paper_shadow_summary_readmodel_v0.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -158,3 +159,85 @@ def test_prj_smoke_ambiguous_stamp_errors(tmp_path: Path) -> None:
     assert "prj_smoke_stamp_ambiguous" in m.errors
     assert "stamp_unresolved_bundle_partial" in m.warnings
     assert m.manifest_present is False
+
+
+_EXPECTED_SUMMARY_JSON_TOP_KEYS = frozenset(
+    {
+        "schema_version",
+        "generated_at_utc",
+        "source_label",
+        "source_kind",
+        "source_owner",
+        "stale",
+        "stale_reason",
+        "snapshot_time_utc",
+        "warnings",
+        "errors",
+        "workflow_name",
+        "workflow_run_id",
+        "source_commit",
+        "artifact_bundle_id",
+        "artifact_bundle_label",
+        "manifest_present",
+        "index_present",
+        "summary_present",
+        "operator_context_present",
+        "paper_account_present",
+        "paper_fills_present",
+        "paper_evidence_manifest_present",
+        "shadow_session_summary_present",
+        "shadow_evidence_manifest_present",
+        "p4c_present",
+        "p5a_present",
+        "artifact_count",
+        "paper_fill_count",
+    }
+)
+
+_FORBIDDEN_AUTHORITY_KEYS = frozenset(
+    {
+        "live_authorization",
+        "live_ready",
+        "testnet_ready",
+        "trading_ready",
+        "execute",
+        "execution",
+        "order",
+        "orders",
+        "approve",
+        "approved",
+        "promote",
+        "readiness",
+        "sign_off",
+        "enable_live",
+        "confirm_token",
+    }
+)
+
+
+def _collect_keys(obj: object, out: set[str]) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str):
+                out.add(k)
+            _collect_keys(v, out)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_keys(item, out)
+
+
+def test_complete_minimal_json_exact_keys_roundtrip_and_no_authority_keys() -> None:
+    root = _fixture("complete_minimal")
+    m = build_paper_shadow_summary_readmodel_v0(
+        root,
+        generated_at_utc="2026-05-02T00:30:00+00:00",
+        metadata=PaperShadowSummaryMetadataInput(
+            source_label="fixture_prj_smoke_complete_minimal",
+        ),
+    )
+    d = to_json_dict(m)
+    assert set(d.keys()) == _EXPECTED_SUMMARY_JSON_TOP_KEYS
+    keys_flat: set[str] = set()
+    _collect_keys(d, keys_flat)
+    assert keys_flat.isdisjoint(_FORBIDDEN_AUTHORITY_KEYS)
+    assert json.loads(json.dumps(d)) == d


### PR DESCRIPTION
## Summary

- Hardens existing Observability Readmodel contract tests.
- Adds/extends coverage for missing or broken market-depth bundles, stable JSON shapes, recursive authority/execution key hygiene, empty bid/ask handling via `tmp_path`, and Paper/Shadow summary JSON roundtrip/key invariants.
- Keeps the slice tests-only and reuses existing readmodel surfaces.

## Scope

Changed files:

- `tests/webui/test_market_depth_readmodel_v0.py`
- `tests/webui/test_paper_shadow_summary_readmodel_v0.py`

No changes to:

- `src/**`
- `docs/**`
- `templates/**`
- `scripts/**`
- `.github/workflows/**`
- Paper/Test data fixtures
- Runtime, Execution, Risk, KillSwitch, Gates, Live/Testnet, Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run pytest tests/webui/test_market_depth_readmodel_v0.py tests/webui/test_paper_shadow_summary_readmodel_v0.py -q`
- `uv run ruff check tests/webui/test_market_depth_readmodel_v0.py tests/webui/test_paper_shadow_summary_readmodel_v0.py`
- `uv run ruff format --check tests/webui/test_market_depth_readmodel_v0.py tests/webui/test_paper_shadow_summary_readmodel_v0.py`

## Safety

This is a bounded tests-only hardening slice. It does not start runners/daemons, does not touch Paper/Test data, and does not add any new observability/evidence/readiness surface.

Made with [Cursor](https://cursor.com)