### PR TITLE
tests(market-sentinel): add daily outlook sensitive-output visibility contract v0

### DIFF
--- a/tests/test_market_sentinel_v0_daily.py
+++ b/tests/test_market_sentinel_v0_daily.py
@@ -655,3 +655,76 @@ def test_generate_market_outlook_daily_help_subprocess_smoke():
     assert "usage:" in combined_output.lower()
     assert "--skip-llm" in combined_output
     assert "--config-path" in combined_output
+
+
+def test_market_sentinel_daily_outlook_sensitive_output_visibility_contract_v0() -> None:
+    """Static owner-review surface for Market Sentinel daily-outlook sensitive output markers.
+
+    This test reads source text only. It must not import market-sentinel modules,
+    generate reports, call OpenAI/webhooks/market-data/network paths, start runtime
+    components, or change logging/report/redaction behavior.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    source = (repo_root / "src" / "market_sentinel" / "v0_daily_outlook.py").read_text(
+        encoding="utf-8"
+    )
+    lowered = source.lower()
+
+    sensitive_markers = {
+        "api_key",
+        "openai",
+        "llm",
+    }
+    output_markers = {
+        "report",
+        "logger.",
+        "markdown",
+    }
+    market_report_markers = {
+        "market",
+        "sentinel",
+        "outlook",
+        "daily",
+    }
+    redaction_markers = {
+        "redact",
+        "redacted",
+        "mask",
+        "masked",
+        "sanitize",
+        "sanitized",
+        "scrub",
+        "safe_secret",
+        "safe_token",
+    }
+
+    missing_sensitive_markers = [
+        marker for marker in sorted(sensitive_markers) if marker not in lowered
+    ]
+    missing_output_markers = [marker for marker in sorted(output_markers) if marker not in lowered]
+    missing_market_report_markers = [
+        marker for marker in sorted(market_report_markers) if marker not in lowered
+    ]
+    present_redaction_markers = [
+        marker for marker in sorted(redaction_markers) if marker in lowered
+    ]
+
+    assert not missing_sensitive_markers
+    assert not missing_output_markers
+    assert not missing_market_report_markers
+    assert present_redaction_markers == []
+
+    forbidden_network_fragments = [
+        "".join(["re", "quests", "."]),
+        "".join(["htt", "px", "."]),
+        "".join(["soc", "ket", "."]),
+        "".join(["openai", "."]),
+        ".".join(["webhook", "send"]),
+    ]
+
+    test_source = Path(__file__).read_text(encoding="utf-8")
+    found = [fragment for fragment in forbidden_network_fragments if fragment in test_source]
+    assert not found, (
+        "static Market Sentinel daily-outlook visibility contract must not use "
+        f"network/API hooks: {found}"
+    )


### PR DESCRIPTION
## Summary

- extends the existing `tests/test_market_sentinel_v0_daily.py` owner with a static sensitive-output visibility contract
- classifies current `src/market_sentinel/v0_daily_outlook.py` sensitive/output/market-report markers as an owner-review surface
- records current absence of redaction markers without changing market-sentinel/report/logging behavior
- keeps the new check text-only: no OpenAI calls, no webhook calls, no market-data/network/API calls, no runtime access

## Scope

Tests-only.

No production code, market-sentinel behavior, report behavior, logging behavior, scheduler, daemon, runtime, paper/shadow/testnet/live, broker, exchange, or order-submission behavior is changed.

## Validation

- `uv run pytest tests/test_market_sentinel_v0_daily.py -q`
- `uv run ruff check tests/test_market_sentinel_v0_daily.py`
- `uv run ruff format --check tests/test_market_sentinel_v0_daily.py`
- `git diff --check`

## No-regression note

This PR does not reduce system capability, change trading logic, alter Master V2 / Double Play semantics, or add hot-path overhead.

Made with [Cursor](https://cursor.com)