### PR TITLE
chore(data): resolve offline realtime duplicate pytest names v0

### DIFF
--- a/config/ci/duplicate_test_names_allowlist.json
+++ b/config/ci/duplicate_test_names_allowlist.json
@@ -6,19 +6,6 @@
       ],
       "reason": "legacy duplicate test names; tracked for future cleanup"
     },
-    "tests/data/feeds/test_offline_realtime_feed.py": {
-      "names": [
-        "test_valid_config"
-      ],
-      "reason": "legacy duplicate test names; tracked for future cleanup"
-    },
-    "tests/data/offline_realtime/test_offline_realtime_feed_v0.py": {
-      "names": [
-        "test_invalid_nu_raises",
-        "test_negative_omega_raises"
-      ],
-      "reason": "legacy duplicate test names; tracked for future cleanup"
-    },
     "tests/ops/test_test_health_v1.py": {
       "names": [
         "test_default_values",

--- a/tests/data/feeds/test_offline_realtime_feed.py
+++ b/tests/data/feeds/test_offline_realtime_feed.py
@@ -135,7 +135,7 @@ class TestSyntheticTick:
 class TestRegimeConfig:
     """Tests für RegimeConfig."""
 
-    def test_valid_config(self):
+    def test_valid_config_accepts_required_fields(self):
         """Gültige Konfiguration wird akzeptiert."""
         config = RegimeConfig(
             regime_id=0,
@@ -180,7 +180,7 @@ class TestRegimeConfig:
 class TestOfflineRealtimeFeedConfig:
     """Tests für OfflineRealtimeFeedConfig."""
 
-    def test_valid_config(self):
+    def test_valid_config_accepts_extended_feed_options(self):
         """Gültige Konfiguration wird akzeptiert."""
         config = create_simple_config()
         assert config.symbol == "BTC/USD"

--- a/tests/data/offline_realtime/test_offline_realtime_feed_v0.py
+++ b/tests/data/offline_realtime/test_offline_realtime_feed_v0.py
@@ -192,7 +192,7 @@ class TestGarchRegimeModelValidation:
                 transition_matrix=[],
             )
 
-    def test_negative_omega_raises(self):
+    def test_negative_omega_raises_for_primary_validation(self):
         """Negatives omega wird abgelehnt."""
         with pytest.raises(ValueError, match="omega"):
             GarchRegimeModelV0(
@@ -202,7 +202,7 @@ class TestGarchRegimeModelValidation:
                 transition_matrix=[[1.0]],
             )
 
-    def test_invalid_nu_raises(self):
+    def test_invalid_nu_raises_for_primary_validation(self):
         """nu <= 2 wird abgelehnt."""
         with pytest.raises(ValueError, match="nu"):
             GarchRegimeModelV0(
@@ -312,7 +312,7 @@ class TestRegimeParams:
         assert d["beta"] == 0.85
         assert d["nu"] == 5.0
 
-    def test_negative_omega_raises(self):
+    def test_negative_omega_raises_for_config_validation(self):
         """Negatives omega wird abgelehnt."""
         with pytest.raises(ValueError, match="omega"):
             RegimeParams(omega=-1e-5, alpha=0.1, beta=0.85, nu=5.0)
@@ -322,7 +322,7 @@ class TestRegimeParams:
         with pytest.raises(ValueError, match="alpha"):
             RegimeParams(omega=1e-5, alpha=1.5, beta=0.85, nu=5.0)
 
-    def test_invalid_nu_raises(self):
+    def test_invalid_nu_raises_for_config_validation(self):
         """nu <= 2 wird abgelehnt."""
         with pytest.raises(ValueError, match="nu"):
             RegimeParams(omega=1e-5, alpha=0.1, beta=0.85, nu=1.5)


### PR DESCRIPTION
## Summary

- rename duplicate pytest test functions in `tests/data/feeds/test_offline_realtime_feed.py`
- rename duplicate pytest test functions in `tests/data/offline_realtime/test_offline_realtime_feed_v0.py`
- remove the resolved offline-realtime files from the duplicate-test-name allowlist

## Safety

- tests/tooling-only
- no source changes
- no scheduler/runtime/paper/testnet/live execution
- no incident-stop artifact mutation
- no Master V2 / Double Play trading logic changes
- no broker/exchange/order paths

## Validation

- uv run python scripts/ci/check_duplicate_pytest_test_names.py
- uv run python scripts/ci/check_duplicate_pytest_test_names.py --paths tests/data/feeds/test_offline_realtime_feed.py tests/data/offline_realtime/test_offline_realtime_feed_v0.py --no-allowlist
- uv run pytest tests/data/feeds/test_offline_realtime_feed.py tests/data/offline_realtime/test_offline_realtime_feed_v0.py tests/ci/test_check_duplicate_pytest_test_names.py -q
- uv run ruff check tests/data/feeds/test_offline_realtime_feed.py tests/data/offline_realtime/test_offline_realtime_feed_v0.py tests/ci/test_check_duplicate_pytest_test_names.py
- uv run ruff format --check tests/data/feeds/test_offline_realtime_feed.py tests/data/offline_realtime/test_offline_realtime_feed_v0.py tests/ci/test_check_duplicate_pytest_test_names.py
- git diff --check

Made with [Cursor](https://cursor.com)