### PR TITLE
test(ops): lock port check result dataclass shape

### DIFF
--- a/tests/ops/test_port_check_result_defaults_contract_v0.py
+++ b/tests/ops/test_port_check_result_defaults_contract_v0.py
@@ -1,4 +1,4 @@
-"""Contract tests for PortCheckResult default field values (v0).
+"""Contract tests for PortCheckResult defaults and stable dataclass shape (v0).
 
 No sockets, subprocess, env toggles, or calls to is_tcp_port_free /
 ensure_tcp_port_free.
@@ -6,11 +6,31 @@ ensure_tcp_port_free.
 
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError, asdict, fields
 
 import pytest
 
 from src.ops.net.ports import PortCheckResult
+
+_EXPECTED_FIELD_NAMES: tuple[str, ...] = ("port", "host", "is_free", "detail")
+
+
+def test_port_check_result_dataclass_field_names_and_order_contract_v0() -> None:
+    assert tuple(f.name for f in fields(PortCheckResult)) == _EXPECTED_FIELD_NAMES
+
+
+def test_port_check_result_asdict_shape_defaults_contract_v0() -> None:
+    r = PortCheckResult(port=49152)
+    d = asdict(r)
+    assert list(d.keys()) == list(_EXPECTED_FIELD_NAMES)
+    assert d == {"port": 49152, "host": "127.0.0.1", "is_free": True, "detail": ""}
+
+
+def test_port_check_result_asdict_shape_explicit_values_contract_v0() -> None:
+    r = PortCheckResult(port=443, host="0.0.0.0", is_free=False, detail="busy")
+    d = asdict(r)
+    assert list(d.keys()) == list(_EXPECTED_FIELD_NAMES)
+    assert d == {"port": 443, "host": "0.0.0.0", "is_free": False, "detail": "busy"}
 
 
 def test_port_check_result_defaults_contract_v0() -> None:


### PR DESCRIPTION
## Summary

- lock `PortCheckResult` dataclass field names and order
- lock `dataclasses.asdict(...)` shape for default values
- lock `dataclasses.asdict(...)` shape for explicit values
- tests-only; no production code changes

## Validation

- `uv run pytest tests/ops/test_port_check_result_defaults_contract_v0.py`
- `uv run ruff check tests/ops/test_port_check_result_defaults_contract_v0.py`
- `uv run ruff format --check tests/ops/test_port_check_result_defaults_contract_v0.py`

## Boundaries

- no sockets or network probes
- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2/Double Play runtime changes
- no secrets, provider/API/network, workflow, WebUI, governance, evidence, or readiness surfaces touched

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)