### PR TITLE
test(ops): cover cursor ma oneblock stdout contract v0

### DIFF
--- a/tests/ops/test_cursor_ma_oneblock_stdout_contract_v0.py
+++ b/tests/ops/test_cursor_ma_oneblock_stdout_contract_v0.py
@@ -1,0 +1,36 @@
+"""Stdout/scaffold contract for scripts/ops/cursor_ma_oneblock.py (v0).
+
+Does not execute the emitted shell scaffold; asserts stable substrings only.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = ROOT / "scripts" / "ops" / "cursor_ma_oneblock.py"
+
+
+def test_cursor_ma_oneblock_stdout_contract_v0() -> None:
+    payload = "peak-trade-cursor-ma-oneblock-contract-v0"
+    proc = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=str(ROOT),
+        input=payload + "\n",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stderr == ""
+    out = proc.stdout
+    assert 'printf "%s\\n" "CONTEXT: REPO ROOT + CURRENT BRANCH"' in out
+    assert 'printf "%s\\n" "INPUT (USER STATUS)"' in out
+    assert payload in out
+    assert (
+        'printf "%s\\n" "CURSOR MULTI-AGENT ORCHESTRATOR: NEXT ACTIONS (single consolidated block)"'
+        in out
+    )
+    assert "cat <<'MSG'" in out


### PR DESCRIPTION
## Summary
- add a tests-only stdout/scaffold contract for `scripts/ops/cursor_ma_oneblock.py`
- run the script via Python subprocess with a small stdin payload
- assert stable scaffold substrings and payload echo without executing the emitted shell text

## Safety / Scope
- tests-only
- no changes to `scripts/ops/cursor_ma_oneblock.py`
- no Live/Testnet/Execution/Risk/Gate/Futures/Snapshot/Paper data changes
- no Truth Map, Governance canonical docs, workflow YAML, or new evidence/readiness/registry/handoff/report surface changes

## Validation
- `uv run pytest tests/ops/test_cursor_ma_oneblock_stdout_contract_v0.py -q`
- `uv run ruff check tests/ops/test_cursor_ma_oneblock_stdout_contract_v0.py`
- `uv run ruff format --check tests/ops/test_cursor_ma_oneblock_stdout_contract_v0.py`
- `git diff --exit-code origin/main -- scripts/ops/cursor_ma_oneblock.py`

Made with [Cursor](https://cursor.com)