### PR TITLE
fix(risk-layer): validate traffic light monitor configuration

### DIFF
--- a/src/risk_layer/var_backtest/traffic_light.py
+++ b/src/risk_layer/var_backtest/traffic_light.py
@@ -311,6 +311,10 @@ class TrafficLightMonitor:
 
     def __post_init__(self):
         """Initialize monitoring state."""
+        if self.window <= 0:
+            raise ValueError(f"window must be > 0, got {self.window}")
+        if not 0 < self.alpha < 1:
+            raise ValueError(f"alpha must be in (0, 1), got {self.alpha}")
         self.violations: list[bool] = []
         self.current_zone: Optional[BaselZone] = None
 

--- a/tests/risk_layer/var_backtest/test_traffic_light.py
+++ b/tests/risk_layer/var_backtest/test_traffic_light.py
@@ -98,6 +98,18 @@ def test_traffic_light_recommendation_is_non_empty_and_avoids_live_authority_cla
         assert bad not in lowered
 
 
+@pytest.mark.parametrize("window", [0, -1])
+def test_traffic_light_monitor_rejects_non_positive_window(window: int) -> None:
+    with pytest.raises(ValueError, match="window"):
+        TrafficLightMonitor(alpha=ALPHA_99, window=window)
+
+
+@pytest.mark.parametrize("alpha", [0.0, 1.0, -0.01, 1.01])
+def test_traffic_light_monitor_rejects_invalid_alpha(alpha: float) -> None:
+    with pytest.raises(ValueError, match="alpha"):
+        TrafficLightMonitor(alpha=alpha, window=5)
+
+
 def test_traffic_light_monitor_update_matches_basel_traffic_light() -> None:
     monitor = TrafficLightMonitor(alpha=ALPHA_99, window=5)
     r1 = monitor.update(realized_loss=1.0, var_estimate=0.5)  # violation


### PR DESCRIPTION
## RISK

RISK: HIGH — touches `src/risk_layer/**`.

This PR is intentionally limited to the explicitly approved narrow scope:

- `src/risk_layer/var_backtest/traffic_light.py`
- `tests/risk_layer/var_backtest/test_traffic_light.py`

## Summary

- validate `TrafficLightMonitor.window > 0` during construction
- validate `0 < TrafficLightMonitor.alpha < 1` during construction
- add focused tests for invalid `window` and invalid `alpha`
- preserve existing valid monitor behavior

## Validation

- `uv run pytest tests/risk_layer/var_backtest/test_traffic_light.py -q`
- `uv run ruff check src/risk_layer/var_backtest/traffic_light.py tests/risk_layer/var_backtest/test_traffic_light.py`
- `uv run ruff format --check src/risk_layer/var_backtest/traffic_light.py tests/risk_layer/var_backtest/test_traffic_light.py`

## Boundaries

- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk runtime enforcement/KillSwitch/Master V2/Double Play runtime changes
- no `basel_traffic_light` semantics, exports, wrappers, or live-gating paths changed
- no secrets, provider/API/network, workflow, WebUI, governance, evidence, readiness, or docs surfaces touched

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)