### PR TITLE
test(core): cover strategy config get precedence contract v0

### DIFF
--- a/tests/test_strategy_config_get_merge_precedence_contract_v0.py
+++ b/tests/test_strategy_config_get_merge_precedence_contract_v0.py
@@ -1,0 +1,72 @@
+"""In-memory contract for ``StrategyConfig.get`` / ``to_dict`` (v0).
+
+No ``ConfigRegistry``, TOML, filesystem, subprocess, env, or network.
+
+Prod definition: ``src.core.config_registry.StrategyConfig``.
+"""
+
+from __future__ import annotations
+
+from src.core.config_registry import StrategyConfig
+
+
+def test_strategy_config_get_params_only_contract_v0() -> None:
+    cfg = StrategyConfig(
+        name="s",
+        active=True,
+        params={"alpha": 1},
+        defaults={},
+        metadata=None,
+    )
+    assert cfg.get("alpha") == 1
+    assert cfg.get("alpha", 99) == 1
+
+
+def test_strategy_config_get_defaults_fallback_contract_v0() -> None:
+    cfg = StrategyConfig(
+        name="s",
+        active=False,
+        params={},
+        defaults={"gamma": "x"},
+    )
+    assert cfg.get("gamma") == "x"
+    assert cfg.get("gamma", "fallback") == "x"
+
+
+def test_strategy_config_get_params_precedence_over_defaults_contract_v0() -> None:
+    cfg = StrategyConfig(
+        name="s",
+        active=True,
+        params={"risk": "low"},
+        defaults={"risk": "high"},
+    )
+    assert cfg.get("risk") == "low"
+
+
+def test_strategy_config_get_missing_returns_call_default_contract_v0() -> None:
+    cfg = StrategyConfig(
+        name="s",
+        active=True,
+        params={},
+        defaults={},
+    )
+    assert cfg.get("missing") is None
+    assert cfg.get("missing", sentinel := object()) is sentinel
+
+
+def test_strategy_config_to_dict_merges_defaults_then_params_contract_v0() -> None:
+    defaults = {"a": 1, "b": 2}
+    params = {"b": 3, "c": 4}
+    cfg = StrategyConfig(name="blend", active=True, params=params, defaults=defaults)
+    assert cfg.to_dict() == {"a": 1, "b": 3, "c": 4}
+
+
+def test_strategy_config_to_dict_does_not_mutate_internal_maps_contract_v0() -> None:
+    defaults = {"k": {"inner": 0}}
+    params = {"k": {"inner": 1}}
+    cfg = StrategyConfig(name="m", active=True, params=params, defaults=defaults)
+    before_params = dict(cfg.params)
+    before_defaults = dict(cfg.defaults)
+    _ = cfg.to_dict()
+    assert cfg.params == before_params
+    assert cfg.defaults == before_defaults


### PR DESCRIPTION
## Summary
- add a tests-only contract for `StrategyConfig` in `src/core/config_registry.py`
- cover `get()` precedence across params/defaults and missing-key fallback behavior
- cover `to_dict()` flattened merge behavior without mutating internal dictionaries

## Safety / Scope
- tests-only
- no changes to `src/core/config_registry.py`
- no ConfigRegistry/TOML/file I/O usage
- no Live/Testnet/Execution/Risk/Gate/Futures/Snapshot/Paper data changes
- no Truth Map, Governance canonical docs, workflow YAML, or new evidence/readiness/registry/handoff/report surface changes

## Validation
- `uv run pytest tests/test_strategy_config_get_merge_precedence_contract_v0.py -q`
- `uv run ruff check tests/test_strategy_config_get_merge_precedence_contract_v0.py`
- `uv run ruff format --check tests/test_strategy_config_get_merge_precedence_contract_v0.py`
- `git diff --exit-code origin/main -- src/core/config_registry.py`

Made with [Cursor](https://cursor.com)