### PR TITLE
feat(ops): add preflight command inventory v0

### DIFF
--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -42,6 +42,86 @@ def _load_paper_shadow_247_preflight_metadata(root: Path) -> dict[str, Any]:
     return tomllib.loads(cfg.read_text(encoding="utf-8"))
 
 
+def _load_scheduler_jobs_by_name(root: Path) -> dict[str, dict[str, Any]]:
+    path = root / SCHEDULER_CONFIG
+    if not path.is_file():
+        return {}
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    jobs_raw = data.get("job", [])
+    if not isinstance(jobs_raw, list):
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for item in jobs_raw:
+        if not isinstance(item, dict):
+            continue
+        name_any = item.get("name")
+        if isinstance(name_any, str):
+            out[name_any] = item
+    return out
+
+
+def _job_to_command_inventory_entry(
+    job_name: str,
+    source: str,
+    job: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if job is None:
+        return {
+            "name": job_name,
+            "source": source,
+            "found": False,
+            "command": None,
+            "args": None,
+            "enabled": None,
+            "schedule_type": None,
+            "tags": None,
+            "timeout_seconds": None,
+        }
+
+    tags_raw = job.get("tags")
+    tags_out: list[Any] | None
+    if isinstance(tags_raw, list):
+        tags_out = list(tags_raw)
+    else:
+        tags_out = None
+
+    args_raw = job.get("args")
+    args_out: dict[str, Any] | None
+    if isinstance(args_raw, dict):
+        args_out = {str(k): v for k, v in args_raw.items()}
+    else:
+        args_out = None
+
+    return {
+        "name": job_name,
+        "source": source,
+        "found": True,
+        "command": job["command"] if isinstance(job.get("command"), str) else None,
+        "args": args_out,
+        "enabled": job.get("enabled") if "enabled" in job else None,
+        "schedule_type": job.get("schedule_type")
+        if isinstance(job.get("schedule_type"), str)
+        else None,
+        "tags": tags_out,
+        "timeout_seconds": job.get("timeout_seconds")
+        if isinstance(job.get("timeout_seconds"), int)
+        else None,
+    }
+
+
+def _build_scheduler_command_inventory(
+    paper_jobs: list[str],
+    shadow_jobs: list[str],
+    jobs_by_name: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    commands: list[dict[str, Any]] = []
+    for name in paper_jobs:
+        commands.append(_job_to_command_inventory_entry(name, "paper", jobs_by_name.get(name)))
+    for name in shadow_jobs:
+        commands.append(_job_to_command_inventory_entry(name, "shadow", jobs_by_name.get(name)))
+    return commands
+
+
 def _build_dry_activation_readiness(payload: dict[str, Any]) -> dict[str, Any]:
     """Return non-authorizing readiness details for a later manual paper-only dry activation."""
 
@@ -122,6 +202,7 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
     paper_jobs = [str(x) for x in metadata.get("paper_jobs", []) if isinstance(x, str)]
     shadow_jobs = [str(x) for x in metadata.get("shadow_jobs", []) if isinstance(x, str)]
     output_paths = [str(x) for x in metadata.get("output_paths", []) if isinstance(x, str)]
+    scheduler_jobs_by_name = _load_scheduler_jobs_by_name(root)
 
     stop_any = metadata.get("stop_command")
     emergency_any = metadata.get("emergency_stop_command")
@@ -173,7 +254,9 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
         "canonical_owner": canonical_owner,
         "paper_jobs": paper_jobs,
         "shadow_jobs": shadow_jobs,
-        "commands": [],
+        "commands": _build_scheduler_command_inventory(
+            paper_jobs, shadow_jobs, scheduler_jobs_by_name
+        ),
         "output_paths": output_paths,
         "state_files": [],
         "log_paths": [],
@@ -194,6 +277,7 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
             "does_not_run_scheduler",
             "does_not_start_daemon",
             "does_not_activate_paper_or_shadow_runtime",
+            "scheduler_command_inventory_v0",
         ],
     }
     payload["dry_activation_readiness"] = _build_dry_activation_readiness(payload)

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -11,9 +11,49 @@ from scripts.ops.report_paper_shadow_247_preflight_status import (
     build_paper_shadow_247_preflight_status,
 )
 
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "ops" / "report_paper_shadow_247_preflight_status.py"
+PREFLIGHT_CONFIG = REPO_ROOT / "config" / "ops" / "paper_shadow_247_preflight.toml"
+
+
+def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
+    meta = tomllib.loads(PREFLIGHT_CONFIG.read_text(encoding="utf-8"))
+    paper = [str(x) for x in meta["paper_jobs"]]
+    shadow = [str(x) for x in meta["shadow_jobs"]]
+    commands = payload["commands"]
+    assert isinstance(commands, list)
+    assert len(commands) == len(paper) + len(shadow)
+    assert [c["name"] for c in commands] == paper + shadow
+    assert [c["source"] for c in commands] == ["paper"] * len(paper) + ["shadow"] * len(shadow)
+
+    by_name = {str(c["name"]): c for c in commands}
+    preflight = by_name["paper_shadow_247_paper_only_preflight_status_v0"]
+    assert preflight["found"] is True
+    assert preflight["enabled"] is True
+    assert preflight["command"] == "python"
+    args_pf = preflight["args"]
+    assert isinstance(args_pf, dict)
+    assert args_pf["script"] == "scripts/ops/report_paper_shadow_247_preflight_status.py"
+
+    min_job = by_name["paper_shadow_247_paper_only_runtime_min_v0"]
+    assert min_job["found"] is True
+    assert min_job["enabled"] is False
+    assert min_job["command"] == "python"
+    args_min = min_job["args"]
+    assert isinstance(args_min, dict)
+    assert args_min["script"] == "scripts/aiops/run_paper_trading_session.py"
+    assert args_min["spec"] == "tests/fixtures/p7/paper_run_min_v0.json"
+
+    assert any(str(c["name"]).startswith("paper_runner_") and c["found"] is False for c in commands)
+    shadow_entry = by_name["p7_shadow_high_vol_no_trade_runner_manual_v0"]
+    assert shadow_entry["source"] == "shadow"
+    assert shadow_entry["found"] is False
 
 
 def _run_json() -> dict[str, object]:
