### PR TITLE
test(ops): cover strategy smoke job-level if guard

### DIFF
--- a/tests/ops/test_check_required_ci_contexts_present_cli_contract_v0.py
+++ b/tests/ops/test_check_required_ci_contexts_present_cli_contract_v0.py
@@ -160,6 +160,43 @@ jobs:
     assert "Job-level if detected on 'tests'" in p.stderr
 
 
+def test_fails_when_strategy_smoke_has_job_level_if(tmp_path: Path) -> None:
+    _write_ci(
+        tmp_path,
+        """name: synthetic-ci
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.event.pull_request.number }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - run: echo tests
+
+  strategy-smoke:
+    name: strategy-smoke
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo strategy
+""",
+    )
+    p = _run(tmp_path)
+    assert p.returncode == 1
+    assert "Job-level if detected on 'strategy-smoke'" in p.stderr
+    assert "Concurrency group is PR-isolated" in p.stdout
+    assert "tests job naming + no job-level if: OK" in p.stdout
+
+
 def test_fails_when_matrix_missing_python_311(tmp_path: Path) -> None:
     _write_ci(
         tmp_path,


### PR DESCRIPTION
## Summary

- extend the required CI contexts guard contract tests
- cover `strategy-smoke` with a job-level `if:` under a PR-isolated synthetic workflow
- assert the guard exits 1 with the stable `Job-level if detected on 'strategy-smoke'` diagnostic

## Safety / scope

- tests-only
- no production code changes
- no workflow changes
- no network, live, paper, testnet, runtime, trading, broker, exchange, or schedule paths
- no new evidence/readiness/registry/pointer surfaces
- uses only synthetic tmp_path workflow input

## Local validation

- uv run pytest tests/ops/test_check_required_ci_contexts_present_cli_contract_v0.py -q
- uv run ruff check tests/ops/test_check_required_ci_contexts_present_cli_contract_v0.py
- uv run ruff format --check tests/ops/test_check_required_ci_contexts_present_cli_contract_v0.py