### PR TITLE
feat(ops): materialize paper shadow 247 preflight metadata v0

### DIFF
--- a/config/ops/paper_shadow_247_preflight.toml
+++ b/config/ops/paper_shadow_247_preflight.toml
@@ -1,0 +1,41 @@
+# Paper/Shadow 24/7 Preflight Metadata v0
+#
+# Read-only operational metadata for scripts/ops/report_paper_shadow_247_preflight_status.py.
+# This file does not authorize scheduler, daemon, testnet, live, broker, exchange, or order paths.
+
+schema_version = "paper_shadow_247_preflight.v0"
+canonical_owner = "ops-paper-shadow-247-readiness"
+
+paper_jobs = [
+  "paper_runner_no_order_no_fill_contract_v0",
+  "paper_runner_single_order_contract_v0",
+  "paper_runner_two_order_roundtrip_contract_v0",
+  "paper_runner_fail_closed_contract_v0",
+  "paper_runner_insufficient_cash_contract_v0",
+  "paper_runner_multisymbol_contract_v0",
+  "paper_runner_partial_sell_contract_v0",
+]
+
+shadow_jobs = [
+  "p7_shadow_high_vol_no_trade_runner_manual_v0",
+]
+
+output_paths = [
+  "out/paper_shadow_247/paper",
+  "out/paper_shadow_247/shadow",
+  "out/paper_shadow_247/logs",
+]
+
+stop_command = "uv run python scripts/ops/report_paper_shadow_247_preflight_status.py --json"
+emergency_stop_command = "uv run python scripts/ops/snapshot_operator_stop_signals.py --json"
+
+activation_authorized = false
+daemon_activation_authorized = false
+scheduler_execution_authorized = false
+paper_runtime_authorized = false
+shadow_runtime_authorized = false
+testnet_authorized = false
+live_authorized = false
+broker_authorized = false
+exchange_authorized = false
+order_submission_authorized = false

--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -104,6 +104,12 @@ Field names and enums may be refined in a later contract version; v0 only fixes 
 - Shadow session runbook: [runbook_shadow_session.md](../p6/runbook_shadow_session.md) (single-run, no daemon).
 - Paper trading runbook: [runbook_paper_trading.md](../p7/runbook_paper_trading.md).
 
+## Paper/Shadow 24/7 Preflight Metadata v0
+
+The read-only metadata source for this preflight is `config/ops/paper_shadow_247_preflight.toml`.
+
+This metadata may populate canonical owner, paper/shadow job identifiers, output path declarations, and stop-command declarations for the preflight reporter. It does **not** authorize daemon execution, scheduler execution, Testnet, Live, broker, exchange, or order submission paths. Runtime activation remains blocked unless separate explicit governance gates authorize it.
+
 ## 8. Revision
 
 - **v0** — Initial contract: BLOCKED default, status model, non-authority, informative JSON shape.

--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -10,14 +10,21 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 CONTRACT = "paper_shadow_247_preflight_status_v0"
 CONTRACT_DOC = "docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
 SCHEDULER_DOC = "docs/SCHEDULER_DAEMON.md"
 SCHEDULER_CONFIG = "config/scheduler/jobs.toml"
+PAPER_SHADOW_247_PREFLIGHT_METADATA = Path("config") / "ops" / "paper_shadow_247_preflight.toml"
 DRY_RUN_COMMAND = (
     "python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml "
     "--dry-run --once --verbose"
@@ -28,8 +35,17 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _load_paper_shadow_247_preflight_metadata(root: Path) -> dict[str, Any]:
+    cfg = root / PAPER_SHADOW_247_PREFLIGHT_METADATA
+    if not cfg.is_file():
+        return {}
+    return tomllib.loads(cfg.read_text(encoding="utf-8"))
+
+
 def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> dict[str, Any]:
     root = (repo_root or _repo_root()).resolve()
+    metadata = _load_paper_shadow_247_preflight_metadata(root)
+
     contract_path = root / CONTRACT_DOC
     scheduler_doc_path = root / SCHEDULER_DOC
     scheduler_config_path = root / SCHEDULER_CONFIG
@@ -48,13 +64,29 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
         SCHEDULER_CONFIG: scheduler_config_path.exists(),
     }
 
