### PR TITLE
fix(ops): reject unknown run helper adoption args

### DIFF
--- a/scripts/ops/check_run_helpers_adoption.sh
+++ b/scripts/ops/check_run_helpers_adoption.sh
@@ -18,7 +18,11 @@ for arg in "$@"; do
       echo "Usage: $0 [--warn-only] [--all-ops]"
       exit 0
       ;;
-    *) ;;
+    *)
+      echo "ERROR: unknown argument: ${arg}" >&2
+      echo "Usage: $0 [--warn-only] [--all-ops]" >&2
+      exit 2
+      ;;
   esac
 done
 

--- a/tests/ops/test_check_run_helpers_adoption_cli_contract_v0.py
+++ b/tests/ops/test_check_run_helpers_adoption_cli_contract_v0.py
@@ -131,3 +131,12 @@ def test_all_ops_fails_when_script_missing_helpers(tmp_path: Path) -> None:
     assert "bad.sh" in p.stdout
     assert "❌ Adoption guard failed." in p.stdout
     assert p.stderr == ""
+
+
+def test_unknown_argument_fails_closed(tmp_path: Path) -> None:
+    script = _install_script(tmp_path)
+    p = _run(script, "--warn-onyl")
+    assert p.returncode == 2
+    assert "unknown argument: --warn-onyl" in p.stderr
+    assert "Usage:" in p.stderr
+    assert p.stdout == ""


### PR DESCRIPTION
## Summary

- make `scripts/ops/check_run_helpers_adoption.sh` fail closed on unknown CLI arguments
- report `ERROR: unknown argument: ...` plus Usage instead of silently ignoring typos
- add CLI contract coverage for misspelled `--warn-onyl`

## Safety / scope

- small ops guard fix + test
- no trading, execution, live, paper, testnet, runtime, broker, exchange, or schedule paths
- no real runtime artifacts touched
- no new evidence/readiness/registry/pointer surfaces

## Local validation

- uv run pytest tests/ops/test_check_run_helpers_adoption_cli_contract_v0.py tests/ops/test_ops_run_helpers_adoption_guard.py -q
- uv run ruff check tests/ops/test_check_run_helpers_adoption_cli_contract_v0.py tests/ops/test_ops_run_helpers_adoption_guard.py
- uv run ruff format --check tests/ops/test_check_run_helpers_adoption_cli_contract_v0.py tests/ops/test_ops_run_helpers_adoption_guard.py
- bash scripts/ops/check_run_helpers_adoption.sh --warn-onyl exits 2 with unknown-argument diagnostic