### PR TITLE
test(r-and-d): lock experiment ordering for equal timestamps

### DIFF
--- a/tests/r_and_d/test_experiments_read_model.py
+++ b/tests/r_and_d/test_experiments_read_model.py
@@ -81,6 +81,24 @@ def test_load_experiments_from_directory_top_level_json_only(tmp_path: Path) -> 
     assert out[0]["_filename"] == "root.json"
 
 
+def test_load_experiments_equal_timestamp_uses_deterministic_filename_order(
+    tmp_path: Path,
+) -> None:
+    """Equal ``experiment.timestamp`` → stable sort preserves sorted-glob filename order."""
+
+    ts = "20240601_120000"
+    first = _minimal_exp(ts, 1.0, 0.1, "a_first.json")
+    second = _minimal_exp(ts, 2.0, 0.2, "b_second.json")
+    # Write lexicographically later file first: result order must still follow sorted(glob).
+    (tmp_path / "b_second.json").write_text(json.dumps(second), encoding="utf-8")
+    (tmp_path / "a_first.json").write_text(json.dumps(first), encoding="utf-8")
+
+    out = load_experiments_from_directory(tmp_path)
+    assert len(out) == 2
+    assert [x["_filename"] for x in out] == ["a_first.json", "b_second.json"]
+    assert out[0]["experiment"]["timestamp"] == ts == out[1]["experiment"]["timestamp"]
+
+
 def test_sort_by_sharpe_desc() -> None:
     a = _minimal_exp("20240101_120000", 1.0, 0.5, "a.json")
     b = _minimal_exp("20240102_120000", 3.0, 0.1, "b.json")


### PR DESCRIPTION
## Summary

- add a tests-only contract for deterministic experiment load order when timestamps tie
- use `tmp_path` with two valid experiment JSON files sharing the same `experiment.timestamp`
- write files in non-lexicographic order and assert returned `_filename` order is lexicographic
- document the effective `sorted(glob)` plus stable timestamp-sort behavior

## Validation

- `uv run pytest tests/r_and_d/test_experiments_read_model.py -q`
- `uv run ruff check tests/r_and_d/test_experiments_read_model.py`
- `uv run ruff format --check tests/r_and_d/test_experiments_read_model.py`

## Boundaries

- tests-only; no production code changes
- offline RnD/read-model determinism contract only
- no live/paper/testnet execution
- no heavy backtests
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2 authority/Double Play runtime authority changes
- no secrets, provider/API/network, workflow, WebUI server, browser, screenshots, governance, evidence, readiness, or docs surfaces touched
- no new Evidence/Readiness/Governance surfaces created

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)