### PR TITLE
docs(installation): link docs overview v0

### DIFF
--- a/docs/INSTALLATION_QUICKSTART.md
+++ b/docs/INSTALLATION_QUICKSTART.md
@@ -58,6 +58,7 @@
 
 ### Setup & Configuration
 - [Dev Setup Guide](./DEV_SETUP.md) – Developer-specific setup
+- [Docs overview](./README.md) – topic index for the docs tree
 - [README.md](../README.md) – Project overview + quick start
 - [CLI Cheatsheet](./CLI_CHEATSHEET.md) – Complete CLI reference (18 sections)
 


### PR DESCRIPTION
## Summary

- Adds one docs overview link to `docs/INSTALLATION_QUICKSTART.md`.
- Places the link under `Related` → `Setup & Configuration`.
- Leaves `docs/README.md` and `docs/GETTING_STARTED.md` unchanged.
- Avoids CI/tooling command duplication.

## Scope

Docs-only, single file:

- `docs/INSTALLATION_QUICKSTART.md`

No changes to:

- `docs/README.md`
- `docs/GETTING_STARTED.md`
- CI/tooling/validator docs
- `.github/workflows/**`
- scripts
- `src/**`
- `tests/**`
- templates
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only onboarding link. It does not change docs policy, CI/tooling commands, scripts, workflows, or runtime behavior.

Made with [Cursor](https://cursor.com)