### PR TITLE
test(master-v2): cover input adapter snapshot suppression contract

### DIFF
--- a/tests/trading/master_v2/test_input_adapter_v1.py
+++ b/tests/trading/master_v2/test_input_adapter_v1.py
@@ -37,6 +37,23 @@ def test_adapt_with_evaluator() -> None:
     assert r.local_flow.packet == r.packet
 
 
+def test_adapt_with_evaluator_with_snapshot_false_omits_local_flow_snapshot() -> None:
+    """Adapter forwards ``with_snapshot=False`` into local flow; no decision snapshot dict is attached.
+
+    Offline contract only — not a readiness/gate/authority claim.
+    """
+    raw = build_master_v2_happy_scenario_raw_input_v1()
+    r = adapt_inputs_to_master_v2_flow_v1(raw, run_evaluator=True, with_snapshot=False)
+    assert r.ok is True
+    assert r.rejection_reason is None
+    assert r.packet is not None
+    assert r.local_flow is not None
+    assert r.local_flow.flow_ok is True
+    assert r.local_flow.snapshot is None
+    assert r.local_flow.rejection_reason is None
+    assert r.local_flow.packet == r.packet
+
+
 def test_optional_layers_minimal_raw() -> None:
     c = get_master_v2_scenario_case_v1(SCENARIO_OPTIONAL_LAYERS_MISSING)
     p = c.packet


### PR DESCRIPTION
## Summary

- add a tests-only contract for `adapt_inputs_to_master_v2_flow_v1(..., run_evaluator=True, with_snapshot=False)`
- verify the adapter uses the local evaluator path while suppressing snapshot output
- assert `local_flow.snapshot is None`, `flow_ok`, no rejection, and packet parity
- no production code changes

## Validation

- `uv run pytest tests/trading/master_v2/test_input_adapter_v1.py tests/trading/master_v2/test_local_evaluator_v1.py -q --maxfail=1`
- `uv run ruff check tests/trading/master_v2/test_input_adapter_v1.py`
- `uv run ruff format --check tests/trading/master_v2/test_input_adapter_v1.py`

## Boundaries

- tests-only; no production code changes
- non-authorizing adapter/evaluator flag-propagation contract only
- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2 authority/Double Play runtime authority changes
- no secrets, provider/API/network, workflow, WebUI server, browser, screenshots, governance, evidence, readiness, or docs surfaces touched
- no new Evidence/Readiness/Governance surfaces created

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)