### PR TITLE
docs(frontdoor): link ci documentation index v0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@
 - [DEVELOPER_WORKFLOW_GUIDE.md](DEVELOPER_WORKFLOW_GUIDE.md) – Workflows & automation
 - [DEV_SETUP.md](DEV_SETUP.md) – Development environment
 - [DEV_WORKFLOW_SHORTCUTS.md](DEV_WORKFLOW_SHORTCUTS.md) – Productivity tips
+- [ci/README.md](ci/README.md) – CI documentation index (workflow navigation, local Markdown checks, Actions workflows)
 
 **Extending the System:**
 - [BACKTEST_ENGINE.md](BACKTEST_ENGINE.md) – Extension hooks


### PR DESCRIPTION
## Summary

- Adds one link from `docs/README.md` to the new CI documentation index.
- Places the link under `Developer / Maintainer` → `Development Workflow`.
- Leaves `docs/ci/README.md` unchanged.

## Scope

Docs-only, single file:

- `docs/README.md`

No changes to:

- `docs/ci/README.md`
- `.github/workflows/**`
- scripts
- `src/**`
- `tests/**`
- templates
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only frontdoor link. It does not change CI policy, workflow YAML, branch protection, scripts, or runtime behavior.

Made with [Cursor](https://cursor.com)