### PR TITLE
test(aiops): add high-vol no-trade runtime spec contract v0

### DIFF
--- a/tests/aiops/p6/test_high_vol_no_trade_runtime_spec_contract_v0.py
+++ b/tests/aiops/p6/test_high_vol_no_trade_runtime_spec_contract_v0.py
@@ -1,0 +1,87 @@
+"""Offline contract for high-vol / no-trade runtime spec fixtures (no runner execution)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SHADOW_SPEC = REPO_ROOT / "tests" / "fixtures" / "p6" / "shadow_session_high_vol_no_trade_v0.json"
+P4C_CAPSULE = REPO_ROOT / "tests" / "fixtures" / "p4c" / "capsule_high_vol_no_trade_v0.json"
+P5A_INPUT = REPO_ROOT / "tests" / "fixtures" / "p5a" / "input_high_vol_no_trade_v0.json"
+P7_SPEC = REPO_ROOT / "tests" / "fixtures" / "p7" / "paper_run_high_vol_no_trade_v0.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_high_vol_no_trade_shadow_spec_links_portable_inputs() -> None:
+    spec = _load(SHADOW_SPEC)
+
+    assert spec["schema_version"] == "p6.shadow_session_spec.v0"
+    assert spec["scenario"] == "high_vol_no_trade"
+    assert spec["profile"] == "high_vol_no_trade"
+    assert spec["expected_decision"] == "NO_TRADE"
+    assert spec["expected_regime"] == "VOL_EXTREME"
+    assert spec["inputs"] == {
+        "capsule_path": "tests/fixtures/p4c/capsule_high_vol_no_trade_v0.json",
+        "p5a_input_path": "tests/fixtures/p5a/input_high_vol_no_trade_v0.json",
+        "paper_run_spec_path": "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json",
+    }
+
+
+def test_high_vol_no_trade_runtime_spec_inputs_are_consistent() -> None:
+    spec = _load(SHADOW_SPEC)
+    capsule = _load(P4C_CAPSULE)
+    p5a = _load(P5A_INPUT)
+    p7 = _load(P7_SPEC)
+
+    assert capsule["scenario"] == spec["scenario"] == p5a["scenario"] == p7["scenario"]
+    assert capsule["decision"] == p5a["decision"] == p7["decision"] == "NO_TRADE"
+    assert capsule["regime"] == p5a["regime"] == spec["expected_regime"] == "VOL_EXTREME"
+    assert p5a["no_trade"] is True
+    assert p5a["trade_allowed"] is False
+    assert p5a["should_trade"] is False
+    assert p7["schema_version"] == "p7.paper_run.v0"
+    assert p7["orders"] == []
+    assert p7["expected_fills"] == []
+    assert p7["expected_positions"] == {"BTC": 0.0}
+
+
+def test_high_vol_no_trade_runtime_spec_is_non_authorizing() -> None:
+    payloads = [_load(SHADOW_SPEC), _load(P4C_CAPSULE), _load(P5A_INPUT), _load(P7_SPEC)]
+
+    for payload in payloads:
+        assert payload.get("activation_authorized") is False
+        assert payload.get("testnet_authorized") is False
+        assert payload.get("live_authorized") is False
+
+    spec = _load(SHADOW_SPEC)
+    p7 = _load(P7_SPEC)
+    for payload in (spec, p7):
+        assert payload["scheduler_authorized"] is False
+        assert payload["daemon_authorized"] is False
+        assert payload["broker_authorized"] is False
+        assert payload["exchange_authorized"] is False
+        assert payload["order_submission_authorized"] is False
+
+
+def test_high_vol_no_trade_runtime_spec_paths_are_portable() -> None:
+    for path in (SHADOW_SPEC, P4C_CAPSULE, P5A_INPUT, P7_SPEC):
+        text = path.read_text(encoding="utf-8")
+        assert "/Users/" not in text
+        assert "/tmp/" not in text
+        assert "api_key" not in text.lower()
+        assert "secret" not in text.lower()
+
+
+def test_high_vol_no_trade_runtime_spec_is_offline_contract_only() -> None:
+    spec = _load(SHADOW_SPEC)
+    p7 = _load(P7_SPEC)
+
+    assert "offline_spec_contract_only" in spec["notes"]
+    assert "does_not_run_shadow" in spec["notes"]
+    assert "does_not_run_paper" in spec["notes"]
+    assert "offline_spec_contract_only" in p7["notes"]
+    assert "flat_account_expected" in p7["notes"]

--- a/tests/fixtures/p4c/capsule_high_vol_no_trade_v0.json
+++ b/tests/fixtures/p4c/capsule_high_vol_no_trade_v0.json
@@ -1,0 +1,28 @@
+{
+  "activation_authorized": false,
+  "context": {
+    "scenario": "high_vol_no_trade",
+    "source": "fixture",
+    "stage": "research"
+  },
+  "decision": "NO_TRADE",
+  "features": {
+    "trend_7d": {
+      "BTC/USDT": 0.05,
+      "ETH/USDT": -0.02
+    },
+    "volatility_14d": {
+      "BTC/USDT": 0.92,
+      "ETH/USDT": 0.95
+    }
+  },
+  "live_authorized": false,
+  "reason": "Synthetic high-volatility no-trade runtime-spec contract fixture.",
+  "regime": "VOL_EXTREME",
+  "schema_version": "p4c.capsule.v0",
+  "scenario": "high_vol_no_trade",
+  "testnet_authorized": false,
+  "trade_allowed": false,
+  "universe": ["BTC/USDT", "ETH/USDT"],
+  "volatility_regime": "VOL_EXTREME"
+}

--- a/tests/fixtures/p5a/input_high_vol_no_trade_v0.json
+++ b/tests/fixtures/p5a/input_high_vol_no_trade_v0.json
@@ -1,0 +1,32 @@
+{
+  "activation_authorized": false,
+  "asof_utc": "2026-02-11T11:02:19Z",
+  "decision": "NO_TRADE",
+  "live_authorized": false,
+  "no_trade": true,
+  "orders": [],
+  "p4c_outlook": {
+    "no_trade": true,
+    "no_trade_reasons": [
+      "VOL_EXTREME"
+    ],
+    "regime": "HIGH_VOL"
+  },
+  "reason": "Synthetic no-trade input for high-volatility P7 Shadow spec contract.",
+  "regime": "VOL_EXTREME",
+  "risk": {
+    "max_gross_exposure": 1,
+    "max_leverage": 1
+  },
+  "schema_version": "p5a.input.v0",
+  "scenario": "high_vol_no_trade",
+  "should_trade": false,
+  "testnet_authorized": false,
+  "timeframe": "1m",
+  "trade_allowed": false,
+  "universe": [
+    "BTC/USDT",
+    "ETH/USDT"
+  ],
+  "volatility_regime": "VOL_EXTREME"
+}

--- a/tests/fixtures/p6/shadow_session_high_vol_no_trade_v0.json
+++ b/tests/fixtures/p6/shadow_session_high_vol_no_trade_v0.json
@@ -1,0 +1,31 @@
+{
+  "activation_authorized": false,
+  "broker_authorized": false,
+  "daemon_authorized": false,
+  "exchange_authorized": false,
+  "expected_decision": "NO_TRADE",
+  "expected_fills": [],
+  "expected_positions": {
+    "BTC": 0.0
+  },
+  "expected_regime": "VOL_EXTREME",
+  "inputs": {
+    "capsule_path": "tests/fixtures/p4c/capsule_high_vol_no_trade_v0.json",
+    "paper_run_spec_path": "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json",
+    "p5a_input_path": "tests/fixtures/p5a/input_high_vol_no_trade_v0.json"
+  },
+  "live_authorized": false,
+  "notes": [
+    "does_not_run_paper",
+    "does_not_run_shadow",
+    "empty_fills_expected",
+    "offline_spec_contract_only"
+  ],
+  "order_submission_authorized": false,
+  "profile": "high_vol_no_trade",
+  "runtime_authorized": false,
+  "scenario": "high_vol_no_trade",
+  "scheduler_authorized": false,
+  "schema_version": "p6.shadow_session_spec.v0",
+  "testnet_authorized": false
+}

--- a/tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json
+++ b/tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json
@@ -1,0 +1,34 @@
+{
+  "activation_authorized": false,
+  "asof_utc": "2026-02-11T13:40:00Z",
+  "broker_authorized": false,
+  "daemon_authorized": false,
+  "decision": "NO_TRADE",
+  "exchange_authorized": false,
+  "expected_fills": [],
+  "expected_positions": {
+    "BTC": 0.0
+  },
+  "fee_rate": 0.001,
+  "initial_cash": 1000.0,
+  "live_authorized": false,
+  "mid_prices": {
+    "BTC": 100.0
+  },
+  "notes": [
+    "empty_fills_expected",
+    "flat_account_expected",
+    "offline_spec_contract_only"
+  ],
+  "order_submission_authorized": false,
+  "orders": [],
+  "profile": "high_vol_no_trade",
+  "scenario": "high_vol_no_trade",
+  "scheduler_authorized": false,
+  "schema_version": "p7.paper_run.v0",
+  "should_trade": false,
+  "slippage_bps": 10.0,
+  "testnet_authorized": false,
+  "timeframe": "1m",
+  "trade_allowed": false
+}


### PR DESCRIPTION
## Summary

- add offline high-vol/no-trade runtime spec contract fixtures across P4C/P5a/P6/P7
- add static contract tests for scenario consistency, no-trade semantics, portable paths, and non-authority flags
- keep this contract-only: it does not make the high-vol/no-trade spec runner-compatible yet

## Safety / scope

- tests/fixtures only
- no Paper/Shadow run executed
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or order paths
- no evidence/readiness/registry/pointer/handoff surface
- p7_ctl run-shadow execution remains blocked until a runner-compatible spec or mapping exists

## Local validation

- uv run pytest tests/aiops/p6/test_high_vol_no_trade_runtime_spec_contract_v0.py tests/aiops/p6 tests/aiops/p7 tests/ops/test_p7_shadow_high_vol_no_trade_fixture_contract_v0.py tests/ops/test_p7_shadow_one_shot_acceptance_contract_v0.py -q
- uv run ruff check tests/aiops/p6/test_high_vol_no_trade_runtime_spec_contract_v0.py
- uv run ruff format --check tests/aiops/p6/test_high_vol_no_trade_runtime_spec_contract_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- static fixture portability/non-secret check