### PR TITLE
feat(ops): show unknown-HOLD context in preflight human output v0

### DIFF
--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -451,9 +451,38 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
+        hold_context = payload.get("hold_context_v0") or {}
+        progression = hold_context.get("progression_authorization") or {}
+
         print(f"status={payload['status']}")
         print(f"activation_authorized={str(payload['activation_authorized']).lower()}")
-        print("dry_run_only=true")
+        print(f"dry_run_only={str(payload['dry_run_only']).lower()}")
+        print(f"hold_current_state={hold_context.get('current_state', 'unknown')}")
+        print(
+            f"hold_operator_classification={hold_context.get('operator_classification', 'unknown')}"
+        )
+        print(f"hold_go_live_next_step={hold_context.get('go_live_next_step', 'blocked')}")
+        print(
+            f"hold_non_authorizing={str(bool(hold_context.get('non_authorizing', True))).lower()}"
+        )
+        print(
+            "hold_daemon_activation_authorized="
+            f"{str(bool(progression.get('daemon_activation_authorized', False))).lower()}"
+        )
+        print(
+            "hold_scheduler_activation_authorized="
+            f"{str(bool(progression.get('scheduler_execution_authorized', False))).lower()}"
+        )
+        print(
+            "hold_paper_validation_authorized="
+            f"{str(bool(progression.get('paper_runtime_authorized', False))).lower()}"
+        )
+        print(
+            f"hold_testnet_authorized={str(bool(progression.get('testnet_authorized', False))).lower()}"
+        )
+        print(
+            f"hold_live_authorized={str(bool(progression.get('live_authorized', False))).lower()}"
+        )
 
     return 0
 

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -374,7 +374,7 @@ def test_unknown_hold_context_v0_is_present_in_build_and_cli_json() -> None:
     )
 
 
-def test_cli_human_output_is_bounded_status_only() -> None:
+def test_cli_human_output_includes_unknown_hold_context() -> None:
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--repo-root", str(REPO_ROOT)],
         cwd=REPO_ROOT,
@@ -389,6 +389,15 @@ def test_cli_human_output_is_bounded_status_only() -> None:
         "status=BLOCKED",
         "activation_authorized=false",
         "dry_run_only=true",
+        "hold_current_state=HOLD_NO_PAPER_RUN",
+        "hold_operator_classification=unknown",
+        "hold_go_live_next_step=blocked",
+        "hold_non_authorizing=true",
+        "hold_daemon_activation_authorized=false",
+        "hold_scheduler_activation_authorized=false",
+        "hold_paper_validation_authorized=false",
+        "hold_testnet_authorized=false",
+        "hold_live_authorized=false",
     ]
 
 


### PR DESCRIPTION
## Summary

- extend the Paper/Shadow-247 preflight human output with `hold_context_v0` fields
- show `HOLD_NO_PAPER_RUN`, `operator_classification=unknown`, and `go_live_next_step=blocked`
- show conservative progression/authorization flags as false in non-json output
- rename the human-output test to reflect the expanded unknown-HOLD context

## Safety

- reporter/tests only
- no scheduler/runtime/paper/testnet/live execution
- no incident-stop artifact mutation
- no Master V2 / Double Play trading logic changes
- no broker/exchange/order paths
- scheduler preflight job uses JSON mode, so this does not alter the scheduled JSON path

## Validation

- uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q
- uv run ruff check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- git diff --check

Made with [Cursor](https://cursor.com)