### PR TITLE
docs(ops): link recent safe contract anchors v0

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -12,6 +12,12 @@
 
 **[Docs Truth Map](registry/DOCS_TRUTH_MAP.md)** — canonical ops documentation registry and change log (truth-first).
 
+### Recent safe contract anchors (discoverability)
+
+- **PR #3237** — Double Play WebUI **read-only** route contract aligned with the pure-stack **dashboard display map** (docs coherence): [`MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md`](specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md), [`MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md`](specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md). **Display/read-only only**; **no** live authorization; **no** order or execution authority; **no** gate bypass and **no** replacement for Master V2, Double Play execution semantics, Risk, Kill Switch, or execution gates.
+
+- **PR #3238** — Observability **read-model** contract **tests** (`tests/webui/test_market_depth_readmodel_v0.py`, `tests/webui/test_paper_shadow_summary_readmodel_v0.py`): **tests-only** fixture-backed regression/readability anchors; **not** operational readiness, telemetry guarantees, or authorization.
+
 <!-- ops readme status navigation note -->
 - Projektstatus / Navigation: `docs&#47;INDEX.md` ist der zentrale Einstieg für Docs-Navigation.
 - Für kompakten Status-/Lookup-Einstieg nutze `docs&#47;ops&#47;STATUS_MATRIX.md`; für datierten narrativen Kontext nutze `docs&#47;ops&#47;STATUS_OVERVIEW_2026-02-19.md`.

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -73,6 +73,8 @@ Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im 
 
 ## Änderungsnachweis (Slice A)
 
+- 2026-05-02 — `docs&#47;ops&#47;README.md` — Discoverability-Zeilen zu PR **#3237** (Double Play WebUI **read-only** Route-Contract ↔ Pure-Stack **Display-Map**) und PR **#3238** (Observability Readmodel **Contract-Tests**); **display/read-only** bzw. **tests-only**; **keine** Live-/Operational-Freigabe; **kein** Gate-Ersatz und **keine** Abweichung von Master V2 &#47; Risk &#47; Kill-Switch &#47; Execution-Gates.
+
 - 2026-04-30 — `src&#47;execution&#47;paper&#47;futures_accounting.py`: **`FuturesPaperAccountingSnapshotV0`** + `build_futures_paper_accounting_snapshot_v0` (rein/offline, ohne WP1B&#47;Runner&#47;Provider); begleitend `docs&#47;ops&#47;specs&#47;MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md` §7.3, `docs&#47;PEAK_TRADE_V1_KNOWN_LIMITATIONS.md`, `tests&#47;execution&#47;paper&#47;test_futures_accounting_snapshot_dto_v0.py`; **keine** Live-&#47;Testnet-Freigabe; **RUNTIME_NOT_WIRED**.
 
 - 2026-04-29 — `src&#47;execution&#47;paper&#47;futures_accounting.py` (Pure-Model v0) mit begleitenden Verweisen in `docs&#47;GOVERNANCE_AND_SAFETY_OVERVIEW.md` und `docs&#47;PEAK_TRADE_V1_KNOWN_LIMITATIONS.md` — offline/deterministisch, ohne Runner/Exchange; **keine** Live-/Testnet-Freigabe, **kein** Futures-Class-A-Abschluss; erfüllt **governance-overview-canonical** / **known-limitations-canonical** Kaskade.


### PR DESCRIPTION
## Summary

- Adds a small `docs/ops/README.md` discoverability note for recent safe contract anchors:
  - PR #3237: Double Play WebUI readonly/display-map contract coherence.
  - PR #3238: Observability Readmodel contract-test hardening.
- Adds a corresponding `DOCS_TRUTH_MAP.md` changelog row.
- Leaves `config/ops/docs_truth_map.yaml` unchanged because no new rule is required.

## Scope

Docs-only:

- `docs/ops/README.md`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`

No changes to:

- `src/**`
- `tests/**`
- `templates/**`
- `scripts/**`
- `.github/workflows/**`
- Runtime / Execution / Risk / KillSwitch / Gates
- Paper/Testnet/Live paths
- Evidence/Readiness/Report/Registry/Handoff surfaces beyond the existing Truth Map changelog row

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a discoverability-only docs update. It does not introduce a new canonical surface and does not claim WebUI/readmodels provide authority, readiness, gate approval, or operational promotion.

Made with [Cursor](https://cursor.com)