### PR TITLE
feat(aiops): propagate shadow summary spec metadata v0

### DIFF
--- a/scripts/aiops/run_shadow_session.py
+++ b/scripts/aiops/run_shadow_session.py
@@ -22,6 +22,19 @@ from src.aiops.p4c.evidence import build_manifest, write_json
 from src.aiops.p6.session_schema import ShadowSessionSummary
 
 
+def _shadow_session_summary_metadata_v0(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Copy non-authorizing campaign metadata from the runner spec into the session summary."""
+    allowed = (
+        "scenario",
+        "profile",
+        "expected_decision",
+        "expected_regime",
+        "expected_fills",
+        "expected_positions",
+    )
+    return {k: spec[k] for k in allowed if k in spec}
+
+
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -213,6 +226,7 @@ def main() -> int:
             p7_printed.append(out_p7_manifest)
 
     summary = ShadowSessionSummary(
+        **_shadow_session_summary_metadata_v0(spec),
         run_id=(args.run_id.strip() or outdir.name),
         asof_utc=str(spec.get("asof_utc", "")),
         steps=[

--- a/src/aiops/p6/session_schema.py
+++ b/src/aiops/p6/session_schema.py
@@ -12,6 +12,12 @@ class ShadowSessionSummary:
     schema_version: str = SCHEMA_VERSION
     run_id: str = ""
     asof_utc: str = ""
+    scenario: str | None = None
+    profile: str | None = None
+    expected_decision: str | None = None
+    expected_regime: str | None = None
+    expected_fills: List[Any] | None = None
+    expected_positions: Dict[str, float] | None = None
     steps: List[Dict[str, Any]] = field(default_factory=list)
     outputs: Dict[str, Any] = field(default_factory=dict)
     no_trade: bool = False
@@ -21,5 +27,15 @@ class ShadowSessionSummary:
 
     def to_dict(self) -> Dict[str, Any]:
         d = asdict(self)
+        for key in (
+            "scenario",
+            "profile",
+            "expected_decision",
+            "expected_regime",
+            "expected_fills",
+            "expected_positions",
+        ):
+            if d.get(key) is None:
+                d.pop(key, None)
         d["notes"] = sorted(set([str(x) for x in d["notes"]]))
         return d

--- a/tests/aiops/p6/test_shadow_summary_metadata_propagation_v0.py
+++ b/tests/aiops/p6/test_shadow_summary_metadata_propagation_v0.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.aiops.run_shadow_session import _shadow_session_summary_metadata_v0
+from src.aiops.p6.session_schema import ShadowSessionSummary
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HIGH_VOL_RUNNER_SPEC = (
+    REPO_ROOT / "tests" / "fixtures" / "p6" / "shadow_session_high_vol_no_trade_runner_v0.json"
+)
+
+
+def test_summary_metadata_helper_copies_only_non_authorizing_allowlist() -> None:
+    spec = {
+        "scenario": "high_vol_no_trade",
+        "profile": "high_vol_no_trade",
+        "expected_decision": "NO_TRADE",
+        "expected_regime": "VOL_EXTREME",
+        "expected_fills": [],
+        "expected_positions": {"BTC": 0.0},
+        "activation_authorized": True,
+        "live_authorized": True,
+        "testnet_authorized": True,
+        "broker_authorized": True,
+        "decision": "NO_TRADE",
+    }
+
+    metadata = _shadow_session_summary_metadata_v0(spec)
+
+    assert metadata == {
+        "scenario": "high_vol_no_trade",
+        "profile": "high_vol_no_trade",
+        "expected_decision": "NO_TRADE",
+        "expected_regime": "VOL_EXTREME",
+        "expected_fills": [],
+        "expected_positions": {"BTC": 0.0},
+    }
+
+
+def test_high_vol_runner_spec_metadata_is_summary_schema_native() -> None:
+    spec = json.loads(HIGH_VOL_RUNNER_SPEC.read_text(encoding="utf-8"))
+    metadata = _shadow_session_summary_metadata_v0(spec)
+
+    summary = ShadowSessionSummary(
+        **metadata,
+        run_id="unit",
+        asof_utc="",
+        steps=[],
+        outputs={},
+        no_trade=True,
+        notes=[],
+        p7_outputs={},
+        p7_account_summary={},
+    )
+
+    payload = summary.to_dict()
+
+    assert payload["scenario"] == "high_vol_no_trade"
+    assert payload["profile"] == "high_vol_no_trade"
+    assert payload["expected_decision"] == "NO_TRADE"
+    assert payload["expected_regime"] == "VOL_EXTREME"
+    assert payload["expected_fills"] == []
+    assert payload["expected_positions"] == {"BTC": 0.0}
+
+    for forbidden in (
+        "activation_authorized",
+        "live_authorized",
+        "testnet_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert forbidden not in payload
+
+
+def test_min_v1_p7_spec_does_not_add_metadata_keys_to_summary() -> None:
+    spec_path = REPO_ROOT / "tests" / "fixtures" / "p6" / "shadow_session_min_v1_p7.json"
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    metadata = _shadow_session_summary_metadata_v0(spec)
+    assert metadata == {}
+
+    summary = ShadowSessionSummary(
+        **metadata,
+        run_id="unit",
+        asof_utc="2026-02-11T14:00:00Z",
+        steps=[],
+        outputs={},
+        no_trade=False,
+        notes=["dry_run_only"],
+        p7_outputs={},
+        p7_account_summary={},
+    )
+    payload = summary.to_dict()
+    for key in (
+        "scenario",
+        "profile",
+        "expected_decision",
+        "expected_regime",
+        "expected_fills",
+        "expected_positions",
+    ):
+        assert key not in payload


### PR DESCRIPTION
## Summary

- add metadata-only propagation from Shadow runner specs into shadow_session_summary.json
- allow scenario/profile/expected_* fields when present in the spec
- omit optional metadata keys when absent so minimal specs stay unchanged
- add tests for allowlist behavior, high_vol_no_trade metadata, and minimal-spec non-regression

## Safety / scope

- additive metadata only
- no Paper/Shadow run executed by this PR
- no p7_ctl run-shadow execution
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or order paths
- authority fields are not propagated into the summary

## Local validation

- uv run pytest tests/aiops/p6 tests/aiops/p7 tests/ops/test_p7_ctl_run_contract_v0.py -q
- uv run ruff check scripts/aiops/run_shadow_session.py src/aiops/p6/session_schema.py tests/aiops/p6/test_shadow_summary_metadata_propagation_v0.py
- uv run ruff format --check scripts/aiops/run_shadow_session.py src/aiops/p6/session_schema.py tests/aiops/p6/test_shadow_summary_metadata_propagation_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs