### PR TITLE
docs(webui): clarify market depth levels_returned object shape

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -170,7 +170,7 @@ The `depth` object includes:
 
 - `bids`
 - `asks`
-- `levels_returned`
+- `levels_returned` — object shaped as `{ "bids": n, "asks": n }`; counts reflect the bid/ask levels returned by the current offline builder after sorting and `level_limit` truncation.
 - `level_limit`
 
 Each bid/ask level includes:


### PR DESCRIPTION
## Summary
- clarify that Market Depth `depth.levels_returned` is an object with separate `bids` and `asks` counts
- align MARKET_SURFACE_V0.md with the existing offline builder/tests on current main
- preserve planned/not-implemented API status and read-only/no-authority boundaries

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `git diff --check`
- `uv run pytest tests/webui/test_market_depth_readmodel_v0.py -q`

Made with [Cursor](https://cursor.com)