### PR TITLE
test(aiops): consolidate p7 paper runner test helpers v0

### DIFF
--- a/tests/aiops/p7/paper_runner_test_helpers_v0.py
+++ b/tests/aiops/p7/paper_runner_test_helpers_v0.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PAPER_RUNNER = REPO_ROOT / "scripts" / "aiops" / "run_paper_trading_session.py"
+PAPER_RUN_MIN_SPEC = REPO_ROOT / "tests" / "fixtures" / "p7" / "paper_run_min_v0.json"
+PAPER_RUN_HIGH_VOL_NO_TRADE_SPEC = (
+    REPO_ROOT / "tests" / "fixtures" / "p7" / "paper_run_high_vol_no_trade_v0.json"
+)
+
+NON_LIVE_MARKERS = (
+    "/Users/",
+    "api_key",
+    "secret",
+    "submit_order",
+    "real_order",
+    "broker_connect",
+    "exchange_connect",
+)
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json_spec(tmp_path: Path, payload: dict, name: str) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def run_paper_session(
+    spec: Path,
+    outdir: Path,
+    *,
+    dry_run: bool = False,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    args = [
+        sys.executable,
+        str(PAPER_RUNNER),
+        "--spec",
+        str(spec),
+        "--outdir",
+        str(outdir),
+    ]
+    if dry_run:
+        args.append("--dry-run")
+    if extra_args:
+        args.extend(extra_args)
+
+    return subprocess.run(
+        args,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def assert_json_outputs_do_not_contain_live_markers(outdir: Path) -> None:
+    for path in sorted(outdir.rglob("*.json")):
+        text = path.read_text(encoding="utf-8")
+        lowered = text.lower()
+        for marker in NON_LIVE_MARKERS:
+            if marker == "/Users/":
+                assert marker not in text
+            else:
+                assert marker not in lowered
+
+
+def assert_no_json_outputs(outdir: Path) -> None:
+    assert outdir.exists()
+    assert sorted(path.name for path in outdir.rglob("*.json")) == []

--- a/tests/aiops/p7/test_paper_runner_multisymbol_contract_v0.py
+++ b/tests/aiops/p7/test_paper_runner_multisymbol_contract_v0.py
@@ -1,61 +1,36 @@
-import json
-import subprocess
-import sys
 from decimal import Decimal
 from pathlib import Path
 
+from tests.aiops.p7.paper_runner_test_helpers_v0 import (
+    PAPER_RUN_MIN_SPEC,
+    assert_json_outputs_do_not_contain_live_markers,
+    load_json,
+    run_paper_session,
+    write_json_spec,
+)
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-RUNNER = REPO_ROOT / "scripts" / "aiops" / "run_paper_trading_session.py"
-BASE_SPEC = REPO_ROOT / "tests" / "fixtures" / "p7" / "paper_run_min_v0.json"
-
-
-def _load(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _write_spec(tmp_path: Path, payload: dict, name: str) -> Path:
-    path = tmp_path / name
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    return path
-
-
-def _run(spec: Path, outdir: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [
-            sys.executable,
-            str(RUNNER),
-            "--spec",
-            str(spec),
-            "--outdir",
-            str(outdir),
-        ],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+BASE_SPEC = PAPER_RUN_MIN_SPEC
 
 
 def test_paper_runner_multisymbol_open_positions_shape(tmp_path: Path) -> None:
-    payload = _load(BASE_SPEC)
+    payload = load_json(BASE_SPEC)
     payload["orders"] = [
         {"symbol": "BTC", "side": "BUY", "qty": 1.0},
         {"symbol": "ETH", "side": "BUY", "qty": 2.0},
     ]
     payload["mid_prices"] = {"BTC": 100.0, "ETH": 50.0}
 
-    spec = _write_spec(tmp_path, payload, "two_symbols_open_positions.json")
+    spec = write_json_spec(tmp_path, payload, "two_symbols_open_positions.json")
     outdir = tmp_path / "two_symbols_open_positions_out"
 
-    result = _run(spec, outdir)
+    result = run_paper_session(spec, outdir)
 
     assert result.returncode == 0
     assert result.stderr == ""
 
-    fills = _load(outdir / "fills.json")
-    account = _load(outdir / "account.json")
-    manifest = _load(outdir / "evidence_manifest.json")
+    fills = load_json(outdir / "fills.json")
+    account = load_json(outdir / "account.json")
+    manifest = load_json(outdir / "evidence_manifest.json")
 
     assert fills["schema_version"] == "p7.fills.v0"
     assert [(fill["symbol"], fill["side"], fill["qty"]) for fill in fills["fills"]] == [
@@ -79,7 +54,7 @@ def test_paper_runner_multisymbol_open_positions_shape(tmp_path: Path) -> None:
 
 
 def test_paper_runner_multisymbol_roundtrip_keeps_symbol_positions_separate(tmp_path: Path) -> None:
-    payload = _load(BASE_SPEC)
+    payload = load_json(BASE_SPEC)
     payload["orders"] = [
         {"symbol": "BTC", "side": "BUY", "qty": 1.0},
         {"symbol": "ETH", "side": "BUY", "qty": 2.0},
@@ -87,16 +62,16 @@ def test_paper_runner_multisymbol_roundtrip_keeps_symbol_positions_separate(tmp_
     ]
     payload["mid_prices"] = {"BTC": 100.0, "ETH": 50.0}
 
-    spec = _write_spec(tmp_path, payload, "two_symbols_roundtrip_one_open.json")
+    spec = write_json_spec(tmp_path, payload, "two_symbols_roundtrip_one_open.json")
     outdir = tmp_path / "two_symbols_roundtrip_one_open_out"
 
-    result = _run(spec, outdir)
+    result = run_paper_session(spec, outdir)
 
     assert result.returncode == 0
     assert result.stderr == ""
 
-    fills = _load(outdir / "fills.json")
-    account = _load(outdir / "account.json")
+    fills = load_json(outdir / "fills.json")
+    account = load_json(outdir / "account.json")
 
     assert [(fill["symbol"], fill["side"], fill["qty"]) for fill in fills["fills"]] == [
         ("BTC", "BUY", 1.0),
@@ -117,27 +92,19 @@ def test_paper_runner_multisymbol_roundtrip_keeps_symbol_positions_separate(tmp_
 
 
 def test_paper_runner_multisymbol_outputs_are_portable_and_non_live(tmp_path: Path) -> None:
-    payload = _load(BASE_SPEC)
+    payload = load_json(BASE_SPEC)
     payload["orders"] = [
         {"symbol": "BTC", "side": "BUY", "qty": 1.0},
         {"symbol": "ETH", "side": "BUY", "qty": 2.0},
     ]
     payload["mid_prices"] = {"BTC": 100.0, "ETH": 50.0}
 
-    spec = _write_spec(tmp_path, payload, "two_symbols_portable.json")
+    spec = write_json_spec(tmp_path, payload, "two_symbols_portable.json")
     outdir = tmp_path / "two_symbols_portable_out"
 
-    result = _run(spec, outdir)
+    result = run_paper_session(spec, outdir)
 
     assert result.returncode == 0
     assert result.stderr == ""
 
-    for path in sorted(outdir.rglob("*.json")):
-        text = path.read_text(encoding="utf-8")
-        assert "/Users/" not in text
-        assert "api_key" not in text.lower()
-        assert "secret" not in text.lower()
-        assert "submit_order" not in text.lower()
-        assert "real_order" not in text.lower()
-        assert "broker_connect" not in text.lower()
-        assert "exchange_connect" not in text.lower()
+    assert_json_outputs_do_not_contain_live_markers(outdir)

--- a/tests/aiops/p7/test_paper_runner_partial_sell_contract_v0.py
+++ b/tests/aiops/p7/test_paper_runner_partial_sell_contract_v0.py
@@ -1,61 +1,36 @@
-import json
-import subprocess
-import sys
 from decimal import Decimal
 from pathlib import Path
 
+from tests.aiops.p7.paper_runner_test_helpers_v0 import (
+    PAPER_RUN_MIN_SPEC,
+    assert_json_outputs_do_not_contain_live_markers,
+    load_json,
+    run_paper_session,
+    write_json_spec,
+)
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-RUNNER = REPO_ROOT / "scripts" / "aiops" / "run_paper_trading_session.py"
-BASE_SPEC = REPO_ROOT / "tests" / "fixtures" / "p7" / "paper_run_min_v0.json"
-
-
-def _load(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _write_spec(tmp_path: Path, payload: dict, name: str) -> Path:
-    path = tmp_path / name
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    return path
-
-
-def _run(spec: Path, outdir: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [
-            sys.executable,
-            str(RUNNER),
-            "--spec",
-            str(spec),
-            "--outdir",
-            str(outdir),
-        ],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+BASE_SPEC = PAPER_RUN_MIN_SPEC
 
 
 def test_paper_runner_partial_sell_keeps_remaining_position(tmp_path: Path) -> None:
-    payload = _load(BASE_SPEC)
+    payload = load_json(BASE_SPEC)
     payload["orders"] = [
         {"symbol": "BTC", "side": "BUY", "qty": 2.0},
         {"symbol": "BTC", "side": "SELL", "qty": 1.0},
     ]
     payload["mid_prices"] = {"BTC": 100.0}
 
-    spec = _write_spec(tmp_path, payload, "buy2_sell1_same_symbol.json")
+    spec = write_json_spec(tmp_path, payload, "buy2_sell1_same_symbol.json")
     outdir = tmp_path / "buy2_sell1_same_symbol_out"
 
-    result = _run(spec, outdir)
+    result = run_paper_session(spec, outdir)
 
     assert result.returncode == 0
     assert result.stderr == ""
 
-    fills = _load(outdir / "fills.json")
-    account = _load(outdir / "account.json")
-    manifest = _load(outdir / "evidence_manifest.json")
+    fills = load_json(outdir / "fills.json")
+    account = load_json(outdir / "account.json")
+    manifest = load_json(outdir / "evidence_manifest.json")
 
     assert fills["schema_version"] == "p7.fills.v0"
     assert [(fill["symbol"], fill["side"], fill["qty"]) for fill in fills["fills"]] == [
@@ -79,7 +54,7 @@ def test_paper_runner_partial_sell_keeps_remaining_position(tmp_path: Path) -> N
 
 
 def test_paper_runner_repeated_partial_sells_reduce_position_stepwise(tmp_path: Path) -> None:
-    payload = _load(BASE_SPEC)
+    payload = load_json(BASE_SPEC)
     payload["orders"] = [
         {"symbol": "BTC", "side": "BUY", "qty": 3.0},
         {"symbol": "BTC", "side": "SELL", "qty": 1.0},
@@ -87,16 +62,16 @@ def test_paper_runner_repeated_partial_sells_reduce_position_stepwise(tmp_path: 
     ]
     payload["mid_prices"] = {"BTC": 100.0}
 
-    spec = _write_spec(tmp_path, payload, "buy3_sell1_sell1_same_symbol.json")
+    spec = write_json_spec(tmp_path, payload, "buy3_sell1_sell1_same_symbol.json")
     outdir = tmp_path / "buy3_sell1_sell1_same_symbol_out"
 
-    result = _run(spec, outdir)
+    result = run_paper_session(spec, outdir)
 
     assert result.returncode == 0
     assert result.stderr == ""
 
-    fills = _load(outdir / "fills.json")
-    account = _load(outdir / "account.json")
+    fills = load_json(outdir / "fills.json")
+    account = load_json(outdir / "account.json")
 
     assert [(fill["symbol"], fill["side"], fill["qty"]) for fill in fills["fills"]] == [
         ("BTC", "BUY", 3.0),
@@ -117,27 +92,19 @@ def test_paper_runner_repeated_partial_sells_reduce_position_stepwise(tmp_path: 
 
 
 def test_paper_runner_partial_sell_outputs_are_portable_and_non_live(tmp_path: Path) -> None:
-    payload = _load(BASE_SPEC)
+    payload = load_json(BASE_SPEC)
     payload["orders"] = [
         {"symbol": "BTC", "side": "BUY", "qty": 2.0},
         {"symbol": "BTC", "side": "SELL", "qty": 1.0},
     ]
     payload["mid_prices"] = {"BTC": 100.0}
 
-    spec = _write_spec(tmp_path, payload, "partial_sell_portable.json")
+    spec = write_json_spec(tmp_path, payload, "partial_sell_portable.json")
     outdir = tmp_path / "partial_sell_portable_out"
 
-    result = _run(spec, outdir)
+    result = run_paper_session(spec, outdir)
 
     assert result.returncode == 0
     assert result.stderr == ""
 
-    for path in sorted(outdir.rglob("*.json")):
-        text = path.read_text(encoding="utf-8")
-        assert "/Users/" not in text
-        assert "api_key" not in text.lower()
-        assert "secret" not in text.lower()
-        assert "submit_order" not in text.lower()
-        assert "real_order" not in text.lower()
-        assert "broker_connect" not in text.lower()
-        assert "exchange_connect" not in text.lower()
+    assert_json_outputs_do_not_contain_live_markers(outdir)

--- a/tests/aiops/p7/test_paper_runner_two_order_roundtrip_contract_v0.py
+++ b/tests/aiops/p7/test_paper_runner_two_order_roundtrip_contract_v0.py
@@ -1,43 +1,27 @@
-import json
-import subprocess
-import sys
 from decimal import Decimal
 from pathlib import Path
 
+from tests.aiops.p7.paper_runner_test_helpers_v0 import (
+    PAPER_RUN_MIN_SPEC,
+    assert_json_outputs_do_not_contain_live_markers,
+    load_json,
+    run_paper_session,
+)
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-RUNNER = REPO_ROOT / "scripts" / "aiops" / "run_paper_trading_session.py"
-SPEC = REPO_ROOT / "tests" / "fixtures" / "p7" / "paper_run_min_v0.json"
-
-
-def _load(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
+SPEC = PAPER_RUN_MIN_SPEC
 
 
 def test_paper_runner_two_order_roundtrip_writes_deterministic_outputs(tmp_path: Path) -> None:
     outdir = tmp_path / "paper_two_order_roundtrip"
 
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(RUNNER),
-            "--spec",
-            str(SPEC),
-            "--outdir",
-            str(outdir),
-        ],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    result = run_paper_session(SPEC, outdir)
 
     assert result.returncode == 0
     assert result.stderr == ""
 
-    fills = _load(outdir / "fills.json")
-    account = _load(outdir / "account.json")
-    manifest = _load(outdir / "evidence_manifest.json")
+    fills = load_json(outdir / "fills.json")
+    account = load_json(outdir / "account.json")
+    manifest = load_json(outdir / "evidence_manifest.json")
 
     assert fills["schema_version"] == "p7.fills.v0"
     assert len(fills["fills"]) == 2
@@ -67,37 +51,16 @@ def test_paper_runner_two_order_roundtrip_writes_deterministic_outputs(tmp_path:
 def test_paper_runner_two_order_roundtrip_output_is_portable_and_non_live(tmp_path: Path) -> None:
     outdir = tmp_path / "paper_two_order_roundtrip_portable"
 
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(RUNNER),
-            "--spec",
-            str(SPEC),
-            "--outdir",
-            str(outdir),
-        ],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    result = run_paper_session(SPEC, outdir)
 
     assert result.returncode == 0
     assert result.stderr == ""
 
-    for path in sorted(outdir.rglob("*.json")):
-        text = path.read_text(encoding="utf-8")
-        assert "/Users/" not in text
-        assert "api_key" not in text.lower()
-        assert "secret" not in text.lower()
-        assert "submit_order" not in text.lower()
-        assert "real_order" not in text.lower()
-        assert "broker_connect" not in text.lower()
-        assert "exchange_connect" not in text.lower()
+    assert_json_outputs_do_not_contain_live_markers(outdir)
 
 
 def test_paper_runner_two_order_fixture_is_minimal_and_offline() -> None:
-    spec = _load(SPEC)
+    spec = load_json(SPEC)
 
     assert spec["schema_version"] == "p7.paper_run.v0"
     assert len(spec["orders"]) == 2


### PR DESCRIPTION
## Summary

- add shared P7 Paper runner test helpers for JSON loading, tmp spec writing, subprocess execution, non-live output scanning, and empty-output assertions
- refactor three Paper runner contract tests to reuse helpers without changing assertions
- keep first consolidation slice bounded; remaining tests can adopt helpers later
- keep helper compatible with Python 3.9 via postponed annotations

## Safety / scope

- tests-only refactor
- no Paper/Shadow run executed outside pytest tmp_path subprocess tests
- no scheduler jobs executed
- no daemon, 24/7, Testnet, Live, broker, exchange, or real order paths
- no evidence/readiness/registry/pointer/handoff surface

## Local validation

- uv run pytest tests/aiops/p7 tests/sim/paper -q
- uv run ruff check tests/aiops/p7 tests/sim/paper
- uv run ruff format --check tests/aiops/p7 tests/sim/paper
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs