### PR TITLE
feat(webui): add market depth ssr display v0

### DIFF
--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -5,6 +5,9 @@ Read-only Market Surface v0 — öffentliche OHLCV + minimale Chart-UI.
 - GET /market — HTML (Close-Line-Chart, Chart.js)
 - GET /api/market/ohlcv — JSON (OHLCV-Bars)
 
+GET /market embeds offline Market Depth read-model state SSR-only via
+``market_depth_json_payload_v0`` (no in-page Depth JSON route, no fetch).
+
 Keine Orders, kein OPS-Cockpit-Bezug. Dummy-Quelle für Offline/CI; Kraken über fetch_ohlcv_df.
 """
 
@@ -20,6 +23,8 @@ import pandas as pd
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+
+from .market_depth_runtime_v0 import market_depth_json_payload_v0
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +131,34 @@ def dataframe_to_bars(df: pd.DataFrame) -> List[Dict[str, Any]]:
     return bars
 
 
+def build_market_depth_display_context() -> Dict[str, Any]:
+    """SSR-only snapshot for templates: tuple from helper, unchanged semantics."""
+
+    depth_http_status, depth_payload = market_depth_json_payload_v0()
+    readmodel_id = str(depth_payload.get("readmodel_id", ""))
+    if depth_http_status == 200:
+        display_status = "ok"
+        depth_obj = depth_payload.get("depth") or {}
+        levels = depth_obj.get("levels_returned") or {}
+        bids_n = levels.get("bids", "—")
+        asks_n = levels.get("asks", "—")
+        sym = depth_payload.get("symbol", "")
+        summary_line = f"{sym} — bids {bids_n}, asks {asks_n} (offline bundle, read-only display)"
+    else:
+        display_status = str(depth_payload.get("runtime_source_status", "unavailable"))
+        warnings = depth_payload.get("warnings")
+        if isinstance(warnings, list) and warnings:
+            summary_line = str(warnings[0])
+        else:
+            summary_line = str(depth_payload.get("stale_reason", display_status))
+    return {
+        "depth_http_status": depth_http_status,
+        "display_status": display_status,
+        "readmodel_id": readmodel_id,
+        "summary_line": summary_line,
+    }
+
+
 def build_market_payload(
     *,
     symbol: str,
@@ -195,12 +228,14 @@ def create_market_router(
         src = _normalize_source(source)
         payload = build_market_payload(symbol=symbol, timeframe=timeframe, limit=limit, source=src)
         proj_status = get_project_status()
+        market_depth = build_market_depth_display_context()
         return templates.TemplateResponse(
             request,
             "market_v0.html",
             {
                 "status": proj_status,
                 "payload": payload,
+                "market_depth": market_depth,
                 "query": {
                     "symbol": symbol,
                     "timeframe": timeframe,

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -56,6 +56,27 @@
     {% endif %}
   </section>
 
+  <section
+    id="market-v0-depth-ssr"
+    aria-label="Market depth read-model (SSR, offline or disabled)"
+    class="rounded-xl border border-slate-700/70 bg-slate-900/55 px-4 py-3 text-xs text-slate-300"
+    data-market-depth-panel="true"
+    data-market-depth-status="{{ market_depth.display_status }}"
+    {% if market_depth.readmodel_id %}
+    data-market-depth-readmodel-id="{{ market_depth.readmodel_id }}"
+    {% endif %}
+  >
+    <p class="font-semibold text-slate-200/95 tracking-wide uppercase text-[11px] mb-1.5">
+      Market Depth (read-only)
+    </p>
+    <p class="leading-relaxed text-slate-300/90 m-0" data-market-depth-summary="true">
+      {{ market_depth.summary_line|e }}
+    </p>
+    <p class="mt-1.5 text-[11px] text-slate-500 m-0">
+      SSR only — keine Browser-Abfrage der Depth-JSON-Route; keine Orders oder Ausführung.
+    </p>
+  </section>
+
   <header class="bg-gradient-to-r from-slate-900/80 to-slate-900/40 rounded-2xl border border-slate-800 p-6">
     <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
       <div>

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -113,56 +113,29 @@ class TestMarketSurfaceHtml:
         assert 'id="market-v0-chart-status"' in body
         assert 'data-market-chart-status="ready"' in body
         assert "Chart bereit — read-only OHLCV-Anzeige." in body
+        assert 'data-market-depth-panel="true"' in body
+        assert 'data-market-depth-status="disabled"' in body
 
-    def test_market_page_pre_depth_ui_baseline_not_integrated_yet(
+    def test_market_page_depth_ssr_forbids_client_depth_route_and_xhr(
         self,
         client: TestClient,
     ) -> None:
-        """Pre-UI freeze: GET /market must stay free of Market Depth display integration.
+        """Depth is embedded SSR-only; page must not steer browsers to the JSON route or XHR."""
 
