### PR TITLE
docs(ops): clarify wave26 ci hygiene anchors v0

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -42,6 +42,7 @@
 - [ops/runbooks/futures/FUTURES_TRADING_READINESS_RUNBOOK_V0.md](ops/runbooks/futures/FUTURES_TRADING_READINESS_RUNBOOK_V0.md) — Futures-/Perp-**Readiness** (Stufenplan, docs-only, non-authority)
 - [ops/](ops/) — Ops-Docs, Merge-Logs
 - [runbooks/](runbooks/) — Runbooks (docs&#47;runbooks&#47;; Ops-Runbooks siehe ops&#47;RUNBOOK_INDEX.md)
+- **Ops-Runbook-Baum:** die meisten operativen Runbooks liegen unter `docs&#47;ops&#47;runbooks&#47;` (Einstieg weiter über [ops/RUNBOOK_INDEX.md](ops/RUNBOOK_INDEX.md)).
 
 <!-- docs INDEX status navigation note -->
 - `docs&#47;ops&#47;STATUS_MATRIX.md` — kompakte Status-Matrix und schneller Navigations-/Lookup-Einstieg.

--- a/docs/ops/GATES_OVERVIEW.md
+++ b/docs/ops/GATES_OVERVIEW.md
@@ -67,6 +67,8 @@ Die wichtigsten PR-relevanten Checks (inkl. required contexts config) sind in `c
 
 **Branch Protection:** Die Config ist an die GitHub Branch-Protection ausgerichtet (9 required contexts). Siehe `config&#47;ci&#47;required_status_checks.json` und `gh api repos/<owner>/<repo>/branches/main/protection` für den aktuellen Stand.
 
+**Lesart:** Branch-Protection-relevante Required-Check-Namen folgen `config&#47;ci&#47;required_status_checks.json` (`required_contexts` minus `ignored_contexts`; Erläuterung in dessen Feld `notes`); einzelne Gate- oder Jobnamen aus Prosa oder dem `CI`-Workflow (z. B. zu „PR Gate“) nicht isoliert dagegen lesen — JSON und GitHub-Schutzliste als Abgleich nutzen.
+
 - **Workflow `CI`** (`.github/workflows/ci.yml`)
   - Job/Check: `ci-required-contexts-contract` (runs always)
   - Job/Check: `tests (3.9)`, `tests (3.10)`, `tests (3.11)` (runs always; step-level skip auf docs-only)


### PR DESCRIPTION
## Summary

- Clarifies `docs/INDEX.md` navigation for the Ops runbook tree under `docs/ops/runbooks/`.
- Adds a conservative Branch Protection/Required Checks reading note to `docs/ops/GATES_OVERVIEW.md`.
- Keeps `config/ci/required_status_checks.json` as the SSOT for branch-protection-relevant required contexts instead of deriving that from prose/job names.

## Scope

Docs-only:

- `docs/INDEX.md`
- `docs/ops/GATES_OVERVIEW.md`

No changes to:

- `.github/workflows/**`
- `config/ci/required_status_checks.json`
- `config/ops/docs_truth_map.yaml`
- `scripts/**`
- `src/**`
- `tests/**`
- Runtime / Execution / Risk / KillSwitch / Gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only hygiene slice. It does not change branch protection, workflows, CI configuration, gates, runtime code, or execution semantics.

Made with [Cursor](https://cursor.com)