@@ -49,7 +89,7 @@ def test_build_paper_shadow_247_preflight_status_is_blocked_and_non_authorizing(
     assert payload["canonical_owner"] == "ops-paper-shadow-247-readiness"
     assert payload["paper_jobs"]
     assert payload["shadow_jobs"]
-    assert payload["commands"] == []
+    _assert_command_inventory_shape(payload)
     assert payload["output_paths"]
     assert isinstance(payload["stop_command"], str)
     assert payload["stop_command"]
@@ -87,6 +127,8 @@ def test_cli_json_output_is_json_native_and_does_not_execute_scheduler() -> None
     assert payload["dry_run_command"].endswith("--dry-run --once --verbose")
     assert "does_not_run_scheduler" in payload["notes"]
     assert "does_not_start_daemon" in payload["notes"]
+    assert "scheduler_command_inventory_v0" in payload["notes"]
+    _assert_command_inventory_shape(payload)
 
 
 def test_cli_human_output_is_bounded_status_only() -> None:


### PR DESCRIPTION
## Summary

Adds a read-only scheduler command inventory to the Paper/Shadow 24/7 preflight reporter.

## Scope

- Extends `scripts/ops/report_paper_shadow_247_preflight_status.py`
- Extends the canonical CLI contract test:
  - `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py`
- Resolves Paper/Shadow 24/7 preflight job names against `config/scheduler/jobs.toml`
- Preserves unresolved jobs as `found: false`
- Preserves disabled-by-default runtime job metadata without enabling anything
- Adds the note `scheduler_command_inventory_v0`

## Validation

```text
uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py
uv run ruff check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
uv run ruff format --check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
```
