### PR TITLE
refactor(webui): extract market depth runtime helper v0

### DIFF
--- a/src/webui/market_depth_api_v0.py
+++ b/src/webui/market_depth_api_v0.py
@@ -2,128 +2,20 @@
 
 from __future__ import annotations
 
-import os
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any
-
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
-from .market_depth_readmodel_v0 import (
-    MarketDepthReadmodelError,
-    build_market_depth_readmodel_v0,
-    to_json_dict,
-)
-from .market_depth_readmodel_v0.builder import READMODEL_ID
-
-_ENV_ENABLED = "PEAK_TRADE_MARKET_DEPTH_ENABLED"
-_ENV_BUNDLE_ROOT = "PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT"
-_FIXED_GEN_ENV = "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
+from .market_depth_runtime_v0 import market_depth_json_payload_v0
 
 _NO_STORE = {"Cache-Control": "no-store"}
 
 router = APIRouter(prefix="/api/market", tags=["market-depth-api-v0"])
 
 
-def _generated_at_iso() -> str:
-    fixed = os.environ.get(_FIXED_GEN_ENV)
-    if fixed:
-        return fixed.strip()
-    return datetime.now(tz=timezone.utc).isoformat()
-
-
-def _enabled_explicitly_on() -> bool:
-    raw = os.environ.get(_ENV_ENABLED)
-    return raw is not None and raw.strip() == "1"
-
-
-def _resolved_bundle_root_or_none() -> Path | None:
-    raw = os.environ.get(_ENV_BUNDLE_ROOT)
-    if raw is None or not str(raw).strip():
-        return None
-    p = Path(raw).expanduser()
-    try:
-        p = p.resolve(strict=True)
-    except OSError:
-        return None
-    if not p.is_dir():
-        return None
-    return p
-
-
-def _disabled_envelope() -> dict[str, Any]:
-    return {
-        "readmodel_id": READMODEL_ID,
-        "generated_at_iso": _generated_at_iso(),
-        "source": "unavailable",
-        "runtime_source_status": "disabled",
-        "stale": True,
-        "stale_reason": "source_disabled",
-        "warnings": ["market_depth_source_disabled"],
-        "errors": ["runtime_source_unavailable"],
-    }
-
-
-def _unconfigured_envelope() -> dict[str, Any]:
-    return {
-        "readmodel_id": READMODEL_ID,
-        "generated_at_iso": _generated_at_iso(),
-        "source": "unavailable",
-        "runtime_source_status": "unconfigured",
-        "stale": True,
-        "stale_reason": "bundle_root_unconfigured",
-        "warnings": ["market_depth_bundle_root_unconfigured"],
-        "errors": ["runtime_source_unavailable"],
-    }
-
-
-def _builder_error_envelope() -> dict[str, Any]:
-    return {
-        "readmodel_id": READMODEL_ID,
-        "generated_at_iso": _generated_at_iso(),
-        "source": "unavailable",
-        "runtime_source_status": "builder_error",
-        "stale": True,
-        "stale_reason": "bundle_build_failed",
-        "warnings": ["market_depth_bundle_build_failed"],
-        "errors": ["readmodel_build_failed"],
-    }
-
-
 @router.get("/depth")
 async def get_market_depth() -> JSONResponse:
-    if not _enabled_explicitly_on():
-        return JSONResponse(
-            status_code=503,
-            content=_disabled_envelope(),
-            headers=_NO_STORE,
-        )
-
-    bundle_root = _resolved_bundle_root_or_none()
-    if bundle_root is None:
-        return JSONResponse(
-            status_code=503,
-            content=_unconfigured_envelope(),
-            headers=_NO_STORE,
-        )
-
-    try:
-        readmodel = build_market_depth_readmodel_v0(
-            bundle_root=bundle_root,
-            generated_at_iso=_generated_at_iso(),
-        )
-    except MarketDepthReadmodelError:
-        return JSONResponse(
-            status_code=503,
-            content=_builder_error_envelope(),
-            headers=_NO_STORE,
-        )
-
-    return JSONResponse(
-        content=to_json_dict(readmodel),
-        headers=_NO_STORE,
-    )
+    status_code, body = market_depth_json_payload_v0()
+    return JSONResponse(status_code=status_code, content=body, headers=_NO_STORE)
 
 
 __all__ = ["router"]

