### PR TITLE
docs(architecture): align docs dev tree v0

### DIFF
--- a/docs/architecture/REPO_STRUCTURE.md
+++ b/docs/architecture/REPO_STRUCTURE.md
@@ -50,6 +50,12 @@ docs/
 │   └── REPO_STRUCTURE.md        # Diese Datei
 │
 ├── dev/                         # 👨‍💻 Developer Guides
+│   ├── PRECOMMIT.md
+│   ├── REPORTING.md
+│   ├── REPORTING_SMOKE.md
+│   ├── RUNNER_INDEX.md
+│   ├── UV_QUICKSTART.md
+│   ├── tooling.md
 │   └── knowledge/               # Knowledge DB Dokumentation
 │       ├── IMPLEMENTATION_SUMMARY_KNOWLEDGE_DB.md
 │       ├── KNOWLEDGE_API_IMPLEMENTATION_SUMMARY.md


### PR DESCRIPTION
## Summary

- Aligns the `docs/dev/` branch in `docs/architecture/REPO_STRUCTURE.md` with the current file inventory.
- Adds the six existing root Markdown guides under `docs/dev/`.
- Keeps the existing `docs/dev/knowledge/` subtree with the three current Knowledge docs.

## Scope

Docs-only, single file:

- `docs/architecture/REPO_STRUCTURE.md`

No changes to:

- files outside `docs/architecture/REPO_STRUCTURE.md`
- new README / index / surface
- `.github/workflows/**`
- `scripts/**`
- `src/**`
- `tests/**`
- `templates/**`
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only structure update. It does not create new surfaces, modify workflows/scripts/code, or change runtime/trading semantics.

Made with [Cursor](https://cursor.com)