### PR TITLE
feat(ops): optional operator decision context for snapshot preflight v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -124,6 +124,10 @@ The read-only preflight reporter includes a nested `hold_context_v0` object with
 
 This object is **non-authorizing**. It records the conservative operating posture when `OPERATOR_CLASSIFICATION=unknown`: `current_state=HOLD_NO_PAPER_RUN`, `go_live_next_step=blocked`, and all listed progression authorization flags remain `false`. Canonical references are documentation pointers only (`docs/ops/runbooks/incident_stop_freeze_rollback.md`, `docs/SCHEDULER_DAEMON.md`, and this contract). It does not clear incident stops, authorize daemon or scheduler execution, or activate Paper, Shadow, Testnet, Live, broker, exchange, or order paths.
 
+## Operator decision record context v0 (optional)
+
+The read-only preflight reporter (`scripts/ops/report_paper_shadow_247_preflight_status.py`) and stop-signal snapshot (`scripts/ops/snapshot_operator_stop_signals.py`) accept an optional `--operator-decision-record <path>` argument. When supplied, JSON includes `operator_decision_context_v0` (schema `operator_decision_context.v0`). This object is **non-authorizing**: it records parsed `OPERATOR_CLASSIFICATION`, `CURRENT_STATE`, and `GO_LIVE_NEXT_STEP` lines from the file for operator traceability only. It does not remove, move, overwrite, or reinterpret incident-stop artifacts; it does not change `hold_context_v0` (which remains the conservative unknown-HOLD projection); and it does not authorize scheduler, daemon, paper-validation, Testnet, Live, broker, exchange, or order paths.
+
 ## 8. Revision
 
 - **v0** — Initial contract: BLOCKED default, status model, non-authority, informative JSON shape.

--- a/docs/ops/runbooks/incident_stop_freeze_rollback.md
+++ b/docs/ops/runbooks/incident_stop_freeze_rollback.md
@@ -67,7 +67,7 @@ Klassifikation:
 
 Diese Klassifikation ist nur Entscheidung und Recordkeeping im Runbook. Sie autorisiert keine operative Freigabe und beschreibt hier keine Schritte zum Löschen, Bereinigen, Überschreiben oder Umdeuten von Stop-Artefakten.
 
-Für die read-only Inspektion kann `scripts&#47;ops&#47;snapshot_operator_stop_signals.py` genutzt werden. Der Snapshot ändert keinen Zustand und ist nicht autorisierend.
+Für die read-only Inspektion kann `scripts&#47;ops&#47;snapshot_operator_stop_signals.py` genutzt werden. Der Snapshot ändert keinen Zustand und ist nicht autorisierend. Optional kann `--operator-decision-record &lt;path&gt;` gesetzt werden, um ein maschinenlesbares `operator_decision_context_v0`-Feld zu ergänzen; das löscht keine Stop-Artefakte und autorisiert keine Laufzeitpfade.
 
 ## ROLLBACK
 Ziel: Rückkehr auf einen bekannten, verifizierten Zustand.

--- a/scripts/ops/report_paper_shadow_247_preflight_status.py
+++ b/scripts/ops/report_paper_shadow_247_preflight_status.py
@@ -214,7 +214,10 @@ def _build_dry_activation_readiness(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _build_stop_signal_snapshot_for_repo(repo_root: Path) -> dict[str, Any]:
+def _build_stop_signal_snapshot_for_repo(
+    repo_root: Path,
+    operator_decision_record: Path | None = None,
+) -> dict[str, Any]:
     """Resolve `build_stop_signal_snapshot` when this module is CLI-invoked from `scripts/ops/`."""
 
     root_s = str(repo_root.resolve())
@@ -222,7 +225,7 @@ def _build_stop_signal_snapshot_for_repo(repo_root: Path) -> dict[str, Any]:
         sys.path.insert(0, root_s)
     from scripts.ops.snapshot_operator_stop_signals import build_stop_signal_snapshot
 
-    return build_stop_signal_snapshot(repo_root)
+    return build_stop_signal_snapshot(repo_root, operator_decision_record=operator_decision_record)
 
 
 def _command_inventory_summary(commands: list[dict[str, Any]]) -> dict[str, Any]:
@@ -285,7 +288,11 @@ def _build_hold_context_v0() -> dict[str, Any]:
     }
 
 
