### PR TITLE
ops: add paper stress evidence review input to readiness report

### DIFF
--- a/scripts/ops/report_paper_testnet_readiness_status.py
+++ b/scripts/ops/report_paper_testnet_readiness_status.py
@@ -11,6 +11,10 @@ sufficient for Paper layer readiness and never authorizes Testnet or Live.
 Optional ``--paper-robustness-evidence-review`` ingests a Paper robustness
 **review or closeout** artifact only; it satisfies the robustness slice of
 Paper readiness context and never authorizes Testnet or Live.
+
+Optional ``--paper-stress-evidence-review`` ingests a Paper stress **review or
+closeout** artifact only; it satisfies the stress slice of Paper readiness
+context and never authorizes Testnet or Live.
 """
 
 from __future__ import annotations
@@ -24,6 +28,7 @@ from typing import Any, Literal
 CONTRACT = "paper_testnet_readiness_status_v0"
 PAPER_RUNTIME_EVIDENCE_SCHEMA = "peak_trade.paper_runtime_evidence_input.v0"
 PAPER_ROBUSTNESS_EVIDENCE_SCHEMA = "peak_trade.paper_robustness_evidence_input.v0"
+PAPER_STRESS_EVIDENCE_SCHEMA = "peak_trade.paper_stress_evidence_input.v0"
 
 CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
     {
@@ -36,6 +41,13 @@ ROBUSTNESS_CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
     {
         "PAPER_ROBUSTNESS_EVIDENCE_PASS",
         "ROBUSTNESS_EVIDENCE_PASS",
+    }
+)
+
+STRESS_CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
+    {
+        "PAPER_STRESS_EVIDENCE_PASS",
+        "STRESS_EVIDENCE_PASS",
     }
 )
 
@@ -78,6 +90,19 @@ def default_paper_robustness_evidence_v0() -> dict[str, Any]:
         "accepted": False,
         "non_authorizing": True,
         "contributes_to": "paper_robustness_only",
+        "does_not_authorize": list(DOES_NOT_AUTHORIZE),
+    }
+
+
+def default_paper_stress_evidence_v0() -> dict[str, Any]:
+    return {
+        "schema_version": PAPER_STRESS_EVIDENCE_SCHEMA,
+        "record_path": None,
+        "record_present": False,
+        "verdict": None,
+        "accepted": False,
+        "non_authorizing": True,
+        "contributes_to": "paper_stress_only",
         "does_not_authorize": list(DOES_NOT_AUTHORIZE),
     }
 
@@ -142,6 +167,40 @@ def _parse_robustness_closeout_markdown(text: str) -> str | None:
     return None
 
 
+def _parse_stress_review_json(text: str) -> str | None:
+    """Accept PASS JSON only when explicitly tagged as paper stress evidence."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("verdict") != "PASS":
+        return None
+    issues = data.get("issues")
+    if issues is not None and issues != []:
+        return None
+    explicit = (
+        data.get("evidence_kind") == "paper_stress"
+        or data.get("kind") == "paper_stress"
+        or data.get("paper_stress_evidence") is True
+    )
+    if not explicit:
+        return None
+    return "PASS"
+
+
+def _parse_stress_closeout_markdown(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("VERDICT="):
+            continue
+        verdict = line.split("=", 1)[1].strip()
+        if verdict in STRESS_CLOSEOUT_VERDICTS_ACCEPTED:
+            return verdict
+    return None
+
+
 def load_paper_runtime_evidence_review(path: Path) -> str | None:
     """Return verdict string if accepted; otherwise None."""
     text = path.read_text(encoding="utf-8", errors="replace")
@@ -166,6 +225,21 @@ def load_paper_robustness_evidence_review(path: Path) -> str | None:
         return verdict_json
 
     verdict_md = _parse_robustness_closeout_markdown(text)
+    if verdict_md is not None:
+        return verdict_md
+
+    return None
+
+
+def load_paper_stress_evidence_review(path: Path) -> str | None:
+    """Return verdict string if accepted; otherwise None."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    verdict_json = _parse_stress_review_json(text)
+    if verdict_json is not None:
+        return verdict_json
+
+    verdict_md = _parse_stress_closeout_markdown(text)
     if verdict_md is not None:
         return verdict_md
 
@@ -272,6 +346,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "or Paper robustness success closeout markdown."
         ),
     )
+    parser.add_argument(
+        "--paper-stress-evidence-review",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional path to JSON (verdict PASS, explicit paper_stress tag) "
+            "or Paper stress success closeout markdown."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -285,6 +369,11 @@ def main(argv: list[str] | None = None) -> int:
     robustness_path = (
         args.paper_robustness_evidence_review.expanduser().resolve()
         if args.paper_robustness_evidence_review is not None
+        else None
+    )
+    stress_path = (
+        args.paper_stress_evidence_review.expanduser().resolve()
+        if args.paper_stress_evidence_review is not None
         else None
     )
 
@@ -345,13 +434,43 @@ def main(argv: list[str] | None = None) -> int:
         robustness_v0["verdict"] = rb_verdict
         robustness_v0["accepted"] = True
 
+    stress_v0 = default_paper_stress_evidence_v0()
+    stress_accepted = False
+    stress_verdict: str | None = None
+
+    if stress_path is not None:
+        stress_v0["record_present"] = True
+        stress_v0["record_path"] = str(stress_path)
+        if not stress_path.is_file():
+            print(
+                "report_paper_testnet_readiness_status: "
+                f"--paper-stress-evidence-review not a file: {stress_path}",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        st_verdict = load_paper_stress_evidence_review(stress_path)
+        if st_verdict is None:
+            print(
+                "report_paper_testnet_readiness_status: "
+                "paper stress evidence file is not a valid review JSON "
+                "(verdict PASS, explicit paper_stress marker, optional empty issues) "
+                "or an accepted closeout markdown verdict line.",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        stress_verdict = st_verdict
+        stress_accepted = True
+        stress_v0["verdict"] = st_verdict
+        stress_v0["accepted"] = True
+
     effective_paper_evidence = bool(args.paper_evidence_present) or runtime_accepted
     effective_paper_robustness = bool(args.paper_robustness_present) or robustness_accepted
+    effective_paper_stress = bool(args.paper_stress_present) or stress_accepted
 
     payload = build_status(
         paper_evidence_present=effective_paper_evidence,
         paper_robustness_present=effective_paper_robustness,
-        paper_stress_present=args.paper_stress_present,
+        paper_stress_present=effective_paper_stress,
         testnet_evidence_present=args.testnet_evidence_present,
         testnet_robustness_present=args.testnet_robustness_present,
         testnet_stress_present=args.testnet_stress_present,
@@ -359,6 +478,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     payload["paper_runtime_evidence_v0"] = runtime_v0
     payload["paper_robustness_evidence_v0"] = robustness_v0
+    payload["paper_stress_evidence_v0"] = stress_v0
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -366,12 +486,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"status={payload['status']}")
         print(f"paper_runtime_evidence_accepted={str(runtime_accepted).lower()}")
         print(f"paper_robustness_evidence_accepted={str(robustness_accepted).lower()}")
+        print(f"paper_stress_evidence_accepted={str(stress_accepted).lower()}")
         print("testnet_authorized=false")
         print("live_authorized=false")
         if review_path is not None and runtime_verdict is not None:
             print(f"paper_runtime_evidence_verdict={runtime_verdict}")
         if robustness_path is not None and robustness_verdict is not None:
             print(f"paper_robustness_evidence_verdict={robustness_verdict}")
+        if stress_path is not None and stress_verdict is not None:
+            print(f"paper_stress_evidence_verdict={stress_verdict}")
 
     return 0
 

--- a/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
+++ b/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
@@ -60,6 +60,11 @@ def test_default_invocation_is_blocked_with_missing_paper_and_testnet_items() ->
     assert pr["accepted"] is False
     assert pr["non_authorizing"] is True
     assert pr["contributes_to"] == "paper_robustness_only"
+    ps = payload["paper_stress_evidence_v0"]
+    assert isinstance(ps, dict)
+    assert ps["accepted"] is False
+    assert ps["non_authorizing"] is True
+    assert ps["contributes_to"] == "paper_stress_only"
 
 
 def test_complete_paper_only_still_blocks_on_testnet() -> None:
@@ -316,6 +321,7 @@ def test_human_summary_includes_evidence_line_without_json(tmp_path: Path) -> No
     assert proc.returncode == 0
     assert "paper_runtime_evidence_accepted=true" in proc.stdout
     assert "paper_robustness_evidence_accepted=false" in proc.stdout
+    assert "paper_stress_evidence_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "testnet ready" not in proc.stdout.lower()
@@ -443,6 +449,7 @@ def test_human_summary_includes_robustness_evidence_line(tmp_path: Path) -> None
     )
     assert proc.returncode == 0
     assert "paper_robustness_evidence_accepted=true" in proc.stdout
+    assert "paper_stress_evidence_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
 
@@ -469,5 +476,165 @@ def test_combined_runtime_and_robustness_accepted_still_blocked_without_stress(
     assert "paper.stress_missing" in payload["blockers"]
     assert payload["paper_runtime_evidence_v0"]["accepted"] is True
     assert payload["paper_robustness_evidence_v0"]["accepted"] is True
+    assert payload["testnet_authorized"] is False
+    assert payload["live_authorized"] is False
+
+
+def test_paper_stress_closeout_review_surfaces_in_json_and_stays_blocked(tmp_path: Path) -> None:
+    closeout = tmp_path / "stress.md"
+    closeout.write_text(
+        "\n".join(
+            [
+                "# x",
+                "VERDICT=PAPER_STRESS_EVIDENCE_PASS",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    proc = run_report("--paper-stress-evidence-review", str(closeout))
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+
+    assert payload["status"] == "BLOCKED"
+    assert payload["testnet_authorized"] is False
+    assert payload["live_authorized"] is False
+    assert payload["paper"]["stress_present"] is True
+    assert payload["paper"]["evidence_present"] is False
+    ps = payload["paper_stress_evidence_v0"]
+    assert isinstance(ps, dict)
+    assert ps["accepted"] is True
+    assert ps["non_authorizing"] is True
+    assert ps["verdict"] == "PAPER_STRESS_EVIDENCE_PASS"
+    assert ps["contributes_to"] == "paper_stress_only"
+    assert ps["does_not_authorize"] == [
+        "testnet",
+        "live",
+        "broker",
+        "exchange",
+        "order_submission",
+    ]
+    assert_non_authorizing(payload)
+
+
+def test_paper_stress_review_json_pass_surfaces_accepted(tmp_path: Path) -> None:
+    review = tmp_path / "review.json"
+    review.write_text(
+        '{"issues": [], "evidence_kind": "paper_stress", "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = run_report("--paper-stress-evidence-review", str(review))
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+    ps = payload["paper_stress_evidence_v0"]
+    assert ps["accepted"] is True
+    assert ps["verdict"] == "PASS"
+    assert payload["status"] == "BLOCKED"
+    assert payload["testnet_authorized"] is False
+
+
+def test_paper_stress_review_missing_file_exits_2(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--paper-stress-evidence-review",
+            str(missing),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_paper_stress_review_invalid_content_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.md"
+    bad.write_text("VERDICT=PAPER_ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--paper-stress-evidence-review", str(bad)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_runtime_json_not_accepted_as_stress_evidence(tmp_path: Path) -> None:
+    review = tmp_path / "runtime_style.json"
+    review.write_text(
+        '{"issues": [], "metrics": {"fills_count": 1}, "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--paper-stress-evidence-review", str(review)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_robustness_json_not_accepted_as_stress_evidence(tmp_path: Path) -> None:
+    review = tmp_path / "robustness_style.json"
+    review.write_text(
+        '{"issues": [], "evidence_kind": "paper_robustness", "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--paper-stress-evidence-review", str(review)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_human_summary_includes_stress_evidence_line(tmp_path: Path) -> None:
+    closeout = tmp_path / "c.md"
+    closeout.write_text("VERDICT=STRESS_EVIDENCE_PASS\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--paper-stress-evidence-review", str(closeout)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "paper_stress_evidence_accepted=true" in proc.stdout
+    assert "paper_stress_evidence_verdict=STRESS_EVIDENCE_PASS" in proc.stdout
+    assert "testnet_authorized=false" in proc.stdout
+    assert "live_authorized=false" in proc.stdout
+
+
+def test_combined_runtime_robustness_and_stress_accepted_still_blocked_on_testnet(
+    tmp_path: Path,
+) -> None:
+    rt = tmp_path / "rt.md"
+    rt.write_text("VERDICT=7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS\n", encoding="utf-8")
+    rb = tmp_path / "rb.md"
+    rb.write_text("VERDICT=PAPER_ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    st = tmp_path / "st.md"
+    st.write_text("VERDICT=PAPER_STRESS_EVIDENCE_PASS\n", encoding="utf-8")
+    proc = run_report(
+        "--paper-runtime-evidence-review",
+        str(rt),
+        "--paper-robustness-evidence-review",
+        str(rb),
+        "--paper-stress-evidence-review",
+        str(st),
+    )
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+    assert payload["status"] == "BLOCKED"
+    assert payload["paper"]["evidence_present"] is True
+    assert payload["paper"]["robustness_present"] is True
+    assert payload["paper"]["stress_present"] is True
+    assert "testnet.evidence_missing" in payload["blockers"]
+    assert payload["paper_runtime_evidence_v0"]["accepted"] is True
+    assert payload["paper_robustness_evidence_v0"]["accepted"] is True
+    assert payload["paper_stress_evidence_v0"]["accepted"] is True
     assert payload["testnet_authorized"] is False
     assert payload["live_authorized"] is False


### PR DESCRIPTION
## Summary

- add optional `--paper-stress-evidence-review` input to `report_paper_testnet_readiness_status.py`
- accept explicit Paper stress PASS evidence from Markdown or JSON
- surface `paper_stress_evidence_v0` as non-authorizing readiness context
- reject runtime/robustness JSON as stress evidence
- keep readiness conservative: Testnet prerequisites still gate readiness
- keep `testnet_authorized=false` and `live_authorized=false`
- add tests for valid closeout, valid JSON, missing/invalid evidence, runtime/robustness rejection, human output, and combined runtime+robustness+stress evidence

## Safety

- non-runtime readiness/reporting slice only
- no scheduler execution
- no runtime daemon execution
- no paper runtime execution
- no paper-validation/testnet/live execution
- no incident-stop artifact mutation
- no broker/exchange/order paths
- does not authorize Testnet or Live

## Validation

- uv run pytest tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py -q
- uv run ruff check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- git diff --check

Made with [Cursor](https://cursor.com)