### PR TITLE
test(ops): parametrize p7 shadow bundle validator profiles v0

### DIFF
--- a/tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py
+++ b/tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py
@@ -99,10 +99,18 @@ def _validate_shadow_session_summary(data: dict[str, Any]) -> None:
     assert isinstance(steps, list) and len(steps) >= 3
 
 
-def _validate_p7_fills(data: dict[str, Any]) -> None:
-    assert data.get("schema_version") == "p7.fills.v0"
+def _validate_p7_fills(data: dict[str, Any], *, fills_may_be_empty: bool) -> None:
     fills = data.get("fills")
-    assert isinstance(fills, list) and len(fills) >= 1
+    assert isinstance(fills, list), "fills must be a list"
+
+    if fills_may_be_empty and len(fills) == 0:
+        return
+
+    if not fills_may_be_empty and len(fills) < 1:
+        raise AssertionError("expected at least one fill")
+
+    assert data.get("schema_version") == "p7.fills.v0"
+    assert len(fills) >= 1
 
 
 def _validate_p7_account(data: dict[str, Any]) -> None:
@@ -126,8 +134,11 @@ def _validate_p7_evidence_manifest(data: dict[str, Any]) -> None:
     assert isinstance(files, list) and len(files) == 2
 
 
-def validate_p7_shadow_one_shot_artifact_bundle(bundle_root: Path) -> None:
+def validate_p7_shadow_one_shot_artifact_bundle(
+    bundle_root: Path, *, profile_name: str = "baseline"
+) -> None:
     """Raise AssertionError when the bundle does not satisfy the v0 acceptance contract."""
+    profile = _profile_config_v0(profile_name)
     root = bundle_root.resolve()
     if not root.is_dir():
         raise AssertionError(f"bundle root is not a directory: {root}")
@@ -144,8 +155,9 @@ def validate_p7_shadow_one_shot_artifact_bundle(bundle_root: Path) -> None:
     _forbidden_scan(root)
 
     _validate_shadow_session_summary(_load_json(root / "shadow_session_summary.json"))
-    _validate_p7_fills(_load_json(root / "p7_fills.json"))
-    _validate_p7_fills(_load_json(root / "p7" / "fills.json"))
+    allow_empty = profile["fills_may_be_empty"]
+    _validate_p7_fills(_load_json(root / "p7_fills.json"), fills_may_be_empty=allow_empty)
+    _validate_p7_fills(_load_json(root / "p7" / "fills.json"), fills_may_be_empty=allow_empty)
     _validate_p7_account(_load_json(root / "p7_account.json"))
     _validate_p7_account(_load_json(root / "p7" / "account.json"))
     _validate_root_evidence_manifest(_load_json(root / "evidence_manifest.json"))
@@ -264,6 +276,15 @@ P7_SHADOW_ACCEPTANCE_FIXTURE_PROFILES_V0 = {
         "fills_may_be_empty": True,
     },
 }
+
+
+def _profile_config_v0(profile_name: str) -> dict[str, Any]:
+    try:
+        return P7_SHADOW_ACCEPTANCE_FIXTURE_PROFILES_V0[profile_name]
+    except KeyError as exc:
+        raise AssertionError(
+            f"unknown P7 Shadow acceptance fixture profile: {profile_name}"
+        ) from exc
 
 
 def p7_shadow_acceptance_fixture_profiles_v0():

--- a/tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py
+++ b/tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+import pytest
+
 from tests.ops.p7_shadow_one_shot_acceptance_bundle_v0 import (
     validate_p7_shadow_one_shot_artifact_bundle,
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_BUNDLE = Path("tests/fixtures/p7_shadow_one_shot_acceptance_v0")
+HIGH_VOL_FIXTURE_BUNDLE = (
+    REPO_ROOT / "tests" / "fixtures" / "p7_shadow_one_shot_acceptance_high_vol_no_trade_v0"
+)
 
 
 def test_p7_shadow_one_shot_acceptance_fixture_dir_contract_v0() -> None:
@@ -21,3 +27,26 @@ def test_p7_shadow_one_shot_acceptance_tmp_path_copy_contract_v0(tmp_path: Path)
     dst = tmp_path / "out"
     shutil.copytree(FIXTURE_BUNDLE, dst)
     validate_p7_shadow_one_shot_artifact_bundle(dst)
+
+
+def test_shared_validator_accepts_high_vol_no_trade_profile() -> None:
+    validate_p7_shadow_one_shot_artifact_bundle(
+        HIGH_VOL_FIXTURE_BUNDLE,
+        profile_name="high_vol_no_trade",
+    )
+
+
+def test_shared_validator_rejects_empty_fills_for_baseline_profile() -> None:
+    with pytest.raises(AssertionError, match="expected at least one fill"):
+        validate_p7_shadow_one_shot_artifact_bundle(
+            HIGH_VOL_FIXTURE_BUNDLE,
+            profile_name="baseline",
+        )
+
+
+def test_shared_validator_rejects_unknown_profile() -> None:
+    with pytest.raises(AssertionError, match="unknown P7 Shadow acceptance fixture profile"):
+        validate_p7_shadow_one_shot_artifact_bundle(
+            FIXTURE_BUNDLE,
+            profile_name="missing_profile",
+        )


### PR DESCRIPTION
## Summary

- parametrize the shared P7 Shadow one-shot acceptance bundle validator by fixture profile
- keep baseline behavior requiring non-empty fills
- allow empty fills for high_vol_no_trade where that is the expected no-trade state
- add tests for high-vol profile validation, baseline rejection, and unknown profile failure

## Safety / scope

- tests/helper only
- no Paper/Shadow run executed
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or order paths
- no evidence/readiness/registry/pointer/handoff surface

## Local validation

- uv run pytest tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py tests/ops/test_p7_shadow_high_vol_no_trade_fixture_contract_v0.py tests/ops/test_p7_shadow_repeated_run_stability_contract_v0.py tests/ops/test_report_p7_shadow_repeated_campaign_summary_cli_v0.py -q
- uv run ruff check tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py
- uv run ruff format --check tests/ops/p7_shadow_one_shot_acceptance_bundle_v0.py tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs