### PR TITLE
docs(ops): mention scheduler temp config helper

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -142,6 +142,7 @@ Treat these as the coordinated sources for this topic—**do not** add parallel 
 
 - `config/ops/paper_shadow_247_preflight.toml` — canonical owner `ops-paper-shadow-247-readiness`, job identifiers, output paths, stop commands; metadata only, not execution authority.
 - `config/scheduler/jobs.toml` — scheduler-visible job shapes; Paper runtime jobs remain **disabled by default** unless a future gate explicitly enables them.
+- `scripts/ops/make_scheduler_temp_config.py` — helper from PR **#3394** that writes a **temporary** scheduler TOML derived from `config/scheduler/jobs.toml`, enabling exactly one operator-selected job key and replacing Paper-runtime dry-run `outdir` placeholders with an operator-provided **absolute** path. It **does not** execute the scheduler or daemon, does not start Paper/Shadow/Testnet/Live/broker/exchange/order paths, and does not modify the canonical `jobs.toml` or evidence bundles; generated files are planning/diagnostics material only (not a new readiness, authority, or evidence surface).
 - `scripts/ops/report_paper_shadow_247_preflight_status.py` — read-only JSON reporter (`status` remains **BLOCKED** in normal operation); command inventory and safety classification are diagnostic.
 - `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py` — contract tests for reporter output, including runtime job inventory fields.
 


### PR DESCRIPTION
## Summary

- Documents `scripts/ops/make_scheduler_temp_config.py` in the existing Paper Shadow 247 preflight contract surface.
- Clarifies that the helper creates a temporary scheduler TOML for one job with an absolute paper runtime outdir.
- Preserves the non-authorizing boundary: no scheduler/daemon/trading path execution and no canonical `jobs.toml` or evidence mutation.

## Scope

Docs-only small alignment following the read-only Paper-Shadow-247 scheduler audit.

Changed file:

- `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`

## Validation

- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- `git diff --check`

## Safety

- No Python/code changes.
- No tests changed.
- No scheduler config changed.
- No runtime, daemon, broker, exchange, testnet, live, order, out/log/evidence, or paper-test data mutation.
- Non-authorizing docs-only clarification.

Made with [Cursor](https://cursor.com)