### PR TITLE
fix(sim): reconcile no-order paper sessions

### DIFF
--- a/src/sim/paper/simulator.py
+++ b/src/sim/paper/simulator.py
@@ -66,12 +66,13 @@ class PaperTradingSimulator:
         )
 
     def reconcile(self, acct: PaperAccount) -> Tuple[float, Dict[str, float]]:
-        if self.ledger:
-            self.ledger.append(
-                snapshot(
-                    step=len(self.ledger),
-                    cash=acct.cash,
-                    positions=acct.positions,
-                )
+        # Always record a terminal snapshot. With zero orders the ledger would otherwise
+        # stay empty and verify_invariants would raise EMPTY_LEDGER.
+        self.ledger.append(
+            snapshot(
+                step=len(self.ledger),
+                cash=acct.cash,
+                positions=acct.positions,
             )
+        )
         return verify_invariants(self.ledger)

--- a/tests/sim/paper/test_reconcile_invariants.py
+++ b/tests/sim/paper/test_reconcile_invariants.py
@@ -18,8 +18,10 @@ def test_ledger_has_snapshots_and_reconcile_returns_last() -> None:
     assert len(sim.ledger) >= 3  # before each execute + final snapshot
 
 
-def test_reconcile_empty_ledger_fails() -> None:
+def test_reconcile_no_orders_returns_initial_account() -> None:
     acct = PaperAccount(cash=1000.0)
     sim = PaperTradingSimulator()
-    with pytest.raises(RuntimeError, match="EMPTY_LEDGER"):
-        sim.reconcile(acct)
+    cash, pos = sim.reconcile(acct)
+    assert cash == 1000.0
+    assert pos == {}
+    assert len(sim.ledger) == 1


### PR DESCRIPTION
## Summary

- fix paper simulator reconciliation for no-order/no-fill sessions
- ensure reconcile produces a final account snapshot instead of raising EMPTY_LEDGER for valid no-trade sessions
- update reconcile invariant coverage for no-order sessions

## Safety / scope

- minimal simulator/test fix
- no Paper/Shadow campaign run executed by this PR
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or order paths
- required before repeating high_vol_no_trade campaign from clean main

## Local validation

- uv run pytest tests/sim/paper tests/aiops/p7 tests/aiops/p6/test_high_vol_no_trade_runner_fixture_contract_v0.py tests/aiops/p6/test_high_vol_no_trade_runtime_spec_contract_v0.py tests/ops/test_p7_ctl_run_contract_v0.py -q
- uv run ruff check src/sim/paper/simulator.py tests/sim/paper/test_reconcile_invariants.py
- uv run ruff format --check src/sim/paper/simulator.py tests/sim/paper/test_reconcile_invariants.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs