### PR TITLE
docs(dev): add tooling docs gates pointer v0

### DIFF
--- a/docs/dev/tooling.md
+++ b/docs/dev/tooling.md
@@ -101,6 +101,23 @@ pre-commit run ruff --all-files
 6. **check-added-large-files** - Prevent large files (>500KB)
 7. **check-merge-conflict** - Detect merge conflict markers
 
+## Documentation gates (Markdown)
+
+Markdown edits can trip multiple documentation validators in CI. For a quick spot-check locally, run:
+
+```bash
+# Token policy (inline-code / illustrative path encoding rules)
+uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
+
+# Reference targets (Markdown link resolution under the docs tree)
+bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
+
+# Drift guard (expected doc companions for certain sensitive edits vs base branch)
+python3 scripts/ops/check_docs_drift_guard.py --base origin/main
+```
+
+For operator guidance—in particular decoding **ILLUSTRATIVE** token-policy failures—see the [Docs Token Policy Gate runbook](../ops/runbooks/RUNBOOK_DOCS_TOKEN_POLICY_GATE_OPERATOR.md).
+
 ## CI Workflow
 
 The lint workflow (`.github/workflows/lint.yml`) runs on:


### PR DESCRIPTION
## Summary

- Adds a short `Documentation gates (Markdown)` section to `docs/dev/tooling.md`.
- Points developers to the three common docs validators:
  - token policy
  - reference targets
  - docs drift guard
- Links the Docs Token Policy Gate operator runbook for deeper troubleshooting.

## Scope

Docs-only:

- `docs/dev/tooling.md`

No changes to:

- `.github/workflows/**`
- `scripts/**`
- `src/**`
- `tests/**`
- `templates/**`
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- Runtime / Execution / Risk / KillSwitch / Gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only developer-tooling pointer. It does not change workflows, scripts, CI configuration, runtime code, or gate semantics.

Made with [Cursor](https://cursor.com)