### PR TITLE
docs(ops): clarify ci audit known issues policy

### DIFF
--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -1,23 +1,39 @@
 # CI Audit — Known Issues
 
 ## Current status
-- `audit` may fail due to a known pre-existing Black formatting/configuration issue.
-- This is currently treated as **non-blocking** for docs/merge-log PRs, unless explicitly changed by policy.
+- Historical context: GitHub [Issue #252](https://github.com/rauterfrank-ui/Peak_Trade/issues/252) tracked an older formatter drift described as a Black formatting/configuration issue.
+- Current CI policy is Ruff-oriented. `scripts/ops/run_audit.sh` runs `ruff check .` and `ruff format --check .`; `scripts/ops/check_no_black_enforcement.sh` guards against `black --check` enforcement in workflows/scripts.
+- `audit` findings are not all hard failures in every workflow path. In `.github/workflows/audit.yml`, `pip-audit` is blocking only for dependency-relevant changes and non-blocking for docs-only scope. The `run_audit.sh` step is currently wrapped so findings are surfaced but do not by themselves fail that workflow step.
+- `lint_gate.yml` remains a separate enforcement surface: it always creates a check run, fails on Black-enforcement drift, and runs Ruff lint/format checks when Python files changed.
 
 ## What to check
 - Confirm `strategy-smoke`, `tests`, and health gates are green for merge readiness.
-- If `audit` fails, cross-check whether the failure is related to the change set.
+- If `audit` or lint/format checks report findings, cross-check the workflow, trigger, and changed-file scope before treating the finding as merge-blocking.
+- Distinguish technically enforced gates from advisory audit output or policy-language documentation.
 
 ## Tracking
-- Root cause and remediation are tracked in GitHub Issues: [Issue #252](https://github.com/rauterfrank-ui/Peak_Trade/issues/252)
+- Historical formatter drift / Black wording: [Issue #252](https://github.com/rauterfrank-ui/Peak_Trade/issues/252)
+- Current formatter source of truth: Ruff format checks, not Black enforcement.
 
 ## Local reproduction
 ```bash
-ruff check .    # ✅ passes
-black --check . # ❌ 61 files would be reformatted
+ruff check .
+ruff format --check .
+bash scripts/ops/check_no_black_enforcement.sh
 ```
 
+## Blocking model
+- Technically enforced:
+  - `pip-audit` in `.github/workflows/audit.yml` when dependency-relevant files changed.
+  - `lint_gate.yml` Ruff lint/format checks when Python files changed.
+  - `lint_gate.yml` Black-enforcement drift guard.
+- Advisory / surfaced but not hard-failing in the current `audit.yml` wrapper:
+  - `run_audit.sh` findings emitted by the `Run audit script (full checks)` step.
+  - `pip-audit` findings for docs-only scope.
+- Policy-language only:
+  - Any historical reference to Black or Issue #252 unless a workflow/script actually enforces Black.
+
 ## Next steps
-1. Decide on policy: fix all files, adjust CI config, or keep as non-blocking
-2. Document final decision in this file
-3. Update CI workflow if needed
+1. Clarify policy/docs if CI enforcement changes.
+2. Keep future wording aligned with Ruff format/check surfaces and workflow-specific blocking behavior.
+3. Do not perform a broad Black formatting sweep from this historical issue alone.


### PR DESCRIPTION
## Summary
- clarify the historical #252 / Black formatter context in `docs/ops/CI_AUDIT_KNOWN_ISSUES.md`
- align the doc with current Ruff-oriented audit behavior and the no-Black-enforcement guard
- distinguish advisory/non-blocking audit language from hard CI enforcement
- keep next steps focused on policy/docs clarification rather than a broad Black formatting sweep

## Safety boundaries
- docs-only
- no workflow/script/code/test changes
- no daemon/scheduler/paper-shadow runs
- no out/ or paper artifact mutation
- no Master V2 / Double Play / Scope / Capital / Risk / KillSwitch / Execution / Live Gates changes

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `git diff --check`

Made with [Cursor](https://cursor.com)