### PR TITLE
ops: add read-only testnet prerequisite checker

### DIFF
--- a/scripts/ops/check_testnet_prerequisites_readonly.py
+++ b/scripts/ops/check_testnet_prerequisites_readonly.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Read-only Testnet prerequisite inventory (stdlib only).
+
+Checks presence (not validity) of a small explicit env/config key set. Never
+reads secret contents into output, never connects to brokers/exchanges, and
+never authorizes Testnet or Live execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Literal
+
+SCHEMA_VERSION = "peak_trade.testnet_prerequisites_readonly.v0"
+
+# Explicit conservative gates: presence-only, no value semantics in this slice.
+REQUIRED_KEYS: tuple[str, ...] = (
+    "PEAK_TRADE_TESTNET_OPERATOR_GATE_ACK",
+    "PEAK_TRADE_TESTNET_CONFIG_DECLARED",
+)
+
+Status = Literal["BLOCKED", "READY_FOR_OPERATOR_REVIEW"]
+
+INVALID_INPUT_EXIT = 2
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Parse KEY=value lines; values are kept in-memory for presence checks only."""
+    parsed: dict[str, str] = {}
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _sep, val = line.partition("=")
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if key:
+            parsed[key] = val
+    return parsed
+
+
+def _resolve_presence(key: str, file_values: dict[str, str]) -> tuple[bool, str]:
+    env_val = os.environ.get(key, "")
+    if str(env_val).strip() != "":
+        return True, "env"
+    if key in file_values and str(file_values[key]).strip() != "":
+        return True, "env_file"
+    return False, "absent"
+
+
+def build_checker_boundary_v0() -> dict[str, Any]:
+    return {
+        "non_authorizing": True,
+        "testnet_authorized": False,
+        "live_authorized": False,
+        "broker_exchange_order_paths_authorized": False,
+        "order_submission_authorized": False,
+        "checker_does_not_connect_to_exchange": True,
+        "checker_does_not_validate_credentials": True,
+    }
+
+
+def run_check(
+    *,
+    env_file: Path | None,
+) -> tuple[dict[str, Any], int]:
+    """Return (payload, exit_code). exit_code 0 for normal run, 2 for bad input."""
+    if env_file is not None:
+        if not env_file.is_file():
+            print(
+                f"check_testnet_prerequisites_readonly: --env-file not a file: {env_file}",
+                file=sys.stderr,
+            )
+            return {}, INVALID_INPUT_EXIT
+
+    file_values: dict[str, str] = {}
+    if env_file is not None:
+        file_values = _parse_env_file(env_file)
+
+    prerequisites: list[dict[str, Any]] = []
+    missing: list[str] = []
+
+    for key in REQUIRED_KEYS:
+        present, source = _resolve_presence(key, file_values)
+        prerequisites.append(
+            {
+                "name": key,
+                "present": present,
+                "value_redacted": True,
+                "source": source,
+            }
+        )
+        if not present:
+            missing.append(key)
+
+    present_count = sum(1 for p in prerequisites if p["present"])
+    status: Status = "READY_FOR_OPERATOR_REVIEW" if not missing else "BLOCKED"
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "required_key_count": len(REQUIRED_KEYS),
+        "required_present_count": present_count,
+        "missing_count": len(missing),
+        "prerequisites": prerequisites,
+        "missing": missing,
+        "checker_boundary_v0": build_checker_boundary_v0(),
+    }
+    return payload, 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Read-only Testnet prerequisite key presence check (no secrets, no network)."
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON to stdout.",
+    )
+    p.add_argument(
+        "--env-file",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Optional env-style file (KEY=value); only key presence is inspected.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    env_path = args.env_file.expanduser().resolve() if args.env_file is not None else None
+
+    payload, code = run_check(env_file=env_path)
+    if code != 0:
+        return code
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        cb = payload["checker_boundary_v0"]
+        print(f"status={payload['status']}")
+        print(f"required_present_count={payload['required_present_count']}")
+        print(f"missing_count={payload['missing_count']}")
+        for pr in payload["prerequisites"]:
+            print(
+                f"prerequisite name={pr['name']} present={str(pr['present']).lower()} "
+                f"value_redacted={str(pr['value_redacted']).lower()} source={pr['source']}"
+            )
+        print(f"non_authorizing={str(cb['non_authorizing']).lower()}")
+        print(f"testnet_authorized={str(cb['testnet_authorized']).lower()}")
+        print(f"live_authorized={str(cb['live_authorized']).lower()}")
+        print(
+            "broker_exchange_order_paths_authorized="
+            f"{str(cb['broker_exchange_order_paths_authorized']).lower()}"
+        )
+        print(f"order_submission_authorized={str(cb['order_submission_authorized']).lower()}")
+        print(
+            "checker_does_not_connect_to_exchange="
+            f"{str(cb['checker_does_not_connect_to_exchange']).lower()}"
+        )
+        print(
+            "checker_does_not_validate_credentials="
+            f"{str(cb['checker_does_not_validate_credentials']).lower()}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_check_testnet_prerequisites_readonly.py
+++ b/tests/ops/test_check_testnet_prerequisites_readonly.py
@@ -1,0 +1,136 @@
+"""Tests for read-only Testnet prerequisite checker."""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path("scripts/ops/check_testnet_prerequisites_readonly.py")
+
+REQUIRED_A = "PEAK_TRADE_TESTNET_OPERATOR_GATE_ACK"
+REQUIRED_B = "PEAK_TRADE_TESTNET_CONFIG_DECLARED"
+
+
+def test_checker_uses_only_allowed_stdlib_imports() -> None:
+    src = SCRIPT.read_text(encoding="utf-8")
+    allowed_top = frozenset(
+        {
+            "__future__",
+            "argparse",
+            "json",
+            "os",
+            "sys",
+            "pathlib",
+            "typing",
+        }
+    )
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                base = alias.name.split(".", 1)[0]
+                assert base in allowed_top, f"unexpected import: {alias.name}"
+        if isinstance(node, ast.ImportFrom) and node.module:
+            base = node.module.split(".", 1)[0]
+            assert base in allowed_top, f"unexpected from-import: {node.module}"
+
+
+def test_checker_source_has_no_exchange_or_broker_execution_hooks() -> None:
+    src = SCRIPT.read_text(encoding="utf-8").lower()
+    assert "ccxt" not in src
+    assert "urllib.request" not in src
+    assert "requests" not in src
+
+
+def test_no_env_no_file_all_missing_blocked(monkeypatch) -> None:
+    monkeypatch.delenv(REQUIRED_A, raising=False)
+    monkeypatch.delenv(REQUIRED_B, raising=False)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "BLOCKED"
+    assert payload["missing_count"] == 2
+    assert payload["required_present_count"] == 0
+    assert set(payload["missing"]) == {REQUIRED_A, REQUIRED_B}
+    cb = payload["checker_boundary_v0"]
+    assert cb["non_authorizing"] is True
+    assert cb["testnet_authorized"] is False
+    assert cb["live_authorized"] is False
+    assert cb["checker_does_not_connect_to_exchange"] is True
+    assert cb["checker_does_not_validate_credentials"] is True
+
+
+def test_env_file_supplies_keys_ready_for_review(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv(REQUIRED_A, raising=False)
+    monkeypatch.delenv(REQUIRED_B, raising=False)
+    f = tmp_path / "e.env"
+    f.write_text(
+        "\n".join(
+            [
+                f"# secret-looking line must not appear in checker stdout",
+                f"{REQUIRED_A}=super_secret_value_xyz_999",
+                f'{REQUIRED_B}="also_secret"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--env-file", str(f)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "READY_FOR_OPERATOR_REVIEW"
+    assert payload["missing_count"] == 0
+    assert payload["required_present_count"] == 2
+    assert payload["missing"] == []
+    cb = payload["checker_boundary_v0"]
+    assert cb["non_authorizing"] is True
+    assert cb["testnet_authorized"] is False
+    assert "super_secret" not in proc.stdout
+    assert "also_secret" not in proc.stdout
+    assert "xyz_999" not in proc.stdout
+
+
+def test_env_file_missing_exits_2(tmp_path) -> None:
+    missing = tmp_path / "nope.env"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--json", "--env-file", str(missing)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_human_output_redacts_and_shows_authorization_false(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv(REQUIRED_A, raising=False)
+    monkeypatch.delenv(REQUIRED_B, raising=False)
+    f = tmp_path / "e.env"
+    leak = "UNIQUE_LEAK_TOKEN_FOR_TEST_7f3a"
+    f.write_text(f"{REQUIRED_A}=x\n{REQUIRED_B}={leak}\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--env-file", str(f)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert leak not in proc.stdout
+    assert leak not in proc.stderr
+    assert "status=READY_FOR_OPERATOR_REVIEW" in proc.stdout
+    assert "testnet_authorized=false" in proc.stdout
+    assert "live_authorized=false" in proc.stdout
+    assert "value_redacted=true" in proc.stdout


### PR DESCRIPTION
## Summary

- add `scripts/ops/check_testnet_prerequisites_readonly.py`
- inspect Testnet prerequisite key presence without printing or validating secret values
- support `--json` and `--env-file`
- emit status, missing keys, redacted prerequisite entries, and `checker_boundary_v0`
- keep all authorization fields false
- add tests for blocked/ready states, env-file handling, redaction, JSON/human output, and import-safety

## Safety

- read-only checker only
- no scheduler execution
- no runtime daemon execution
- no paper runtime execution
- no paper-validation/testnet/live execution
- no credential validation
- no secret values printed
- no broker/exchange/order execution paths
- does not authorize Testnet or Live
- does not touch the active 24h Paper Observation artifacts

## Validation

- uv run pytest tests/ops/test_check_testnet_prerequisites_readonly.py -q
- uv run ruff check scripts/ops/check_testnet_prerequisites_readonly.py tests/ops/test_check_testnet_prerequisites_readonly.py
- uv run ruff format --check scripts/ops/check_testnet_prerequisites_readonly.py tests/ops/test_check_testnet_prerequisites_readonly.py
- git diff --check

Made with [Cursor](https://cursor.com)