### PR TITLE
docs(ops): record paper-only runtime-min daemon 120min evidence v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -184,3 +184,40 @@ The empty positions object `{}` is accepted as the flat position representation 
 This evidence is non-authorizing. It proves only that the tag-gated Paper-only runtime scheduler daemon can run for the bounded window, execute the high-vol no-trade Paper runtime job once, produce flat/no-fill runtime artifacts, and then remain idle. It does not prove multi-run Paper runtime stability, Shadow runtime stability, broker connectivity, exchange connectivity, order submission, Testnet readiness, or Live readiness.
 
 Next gate: either repeat the Paper-only runtime daemon with a longer bound or introduce a second Paper-only runtime fixture type under explicit tag gating and bounded execution. Do not use this evidence to authorize Testnet, Live, broker, exchange, or order paths.
+
+## Paper-only Runtime-Min Daemon 120-Minute Stability Evidence v0
+
+A controlled Paper-only runtime-min scheduler daemon run completed successfully under a 120-minute bound.
+
+Local evidence bundle:
+
+- `/tmp/peak_trade_paper_only_runtime_min_daemon_120min_final_20260506T143652Z/PAPER_ONLY_RUNTIME_MIN_DAEMON_120MIN_RESULT.md`
+- `/tmp/peak_trade_paper_only_runtime_min_daemon_120min_final_20260506T143652Z/DAEMON_ANALYSIS.json`
+- `/tmp/peak_trade_paper_only_runtime_min_daemon_120min_final_20260506T143652Z/PREFLIGHT_AFTER.json`
+- `/tmp/peak_trade_paper_only_runtime_min_daemon_120min_final_20260506T143652Z/runtime_out/account.json`
+- `/tmp/peak_trade_paper_only_runtime_min_daemon_120min_final_20260506T143652Z/runtime_out/fills.json`
+- `/tmp/peak_trade_paper_only_runtime_min_daemon_120min_final_20260506T143652Z/runtime_out/evidence_manifest.json`
+
+Observed result:
+
+- tag gate: `paper_runtime_min`
+- target job: `paper_shadow_247_paper_only_runtime_min_v0`
+- runtime fixture: `tests/fixtures/p7/paper_run_min_v0.json`
+- bounded runtime: 7200 seconds
+- scheduler checks: 240
+- runtime-min job mentions: 3
+- no-due-job observations: 239
+- error mentions: 0
+- fills count: 2
+- fill sides: `BUY`, `SELL`
+- fill prices: `100.1`, `99.9`
+- fill fees: `0.1001`, `0.0999`
+- account cash: 999.6
+- positions shape: `{'BTC': 0.0}`
+- post-run preflight status: `BLOCKED`
+- `dry_activation_readiness.ready`: `false`
+- all daemon, scheduler, Paper/Shadow runtime, Testnet, Live, broker, exchange, and order authorization flags remained `false`
+
+This evidence is non-authorizing. It proves only that the tag-gated Paper-only runtime-min scheduler daemon can run for the bounded window, execute the min Paper runtime job once, produce the expected BUY/SELL roundtrip artifacts, and then remain idle. It does not prove multi-symbol Paper runtime stability, longer-horizon Paper runtime stability, Shadow runtime stability, broker connectivity, exchange connectivity, order submission, Testnet readiness, or Live readiness.
+
+Next gate: either repeat with a longer bound, add another Paper-only runtime fixture class, or promote a strictly bounded Paper-only runtime job only through an explicit non-live governance gate. Do not use this evidence to authorize Testnet, Live, broker, exchange, or order paths.

--- a/tests/ops/test_paper_shadow_247_runtime_min_daemon_120min_evidence_doc_v0.py
+++ b/tests/ops/test_paper_shadow_247_runtime_min_daemon_120min_evidence_doc_v0.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+
+
+def test_paper_only_runtime_min_daemon_120min_evidence_is_documented_as_non_authorizing() -> None:
+    text = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "Paper-only Runtime-Min Daemon 120-Minute Stability Evidence v0" in text
+    assert "`paper_runtime_min`" in text
+    assert "`paper_shadow_247_paper_only_runtime_min_v0`" in text
+    assert "`tests/fixtures/p7/paper_run_min_v0.json`" in text
+    assert "bounded runtime: 7200 seconds" in text
+    assert "error mentions: 0" in text
+    assert "fills count: 2" in text
+    assert "fill sides: `BUY`, `SELL`" in text
+    assert "fill prices: `100.1`, `99.9`" in text
+    assert "fill fees: `0.1001`, `0.0999`" in text
+    assert "account cash: 999.6" in text
+    assert "post-run preflight status: `BLOCKED`" in text
+    assert "`dry_activation_readiness.ready`: `false`" in text
+    assert "This evidence is non-authorizing." in text
+
+
+def test_paper_only_runtime_min_daemon_120min_evidence_does_not_claim_live_readiness() -> None:
+    text = RUNBOOK.read_text(encoding="utf-8")
+
+    required_denials = (
+        "It does not prove multi-symbol Paper runtime stability",
+        "longer-horizon Paper runtime stability",
+        "Shadow runtime stability",
+        "broker connectivity",
+        "exchange connectivity",
+        "order submission",
+        "Testnet readiness",
+        "Live readiness",
+        "Do not use this evidence to authorize Testnet, Live, broker, exchange, or order paths.",
+    )
+
+    for denial in required_denials:
+        assert denial in text


### PR DESCRIPTION
## Summary

- document the successful 120-minute tag-gated Paper-only runtime-min daemon run
- record local evidence bundle paths, runtime artifacts, and observed metrics
- document the BUY/SELL roundtrip evidence for `paper_run_min_v0.json`
- explicitly mark the evidence as non-authorizing
- add docs contract tests preventing this evidence from being interpreted as multi-symbol Paper runtime, Testnet, Live, broker, exchange, or order readiness

## Safety / scope

- docs/tests only
- no daemon started
- no scheduler run executed
- no Paper/Shadow runtime job executed
- no Testnet/Live/broker/exchange/order path enabled

## Prometheus follow-up

During the bounded Paper-only daemon runs, stderr contained the known optional warning: `prometheus_client not installed`. This PR does not change dependencies or metrics behavior. Handle that separately as an optional metrics dependency/importability follow-up after this evidence PR.

## Local validation

- uv run pytest tests/ops/test_paper_shadow_247_runtime_min_daemon_120min_evidence_doc_v0.py tests/ops/test_paper_shadow_247_runtime_daemon_120min_evidence_doc_v0.py tests/ops/test_paper_shadow_247_runtime_min_scheduler_job_config_v0.py tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py tests/ops/test_paper_shadow_247_120min_stability_evidence_doc_v0.py tests/ops/test_paper_shadow_247_scheduler_job_config_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check tests/ops/test_paper_shadow_247_runtime_min_daemon_120min_evidence_doc_v0.py
- uv run ruff format --check tests/ops/test_paper_shadow_247_runtime_min_daemon_120min_evidence_doc_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs