### PR TITLE
test(ops): add p7 shadow repeated-run stability contract v0

### DIFF
--- a/docs/ops/runbooks/P7_SHADOW_ONE_SHOT_ACCEPTANCE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/P7_SHADOW_ONE_SHOT_ACCEPTANCE_CONTRACT_V0.md
@@ -64,4 +64,12 @@ For 24/7 preflight status and activation boundaries, see
 | `tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py` | Validator |
 | `tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py` | Contract tests |
 
+## Repeated-run stability boundary
+
+For repeated manual one-shot dry-runs, the acceptance layer distinguishes **volatile repeated-run fields** from **stable business-critical artifacts**.
+
+Allowed volatile repeated-run fields include timestamps such as `created_at_utc`, run-local output paths, and **Evidence-Manifest hashes** for artifacts whose contents include run-local timestamps or paths.
+
+Stable business-critical artifacts include `shadow_session_summary.json`, `p5a&#47;l3_trade_plan_advisory.json`, `p7&#47;fills.json`, and `p7&#47;account.json`. Drift in those stable artifacts after volatility normalization is a failed repeated-run stability check.
+
 This document does **not** require invoking `p7_ctl` in CI; tests are static against committed fixtures.

--- a/docs/ops/runbooks/P7_SHADOW_REPEATED_ONE_SHOT_DRY_RUN_GOVERNANCE_V0.md
+++ b/docs/ops/runbooks/P7_SHADOW_REPEATED_ONE_SHOT_DRY_RUN_GOVERNANCE_V0.md
@@ -125,6 +125,14 @@ Do not interpret a successful dry-run or passing repo tests as Paper/Shadow 24/7
 - Do not commit personal machine paths or secrets into fixtures or docs.
 - When updating golden fixtures, follow [P7_SHADOW_ONE_SHOT_ACCEPTANCE_CONTRACT_V0.md](P7_SHADOW_ONE_SHOT_ACCEPTANCE_CONTRACT_V0.md) and normalize paths to repo-relative strings.
 
+## Repeated-run stability interpretation
+
+Repeated-run campaign comparison must allow expected run-local volatility while still rejecting **business-critical artifact drift**.
+
+Allowed volatility includes `created_at_utc`, run-local output paths, and **Evidence-Manifest hashes** for timestamped or path-bearing artifacts.
+
+The campaign must fail if stable business-critical artifacts drift after volatility normalization. Stable artifacts include the Shadow session summary, the P5a trade plan advisory, P7 fills (including `p7&#47;fills.json`), and P7 account state.
+
 ## 11. Revision
 
 - **v0** — Initial governance: manual repeated one-shot dry-runs only; no scheduler or daemon authority.

--- a/tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py
+++ b/tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py
@@ -150,3 +150,101 @@ def validate_p7_shadow_one_shot_artifact_bundle(bundle_root: Path) -> None:
     _validate_p7_account(_load_json(root / "p7" / "account.json"))
     _validate_root_evidence_manifest(_load_json(root / "evidence_manifest.json"))
     _validate_p7_evidence_manifest(_load_json(root / "p7" / "evidence_manifest.json"))
