### PR TITLE
webui(market-v0): improve read-only visual dashboard encoding

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -17,21 +17,36 @@
 >
   <section
     aria-label="Read-only market constraints"
-    class="rounded-xl border border-slate-700/60 bg-slate-900/50 px-4 py-3 text-xs text-slate-300"
+    class="rounded-xl border border-slate-700/60 bg-slate-900/55 px-3 py-2.5 sm:px-4"
     data-market-v1-readonly-banner="true"
   >
-    <ul class="m-0 p-0 list-none grid gap-x-4 gap-y-1 sm:grid-cols-2 lg:grid-cols-5">
-      <li>Read-only market display</li>
-      <li>No orders</li>
-      <li>No strategy authority</li>
-      <li>No Live/Testnet action</li>
-      <li>No Risk/KillSwitch override</li>
+    <ul class="m-0 p-0 list-none flex flex-wrap gap-2">
+      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+        <span class="h-1.5 w-1.5 rounded-full bg-emerald-400/90 shrink-0" aria-hidden="true"></span>
+        Read-only market display
+      </li>
+      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+        <span class="h-1.5 w-1.5 rounded-full bg-slate-500 shrink-0" aria-hidden="true"></span>
+        No orders
+      </li>
+      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+        <span class="h-1.5 w-1.5 rounded-full bg-slate-500 shrink-0" aria-hidden="true"></span>
+        No strategy authority
+      </li>
+      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+        <span class="h-1.5 w-1.5 rounded-full bg-amber-400/85 shrink-0" aria-hidden="true"></span>
+        No Live/Testnet action
+      </li>
+      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+        <span class="h-1.5 w-1.5 rounded-full bg-rose-400/80 shrink-0" aria-hidden="true"></span>
+        No Risk/KillSwitch override
+      </li>
     </ul>
   </section>
 
   <section
     aria-label="Read-only und Datenquelle"
-    class="rounded-xl border border-amber-900/40 bg-amber-950/25 px-4 py-3 text-xs text-amber-100/95"
+    class="rounded-xl border border-amber-900/45 bg-gradient-to-br from-amber-950/35 via-slate-950/35 to-slate-950/20 px-3 py-2.5 sm:px-4 text-xs text-amber-100/95"
     data-market-safety-banner="true"
     {% if query.source == 'dummy' %}
     data-market-source-kind="dummy-offline-synthetic"
@@ -39,18 +54,24 @@
     data-market-source-kind="kraken-public-ohlcv-network"
     {% endif %}
   >
-    <p class="font-semibold text-amber-200/95 tracking-wide uppercase text-[11px] mb-1.5">
-      Market Surface v0 · read-only · non-authorizing
-    </p>
+    <div class="flex flex-wrap items-center justify-between gap-2 mb-2">
+      <p class="font-semibold text-amber-200/95 tracking-wide uppercase text-[11px] m-0">
+        Market Surface v0 · read-only · non-authorizing
+      </p>
+      <div class="flex flex-wrap gap-1.5">
+        <span class="inline-flex items-center rounded-md border border-amber-800/50 bg-amber-950/45 px-2 py-0.5 text-[10px] font-semibold text-amber-100/90 tabular-nums">SSR only</span>
+        <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-950/55 px-2 py-0.5 text-[10px] font-semibold text-slate-200/90 tabular-nums">No order controls</span>
+      </div>
+    </div>
     {% if query.source == 'dummy' %}
-    <p class="leading-relaxed text-amber-100/90">
-      <span class="text-sky-200/95 font-medium">Dummy / Offline / synthetisch</span>
+    <p class="leading-snug text-amber-100/90 m-0 text-[11px]">
+      <span class="text-sky-200/95 font-semibold">Dummy / Offline / synthetisch</span>
       — keine Orders, kein Testnet, kein Live, keine Paper-Aktivierung.
       Keine Capital-/Scope-Freigabe, kein Risk-/KillSwitch-Bypass, keine Ausführungsautorität.
     </p>
     {% elif query.source == 'kraken' %}
