### PR TITLE
webui(market-v0): inline visual capability cockpit

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -102,40 +102,108 @@
           <span class="inline-flex items-center rounded-md border border-slate-700/80 bg-slate-950/60 px-2 py-0.5 text-[10px] font-semibold text-slate-300/90 tabular-nums">SSR ladder</span>
           <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-950/55 px-2 py-0.5 text-[10px] font-medium text-slate-400/90 tabular-nums">No polling</span>
         </div>
-        <p class="text-[10px] text-slate-500 m-0 pt-0.5">Weitere Ziele unten als Karten — nicht nur kleine Header-Buttons.</p>
+        <p class="text-[10px] text-slate-500 m-0 pt-0.5">Cockpit-Strip direkt unter dem Header — danach Kontext, dominant Chart und SSR-Leiter.</p>
       </div>
     </div>
   </header>
 
+  <section
+    aria-label="Single-page visual cockpit"
+    class="rounded-xl border border-slate-600/50 bg-gradient-to-b from-slate-950/90 via-slate-900/80 to-slate-950/70 p-3 sm:p-4 ring-1 ring-sky-900/25 shadow-lg shadow-black/25 space-y-3"
+    data-market-v0-visual-cockpit="true"
+  >
+    <div class="flex flex-wrap items-end justify-between gap-2">
+      <div>
+        <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">Visual cockpit</h2>
+        <p class="text-[10px] text-slate-500 m-0 mt-0.5">Same-page preview · read-only · visible here</p>
+      </div>
+      <span class="text-[9px] font-semibold uppercase tracking-wide text-emerald-400/90">Integrated strip</span>
+    </div>
+
+    <div
+      class="flex flex-wrap gap-1.5 sm:gap-2 rounded-lg border border-slate-800/80 bg-slate-950/70 px-2.5 py-2"
+      data-market-v0-ssr-metrics-strip="true"
+      aria-label="SSR metrics snapshot"
+    >
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[10px] font-semibold text-slate-200 tabular-nums">
+        <span class="text-slate-500 mr-1">Source</span><span class="font-mono text-sky-300/95">{{ query.source }}</span>
+      </span>
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[10px] font-semibold text-slate-200 tabular-nums">
+        <span class="text-slate-500 mr-1">Symbol</span><span class="font-mono text-slate-200">{{ query.symbol }}</span>
+      </span>
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[10px] font-semibold text-slate-200 tabular-nums">
+        <span class="text-slate-500 mr-1">TF</span><span class="font-mono text-slate-200">{{ query.timeframe }}</span>
+      </span>
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[10px] font-semibold text-slate-200 tabular-nums">
+        <span class="text-slate-500 mr-1">Limit</span><span class="font-mono text-slate-200">{{ query.limit }}</span>
+      </span>
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[10px] font-semibold text-slate-200 tabular-nums">
+        <span class="text-slate-500 mr-1">Bars</span><span class="font-mono text-slate-200">{{ payload.bars_returned }}</span>
+      </span>
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[10px] font-semibold {% if payload.bars_returned == 0 %}text-amber-300/95{% else %}text-emerald-300/95{% endif %} tabular-nums">
+        <span class="text-slate-500 mr-1">Chart</span><span class="font-mono">{% if payload.bars_returned == 0 %}empty{% else %}ready{% endif %}</span>
+      </span>
+      <span class="inline-flex items-center rounded-md border border-amber-900/40 bg-amber-950/35 px-2 py-0.5 text-[10px] font-semibold text-amber-100/90 tabular-nums">
+        <span class="text-slate-500 mr-1">Depth</span><span class="font-mono text-amber-200/95">{{ market_depth.display_status }}</span>
+      </span>
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-900/80 px-2 py-0.5 text-[10px] font-medium text-slate-400 tabular-nums">Top-N {{ market_depth.top_levels_limit }}</span>
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-950/60 px-2 py-0.5 text-[9px] font-semibold text-slate-400">No polling</span>
+      <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-950/60 px-2 py-0.5 text-[9px] font-semibold text-slate-400">No order controls</span>
+    </div>
+
+    <div class="space-y-3" data-market-v0-visual-surface-strip="true">
   <section
     aria-label="Available read-only surfaces"
     class="rounded-xl border border-slate-700/70 bg-slate-900/75 p-3 sm:p-4 ring-1 ring-emerald-900/20 shadow-sm shadow-black/20"
     data-market-v0-surface-links="true"
   >
     <div class="flex flex-wrap items-center justify-between gap-2 mb-2.5">
