### PR TITLE
ui(webui): clarify market dashboard non-authority guardrail copy

### DIFF
--- a/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
+++ b/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
@@ -34,7 +34,7 @@
           Double-Play Market Dashboard v1
         </h1>
         <p class="text-xs text-slate-500 mt-1 m-0">
-          v1.2 read-only · Candlestick view · non-authority
+          v1.2 read-only · Candlestick view · keine Freigabe · non-authority
         </p>
       </div>
       <div class="flex flex-wrap items-center gap-2">
@@ -80,6 +80,10 @@
     data-double-play-market-safety="true"
     data-double-play-market-cockpit-safety-chips="true"
   >
+    <p class="text-[11px] text-amber-100/85 m-0 mb-2 leading-snug">
+      <strong class="text-amber-200/95">Guardrails:</strong>
+      Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval — reine Anzeige, keine Broker-/Order-/Live-Autorität.
+    </p>
     <div class="flex flex-wrap gap-2 text-[10px] font-semibold uppercase tracking-wide text-amber-100/95">
       <span class="rounded-md border border-amber-800/55 bg-amber-950/50 px-2 py-0.5">No orders</span>
       <span class="rounded-md border border-amber-800/55 bg-amber-950/50 px-2 py-0.5">No live</span>

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -77,6 +77,10 @@
       Keine Orders, kein Testnet, kein Live.
     </p>
     {% endif %}
+    <p class="mt-2 border-t border-amber-800/30 pt-2 leading-snug text-amber-100/85 m-0 text-[11px]">
+      <strong class="text-amber-200/95">Guardrails:</strong>
+      Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval — reine Anzeige, keine Broker-/Order-/Live-Autorität.
+    </p>
   </section>
 
   <section


### PR DESCRIPTION
## Summary
- Clarifies non-authority guardrail copy on `/market`
- Adds matching guardrail copy to `/market/double-play`
- Keeps both dashboard surfaces read-only and non-authorizing

## Guardrails
- Dashboard ≠ Freigabe
- AI ≠ Authority
- Signal ≠ Trade
- Docs ≠ Approval
- No broker/order/live authority added
- No routing/API/runtime/secret/trading logic changes

## Validation
- `uv run pytest -q tests/webui/test_market_dashboard_readonly_structure_contract_v0.py tests/webui/test_double_play_market_dashboard_v0.py tests/test_market_surface_api.py`
- `uv run ruff check`
- `uv run ruff format --check`

## Notes
- Template-only copy change
- No new `data-*` markers
- Secret/Kraken governance chain remains complete and untouched

Made with [Cursor](https://cursor.com)