### PR TITLE
test(ops): cover workflow dispatch fail-on-warn contract v0

### DIFF
--- a/tests/ops/test_validate_workflow_dispatch_guards.py
+++ b/tests/ops/test_validate_workflow_dispatch_guards.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from pathlib import Path
 
 from scripts.ops.validate_workflow_dispatch_guards import validate_file
@@ -21,3 +23,40 @@ def test_bad_workflow_has_errors() -> None:
     msgs = " | ".join(f.message for f in findings)
     assert "missing_key" in msgs
     assert "inputs.mode" in msgs or "inputs." in msgs
+
+
+def test_cli_fail_on_warn_inline_workflow_dispatch_list_exits_one(tmp_path: Path) -> None:
+    wf = tmp_path / "inline_dispatch.yml"
+    wf.write_text(
+        "name: synthetic-inline-dispatch\n"
+        "on: [workflow_dispatch]\n"
+        "\n"
+        "jobs:\n"
+        "  t:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: echo ${{ github.event.inputs.only_warn_key }}\n",
+        encoding="utf-8",
+    )
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "ops" / "validate_workflow_dispatch_guards.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--paths",
+            str(wf),
+            "--fail-on-warn",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert proc.returncode == 1
+    assert "WARN" in proc.stdout
+    assert "inline 'on:' Form" in proc.stdout
+    assert "only_warn_key" in proc.stdout
+    assert "ERROR " not in proc.stdout


### PR DESCRIPTION
## Summary

- extend the existing workflow dispatch guard tests with a tmp_path-only CLI contract
- cover inline `on: [workflow_dispatch]` as a WARN-only condition
- assert `--fail-on-warn` exits 1 without entering the ERROR path

## Safety / scope

- tests-only
- no production code changes
- no workflow changes
- no network, live, paper, testnet, runtime, trading, broker, exchange, or schedule paths
- no new evidence/readiness/registry/pointer surfaces
- uses only synthetic tmp_path workflow input

## Local validation

- uv run pytest tests/ops/test_validate_workflow_dispatch_guards.py -q
- uv run ruff check tests/ops/test_validate_workflow_dispatch_guards.py
- uv run ruff format --check tests/ops/test_validate_workflow_dispatch_guards.py
- uv run python scripts/ops/validate_workflow_dispatch_guards.py --paths .github/workflows