-def _build_operator_moment_snapshot_v0(payload: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+def _build_operator_moment_snapshot_v0(
+    payload: dict[str, Any],
+    repo_root: Path,
+    operator_decision_record: Path | None = None,
+) -> dict[str, Any]:
     """Derived, non-authorizing operator snapshot: preflight mirror + inventory stats + stop signals."""
 
     commands_raw = payload.get("commands")
@@ -293,7 +300,7 @@ def _build_operator_moment_snapshot_v0(payload: dict[str, Any], repo_root: Path)
     dry = payload.get("dry_activation_readiness")
     dry_ready = dry.get("ready") if isinstance(dry, dict) else None
 
-    stop_snapshot = _build_stop_signal_snapshot_for_repo(repo_root)
+    stop_snapshot = _build_stop_signal_snapshot_for_repo(repo_root, operator_decision_record)
 
     return {
         "schema_version": "paper_shadow_247_operator_moment_snapshot.v0",
@@ -320,8 +327,19 @@ def _build_operator_moment_snapshot_v0(payload: dict[str, Any], repo_root: Path)
     }
 
 
-def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> dict[str, Any]:
+def build_paper_shadow_247_preflight_status(
+    repo_root: Path | None = None,
+    operator_decision_record: Path | None = None,
+) -> dict[str, Any]:
     root = (repo_root or _repo_root()).resolve()
+    op_rec: Path | None = None
+    if operator_decision_record is not None:
+        root_s = str(root)
+        if root_s not in sys.path:
+            sys.path.insert(0, root_s)
+        from scripts.ops.snapshot_operator_stop_signals import resolve_operator_decision_record_path
+
+        op_rec = resolve_operator_decision_record_path(operator_decision_record)
     metadata = _load_paper_shadow_247_preflight_metadata(root)
 
     contract_path = root / CONTRACT_DOC
@@ -364,6 +382,19 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
         blockers.append("output_paths_missing")
     if not stop_command or not emergency_stop_command:
         blockers.append("stop_commands_missing")
+
+    notes_list = [
+        "read_only_reporter",
+        "does_not_run_scheduler",
+        "does_not_start_daemon",
+        "does_not_activate_paper_or_shadow_runtime",
+        "scheduler_command_inventory_v0",
+        "scheduler_command_safety_classification_v0",
+        "operator_moment_snapshot_v0",
+        "unknown_hold_context_v0",
+    ]
+    if op_rec is not None:
+        notes_list.append("operator_decision_context_v0")
 
     # Authorization flags: never inferred from metadata alone (documentation-only TOML keys).
     payload: dict[str, Any] = {
@@ -418,20 +449,16 @@ def build_paper_shadow_247_preflight_status(repo_root: Path | None = None) -> di
         },
         "status_reasons": blockers,
         "blockers": blockers,
-        "notes": [
-            "read_only_reporter",
-            "does_not_run_scheduler",
-            "does_not_start_daemon",
-            "does_not_activate_paper_or_shadow_runtime",
-            "scheduler_command_inventory_v0",
-            "scheduler_command_safety_classification_v0",
-            "operator_moment_snapshot_v0",
-            "unknown_hold_context_v0",
-        ],
+        "notes": notes_list,
     }
     payload["hold_context_v0"] = _build_hold_context_v0()
     payload["dry_activation_readiness"] = _build_dry_activation_readiness(payload)
-    payload["operator_moment_snapshot_v0"] = _build_operator_moment_snapshot_v0(payload, root)
+    payload["operator_moment_snapshot_v0"] = _build_operator_moment_snapshot_v0(
+        payload, root, op_rec
+    )
+    stop_snap = payload["operator_moment_snapshot_v0"].get("stop_signal_snapshot")
+    if isinstance(stop_snap, dict) and "operator_decision_context_v0" in stop_snap:
+        payload["operator_decision_context_v0"] = stop_snap["operator_decision_context_v0"]
     return payload
 
 
@@ -443,10 +470,26 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Repository root to inspect. Defaults to the current Peak_Trade checkout.",
     )
+    parser.add_argument(
+        "--operator-decision-record",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path to an operator decision record; adds operator_decision_context_v0 "
+            "(read-only, non-authorizing; does not change stop artifacts)."
+        ),
+    )
     args = parser.parse_args(argv)
 
-    root = Path(args.repo_root).resolve() if args.repo_root else None
-    payload = build_paper_shadow_247_preflight_status(root)
+    root = Path(args.repo_root).resolve() if args.repo_root else _repo_root().resolve()
+    try:
+        payload = build_paper_shadow_247_preflight_status(
+            root,
+            operator_decision_record=args.operator_decision_record,
+        )
+    except ValueError as e:
+        print(f"ERR: {e}", file=sys.stderr)
+        return 2
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/ops/snapshot_operator_stop_signals.py
+++ b/scripts/ops/snapshot_operator_stop_signals.py
@@ -28,6 +28,13 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 CONTRACT_ID = "operator_stop_signal_snapshot_v1"
+OPERATOR_DECISION_CONTEXT_SCHEMA_VERSION = "operator_decision_context.v0"
+
+OPERATOR_DECISION_CONTEXT_REASON = (
+    "Operator-supplied decision record context only. "
+    "Does not clear, move, overwrite, or reinterpret incident-stop artifacts; "
+    "does not authorize scheduler, daemon, paper-validation, testnet, live, broker, exchange, or order paths."
+)
 
 # Aligned with ``scripts/ops/incident_stop_now.sh`` and cockpit incident_state PT_* fields.
 PT_STOP_KEYS = (
@@ -127,6 +134,48 @@ def _read_kill_switch(repo_root: Path) -> Dict[str, Any]:
         }
 
 
