### PR TITLE
test(webui): add market depth ssr context contract v0

### DIFF
--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -135,6 +135,46 @@ class TestMarketSurfaceHtml:
         assert "market_depth" not in body
         assert "XMLHttpRequest" not in body
 
+    @pytest.mark.xfail(
+        reason=(
+            "SSR Market Depth on GET /market not wired: embed display state from "
+            "market_depth_json_payload_v0() only; remove xfail when Phase-2 SSR lands "
+            "(and relax #3359 negative markers in the same slice)."
+        ),
+        strict=False,
+    )
+    def test_market_depth_ssr_context_contract_v0_future_seam(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Tests-first contract: future GET /market SSR depth seam vs current system helper.
+
+        Non-negotiables (must hold once implemented):
+        - Depth display context comes from ``market_depth_json_payload_v0()`` (no builder/API
+          shape changes to satisfy HTML).
+        - ``GET /market`` stays HTTP 200 even when the tuple status is ``503`` diagnostics
+          for the standalone JSON route; depth outcome is embedded read-only context, not page
+          status.
+        - No ``fetch()``, XMLHttpRequest, polling, or in-page ``/api/market/depth`` usage.
+
+        This slice does not set ``PEAK_TRADE_MARKET_DEPTH_*`` — default env matches production
+        "disabled" characterization without touching filesystem bundles.
+
+        Narrow stable markers are intentionally spelled here so the eventual template can mirror
+        them without broad ``data-market-depth-*`` wildcard tests.
+        """
+        resp = client.get("/market", params={"source": "dummy", "limit": 20})
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers.get("content-type", "")
+        body = resp.text
+
+        assert "/api/market/depth" not in body
+        assert "fetch(" not in body
+        assert "XMLHttpRequest" not in body
+
+        assert 'data-market-depth-panel="true"' in body
+        assert 'data-market-depth-status="' in body
+
     def test_market_html_invalid_timeframe_422(self, client: TestClient) -> None:
         r = client.get("/market", params={"source": "dummy", "timeframe": "bad"})
         assert r.status_code == 422


### PR DESCRIPTION
## Summary
- add a tests-only xfail contract for the future `GET /market` SSR Market Depth seam
- preserve the current rule that the dashboard adapts to the system, not the system to the dashboard
- document the future expectation for narrow SSR markers such as `data-market-depth-panel` and `data-market-depth-status`
- keep current pre-depth baseline assertions intact until an explicit SSR implementation slice updates them

## Safety boundaries
- tests-only
- no src/template/docs changes
- no browser fetch, XHR, polling, or client call to `/api/market/depth`
- no provider/network/exchange access
- no live/testnet/execution/order/signal authority
- no secrets/API-key handling

## Validation
- `uv run pytest tests/test_market_surface_api.py -q`
- `uv run pytest tests/webui/test_market_depth_api_v0.py tests/webui/test_market_depth_readmodel_v0.py tests/webui/test_market_depth_runtime_v0.py tests/test_market_surface_api.py -q`
- `uv run ruff check tests/test_market_surface_api.py`
- `uv run ruff format --check tests/test_market_surface_api.py`
- `git diff --check`

Made with [Cursor](https://cursor.com)