### PR TITLE
feat(ops): unknown-HOLD context in preflight reporter v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -118,6 +118,12 @@ This object is **non-authorizing**. It may confirm that metadata, output-path de
 
 The operator command in this object is a readiness reference only. It is not executed by the reporter and does not start a daemon, scheduler, Paper runtime, Shadow runtime, Testnet, Live, broker, exchange, or order path.
 
+## Unknown operator classification / HOLD context v0
+
+The read-only preflight reporter includes a nested `hold_context_v0` object with schema version `unknown_hold_context.v0`.
+
+This object is **non-authorizing**. It records the conservative operating posture when `OPERATOR_CLASSIFICATION=unknown`: `current_state=HOLD_NO_PAPER_RUN`, `go_live_next_step=blocked`, and all listed progression authorization flags remain `false`. Canonical references are documentation pointers only (`docs/ops/runbooks/incident_stop_freeze_rollback.md`, `docs/SCHEDULER_DAEMON.md`, and this contract). It does not clear incident stops, authorize daemon or scheduler execution, or activate Paper, Shadow, Testnet, Live, broker, exchange, or order paths.
+
 ## 8. Revision
 
 - **v0** — Initial contract: BLOCKED default, status model, non-authority, informative JSON shape.

--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -22,6 +22,7 @@ else:
 
 CONTRACT = "paper_shadow_247_preflight_status_v0"
 CONTRACT_DOC = "docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+INCIDENT_STOP_DOC = "docs/ops/runbooks/incident_stop_freeze_rollback.md"
 SCHEDULER_DOC = "docs/SCHEDULER_DAEMON.md"
 SCHEDULER_CONFIG = "config/scheduler/jobs.toml"
 PAPER_SHADOW_247_PREFLIGHT_METADATA = Path("config") / "ops" / "paper_shadow_247_preflight.toml"
@@ -251,6 +252,39 @@ def _command_inventory_summary(commands: list[dict[str, Any]]) -> dict[str, Any]
     }
 
 
+def _build_hold_context_v0() -> dict[str, Any]:
+    """Explicit unknown-HOLD audit projection: non-authorizing, JSON-native, deterministic."""
+
+    return {
+        "schema_version": "unknown_hold_context.v0",
+        "current_state": "HOLD_NO_PAPER_RUN",
+        "operator_classification": "unknown",
+        "go_live_next_step": "blocked",
+        "non_authorizing": True,
+        "reason": (
+            "OPERATOR_CLASSIFICATION=unknown is not a clearance state; HOLD_NO_PAPER_RUN "
+            "remains active until incident-stop and governance boundaries are explicitly resolved."
+        ),
+        "canonical_doc_refs": [
+            INCIDENT_STOP_DOC,
+            SCHEDULER_DOC,
+            CONTRACT_DOC,
+        ],
+        "progression_authorization": {
+            "activation_authorized": False,
+            "daemon_activation_authorized": False,
+            "scheduler_execution_authorized": False,
+            "paper_runtime_authorized": False,
+            "shadow_runtime_authorized": False,
+            "testnet_authorized": False,
+            "live_authorized": False,
+            "broker_authorized": False,
+            "exchange_authorized": False,
+            "order_submission_authorized": False,
+        },
+    }
+
+
 def _build_operator_moment_snapshot_v0(payload: dict[str, Any], repo_root: Path) -> dict[str, Any]:
     """Derived, non-authorizing operator snapshot: preflight mirror + inventory stats + stop signals."""
 
@@ -280,6 +314,7 @@ def _build_operator_moment_snapshot_v0(payload: dict[str, Any], repo_root: Path)
             "dry_run_only": payload.get("dry_run_only"),
         },
         "dry_activation_readiness_ready": dry_ready,
+        "hold_context_v0": payload.get("hold_context_v0"),
         "command_inventory_summary": _command_inventory_summary(commands),
         "stop_signal_snapshot": stop_snapshot,
     }
@@ -391,8 +426,10 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
             "scheduler_command_inventory_v0",
             "scheduler_command_safety_classification_v0",
             "operator_moment_snapshot_v0",
+            "unknown_hold_context_v0",
         ],
     }
+    payload["hold_context_v0"] = _build_hold_context_v0()
     payload["dry_activation_readiness"] = _build_dry_activation_readiness(payload)
     payload["operator_moment_snapshot_v0"] = _build_operator_moment_snapshot_v0(payload, root)
     return payload

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -207,6 +207,38 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
     assert "safety_classification" not in shadow_entry
 
 
