### PR TITLE
test(webui): double-play excludes market depth SSR markers

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -69,6 +69,16 @@ def test_double_play_market_dashboard_does_not_embed_market_depth_api_fetch(
     assert "XMLHttpRequest" not in html
 
 
+def test_double_play_dashboard_excludes_market_depth_ssr_markers_v0(
+    client: TestClient,
+) -> None:
+    """Double-Play page must not carry `/market` SSR Market Depth strip markup."""
+    html = _html(client, "/market/double-play")
+
+    assert "data-market-depth-panel" not in html
+    assert "market-v0-depth-ssr" not in html
+
+
 def test_market_dashboard_has_no_trade_action_affordance(client: TestClient) -> None:
     combined_html = "\n".join(
         [


### PR DESCRIPTION
## Summary

Micro tests-only: `GET /market/double-play` HTML must not include `/market` SSR Market Depth strip markers (`data-market-depth-panel`, `#market-v0-depth-ssr` id fragment).

Single-file extension to existing structure contract tests.

## Safety

- Tests-only; no `src/`, `docs/`, or `templates/` changes.

## Validation

```bash
uv run python -m pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q
uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
uv run ruff format --check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
```

Made with [Cursor](https://cursor.com)