-    <p class="leading-relaxed text-amber-100/90">
-      <span class="text-sky-200/95 font-medium">Öffentliche OHLCV über Netzwerk (Kraken)</span>
+    <p class="leading-snug text-amber-100/90 m-0 text-[11px]">
+      <span class="text-sky-200/95 font-semibold">Öffentliche OHLCV über Netzwerk (Kraken)</span>
       — rein anzeigend (read-only), non-authorizing, <strong class="font-medium text-amber-200">kein Nachweis von Futures‑Readiness</strong>.
       Keine Orders, kein Testnet, kein Live.
     </p>
@@ -63,21 +84,29 @@
     data-market-v0-pro-grid="true"
   >
     <div class="xl:col-span-8 space-y-6 min-w-0" data-market-v0-chart-panel="true">
-  <header class="bg-gradient-to-r from-slate-900/85 to-slate-900/45 rounded-xl border border-slate-800/90 p-4 sm:p-5 shadow-sm shadow-black/20">
-    <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
-      <div>
-        <p class="text-xs uppercase tracking-wide text-slate-500 mb-1">Market Surface</p>
-        <h1 class="text-2xl font-bold text-slate-100">v1 Shell · PeakTrade Dashboard (read-only)</h1>
-        <p class="text-sm text-slate-400 mt-2 max-w-2xl">
-          READ-ONLY · Keine Orders · Öffentliche OHLCV (Kraken) oder offline Dummy-Daten.
-          Chart: Schlusskurs-Linie (V0 — bewusst minimal, kein Candlestick-Plugin).
+  <header class="relative overflow-hidden rounded-xl border border-sky-900/35 bg-gradient-to-br from-slate-900/95 via-slate-900/80 to-slate-950/90 p-4 sm:p-6 shadow-lg shadow-black/25 ring-1 ring-sky-900/20">
+    <div class="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-[radial-gradient(ellipse_at_top,_rgba(56,189,248,0.12),_transparent_55%)]" aria-hidden="true"></div>
+    <div class="relative flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+      <div class="min-w-0 space-y-2">
+        <p class="text-[11px] uppercase tracking-[0.14em] text-sky-400/80 font-semibold m-0">Market Surface</p>
+        <h1 class="text-2xl sm:text-3xl font-bold text-slate-50 tracking-tight m-0">
+          Read-only cockpit · <span class="text-sky-300/95">Close-line chart</span>
+        </h1>
+        <p class="text-sm text-slate-400 max-w-2xl m-0 leading-snug">
+          Keine Orders · nur Anzeige · öffentliche OHLCV (Kraken) oder Dummy.
+          Fokus: Kursverlauf — kein Candlestick-Plugin in v0.
         </p>
+        <div class="flex flex-wrap gap-2 pt-1">
+          <span class="inline-flex items-center rounded-md border border-emerald-900/45 bg-emerald-950/35 px-2 py-0.5 text-[10px] font-semibold text-emerald-200/90 tabular-nums">Read-only</span>
+          <span class="inline-flex items-center rounded-md border border-sky-900/45 bg-sky-950/30 px-2 py-0.5 text-[10px] font-semibold text-sky-200/90 tabular-nums">Non-authorizing</span>
+          <span class="inline-flex items-center rounded-md border border-slate-700/80 bg-slate-950/60 px-2 py-0.5 text-[10px] font-semibold text-slate-300/90 tabular-nums">SSR ladder</span>
+        </div>
       </div>
-      <div class="flex flex-wrap gap-2">
-        <a href="/" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-800 hover:bg-slate-700 text-slate-300">
+      <div class="flex flex-wrap gap-2 shrink-0">
+        <a href="/" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-800/90 hover:bg-slate-700 text-slate-200 border border-slate-700/80">
           ← Dashboard
         </a>
-        <a href="/r_and_d/charts" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-slate-800 hover:bg-slate-700 text-slate-300">
+        <a href="/r_and_d/charts" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-slate-800/90 hover:bg-slate-700 text-slate-200 border border-slate-700/80">
           R&amp;D Charts
         </a>
       </div>