-    blockers = [
-        "canonical_owner_missing",
-        "paper_shadow_job_set_missing",
-        "output_paths_missing",
-        "stop_commands_missing",
-    ]
+    canonical_owner_any = metadata.get("canonical_owner")
+    canonical_owner = canonical_owner_any if isinstance(canonical_owner_any, str) else None
 
+    paper_jobs = [str(x) for x in metadata.get("paper_jobs", []) if isinstance(x, str)]
+    shadow_jobs = [str(x) for x in metadata.get("shadow_jobs", []) if isinstance(x, str)]
+    output_paths = [str(x) for x in metadata.get("output_paths", []) if isinstance(x, str)]
+
+    stop_any = metadata.get("stop_command")
+    emergency_any = metadata.get("emergency_stop_command")
+    stop_command = stop_any if isinstance(stop_any, str) else None
+    emergency_stop_command = emergency_any if isinstance(emergency_any, str) else None
+
+    blockers: list[str] = []
+    if not canonical_owner:
+        blockers.append("canonical_owner_missing")
+    if not paper_jobs or not shadow_jobs:
+        blockers.append("paper_shadow_job_set_missing")
+    if not output_paths:
+        blockers.append("output_paths_missing")
+    if not stop_command or not emergency_stop_command:
+        blockers.append("stop_commands_missing")
+
+    # Authorization flags: never inferred from metadata alone (documentation-only TOML keys).
     return {
         "contract": CONTRACT,
         "schema_version": 0,
@@ -65,6 +97,9 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
         "shadow_runtime_authorized": False,
         "testnet_authorized": False,
         "live_authorized": False,
+        "broker_authorized": False,
+        "exchange_authorized": False,
+        "order_submission_authorized": False,
         "scheduler_execution_authorized": False,
         "dry_run_command": DRY_RUN_COMMAND,
         "dry_run_only": True,
@@ -83,15 +118,15 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
                 for token in ("paper_shadow_247", "paper-shadow-247", "24/7")
             ),
         },
-        "canonical_owner": None,
-        "paper_jobs": [],
-        "shadow_jobs": [],
+        "canonical_owner": canonical_owner,
+        "paper_jobs": paper_jobs,
+        "shadow_jobs": shadow_jobs,
         "commands": [],
-        "output_paths": [],
+        "output_paths": output_paths,
         "state_files": [],
         "log_paths": [],
