### PR TITLE
ops: add paper robustness evidence review input to readiness report

### DIFF
--- a/scripts/ops/report_paper_testnet_readiness_status.py
+++ b/scripts/ops/report_paper_testnet_readiness_status.py
@@ -7,6 +7,10 @@ artifacts, registries, out/ops data, execution state, or live state.
 Optional ``--paper-runtime-evidence-review`` ingests a bounded scheduler
 Paper-runtime **review or closeout** artifact only; it is necessary-but-not-
 sufficient for Paper layer readiness and never authorizes Testnet or Live.
+
+Optional ``--paper-robustness-evidence-review`` ingests a Paper robustness
+**review or closeout** artifact only; it satisfies the robustness slice of
+Paper readiness context and never authorizes Testnet or Live.
 """
 
 from __future__ import annotations
@@ -19,11 +23,19 @@ from typing import Any, Literal
 
 CONTRACT = "paper_testnet_readiness_status_v0"
 PAPER_RUNTIME_EVIDENCE_SCHEMA = "peak_trade.paper_runtime_evidence_input.v0"
+PAPER_ROBUSTNESS_EVIDENCE_SCHEMA = "peak_trade.paper_robustness_evidence_input.v0"
 
 CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
     {
         "7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS",
         "SIXTY_MIN_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS",
+    }
+)
+
+ROBUSTNESS_CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
+    {
+        "PAPER_ROBUSTNESS_EVIDENCE_PASS",
+        "ROBUSTNESS_EVIDENCE_PASS",
     }
 )
 
@@ -57,6 +69,19 @@ def default_paper_runtime_evidence_v0() -> dict[str, Any]:
     }
 
 
+def default_paper_robustness_evidence_v0() -> dict[str, Any]:
+    return {
+        "schema_version": PAPER_ROBUSTNESS_EVIDENCE_SCHEMA,
+        "record_path": None,
+        "record_present": False,
+        "verdict": None,
+        "accepted": False,
+        "non_authorizing": True,
+        "contributes_to": "paper_robustness_only",
+        "does_not_authorize": list(DOES_NOT_AUTHORIZE),
+    }
+
+
 def _parse_review_json(text: str) -> str | None:
     try:
         data = json.loads(text)
@@ -83,6 +108,40 @@ def _parse_closeout_markdown(text: str) -> str | None:
     return None
 
 
+def _parse_robustness_review_json(text: str) -> str | None:
+    """Accept PASS JSON only when explicitly tagged as paper robustness evidence."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("verdict") != "PASS":
+        return None
+    issues = data.get("issues")
+    if issues is not None and issues != []:
+        return None
+    explicit = (
+        data.get("evidence_kind") == "paper_robustness"
+        or data.get("kind") == "paper_robustness"
+        or data.get("paper_robustness_evidence") is True
+    )
+    if not explicit:
+        return None
+    return "PASS"
+
+
+def _parse_robustness_closeout_markdown(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("VERDICT="):
+            continue
+        verdict = line.split("=", 1)[1].strip()
+        if verdict in ROBUSTNESS_CLOSEOUT_VERDICTS_ACCEPTED:
+            return verdict
+    return None
+
+
 def load_paper_runtime_evidence_review(path: Path) -> str | None:
     """Return verdict string if accepted; otherwise None."""
     text = path.read_text(encoding="utf-8", errors="replace")
@@ -92,6 +151,21 @@ def load_paper_runtime_evidence_review(path: Path) -> str | None:
         return verdict_json
 
     verdict_md = _parse_closeout_markdown(text)
+    if verdict_md is not None:
+        return verdict_md
+
+    return None
+
+
+def load_paper_robustness_evidence_review(path: Path) -> str | None:
+    """Return verdict string if accepted; otherwise None."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    verdict_json = _parse_robustness_review_json(text)
+    if verdict_json is not None:
+        return verdict_json
+
+    verdict_md = _parse_robustness_closeout_markdown(text)
     if verdict_md is not None:
         return verdict_md
 
@@ -188,6 +262,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "(verdict PASS, empty issues) or Paper-runtime success closeout markdown."
         ),
     )
+    parser.add_argument(
+        "--paper-robustness-evidence-review",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional path to JSON (verdict PASS, explicit paper_robustness tag) "
+            "or Paper robustness success closeout markdown."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -196,6 +280,11 @@ def main(argv: list[str] | None = None) -> int:
     review_path = (
         args.paper_runtime_evidence_review.expanduser().resolve()
         if args.paper_runtime_evidence_review is not None
+        else None
+    )
+    robustness_path = (
+        args.paper_robustness_evidence_review.expanduser().resolve()
+        if args.paper_robustness_evidence_review is not None
         else None
     )
 
@@ -227,11 +316,41 @@ def main(argv: list[str] | None = None) -> int:
         runtime_v0["verdict"] = verdict
         runtime_v0["accepted"] = True
 
+    robustness_v0 = default_paper_robustness_evidence_v0()
+    robustness_accepted = False
+    robustness_verdict: str | None = None
+
+    if robustness_path is not None:
+        robustness_v0["record_present"] = True
+        robustness_v0["record_path"] = str(robustness_path)
+        if not robustness_path.is_file():
+            print(
+                "report_paper_testnet_readiness_status: "
+                f"--paper-robustness-evidence-review not a file: {robustness_path}",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        rb_verdict = load_paper_robustness_evidence_review(robustness_path)
+        if rb_verdict is None:
+            print(
+                "report_paper_testnet_readiness_status: "
+                "paper robustness evidence file is not a valid review JSON "
+                "(verdict PASS, explicit paper_robustness marker, optional empty issues) "
+                "or an accepted closeout markdown verdict line.",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        robustness_verdict = rb_verdict
+        robustness_accepted = True
+        robustness_v0["verdict"] = rb_verdict
+        robustness_v0["accepted"] = True
+
     effective_paper_evidence = bool(args.paper_evidence_present) or runtime_accepted
+    effective_paper_robustness = bool(args.paper_robustness_present) or robustness_accepted
 
     payload = build_status(
         paper_evidence_present=effective_paper_evidence,
-        paper_robustness_present=args.paper_robustness_present,
+        paper_robustness_present=effective_paper_robustness,
         paper_stress_present=args.paper_stress_present,
         testnet_evidence_present=args.testnet_evidence_present,
         testnet_robustness_present=args.testnet_robustness_present,
@@ -239,16 +358,20 @@ def main(argv: list[str] | None = None) -> int:
         external_review_decision_present=args.external_review_decision_present,
     )
     payload["paper_runtime_evidence_v0"] = runtime_v0
+    payload["paper_robustness_evidence_v0"] = robustness_v0
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print(f"status={payload['status']}")
         print(f"paper_runtime_evidence_accepted={str(runtime_accepted).lower()}")
+        print(f"paper_robustness_evidence_accepted={str(robustness_accepted).lower()}")
         print("testnet_authorized=false")
         print("live_authorized=false")
         if review_path is not None and runtime_verdict is not None:
             print(f"paper_runtime_evidence_verdict={runtime_verdict}")
+        if robustness_path is not None and robustness_verdict is not None:
+            print(f"paper_robustness_evidence_verdict={robustness_verdict}")
 
     return 0
 

--- a/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
+++ b/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
@@ -55,6 +55,11 @@ def test_default_invocation_is_blocked_with_missing_paper_and_testnet_items() ->
         "testnet.stress_missing",
     ]
     assert_non_authorizing(payload)
+    pr = payload["paper_robustness_evidence_v0"]
+    assert isinstance(pr, dict)
+    assert pr["accepted"] is False
+    assert pr["non_authorizing"] is True
+    assert pr["contributes_to"] == "paper_robustness_only"
 
 
 def test_complete_paper_only_still_blocks_on_testnet() -> None:
@@ -310,6 +315,159 @@ def test_human_summary_includes_evidence_line_without_json(tmp_path: Path) -> No
     )
     assert proc.returncode == 0
     assert "paper_runtime_evidence_accepted=true" in proc.stdout
+    assert "paper_robustness_evidence_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "testnet ready" not in proc.stdout.lower()
+
+
+def test_paper_robustness_closeout_review_surfaces_in_json_and_stays_blocked(
+    tmp_path: Path,
+) -> None:
+    closeout = tmp_path / "robustness.md"
+    closeout.write_text(
+        "\n".join(
+            [
+                "# x",
+                "VERDICT=PAPER_ROBUSTNESS_EVIDENCE_PASS",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    proc = run_report("--paper-robustness-evidence-review", str(closeout))
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+
+    assert payload["status"] == "BLOCKED"
+    assert payload["testnet_authorized"] is False
+    assert payload["live_authorized"] is False
+    assert payload["paper"]["robustness_present"] is True
+    assert payload["paper"]["evidence_present"] is False
+    pr = payload["paper_robustness_evidence_v0"]
+    assert isinstance(pr, dict)
+    assert pr["accepted"] is True
+    assert pr["non_authorizing"] is True
+    assert pr["verdict"] == "PAPER_ROBUSTNESS_EVIDENCE_PASS"
+    assert pr["contributes_to"] == "paper_robustness_only"
+    assert pr["does_not_authorize"] == [
+        "testnet",
+        "live",
+        "broker",
+        "exchange",
+        "order_submission",
+    ]
+    assert_non_authorizing(payload)
+
+
+def test_paper_robustness_review_json_pass_surfaces_accepted(tmp_path: Path) -> None:
+    review = tmp_path / "review.json"
+    review.write_text(
+        '{"issues": [], "evidence_kind": "paper_robustness", "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = run_report("--paper-robustness-evidence-review", str(review))
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+    pr = payload["paper_robustness_evidence_v0"]
+    assert pr["accepted"] is True
+    assert pr["verdict"] == "PASS"
+    assert payload["status"] == "BLOCKED"
+    assert payload["testnet_authorized"] is False
+
+
+def test_paper_robustness_still_blocked_when_stress_and_testnet_missing(tmp_path: Path) -> None:
+    closeout = tmp_path / "r.md"
+    closeout.write_text("VERDICT=ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    proc = run_report("--paper-robustness-evidence-review", str(closeout))
+    payload = parse_payload(proc)
+    assert payload["status"] == "BLOCKED"
+    assert "paper.stress_missing" in payload["blockers"]
+    assert "paper.evidence_missing" in payload["blockers"]
+    assert payload["testnet_authorized"] is False
+
+
+def test_paper_robustness_review_missing_file_exits_2(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--paper-robustness-evidence-review",
+            str(missing),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_paper_robustness_review_invalid_content_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.md"
+    bad.write_text("VERDICT=7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--paper-robustness-evidence-review", str(bad)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_runtime_json_not_accepted_as_robustness_evidence(tmp_path: Path) -> None:
+    review = tmp_path / "runtime_style.json"
+    review.write_text(
+        '{"issues": [], "metrics": {"fills_count": 1}, "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--paper-robustness-evidence-review", str(review)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_human_summary_includes_robustness_evidence_line(tmp_path: Path) -> None:
+    closeout = tmp_path / "c.md"
+    closeout.write_text("VERDICT=ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--paper-robustness-evidence-review", str(closeout)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "paper_robustness_evidence_accepted=true" in proc.stdout
+    assert "testnet_authorized=false" in proc.stdout
+    assert "live_authorized=false" in proc.stdout
+
+
+def test_combined_runtime_and_robustness_accepted_still_blocked_without_stress(
+    tmp_path: Path,
+) -> None:
+    rt = tmp_path / "rt.md"
+    rt.write_text("VERDICT=7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS\n", encoding="utf-8")
+    rb = tmp_path / "rb.md"
+    rb.write_text("VERDICT=PAPER_ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    proc = run_report(
+        "--paper-runtime-evidence-review",
+        str(rt),
+        "--paper-robustness-evidence-review",
+        str(rb),
+    )
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+    assert payload["status"] == "BLOCKED"
+    assert payload["paper"]["evidence_present"] is True
+    assert payload["paper"]["robustness_present"] is True
+    assert payload["paper"]["stress_present"] is False
+    assert "paper.stress_missing" in payload["blockers"]
+    assert payload["paper_runtime_evidence_v0"]["accepted"] is True
+    assert payload["paper_robustness_evidence_v0"]["accepted"] is True
+    assert payload["testnet_authorized"] is False
+    assert payload["live_authorized"] is False


### PR DESCRIPTION
## Summary

- add optional `--paper-robustness-evidence-review` input to `report_paper_testnet_readiness_status.py`
- accept explicit Paper robustness PASS evidence from Markdown or JSON
- surface `paper_robustness_evidence_v0` as non-authorizing readiness context
- keep readiness conservative: status remains BLOCKED when stress/testnet prerequisites are missing
- keep `testnet_authorized=false` and `live_authorized=false`
- add tests for valid closeout, valid JSON, missing/invalid evidence, runtime JSON rejection, human output, and runtime+robustness combination

## Safety

- non-runtime readiness/reporting slice only
- no scheduler execution
- no runtime daemon execution
- no paper runtime execution
- no paper-validation/testnet/live execution
- no incident-stop artifact mutation
- no broker/exchange/order paths
- does not authorize Testnet or Live
- does not mark stress evidence true

## Validation

- uv run pytest tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py -q
- uv run ruff check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- git diff --check

Made with [Cursor](https://cursor.com)