### PR TITLE
test(obs): lock prom json parse diagnostics for truncated input

### DIFF
--- a/tests/obs/test_prom_json_safe_parse.py
+++ b/tests/obs/test_prom_json_safe_parse.py
@@ -30,3 +30,13 @@ def test_prom_json_safe_parse_non_json_body_fails_with_diagnostics() -> None:
     assert proc.returncode != 0
     assert "prom_json_parse_error=" in proc.stderr
     assert "not json" in proc.stderr
+
+
+def test_prom_json_safe_parse_truncated_json_fails_with_diagnostics() -> None:
+    body = b'{"status":"success"'
+    proc = _run_parser(body)
+    assert proc.returncode != 0
+    assert proc.stdout.strip() == ""
+    assert "prom_json_parse_error=" in proc.stderr
+    assert "prom_body_first_200_bytes" in proc.stderr
+    assert '{"status":"success"' in proc.stderr


### PR DESCRIPTION
## Summary

- add tests-only coverage for truncated/incomplete Prometheus JSON input
- assert non-zero exit, empty stdout, and stable parse diagnostics
- preserve existing `prom_json_parse_error=` and `prom_body_first_200_bytes` diagnostic format
- no production/script code changes

## Validation

- `uv run pytest tests/obs/test_prom_json_safe_parse.py -q`
- `uv run ruff check tests/obs/test_prom_json_safe_parse.py`
- `uv run ruff format --check tests/obs/test_prom_json_safe_parse.py`

## Boundaries

- tests-only; no production/script code changes
- offline OBS/operator-tooling diagnostics contract only
- no network calls
- no live/paper/testnet execution
- no runtime/state/cache/run artifacts touched
- no Execution/Risk/KillSwitch/Master V2 authority/Double Play runtime authority changes
- no secrets, provider/API, workflow, WebUI server, browser, screenshots, governance, evidence, readiness, or docs surfaces touched
- no new Evidence/Readiness/Governance surfaces created

## CI

No long CI watch by default; targeted local validation passed.

Made with [Cursor](https://cursor.com)