### PR TITLE
feat(ops): add preflight command safety classification v0

### DIFF
--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -29,6 +29,13 @@ DRY_RUN_COMMAND = (
     "python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml "
     "--dry-run --once --verbose"
 )
+JOB_AUTHORIZATION_FLAGS = (
+    "testnet_authorized",
+    "live_authorized",
+    "broker_authorized",
+    "exchange_authorized",
+    "order_submission_authorized",
+)
 
 
 def _repo_root() -> Path:
@@ -58,6 +65,37 @@ def _load_scheduler_jobs_by_name(root: Path) -> dict[str, dict[str, Any]]:
         if isinstance(name_any, str):
             out[name_any] = item
     return out
+
+
+def _job_bool_or_none(job: dict[str, Any], key: str) -> bool | None:
+    value = job.get(key)
+    return value if isinstance(value, bool) else None
+
+
+def _build_job_safety_classification(job: dict[str, Any]) -> dict[str, Any]:
+    enabled = _job_bool_or_none(job, "enabled")
+    authorization_flags = {
+        key: _job_bool_or_none(job, key) if key in job else None for key in JOB_AUTHORIZATION_FLAGS
+    }
+    non_authorizing = (
+        all(value is False for value in authorization_flags.values())
+        if all(value is not None for value in authorization_flags.values())
+        else None
+    )
+
+    return {
+        "paper_only": _job_bool_or_none(job, "paper_only") if "paper_only" in job else None,
+        "dry_run_visible": _job_bool_or_none(job, "dry_run_visible")
+        if "dry_run_visible" in job
+        else None,
+        "paper_runtime_job": _job_bool_or_none(job, "paper_runtime_job")
+        if "paper_runtime_job" in job
+        else None,
+        "enabled": enabled,
+        "disabled_by_default": (enabled is False) if enabled is not None else None,
+        "authorization_flags": authorization_flags,
+        "non_authorizing": non_authorizing,
+    }
 
 
 def _job_to_command_inventory_entry(
@@ -106,6 +144,7 @@ def _job_to_command_inventory_entry(
         "timeout_seconds": job.get("timeout_seconds")
         if isinstance(job.get("timeout_seconds"), int)
         else None,
+        "safety_classification": _build_job_safety_classification(job),
     }
 
 
@@ -278,6 +317,7 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
             "does_not_start_daemon",
             "does_not_activate_paper_or_shadow_runtime",
             "scheduler_command_inventory_v0",
+            "scheduler_command_safety_classification_v0",
         ],
     }
     payload["dry_activation_readiness"] = _build_dry_activation_readiness(payload)

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -37,6 +37,21 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
     assert preflight["found"] is True
     assert preflight["enabled"] is True
     assert preflight["command"] == "python"
+    safety_pf = preflight["safety_classification"]
+    assert isinstance(safety_pf, dict)
+    assert safety_pf["paper_only"] is True
+    assert safety_pf["dry_run_visible"] is True
+    assert safety_pf["paper_runtime_job"] is None
+    assert safety_pf["enabled"] is True
+    assert safety_pf["disabled_by_default"] is False
+    assert safety_pf["authorization_flags"] == {
+        "testnet_authorized": False,
+        "live_authorized": False,
+        "broker_authorized": False,
+        "exchange_authorized": False,
+        "order_submission_authorized": False,
+    }
+    assert safety_pf["non_authorizing"] is True
     args_pf = preflight["args"]
     assert isinstance(args_pf, dict)
     assert args_pf["script"] == "scripts/ops/report_paper_shadow_247_preflight_status.py"
@@ -45,15 +60,35 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
     assert min_job["found"] is True
     assert min_job["enabled"] is False
     assert min_job["command"] == "python"
+    safety_min = min_job["safety_classification"]
+    assert isinstance(safety_min, dict)
+    assert safety_min["paper_only"] is True
+    assert safety_min["dry_run_visible"] is True
+    assert safety_min["paper_runtime_job"] is True
+    assert safety_min["enabled"] is False
+    assert safety_min["disabled_by_default"] is True
+    assert safety_min["authorization_flags"] == {
+        "testnet_authorized": False,
+        "live_authorized": False,
+        "broker_authorized": False,
+        "exchange_authorized": False,
+        "order_submission_authorized": False,
+    }
+    assert safety_min["non_authorizing"] is True
     args_min = min_job["args"]
     assert isinstance(args_min, dict)
     assert args_min["script"] == "scripts/aiops/run_paper_trading_session.py"
     assert args_min["spec"] == "tests/fixtures/p7/paper_run_min_v0.json"
 
     assert any(str(c["name"]).startswith("paper_runner_") and c["found"] is False for c in commands)
+    for c in commands:
+        if str(c["name"]).startswith("paper_runner_") and c["found"] is False:
+            assert "safety_classification" not in c
+            break
     shadow_entry = by_name["p7_shadow_high_vol_no_trade_runner_manual_v0"]
     assert shadow_entry["source"] == "shadow"
     assert shadow_entry["found"] is False
+    assert "safety_classification" not in shadow_entry
 
 
 def _run_json() -> dict[str, object]:
@@ -128,6 +163,7 @@ def test_cli_json_output_is_json_native_and_does_not_execute_scheduler() -> None
     assert "does_not_run_scheduler" in payload["notes"]
     assert "does_not_start_daemon" in payload["notes"]
     assert "scheduler_command_inventory_v0" in payload["notes"]
+    assert "scheduler_command_safety_classification_v0" in payload["notes"]
     _assert_command_inventory_shape(payload)
 
 


### PR DESCRIPTION
## Summary

Adds read-only safety classification metadata to found Paper/Shadow 24/7 preflight command inventory entries.

## Scope

- Extends `scripts/ops/report_paper_shadow_247_preflight_status.py`
- Extends the canonical CLI contract test:
  - `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py`
- Adds `safety_classification` for `commands[]` entries with `found: true`
- Keeps `found: false` entries visible without inventing classification metadata
- Adds the note `scheduler_command_safety_classification_v0`
- Preserves disabled-by-default runtime job semantics

## Validation

```text
uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
uv run ruff check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
uv run ruff format --check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
```
