### PR TITLE
ops: add external operator testnet gate record input

### DIFF
--- a/scripts/ops/report_paper_testnet_readiness_status.py
+++ b/scripts/ops/report_paper_testnet_readiness_status.py
@@ -29,6 +29,10 @@ Optional ``--testnet-evidence-review``, ``--testnet-robustness-evidence-review``
 and ``--testnet-stress-evidence-review`` ingest Testnet-layer **review or
 closeout** artifacts only; they clear modeled Testnet readiness flags without
 authorizing execution.
+
+Optional ``--external-operator-testnet-gate-record`` ingests a non-runtime
+**external operator** gate record (Markdown or JSON). It records review-gate
+context only and does not authorize Testnet execution, Live, or order paths.
 """
 
 from __future__ import annotations
@@ -49,6 +53,7 @@ TESTNET_ROBUSTNESS_EVIDENCE_SCHEMA = "peak_trade.testnet_robustness_evidence_inp
 TESTNET_STRESS_EVIDENCE_SCHEMA = "peak_trade.testnet_stress_evidence_input.v0"
 TESTNET_PREREQUISITE_CHECKER_REPORT_SCHEMA = "peak_trade.testnet_prerequisite_checker_report.v0"
 TESTNET_PREREQUISITES_READONLY_CHECKER_SCHEMA = "peak_trade.testnet_prerequisites_readonly.v0"
+EXTERNAL_OPERATOR_TESTNET_GATE_RECORD_SCHEMA = "peak_trade.external_operator_testnet_gate_record.v0"
 AUTHORIZATION_BOUNDARY_V0_SCHEMA = "peak_trade.authorization_boundary.v0"
 
 CLOSEOUT_VERDICTS_ACCEPTED = frozenset(
@@ -98,6 +103,13 @@ AUTHORITY_FLAGS = {
 }
 
 DOES_NOT_AUTHORIZE = ["testnet", "live", "broker", "exchange", "order_submission"]
+EXTERNAL_OPERATOR_GATE_DOES_NOT_AUTHORIZE = [
+    "testnet_execution",
+    "live",
+    "broker",
+    "exchange",
+    "order_submission",
+]
 
 MISSING_REVIEW_EXIT = 2
 
@@ -221,6 +233,91 @@ def default_testnet_stress_evidence_v0() -> dict[str, Any]:
         "contributes_to": "testnet_stress_only",
         "does_not_authorize": list(DOES_NOT_AUTHORIZE),
     }
+
+
+def default_external_operator_testnet_gate_record_v0() -> dict[str, Any]:
+    return {
+        "schema_version": EXTERNAL_OPERATOR_TESTNET_GATE_RECORD_SCHEMA,
+        "record_path": None,
+        "record_present": False,
+        "verdict": None,
+        "accepted": False,
+        "non_authorizing": True,
+        "non_execution_authority": True,
+        "contributes_to": "external_operator_testnet_review_gate_only",
+        "does_not_authorize": list(EXTERNAL_OPERATOR_GATE_DOES_NOT_AUTHORIZE),
+    }
+
+
+EXTERNAL_OPERATOR_GATE_MD_VERDICT = "EXTERNAL_OPERATOR_TESTNET_GATE_REVIEW_PASS"
+
+
+def _parse_external_operator_gate_markdown(text: str) -> str | None:
+    required = {
+        "VERDICT": EXTERNAL_OPERATOR_GATE_MD_VERDICT,
+        "OPERATOR_APPROVES_TESTNET_REVIEW_GATE": "yes",
+        "NON_EXECUTION_AUTHORITY": "true",
+        "TESTNET_EXECUTION_AUTHORIZED": "false",
+        "LIVE_AUTHORIZED": "false",
+    }
+    found: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if "=" not in line or line.startswith("#"):
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip()
+        found[key] = val
+    for k, exp in required.items():
+        if found.get(k) != exp:
+            return None
+    return EXTERNAL_OPERATOR_GATE_MD_VERDICT
+
+
+def _parse_external_operator_gate_json_dict(data: dict[str, Any]) -> str | None:
+    if data.get("schema_version") != EXTERNAL_OPERATOR_TESTNET_GATE_RECORD_SCHEMA:
+        return None
+    if data.get("verdict") != "PASS":
+        return None
+    issues = data.get("issues")
+    if issues is not None and issues != []:
+        return None
+    if data.get("operator_approves_testnet_review_gate") is not True:
+        return None
+    if data.get("non_execution_authority") is not True:
+        return None
+    if data.get("testnet_execution_authorized") is not False:
+        return None
+    if data.get("live_authorized") is not False:
+        return None
+    if data.get("broker_exchange_order_paths_authorized") is True:
+        return None
+    if data.get("order_submission_authorized") is True:
+        return None
+    return "PASS"
+
+
+def _parse_external_operator_gate_json_text(text: str) -> str | None:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return _parse_external_operator_gate_json_dict(data)
+
+
+def load_external_operator_testnet_gate_record(path: Path) -> str | None:
+    """Return verdict string if gate record is valid; otherwise None."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    stripped = text.lstrip()
+    if stripped.startswith("{"):
+        vj = _parse_external_operator_gate_json_text(text)
+        if vj is not None:
+            return vj
+        return None
+    return _parse_external_operator_gate_markdown(text)
 
 
 def _checker_boundary_v0_is_valid(boundary: Any) -> bool:
