### PR TITLE
ops: accept testnet prerequisite checker JSON in readiness reporter

### DIFF
--- a/scripts/ops/report_paper_testnet_readiness_status.py
+++ b/scripts/ops/report_paper_testnet_readiness_status.py
@@ -19,6 +19,11 @@ context and never authorizes Testnet or Live.
 Optional ``--testnet-prerequisites-review`` ingests a Testnet prerequisites
 **review or inventory** artifact only; it records non-authorizing prerequisites
 context and never enables Testnet or Live.
+
+Optional ``--testnet-prerequisites-checker-report`` ingests JSON emitted by
+``check_testnet_prerequisites_readonly.py`` only (read from disk). The reporter
+never runs the checker, never validates credentials, and never authorizes
+Testnet or Live from this input.
 """
 
 from __future__ import annotations
@@ -34,6 +39,8 @@ PAPER_RUNTIME_EVIDENCE_SCHEMA = "peak_trade.paper_runtime_evidence_input.v0"
 PAPER_ROBUSTNESS_EVIDENCE_SCHEMA = "peak_trade.paper_robustness_evidence_input.v0"
 PAPER_STRESS_EVIDENCE_SCHEMA = "peak_trade.paper_stress_evidence_input.v0"
 TESTNET_PREREQUISITES_EVIDENCE_SCHEMA = "peak_trade.testnet_prerequisites_evidence_input.v0"
+TESTNET_PREREQUISITE_CHECKER_REPORT_SCHEMA = "peak_trade.testnet_prerequisite_checker_report.v0"
+TESTNET_PREREQUISITES_READONLY_CHECKER_SCHEMA = "peak_trade.testnet_prerequisites_readonly.v0"
 AUTHORIZATION_BOUNDARY_V0_SCHEMA = "peak_trade.authorization_boundary.v0"
 
 CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
@@ -146,6 +153,72 @@ def default_testnet_prerequisites_evidence_v0() -> dict[str, Any]:
         "contributes_to": "testnet_prerequisites_only",
         "does_not_authorize": list(DOES_NOT_AUTHORIZE),
     }
+
+
+def default_testnet_prerequisite_checker_report_v0() -> dict[str, Any]:
+    return {
+        "schema_version": TESTNET_PREREQUISITE_CHECKER_REPORT_SCHEMA,
+        "record_path": None,
+        "record_present": False,
+        "accepted": False,
+        "checker_status": None,
+        "missing_count": None,
+        "required_count": None,
+        "non_authorizing": True,
+        "contributes_to": "testnet_prerequisite_checker_context_only",
+        "does_not_authorize": list(DOES_NOT_AUTHORIZE),
+    }
+
+
+def _checker_boundary_v0_is_valid(boundary: Any) -> bool:
+    if not isinstance(boundary, dict):
+        return False
+    return (
+        boundary.get("non_authorizing") is True
+        and boundary.get("testnet_authorized") is False
+        and boundary.get("live_authorized") is False
+        and boundary.get("broker_exchange_order_paths_authorized") is False
+        and boundary.get("order_submission_authorized") is False
+        and boundary.get("checker_does_not_connect_to_exchange") is True
+        and boundary.get("checker_does_not_validate_credentials") is True
+    )
+
+
+def _parse_testnet_prerequisite_checker_report_json(text: str) -> dict[str, Any] | None:
+    """Parse and validate read-only checker JSON; return summary fields or None."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("schema_version") != TESTNET_PREREQUISITES_READONLY_CHECKER_SCHEMA:
+        return None
+    if not _checker_boundary_v0_is_valid(data.get("checker_boundary_v0")):
+        return None
+    status = data.get("status")
+    if status not in ("BLOCKED", "READY_FOR_OPERATOR_REVIEW"):
+        return None
+    missing = data.get("missing")
+    if missing is not None and not isinstance(missing, list):
+        return None
+    req_raw = data.get("required_key_count")
+    if not isinstance(req_raw, int) or req_raw < 0:
+        return None
+    miss_raw = data.get("missing_count")
+    if not isinstance(miss_raw, int) or miss_raw < 0:
+        return None
+    return {
+        "checker_status": status,
+        "missing_count": miss_raw,
+        "required_count": req_raw,
+    }
+
+
+def load_testnet_prerequisite_checker_report(path: Path) -> dict[str, Any] | None:
+    """Return summary dict if file is valid checker JSON; otherwise None."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return _parse_testnet_prerequisite_checker_report_json(text)
 
 
 def _parse_review_json(text: str) -> str | None:
@@ -456,6 +529,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "or Testnet prerequisites success closeout markdown."
         ),
     )
+    parser.add_argument(
+        "--testnet-prerequisites-checker-report",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional path to JSON emitted by check_testnet_prerequisites_readonly.py "
+            f"({TESTNET_PREREQUISITES_READONLY_CHECKER_SCHEMA})."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -479,6 +562,11 @@ def main(argv: list[str] | None = None) -> int:
     testnet_prereq_path = (
         args.testnet_prerequisites_review.expanduser().resolve()
         if args.testnet_prerequisites_review is not None
+        else None
+    )
+    checker_report_path = (
+        args.testnet_prerequisites_checker_report.expanduser().resolve()
+        if args.testnet_prerequisites_checker_report is not None
         else None
     )
 
@@ -597,6 +685,35 @@ def main(argv: list[str] | None = None) -> int:
         testnet_prereq_v0["verdict"] = tp_verdict
         testnet_prereq_v0["accepted"] = True
 
+    checker_report_v0 = default_testnet_prerequisite_checker_report_v0()
+    checker_report_accepted = False
+    checker_summary: dict[str, Any] | None = None
+
+    if checker_report_path is not None:
+        checker_report_v0["record_present"] = True
+        checker_report_v0["record_path"] = str(checker_report_path)
+        if not checker_report_path.is_file():
+            print(
+                "report_paper_testnet_readiness_status: "
+                f"--testnet-prerequisites-checker-report not a file: {checker_report_path}",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        checker_summary = load_testnet_prerequisite_checker_report(checker_report_path)
+        if checker_summary is None:
+            print(
+                "report_paper_testnet_readiness_status: "
+                "testnet prerequisites checker report is not valid read-only checker JSON "
+                f"({TESTNET_PREREQUISITES_READONLY_CHECKER_SCHEMA}, checker_boundary_v0).",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        checker_report_accepted = True
+        checker_report_v0["accepted"] = True
+        checker_report_v0["checker_status"] = checker_summary["checker_status"]
+        checker_report_v0["missing_count"] = checker_summary["missing_count"]
+        checker_report_v0["required_count"] = checker_summary["required_count"]
+
     effective_paper_evidence = bool(args.paper_evidence_present) or runtime_accepted
     effective_paper_robustness = bool(args.paper_robustness_present) or robustness_accepted
     effective_paper_stress = bool(args.paper_stress_present) or stress_accepted
@@ -614,6 +731,7 @@ def main(argv: list[str] | None = None) -> int:
     payload["paper_robustness_evidence_v0"] = robustness_v0
     payload["paper_stress_evidence_v0"] = stress_v0
     payload["testnet_prerequisites_evidence_v0"] = testnet_prereq_v0
+    payload["testnet_prerequisite_checker_report_v0"] = checker_report_v0
     payload["authorization_boundary_v0"] = build_authorization_boundary_v0()
 
     if args.json:
@@ -624,8 +742,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"paper_robustness_evidence_accepted={str(robustness_accepted).lower()}")
         print(f"paper_stress_evidence_accepted={str(stress_accepted).lower()}")
         print(f"testnet_prerequisites_evidence_accepted={str(testnet_prereq_accepted).lower()}")
+        print(
+            f"testnet_prerequisite_checker_report_accepted={str(checker_report_accepted).lower()}"
+        )
         print("testnet_authorized=false")
         print("live_authorized=false")
+        if checker_report_accepted and checker_summary is not None:
+            print(f"testnet_prerequisite_checker_status={checker_summary['checker_status']}")
+            print(f"testnet_prerequisite_checker_missing_count={checker_summary['missing_count']}")
         if review_path is not None and runtime_verdict is not None:
             print(f"paper_runtime_evidence_verdict={runtime_verdict}")
         if robustness_path is not None and robustness_verdict is not None:

--- a/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
+++ b/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
@@ -93,6 +93,14 @@ def test_default_invocation_is_blocked_with_missing_paper_and_testnet_items() ->
     assert tp["accepted"] is False
     assert tp["non_authorizing"] is True
     assert tp["contributes_to"] == "testnet_prerequisites_only"
+    cr = payload["testnet_prerequisite_checker_report_v0"]
+    assert isinstance(cr, dict)
+    assert cr["schema_version"] == "peak_trade.testnet_prerequisite_checker_report.v0"
+    assert cr["record_present"] is False
+    assert cr["accepted"] is False
+    assert cr["non_authorizing"] is True
+    assert cr["contributes_to"] == "testnet_prerequisite_checker_context_only"
+    assert cr["does_not_authorize"] == EVIDENCE_INPUTS_DO_NOT_AUTHORIZE
 
 
 def test_complete_paper_only_still_blocks_on_testnet() -> None:
@@ -351,6 +359,7 @@ def test_human_summary_includes_evidence_line_without_json(tmp_path: Path) -> No
     assert "paper_robustness_evidence_accepted=false" in proc.stdout
     assert "paper_stress_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
+    assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
@@ -483,6 +492,7 @@ def test_human_summary_includes_robustness_evidence_line(tmp_path: Path) -> None
     assert "paper_robustness_evidence_accepted=true" in proc.stdout
     assert "paper_stress_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
+    assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
@@ -642,6 +652,7 @@ def test_human_summary_includes_stress_evidence_line(tmp_path: Path) -> None:
     assert "paper_stress_evidence_accepted=true" in proc.stdout
     assert "paper_stress_evidence_verdict=STRESS_EVIDENCE_PASS" in proc.stdout
     assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
+    assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
@@ -822,6 +833,7 @@ def test_human_summary_includes_testnet_prerequisites_evidence_line(tmp_path: Pa
     assert proc.returncode == 0
     assert "testnet_prerequisites_evidence_accepted=true" in proc.stdout
     assert "testnet_prerequisites_evidence_verdict=TESTNET_PREREQUISITES_REVIEW_PASS" in proc.stdout
+    assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
@@ -895,6 +907,235 @@ def test_human_summary_includes_authorization_boundary_when_all_evidence_inputs_
         text=True,
     )
     assert proc.returncode == 0
+    assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
     assert "authorization_boundary_testnet_authorized=false" in proc.stdout
     assert "authorization_boundary_order_submission_authorized=false" in proc.stdout
+
+
+CHECKER_READONLY_SCHEMA = "peak_trade.testnet_prerequisites_readonly.v0"
+
+_CHECKER_BOUNDARY_OK: dict[str, bool] = {
+    "non_authorizing": True,
+    "testnet_authorized": False,
+    "live_authorized": False,
+    "broker_exchange_order_paths_authorized": False,
+    "order_submission_authorized": False,
+    "checker_does_not_connect_to_exchange": True,
+    "checker_does_not_validate_credentials": True,
+}
+
+
+def _checker_payload_blocked_extra_note() -> dict[str, object]:
+    return {
+        "schema_version": CHECKER_READONLY_SCHEMA,
+        "status": "BLOCKED",
+        "required_key_count": 2,
+        "required_present_count": 0,
+        "missing_count": 2,
+        "prerequisites": [],
+        "missing": [
+            "PEAK_TRADE_TESTNET_OPERATOR_GATE_ACK",
+            "PEAK_TRADE_TESTNET_CONFIG_DECLARED",
+        ],
+        "checker_boundary_v0": dict(_CHECKER_BOUNDARY_OK),
+        "_archive_note": "SHOULD_NOT_LEAK_IN_READINESS_OUTPUT_99zz",
+    }
+
+
+def _write_checker_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def test_valid_testnet_prerequisite_checker_report_surfaces_in_json(
+    tmp_path: Path,
+) -> None:
+    rep = tmp_path / "checker.json"
+    _write_checker_json(rep, _checker_payload_blocked_extra_note())
+    proc = run_report("--testnet-prerequisites-checker-report", str(rep))
+    assert proc.returncode == 0
+    out = parse_payload(proc)
+    cr = out["testnet_prerequisite_checker_report_v0"]
+    assert isinstance(cr, dict)
+    assert cr["accepted"] is True
+    assert cr["schema_version"] == "peak_trade.testnet_prerequisite_checker_report.v0"
+    assert cr["record_present"] is True
+    assert cr["checker_status"] == "BLOCKED"
+    assert cr["missing_count"] == 2
+    assert cr["required_count"] == 2
+    assert cr["non_authorizing"] is True
+    assert cr["contributes_to"] == "testnet_prerequisite_checker_context_only"
+    assert cr["does_not_authorize"] == EVIDENCE_INPUTS_DO_NOT_AUTHORIZE
+    assert "SHOULD_NOT_LEAK" not in proc.stdout
+    assert_non_authorizing(out)
+
+
+def test_valid_checker_report_ready_for_operator_review_keeps_auth_false(
+    tmp_path: Path,
+) -> None:
+    rep = tmp_path / "c.json"
+    payload: dict[str, object] = {
+        "schema_version": CHECKER_READONLY_SCHEMA,
+        "status": "READY_FOR_OPERATOR_REVIEW",
+        "required_key_count": 2,
+        "required_present_count": 2,
+        "missing_count": 0,
+        "prerequisites": [],
+        "missing": [],
+        "checker_boundary_v0": dict(_CHECKER_BOUNDARY_OK),
+    }
+    _write_checker_json(rep, payload)
+    proc = run_report("--testnet-prerequisites-checker-report", str(rep))
+    out = parse_payload(proc)
+    assert out["testnet_authorized"] is False
+    assert out["live_authorized"] is False
+    cr = out["testnet_prerequisite_checker_report_v0"]
+    assert cr["accepted"] is True
+    assert cr["checker_status"] == "READY_FOR_OPERATOR_REVIEW"
+    assert cr["missing_count"] == 0
+    assert_non_authorizing(out)
+
+
+def test_checker_report_missing_file_exits_2(tmp_path: Path) -> None:
+    missing = tmp_path / "no.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--testnet-prerequisites-checker-report",
+            str(missing),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_runtime_review_json_not_accepted_as_checker_report(
+    tmp_path: Path,
+) -> None:
+    rep = tmp_path / "runtime.json"
+    rep.write_text(
+        '{"issues": [], "metrics": {"fills_count": 1}, "verdict": "PASS"}\n',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--testnet-prerequisites-checker-report",
+            str(rep),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_checker_report_invalid_boundary_exits_2(tmp_path: Path) -> None:
+    rep = tmp_path / "bad.json"
+    p = dict(_checker_payload_blocked_extra_note())
+    b = dict(_CHECKER_BOUNDARY_OK)
+    b["testnet_authorized"] = True
+    p["checker_boundary_v0"] = b
+    del p["_archive_note"]
+    _write_checker_json(rep, p)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--testnet-prerequisites-checker-report",
+            str(rep),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_wrong_checker_schema_version_exits_2(tmp_path: Path) -> None:
+    rep = tmp_path / "wrong.json"
+    p = dict(_checker_payload_blocked_extra_note())
+    p["schema_version"] = "peak_trade.other.v0"
+    del p["_archive_note"]
+    _write_checker_json(rep, p)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--testnet-prerequisites-checker-report",
+            str(rep),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_human_summary_includes_checker_report_lines(
+    tmp_path: Path,
+) -> None:
+    rep = tmp_path / "c.json"
+    p = dict(_checker_payload_blocked_extra_note())
+    del p["_archive_note"]
+    _write_checker_json(rep, p)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--testnet-prerequisites-checker-report", str(rep)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "testnet_prerequisite_checker_report_accepted=true" in proc.stdout
+    assert "testnet_prerequisite_checker_status=BLOCKED" in proc.stdout
+    assert "testnet_prerequisite_checker_missing_count=2" in proc.stdout
+    assert "testnet_authorized=false" in proc.stdout
+    assert "live_authorized=false" in proc.stdout
+
+
+def test_combined_all_evidence_reviews_and_checker_report_still_blocked_non_authorizing(
+    tmp_path: Path,
+) -> None:
+    rt = tmp_path / "rt.md"
+    rt.write_text("VERDICT=7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS\n", encoding="utf-8")
+    rb = tmp_path / "rb.md"
+    rb.write_text("VERDICT=PAPER_ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    st = tmp_path / "st.md"
+    st.write_text("VERDICT=PAPER_STRESS_EVIDENCE_PASS\n", encoding="utf-8")
+    tp = tmp_path / "tp.md"
+    tp.write_text("VERDICT=TESTNET_PREREQUISITES_REVIEW_PASS\n", encoding="utf-8")
+    chk = tmp_path / "chk.json"
+    p = dict(_checker_payload_blocked_extra_note())
+    del p["_archive_note"]
+    _write_checker_json(chk, p)
+    proc = run_report(
+        "--paper-runtime-evidence-review",
+        str(rt),
+        "--paper-robustness-evidence-review",
+        str(rb),
+        "--paper-stress-evidence-review",
+        str(st),
+        "--testnet-prerequisites-review",
+        str(tp),
+        "--testnet-prerequisites-checker-report",
+        str(chk),
+    )
+    assert proc.returncode == 0
+    out = parse_payload(proc)
+    assert out["status"] == "BLOCKED"
+    assert out["testnet_prerequisite_checker_report_v0"]["accepted"] is True
+    assert out["testnet_authorized"] is False
+    assert out["live_authorized"] is False
+    assert_non_authorizing(out)


### PR DESCRIPTION
## Summary

- add optional `--testnet-prerequisites-checker-report` input to `report_paper_testnet_readiness_status.py`
- accept JSON emitted by the read-only Testnet prerequisite checker
- validate checker schema, status, required/missing counts, and `checker_boundary_v0`
- surface `testnet_prerequisite_checker_report_v0` as summary-only non-authorizing context
- avoid copying full prerequisite records or arbitrary checker fields into readiness output
- keep `testnet_authorized=false` and `live_authorized=false`
- add tests for valid checker JSON, READY/BLOCKED statuses, invalid inputs, human output, all-evidence combination, and leak prevention

## Safety

- non-runtime readiness/reporting slice only
- reporter reads a provided checker JSON file but does not run the checker
- no scheduler execution
- no runtime daemon execution
- no paper runtime execution
- no paper-validation/testnet/live execution
- no credential validation
- no secret values printed or propagated
- no broker/exchange/order execution paths
- does not authorize Testnet or Live
- does not touch the active 24h Paper Observation artifacts

## Validation

- uv run pytest tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py -q
- uv run ruff check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- git diff --check

Made with [Cursor](https://cursor.com)