### PR TITLE
webui(market-v0): keep dashboard content one-page

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -14,6 +14,7 @@
   data-market-source="{{ query.source }}"
   data-market-bars="{{ payload.bars_returned }}"
   data-market-symbol="{{ query.symbol }}"
+  data-market-v0-one-page-link-cleanup-v1="true"
 >
   <section
     aria-label="Read-only market constraints"
@@ -252,24 +253,24 @@
     <div class="flex flex-wrap items-center gap-2">
       <span class="text-[9px] font-semibold uppercase tracking-wide text-slate-500 shrink-0">Terminal rail</span>
       <div class="flex flex-wrap gap-1.5 flex-1 min-w-0 items-center">
-        <a
-          href="/"
-          class="inline-flex items-center gap-1 rounded-md border border-emerald-900/40 bg-slate-950/70 px-2 py-1 text-[10px] font-semibold text-emerald-200/90 hover:bg-slate-900/85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500/60 transition"
+        <span
+          class="inline-flex items-center gap-1 rounded-md border border-emerald-900/40 bg-slate-950/70 px-2 py-1 text-[10px] font-semibold text-emerald-200/90 cursor-default select-text"
           data-market-v0-dashboard-surface="true"
           data-market-v0-dashboard-preview="true"
+          data-market-v0-one-page-surface-label="true"
         >
           <span class="font-mono text-sky-300/90">/</span>
           <span class="text-slate-200">Dashboard shell</span>
-        </a>
-        <a
-          href="/r_and_d/charts"
-          class="inline-flex items-center gap-1 rounded-md border border-violet-900/40 bg-slate-950/70 px-2 py-1 text-[10px] font-semibold text-violet-200/90 hover:bg-slate-900/85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500/60 transition"
+        </span>
+        <span
+          class="inline-flex items-center gap-1 rounded-md border border-violet-900/40 bg-slate-950/70 px-2 py-1 text-[10px] font-semibold text-violet-200/90 cursor-default select-text"
           data-market-v0-rd-charts-surface="true"
           data-market-v0-rd-preview="true"
+          data-market-v0-one-page-surface-label="true"
         >
           <span class="text-slate-200">R&amp;D charts</span>
-        </a>
-        <span class="text-[9px] text-slate-500 hidden sm:inline">Secondary · read-only navigation</span>
+        </span>
+        <span class="text-[9px] text-slate-500 hidden sm:inline">One-page mode · labels only · no navigation</span>
       </div>
     </div>
   </section>
@@ -298,14 +299,14 @@
           <span class="rounded border border-emerald-900/40 bg-emerald-950/30 px-1.5 py-0.5 text-[9px] font-semibold text-emerald-200/90">SSR · close-line + candles</span>
         </div>
         <p class="text-[11px] leading-snug text-slate-400 m-0">
-          Eingebettete Serie — read-only JSON mit identischer Query (sekundärer Link).
+          Eingebettete Serie — identische Query wie API-Pfad unten (nur Referenz · kein Klick · eine Seite).
         </p>
         <div class="flex flex-wrap items-center gap-2">
-          <a
-            href="/api/market/ohlcv?source={{ query.source }}&amp;symbol={{ query.symbol | replace('/', '%2F') }}&amp;timeframe={{ query.timeframe }}&amp;limit={{ query.limit }}"
-            class="inline-flex items-center rounded-md border border-sky-800/50 bg-slate-950/70 px-2 py-1 text-[10px] font-semibold text-sky-300/95 hover:bg-slate-900/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500/60"
-          >OHLCV JSON</a>
-          <span class="text-[9px] text-slate-500">Secondary · not live</span>
+          <span
+            class="inline-flex max-w-full items-center rounded-md border border-sky-800/50 bg-slate-950/70 px-2 py-1 text-[10px] font-semibold text-sky-300/95 font-mono break-all cursor-default select-text"
+            data-market-v0-ohlcv-api-path-hint="true"
+          >/api/market/ohlcv?source={{ query.source }}&amp;symbol={{ query.symbol | replace('/', '%2F') }}&amp;timeframe={{ query.timeframe }}&amp;limit={{ query.limit }}</span>
+          <span class="text-[9px] text-slate-500">Reference only · not live</span>
         </div>
         <p class="text-[10px] text-slate-500 m-0 tabular-nums">
           Bars (SSR): <span class="font-mono text-slate-300">{{ payload.bars_returned }}</span>

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -117,6 +117,7 @@ def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> No
     market_html = _html(client, "/market")
 
     assert 'data-market-v0-pro-shell="true"' in market_html
+    assert 'data-market-v0-one-page-link-cleanup-v1="true"' in market_html
     assert 'data-market-v0-pro-grid="true"' in market_html
     assert 'data-market-v0-chart-panel="true"' in market_html
     assert 'data-market-v0-chart-candle-stack="true"' in market_html


### PR DESCRIPTION
## Summary

This PR implements Market Dashboard One-Page Link Cleanup v1.

It neutralizes off-page/navigation links inside the Market Dashboard content while preserving the same visible labels/path hints.

Neutralized links:

- `/`
- `/r_and_d/charts`
- `/api/market/ohlcv?...`

## Scope

Changed files:

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Safety boundary

- SSR-template + WebUI structure test only
- No `src/**`, docs, config, API, route, readmodel, runtime, scheduler, paper/test data, broker, exchange, order, KillSwitch, risk, scope, capital, strategy, Master V2 / Double Play trading logic, execution/live gates, dashboard authority, AI authority, or strategy live authority changes
- No browser fetch
- No polling
- No iframe
- No Financial Plugin strings
- No market-depth live activation
- No fake buy/sell/order markers
- No order controls

## Validation

- `uv run pytest tests/test_market_surface_api.py -q` — passed
- `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` — passed
- `uv run pytest tests/webui tests/test_market_surface_api.py -q -k "market or dashboard or candle or chart or link"` — passed
- `uv run ruff check tests/webui tests/test_market_surface_api.py` — passed
- `git diff --check origin/main...HEAD` — passed
- Template scan clean for `href="/"`, `href="/r_and_d/charts"`, and `href="/api/market/ohlcv`
- Diff-aware risky scan — clean for fetch/iframe/plugin/API/router/readmodel/live/order patterns

## Notes

This PR intentionally does not add buy/sell markers or live chart behavior. Those require a governed read-only data source and must remain a separate future item.
