### PR TITLE
webui(market-v0): add ranking funnel empty state v0

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -79,6 +79,58 @@
     {% endif %}
   </section>
 
+  <section
+    aria-label="Ranking funnel empty state"
+    class="rounded-xl border border-violet-900/45 bg-gradient-to-br from-slate-950/92 via-violet-950/22 to-slate-950/85 px-3 py-3 sm:px-4 ring-1 ring-violet-900/25 shadow-md shadow-black/20"
+    data-market-v0-ranking-funnel-empty-state-v0="true"
+  >
+    <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
+      <div class="min-w-0 space-y-1">
+        <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">
+          Futures ranking funnel · contract-first (empty)
+        </h2>
+        <p class="text-[10px] text-slate-500 m-0 max-w-2xl leading-snug">
+          Zielpfad auf <strong class="text-slate-400 font-semibold">einer Seite</strong>, ohne separate Ranking-Route.
+          <strong class="text-amber-200/90 font-semibold">Noch keine Live-Ranking-Daten</strong>, keine Kandidatenlisten, keine erfundenen Scores oder Auswahlkriterien-Werte — reines SSR-Platzhalter-Panel bis ein kanonischer Producer angebunden ist.
+        </p>
+      </div>
+      <span class="shrink-0 inline-flex items-center rounded-md border border-amber-800/55 bg-amber-950/45 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide text-amber-200/90">Not wired</span>
+    </div>
+    <div
+      class="grid grid-cols-1 sm:grid-cols-3 gap-2"
+      data-market-v0-ranking-funnel-stages-v0="true"
+      aria-label="Target funnel stages, illustrative only"
+    >
+      <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
+        <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 1</p>
+        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top 50 · breites Universum</p>
+        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Illustrativ — keine Symbole, keine Reihenfolge.</p>
+      </div>
+      <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
+        <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 2</p>
+        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top 20 · Shortlist</p>
+        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Illustrativ — keine Shortlist-Daten.</p>
+      </div>
+      <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
+        <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 3</p>
+        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top 5 · Daytrading-Kandidaten</p>
+        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Illustrativ — keine Auswahl, keine Markierungen.</p>
+      </div>
+    </div>
+    <div class="mt-2.5 rounded-lg border border-slate-800/85 bg-slate-950/55 px-2.5 py-2">
+      <p class="text-[9px] font-semibold text-slate-400 uppercase tracking-wide m-0 mb-1.5">
+        Vorgesehene Kriterien-Kategorien (nur Bezeichner, keine Werte)
+      </p>
+      <ul class="m-0 p-0 list-none flex flex-wrap gap-1.5 text-[9px] text-slate-500">
+        <li class="rounded border border-slate-800/80 bg-slate-950/40 px-1.5 py-0.5">Liquidität / Spread-Qualität</li>
+        <li class="rounded border border-slate-800/80 bg-slate-950/40 px-1.5 py-0.5">Volatilität / Bewegung</li>
+        <li class="rounded border border-slate-800/80 bg-slate-950/40 px-1.5 py-0.5">Datenstände &amp; Provenance</li>
+        <li class="rounded border border-slate-800/80 bg-slate-950/40 px-1.5 py-0.5">Gebühren &amp; Slippage-Rahmen</li>
+        <li class="rounded border border-slate-800/80 bg-slate-950/40 px-1.5 py-0.5">Score-Aufschlüsselung (später)</li>
+      </ul>
+    </div>
+  </section>
+
   <!-- Pro cockpit grid: chart/main column + read-only side panels (IA inspiration only; no order UI) -->
   <div
     class="grid grid-cols-1 xl:grid-cols-12 gap-3 lg:gap-5 xl:gap-6 items-start"

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -112,6 +112,12 @@ def test_market_dashboard_readonly_banner_markers(client: TestClient) -> None:
     assert 'data-market-non-authorizing="true"' in market_html
 
 
+def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClient) -> None:
+    """Contract-first funnel panel: stable marker only; no ranking data wired on /market."""
+    market_html = _html(client, "/market")
+    assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' in market_html
+
+
 def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> None:
     """Read-only IA shell on GET /market: stable markers, no order-affordance attributes."""
     market_html = _html(client, "/market")


### PR DESCRIPTION
## Summary

This PR adds a contract-first Ranking Funnel Empty-State v0 to the main Market Dashboard.

The panel makes the intended future Top 50 → Top 20 → Top 5 selection funnel visible on `/market`, but explicitly marks it as not wired yet. It does not fake symbols, rankings, scores, score breakdowns, or daytrading selections.

## Scope

Changed files:

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Contract-first decision

- No wired ranking producer/readmodel currently feeds a real Top 50 → Top 20 → Top 5 funnel into `/market`.
- This PR adds only an honest one-page SSR empty-state contract.
- No fake ranking values, symbols, scores, candidates, or criteria values are introduced.
- No separate dashboard or navigation link is introduced.

## Safety boundary

- SSR-template + WebUI structure test only
- No `src/**`, docs, config, API, route, readmodel, runtime, scheduler, paper/test data, broker, exchange, order, KillSwitch, risk, scope, capital, strategy, Master V2 / Double Play trading logic, execution/live gates, dashboard authority, AI authority, or strategy live authority changes
- No browser fetch
- No polling
- No iframe
- No Financial Plugin strings
- No Chart.js financial plugin
- No market-depth live activation
- No buy/sell/order markers
- No href/navigation reintroduced

## Validation

- `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` — passed
- `uv run pytest tests/webui tests/test_market_surface_api.py -q -k "market or dashboard or candle or chart or depth or link or ranking"` — passed
- `uv run ruff check tests/webui tests/test_market_surface_api.py` — passed
- `git diff --check` — passed
- Template href scan — clean
- Diff-aware risky scan — clean

## Notes

Real ranking visuals require a governed read-only producer/readmodel first. This PR intentionally does not implement that producer.
