### PR TITLE
test(ops): cover docs drift guard git error diagnostic

### DIFF
--- a/tests/ops/test_check_docs_drift_guard.py
+++ b/tests/ops/test_check_docs_drift_guard.py
@@ -73,3 +73,44 @@ def test_script_exists() -> None:
     root = Path(__file__).resolve().parents[2]
     script = root / "scripts" / "ops" / "check_docs_drift_guard.py"
     assert script.is_file()
+
+
+def test_cli_reports_git_diff_failure_for_missing_base_ref(tmp_path: Path) -> None:
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "docs").mkdir()
+    (repo / "src").mkdir()
+    (repo / "docs" / "README.md").write_text("# Probe\n", encoding="utf-8")
+    (repo / "src" / "probe.py").write_text('print("probe")\n', encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "scripts/ops/check_docs_drift_guard.py",
+            "--base",
+            "definitely_missing_base_ref_for_contract_probe",
+            "--repo-root",
+            str(repo),
+            "--config",
+            "config/ops/docs_truth_map.yaml",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "ERR: git diff failed (exit 128)." in result.stderr
+    assert "definitely_missing_base_ref_for_contract_probe...HEAD" in result.stderr
+    assert "Hint: ensure the base ref exists" in result.stderr

--- a/tests/ops/test_check_docs_drift_guard.py
+++ b/tests/ops/test_check_docs_drift_guard.py
@@ -77,6 +77,7 @@ def test_script_exists() -> None:
 
 def test_cli_reports_git_diff_failure_for_missing_base_ref(tmp_path: Path) -> None:
     import subprocess
+import sys
 
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -92,16 +93,14 @@ def test_cli_reports_git_diff_failure_for_missing_base_ref(tmp_path: Path) -> No
 
     result = subprocess.run(
         [
-            "uv",
-            "run",
-            "python",
-            "scripts/ops/check_docs_drift_guard.py",
+            sys.executable,
+            str(Path(__file__).resolve().parents[2] / "scripts" / "ops" / "check_docs_drift_guard.py"),
             "--base",
             "definitely_missing_base_ref_for_contract_probe",
             "--repo-root",
             str(repo),
             "--config",
-            "config/ops/docs_truth_map.yaml",
+            str(Path(__file__).resolve().parents[2] / "config" / "ops" / "docs_truth_map.yaml"),
         ],
         cwd=Path(__file__).resolve().parents[2],
         text=True,

--- a/tests/ops/test_check_docs_drift_guard.py
+++ b/tests/ops/test_check_docs_drift_guard.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
+import sys
 
 from ops.truth import TruthStatus, evaluate_docs_drift
 
@@ -76,9 +78,6 @@ def test_script_exists() -> None:
 
 
 def test_cli_reports_git_diff_failure_for_missing_base_ref(tmp_path: Path) -> None:
-    import subprocess
-import sys
-
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
@@ -94,7 +93,12 @@ import sys
     result = subprocess.run(
         [
             sys.executable,
-            str(Path(__file__).resolve().parents[2] / "scripts" / "ops" / "check_docs_drift_guard.py"),
+            str(
+                Path(__file__).resolve().parents[2]
+                / "scripts"
+                / "ops"
+                / "check_docs_drift_guard.py"
+            ),
             "--base",
             "definitely_missing_base_ref_for_contract_probe",
             "--repo-root",


### PR DESCRIPTION
## Summary

- add a subprocess CLI contract for `scripts/ops/check_docs_drift_guard.py`
- cover missing/invalid `--base` ref behavior against a synthetic tmp_path git repo
- assert exit 2, empty stdout, and stable stderr diagnostics including `ERR: git diff failed` and the base-ref hint

## Safety / scope

- tests-only
- no production code changes
- no real docs modified
- no network, live, paper, testnet, runtime, trading, broker, exchange, or schedule paths
- no new evidence/readiness/registry/pointer surfaces
- uses only a synthetic tmp_path git repo

## Local validation

- uv run pytest tests/ops/test_check_docs_drift_guard.py -q
- uv run ruff check tests/ops/test_check_docs_drift_guard.py
- uv run ruff format --check tests/ops/test_check_docs_drift_guard.py