@@ -86,48 +115,51 @@
 
   <section
     aria-label="Market query context"
-    class="bg-slate-900/75 rounded-xl border border-slate-800 p-3 sm:p-4"
+    class="bg-slate-900/80 rounded-xl border border-slate-800/90 p-3 sm:p-4 ring-1 ring-slate-800/60"
     data-market-v1-context="true"
   >
-    <h2 class="text-xs sm:text-sm font-medium text-slate-200 mb-2 tracking-tight">PeakTrade Market Dashboard · context</h2>
+    <div class="flex flex-wrap items-baseline justify-between gap-2 mb-2.5">
+      <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">PeakTrade Market Dashboard · context</h2>
+      <span class="text-[10px] font-medium uppercase tracking-wide text-slate-500">Snapshot · keine Live-Autorisierung</span>
+    </div>
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 sm:gap-2.5 text-[11px]">
       <div
-        class="rounded-md border border-slate-800/90 bg-slate-950/55 px-2.5 py-1.5"
+        class="rounded-lg border border-slate-800/90 bg-slate-950/60 px-2.5 py-2 shadow-sm shadow-black/15"
         data-market-v1-stat-card="true"
       >
         <span class="text-slate-500 block mb-1">Source</span>
         <span class="font-mono text-sky-300/95">{{ query.source }}</span>
       </div>
       <div
-        class="rounded-md border border-slate-800/90 bg-slate-950/55 px-2.5 py-1.5"
+        class="rounded-lg border border-slate-800/90 bg-slate-950/60 px-2.5 py-2 shadow-sm shadow-black/15"
         data-market-v1-stat-card="true"
       >
         <span class="text-slate-500 block mb-1">Symbol</span>
         <span class="font-mono text-slate-200">{{ query.symbol }}</span>
       </div>
       <div
-        class="rounded-md border border-slate-800/90 bg-slate-950/55 px-2.5 py-1.5"
+        class="rounded-lg border border-slate-800/90 bg-slate-950/60 px-2.5 py-2 shadow-sm shadow-black/15"
         data-market-v1-stat-card="true"
       >
         <span class="text-slate-500 block mb-1">Timeframe</span>
         <span class="font-mono text-slate-200">{{ query.timeframe }}</span>
       </div>
       <div
-        class="rounded-md border border-slate-800/90 bg-slate-950/55 px-2.5 py-1.5"
+        class="rounded-lg border border-slate-800/90 bg-slate-950/60 px-2.5 py-2 shadow-sm shadow-black/15"
         data-market-v1-stat-card="true"
       >
         <span class="text-slate-500 block mb-1">Limit</span>
         <span class="font-mono text-slate-200">{{ query.limit }}</span>
       </div>
       <div
-        class="rounded-md border border-slate-800/90 bg-slate-950/55 px-2.5 py-1.5"
+        class="rounded-lg border border-slate-800/90 bg-slate-950/60 px-2.5 py-2 shadow-sm shadow-black/15"
         data-market-v1-stat-card="true"
       >
         <span class="text-slate-500 block mb-1">Bars returned</span>
         <span class="font-mono text-slate-200">{{ payload.bars_returned }}</span>
       </div>
       <div
-        class="rounded-md border border-slate-800/90 bg-slate-950/55 px-2.5 py-1.5"
+        class="rounded-lg border border-slate-800/90 bg-slate-950/60 px-2.5 py-2 shadow-sm shadow-black/15"
         data-market-v1-stat-card="true"
       >
         <span class="text-slate-500 block mb-1">Chart hint (SSR)</span>
@@ -138,19 +170,19 @@
         </span>
       </div>
     </div>
