### PR TITLE
docs(dev): align reporting smoke with quarto no-exec policy v0

### DIFF
--- a/docs/dev/REPORTING_SMOKE.md
+++ b/docs/dev/REPORTING_SMOKE.md
@@ -11,8 +11,8 @@ The **Quarto smoke report** is a minimal test report that verifies Quarto render
 
 - **Smoke test**: Quickly verify Quarto installation and basic functionality
 - **CI/CD validation**: Test report generation in GitHub Actions
-- **Self-contained output**: HTML with embedded resources (no external dependencies)
-- **Minimal dependencies**: Only requires Python, NumPy, Pandas, and Matplotlib
+- **Self-contained output**: HTML with embedded resources (no external runtime dependencies beyond Quarto/HTML path)
+- **No-exec in CI**: The workflow enforces **`execute.enabled: false`** and forbids executable ` ```{python}` / ````{r}`-style chunks in guarded `.qmd` files (`scripts/ci/check_quarto_no_exec.sh`). Rendering is Markdown-to-HTML with static fenced code (syntax highlighting), not Python notebook execution.
 
 ## Quick Start
 
@@ -45,16 +45,18 @@ quarto render templates/quarto/smoke.qmd --to html --output-dir reports/quarto
 ### Software
 
 - **Quarto**: >= 1.3.0 (install via homebrew: `brew install quarto`)
-- **Python**: >= 3.10
+- **Python**: >= 3.10 (used by tooling; CI uses 3.11 for the Quarto smoke job)
 - **Git**: For repository context
 
-### Python Packages
+### Python packages (local / manual only)
+
+The smoke template illustrates NumPy/Pandas/Matplotlib in **static** fenced ` ```python ` blocks while **`execute.enabled: false`**. CI does **not** `pip install` NumPy/Pandas/Matplotlib for report execution—it only upgrades `pip` and documents that **no Python runtime deps** are required for the no-exec smoke render.
+
+Optional, if you run a separate **manual** Quarto workflow with execution enabled elsewhere (not the CI smoke path):
 
 ```bash
 pip install numpy pandas matplotlib
 ```
-
-These are typically already installed in the Peak Trade development environment.
 
 ## Output
 
@@ -62,7 +64,7 @@ These are typically already installed in the Peak Trade development environment.
 
 - **Output file**: `reports&#47;quarto&#47;smoke.html`
 - **Format**: Self-contained HTML (all resources embedded)
-- **Size**: ~500KB (includes base64-encoded plots)
+- **Size**: Varies with content; **no-exec CI** renders static examples (no matplotlib output from execution). Larger artifacts only if you deliberately enable execution and produce figures locally—out of scope for the guarded CI smoke posture.
 
 ### CI Artifact
 
@@ -76,10 +78,10 @@ These are typically already installed in the Peak Trade development environment.
 The smoke report includes:
 
 1. **Markdown rendering**: Headers, lists, tables, formatting
-2. **Python code execution**: Simple computations with NumPy/Pandas
-3. **Matplotlib plots**: Bar charts with embedded images
-4. **Environment info**: Python version, platform, timestamp
-5. **Self-contained HTML**: No external resource dependencies
+2. **Python syntax highlighting**: Fenced `` ```python `` blocks illustrate sample code **without CI execution**
+3. **Illustrative “visualization” code**: Presented as non-executable static blocks when `execute.enabled: false`
+4. **Environment-style snippets**: Shown as static code, not evaluated in the no-exec CI path
+5. **Self-contained HTML**: No Jupyter/R/TinyTeX required for this workflow
 
 ## CI/CD Integration
 
@@ -93,14 +95,16 @@ File: `.github/workflows/quarto_smoke.yml`
 - Manual workflow dispatch
 
 **Steps:**
-1. Checkout repository
-2. Set up Python 3.11 with pip cache
-3. Install Python dependencies (numpy, pandas, matplotlib)
-4. Set up Quarto (latest release)
-5. Verify Quarto installation
-6. Render smoke report via `make report-smoke`
-7. Upload HTML artifact (7-day retention)
-8. Validate output file exists
+1. Job info summary
+2. Checkout repository
+3. **Guard**: Quarto no-exec (`bash scripts/ci/check_quarto_no_exec.sh`) — no executable ````{python}` / ````{r}` chunks on guarded paths; expect `execute.enabled: false` where required by the checker
+4. Set up Python 3.11 (pip cache)
+5. Install Python dependencies: **`pip upgrade` only** plus log line `no-exec Quarto smoke: no Python runtime deps required` (**no** NumPy/Pandas/Matplotlib install in CI for this job)
+6. Set up Quarto (release channel)
+7. Verify Quarto installation
+8. Render smoke report via `make report-smoke`
+9. Upload HTML artifact (`quarto-smoke-html`, 7-day retention, `warn` if missing)
+10. Check that `reports&#47;quarto&#47;smoke.html` exists
 
 **Artifact access:**
 1. Navigate to GitHub Actions workflow run
