### PR TITLE
docs(backtest): clarify registry api boundary v0

### DIFF
--- a/docs/REGISTRY_BACKTEST_API.md
+++ b/docs/REGISTRY_BACKTEST_API.md
@@ -5,6 +5,12 @@
 
 ---
 
+## Dokumentgrenzen
+
+Die Angabe **„implementiert & getestet“** am Dokumentkopf bezieht sich auf die **vorhandene Registry-/Backtest-API-Oberfläche** und die in diesem Dokument als **lauffähig beschriebenen** Pfade (**Single-Strategy** aus der Registry sowie **Portfolio-Backtests** mit den hier dokumentierten **Capital-Allocation-Modi `equal` und `manual`**, inklusive der beschriebenen Filter/Workflow-Schritte). **Nicht** jede spätere oder in Konfigurationsbeispielen genannte Allocator-Variante ist damit bereits als produktiv gelieferte Semantik zu lesen.
+
+**Offene Erweiterungspunkte:** Allocator-Kennzeichnungen wie **`risk_parity`** und **`sharpe_weighted`** sowie **Dynamic Rebalancing** sind in diesem Dokument im **Portfolio-Workflow** (Schritt **Capital Allocation** unter **„2. Portfolio-Backtest“ → Workflow**) sowie in **„5. Erweiterungspunkte“** ausdrücklich als **TODO** bzw. **Roadmap** geführt — solange dort **`TODO`**-/Stub-Inhalt dokumentiert ist, handelt es sich nicht um einen abgeschlossenen, produktreifen Lieferpfad. Daraus **keine** Live-, Trading-, Strategy-Readiness oder Gate-/Freigabe-Claims ableiten.
+
 ## Überblick
 
 Die **Registry-Backtest-Integration** erweitert die bestehende `BacktestEngine` um zwei neue, konfigurationsbasierte Entry-Points:


### PR DESCRIPTION
## Summary

- Adds a `Dokumentgrenzen` section to `docs/REGISTRY_BACKTEST_API.md`.
- Clarifies that the “implemented & tested” status applies to the existing Registry/Backtest API surface and documented covered paths.
- Marks `risk_parity`, `sharpe_weighted`, and dynamic rebalancing as documented TODO / §5 extension points, not delivered production modes.
- Avoids any live/trading/strategy-readiness interpretation.

## Scope

Docs-only:

- `docs/REGISTRY_BACKTEST_API.md`

No changes to:

- `src/backtest/**`
- `src/strategies/**`
- `.github/workflows/**`
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- `scripts/**`
- `tests/**`
- Runtime / Execution / Risk / KillSwitch / Gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk documentation boundary clarification. It does not change backtest logic, strategy logic, CI, runtime code, or trading authority.

Made with [Cursor](https://cursor.com)