### PR TITLE
test(webui): cover app openapi metadata contract v0

### DIFF
--- a/tests/webui/test_app_openapi_metadata_contract_v0.py
+++ b/tests/webui/test_app_openapi_metadata_contract_v0.py
@@ -1,0 +1,19 @@
+"""
+Contract tests for FastAPI/OpenAPI identity metadata returned by create_app() (v0).
+
+Covers stable public strings only; no routes, authority flags, live wiring checks,
+or full OpenAPI/schema dumps.
+"""
+
+from __future__ import annotations
+
+from src.webui.app import create_app
+
+
+def test_create_app_openapi_metadata_contract_v0() -> None:
+    app = create_app()
+    assert app.title == "Peak_Trade Dashboard v1.2"
+    assert app.version == "1.2.0"
+    desc = app.description or ""
+    assert desc.startswith("Read-only Dashboard")
+    assert "Phase 76" in desc


### PR DESCRIPTION
## Summary
- add a tests-only contract for `create_app()` OpenAPI/FastAPI metadata
- cover stable public metadata: title, version, and robust description markers
- avoid full OpenAPI-spec assertions, route assertions, and production-code changes

## Safety / Scope
- tests-only
- no changes to `src/webui/app.py`
- no Live/Testnet/Execution/Risk/Gate/Futures/Snapshot/Paper data changes
- no Truth Map, Governance canonical docs, workflow YAML, or new evidence/readiness/registry/handoff/report surface changes

## Validation
- `uv run pytest tests/webui/test_app_openapi_metadata_contract_v0.py -q`
- `uv run ruff check tests/webui/test_app_openapi_metadata_contract_v0.py`
- `uv run ruff format --check tests/webui/test_app_openapi_metadata_contract_v0.py`
- `git diff --exit-code origin/main -- src/webui/app.py`

Made with [Cursor](https://cursor.com)