-        "stop_command": None,
-        "emergency_stop_command": None,
+        "stop_command": stop_command,
+        "emergency_stop_command": emergency_stop_command,
         "risk_flags": {
             "live": False,
             "testnet": False,

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -16,6 +16,19 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "ops" / "report_paper_shadow_247_preflight_status.py"
 
 
+def _run_json() -> dict[str, object]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--repo-root", str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert result.stderr == ""
+    return json.loads(result.stdout)
+
+
 def test_build_paper_shadow_247_preflight_status_is_blocked_and_non_authorizing() -> None:
     payload = build_paper_shadow_247_preflight_status(REPO_ROOT)
 
@@ -28,14 +41,20 @@ def test_build_paper_shadow_247_preflight_status_is_blocked_and_non_authorizing(
     assert payload["shadow_runtime_authorized"] is False
     assert payload["testnet_authorized"] is False
     assert payload["live_authorized"] is False
+    assert payload["broker_authorized"] is False
+    assert payload["exchange_authorized"] is False
+    assert payload["order_submission_authorized"] is False
     assert payload["scheduler_execution_authorized"] is False
     assert payload["dry_run_only"] is True
-    assert payload["paper_jobs"] == []
-    assert payload["shadow_jobs"] == []
+    assert payload["canonical_owner"] == "ops-paper-shadow-247-readiness"
+    assert payload["paper_jobs"]
+    assert payload["shadow_jobs"]
     assert payload["commands"] == []
-    assert payload["output_paths"] == []
-    assert payload["stop_command"] is None
-    assert payload["emergency_stop_command"] is None
+    assert payload["output_paths"]
+    assert isinstance(payload["stop_command"], str)
+    assert payload["stop_command"]
+    assert isinstance(payload["emergency_stop_command"], str)
+    assert payload["emergency_stop_command"]
     assert payload["risk_flags"] == {
         "live": False,
         "testnet": False,
@@ -44,6 +63,8 @@ def test_build_paper_shadow_247_preflight_status_is_blocked_and_non_authorizing(
         "orders": False,
         "network": False,
     }
+    assert payload["blockers"] == []
+    assert payload["status_reasons"] == []
 
 
 def test_build_paper_shadow_247_preflight_status_reuses_existing_contract_surfaces() -> None:
@@ -56,22 +77,11 @@ def test_build_paper_shadow_247_preflight_status_reuses_existing_contract_surfac
     assert payload["contract_markers"]["contract_non_authority"] is True
     assert payload["contract_markers"]["scheduler_doc_links_contract"] is True
     assert payload["contract_markers"]["scheduler_config_has_direct_247_job"] is False
-    assert "canonical_owner_missing" in payload["blockers"]
-    assert "paper_shadow_job_set_missing" in payload["blockers"]
 
 
 def test_cli_json_output_is_json_native_and_does_not_execute_scheduler() -> None:
-    result = subprocess.run(
-        [sys.executable, str(SCRIPT), "--json", "--repo-root", str(REPO_ROOT)],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    payload = _run_json()
 
-    assert result.returncode == 0
-    assert result.stderr == ""
-    payload = json.loads(result.stdout)
     assert payload["status"] == "BLOCKED"
     assert payload["activation_authorized"] is False
     assert payload["dry_run_command"].endswith("--dry-run --once --verbose")
@@ -95,3 +105,60 @@ def test_cli_human_output_is_bounded_status_only() -> None:
         "activation_authorized=false",
         "dry_run_only=true",
     ]
+
+
+def test_paper_shadow_247_preflight_metadata_config_is_materialized() -> None:
+    config_path = REPO_ROOT / "config" / "ops" / "paper_shadow_247_preflight.toml"
+
+    assert config_path.exists()
+    text = config_path.read_text(encoding="utf-8")
+
+    assert 'schema_version = "paper_shadow_247_preflight.v0"' in text
+    assert "canonical_owner" in text
+    assert "paper_jobs" in text
+    assert "shadow_jobs" in text
+    assert "output_paths" in text
+    assert "stop_command" in text
+    assert "emergency_stop_command" in text
+    assert "activation_authorized = false" in text
+    assert "daemon_activation_authorized = false" in text
+    assert "scheduler_execution_authorized = false" in text
+
+
+def test_paper_shadow_247_preflight_metadata_removes_missing_field_blockers() -> None:
+    payload = _run_json()
+
+    assert payload["status"] == "BLOCKED"
+    assert payload["activation_authorized"] is False
+    assert payload["daemon_activation_authorized"] is False
+    assert payload["scheduler_execution_authorized"] is False
+    assert payload["paper_runtime_authorized"] is False
+    assert payload["shadow_runtime_authorized"] is False
+
+    assert payload["canonical_owner"] == "ops-paper-shadow-247-readiness"
+    assert payload["paper_jobs"]
+    assert payload["shadow_jobs"]
+    assert payload["output_paths"]
+    assert payload["stop_command"]
+    assert payload["emergency_stop_command"]
+
+    status_reasons = set(payload.get("status_reasons", []))
+    blockers = set(payload.get("blockers", []))
+
+    for removed in (
+        "canonical_owner_missing",
+        "paper_shadow_job_set_missing",
+        "output_paths_missing",
+        "stop_commands_missing",
+    ):
+        assert removed not in status_reasons
+        assert removed not in blockers
+
+    for key in (
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert payload[key] is False


### PR DESCRIPTION
## Summary

- add read-only Paper/Shadow 24/7 preflight metadata config
- materialize canonical owner, paper/shadow job identifiers, output paths, and stop-command declarations
- remove the four missing-field blockers from the reporter while keeping status BLOCKED
- keep all runtime, daemon, scheduler, Testnet, Live, broker, exchange, and order authorization flags false
- update reporter tests and runbook note for the metadata source

## Safety / scope

- metadata/config/reporter/test/runbook only
- no daemon started
- no scheduler job executed
- no Paper/Shadow runtime run executed
- no Testnet/Live/broker/exchange/order path enabled
- no Master V2 / Double Play trading logic changed

## Local validation

- uv run python scripts/ops/report_paper_shadow_247_preflight_status.py --json
- uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Expected status after this PR

- `status`: `BLOCKED`
- `blockers`: empty or no missing-field blockers
- all authorization flags: `false`
- no scheduler/daemon/runtime activation