+
+
+VOLATILE_REPEATED_RUN_KEYS_V0: frozenset[str] = frozenset(
+    {
+        "created_at",
+        "created_at_utc",
+        "generated_at",
+        "timestamp",
+        "ts",
+        "started_at",
+        "completed_at",
+        "run_started_at",
+        "run_completed_at",
+        "sha256",
+        "digest",
+        "hash",
+        "path",
+        "paths",
+        "outdir",
+        "output_dir",
+        "output_path",
+    }
+)
+
+VOLATILE_REPEATED_RUN_PATH_PARTS_V0: frozenset[str] = frozenset(
+    {
+        "run_001",
+        "run_002",
+        "run_003",
+        "peak_trade_manual_p7_shadow_repeated_campaign_scope_20260505T162028Z",
+    }
+)
+
+STABLE_REPEATED_RUN_ARTIFACTS_V0: frozenset[str] = frozenset(
+    {
+        "shadow_session_summary.json",
+        "p5a/l3_trade_plan_advisory.json",
+        "p7/fills.json",
+        "p7/account.json",
+        "p7_fills.json",
+        "p7_account.json",
+    }
+)
+
+
+def normalize_p7_shadow_repeated_run_value_v0(value: Any) -> Any:
+    """Normalize expected run-local volatility for repeated-run stability checks."""
+    if isinstance(value, dict):
+        return {
+            key: normalize_p7_shadow_repeated_run_value_v0(item)
+            for key, item in sorted(value.items())
+            if key not in VOLATILE_REPEATED_RUN_KEYS_V0
+        }
+
+    if isinstance(value, list):
+        return [normalize_p7_shadow_repeated_run_value_v0(item) for item in value]
+
+    if isinstance(value, str):
+        normalized = value
+        for part in VOLATILE_REPEATED_RUN_PATH_PARTS_V0:
+            normalized = normalized.replace(part, "<RUN_LOCAL>")
+        return normalized
+
+    return value
+
+
+def stable_repeated_run_artifact_paths_v0() -> frozenset[str]:
+    """Return artifact paths that must remain stable across repeated one-shot runs."""
+    return STABLE_REPEATED_RUN_ARTIFACTS_V0
+
+
+def assert_p7_shadow_repeated_run_stability_v0(
+    run_payloads_by_relpath: dict[str, dict[str, Any]],
+) -> None:
+    """Assert normalized stable artifacts are identical across repeated runs.
+
+    The input shape is:
+    {
+        "run_001": {"relative/artifact.json": parsed_json, ...},
+        "run_002": {"relative/artifact.json": parsed_json, ...},
+        ...
+    }
+    """
+    run_names = sorted(run_payloads_by_relpath)
+    assert run_names, "at least one run is required"
+
+    baseline = run_names[0]
+    baseline_payloads = run_payloads_by_relpath[baseline]
+
+    for relpath in STABLE_REPEATED_RUN_ARTIFACTS_V0:
+        assert relpath in baseline_payloads, f"missing stable artifact in {baseline}: {relpath}"
+        expected = normalize_p7_shadow_repeated_run_value_v0(baseline_payloads[relpath])
+
+        for run_name in run_names[1:]:
+            run_payloads = run_payloads_by_relpath[run_name]
+            assert relpath in run_payloads, f"missing stable artifact in {run_name}: {relpath}"
+            actual = normalize_p7_shadow_repeated_run_value_v0(run_payloads[relpath])
+            assert actual == expected, f"stable artifact drifted after normalization: {relpath}"

