### PR TITLE
chore(ops): resolve docs graph triage duplicate pytest names v0

### DIFF
--- a/config/ci/duplicate_test_names_allowlist.json
+++ b/config/ci/duplicate_test_names_allowlist.json
@@ -19,13 +19,6 @@
       ],
       "reason": "legacy duplicate test names; tracked for future cleanup"
     },
-    "tests/ops/test_docs_graph_triage.py": {
-      "names": [
-        "test_generate_output_file",
-        "test_path_escaping_in_output"
-      ],
-      "reason": "legacy duplicate test names; tracked for future cleanup"
-    },
     "tests/ops/test_test_health_v1.py": {
       "names": [
         "test_default_values",

--- a/tests/ops/test_docs_graph_triage.py
+++ b/tests/ops/test_docs_graph_triage.py
@@ -159,7 +159,7 @@ class TestCategorizeOrphans:
 class TestGenerateBrokenTargetsMd:
     """Test broken targets markdown generation."""
 
-    def test_generate_output_file(self):
+    def test_generate_output_file_writes_expected_sections(self):
         """Should generate a valid markdown file."""
         broken = MINIMAL_SNAPSHOT["broken_targets"]
 
@@ -180,7 +180,7 @@ class TestGenerateBrokenTargetsMd:
             assert "file not found" in content.lower()
             assert "outside repo" in content.lower()
 
-    def test_path_escaping_in_output(self):
+    def test_path_escaping_in_output_for_primary_report(self):
         """Paths in output should be escaped per Token Policy."""
         broken = MINIMAL_SNAPSHOT["broken_targets"]
 
@@ -214,7 +214,7 @@ class TestGenerateBrokenTargetsMd:
 class TestGenerateOrphansMd:
     """Test orphans markdown generation."""
 
-    def test_generate_output_file(self):
+    def test_generate_output_file_preserves_expected_triage_content(self):
         """Should generate a valid markdown file."""
         orphans = MINIMAL_SNAPSHOT["orphans"]
 
@@ -248,7 +248,7 @@ class TestGenerateOrphansMd:
 
             assert out_path1.read_text() == out_path2.read_text()
 
-    def test_path_escaping_in_output(self):
+    def test_path_escaping_in_output_for_reference_entries(self):
         """Paths in output should be escaped per Token Policy."""
         orphans = MINIMAL_SNAPSHOT["orphans"]
 


### PR DESCRIPTION
## Summary

- rename duplicate pytest test functions in `tests/ops/test_docs_graph_triage.py`
- remove the resolved docs graph triage file from the duplicate-test-name allowlist
- keep assertions and test behavior unchanged

## Safety

- tests/tooling-only
- no source changes
- no scheduler/runtime/paper/testnet/live execution
- no incident-stop artifact mutation
- no Master V2 / Double Play trading logic changes
- no broker/exchange/order paths

## Validation

- uv run python scripts/ci/check_duplicate_pytest_test_names.py
- uv run python scripts/ci/check_duplicate_pytest_test_names.py --paths tests/ops/test_docs_graph_triage.py --no-allowlist
- uv run pytest tests/ops/test_docs_graph_triage.py tests/ci/test_check_duplicate_pytest_test_names.py -q
- uv run ruff check tests/ops/test_docs_graph_triage.py tests/ci/test_check_duplicate_pytest_test_names.py
- uv run ruff format --check tests/ops/test_docs_graph_triage.py tests/ci/test_check_duplicate_pytest_test_names.py
- git diff --check

Made with [Cursor](https://cursor.com)