### PR TITLE
fix(core): isolate to_dict outputs from mutable sources

### DIFF
--- a/src/core/config_registry.py
+++ b/src/core/config_registry.py
@@ -11,6 +11,7 @@ Verwendung:
     )
 """
 
+import copy
 import os
 from pathlib import Path
 from typing import Optional, Dict, Any, List
@@ -74,7 +75,8 @@ class StrategyConfig:
 
     def to_dict(self) -> Dict[str, Any]:
         """Merged Dict aller Parameter."""
-        return {**self.defaults, **self.params}
+        merged = {**self.defaults, **self.params}
+        return copy.deepcopy(merged)
 
 
 class ConfigRegistry:

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -75,7 +75,7 @@ class MetricSnapshot:
         return {
             "name": self.name,
             "value": self.value,
-            "labels": self.labels,
+            "labels": dict(self.labels),
             "timestamp": self.timestamp.isoformat(),
         }
 

--- a/tests/test_metric_snapshot_to_dict_shape_contract_v0.py
+++ b/tests/test_metric_snapshot_to_dict_shape_contract_v0.py
@@ -37,3 +37,17 @@ def test_metric_snapshot_to_dict_shape_v0() -> None:
     assert len(d["timestamp"]) > 0
     parsed = datetime.fromisoformat(d["timestamp"])
     assert parsed == ts
+
+
+def test_metric_snapshot_to_dict_labels_output_isolation_contract_v0() -> None:
+    name = "peak_trade_metric_snapshot_labels_isolation_v0"
+    value = 1.0
+    labels = {"env": "test", "shard": "0"}
+    ts = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    snap = MetricSnapshot(name=name, value=value, labels=labels, timestamp=ts)
+    d = snap.to_dict()
+
+    assert d["labels"] == labels
+    assert d["labels"] is not snap.labels
+    d["labels"]["env"] = "mutated"
+    assert snap.labels["env"] == "test"

--- a/tests/test_strategy_config_get_merge_precedence_contract_v0.py
+++ b/tests/test_strategy_config_get_merge_precedence_contract_v0.py
@@ -70,3 +70,19 @@ def test_strategy_config_to_dict_does_not_mutate_internal_maps_contract_v0() -> 
     _ = cfg.to_dict()
     assert cfg.params == before_params
     assert cfg.defaults == before_defaults
+
+
+def test_strategy_config_to_dict_output_isolation_nested_mutation_contract_v0() -> None:
+    defaults = {"a": {"x": 1}, "shared": [1, 2]}
+    params = {"b": {"y": 2}, "shared": [9]}
+    cfg = StrategyConfig(name="iso", active=True, params=params, defaults=defaults)
+    out = cfg.to_dict()
+
+    out["a"]["x"] = 999
+    out["b"]["y"] = 888
+    out["shared"].append(7)
+
+    assert cfg.defaults["a"]["x"] == 1
+    assert cfg.params["b"]["y"] == 2
+    assert cfg.defaults["shared"] == [1, 2]
+    assert cfg.params["shared"] == [9]


### PR DESCRIPTION
## Summary

- deep-copy `StrategyConfig.to_dict()` merged output so caller mutations cannot affect original config nested structures
- copy `MetricSnapshot.to_dict()["labels"]` so callers cannot mutate `MetricSnapshot.labels`
- add focused output-isolation contract tests for both surfaces

## Validation

- `uv run pytest tests/test_strategy_config_get_merge_precedence_contract_v0.py tests/test_metric_snapshot_to_dict_shape_contract_v0.py`
- `uv run ruff check src/core/config_registry.py src/core/metrics.py tests/test_strategy_config_get_merge_precedence_contract_v0.py tests/test_metric_snapshot_to_dict_shape_contract_v0.py`
- `uv run ruff format --check src/core/config_registry.py src/core/metrics.py tests/test_strategy_config_get_merge_precedence_contract_v0.py tests/test_metric_snapshot_to_dict_shape_contract_v0.py`

## Boundaries

- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2/Double Play runtime changes
- no secrets, provider/API/network, workflow, WebUI, governance, evidence, or readiness surfaces touched

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)