### PR TITLE
tests(webui): assert market-v0 chart-candle SSR stack marker

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -119,6 +119,7 @@ def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> No
     assert 'data-market-v0-pro-shell="true"' in market_html
     assert 'data-market-v0-pro-grid="true"' in market_html
     assert 'data-market-v0-chart-panel="true"' in market_html
+    assert 'data-market-v0-chart-candle-stack="true"' in market_html
     assert 'data-market-v0-orderbook-placeholder="true"' in market_html
     assert 'data-market-v0-depth-chart-placeholder="true"' in market_html
     assert 'data-market-v0-pro-boundary="true"' in market_html


### PR DESCRIPTION
## Summary

This PR adds a tests-only Market Dashboard regression contract for the SSR chart/candle stack marker.

It asserts that the rendered Market Dashboard HTML includes:

- `data-market-v0-chart-candle-stack="true"`

## Scope

Changed file:

- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Safety boundary

- Tests-only
- No template/source/runtime changes
- No API changes
- No client-side fetch
- No iframe
- No Financial Plugin strings
- No market-depth route/link expansion
- No scheduler, runtime, paper/test data, broker, exchange, order, KillSwitch, risk, scope, capital, strategy, Master V2 / Double Play trading logic, execution/live gates, dashboard authority, AI authority, or strategy live authority changes

## Validation

- `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` — passed
- `uv run pytest tests/webui tests/test_market_surface_api.py -q -k "market or dashboard or candle"` — passed
- `uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py` — passed
- `git diff --check origin/main...HEAD` — passed
