### PR TITLE
tests(ops): add e2e verification network marker contract v0

### DIFF
--- a/tests/ops/test_run_end_to_end_verification_syntax.py
+++ b/tests/ops/test_run_end_to_end_verification_syntax.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 from pathlib import Path
 
@@ -6,3 +7,65 @@ def test_run_end_to_end_verification_syntax():
     p = Path("scripts/ops/run_end_to_end_verification.sh")
     assert p.exists()
     subprocess.run(["bash", "-n", str(p)], check=True)
+
+
+def test_run_end_to_end_verification_network_marker_contract_v0() -> None:
+    """Static owner-review surface for E2E verification network/CLI markers.
+
+    Reads the script as text only. It must not execute the script, run gh/aws,
+    dispatch workflows, call network/API endpoints, or touch runtime paths.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "ops" / "run_end_to_end_verification.sh"
+    source = script.read_text(encoding="utf-8")
+    lowered = source.lower()
+
+    assert script.exists()
+    assert "run_end_to_end_verification.sh" in str(script)
+    assert "gh " in source
+    assert "aws" in lowered or "AWS" in source
+    assert "workflow" in lowered or "verification" in lowered
+    assert "runtime" in lowered or "testnet" in lowered or "live" in lowered
+    assert "set -euo pipefail" in source
+    assert "gh workflow view" in lowered
+    assert "gh workflow run" in lowered
+
+    forbidden_dispatch_or_network_mutation_patterns = [
+        "gh run rerun",
+        "gh api repos/",
+        "curl" + " ",
+        "wget" + " ",
+    ]
+    found = [
+        pattern for pattern in forbidden_dispatch_or_network_mutation_patterns if pattern in lowered
+    ]
+    assert not found, (
+        "run_end_to_end_verification network-marker contract should not gain "
+        f"rerun/API-repo mutation or direct HTTP download surfaces: {found}"
+    )
+
+    test_source = Path(__file__).read_text(encoding="utf-8")
+    marker = "def test_run_end_to_end_verification_network_marker_contract_v0"
+    start = test_source.find(marker)
+    assert start != -1
+    tail = test_source[start:]
+    after_sig = tail[len(marker) :]
+    next_fn = re.search(r"\n^def test_", after_sig, re.MULTILINE)
+    contract_src = tail[: len(marker) + next_fn.start()] if next_fn else tail
+
+    forbidden_test_fragments = [
+        "subprocess" + ".",
+        "os" + ".system",
+        "runpy" + ".",
+        "importlib" + ".import_module",
+        "requests" + ".",
+        "httpx" + ".",
+        "urllib" + ".",
+        "socket" + ".",
+        "aws " + " ",
+    ]
+    test_hits = [fragment for fragment in forbidden_test_fragments if fragment in contract_src]
+    assert not test_hits, (
+        "static run_end_to_end_verification network-marker contract must not use "
+        f"execution/network hooks: {test_hits}"
+    )


### PR DESCRIPTION
## Summary

- extends the existing `tests/ops/test_run_end_to_end_verification_syntax.py` owner with a static network-marker visibility contract
- freezes current `scripts/ops/run_end_to_end_verification.sh` E2E/network surfaces including `gh workflow view`, `gh workflow run`, AWS context, testnet/live context, and strict shell guard visibility
- rejects additional direct HTTP/download/API mutation surfaces such as `gh run rerun`, `gh api repos/`, `curl`, and `wget`
- keeps the check text-only: no script execution, no `gh` execution, no AWS/network/API calls, no workflow dispatch

## Scope

Tests-only.

No production code, script behavior, network behavior, GitHub behavior, workflow behavior, scheduler, daemon, runtime, paper/shadow/testnet/live, broker, exchange, or order-submission behavior is changed.

## Validation

- `uv run pytest tests/ops/test_run_end_to_end_verification_syntax.py -q`
- `uv run ruff check tests/ops/test_run_end_to_end_verification_syntax.py`
- `uv run ruff format --check tests/ops/test_run_end_to_end_verification_syntax.py`
- `git diff --check`
- `git diff --cached --check`

## No-regression note

This PR does not reduce system capability, change trading logic, alter Master V2 / Double Play semantics, or add hot-path overhead.

Made with [Cursor](https://cursor.com)