### PR TITLE
docs(dev): crosslink knowledge docs v0

### DIFF
--- a/docs/dev/knowledge/IMPLEMENTATION_SUMMARY_KNOWLEDGE_DB.md
+++ b/docs/dev/knowledge/IMPLEMENTATION_SUMMARY_KNOWLEDGE_DB.md
@@ -10,6 +10,8 @@
 
 Successfully implemented external knowledge databases and learning data integration for AI-based research and decision-making processes in Peak_Trade.
 
+For the **WebUI Knowledge HTTP API** layer see [Knowledge DB API Implementation Summary](./KNOWLEDGE_API_IMPLEMENTATION_SUMMARY.md); for **manual curl smokes** on those endpoints see [Knowledge DB API Smoke Tests](./KNOWLEDGE_API_SMOKE_TESTS.md).
+
 ---
 
 ## What Was Implemented

--- a/docs/dev/knowledge/KNOWLEDGE_API_IMPLEMENTATION_SUMMARY.md
+++ b/docs/dev/knowledge/KNOWLEDGE_API_IMPLEMENTATION_SUMMARY.md
@@ -10,6 +10,8 @@
 
 Die Knowledge DB API wurde vollständig implementiert und ist in die Peak_Trade WebUI integriert. Alle geforderten Endpoints, Sicherheitsmechanismen und Tests sind vorhanden und funktionieren.
 
+Für **[manuelle API-Smoke-Tests](./KNOWLEDGE_API_SMOKE_TESTS.md)** sowie die **[übergeordnete Knowledge-/Research-Infrastruktur](./IMPLEMENTATION_SUMMARY_KNOWLEDGE_DB.md)** (über die HTTP-Schicht hinaus) siehe die verlinkten Dateien.
+
 ---
 
 ## ✅ Implementierte Features

--- a/docs/dev/knowledge/KNOWLEDGE_API_SMOKE_TESTS.md
+++ b/docs/dev/knowledge/KNOWLEDGE_API_SMOKE_TESTS.md
@@ -2,6 +2,8 @@
 
 Manuelle Smoke Tests für die Knowledge DB WebUI API Endpoints.
 
+Siehe **[Knowledge DB API Implementation Summary](./KNOWLEDGE_API_IMPLEMENTATION_SUMMARY.md)** zur Architektur und zum Flag-Gating. Siehe **[Implementation Summary: Knowledge Databases](./IMPLEMENTATION_SUMMARY_KNOWLEDGE_DB.md)** für den Überblick über den `src/knowledge/`-Stack jenseits der HTTP-Schicht.
+
 ## Prerequisites
 
 Starte die WebUI:


### PR DESCRIPTION
## Summary

- Cross-links the three existing docs under `docs/dev/knowledge/`.
- Adds minimal internal `./…md` navigation between:
  - `KNOWLEDGE_API_SMOKE_TESTS.md`
  - `KNOWLEDGE_API_IMPLEMENTATION_SUMMARY.md`
  - `IMPLEMENTATION_SUMMARY_KNOWLEDGE_DB.md`
- Keeps the package constrained to the existing knowledge-doc cohort.

## Scope

Docs-only:

- `docs/dev/knowledge/KNOWLEDGE_API_SMOKE_TESTS.md`
- `docs/dev/knowledge/KNOWLEDGE_API_IMPLEMENTATION_SUMMARY.md`
- `docs/dev/knowledge/IMPLEMENTATION_SUMMARY_KNOWLEDGE_DB.md`

No changes to:

- files outside `docs/dev/knowledge/*.md`
- new README / index / surface
- `.github/workflows/**`
- `scripts/**`
- `src/**`
- `tests/**`
- `templates/**`
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only package. It does not create a new index/surface, does not alter workflows/scripts/code, and does not change runtime or trading semantics.

Made with [Cursor](https://cursor.com)