### PR TITLE
fix(aiops): configure promptfoo openai model v0

### DIFF
--- a/evals/aiops/promptfooconfig.yaml
+++ b/evals/aiops/promptfooconfig.yaml
@@ -1,6 +1,6 @@
 description: "Peak_Trade AI Ops evals (V1)"
 providers:
-  - openai:gpt-4
+  - "openai:chat:__PROMPTFOO_OPENAI_MODEL__"
 
 prompts:
   - id: docs_link_fixer

--- a/scripts/aiops/run_promptfoo_eval.sh
+++ b/scripts/aiops/run_promptfoo_eval.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 # === VERSION PINS (for reproducibility) ===
 PROMPTFOO_VERSION="0.120.8"  # Update this for new promptfoo releases
 CANONICAL_NODE_VERSION="v25.2.1"  # Canonical Node version (see .nvmrc)
+PROMPTFOO_OPENAI_MODEL="${PROMPTFOO_OPENAI_MODEL:-gpt-5.5}"
+export PROMPTFOO_OPENAI_MODEL
 
 # === PRE-FLIGHT ===
 echo "==> AI-Ops Eval Runner: Pre-Flight"
@@ -55,6 +57,7 @@ if [ ! -f "$config_path" ]; then
 fi
 
 echo "Config found: $config_path"
+echo "OpenAI model: ${PROMPTFOO_OPENAI_MODEL}"
 echo "Promptfoo version (pinned): $PROMPTFOO_VERSION"
 
 # 4) Check OPENAI_API_KEY (skip gracefully if missing)
@@ -85,6 +88,7 @@ echo "Log file: $log_file"
   echo "Node version: $node_version"
   echo "npx version: $npx_version"
   echo "Promptfoo version: $PROMPTFOO_VERSION"
+  echo "OpenAI model: ${PROMPTFOO_OPENAI_MODEL}"
   echo "Config path: $config_path"
   echo "==========================="
   echo ""
@@ -95,7 +99,24 @@ echo ""
 echo "==> Running promptfoo eval..."
 echo ""
 
-npx promptfoo@${PROMPTFOO_VERSION} eval -c "$config_path" 2>&1 | tee -a "$log_file"
+RESOLVED_CONFIG_PATH="${TMPDIR:-/tmp}/peak_trade_promptfooconfig_${GITHUB_RUN_ID:-local}_${GITHUB_RUN_ATTEMPT:-0}.yaml"
+python3 - "$config_path" "$RESOLVED_CONFIG_PATH" "$PROMPTFOO_OPENAI_MODEL" <<'PY'
+from pathlib import Path
+import sys
+
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+model = sys.argv[3]
+if not model or any(ch.isspace() for ch in model):
+    raise SystemExit("invalid PROMPTFOO_OPENAI_MODEL")
+text = src.read_text(encoding="utf-8")
+if "__PROMPTFOO_OPENAI_MODEL__" not in text:
+    raise SystemExit("promptfoo model placeholder missing")
+dst.write_text(text.replace("__PROMPTFOO_OPENAI_MODEL__", model), encoding="utf-8")
+print(f"[promptfoo] Resolved config: {dst}")
+PY
+
+npx promptfoo@${PROMPTFOO_VERSION} eval -c "$RESOLVED_CONFIG_PATH" 2>&1 | tee -a "$log_file"
 
 exit_code=${PIPESTATUS[0]}
 

--- a/tests/aiops/test_promptfoo_model_config_v0.py
+++ b/tests/aiops/test_promptfoo_model_config_v0.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG = REPO_ROOT / "evals" / "aiops" / "promptfooconfig.yaml"
+RUNNER = REPO_ROOT / "scripts" / "aiops" / "run_promptfoo_eval.sh"
+
+
+def test_promptfoo_config_uses_env_configurable_gpt55_default() -> None:
+    config_text = CONFIG.read_text(encoding="utf-8")
+    data = yaml.safe_load(config_text)
+
+    assert data["providers"] == ["openai:chat:__PROMPTFOO_OPENAI_MODEL__"]
+    assert "openai:gpt-4" not in config_text
+
+
+def test_promptfoo_runner_exports_model_default_without_secret_values() -> None:
+    runner_text = RUNNER.read_text(encoding="utf-8")
+
+    assert 'PROMPTFOO_OPENAI_MODEL="${PROMPTFOO_OPENAI_MODEL:-gpt-5.5}"' in runner_text
+    assert "export PROMPTFOO_OPENAI_MODEL" in runner_text
+    assert "OPENAI_API_KEY" in runner_text
+    assert "OpenAI model:" in runner_text
+
+
+def test_promptfoo_config_change_is_static_only() -> None:
+    runner_text = RUNNER.read_text(encoding="utf-8")
+
+    assert "promptfoo" in runner_text
+    assert "run-shadow" not in runner_text
+    assert "run_scheduler" not in runner_text
+
+
+def test_promptfoo_runner_resolves_config_before_eval() -> None:
+    runner_text = RUNNER.read_text(encoding="utf-8")
+
+    assert "RESOLVED_CONFIG_PATH=" in runner_text
+    assert "__PROMPTFOO_OPENAI_MODEL__" in runner_text
+    assert "PROMPTFOO_OPENAI_MODEL" in runner_text
+    assert 'eval -c "$RESOLVED_CONFIG_PATH"' in runner_text


### PR DESCRIPTION
## Summary

- replace hardcoded Promptfoo provider `openai:gpt-4` with env-configurable GPT-5.5 default
- add `PROMPTFOO_OPENAI_MODEL` export in the Promptfoo runner
- log the selected OpenAI model in the Promptfoo audit header
- add static tests for the Promptfoo model configuration

## Safety / scope

- AI-Ops eval config only
- no Promptfoo eval executed locally
- no Paper/Shadow run executed
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or order paths
- no secret values printed or asserted

## Local validation

- uv run pytest tests/aiops/test_promptfoo_model_config_v0.py -q
- uv run ruff check tests/aiops/test_promptfoo_model_config_v0.py
- uv run ruff format --check tests/aiops/test_promptfoo_model_config_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- static YAML/runner check: promptfoo_model_config_static_check_ok=true

## Notes

- Default model is `gpt-5.5` via `PROMPTFOO_OPENAI_MODEL`.
- CI will be the first place that verifies whether Promptfoo 0.120.8 expands the shell-default expression in provider strings as intended.