### PR TITLE
feat(ops): add paper shadow 24-7 preflight status reporter v0

### DIFF
--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Report the current Paper/Shadow 24/7 preflight status.
+
+This reporter is intentionally read-only and non-authorizing. It does not run
+the scheduler, does not start daemons, and does not activate Paper, Shadow,
+Testnet, or Live runtime paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+CONTRACT = "paper_shadow_247_preflight_status_v0"
+CONTRACT_DOC = "docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+SCHEDULER_DOC = "docs/SCHEDULER_DAEMON.md"
+SCHEDULER_CONFIG = "config/scheduler/jobs.toml"
+DRY_RUN_COMMAND = (
+    "python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml "
+    "--dry-run --once --verbose"
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> dict[str, Any]:
+    root = (repo_root or _repo_root()).resolve()
+    contract_path = root / CONTRACT_DOC
+    scheduler_doc_path = root / SCHEDULER_DOC
+    scheduler_config_path = root / SCHEDULER_CONFIG
+
+    contract_text = contract_path.read_text(encoding="utf-8") if contract_path.exists() else ""
+    scheduler_doc_text = (
+        scheduler_doc_path.read_text(encoding="utf-8") if scheduler_doc_path.exists() else ""
+    )
+    scheduler_config_text = (
+        scheduler_config_path.read_text(encoding="utf-8") if scheduler_config_path.exists() else ""
+    )
+
+    required_files = {
+        CONTRACT_DOC: contract_path.exists(),
+        SCHEDULER_DOC: scheduler_doc_path.exists(),
+        SCHEDULER_CONFIG: scheduler_config_path.exists(),
+    }
+
+    blockers = [
+        "canonical_owner_missing",
+        "paper_shadow_job_set_missing",
+        "output_paths_missing",
+        "stop_commands_missing",
+    ]
+
+    return {
+        "contract": CONTRACT,
+        "schema_version": 0,
+        "status": "BLOCKED",
+        "activation_authorized": False,
+        "daemon_activation_authorized": False,
+        "paper_runtime_authorized": False,
+        "shadow_runtime_authorized": False,
+        "testnet_authorized": False,
+        "live_authorized": False,
+        "scheduler_execution_authorized": False,
+        "dry_run_command": DRY_RUN_COMMAND,
+        "dry_run_only": True,
+        "required_files": required_files,
+        "contract_markers": {
+            "contract_doc_exists": required_files[CONTRACT_DOC],
+            "contract_states_blocked": "Current status: **BLOCKED**." in contract_text,
+            "contract_mentions_stop": "STOP" in contract_text
+            and "do not activate Paper/Shadow 24/7" in contract_text,
+            "contract_non_authority": "not trading authority" in contract_text
+            or "Non-authority" in contract_text,
+            "scheduler_doc_links_contract": "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+            in scheduler_doc_text,
+            "scheduler_config_has_direct_247_job": any(
+                token in scheduler_config_text.lower()
+                for token in ("paper_shadow_247", "paper-shadow-247", "24/7")
+            ),
+        },
+        "canonical_owner": None,
+        "paper_jobs": [],
+        "shadow_jobs": [],
+        "commands": [],
+        "output_paths": [],
+        "state_files": [],
+        "log_paths": [],
+        "stop_command": None,
+        "emergency_stop_command": None,
+        "risk_flags": {
+            "live": False,
+            "testnet": False,
+            "broker": False,
+            "exchange": False,
+            "orders": False,
+            "network": False,
+        },
+        "status_reasons": blockers,
+        "blockers": blockers,
+        "notes": [
+            "read_only_reporter",
+            "does_not_run_scheduler",
+            "does_not_start_daemon",
+            "does_not_activate_paper_or_shadow_runtime",
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root to inspect. Defaults to the current Peak_Trade checkout.",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.repo_root).resolve() if args.repo_root else None
+    payload = build_paper_shadow_247_preflight_status(root)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"status={payload['status']}")
+        print(f"activation_authorized={str(payload['activation_authorized']).lower()}")
+        print("dry_run_only=true")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -1,0 +1,97 @@
+"""CLI tests for the Paper/Shadow 24/7 preflight status reporter (read-only)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.ops.report_paper_shadow_247_preflight_status import (
+    build_paper_shadow_247_preflight_status,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ops" / "report_paper_shadow_247_preflight_status.py"
+
+
+def test_build_paper_shadow_247_preflight_status_is_blocked_and_non_authorizing() -> None:
+    payload = build_paper_shadow_247_preflight_status(REPO_ROOT)
+
+    assert payload["contract"] == "paper_shadow_247_preflight_status_v0"
+    assert payload["schema_version"] == 0
+    assert payload["status"] == "BLOCKED"
+    assert payload["activation_authorized"] is False
+    assert payload["daemon_activation_authorized"] is False
+    assert payload["paper_runtime_authorized"] is False
+    assert payload["shadow_runtime_authorized"] is False
+    assert payload["testnet_authorized"] is False
+    assert payload["live_authorized"] is False
+    assert payload["scheduler_execution_authorized"] is False
+    assert payload["dry_run_only"] is True
+    assert payload["paper_jobs"] == []
+    assert payload["shadow_jobs"] == []
+    assert payload["commands"] == []
+    assert payload["output_paths"] == []
+    assert payload["stop_command"] is None
+    assert payload["emergency_stop_command"] is None
+    assert payload["risk_flags"] == {
+        "live": False,
+        "testnet": False,
+        "broker": False,
+        "exchange": False,
+        "orders": False,
+        "network": False,
+    }
+
+
+def test_build_paper_shadow_247_preflight_status_reuses_existing_contract_surfaces() -> None:
+    payload = build_paper_shadow_247_preflight_status(REPO_ROOT)
+
+    assert all(payload["required_files"].values())
+    assert payload["contract_markers"]["contract_doc_exists"] is True
+    assert payload["contract_markers"]["contract_states_blocked"] is True
+    assert payload["contract_markers"]["contract_mentions_stop"] is True
+    assert payload["contract_markers"]["contract_non_authority"] is True
+    assert payload["contract_markers"]["scheduler_doc_links_contract"] is True
+    assert payload["contract_markers"]["scheduler_config_has_direct_247_job"] is False
+    assert "canonical_owner_missing" in payload["blockers"]
+    assert "paper_shadow_job_set_missing" in payload["blockers"]
+
+
+def test_cli_json_output_is_json_native_and_does_not_execute_scheduler() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--repo-root", str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "BLOCKED"
+    assert payload["activation_authorized"] is False
+    assert payload["dry_run_command"].endswith("--dry-run --once --verbose")
+    assert "does_not_run_scheduler" in payload["notes"]
+    assert "does_not_start_daemon" in payload["notes"]
+
+
+def test_cli_human_output_is_bounded_status_only() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.splitlines() == [
+        "status=BLOCKED",
+        "activation_authorized=false",
+        "dry_run_only=true",
+    ]


### PR DESCRIPTION
## Summary

- add a read-only JSON/human reporter for the Paper/Shadow 24/7 preflight status
- keep status `BLOCKED` and all activation/runtime authority flags false
- reuse the existing preflight contract, scheduler daemon doc, and scheduler config as read-only inputs

## Safety / scope

- read-only ops reporter + tests
- no daemon started
- no scheduler execution
- no Paper/Shadow runtime activation
- no Testnet/Live/broker/exchange/order paths
- no new evidence/readiness/registry/pointer surfaces

## Local validation

- uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q
- uv run ruff check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- uv run python scripts/ops/report_paper_shadow_247_preflight_status.py --json | python3 -m json.tool >/dev/null