### PR TITLE
test(aiops): cover paper runner no-order no-fill session v0

### DIFF
--- a/tests/aiops/p7/test_paper_runner_no_order_no_fill_contract_v0.py
+++ b/tests/aiops/p7/test_paper_runner_no_order_no_fill_contract_v0.py
@@ -1,0 +1,102 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNNER = REPO_ROOT / "scripts" / "aiops" / "run_paper_trading_session.py"
+SPEC = REPO_ROOT / "tests" / "fixtures" / "p7" / "paper_run_high_vol_no_trade_v0.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_paper_runner_no_order_no_fill_session_writes_flat_outputs(tmp_path: Path) -> None:
+    outdir = tmp_path / "paper_no_order_no_fill"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "--spec",
+            str(SPEC),
+            "--outdir",
+            str(outdir),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "EMPTY_LEDGER" not in result.stdout
+    assert "EMPTY_LEDGER" not in result.stderr
+
+    fills_path = outdir / "fills.json"
+    account_path = outdir / "account.json"
+    manifest_path = outdir / "evidence_manifest.json"
+
+    assert fills_path.exists()
+    assert account_path.exists()
+    assert manifest_path.exists()
+
+    fills = _load(fills_path)
+    account = _load(account_path)
+    manifest = _load(manifest_path)
+
+    assert fills["fills"] == []
+    assert account.get("positions") in ({}, {"BTC": 0.0})
+
+    assert manifest["meta"]["kind"] == "p7_paper_manifest"
+    assert manifest["meta"]["schema_version"] == "p7.paper_run.v0"
+    names = {entry["name"] for entry in manifest["files"]}
+    assert names == {"account.json", "fills.json"}
+
+
+def test_paper_runner_no_order_no_fill_dry_run_does_not_write_outputs(tmp_path: Path) -> None:
+    outdir = tmp_path / "paper_no_order_no_fill_dry_run"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "--spec",
+            str(SPEC),
+            "--outdir",
+            str(outdir),
+            "--dry-run",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "P7_PAPER_DRY_RUN_OK" in result.stdout
+    assert not outdir.exists() or not any(outdir.iterdir())
+
+
+def test_paper_runner_no_order_no_fill_fixture_is_non_authorizing() -> None:
+    spec = _load(SPEC)
+
+    assert spec["orders"] == []
+    assert spec["expected_fills"] == []
+    assert spec["expected_positions"] == {"BTC": 0.0}
+
+    for key in (
+        "activation_authorized",
+        "scheduler_authorized",
+        "daemon_authorized",
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert spec[key] is False


### PR DESCRIPTION
## Summary

- add offline Paper runner contract coverage for no-order/no-fill sessions
- assert runner exits successfully for `paper_run_high_vol_no_trade_v0.json`
- verify empty fills, flat account state, and expected manifest shape
- verify dry-run mode does not write outputs
- assert fixture authority flags remain false

## Safety / scope

- tests-only
- uses offline fixture and tmp_path output
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or order paths
- no evidence/readiness/registry/pointer/handoff surface

## Local validation

- uv run pytest tests/aiops/p7/test_paper_runner_no_order_no_fill_contract_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check scripts/aiops/run_paper_trading_session.py tests/aiops/p7/test_paper_runner_no_order_no_fill_contract_v0.py
- uv run ruff format --check scripts/aiops/run_paper_trading_session.py tests/aiops/p7/test_paper_runner_no_order_no_fill_contract_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs