### PR TITLE
webui(market-v0): add read-only pro panel shell

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -4,10 +4,11 @@
 
 {% block content %}
 <div
-  class="space-y-6 max-w-6xl mx-auto"
+  class="space-y-6 max-w-7xl mx-auto px-2 sm:px-0"
   data-section="market-v0"
   data-market-surface-v0="true"
   data-market-v1-dashboard-shell="true"
+  data-market-v0-pro-shell="true"
   data-market-readonly="true"
   data-market-non-authorizing="true"
   data-market-source="{{ query.source }}"
@@ -56,27 +57,12 @@
     {% endif %}
   </section>
 
-  <section
-    id="market-v0-depth-ssr"
-    aria-label="Market depth read-model (SSR, offline or disabled)"
-    class="rounded-xl border border-slate-700/70 bg-slate-900/55 px-4 py-3 text-xs text-slate-300"
-    data-market-depth-panel="true"
-    data-market-depth-status="{{ market_depth.display_status }}"
-    {% if market_depth.readmodel_id %}
-    data-market-depth-readmodel-id="{{ market_depth.readmodel_id }}"
-    {% endif %}
+  <!-- Pro cockpit grid: chart/main column + read-only side panels (IA inspiration only; no order UI) -->
+  <div
+    class="grid grid-cols-1 xl:grid-cols-12 gap-4 lg:gap-6 items-start"
+    data-market-v0-pro-grid="true"
   >
-    <p class="font-semibold text-slate-200/95 tracking-wide uppercase text-[11px] mb-1.5">
-      Market Depth (read-only)
-    </p>
-    <p class="leading-relaxed text-slate-300/90 m-0" data-market-depth-summary="true">
-      {{ market_depth.summary_line|e }}
-    </p>
-    <p class="mt-1.5 text-[11px] text-slate-500 m-0">
-      SSR only — keine Browser-Abfrage der Depth-JSON-Route; keine Orders oder Ausführung.
-    </p>
-  </section>
-
+    <div class="xl:col-span-8 space-y-6 min-w-0" data-market-v0-chart-panel="true">
   <header class="bg-gradient-to-r from-slate-900/80 to-slate-900/40 rounded-2xl border border-slate-800 p-6">
     <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
       <div>
@@ -249,6 +235,85 @@
       <canvas id="chart-market-v0-close" class="block w-full h-full"></canvas>
     </div>
   </section>