@@ -122,13 +126,16 @@ quarto --version
 
 ### Python packages missing
 
+If **you** are experimenting with execution-enabled Quarto configs **outside** the CI no-exec smoke path:
+
 ```bash
-# Install required packages
 pip install numpy pandas matplotlib
 
 # Or use requirements if available
 pip install -r requirements.txt
 ```
+
+The Quarto smoke **CI job** itself does **not** require these installs.
 
 ### Permission denied on script
 
@@ -140,7 +147,7 @@ chmod +x scripts/dev/report_smoke.sh
 ### CI artifact not found
 
 Check workflow logs for errors:
-1. Verify Quarto setup step succeeded
+1. Verify the no-exec guard and Quarto setup steps succeeded
 2. Check render step output for errors
 3. Confirm `reports&#47;quarto&#47;smoke.html` was created
 4. Review upload-artifact step logs
@@ -155,28 +162,36 @@ make report-smoke
 quarto render templates/quarto/smoke.qmd --to html --output-dir reports/quarto --verbose
 ```
 
+### Guard failures (executable chunks)
+
+Tracked `.qmd` covered by `check_quarto_no_exec.sh` must not use Quarto executable chunk headers like `` ```{python} `` — use fenced `` ```python `` for **static** display only while keeping **`execute.enabled: false`** aligned with CI policy.
+
 ## Extending the Smoke Report
 
-To add more smoke tests:
+To add more smoke-visible content while staying CI-safe:
 
-1. **Edit** `templates/quarto/smoke.qmd`
-2. **Add** new code blocks with `{python}` or `{r}` (if R support added)
-3. **Test locally**: `make report-smoke`
-4. **Commit** changes and verify CI workflow
+1. **Edit** `templates/quarto/smoke.qmd` (this doc does not change templates in the alignment slice)
+2. **Prefer** Markdown and **static** fenced `` ```python `` blocks and `` ```bash `` blocks; **do not** add executable ````{python}` or ````{r}` chunks on guarded paths if the no-exec guard must keep passing
+3. **Keep** `execute.enabled: false` for the no-exec CI workflow unless you intentionally redesign execution policy (separate change, out of scope here)
+4. **Test locally**: `make report-smoke`
+5. **Commit** changes and verify CI workflow
+
+**Future / manual / out of scope for CI smoke:** turning on engines, `{python}` execution, or scientific-stack installs inside the **guarded** smoke path would require workflow and policy changes beyond this documentation slice.
 
 ### Example: Adding a new section
 
-```markdown
+Add headings and prose in Markdown, then a separate **static** fenced Python block (not ````{python}`):
+
+````markdown
 ## New Test Section
 
 Description of what you're testing.
+````
 
-{python}
-# Your test code here
-import some_module
-result = some_module.test_function()
-print(result)
-```
+````python
+# Static sample only (won't execute with execute.enabled: false)
+answer = 42
+````
 
 ## Related Documentation
 
@@ -186,8 +201,10 @@ print(result)
 
 ## Notes
 
-- **No Jupyter required**: Quarto executes Python code directly
+- **No Jupyter required**: The no-exec CI path renders without running Python kernels
+- **Template posture**: YAML `execute.enabled: false`; static code blocks are highlighted, not executed in CI smoke
 - **No R/TinyTeX required**: Using HTML output only (no PDF)
-- **Self-contained**: Single HTML file with all resources embedded
-- **Fast**: Renders in ~5-10 seconds locally, ~30-60 seconds in CI
-- **Graceful degradation**: CI won't fail if artifact upload has issues (uses `warn` mode)
+- **Self-contained**: Single HTML file with embedded tooling output as applicable
+- **Fast**: Typical local render stays in the seconds range; CI includes setup plus render
+- **Graceful degradation**: CI won't fail the upload step outright if artifact is missing (`warn` mode)
+


### PR DESCRIPTION
## Summary

- Aligns `docs/dev/REPORTING_SMOKE.md` with the existing Quarto no-exec CI posture.
- Clarifies that the smoke path is guarded by `scripts/ci/check_quarto_no_exec.sh`.
- Documents that guarded Quarto paths should not contain executable `{python}` / `{r}` chunks and should use `execute.enabled: false`.
- Clarifies that NumPy/Pandas/Matplotlib-style report dependencies are optional/manual outside the CI no-exec smoke path, not CI smoke requirements.

## Scope

Docs-only:

- `docs/dev/REPORTING_SMOKE.md`

No changes to:

- `.github/workflows/quarto_smoke.yml`
- `scripts/ci/check_quarto_no_exec.sh`
- templates
- tests
- `src/**`
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Paper-Test data/artifacts/state
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only alignment. It does not execute Quarto, run tests/benchmarks, install report dependencies, or change workflows/scripts.

Made with [Cursor](https://cursor.com)