-      <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">Available surfaces</h2>
-      <span class="text-[9px] font-semibold uppercase tracking-wide text-slate-500">Read-only navigation</span>
+      <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">Surface previews · navigation</h2>
+      <span class="text-[9px] font-semibold uppercase tracking-wide text-slate-500">Secondary links</span>
     </div>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
       <a
         href="/"
         class="group flex flex-col rounded-lg border border-emerald-900/35 bg-gradient-to-br from-slate-950/80 to-slate-900/60 p-3 text-left shadow-sm shadow-black/15 ring-1 ring-emerald-900/10 transition hover:border-emerald-700/50 hover:bg-slate-900/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500/60"
         data-market-v0-dashboard-surface="true"
+        data-market-v0-dashboard-preview="true"
       >
-        <span class="text-[10px] font-bold uppercase tracking-wide text-emerald-300/90">Dashboard shell</span>
-        <span class="mt-1 text-sm font-semibold text-slate-100">PeakTrade home</span>
-        <span class="mt-1.5 text-[10px] leading-snug text-slate-400">Öffnet die Haupt-Dashboard-Ansicht (<span class="font-mono text-sky-400/90">/</span>) — Anzeige, keine Order-Steuerung.</span>
-        <span class="mt-2 text-[10px] font-semibold text-sky-400/90 group-hover:underline">Zum Dashboard →</span>
+        <div class="flex items-center justify-between gap-2 mb-2">
+          <span class="text-[10px] font-bold uppercase tracking-wide text-emerald-300/90">Dashboard shell</span>
+          <span class="rounded border border-emerald-800/50 bg-emerald-950/40 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wide text-emerald-200/90">Visible here</span>
+        </div>
+        <div class="mb-2 h-14 rounded-lg border border-slate-800/80 bg-slate-950/80 flex items-end gap-0.5 px-2 pb-1.5" aria-hidden="true">
+          <div class="w-1 rounded-sm bg-emerald-400/35" style="height: 35%"></div>
+          <div class="w-1 rounded-sm bg-emerald-400/45" style="height: 55%"></div>
+          <div class="w-1 rounded-sm bg-emerald-400/30" style="height: 25%"></div>
+          <div class="w-1 rounded-sm bg-emerald-400/50" style="height: 70%"></div>
+          <div class="w-1 rounded-sm bg-emerald-400/40" style="height: 45%"></div>
+          <div class="w-1 rounded-sm bg-sky-400/25" style="height: 50%"></div>
+        </div>
+        <span class="text-sm font-semibold text-slate-100">PeakTrade home</span>
+        <span class="mt-1.5 text-[10px] leading-snug text-slate-400">Route <span class="font-mono text-sky-400/90">/</span> — read-only shell, keine Order-Steuerung.</span>
+        <span class="mt-2 text-[10px] font-semibold text-slate-500 group-hover:text-sky-400/90">Secondary · open dashboard →</span>
       </a>
       <a
         href="/r_and_d/charts"
         class="group flex flex-col rounded-lg border border-violet-900/35 bg-gradient-to-br from-slate-950/80 to-slate-900/60 p-3 text-left shadow-sm shadow-black/15 ring-1 ring-violet-900/10 transition hover:border-violet-700/50 hover:bg-slate-900/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500/60"
         data-market-v0-rd-charts-surface="true"
+        data-market-v0-rd-preview="true"
       >
-        <span class="text-[10px] font-bold uppercase tracking-wide text-violet-300/90">R&amp;D charts</span>
-        <span class="mt-1 text-sm font-semibold text-slate-100">Experimentelle Chart-Fläche</span>
+        <div class="flex items-center justify-between gap-2 mb-2">
+          <span class="text-[10px] font-bold uppercase tracking-wide text-violet-300/90">R&amp;D charts</span>
+          <span class="rounded border border-violet-800/50 bg-violet-950/40 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wide text-violet-200/90">Preview strip</span>
+        </div>
+        <div class="mb-2 h-14 rounded-lg border border-slate-800/80 bg-slate-950/80 flex items-end gap-0.5 px-2 pb-1.5" aria-hidden="true">
+          <div class="w-1 rounded-sm bg-violet-400/40" style="height: 40%"></div>
+          <div class="w-1 rounded-sm bg-violet-400/35" style="height: 65%"></div>
+          <div class="w-1 rounded-sm bg-fuchsia-400/30" style="height: 30%"></div>
+          <div class="w-1 rounded-sm bg-violet-400/45" style="height: 50%"></div>
+          <div class="w-1 rounded-sm bg-violet-400/38" style="height: 38%"></div>
+        </div>
+        <span class="text-sm font-semibold text-slate-100">Experimentelle Chart-Fläche</span>
         <span class="mt-1.5 text-[10px] leading-snug text-slate-400">Separates read-only R&amp;D-Readmodel — nicht mit Depth-JSON verwechseln.</span>
