### PR TITLE
docs(ops): document AI/KI cost and autonomy CI policy

### DIFF
--- a/docs/ai/AI_EVALS_RUNBOOK.md
+++ b/docs/ai/AI_EVALS_RUNBOOK.md
@@ -21,6 +21,10 @@ This runbook describes how to run AI agent evaluations using promptfoo for Peak_
 - Trading strategy backtests (see `docs/risk/`)
 - Production observability (see `docs/ops/`)
 
+### GitHub Actions — paid evals (cost gate)
+
+In CI, **billable OpenAI-backed Promptfoo evals are default-off** on `pull_request` and `push`. Paid runs require **both** a manual `workflow_dispatch` input (`run_paid_openai_evals`) and repository variable `PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS=true`. Operator policy and workflow surfaces: [`docs/ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md`](../ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md).
+
 ---
 
 ## Prerequisites

--- a/docs/ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md
+++ b/docs/ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md
@@ -1,0 +1,62 @@
+# AI/KI — CI cost & autonomy operator policy (v0)
+
+Version: v0
+
+Owner: Ops / AI governance alignment
+
+Scope: **GitHub Actions and operator posture** for paid LLM usage and repo autonomy.
+Out of scope: Trading logic, Master V2, Double Play, Risk, Kill Switch, execution/live enablement (see [`ai_activation_gate_v1.md`](governance/ai_activation_gate_v1.md)).
+
+## Purpose
+
+Peak_Trade keeps **kostenpflichtige AI/KI/LLM** usage **default-off** in CI and scheduled automation until the system is intentionally mature. This note records the **operator policy** after Promptfoo cost gating (PR #3461) and follow-up workflow reviews.
+
+## Principles (operators)
+
+1. **Paid AI/KI/LLM is default-off** in `pull_request`, `push`, and routine `schedule` paths.
+2. **A present `OPENAI_API_KEY` GitHub Actions secret does not imply permission to spend.** Runtime and workflow gates still apply.
+3. **No silent paid LLM** on ordinary PR/push or cron: prefer `--skip-llm`, `--skip-ai`, offline/no-op, replay, or placeholder outputs.
+4. **Real (billable) LLM calls** are allowed only when an operator **explicitly opts in**, with **auditable** workflow inputs and/or repository variables plus existing **hard gates** (see model enablement runbooks).
+5. **AI must not grant trading or live execution authority.** Advisory and orchestration remain bounded by governance; see [`AI_AUTONOMY_GO_NO_GO_OVERVIEW.md`](../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md).
+
+## Workflow surfaces (expected posture)
+
+| Surface | Current expected state | Paid / billable LLM allowed? | Notes |
+|--------|-------------------------|--------------------------------|-------|
+| **AI-Ops Promptfoo Evals** | Active; PR/push run cost-safe path | **Only** manual `workflow_dispatch` with `run_paid_openai_evals=true` **and** repo var `PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS=true` | After PR #3461; see also [`AI_EVALS_RUNBOOK.md`](../ai/AI_EVALS_RUNBOOK.md). |
+| **InfoStream Automation** | Schedule + manual | **Schedule:** only if affirmative repo variables (e.g. `PT_AI_MODELS_ENABLED`, `PT_PAPERTRAIL_READY`) and runtime gates allow; keep vars **absent/false** unless owner-approved. | Treat scheduled model clients as **high sensitivity**. |
+| **MarketSentinel – Daily Market Outlook** | Schedule + manual | **Schedule:** uses `--skip-llm` (placeholder path). **Manual dispatch:** review point — no dedicated “paid LLM” workflow input today; rely on runtime gates and avoid casual manual runs. | Prefer manual-only or explicit paid opt-in in a future guardrail slice. |
+| **AIOps trend seed / ledger** | `workflow_run` / dispatch | **No** OpenAI secret in workflow (artifact chain) | Offline/deterministic chain. |
+| **Cursor Auto-PR / Auto-merge** | Push / PR automation | **No LLM cost**; uses `GITHUB_TOKEN` | **Repo autonomy** (PRs, labels, merge) — separate governance from LLM cost. |
+| **`ai-model-cards-validate`** | PR | **No** — local validation of docs | Safe. |
+| **Audit workflow** | Various | Dummy `OPENAI_API_KEY` in CI only where documented | No live key dependency for audit path. |
+
+## Repository variables (cost-relevant)
+
+Keep **absent or non-affirmative** unless an owner explicitly arms automation:
+
+- `PT_AI_MODELS_ENABLED`
+- `PT_PAPERTRAIL_READY`
+- `PT_AI_MODELS_ARMED`
+
+Treat **`PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS`** as **false/absent** unless paid Promptfoo evals are intentionally required.
+
+Also check **GitHub Environments** and **organization-level** variables if workflows bind to environments.
+
+## Related documentation
+
+- Promptfoo / local evals: [`docs/ai/AI_EVALS_RUNBOOK.md`](../ai/AI_EVALS_RUNBOOK.md)
+- Live AI activation (execution boundary): [`docs/ops/governance/ai_activation_gate_v1.md`](governance/ai_activation_gate_v1.md)
+- Model enablement operations: [`docs/ops/ai/ai_model_enablement_runbook_v1.md`](ai/ai_model_enablement_runbook_v1.md)
+- Autonomy overview: [`docs/governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md`](../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md)
+
+## Next review points (no implementation commitment)
+
+1. **Market Outlook** — manual `workflow_dispatch`: optional explicit “paid LLM” input + repo variable (align with Promptfoo pattern).
+2. **InfoStream** — confirm repo variables and policy artifacts stay **disarmed** in GitHub UI when daily KI is not intended.
+3. **Org/environment variables** — periodic audit that no environment inherits unintended affirmative AI flags.
+
+## Non-goals
+
+- Changing trading, risk, execution, or live gates.
+- Mandating removal of `OPENAI_API_KEY`; controlling **when** workflows may use it is the goal.

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -18,6 +18,8 @@
 
 - **PR #3238** — Observability **read-model** contract **tests** (`tests/webui/test_market_depth_readmodel_v0.py`, `tests/webui/test_paper_shadow_summary_readmodel_v0.py`): **tests-only** fixture-backed regression/readability anchors; **not** operational readiness, telemetry guarantees, or authorization.
 
+- **AI/KI CI cost & autonomy (v0)** — Operator policy: paid LLM **default-off** on PR/push/schedule; explicit opt-in for billable paths; InfoStream / Market Outlook / Promptfoo posture: [`AI_KI_COST_AUTONOMY_CI_POLICY_V0.md`](AI_KI_COST_AUTONOMY_CI_POLICY_V0.md).
+
 <!-- ops readme status navigation note -->
 - Projektstatus / Navigation: `docs&#47;INDEX.md` ist der zentrale Einstieg für Docs-Navigation.
 - Für kompakten Status-/Lookup-Einstieg nutze `docs&#47;ops&#47;STATUS_MATRIX.md`; für datierten narrativen Kontext nutze `docs&#47;ops&#47;STATUS_OVERVIEW_2026-02-19.md`.


### PR DESCRIPTION
## Summary

- adds a central operator policy for AI/KI cost and autonomy boundaries in CI
- documents paid AI/LLM as default-off for PR, push, and schedule paths
- records Promptfoo after #3461 as requiring explicit manual dispatch input plus repo variable opt-in
- links the local AI evals runbook to the CI cost-gate policy
- adds discoverability from docs/ops/README.md

## Safety

- docs-only
- no workflow changes
- no source/runtime changes
- no scheduler, broker, exchange, testnet, live, or order-path changes
- no Master V2 / Double Play / Risk / KillSwitch / Execution changes
- no secrets exposed

## Validation

- `git diff --check main...HEAD`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Notes

Remaining review points stay explicitly non-implementing:
- Market Outlook manual dispatch paid-input/default-off review
- InfoStream affirmative vars review
- GitHub Environments/org-level vars check

Made with [Cursor](https://cursor.com)