### PR TITLE
fix(core): reject mismatched regime label indexes

### DIFF
--- a/src/core/regime.py
+++ b/src/core/regime.py
@@ -163,6 +163,11 @@ def label_combined_regime(
     Kombiniert Trend- und Vol-Regime zu einem String-Label pro Zeitstempel.
     Beispiel: TREND_UP_HIGH_VOL, RANGE_LOW_VOL, ...
     """
+    if not trend_labels.index.equals(vol_labels.index):
+        raise ValueError(
+            "trend and volatility label indexes must match "
+            f"(trend len={len(trend_labels.index)}, vol len={len(vol_labels.index)})"
+        )
     trend = trend_labels.astype("string").fillna("UNKNOWN")
     vol = vol_labels.astype("string").fillna("UNKNOWN")
 

--- a/tests/test_core_regime_combined_index_contract_v0.py
+++ b/tests/test_core_regime_combined_index_contract_v0.py
@@ -1,0 +1,45 @@
+"""Contract tests for ``label_combined_regime`` index alignment (v0)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.core.regime import label_combined_regime
+
+
+def test_label_combined_regime_same_index_contract_v0() -> None:
+    idx = pd.date_range("2024-01-01", periods=3, freq="D", tz="UTC")
+    trend = pd.Series(
+        ["TREND_UP", "RANGE", "TREND_DOWN"], index=idx, dtype="object", name="trend_regime"
+    )
+    vol = pd.Series(
+        ["HIGH_VOL", "LOW_VOL", "LOW_VOL"], index=idx, dtype="object", name="vol_regime"
+    )
+
+    out = label_combined_regime(trend, vol)
+
+    assert out.name == "regime"
+    assert str(out.dtype) == "string"
+    pd.testing.assert_index_equal(out.index, idx)
+    assert list(out) == ["TREND_UP_HIGH_VOL", "RANGE_LOW_VOL", "TREND_DOWN_LOW_VOL"]
+
+
+def test_label_combined_regime_rejects_mismatched_index_contract_v0() -> None:
+    idx_a = pd.date_range("2024-01-01", periods=2, freq="D", tz="UTC")
+    idx_b = pd.date_range("2024-01-02", periods=2, freq="D", tz="UTC")
+    trend = pd.Series(["RANGE", "RANGE"], index=idx_a, dtype="object")
+    vol = pd.Series(["LOW_VOL", "LOW_VOL"], index=idx_b, dtype="object")
+
+    with pytest.raises(ValueError, match="trend and volatility label indexes must match"):
+        label_combined_regime(trend, vol)
+
+
+def test_label_combined_regime_rejects_mismatched_length_contract_v0() -> None:
+    idx_a = pd.date_range("2024-01-01", periods=2, freq="D", tz="UTC")
+    idx_b = pd.date_range("2024-01-01", periods=3, freq="D", tz="UTC")
+    trend = pd.Series(["RANGE", "RANGE"], index=idx_a, dtype="object")
+    vol = pd.Series(["LOW_VOL", "LOW_VOL", "LOW_VOL"], index=idx_b, dtype="object")
+
+    with pytest.raises(ValueError, match="trend and volatility label indexes must match"):
+        label_combined_regime(trend, vol)


### PR DESCRIPTION
## Summary

- reject mismatched trend/volatility label indexes in `label_combined_regime(...)`
- prevent silent pandas union alignment when combining regime labels
- add focused contract tests for matching indexes, shifted indexes, and different-length indexes

## Validation

- `uv run pytest tests/test_core_regime_combined_index_contract_v0.py -q`
- `uv run ruff check src/core/regime.py tests/test_core_regime_combined_index_contract_v0.py`
- `uv run ruff format --check src/core/regime.py tests/test_core_regime_combined_index_contract_v0.py`

## Boundaries

- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2/Double Play runtime changes
- no secrets, provider/API/network, workflow, WebUI, governance, evidence, or readiness surfaces touched
- no broader regime/model refactor

## CI

No long CI watch by default; targeted local validation passed.

## Follow-up

This is intended as the last micro-slice in the current chain. After this PR, stop the micro-slice loop and choose a broader operator-selected product/system trigger.

Made with [Cursor](https://cursor.com)