### PR TITLE
test(webui): cover knowledge service availability contract v0

### DIFF
--- a/tests/webui/test_knowledge_service_availability_contract_v0.py
+++ b/tests/webui/test_knowledge_service_availability_contract_v0.py
@@ -1,0 +1,32 @@
+"""In-memory contract for Knowledge service availability helpers (v0).
+
+No TestClient, router/HTTP, filesystem, subprocess, env patches, or network.
+
+Prod helpers live in ``src.webui.services.knowledge_service`` unchanged by this slice.
+"""
+
+from __future__ import annotations
+
+from src.webui.services.knowledge_service import is_rag_available, is_vector_db_available
+
+
+def test_is_vector_db_available_returns_bool_contract_v0() -> None:
+    v = is_vector_db_available()
+    assert isinstance(v, bool)
+
+
+def test_is_rag_available_returns_bool_contract_v0() -> None:
+    r = is_rag_available()
+    assert isinstance(r, bool)
+
+
+def test_is_rag_matches_vector_availability_contract_v0() -> None:
+    """Public delegation: RAG availability follows vector DB probe (same process)."""
+    assert is_rag_available() == is_vector_db_available()
+
+
+def test_availability_stable_on_repeated_calls_contract_v0() -> None:
+    v1 = is_vector_db_available()
+    v2 = is_vector_db_available()
+    assert v1 is v2 or v1 == v2
+    assert is_rag_available() == v1 == v2


### PR DESCRIPTION
## Summary
- add a tests-only contract for Knowledge Service availability helpers
- cover boolean return shape, repeated-call consistency, and `is_rag_available()` parity with `is_vector_db_available()`
- avoid TestClient, router/HTTP execution, database access, filesystem access, env monkeypatching, and production-code changes

## Safety / Scope
- tests-only
- no changes to `src/webui/services/knowledge_service.py`
- no Live/Testnet/Execution/Risk/Gate/Futures/Snapshot/Paper data changes
- no Truth Map, Governance canonical docs, workflow YAML, or new evidence/readiness/registry/handoff/report surface changes

## Validation
- `uv run pytest tests/webui/test_knowledge_service_availability_contract_v0.py -q`
- `uv run ruff check tests/webui/test_knowledge_service_availability_contract_v0.py`
- `uv run ruff format --check tests/webui/test_knowledge_service_availability_contract_v0.py`
- `git diff --exit-code origin/main -- src/webui/services/knowledge_service.py`

Made with [Cursor](https://cursor.com)