@@ -757,6 +854,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "or Testnet stress success closeout markdown."
         ),
     )
+    parser.add_argument(
+        "--external-operator-testnet-gate-record",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional path to external operator Testnet review gate record "
+            f"(JSON {EXTERNAL_OPERATOR_TESTNET_GATE_RECORD_SCHEMA} or strict markdown)."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -800,6 +907,11 @@ def main(argv: list[str] | None = None) -> int:
     testnet_stress_evidence_path = (
         args.testnet_stress_evidence_review.expanduser().resolve()
         if args.testnet_stress_evidence_review is not None
+        else None
+    )
+    external_operator_gate_path = (
+        args.external_operator_testnet_gate_record.expanduser().resolve()
+        if args.external_operator_testnet_gate_record is not None
         else None
     )
 
@@ -1035,6 +1147,35 @@ def main(argv: list[str] | None = None) -> int:
         testnet_stress_evidence_v0["verdict"] = ts_verdict
         testnet_stress_evidence_v0["accepted"] = True
 
+    external_operator_gate_v0 = default_external_operator_testnet_gate_record_v0()
+    external_operator_gate_accepted = False
+    external_operator_gate_verdict: str | None = None
+
+    if external_operator_gate_path is not None:
+        external_operator_gate_v0["record_present"] = True
+        external_operator_gate_v0["record_path"] = str(external_operator_gate_path)
+        if not external_operator_gate_path.is_file():
+            print(
+                "report_paper_testnet_readiness_status: "
+                f"--external-operator-testnet-gate-record not a file: "
+                f"{external_operator_gate_path}",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        og_verdict = load_external_operator_testnet_gate_record(external_operator_gate_path)
+        if og_verdict is None:
+            print(
+                "report_paper_testnet_readiness_status: "
+                "external operator Testnet gate record is not valid strict markdown or JSON "
+                f"({EXTERNAL_OPERATOR_TESTNET_GATE_RECORD_SCHEMA}).",
+                file=sys.stderr,
+            )
+            return MISSING_REVIEW_EXIT
+        external_operator_gate_verdict = og_verdict
+        external_operator_gate_accepted = True
+        external_operator_gate_v0["verdict"] = og_verdict
+        external_operator_gate_v0["accepted"] = True
+
     effective_paper_evidence = bool(args.paper_evidence_present) or runtime_accepted
     effective_paper_robustness = bool(args.paper_robustness_present) or robustness_accepted
     effective_paper_stress = bool(args.paper_stress_present) or stress_accepted
@@ -1061,6 +1202,7 @@ def main(argv: list[str] | None = None) -> int:
     payload["testnet_evidence_v0"] = testnet_evidence_v0
     payload["testnet_robustness_evidence_v0"] = testnet_robustness_evidence_v0
     payload["testnet_stress_evidence_v0"] = testnet_stress_evidence_v0
+    payload["external_operator_testnet_gate_record_v0"] = external_operator_gate_v0
     payload["authorization_boundary_v0"] = build_authorization_boundary_v0()
 
     if args.json:
@@ -1079,6 +1221,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"testnet_prerequisites_evidence_accepted={str(testnet_prereq_accepted).lower()}")
         print(
             f"testnet_prerequisite_checker_report_accepted={str(checker_report_accepted).lower()}"
+        )
+        print(
+            "external_operator_testnet_gate_record_accepted="
+            f"{str(external_operator_gate_accepted).lower()}"
         )
         print("testnet_authorized=false")
         print("live_authorized=false")
@@ -1102,6 +1248,12 @@ def main(argv: list[str] | None = None) -> int:
             print(f"testnet_stress_evidence_verdict={testnet_stress_evidence_verdict}")
         if testnet_prereq_path is not None and testnet_prereq_verdict is not None:
             print(f"testnet_prerequisites_evidence_verdict={testnet_prereq_verdict}")
+        if external_operator_gate_path is not None and external_operator_gate_verdict is not None:
+            print(f"external_operator_testnet_gate_record_verdict={external_operator_gate_verdict}")
+        print(
+            "external_operator_testnet_gate_non_execution_authority="
+            f"{str(external_operator_gate_accepted).lower()}"
+        )
         ab = payload["authorization_boundary_v0"]
         print(
             "authorization_boundary_non_authorizing_evidence_inputs="

--- a/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
+++ b/tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
@@ -116,6 +116,20 @@ def test_default_invocation_is_blocked_with_missing_paper_and_testnet_items() ->
     assert tst["accepted"] is False
     assert tst["contributes_to"] == "testnet_stress_only"
     assert tst["schema_version"] == "peak_trade.testnet_stress_evidence_input.v0"
+    og = payload["external_operator_testnet_gate_record_v0"]
+    assert isinstance(og, dict)
+    assert og["accepted"] is False
+    assert og["non_authorizing"] is True
+    assert og["non_execution_authority"] is True
+    assert og["contributes_to"] == "external_operator_testnet_review_gate_only"
+    assert og["schema_version"] == "peak_trade.external_operator_testnet_gate_record.v0"
+    assert og["does_not_authorize"] == [
+        "testnet_execution",
+        "live",
+        "broker",
+        "exchange",
+        "order_submission",
+    ]
 
 
 def test_complete_paper_only_still_blocks_on_testnet() -> None:
@@ -378,6 +392,8 @@ def test_human_summary_includes_evidence_line_without_json(tmp_path: Path) -> No
     assert "testnet_stress_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_record_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_non_execution_authority=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
@@ -514,6 +530,8 @@ def test_human_summary_includes_robustness_evidence_line(tmp_path: Path) -> None
     assert "testnet_stress_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_record_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_non_execution_authority=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
@@ -677,6 +695,8 @@ def test_human_summary_includes_stress_evidence_line(tmp_path: Path) -> None:
     assert "testnet_stress_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_record_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_non_execution_authority=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
@@ -861,6 +881,8 @@ def test_human_summary_includes_testnet_prerequisites_evidence_line(tmp_path: Pa
     assert "testnet_robustness_evidence_accepted=false" in proc.stdout
     assert "testnet_stress_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_record_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_non_execution_authority=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
     assert "live_authorized=false" in proc.stdout
     assert "authorization_boundary_non_authorizing_evidence_inputs=true" in proc.stdout
@@ -935,6 +957,8 @@ def test_human_summary_includes_authorization_boundary_when_all_evidence_inputs_
     )
     assert proc.returncode == 0
     assert "testnet_prerequisite_checker_report_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_record_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_non_execution_authority=false" in proc.stdout
     assert "testnet_evidence_accepted=false" in proc.stdout
     assert "testnet_robustness_evidence_accepted=false" in proc.stdout
     assert "testnet_stress_evidence_accepted=false" in proc.stdout
@@ -1128,9 +1152,12 @@ def test_human_summary_includes_checker_report_lines(
         text=True,
     )
     assert proc.returncode == 0
+    assert "testnet_prerequisites_evidence_accepted=false" in proc.stdout
     assert "testnet_prerequisite_checker_report_accepted=true" in proc.stdout
     assert "testnet_prerequisite_checker_status=BLOCKED" in proc.stdout
     assert "testnet_prerequisite_checker_missing_count=2" in proc.stdout
+    assert "external_operator_testnet_gate_record_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_non_execution_authority=false" in proc.stdout
     assert "testnet_evidence_accepted=false" in proc.stdout
     assert "testnet_robustness_evidence_accepted=false" in proc.stdout
     assert "testnet_stress_evidence_accepted=false" in proc.stdout
@@ -1426,6 +1453,8 @@ def test_human_summary_includes_testnet_layer_evidence_verdict_lines(
     assert "testnet_evidence_verdict=TESTNET_EVIDENCE_PASS" in proc.stdout
     assert "testnet_robustness_evidence_verdict=TESTNET_ROBUSTNESS_EVIDENCE_PASS" in proc.stdout
     assert "testnet_stress_evidence_verdict=TESTNET_STRESS_EVIDENCE_PASS" in proc.stdout
+    assert "external_operator_testnet_gate_record_accepted=false" in proc.stdout
+    assert "external_operator_testnet_gate_non_execution_authority=false" in proc.stdout
     assert "testnet_authorized=false" in proc.stdout
 
 
@@ -1446,3 +1475,237 @@ def test_testnet_evidence_json_does_not_copy_extra_fields_to_readiness_output(
     assert "LEAK_MARKER_XYZZY99" not in proc.stdout
     out = parse_payload(proc)
     assert "operator_secret_note" not in json.dumps(out)
+
+
+EXTERNAL_OPERATOR_GATE_SCHEMA = "peak_trade.external_operator_testnet_gate_record.v0"
+
+
+def _external_operator_gate_md_text() -> str:
+    return (
+        "VERDICT=EXTERNAL_OPERATOR_TESTNET_GATE_REVIEW_PASS\n"
+        "OPERATOR_APPROVES_TESTNET_REVIEW_GATE=yes\n"
+        "NON_EXECUTION_AUTHORITY=true\n"
+        "TESTNET_EXECUTION_AUTHORIZED=false\n"
+        "LIVE_AUTHORIZED=false\n"
+    )
+
+
+def _external_operator_gate_json_base() -> dict[str, object]:
+    return {
+        "schema_version": EXTERNAL_OPERATOR_GATE_SCHEMA,
+        "verdict": "PASS",
+        "operator_approves_testnet_review_gate": True,
+        "non_execution_authority": True,
+        "testnet_execution_authorized": False,
+        "live_authorized": False,
+    }
+
+
+def test_external_operator_gate_valid_markdown_surfaces_in_json(tmp_path: Path) -> None:
+    md = tmp_path / "gate.md"
+    md.write_text(_external_operator_gate_md_text(), encoding="utf-8")
+    proc = run_report("--external-operator-testnet-gate-record", str(md))
+    assert proc.returncode == 0
+    out = parse_payload(proc)
+    og = out["external_operator_testnet_gate_record_v0"]
+    assert isinstance(og, dict)
+    assert og["accepted"] is True
+    assert og["record_present"] is True
+    assert og["verdict"] == "EXTERNAL_OPERATOR_TESTNET_GATE_REVIEW_PASS"
+    assert og["schema_version"] == EXTERNAL_OPERATOR_GATE_SCHEMA
+    assert og["non_authorizing"] is True
+    assert og["non_execution_authority"] is True
+    assert og["contributes_to"] == "external_operator_testnet_review_gate_only"
+    assert og["does_not_authorize"] == [
+        "testnet_execution",
+        "live",
+        "broker",
+        "exchange",
+        "order_submission",
+    ]
+    assert out["testnet_authorized"] is False
+    assert out["live_authorized"] is False
+    assert_non_authorizing(out)
+
+
+def test_external_operator_gate_valid_json_surfaces_in_json(tmp_path: Path) -> None:
+    js = tmp_path / "gate.json"
+    js.write_text(
+        json.dumps(_external_operator_gate_json_base(), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    proc = run_report("--external-operator-testnet-gate-record", str(js))
+    assert proc.returncode == 0
+    out = parse_payload(proc)
+    og = out["external_operator_testnet_gate_record_v0"]
+    assert isinstance(og, dict)
+    assert og["accepted"] is True
+    assert og["verdict"] == "PASS"
+    assert_non_authorizing(out)
+
+
+def test_external_operator_gate_missing_path_json_exits_2(tmp_path: Path) -> None:
+    missing = tmp_path / "gone.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--external-operator-testnet-gate-record",
+            str(missing),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_external_operator_gate_invalid_markdown_json_exits_2(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.md"
+    bad.write_text("VERDICT=EXTERNAL_OPERATOR_TESTNET_GATE_REVIEW_PASS\n", encoding="utf-8")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--external-operator-testnet-gate-record",
+            str(bad),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def _reject_gate(tmp_path: Path, extra: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    p = tmp_path / "bad.json"
+    base = dict(_external_operator_gate_json_base())
+    base.update(extra)
+    p.write_text(json.dumps(base) + "\n", encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--json",
+            "--external-operator-testnet-gate-record",
+            str(p),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_external_operator_gate_rejects_testnet_execution_authorized_true(
+    tmp_path: Path,
+) -> None:
+    proc = _reject_gate(tmp_path, {"testnet_execution_authorized": True})
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_external_operator_gate_rejects_live_authorized_true(tmp_path: Path) -> None:
+    proc = _reject_gate(tmp_path, {"live_authorized": True})
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_external_operator_gate_rejects_broker_exchange_order_paths_authorized_true(
+    tmp_path: Path,
+) -> None:
+    proc = _reject_gate(tmp_path, {"broker_exchange_order_paths_authorized": True})
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_external_operator_gate_rejects_order_submission_authorized_true(
+    tmp_path: Path,
+) -> None:
+    proc = _reject_gate(tmp_path, {"order_submission_authorized": True})
+    assert proc.returncode == 2
+    assert proc.stdout.strip() == ""
+
+
+def test_human_summary_includes_external_operator_gate_lines(tmp_path: Path) -> None:
+    md = tmp_path / "gate.md"
+    md.write_text(_external_operator_gate_md_text(), encoding="utf-8")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--external-operator-testnet-gate-record",
+            str(md),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "external_operator_testnet_gate_record_accepted=true" in proc.stdout
+    assert (
+        "external_operator_testnet_gate_record_verdict=EXTERNAL_OPERATOR_TESTNET_GATE_REVIEW_PASS"
+        in proc.stdout
+    )
+    assert "external_operator_testnet_gate_non_execution_authority=true" in proc.stdout
+    assert "testnet_authorized=false" in proc.stdout
+    assert "live_authorized=false" in proc.stdout
+
+
+def test_full_modeled_e2e_with_checker_and_external_gate_stays_ready_non_authorizing(
+    tmp_path: Path,
+) -> None:
+    rt = tmp_path / "rt.md"
+    rt.write_text("VERDICT=7200S_SCHEDULER_PAPER_RUNTIME_EVIDENCE_PASS\n", encoding="utf-8")
+    rb = tmp_path / "rb.md"
+    rb.write_text("VERDICT=PAPER_ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    st = tmp_path / "st.md"
+    st.write_text("VERDICT=PAPER_STRESS_EVIDENCE_PASS\n", encoding="utf-8")
+    tp = tmp_path / "tp.md"
+    tp.write_text("VERDICT=TESTNET_PREREQUISITES_REVIEW_PASS\n", encoding="utf-8")
+    chk = tmp_path / "chk.json"
+    p = dict(_checker_payload_blocked_extra_note())
+    del p["_archive_note"]
+    _write_checker_json(chk, p)
+    tne = tmp_path / "tne.md"
+    tne.write_text("VERDICT=TESTNET_EVIDENCE_PASS\n", encoding="utf-8")
+    tnr = tmp_path / "tnr.md"
+    tnr.write_text("VERDICT=TESTNET_ROBUSTNESS_EVIDENCE_PASS\n", encoding="utf-8")
+    tns = tmp_path / "tns.md"
+    tns.write_text("VERDICT=TESTNET_STRESS_EVIDENCE_PASS\n", encoding="utf-8")
+    gate = tmp_path / "gate.md"
+    gate.write_text(_external_operator_gate_md_text(), encoding="utf-8")
+    proc = run_report(
+        "--paper-runtime-evidence-review",
+        str(rt),
+        "--paper-robustness-evidence-review",
+        str(rb),
+        "--paper-stress-evidence-review",
+        str(st),
+        "--testnet-prerequisites-review",
+        str(tp),
+        "--testnet-prerequisites-checker-report",
+        str(chk),
+        "--testnet-evidence-review",
+        str(tne),
+        "--testnet-robustness-evidence-review",
+        str(tnr),
+        "--testnet-stress-evidence-review",
+        str(tns),
+        "--external-operator-testnet-gate-record",
+        str(gate),
+    )
+    assert proc.returncode == 0
+    out = parse_payload(proc)
+    assert out["status"] == "READY_FOR_REVIEW"
+    assert out["blockers"] == []
+    assert out["testnet_prerequisite_checker_report_v0"]["accepted"] is True
+    og = out["external_operator_testnet_gate_record_v0"]
+    assert isinstance(og, dict)
+    assert og["accepted"] is True
+    assert out["testnet_authorized"] is False
+    assert out["live_authorized"] is False
+    assert_non_authorizing(out)


### PR DESCRIPTION
## Summary

- add optional `--external-operator-testnet-gate-record` input to `report_paper_testnet_readiness_status.py`
- accept strict Markdown and JSON external operator Testnet gate records
- surface `external_operator_testnet_gate_record_v0` as non-execution, non-authorizing readiness context
- reject records that attempt to authorize Testnet execution, Live, broker/exchange/order paths, or order submission
- preserve `authorization_boundary_v0` semantics: readiness is not execution authority
- keep `testnet_authorized=false` and `live_authorized=false`
- add tests for valid Markdown/JSON, invalid/missing paths, forbidden true flags, human output, and full E2E READY_FOR_REVIEW with all auth flags false

## Safety

- non-runtime readiness/reporting slice only
- no scheduler execution
- no runtime daemon execution
- no paper runtime execution
- no paper-validation/testnet/live execution
- no credential validation
- no secret values printed or propagated
- no broker/exchange/order execution paths
- does not authorize Testnet execution or Live
- does not touch the active 24h Paper Observation artifacts

## Validation

- uv run pytest tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py -q
- uv run ruff check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- uv run ruff format --check scripts/ops/report_paper_testnet_readiness_status.py tests/ops/test_report_paper_testnet_readiness_status_cli_v0.py
- git diff --check

Made with [Cursor](https://cursor.com)