+def resolve_operator_decision_record_path(operator_decision_record: Path) -> Path:
+    """Resolve an operator decision record path; raise if it is not a readable file."""
+
+    rec = operator_decision_record.expanduser().resolve()
+    if not rec.is_file():
+        raise ValueError(f"operator decision record not a file: {operator_decision_record}")
+    return rec
+
+
+def _parse_operator_decision_record_key_values(text: str) -> Dict[str, str]:
+    keys = ("OPERATOR_CLASSIFICATION", "CURRENT_STATE", "GO_LIVE_NEXT_STEP")
+    out: Dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        for key in keys:
+            prefix = f"{key}="
+            if stripped.startswith(prefix) and key not in out:
+                out[key] = stripped[len(prefix) :].strip()
+                break
+    return out
+
+
+def build_operator_decision_context_v0(record_path: Path) -> Dict[str, Any]:
+    """Parse a human-readable operator decision record into a non-authorizing JSON context."""
+
+    resolved = record_path.resolve()
+    text = resolved.read_text(encoding="utf-8")
+    kv = _parse_operator_decision_record_key_values(text)
+    return {
+        "schema_version": OPERATOR_DECISION_CONTEXT_SCHEMA_VERSION,
+        "record_path": str(resolved),
+        "record_present": True,
+        "operator_classification": kv.get("OPERATOR_CLASSIFICATION"),
+        "current_state": kv.get("CURRENT_STATE"),
+        "go_live_next_step": kv.get("GO_LIVE_NEXT_STEP"),
+        "non_authorizing": True,
+        "raw_artifacts_preserved": True,
+        "permits_scheduler_runtime_paper_testnet_live": False,
+        "reason": OPERATOR_DECISION_CONTEXT_REASON,
+    }
+
+
 def _build_consistency_notes(
     pt_env: Dict[str, Any],
     artifact: Dict[str, Any],
@@ -162,7 +211,10 @@ def _build_consistency_notes(
     return notes
 
 
-def build_stop_signal_snapshot(repo_root: Path) -> Dict[str, Any]:
+def build_stop_signal_snapshot(
+    repo_root: Path,
+    operator_decision_record: Optional[Path] = None,
+) -> Dict[str, Any]:
     root = repo_root.resolve()
     pt_env = _snapshot_process_pt()
     latest_sf = _find_latest_incident_stop_state_file(root)
@@ -193,7 +245,7 @@ def build_stop_signal_snapshot(repo_root: Path) -> Dict[str, Any]:
     if notes:
         summary_parts.append("consistency_notes=see_json")
 
-    return {
+    out: Dict[str, Any] = {
         "contract": CONTRACT_ID,
         "repo_root": str(root),
         "process_environment_pt": pt_env,
@@ -202,6 +254,10 @@ def build_stop_signal_snapshot(repo_root: Path) -> Dict[str, Any]:
         "consistency_notes": notes,
         "summary": "; ".join(summary_parts),
     }
+    if operator_decision_record is not None:
+        rec = resolve_operator_decision_record_path(operator_decision_record)
+        out["operator_decision_context_v0"] = build_operator_decision_context_v0(rec)
+    return out
 
 
 def _print_text(snapshot: Dict[str, Any]) -> None:
@@ -230,6 +286,12 @@ def _print_text(snapshot: Dict[str, Any]) -> None:
         print("--- consistency_notes ---")
         for n in notes:
             print(f"  - {n}")
+    ctx = snapshot.get("operator_decision_context_v0")
+    if isinstance(ctx, dict):
+        print("--- operator_decision_context_v0 ---")
+        print(f"  record_path={ctx.get('record_path')!r}")
+        print(f"  operator_classification={ctx.get('operator_classification')!r}")
+        print(f"  non_authorizing={ctx.get('non_authorizing')!r}")
 
 
 def main() -> int:
@@ -247,13 +309,28 @@ def main() -> int:
         action="store_true",
         help="Emit full snapshot as JSON",
     )
+    parser.add_argument(
+        "--operator-decision-record",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path to an operator decision record; adds operator_decision_context_v0 "
+            "(read-only, non-authorizing; does not change stop artifacts)."
+        ),
+    )
     args = parser.parse_args()
     repo_root = args.repo_root or _REPO_ROOT
     if not repo_root.is_dir():
         print(f"ERR: repo root not a directory: {repo_root}", file=sys.stderr)
         return 2
     try:
-        snapshot = build_stop_signal_snapshot(repo_root)
+        snapshot = build_stop_signal_snapshot(
+            repo_root,
+            operator_decision_record=args.operator_decision_record,
+        )
+    except ValueError as e:
+        print(f"ERR: {e}", file=sys.stderr)
+        return 2
     except Exception as e:
         print(f"ERR: {e}", file=sys.stderr)
         return 2

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -374,7 +374,107 @@ def test_unknown_hold_context_v0_is_present_in_build_and_cli_json() -> None:
     )
 
 
