### PR TITLE
ui(webui): add double-play market operator reading guide

### DIFF
--- a/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
+++ b/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
@@ -102,6 +102,36 @@
     </details>
   </section>
 
+  <section
+    aria-label="Operator reading guide"
+    class="rounded-xl border border-slate-800/90 bg-slate-950/40 px-3 py-2.5 ring-1 ring-slate-800/60"
+    data-double-play-market-operator-reading-guide-v0="true"
+  >
+    <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-500 m-0 mb-1.5">
+      So lesen Sie diese Ansicht
+    </p>
+    <ul class="m-0 pl-4 list-disc text-[11px] text-slate-300/95 space-y-1 leading-snug marker:text-slate-600">
+      <li>
+        <span class="text-slate-200 font-medium">Linke Spalte:</span>
+        eingebetteter OHLC- und Candlestick-Snapshot (SSR) — nur
+        <span class="font-medium text-slate-200">Marktkontext</span>; read-only Visualization, keine Operational-Freigabe.
+      </li>
+      <li>
+        <span class="text-slate-200 font-medium">Rechte Rail:</span>
+        Double-Play-Display-Snapshot (gleicher Anzeige-Vertrag wie
+        <span class="font-mono text-sky-400/90">dashboard-display.json</span>) —
+        nur diagnostische Metadaten; keine Order-, Broker- oder Live-Autorität.
+      </li>
+      <li>
+        <span class="font-medium text-slate-400">Ordinal</span>,
+        <span class="font-medium text-slate-400">Panel group</span>
+        und
+        <span class="font-medium text-slate-400">Severity rank</span>
+        sind Display-/Readout-Hinweise für diese Oberfläche — keine Ausführungs-Priorität, kein Routing- oder Freigabe-Signal.
+      </li>
+    </ul>
+  </section>
+
   <div
     class="flex flex-col gap-6 xl:grid xl:grid-cols-[minmax(0,1fr)_min(21rem,100%)] xl:items-start xl:gap-6"
     data-double-play-market-cockpit-grid="true"

--- a/tests/webui/test_double_play_market_dashboard_v0.py
+++ b/tests/webui/test_double_play_market_dashboard_v0.py
@@ -259,6 +259,37 @@ def test_double_play_market_dashboard_consumes_structured_metadata_v2(client: Te
     assert "live_authorization" not in lower
 
 
+def test_double_play_market_dashboard_operator_reading_guide_v0(client: TestClient) -> None:
+    """Orientation block: OHLC SSR vs DP display rail semantics (readonly, display metadata)."""
+    r = client.get("/market/double-play")
+    assert r.status_code == 200
+    body = r.text
+
+    assert 'data-double-play-market-operator-reading-guide-v0="true"' in body
+    assert "So lesen Sie diese Ansicht" in body
+    assert "Marktkontext" in body
+    assert "Double-Play-Display-Snapshot" in body
+    assert "dashboard-display.json" in body
+    assert "Ordinal" in body
+    assert "Panel group" in body
+    assert "Severity rank" in body
+    assert "Display-/Readout-Hinweise" in body
+    assert "Ausführungs-Priorität" in body
+
+    forbidden = ("BUY", "SELL", "GO", "APPROVED", "ACTIVE TRADE")
+    for w in forbidden:
+        assert w not in body
+
+    lower = body.lower()
+    assert "<form" not in lower
+    assert 'method="post"' not in lower
+    assert "<button" not in lower
+    assert 'type="submit"' not in lower
+    assert "fetch(" not in body
+    assert "setinterval" not in lower
+    assert "live_authorization" not in lower
+
+
 def test_double_play_market_dashboard_bad_timeframe_422(client: TestClient) -> None:
     r = client.get("/market/double-play", params={"timeframe": "bogus"})
     assert r.status_code == 422


### PR DESCRIPTION
## Summary
- Adds a compact operator reading guide to `/market/double-play`
- Explains the left OHLC/Candlestick SSR area as read-only market context
- Explains the Double-Play display snapshot / rail / panels as read-only diagnostic metadata
- Clarifies Ordinal, panel group, and severity rank as display/readout metadata, not order priority or execution authority
- Adds focused contract assertions for the new guide

## Guardrails
- Template + focused test only
- No routes/API/runtime changes
- No Master V2 / Double Play strategy logic changes
- No Risk/KillSwitch/Live Gate changes
- No secrets/Kraken/account changes
- No scheduler/paper/testnet/live/broker/exchange/order paths
- No order UI, broker UI, Freigabe UI, or authorizing controls
- `/market/double-play` remains read-only diagnostic/advisory

## Validation
- `uv run pytest -q tests/webui/test_double_play_market_dashboard_v0.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- `uv run ruff check`
- `uv run ruff format --check`

## Notes
- This PR is separate from the closed Secret/Kraken, guardrails-copy, Depth/SSR clarity, and Downloads-ingest chains

Made with [Cursor](https://cursor.com)