### PR TITLE
webui(market-v0): unify lower visual band density v1

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -693,13 +693,18 @@
       </section>
 
       <div
-        class="space-y-3 min-w-0"
+        class="rounded-xl border border-slate-600/45 bg-gradient-to-b from-slate-950/92 via-slate-900/55 to-slate-950/90 ring-1 ring-slate-800/45 shadow-lg shadow-black/20 overflow-hidden"
+        data-market-v0-visual-density-lower-band-v1="true"
+        aria-label="Unified lower band: ladder, depth visuals, read-model summary, and diagnostics (read-only)"
+      >
+      <div
+        class="min-w-0 divide-y divide-slate-800/65"
         data-market-v0-lower-depth-orderbook-visuals-v1="true"
         data-market-v0-lower-disabled-depth-visual-state-v1="true"
       >
 
       <section
-        class="rounded-xl border border-slate-600/55 bg-gradient-to-b from-slate-950/92 via-slate-900/80 to-slate-950/88 ring-1 ring-emerald-900/15 shadow-lg shadow-black/20 overflow-hidden"
+        class="bg-gradient-to-b from-slate-950/92 via-slate-900/80 to-slate-950/88 overflow-hidden"
         data-market-v0-orderbook-placeholder="true"
         aria-label="Price ladder (read-only)"
       >
@@ -879,7 +884,7 @@
       </section>
 
       <section
-        class="rounded-xl border border-amber-900/35 bg-gradient-to-br from-amber-950/22 via-slate-950/88 to-slate-900/85 px-2.5 py-2.5 text-[10px] text-slate-400 ring-1 ring-amber-900/20 shadow-inner shadow-black/25"
+        class="bg-gradient-to-br from-amber-950/22 via-slate-950/88 to-slate-900/85 px-2.5 py-2.5 text-[10px] text-slate-400 shadow-inner shadow-black/25"
         data-market-v0-depth-chart-placeholder="true"
         aria-label="Depth chart placeholder (read-only)"
       >
@@ -983,7 +988,7 @@
       <section
         id="market-v0-depth-ssr"
         aria-label="Market depth read-model (SSR, offline or disabled)"
-        class="rounded-xl border border-slate-700/70 border-l-4 {% if market_depth.display_status == 'ok' %}border-l-emerald-500/55{% else %}border-l-amber-500/50{% endif %} bg-slate-900/70 px-3 py-3 text-[11px] text-slate-300 shadow-md shadow-black/20"
+        class="border-0 border-l-4 {% if market_depth.display_status == 'ok' %}border-l-emerald-500/55{% else %}border-l-amber-500/50{% endif %} bg-slate-900/70 px-3 py-3 text-[11px] text-slate-300"
         data-market-depth-panel="true"
         data-market-depth-status="{{ market_depth.display_status }}"
         {% if market_depth.readmodel_id %}
@@ -1010,7 +1015,7 @@
       </div>
 
       <section
-        class="rounded-lg border border-slate-700/60 bg-slate-900/60 px-2.5 py-2.5 text-[10px] text-slate-400 space-y-2"
+        class="border-0 border-t border-slate-800/60 bg-slate-900/60 px-2.5 py-2.5 text-[10px] text-slate-400 space-y-2"
         data-market-v0-status-panel="true"
         data-market-v0-status-diagnostics-visual-rails-v1="true"
         aria-label="Market diagnostic status (read-only)"
@@ -1053,6 +1058,7 @@
           </div>
         </div>
       </section>
+      </div>
     </aside>
   </div>
 

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -122,6 +122,7 @@ def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> No
     """Read-only IA shell on GET /market: stable markers, no order-affordance attributes."""
     market_html = _html(client, "/market")
 
+    assert 'data-market-v0-visual-density-lower-band-v1="true"' in market_html
     assert 'data-market-v0-pro-shell="true"' in market_html
     assert 'data-market-v0-one-page-link-cleanup-v1="true"' in market_html
     assert 'data-market-v0-pro-grid="true"' in market_html


### PR DESCRIPTION
## Summary

This PR implements Market Dashboard Visual Density Lower Band v1.

It unifies the lower Orderbook / Depth / Status area into one coherent visual band with shared framing and internal dividers, reducing the “separate block/card” feel while preserving all existing data and safety semantics.

## Scope

Changed files:

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Visual decision

- Unified lower band around existing depth/orderbook/status visuals
- No data semantics change
- No fake live/orderbook/ranking data
- No new API, route, readmodel, or source changes
- No href/navigation reintroduced

## Safety boundary

- SSR-template + WebUI structure test only
- No `src/**`, docs, config, API, route, readmodel, runtime, scheduler, paper/test data, broker, exchange, order, KillSwitch, risk, scope, capital, strategy, Master V2 / Double Play trading logic, execution/live gates, dashboard authority, AI authority, or strategy live authority changes
- No browser fetch
- No polling
- No iframe
- No Financial Plugin strings
- No Chart.js financial plugin
- No market-depth live activation
- No fake depth/orderbook/ranking/buy/sell/order data

## Validation

- `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` — passed
- `uv run pytest tests/webui tests/test_market_surface_api.py -q -k "market or dashboard or candle or chart or depth or link or ranking"` — passed
- `uv run ruff check tests/webui tests/test_market_surface_api.py` — passed
- `git diff --check` — passed
- Template href scan — clean
- Diff-aware risky scan — clean

## Notes

This PR intentionally does not implement a real ranking producer, real score breakdown, buy/sell markers, live depth, or additional dashboard routes.