-def test_cli_human_output_includes_unknown_hold_context() -> None:
+def test_operator_decision_context_v0_absent_without_decision_record() -> None:
+    payload = build_paper_shadow_247_preflight_status(REPO_ROOT)
+    assert "operator_decision_context_v0" not in payload
+    moment = payload["operator_moment_snapshot_v0"]["stop_signal_snapshot"]
+    assert "operator_decision_context_v0" not in moment
+
+
+def test_build_paper_shadow_247_preflight_status_operator_decision_context_v0_when_record_provided(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in ("PT_INCIDENT_STOP", "PT_FORCE_NO_TRADE", "PT_ENABLED", "PT_ARMED"):
+        monkeypatch.delenv(key, raising=False)
+    _materialize_minimal_preflight_repo(tmp_path, include_scheduler_jobs=True)
+    decision = tmp_path / "op_decision.md"
+    decision.write_text(
+        "\n".join(
+            [
+                "OPERATOR_CLASSIFICATION=stale_closed",
+                "CURRENT_STATE=HOLD_NO_PAPER_RUN_PENDING_RERUN",
+                "GO_LIVE_NEXT_STEP=read_only_snapshot_and_preflight_rerun",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = build_paper_shadow_247_preflight_status(
+        tmp_path,
+        operator_decision_record=decision,
+    )
+    ctx = payload["operator_decision_context_v0"]
+    assert ctx["schema_version"] == "operator_decision_context.v0"
+    assert ctx["operator_classification"] == "stale_closed"
+    assert ctx["non_authorizing"] is True
+    assert ctx["permits_scheduler_runtime_paper_testnet_live"] is False
+    assert "operator_decision_context_v0" in payload["notes"]
+
+    _assert_hold_context_v0(payload)
+    assert payload["status"] == "BLOCKED"
+    assert payload["activation_authorized"] is False
+
+    stop = payload["operator_moment_snapshot_v0"]["stop_signal_snapshot"]
+    assert stop["operator_decision_context_v0"] == ctx
+
+
+def test_build_paper_shadow_247_preflight_status_invalid_operator_record_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in ("PT_INCIDENT_STOP", "PT_FORCE_NO_TRADE", "PT_ENABLED", "PT_ARMED"):
+        monkeypatch.delenv(key, raising=False)
+    _materialize_minimal_preflight_repo(tmp_path, include_scheduler_jobs=True)
+    missing = tmp_path / "missing.md"
+    with pytest.raises(ValueError, match="not a file"):
+        build_paper_shadow_247_preflight_status(tmp_path, operator_decision_record=missing)
+
+
+def test_preflight_cli_operator_decision_record_propagates_to_json(tmp_path: Path) -> None:
+    decision = tmp_path / "decision.md"
+    decision.write_text("OPERATOR_CLASSIFICATION=stale_closed\n", encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--operator-decision-record",
+            str(decision),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["operator_decision_context_v0"]["operator_classification"] == "stale_closed"
+    stop = payload["operator_moment_snapshot_v0"]["stop_signal_snapshot"]
+    assert stop["operator_decision_context_v0"]["operator_classification"] == "stale_closed"
+    _assert_hold_context_v0(payload)
+
+
+def test_preflight_cli_operator_decision_record_missing_file_exits_2(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.md"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(REPO_ROOT),
+            "--operator-decision-record",
+            str(missing),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "ERR:" in result.stderr
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--repo-root", str(REPO_ROOT)],
         cwd=REPO_ROOT,

--- a/tests/ops/test_snapshot_operator_stop_signals.py
+++ b/tests/ops/test_snapshot_operator_stop_signals.py
@@ -143,3 +143,102 @@ def test_build_stop_signal_snapshot_selects_newest_incident_stop_directory(
     parsed = snap["incident_stop_artifact"]["parsed"]
     assert isinstance(parsed, dict)
     assert parsed.get("PT_FORCE_NO_TRADE") == "1"
+
+
+def test_build_stop_signal_snapshot_without_operator_record_has_no_context_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    for k in mod.PT_STOP_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    snap = mod.build_stop_signal_snapshot(tmp_path)
+    assert "operator_decision_context_v0" not in snap
+
+
+def test_build_stop_signal_snapshot_operator_decision_record_includes_context_v0(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    for k in mod.PT_STOP_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    decision = tmp_path / "OPERATOR_DECISION.md"
+    decision.write_text(
+        "\n".join(
+            [
+                "# decision",
+                "OPERATOR_CLASSIFICATION=stale_closed",
+                "CURRENT_STATE=HOLD_NO_PAPER_RUN_PENDING_RERUN",
+                "GO_LIVE_NEXT_STEP=read_only_snapshot_and_preflight_rerun",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    snap = mod.build_stop_signal_snapshot(tmp_path, operator_decision_record=decision)
+    ctx = snap["operator_decision_context_v0"]
+    assert ctx["schema_version"] == "operator_decision_context.v0"
+    assert ctx["record_present"] is True
+    assert ctx["non_authorizing"] is True
+    assert ctx["raw_artifacts_preserved"] is True
+    assert ctx["permits_scheduler_runtime_paper_testnet_live"] is False
+    assert ctx["operator_classification"] == "stale_closed"
+    assert ctx["current_state"] == "HOLD_NO_PAPER_RUN_PENDING_RERUN"
+    assert ctx["go_live_next_step"] == "read_only_snapshot_and_preflight_rerun"
+    assert ctx["record_path"] == str(decision.resolve())
+
+
+def test_build_stop_signal_snapshot_operator_record_preserves_incident_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    for k in mod.PT_STOP_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    inc_dir = tmp_path / "out" / "ops" / "incident_stop_20990101T000000Z_test"
+    inc_dir.mkdir(parents=True)
+    (inc_dir / "incident_stop_state.env").write_text(
+        "PT_INCIDENT_STOP=1\nPT_FORCE_NO_TRADE=1\nPT_ENABLED=0\nPT_ARMED=0\n",
+        encoding="utf-8",
+    )
+    decision = tmp_path / "decision.md"
+    decision.write_text("OPERATOR_CLASSIFICATION=stale_closed\n", encoding="utf-8")
+    snap = mod.build_stop_signal_snapshot(tmp_path, operator_decision_record=decision)
+    art = snap["incident_stop_artifact"]
+    assert art["status"] == "ok"
+    assert art["parsed"] is not None
+    assert art["parsed"].get("PT_INCIDENT_STOP") == "1"
+    assert art["parsed"].get("PT_FORCE_NO_TRADE") == "1"
+    assert snap["operator_decision_context_v0"]["operator_classification"] == "stale_closed"
+
+
+def test_build_stop_signal_snapshot_invalid_operator_record_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import scripts.ops.snapshot_operator_stop_signals as mod
+
+    for k in mod.PT_STOP_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    missing = tmp_path / "nope.md"
+    with pytest.raises(ValueError, match="not a file"):
+        mod.build_stop_signal_snapshot(tmp_path, operator_decision_record=missing)
+
+
+def test_main_operator_decision_record_missing_file_exits_2(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("snapshot_operator_stop_signals", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    missing = tmp_path / "missing_decision.md"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["x", "--json", "--repo-root", str(tmp_path), "--operator-decision-record", str(missing)],
+    )
+    assert mod.main() == 2


### PR DESCRIPTION
## Summary

- add optional `--operator-decision-record <path>` to stop-signal snapshot and Paper/Shadow-247 preflight reporter
- expose read-only `operator_decision_context_v0` when a decision record is supplied
- keep raw incident-stop artifacts visible and preserve `hold_context_v0` as conservative `unknown` / `blocked`
- document the optional non-authorizing context in existing runbook/contract surfaces
- add tests for parsing, missing record handling, CLI JSON, and non-authorizing behavior

## Safety

- read-only operator-decision context only
- no incident-stop artifact mutation
- no scheduler/runtime/paper/testnet/live execution
- no broker/exchange/order paths
- no Master V2 / Double Play trading logic changes
- `operator_decision_context_v0` does not authorize daemon, paper, testnet, or live progression

## Validation

- uv run pytest tests/ops/test_snapshot_operator_stop_signals.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q
- uv run ruff check scripts/ops/snapshot_operator_stop_signals.py scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_snapshot_operator_stop_signals.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run ruff format --check scripts/ops/snapshot_operator_stop_signals.py scripts/ops/report_paper_shadow_247_preflight_status.py tests/ops/test_snapshot_operator_stop_signals.py tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
- uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs
- bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs
- git diff --check

Made with [Cursor](https://cursor.com)