### PR TITLE
fix(experiments): isolate dummy returns RNG state

### DIFF
--- a/src/experiments/dummy_returns_timeline.py
+++ b/src/experiments/dummy_returns_timeline.py
@@ -25,7 +25,7 @@ def create_dummy_returns(n_bars: int = 500, seed: int = 42) -> pd.Series:
     Returns:
         Returns-Serie mit DatetimeIndex (UTC, stündlich ab DUMMY_RETURNS_TIMELINE_START)
     """
-    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
     dates = pd.date_range(DUMMY_RETURNS_TIMELINE_START, periods=n_bars, freq="1h")
-    returns = np.random.normal(0.0005, 0.02, n_bars)
+    returns = rng.normal(0.0005, 0.02, n_bars)
     return pd.Series(returns, index=dates)

--- a/tests/test_dummy_returns_timeline_contract_v0.py
+++ b/tests/test_dummy_returns_timeline_contract_v0.py
@@ -1,0 +1,43 @@
+"""Contract tests for ``create_dummy_returns`` — local RNG, no global mutation (v0).
+
+Offline dummy helper only. No network, subprocess, or live trading paths.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.experiments.dummy_returns_timeline import (
+    DUMMY_RETURNS_TIMELINE_START,
+    create_dummy_returns,
+)
+
+
+def test_create_dummy_returns_same_seed_is_deterministic_contract_v0() -> None:
+    a = create_dummy_returns(120, seed=7)
+    b = create_dummy_returns(120, seed=7)
+    pd.testing.assert_series_equal(a, b)
+
+
+@pytest.mark.parametrize(("seed_a", "seed_b"), [(1, 99), (0, 100)])
+def test_create_dummy_returns_different_seeds_same_index_different_values_contract_v0(
+    seed_a: int,
+    seed_b: int,
+) -> None:
+    a = create_dummy_returns(48, seed=seed_a)
+    b = create_dummy_returns(48, seed=seed_b)
+    pd.testing.assert_index_equal(a.index, b.index)
+    assert a.index[0] == DUMMY_RETURNS_TIMELINE_START
+    assert not np.allclose(a.to_numpy(), b.to_numpy())
+
+
+def test_create_dummy_returns_does_not_mutate_global_numpy_rng_contract_v0() -> None:
+    np.random.seed(100)
+    expected_first = float(np.random.random())
+    expected_second = float(np.random.random())
+    np.random.seed(100)
+    assert float(np.random.random()) == expected_first
+    create_dummy_returns(30, seed=999_001)
+    assert float(np.random.random()) == expected_second


### PR DESCRIPTION
## Summary

- replace global `np.random.seed(...)` usage in `create_dummy_returns(...)`
- use local legacy-compatible `np.random.RandomState(seed)` instead
- preserve deterministic same-seed output while avoiding global NumPy RNG state mutation
- add focused contract tests for determinism, different seeds, and global RNG isolation

## Validation

- `uv run pytest tests/test_dummy_returns_timeline_contract_v0.py tests/test_portfolio_robustness_dummy_path_smoke.py -q`
- `uv run ruff check src/experiments/dummy_returns_timeline.py tests/test_dummy_returns_timeline_contract_v0.py`
- `uv run ruff format --check src/experiments/dummy_returns_timeline.py tests/test_dummy_returns_timeline_contract_v0.py`

## Boundaries

- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2/Double Play runtime changes
- no secrets, provider/API/network, workflow, WebUI, governance, evidence, or readiness surfaces touched
- no broad experiment framework refactor

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)