### PR TITLE
docs(ops): record paper-only daemon 120min stability evidence v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -121,3 +121,30 @@ The operator command in this object is a readiness reference only. It is not exe
 ## 8. Revision
 
 - **v0** — Initial contract: BLOCKED default, status model, non-authority, informative JSON shape.
+
+## Paper-only Tag-Gated Scheduler Daemon Stability Evidence v0
+
+A controlled Paper-only, tag-gated scheduler daemon run completed successfully under a 120-minute bound.
+
+Local evidence bundle:
+
+- `/tmp/peak_trade_paper_only_daemon_120min_20260506T041114Z/PAPER_ONLY_DAEMON_120MIN_RESULT.md`
+- `/tmp/peak_trade_paper_only_daemon_120min_20260506T041114Z/DAEMON_ANALYSIS.json`
+- `/tmp/peak_trade_paper_only_daemon_120min_20260506T041114Z/PREFLIGHT_AFTER.json`
+
+Observed result:
+
+- tag gate: `paper_shadow_247`
+- target job: `paper_shadow_247_paper_only_preflight_status_v0`
+- bounded runtime: 7200 seconds
+- scheduler iterations: 240
+- executed jobs: 1
+- no-due-job observations: 239
+- error mentions: 0
+- post-run preflight status: `BLOCKED`
+- `dry_activation_readiness.ready`: `false`
+- all daemon, scheduler, Paper/Shadow runtime, Testnet, Live, broker, exchange, and order authorization flags remained `false`
+
+This evidence is non-authorizing. It proves only that the tag-gated scheduler daemon can run for the bounded window while executing the Paper/Shadow 24/7 preflight-status job once and then remaining idle. It does not prove Paper runtime stability, Shadow runtime stability, broker connectivity, exchange connectivity, order submission, Testnet readiness, or Live readiness.
+
+Next gate: add or select a Paper-only runtime job and prove it first under explicit tag gating and bounded execution. Do not use this evidence to authorize Testnet, Live, broker, exchange, or order paths.

--- a/tests/ops/test_paper_shadow_247_120min_stability_evidence_doc_v0.py
+++ b/tests/ops/test_paper_shadow_247_120min_stability_evidence_doc_v0.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+
+
+def test_paper_shadow_247_120min_stability_evidence_is_documented_as_non_authorizing() -> None:
+    text = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "Paper-only Tag-Gated Scheduler Daemon Stability Evidence v0" in text
+    assert "`paper_shadow_247`" in text
+    assert "`paper_shadow_247_paper_only_preflight_status_v0`" in text
+    assert "bounded runtime: 7200 seconds" in text
+    assert "scheduler iterations: 240" in text
+    assert "executed jobs: 1" in text
+    assert "no-due-job observations: 239" in text
+    assert "error mentions: 0" in text
+    assert "post-run preflight status: `BLOCKED`" in text
+    assert "`dry_activation_readiness.ready`: `false`" in text
+    assert "This evidence is non-authorizing." in text
+
+
+def test_paper_shadow_247_120min_stability_evidence_does_not_claim_runtime_or_live_readiness() -> (
+    None
+):
+    text = RUNBOOK.read_text(encoding="utf-8")
+
+    required_denials = (
+        "It does not prove Paper runtime stability",
+        "Shadow runtime stability",
+        "broker connectivity",
+        "exchange connectivity",
+        "order submission",
+        "Testnet readiness",
+        "Live readiness",
+        "Do not use this evidence to authorize Testnet, Live, broker, exchange, or order paths.",
+    )
+
+    for denial in required_denials:
+        assert denial in text


### PR DESCRIPTION
## Summary

- document the successful 120-minute tag-gated Paper-only scheduler daemon run
- record local evidence bundle paths and observed metrics
- explicitly mark the evidence as non-authorizing
- add docs contract tests that prevent this evidence from being interpreted as Paper runtime, Testnet, Live, broker, exchange, or order readiness

## Safety / scope

- docs/tests only
- no daemon started
- no scheduler run executed
- no Paper/Shadow runtime job executed
- no Testnet/Live/broker/exchange/order path enabled

## Local validation

- uv run pytest tests/ops/test_paper_shadow_247_120min_stability_evidence_doc_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check tests/ops/test_paper_shadow_247_120min_stability_evidence_doc_v0.py
- uv run ruff format --check tests/ops/test_paper_shadow_247_120min_stability_evidence_doc_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs