### PR TITLE
ops: paper runtime evidence input for testnet readiness status v0

### DIFF
--- a/scripts/ops/report_paper_testnet_readiness_status.py
+++ b/scripts/ops/report_paper_testnet_readiness_status.py
@@ -3,16 +3,29 @@
 This CLI is intentionally conservative: unless explicit evidence flags are
 provided, the report remains BLOCKED. It does not read or mutate paper/testnet
 artifacts, registries, out/ops data, execution state, or live state.
+
+Optional ``--paper-runtime-evidence-review`` ingests a bounded scheduler
+Paper-runtime **review or closeout** artifact only; it is necessary-but-not-
+sufficient for Paper layer readiness and never authorizes Testnet or Live.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import sys
+from pathlib import Path
 from typing import Any, Literal
 
-
 CONTRACT = "paper_testnet_readiness_status_v0"
+PAPER_RUNTIME_EVIDENCE_SCHEMA = "peak_trade.paper_runtime_evidence_input.v0"
+
+CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
+    {
+        "7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS",
+        "SIXTY_MIN_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS",
+    }
+)
 
 Status = Literal["BLOCKED", "READY_FOR_REVIEW", "REVIEW_ONLY"]
 
@@ -25,6 +38,64 @@ AUTHORITY_FLAGS = {
     "autonomy_readiness": False,
     "external_authority_completion": False,
 }
