### PR TITLE
ops: add scheduler paper-runtime evidence review v0

### DIFF
--- a/scripts/ops/review_scheduler_paper_runtime_evidence.py
+++ b/scripts/ops/review_scheduler_paper_runtime_evidence.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Review bounded scheduler paper-runtime evidence without running anything."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+PASS = "PASS"
+REVIEW_REQUIRED = "REVIEW_REQUIRED"
+REVIEW_REQUIRED_EXIT = 1
+USAGE_EXIT = 2
+
+ACCOUNT_FILE = "account.json"
+FILLS_FILE = "fills.json"
+MANIFEST_FILE = "evidence_manifest.json"
+STDOUT_FILE = "scheduler_stdout.log"
+STDERR_FILE = "scheduler_stderr.log"
+
+TIMEOUT_RE = re.compile(
+    r"run_with_timeout:\s*exceeded\s+--timeout-seconds=(?P<seconds>[0-9]+(?:\.[0-9]+)?)"
+)
+
+
+def _consume_argv(argv: list[str] | None) -> list[str]:
+    if argv is None:
+        return sys.argv[1:]
+    if argv and not argv[0].startswith("-"):
+        return list(argv[1:])
+    return list(argv)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_json(path: Path) -> tuple[Any | None, str | None]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"{path.name} is not valid JSON: {exc}"
+
+
+def _json_contains_string(value: Any, needle: str) -> bool:
+    if isinstance(value, str):
+        return value == needle
+    if isinstance(value, dict):
+        return any(_json_contains_string(v, needle) for v in value.values())
+    if isinstance(value, list):
+        return any(_json_contains_string(v, needle) for v in value)
+    return False
+
+
+def _timeout_observed(stderr_text: str, expected_timeout_seconds: float) -> bool:
+    for match in TIMEOUT_RE.finditer(stderr_text):
+        try:
+            observed = float(match.group("seconds"))
+        except ValueError:
+            continue
+        if math.isclose(observed, expected_timeout_seconds, rel_tol=0.0, abs_tol=1e-9):
+            return True
+    return False
+
+
+def _fills_count(data: Any) -> int | None:
+    if isinstance(data, dict) and isinstance(data.get("fills"), list):
+        return len(data["fills"])
+    if isinstance(data, list):
+        return len(data)
+    return None
+
+
+def _account_cash(data: Any) -> int | float | None:
+    if not isinstance(data, dict):
+        return None
+    cash = data.get("cash")
+    if isinstance(cash, bool) or not isinstance(cash, (int, float)):
+        return None
+    return cash
+
+
+def _positions_count(data: Any) -> int | None:
+    if not isinstance(data, dict):
+        return None
+    positions = data.get("positions")
+    if not isinstance(positions, dict):
+        return None
+    return len(positions)
+
+
+def review_evidence(
+    *,
+    outroot: Path,
+    logroot: Path,
+    expected_timeout_seconds: float,
+) -> dict[str, Any]:
+    issues: list[str] = []
+    outroot = outroot.expanduser()
+    logroot = logroot.expanduser()
+
+    paths = {
+        "account": outroot / ACCOUNT_FILE,
+        "fills": outroot / FILLS_FILE,
+        "manifest": outroot / MANIFEST_FILE,
+        "stdout": logroot / STDOUT_FILE,
+        "stderr": logroot / STDERR_FILE,
+    }
+
+    if not outroot.is_dir():
+        issues.append(f"outroot does not exist or is not a directory: {outroot}")
+    if not logroot.is_dir():
+        issues.append(f"logroot does not exist or is not a directory: {logroot}")
+
+    for path in paths.values():
+        if not path.is_file():
+            issues.append(f"missing required file: {path}")
+
+    account_json: Any | None = None
+    fills_json: Any | None = None
+    manifest_json: Any | None = None
+
+    if paths["account"].is_file():
+        account_json, error = _load_json(paths["account"])
+        if error:
+            issues.append(error)
+    if paths["fills"].is_file():
+        fills_json, error = _load_json(paths["fills"])
+        if error:
+            issues.append(error)
+    if paths["manifest"].is_file():
+        manifest_json, error = _load_json(paths["manifest"])
+        if error:
+            issues.append(error)
+
+    fills_count = _fills_count(fills_json)
+    account_cash = _account_cash(account_json)
+    positions_count = _positions_count(account_json)
+
+    if fills_json is not None and fills_count is None:
+        issues.append("fills_count is not parseable")
+    if account_json is not None and account_cash is None:
+        issues.append("account_cash is not parseable")
+    if account_json is not None and positions_count is None:
+        issues.append("positions_count is not parseable")
+
+    stdout_bytes = paths["stdout"].stat().st_size if paths["stdout"].is_file() else None
+    stderr_bytes = paths["stderr"].stat().st_size if paths["stderr"].is_file() else None
+
+    stderr_text = ""
+    if paths["stderr"].is_file():
+        stderr_text = paths["stderr"].read_text(encoding="utf-8", errors="replace")
+    timeout_observed = _timeout_observed(stderr_text, expected_timeout_seconds)
+    if not timeout_observed:
+        issues.append(
+            "scheduler_stderr.log does not contain matching run_with_timeout timeout semantics"
+        )
+
+    manifest_references_computed_hashes = False
+    computed_hashes: dict[str, str] = {}
+    if paths["account"].is_file() and paths["fills"].is_file():
+        computed_hashes = {
+            ACCOUNT_FILE: _sha256(paths["account"]),
+            FILLS_FILE: _sha256(paths["fills"]),
+        }
+    if manifest_json is not None and computed_hashes:
+        manifest_references_computed_hashes = all(
+            _json_contains_string(manifest_json, digest) for digest in computed_hashes.values()
+        )
+    if manifest_json is not None and not manifest_references_computed_hashes:
+        issues.append("evidence_manifest.json does not reference computed account/fills sha256")
+
+    metrics = {
+        "fills_count": fills_count,
+        "account_cash": account_cash,
+        "positions_count": positions_count,
+        "stdout_bytes": stdout_bytes,
+        "stderr_bytes": stderr_bytes,
+        "timeout_observed": timeout_observed,
+        "manifest_references_computed_hashes": manifest_references_computed_hashes,
+    }
+    verdict = (
+        PASS
+        if not issues and all(value is not None for value in metrics.values())
+        else REVIEW_REQUIRED
+    )
+
+    return {
+        "verdict": verdict,
+        "metrics": metrics,
+        "issues": issues,
+        "computed_hashes": computed_hashes,
+        "inputs": {
+            "outroot": str(outroot),
+            "logroot": str(logroot),
+            "expected_timeout_seconds": expected_timeout_seconds,
+        },
+    }
+
+
+def _print_human(result: dict[str, Any]) -> None:
+    print(f"VERDICT: {result['verdict']}")
+    print("METRICS:")
+    for key, value in result["metrics"].items():
+        print(f"  {key}: {value}")
+    if result["issues"]:
+        print("issues:")
+        for issue in result["issues"]:
+            print(f"  - {issue}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Review scheduler paper-runtime evidence files without executing runtime paths."
+    )
+    parser.add_argument("--outroot", type=Path, required=True)
+    parser.add_argument("--logroot", type=Path, required=True)
+    parser.add_argument("--expected-timeout-seconds", type=float, required=True)
+    parser.add_argument("--json", action="store_true", dest="json_output")
+
+    try:
+        args = parser.parse_args(_consume_argv(argv))
+    except SystemExit:
+        return USAGE_EXIT
+
+    if args.expected_timeout_seconds <= 0:
+        print(
+            "review_scheduler_paper_runtime_evidence: --expected-timeout-seconds must be > 0",
+            file=sys.stderr,
+        )
+        return USAGE_EXIT
+
+    outroot = args.outroot.expanduser().resolve()
+    logroot = args.logroot.expanduser().resolve()
+    if not outroot.is_dir() or not logroot.is_dir():
+        print(
+            "review_scheduler_paper_runtime_evidence: "
+            "--outroot and --logroot must exist as directories",
+            file=sys.stderr,
+        )
+        return USAGE_EXIT
+
+    result = review_evidence(
+        outroot=outroot,
+        logroot=logroot,
+        expected_timeout_seconds=args.expected_timeout_seconds,
+    )
+
+    if args.json_output:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_human(result)
+
+    return 0 if result["verdict"] == PASS else REVIEW_REQUIRED_EXIT
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_review_scheduler_paper_runtime_evidence.py
+++ b/tests/ops/test_review_scheduler_paper_runtime_evidence.py
@@ -1,0 +1,301 @@
+"""Tests for scheduler paper-runtime evidence review helper."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "scripts" / "ops" / "review_scheduler_paper_runtime_evidence.py"
+
+
+def _load_mod():
+    spec = importlib.util.spec_from_file_location("review_scheduler_paper_runtime_evidence", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_pass_fixture(
+    tmp_path: Path,
+    *,
+    timeout_text: str = "run_with_timeout: exceeded --timeout-seconds=3600.0; terminated: []\n",
+) -> tuple[Path, Path]:
+    outroot = tmp_path / "out"
+    logroot = tmp_path / "logs"
+    outroot.mkdir()
+    logroot.mkdir()
+
+    account = outroot / "account.json"
+    fills = outroot / "fills.json"
+    account.write_text(
+        json.dumps(
+            {
+                "schema_version": "p7.account.v0",
+                "cash": 999.6,
+                "positions": {"BTC": 0.0},
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    fills.write_text(
+        json.dumps(
+            {
+                "schema_version": "p7.fills.v0",
+                "fills": [
+                    {"symbol": "BTC", "side": "BUY", "qty": 1.0, "price": 100.1},
+                    {"symbol": "BTC", "side": "SELL", "qty": 1.0, "price": 99.9},
+                ],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (outroot / "evidence_manifest.json").write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "name": "account.json",
+                        "relpath": "account.json",
+                        "sha256": _sha256(account),
+                    },
+                    {
+                        "name": "fills.json",
+                        "relpath": "fills.json",
+                        "sha256": _sha256(fills),
+                    },
+                ],
+                "meta": {"kind": "p7_paper_manifest"},
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (logroot / "scheduler_stdout.log").write_text("scheduler output\n", encoding="utf-8")
+    (logroot / "scheduler_stderr.log").write_text(timeout_text, encoding="utf-8")
+    return outroot, logroot
+
+
+def _argv(outroot: Path, logroot: Path, *extra: str) -> list[str]:
+    return [
+        "review_scheduler_paper_runtime_evidence.py",
+        "--outroot",
+        str(outroot),
+        "--logroot",
+        str(logroot),
+        "--expected-timeout-seconds",
+        "3600",
+        *extra,
+    ]
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file()
+
+
+def test_pass_fixture_with_manifest_hashes_and_timeout_text(tmp_path: Path) -> None:
+    mod = _load_mod()
+    outroot, logroot = _write_pass_fixture(tmp_path)
+
+    result = mod.review_evidence(
+        outroot=outroot,
+        logroot=logroot,
+        expected_timeout_seconds=3600,
+    )
+
+    assert result["verdict"] == mod.PASS
+    assert result["metrics"]["fills_count"] == 2
+    assert result["metrics"]["account_cash"] == 999.6
+    assert result["metrics"]["positions_count"] == 1
+    assert result["metrics"]["timeout_observed"] is True
+    assert result["metrics"]["manifest_references_computed_hashes"] is True
+
+
+def test_accepts_float_timeout_text(tmp_path: Path) -> None:
+    mod = _load_mod()
+    outroot, logroot = _write_pass_fixture(
+        tmp_path,
+        timeout_text="run_with_timeout: exceeded --timeout-seconds=3600.0; terminated: ['x']\n",
+    )
+
+    assert mod.main(_argv(outroot, logroot)) == 0
+
+
+def test_rejects_missing_files(tmp_path: Path) -> None:
+    mod = _load_mod()
+    outroot, logroot = _write_pass_fixture(tmp_path)
+    (outroot / "fills.json").unlink()
+
+    result = mod.review_evidence(
+        outroot=outroot,
+        logroot=logroot,
+        expected_timeout_seconds=3600,
+    )
+
+    assert result["verdict"] == mod.REVIEW_REQUIRED
+    assert any("missing required file" in issue for issue in result["issues"])
+    assert mod.main(_argv(outroot, logroot)) == mod.REVIEW_REQUIRED_EXIT
+
+
+def test_rejects_hash_mismatch(tmp_path: Path) -> None:
+    mod = _load_mod()
+    outroot, logroot = _write_pass_fixture(tmp_path)
+    (outroot / "account.json").write_text(
+        json.dumps({"cash": 1000.0, "positions": {}}),
+        encoding="utf-8",
+    )
+
+    result = mod.review_evidence(
+        outroot=outroot,
+        logroot=logroot,
+        expected_timeout_seconds=3600,
+    )
+
+    assert result["verdict"] == mod.REVIEW_REQUIRED
+    assert result["metrics"]["manifest_references_computed_hashes"] is False
+    assert any("sha256" in issue for issue in result["issues"])
+
+
+def test_rejects_missing_timeout_text(tmp_path: Path) -> None:
+    mod = _load_mod()
+    outroot, logroot = _write_pass_fixture(tmp_path)
+    (logroot / "scheduler_stderr.log").write_text("completed without timeout\n", encoding="utf-8")
+
+    result = mod.review_evidence(
+        outroot=outroot,
+        logroot=logroot,
+        expected_timeout_seconds=3600,
+    )
+
+    assert result["verdict"] == mod.REVIEW_REQUIRED
+    assert result["metrics"]["timeout_observed"] is False
+    assert any("timeout semantics" in issue for issue in result["issues"])
+
+
+def test_json_output_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mod = _load_mod()
+    outroot, logroot = _write_pass_fixture(tmp_path)
+
+    err = StringIO()
+    monkeypatch.setattr(sys, "stderr", err)
+    assert mod.main(_argv(outroot, logroot, "--json")) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verdict"] == "PASS"
+    assert payload["issues"] == []
+    assert payload["inputs"]["expected_timeout_seconds"] == 3600
+    assert payload["metrics"] == {
+        "account_cash": 999.6,
+        "fills_count": 2,
+        "manifest_references_computed_hashes": True,
+        "positions_count": 1,
+        "stderr_bytes": len(
+            "run_with_timeout: exceeded --timeout-seconds=3600.0; terminated: []\n".encode()
+        ),
+        "stdout_bytes": len("scheduler output\n".encode()),
+        "timeout_observed": True,
+    }
+
+
+def test_human_output_includes_verdict_and_metrics(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mod = _load_mod()
+    outroot, logroot = _write_pass_fixture(tmp_path)
+
+    assert mod.main(_argv(outroot, logroot)) == 0
+
+    out = capsys.readouterr().out
+    assert "VERDICT: PASS" in out
+    assert "fills_count: 2" in out
+    assert "account_cash: 999.6" in out
+    assert "timeout_observed: True" in out
+
+
+@pytest.mark.parametrize("expected_timeout", ("0", "-1", "0.0"))
+def test_invalid_expected_timeout_exits_2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    expected_timeout: str,
+) -> None:
+    mod = _load_mod()
+    outroot, logroot = _write_pass_fixture(tmp_path)
+    err = StringIO()
+    monkeypatch.setattr(sys, "stderr", err)
+
+    argv = [
+        "review_scheduler_paper_runtime_evidence.py",
+        "--outroot",
+        str(outroot),
+        "--logroot",
+        str(logroot),
+        "--expected-timeout-seconds",
+        expected_timeout,
+    ]
+
+    assert mod.main(argv) == mod.USAGE_EXIT == 2
+    assert "expected-timeout-seconds" in err.getvalue()
+
+
+def test_missing_directory_returns_invalid_input(tmp_path: Path) -> None:
+    mod = _load_mod()
+    outroot = tmp_path / "nope"
+    logroot = tmp_path / "logs"
+    logroot.mkdir()
+
+    assert (
+        mod.main(
+            [
+                "review_scheduler_paper_runtime_evidence.py",
+                "--outroot",
+                str(outroot),
+                "--logroot",
+                str(logroot),
+                "--expected-timeout-seconds",
+                "1",
+            ]
+        )
+        == mod.USAGE_EXIT
+    )
+
+
+def test_cli_invocation_matches_module_returncode(tmp_path: Path) -> None:
+    outroot, logroot = _write_pass_fixture(
+        tmp_path,
+        timeout_text="run_with_timeout: exceeded --timeout-seconds=5.0; terminated: []\n",
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--outroot",
+            str(outroot),
+            "--logroot",
+            str(logroot),
+            "--expected-timeout-seconds",
+            "5",
+        ],
+        cwd=str(ROOT),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "VERDICT: PASS" in proc.stdout


### PR DESCRIPTION
## Summary

- add `scripts/ops/review_scheduler_paper_runtime_evidence.py`
- validate scheduler Paper-runtime OUTROOT/LOGROOT artifacts after bounded runs
- verify required files, JSON parsing, manifest SHA256 references, and run_with_timeout timeout stderr
- report runtime-min metrics such as fills count, account cash, positions count, log sizes, and verdict
- add focused tests for PASS, missing files, hash mismatch, missing timeout text, JSON output, human output, and invalid timeout

## Safety

- tooling/tests-only
- no scheduler execution
- no runtime daemon execution
- no paper runtime execution
- no paper-validation/testnet/live execution
- no incident-stop artifact mutation
- no broker/exchange/order paths
- no Master V2 / Double Play trading logic changes

## Validation

- uv run pytest tests/ops/test_review_scheduler_paper_runtime_evidence.py -q
- uv run ruff check scripts/ops/review_scheduler_paper_runtime_evidence.py tests/ops/test_review_scheduler_paper_runtime_evidence.py
- uv run ruff format --check scripts/ops/review_scheduler_paper_runtime_evidence.py tests/ops/test_review_scheduler_paper_runtime_evidence.py
- git diff --check

Made with [Cursor](https://cursor.com)