-        <span class="mt-2 text-[10px] font-semibold text-sky-400/90 group-hover:underline">Zu R&amp;D Charts →</span>
+        <span class="mt-2 text-[10px] font-semibold text-slate-500 group-hover:text-sky-400/90">Secondary · open R&amp;D charts →</span>
       </a>
     </div>
   </section>
@@ -146,7 +214,7 @@
     data-market-v0-data-surfaces="true"
   >
     <div class="flex flex-wrap items-center justify-between gap-2">
-      <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">Data source · API surface</h2>
+      <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">OHLCV · Depth · inline auf dieser Seite</h2>
       <div class="flex flex-wrap gap-1.5">
         <span class="rounded border border-slate-700/80 bg-slate-900/70 px-1.5 py-0.5 text-[9px] font-semibold text-slate-400 tabular-nums">No Live authorization</span>
         <span class="rounded border border-slate-700/80 bg-slate-900/70 px-1.5 py-0.5 text-[9px] font-semibold text-slate-400 tabular-nums">SSR snapshot</span>
@@ -157,10 +225,16 @@
         class="rounded-lg border border-sky-800/40 bg-slate-900/65 p-3 flex flex-col gap-2 min-w-0"
         data-market-v0-ohlcv-surface="true"
         data-market-v1-api-reference="true"
+        data-market-v0-ohlcv-preview="true"
       >
         <div class="flex flex-wrap items-center gap-2">
           <span class="text-[10px] font-bold uppercase tracking-wide text-sky-300/90">OHLCV source</span>
-          <span class="rounded border border-emerald-900/40 bg-emerald-950/30 px-1.5 py-0.5 text-[9px] font-semibold text-emerald-200/90">Powers close-line chart</span>
+          <span class="rounded border border-emerald-900/40 bg-emerald-950/30 px-1.5 py-0.5 text-[9px] font-semibold text-emerald-200/90">Visible here · close-line</span>
+        </div>
+        <div class="h-12 rounded-md border border-slate-800/70 bg-slate-950/75 flex items-end gap-0.5 px-2 pb-1" aria-hidden="true">
+          {% for bar_h in [35, 55, 40, 70, 45, 60, 50, 65] %}
+          <div class="w-1 rounded-sm bg-sky-400/30" style="height: {{ bar_h }}%"></div>
+          {% endfor %}
         </div>
         <p class="text-[11px] leading-snug text-slate-400 m-0">
           Dieselbe OHLCV-Serie, die oben eingebettet ist, kann als read-only JSON abgerufen werden — identische Query wie diese Seite.
@@ -179,11 +253,24 @@
       <div
         class="rounded-lg border border-amber-900/35 bg-slate-900/60 p-3 flex flex-col gap-2 min-w-0"
         data-market-v0-depth-surface="true"
+        data-market-v0-depth-preview="true"
       >
         <div class="flex flex-wrap items-center gap-2">
           <span class="text-[10px] font-bold uppercase tracking-wide text-amber-200/90">Depth SSR</span>
+          <span class="rounded border border-amber-800/45 bg-amber-950/35 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wide text-amber-100/90">Visible here</span>
           <span class="rounded border border-slate-700/70 bg-slate-950/55 px-1.5 py-0.5 text-[9px] font-semibold text-slate-400">Offline / bundle</span>
         </div>
+        <div class="grid grid-cols-2 gap-2" aria-hidden="true">
+          <div class="space-y-1">
+            <div class="h-2 rounded bg-emerald-400/25 border border-emerald-500/20" style="width: 72%"></div>
+            <div class="h-2 rounded bg-emerald-400/20 border border-emerald-500/15" style="width: 45%"></div>
+          </div>
+          <div class="space-y-1">
+            <div class="h-2 rounded bg-rose-400/25 border border-rose-500/20" style="width: 68%"></div>
+            <div class="h-2 rounded bg-rose-400/20 border border-rose-500/15" style="width: 52%"></div>
+          </div>
+        </div>
+        <p class="text-[9px] text-slate-500 m-0 leading-snug">Skizze: angezeigte Top-N-Größe — <strong class="text-slate-400 font-semibold">nicht</strong> kumulativ · keine Live-Feed-Animation.</p>
         <p class="text-[11px] leading-snug text-slate-400 m-0">
           Markttiefe für Leiter &amp; Diagnostik kommt nur per Server-Side Rendering in diese Seite — <strong class="text-slate-300 font-semibold">kein</strong> direkter Browser-Abruf einer separaten Depth-JSON-Route von hier.
         </p>
@@ -191,8 +278,10 @@
           Depth status (SSR): <span class="font-mono text-slate-300">{{ market_depth.display_status }}</span>
           · Top levels: <span class="font-mono text-slate-300">{{ market_depth.top_levels_limit }}</span>
         </p>