+def _assert_hold_context_v0(payload: dict[str, object]) -> None:
+    hc = payload["hold_context_v0"]
+    assert isinstance(hc, dict)
+    assert hc["schema_version"] == "unknown_hold_context.v0"
+    assert hc["current_state"] == "HOLD_NO_PAPER_RUN"
+    assert hc["operator_classification"] == "unknown"
+    assert hc["go_live_next_step"] == "blocked"
+    assert hc["non_authorizing"] is True
+    assert isinstance(hc.get("reason"), str) and "unknown" in hc["reason"].lower()
+    refs = hc["canonical_doc_refs"]
+    assert refs == [
+        "docs/ops/runbooks/incident_stop_freeze_rollback.md",
+        "docs/SCHEDULER_DAEMON.md",
+        "docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md",
+    ]
+    prog = hc["progression_authorization"]
+    assert isinstance(prog, dict)
+    for key in (
+        "activation_authorized",
+        "daemon_activation_authorized",
+        "scheduler_execution_authorized",
+        "paper_runtime_authorized",
+        "shadow_runtime_authorized",
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert prog[key] is False
+
+
 def _assert_operator_moment_snapshot_v0(payload: dict[str, object]) -> None:
     moment = payload["operator_moment_snapshot_v0"]
     assert isinstance(moment, dict)
@@ -228,6 +260,8 @@ def _assert_operator_moment_snapshot_v0(payload: dict[str, object]) -> None:
     assert mirror["scheduler_execution_authorized"] is False
     assert mirror["dry_run_only"] is True
     assert moment["dry_activation_readiness_ready"] is False
+    assert moment["hold_context_v0"] == payload["hold_context_v0"]
+    _assert_hold_context_v0(payload)
     summary = moment["command_inventory_summary"]
     assert isinstance(summary, dict)
     commands = payload["commands"]
@@ -295,6 +329,7 @@ def test_build_paper_shadow_247_preflight_status_is_blocked_and_non_authorizing(
     assert payload["blockers"] == []
     assert payload["status_reasons"] == []
     assert "operator_moment_snapshot_v0" in payload["notes"]
+    assert "unknown_hold_context_v0" in payload["notes"]
     _assert_operator_moment_snapshot_v0(payload)
 
 
@@ -321,8 +356,22 @@ def test_cli_json_output_is_json_native_and_does_not_execute_scheduler() -> None
     assert "scheduler_command_inventory_v0" in payload["notes"]
     assert "scheduler_command_safety_classification_v0" in payload["notes"]
     assert "operator_moment_snapshot_v0" in payload["notes"]
+    assert "unknown_hold_context_v0" in payload["notes"]
     _assert_command_inventory_shape(payload)
     _assert_operator_moment_snapshot_v0(payload)
+
+
+def test_unknown_hold_context_v0_is_present_in_build_and_cli_json() -> None:
+    built = build_paper_shadow_247_preflight_status(REPO_ROOT)
+    _assert_hold_context_v0(built)
+
+    cli_payload = _run_json()
+    _assert_hold_context_v0(cli_payload)
+    assert cli_payload["hold_context_v0"] == built["hold_context_v0"]
+    assert all(
+        cli_payload["hold_context_v0"]["progression_authorization"][k] is False
+        for k in cli_payload["hold_context_v0"]["progression_authorization"]
+    )
 
 
 def test_cli_human_output_is_bounded_status_only() -> None:


### PR DESCRIPTION
## Summary

- add `hold_context_v0` to the Paper/Shadow-247 preflight reporter payload
- expose `HOLD_NO_PAPER_RUN`, `operator_classification=unknown`, and `go_live_next_step=blocked`
- make progression/authorization flags explicitly false under unknown-HOLD
- mirror the context into `operator_moment_snapshot_v0`
- document the field in the existing Paper/Shadow-247 preflight contract

## Safety

- reporter/tests/contract-doc only
- non-authorizing payload field
- no scheduler/runtime/paper/testnet/live execution
- no incident-stop artifact mutation
- no Master V2 / Double Play trading logic changes
- no broker/exchange/order paths

## Validation

- uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q
- uv run ruff check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- git diff --check

Made with [Cursor](https://cursor.com)