--- a/src/webui/market_depth_runtime_v0.py
+++ b/src/webui/market_depth_runtime_v0.py
@@ -1,0 +1,117 @@
+"""Market Depth runtime resolution (env + offline bundle builder), shared by HTTP and future SSR."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .market_depth_readmodel_v0 import (
+    MarketDepthReadmodelError,
+    build_market_depth_readmodel_v0,
+    to_json_dict,
+)
+from .market_depth_readmodel_v0.builder import READMODEL_ID
+
+ENV_ENABLED = "PEAK_TRADE_MARKET_DEPTH_ENABLED"
+ENV_BUNDLE_ROOT = "PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT"
+FIXED_GEN_ENV = "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
+
+
+def generated_at_iso() -> str:
+    fixed = os.environ.get(FIXED_GEN_ENV)
+    if fixed:
+        return fixed.strip()
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def enabled_explicitly_on() -> bool:
+    raw = os.environ.get(ENV_ENABLED)
+    return raw is not None and raw.strip() == "1"
+
+
+def resolved_bundle_root_or_none() -> Path | None:
+    raw = os.environ.get(ENV_BUNDLE_ROOT)
+    if raw is None or not str(raw).strip():
+        return None
+    p = Path(raw).expanduser()
+    try:
+        p = p.resolve(strict=True)
+    except OSError:
+        return None
+    if not p.is_dir():
+        return None
+    return p
+
+
+def _disabled_envelope(*, ga: str) -> dict[str, Any]:
+    return {
+        "readmodel_id": READMODEL_ID,
+        "generated_at_iso": ga,
+        "source": "unavailable",
+        "runtime_source_status": "disabled",
+        "stale": True,
+        "stale_reason": "source_disabled",
+        "warnings": ["market_depth_source_disabled"],
+        "errors": ["runtime_source_unavailable"],
+    }
+
+
+def _unconfigured_envelope(*, ga: str) -> dict[str, Any]:
+    return {
+        "readmodel_id": READMODEL_ID,
+        "generated_at_iso": ga,
+        "source": "unavailable",
+        "runtime_source_status": "unconfigured",
+        "stale": True,
+        "stale_reason": "bundle_root_unconfigured",
+        "warnings": ["market_depth_bundle_root_unconfigured"],
+        "errors": ["runtime_source_unavailable"],
+    }
+
+
+def _builder_error_envelope(*, ga: str) -> dict[str, Any]:
+    return {
+        "readmodel_id": READMODEL_ID,
+        "generated_at_iso": ga,
+        "source": "unavailable",
+        "runtime_source_status": "builder_error",
+        "stale": True,
+        "stale_reason": "bundle_build_failed",
+        "warnings": ["market_depth_bundle_build_failed"],
+        "errors": ["readmodel_build_failed"],
+    }
+
+
+def market_depth_json_payload_v0() -> tuple[int, dict[str, Any]]:
+    """Return ``(status_code, body)`` mirroring ``GET`` ``/api/market/depth`` (no FastAPI types)."""
+
+    ga = generated_at_iso()
+    if not enabled_explicitly_on():
+        return 503, _disabled_envelope(ga=ga)
+
+    bundle_root = resolved_bundle_root_or_none()
+    if bundle_root is None:
+        return 503, _unconfigured_envelope(ga=ga)
+
+    try:
+        readmodel = build_market_depth_readmodel_v0(
+            bundle_root=bundle_root,
+            generated_at_iso=ga,
+        )
+    except MarketDepthReadmodelError:
+        return 503, _builder_error_envelope(ga=ga)
+
+    return 200, to_json_dict(readmodel)
+
+
+__all__ = [
+    "ENV_BUNDLE_ROOT",
+    "ENV_ENABLED",
+    "FIXED_GEN_ENV",
+    "enabled_explicitly_on",
+    "generated_at_iso",
+    "market_depth_json_payload_v0",
+    "resolved_bundle_root_or_none",
+]

--- a/tests/webui/test_market_depth_runtime_v0.py
+++ b/tests/webui/test_market_depth_runtime_v0.py
@@ -1,0 +1,62 @@
+"""Market Depth runtime helper v0 — no FastAPI/TestClient coupling."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+from src.webui.market_depth_runtime_v0 import market_depth_json_payload_v0
+
+pytestmark = pytest.mark.web
+
+FIXTURES = project_root / "tests" / "fixtures" / "market_depth_readmodel_v0"
+
+
+@pytest.fixture(autouse=True)
+def _fixed_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "PEAK_TRADE_FIXED_GENERATED_AT_UTC",
+        "2026-05-02T12:00:00+00:00",
+    )
+
+
+def _clear_md_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", raising=False)
+
+
+def test_runtime_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_md_env(monkeypatch)
+    status, body = market_depth_json_payload_v0()
+    assert status == 503
+    assert body["runtime_source_status"] == "disabled"
+    assert body["generated_at_iso"] == "2026-05-02T12:00:00+00:00"
+
+
+def test_runtime_builder_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_md_env(monkeypatch)
+    bundle = tmp_path / "mal"
+    shutil.copytree(FIXTURES / "malformed_levels", bundle)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(bundle))
+    status, body = market_depth_json_payload_v0()
+    assert status == 503
+    assert body["runtime_source_status"] == "builder_error"
+
+
+def test_runtime_success_minimal(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_md_env(monkeypatch)
+    bundle = tmp_path / "bundle"
+    shutil.copytree(FIXTURES / "complete_minimal", bundle)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(bundle))
+    status, body = market_depth_json_payload_v0()
+    assert status == 200
+    assert body["symbol"] == "BTC/EUR"
+    assert body["runtime_source_status"] == "offline_bundle"


### PR DESCRIPTION
## Summary
- extract Market Depth env-gate, bundle-root resolution, timestamp, and builder orchestration into `market_depth_runtime_v0.py`
- keep `market_depth_api_v0.py` thin: router + JSONResponse + no-store header
- preserve existing read-only API behavior while preparing a shared SSR-safe helper for future `GET /market` integration
- add focused runtime helper tests

## Safety boundaries
- no template or SSR integration in this slice
- no browser polling or client fetch
- no provider/network/exchange access
- no live/testnet/execution/order/signal authority
- no secrets/API-key handling
- no builder payload shape change

## Validation
- `uv run pytest tests/webui/test_market_depth_api_v0.py tests/webui/test_market_depth_readmodel_v0.py tests/webui/test_market_depth_runtime_v0.py -q`
- `uv run pytest tests/test_market_surface_api.py -q`
- `uv run ruff check src/webui/market_depth_api_v0.py src/webui/market_depth_runtime_v0.py tests/webui/test_market_depth_api_v0.py tests/webui/test_market_depth_runtime_v0.py`
- `uv run ruff format --check src/webui/market_depth_api_v0.py src/webui/market_depth_runtime_v0.py tests/webui/test_market_depth_api_v0.py tests/webui/test_market_depth_runtime_v0.py`
- `git diff --check`

Made with [Cursor](https://cursor.com)