### PR TITLE
ci(aiops): gate paid promptfoo evals default-off

### DIFF
--- a/.github/workflows/aiops-promptfoo-evals.yml
+++ b/.github/workflows/aiops-promptfoo-evals.yml
@@ -17,19 +17,27 @@ on:
       - 'scripts/aiops/**'
       - '.github/workflows/aiops-promptfoo-evals.yml'
   workflow_dispatch:
+    inputs:
+      run_paid_openai_evals:
+        description: >-
+          Run paid OpenAI-backed Promptfoo evals. Requires repository variable
+          PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS set to true.
+        type: boolean
+        default: false
 
 jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      run_evals: ${{ steps.filter.outputs.run_evals }}
+      run_evals: ${{ steps.resolve.outputs.run_evals }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
       - name: Check for eval-relevant changes
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@v3
         with:
           filters: |
@@ -39,6 +47,16 @@ jobs:
               - 'evals/aiops/**'
               - 'scripts/aiops/**'
               - '.github/workflows/aiops-promptfoo-evals.yml'
+
+      - name: Resolve whether eval job should run
+        id: resolve
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_evals=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_evals=${{ steps.filter.outputs.run_evals }}" >> "$GITHUB_OUTPUT"
+          fi
 
   promptfoo-eval:
     name: Run Promptfoo Evals
@@ -58,11 +76,36 @@ jobs:
       - name: Prepare AIOps artifacts dir
         run: mkdir -p .artifacts/aiops
 
-      - name: Run Promptfoo Eval
+      - name: Run paid Promptfoo Eval (OpenAI)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && github.event.inputs.run_paid_openai_evals == 'true'
+          && vars.PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           bash scripts/aiops/run_promptfoo_eval.sh
+
+      - name: PR/Push — paid Promptfoo/OpenAI disabled (cost gate)
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts/aiops
+          TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          printf '%s\n' "{\"status\":\"skipped_paid_eval\",\"reason\":\"pr_push_cost_gate\",\"ts_utc\":\"$TS\"}" > .artifacts/aiops/pr_push_cost_gate.json
+          echo "::notice::Paid Promptfoo/OpenAI evals are not executed on pull_request/push (default cost gate)."
+
+      - name: Manual run — paid Promptfoo skipped (missing opt-in)
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && (github.event.inputs.run_paid_openai_evals != 'true'
+          || vars.PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS != 'true')
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts/aiops
+          TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          printf '%s\n' "{\"status\":\"skipped_paid_eval\",\"reason\":\"manual_dispatch_missing_opt_in\",\"ts_utc\":\"$TS\"}" > .artifacts/aiops/manual_skip.json
+          echo "::notice::Paid Promptfoo requires workflow_dispatch input run_paid_openai_evals=true AND repository variable PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS=true."
 
       - name: Ensure eval artifacts (fallback if empty)
         run: |
@@ -94,11 +137,11 @@ jobs:
       - name: Write skip marker
         run: |
           TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          echo "{\"status\":\"skipped\",\"reason\":\"run_evals=false or missing OPENAI_API_KEY\",\"ts_utc\":\"$TS\"}" > .artifacts/aiops/skip.json
+          echo "{\"status\":\"skipped\",\"reason\":\"no eval-relevant path changes\",\"ts_utc\":\"$TS\"}" > .artifacts/aiops/skip.json
 
       - name: Log skip reason
         run: |
-          echo "No eval-relevant changes detected. Skipping promptfoo evals."
+          echo "No eval-relevant changes detected. Skipping promptfoo eval job."
           echo "This job succeeds to avoid false negatives in CI status."
 
       - name: Upload Artifacts

--- a/tests/ci/test_aiops_promptfoo_cost_gate_workflow_contract_v0.py
+++ b/tests/ci/test_aiops_promptfoo_cost_gate_workflow_contract_v0.py
@@ -1,0 +1,46 @@
+"""Static cost-gate contract for AI-Ops Promptfoo workflow.
+
+Reads workflow YAML as UTF-8 text only. No subprocess, no network, no PyYAML
+requirement beyond what the repo already uses elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "aiops-promptfoo-evals.yml"
+
+
+def test_aiops_promptfoo_workflow_defaults_paid_evals_off() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in text
+    assert "run_paid_openai_evals:" in text
+    assert "default: false" in text
+    assert "vars.PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS == 'true'" in text
+    assert "github.event.inputs.run_paid_openai_evals == 'true'" in text
+
+
+def test_aiops_promptfoo_workflow_injects_openai_secret_only_behind_opt_in_if() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count("OPENAI_API_KEY:") == 1
+    assert text.count("${{ secrets.OPENAI_API_KEY }}") == 1
+
+    key_idx = text.index("OPENAI_API_KEY:")
+    prefix = text[max(0, key_idx - 1200) : key_idx]
+
+    assert "Run paid Promptfoo Eval (OpenAI)" in prefix
+    assert "github.event_name == 'workflow_dispatch'" in prefix
+    assert "run_paid_openai_evals" in prefix
+    assert "PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS" in prefix
+
+
+def test_aiops_promptfoo_workflow_pr_push_skips_paid_path() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "PR/Push — paid Promptfoo/OpenAI disabled (cost gate)" in text
+    assert "pr_push_cost_gate.json" in text
+    assert "github.event_name == 'pull_request'" in text
+    assert "github.event_name == 'push'" in text


### PR DESCRIPTION
## Summary

- gates paid Promptfoo/OpenAI eval execution behind explicit manual `workflow_dispatch` input
- requires repository variable `PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS == true` for paid runs
- keeps PR/push runs cost-safe with no `OPENAI_API_KEY` exposure in default CI path
- adds static workflow contract tests for the default-off cost boundary

## Safety

- no trading logic changes
- no Master V2 / Double Play / Risk / KillSwitch / Execution / Live / Broker / Exchange changes
- no scheduler/runtime/paper/testnet/live changes
- no external API calls in tests
- no secrets printed

## Validation

- `uv run pytest tests/ci/test_aiops_promptfoo_cost_gate_workflow_contract_v0.py -q`
- `uv run ruff check tests/ci/test_aiops_promptfoo_cost_gate_workflow_contract_v0.py`
- `uv run ruff format --check tests/ci/test_aiops_promptfoo_cost_gate_workflow_contract_v0.py`
- `git diff --check main...HEAD`

## Manual GitHub note

Paid Promptfoo/OpenAI evals require both:
1. manual workflow dispatch input `run_paid_openai_evals=true`
2. repository variable `PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS=true`

Default state should remain absent/false while the system is not mature.

Made with [Cursor](https://cursor.com)