### PR TITLE
fix(tests): make paper fail-closed test py39 compatible

### DIFF
--- a/tests/aiops/p7/test_paper_runner_fail_closed_contract_v0.py
+++ b/tests/aiops/p7/test_paper_runner_fail_closed_contract_v0.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import subprocess
 import sys


### PR DESCRIPTION
## Summary

- add postponed annotations to the Paper runner fail-closed contract test
- fix Python 3.9 collection failure caused by PEP 604 style runtime annotation evaluation
- include adjacent insufficient-cash/P7 paper tests in local validation

## Safety / scope

- tests-only compatibility fix
- no Paper/Shadow run executed
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or real order paths
- no evidence/readiness/registry/pointer/handoff surface

## Local validation

- uv run pytest tests/aiops/p7/test_paper_runner_fail_closed_contract_v0.py tests/aiops/p7/test_paper_runner_insufficient_cash_contract_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check tests/aiops/p7/test_paper_runner_fail_closed_contract_v0.py tests/aiops/p7/test_paper_runner_insufficient_cash_contract_v0.py
- uv run ruff format --check tests/aiops/p7/test_paper_runner_fail_closed_contract_v0.py tests/aiops/p7/test_paper_runner_insufficient_cash_contract_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs