### PR TITLE
docs(ops): index incident stop hold classification v0

### DIFF
--- a/docs/ops/RUNBOOK_INDEX.md
+++ b/docs/ops/RUNBOOK_INDEX.md
@@ -78,3 +78,14 @@ Für eine zentrale Workflow- und Runbook-Übersicht siehe:
 - [live_pilot_session_wrapper.md](runbooks/live_pilot_session_wrapper.md)
 - [KILL_SWITCH_DRILL_PROCEDURE.md](../runbooks/KILL_SWITCH_DRILL_PROCEDURE.md)
 
+## Incident-stop / HOLD classification discoverability
+
+- Canonical incident-stop runbook: `docs/ops/runbooks/incident_stop_freeze_rollback.md`
+- Scheduler/preflight HOLD boundary: `docs/SCHEDULER_DAEMON.md`
+- Paper/Shadow-247 preflight contract: `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`
+
+Use these as index pointers only. Under `HOLD_NO_PAPER_RUN`, `active` and `unknown`
+classifications keep runtime and go-live progression blocked. `stale_closed` requires
+the documented follow-up procedure before read-only snapshot/preflight checks are rerun.
+This index is non-authorizing and must not become a duplicate readiness or evidence
+surface.

--- a/docs/ops/runbooks/README.md
+++ b/docs/ops/runbooks/README.md
@@ -195,3 +195,18 @@ This hybrid approach balances discoverability (all findable from this index) wit
 
 **Last Updated:** 2026-04-15  
 **Maintainer:** ops
+
+## Incident-stop / HOLD classification discoverability
+
+For operator classification of incident-stop artifacts under `HOLD_NO_PAPER_RUN`, use
+`docs/ops/runbooks/incident_stop_freeze_rollback.md` as the canonical runbook. It
+clarifies the conservative classification vocabulary:
+
+- `active`: keep `HOLD_NO_PAPER_RUN` active.
+- `unknown`: keep `HOLD_NO_PAPER_RUN` active; this is not a clearance state.
+- `stale_closed`: only after a human operator records this decision may the documented
+  follow-up procedure be used before rerunning read-only snapshot/preflight checks.
+
+Scheduler/preflight boundaries under HOLD are documented in `docs/SCHEDULER_DAEMON.md`.
+These references are discoverability pointers only; they do not create a new readiness,
+evidence, or go-live authorization surface.


### PR DESCRIPTION
## Summary

- add discoverability pointers for incident-stop / HOLD classification to existing runbook indexes
- point operators to the canonical incident-stop runbook, scheduler HOLD boundary, and Paper/Shadow-247 preflight contract
- clarify that `active` and `unknown` keep HOLD active, while `stale_closed` requires the documented follow-up procedure
- preserve the indexes as non-authorizing pointers, not duplicate readiness/evidence/go-live surfaces

## Safety

- docs-only
- no scheduler/runtime/paper/testnet/live execution
- no incident-stop artifact mutation
- no Master V2 / Double Play trading logic changes
- no broker/exchange/order paths

## Validation

- git diff --check
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs

Made with [Cursor](https://cursor.com)