### PR TITLE
ci: duplicate pytest allowlist integrity guard v1

### DIFF
--- a/scripts/ci/check_duplicate_pytest_test_names.py
+++ b/scripts/ci/check_duplicate_pytest_test_names.py
@@ -5,6 +5,10 @@ AST-only: does not import test modules, does not run pytest, no network.
 
 Allowlist (see config/ci/duplicate_test_names_allowlist.json) tolerates known legacy
 duplicate names until cleaned up.
+
+Allowlist integrity: entries whose paths fall under the current scan roots must point to
+an existing file, and each allowlisted name must currently be duplicated in that file.
+Entries for paths outside a scoped ``--paths`` scan are not validated.
 """
 
 from __future__ import annotations
@@ -49,6 +53,65 @@ def _collect_files_from_roots(repo_root: Path, roots: list[Path]) -> list[Path]:
 
 def _default_scan_roots(repo_root: Path) -> list[Path]:
     return [repo_root / "tests"]
+
+
+def _allowlist_path_covered_by_scan(rel: str, repo_root: Path, roots: list[Path]) -> bool:
+    """Whether allowlist key ``rel`` is under one of ``roots`` (scan scope)."""
+    repo_resolved = repo_root.resolve()
+    rel_key = str(rel).replace("\\", "/")
+    target = (repo_resolved / rel_key).resolve()
+    try:
+        target.relative_to(repo_resolved)
+    except ValueError:
+        return False
+    for r in roots:
+        base = (repo_resolved / r).resolve() if not r.is_absolute() else r.resolve()
+        try:
+            base.relative_to(repo_resolved)
+        except ValueError:
+            continue
+        if base.is_file():
+            if target == base:
+                return True
+        elif base.is_dir():
+            try:
+                target.relative_to(base)
+                return True
+            except ValueError:
+                pass
+    return False
+
+
+def collect_allowlist_integrity_violations(
+    *,
+    repo_root: Path,
+    roots: list[Path],
+    allowed_map_raw: dict[str, Any],
+) -> list[str]:
+    """Stale allowlist entries that fall under the current scan roots."""
+    repo_resolved = repo_root.resolve()
+    violations: list[str] = []
+    for rel, entry in allowed_map_raw.items():
+        rel_key = str(rel).replace("\\", "/")
+        if not _allowlist_path_covered_by_scan(rel_key, repo_root, roots):
+            continue
+        path = (repo_resolved / rel_key).resolve()
+        if not path.is_file():
+            violations.append(f"{rel_key}: allowlisted file missing under scan scope")
+            continue
+        names = entry.get("names") or []
+        if not isinstance(names, list):
+            continue
+        dups = find_duplicate_test_names(path)
+        dup_names = set(dups.keys())
+        for name in names:
+            if not isinstance(name, str):
+                continue
+            if name not in dup_names:
+                violations.append(
+                    f"{rel_key}: allowlisted name {name!r} is not duplicated in this file"
+                )
+    return violations
 
 
 def find_duplicate_test_names(path: Path) -> dict[str, list[int]]:
@@ -150,10 +213,23 @@ def main(argv: list[str] | None = None) -> int:
             if name not in permitted:
                 violations.append(f"{rel}: duplicate {name!r} at lines {lines}")
 
+    integrity: list[str] = []
+    if not args.no_allowlist and allowed_map_raw:
+        integrity = collect_allowlist_integrity_violations(
+            repo_root=repo_root,
+            roots=roots,
+            allowed_map_raw=allowed_map_raw,
+        )
+
     if violations:
         print("duplicate pytest test names (same file, unallowlisted):", file=sys.stderr)
         for line in violations:
             print(f"  {line}", file=sys.stderr)
+    if integrity:
+        print("allowlist integrity errors:", file=sys.stderr)
+        for line in integrity:
+            print(f"  {line}", file=sys.stderr)
+    if violations or integrity:
         return 1
     return 0
 

--- a/tests/ci/test_check_duplicate_pytest_test_names.py
+++ b/tests/ci/test_check_duplicate_pytest_test_names.py
@@ -46,6 +46,116 @@ def test_checker_fails_on_duplicate_without_allowlist(tmp_path: Path) -> None:
     assert "test_same" in proc.stderr
 
 
+def test_checker_stale_allowlisted_name_fails(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_dup.py").write_text(
+        "def test_same() -> None:\n    pass\n\n"
+        "def test_same() -> None:\n    pass\n\n"
+        "def test_only_once() -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    cfg = tmp_path / "config" / "ci"
+    cfg.mkdir(parents=True)
+    allow = {
+        "version": 1,
+        "allowed": {
+            "tests/test_dup.py": {
+                "reason": "stale allowlist name should fail integrity",
+                "names": ["test_same", "test_only_once"],
+            },
+        },
+    }
+    (cfg / "duplicate_test_names_allowlist.json").write_text(
+        json.dumps(allow),
+        encoding="utf-8",
+    )
+    proc = _run_script(
+        "--repo-root",
+        str(tmp_path),
+        "--paths",
+        "tests",
+        "--allowlist",
+        str(cfg / "duplicate_test_names_allowlist.json"),
+    )
+    assert proc.returncode == 1
+    assert "integrity" in proc.stderr.lower()
+    assert "test_only_once" in proc.stderr
+
+
+def test_checker_missing_allowlisted_file_fails_under_scan_scope(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    cfg = tmp_path / "config" / "ci"
+    cfg.mkdir(parents=True)
+    allow = {
+        "version": 1,
+        "allowed": {
+            "tests/test_missing.py": {
+                "reason": "missing path under scope",
+                "names": ["test_x"],
+            },
+        },
+    }
+    (cfg / "duplicate_test_names_allowlist.json").write_text(
+        json.dumps(allow),
+        encoding="utf-8",
+    )
+    proc = _run_script(
+        "--repo-root",
+        str(tmp_path),
+        "--paths",
+        "tests",
+        "--allowlist",
+        str(cfg / "duplicate_test_names_allowlist.json"),
+    )
+    assert proc.returncode == 1
+    assert "integrity" in proc.stderr.lower()
+    assert "missing" in proc.stderr.lower()
+
+
+def test_checker_scoped_paths_skip_off_scope_allowlist_integrity(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    (tests / "a").mkdir(parents=True)
+    (tests / "b").mkdir(parents=True)
+    (tests / "a" / "test_fine.py").write_text(
+        "def test_same() -> None:\n    pass\n\ndef test_same() -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    (tests / "b" / "test_stale.py").write_text(
+        "def test_only_once() -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    cfg = tmp_path / "config" / "ci"
+    cfg.mkdir(parents=True)
+    allow = {
+        "version": 1,
+        "allowed": {
+            "tests/a/test_fine.py": {
+                "reason": "in-scope duplicate",
+                "names": ["test_same"],
+            },
+            "tests/b/test_stale.py": {
+                "reason": "would fail integrity if scanned (name not duplicated)",
+                "names": ["test_only_once"],
+            },
+        },
+    }
+    (cfg / "duplicate_test_names_allowlist.json").write_text(
+        json.dumps(allow),
+        encoding="utf-8",
+    )
+    proc = _run_script(
+        "--repo-root",
+        str(tmp_path),
+        "--paths",
+        "tests/a",
+        "--allowlist",
+        str(cfg / "duplicate_test_names_allowlist.json"),
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
 def test_checker_allows_listed_duplicates(tmp_path: Path) -> None:
     tests = tmp_path / "tests"
     tests.mkdir()


### PR DESCRIPTION
## Summary

- validate duplicate-test-name allowlist entries against the effective scanned file set
- fail on stale allowlisted names when the file is in scan scope
- fail on missing allowlisted files when they are in scan scope
- preserve scoped `--paths` behavior so out-of-scope allowlist entries do not block focused checks
- add contract tests for allowlist integrity behavior

## Safety

- CI/tooling + tests only
- stdlib/AST-only checker behavior
- no runtime imports of test modules
- no scheduler/runtime/paper/testnet/live execution
- no incident-stop artifact mutation
- no Master V2 / Double Play trading logic changes
- no broker/exchange/order paths

## Validation

- uv run python scripts/ci/check_duplicate_pytest_test_names.py
- uv run pytest tests/ci/test_check_duplicate_pytest_test_names.py -q
- uv run ruff check scripts/ci/check_duplicate_pytest_test_names.py tests/ci/test_check_duplicate_pytest_test_names.py
- uv run ruff format --check scripts/ci/check_duplicate_pytest_test_names.py tests/ci/test_check_duplicate_pytest_test_names.py
- git diff --check

Made with [Cursor](https://cursor.com)