### PR TITLE
feat(ops): runtime-min scheduler timeout contract v0

### DIFF
--- a/config/scheduler/jobs.toml
+++ b/config/scheduler/jobs.toml
@@ -247,6 +247,7 @@ schedule_type = "once"
 command = "python"
 description = "Paper-only runtime min fixture runner; disabled until explicit bounded gate."
 tags = ["paper_shadow_247", "paper_runtime", "paper_runtime_min", "disabled_by_default"]
+timeout_seconds = 600
 paper_only = true
 paper_runtime_job = true
 dry_run_visible = true

--- a/tests/ops/test_paper_shadow_247_runtime_min_scheduler_job_config_v0.py
+++ b/tests/ops/test_paper_shadow_247_runtime_min_scheduler_job_config_v0.py
@@ -33,6 +33,7 @@ def test_paper_only_runtime_min_scheduler_job_is_present_disabled_and_non_author
     assert target["paper_only"] is True
     assert target["paper_runtime_job"] is True
     assert target["dry_run_visible"] is True
+    assert target["timeout_seconds"] == 600
     assert target["runtime_fixture"] == "tests/fixtures/p7/paper_run_min_v0.json"
     assert target["runtime_outdir_template"] == "out/paper_shadow_247/runtime/min/{timestamp}"
 

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -60,6 +60,7 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
     assert min_job["found"] is True
     assert min_job["enabled"] is False
     assert min_job["command"] == "python"
+    assert min_job["timeout_seconds"] == 600
     safety_min = min_job["safety_classification"]
     assert isinstance(safety_min, dict)
     assert safety_min["paper_only"] is True


### PR DESCRIPTION
## Summary

Locks the disabled paper-only runtime-min scheduler job to an explicit bounded timeout.

## Scope

- Updates `config/scheduler/jobs.toml`
  - `paper_shadow_247_paper_only_runtime_min_v0`
  - `timeout_seconds = 600`
- Extends the runtime-min scheduler job config contract:
  - `tests/ops/test_paper_shadow_247_runtime_min_scheduler_job_config_v0.py`
- Extends the preflight reporter CLI contract:
  - `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py`
  - asserts the command inventory exposes `timeout_seconds == 600`

## Validation

```text
python3 -m pytest tests/ops/test_paper_shadow_247_runtime_min_scheduler_job_config_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py -q
```

## Notes

- Parity with `paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0` (`timeout_seconds = 600`).
- Job remains `enabled = false`; no scheduler/daemon/runtime execution in this change.
