### PR TITLE
docs(architecture): link docs overview v0

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,7 @@ Fokus:
 - Einfache Erweiterbarkeit: neue Strategien, neue Sizing-Methoden, neue Risk-Module
 - Konfiguration über eine zentrale **`config.toml`**
 - Vollständiges Experiment-Tracking aller Runs
+- [Docs-Übersicht](./README.md) — zentraler Einstieg in die Dokumentation unter `docs/`
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds one docs overview link to `docs/ARCHITECTURE.md`.
- Places the link in the early focus list as an architecture-reader entry point to the docs tree.
- Leaves `docs/README.md` unchanged.
- Avoids CI/tooling command duplication.

## Scope

Docs-only, single file:

- `docs/ARCHITECTURE.md`

No changes to:

- `docs/README.md`
- CI/tooling/validator docs
- `.github/workflows/**`
- scripts
- `src/**`
- `tests/**`
- templates
- `config/ops/docs_truth_map.yaml`
- `docs/ops/registry/DOCS_TRUTH_MAP.md`
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `uv run python scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`

## Safety

This is a low-risk docs-only architecture navigation link. It does not change docs policy, CI/tooling commands, scripts, workflows, or runtime behavior.

Made with [Cursor](https://cursor.com)