### PR TITLE
ops: add testnet prerequisites review input to readiness report

### DIFF
--- a/scripts/ops/report_paper_testnet_readiness_status.py
+++ b/scripts/ops/report_paper_testnet_readiness_status.py
@@ -15,6 +15,10 @@ Paper readiness context and never authorizes Testnet or Live.
 Optional ``--paper-stress-evidence-review`` ingests a Paper stress **review or
 closeout** artifact only; it satisfies the stress slice of Paper readiness
 context and never authorizes Testnet or Live.
+
+Optional ``--testnet-prerequisites-review`` ingests a Testnet prerequisites
+**review or inventory** artifact only; it records non-authorizing prerequisites
+context and never enables Testnet or Live.
 """
 
 from __future__ import annotations
@@ -29,6 +33,7 @@ CONTRACT = "paper_testnet_readiness_status_v0"
 PAPER_RUNTIME_EVIDENCE_SCHEMA = "peak_trade.paper_runtime_evidence_input.v0"
 PAPER_ROBUSTNESS_EVIDENCE_SCHEMA = "peak_trade.paper_robustness_evidence_input.v0"
 PAPER_STRESS_EVIDENCE_SCHEMA = "peak_trade.paper_stress_evidence_input.v0"
+TESTNET_PREREQUISITES_EVIDENCE_SCHEMA = "peak_trade.testnet_prerequisites_evidence_input.v0"
 
 CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
     {
@@ -48,6 +53,13 @@ STRESS_CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
     {
         "PAPER_STRESS_EVIDENCE_PASS",
         "STRESS_EVIDENCE_PASS",
+    }
+)
+
+TESTNET_PREREQUISITES_CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
+    {
+        "TESTNET_PREREQUISITES_EVIDENCE_PASS",
+        "TESTNET_PREREQUISITES_REVIEW_PASS",
     }
 )
 
@@ -103,6 +115,19 @@ def default_paper_stress_evidence_v0() -> dict[str, Any]:
         "accepted": False,
         "non_authorizing": True,
         "contributes_to": "paper_stress_only",
+        "does_not_authorize": list(DOES_NOT_AUTHORIZE),
+    }
+
+
+def default_testnet_prerequisites_evidence_v0() -> dict[str, Any]:
+    return {
+        "schema_version": TESTNET_PREREQUISITES_EVIDENCE_SCHEMA,
+        "record_path": None,
+        "record_present": False,
+        "verdict": None,
+        "accepted": False,
+        "non_authorizing": True,
+        "contributes_to": "testnet_prerequisites_only",
         "does_not_authorize": list(DOES_NOT_AUTHORIZE),
     }
 
@@ -201,6 +226,40 @@ def _parse_stress_closeout_markdown(text: str) -> str | None:
     return None
 
 
+def _parse_testnet_prerequisites_review_json(text: str) -> str | None:
+    """Accept PASS JSON only when explicitly tagged as testnet prerequisites evidence."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("verdict") != "PASS":
+        return None
+    issues = data.get("issues")
+    if issues is not None and issues != []:
+        return None
+    explicit = (
+        data.get("evidence_kind") == "testnet_prerequisites"
+        or data.get("kind") == "testnet_prerequisites"
+        or data.get("testnet_prerequisites_evidence") is True
+    )
+    if not explicit:
+        return None
+    return "PASS"
+
+
+def _parse_testnet_prerequisites_closeout_markdown(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("VERDICT="):
+            continue
+        verdict = line.split("=", 1)[1].strip()
+        if verdict in TESTNET_PREREQUISITES_CLOSEOUT_VERDICTS_ACCEPTED:
+            return verdict
+    return None
+
+
 def load_paper_runtime_evidence_review(path: Path) -> str | None:
     """Return verdict string if accepted; otherwise None."""
     text = path.read_text(encoding="utf-8", errors="replace")
@@ -240,6 +299,21 @@ def load_paper_stress_evidence_review(path: Path) -> str | None:
         return verdict_json
 
     verdict_md = _parse_stress_closeout_markdown(text)
+    if verdict_md is not None:
+        return verdict_md
+
+    return None
+
+
+def load_testnet_prerequisites_review(path: Path) -> str | None:
+    """Return verdict string if accepted; otherwise None."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    verdict_json = _parse_testnet_prerequisites_review_json(text)
+    if verdict_json is not None:
+        return verdict_json
+
+    verdict_md = _parse_testnet_prerequisites_closeout_markdown(text)
     if verdict_md is not None:
         return verdict_md
 
@@ -356,6 +430,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "or Paper stress success closeout markdown."
         ),
     )
+    parser.add_argument(
+        "--testnet-prerequisites-review",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional path to JSON (verdict PASS, explicit testnet_prerequisites tag) "
+            "or Testnet prerequisites success closeout markdown."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -374,6 +458,11 @@ def main(argv: list[str] | None = None) -> int:
     stress_path = (
         args.paper_stress_evidence_review.expanduser().resolve()
         if args.paper_stress_evidence_review is not None
+        else None
+    )
+    testnet_prereq_path = (
+        args.testnet_prerequisites_review.expanduser().resolve()
+        if args.testnet_prerequisites_review is not None
         else None
     )
 
@@ -463,6 +552,35 @@ def main(argv: list[str] | None = None) -> int:
         stress_v0["verdict"] = st_verdict
         stress_v0["accepted"] = True
 
+    testnet_prereq_v0 = default_testnet_prerequisites_evidence_v0()
+    testnet_prereq_accepted = False
+    testnet_prereq_verdict: str | None = None
+
+    if testnet_prereq_path is not None:
+        testnet_prereq_v0["record_present"] = True
+        testnet_prereq_v0["record_path"] = str(testnet_prereq_path)
+        if not testnet_prereq_path.is_file():
+            print(
+                "report_paper_testnet_readiness_status: "
+                f"--testnet-prerequisites-review not a file: {testnet_prereq_path}",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        tp_verdict = load_testnet_prerequisites_review(testnet_prereq_path)
+        if tp_verdict is None:
+            print(
+                "report_paper_testnet_readiness_status: "
+                "testnet prerequisites file is not a valid review JSON "
+                "(verdict PASS, explicit testnet_prerequisites marker, optional empty issues) "
+                "or an accepted closeout markdown verdict line.",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        testnet_prereq_verdict = tp_verdict
+        testnet_prereq_accepted = True
+        testnet_prereq_v0["verdict"] = tp_verdict
+        testnet_prereq_v0["accepted"] = True
+
     effective_paper_evidence = bool(args.paper_evidence_present) or runtime_accepted
     effective_paper_robustness = bool(args.paper_robustness_present) or robustness_accepted
     effective_paper_stress = bool(args.paper_stress_present) or stress_accepted
@@ -479,6 +597,7 @@ def main(argv: list[str] | None = None) -> int:
     payload["paper_runtime_evidence_v0"] = runtime_v0
     payload["paper_robustness_evidence_v0"] = robustness_v0
     payload["paper_stress_evidence_v0"] = stress_v0
+    payload["testnet_prerequisites_evidence_v0"] = testnet_prereq_v0
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -487,6 +606,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"paper_runtime_evidence_accepted={str(runtime_accepted).lower()}")
         print(f"paper_robustness_evidence_accepted={str(robustness_accepted).lower()}")
         print(f"paper_stress_evidence_accepted={str(stress_accepted).lower()}")
+        print(f"testnet_prerequisites_evidence_accepted={str(testnet_prereq_accepted).lower()}")
         print("testnet_authorized=false")
         print("live_authorized=false")
         if review_path is not None and runtime_verdict is not None:
@@ -495,6 +615,8 @@ def main(argv: list[str] | None = None) -> int:
             print(f"paper_robustness_evidence_verdict={robustness_verdict}")
         if stress_path is not None and stress_verdict is not None:
             print(f"paper_stress_evidence_verdict={stress_verdict}")
+        if testnet_prereq_path is not None and testnet_prereq_verdict is not None:
+            print(f"testnet_prerequisites_evidence_verdict={testnet_prereq_verdict}")
 
     return 0
 

--- a/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
+++ b/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
@@ -65,6 +65,11 @@ def test_default_invocation_is_blocked_with_missing_paper_and_testnet_items() ->
     assert ps["accepted"] is False
     assert ps["non_authorizing"] is True
     assert ps["contributes_to"] == "paper_stress_only"
+    tp = payload["testnet_prerequisites_evidence_v0"]
+    assert isinstance(tp, dict)
+    assert tp["accepted"] is False
+    assert tp["non_authorizing"] is True
+    assert tp["contributes_to"] == "testnet_prerequisites_only"
 
 
 def test_complete_paper_only_still_blocks_on_testnet() -> None:
@@ -322,6 +327,7 @@ def test_human_summary_includes_evidence_line_without_json(tmp_path: Path) -> No
     assert "paper_runtime_evidence_accepted=true" in proc.stdout
     assert "paper_robustness_evidence_accepted=false" in proc.stdout
     assert "paper_stress_evidence_accepted=false" in proc.stdout
+    assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "testnet ready" not in proc.stdout.lower()
@@ -450,6 +456,7 @@ def test_human_summary_includes_robustness_evidence_line(tmp_path: Path) -> None
     assert proc.returncode == 0
     assert "paper_robustness_evidence_accepted=true" in proc.stdout
     assert "paper_stress_evidence_accepted=false" in proc.stdout
+    assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
 
@@ -605,6 +612,7 @@ def test_human_summary_includes_stress_evidence_line(tmp_path: Path) -> None:
     assert proc.returncode == 0
     assert "paper_stress_evidence_accepted=true" in proc.stdout
     assert "paper_stress_evidence_verdict=STRESS_EVIDENCE_PASS" in proc.stdout
+    assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
 
@@ -636,5 +644,187 @@ def test_combined_runtime_robustness_and_stress_accepted_still_blocked_on_testne
     assert payload["paper_runtime_evidence_v0"]["accepted"] is True
     assert payload["paper_robustness_evidence_v0"]["accepted"] is True
     assert payload["paper_stress_evidence_v0"]["accepted"] is True
+    assert payload["testnet_authorized"] is False
+    assert payload["live_authorized"] is False
+
+
+def test_testnet_prerequisites_closeout_review_surfaces_in_json_and_stays_blocked(
+    tmp_path: Path,
+) -> None:
+    closeout = tmp_path / "tp.md"
+    closeout.write_text(
+        "\n".join(
+            [
+                "# x",
+                "VERDICT=TESTNET_PREREQUISITES_EVIDENCE_PASS",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    proc = run_report("--testnet-prerequisites-review", str(closeout))
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+
+    assert payload["status"] == "BLOCKED"
+    assert payload["testnet_authorized"] is False
+    assert payload["live_authorized"] is False
+    tp = payload["testnet_prerequisites_evidence_v0"]
+    assert isinstance(tp, dict)
+    assert tp["accepted"] is True
+    assert tp["non_authorizing"] is True
+    assert tp["verdict"] == "TESTNET_PREREQUISITES_EVIDENCE_PASS"
+    assert tp["contributes_to"] == "testnet_prerequisites_only"
+    assert tp["does_not_authorize"] == [
+        "testnet",
+        "live",
+        "broker",
+        "exchange",
+        "order_submission",
+    ]
+    assert_non_authorizing(payload)
+
+
+def test_testnet_prerequisites_review_json_pass_surfaces_accepted(tmp_path: Path) -> None:
+    review = tmp_path / "tp.json"
+    review.write_text(
+        '{"issues": [], "evidence_kind": "testnet_prerequisites", "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = run_report("--testnet-prerequisites-review", str(review))
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+    tp = payload["testnet_prerequisites_evidence_v0"]
+    assert tp["accepted"] is True
+    assert tp["verdict"] == "PASS"
+    assert payload["status"] == "BLOCKED"
+    assert payload["testnet_authorized"] is False
+
+
+def test_testnet_prerequisites_review_missing_file_exits_2(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--testnet-prerequisites-review",
+            str(missing),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_testnet_prerequisites_review_invalid_content_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.md"
+    bad.write_text("VERDICT=PAPER_STRESS_EVIDENCE_PASS\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--testnet-prerequisites-review", str(bad)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_runtime_json_not_accepted_as_testnet_prerequisites_evidence(tmp_path: Path) -> None:
+    review = tmp_path / "runtime_style.json"
+    review.write_text(
+        '{"issues": [], "metrics": {"fills_count": 1}, "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--testnet-prerequisites-review", str(review)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_robustness_json_not_accepted_as_testnet_prerequisites_evidence(
+    tmp_path: Path,
+) -> None:
+    review = tmp_path / "rb.json"
+    review.write_text(
+        '{"issues": [], "evidence_kind": "paper_robustness", "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--testnet-prerequisites-review", str(review)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_stress_json_not_accepted_as_testnet_prerequisites_evidence(tmp_path: Path) -> None:
+    review = tmp_path / "st.json"
+    review.write_text(
+        '{"issues": [], "evidence_kind": "paper_stress", "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--testnet-prerequisites-review", str(review)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+def test_human_summary_includes_testnet_prerequisites_evidence_line(tmp_path: Path) -> None:
+    closeout = tmp_path / "c.md"
+    closeout.write_text("VERDICT=TESTNET_PREREQUISITES_REVIEW_PASS\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--testnet-prerequisites-review", str(closeout)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "testnet_prerequisites_evidence_accepted=true" in proc.stdout
+    assert "testnet_prerequisites_evidence_verdict=TESTNET_PREREQUISITES_REVIEW_PASS" in proc.stdout
+    assert "testnet_authorized=false" in proc.stdout
+    assert "live_authorized=false" in proc.stdout
+
+
+def test_combined_all_paper_reviews_and_testnet_prerequisites_still_blocked_on_testnet(
+    tmp_path: Path,
+) -> None:
+    rt = tmp_path / "rt.md"
+    rt.write_text("VERDICT=7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS\n", encoding="utf-8")
+    rb = tmp_path / "rb.md"
+    rb.write_text("VERDICT=PAPER_ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    st = tmp_path / "st.md"
+    st.write_text("VERDICT=PAPER_STRESS_EVIDENCE_PASS\n", encoding="utf-8")
+    tp = tmp_path / "tp.md"
+    tp.write_text("VERDICT=TESTNET_PREREQUISITES_REVIEW_PASS\n", encoding="utf-8")
+    proc = run_report(
+        "--paper-runtime-evidence-review",
+        str(rt),
+        "--paper-robustness-evidence-review",
+        str(rb),
+        "--paper-stress-evidence-review",
+        str(st),
+        "--testnet-prerequisites-review",
+        str(tp),
+    )
+    assert proc.returncode == 0
+    payload = parse_payload(proc)
+    assert payload["status"] == "BLOCKED"
+    assert payload["paper"]["evidence_present"] is True
+    assert payload["paper"]["robustness_present"] is True
+    assert payload["paper"]["stress_present"] is True
+    assert "testnet.evidence_missing" in payload["blockers"]
+    assert payload["paper_runtime_evidence_v0"]["accepted"] is True
+    assert payload["paper_robustness_evidence_v0"]["accepted"] is True
+    assert payload["paper_stress_evidence_v0"]["accepted"] is True
+    assert payload["testnet_prerequisites_evidence_v0"]["accepted"] is True
     assert payload["testnet_authorized"] is False
     assert payload["live_authorized"] is False


### PR DESCRIPTION
## Summary

- add optional `--testnet-prerequisites-review` input to `report_paper_testnet_readiness_status.py`
- accept explicit Testnet prerequisites PASS evidence from Markdown or JSON
- surface `testnet_prerequisites_evidence_v0` as non-authorizing readiness context
- reject Paper runtime/robustness/stress JSON as Testnet prerequisites evidence
- keep readiness conservative: Testnet evidence flags still gate readiness
- keep `testnet_authorized=false` and `live_authorized=false`
- add tests for valid Markdown, valid JSON, missing/invalid evidence, wrong-kind rejection, human output, and combined Paper + Testnet prerequisites evidence

## Safety

- non-runtime readiness/reporting slice only
- no scheduler execution
- no runtime daemon execution
- no paper runtime execution
- no paper-validation/testnet/live execution
- no credentials, API keys, or secrets
- no incident-stop artifact mutation
- no broker/exchange/order execution paths
- does not authorize Testnet or Live

## Validation

- uv run pytest tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py -q
- uv run ruff check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- git diff --check

Made with [Cursor](https://cursor.com)