-    <p class="mt-3 text-[11px] text-slate-500 leading-relaxed">
-      Kraken verwendet timeframe; Dummy bleibt synthetisch 1h —
-      öffentliche Netzwerk-OHLCV: <span class="text-sky-400 font-mono">?source=kraken</span>
+    <p class="mt-2.5 text-[10px] text-slate-500 leading-snug m-0">
+      Kraken nutzt <span class="font-mono text-slate-400">timeframe</span>; Dummy bleibt 1h synthetisch — öffentliche OHLCV:
+      <span class="text-sky-400 font-mono">?source=kraken</span>
     </p>
   </section>
 
   <section
     aria-label="OHLCV API reference"
-    class="rounded-lg border border-dashed border-slate-700/70 bg-slate-950/40 px-4 py-3 text-xs text-slate-400"
+    class="rounded-lg border border-dashed border-slate-700/70 bg-slate-950/45 px-3 py-2.5 text-[11px] text-slate-400 flex flex-wrap items-center justify-between gap-2"
     data-market-v1-api-reference="true"
   >
-    <p class="font-medium text-slate-300 mb-1">Read-only JSON (gleiche Query wie diese Seite)</p>
-    <p class="font-mono leading-relaxed break-all">
+    <p class="font-semibold text-slate-300 m-0">Read-only JSON</p>
+    <p class="font-mono leading-snug break-all m-0 text-right min-w-[12rem] flex-1">
       <a
         href="/api/market/ohlcv?source={{ query.source }}&amp;symbol={{ query.symbol | replace('/', '%2F') }}&amp;timeframe={{ query.timeframe }}&amp;limit={{ query.limit }}"
         class="text-sky-400 hover:text-sky-300 underline underline-offset-2"
@@ -160,24 +192,27 @@
 
   <section
     aria-label="Close-Preis"
-    class="bg-slate-900/60 rounded-xl border border-slate-800 ring-1 ring-slate-700/50 shadow-lg shadow-black/20 p-4 min-h-[28rem]"
+    class="bg-slate-900/65 rounded-xl border border-slate-800 ring-2 ring-sky-900/15 shadow-xl shadow-black/30 p-4 sm:p-5 min-h-[30rem]"
     data-chart="market-v0-close-line"
     data-market-v11-chart-diagnostics="true"
   >
-    <h2 class="text-sm font-medium text-slate-200 mb-3">Schlusskurs (Close)</h2>
+    <div class="flex flex-wrap items-end justify-between gap-2 mb-3">
+      <h2 class="text-base font-semibold text-slate-100 m-0 tracking-tight">Schlusskurs (Close)</h2>
+      <span class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Dominant panel · keine Order-UI</span>
+    </div>
 
     <div
-      class="mb-4 rounded-lg border border-slate-700/90 bg-slate-950/70 p-4 text-xs text-slate-300 space-y-2"
+      class="mb-3 rounded-lg border border-slate-700/90 bg-slate-950/75 p-3 sm:p-3.5 text-xs text-slate-300"
       data-market-v11-diagnostics-inner="true"
     >
-      <h3 class="text-sm font-semibold text-slate-100 tracking-tight">Chart diagnostics</h3>
-      <p class="text-[11px] text-slate-400 leading-relaxed m-0">
+      <h3 class="text-sm font-semibold text-slate-100 tracking-tight m-0 mb-2">Chart diagnostics</h3>
+      <p class="text-[11px] text-slate-400 leading-snug m-0 mb-3">
         No backend/API/provider change. Chart.js loads from CDN; if blank:
         <span class="text-rose-400/95 font-medium">Chart library missing or blocked</span>
         oder
         <span class="text-rose-400/95 font-medium">Chart render error</span>.
       </p>
-      <dl class="grid grid-cols-1 sm:grid-cols-3 gap-4 font-mono text-[11px] mt-3">
+      <dl class="grid grid-cols-1 sm:grid-cols-3 gap-3 font-mono text-[11px]">
         <div>
           <dt class="text-slate-500 uppercase tracking-wide text-[10px] mb-1" data-market-v11-chart-library-status="true">
             Chart.js status
@@ -204,7 +239,7 @@
       data-market-v11-render-fallback="true"
       data-market-v11-fallback-mode="{% if payload.bars_returned == 0 %}empty-ssr{% else %}client-alert{% endif %}"
       role="alert"
