### PR TITLE
test(ops): cover ops doctor json repo root contract

### DIFF
--- a/tests/ops/test_ops_doctor_cli_contract_v0.py
+++ b/tests/ops/test_ops_doctor_cli_contract_v0.py
@@ -1,0 +1,50 @@
+"""CLI contract tests for scripts/ops/ops_doctor.sh (JSON + --repo-root)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ops" / "ops_doctor.sh"
+
+
+def test_ops_doctor_json_reporoot_stdout_is_pure_json(tmp_path: Path) -> None:
+    repo = tmp_path / "synthetic_repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    repo_resolved = str(repo.resolve())
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "--json",
+            "--repo-root",
+            str(repo),
+            "--check",
+            "repo.git_root",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "Peak_Trade Ops Doctor" not in result.stdout
+    assert "Repository:" not in result.stdout
+
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "ops_inspector"
+    assert payload["mode"] == "doctor"
+
+    checks = payload["checks"]
+    assert isinstance(checks, list)
+    repo_git_root = next(c for c in checks if c["id"] == "repo.git_root")
+    assert repo_git_root["status"] == "ok"
+    assert repo_resolved in repo_git_root["message"] or any(
+        repo_resolved in str(ev) for ev in repo_git_root.get("evidence", [])
+    )


### PR DESCRIPTION
## Summary

- add a focused CLI contract for `scripts/ops/ops_doctor.sh --json --repo-root`
- assert stdout is pure JSON without human banner/header lines
- assert `--repo-root` is forwarded into the JSON doctor payload via the `repo.git_root` check

## Safety / scope

- tests-only
- no production code changes
- no network, live, paper, testnet, runtime, trading, broker, exchange, or schedule paths
- no new evidence/readiness/registry/pointer surfaces
- uses only synthetic tmp_path repo input

## Local validation

- uv run pytest tests/ops/test_ops_doctor_cli_contract_v0.py -q
- uv run ruff check tests/ops/test_ops_doctor_cli_contract_v0.py
- uv run ruff format --check tests/ops/test_ops_doctor_cli_contract_v0.py