### PR TITLE
ui(webui): attribute Chart.js CDN load failures with readonly markers

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -100,7 +100,9 @@ Dashboard markers remain non-authorizing: **Dashboard ≠ Freigabe**; no marker 
 - **Prominenter Fallback‑Kasten** bei **SSR‑Empty** sowie ein **client‑gesteuerter** Fehler‑Kasten für **Chart library missing or blocked** bzw. **Chart render error** (**keine** neue Autorität).
 - **Keine** lokale Chart.js‑Vendor‑ oder Static‑Asset‑Einbindung; **GET &#47;api&#47;market&#47;ohlcv** bleibt unverändert.
 - **Keine** Double‑Play‑Komposition oder Trading‑/Risk‑/Capital‑Interpretation durch diese Diagnosemarker.
-- **v1.2** kann einen **lokalen Chart.js‑Fallback** planen, falls CDN‑Blocking **evidenziert** ist.
+- **v0 CDN load attribution (template):** Die Chart.js‑Einbindung über **jsdelivr** setzt am `<script>`‑Tag ein **`onerror`**, markiert das Skript bei Ladefehler mit **`data-chartjs-cdn-load-error`** und spiegelt den Zustand auf den jeweiligen Dashboard‑Shell‑Container (**`data-chartjs-cdn-load-error`** auf **`#market-v0-shell`**, **`#double-play-market-v0-shell`**, bzw. **`#r-and-d-charts-shell`** wenn Diagramme geladen werden). Zusätzlich **`data-chartjs-cdn-monitored-v0="true"`** kennzeichnet Oberflächen mit dieser Überwachung. **Lokaler Vendor‑Chart.js‑Fallback** bleibt **separates** Arbeitspaket (siehe Hinweis zu **v1.2** unten); Oberflächen bleiben **read-only** und **non-authorizing**.
+
+**v1.2** kann einen **lokalen Chart.js‑Fallback** planen, falls CDN‑Blocking **evidenziert** ist.
 
 ## Double-Play Market Dashboard v1 SSR
 

--- a/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
+++ b/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
@@ -4,6 +4,8 @@
 {% block content %}
 <div
   class="space-y-5 max-w-7xl mx-auto px-4 py-6 pb-12"
+  id="double-play-market-v0-shell"
+  data-chartjs-cdn-monitored-v0="true"
   data-double-play-market-dashboard-v0="true"
   data-double-play-market-composition-ssr-v1="true"
   data-double-play-market-ssr-only="true"
@@ -262,7 +264,12 @@
       </div>
 
       <script type="application/json" id="dp-market-ssr-payload">{{ payload | tojson }}</script>
