### PR TITLE
docs(webui): align MARKET_SURFACE_V0 with template guardrails copy

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -51,6 +51,8 @@ Stabile `data-*`‑Marker (Anker für Anzeige und automatisierte Tests — **kei
 
 Banner‑Inhalt fasst u. a.: keine Orders, kein Testnet/Live, keine Capital/Scope‑Freigabe, kein Risk-/KillSwitch‑Bypass — rein erklärend; **kein** Gate, **keine** Strategie- oder Ausführungsfreigabe.
 
+**Guardrails-Kurzzeile (Templates):** **`GET &#47;market`** und **`GET &#47;market&#47;double-play`** rendern dieselbe sichtbare **Guardrails**-Botschaft: **Dashboard ≠ Freigabe** · **AI ≠ Authority** · **Signal ≠ Trade** · **Docs ≠ Approval** — rein darstellend; **keine** Broker-/Order-/Live-Autorität.
+
 ## Ranking funnel empty state (dynamic labels)
 
 Auf **`GET`** **`/market`** zeigt das Template einen **Futures-Ranking-Funnel** ausschließlich als **read-only**, **non-authorizing** **Empty-State** / Platzhalter:


### PR DESCRIPTION
## Summary
- Aligns `docs/webui/MARKET_SURFACE_V0.md` with the guardrails copy now present in the `/market` and `/market/double-play` templates
- Documents the short non-authority line: Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval
- Clarifies that the dashboard surfaces remain display-only and add no broker/order/live authority

## Guardrails
- Docs-only
- No template/code/test/runtime changes
- No secrets or Kraken/account changes
- No scheduler/paper/testnet/live/broker/exchange/order paths
- Secret/Kraken governance chain remains complete and untouched

## Validation
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)