### PR TITLE
feat(ops): add paper shadow operator moment snapshot v0

### DIFF
--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -213,6 +213,78 @@ def _build_dry_activation_readiness(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _build_stop_signal_snapshot_for_repo(repo_root: Path) -> dict[str, Any]:
+    """Resolve `build_stop_signal_snapshot` when this module is CLI-invoked from `scripts/ops/`."""
+
+    root_s = str(repo_root.resolve())
+    if root_s not in sys.path:
+        sys.path.insert(0, root_s)
+    from scripts.ops.snapshot_operator_stop_signals import build_stop_signal_snapshot
+
+    return build_stop_signal_snapshot(repo_root)
+
+
+def _command_inventory_summary(commands: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(commands)
+    found_true = sum(1 for c in commands if c.get("found") is True)
+    found_false = sum(1 for c in commands if c.get("found") is False)
+    enabled_true = sum(1 for c in commands if c.get("enabled") is True)
+    enabled_false = sum(1 for c in commands if c.get("enabled") is False)
+    enabled_unset = sum(1 for c in commands if c.get("enabled") is None)
+    paper_runtime_disabled = 0
+    for c in commands:
+        sc = c.get("safety_classification")
+        if (
+            isinstance(sc, dict)
+            and sc.get("paper_runtime_job") is True
+            and c.get("enabled") is False
+        ):
+            paper_runtime_disabled += 1
+    return {
+        "commands_total": total,
+        "found_true": found_true,
+        "found_false": found_false,
+        "enabled_true": enabled_true,
+        "enabled_false": enabled_false,
+        "enabled_unset": enabled_unset,
+        "paper_runtime_jobs_scheduled_disabled": paper_runtime_disabled,
+    }
+
+
+def _build_operator_moment_snapshot_v0(payload: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+    """Derived, non-authorizing operator snapshot: preflight mirror + inventory stats + stop signals."""
+
+    commands_raw = payload.get("commands")
+    commands: list[dict[str, Any]] = commands_raw if isinstance(commands_raw, list) else []
+    dry = payload.get("dry_activation_readiness")
+    dry_ready = dry.get("ready") if isinstance(dry, dict) else None
+
+    stop_snapshot = _build_stop_signal_snapshot_for_repo(repo_root)
+
+    return {
+        "schema_version": "paper_shadow_247_operator_moment_snapshot.v0",
+        "non_authorizing": True,
+        "does_not_activate_runtime": True,
+        "mirror_top_level": {
+            "status": payload.get("status"),
+            "activation_authorized": payload.get("activation_authorized"),
+            "daemon_activation_authorized": payload.get("daemon_activation_authorized"),
+            "paper_runtime_authorized": payload.get("paper_runtime_authorized"),
+            "shadow_runtime_authorized": payload.get("shadow_runtime_authorized"),
+            "testnet_authorized": payload.get("testnet_authorized"),
+            "live_authorized": payload.get("live_authorized"),
+            "broker_authorized": payload.get("broker_authorized"),
+            "exchange_authorized": payload.get("exchange_authorized"),
+            "order_submission_authorized": payload.get("order_submission_authorized"),
+            "scheduler_execution_authorized": payload.get("scheduler_execution_authorized"),
+            "dry_run_only": payload.get("dry_run_only"),
+        },
+        "dry_activation_readiness_ready": dry_ready,
+        "command_inventory_summary": _command_inventory_summary(commands),
+        "stop_signal_snapshot": stop_snapshot,
+    }
+
+
 def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> dict[str, Any]:
     root = (repo_root or _repo_root()).resolve()
     metadata = _load_paper_shadow_247_preflight_metadata(root)
@@ -318,9 +390,11 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
             "does_not_activate_paper_or_shadow_runtime",
             "scheduler_command_inventory_v0",
             "scheduler_command_safety_classification_v0",
+            "operator_moment_snapshot_v0",
         ],
     }
     payload["dry_activation_readiness"] = _build_dry_activation_readiness(payload)
+    payload["operator_moment_snapshot_v0"] = _build_operator_moment_snapshot_v0(payload, root)
     return payload
 
 

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -122,6 +122,44 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
     assert "safety_classification" not in shadow_entry
 
 
+def _assert_operator_moment_snapshot_v0(payload: dict[str, object]) -> None:
+    moment = payload["operator_moment_snapshot_v0"]
+    assert isinstance(moment, dict)
+    assert moment["schema_version"] == "paper_shadow_247_operator_moment_snapshot.v0"
+    assert moment["non_authorizing"] is True
+    assert moment["does_not_activate_runtime"] is True
+    mirror = moment["mirror_top_level"]
+    assert isinstance(mirror, dict)
+    assert mirror["status"] == "BLOCKED"
+    assert mirror["activation_authorized"] is False
+    assert mirror["daemon_activation_authorized"] is False
+    assert mirror["paper_runtime_authorized"] is False
+    assert mirror["shadow_runtime_authorized"] is False
+    assert mirror["testnet_authorized"] is False
+    assert mirror["live_authorized"] is False
+    assert mirror["broker_authorized"] is False
+    assert mirror["exchange_authorized"] is False
+    assert mirror["order_submission_authorized"] is False
+    assert mirror["scheduler_execution_authorized"] is False
+    assert mirror["dry_run_only"] is True
+    assert moment["dry_activation_readiness_ready"] is False
+    summary = moment["command_inventory_summary"]
+    assert isinstance(summary, dict)
+    commands = payload["commands"]
+    assert isinstance(commands, list)
+    assert summary["commands_total"] == len(commands)
+    assert summary["found_true"] + summary["found_false"] == summary["commands_total"]
+    assert (
+        summary["enabled_true"] + summary["enabled_false"] + summary["enabled_unset"]
+        == summary["commands_total"]
+    )
+    assert summary["paper_runtime_jobs_scheduled_disabled"] == 2
+    stop = moment["stop_signal_snapshot"]
+    assert isinstance(stop, dict)
+    assert stop["contract"] == "operator_stop_signal_snapshot_v1"
+    assert isinstance(stop.get("summary"), str)
+
+
 def _run_json() -> dict[str, object]:
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--json", "--repo-root", str(REPO_ROOT)],
@@ -171,6 +209,8 @@ def test_build_paper_shadow_247_preflight_status_is_blocked_and_non_authorizing(
     }
     assert payload["blockers"] == []
     assert payload["status_reasons"] == []
+    assert "operator_moment_snapshot_v0" in payload["notes"]
+    _assert_operator_moment_snapshot_v0(payload)
 
 
 def test_build_paper_shadow_247_preflight_status_reuses_existing_contract_surfaces() -> None:
@@ -195,7 +235,9 @@ def test_cli_json_output_is_json_native_and_does_not_execute_scheduler() -> None
     assert "does_not_start_daemon" in payload["notes"]
     assert "scheduler_command_inventory_v0" in payload["notes"]
     assert "scheduler_command_safety_classification_v0" in payload["notes"]
+    assert "operator_moment_snapshot_v0" in payload["notes"]
     _assert_command_inventory_shape(payload)
+    _assert_operator_moment_snapshot_v0(payload)
 
 
 def test_cli_human_output_is_bounded_status_only() -> None:


### PR DESCRIPTION
## Summary

Adds a compact, read-only operator moment snapshot to the existing Paper/Shadow 24/7 preflight reporter.

## Scope

- Extends `scripts/ops/report_paper_shadow_247_preflight_status.py`
- Adds `operator_moment_snapshot_v0`
- Mirrors top-level BLOCKED / authorization state into an operator-facing compact snapshot
- Adds command inventory summary counts
- Embeds the existing stop-signal snapshot via `build_stop_signal_snapshot`
- Adds note `operator_moment_snapshot_v0`
- Extends canonical reporter CLI contract coverage:
  - `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py`

## Validation

```text
uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
uv run pytest tests/ops/test_paper_shadow_247_preflight_contract_v0.py
uv run ruff check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
uv run ruff format --check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
```

## Notes

- Read-only / non-authorizing; no scheduler, daemon, or runtime activation.
- CLI human output unchanged (`--json` exposes the new nested object).
