### PR TITLE
test(webui): cover health timestamp iso contract v0

### DIFF
--- a/tests/webui/test_health_endpoint_json_contract.py
+++ b/tests/webui/test_health_endpoint_json_contract.py
@@ -4,6 +4,7 @@ Contract test for GET /health (src.webui.health_endpoint): minimal stable JSON s
 
 from __future__ import annotations
 
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -38,6 +39,7 @@ def test_health_basic_json_contract_stable_keys(health_client: TestClient) -> No
     assert data["status"] == "healthy"
     assert isinstance(data["timestamp"], str)
     assert len(data["timestamp"]) >= 10
+    assert datetime.fromisoformat(data["timestamp"].replace("Z", "+00:00"))
 
 
 def test_health_basic_json_contract_unhealthy_returns_503(health_client: TestClient) -> None:
@@ -53,3 +55,5 @@ def test_health_basic_json_contract_unhealthy_returns_503(health_client: TestCli
     assert isinstance(data, dict)
     assert data["status"] == "unhealthy"
     assert "timestamp" in data
+    assert isinstance(data["timestamp"], str)
+    assert datetime.fromisoformat(data["timestamp"].replace("Z", "+00:00"))


### PR DESCRIPTION
## Summary

- Adds ISO-parseability coverage for the WebUI health endpoint `timestamp`.
- Covers both existing healthy and unhealthy 503 JSON contract tests.
- Uses `datetime.fromisoformat(...replace("Z", "+00:00"))` to preserve compatibility with UTC-style `Z` timestamps.
- Leaves health endpoint implementation unchanged.

## Scope

Tests-only, single file:

- `tests/webui/test_health_endpoint_json_contract.py`

No changes to:

- `src/webui/health_endpoint.py`
- docs
- truth map / docs drift config
- workflows
- scripts
- other tests
- templates
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run pytest tests/webui/test_health_endpoint_json_contract.py -q`
- `uv run ruff check tests/webui/test_health_endpoint_json_contract.py`
- `uv run ruff format --check tests/webui/test_health_endpoint_json_contract.py`

## Safety

This is a low-risk tests-only contract update. It does not change WebUI runtime behavior, endpoint logic, workflows, or trading semantics.

Made with [Cursor](https://cursor.com)