### PR TITLE
test(master-v2): cover decision packet snapshot jsonable contract

### DIFF
--- a/tests/trading/master_v2/test_decision_packet_snapshot_jsonable_contract_v1.py
+++ b/tests/trading/master_v2/test_decision_packet_snapshot_jsonable_contract_v1.py
@@ -1,0 +1,68 @@
+"""Contract: Decision-Packet-Snapshot v1 is JSON-round-trippable via Ops `to_jsonable_v1`.
+
+Non-authorizing reproducibility anchor only — no readiness, gate, execution, or signoff claims.
+"""
+
+from __future__ import annotations
+
+import json
+
+from trading.master_v2.decision_packet_fixtures_v1 import sample_decision_packet_snapshot_v1
+from trading.master_v2.decision_packet_replay_v1 import decision_packet_from_snapshot_v1
+from trading.master_v2.decision_packet_snapshot_v1 import (
+    DECISION_PACKET_SNAPSHOT_LAYER_VERSION,
+    validate_decision_packet_snapshot_v1,
+)
+
+from src.ops.common.serialize_v1 import to_jsonable_v1
+
+
+_EXPECTED_SNAPSHOT_TOP_LEVEL_KEYS = frozenset(
+    {
+        "snapshot_layer_version",
+        "layer_version",
+        "correlation_id",
+        "staged",
+        "universe",
+        "doubleplay",
+        "scope_envelope",
+        "risk_cap",
+        "safety",
+    }
+)
+
+
+def _assert_json_native(obj: object, *, depth: int = 0) -> None:
+    if depth > 24:
+        raise AssertionError("json structure too deep for contract bound")
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            assert isinstance(k, str), (type(k), obj)
+            _assert_json_native(v, depth=depth + 1)
+        return
+    if isinstance(obj, list):
+        for x in obj:
+            _assert_json_native(x, depth=depth + 1)
+        return
+    raise AssertionError(f"non-json-native type after serialization: {type(obj)!r}")
+
+
+def test_decision_packet_snapshot_v1_jsonable_round_trip_stable_shape() -> None:
+    snapshot = sample_decision_packet_snapshot_v1()
+    assert snapshot, "fixture must produce a non-empty snapshot dict"
+    assert snapshot["snapshot_layer_version"] == DECISION_PACKET_SNAPSHOT_LAYER_VERSION
+    validate_decision_packet_snapshot_v1(snapshot)
+
+    jsonable = to_jsonable_v1(snapshot)
+    assert jsonable == snapshot
+    _assert_json_native(jsonable)
+
+    wire = json.dumps(jsonable, sort_keys=True)
+    decoded = json.loads(wire)
+    assert decoded == snapshot
+    assert set(decoded.keys()) == _EXPECTED_SNAPSHOT_TOP_LEVEL_KEYS
+
+    validate_decision_packet_snapshot_v1(decoded)
+    assert decision_packet_from_snapshot_v1(snapshot) == decision_packet_from_snapshot_v1(decoded)


### PR DESCRIPTION
## Summary

- add a tests-only Decision Packet Snapshot v1 JSONable round-trip contract
- reuse existing `sample_decision_packet_snapshot_v1()`, validator, and packet-from-snapshot helpers
- verify `to_jsonable_v1(...)` output is stdlib-JSON serializable and stable after `json.dumps` / `json.loads`
- assert fixed top-level keys, JSON-native structure, validation after round-trip, and packet parity

## Validation

- `uv run pytest tests/trading/master_v2/test_decision_packet_snapshot_jsonable_contract_v1.py -q`
- `uv run pytest tests/trading/master_v2/test_scenario_matrix_v1.py -q --maxfail=1`
- `uv run ruff check tests/trading/master_v2/test_decision_packet_snapshot_jsonable_contract_v1.py`
- `uv run ruff format --check tests/trading/master_v2/test_decision_packet_snapshot_jsonable_contract_v1.py`

## Boundaries

- tests-only; no production code changes
- non-authorizing serialization/reproducibility contract only
- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2 authority/Double Play runtime authority changes
- no secrets, provider/API/network, workflow, WebUI server, browser, screenshots, governance, evidence, readiness, or docs surfaces touched
- no new Evidence/Readiness/Governance surfaces created

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)