### PR TITLE
test(webui): lock market dashboard read-only structure v0

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -1,0 +1,131 @@
+"""Market Dashboard read-only structure contract v0.
+
+This module is intentionally UI/HTML-structure only. It must not authorize
+runtime, scheduler, paper/testnet/live, broker, exchange, or order flows.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+
+FORM_ACTION_RE = re.compile(
+    r"<form\b[^>]*\baction\s*=\s*[\"']([^\"']*)[\"']",
+    re.IGNORECASE,
+)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _html(client: TestClient, path: str) -> str:
+    response = client.get(path)
+    assert response.status_code == 200
+    ctype = response.headers.get("content-type", "")
+    assert "text/html" in ctype
+    return response.text
+
+
+def test_market_dashboard_keeps_depth_ssr_without_client_depth_fetch(
+    client: TestClient,
+) -> None:
+    html = _html(client, "/market")
+
+    assert 'data-market-depth-panel="true"' in html
+    assert "data-market-depth-status=" in html
+    assert 'data-market-depth-summary="true"' in html
+
+    assert "/api/market/depth" not in html
+    assert "fetch(" not in html
+    assert "XMLHttpRequest" not in html
+
+
+def test_double_play_market_dashboard_does_not_embed_market_depth_api_fetch(
+    client: TestClient,
+) -> None:
+    html = _html(client, "/market/double-play")
+
+    assert "/api/market/depth" not in html
+    assert "fetch(" not in html
+    assert "XMLHttpRequest" not in html
+
+
+def test_market_dashboard_has_no_trade_action_affordance(client: TestClient) -> None:
+    combined_html = "\n".join(
+        [
+            _html(client, "/market"),
+            _html(client, "/market/double-play"),
+        ]
+    ).lower()
+
+    forbidden_action_terms = [
+        "place order",
+        "submit order",
+        "send order",
+        "buy now",
+        "sell now",
+        "go long",
+        "go short",
+        "execute trade",
+        "live authorize",
+        "authorize live",
+        "broker submit",
+        "exchange submit",
+    ]
+
+    for term in forbidden_action_terms:
+        assert term not in combined_html
+
+
+def test_market_dashboard_readonly_banner_markers(client: TestClient) -> None:
+    market_html = _html(client, "/market")
+    assert 'data-market-readonly="true"' in market_html
+    assert 'data-market-non-authorizing="true"' in market_html
+
+
+def test_market_dashboard_forms_do_not_target_order_or_live_paths(
+    client: TestClient,
+) -> None:
+    combined_html = "\n".join(
+        [
+            _html(client, "/market"),
+            _html(client, "/market/double-play"),
+        ]
+    )
+
+    form_actions = [m for m in FORM_ACTION_RE.findall(combined_html) if m.strip()]
+
+    forbidden_fragments = [
+        "order",
+        "broker",
+        "exchange",
+        "live",
+        "testnet",
+        "kill",
+        "scheduler",
+        "runtime",
+    ]
+
+    for action in form_actions:
+        lowered = action.lower()
+        for fragment in forbidden_fragments:
+            assert fragment not in lowered


### PR DESCRIPTION
## Summary

Adds a tests-only Market Dashboard read-only structure contract.

The contract verifies that the existing Market Dashboard pages remain observation/read-only surfaces:
- `/market` keeps SSR market-depth diagnostic markers (`data-market-depth-*`) without embedding the JSON Depth route URL for browser fetch.
- Dashboard HTML does not embed `/api/market/depth` client fetch behavior (`fetch(`, `XMLHttpRequest`).
- Banner markers `data-market-readonly` / `data-market-non-authorizing` remain on `/market`.
- Dashboard HTML does not expose naive trade/order/live-authorization phrases.
- `<form … action>` values (when present) stay away from order/broker/exchange/live/testnet/kill/scheduler/runtime path fragments.

## Safety

- Tests-only
- No runtime/scheduler/paper/testnet/live changes
- No broker/exchange/order changes
- No API route shape changes
- No template/CSS/JS changes
- No Market Depth semantics changes
- No Double-Play/Master-V2 semantics changes
- No authorization-surface changes

## Validation

```bash
uv run python -m pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q
uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
uv run ruff format --check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
git diff --check
```

Made with [Cursor](https://cursor.com)