+    </div>
+
+    <aside
+      class="xl:col-span-4 space-y-4 min-w-0"
+      aria-label="Read-only market side panels (no order controls)"
+    >
+      <section
+        class="rounded-xl border border-slate-700/70 bg-slate-900/60 px-3 py-2.5 text-[11px] text-slate-300"
+        data-market-v0-pro-boundary="true"
+        aria-label="Read-only boundaries"
+      >
+        <ul class="m-0 p-0 list-none flex flex-wrap gap-x-4 gap-y-1">
+          <li class="text-emerald-300/95 font-semibold uppercase tracking-wide">Read-only</li>
+          <li class="text-sky-300/90 font-semibold uppercase tracking-wide">Non-authorizing</li>
+          <li class="text-slate-400">No order controls</li>
+        </ul>
+      </section>
+
+      <section
+        class="rounded-xl border border-dashed border-slate-600/80 bg-slate-950/50 px-3 py-3 text-xs text-slate-400"
+        data-market-v0-orderbook-placeholder="true"
+        aria-label="Price ladder placeholder (read-only)"
+      >
+        <p class="font-semibold text-slate-200 uppercase tracking-wide text-[10px] mb-1.5">
+          Price ladder · order book slice
+        </p>
+        <p class="m-0 leading-relaxed">
+          Display-only placeholder — read-only IA target. Bid/Ask ladder wiring deferred (depth/offline display only elsewhere). No broker or exchange interaction.
+        </p>
+      </section>
+
+      <section
+        class="rounded-xl border border-dashed border-slate-600/80 bg-slate-950/50 px-3 py-3 text-xs text-slate-400"
+        data-market-v0-depth-chart-placeholder="true"
+        aria-label="Depth chart placeholder (read-only)"
+      >
+        <p class="font-semibold text-slate-200 uppercase tracking-wide text-[10px] mb-1.5">
+          Depth chart (cumulative)
+        </p>
+        <p class="m-0 leading-relaxed">
+          Read-only placeholder — cumulative visualization deferred. SSR depth summary remains the canonical diagnostic strip below.
+        </p>
+      </section>
+
+      <section
+        id="market-v0-depth-ssr"
+        aria-label="Market depth read-model (SSR, offline or disabled)"
+        class="rounded-xl border border-slate-700/70 bg-slate-900/55 px-4 py-3 text-xs text-slate-300"
+        data-market-depth-panel="true"
+        data-market-depth-status="{{ market_depth.display_status }}"
+        {% if market_depth.readmodel_id %}
+        data-market-depth-readmodel-id="{{ market_depth.readmodel_id }}"
+        {% endif %}
+      >
+        <p class="font-semibold text-slate-200/95 tracking-wide uppercase text-[11px] mb-1.5">
+          Market Depth (read-only)
+        </p>
+        <p class="leading-relaxed text-slate-300/90 m-0" data-market-depth-summary="true">
+          {{ market_depth.summary_line|e }}
+        </p>
+        <p class="mt-1.5 text-[11px] text-slate-500 m-0">
+          Depth/offline display only — SSR only; keine Browser-Abfrage der Depth-JSON-Route; keine Orders oder Ausführung.
+        </p>
+      </section>
+
+      <section
+        class="rounded-xl border border-slate-700/60 bg-slate-900/50 px-3 py-3 text-xs text-slate-400"
+        data-market-v0-status-panel="true"
+        aria-label="Market diagnostic status (read-only)"
+      >
+        <p class="font-semibold text-slate-200 uppercase tracking-wide text-[10px] mb-1.5">
+          Status · diagnostics
+        </p>
+        <p class="m-0 leading-relaxed">
+          Snapshot at page load — non-authorizing. No polling, no auto-refresh, no Live authorization. See chart block for render state.
+        </p>
+      </section>
+    </aside>
+  </div>
 
   <script type="application/json" id="market-v0-payload">{{ payload | tojson }}</script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -112,6 +112,25 @@ def test_market_dashboard_readonly_banner_markers(client: TestClient) -> None:
     assert 'data-market-non-authorizing="true"' in market_html
 
 
+def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> None:
+    """Read-only IA shell on GET /market: stable markers, no order-affordance attributes."""
+    market_html = _html(client, "/market")
+
+    assert 'data-market-v0-pro-shell="true"' in market_html
+    assert 'data-market-v0-pro-grid="true"' in market_html
+    assert 'data-market-v0-chart-panel="true"' in market_html
+    assert 'data-market-v0-orderbook-placeholder="true"' in market_html
+    assert 'data-market-v0-depth-chart-placeholder="true"' in market_html
+    assert 'data-market-v0-pro-boundary="true"' in market_html
+    assert 'data-market-v0-status-panel="true"' in market_html
+
+    lowered = market_html.lower()
+    assert "place order" not in lowered
+    assert "data-order-form" not in lowered
+    assert "data-order-submit" not in lowered
+    assert "market-v0-order-form" not in lowered
+
+
 def test_market_dashboard_forms_do_not_target_order_or_live_paths(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds the first Market Dashboard visual implementation slice after the merged Visual Contract v0.

This PR introduces a Kraken-like information-architecture panel shell for the existing `/market` route while preserving the dashboard as read-only and non-authorizing.

## Scope

Changed files:

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

No changes to:

- `src/**`
- `docs/**`
- `config/**`
- `.github/**`
- runtime/scheduler/paper/testnet/live paths
- broker/exchange/order paths
- Master V2 / Double Play trading logic

## What changed

The `/market` template now exposes stable, testable visual structure markers:

- `data-market-v0-pro-shell`
- `data-market-v0-pro-grid`
- `data-market-v0-chart-panel`
- `data-market-v0-pro-boundary`
- `data-market-v0-orderbook-placeholder`
- `data-market-v0-depth-chart-placeholder`
- `data-market-v0-status-panel`

The existing SSR Market Depth block remains present and read-only.

The new structure test verifies the shell markers and guards against order UI markers such as:

- `data-order-form`
- `data-order-submit`
- `market-v0-order-form`
- `Place order`

## Validation

Passed before push:

```text
uv run pytest tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q
# 18 passed

uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
uv run ruff format --check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
git diff --check
```
