### PR TITLE
feat(webui): render market v0 top depth levels read-only

### DIFF
--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 # Aligniert mit scripts/_shared_forward_args.OHLCV_TIMEFRAME_CHOICES / Kraken-ccxt-Übliches
 MARKET_TIMEFRAMES: tuple[str, ...] = ("1m", "5m", "15m", "1h", "4h", "1d")
 MAX_OHLCV_LIMIT = 720
+MARKET_DEPTH_SSR_TOP_LEVELS = 8
 DEFAULT_SYMBOL = "BTC/USD"
 DEFAULT_TIMEFRAME = "1h"
 DEFAULT_LIMIT = 120
@@ -113,6 +114,57 @@ def load_ohlcv_dataframe(
     return df, meta
 
 
+def _sanitize_depth_level_item(item: object) -> Dict[str, str] | None:
+    """Normalize a bid/ask level for template display only (strings, JSON-safe subset)."""
+
+    if not isinstance(item, dict):
+        return None
+
+    raw_price = item.get("price")
+    raw_size = item.get("size")
+    if raw_price is None and raw_size is None:
+        return None
+
+    price = str(raw_price).strip()
+    size = str(raw_size).strip()
+    row: Dict[str, str] = {"price": price, "size": size}
+    if "notional" in item and item["notional"] is not None:
+        row["notional"] = str(item["notional"]).strip()
+    return row
+
+
+def _top_depth_level_rows(
+    depth_obj: Any, *, limit: int
+) -> tuple[List[Dict[str, str]], List[Dict[str, str]]]:
+    """Return sanitized top-N bids/asks from offline depth envelope (deterministic slicing only)."""
+
+    if not isinstance(depth_obj, dict) or limit <= 0:
+        return [], []
+
+    bids_out: List[Dict[str, str]] = []
+    asks_out: List[Dict[str, str]] = []
+
+    raw_bids = depth_obj.get("bids")
+    if isinstance(raw_bids, list):
+        for it in raw_bids:
+            if len(bids_out) >= limit:
+                break
+            row = _sanitize_depth_level_item(it)
+            if row is not None and (row["price"] or row["size"]):
+                bids_out.append(row)
+
+    raw_asks = depth_obj.get("asks")
+    if isinstance(raw_asks, list):
+        for it in raw_asks:
+            if len(asks_out) >= limit:
+                break
+            row = _sanitize_depth_level_item(it)
+            if row is not None and (row["price"] or row["size"]):
+                asks_out.append(row)
+
+    return bids_out, asks_out
+
+
 def dataframe_to_bars(df: pd.DataFrame) -> List[Dict[str, Any]]:
     """Serialisiert DataFrame mit open/high/low/close/volume in JSON-Bar-Objekte."""
     bars: List[Dict[str, Any]] = []
@@ -134,16 +186,29 @@ def dataframe_to_bars(df: pd.DataFrame) -> List[Dict[str, Any]]:
 def build_market_depth_display_context() -> Dict[str, Any]:
     """SSR-only snapshot for templates: tuple from helper, unchanged semantics."""
 
+    top_limit = MARKET_DEPTH_SSR_TOP_LEVELS
+
     depth_http_status, depth_payload = market_depth_json_payload_v0()
     readmodel_id = str(depth_payload.get("readmodel_id", ""))
+
+    top_bids: List[Dict[str, str]] = []
+    top_asks: List[Dict[str, str]] = []
+    summary_line = ""
+
     if depth_http_status == 200:
         display_status = "ok"
         depth_obj = depth_payload.get("depth") or {}
-        levels = depth_obj.get("levels_returned") or {}
+        levels = (
+            depth_obj.get("levels_returned")
+            if isinstance(depth_obj.get("levels_returned"), dict)
+            else {}
+        )
         bids_n = levels.get("bids", "—")
         asks_n = levels.get("asks", "—")
         sym = depth_payload.get("symbol", "")
         summary_line = f"{sym} — bids {bids_n}, asks {asks_n} (offline bundle, read-only display)"
+        if isinstance(depth_obj, dict):
+            top_bids, top_asks = _top_depth_level_rows(depth_obj, limit=top_limit)
     else:
         display_status = str(depth_payload.get("runtime_source_status", "unavailable"))
         warnings = depth_payload.get("warnings")
@@ -151,11 +216,18 @@ def build_market_depth_display_context() -> Dict[str, Any]:
             summary_line = str(warnings[0])
         else:
             summary_line = str(depth_payload.get("stale_reason", display_status))
+
+    has_depth_levels = len(top_bids) > 0 or len(top_asks) > 0
+
     return {
         "depth_http_status": depth_http_status,
         "display_status": display_status,
         "readmodel_id": readmodel_id,
         "summary_line": summary_line,
+        "top_bids": top_bids,
+        "top_asks": top_asks,
+        "top_levels_limit": top_limit,
+        "has_depth_levels": has_depth_levels,
     }
 
 

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -256,14 +256,83 @@
       <section
         class="rounded-xl border border-dashed border-slate-600/80 bg-slate-950/50 px-3 py-3 text-xs text-slate-400"
         data-market-v0-orderbook-placeholder="true"
-        aria-label="Price ladder placeholder (read-only)"
+        aria-label="Price ladder (read-only)"
       >
         <p class="font-semibold text-slate-200 uppercase tracking-wide text-[10px] mb-1.5">
           Price ladder · order book slice
         </p>
-        <p class="m-0 leading-relaxed">
-          Display-only placeholder — read-only IA target. Bid/Ask ladder wiring deferred (depth/offline display only elsewhere). No broker or exchange interaction.
+        <p class="mt-0 mb-3 leading-relaxed text-[11px] text-slate-500">
+          Read-only · offline depth bundle · Top&nbsp;{{ market_depth.top_levels_limit }} levels · no order controls.
         </p>
+        <div
+          data-market-v0-orderbook-topn="true"
+          {% if market_depth.has_depth_levels %}
+          data-market-v0-orderbook-has-levels="true"
+          {% else %}
+          data-market-v0-orderbook-has-levels="false"
+          {% endif %}
+        >
+          {% if market_depth.has_depth_levels %}
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-1">
+            <div
+              class="rounded-lg border border-slate-700/70 bg-slate-900/40 overflow-hidden"
+              data-market-v0-orderbook-bids="true"
+            >
+              <p class="text-[10px] font-semibold uppercase tracking-wide text-emerald-300/90 px-2 py-1.5 border-b border-slate-700/60 bg-slate-950/50">
+                Levels · bid-side (display only)
+              </p>
+              <table class="w-full text-left font-mono text-[11px] text-slate-300">
+                <thead class="text-slate-500 border-b border-slate-700/50">
+                  <tr>
+                    <th class="px-2 py-1 font-normal">Price</th>
+                    <th class="px-2 py-1 font-normal">Size</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in market_depth.top_bids %}
+                  <tr class="border-b border-slate-800/80 last:border-b-0">
+                    <td class="px-2 py-0.5">{{ row.price|e }}</td>
+                    <td class="px-2 py-0.5 text-slate-400">{{ row.size|e }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            <div
+              class="rounded-lg border border-slate-700/70 bg-slate-900/40 overflow-hidden"
+              data-market-v0-orderbook-asks="true"
+            >
+              <p class="text-[10px] font-semibold uppercase tracking-wide text-rose-300/90 px-2 py-1.5 border-b border-slate-700/60 bg-slate-950/50">
+                Levels · ask-side (display only)
+              </p>
+              <table class="w-full text-left font-mono text-[11px] text-slate-300">
+                <thead class="text-slate-500 border-b border-slate-700/50">
+                  <tr>
+                    <th class="px-2 py-1 font-normal">Price</th>
+                    <th class="px-2 py-1 font-normal">Size</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in market_depth.top_asks %}
+                  <tr class="border-b border-slate-800/80 last:border-b-0">
+                    <td class="px-2 py-0.5">{{ row.price|e }}</td>
+                    <td class="px-2 py-0.5 text-slate-400">{{ row.size|e }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          {% else %}
+          <div
+            class="rounded-lg border border-slate-800/70 bg-slate-950/40 px-2 py-2 text-[11px] text-slate-500 leading-relaxed"
+            data-market-v0-orderbook-empty="true"
+            role="note"
+          >
+            No ladder rows · depth disabled, unconfigured, or empty SSR snapshot · display-only diagnostics.
+          </div>
+          {% endif %}
+        </div>
       </section>
 
       <section

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -115,6 +115,9 @@ class TestMarketSurfaceHtml:
         assert "Chart bereit — read-only OHLCV-Anzeige." in body
         assert 'data-market-depth-panel="true"' in body
         assert 'data-market-depth-status="disabled"' in body
+        assert 'data-market-v0-orderbook-topn="true"' in body
+        assert 'data-market-v0-orderbook-has-levels="false"' in body
+        assert 'data-market-v0-orderbook-empty="true"' in body
 
     def test_market_page_depth_ssr_forbids_client_depth_route_and_xhr(
         self,
@@ -173,6 +176,8 @@ class TestMarketSurfaceHtml:
         assert resp.status_code == 200
         body = resp.text
         assert 'data-market-depth-status="builder_error"' in body
+        assert 'data-market-v0-orderbook-has-levels="false"' in body
+        assert 'data-market-v0-orderbook-empty="true"' in body
         assert "/api/market/depth" not in body
 
     def test_market_depth_ssr_ok_branch_uses_display_status_ok(
@@ -198,7 +203,40 @@ class TestMarketSurfaceHtml:
         assert resp.status_code == 200
         body = resp.text
         assert 'data-market-depth-status="ok"' in body
+        assert 'data-market-v0-orderbook-has-levels="false"' in body
+        assert 'data-market-v0-orderbook-empty="true"' in body
         assert "/api/market/depth" not in body
+
+    def test_market_dashboard_orderbook_topn_ssr_with_fixture_bundle(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        bundle = (
+            Path(__file__).resolve().parents[1]
+            / "tests"
+            / "fixtures"
+            / "market_depth_readmodel_v0"
+            / "complete_minimal"
+        )
+        monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+        monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(bundle.resolve()))
+        monkeypatch.setenv("PEAK_TRADE_FIXED_GENERATED_AT_UTC", "2026-05-02T12:00:00+00:00")
+        client = TestClient(create_app())
+
+        resp = client.get("/market", params={"source": "dummy", "limit": 20})
+        assert resp.status_code == 200
+        body = resp.text
+        assert 'data-market-v0-orderbook-topn="true"' in body
+        assert 'data-market-v0-orderbook-has-levels="true"' in body
+        assert 'data-market-v0-orderbook-bids="true"' in body
+        assert 'data-market-v0-orderbook-asks="true"' in body
+        assert 'data-market-v0-orderbook-empty="true"' not in body
+        assert "63010" in body
+        assert "63020" in body
+        assert 'data-market-depth-status="ok"' in body
+        assert "/api/market/depth" not in body
+        assert "fetch(" not in body
+        assert "XMLHttpRequest" not in body
 
     def test_market_html_invalid_timeframe_422(self, client: TestClient) -> None:
         r = client.get("/market", params={"source": "dummy", "timeframe": "bad"})
@@ -239,3 +277,4 @@ def test_market_v0_template_kraken_banner_markers_in_source() -> None:
     assert "Chart-Daten konnten nicht gerendert werden; keine Trading-Aktion verfügbar." in txt
     assert 'data-market-depth-panel="true"' in txt
     assert "data-market-depth-status" in txt
+    assert 'data-market-v0-orderbook-topn="true"' in txt

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -124,6 +124,10 @@ def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> No
     assert 'data-market-v0-pro-boundary="true"' in market_html
     assert 'data-market-v0-status-panel="true"' in market_html
 
+    assert 'data-market-v0-orderbook-topn="true"' in market_html
+    assert 'data-market-v0-orderbook-has-levels="false"' in market_html
+    assert 'data-market-v0-orderbook-empty="true"' in market_html
+
     lowered = market_html.lower()
     assert "place order" not in lowered
     assert "data-order-form" not in lowered


### PR DESCRIPTION
## Summary

Renders read-only Top-N Market Depth levels on the existing `/market` dashboard.

This PR extends the existing SSR display context to expose a small deterministic Top-N bid/ask subset from the already-existing offline Market Depth payload, then renders it inside the previously merged Market v0 pro panel shell.

## Scope

Changed files:

- `src/webui/market_surface.py`
- `templates/peak_trade_dashboard/market_v0.html`
- `tests/test_market_surface_api.py`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

No changes to:

- `src/execution/**`
- `src/risk_layer/**`
- `src/strategies/**`
- `docs/**`
- `config/**`
- `.github/**`
- `out/**`
- runtime/scheduler/paper/testnet/live paths
- broker/exchange/order paths
- Master V2 / Double Play trading logic

## What changed

`build_market_depth_display_context()` now exposes deterministic read-only display keys:

- `top_bids`
- `top_asks`
- `top_levels_limit`
- `has_depth_levels`

The `/market` template now renders stable structure markers:

- `data-market-v0-orderbook-topn`
- `data-market-v0-orderbook-has-levels`
- `data-market-v0-orderbook-bids`
- `data-market-v0-orderbook-asks`
- `data-market-v0-orderbook-empty`

Disabled/unconfigured states remain diagnostic and render an empty/read-only state.

## Validation

Passed before push:

```text
uv run pytest tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py tests/webui/test_market_depth_api_v0.py tests/webui/test_market_depth_readmodel_v0.py -q
# 37 passed

uv run ruff check src/webui/market_surface.py tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
uv run ruff format --check src/webui/market_surface.py tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
git diff --check
```
