### PR TITLE
docs(dev): align hook large-file docs with pre-commit config v0

### DIFF
--- a/docs/dev/PRECOMMIT.md
+++ b/docs/dev/PRECOMMIT.md
@@ -23,7 +23,7 @@ pre-commit install
 | `trailing-whitespace` | Entfernt trailing whitespace |
 | `end-of-file-fixer` | Stellt newline am Dateiende sicher |
 | `check-yaml` | Validiert YAML-Syntax |
-| `check-added-large-files` | Warnt bei Dateien >1MB |
+| `check-added-large-files` | Warnt bei Dateien >1024 KB (`--maxkb=1024`; ca. 1 MB) |
 | `check-merge-conflict` | Erkennt ungelöste Merge-Konflikte |
 
 ## Nutzung

--- a/docs/dev/tooling.md
+++ b/docs/dev/tooling.md
@@ -98,7 +98,7 @@ pre-commit run ruff --all-files
 3. **trailing-whitespace** - Remove trailing whitespace
 4. **end-of-file-fixer** - Ensure files end with newline
 5. **check-yaml** - Validate YAML syntax
-6. **check-added-large-files** - Prevent large files (>500KB)
+6. **check-added-large-files** - Warn when staged files exceed **1024 KB** (`args: [--maxkb=1024]` in `.pre-commit-config.yaml`, approx. **1 MB**)
 7. **check-merge-conflict** - Detect merge conflict markers
 
 ## Documentation gates (Markdown)


### PR DESCRIPTION
## Summary

- Aligns developer docs for `check-added-large-files` with `.pre-commit-config.yaml`.
- Updates `docs/dev/tooling.md` from stale `>500KB` wording to `1024 KB` / `--maxkb=1024` / approx. `1 MB`.
- Clarifies the matching row in `docs/dev/PRECOMMIT.md`.

## Scope

Docs-only:

- `docs/dev/tooling.md`
- `docs/dev/PRECOMMIT.md`

No changes to:

- `.pre-commit-config.yaml`
- `.github/workflows/**`
- `scripts/**`
- `src/**`
- `tests/**`
- `templates/**`
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- Runtime / Execution / Risk / KillSwitch / Gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only reconciliation. It does not change pre-commit config, hooks, workflows, scripts, runtime code, or gate semantics.

Made with [Cursor](https://cursor.com)