-        <p class="text-[10px] text-slate-500 m-0 leading-snug">Siehe rechts: SSR depth panel &amp; angezeigte Top-N-Stufen — rein Anzeige.</p>
+        <p class="text-[10px] text-slate-500 m-0 leading-snug">Rechts: SSR depth panel &amp; angezeigte Top-N-Stufen — rein Anzeige.</p>
       </div>
+    </div>
+  </section>
     </div>
   </section>
 

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -77,6 +77,13 @@ class TestMarketSurfaceHtml:
         assert 'data-market-v0-data-surfaces="true"' in body
         assert 'data-market-v0-ohlcv-surface="true"' in body
         assert 'data-market-v0-depth-surface="true"' in body
+        assert 'data-market-v0-visual-cockpit="true"' in body
+        assert 'data-market-v0-visual-surface-strip="true"' in body
+        assert 'data-market-v0-dashboard-preview="true"' in body
+        assert 'data-market-v0-rd-preview="true"' in body
+        assert 'data-market-v0-ohlcv-preview="true"' in body
+        assert 'data-market-v0-depth-preview="true"' in body
+        assert 'data-market-v0-ssr-metrics-strip="true"' in body
         assert 'data-market-v11-chart-diagnostics="true"' in body
         assert 'data-market-v11-chart-library-status="true"' in body
         assert 'data-market-v11-payload-bars="true"' in body
@@ -273,6 +280,13 @@ def test_market_v0_template_kraken_banner_markers_in_source() -> None:
     assert 'data-market-v0-data-surfaces="true"' in txt
     assert 'data-market-v0-ohlcv-surface="true"' in txt
     assert 'data-market-v0-depth-surface="true"' in txt
+    assert 'data-market-v0-visual-cockpit="true"' in txt
+    assert 'data-market-v0-visual-surface-strip="true"' in txt
+    assert 'data-market-v0-dashboard-preview="true"' in txt
+    assert 'data-market-v0-rd-preview="true"' in txt
+    assert 'data-market-v0-ohlcv-preview="true"' in txt
+    assert 'data-market-v0-depth-preview="true"' in txt
+    assert 'data-market-v0-ssr-metrics-strip="true"' in txt
     assert 'data-market-v11-chart-diagnostics="true"' in txt
     assert 'data-market-v11-chart-library-status="true"' in txt
     assert 'data-market-v11-payload-bars="true"' in txt

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -134,6 +134,13 @@ def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> No
     assert 'data-market-v0-data-surfaces="true"' in market_html
     assert 'data-market-v0-ohlcv-surface="true"' in market_html
     assert 'data-market-v0-depth-surface="true"' in market_html
+    assert 'data-market-v0-visual-cockpit="true"' in market_html
+    assert 'data-market-v0-visual-surface-strip="true"' in market_html
+    assert 'data-market-v0-dashboard-preview="true"' in market_html
+    assert 'data-market-v0-rd-preview="true"' in market_html
+    assert 'data-market-v0-ohlcv-preview="true"' in market_html
+    assert 'data-market-v0-depth-preview="true"' in market_html
+    assert 'data-market-v0-ssr-metrics-strip="true"' in market_html
 
     lowered = market_html.lower()
     assert "place order" not in lowered


### PR DESCRIPTION
## Summary

Makes `/market` feel more like one integrated visual cockpit instead of a set of links.

This PR converts the existing safe Market Dashboard capabilities into inline visual previews and a compact SSR metrics strip, while preserving all read-only/non-authorizing boundaries.

## Scope

Changed files:

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/test_market_surface_api.py`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

No changes to:

- `src/**`
- `docs/**`
- `config/**`
- `.github/**`
- `out/**`
- runtime/scheduler/paper/testnet/live paths
- broker/exchange/order paths
- Master V2 / Double Play trading logic

## What changed

Adds stable single-page cockpit markers:

- `data-market-v0-visual-cockpit`
- `data-market-v0-visual-surface-strip`
- `data-market-v0-dashboard-preview`
- `data-market-v0-rd-preview`
- `data-market-v0-ohlcv-preview`
- `data-market-v0-depth-preview`
- `data-market-v0-ssr-metrics-strip`

The page now presents:

- Dashboard shell preview inline
- R&D chart surface preview inline
- OHLCV source preview inline
- Depth SSR preview inline
- compact SSR metric chips
- "visible here" / "same-page preview" language

Existing safe links remain secondary actions:

- `/`
- `/r_and_d/charts`
- `/api/market/ohlcv`

Boundary preserved:

- no clickable `/api/market/depth` route added to `/market`
- no `fetch(` added
- no iframe added
- no polling/auto-refresh added
- no order UI added

## Validation

Passed before push:

```text
uv run pytest tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q
# 19 passed

uv run ruff check tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
uv run ruff format --check tests/test_market_surface_api.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
git diff --check
```