--- a/tests/ops/test_p7_shadow_repeated_run_stability_contract_v0.py
+++ b/tests/ops/test_p7_shadow_repeated_run_stability_contract_v0.py
@@ -1,0 +1,111 @@
+"""Contract tests for P7 Shadow repeated-run stability (fixture-only, no live runs)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.ops.p7_shadow_one_shot_acceptance_bundle_v0 import (
+    assert_p7_shadow_repeated_run_stability_v0,
+    normalize_p7_shadow_repeated_run_value_v0,
+    stable_repeated_run_artifact_paths_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "p7_shadow_one_shot_acceptance_v0"
+ACCEPTANCE_RUNBOOK = (
+    REPO_ROOT / "docs" / "ops" / "runbooks" / "P7_SHADOW_ONE_SHOT_ACCEPTANCE_CONTRACT_V0.md"
+)
+GOVERNANCE_RUNBOOK = (
+    REPO_ROOT / "docs" / "ops" / "runbooks" / "P7_SHADOW_REPEATED_ONE_SHOT_DRY_RUN_GOVERNANCE_V0.md"
+)
+
+
+def _fixture_payloads() -> dict[str, object]:
+    return {
+        path.relative_to(FIXTURE_DIR).as_posix(): json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(FIXTURE_DIR.rglob("*.json"))
+    }
+
+
+def test_normalizer_removes_expected_timestamp_hash_and_path_volatility() -> None:
+    payload = {
+        "created_at_utc": "2026-05-05T16:20:00Z",
+        "sha256": "abc",
+        "path": "/tmp/peak_trade_manual_p7_shadow_repeated_campaign_scope_20260505T162028Z/runs/run_001/x.json",
+        "stable": {"symbol": "BTC", "fills": [{"side": "BUY", "qty": 1.0}]},
+    }
+
+    normalized = normalize_p7_shadow_repeated_run_value_v0(payload)
+
+    assert "created_at_utc" not in normalized
+    assert "sha256" not in normalized
+    assert "path" not in normalized
+    assert normalized["stable"] == {"fills": [{"qty": 1.0, "side": "BUY"}], "symbol": "BTC"}
+
+
+def test_stability_contract_accepts_expected_run_local_volatility() -> None:
+    run_001 = _fixture_payloads()
+    run_002 = copy.deepcopy(run_001)
+    run_003 = copy.deepcopy(run_001)
+
+    run_002["shadow_session_summary.json"]["created_at_utc"] = "2026-05-05T16:21:00Z"
+    run_003["shadow_session_summary.json"]["created_at_utc"] = "2026-05-05T16:22:00Z"
+
+    for relpath in (
+        "p7/evidence_manifest.json",
+        "evidence_manifest.json",
+        "p7_evidence_manifest.json",
+    ):
+        if relpath in run_002 and isinstance(run_002[relpath], dict):
+            meta = run_002[relpath].setdefault("meta", {})
+            assert isinstance(meta, dict)
+            meta["created_at_utc"] = "2026-05-05T16:21:05Z"
+        if relpath in run_003 and isinstance(run_003[relpath], dict):
+            meta = run_003[relpath].setdefault("meta", {})
+            assert isinstance(meta, dict)
+            meta["created_at_utc"] = "2026-05-05T16:22:05Z"
+
+    assert_p7_shadow_repeated_run_stability_v0(
+        {"run_001": run_001, "run_002": run_002, "run_003": run_003}
+    )
+
+
+def test_stability_contract_rejects_business_artifact_drift() -> None:
+    run_001 = _fixture_payloads()
+    run_002 = copy.deepcopy(run_001)
+
+    fills_list = run_002["p7/fills.json"]
+    assert isinstance(fills_list, dict)
+    rows = fills_list["fills"]
+    assert isinstance(rows, list) and rows
+    first = rows[0]
+    assert isinstance(first, dict)
+    first["side"] = "SELL" if first.get("side") == "BUY" else "BUY"
+
+    with pytest.raises(AssertionError, match="stable artifact drifted"):
+        assert_p7_shadow_repeated_run_stability_v0({"run_001": run_001, "run_002": run_002})
+
+
+def test_stability_contract_names_stable_business_artifacts() -> None:
+    stable_paths = stable_repeated_run_artifact_paths_v0()
+
+    assert "shadow_session_summary.json" in stable_paths
+    assert "p5a/l3_trade_plan_advisory.json" in stable_paths
+    assert "p7/fills.json" in stable_paths
+    assert "p7/account.json" in stable_paths
+
+
+def test_runbooks_document_stable_vs_volatile_repeated_run_boundary() -> None:
+    acceptance = ACCEPTANCE_RUNBOOK.read_text(encoding="utf-8")
+    governance = GOVERNANCE_RUNBOOK.read_text(encoding="utf-8")
+
+    assert "volatile repeated-run fields" in acceptance
+    assert "stable business-critical artifacts" in acceptance
+    assert "created_at_utc" in acceptance
+    assert "p7&#47;fills.json" in acceptance
+    assert "Evidence-Manifest hashes" in governance
+    assert "business-critical artifact drift" in governance


### PR DESCRIPTION
## Summary

- add repeated-run stability normalization for P7 Shadow one-shot dry-run artifacts
- distinguish allowed volatile fields from stable business-critical artifacts
- add tests covering accepted timestamp/meta volatility and rejected fills drift
- document the stability boundary in the one-shot acceptance and repeated-run governance runbooks

## Safety / scope

- tests/docs only
- no Paper/Shadow run executed
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or order paths
- no new evidence/readiness/registry/pointer/handoff surface

## Local validation

- uv run pytest tests/ops/test_p7_shadow_repeated_run_stability_contract_v0.py tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py tests/ops/test_p7_shadow_repeated_one_shot_governance_doc_contract_v0.py -q
- uv run ruff check tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py tests/ops/test_p7_shadow_repeated_run_stability_contract_v0.py
- uv run ruff format --check tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py tests/ops/test_p7_shadow_repeated_run_stability_contract_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs