### PR TITLE
test(core): cover peak config public constants contract v0

### DIFF
--- a/tests/test_peak_config_public_constants_contract_v0.py
+++ b/tests/test_peak_config_public_constants_contract_v0.py
@@ -1,0 +1,28 @@
+"""
+Contract tests for public module-level constants in src.core.peak_config (v0).
+
+Reads only stable public surface: PEAK_TRADE_CONFIG_ENV_VAR, AUTO_LIVE_OVERRIDES_PATH.
+No subprocess, no TOML load, no assertions on underscore-prefixed module internals,
+no assertions on filesystem existence for override paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.core import peak_config as pc
+
+
+def test_peak_trade_config_env_var_public_contract() -> None:
+    assert hasattr(pc, "PEAK_TRADE_CONFIG_ENV_VAR")
+    raw = getattr(pc, "PEAK_TRADE_CONFIG_ENV_VAR")
+    assert isinstance(raw, str)
+    assert raw == "PEAK_TRADE_CONFIG_PATH"
+
+
+def test_auto_live_overrides_path_public_contract() -> None:
+    assert hasattr(pc, "AUTO_LIVE_OVERRIDES_PATH")
+    p = getattr(pc, "AUTO_LIVE_OVERRIDES_PATH")
+    assert isinstance(p, Path)
+    assert p.name == "auto.toml"
+    assert "live_overrides" in p.parts


### PR DESCRIPTION
## Summary
- add a tests-only contract for public constants in `src.core.peak_config`
- cover `PEAK_TRADE_CONFIG_ENV_VAR` and `AUTO_LIVE_OVERRIDES_PATH`
- avoid subprocess execution, TOML loading, private internals, and filesystem-existence assertions

## Safety / Scope
- tests-only
- no changes to `src/core/peak_config.py`
- no Live/Testnet/Execution/Risk/Gate/Futures/Snapshot/Paper data changes
- no Truth Map, Governance canonical docs, workflow YAML, or new evidence/readiness/registry/handoff/report surface changes

## Validation
- `uv run pytest tests/test_peak_config_public_constants_contract_v0.py -q`
- `uv run ruff check tests/test_peak_config_public_constants_contract_v0.py`
- `uv run ruff format --check tests/test_peak_config_public_constants_contract_v0.py`
- `git diff --exit-code origin/main -- src/core/peak_config.py`

Made with [Cursor](https://cursor.com)