### PR TITLE
test(ops): runtime inventory outdir contract v0

### DIFF
--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -80,6 +80,7 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
     assert isinstance(args_min, dict)
     assert args_min["script"] == "scripts/aiops/run_paper_trading_session.py"
     assert args_min["spec"] == "tests/fixtures/p7/paper_run_min_v0.json"
+    assert args_min["outdir"] == "out/paper_shadow_247/runtime/min/__DRY_RUN_PLACEHOLDER__"
 
     high_job = by_name["paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0"]
     assert high_job["found"] is True
@@ -105,6 +106,10 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
     assert isinstance(args_high, dict)
     assert args_high["script"] == "scripts/aiops/run_paper_trading_session.py"
     assert args_high["spec"] == "tests/fixtures/p7/paper_run_high_vol_no_trade_v0.json"
+    assert (
+        args_high["outdir"]
+        == "out/paper_shadow_247/runtime/high_vol_no_trade/__DRY_RUN_PLACEHOLDER__"
+    )
 
     assert any(str(c["name"]).startswith("paper_runner_") and c["found"] is False for c in commands)
     for c in commands:


### PR DESCRIPTION
## Summary

Locks the Paper/Shadow 24/7 preflight command-inventory `args["outdir"]` placeholders for both disabled paper-runtime jobs.

## Scope

- Extends `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py`
- Locks runtime-min command inventory outdir:
  - `out/paper_shadow_247/runtime/min/__DRY_RUN_PLACEHOLDER__`
- Locks high-vol/no-trade command inventory outdir:
  - `out/paper_shadow_247/runtime/high_vol_no_trade/__DRY_RUN_PLACEHOLDER__`

## Validation

```text
python3 -m pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py -q
```

## Notes

- Tests-only; follows the post-#3375 package gap closure (inventory parity for `outdir`).
- No scheduler config, reporter implementation, or runtime activation changes.