-      class="mb-4 rounded-xl border-2 px-4 py-4 {% if payload.bars_returned == 0 %}block border-amber-500/80 bg-amber-950/50 text-amber-50{% else %}hidden border-rose-600/85 bg-rose-950/40 text-rose-50{% endif %}"
+      class="mb-3 rounded-xl border-2 px-4 py-3 {% if payload.bars_returned == 0 %}block border-amber-500/80 bg-amber-950/50 text-amber-50{% else %}hidden border-rose-600/85 bg-rose-950/40 text-rose-50{% endif %}"
       {% if payload.bars_returned != 0 %}aria-hidden="true"{% endif %}
     >
       {% if payload.bars_returned == 0 %}
@@ -231,7 +266,7 @@
       Chart bereit — read-only OHLCV-Anzeige.
       {% endif %}
     </div>
-    <div class="relative min-h-[20rem] h-96 w-full rounded-lg border border-slate-700/70 bg-slate-950/30">
+    <div class="relative min-h-[22rem] h-[28rem] sm:h-[30rem] w-full rounded-xl border border-slate-700/70 bg-gradient-to-b from-slate-950/40 to-slate-950/70 shadow-inner shadow-black/30">
       <canvas id="chart-market-v0-close" class="block w-full h-full"></canvas>
     </div>
   </section>
@@ -242,14 +277,14 @@
       aria-label="Read-only market side panels (no order controls)"
     >
       <section
-        class="rounded-lg border border-slate-600/50 bg-slate-900/75 px-2.5 py-2 text-[10px] text-slate-300 leading-tight"
+        class="rounded-lg border border-slate-600/50 bg-gradient-to-r from-slate-900/80 to-slate-950/70 px-2.5 py-2 text-[10px] text-slate-300 leading-tight"
         data-market-v0-pro-boundary="true"
         aria-label="Read-only boundaries"
       >
-        <ul class="m-0 p-0 list-none flex flex-wrap gap-x-3 gap-y-1 items-center">
-          <li class="text-emerald-300/95 font-semibold uppercase tracking-wide">Read-only</li>
-          <li class="text-sky-300/90 font-semibold uppercase tracking-wide">Non-authorizing</li>
-          <li class="text-slate-400 font-medium">No order controls · offline depth · Top levels</li>
+        <ul class="m-0 p-0 list-none flex flex-wrap gap-2 items-center">
+          <li class="inline-flex items-center gap-1 rounded-full border border-emerald-900/45 bg-emerald-950/35 px-2 py-0.5 text-emerald-200/95 font-semibold uppercase tracking-wide">Read-only</li>
+          <li class="inline-flex items-center gap-1 rounded-full border border-sky-900/45 bg-sky-950/35 px-2 py-0.5 text-sky-200/95 font-semibold uppercase tracking-wide">Non-authorizing</li>
+          <li class="inline-flex items-center gap-1 rounded-full border border-slate-700/70 bg-slate-950/55 px-2 py-0.5 text-slate-300/95 font-medium">No order controls · offline depth · Top levels</li>
         </ul>
       </section>
 
@@ -273,65 +308,80 @@
           {% endif %}
         >
           {% if market_depth.has_depth_levels %}
+          {% set ladder_ns = namespace(max_bid=0.0, max_ask=0.0) %}
+          {% for row in market_depth.top_bids %}
+            {% set _v = (row.size|string)|replace(',', '')|float(0) %}
+            {% if _v > ladder_ns.max_bid %}{% set ladder_ns.max_bid = _v %}{% endif %}
+          {% endfor %}
+          {% for row in market_depth.top_asks %}
+            {% set _v = (row.size|string)|replace(',', '')|float(0) %}
+            {% if _v > ladder_ns.max_ask %}{% set ladder_ns.max_ask = _v %}{% endif %}
+          {% endfor %}
+          {% set bid_scale = ladder_ns.max_bid if ladder_ns.max_bid > 0 else 1 %}
+          {% set ask_scale = ladder_ns.max_ask if ladder_ns.max_ask > 0 else 1 %}
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-2.5 mt-0.5">
             <div
