### PR TITLE
feat(ops): add macOS-safe run_with_timeout helper v0

### DIFF
--- a/scripts/ops/run_with_timeout.py
+++ b/scripts/ops/run_with_timeout.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Run a subprocess with a hard wall-clock timeout using only the stdlib.
+
+Useful on macOS and elsewhere when GNU ``timeout`` is not installed.
+On timeout, exits with code **124** (GNU ``timeout`` convention).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+TIMEOUT_EXIT = 124
+USAGE_EXIT = 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    args_list = sys.argv if argv is None else argv
+    rest = list(args_list[1:])
+    if "--" not in rest:
+        print(
+            "run_with_timeout: missing `--` separator before command "
+            "(example: ... --timeout-seconds 600 -- python -c 'print(1)')",
+            file=sys.stderr,
+        )
+        return USAGE_EXIT
+
+    sep = rest.index("--")
+    head, cmd = rest[:sep], rest[sep + 1 :]
+
+    parser = argparse.ArgumentParser(
+        prog=args_list[0] if args_list else "run_with_timeout.py",
+        description="Run COMMAND with subprocess timeout (no shell).",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        required=True,
+        help="Maximum wall-clock seconds for the child process (must be > 0).",
+    )
+    try:
+        opts = parser.parse_args(head)
+    except SystemExit:
+        return USAGE_EXIT
+
+    if opts.timeout_seconds <= 0:
+        print("run_with_timeout: --timeout-seconds must be > 0", file=sys.stderr)
+        return USAGE_EXIT
+
+    if not cmd:
+        print("run_with_timeout: no command after --", file=sys.stderr)
+        return USAGE_EXIT
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            timeout=opts.timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"run_with_timeout: exceeded --timeout-seconds={opts.timeout_seconds!r}; "
+            f"terminated: {cmd!r}",
+            file=sys.stderr,
+        )
+        return TIMEOUT_EXIT
+    except OSError as e:
+        print(f"run_with_timeout: failed to start process: {e}", file=sys.stderr)
+        return USAGE_EXIT
+
+    rc = proc.returncode
+    return USAGE_EXIT if rc is None else int(rc)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_run_with_timeout.py
+++ b/tests/ops/test_run_with_timeout.py
@@ -1,0 +1,115 @@
+"""Tests for scripts/ops/run_with_timeout.py — stdlib subprocess timeout wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "scripts" / "ops" / "run_with_timeout.py"
+
+
+def _load_mod():
+    spec = importlib.util.spec_from_file_location("run_with_timeout", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file()
+
+
+def test_fast_command_exits_zero() -> None:
+    mod = _load_mod()
+    argv = [
+        "run_with_timeout.py",
+        "--timeout-seconds",
+        "30",
+        "--",
+        sys.executable,
+        "-c",
+        "raise SystemExit(0)",
+    ]
+    assert mod.main(argv) == 0
+
+
+def test_child_nonzero_exit_preserved() -> None:
+    mod = _load_mod()
+    argv = [
+        "run_with_timeout.py",
+        "--timeout-seconds",
+        "30",
+        "--",
+        sys.executable,
+        "-c",
+        "raise SystemExit(19)",
+    ]
+    assert mod.main(argv) == 19
+
+
+def test_timeout_returns_124_and_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+    err = StringIO()
+    monkeypatch.setattr(sys, "stderr", err)
+    argv = [
+        "run_with_timeout.py",
+        "--timeout-seconds",
+        "0.25",
+        "--",
+        sys.executable,
+        "-c",
+        "import time; time.sleep(10)",
+    ]
+    assert mod.main(argv) == mod.TIMEOUT_EXIT == 124
+    assert "exceeded" in err.getvalue().lower()
+    assert "timeout-seconds" in err.getvalue().lower()
+
+
+@pytest.mark.parametrize("bad_timeout", ("0", "-1", "0.0"))
+def test_non_positive_timeout_fails(bad_timeout: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+    err = StringIO()
+    monkeypatch.setattr(sys, "stderr", err)
+    argv = [
+        "run_with_timeout.py",
+        "--timeout-seconds",
+        bad_timeout,
+        "--",
+        sys.executable,
+        "-c",
+        "pass",
+    ]
+    assert mod.main(argv) == mod.USAGE_EXIT
+    assert "timeout-seconds" in err.getvalue().lower()
+
+
+def test_missing_command_after_separator(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+    err = StringIO()
+    monkeypatch.setattr(sys, "stderr", err)
+    argv = ["run_with_timeout.py", "--timeout-seconds", "10", "--"]
+    assert mod.main(argv) == mod.USAGE_EXIT
+    assert "no command" in err.getvalue().lower()
+
+
+def test_missing_separator(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+    err = StringIO()
+    monkeypatch.setattr(sys, "stderr", err)
+    argv = ["run_with_timeout.py", "--timeout-seconds", "10", sys.executable, "-c", "pass"]
+    assert mod.main(argv) == mod.USAGE_EXIT
+    assert "missing" in err.getvalue().lower() and "--" in err.getvalue()
+
+
+def test_invalid_args_no_timeout_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_mod()
+    err = StringIO()
+    monkeypatch.setattr(sys, "stderr", err)
+    argv = ["run_with_timeout.py", "--", sys.executable, "-c", "pass"]
+    assert mod.main(argv) == mod.USAGE_EXIT


### PR DESCRIPTION
## Summary

- add a stdlib-only `scripts/ops/run_with_timeout.py` helper for bounded wrapper scripts
- support `--timeout-seconds <n> -- <command...>` without shell parsing
- preserve child exit codes and return 124 on timeout
- add focused tests for success, child failure, timeout, and invalid CLI usage

## Safety

- tooling/tests-only
- no p7 paper runtime execution
- no scheduler/runtime daemon execution
- no paper-validation/testnet/live execution
- no incident-stop artifact mutation
- no broker/exchange/order paths
- no Master V2 / Double Play trading logic changes

## Validation

- uv run pytest tests/ops/test_run_with_timeout.py -q
- uv run ruff check scripts/ops/run_with_timeout.py tests/ops/test_run_with_timeout.py
- uv run ruff format --check scripts/ops/run_with_timeout.py tests/ops/test_run_with_timeout.py
- git diff --check

Made with [Cursor](https://cursor.com)