### PR TITLE
docs(ops): link runbook workflow policy notes v0

### DIFF
--- a/docs/ops/runbooks/README.md
+++ b/docs/ops/runbooks/README.md
@@ -13,6 +13,17 @@
 
 ---
 
+## Workflow / policy references
+
+Markdown workflow-policy notes live under `docs&#47;ops&#47;workflows&#47;`:
+
+- [WORKFLOW_NOTES_FRONTDOOR.md](../workflows/WORKFLOW_NOTES_FRONTDOOR.md)
+- [PEAK_TRADE_WORKFLOW_NOTES_2025-12-03.md](../workflows/PEAK_TRADE_WORKFLOW_NOTES_2025-12-03.md)
+
+Broader Ops runbook/script orientation stays in [`RUNBOOK_INDEX.md`](../RUNBOOK_INDEX.md).
+
+---
+
 - [RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md](./RUNBOOK_TECH_DEBT_TOP3_ROI_FINISH.md): Tech-Debt Top-3 ROI bis Finish (Cursor Multi-Agent)
 
 


### PR DESCRIPTION
## Summary

- Adds a small Workflow / policy references section to `docs/ops/runbooks/README.md`.
- Links existing workflow-policy notes under `docs/ops/workflows/`.
- Points readers back to `docs/ops/RUNBOOK_INDEX.md` for the broader Ops runbook/script orientation.

## Scope

Docs-only:

- `docs/ops/runbooks/README.md`

No changes to:

- `docs/ops/RUNBOOK_INDEX.md`
- `docs/ops/workflows/**`
- `.github/workflows/**`
- `config/ops/docs_truth_map.yaml`
- `scripts/**`
- `src/**`
- `tests/**`
- Runtime / Execution / Risk / KillSwitch / Gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only navigation update. It does not change workflows, branch protection, CI configuration, runtime code, or gate semantics.

Made with [Cursor](https://cursor.com)