-              class="rounded-md border border-slate-700/80 bg-slate-900/50 overflow-hidden flex flex-col min-h-0"
+              class="rounded-lg border border-emerald-900/35 bg-slate-900/55 overflow-hidden flex flex-col min-h-0 shadow-sm shadow-black/20"
               data-market-v0-orderbook-bids="true"
             >
-              <p class="text-[10px] font-semibold uppercase tracking-wide text-emerald-300/90 px-2 py-1 border-b border-slate-700/60 bg-slate-950/60 shrink-0">
-                Levels · bid-side (display only)
+              <p class="text-[10px] font-semibold uppercase tracking-wide text-emerald-300/90 px-2 py-1.5 border-b border-slate-700/60 bg-slate-950/70 shrink-0 flex items-center justify-between gap-2">
+                <span>Levels · bid-side (display only)</span>
+                <span class="text-[9px] font-medium normal-case text-slate-500">Horizontal bars = displayed size</span>
               </p>
-              <div class="max-h-[min(19rem,42vh)] overflow-y-auto overscroll-y-contain">
-                <table class="w-full text-left font-mono tabular-nums text-[10px] text-slate-300">
-                  <thead class="text-slate-500 border-b border-slate-700/50 bg-slate-950/80 sticky top-0 z-[1] backdrop-blur-[2px]">
-                    <tr>
-                      <th scope="col" class="px-2 py-1 font-medium text-left w-[36%]">Price</th>
-                      <th scope="col" class="px-2 py-1 font-medium text-right">Size</th>
-                      <th scope="col" class="px-2 py-1 font-medium text-right text-slate-500">Notional</th>
-                    </tr>
-                  </thead>
-                  <tbody>
+              <div class="max-h-[min(20rem,44vh)] overflow-y-auto overscroll-y-contain">
+                <div class="divide-y divide-slate-800/80">
                   {% for row in market_depth.top_bids %}
-                  <tr class="border-b border-slate-800/70 last:border-b-0 hover:bg-slate-800/25">
-                    <td class="px-2 py-0.5 align-middle text-slate-100">{{ row.price|e }}</td>
-                    <td class="px-2 py-0.5 align-middle text-right text-slate-400">{{ row.size|e }}</td>
-                    <td class="px-2 py-0.5 align-middle text-right text-slate-500 text-[9px]">
+                  {% set szv = (row.size|string)|replace(',', '')|float(0) %}
+                  {% set pct = (100.0 * szv / bid_scale) %}
+                  {% if pct > 100 %}{% set pct = 100.0 %}{% endif %}
+                  <div class="group grid grid-cols-[5.5rem_1fr_minmax(0,4rem)] gap-x-2 items-center px-2 py-1.5 hover:bg-slate-800/30 font-mono tabular-nums text-[10px] sm:text-[11px]">
+                    <div class="text-slate-100 font-medium truncate">{{ row.price|e }}</div>
+                    <div class="relative min-w-0 h-6 rounded-md bg-slate-950/75 border border-slate-800/80 overflow-hidden">
+                      <div
+                        class="absolute inset-y-0 left-0 rounded-md bg-emerald-400/25 border-r border-emerald-400/20"
+                        style="width: {{ pct|round(1) }}%; min-width: 6%;"
+                        aria-hidden="true"
+                      ></div>
+                      <span class="relative z-[1] flex h-full items-center justify-end pr-1.5 text-slate-200 tabular-nums">{{ row.size|e }}</span>
+                    </div>
+                    <div class="text-right text-slate-500 text-[9px] tabular-nums truncate">
                       {% if row.notional %}{{ row.notional|e }}{% else %}—{% endif %}
-                    </td>
-                  </tr>
+                    </div>
+                  </div>
                   {% endfor %}
-                  </tbody>
-                </table>
+                </div>
               </div>
             </div>
             <div
-              class="rounded-md border border-slate-700/80 bg-slate-900/50 overflow-hidden flex flex-col min-h-0"
+              class="rounded-lg border border-rose-900/35 bg-slate-900/55 overflow-hidden flex flex-col min-h-0 shadow-sm shadow-black/20"
               data-market-v0-orderbook-asks="true"
             >
-              <p class="text-[10px] font-semibold uppercase tracking-wide text-rose-300/90 px-2 py-1 border-b border-slate-700/60 bg-slate-950/60 shrink-0">
-                Levels · ask-side (display only)
+              <p class="text-[10px] font-semibold uppercase tracking-wide text-rose-300/90 px-2 py-1.5 border-b border-slate-700/60 bg-slate-950/70 shrink-0 flex items-center justify-between gap-2">
+                <span>Levels · ask-side (display only)</span>
+                <span class="text-[9px] font-medium normal-case text-slate-500">Horizontal bars = displayed size</span>
               </p>
-              <div class="max-h-[min(19rem,42vh)] overflow-y-auto overscroll-y-contain">
-                <table class="w-full text-left font-mono tabular-nums text-[10px] text-slate-300">
-                  <thead class="text-slate-500 border-b border-slate-700/50 bg-slate-950/80 sticky top-0 z-[1] backdrop-blur-[2px]">
-                    <tr>
-                      <th scope="col" class="px-2 py-1 font-medium text-left w-[36%]">Price</th>
-                      <th scope="col" class="px-2 py-1 font-medium text-right">Size</th>
-                      <th scope="col" class="px-2 py-1 font-medium text-right text-slate-500">Notional</th>
-                    </tr>
-                  </thead>
-                  <tbody>
+              <div class="max-h-[min(20rem,44vh)] overflow-y-auto overscroll-y-contain">
+                <div class="divide-y divide-slate-800/80">
                   {% for row in market_depth.top_asks %}
-                  <tr class="border-b border-slate-800/70 last:border-b-0 hover:bg-slate-800/25">
-                    <td class="px-2 py-0.5 align-middle text-slate-100">{{ row.price|e }}</td>
-                    <td class="px-2 py-0.5 align-middle text-right text-slate-400">{{ row.size|e }}</td>
-                    <td class="px-2 py-0.5 align-middle text-right text-slate-500 text-[9px]">
+                  {% set szv = (row.size|string)|replace(',', '')|float(0) %}
+                  {% set pct = (100.0 * szv / ask_scale) %}
+                  {% if pct > 100 %}{% set pct = 100.0 %}{% endif %}
+                  <div class="group grid grid-cols-[5.5rem_1fr_minmax(0,4rem)] gap-x-2 items-center px-2 py-1.5 hover:bg-slate-800/30 font-mono tabular-nums text-[10px] sm:text-[11px]">
+                    <div class="text-slate-100 font-medium truncate">{{ row.price|e }}</div>
+                    <div class="relative min-w-0 h-6 rounded-md bg-slate-950/75 border border-slate-800/80 overflow-hidden">
+                      <div
+                        class="absolute inset-y-0 left-0 rounded-md bg-rose-400/22 border-r border-rose-400/18"
+                        style="width: {{ pct|round(1) }}%; min-width: 6%;"
+                        aria-hidden="true"
+                      ></div>
+                      <span class="relative z-[1] flex h-full items-center justify-end pr-1.5 text-slate-200 tabular-nums">{{ row.size|e }}</span>
+                    </div>
+                    <div class="text-right text-slate-500 text-[9px] tabular-nums truncate">
                       {% if row.notional %}{{ row.notional|e }}{% else %}—{% endif %}
-                    </td>
-                  </tr>
+                    </div>
+                  </div>
                   {% endfor %}
-                  </tbody>
-                </table>
+                </div>
               </div>
             </div>
           </div>
@@ -351,15 +401,18 @@
       </section>
 
       <section
-        class="rounded-lg border border-dashed border-slate-600/70 bg-slate-950/50 px-2.5 py-2 text-[10px] text-slate-400"
+        class="rounded-lg border border-dashed border-slate-600/70 bg-slate-950/55 px-2.5 py-2.5 text-[10px] text-slate-400"
         data-market-v0-depth-chart-placeholder="true"
         aria-label="Depth chart placeholder (read-only)"
       >
