### PR TITLE
refactor(master-v2): hoist double-play dashboard JSON mapper to core

### DIFF
--- a/src/trading/master_v2/double_play_dashboard_display.py
+++ b/src/trading/master_v2/double_play_dashboard_display.py
@@ -10,8 +10,9 @@ See docs/ops/specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 from trading.master_v2.double_play_capital_slot import (
     CapitalSlotRatchetDecision,
@@ -75,6 +76,28 @@ class DoublePlayDashboardDisplaySnapshot:
     live_ready: bool = False
     live_authorization: bool = False
     warnings: Tuple[str, ...] = ()
+
+
+# HTTP / JSON payload schema for read-only dashboard display (structured metadata v2).
+DISPLAY_JSON_LAYER_VERSION = "v2"
+
+_DISPLAY_JSON_PANEL_GROUP: Mapping[str, str] = {
+    "futures_input": "input",
+    "state_transition": "state",
+    "survival_envelope": "scope",
+    "strategy_suitability": "strategy",
+    "capital_slot_ratchet": "capital",
+    "capital_slot_release": "capital",
+    "composition": "composition",
+}
+
+_DISPLAY_JSON_PAYLOAD_SEVERITY: Mapping[DashboardDisplayStatus, int] = {
+    DashboardDisplayStatus.DISPLAY_READY: 0,
+    DashboardDisplayStatus.DISPLAY_WARNING: 10,
+    DashboardDisplayStatus.DISPLAY_MISSING: 20,
+    DashboardDisplayStatus.DISPLAY_BLOCKED: 30,
+    DashboardDisplayStatus.DISPLAY_ERROR: 40,
+}
 
 
 def _panel(
@@ -424,3 +447,50 @@ def build_dashboard_display_snapshot(
         live_authorization=False,
         warnings=warnings,
     )
+
+
+def _assembled_at_iso_utc() -> str:
+    dt = datetime.now(timezone.utc).replace(microsecond=0)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _jsonable_dashboard_panel(panel: DoublePlayDashboardPanel, ordinal: int) -> Dict[str, Any]:
+    st = panel.status
+    status_val = st.value if isinstance(st, Enum) else str(st)
+    panel_group = _DISPLAY_JSON_PANEL_GROUP.get(panel.name, "unknown")
+    return {
+        "name": panel.name,
+        "status": status_val,
+        "summary": panel.summary,
+        "blockers": list(panel.blockers),
+        "missing_inputs": list(panel.missing_inputs),
+        "live_authorization": panel.live_authorization,
+        "is_authority": panel.is_authority,
+        "is_signal": panel.is_signal,
+        "ordinal": ordinal,
+        "panel_group": panel_group,
+        "severity_rank": _DISPLAY_JSON_PAYLOAD_SEVERITY[st],
+    }
+
+
+def snapshot_to_jsonable(snap: DoublePlayDashboardDisplaySnapshot) -> Dict[str, Any]:
+    """Convert display snapshot to JSON-serializable dict (enum values as strings)."""
+    overall = snap.overall_status
+    overall_val = overall.value if isinstance(overall, Enum) else str(overall)
+    return {
+        "display_layer_version": DISPLAY_JSON_LAYER_VERSION,
+        "display_snapshot_meta": {
+            "source_kind": "static_display_v0",
+            "source_id": "webui_dashboard_display_static_v0",
+            "assembled_at_iso": _assembled_at_iso_utc(),
+        },
+        "panels": [_jsonable_dashboard_panel(p, i) for i, p in enumerate(snap.panels)],
+        "overall_status": overall_val,
+        "no_live_banner_visible": snap.no_live_banner_visible,
+        "display_only": snap.display_only,
+        "trading_ready": snap.trading_ready,
+        "testnet_ready": snap.testnet_ready,
+        "live_ready": snap.live_ready,
+        "live_authorization": snap.live_authorization,
+        "warnings": list(snap.warnings),
+    }

--- a/src/webui/double_play_dashboard_display_json_route_v0.py
+++ b/src/webui/double_play_dashboard_display_json_route_v0.py
@@ -10,9 +10,7 @@ See docs/ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from enum import Enum
-from typing import Any, Dict, Mapping
+from typing import Any, Dict
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
@@ -29,10 +27,9 @@ from trading.master_v2.double_play_composition import (
     compose_double_play_decision,
 )
 from trading.master_v2.double_play_dashboard_display import (
-    DashboardDisplayStatus,
     DoublePlayDashboardDisplaySnapshot,
-    DoublePlayDashboardPanel,
     build_dashboard_display_snapshot,
+    snapshot_to_jsonable,
 )
 from trading.master_v2.double_play_futures_input import (
     FuturesCandidateSnapshot,
@@ -78,36 +75,6 @@ router = APIRouter(
     prefix="/api/master-v2/double-play",
     tags=["master-v2", "double-play", "dashboard-display-readonly"],
 )
-
-_DISPLAY_JSON_LAYER_VERSION = "v2"
-
-_DISPLAY_PANEL_GROUP: Mapping[str, str] = {
-    "futures_input": "input",
-    "state_transition": "state",
-    "survival_envelope": "scope",
-    "strategy_suitability": "strategy",
-    "capital_slot_ratchet": "capital",
-    "capital_slot_release": "capital",
-    "composition": "composition",
-}
-
-_DISPLAY_SEVERITY_RANK: Mapping[DashboardDisplayStatus, int] = {
-    DashboardDisplayStatus.DISPLAY_READY: 0,
-    DashboardDisplayStatus.DISPLAY_WARNING: 10,
-    DashboardDisplayStatus.DISPLAY_MISSING: 20,
-    DashboardDisplayStatus.DISPLAY_BLOCKED: 30,
-    DashboardDisplayStatus.DISPLAY_ERROR: 40,
-}
-
-
-def _display_severity_rank(status: DashboardDisplayStatus) -> int:
-    return _DISPLAY_SEVERITY_RANK[status]
-
-
-def _assembled_at_iso_utc() -> str:
-    dt = datetime.now(timezone.utc).replace(microsecond=0)
-    return dt.isoformat().replace("+00:00", "Z")
-
 
 _GOOD_LIMITS = StaticHardLimits(
     max_notional=1.0,
@@ -379,48 +346,6 @@ def _build_static_double_play_dashboard_display_snapshot_v0() -> DoublePlayDashb
         capital_slot_release=rel,
         composition=comp,
     )
-
-
-def _jsonable_panel(panel: DoublePlayDashboardPanel, ordinal: int) -> Dict[str, Any]:
-    st = panel.status
-    status_val = st.value if isinstance(st, Enum) else str(st)
-    panel_group = _DISPLAY_PANEL_GROUP.get(panel.name, "unknown")
-    return {
-        "name": panel.name,
-        "status": status_val,
-        "summary": panel.summary,
-        "blockers": list(panel.blockers),
-        "missing_inputs": list(panel.missing_inputs),
-        "live_authorization": panel.live_authorization,
-        "is_authority": panel.is_authority,
-        "is_signal": panel.is_signal,
-        "ordinal": ordinal,
-        "panel_group": panel_group,
-        "severity_rank": _display_severity_rank(st),
-    }
-
-
-def snapshot_to_jsonable(snap: DoublePlayDashboardDisplaySnapshot) -> Dict[str, Any]:
-    """Convert display snapshot to JSON-serializable dict (enum values as strings)."""
-    overall = snap.overall_status
-    overall_val = overall.value if isinstance(overall, Enum) else str(overall)
-    return {
-        "display_layer_version": _DISPLAY_JSON_LAYER_VERSION,
-        "display_snapshot_meta": {
-            "source_kind": "static_display_v0",
-            "source_id": "webui_dashboard_display_static_v0",
-            "assembled_at_iso": _assembled_at_iso_utc(),
-        },
-        "panels": [_jsonable_panel(p, i) for i, p in enumerate(snap.panels)],
-        "overall_status": overall_val,
-        "no_live_banner_visible": snap.no_live_banner_visible,
-        "display_only": snap.display_only,
-        "trading_ready": snap.trading_ready,
-        "testnet_ready": snap.testnet_ready,
-        "live_ready": snap.live_ready,
-        "live_authorization": snap.live_authorization,
-        "warnings": list(snap.warnings),
-    }
 
 
 def build_static_dashboard_display_dict() -> Dict[str, Any]:

--- a/tests/trading/master_v2/test_double_play_dashboard_display.py
+++ b/tests/trading/master_v2/test_double_play_dashboard_display.py
@@ -8,8 +8,6 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
-import pytest
-
 from trading.master_v2.double_play_capital_slot import (
     CapitalSlotConfig,
     CapitalSlotState,
@@ -25,6 +23,7 @@ from trading.master_v2.double_play_dashboard_display import (
     DOUBLE_PLAY_DASHBOARD_DISPLAY_LAYER_VERSION,
     DashboardDisplayStatus,
     build_dashboard_display_snapshot,
+    snapshot_to_jsonable,
 )
 from trading.master_v2.double_play_futures_input import evaluate_futures_input_snapshot
 from trading.master_v2.double_play_state import ScopeEvent, SideState
@@ -304,7 +303,7 @@ def test_snapshot_invariants_always() -> None:
     assert snap.no_live_banner_visible
 
 
-# --- snapshot_to_jsonable (same mapper as WebUI read-only JSON route; tests avoid HTTP) ---
+# --- snapshot_to_jsonable (canonical mapper in trading.master_v2; aligned with WebUI route) ---
 # Keep key surfaces aligned with tests/webui/test_double_play_dashboard_display_json_route.py
 
 _EXPECTED_JSON_TOP_LEVEL_KEYS = frozenset(
@@ -387,13 +386,6 @@ _FORBIDDEN_JSON_KEYS = frozenset(
 )
 
 
-def _require_snapshot_to_jsonable():
-    pytest.importorskip("fastapi")
-    from src.webui.double_play_dashboard_display_json_route_v0 import snapshot_to_jsonable
-
-    return snapshot_to_jsonable
-
-
 def _collect_object_keys(obj: object, out: set[str]) -> None:
     if isinstance(obj, dict):
         for k, v in obj.items():
@@ -454,7 +446,6 @@ def _assert_serialized_dashboard_authority_invariants(data: dict) -> None:
 
 
 def test_snapshot_to_jsonable_full_stack_matches_route_contract() -> None:
-    snapshot_to_jsonable = _require_snapshot_to_jsonable()
     fi, t2, surv, suit, rat, rel, comp = _full_stack_decisions()
     snap = build_dashboard_display_snapshot(
         futures_input=fi,
@@ -486,7 +477,6 @@ def test_snapshot_to_jsonable_full_stack_matches_route_contract() -> None:
 
 
 def test_snapshot_to_jsonable_blocked_survival_still_matches_contract() -> None:
-    snapshot_to_jsonable = _require_snapshot_to_jsonable()
     fi, t2, _, suit, rat, rel, comp = _full_stack_decisions()
     bad_surv = SurvivalEnvelopeDecision(
         status=SurvivalEnvelopeStatus.BLOCKED,
@@ -510,7 +500,6 @@ def test_snapshot_to_jsonable_blocked_survival_still_matches_contract() -> None:
 
 
 def test_snapshot_to_jsonable_empty_snapshot_still_matches_contract() -> None:
-    snapshot_to_jsonable = _require_snapshot_to_jsonable()
     snap = build_dashboard_display_snapshot()
     data = snapshot_to_jsonable(snap)
     _assert_serialized_dashboard_authority_invariants(data)


### PR DESCRIPTION
## Summary

- hoist the Double Play dashboard display JSON/jsonable mapper into `trading.master_v2`
- keep the WebUI route module delegating to the core mapper
- preserve the existing route import surface for `snapshot_to_jsonable`
- remove FastAPI import gating from route-independent snapshot JSON tests
- preserve payload shape, metadata, enum-string conversion, panel grouping, and severity ranking semantics

## Validation

- `uv run pytest tests/trading/master_v2/test_double_play_dashboard_display.py tests/webui/test_double_play_dashboard_display_json_route.py -q`
- `uv run ruff check src/trading/master_v2/double_play_dashboard_display.py src/webui/double_play_dashboard_display_json_route_v0.py tests/trading/master_v2/test_double_play_dashboard_display.py tests/webui/test_double_play_dashboard_display_json_route.py`
- `uv run ruff format --check src/trading/master_v2/double_play_dashboard_display.py src/webui/double_play_dashboard_display_json_route_v0.py tests/trading/master_v2/test_double_play_dashboard_display.py tests/webui/test_double_play_dashboard_display_json_route.py`

## Boundaries

- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2 authority/Double Play runtime authority changes
- no secrets, provider/API/network, workflow, WebUI server, browser, screenshots, governance, evidence, or readiness surfaces touched
- no new docs/evidence/readiness/governance surfaces created

## CI

No long CI watch by default; targeted local validation passed.

## Known follow-up

Some docs may still describe the mapper as living in the WebUI route module. That was intentionally not changed in this scoped PR and can be handled later as an explicit docs-only follow-up.

Made with [Cursor](https://cursor.com)