### PR TITLE
test(core): cover metric snapshot dict shape contract v0

### DIFF
--- a/tests/test_metric_snapshot_to_dict_shape_contract_v0.py
+++ b/tests/test_metric_snapshot_to_dict_shape_contract_v0.py
@@ -1,0 +1,39 @@
+"""
+Contract tests for MetricSnapshot.to_dict() shape (v0).
+
+Does not cover MetricsCollector.get_summary() (see #3269 contract tests).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.core.metrics import MetricSnapshot
+
+_EXPECTED_KEYS = frozenset({"labels", "name", "timestamp", "value"})
+
+
+def test_metric_snapshot_to_dict_shape_v0() -> None:
+    name = "peak_trade_metric_snapshot_contract_v0"
+    value = 42.5
+    labels = {"env": "test"}
+    ts = datetime(2026, 5, 2, 15, 30, 45, tzinfo=timezone.utc)
+
+    snap = MetricSnapshot(name=name, value=value, labels=labels, timestamp=ts)
+    d = snap.to_dict()
+
+    assert isinstance(d, dict)
+    assert frozenset(d.keys()) == _EXPECTED_KEYS
+
+    assert isinstance(d["name"], str)
+    assert d["name"] == name
+
+    assert d["value"] == value
+
+    assert isinstance(d["labels"], dict)
+    assert d["labels"] == labels
+
+    assert isinstance(d["timestamp"], str)
+    assert len(d["timestamp"]) > 0
+    parsed = datetime.fromisoformat(d["timestamp"])
+    assert parsed == ts


### PR DESCRIPTION
## Summary

- Adds a focused contract test for `MetricSnapshot.to_dict()`.
- Locks the exact output key set:
  - `name`
  - `value`
  - `labels`
  - `timestamp`
- Verifies stable value/type behavior with a fixed `timezone.utc` timestamp.
- Confirms the serialized timestamp is parseable via `datetime.fromisoformat(...)`.
- Does not repeat the `MetricsCollector.get_summary()` contract from #3269.

## Scope

Tests-only, single new file:

- `tests/test_metric_snapshot_to_dict_shape_contract_v0.py`

No changes to:

- `src/core/metrics.py`
- docs
- truth map / docs drift config
- workflows
- scripts
- other tests
- templates
- runtime / execution / risk / KillSwitch / gates
- Live/Testnet/Exchange/Provider paths
- Evidence/Readiness/Report/Registry/Handoff surfaces

## Validation

- `uv run pytest tests/test_metric_snapshot_to_dict_shape_contract_v0.py -q` — 1 passed
- `uv run ruff check tests/test_metric_snapshot_to_dict_shape_contract_v0.py`
- `uv run ruff format --check tests/test_metric_snapshot_to_dict_shape_contract_v0.py`

## Safety

This is a low-risk tests-only contract update. It does not change metrics behavior, runtime code, workflows, or trading semantics.

Made with [Cursor](https://cursor.com)