-      <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+      <script
+        id="peak-trade-double-play-chartjs-cdn-v0"
+        src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+        data-chartjs-cdn-script-v0="true"
+        onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('double-play-market-v0-shell');if(s)s.setAttribute('data-chartjs-cdn-load-error','true');"
+      ></script>
       <script>
         (function () {
           function num(x) {

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -5,7 +5,9 @@
 {% block content %}
 <div
   class="space-y-5 max-w-7xl mx-auto px-2 sm:px-0 pb-1"
+  id="market-v0-shell"
   data-section="market-v0"
+  data-chartjs-cdn-monitored-v0="true"
   data-market-surface-v0="true"
   data-market-v1-dashboard-shell="true"
   data-market-v0-pro-shell="true"
@@ -1095,7 +1097,12 @@
   </div>
 
   <script type="application/json" id="market-v0-payload">{{ payload | tojson }}</script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script
+    id="peak-trade-market-chartjs-cdn-v0"
+    src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+    data-chartjs-cdn-script-v0="true"
+    onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('market-v0-shell');if(s)s.setAttribute('data-chartjs-cdn-load-error','true');"
+  ></script>
   <script>
     (function () {
       function setDiagRender(kind) {

--- a/templates/peak_trade_dashboard/r_and_d_charts.html
+++ b/templates/peak_trade_dashboard/r_and_d_charts.html
@@ -5,6 +5,8 @@
 {% block content %}
 <div
   class="space-y-6 max-w-6xl mx-auto"
+  id="r-and-d-charts-shell"
+  data-chartjs-cdn-monitored-v0="true"
   data-section="r-and-d-charts"
   data-r-and-d-charts-empty="{{ 'true' if charts.empty else 'false' }}"
   data-r-and-d-charts-no-plot-points="{{ 'true' if charts.no_plot_points else 'false' }}"
@@ -107,7 +109,12 @@
     </section>
   </div>
   <script type="application/json" id="r-and-d-charts-payload">{{ charts | tojson }}</script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script
+    id="peak-trade-r-and-d-chartjs-cdn-v0"
+    src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+    data-chartjs-cdn-script-v0="true"
+    onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('r-and-d-charts-shell');if(s)s.setAttribute('data-chartjs-cdn-load-error','true');"
+  ></script>
   <script>
     (function () {
       const el = document.getElementById("r-and-d-charts-payload");

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -123,6 +123,12 @@ class TestMarketSurfaceHtml:
         assert "Capital" in body or "Scope" in body
         assert "KillSwitch" in body or "Risk" in body
         assert "chart.js@4.4.1" in body.lower() or "chart.umd.min.js" in body
+        assert 'data-chartjs-cdn-script-v0="true"' in body
+        assert 'data-chartjs-cdn-monitored-v0="true"' in body
+        assert 'id="peak-trade-market-chartjs-cdn-v0"' in body
+        assert 'id="market-v0-shell"' in body
+        assert "data-chartjs-cdn-load-error" in body
+        assert "onerror=" in body.lower()
         lower = body.lower()
         assert "<form" not in lower
         assert 'method="post"' not in lower

--- a/tests/test_r_and_d_api.py
+++ b/tests/test_r_and_d_api.py
@@ -640,6 +640,12 @@ class TestRnDChartsHtmlPage:
         assert 'data-chart="r-and-d-sharpe-histogram"' in body
         assert 'data-chart="r-and-d-return-vs-sharpe-scatter"' in body
         assert 'id="r-and-d-charts-payload"' in body
+        assert 'id="peak-trade-r-and-d-chartjs-cdn-v0"' in body
+        assert 'id="r-and-d-charts-shell"' in body
+        assert 'data-chartjs-cdn-script-v0="true"' in body
+        assert 'data-chartjs-cdn-monitored-v0="true"' in body
+        assert "data-chartjs-cdn-load-error" in body
+        assert "onerror=" in body.lower()
         assert '"histogram_labels"' in body
         assert '"scatter_points"' in body
         assert 'method="POST"' not in body

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -79,6 +79,30 @@ def test_double_play_dashboard_excludes_market_depth_ssr_markers_v0(
     assert "market-v0-depth-ssr" not in html
 
 
+def test_market_and_double_play_chartjs_cdn_failure_attribution_v0(
+    client: TestClient,
+) -> None:
+    """Chart.js loads from CDN; templates attribute CDN load failures (read-only markers)."""
+    for path, cdn_id, shell_id in (
+        ("/market", "peak-trade-market-chartjs-cdn-v0", "market-v0-shell"),
+        (
+            "/market/double-play",
+            "peak-trade-double-play-chartjs-cdn-v0",
+            "double-play-market-v0-shell",
+        ),
+    ):
+        html = _html(client, path)
+        assert "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" in html
+        assert f'id="{cdn_id}"' in html
+        assert f'id="{shell_id}"' in html
+        assert 'data-chartjs-cdn-script-v0="true"' in html
+        assert 'data-chartjs-cdn-monitored-v0="true"' in html
+        assert "data-chartjs-cdn-load-error" in html
+        assert "onerror=" in html.lower()
+        assert "fetch(" not in html
+        assert "XMLHttpRequest" not in html
+
+
 def test_market_dashboard_has_no_trade_action_affordance(client: TestClient) -> None:
     combined_html = "\n".join(
         [


### PR DESCRIPTION
## Summary
- Adds read-only Chart.js CDN load-failure attribution markers to Market, Double-Play Market, and R&D chart templates
- Sets stable `data-chartjs-cdn-*` markers without vendoring Chart.js or changing runtime/API behavior
- Updates focused tests for Market, Double-Play, Market Surface, and R&D chart surfaces
- Documents v0 CDN load attribution in `MARKET_SURFACE_V0.md`

## Guardrails
- Templates/docs/tests only
- No vendored Chart.js
- No package/dependency changes
- No Python runtime/API/router changes
- No network calls in tests
- No secrets/Kraken/account changes
- No scheduler/paper/testnet/live/broker/exchange/order paths
- No Master V2 / Double Play strategy logic / Risk / KillSwitch / Live Gate changes
- No order UI or authorizing controls

## Validation
- `uv run pytest -q tests/webui/test_market_dashboard_readonly_structure_contract_v0.py tests/webui/test_double_play_market_dashboard_v0.py tests/test_market_surface_api.py tests/test_r_and_d_api.py::TestRnDChartsHtmlPage::test_charts_page_ok_and_markers`
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

Made with [Cursor](https://cursor.com)