### PR TITLE
docs(ops): clarify incident stop artifact classification v0

### DIFF
--- a/docs/ops/runbooks/incident_stop_freeze_rollback.md
+++ b/docs/ops/runbooks/incident_stop_freeze_rollback.md
@@ -31,6 +31,20 @@ Ziel: System in bekanntem Zustand halten, keine weiteren Aktionen.
 3. Keine manuellen Orders platzieren.
 4. Evidence-Snapshot erstellen (siehe Evidence Capture).
 
+## HOLD-Klassifikation nach Incident Stop
+Ziel: Unter `HOLD_NO_PAPER_RUN` eindeutig festhalten, ob ein vorhandenes Stop-Signal noch aktiv, stale/geschlossen oder unbekannt ist.
+
+Wenn ein aktuelles `out&#47;ops&#47;incident_stop_*&#47;incident_stop_state.env` Artefakt oder gleichwertige Stop-Semantik vorhanden ist, bleibt bounded Paper-only Validation blockiert, bis ein Operator die Lage explizit klassifiziert hat.
+
+Klassifikation:
+- `active`: Stop-Signal ist weiterhin gültig; HOLD bleibt aktiv.
+- `stale&#47;closed`: Stop-Signal ist fachlich geschlossen; weitere Freigaben bleiben separate Operator-Entscheidungen.
+- `unknown`: Lage ist nicht eindeutig; Standard bleibt HOLD, keine Paper-Validation starten.
+
+Diese Klassifikation ist nur Entscheidung und Recordkeeping im Runbook. Sie autorisiert keine operative Freigabe und beschreibt hier keine Schritte zum Löschen, Bereinigen, Überschreiben oder Umdeuten von Stop-Artefakten.
+
+Für die read-only Inspektion kann `scripts&#47;ops&#47;snapshot_operator_stop_signals.py` genutzt werden. Der Snapshot ändert keinen Zustand und ist nicht autorisierend.
+
 ## ROLLBACK
 Ziel: Rückkehr auf einen bekannten, verifizierten Zustand.
 


### PR DESCRIPTION
## Summary

Docs-only clarification in the existing incident-stop runbook: operator-facing **HOLD classification** after an incident stop (`active` / `stale/closed` / `unknown`), with **unknown ⇒ remain on HOLD** and **no bounded Paper-only validation** until explicit operator classification.

## Scope

- **Single file:** `docs/ops/runbooks/incident_stop_freeze_rollback.md`
- New section **HOLD-Klassifikation nach Incident Stop** (after FREEZE, before ROLLBACK).

## Non-goals / boundaries

- No operational steps to delete, clear, override, or reinterpret stop artifacts.
- No script, runtime, config, CI, scheduler, broker, exchange, or trading-logic changes.
- Does **not** classify any live incident-stop artifact or authorize Paper runs.

## Validation

- `git diff --check -- docs/ops/runbooks/incident_stop_freeze_rollback.md`
- `./scripts/ops/pt_docs_gates_snapshot.sh --changed --base origin/main`

## Related context

Implements the docs-only recommendation from post–incident-stop HOLD planning (procedure clarity without new doc surfaces).