+
+DOES_NOT_AUTHORIZE = ["testnet", "live", "broker", "exchange", "order_submission"]
+
+MISSING_REVIEW_EXIT = 2
+
+
+def default_paper_runtime_evidence_v0() -> dict[str, Any]:
+    return {
+        "schema_version": PAPER_RUNTIME_EVIDENCE_SCHEMA,
+        "record_path": None,
+        "record_present": False,
+        "verdict": None,
+        "accepted": False,
+        "non_authorizing": True,
+        "contributes_to": "paper_evidence_only",
+        "does_not_authorize": list(DOES_NOT_AUTHORIZE),
+    }
+
+
+def _parse_review_json(text: str) -> str | None:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("verdict") != "PASS":
+        return None
+    issues = data.get("issues")
+    if issues != []:
+        return None
+    return "PASS"
+
+
+def _parse_closeout_markdown(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("VERDICT="):
+            continue
+        verdict = line.split("=", 1)[1].strip()
+        if verdict in CLOSEOUT_VERDICTS_ACCEPTED:
+            return verdict
+    return None
+
+
+def load_paper_runtime_evidence_review(path: Path) -> str | None:
+    """Return verdict string if accepted; otherwise None."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    verdict_json = _parse_review_json(text)
+    if verdict_json is not None:
+        return verdict_json
+
+    verdict_md = _parse_closeout_markdown(text)
+    if verdict_md is not None:
+        return verdict_md
+
+    return None
 
 
 def build_status(
@@ -85,14 +156,21 @@ def build_status(
         "missing_or_open_items": sorted(set(missing_or_open_items)),
         "external_review_decision_present": external_review_decision_present,
         "authority_boundary": dict(AUTHORITY_FLAGS),
+        # Explicit non-authorization for consumers that expect these keys.
+        "live_authorized": False,
+        "testnet_authorized": False,
     }
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Emit read-only Paper/Testnet readiness status JSON."
+        description="Emit read-only Paper/Testnet readiness status (JSON or human summary)."
     )
-    parser.add_argument("--json", action="store_true", required=True, help="Emit JSON to stdout.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON to stdout.",
+    )
     parser.add_argument("--paper-evidence-present", action="store_true")
     parser.add_argument("--paper-robustness-present", action="store_true")
     parser.add_argument("--paper-stress-present", action="store_true")
@@ -100,13 +178,59 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--testnet-robustness-present", action="store_true")
     parser.add_argument("--testnet-stress-present", action="store_true")
     parser.add_argument("--external-review-decision-present", action="store_true")
+    parser.add_argument(
+        "--paper-runtime-evidence-review",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional path to `review_scheduler_paper_runtime_evidence.py` JSON "
+            "(verdict PASS, empty issues) or Paper-runtime success closeout markdown."
+        ),
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    review_path = (
+        args.paper_runtime_evidence_review.expanduser().resolve()
+        if args.paper_runtime_evidence_review is not None
+        else None
+    )
+
+    runtime_v0 = default_paper_runtime_evidence_v0()
+    runtime_accepted = False
+    runtime_verdict: str | None = None
+
+    if review_path is not None:
+        runtime_v0["record_present"] = True
+        runtime_v0["record_path"] = str(review_path)
+        if not review_path.is_file():
+            print(
+                "report_paper_testnet_readiness_status: "
+                f"--paper-runtime-evidence-review not a file: {review_path}",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        verdict = load_paper_runtime_evidence_review(review_path)
+        if verdict is None:
+            print(
+                "report_paper_testnet_readiness_status: "
+                "paper runtime evidence file is not a valid review JSON (PASS, empty issues) "
+                "or an accepted closeout markdown verdict line.",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        runtime_verdict = verdict
+        runtime_accepted = True
+        runtime_v0["verdict"] = verdict
+        runtime_v0["accepted"] = True
+
+    effective_paper_evidence = bool(args.paper_evidence_present) or runtime_accepted
+
     payload = build_status(
-        paper_evidence_present=args.paper_evidence_present,
+        paper_evidence_present=effective_paper_evidence,
         paper_robustness_present=args.paper_robustness_present,
         paper_stress_present=args.paper_stress_present,
         testnet_evidence_present=args.testnet_evidence_present,
@@ -114,7 +238,18 @@ def main(argv: list[str] | None = None) -> int:
         testnet_stress_present=args.testnet_stress_present,
         external_review_decision_present=args.external_review_decision_present,
     )
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    payload["paper_runtime_evidence_v0"] = runtime_v0
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"status={payload['status']}")
+        print(f"paper_runtime_evidence_accepted={str(runtime_accepted).lower()}")
+        print("testnet_authorized=false")
+        print("live_authorized=false")
+        if review_path is not None and runtime_verdict is not None:
+            print(f"paper_runtime_evidence_verdict={runtime_verdict}")
+
     return 0
 
 

--- a/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
+++ b/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
@@ -220,3 +220,96 @@ def test_this_cli_test_does_not_read_real_artifact_locations() -> None:
 
     for fragment in forbidden_fragments:
         assert fragment not in source_text
+
+
+def test_paper_runtime_closeout_review_surfaces_in_json_and_stays_blocked(tmp_path: Path) -> None:
+    closeout = tmp_path / "closeout.md"
+    closeout.write_text(
+        "\n".join(
+            [
+                "# x",
+                "VERDICT=7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    proc = run_report("--paper-runtime-evidence-review", str(closeout))
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+
+    assert payload["status"] == "BLOCKED"
+    assert payload["testnet_authorized"] is False
+    assert payload["live_authorized"] is False
+    assert payload["paper"]["evidence_present"] is True
+    pr = payload["paper_runtime_evidence_v0"]
+    assert isinstance(pr, dict)
+    assert pr["accepted"] is True
+    assert pr["non_authorizing"] is True
+    assert pr["verdict"] == "7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS"
+    assert pr["does_not_authorize"] == [
+        "testnet",
+        "live",
+        "broker",
+        "exchange",
+        "order_submission",
+    ]
+    assert_non_authorizing(payload)
+
+
+def test_paper_runtime_review_json_pass_surfaces_accepted(tmp_path: Path) -> None:
+    review = tmp_path / "review.json"
+    review.write_text(
+        '{"issues": [], "metrics": {"fills_count": 1}, "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = run_report("--paper-runtime-evidence-review", str(review))
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+    pr = payload["paper_runtime_evidence_v0"]
+    assert pr["accepted"] is True
+    assert pr["verdict"] == "PASS"
+    assert payload["status"] == "BLOCKED"
+    assert payload["testnet_authorized"] is False
+
+
+def test_paper_runtime_review_missing_file_exits_2(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.md"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--paper-runtime-evidence-review", str(missing)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_paper_runtime_review_invalid_content_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.md"
+    bad.write_text("VERDICT=NOT_A_REAL_CLOSEOUT\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--paper-runtime-evidence-review", str(bad)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_human_summary_includes_evidence_line_without_json(tmp_path: Path) -> None:
+    closeout = tmp_path / "c.md"
+    closeout.write_text(
+        "VERDICT=SIXTY_MIN_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS\n", encoding="utf-8"
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--paper-runtime-evidence-review", str(closeout)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "paper_runtime_evidence_accepted=true" in proc.stdout
+    assert "testnet_authorized=false" in proc.stdout
+    assert "live_authorized=false" in proc.stdout
+    assert "testnet ready" not in proc.stdout.lower()


### PR DESCRIPTION
## Summary

- add optional `--paper-runtime-evidence-review` input to `report_paper_testnet_readiness_status.py`
- accept bounded scheduler Paper-runtime PASS evidence from review JSON or approved closeout Markdown
- surface `paper_runtime_evidence_v0` as non-authorizing readiness context
- keep readiness conservative: status remains BLOCKED unless other prerequisites are satisfied
- keep `testnet_authorized=false` and `live_authorized=false`
- add tests for valid closeout, valid review JSON, missing/invalid evidence, and human output

## Safety

- non-runtime readiness/reporting slice only
- no scheduler execution
- no runtime daemon execution
- no paper runtime execution
- no paper-validation/testnet/live execution
- no incident-stop artifact mutation
- no broker/exchange/order paths
- does not authorize Testnet or Live

## Validation

- uv run pytest tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py -q
- uv run ruff check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- git diff --check

Made with [Cursor](https://cursor.com)