### PR TITLE
feat(webui): add market depth readonly api route v0

### DIFF
--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -82,6 +82,7 @@ System:
 
 Market Surface v0 (read-only):
 - GET /api/market/ohlcv (JSON — öffentliche OHLCV oder Dummy)
+- GET /api/market/depth (Market Depth fixture read-model v0 — read-only JSON, nur server-seitiges Bundle via Env)
 
 Paper/Shadow summary read-model v0 (read-only, server-configured bundle only):
 - GET /api/observability/paper-shadow-summary
@@ -189,6 +190,7 @@ from .ops_ci_health_router import (
 from .execution_watch_api_v0 import router as execution_watch_v0_router
 from .execution_watch_api_v0_2 import router as execution_watch_v0_2_router
 from .paper_shadow_summary_api_v0 import router as paper_shadow_summary_api_v0_router
+from .market_depth_api_v0 import router as market_depth_api_v0_router
 from .market_surface import (
     MAX_OHLCV_LIMIT,
     MARKET_TIMEFRAMES,
@@ -533,6 +535,7 @@ def create_app() -> FastAPI:
 
     # Paper/Shadow Summary read-model v0 — read-only JSON (server-side bundle root only)
     app.include_router(paper_shadow_summary_api_v0_router)
+    app.include_router(market_depth_api_v0_router)
 
     # Market Surface v0 — read-only OHLCV (kein OPS-Cockpit-Bezug)
     app.include_router(create_market_router(templates, get_project_status))

--- a/src/webui/market_depth_api_v0.py
+++ b/src/webui/market_depth_api_v0.py
@@ -1,0 +1,129 @@
+"""Market Depth read-model API v0 — read-only GET for `market_depth_readmodel_v0` (server-configured bundle only)."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from .market_depth_readmodel_v0 import (
+    MarketDepthReadmodelError,
+    build_market_depth_readmodel_v0,
+    to_json_dict,
+)
+from .market_depth_readmodel_v0.builder import READMODEL_ID
+
+_ENV_ENABLED = "PEAK_TRADE_MARKET_DEPTH_ENABLED"
+_ENV_BUNDLE_ROOT = "PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT"
+_FIXED_GEN_ENV = "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
+
+_NO_STORE = {"Cache-Control": "no-store"}
+
+router = APIRouter(prefix="/api/market", tags=["market-depth-api-v0"])
+
+
+def _generated_at_iso() -> str:
+    fixed = os.environ.get(_FIXED_GEN_ENV)
+    if fixed:
+        return fixed.strip()
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _enabled_explicitly_on() -> bool:
+    raw = os.environ.get(_ENV_ENABLED)
+    return raw is not None and raw.strip() == "1"
+
+
+def _resolved_bundle_root_or_none() -> Path | None:
+    raw = os.environ.get(_ENV_BUNDLE_ROOT)
+    if raw is None or not str(raw).strip():
+        return None
+    p = Path(raw).expanduser()
+    try:
+        p = p.resolve(strict=True)
+    except OSError:
+        return None
+    if not p.is_dir():
+        return None
+    return p
+
+
+def _disabled_envelope() -> dict[str, Any]:
+    return {
+        "readmodel_id": READMODEL_ID,
+        "generated_at_iso": _generated_at_iso(),
+        "source": "unavailable",
+        "runtime_source_status": "disabled",
+        "stale": True,
+        "stale_reason": "source_disabled",
+        "warnings": ["market_depth_source_disabled"],
+        "errors": ["runtime_source_unavailable"],
+    }
+
+
+def _unconfigured_envelope() -> dict[str, Any]:
+    return {
+        "readmodel_id": READMODEL_ID,
+        "generated_at_iso": _generated_at_iso(),
+        "source": "unavailable",
+        "runtime_source_status": "unconfigured",
+        "stale": True,
+        "stale_reason": "bundle_root_unconfigured",
+        "warnings": ["market_depth_bundle_root_unconfigured"],
+        "errors": ["runtime_source_unavailable"],
+    }
+
+
+def _builder_error_envelope() -> dict[str, Any]:
+    return {
+        "readmodel_id": READMODEL_ID,
+        "generated_at_iso": _generated_at_iso(),
+        "source": "unavailable",
+        "runtime_source_status": "builder_error",
+        "stale": True,
+        "stale_reason": "bundle_build_failed",
+        "warnings": ["market_depth_bundle_build_failed"],
+        "errors": ["readmodel_build_failed"],
+    }
+
+
+@router.get("/depth")
+async def get_market_depth() -> JSONResponse:
+    if not _enabled_explicitly_on():
+        return JSONResponse(
+            status_code=503,
+            content=_disabled_envelope(),
+            headers=_NO_STORE,
+        )
+
+    bundle_root = _resolved_bundle_root_or_none()
+    if bundle_root is None:
+        return JSONResponse(
+            status_code=503,
+            content=_unconfigured_envelope(),
+            headers=_NO_STORE,
+        )
+
+    try:
+        readmodel = build_market_depth_readmodel_v0(
+            bundle_root=bundle_root,
+            generated_at_iso=_generated_at_iso(),
+        )
+    except MarketDepthReadmodelError:
+        return JSONResponse(
+            status_code=503,
+            content=_builder_error_envelope(),
+            headers=_NO_STORE,
+        )
+
+    return JSONResponse(
+        content=to_json_dict(readmodel),
+        headers=_NO_STORE,
+    )
+
+
+__all__ = ["router"]

--- a/tests/webui/test_market_depth_api_v0.py
+++ b/tests/webui/test_market_depth_api_v0.py
@@ -1,0 +1,207 @@
+"""Market Depth API v0 — GET /api/market/depth (read-only, env-gated server bundle only)."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+
+pytestmark = pytest.mark.web
+
+FIXTURES = project_root / "tests" / "fixtures" / "market_depth_readmodel_v0"
+
+_FORBIDDEN_JSON_KEYS = frozenset(
+    {
+        "live_authorization",
+        "live_ready",
+        "testnet_ready",
+        "trading_ready",
+        "execute",
+        "execution",
+        "order",
+        "orders",
+        "approve",
+        "approved",
+        "promote",
+        "sign_off",
+        "enable_live",
+        "confirm_token",
+    }
+)
+
+
+def _collect_object_keys(obj: object, out: set[str]) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str):
+                out.add(k)
+            _collect_object_keys(v, out)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_object_keys(item, out)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", raising=False)
+    return TestClient(create_app())
+
+
+def _clear_md_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _fixed_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "PEAK_TRADE_FIXED_GENERATED_AT_UTC",
+        "2026-05-02T12:00:00+00:00",
+    )
+
+
+def test_market_depth_disabled_when_env_unset(client: TestClient) -> None:
+    r = client.get("/api/market/depth")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["readmodel_id"] == "market_depth_readmodel.v0"
+    assert body["generated_at_iso"] == "2026-05-02T12:00:00+00:00"
+    assert body["runtime_source_status"] == "disabled"
+    assert "market_depth_source_disabled" in body["warnings"]
+    assert body["errors"] == ["runtime_source_unavailable"]
+    assert body["stale"] is True
+    assert r.headers.get("cache-control") == "no-store"
+
+
+def test_market_depth_disabled_when_enabled_not_one(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_md_env(monkeypatch)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    r = client.get("/api/market/depth")
+    assert r.status_code == 503
+    assert r.json()["runtime_source_status"] == "disabled"
+
+
+def test_market_depth_unconfigured_when_enabled_without_root(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_md_env(monkeypatch)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", raising=False)
+    r = client.get("/api/market/depth")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["runtime_source_status"] == "unconfigured"
+    assert "market_depth_bundle_root_unconfigured" in body["warnings"]
+
+
+def test_market_depth_unconfigured_when_root_missing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_md_env(monkeypatch)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    missing = tmp_path / "no_such_bundle"
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(missing))
+    r = client.get("/api/market/depth")
+    assert r.status_code == 503
+    assert r.json()["runtime_source_status"] == "unconfigured"
+
+
+def test_market_depth_unconfigured_when_root_is_file(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_md_env(monkeypatch)
+    fpath = tmp_path / "not_a_dir.txt"
+    fpath.write_text("x", encoding="utf-8")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(fpath.resolve()))
+    r = client.get("/api/market/depth")
+    assert r.status_code == 503
+    assert r.json()["runtime_source_status"] == "unconfigured"
+
+
+def test_market_depth_503_when_bundle_malformed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_md_env(monkeypatch)
+    bundle = tmp_path / "mal"
+    shutil.copytree(FIXTURES / "malformed_levels", bundle)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(bundle))
+    r = client.get("/api/market/depth")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["runtime_source_status"] == "builder_error"
+    assert "market_depth_bundle_build_failed" in body["warnings"]
+    assert body["errors"] == ["readmodel_build_failed"]
+
+
+def test_market_depth_200_complete_minimal_bundle(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_md_env(monkeypatch)
+    bundle = tmp_path / "bundle"
+    shutil.copytree(FIXTURES / "complete_minimal", bundle)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(bundle))
+    r = client.get("/api/market/depth")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["readmodel_id"] == "market_depth_readmodel.v0"
+    assert body["symbol"] == "BTC/EUR"
+    assert body["source"] == "dummy"
+    assert body["limit"] == 3
+    assert body["generated_at_iso"] == "2026-05-02T12:00:00+00:00"
+    assert body["runtime_source_status"] == "offline_bundle"
+    assert body["stale"] is True
+    assert body["stale_reason"] == "offline_bundle_scan"
+    assert body["depth"]["levels_returned"] == {"bids": 3, "asks": 3}
+    assert r.headers.get("cache-control") == "no-store"
+
+
+def test_market_depth_ignores_query_bundle_root_and_limit(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_md_env(monkeypatch)
+    bundle = tmp_path / "bundle"
+    shutil.copytree(FIXTURES / "complete_minimal", bundle)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(bundle))
+    plain = client.get("/api/market/depth")
+    evil = client.get("/api/market/depth?bundle_root=/tmp/evil&limit=1&source=kraken")
+    assert plain.status_code == 200
+    assert evil.status_code == 200
+    assert plain.json() == evil.json()
+
+
+def test_market_depth_response_has_no_authority_keys_success_and_failure(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_md_env(monkeypatch)
+    bundle = tmp_path / "bundle"
+    shutil.copytree(FIXTURES / "complete_minimal", bundle)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(bundle))
+    keys_ok: set[str] = set()
+    _collect_object_keys(client.get("/api/market/depth").json(), keys_ok)
+    keys_diag: set[str] = set()
+    _clear_md_env(monkeypatch)
+    _collect_object_keys(client.get("/api/market/depth").json(), keys_diag)
+
+    forbidden_hits_ok = sorted(keys_ok & _FORBIDDEN_JSON_KEYS)
+    forbidden_hits_diag = sorted(keys_diag & _FORBIDDEN_JSON_KEYS)
+    assert forbidden_hits_ok == []
+    assert forbidden_hits_diag == []


### PR DESCRIPTION
## Summary
- add env-gated read-only `GET /api/market/depth` route
- expose existing offline Market Depth readmodel builder payload without query bundle-root override
- return diagnostic 503 JSON for disabled/unconfigured/build failures
- wire API router into webui app without templates, browser polling, provider/network, live, execution, order, signal, secret, or authority paths
- add focused API contract tests

## Validation
- `uv run pytest tests/webui/test_market_depth_api_v0.py tests/webui/test_market_depth_readmodel_v0.py -q`
- `uv run pytest tests/webui/test_paper_shadow_summary_api_v0.py -q`
- `uv run pytest tests/webui/test_market_depth_api_v0.py tests/webui/test_market_depth_readmodel_v0.py tests/test_market_surface_api.py -q`
- `uv run ruff check src/webui/market_depth_api_v0.py src/webui/app.py tests/webui/test_market_depth_api_v0.py`
- `uv run ruff format --check src/webui/market_depth_api_v0.py src/webui/app.py tests/webui/test_market_depth_api_v0.py`
- `git diff --check`

Made with [Cursor](https://cursor.com)