### PR TITLE
docs(ops): paper-shadow 247 readiness closeout after PR3376 v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -122,6 +122,40 @@ The operator command in this object is a readiness reference only. It is not exe
 
 - **v0** — Initial contract: BLOCKED default, status model, non-authority, informative JSON shape.
 
+## Post-PR3376 operator readiness closeout v0
+
+After PRs **#3371** through **#3376**, the repository completed a focused **tests and reporting-contract** slice for Paper/Shadow 24/7 **read-only diagnostics** (prometheus declaration contract, preflight command inventory, safety classification, runtime-min timeout, high-vol inventory parity, runtime `outdir` placeholders in reporter inventory). This section is an operator-facing closeout. It does **not** authorize scheduler execution, daemon execution, Paper runtime, Shadow runtime, Testnet, Live, broker, exchange, or order submission.
+
+### Canonical surfaces (reuse only)
+
+Treat these as the coordinated sources for this topic—**do not** add parallel readiness maps, handoffs, or evidence indexes:
+
+- `config/ops/paper_shadow_247_preflight.toml` — canonical owner `ops-paper-shadow-247-readiness`, job identifiers, output paths, stop commands; metadata only, not execution authority.
+- `config/scheduler/jobs.toml` — scheduler-visible job shapes; Paper runtime jobs remain **disabled by default** unless a future gate explicitly enables them.
+- `scripts/ops/report_paper_shadow_247_preflight_status.py` — read-only JSON reporter (`status` remains **BLOCKED** in normal operation); command inventory and safety classification are diagnostic.
+- `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py` — contract tests for reporter output, including runtime job inventory fields.
+
+### Read-only diagnostics (examples)
+
+Manual inspection only; they do not start daemons, schedulers in non-dry modes, or external trading paths:
+
+```bash
+python3 scripts/ops/report_paper_shadow_247_preflight_status.py --json --repo-root .
+python3 scripts/ops/snapshot_operator_stop_signals.py --json --repo-root .
+```
+
+Prefer `uv run python` for interpreter parity (see **Operator Python Environment Note v0**).
+
+### Evidence sections above
+
+The tag-gated daemon and Paper-only runtime evidence sections in this contract remain **non-authorizing**: they describe bounded historical runs and flat/no-fill or roundtrip artifacts only. They do **not** approve continuous 24/7 operation, Shadow runtime, broker/exchange connectivity, Testnet, or Live.
+
+### Operator decision
+
+- Contract status stays **BLOCKED**; reporter `dry_activation_readiness.ready` remains **false** until a **separate explicit governance** step authorizes otherwise.
+- **STOP — do not activate Paper/Shadow 24/7** based on this closeout alone.
+- The next gate should be an explicit reviewed readiness or arming process—not implicit activation and not another single-field micro-contract unless a concrete safety defect requires it.
+
 ## Paper-only Tag-Gated Scheduler Daemon Stability Evidence v0
 
 A controlled Paper-only, tag-gated scheduler daemon run completed successfully under a 120-minute bound.

--- a/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
+++ b/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
@@ -69,6 +69,17 @@ def test_paper_shadow_247_contract_example_report_is_blocked_json() -> None:
     assert "paper_shadow_247_canonical_job_set_missing" in reasons
 
 
+def test_paper_shadow_247_contract_includes_post_pr3376_readiness_closeout() -> None:
+    text = _read_contract()
+
+    assert "## Post-PR3376 operator readiness closeout v0" in text
+    assert "ops-paper-shadow-247-readiness" in text
+    assert "#3371" in text and "#3376" in text
+    assert "does **not** authorize scheduler execution" in text
+    assert "scripts/ops/report_paper_shadow_247_preflight_status.py" in text
+    assert "scripts/ops/snapshot_operator_stop_signals.py" in text
+
+
 def test_scheduler_daemon_links_to_paper_shadow_247_contract() -> None:
     scheduler_text = SCHEDULER_DAEMON.read_text(encoding="utf-8")
     assert "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md" in scheduler_text


### PR DESCRIPTION
## Summary

Adds the larger operator-readiness closeout after the closed Paper/Shadow runtime command inventory hardening package (#3371–#3376).

## Scope

- Extends the existing canonical runbook:
  - `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`
- Adds section:
  - `Post-PR3376 operator readiness closeout v0`
- Extends canonical runbook contract coverage:
  - `tests/ops/test_paper_shadow_247_preflight_contract_v0.py`

## Closeout Coverage

Documents that the package now consolidates:

- `prometheus-client` dependency metadata contract
- preflight reporter scheduler command inventory
- command safety classification
- runtime-min timeout contract
- high-vol/no-trade runtime inventory parity
- runtime inventory outdir placeholder contract

## Validation

```text
uv run pytest tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q
```

Optional related runbook tests:

```text
uv run pytest tests/ops/test_operator_python_prometheus_client_note_v0.py tests/ops/test_paper_shadow_247_120min_stability_evidence_doc_v0.py tests/ops/test_paper_shadow_247_runtime_daemon_120min_evidence_doc_v0.py tests/ops/test_paper_shadow_247_runtime_min_daemon_120min_evidence_doc_v0.py -q
```

## Notes

- Docs + targeted tests only; contract status remains **BLOCKED** / non-authorizing.
- No scheduler, reporter implementation, config, or runtime changes.
