### PR TITLE
tests(ci): add workflow dispatch input metadata visibility v1

### DIFF
--- a/tests/ci/test_workflow_manual_dispatch_sensitive_surface_contract_v0.py
+++ b/tests/ci/test_workflow_manual_dispatch_sensitive_surface_contract_v0.py
@@ -7,6 +7,10 @@ scheduler, daemon, paper/shadow/testnet/live, broker/exchange, or order paths.
 This contract freezes the current manual-dispatch + sensitive-surface inventory
 as an owner-review surface. It does not require workflow YAML changes and does
 not treat the current set as a new hard failure without owner decision.
+
+Follow-up (workflow_dispatch_input_metadata_visibility_v1): best-effort
+``required`` / ``type`` / ``default`` fields under each ``workflow_dispatch`` input
+key (indent-heuristic only). Missing or unrecognized metadata stays ``None``.
 """
 
 from __future__ import annotations
@@ -149,6 +153,107 @@ def _extract_workflow_dispatch_input_keys(text: str) -> list[str]:
     return collected
 
 
+def _strip_yaml_scalar_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def _consume_input_metadata_lines(
+    lines: list[str], start: int, input_key_indent: int
+) -> tuple[dict[str, Any], int]:
+    """Parse nested lines under one ``inputs.<name>:`` key until next sibling input."""
+    required: bool | None = None
+    typ: str | None = None
+    default: str | None = None
+    j = start
+    while j < len(lines):
+        raw = lines[j]
+        if not raw.strip():
+            j += 1
+            continue
+        indent = len(raw) - len(raw.lstrip(" \t"))
+        if raw.strip().startswith("#"):
+            j += 1
+            continue
+        if indent <= input_key_indent:
+            break
+        stripped = raw.strip()
+        m_req = re.match(r"^required\s*:\s*(true|false)\s*$", stripped, re.I)
+        if m_req:
+            required = m_req.group(1).lower() == "true"
+            j += 1
+            continue
+        m_type = re.match(r"^type\s*:\s*(.+?)\s*$", stripped)
+        if m_type:
+            typ = _strip_yaml_scalar_quotes(m_type.group(1).strip())
+            j += 1
+            continue
+        m_def = re.match(r"^default\s*:\s*(.*)$", stripped)
+        if m_def:
+            default = _strip_yaml_scalar_quotes(m_def.group(1).strip())
+            j += 1
+            continue
+        j += 1
+    return {"required": required, "type": typ, "default": default}, j
+
+
+def _extract_workflow_dispatch_inputs_metadata(text: str) -> dict[str, dict[str, Any]]:
+    """Best-effort metadata map per input key (merged across dispatch blocks in order)."""
+    lines = text.splitlines()
+    result: dict[str, dict[str, Any]] = {}
+    i = 0
+    while i < len(lines):
+        m_dispatch = re.match(r"^(\s*)workflow_dispatch\s*:", lines[i])
+        if not m_dispatch:
+            i += 1
+            continue
+        indent_d = len(m_dispatch.group(1))
+        i += 1
+        inputs_indent: int | None = None
+        child_indent: int | None = None
+        while i < len(lines):
+            raw = lines[i]
+            if not raw.strip():
+                i += 1
+                continue
+            indent = len(raw) - len(raw.lstrip(" \t"))
+            if raw.strip().startswith("#"):
+                i += 1
+                continue
+            if indent <= indent_d:
+                break
+            if inputs_indent is None:
+                if re.match(r"^\s*inputs\s*:", raw):
+                    inputs_indent = indent
+                i += 1
+                continue
+            if indent <= inputs_indent:
+                break
+            m_key = re.match(r"^\s*([A-Za-z0-9_-]+)\s*:\s*(?:#.*)?$", raw)
+            if m_key:
+                if child_indent is None:
+                    child_indent = indent
+                elif indent < child_indent:
+                    break
+                if indent == child_indent:
+                    key = m_key.group(1)
+                    meta, j = _consume_input_metadata_lines(lines, i + 1, child_indent)
+                    result[key] = meta
+                    i = j
+                    continue
+            i += 1
+    return result
+
+
+def _inputs_metadata_for_inventory(text: str, keys: list[str]) -> dict[str, dict[str, Any]]:
+    raw_meta = _extract_workflow_dispatch_inputs_metadata(text)
+    return {
+        k: dict(raw_meta[k]) if k in raw_meta else {"required": None, "type": None, "default": None}
+        for k in keys
+    }
+
+
 def _input_keys_flagged_for_sensitive_name_markers(keys: list[str]) -> list[str]:
     flagged: list[str] = []
     for key in keys:
@@ -171,6 +276,7 @@ def _workflow_dispatch_inputs_inventory_v1() -> dict[str, dict[str, Any]]:
             "input_keys": keys,
             "sensitive_input_name_markers": _input_keys_flagged_for_sensitive_name_markers(keys),
             "defines_inputs_block": bool(keys),
+            "inputs_metadata": _inputs_metadata_for_inventory(text, keys),
         }
 
     return inventory
@@ -306,6 +412,14 @@ def test_workflow_dispatch_inputs_visibility_followup_v1_inventory_shape() -> No
         assert isinstance(row["input_keys"], list)
         assert isinstance(row["sensitive_input_name_markers"], list)
         assert isinstance(row["defines_inputs_block"], bool)
+        assert isinstance(row["inputs_metadata"], dict)
+        assert list(row["inputs_metadata"]) == sorted(row["inputs_metadata"])
+        for in_key, meta in row["inputs_metadata"].items():
+            assert in_key in row["input_keys"]
+            assert set(meta.keys()) == {"required", "type", "default"}
+            assert meta["required"] is None or isinstance(meta["required"], bool)
+            assert meta["type"] is None or isinstance(meta["type"], str)
+            assert meta["default"] is None or isinstance(meta["default"], str)
 
 
 def test_workflow_dispatch_inputs_visibility_followup_v1_some_workflows_define_inputs() -> None:
@@ -328,3 +442,54 @@ def test_workflow_dispatch_inputs_visibility_followup_v1_weekly_audit_lists_note
     row = inventory.get("weekly_core_audit.yml")
     assert row is not None
     assert "note" in row["input_keys"]
+
+
+_SYNTHETIC_DISPATCH_INPUT_METADATA = (
+    "on:\n"
+    "  workflow_dispatch:\n"
+    "    inputs:\n"
+    "      alpha:\n"
+    "        description: sample\n"
+    "        required: true\n"
+    "        type: string\n"
+    "        default: 'hello'\n"
+    "      beta:\n"
+    "        required: false\n"
+    '        default: ""\n'
+)
+
+
+def test_workflow_dispatch_input_metadata_visibility_v1_parser_synthetic_snippet() -> None:
+    meta = _extract_workflow_dispatch_inputs_metadata(_SYNTHETIC_DISPATCH_INPUT_METADATA)
+    assert meta["alpha"]["required"] is True
+    assert meta["alpha"]["type"] == "string"
+    assert meta["alpha"]["default"] == "hello"
+    assert meta["beta"]["required"] is False
+    assert meta["beta"]["type"] is None
+    assert meta["beta"]["default"] == ""
+
+
+def test_workflow_dispatch_input_metadata_visibility_v1_inventory_sorted_deterministic() -> None:
+    first = _workflow_dispatch_inputs_inventory_v1()
+    second = _workflow_dispatch_inputs_inventory_v1()
+    assert first == second
+
+
+def test_workflow_dispatch_input_metadata_visibility_v1_prcd_confirm_token_metadata_smoke() -> None:
+    inventory = _workflow_dispatch_inputs_inventory_v1()
+    row = inventory.get("prcd-aws-export-write-smoke.yml")
+    assert row is not None
+    meta = row["inputs_metadata"]["confirm_token"]
+    assert meta["required"] is True
+    assert meta["default"] == ""
+    assert meta["type"] is None
+
+
+def test_workflow_dispatch_input_metadata_visibility_v1_weekly_note_metadata_smoke() -> None:
+    inventory = _workflow_dispatch_inputs_inventory_v1()
+    row = inventory.get("weekly_core_audit.yml")
+    assert row is not None
+    meta = row["inputs_metadata"]["note"]
+    assert meta["required"] is False
+    assert meta["default"] == "weekly core audit"
+    assert meta["type"] is None


### PR DESCRIPTION
## Summary

- extend the existing manual dispatch security contract in place
- add deterministic static metadata inventory for `workflow_dispatch.inputs`
- surface best-effort `required`, `type`, and `default` metadata per input
- preserve existing input-key and sensitive-marker visibility behavior
- add smoke coverage for known workflow inputs including `confirm_token` and `note`

## Safety

- tests-only defensive cybersecurity follow-up
- repo-local static workflow file reads only
- no scheduler execution
- no runtime daemon execution
- no paper/testnet/live execution
- no broker/exchange/order paths
- no external network calls
- no offensive scanning
- no credential validation
- no secrets read or printed
- no GitHub API/variable/secret reads
- no Master V2 / Double Play trading logic changes
- reuse-before-new honored by extending `tests/ci/test_workflow_manual_dispatch_sensitive_surface_contract_v0.py`

## Validation

- `uv run pytest tests/ci/test_workflow_manual_dispatch_sensitive_surface_contract_v0.py -q`
- `uv run ruff check tests/ci/test_workflow_manual_dispatch_sensitive_surface_contract_v0.py`
- `uv run ruff format --check tests/ci/test_workflow_manual_dispatch_sensitive_surface_contract_v0.py`
- `git diff --check`

## Result artifact

`/tmp/peak_trade_workflow_dispatch_input_metadata_visibility_v1_20260511T190125Z/WORKFLOW_DISPATCH_INPUT_METADATA_VISIBILITY_V1_RESULT.md`

Made with [Cursor](https://cursor.com)