### PR TITLE
test(ops): add prometheus client dependency contract v0

### DIFF
--- a/tests/ops/test_peak_trade_pyproject_declares_prometheus_client_v0.py
+++ b/tests/ops/test_peak_trade_pyproject_declares_prometheus_client_v0.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.9/3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _normalize_dependency_name(requirement: str) -> str:
+    match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
+    assert match is not None, f"Could not parse dependency requirement: {requirement!r}"
+    return match.group(1).replace("_", "-").lower()
+
+
+def test_peak_trade_pyproject_declares_prometheus_client_dependency_v0() -> None:
+    pyproject_path = REPO_ROOT / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    dependencies = pyproject["project"]["dependencies"]
+
+    prometheus_requirements = [
+        requirement
+        for requirement in dependencies
+        if _normalize_dependency_name(requirement) == "prometheus-client"
+    ]
+
+    assert prometheus_requirements == ["prometheus-client>=0.19.0"]


### PR DESCRIPTION
## Summary

Adds a small tests-only Ops contract that locks the project dependency metadata for `prometheus-client`.

## Scope

- Adds `tests/ops/test_peak_trade_pyproject_declares_prometheus_client_v0.py`
- Reads `pyproject.toml`
- Verifies `[project].dependencies` contains exactly `prometheus-client>=0.19.0`
- Does not import `prometheus_client`
- Does not start scheduler/runtime/daemon/uvicorn
- Does not touch Master V2 / Double Play trading logic
- Does not touch Testnet/Live/Broker/Exchange/Order paths

## Validation

```text
uv run pytest tests/ops/test_peak_trade_pyproject_declares_prometheus_client_v0.py
uv run ruff check tests/ops/test_peak_trade_pyproject_declares_prometheus_client_v0.py
uv run ruff format --check tests/ops/test_peak_trade_pyproject_declares_prometheus_client_v0.py
uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
```
