### PR TITLE
chore(meta): resolve infostream duplicate pytest names v0

### DIFF
--- a/config/ci/duplicate_test_names_allowlist.json
+++ b/config/ci/duplicate_test_names_allowlist.json
@@ -19,20 +19,6 @@
       ],
       "reason": "legacy duplicate test names; tracked for future cleanup"
     },
-    "tests/meta/test_infostream_basic.py": {
-      "names": [
-        "test_create_default",
-        "test_create_with_values"
-      ],
-      "reason": "legacy duplicate test names; tracked for future cleanup"
-    },
-    "tests/meta/test_infostream_models.py": {
-      "names": [
-        "test_json_serializable",
-        "test_roundtrip_basic"
-      ],
-      "reason": "legacy duplicate test names; tracked for future cleanup"
-    },
     "tests/ops/test_docs_graph_triage.py": {
       "names": [
         "test_generate_output_file",

--- a/tests/meta/test_infostream_basic.py
+++ b/tests/meta/test_infostream_basic.py
@@ -133,7 +133,7 @@ def mock_client(mock_ai_response_text: str) -> MagicMock:
 class TestIntelEvent:
     """Tests für IntelEvent-Dataclass."""
 
-    def test_create_default(self):
+    def test_intel_event_create_default(self):
         """Test: Event mit Default-Werten erstellen."""
         event = IntelEvent()
 
@@ -143,7 +143,7 @@ class TestIntelEvent:
         assert event.status == "new"
         assert isinstance(event.created_at, datetime)
 
-    def test_create_with_values(self):
+    def test_intel_event_create_with_values(self):
         """Test: Event mit spezifischen Werten erstellen."""
         event = IntelEvent(
             event_id="INF-test123",
@@ -185,7 +185,7 @@ class TestIntelEvent:
 class TestIntelEval:
     """Tests für IntelEval-Dataclass."""
 
-    def test_create_default(self):
+    def test_intel_eval_create_default(self):
         """Test: Eval mit Default-Werten erstellen."""
         eval_obj = IntelEval()
 
@@ -193,7 +193,7 @@ class TestIntelEval:
         assert eval_obj.risk_level == "none"
         assert eval_obj.key_findings == []
 
-    def test_create_with_values(self):
+    def test_intel_eval_create_with_values(self):
         """Test: Eval mit spezifischen Werten erstellen."""
         eval_obj = IntelEval(
             event_id="INF-test",
@@ -213,7 +213,7 @@ class TestIntelEval:
 class TestLearningSnippet:
     """Tests für LearningSnippet-Dataclass."""
 
-    def test_create_default(self):
+    def test_learning_snippet_create_default(self):
         """Test: Snippet mit Default-Werten erstellen."""
         snippet = LearningSnippet()
 

--- a/tests/meta/test_infostream_models.py
+++ b/tests/meta/test_infostream_models.py
@@ -18,7 +18,7 @@ from src.meta.infostream import IntelEvent, InfoPacket, LearningSnippet
 class TestIntelEvent:
     """Tests für IntelEvent."""
 
-    def test_roundtrip_basic(self) -> None:
+    def test_intel_event_roundtrip_basic(self) -> None:
         """Test: Einfacher Roundtrip mit to_dict/from_dict."""
         event = IntelEvent(
             source="GLOBAL_MACRO",
@@ -52,7 +52,7 @@ class TestIntelEvent:
         assert event.created_at.tzinfo is not None
         assert event.created_at.tzinfo == timezone.utc
 
-    def test_json_serializable(self) -> None:
+    def test_intel_event_json_serializable(self) -> None:
         """Test: to_dict() Ergebnis ist JSON-serialisierbar."""
         event = IntelEvent(
             source="TEST",
@@ -83,7 +83,7 @@ class TestIntelEvent:
 class TestInfoPacket:
     """Tests für InfoPacket."""
 
-    def test_roundtrip_basic(self) -> None:
+    def test_info_packet_roundtrip_basic(self) -> None:
         """Test: Einfacher Roundtrip mit eingebettetem IntelEvent."""
         event = IntelEvent(source="TEST_SOURCE", topic="Test Topic")
         packet = InfoPacket(
@@ -132,7 +132,7 @@ class TestInfoPacket:
             cloned = InfoPacket.from_dict(data)
             assert cloned.status == status
 
-    def test_json_serializable(self) -> None:
+    def test_info_packet_json_serializable(self) -> None:
         """Test: Komplettes InfoPacket ist JSON-serialisierbar."""
         event = IntelEvent(source="JSON_TEST", payload={"key": [1, 2, 3]})
         packet = InfoPacket(
@@ -151,7 +151,7 @@ class TestInfoPacket:
 class TestLearningSnippet:
     """Tests für LearningSnippet."""
 
-    def test_roundtrip_basic(self) -> None:
+    def test_learning_snippet_roundtrip_basic(self) -> None:
         """Test: Einfacher Roundtrip mit allen Feldern."""
         snippet = LearningSnippet(
             source_packet_id="packet_123",
@@ -196,7 +196,7 @@ class TestLearningSnippet:
 
         assert cloned.quality_score == 0.75
 
-    def test_json_serializable(self) -> None:
+    def test_learning_snippet_json_serializable(self) -> None:
         """Test: LearningSnippet ist JSON-serialisierbar."""
         snippet = LearningSnippet(
             topic="JSON Test",


### PR DESCRIPTION
## Summary

- rename duplicate pytest test functions in `tests/meta/test_infostream_basic.py`
- rename duplicate pytest test functions in `tests/meta/test_infostream_models.py`
- remove the two resolved Infostream files from the duplicate-test-name allowlist

## Safety

- tests/tooling-only
- no source changes
- no scheduler/runtime/paper/testnet/live execution
- no incident-stop artifact mutation
- no Master V2 / Double Play trading logic changes
- no broker/exchange/order paths

## Validation

- uv run python scripts/ci/check_duplicate_pytest_test_names.py
- uv run python scripts/ci/check_duplicate_pytest_test_names.py --paths tests/meta/test_infostream_basic.py tests/meta/test_infostream_models.py --no-allowlist
- uv run pytest tests/meta/test_infostream_basic.py tests/meta/test_infostream_models.py tests/ci/test_check_duplicate_pytest_test_names.py -q
- uv run ruff check tests/meta/test_infostream_basic.py tests/meta/test_infostream_models.py tests/ci/test_check_duplicate_pytest_test_names.py
- uv run ruff format --check tests/meta/test_infostream_basic.py tests/meta/test_infostream_models.py tests/ci/test_check_duplicate_pytest_test_names.py
- git diff --check

Made with [Cursor](https://cursor.com)