### PR TITLE
test(master-v2): lock input adapter structural rejects

### DIFF
--- a/tests/trading/master_v2/test_input_adapter_v1.py
+++ b/tests/trading/master_v2/test_input_adapter_v1.py
@@ -99,6 +99,31 @@ def test_reject_missing_correlation() -> None:
     assert r.rejection_reason == "INVALID_CORRELATION_ID"
 
 
+def test_reject_raw_input_not_object() -> None:
+    """Offline structural contract: non-mapping JSON root fails closed before evaluator."""
+    r = adapt_inputs_to_master_v2_flow_v1([], run_evaluator=True)  # type: ignore[arg-type]
+    assert r.ok is False
+    assert r.rejection_reason == "RAW_INPUT_NOT_OBJECT"
+    assert r.correlation_id is None
+    assert r.staged is None
+    assert r.packet is None
+    assert r.local_flow is None
+
+
+def test_reject_missing_staged() -> None:
+    """Offline structural contract: ``staged`` is required once ``correlation_id`` is valid."""
+    r = adapt_inputs_to_master_v2_flow_v1(
+        {"correlation_id": "op-contract-missing-staged"},
+        run_evaluator=True,
+    )
+    assert r.ok is False
+    assert r.rejection_reason == "MISSING_STAGED"
+    assert r.correlation_id is None
+    assert r.staged is None
+    assert r.packet is None
+    assert r.local_flow is None
+
+
 def test_reject_null_handoff() -> None:
     raw = build_master_v2_happy_scenario_raw_input_v1()
     raw["universe"] = None  # type: ignore[assignment]


### PR DESCRIPTION
## Summary

- add tests-only coverage for Master V2 input adapter structural fail-closed rejects
- lock `RAW_INPUT_NOT_OBJECT` for non-mapping raw input
- lock `MISSING_STAGED` for mappings without `staged`
- assert malformed inputs do not reach evaluator/local-flow output even with `run_evaluator=True`
- no production code changes

## Validation

- `uv run pytest tests/trading/master_v2/test_input_adapter_v1.py -q --maxfail=1`
- `uv run ruff check tests/trading/master_v2/test_input_adapter_v1.py`
- `uv run ruff format --check tests/trading/master_v2/test_input_adapter_v1.py`

## Boundaries

- tests-only; no production code changes
- non-authorizing adapter fail-closed contract only
- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2 authority/Double Play runtime authority changes
- no secrets, provider/API/network, workflow, WebUI server, browser, screenshots, governance, evidence, readiness, or docs surfaces touched
- no new Evidence/Readiness/Governance surfaces created

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)