### PR TITLE
docs(ci): replace readme placeholder v0

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,11 +1,13 @@
-# CI Documentation
+# CI documentation (index)
 
-Status: PLACEHOLDER (reference target)
+This folder provides a **small entry point** for CI-oriented documentation links. It does **not** describe branch protection, merge requirements, or required GitHub checks, and it does **not** change how workflows run.
 
-This file exists to satisfy `docs-reference-targets-gate`.
+- Navigation for operators and contributors lives in the workflow frontdoor linked below.
+- Typical **local Markdown checks** before a docs change are documented under development tooling (documentation gates).
+- **Workflow definitions** themselves live as YAML under `.github/workflows/` at the repository root; treat those files as authoritative for what Actions executes.
 
-## Intended contents (TBD)
-- Overview of CI workflows and required checks
-- Policy guards and reference-target validation
-- Local verification commands and troubleshooting playbooks
-- Conventions for docs-only PRs and safety gates
+**Links**
+
+- [Workflow documentation frontdoor](../WORKFLOW_FRONTDOOR.md)
+- [Development tooling (includes Documentation gates for Markdown)](../dev/tooling.md)
+- [GitHub Actions workflows directory](../../.github/workflows/)


### PR DESCRIPTION
## Summary

- Replaces the placeholder `docs/ci/README.md` with a small CI documentation entry point.
- Links to:
  - `docs/WORKFLOW_FRONTDOOR.md`
  - `docs/dev/tooling.md`
  - `.github/workflows/`
- Clarifies that workflow YAML under `.github/workflows/` remains authoritative for what GitHub Actions executes.
- Avoids branch-protection, merge-requirement, or required-check claims.

## Scope

Docs-only, single file:

- `docs/ci/README.md`

No changes to:

- `.github/workflows/**`
- scripts
- `src/**`
- `tests/**`
- templates
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only placeholder replacement. It does not change workflows, branch protection, CI policy, scripts, or runtime behavior.

Made with [Cursor](https://cursor.com)