### PR TITLE
test(webui): cover r and d api router registration contract v0

### DIFF
--- a/tests/webui/test_r_and_d_api_router_registration_contract_v0.py
+++ b/tests/webui/test_r_and_d_api_router_registration_contract_v0.py
@@ -1,0 +1,18 @@
+"""
+Contract tests for static registration metadata of the R&D APIRouter (v0).
+
+No TestClient, no route execution, no batch/comparison/response assertions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from src.webui.r_and_d_api import router
+
+
+def test_r_and_d_api_router_registration_contract_v0() -> None:
+    assert router.prefix == "/api/r_and_d"
+    assert router.tags == ["r_and_d"]


### PR DESCRIPTION
## Summary
- add a tests-only static contract for the R&D APIRouter registration metadata
- cover `router.prefix == "/api/r_and_d"` and `router.tags == ["r_and_d"]`
- avoid TestClient, route execution, response body assertions, and batch/comparison assertions

## Safety / Scope
- tests-only
- no changes to `src/webui/r_and_d_api.py`
- no Live/Testnet/Execution/Risk/Gate/Futures/Snapshot/Paper data changes
- no Truth Map, Governance canonical docs, workflow YAML, or new evidence/readiness/registry/handoff/report surface changes

## Validation
- `uv run pytest tests/webui/test_r_and_d_api_router_registration_contract_v0.py -q`
- `uv run ruff check tests/webui/test_r_and_d_api_router_registration_contract_v0.py`
- `uv run ruff format --check tests/webui/test_r_and_d_api_router_registration_contract_v0.py`
- `git diff --exit-code origin/main -- src/webui/r_and_d_api.py`