### PR TITLE
test(webui): cover health router registration contract v0

### DIFF
--- a/tests/webui/test_health_router_registration_contract_v0.py
+++ b/tests/webui/test_health_router_registration_contract_v0.py
@@ -1,0 +1,18 @@
+"""
+Contract tests for static registration metadata of the Health APIRouter (v0).
+
+No TestClient, no route execution, no response/timestamp assertions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from src.webui.health_endpoint import router
+
+
+def test_health_router_registration_contract_v0() -> None:
+    assert router.prefix == "/health"
+    assert router.tags == ["health"]


### PR DESCRIPTION
## Summary
- add a tests-only static contract for the Health APIRouter registration metadata
- cover `router.prefix == "/health"` and `router.tags == ["health"]`
- avoid TestClient, route execution, response body assertions, and timestamp assertions

## Safety / Scope
- tests-only
- no changes to `src/webui/health_endpoint.py`
- no Live/Testnet/Execution/Risk/Gate/Futures/Snapshot/Paper data changes
- no Truth Map, Governance canonical docs, workflow YAML, or new evidence/readiness/registry/handoff/report surface changes

## Validation
- `uv run pytest tests/webui/test_health_router_registration_contract_v0.py -q`
- `uv run ruff check tests/webui/test_health_router_registration_contract_v0.py`
- `uv run ruff format --check tests/webui/test_health_router_registration_contract_v0.py`
- `git diff --exit-code origin/main -- src/webui/health_endpoint.py`

Made with [Cursor](https://cursor.com)