### PR TITLE
tests(ops): cover knowledge prod smoke cleanup scope

### DIFF
--- a/tests/ops/test_knowledge_prod_smoke_script.py
+++ b/tests/ops/test_knowledge_prod_smoke_script.py
@@ -215,3 +215,27 @@ def test_script_handles_graceful_degradation(script_path: Path) -> None:
     assert "EXPECT_501_OK" in content or "degraded" in content.lower(), (
         "Script should have logic for handling degraded state"
     )
+
+
+def test_knowledge_prod_smoke_contract_keeps_temp_cleanup_scoped(script_path: Path) -> None:
+    """R-005: cleanup may remove only the script-owned temporary directory."""
+    assert script_path.exists(), f"Script not found: {script_path}"
+
+    text = script_path.read_text(encoding="utf-8")
+
+    assert 'rm -rf "$TEMP_DIR"' in text
+    assert "trap" in text
+    assert "TEMP_DIR" in text
+
+    forbidden_fragments = (
+        "rm -rf /",
+        "rm -rf .git",
+        "rm -rf $REPO_ROOT",
+        "rm -rf ${REPO_ROOT}",
+        'rm -rf "$REPO_ROOT"',
+        "git clean -fdx",
+        "git reset --hard",
+    )
+
+    found = [fragment for fragment in forbidden_fragments if fragment in text]
+    assert not found, f"knowledge prod smoke cleanup must stay scoped: {found}"


### PR DESCRIPTION
## Summary

- adds a narrow R-005 static assertion to the existing `tests/ops/test_knowledge_prod_smoke_script.py`
- verifies `knowledge_prod_smoke.sh` cleanup remains scoped to the script-owned temporary directory
- guards against unscoped destructive cleanup patterns such as repo-root deletion, `.git` deletion, `git clean -fdx`, or `git reset --hard`

## Scope

Tests-only.

No production code, smoke-script behavior, workflow behavior, scheduler, daemon, runtime, paper/shadow/testnet/live, broker, exchange, or order-submission behavior is changed.

## PR package assessment

Read-only package assessment recommended a single focused PR:

- `PR_STRATEGY=single-focused-pr`
- `PACKAGE_NOW=false`

## Validation

- `uv run pytest tests/ops/test_knowledge_prod_smoke_script.py -q`
- `uv run ruff check tests/ops/test_knowledge_prod_smoke_script.py`
- `uv run ruff format --check tests/ops/test_knowledge_prod_smoke_script.py`
- `git diff --check`

## No-regression note

This PR does not reduce system capability, change trading logic, alter Master V2 / Double Play semantics, or add hot-path overhead.

Made with [Cursor](https://cursor.com)