### PR TITLE
webui(market-v0): use dynamic ranking funnel labels v0

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -83,6 +83,7 @@
     aria-label="Ranking funnel empty state"
     class="rounded-xl border border-violet-900/45 bg-gradient-to-br from-slate-950/92 via-violet-950/22 to-slate-950/85 px-3 py-3 sm:px-4 ring-1 ring-violet-900/25 shadow-md shadow-black/20"
     data-market-v0-ranking-funnel-empty-state-v0="true"
+    data-market-v0-ranking-funnel-dynamic-labels-v0="true"
   >
     <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
       <div class="min-w-0 space-y-1">
@@ -99,22 +100,22 @@
     <div
       class="grid grid-cols-1 sm:grid-cols-3 gap-2"
       data-market-v0-ranking-funnel-stages-v0="true"
-      aria-label="Target funnel stages, illustrative only"
+      aria-label="Target funnel stages: dynamic labels only, no fixed candidate counts"
     >
       <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
         <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 1</p>
-        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top 50 · breites Universum</p>
-        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Illustrativ — keine Symbole, keine Reihenfolge.</p>
+        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top Universe</p>
+        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Breites Kandidatenfeld — Größe nur vom Producer, keine Symbole, keine Reihenfolge.</p>
       </div>
       <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
         <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 2</p>
-        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top 20 · Shortlist</p>
-        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Illustrativ — keine Shortlist-Daten.</p>
+        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Shortlist</p>
+        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Vorgefilterte Menge — Umfang producer-definiert, keine Shortlist-Daten.</p>
       </div>
       <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
         <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 3</p>
-        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top 5 · Daytrading-Kandidaten</p>
-        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Illustrativ — keine Auswahl, keine Markierungen.</p>
+        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top Ranking / Selected Candidates</p>
+        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Auswahl ohne feste Stückzahl — Anzahl komplett vom Producer, keine Markierungen.</p>
       </div>
     </div>
     <div class="mt-2.5 rounded-lg border border-slate-800/85 bg-slate-950/55 px-2.5 py-2">

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -118,6 +118,12 @@ def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClien
     assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' in market_html
 
 
+def test_market_dashboard_ranking_funnel_dynamic_labels_v0_marker(client: TestClient) -> None:
+    """Funnel stages use dynamic labels (no fixed final-count wording in UI contract)."""
+    market_html = _html(client, "/market")
+    assert 'data-market-v0-ranking-funnel-dynamic-labels-v0="true"' in market_html
+
+
 def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> None:
     """Read-only IA shell on GET /market: stable markers, no order-affordance attributes."""
     market_html = _html(client, "/market")


### PR DESCRIPTION
## Summary

This PR implements Runbook Slice 1.2: dynamic labels for the Market Dashboard ranking funnel.

It removes fixed “Top 5” wording from the ranking funnel empty-state and uses dynamic, producer-defined stage language instead:

- Top Universe
- Shortlist
- Top Ranking / Selected Candidates

## Scope

Changed files:

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Dynamic-label decision

- No fixed final candidate count.
- Final selected count is producer-defined.
- Existing ranking funnel remains an honest empty-state.
- No fake ranking data, symbols, scores, or candidates.
- No ranking producer/readmodel implementation in this PR.

## Safety boundary

- SSR-template + WebUI structure test only
- No `src/**`, docs, config, API, route, readmodel, runtime, scheduler, paper/test data, broker, exchange, order, KillSwitch, risk, scope, capital, strategy, Master V2 / Double Play trading logic, execution/live gates, dashboard authority, AI authority, or strategy live authority changes
- No browser fetch
- No polling
- No iframe
- No Financial Plugin strings
- No Chart.js financial plugin
- No market-depth live activation
- No buy/sell/order markers
- No href/navigation reintroduced

## Validation

- `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` — passed
- `uv run pytest tests/webui tests/test_market_surface_api.py -q -k "market or dashboard or ranking or link"` — passed
- `uv run ruff check tests/webui tests/test_market_surface_api.py` — passed
- `git diff --check` — passed
- Template href scan — clean
- Fixed Top 5 wording scan — clean
- Diff-aware risky scan — clean

## Notes

Ranking Producer Contract v0 remains the next runbook step before real ranking data can be displayed.