-        Plan-of-record owner for a later SSR depth slice is documented in
-        ``MARKET_SURFACE_V0.md`` (#3358); this test locks the *current* baseline only.
-        """
         resp = client.get("/market", params={"source": "dummy", "limit": 20})
         assert resp.status_code == 200
         assert "text/html" in resp.headers.get("content-type", "")
         body = resp.text
 
         assert "/api/market/depth" not in body
-        assert "data-market-depth" not in body
-        assert 'id="market-depth' not in body.lower()
-        assert "market-depth-" not in body.lower()
-        assert "market_depth" not in body
+        assert "fetch(" not in body
         assert "XMLHttpRequest" not in body
 
-    @pytest.mark.xfail(
-        reason=(
-            "SSR Market Depth on GET /market not wired: embed display state from "
-            "market_depth_json_payload_v0() only; remove xfail when Phase-2 SSR lands "
-            "(and relax #3359 negative markers in the same slice)."
-        ),
-        strict=False,
-    )
     def test_market_depth_ssr_context_contract_v0_future_seam(
         self,
         client: TestClient,
     ) -> None:
-        """Tests-first contract: future GET /market SSR depth seam vs current system helper.
-
-        Non-negotiables (must hold once implemented):
-        - Depth display context comes from ``market_depth_json_payload_v0()`` (no builder/API
-          shape changes to satisfy HTML).
-        - ``GET /market`` stays HTTP 200 even when the tuple status is ``503`` diagnostics
-          for the standalone JSON route; depth outcome is embedded read-only context, not page
-          status.
-        - No ``fetch()``, XMLHttpRequest, polling, or in-page ``/api/market/depth`` usage.
-
-        This slice does not set ``PEAK_TRADE_MARKET_DEPTH_*`` — default env matches production
-        "disabled" characterization without touching filesystem bundles.
-
-        Narrow stable markers are intentionally spelled here so the eventual template can mirror
-        them without broad ``data-market-depth-*`` wildcard tests.
-        """
+        """Contract: GET /market carries narrow depth markers and no client Depth fetch."""
         resp = client.get("/market", params={"source": "dummy", "limit": 20})
         assert resp.status_code == 200
         assert "text/html" in resp.headers.get("content-type", "")
@@ -174,6 +147,58 @@ class TestMarketSurfaceHtml:
 
         assert 'data-market-depth-panel="true"' in body
         assert 'data-market-depth-status="' in body
+
+    def test_market_depth_ssr_page_stays_200_when_helper_returns_diagnostic_tuple(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Page HTTP status stays 200 when JSON route would use 503 (monkeypatch, no bundles)."""
+
+        def _fake_diagnostic() -> tuple[int, dict[str, object]]:
+            return 503, {
+                "readmodel_id": "market_depth_readmodel.v0",
+                "generated_at_iso": "2026-05-06T12:00:00+00:00",
+                "runtime_source_status": "builder_error",
+                "warnings": ["market_depth_bundle_build_failed"],
+                "stale_reason": "bundle_build_failed",
+            }
+
+        monkeypatch.setattr(
+            "src.webui.market_surface.market_depth_json_payload_v0",
+            _fake_diagnostic,
+        )
+
+        resp = client.get("/market", params={"source": "dummy", "limit": 20})
+        assert resp.status_code == 200
+        body = resp.text
+        assert 'data-market-depth-status="builder_error"' in body
+        assert "/api/market/depth" not in body
+
+    def test_market_depth_ssr_ok_branch_uses_display_status_ok(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When helper succeeds, SSR shows display_status ok (mocked tuple, env-independent)."""
+
+        def _fake_ok() -> tuple[int, dict[str, object]]:
+            return 200, {
+                "readmodel_id": "market_depth_readmodel.v0",
+                "symbol": "BTC/EUR",
+                "depth": {"levels_returned": {"bids": 2, "asks": 3}},
+            }
+
+        monkeypatch.setattr(
+            "src.webui.market_surface.market_depth_json_payload_v0",
+            _fake_ok,
+        )
+
+        resp = client.get("/market", params={"source": "dummy", "limit": 20})
+        assert resp.status_code == 200
+        body = resp.text
+        assert 'data-market-depth-status="ok"' in body
+        assert "/api/market/depth" not in body
 
     def test_market_html_invalid_timeframe_422(self, client: TestClient) -> None:
         r = client.get("/market", params={"source": "dummy", "timeframe": "bad"})
@@ -212,3 +237,5 @@ def test_market_v0_template_kraken_banner_markers_in_source() -> None:
     assert "Chart bereit — read-only OHLCV-Anzeige." in txt
     assert "Keine OHLCV-Bars für diese Abfrage verfügbar." in txt
     assert "Chart-Daten konnten nicht gerendert werden; keine Trading-Aktion verfügbar." in txt
+    assert 'data-market-depth-panel="true"' in txt
+    assert "data-market-depth-status" in txt


### PR DESCRIPTION
## Summary
- add SSR-only Market Depth display context to `GET /market`
- consume existing `market_depth_json_payload_v0()` helper in-process without changing runtime/API/builder semantics
- render narrow read-only SSR markers such as `data-market-depth-panel` and `data-market-depth-status`
- keep `GET /market` HTTP 200 while embedding disabled/unconfigured/builder_error diagnostics as display state
- update the pre-depth baseline and xfail contract into passing SSR display contracts

## Safety boundaries
- dashboard adapts to current system/main; system/runtime/API/builder unchanged
- no browser fetch, XHR, polling, or client call to `/api/market/depth`
- no provider/network/exchange access
- no live/testnet/execution/order/signal authority
- no secrets/API-key handling
- no `/market/double-play` or `dp_display` changes

## Validation
- `uv run pytest tests/test_market_surface_api.py -q`
- `uv run pytest tests/webui/test_market_depth_api_v0.py tests/webui/test_market_depth_readmodel_v0.py tests/webui/test_market_depth_runtime_v0.py tests/test_market_surface_api.py -q`
- `uv run ruff check src/webui/market_surface.py tests/test_market_surface_api.py`
- `uv run ruff format --check src/webui/market_surface.py tests/test_market_surface_api.py`
- `git diff --check`

Made with [Cursor](https://cursor.com)