### PR TITLE
ci: duplicate pytest test name guard v0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
       - 'src/**/*.py'
       - 'tests/**/*.py'
       - 'scripts/**/*.py'
+      - 'config/ci/duplicate_test_names_allowlist.json'
       - 'pyproject.toml'
       - '.github/workflows/lint.yml'
   pull_request:
@@ -18,6 +19,7 @@ on:
       - 'src/**/*.py'
       - 'tests/**/*.py'
       - 'scripts/**/*.py'
+      - 'config/ci/duplicate_test_names_allowlist.json'
       - 'pyproject.toml'
       - '.github/workflows/**'
   merge_group:
@@ -44,6 +46,9 @@ jobs:
       - name: Run ruff linter (conservative gate)
         # Uses pyproject.toml config for select/ignore rules
         run: uv run ruff check src tests scripts
+
+      - name: Check duplicate pytest test names (AST-only)
+        run: uv run python scripts/ci/check_duplicate_pytest_test_names.py
 
       # Note: Formatter is enforced via pre-commit locally
       # Repo-wide format CI can be added later if needed

--- a/config/ci/duplicate_test_names_allowlist.json
+++ b/config/ci/duplicate_test_names_allowlist.json
@@ -1,0 +1,238 @@
+{
+  "allowed": {
+    "tests/ai_orchestration/test_models.py": {
+      "names": [
+        "test_sod_fail_same_models"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/data/feeds/test_offline_realtime_feed.py": {
+      "names": [
+        "test_valid_config"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/data/offline_realtime/test_offline_realtime_feed_v0.py": {
+      "names": [
+        "test_invalid_nu_raises",
+        "test_negative_omega_raises"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/meta/test_infostream_basic.py": {
+      "names": [
+        "test_create_default",
+        "test_create_with_values"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/meta/test_infostream_models.py": {
+      "names": [
+        "test_json_serializable",
+        "test_roundtrip_basic"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/ops/test_docs_graph_triage.py": {
+      "names": [
+        "test_generate_output_file",
+        "test_path_escaping_in_output"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/ops/test_test_health_v1.py": {
+      "names": [
+        "test_default_values",
+        "test_load_from_toml"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/risk/test_portfolio.py": {
+      "names": [
+        "test_empty_positions"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/risk_layer/var_backtest/test_christoffersen.py": {
+      "names": [
+        "test_validation_too_few_observations"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/risk_layer/var_backtest/test_duration_diagnostics.py": {
+      "names": [
+        "test_empty_exceedances",
+        "test_with_datetime_index"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_alert_pipeline.py": {
+      "names": [
+        "test_from_string",
+        "test_properties",
+        "test_send_failure_does_not_raise",
+        "test_send_success",
+        "test_severity_filtering"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_autonomous_monitors.py": {
+      "names": [
+        "test_custom_thresholds",
+        "test_monitor_initialization"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_backup_recovery.py": {
+      "names": [
+        "test_restore_dry_run"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_environment_and_safety.py": {
+      "names": [
+        "test_live_mode_blocked_by_armed_flag",
+        "test_testnet_dry_run_blocks_orders"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_escalation_manager.py": {
+      "names": [
+        "test_construction",
+        "test_from_dict",
+        "test_name",
+        "test_to_dict"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_experiments_base.py": {
+      "names": [
+        "test_basic_creation",
+        "test_to_dict"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_experiments_regime_sweeps.py": {
+      "names": [
+        "test_all_values_are_lists",
+        "test_returns_list"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_live_readiness_script.py": {
+      "names": [
+        "test_shadow_with_valid_config",
+        "test_warning_count"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_market_sentinel_v0_daily.py": {
+      "names": [
+        "test_create_valid_config"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_orders_smoke.py": {
+      "names": [
+        "test_basic_instantiation",
+        "test_basic_mapping"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_performance.py": {
+      "names": [
+        "test_func"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_portfolio_presets_tiering.py": {
+      "names": [
+        "test_builds_valid_preset",
+        "test_weights_sum_to_one"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_r_and_d_api.py": {
+      "names": [
+        "test_status_no_trades"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_regime_detection.py": {
+      "names": [
+        "test_detect_regimes_returns_series",
+        "test_detect_regimes_valid_labels"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_reporting_experiment_report.py": {
+      "names": [
+        "test_creates_section",
+        "test_empty_df"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_reporting_v2.py": {
+      "names": [
+        "test_build_parser",
+        "test_create_minimal",
+        "test_parser_all_options"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_research_e2e_scenarios.py": {
+      "names": [
+        "test_is_regime_category"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_run_logging_and_reporting.py": {
+      "names": [
+        "test_to_dict"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_strategies_research_playground.py": {
+      "names": [
+        "test_generate_signals_requires_ohlc",
+        "test_generate_signals_returns_series",
+        "test_generate_signals_too_few_bars",
+        "test_generate_signals_values",
+        "test_import",
+        "test_instantiation_custom_params",
+        "test_instantiation_default_params",
+        "test_metadata",
+        "test_validation_invalid_lookback",
+        "test_validation_invalid_thresholds"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_strategy_profiles.py": {
+      "names": [
+        "test_to_dict"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_sweeps.py": {
+      "names": [
+        "test_basic_instantiation",
+        "test_import"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_testnet_limits.py": {
+      "names": [
+        "test_custom_values",
+        "test_default_values"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    },
+    "tests/test_webui_live_track.py": {
+      "names": [
+        "test_client"
+      ],
+      "reason": "legacy duplicate test names; tracked for future cleanup"
+    }
+  },
+  "version": 1
+}

--- a/scripts/ci/check_duplicate_pytest_test_names.py
+++ b/scripts/ci/check_duplicate_pytest_test_names.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Fail when the same test function name is defined twice in one test_*.py file.
+
+AST-only: does not import test modules, does not run pytest, no network.
+
+Allowlist (see config/ci/duplicate_test_names_allowlist.json) tolerates known legacy
+duplicate names until cleaned up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _rel_posix(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError as e:
+        raise SystemExit(f"path outside repo root {repo_root}: {path}") from e
+
+
+def _collect_files_from_roots(repo_root: Path, roots: list[Path]) -> list[Path]:
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for r in roots:
+        base = (repo_root / r).resolve() if not r.is_absolute() else r.resolve()
+        if base.is_file():
+            if base.suffix == ".py" and base.name.startswith("test_"):
+                if base not in seen:
+                    seen.add(base)
+                    out.append(base)
+            continue
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("test_*.py")):
+            if path not in seen:
+                seen.add(path)
+                out.append(path)
+    return sorted(out)
+
+
+def _default_scan_roots(repo_root: Path) -> list[Path]:
+    return [repo_root / "tests"]
+
+
+def find_duplicate_test_names(path: Path) -> dict[str, list[int]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: dict[str, list[int]] = defaultdict(list)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
+            "test_"
+        ):
+            names[node.name].append(node.lineno)
+    return {k: sorted(v) for k, v in names.items() if len(v) > 1}
+
+
+def load_allowlist(path: Path | None, *, no_allowlist: bool) -> dict[str, Any]:
+    if no_allowlist or path is None:
+        return {"version": 1, "allowed": {}}
+    if not path.is_file():
+        raise ValueError(f"allowlist file not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("allowlist root must be a JSON object")
+    ver = data.get("version")
+    if ver != 1:
+        raise ValueError(f"unsupported allowlist version: {ver!r}")
+    allowed = data.get("allowed")
+    if allowed is None:
+        allowed = {}
+    if not isinstance(allowed, dict):
+        raise ValueError("allowlist 'allowed' must be an object")
+    for rel, entry in allowed.items():
+        if not isinstance(rel, str):
+            raise ValueError(f"allowlist key must be string path: {rel!r}")
+        if not isinstance(entry, dict):
+            raise ValueError(f"allowlist entry for {rel!r} must be an object")
+        names = entry.get("names")
+        if not isinstance(names, list) or not all(isinstance(x, str) for x in names):
+            raise ValueError(f"allowlist.names for {rel!r} must be a string array")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (defaults to Peak_Trade checkout)",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional paths (files or dirs) under repo root to scan for test_*.py",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="JSON allowlist path (default: config/ci/duplicate_test_names_allowlist.json)",
+    )
+    parser.add_argument(
+        "--no-allowlist",
+        action="store_true",
+        help="Ignore allowlist (report every duplicate)",
+    )
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+
+    allowlist_path = args.allowlist
+    if allowlist_path is None and not args.no_allowlist:
+        allowlist_path = repo_root / "config" / "ci" / "duplicate_test_names_allowlist.json"
+
+    try:
+        allow_doc = load_allowlist(allowlist_path, no_allowlist=args.no_allowlist)
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        print(f"allowlist error: {e}", file=sys.stderr)
+        return 2
+
+    allowed_map_raw = allow_doc.get("allowed") or {}
+    allowed_sets: dict[str, set[str]] = {}
+    for rel, entry in allowed_map_raw.items():
+        names = entry.get("names") or []
+        allowed_sets[str(rel).replace("\\", "/")] = set(names)
+
+    if args.paths:
+        roots = [Path(p) for p in args.paths]
+    else:
+        roots = _default_scan_roots(repo_root)
+    files = _collect_files_from_roots(repo_root, roots)
+
+    violations: list[str] = []
+    for path in files:
+        rel = _rel_posix(path, repo_root)
+        dups = find_duplicate_test_names(path)
+        if not dups:
+            continue
+        permitted = allowed_sets.get(rel, set())
+        for name, lines in sorted(dups.items()):
+            if name not in permitted:
+                violations.append(f"{rel}: duplicate {name!r} at lines {lines}")
+
+    if violations:
+        print("duplicate pytest test names (same file, unallowlisted):", file=sys.stderr)
+        for line in violations:
+            print(f"  {line}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_check_duplicate_pytest_test_names.py
+++ b/tests/ci/test_check_duplicate_pytest_test_names.py
@@ -1,0 +1,94 @@
+"""Contract tests for scripts/ci/check_duplicate_pytest_test_names.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "check_duplicate_pytest_test_names.py"
+
+
+def _run_script(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=cwd or REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_checker_passes_on_repo_with_allowlist() -> None:
+    proc = _run_script()
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stderr == ""
+
+
+def test_checker_fails_on_duplicate_without_allowlist(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_dup.py").write_text(
+        "def test_same() -> None:\n    pass\n\ndef test_same() -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    proc = _run_script(
+        "--repo-root",
+        str(tmp_path),
+        "--paths",
+        "tests",
+        "--no-allowlist",
+    )
+    assert proc.returncode == 1
+    assert "duplicate" in proc.stderr.lower()
+    assert "test_same" in proc.stderr
+
+
+def test_checker_allows_listed_duplicates(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_dup.py").write_text(
+        "def test_same() -> None:\n    pass\n\ndef test_same() -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    cfg = tmp_path / "config" / "ci"
+    cfg.mkdir(parents=True)
+    allow = {
+        "version": 1,
+        "allowed": {
+            "tests/test_dup.py": {
+                "reason": "fixture duplicate for allowlist contract",
+                "names": ["test_same"],
+            },
+        },
+    }
+    (cfg / "duplicate_test_names_allowlist.json").write_text(
+        json.dumps(allow),
+        encoding="utf-8",
+    )
+    proc = _run_script(
+        "--repo-root",
+        str(tmp_path),
+        "--paths",
+        "tests",
+        "--allowlist",
+        str(cfg / "duplicate_test_names_allowlist.json"),
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_checker_malformed_allowlist_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{", encoding="utf-8")
+    proc = _run_script("--allowlist", str(bad))
+    assert proc.returncode == 2
+    assert "allowlist" in proc.stderr.lower()
+
+
+def test_checker_wrong_allowlist_version_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"version": 99, "allowed": {}}', encoding="utf-8")
+    proc = _run_script("--allowlist", str(bad))
+    assert proc.returncode == 2

--- a/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
+++ b/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
@@ -144,66 +144,6 @@ def test_blocked_when_robustness_and_stress_missing_but_evidence_present() -> No
     assert_non_authorizing(payload)
 
 
-def test_blocked_when_only_paper_evidence_missing() -> None:
-    proc = run_report(
-        "--paper-robustness-present",
-        "--paper-stress-present",
-        "--testnet-evidence-present",
-        "--testnet-robustness-present",
-        "--testnet-stress-present",
-    )
-    payload = parse_payload(proc)
-
-    assert proc.returncode == 0
-    assert payload["status"] == "BLOCKED"
-    assert payload["blockers"] == ["paper.evidence_missing"]
-    assert_non_authorizing(payload)
-
-
-def test_blocked_when_only_testnet_evidence_missing() -> None:
-    proc = run_report(
-        "--paper-evidence-present",
-        "--paper-robustness-present",
-        "--paper-stress-present",
-        "--testnet-robustness-present",
-        "--testnet-stress-present",
-    )
-    payload = parse_payload(proc)
-
-    assert proc.returncode == 0
-    assert payload["status"] == "BLOCKED"
-    assert payload["blockers"] == ["testnet.evidence_missing"]
-    assert_non_authorizing(payload)
-
-
-def test_blocked_when_robustness_and_stress_missing_but_evidence_present() -> None:
-    proc = run_report(
-        "--paper-evidence-present",
-        "--testnet-evidence-present",
-    )
-    payload = parse_payload(proc)
-
-    assert proc.returncode == 0
-    assert payload["status"] == "BLOCKED"
-    assert payload["blockers"] == [
-        "paper.robustness_missing",
-        "paper.stress_missing",
-        "testnet.robustness_missing",
-        "testnet.stress_missing",
-    ]
-    assert payload["paper"] == {
-        "evidence_present": True,
-        "robustness_present": False,
-        "stress_present": False,
-    }
-    assert payload["testnet"] == {
-        "evidence_present": True,
-        "robustness_present": False,
-        "stress_present": False,
-    }
-    assert_non_authorizing(payload)
-
-
 def test_complete_paper_and_testnet_without_external_decision_is_ready_for_review() -> None:
     proc = run_report(
         "--paper-evidence-present",


### PR DESCRIPTION
## Summary

- add an AST-only duplicate pytest test-name guard for duplicate `test_*` definitions within the same file
- add a legacy allowlist for existing duplicate-name debt
- remove confirmed duplicate copied tests in `test_report_paper_testnet_readiness_status_cli_v0.py`
- add contract tests for the guard
- wire the guard into the lint workflow

## Safety

- CI/tooling + tests only
- no runtime imports of test modules
- no scheduler/runtime/paper/testnet/live execution
- no incident-stop artifact mutation
- no Master V2 / Double Play trading logic changes
- no broker/exchange/order paths

## Validation

- uv run python scripts/ci/check_duplicate_pytest_test_names.py
- uv run pytest tests/ci/test_check_duplicate_pytest_test_names.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py -q
- uv run ruff check scripts/ci/check_duplicate_pytest_test_names.py tests/ci/test_check_duplicate_pytest_test_names.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- uv run ruff format --check scripts/ci/check_duplicate_pytest_test_names.py tests/ci/test_check_duplicate_pytest_test_names.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- git diff --check

Made with [Cursor](https://cursor.com)