### PR TITLE
test(ops): runtime paper job inventory parity contract v0

### DIFF
--- a/tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py
+++ b/tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py
@@ -36,6 +36,7 @@ def test_paper_only_runtime_scheduler_job_is_present_disabled_and_non_authorizin
     assert target["paper_only"] is True
     assert target["paper_runtime_job"] is True
     assert target["dry_run_visible"] is True
+    assert target["timeout_seconds"] == 600
     assert target["runtime_fixture"] == "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json"
     assert (
         target["runtime_outdir_template"]

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -81,6 +81,31 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
     assert args_min["script"] == "scripts/aiops/run_paper_trading_session.py"
     assert args_min["spec"] == "tests/fixtures/p7/paper_run_min_v0.json"
 
+    high_job = by_name["paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0"]
+    assert high_job["found"] is True
+    assert high_job["enabled"] is False
+    assert high_job["command"] == "python"
+    assert high_job["timeout_seconds"] == 600
+    safety_high = high_job["safety_classification"]
+    assert isinstance(safety_high, dict)
+    assert safety_high["paper_only"] is True
+    assert safety_high["dry_run_visible"] is True
+    assert safety_high["paper_runtime_job"] is True
+    assert safety_high["enabled"] is False
+    assert safety_high["disabled_by_default"] is True
+    assert safety_high["authorization_flags"] == {
+        "testnet_authorized": False,
+        "live_authorized": False,
+        "broker_authorized": False,
+        "exchange_authorized": False,
+        "order_submission_authorized": False,
+    }
+    assert safety_high["non_authorizing"] is True
+    args_high = high_job["args"]
+    assert isinstance(args_high, dict)
+    assert args_high["script"] == "scripts/aiops/run_paper_trading_session.py"
+    assert args_high["spec"] == "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json"
+
     assert any(str(c["name"]).startswith("paper_runner_") and c["found"] is False for c in commands)
     for c in commands:
         if str(c["name"]).startswith("paper_runner_") and c["found"] is False:


### PR DESCRIPTION
## Summary

Adds parity contract coverage for the disabled paper-only high-vol/no-trade runtime scheduler job.

## Scope

- Extends `tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py`
  - asserts `paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0`
  - locks `timeout_seconds == 600`
- Extends `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py`
  - asserts command inventory metadata for the same high-vol/no-trade runtime job
  - asserts `timeout_seconds == 600`
  - asserts high-vol fixture wiring in args
  - asserts safety classification remains non-authorizing and paper-runtime scoped

## Validation

```text
uv run pytest tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
```

## Notes

- Tests-only; no scheduler config, reporter, or runtime behavior changes.
- Parity with runtime-min timeout + preflight inventory contract (#3374 pattern).
