### PR TITLE
feat(ops): add paper shadow 247 dry activation readiness v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -110,6 +110,14 @@ The read-only metadata source for this preflight is `config/ops/paper_shadow_247
 
 This metadata may populate canonical owner, paper/shadow job identifiers, output path declarations, and stop-command declarations for the preflight reporter. It does **not** authorize daemon execution, scheduler execution, Testnet, Live, broker, exchange, or order submission paths. Runtime activation remains blocked unless separate explicit governance gates authorize it.
 
+## Controlled Paper-only Dry Activation Readiness v0
+
+The preflight reporter exposes a nested `dry_activation_readiness` object with schema version `paper_shadow_247_dry_activation_readiness.v0`.
+
+This object is **non-authorizing**. It may confirm that metadata, output-path declarations, stop controls, and paper/shadow job declarations are present, but it must keep `ready=false` until a separate explicit governance step authorizes a manual paper-only dry activation. The top-level daemon, scheduler, Paper/Shadow runtime, Testnet, Live, broker, exchange, and order authorization flags remain `false`.
+
+The operator command in this object is a readiness reference only. It is not executed by the reporter and does not start a daemon, scheduler, Paper runtime, Shadow runtime, Testnet, Live, broker, exchange, or order path.
+
 ## 8. Revision
 
 - **v0** — Initial contract: BLOCKED default, status model, non-authority, informative JSON shape.

--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -42,6 +42,58 @@ def _load_paper_shadow_247_preflight_metadata(root: Path) -> dict[str, Any]:
     return tomllib.loads(cfg.read_text(encoding="utf-8"))
 
 
+def _build_dry_activation_readiness(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return non-authorizing readiness details for a later manual paper-only dry activation."""
+
+    metadata_ready = bool(
+        payload.get("canonical_owner")
+        and payload.get("paper_jobs")
+        and payload.get("output_paths")
+        and payload.get("stop_command")
+        and payload.get("emergency_stop_command")
+    )
+    authorization_flags_false = all(
+        payload.get(key) is False
+        for key in (
+            "activation_authorized",
+            "daemon_activation_authorized",
+            "scheduler_execution_authorized",
+            "paper_runtime_authorized",
+            "shadow_runtime_authorized",
+            "testnet_authorized",
+            "live_authorized",
+            "broker_authorized",
+            "exchange_authorized",
+            "order_submission_authorized",
+        )
+    )
+    stop_controls_declared = bool(
+        payload.get("stop_command") and payload.get("emergency_stop_command")
+    )
+    output_paths_declared = bool(payload.get("output_paths"))
+
+    checks = {
+        "metadata_ready": metadata_ready,
+        "authorization_flags_false": authorization_flags_false,
+        "stop_controls_declared": stop_controls_declared,
+        "output_paths_declared": output_paths_declared,
+        "paper_jobs_declared": bool(payload.get("paper_jobs")),
+        "shadow_jobs_declared": bool(payload.get("shadow_jobs")),
+    }
+
+    return {
+        "schema_version": "paper_shadow_247_dry_activation_readiness.v0",
+        "ready": False,
+        "mode": "paper_only_dry_activation_readiness",
+        "dry_run_only": True,
+        "checks": checks,
+        "operator_command": payload.get("dry_run_command"),
+        "stop_command": payload.get("stop_command"),
+        "emergency_stop_command": payload.get("emergency_stop_command"),
+        "decision": "BLOCKED_NON_AUTHORIZING_READINESS_ONLY",
+    }
+
+
 def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> dict[str, Any]:
     root = (repo_root or _repo_root()).resolve()
     metadata = _load_paper_shadow_247_preflight_metadata(root)
@@ -87,7 +139,7 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
         blockers.append("stop_commands_missing")
 
     # Authorization flags: never inferred from metadata alone (documentation-only TOML keys).
-    return {
+    payload: dict[str, Any] = {
         "contract": CONTRACT,
         "schema_version": 0,
         "status": "BLOCKED",
@@ -144,6 +196,8 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
             "does_not_activate_paper_or_shadow_runtime",
         ],
     }
+    payload["dry_activation_readiness"] = _build_dry_activation_readiness(payload)
+    return payload
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -162,3 +162,43 @@ def test_paper_shadow_247_preflight_metadata_removes_missing_field_blockers() ->
         "order_submission_authorized",
     ):
         assert payload[key] is False
+
+
+def test_paper_shadow_247_preflight_reports_dry_activation_readiness_without_authorization() -> (
+    None
+):
+    payload = _run_json()
+    readiness = payload["dry_activation_readiness"]
+
+    assert readiness["schema_version"] == "paper_shadow_247_dry_activation_readiness.v0"
+    assert readiness["ready"] is False
+    assert readiness["mode"] == "paper_only_dry_activation_readiness"
+    assert readiness["dry_run_only"] is True
+    assert readiness["decision"] == "BLOCKED_NON_AUTHORIZING_READINESS_ONLY"
+
+    assert readiness["operator_command"] == payload["dry_run_command"]
+    assert readiness["stop_command"] == payload["stop_command"]
+    assert readiness["emergency_stop_command"] == payload["emergency_stop_command"]
+
+    assert readiness["checks"] == {
+        "metadata_ready": True,
+        "authorization_flags_false": True,
+        "stop_controls_declared": True,
+        "output_paths_declared": True,
+        "paper_jobs_declared": True,
+        "shadow_jobs_declared": True,
+    }
+
+    for key in (
+        "activation_authorized",
+        "daemon_activation_authorized",
+        "scheduler_execution_authorized",
+        "paper_runtime_authorized",
+        "shadow_runtime_authorized",
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert payload[key] is False


### PR DESCRIPTION
## Summary

- add a nested non-authorizing `dry_activation_readiness` object to the Paper/Shadow 24/7 preflight reporter
- mirror operator dry-run, stop, and emergency-stop command references without executing them
- report metadata/stop/output/job readiness checks while keeping `ready=false`
- keep status `BLOCKED`, blockers empty, and all daemon/scheduler/runtime/Testnet/Live/broker/exchange/order authorization flags false
- update reporter tests and the preflight runbook

## Safety / scope

- reporter/test/runbook only
- no daemon started
- no scheduler job executed
- no Paper/Shadow runtime run executed
- no Testnet/Live/broker/exchange/order path enabled
- no Master V2 / Double Play trading logic changed

## Local validation

- uv run python scripts/ops/report_paper_shadow_247_preflight_status.py --json
- uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Expected status after this PR

- `status`: `BLOCKED`
- `blockers`: `[]`
- `status_reasons`: `[]`
- `dry_activation_readiness.ready`: `false`
- all authorization flags: `false`
- no scheduler/daemon/runtime activation