### PR TITLE
test(core): cover metrics summary shape contract v0

### DIFF
--- a/tests/test_metrics_collector_summary_shape_contract_v0.py
+++ b/tests/test_metrics_collector_summary_shape_contract_v0.py
@@ -1,0 +1,31 @@
+"""
+Contract tests for MetricsCollector.get_summary() top-level shape (v0).
+
+Does not validate timestamp parsing (implementation uses isoformat strings).
+"""
+
+from __future__ import annotations
+
+from src.core.metrics import PROMETHEUS_AVAILABLE, MetricsCollector
+
+_NS = "peak_trade_contract_shape_v0"
+_EXPECTED_KEYS = frozenset({"metrics", "namespace", "prometheus_available", "timestamp"})
+
+
+def test_metrics_collector_get_summary_top_level_shape() -> None:
+    collector = MetricsCollector(namespace=_NS)
+    summary = collector.get_summary()
+
+    assert isinstance(summary, dict)
+    assert frozenset(summary.keys()) == _EXPECTED_KEYS
+
+    assert isinstance(summary["namespace"], str)
+    assert summary["namespace"] == _NS
+
+    assert isinstance(summary["prometheus_available"], bool)
+    assert summary["prometheus_available"] is PROMETHEUS_AVAILABLE
+
+    assert isinstance(summary["timestamp"], str)
+    assert len(summary["timestamp"]) > 0
+
+    assert isinstance(summary["metrics"], dict)


### PR DESCRIPTION
## Summary

- Adds a focused contract test for `MetricsCollector.get_summary()`.
- Uses an isolated `MetricsCollector(namespace="peak_trade_contract_shape_v0")`.
- Locks the top-level summary keys:
  - `namespace`
  - `prometheus_available`
  - `timestamp`
  - `metrics`
- Verifies stable types against the current implementation:
  - `namespace`: `str`
  - `prometheus_available`: `bool`, matching `PROMETHEUS_AVAILABLE`
  - `timestamp`: non-empty `str`
  - `metrics`: `dict`

## Scope

Tests-only, single new file:

- `tests/test_metrics_collector_summary_shape_contract_v0.py`

No changes to:

- `src/core/metrics.py`
- docs
- truth map / docs drift config
- workflows
- scripts
- other tests
- templates
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run pytest tests/test_metrics_collector_summary_shape_contract_v0.py -q` — 1 passed
- `uv run ruff check tests/test_metrics_collector_summary_shape_contract_v0.py`
- `uv run ruff format --check tests/test_metrics_collector_summary_shape_contract_v0.py`

## Safety

This is a low-risk tests-only contract update. It does not change metrics behavior, runtime code, workflows, or trading semantics.

Made with [Cursor](https://cursor.com)