### PR TITLE
test(ops): add p7 shadow one-shot acceptance contract v0

### DIFF
--- a/docs/ops/runbooks/P7_SHADOW_ONE_SHOT_ACCEPTANCE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/P7_SHADOW_ONE_SHOT_ACCEPTANCE_CONTRACT_V0.md
@@ -1,0 +1,66 @@
+# P7 Shadow One-Shot Dry-Run Acceptance Contract v0
+
+## 1. Purpose
+
+This contract defines acceptance criteria for a **controlled local** P7 Shadow **one-shot** **dry-run** artifact bundle.
+
+It is based on a successful local dry-run whose outputs are preserved as committed test fixtures under:
+
+- `tests/fixtures/p7_shadow_one_shot_acceptance_v0/`
+
+Passing the automated checks in this slice **does not** change operational status. It only freezes **shape and hygiene** of JSON artifacts from the approved **dry-run** code path.
+
+## 2. Scope and boundaries
+
+**In scope**
+
+- One local invocation class equivalent to:
+
+```bash
+uv run python scripts/ops/p7_ctl.py run-shadow \
+  --dry-run \
+  --outdir <fresh-empty-outdir> \
+  --spec tests/fixtures/p6/shadow_session_min_v1_p7.json
+```
+
+- **Eleven** JSON files under the outdir, matching relative paths and schemas asserted by
+  `validate_p7_shadow_one_shot_artifact_bundle()` in
+  `tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py`.
+
+**Explicitly out of scope (not authorized by this document)**
+
+- 24/7 operation, scheduling, daemon activation
+- Live, Testnet, broker, exchange, or real order submission
+- Treating CI/test pass as **Paper/Shadow 24/7** readiness or activation
+
+For 24/7 preflight status and activation boundaries, see
+[`PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`](PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md) (expected **BLOCKED** until a separate governed update).
+
+## 3. PASS / FAIL
+
+**PASS** when:
+
+- `uv run pytest tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py -q` exits 0.
+- Bundle validator reports no `AssertionError` (exact file set, portable path strings, forbidden-token scan, required keys per artifact).
+
+**FAIL** when:
+
+- Any committed fixture is missing, extra, or invalid JSON.
+- Any string value in bundled JSON looks like an absolute filesystem path (leading `/`).
+- Concatenated bundle text matches the curated deny-list (e.g. `testnet`, `broker`, `https://`) — heuristic, not a substitute for design review.
+
+## 4. Operator notes
+
+- Use a **fresh empty** `--outdir`; `p7_ctl` rejects non-empty outdirs.
+- After a real dry-run, compare only **relative** filenames under the outdir to the fixture set; normalize machine-specific absolute paths before committing (repo-relative strings only).
+- Do not point production or personal `/tmp` trees at tests; fixtures and tests read only `tests&#47;fixtures&#47;...` and `tmp_path` copies.
+
+## 5. Implementation references
+
+| Artifact | Role |
+|----------|------|
+| `tests&#47;fixtures&#47;p7_shadow_one_shot_acceptance_v0&#47;*.json` | Golden bundle |
+| `tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py` | Validator |
+| `tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py` | Contract tests |
+
+This document does **not** require invoking `p7_ctl` in CI; tests are static against committed fixtures.

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/evidence_manifest.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/evidence_manifest.json
@@ -1,0 +1,45 @@
+{
+  "files": [
+    {
+      "bytes": 466,
+      "name": "l2_market_outlook.json",
+      "relpath": "p4c/l2_market_outlook.json",
+      "sha256": "adc347bc925650acb7328541cddf2adcd955e0eb0864204a0c633f32f597319a"
+    },
+    {
+      "bytes": 364,
+      "name": "l3_trade_plan_advisory.json",
+      "relpath": "p5a/l3_trade_plan_advisory.json",
+      "sha256": "d228bc5f54d20f936d25d5a976b571709799c001e4b1769b1d1e4db3ad6fce9a"
+    },
+    {
+      "bytes": 94,
+      "name": "p7_account.json",
+      "relpath": "p7_account.json",
+      "sha256": "ee263b02ac3c125797ecb24dda8b14e01752131008c22e9af949eefec86d21ba"
+    },
+    {
+      "bytes": 516,
+      "name": "p7_evidence_manifest.json",
+      "relpath": "p7_evidence_manifest.json",
+      "sha256": "b9f0eca52ebaaa67c69ee24b3f04631619f9e698250adae646fb48b2222e1378"
+    },
+    {
+      "bytes": 289,
+      "name": "p7_fills.json",
+      "relpath": "p7_fills.json",
+      "sha256": "1880eda16fa9b5b96dcfa02b0fbd2b374b86bd2e88679ebf16420f2410893115"
+    },
+    {
+      "bytes": 942,
+      "name": "shadow_session_summary.json",
+      "relpath": "shadow_session_summary.json",
+      "sha256": "63fb609d6e7739beec9dcc20c4066108f27a4ee76bf57f4ae8dc890164a74bfb"
+    }
+  ],
+  "meta": {
+    "created_at_utc": "2026-05-05T15:09:21.000900Z",
+    "kind": "p6_shadow_session_manifest",
+    "schema_version": "p6.shadow_session.v0"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p4c/l2_market_outlook.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p4c/l2_market_outlook.json
@@ -1,0 +1,22 @@
+{
+  "capsule_preview_keys": [
+    "asof_utc",
+    "context",
+    "features",
+    "schema_version",
+    "universe"
+  ],
+  "inputs": {
+    "capsule": "tests/fixtures/p4c/capsule_min_v0.json"
+  },
+  "meta": {
+    "created_at_utc": "2026-05-05T15:00:46.371723Z",
+    "runner_version": "0.0.0",
+    "schema_version": "p4c.l2_market_outlook.v0"
+  },
+  "outlook": {
+    "no_trade": false,
+    "no_trade_reasons": [],
+    "regime": "NEUTRAL"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p4c/market_outlook.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p4c/market_outlook.json
@@ -1,0 +1,22 @@
+{
+  "capsule_preview_keys": [
+    "asof_utc",
+    "context",
+    "features",
+    "schema_version",
+    "universe"
+  ],
+  "inputs": {
+    "capsule": "tests/fixtures/p4c/capsule_min_v0.json"
+  },
+  "meta": {
+    "created_at_utc": "2026-05-05T15:00:46.371723Z",
+    "runner_version": "0.0.0",
+    "schema_version": "p4c.l2_market_outlook.v0"
+  },
+  "outlook": {
+    "no_trade": false,
+    "no_trade_reasons": [],
+    "regime": "NEUTRAL"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p5a/l3_trade_plan_advisory.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p5a/l3_trade_plan_advisory.json
@@ -1,0 +1,20 @@
+{
+  "allocations": {},
+  "asof_utc": "2026-02-11T11:02:19Z",
+  "constraints": {
+    "max_gross_exposure": 1,
+    "max_leverage": 1
+  },
+  "evidence": {},
+  "no_trade": false,
+  "no_trade_reasons": [],
+  "rationale": [
+    "p5a_v0_stub"
+  ],
+  "schema_version": "p5a.trade_plan_advisory.v0",
+  "stance": "HOLD",
+  "universe": [
+    "BTC/USDT",
+    "ETH/USDT"
+  ]
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7/account.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7/account.json
@@ -1,0 +1,7 @@
+{
+  "cash": 999.6,
+  "positions": {
+    "BTC": 0.0
+  },
+  "schema_version": "p7.account.v0"
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7/evidence_manifest.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7/evidence_manifest.json
@@ -1,0 +1,21 @@
+{
+  "files": [
+    {
+      "bytes": 94,
+      "name": "account.json",
+      "relpath": "p7/account.json",
+      "sha256": "ee263b02ac3c125797ecb24dda8b14e01752131008c22e9af949eefec86d21ba"
+    },
+    {
+      "bytes": 289,
+      "name": "fills.json",
+      "relpath": "p7/fills.json",
+      "sha256": "1880eda16fa9b5b96dcfa02b0fbd2b374b86bd2e88679ebf16420f2410893115"
+    }
+  ],
+  "meta": {
+    "created_at_utc": "2026-05-05T15:09:20.999375Z",
+    "kind": "p7_paper_manifest",
+    "schema_version": "p7.paper_run.v0"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7/fills.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7/fills.json
@@ -1,0 +1,19 @@
+{
+  "fills": [
+    {
+      "fee": 0.1001,
+      "price": 100.1,
+      "qty": 1.0,
+      "side": "BUY",
+      "symbol": "BTC"
+    },
+    {
+      "fee": 0.0999,
+      "price": 99.9,
+      "qty": 1.0,
+      "side": "SELL",
+      "symbol": "BTC"
+    }
+  ],
+  "schema_version": "p7.fills.v0"
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7_account.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7_account.json
@@ -1,0 +1,7 @@
+{
+  "cash": 999.6,
+  "positions": {
+    "BTC": 0.0
+  },
+  "schema_version": "p7.account.v0"
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7_evidence_manifest.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7_evidence_manifest.json
@@ -1,0 +1,21 @@
+{
+  "files": [
+    {
+      "bytes": 94,
+      "name": "account.json",
+      "relpath": "account.json",
+      "sha256": "ee263b02ac3c125797ecb24dda8b14e01752131008c22e9af949eefec86d21ba"
+    },
+    {
+      "bytes": 289,
+      "name": "fills.json",
+      "relpath": "fills.json",
+      "sha256": "1880eda16fa9b5b96dcfa02b0fbd2b374b86bd2e88679ebf16420f2410893115"
+    }
+  ],
+  "meta": {
+    "created_at_utc": "2026-05-05T15:00:46.928681Z",
+    "kind": "p7_paper_manifest",
+    "schema_version": "p7.paper_run.v0"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7_fills.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/p7_fills.json
@@ -1,0 +1,19 @@
+{
+  "fills": [
+    {
+      "fee": 0.1001,
+      "price": 100.1,
+      "qty": 1.0,
+      "side": "BUY",
+      "symbol": "BTC"
+    },
+    {
+      "fee": 0.0999,
+      "price": 99.9,
+      "qty": 1.0,
+      "side": "SELL",
+      "symbol": "BTC"
+    }
+  ],
+  "schema_version": "p7.fills.v0"
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_v0/shadow_session_summary.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_v0/shadow_session_summary.json
@@ -1,0 +1,43 @@
+{
+  "asof_utc": "2026-02-11T14:00:00Z",
+  "no_trade": false,
+  "notes": [
+    "dry_run_only",
+    "no_execution"
+  ],
+  "outputs": {
+    "p4c_out": "p4c/l2_market_outlook.json",
+    "p5a_out": "p5a/l3_trade_plan_advisory.json",
+    "p7_account": "p7_account.json",
+    "p7_evidence_manifest": "p7_evidence_manifest.json",
+    "p7_fills": "p7_fills.json"
+  },
+  "p7_account_summary": {
+    "cash": 999.6,
+    "positions": {
+      "BTC": 0.0
+    },
+    "schema_version": "p7.account.v0"
+  },
+  "p7_outputs": {
+    "p7_account": "p7_account.json",
+    "p7_evidence_manifest": "p7_evidence_manifest.json",
+    "p7_fills": "p7_fills.json"
+  },
+  "run_id": "p7_ctl",
+  "schema_version": "p6.shadow_session.v0",
+  "steps": [
+    {
+      "name": "p4c",
+      "out": "p4c/l2_market_outlook.json"
+    },
+    {
+      "name": "p5a",
+      "out": "p5a/l3_trade_plan_advisory.json"
+    },
+    {
+      "name": "p7",
+      "out": "p7_fills.json"
+    }
+  ]
+}

--- a/tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py
+++ b/tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py
@@ -1,0 +1,152 @@
+"""Static acceptance checks for a P7 Shadow one-shot dry-run artifact bundle (fixtures only)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Normalized relpaths (posix) under the bundle root — matches
+# tests/fixtures/p7_shadow_one_shot_acceptance_v0/ from a successful local dry-run.
+EXPECTED_RELATIVE_JSON_FILES: frozenset[str] = frozenset(
+    {
+        "evidence_manifest.json",
+        "p4c/l2_market_outlook.json",
+        "p4c/market_outlook.json",
+        "p5a/l3_trade_plan_advisory.json",
+        "p7/account.json",
+        "p7/evidence_manifest.json",
+        "p7/fills.json",
+        "p7_account.json",
+        "p7_evidence_manifest.json",
+        "p7_fills.json",
+        "shadow_session_summary.json",
+    }
+)
+
+# Case-insensitive substring deny-list for bundled JSON *content* (heuristic; not a security gate).
+FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (
+    "testnet",
+    "broker",
+    "exchange",
+    "api_key",
+    "apikey",
+    "https://",
+    "wss://",
+    "-----begin",
+)
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _all_paths_portable(bundle_root: Path) -> None:
+    """Reject absolute-looking path strings inside any JSON value."""
+    root = bundle_root.resolve()
+
+    def walk(obj: Any) -> None:
+        if isinstance(obj, dict):
+            for v in obj.values():
+                walk(v)
+        elif isinstance(obj, list):
+            for x in obj:
+                walk(x)
+        elif isinstance(obj, str):
+            if obj.startswith("/"):
+                raise AssertionError(
+                    f"non-portable absolute path string in bundle under {root}: {obj!r}"
+                )
+
+    for rel in sorted(EXPECTED_RELATIVE_JSON_FILES):
+        walk(_load_json(root / rel))
+
+
+def _forbidden_scan(bundle_root: Path) -> None:
+    root = bundle_root.resolve()
+    blob_parts: list[str] = []
+    for rel in sorted(EXPECTED_RELATIVE_JSON_FILES):
+        data = _load_json(root / rel)
+        blob_parts.append(json.dumps(data, sort_keys=True))
+    blob = "\n".join(blob_parts).lower()
+    for token in FORBIDDEN_SUBSTRINGS:
+        if token.lower() in blob:
+            raise AssertionError(
+                f"forbidden substring {token!r} found in bundled JSON under {root}"
+            )
+
+
+def _validate_shadow_session_summary(data: dict[str, Any]) -> None:
+    for key in (
+        "run_id",
+        "schema_version",
+        "steps",
+        "notes",
+        "outputs",
+        "p7_outputs",
+        "p7_account_summary",
+        "asof_utc",
+        "no_trade",
+    ):
+        assert key in data, f"shadow_session_summary.json missing {key!r}"
+    notes = data["notes"]
+    assert isinstance(notes, list) and "dry_run_only" in notes and "no_execution" in notes
+    outs = data["outputs"]
+    assert isinstance(outs, dict)
+    assert outs.get("p4c_out", "").startswith("p4c/")
+    assert outs.get("p5a_out", "").startswith("p5a/")
+    steps = data["steps"]
+    assert isinstance(steps, list) and len(steps) >= 3
+
+
+def _validate_p7_fills(data: dict[str, Any]) -> None:
+    assert data.get("schema_version") == "p7.fills.v0"
+    fills = data.get("fills")
+    assert isinstance(fills, list) and len(fills) >= 1
+
+
+def _validate_p7_account(data: dict[str, Any]) -> None:
+    assert data.get("schema_version") == "p7.account.v0"
+    assert "cash" in data and isinstance(data["cash"], (int, float))
+    pos = data.get("positions")
+    assert isinstance(pos, dict)
+
+
+def _validate_root_evidence_manifest(data: dict[str, Any]) -> None:
+    meta = data.get("meta") or {}
+    assert meta.get("kind") == "p6_shadow_session_manifest"
+    files = data.get("files")
+    assert isinstance(files, list) and len(files) == 6
+
+
+def _validate_p7_evidence_manifest(data: dict[str, Any]) -> None:
+    meta = data.get("meta") or {}
+    assert meta.get("kind") == "p7_paper_manifest"
+    files = data.get("files")
+    assert isinstance(files, list) and len(files) == 2
+
+
+def validate_p7_shadow_one_shot_artifact_bundle(bundle_root: Path) -> None:
+    """Raise AssertionError when the bundle does not satisfy the v0 acceptance contract."""
+    root = bundle_root.resolve()
+    if not root.is_dir():
+        raise AssertionError(f"bundle root is not a directory: {root}")
+
+    present: set[str] = set()
+    for path in root.rglob("*.json"):
+        present.add(str(path.relative_to(root).as_posix()))
+
+    assert present == set(EXPECTED_RELATIVE_JSON_FILES), (
+        f"json path mismatch: extra={present - EXPECTED_RELATIVE_JSON_FILES} missing={EXPECTED_RELATIVE_JSON_FILES - present}"
+    )
+
+    _all_paths_portable(root)
+    _forbidden_scan(root)
+
+    _validate_shadow_session_summary(_load_json(root / "shadow_session_summary.json"))
+    _validate_p7_fills(_load_json(root / "p7_fills.json"))
+    _validate_p7_fills(_load_json(root / "p7" / "fills.json"))
+    _validate_p7_account(_load_json(root / "p7_account.json"))
+    _validate_p7_account(_load_json(root / "p7" / "account.json"))
+    _validate_root_evidence_manifest(_load_json(root / "evidence_manifest.json"))
+    _validate_p7_evidence_manifest(_load_json(root / "p7" / "evidence_manifest.json"))

--- a/tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py
+++ b/tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py
@@ -1,0 +1,23 @@
+"""Contract tests for the committed P7 Shadow one-shot dry-run artifact bundle v0."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from tests.ops.p7_shadow_one_shot_acceptance_bundle_v0 import (
+    validate_p7_shadow_one_shot_artifact_bundle,
+)
+
+FIXTURE_BUNDLE = Path("tests/fixtures/p7_shadow_one_shot_acceptance_v0")
+
+
+def test_p7_shadow_one_shot_acceptance_fixture_dir_contract_v0() -> None:
+    validate_p7_shadow_one_shot_artifact_bundle(FIXTURE_BUNDLE)
+
+
+def test_p7_shadow_one_shot_acceptance_tmp_path_copy_contract_v0(tmp_path: Path) -> None:
+    """A fresh outdir copy must match the same contract (relative layout only)."""
+    dst = tmp_path / "out"
+    shutil.copytree(FIXTURE_BUNDLE, dst)
+    validate_p7_shadow_one_shot_artifact_bundle(dst)


### PR DESCRIPTION
## Summary

- add a P7 Shadow one-shot dry-run acceptance contract and runbook
- add a static fixture bundle from the successful local one-shot dry-run
- add tests/validator coverage for artifact shape, JSON validity, portability, and non-authority boundaries

## Safety / scope

- tests/docs only
- no new Paper/Shadow run executed by tests
- no daemon started
- no scheduler jobs executed
- no Testnet/Live/broker/exchange/order paths
- fixture paths are normalized to portable repo-relative strings

## Local validation

- uv run pytest tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py tests/ops/test_p7_ctl_run_contract_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q
- uv run ruff check tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py
- uv run ruff format --check tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs