### PR TITLE
fix(ops): reject markdown links escaping root

### DIFF
--- a/scripts/ops/check_markdown_links.py
+++ b/scripts/ops/check_markdown_links.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import sys
 from dataclasses import dataclass
@@ -122,9 +121,19 @@ def _read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
 
 
+def _is_resolved_path_under_root(path: Path, root: Path) -> bool:
+    """True if path is the root directory or contained in it (both paths resolved)."""
+    try:
+        path.resolve().relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
 def check_links(root: Path, paths: Sequence[str]) -> List[BrokenLink]:
     broken: List[BrokenLink] = []
 
+    root = root.resolve()
     md_files = sorted({p for p in _iter_markdown_files(root, paths)})
 
     # cache anchors per file
@@ -172,6 +181,16 @@ def check_links(root: Path, paths: Sequence[str]) -> List[BrokenLink]:
 
             # Resolve referenced file
             ref_path = (src_dir / path_part).resolve()
+
+            if not _is_resolved_path_under_root(ref_path, root):
+                broken.append(
+                    BrokenLink(
+                        src_rel,
+                        raw_target,
+                        "target escapes repository root",
+                    )
+                )
+                continue
 
             # Allow links to directories? (rare) -> treat as broken
             if not ref_path.exists():

--- a/tests/ops/test_check_markdown_links_cli_contract_v0.py
+++ b/tests/ops/test_check_markdown_links_cli_contract_v0.py
@@ -42,6 +42,39 @@ def test_cli_exit_0_when_no_broken_internal_links(tmp_path: Path) -> None:
     assert p.stderr == ""
 
 
+def test_cli_exit_1_when_target_escapes_repository_root(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    docs = repo / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside"
+    outside.mkdir(parents=True, exist_ok=True)
+    target = outside / "target.md"
+    target.write_text("# Outside\n\n", encoding="utf-8")
+    (docs / "index.md").write_text(
+        "# Index\n\n[escape](../../outside/target.md)\n",
+        encoding="utf-8",
+    )
+
+    p = _run_cli(repo, "docs/index.md")
+
+    assert p.returncode == 1
+    assert "❌ Markdown link check: BROKEN LINKS FOUND" in p.stdout
+    assert "target escapes repository root" in p.stdout
+    assert re.search(
+        r"^- docs/index\.md: \(\.\./\.\./outside/target\.md\) -> target escapes repository root$",
+        p.stdout,
+        flags=re.MULTILINE,
+    )
+    assert "Total broken links: 1" in p.stdout
+    assert p.stderr == ""
+
+    target.unlink()
+    p2 = _run_cli(repo, "docs/index.md")
+    assert p2.returncode == 1
+    assert "target escapes repository root" in p2.stdout
+    assert p2.stderr == ""
+
+
 def test_cli_exit_1_when_target_file_missing(tmp_path: Path) -> None:
     docs = tmp_path / "docs"
     docs.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- reject Markdown links whose resolved local target escapes the configured `--root`
- report a bounded `target escapes repository root` diagnostic before file-existence checks
- add CLI regression coverage for escaping links whether the outside target exists or not

## Safety / scope

- ops/docs checker only
- no trading, execution, live, paper, testnet, runtime, broker, exchange, or schedule paths
- no real docs modified
- no new evidence/readiness/registry/pointer surfaces

## Local validation

- uv run pytest tests/ops/test_check_markdown_links_cli_contract_v0.py tests/ops/test_markdown_link_checker.py tests/ops/test_check_ops_docs_navigation_cli_contract_v0.py -q
- uv run ruff check scripts/ops/check_markdown_links.py tests/ops/test_check_markdown_links_cli_contract_v0.py
- uv run ruff format --check scripts/ops/check_markdown_links.py tests/ops/test_check_markdown_links_cli_contract_v0.py