### PR TITLE
docs(ops): clarify operator python prometheus client boundary v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -221,3 +221,11 @@ Observed result:
 This evidence is non-authorizing. It proves only that the tag-gated Paper-only runtime-min scheduler daemon can run for the bounded window, execute the min Paper runtime job once, produce the expected BUY/SELL roundtrip artifacts, and then remain idle. It does not prove multi-symbol Paper runtime stability, longer-horizon Paper runtime stability, Shadow runtime stability, broker connectivity, exchange connectivity, order submission, Testnet readiness, or Live readiness.
 
 Next gate: either repeat with a longer bound, add another Paper-only runtime fixture class, or promote a strictly bounded Paper-only runtime job only through an explicit non-live governance gate. Do not use this evidence to authorize Testnet, Live, broker, exchange, or order paths.
+
+## Operator Python Environment Note v0
+
+Bounded Paper-only scheduler and runtime daemon runs should be launched with the project environment, preferably through `uv run python`, not a system Python such as `/usr/bin/python3`.
+
+Reason: `prometheus_client` is available in the project-managed environment, while Apple Command Line Tools Python may not include it. If the scheduler is started with system Python, stderr may show the optional warning `prometheus_client not installed`. This warning is non-fatal for the current Paper-only evidence gates, but it reduces observability quality and can confuse operator triage.
+
+This note does **not** change runtime authorization. It does not authorize daemon execution, scheduler execution, Paper runtime, Shadow runtime, Testnet, Live, broker, exchange, or order submission paths. It only documents the preferred interpreter boundary for future bounded Paper-only operator runs.

--- a/tests/ops/test_operator_python_prometheus_client_note_v0.py
+++ b/tests/ops/test_operator_python_prometheus_client_note_v0.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+
+
+def test_operator_python_environment_note_documents_uv_run_preference() -> None:
+    text = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "Operator Python Environment Note v0" in text
+    assert "`uv run python`" in text
+    assert "not a system Python such as `/usr/bin/python3`" in text
+    assert "`prometheus_client` is available in the project-managed environment" in text
+    assert "Apple Command Line Tools Python may not include it" in text
+    assert "optional warning `prometheus_client not installed`" in text
+    assert "non-fatal for the current Paper-only evidence gates" in text
+    assert "reduces observability quality" in text
+
+
+def test_operator_python_environment_note_is_non_authorizing() -> None:
+    text = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "This note does **not** change runtime authorization." in text
+    assert "It does not authorize daemon execution" in text
+    assert "scheduler execution" in text
+    assert "Paper runtime" in text
+    assert "Shadow runtime" in text
+    assert "Testnet" in text
+    assert "Live" in text
+    assert "broker" in text
+    assert "exchange" in text
+    assert "order submission" in text


### PR DESCRIPTION
## Summary

- document that bounded Paper-only scheduler/runtime daemon runs should use `uv run python`
- clarify that system Python may lack `prometheus_client` even when the project env has it
- explain that the warning is non-fatal for current evidence gates but reduces observability quality
- add docs contract tests keeping the note non-authorizing

## Safety / scope

- docs/tests only
- no dependency changes
- no daemon started
- no scheduler run executed
- no Paper/Shadow runtime job executed
- no Testnet/Live/broker/exchange/order path enabled

## Local validation

- uv run pytest tests/ops/test_operator_python_prometheus_client_note_v0.py tests/ops/test_paper_shadow_247_runtime_min_daemon_120min_evidence_doc_v0.py tests/ops/test_paper_shadow_247_runtime_daemon_120min_evidence_doc_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/aiops/p7 tests/sim/paper -q
- uv run ruff check tests/ops/test_operator_python_prometheus_client_note_v0.py
- uv run ruff format --check tests/ops/test_operator_python_prometheus_client_note_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs