### PR TITLE
feat(ops): add paper-only runtime scheduler job gate v0

### DIFF
--- a/config/ops/paper_shadow_247_preflight.toml
+++ b/config/ops/paper_shadow_247_preflight.toml
@@ -7,6 +7,7 @@ schema_version = "paper_shadow_247_preflight.v0"
 canonical_owner = "ops-paper-shadow-247-readiness"
 
 paper_jobs = [
+  "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0",
   "paper_shadow_247_paper_only_preflight_status_v0",
   "paper_runner_no_order_no_fill_contract_v0",
   "paper_runner_single_order_contract_v0",

--- a/config/scheduler/jobs.toml
+++ b/config/scheduler/jobs.toml
@@ -208,3 +208,29 @@ live_authorized = false
 broker_authorized = false
 exchange_authorized = false
 order_submission_authorized = false
+
+
+# =============================================================================
+# Paper-only runtime job gate v0 (disabled by default)
+# =============================================================================
+# Scheduler-visible Paper runtime shape for a later explicit bounded run.
+# Not Testnet/Live/Broker/Exchange/order authorization.
+[[job]]
+name = "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0"
+enabled = false
+schedule_type = "once"
+command = "python"
+args = { script = "scripts/aiops/run_paper_trading_session.py", spec = "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json", outdir = "out/paper_shadow_247/runtime/high_vol_no_trade/__DRY_RUN_PLACEHOLDER__" }
+description = "Paper-only runtime high-vol no-trade fixture runner; disabled until explicit bounded gate."
+tags = ["paper_shadow_247", "paper_runtime", "readonly", "disabled_by_default"]
+timeout_seconds = 600
+paper_only = true
+paper_runtime_job = true
+dry_run_visible = true
+runtime_fixture = "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json"
+runtime_outdir_template = "out/paper_shadow_247/runtime/high_vol_no_trade/{timestamp}"
+testnet_authorized = false
+live_authorized = false
+broker_authorized = false
+exchange_authorized = false
+order_submission_authorized = false

--- a/tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py
+++ b/tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py
@@ -1,0 +1,99 @@
+"""Scheduler surface for Paper-only runtime job gate v0 (disabled by default)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JOBS_CONFIG = REPO_ROOT / "config" / "scheduler" / "jobs.toml"
+PREFLIGHT_CONFIG = REPO_ROOT / "config" / "ops" / "paper_shadow_247_preflight.toml"
+
+
+def _jobs() -> list[dict]:
+    payload = tomllib.loads(JOBS_CONFIG.read_text(encoding="utf-8"))
+    return payload.get("job", [])
+
+
+def _runtime_job() -> dict:
+    return next(
+        job
+        for job in _jobs()
+        if job.get("name") == "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0"
+    )
+
+
+def test_paper_only_runtime_scheduler_job_is_present_disabled_and_non_authorizing() -> None:
+    target = _runtime_job()
+
+    assert target["enabled"] is False
+    assert target["schedule_type"] == "once"
+    assert target["command"] == "python"
+    assert target["paper_only"] is True
+    assert target["paper_runtime_job"] is True
+    assert target["dry_run_visible"] is True
+    assert target["runtime_fixture"] == "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json"
+    assert (
+        target["runtime_outdir_template"]
+        == "out/paper_shadow_247/runtime/high_vol_no_trade/{timestamp}"
+    )
+
+    assert "paper_shadow_247" in target["tags"]
+    assert "paper_runtime" in target["tags"]
+    assert "disabled_by_default" in target["tags"]
+
+    for key in (
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert target[key] is False
+
+
+def test_paper_only_runtime_scheduler_job_command_shape_is_fixture_bound_and_not_live() -> None:
+    target = _runtime_job()
+    args = target["args"]
+
+    assert args["script"] == "scripts/aiops/run_paper_trading_session.py"
+    assert args["spec"] == "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json"
+    assert (
+        args["outdir"] == "out/paper_shadow_247/runtime/high_vol_no_trade/__DRY_RUN_PLACEHOLDER__"
+    )
+
+    command_blob = f"{target['command']} {args}".lower()
+
+    assert "run_paper_trading_session.py" in command_blob
+    assert "paper_run_high_vol_no_trade_v0.json" in command_blob
+
+    for forbidden in (
+        "--live",
+        "--testnet",
+        "p7_ctl.py run-shadow",
+        "run_shadow_session.py",
+        "submit_order",
+        "real_order",
+        "broker_connect",
+        "exchange_connect",
+        "api_key",
+        "secret",
+    ):
+        assert forbidden not in command_blob
+
+
+def test_paper_only_runtime_scheduler_job_is_referenced_by_preflight_metadata() -> None:
+    payload = tomllib.loads(PREFLIGHT_CONFIG.read_text(encoding="utf-8"))
+
+    assert "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0" in payload["paper_jobs"]
+
+
+def test_paper_only_runtime_scheduler_job_is_not_enabled_in_dry_run_job_set() -> None:
+    enabled_names = {job["name"] for job in _jobs() if job.get("enabled") is True}
+
+    assert "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0" not in enabled_names
+    assert "paper_shadow_247_paper_only_preflight_status_v0" in enabled_names


### PR DESCRIPTION
## Summary

- add a disabled-by-default Paper-only runtime scheduler job gate
- bind the job to `paper_run_high_vol_no_trade_v0.json` and an explicit runtime output path template
- tag the job with `paper_shadow_247` and `paper_runtime`
- wire the job ID into Paper/Shadow 24/7 preflight metadata
- add contract tests that keep it disabled and non-authorizing

## Safety / scope

- config/tests only plus preflight metadata reference
- runtime job remains `enabled = false`
- no daemon started
- no scheduler run without `--dry-run`
- no Paper/Shadow runtime job executed
- no Testnet/Live/broker/exchange/order path enabled

## Local validation

- python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose --include-tags paper_shadow_247 --exclude-tags paper_runtime
- python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose --include-tags paper_shadow_247,paper_runtime
- uv run python scripts/ops/report_paper_shadow_247_preflight_status.py --json
- uv run pytest tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py tests/ops/test_paper_shadow_247_scheduler_job_config_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py scripts/ops/report_paper_shadow_247_preflight_status.py
- uv run ruff format --check tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py scripts/ops/report_paper_shadow_247_preflight_status.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

## Expected behavior

- Normal paper-shadow preflight dry-run excludes the runtime job via `--exclude-tags paper_runtime`
- Runtime job is visible only when `paper_runtime` is explicitly included
- Runtime job remains disabled by default
- Preflight remains `BLOCKED`
- all authorization flags remain `false`