### PR TITLE
test(ops): cover docs token path classification corner v0

### DIFF
--- a/tests/ops/test_validate_docs_token_policy.py
+++ b/tests/ops/test_validate_docs_token_policy.py
@@ -73,6 +73,23 @@ class TestTokenClassification:
         assert validator._classify_token("docs/update-readme") == TokenType.BRANCH_NAME
         assert validator._classify_token("fix/bug-123") == TokenType.BRANCH_NAME
 
+    @pytest.mark.parametrize(
+        "token",
+        (
+            "docs/manual.md",
+            "feat/patch.py",
+            "feature/extra/path",
+        ),
+    )
+    def test_classify_path_with_extension_or_multi_segment_not_branch_name(
+        self,
+        validator: DocsTokenPolicyValidator,
+        token: str,
+    ) -> None:
+        """Repo-like suffixes block BRANCH_NAME; multi-segment paths miss the branch regex."""
+
+        assert validator._classify_token(token) == TokenType.ILLUSTRATIVE
+
     def test_classify_local_path(self, validator):
         """Local paths should be classified as LOCAL_PATH."""
         assert validator._classify_token("./scripts/run.py") == TokenType.LOCAL_PATH


### PR DESCRIPTION
## Summary

- Adds one parametrized classification corner-case test to `TestTokenClassification`.
- Covers path-like tokens that must classify as `ILLUSTRATIVE`, not `BRANCH_NAME`:
  - `docs/manual.md`
  - `feat/patch.py`
  - `feature/extra/path`
- Documents the current contract without changing the validator implementation.

## Scope

Tests-only, single file:

- `tests/ops/test_validate_docs_token_policy.py`

No changes to:

- `scripts/ops/validate_docs_token_policy.py`
- docs
- truth map / docs drift config
- workflows
- scripts
- `src/**`
- templates
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run pytest tests/ops/test_validate_docs_token_policy.py::TestTokenClassification::test_classify_path_with_extension_or_multi_segment_not_branch_name -q` — 3 passed
- `uv run pytest tests/ops/test_validate_docs_token_policy.py -q` — 29 passed
- `uv run ruff check tests/ops/test_validate_docs_token_policy.py`
- `uv run ruff format --check tests/ops/test_validate_docs_token_policy.py`

## Safety

This is a low-risk tests-only contract update. It does not change validator behavior, docs policy workflows, or runtime code.

Made with [Cursor](https://cursor.com)