### PR TITLE
test(webui): cover ops ci health timestamps iso contract v0

### DIFF
--- a/tests/webui/test_ops_ci_health_router.py
+++ b/tests/webui/test_ops_ci_health_router.py
@@ -7,6 +7,7 @@ Smoke tests for the CI Health Panel v0.2 (with snapshot persistence).
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -199,6 +200,11 @@ def test_ci_health_status_json(client: TestClient) -> None:
     assert "summary" in data
     assert "checks" in data
     assert "generated_at" in data
+    assert "server_timestamp_utc" in data
+    assert isinstance(data["generated_at"], str)
+    assert isinstance(data["server_timestamp_utc"], str)
+    assert datetime.fromisoformat(data["generated_at"].replace("Z", "+00:00"))
+    assert datetime.fromisoformat(data["server_timestamp_utc"].replace("Z", "+00:00"))
 
     # Validate summary
     summary = data["summary"]
@@ -637,6 +643,10 @@ def test_ci_health_run_endpoint_returns_200(client: TestClient) -> None:
     assert "checks" in data
     assert "generated_at" in data
     assert "server_timestamp_utc" in data
+    assert isinstance(data["generated_at"], str)
+    assert isinstance(data["server_timestamp_utc"], str)
+    assert datetime.fromisoformat(data["generated_at"].replace("Z", "+00:00"))
+    assert datetime.fromisoformat(data["server_timestamp_utc"].replace("Z", "+00:00"))
     assert "git_head_sha" in data
     assert "app_version" in data
 


### PR DESCRIPTION
## Summary

- Adds ISO-parseability coverage for Ops CI health JSON timestamps.
- Covers `generated_at` and `server_timestamp_utc` in:
  - `test_ci_health_status_json`
  - `test_ci_health_run_endpoint_returns_200`
- Uses `datetime.fromisoformat(...replace("Z", "+00:00"))`.
- Leaves `src/webui/ops_ci_health_router.py` unchanged.

## Scope

Tests-only, single file:

- `tests/webui/test_ops_ci_health_router.py`

No changes to:

- `src/webui/ops_ci_health_router.py`
- docs
- truth map / docs drift config
- workflows
- scripts
- other tests
- templates
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run pytest tests/webui/test_ops_ci_health_router.py -q` — 28 passed
- `uv run ruff check tests/webui/test_ops_ci_health_router.py`
- `uv run ruff format --check tests/webui/test_ops_ci_health_router.py`

## Safety

This is a low-risk tests-only contract update. It does not change WebUI runtime behavior, endpoint logic, workflows, or trading semantics.

Made with [Cursor](https://cursor.com)