### PR TITLE
ui(webui): clarify market depth SSR empty and diagnostic states

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -833,8 +833,18 @@
               </span>
             </div>
             <p class="m-0 font-medium text-slate-500">Diagnostics — empty ladder</p>
-            <p class="m-0 mt-1 text-slate-500">
-              No ladder rows · depth disabled, unconfigured, or empty SSR snapshot · display-only diagnostics.
+            <p class="m-0 mt-1 text-slate-500" data-market-v0-ladder-empty-explain="true">
+              {% if market_depth.display_status == 'ok' %}
+              SSR depth status is <strong class="text-slate-400">ok</strong>, but this snapshot has no bid/ask rows to render (empty levels in offline bundle or placeholder payload).
+              {% elif market_depth.display_status == 'disabled' %}
+              Depth SSR is <strong class="text-slate-400">disabled</strong> for this process — illustrative ladder only; enable the offline depth feature to load fixture data (see Market Depth summary below).
+              {% elif market_depth.display_status == 'unconfigured' %}
+              Depth bundle directory is <strong class="text-slate-400">unconfigured</strong> or not reachable — illustrative ladder only; set bundle root to a valid offline fixture path (see summary below).
+              {% elif market_depth.display_status == 'builder_error' %}
+              Offline depth bundle <strong class="text-slate-400">failed build or validation</strong> — illustrative ladder only; fix the bundle or warnings shown in the summary below.
+              {% else %}
+              Ladder unavailable for this SSR snapshot (<strong class="text-slate-400">{{ market_depth.display_status|e }}</strong>) — display-only diagnostics; see Market Depth strip below.
+              {% endif %}
               <span class="text-slate-500">No orders · no polling · not streamed after load.</span>
             </p>
             <div class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2" aria-hidden="true">
@@ -1012,6 +1022,23 @@
         <p class="leading-relaxed text-slate-300/90 m-0" data-market-depth-summary="true">
           {{ market_depth.summary_line|e }}
         </p>
+        {% if market_depth.display_status != 'ok' %}
+        <p class="mt-1.5 text-[10px] text-slate-400 m-0 leading-snug" data-market-depth-operator-hint="true">
+          {% if market_depth.display_status == 'disabled' %}
+          <strong class="text-slate-300">Operator:</strong> depth SSR is off for this process — placeholders only until the offline feature is enabled (see warning above).
+          {% elif market_depth.display_status == 'unconfigured' %}
+          <strong class="text-slate-300">Operator:</strong> point bundle root env to a directory with a valid offline depth fixture (see warning above).
+          {% elif market_depth.display_status == 'builder_error' %}
+          <strong class="text-slate-300">Operator:</strong> bundle build or validation failed — repair fixture files or paths (see warning above).
+          {% else %}
+          <strong class="text-slate-300">Operator:</strong> depth snapshot unavailable (status {{ market_depth.display_status|e }}) — ladder shows placeholders only.
+          {% endif %}
+        </p>
+        {% elif not market_depth.has_depth_levels %}
+        <p class="mt-1.5 text-[10px] text-slate-400 m-0 leading-snug" data-market-depth-operator-hint="true">
+          <strong class="text-slate-300">Operator:</strong> readmodel returned <strong class="text-slate-200">ok</strong> but no bid/ask ladder rows — bundle may hold zero levels for this context.
+        </p>
+        {% endif %}
         <p class="mt-2 text-[10px] text-slate-500 m-0 leading-snug">
           Depth/offline display only — SSR only; keine Browser-Abfrage der Depth-JSON-Route; keine Orders oder Ausführung.
         </p>

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -138,6 +138,9 @@ class TestMarketSurfaceHtml:
         assert 'data-market-v0-orderbook-topn="true"' in body
         assert 'data-market-v0-orderbook-has-levels="false"' in body
         assert 'data-market-v0-orderbook-empty="true"' in body
+        assert 'data-market-v0-ladder-empty-explain="true"' in body
+        assert "Depth SSR is" in body
+        assert 'data-market-depth-operator-hint="true"' in body
 
     def test_market_page_depth_ssr_forbids_client_depth_route_and_xhr(
         self,
@@ -199,6 +202,9 @@ class TestMarketSurfaceHtml:
         assert 'data-market-v0-orderbook-has-levels="false"' in body
         assert 'data-market-v0-orderbook-empty="true"' in body
         assert "/api/market/depth" not in body
+        assert "failed build" in body
+        assert "validation" in body
+        assert 'data-market-depth-operator-hint="true"' in body
 
     def test_market_depth_ssr_ok_branch_uses_display_status_ok(
         self,
@@ -226,6 +232,8 @@ class TestMarketSurfaceHtml:
         assert 'data-market-v0-orderbook-has-levels="false"' in body
         assert 'data-market-v0-orderbook-empty="true"' in body
         assert "/api/market/depth" not in body
+        assert "no bid/ask rows" in body
+        assert 'data-market-depth-operator-hint="true"' in body
 
     def test_market_dashboard_orderbook_topn_ssr_with_fixture_bundle(
         self,


### PR DESCRIPTION
## Summary
- Clarifies existing SSR Market Depth / Ladder empty-state copy on `/market`
- Adds operator-facing diagnostic hints for disabled, unconfigured, builder-error, and ok-without-ladder-row states
- Locks the new read-only UI markers/phrases in focused Market Surface API tests

## Guardrails
- Read-only display/copy change
- No API/router/runtime changes
- No exchange/Kraken calls
- No secrets or account changes
- No scheduler/paper/testnet/live/broker/exchange/order paths
- No broker/order/live authority added
- Market Dashboard remains non-authorizing

## Validation
- `uv run pytest -q tests/webui/test_market_dashboard_readonly_structure_contract_v0.py tests/test_market_surface_api.py`
- `uv run ruff check`
- `uv run ruff format --check`

Made with [Cursor](https://cursor.com)