### PR TITLE
test(ops): add p7 shadow high-vol no-trade fixture family v0

### DIFF
--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/evidence_manifest.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/evidence_manifest.json
@@ -1,0 +1,45 @@
+{
+  "files": [
+    {
+      "bytes": 466,
+      "name": "l2_market_outlook.json",
+      "relpath": "p4c/l2_market_outlook.json",
+      "sha256": "adc347bc925650acb7328541cddf2adcd955e0eb0864204a0c633f32f597319a"
+    },
+    {
+      "bytes": 364,
+      "name": "l3_trade_plan_advisory.json",
+      "relpath": "p5a/l3_trade_plan_advisory.json",
+      "sha256": "d228bc5f54d20f936d25d5a976b571709799c001e4b1769b1d1e4db3ad6fce9a"
+    },
+    {
+      "bytes": 94,
+      "name": "p7_account.json",
+      "relpath": "p7_account.json",
+      "sha256": "ee263b02ac3c125797ecb24dda8b14e01752131008c22e9af949eefec86d21ba"
+    },
+    {
+      "bytes": 516,
+      "name": "p7_evidence_manifest.json",
+      "relpath": "p7_evidence_manifest.json",
+      "sha256": "b9f0eca52ebaaa67c69ee24b3f04631619f9e698250adae646fb48b2222e1378"
+    },
+    {
+      "bytes": 289,
+      "name": "p7_fills.json",
+      "relpath": "p7_fills.json",
+      "sha256": "1880eda16fa9b5b96dcfa02b0fbd2b374b86bd2e88679ebf16420f2410893115"
+    },
+    {
+      "bytes": 942,
+      "name": "shadow_session_summary.json",
+      "relpath": "shadow_session_summary.json",
+      "sha256": "63fb609d6e7739beec9dcc20c4066108f27a4ee76bf57f4ae8dc890164a74bfb"
+    }
+  ],
+  "meta": {
+    "created_at_utc": "2026-05-05T15:09:21.000900Z",
+    "kind": "p6_shadow_session_manifest",
+    "schema_version": "p6.shadow_session.v0"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p4c/l2_market_outlook.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p4c/l2_market_outlook.json
@@ -1,0 +1,22 @@
+{
+  "capsule_preview_keys": [
+    "asof_utc",
+    "context",
+    "features",
+    "schema_version",
+    "universe"
+  ],
+  "inputs": {
+    "capsule": "tests/fixtures/p4c/capsule_min_v0.json"
+  },
+  "meta": {
+    "created_at_utc": "2026-05-05T15:00:46.371723Z",
+    "runner_version": "0.0.0",
+    "schema_version": "p4c.l2_market_outlook.v0"
+  },
+  "outlook": {
+    "no_trade": false,
+    "no_trade_reasons": [],
+    "regime": "VOL_EXTREME"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p4c/market_outlook.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p4c/market_outlook.json
@@ -1,0 +1,22 @@
+{
+  "capsule_preview_keys": [
+    "asof_utc",
+    "context",
+    "features",
+    "schema_version",
+    "universe"
+  ],
+  "inputs": {
+    "capsule": "tests/fixtures/p4c/capsule_min_v0.json"
+  },
+  "meta": {
+    "created_at_utc": "2026-05-05T15:00:46.371723Z",
+    "runner_version": "0.0.0",
+    "schema_version": "p4c.l2_market_outlook.v0"
+  },
+  "outlook": {
+    "no_trade": false,
+    "no_trade_reasons": [],
+    "regime": "VOL_EXTREME"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p5a/l3_trade_plan_advisory.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p5a/l3_trade_plan_advisory.json
@@ -1,0 +1,42 @@
+{
+  "allocations": {
+    "decision": "NO_TRADE",
+    "reason": "high volatility no-trade fixture",
+    "regime": "VOL_EXTREME",
+    "scenario": "high_vol_no_trade",
+    "trade_allowed": false
+  },
+  "asof_utc": "2026-02-11T11:02:19Z",
+  "constraints": {
+    "decision": "NO_TRADE",
+    "max_gross_exposure": 1,
+    "max_leverage": 1,
+    "reason": "high volatility no-trade fixture",
+    "regime": "VOL_EXTREME",
+    "scenario": "high_vol_no_trade",
+    "trade_allowed": false
+  },
+  "decision": "NO_TRADE",
+  "evidence": {
+    "decision": "NO_TRADE",
+    "reason": "high volatility no-trade fixture",
+    "regime": "VOL_EXTREME",
+    "scenario": "high_vol_no_trade",
+    "trade_allowed": false
+  },
+  "no_trade": false,
+  "no_trade_reasons": [],
+  "rationale": [
+    "p5a_v0_stub"
+  ],
+  "reason": "high volatility no-trade fixture",
+  "regime": "VOL_EXTREME",
+  "scenario": "high_vol_no_trade",
+  "schema_version": "p5a.trade_plan_advisory.v0",
+  "stance": "HOLD",
+  "trade_allowed": false,
+  "universe": [
+    "BTC/USDT",
+    "ETH/USDT"
+  ]
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7/account.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7/account.json
@@ -1,0 +1,9 @@
+{
+  "cash": 999.6,
+  "positions": {
+    "BTC": 0.0,
+    "scenario": 0.0
+  },
+  "scenario": "high_vol_no_trade",
+  "schema_version": "p7.account.v0"
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7/evidence_manifest.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7/evidence_manifest.json
@@ -1,0 +1,21 @@
+{
+  "files": [
+    {
+      "bytes": 94,
+      "name": "account.json",
+      "relpath": "p7/account.json",
+      "sha256": "ee263b02ac3c125797ecb24dda8b14e01752131008c22e9af949eefec86d21ba"
+    },
+    {
+      "bytes": 289,
+      "name": "fills.json",
+      "relpath": "p7/fills.json",
+      "sha256": "1880eda16fa9b5b96dcfa02b0fbd2b374b86bd2e88679ebf16420f2410893115"
+    }
+  ],
+  "meta": {
+    "created_at_utc": "2026-05-05T15:09:20.999375Z",
+    "kind": "p7_paper_manifest",
+    "schema_version": "p7.paper_run.v0"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7/fills.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7/fills.json
@@ -1,0 +1,5 @@
+{
+  "decision": "NO_TRADE",
+  "fills": [],
+  "scenario": "high_vol_no_trade"
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7_account.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7_account.json
@@ -1,0 +1,9 @@
+{
+  "cash": 999.6,
+  "positions": {
+    "BTC": 0.0,
+    "scenario": 0.0
+  },
+  "scenario": "high_vol_no_trade",
+  "schema_version": "p7.account.v0"
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7_evidence_manifest.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7_evidence_manifest.json
@@ -1,0 +1,21 @@
+{
+  "files": [
+    {
+      "bytes": 94,
+      "name": "account.json",
+      "relpath": "account.json",
+      "sha256": "ee263b02ac3c125797ecb24dda8b14e01752131008c22e9af949eefec86d21ba"
+    },
+    {
+      "bytes": 289,
+      "name": "fills.json",
+      "relpath": "fills.json",
+      "sha256": "1880eda16fa9b5b96dcfa02b0fbd2b374b86bd2e88679ebf16420f2410893115"
+    }
+  ],
+  "meta": {
+    "created_at_utc": "2026-05-05T15:00:46.928681Z",
+    "kind": "p7_paper_manifest",
+    "schema_version": "p7.paper_run.v0"
+  }
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7_fills.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/p7_fills.json
@@ -1,0 +1,5 @@
+{
+  "decision": "NO_TRADE",
+  "fills": [],
+  "scenario": "high_vol_no_trade"
+}

--- a/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/shadow_session_summary.json
+++ b/tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0/shadow_session_summary.json
@@ -1,0 +1,75 @@
+{
+  "asof_utc": "2026-02-11T14:00:00Z",
+  "decision": "NO_TRADE",
+  "no_trade": false,
+  "notes": [
+    "dry_run_only",
+    "no_execution"
+  ],
+  "outputs": {
+    "decision": "NO_TRADE",
+    "p4c_out": "p4c/l2_market_outlook.json",
+    "p5a_out": "p5a/l3_trade_plan_advisory.json",
+    "p7_account": "p7_account.json",
+    "p7_evidence_manifest": "p7_evidence_manifest.json",
+    "p7_fills": "p7_fills.json",
+    "regime": "VOL_EXTREME",
+    "scenario": "high_vol_no_trade",
+    "trade_allowed": false
+  },
+  "p7_account_summary": {
+    "cash": 999.6,
+    "decision": "NO_TRADE",
+    "positions": {
+      "BTC": 0.0,
+      "decision": "NO_TRADE",
+      "regime": "VOL_EXTREME",
+      "scenario": "high_vol_no_trade",
+      "trade_allowed": false
+    },
+    "regime": "VOL_EXTREME",
+    "scenario": "high_vol_no_trade",
+    "schema_version": "p7.account.v0",
+    "trade_allowed": false
+  },
+  "p7_outputs": {
+    "decision": "NO_TRADE",
+    "p7_account": "p7_account.json",
+    "p7_evidence_manifest": "p7_evidence_manifest.json",
+    "p7_fills": "p7_fills.json",
+    "regime": "VOL_EXTREME",
+    "scenario": "high_vol_no_trade",
+    "trade_allowed": false
+  },
+  "regime": "VOL_EXTREME",
+  "run_id": "p7_ctl",
+  "scenario": "high_vol_no_trade",
+  "schema_version": "p6.shadow_session.v0",
+  "steps": [
+    {
+      "decision": "NO_TRADE",
+      "name": "p4c",
+      "out": "p4c/l2_market_outlook.json",
+      "regime": "VOL_EXTREME",
+      "scenario": "high_vol_no_trade",
+      "trade_allowed": false
+    },
+    {
+      "decision": "NO_TRADE",
+      "name": "p5a",
+      "out": "p5a/l3_trade_plan_advisory.json",
+      "regime": "VOL_EXTREME",
+      "scenario": "high_vol_no_trade",
+      "trade_allowed": false
+    },
+    {
+      "decision": "NO_TRADE",
+      "name": "p7",
+      "out": "p7_fills.json",
+      "regime": "VOL_EXTREME",
+      "scenario": "high_vol_no_trade",
+      "trade_allowed": false
+    }
+  ],
+  "trade_allowed": false
+}

--- a/tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py
+++ b/tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py
@@ -248,3 +248,25 @@ def assert_p7_shadow_repeated_run_stability_v0(
             assert relpath in run_payloads, f"missing stable artifact in {run_name}: {relpath}"
             actual = normalize_p7_shadow_repeated_run_value_v0(run_payloads[relpath])
             assert actual == expected, f"stable artifact drifted after normalization: {relpath}"
+
+
+P7_SHADOW_ACCEPTANCE_FIXTURE_PROFILES_V0 = {
+    "baseline": {
+        "fixture_dir": "tests/fixtures/p7_shadow_one_shot_acceptance_v0",
+        "expected_scenario": None,
+        "expected_decision": None,
+        "fills_may_be_empty": False,
+    },
+    "high_vol_no_trade": {
+        "fixture_dir": "tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0",
+        "expected_scenario": "high_vol_no_trade",
+        "expected_decision": "NO_TRADE",
+        "fills_may_be_empty": True,
+    },
+}
+
+
+def p7_shadow_acceptance_fixture_profiles_v0():
+    """Return supported offline P7 Shadow acceptance fixture profiles."""
+
+    return P7_SHADOW_ACCEPTANCE_FIXTURE_PROFILES_V0

--- a/tests/ops/test_p7_shadow_high_vol_no_trade_fixture_contract_v0.py
+++ b/tests/ops/test_p7_shadow_high_vol_no_trade_fixture_contract_v0.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+from tests.ops.p7_shadow_one_shot_acceptance_bundle_v0 import (
+    p7_shadow_acceptance_fixture_profiles_v0,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = (
+    REPO_ROOT / "tests" / "fixtures" / "p7_shadow_one_shot_acceptance_high_vol_no_trade_v0"
+)
+BASELINE_DIR = REPO_ROOT / "tests" / "fixtures" / "p7_shadow_one_shot_acceptance_v0"
+
+
+def _json_files(root: Path) -> list[Path]:
+    return sorted(root.rglob("*.json"))
+
+
+def _load(relpath: str) -> object:
+    return json.loads((FIXTURE_DIR / relpath).read_text(encoding="utf-8"))
+
+
+def test_high_vol_no_trade_fixture_has_same_relative_artifact_set_as_baseline() -> None:
+    baseline = {path.relative_to(BASELINE_DIR).as_posix() for path in _json_files(BASELINE_DIR)}
+    candidate = {path.relative_to(FIXTURE_DIR).as_posix() for path in _json_files(FIXTURE_DIR)}
+
+    assert len(candidate) == 11
+    assert candidate == baseline
+
+
+def test_high_vol_no_trade_fixture_json_is_valid_and_portable() -> None:
+    for path in _json_files(FIXTURE_DIR):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        serialized = json.dumps(data, sort_keys=True)
+        assert "/Users/" not in serialized
+        assert "/tmp/" not in serialized
+
+
+def test_high_vol_no_trade_fixture_declares_no_trade_semantics() -> None:
+    summary = _load("shadow_session_summary.json")
+    trade_plan = _load("p5a/l3_trade_plan_advisory.json")
+
+    assert isinstance(summary, dict)
+    assert isinstance(trade_plan, dict)
+    assert summary["scenario"] == "high_vol_no_trade"
+    assert summary["regime"] == "VOL_EXTREME"
+    assert summary["decision"] == "NO_TRADE"
+    assert summary["trade_allowed"] is False
+    assert trade_plan["scenario"] == "high_vol_no_trade"
+    assert trade_plan["regime"] == "VOL_EXTREME"
+    assert trade_plan["decision"] == "NO_TRADE"
+    assert trade_plan["trade_allowed"] is False
+
+
+def test_high_vol_no_trade_fixture_has_empty_fills_and_flat_account() -> None:
+    fills = _load("p7/fills.json")
+    promoted_fills = _load("p7_fills.json")
+    account = _load("p7/account.json")
+    promoted_account = _load("p7_account.json")
+
+    assert isinstance(fills, dict)
+    assert isinstance(promoted_fills, dict)
+    assert fills["fills"] == []
+    assert promoted_fills["fills"] == []
+    assert isinstance(account, dict)
+    assert isinstance(promoted_account, dict)
+    assert all(value == 0.0 for value in account.get("positions", {}).values())
+    assert all(value == 0.0 for value in promoted_account.get("positions", {}).values())
+
+
+def test_fixture_profiles_register_high_vol_no_trade_family() -> None:
+    profiles = p7_shadow_acceptance_fixture_profiles_v0()
+
+    assert profiles["high_vol_no_trade"] == {
+        "fixture_dir": "tests/fixtures/p7_shadow_one_shot_acceptance_high_vol_no_trade_v0",
+        "expected_scenario": "high_vol_no_trade",
+        "expected_decision": "NO_TRADE",
+        "fills_may_be_empty": True,
+    }


### PR DESCRIPTION
## Summary

- add a second offline P7 Shadow one-shot acceptance fixture family for high-vol/no-trade semantics
- register fixture profiles for baseline and high_vol_no_trade
- add contract tests for artifact set parity, portability, NO_TRADE semantics, empty fills, and flat account state

## Safety / scope

- tests/fixtures only plus helper profile registration
- no Paper/Shadow run executed
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or order paths
- no evidence/readiness/registry/pointer/handoff surface

## Local validation

- uv run pytest tests/ops/test_p7_shadow_high_vol_no_trade_fixture_contract_v0.py tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py tests/ops/test_p7_shadow_repeated_run_stability_contract_v0.py tests/ops/test_report_p7_shadow_repeated_campaign_summary_cli_v0.py -q
- uv run ruff check tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py tests/ops/test_p7_shadow_high_vol_no_trade_fixture_contract_v0.py
- uv run ruff format --check tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py tests/ops/test_p7_shadow_high_vol_no_trade_fixture_contract_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- profile static check: profiles_ok=true