### PR TITLE
fix(ops): gate p7 dry-run runner commands

### DIFF
--- a/scripts/aiops/run_paper_trading_session.py
+++ b/scripts/aiops/run_paper_trading_session.py
@@ -120,12 +120,26 @@ def ensure_outdir(repo: Path, run_id: str) -> Path:
     return out.resolve()
 
 
+def planned_paper_outdir(repo: Path, run_id: str, outdir_override: str) -> Path:
+    if outdir_override:
+        p = Path(outdir_override).expanduser()
+        return p.resolve() if p.is_absolute() else (repo / p).resolve()
+    rid = run_id.strip() or datetime.now().strftime("%Y%m%d_%H%M%S")
+    return (repo / "out" / "ops" / "p7" / f"paper_{rid}").resolve()
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--spec", type=str, required=True, help="Paper run spec JSON")
     ap.add_argument("--run-id", type=str, default="", help="Deterministic run id (optional)")
     ap.add_argument("--outdir", type=str, default="", help="Override output dir (optional)")
     ap.add_argument("--evidence", type=int, default=1, help="Write evidence manifest (1 default)")
+    ap.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Validate spec and outdir only; do not write output files (default: off)",
+    )
     args = ap.parse_args()
 
     repo = _repo_root
@@ -135,12 +149,26 @@ def main() -> int:
         else (repo / args.spec).resolve()
     )
     spec = load_json(spec_path)
+    outdir = planned_paper_outdir(repo, args.run_id, args.outdir)
 
-    outdir = (
-        Path(args.outdir).expanduser().resolve()
-        if args.outdir
-        else ensure_outdir(repo, args.run_id)
-    )
+    if args.dry_run:
+        if outdir.exists() and any(outdir.iterdir()):
+            print(
+                f"run_paper_trading_session: output directory is not empty: {outdir}",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"P7_PAPER_DRY_RUN_OK {spec_path} {outdir}")
+        return 0
+
+    if args.outdir:
+        outdir = (
+            Path(args.outdir).expanduser().resolve()
+            if Path(args.outdir).is_absolute()
+            else (repo / args.outdir).resolve()
+        )
+    else:
+        outdir = ensure_outdir(repo, args.run_id)
     outdir.mkdir(parents=True, exist_ok=True)
 
     acct = PaperAccount(cash=float(spec["initial_cash"]))

--- a/scripts/aiops/run_shadow_session.py
+++ b/scripts/aiops/run_shadow_session.py
@@ -66,7 +66,10 @@ def main() -> int:
         "--evidence", type=int, default=1, help="Write evidence manifest (1 default, 0 disable)"
     )
     ap.add_argument(
-        "--dry-run", action="store_true", default=True, help="Dry-run only (default true)"
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Dry-run for P4C/P5A sub-steps (default: on)",
     )
     ap.add_argument(
         "--p7-spec",
@@ -116,6 +119,7 @@ def main() -> int:
     if not p5a_runner.is_file():
         raise FileNotFoundError(p5a_runner)
 
+    dr = ["--dry-run"] if args.dry_run else []
     # Step 1: P4C (no evidence here; session handles evidence)
     p4c_out_lines = _run(
         [
@@ -127,7 +131,7 @@ def main() -> int:
             str(outdir / "p4c"),
             "--evidence",
             "0",
-            "--dry-run",
+            *dr,
         ],
         cwd=repo,
     )
@@ -146,7 +150,7 @@ def main() -> int:
             str(outdir / "p5a"),
             "--evidence",
             "0",
-            "--dry-run",
+            *dr,
         ],
         cwd=repo,
     )
@@ -176,21 +180,21 @@ def main() -> int:
 
         p7_subdir = outdir / "p7"
         p7_subdir.mkdir(parents=True, exist_ok=True)
-        p7_out_lines = _run(
-            [
-                sys.executable,
-                str(p7_runner),
-                "--spec",
-                str(p7_spec_path),
-                "--run-id",
-                args.run_id.strip() or outdir.name,
-                "--outdir",
-                str(p7_subdir),
-                "--evidence",
-                str(args.p7_evidence),
-            ],
-            cwd=repo,
-        )
+        # P7 paper step materializes deterministic sim outputs; do not pass shadow --dry-run
+        # into run_paper_trading_session (that flag means validate-only / no artifact writes).
+        p7_argv = [
+            sys.executable,
+            str(p7_runner),
+            "--spec",
+            str(p7_spec_path),
+            "--run-id",
+            args.run_id.strip() or outdir.name,
+            "--outdir",
+            str(p7_subdir),
+            "--evidence",
+            str(args.p7_evidence),
+        ]
+        p7_out_lines = _run(p7_argv, cwd=repo)
         p7_fills = p7_subdir / "fills.json"
         p7_acct = p7_subdir / "account.json"
         p7_manifest = p7_subdir / "evidence_manifest.json"

--- a/scripts/ops/p7_ctl.py
+++ b/scripts/ops/p7_ctl.py
@@ -8,9 +8,33 @@ import subprocess
 import sys
 from pathlib import Path
 
+_P7_ERR_OUTDIR_NOT_EMPTY = 2
+
 
 def root_dir() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def resolve_repo_path(root: Path, raw: str) -> Path:
+    p = Path(raw).expanduser()
+    return p.resolve() if p.is_absolute() else (root / p).resolve()
+
+
+def reject_nonempty_outdir(outdir: Path) -> int | None:
+    """If outdir exists and is non-empty, print to stderr and return exit code; else None."""
+    if not outdir.exists():
+        return None
+    try:
+        if any(outdir.iterdir()):
+            print(
+                f"p7_ctl: output directory is not empty (refusing to reuse): {outdir}",
+                file=sys.stderr,
+            )
+            return _P7_ERR_OUTDIR_NOT_EMPTY
+    except OSError as exc:
+        print(f"p7_ctl: cannot inspect output directory {outdir}: {exc}", file=sys.stderr)
+        return _P7_ERR_OUTDIR_NOT_EMPTY
+    return None
 
 
 def runpy(script: Path, *args: str) -> int:
@@ -52,17 +76,19 @@ def cmd_run_paper(args: argparse.Namespace) -> int:
     if not runner.is_file():
         print(f"missing {runner}", file=sys.stderr)
         return 1
-    spec = (root / args.spec).resolve() if not Path(args.spec).is_absolute() else Path(args.spec)
+    spec = resolve_repo_path(root, args.spec)
     cmd = [sys.executable, str(runner), "--spec", str(spec)]
     if args.run_id:
         cmd.extend(["--run-id", str(args.run_id)])
     if args.outdir:
-        outdir = (
-            (root / args.outdir).resolve()
-            if not Path(args.outdir).is_absolute()
-            else Path(args.outdir)
-        )
+        outdir = resolve_repo_path(root, args.outdir)
+        if (bad := reject_nonempty_outdir(outdir)) is not None:
+            return bad
         cmd.extend(["--outdir", str(outdir)])
+    if args.dry_run:
+        cmd.append("--dry-run")
+    else:
+        cmd.append("--no-dry-run")
     cmd.extend(["--evidence", str(args.evidence)])
     return subprocess.run(cmd, cwd=str(root)).returncode
 
@@ -74,10 +100,10 @@ def cmd_run_shadow(args: argparse.Namespace) -> int:
     if not runner.is_file():
         print(f"missing {runner}", file=sys.stderr)
         return 1
-    spec = (root / args.spec).resolve() if not Path(args.spec).is_absolute() else Path(args.spec)
-    outdir = (
-        (root / args.outdir).resolve() if not Path(args.outdir).is_absolute() else Path(args.outdir)
-    )
+    spec = resolve_repo_path(root, args.spec)
+    outdir = resolve_repo_path(root, args.outdir)
+    if (bad := reject_nonempty_outdir(outdir)) is not None:
+        return bad
     cmd = [
         sys.executable,
         str(runner),
@@ -92,6 +118,10 @@ def cmd_run_shadow(args: argparse.Namespace) -> int:
         "--p7-evidence",
         str(args.p7_evidence),
     ]
+    if args.dry_run:
+        cmd.append("--dry-run")
+    else:
+        cmd.append("--no-dry-run")
     return subprocess.run(cmd, cwd=str(root)).returncode
 
 
@@ -109,6 +139,12 @@ def main() -> int:
     sp.add_argument("--run-id", type=str, default="", help="Deterministic run id")
     sp.add_argument("--outdir", type=str, default="", help="Override output dir")
     sp.add_argument("--evidence", type=int, default=1, help="Write evidence manifest (1 default)")
+    sp.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Propagate dry-run to the paper runner (default: on; validate only, no output files)",
+    )
     sp.set_defaults(func=cmd_run_paper)
 
     sp = sub.add_parser("run-shadow", help="run shadow session with P7 enabled")
@@ -116,6 +152,12 @@ def main() -> int:
     sp.add_argument("--run-id", type=str, default="p7_ctl", help="Run id")
     sp.add_argument("--outdir", type=str, required=True, help="Output dir")
     sp.add_argument("--p7-evidence", type=int, default=1, help="Write P7 evidence manifest")
+    sp.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Propagate dry-run to the shadow session runner (default: on)",
+    )
     sp.set_defaults(func=cmd_run_shadow)
 
     args = p.parse_args()

--- a/tests/ops/test_p7_ctl_run_contract_v0.py
+++ b/tests/ops/test_p7_ctl_run_contract_v0.py
@@ -1,0 +1,207 @@
+"""Contract tests for p7_ctl run-shadow / run-paper (argv, dry-run, outdir guards).
+
+Uses subprocess mocking — does not execute real paper/shadow runners.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+P7_CTL = ROOT / "scripts" / "ops" / "p7_ctl.py"
+SHADOW_SPEC = ROOT / "tests" / "fixtures" / "p6" / "shadow_session_min_v1_p7.json"
+PAPER_SPEC = ROOT / "tests" / "fixtures" / "p7" / "paper_run_min_v0.json"
+
+
+def _import_p7ctl():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("p7_ctl", P7_CTL)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def p7():
+    return _import_p7ctl()
+
+
+def test_run_shadow_cmd_includes_dry_run_when_default(
+    p7: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(p7.subprocess, "run", fake_run)
+    out = tmp_path / "shadow_out"
+    out.mkdir()
+    args = SimpleNamespace(
+        spec=str(SHADOW_SPEC.relative_to(ROOT)),
+        run_id="contract_rid",
+        outdir=str(out.resolve()),
+        p7_evidence=1,
+        dry_run=True,
+    )
+    assert p7.cmd_run_shadow(args) == 0
+    cmd = captured["cmd"]
+    runner = cmd.index(str(ROOT / "scripts" / "aiops" / "run_shadow_session.py"))
+    assert "--dry-run" in cmd[runner:]
+
+
+def test_run_shadow_cmd_includes_no_dry_run(
+    p7: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(p7.subprocess, "run", fake_run)
+    out = tmp_path / "shadow_out"
+    out.mkdir()
+    args = SimpleNamespace(
+        spec=str(SHADOW_SPEC.relative_to(ROOT)),
+        run_id="contract_rid",
+        outdir=str(out.resolve()),
+        p7_evidence=0,
+        dry_run=False,
+    )
+    assert p7.cmd_run_shadow(args) == 0
+    cmd = captured["cmd"]
+    assert "--no-dry-run" in cmd
+    assert "--dry-run" not in cmd
+
+
+def test_run_shadow_rejects_nonempty_outdir_before_subprocess(
+    p7: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("subprocess.run must not be called")
+
+    monkeypatch.setattr(p7.subprocess, "run", boom)
+    out = tmp_path / "shadow_out"
+    out.mkdir()
+    (out / "stale.json").write_text("{}", encoding="utf-8")
+    args = SimpleNamespace(
+        spec=str(SHADOW_SPEC.relative_to(ROOT)),
+        run_id="x",
+        outdir=str(out),
+        p7_evidence=1,
+        dry_run=True,
+    )
+    assert p7.cmd_run_shadow(args) == p7._P7_ERR_OUTDIR_NOT_EMPTY
+
+
+def test_run_paper_cmd_includes_dry_run(
+    p7: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(p7.subprocess, "run", fake_run)
+    out = tmp_path / "paper_out"
+    out.mkdir()
+    args = SimpleNamespace(
+        spec=str(PAPER_SPEC.relative_to(ROOT)),
+        run_id="",
+        outdir=str(out.resolve()),
+        evidence=0,
+        dry_run=True,
+    )
+    assert p7.cmd_run_paper(args) == 0
+    cmd = captured["cmd"]
+    r = cmd.index(str(ROOT / "scripts" / "aiops" / "run_paper_trading_session.py"))
+    assert "--dry-run" in cmd[r:]
+
+
+def test_run_paper_rejects_nonempty_outdir(
+    p7: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        p7.subprocess,
+        "run",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("subprocess.run")),
+    )
+    out = tmp_path / "paper_out"
+    out.mkdir()
+    (out / "fills.json").write_text("{}", encoding="utf-8")
+    args = SimpleNamespace(
+        spec=str(PAPER_SPEC.relative_to(ROOT)),
+        run_id="",
+        outdir=str(out),
+        evidence=1,
+        dry_run=False,
+    )
+    assert p7.cmd_run_paper(args) == p7._P7_ERR_OUTDIR_NOT_EMPTY
+
+
+def test_main_run_shadow_invocation_integration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    p7 = _import_p7ctl()
+    monkeypatch.setattr(p7.subprocess, "run", fake_run)
+    out = tmp_path / "sout"
+    out.mkdir()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "p7_ctl",
+            "run-shadow",
+            "--spec",
+            str(SHADOW_SPEC.relative_to(ROOT)),
+            "--outdir",
+            str(out.resolve()),
+        ],
+    )
+    assert p7.main() == 0
+    assert "--dry-run" in captured["cmd"]
+
+
+def test_main_run_paper_dry_run_invocation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    p7 = _import_p7ctl()
+    monkeypatch.setattr(p7.subprocess, "run", fake_run)
+    out = tmp_path / "pout"
+    out.mkdir()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "p7_ctl",
+            "run-paper",
+            "--spec",
+            str(PAPER_SPEC.relative_to(ROOT)),
+            "--outdir",
+            str(out.resolve()),
+            "--dry-run",
+        ],
+    )
+    assert p7.main() == 0
+    assert "--dry-run" in captured["cmd"]


### PR DESCRIPTION
## Summary

- make `p7_ctl.py` fail closed on non-empty output directories before invoking Paper/Shadow runners
- propagate explicit dry-run intent through P7 control paths for one-shot Paper/Shadow safety
- add subprocess-mocked contract tests so no real Paper/Shadow runner executes

## Safety / scope

- no daemon started
- no scheduler jobs executed
- no Paper/Shadow runtime run in tests
- no Testnet/Live/broker/exchange/order paths
- output-directory reuse is rejected before runner invocation
- moves toward controlled one-shot Paper/Shadow testing, not 24/7 activation

## Local validation

- uv run pytest tests/ops/test_p7_ctl_cli_smoke.py tests/ops/test_p7_ctl_run_contract_v0.py tests/aiops/p6 tests/aiops/p7 tests/sim/paper/test_paper_runner_smoke.py tests/execution/test_paper_session_cli_contract.py -q
- uv run ruff check scripts/aiops/run_paper_trading_session.py scripts/aiops/run_shadow_session.py scripts/ops/p7_ctl.py tests/ops/test_p7_ctl_run_contract_v0.py
- uv run ruff format --check scripts/aiops/run_paper_trading_session.py scripts/aiops/run_shadow_session.py scripts/ops/p7_ctl.py tests/ops/test_p7_ctl_run_contract_v0.py