### PR TITLE
feat(ops): add paper shadow 247 paper-only scheduler dry-run job v0

### DIFF
--- a/config/ops/paper_shadow_247_preflight.toml
+++ b/config/ops/paper_shadow_247_preflight.toml
@@ -7,6 +7,7 @@ schema_version = "paper_shadow_247_preflight.v0"
 canonical_owner = "ops-paper-shadow-247-readiness"
 
 paper_jobs = [
+  "paper_shadow_247_paper_only_preflight_status_v0",
   "paper_runner_no_order_no_fill_contract_v0",
   "paper_runner_single_order_contract_v0",
   "paper_runner_two_order_roundtrip_contract_v0",

--- a/config/scheduler/jobs.toml
+++ b/config/scheduler/jobs.toml
@@ -182,3 +182,29 @@ interval_seconds = 3600  # 1 Stunde
 enabled = false  # Manuell aktivieren bei Bedarf
 tags = ["autonomous", "ai", "monitoring"]
 timeout_seconds = 180
+
+
+# =============================================================================
+# Paper-Shadow 247 — read-only preflight reporter (scheduler visibility only)
+# =============================================================================
+# Non-authorizing: runs only scripts/ops/report_paper_shadow_247_preflight_status.py.
+# Safe to inspect with:
+#   python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose
+# Not Testnet/Live/Broker/Exchange/order authorization.
+
+[[job]]
+name = "paper_shadow_247_paper_only_preflight_status_v0"
+enabled = true
+schedule_type = "once"
+command = "python"
+args = { script = "scripts/ops/report_paper_shadow_247_preflight_status.py", json = true }
+description = "Paper/Shadow 24/7 preflight status reporter; dry-run-visible, non-authorizing."
+tags = ["paper_shadow_247", "preflight", "readonly"]
+timeout_seconds = 120
+paper_only = true
+dry_run_visible = true
+testnet_authorized = false
+live_authorized = false
+broker_authorized = false
+exchange_authorized = false
+order_submission_authorized = false

--- a/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
+++ b/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
@@ -74,9 +74,13 @@ def test_scheduler_daemon_links_to_paper_shadow_247_contract() -> None:
     assert "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md" in scheduler_text
 
 
-def test_scheduler_config_is_not_a_direct_paper_shadow_247_activation() -> None:
-    jobs_text = JOBS_TOML.read_text(encoding="utf-8").lower()
+def test_scheduler_config_exposes_read_only_paper_shadow_247_preflight_job_only() -> None:
+    jobs_text = JOBS_TOML.read_text(encoding="utf-8")
 
-    assert "paper_shadow_247" not in jobs_text
-    assert "paper-shadow-247" not in jobs_text
-    assert "24/7" not in jobs_text
+    assert "paper_shadow_247_paper_only_preflight_status_v0" in jobs_text
+    assert "report_paper_shadow_247_preflight_status.py" in jobs_text
+    assert "paper_only = true" in jobs_text.lower()
+    assert "dry_run_visible = true" in jobs_text.lower()
+
+    lowered = jobs_text.lower()
+    assert "run_shadow_paper_session" not in lowered

--- a/tests/ops/test_paper_shadow_247_scheduler_job_config_v0.py
+++ b/tests/ops/test_paper_shadow_247_scheduler_job_config_v0.py
@@ -1,0 +1,62 @@
+"""Scheduler job surface for Paper-Shadow 247 read-only preflight reporter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JOBS_CONFIG = REPO_ROOT / "config" / "scheduler" / "jobs.toml"
+
+
+def _paper_shadow_job() -> dict:
+    payload = tomllib.loads(JOBS_CONFIG.read_text(encoding="utf-8"))
+    jobs = payload.get("job", [])
+    return next(
+        job for job in jobs if job.get("name") == "paper_shadow_247_paper_only_preflight_status_v0"
+    )
+
+
+def test_paper_shadow_247_scheduler_job_is_present_and_non_authorizing() -> None:
+    target = _paper_shadow_job()
+
+    assert target["enabled"] is True
+    assert target["schedule_type"] == "once"
+    assert target["paper_only"] is True
+    assert target["dry_run_visible"] is True
+    assert target["command"] == "python"
+    assert target["args"]["script"] == "scripts/ops/report_paper_shadow_247_preflight_status.py"
+    assert target["args"]["json"] is True
+
+    for key in (
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert target[key] is False
+
+
+def test_paper_shadow_247_scheduler_job_command_is_status_only() -> None:
+    command = _paper_shadow_job()["command"].lower()
+    args = _paper_shadow_job()["args"]
+
+    assert "report_paper_shadow_247_preflight_status.py" in args["script"].lower()
+    assert "run_scheduler.py" not in command
+    assert "run_scheduler.py" not in args["script"].lower()
+    assert "p7_ctl.py run-shadow" not in command
+
+    combined = (command + " " + args["script"]).lower()
+    assert "--live" not in combined
+    assert "--testnet" not in combined
+    assert "submit_order" not in combined
+    assert "real_order" not in combined
+    assert "broker_connect" not in combined
+    assert "exchange_connect" not in combined
+    assert "api_key" not in combined
+    assert "secret" not in combined

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -76,7 +76,7 @@ def test_build_paper_shadow_247_preflight_status_reuses_existing_contract_surfac
     assert payload["contract_markers"]["contract_mentions_stop"] is True
     assert payload["contract_markers"]["contract_non_authority"] is True
     assert payload["contract_markers"]["scheduler_doc_links_contract"] is True
-    assert payload["contract_markers"]["scheduler_config_has_direct_247_job"] is False
+    assert payload["contract_markers"]["scheduler_config_has_direct_247_job"] is True
 
 
 def test_cli_json_output_is_json_native_and_does_not_execute_scheduler() -> None:


### PR DESCRIPTION
## Summary

- add one explicit paper-only scheduler job visible under `--dry-run --once`
- job command calls only the Paper/Shadow 24/7 preflight status reporter
- wire the job name into Paper/Shadow 24/7 preflight metadata
- add/update scheduler/preflight contract tests
- keep preflight BLOCKED and all authorization flags false

## Safety / scope

- config/tests only plus preflight metadata reference
- no daemon started
- no scheduler run without `--dry-run`
- no Paper/Shadow runtime job executed
- no Testnet/Live/broker/exchange/order path enabled

## Local validation

- python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose
- uv run python scripts/ops/report_paper_shadow_247_preflight_status.py --json
- uv run pytest tests/ops/test_paper_shadow_247_scheduler_job_config_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check tests/ops/test_paper_shadow_247_scheduler_job_config_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py scripts/ops/report_paper_shadow_247_preflight_status.py
- uv run ruff format --check tests/ops/test_paper_shadow_247_scheduler_job_config_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py scripts/ops/report_paper_shadow_247_preflight_status.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Expected behavior

- Scheduler dry-run sees `paper_shadow_247_paper_only_preflight_status_v0`
- Dry-run reports one would-run job
- Preflight remains `BLOCKED`
- `dry_activation_readiness.ready=false`
- all authorization flags remain `false`