-        <p class="font-semibold text-slate-200 uppercase tracking-wide mb-1 leading-snug">
-          Depth chart (cumulative)
-        </p>
+        <div class="flex flex-wrap items-start justify-between gap-2 mb-1.5">
+          <p class="font-semibold text-slate-200 uppercase tracking-wide leading-snug m-0">
+            Displayed top-level depth (static)
+          </p>
+          <span class="inline-flex items-center rounded border border-amber-900/50 bg-amber-950/40 px-1.5 py-0.5 text-[9px] font-semibold text-amber-100/90 tabular-nums">Not cumulative</span>
+        </div>
         <p class="m-0 leading-snug">
-          Read-only placeholder — cumulative visualization deferred. SSR depth summary remains the canonical diagnostic strip below.
+          Visual impression only from SSR Top-N levels — <strong class="font-semibold text-slate-200">not</strong> a full cumulative depth chart, <strong class="font-semibold text-slate-200">no</strong> live feed, <strong class="font-semibold text-slate-200">no</strong> polling. Canonical diagnostic strip remains the depth summary below.
         </p>
       </section>
 
@@ -385,15 +438,18 @@
       </section>
 
       <section
-        class="rounded-lg border border-slate-700/60 bg-slate-900/55 px-2.5 py-2 text-[10px] text-slate-400"
+        class="rounded-lg border border-slate-700/60 bg-slate-900/60 px-2.5 py-2 text-[10px] text-slate-400"
         data-market-v0-status-panel="true"
         aria-label="Market diagnostic status (read-only)"
       >
-        <p class="font-semibold text-slate-200 uppercase tracking-wide mb-1 leading-snug">
-          Status · diagnostics
-        </p>
-        <p class="m-0 leading-snug">
-          Snapshot at page load — non-authorizing. No polling, no auto-refresh, no Live authorization. See chart block for render state.
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <p class="font-semibold text-slate-200 uppercase tracking-wide m-0 leading-snug">
+            Status · diagnostics
+          </p>
+          <span class="inline-flex rounded border border-slate-700/80 bg-slate-950/60 px-1.5 py-0.5 text-[9px] font-semibold text-slate-400 tabular-nums">SSR snapshot</span>
+        </div>
+        <p class="m-0 mt-1.5 leading-snug text-slate-500">
+          Single load — non-authorizing. No polling, no auto-refresh, no Live authorization. Chart block owns render state.
         </p>
       </section>
     </aside>


### PR DESCRIPTION
## Summary

Improves the `/market` dashboard visual encoding while keeping the existing Market Dashboard read-only and non-authorizing.

This is a template-only redesign using existing SSR data and existing owners. It makes the dashboard less text-heavy and more visually understandable without adding new data, runtime behavior, polling, browser fetches, order controls, or trading authority.

## Scope

Changed file:

- `templates/peak_trade_dashboard/market_v0.html`

No changes to:

- `src/**`
- `tests/**`
- `docs/**`
- `config/**`
- `.github/**`
- `out/**`
- runtime/scheduler/paper/testnet/live paths
- broker/exchange/order paths
- Master V2 / Double Play trading logic

## What changed

- Clearer visual hierarchy for the `/market` pro shell
- More dominant chart/market area
- More compact context and safety areas
- Orderbook/Depth ladder rendered with stronger visual encoding
- Relative size bars from already-rendered SSR row values
- More explicit “displayed top-level only / not cumulative” depth labeling
- Preserves existing `data-market-v0-*` structure markers
- Preserves read-only / non-authorizing / no-order-control boundary
- No JavaScript behavior added
- No `fetch(` added
- No polling/auto-refresh added
- No order UI added

## Validation

Passed before push:

```text
uv run pytest tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q
# 19 passed

uv run ruff check tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
uv run ruff format --check tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
git diff --check
```
