### PR TITLE
docs(getting-started): link docs frontdoor v0

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,6 +12,8 @@ Dieses Dokument führt dich Schritt für Schritt durch deine erste Stunde mit Pe
 
 **R&D Web-Dashboard (read-only, v0):** Ist-Umfang und Spezifikation in [`PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md`](PHASE_76_R_AND_D_DASHBOARD_V0_DESIGN.md) — keine Job-Trigger aus dem UI.
 
+**Dokumentations-Übersicht:** [Zentrale Übersicht über alle Themenbereiche (Docs-Frontdoor)](README.md)
+
 ---
 
 ## 1. Voraussetzungen


### PR DESCRIPTION
## Summary

- Adds one docs-frontdoor link to `docs/GETTING_STARTED.md`.
- Places the link after the existing Truth Map and R&D dashboard intro links.
- Leaves `docs/README.md` unchanged.
- Avoids CI/tooling command duplication.

## Scope

Docs-only, single file:

- `docs/GETTING_STARTED.md`

No changes to:

- `docs/README.md`
- CI/tooling/validator docs
- `.github/workflows/**`
- scripts
- `src/**`
- `tests/**`
- templates
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only onboarding link. It does not change docs policy, CI/tooling commands, scripts, workflows, or runtime behavior.

Made with [Cursor](https://cursor.com)