### PR TITLE
webui: add market dashboard landmark a11y pack v0

### DIFF
--- a/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
+++ b/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
@@ -5,6 +5,8 @@
 <div
   class="space-y-5 max-w-7xl mx-auto px-4 py-6 pb-12"
   id="double-play-market-v0-shell"
+  role="region"
+  aria-labelledby="double-play-market-v0-landmark-page-title"
   data-chartjs-cdn-monitored-v0="true"
   data-double-play-market-dashboard-v0="true"
   data-double-play-market-composition-ssr-v1="true"
@@ -32,7 +34,7 @@
     <div class="flex flex-wrap items-start justify-between gap-3">
       <div class="min-w-0">
         <p class="text-[10px] uppercase tracking-wider text-slate-500 mb-1">PeakTrade · Cockpit</p>
-        <h1 class="text-xl sm:text-2xl font-bold text-slate-100 tracking-tight">
+        <h1 id="double-play-market-v0-landmark-page-title" class="text-xl sm:text-2xl font-bold text-slate-100 tracking-tight">
           Double-Play Market Dashboard v1
         </h1>
         <p class="text-xs text-slate-500 mt-1 m-0">
@@ -77,11 +79,13 @@
   </header>
 
   <section
-    aria-label="Safety boundaries"
+    role="region"
+    aria-labelledby="double-play-market-v0-landmark-safety-h2"
     class="rounded-xl border border-amber-900/45 bg-amber-950/15 px-3 py-2.5"
     data-double-play-market-safety="true"
     data-double-play-market-cockpit-safety-chips="true"
   >
+    <h2 id="double-play-market-v0-landmark-safety-h2" class="sr-only">Safety boundaries</h2>
     <p class="text-[11px] text-amber-100/85 m-0 mb-2 leading-snug">
       <strong class="text-amber-200/95">Guardrails:</strong>
       Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval — reine Anzeige, keine Broker-/Order-/Live-Autorität.
@@ -105,13 +109,14 @@
   </section>
 
   <section
-    aria-label="Operator reading guide"
+    role="region"
+    aria-labelledby="double-play-market-v0-landmark-reading-guide-h2"
     class="rounded-xl border border-slate-800/90 bg-slate-950/40 px-3 py-2.5 ring-1 ring-slate-800/60"
     data-double-play-market-operator-reading-guide-v0="true"
   >
-    <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-500 m-0 mb-1.5">
+    <h2 id="double-play-market-v0-landmark-reading-guide-h2" class="text-[10px] font-semibold uppercase tracking-wide text-slate-500 m-0 mb-1.5">
       So lesen Sie diese Ansicht
-    </p>
+    </h2>
     <ul class="m-0 pl-4 list-disc text-[11px] text-slate-300/95 space-y-1 leading-snug marker:text-slate-600">
       <li>
         <span class="text-slate-200 font-medium">Linke Spalte:</span>
@@ -156,7 +161,8 @@
 
       {# --- Candlestick (dominant) — custom canvas, no financial plugin --- #}
       <section
-        aria-label="Candlestick chart read-only"
+        role="region"
+        aria-labelledby="double-play-market-v0-landmark-candlestick-h2"
         class="rounded-xl border border-slate-800 bg-slate-950/60 ring-1 ring-cyan-900/30 shadow-xl shadow-black/30 overflow-hidden"
         data-double-play-market-candlestick-v1-2="true"
         data-double-play-market-candlestick-no-plugin="true"
@@ -164,7 +170,7 @@
       >
         <div class="flex flex-wrap items-center justify-between gap-2 border-b border-slate-800/95 px-4 py-3 bg-gradient-to-r from-slate-950 via-slate-900/95 to-slate-950">
           <div>
-            <h2 class="text-sm font-semibold text-slate-50 m-0 tracking-tight">Candlestick view</h2>
+            <h2 id="double-play-market-v0-landmark-candlestick-h2" class="text-sm font-semibold text-slate-50 m-0 tracking-tight">Candlestick view</h2>
             <p class="text-[10px] text-slate-400 m-0 mt-1 leading-relaxed">
               <span class="text-sky-400/95">Embedded OHLC bars</span>
               · <span class="text-slate-300">No external financial chart plugin</span>
@@ -666,7 +672,7 @@
 
     <aside
       class="rounded-xl border border-slate-900/95 bg-gradient-to-b from-black/85 via-slate-950 to-slate-950 p-4 shadow-2xl shadow-black/45 ring-1 ring-cyan-950/45 xl:sticky xl:top-4"
-      aria-label="Double-Play snapshot rail"
+      aria-labelledby="double-play-market-v0-landmark-rail-h2"
       data-double-play-market-cockpit-rail="true"
       data-double-play-display-ssr-v1="true"
       data-double-play-market-visual-panels-v1-2="true"
@@ -704,7 +710,7 @@
         <span class="rounded-full border border-dashed border-slate-700 px-2 py-0.5 text-[9px] text-slate-500">Model label only</span>
       </div>
 
-      <h2 class="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2 m-0">Double-Play · Rail</h2>
+      <h2 id="double-play-market-v0-landmark-rail-h2" class="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2 m-0">Double-Play · Rail</h2>
       <p class="text-[11px] text-slate-400 mb-3 m-0 leading-snug border-b border-slate-800 pb-3">
         Display-only Snapshot — keine Operational-Freigabe.
         <a href="{{ double_play_json_url }}" class="text-sky-400 underline underline-offset-2 font-mono break-all block mt-2" data-double-play-market-display-json-link="true">{{ double_play_json_url }}</a>

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -6,6 +6,8 @@
 <div
   class="space-y-5 max-w-7xl mx-auto px-2 sm:px-0 pb-1"
   id="market-v0-shell"
+  role="region"
+  aria-labelledby="market-v0-landmark-page-title"
   data-section="market-v0"
   data-chartjs-cdn-monitored-v0="true"
   data-market-surface-v0="true"
@@ -19,10 +21,12 @@
   data-market-v0-one-page-link-cleanup-v1="true"
 >
   <section
-    aria-label="Read-only market constraints"
+    role="region"
+    aria-labelledby="market-v0-landmark-readonly-constraints-h2"
     class="rounded-xl border border-slate-700/60 bg-slate-900/55 px-3 py-2.5 sm:px-4"
     data-market-v1-readonly-banner="true"
   >
+    <h2 id="market-v0-landmark-readonly-constraints-h2" class="sr-only">Read-only market constraints</h2>
     <ul class="m-0 p-0 list-none flex flex-wrap gap-2">
       <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
         <span class="h-1.5 w-1.5 rounded-full bg-emerald-400/90 shrink-0" aria-hidden="true"></span>
@@ -48,7 +52,8 @@
   </section>
 
   <section
-    aria-label="Read-only und Datenquelle"
+    role="region"
+    aria-labelledby="market-v0-landmark-safety-banner-h2"
     class="rounded-xl border border-amber-900/45 bg-gradient-to-br from-amber-950/35 via-slate-950/35 to-slate-950/20 px-3 py-2.5 sm:px-4 text-xs text-amber-100/95"
     data-market-safety-banner="true"
     {% if query.source == 'dummy' %}
@@ -58,9 +63,9 @@
     {% endif %}
   >
     <div class="flex flex-wrap items-center justify-between gap-2 mb-2">
-      <p class="font-semibold text-amber-200/95 tracking-wide uppercase text-[11px] m-0">
+      <h2 id="market-v0-landmark-safety-banner-h2" class="font-semibold text-amber-200/95 tracking-wide uppercase text-[11px] m-0">
         Market Surface v0 · read-only · non-authorizing
-      </p>
+      </h2>
       <div class="flex flex-wrap gap-1.5">
         <span class="inline-flex items-center rounded-md border border-amber-800/50 bg-amber-950/45 px-2 py-0.5 text-[10px] font-semibold text-amber-100/90 tabular-nums">SSR only</span>
         <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-950/55 px-2 py-0.5 text-[10px] font-semibold text-slate-200/90 tabular-nums">No order controls</span>
@@ -86,14 +91,15 @@
   </section>
 
   <section
-    aria-label="Ranking funnel empty state"
+    role="region"
+    aria-labelledby="market-v0-landmark-ranking-funnel-h2"
     class="rounded-xl border border-violet-900/45 bg-gradient-to-br from-slate-950/92 via-violet-950/22 to-slate-950/85 px-3 py-3 sm:px-4 ring-1 ring-violet-900/25 shadow-md shadow-black/20"
     data-market-v0-ranking-funnel-empty-state-v0="true"
     data-market-v0-ranking-funnel-dynamic-labels-v0="true"
   >
     <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
       <div class="min-w-0 space-y-1">
-        <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">
+        <h2 id="market-v0-landmark-ranking-funnel-h2" class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">
           Futures ranking funnel · contract-first (empty)
         </h2>
         <p class="text-[10px] text-slate-500 m-0 max-w-2xl leading-snug">
@@ -149,7 +155,7 @@
     <div class="relative flex flex-col gap-4">
       <div class="min-w-0 space-y-2">
         <p class="text-[11px] uppercase tracking-[0.14em] text-sky-400/80 font-semibold m-0">Market Surface</p>
-        <h1 class="text-2xl sm:text-3xl font-bold text-slate-50 tracking-tight m-0">
+        <h1 id="market-v0-landmark-page-title" class="text-2xl sm:text-3xl font-bold text-slate-50 tracking-tight m-0">
           Read-only cockpit · <span class="text-sky-300/95">Close-line chart</span>
         </h1>
         <p class="text-sm text-slate-400 max-w-2xl m-0 leading-snug">
@@ -168,14 +174,15 @@
   </header>
 
   <section
-    aria-label="Single-page visual cockpit"
+    role="region"
+    aria-labelledby="market-v0-landmark-visual-cockpit-h2"
     class="rounded-xl border border-slate-600/50 bg-gradient-to-b from-slate-950/90 via-slate-900/80 to-slate-950/70 p-3 sm:p-4 ring-1 ring-sky-900/25 shadow-lg shadow-black/25 space-y-3"
     data-market-v0-visual-cockpit="true"
     data-market-v0-visual-cockpit-v1="true"
   >
     <div class="flex flex-wrap items-end justify-between gap-2">
       <div>
-        <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">Visual cockpit</h2>
+        <h2 id="market-v0-landmark-visual-cockpit-h2" class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">Visual cockpit</h2>
         <p class="text-[10px] text-slate-500 m-0 mt-0.5">SSR overview · read-only snapshot · not live</p>
       </div>
       <span class="text-[9px] font-semibold uppercase tracking-wide text-emerald-400/90">v1 tiles</span>
@@ -305,10 +312,12 @@
 
     <div class="space-y-3" data-market-v0-visual-surface-strip="true">
   <section
-    aria-label="Available read-only surfaces"
+    role="region"
+    aria-labelledby="market-v0-landmark-surface-links-h2"
     class="rounded-lg border border-slate-700/70 bg-slate-900/80 px-2.5 py-2 ring-1 ring-emerald-900/15"
     data-market-v0-surface-links="true"
   >
+    <h2 id="market-v0-landmark-surface-links-h2" class="sr-only">Available read-only surfaces</h2>
     <div class="flex flex-wrap items-center gap-2">
       <span class="text-[9px] font-semibold uppercase tracking-wide text-slate-500 shrink-0">Terminal rail</span>
       <div class="flex flex-wrap gap-1.5 flex-1 min-w-0 items-center">
@@ -335,12 +344,13 @@
   </section>
 
   <section
-    aria-label="Read-only data and API surfaces"
+    role="region"
+    aria-labelledby="market-v0-landmark-data-rails-h2"
     class="rounded-xl border border-slate-700/70 bg-slate-950/55 p-3 sm:p-4 ring-1 ring-sky-900/15 space-y-3"
     data-market-v0-data-surfaces="true"
   >
     <div class="flex flex-wrap items-center justify-between gap-2">
-      <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">Data rails · OHLCV · Depth</h2>
+      <h2 id="market-v0-landmark-data-rails-h2" class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">Data rails · OHLCV · Depth</h2>
       <div class="flex flex-wrap gap-1.5">
         <span class="rounded border border-slate-700/80 bg-slate-900/70 px-1.5 py-0.5 text-[9px] font-semibold text-slate-400 tabular-nums">No Live authorization</span>
         <span class="rounded border border-slate-700/80 bg-slate-900/70 px-1.5 py-0.5 text-[9px] font-semibold text-slate-400 tabular-nums">SSR snapshot</span>
@@ -408,12 +418,13 @@
   </section>
 
   <section
-    aria-label="Market query context"
+    role="region"
+    aria-labelledby="market-v0-landmark-query-context-h2"
     class="bg-slate-900/80 rounded-xl border border-slate-800/90 p-3 sm:p-4 ring-1 ring-slate-800/60"
     data-market-v1-context="true"
   >
     <div class="flex flex-wrap items-baseline justify-between gap-2 mb-2.5">
-      <h2 class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">PeakTrade Market Dashboard · context</h2>
+      <h2 id="market-v0-landmark-query-context-h2" class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">PeakTrade Market Dashboard · context</h2>
       <span class="text-[10px] font-medium uppercase tracking-wide text-slate-500">Snapshot · keine Live-Autorisierung</span>
     </div>
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 sm:gap-2.5 text-[11px]">
@@ -471,13 +482,14 @@
   </section>
 
   <section
-    aria-label="Close-Preis"
+    role="region"
+    aria-labelledby="market-v0-landmark-close-chart-h2"
     class="bg-slate-900/65 rounded-xl border border-slate-800 ring-2 ring-sky-900/15 shadow-xl shadow-black/30 p-4 sm:p-5 min-h-[30rem]"
     data-chart="market-v0-close-line"
     data-market-v11-chart-diagnostics="true"
   >
     <div class="flex flex-wrap items-end justify-between gap-2 mb-3">
-      <h2 class="text-base font-semibold text-slate-100 m-0 tracking-tight">Schlusskurs (Close)</h2>
+      <h2 id="market-v0-landmark-close-chart-h2" class="text-base font-semibold text-slate-100 m-0 tracking-tight">Schlusskurs (Close)</h2>
       <span class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Dominant panel · keine Order-UI</span>
     </div>
 

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -200,6 +200,58 @@ def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> No
     assert "market-v0-order-form" not in lowered
 
 
+def test_market_dashboard_landmarks_and_labelled_regions_v0(client: TestClient) -> None:
+    """Stable region landmarks + aria-labelledby hooks; read-only markers unchanged."""
+    html = _html(client, "/market")
+    assert 'id="market-v0-shell"' in html
+    assert 'role="region"' in html
+    assert 'aria-labelledby="market-v0-landmark-page-title"' in html
+    assert 'id="market-v0-landmark-page-title"' in html
+    assert 'id="market-v0-landmark-readonly-constraints-h2"' in html
+    assert 'aria-labelledby="market-v0-landmark-readonly-constraints-h2"' in html
+    assert 'id="market-v0-landmark-safety-banner-h2"' in html
+    assert 'aria-labelledby="market-v0-landmark-safety-banner-h2"' in html
+    assert 'id="market-v0-landmark-ranking-funnel-h2"' in html
+    assert 'aria-labelledby="market-v0-landmark-ranking-funnel-h2"' in html
+    assert 'id="market-v0-landmark-visual-cockpit-h2"' in html
+    assert 'aria-labelledby="market-v0-landmark-visual-cockpit-h2"' in html
+    assert 'id="market-v0-landmark-surface-links-h2"' in html
+    assert 'aria-labelledby="market-v0-landmark-surface-links-h2"' in html
+    assert 'id="market-v0-landmark-data-rails-h2"' in html
+    assert 'aria-labelledby="market-v0-landmark-data-rails-h2"' in html
+    assert 'id="market-v0-landmark-query-context-h2"' in html
+    assert 'aria-labelledby="market-v0-landmark-query-context-h2"' in html
+    assert 'id="market-v0-landmark-close-chart-h2"' in html
+    assert 'aria-labelledby="market-v0-landmark-close-chart-h2"' in html
+    assert 'data-market-readonly="true"' in html
+    assert 'data-market-non-authorizing="true"' in html
+    lowered = html.lower()
+    assert "<form" not in lowered
+    assert "<button" not in lowered
+
+
+def test_double_play_market_dashboard_landmarks_and_labelled_regions_v0(
+    client: TestClient,
+) -> None:
+    html = _html(client, "/market/double-play")
+    assert 'id="double-play-market-v0-shell"' in html
+    assert 'aria-labelledby="double-play-market-v0-landmark-page-title"' in html
+    assert 'id="double-play-market-v0-landmark-page-title"' in html
+    assert 'id="double-play-market-v0-landmark-safety-h2"' in html
+    assert 'aria-labelledby="double-play-market-v0-landmark-safety-h2"' in html
+    assert 'id="double-play-market-v0-landmark-reading-guide-h2"' in html
+    assert 'aria-labelledby="double-play-market-v0-landmark-reading-guide-h2"' in html
+    assert 'id="double-play-market-v0-landmark-candlestick-h2"' in html
+    assert 'aria-labelledby="double-play-market-v0-landmark-candlestick-h2"' in html
+    assert 'aria-labelledby="double-play-market-v0-landmark-rail-h2"' in html
+    assert 'id="double-play-market-v0-landmark-rail-h2"' in html
+    assert 'data-double-play-market-readonly="true"' in html
+    assert 'data-double-play-market-no-orders="true"' in html
+    assert 'data-double-play-market-no-authority="true"' in html
+    lowered = html.lower()
+    assert "<form" not in lowered
+
+
 def test_market_dashboard_forms_do_not_target_order_or_live_paths(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds a bounded landmark/a11y layer to the read-only Market Dashboard surfaces:

- `/market`
- `/market/double-play`

The slice adds stable `role="region"` / `aria-labelledby` relationships around existing dashboard sections while preserving existing read-only and non-authorizing semantics.

## Scope

Changed files:

- `templates/peak_trade_dashboard/market_v0.html`
- `templates/peak_trade_dashboard/double_play_market_dashboard_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

No docs patch, no `src/` changes, no runtime changes.

## Safety / Boundaries

- Dashboard remains read-only and non-authorizing.
- No order UI.
- No forms.
- No broker/Kraken/exchange controls.
- No Testnet/Live behavior.
- No scheduler/runtime/Paper run.
- Master V2 / Double Play / Risk / KillSwitch / Live Gates untouched.

## Validation

- `uv run pytest -q tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- `uv run pytest -q tests/test_market_surface_api.py -k "market or double or dashboard"`
- `uv run ruff check templates tests/webui tests/test_market_surface_api.py`
- `uv run ruff format --check templates tests/webui tests/test_market_surface_api.py`
- `git diff --check`

All passed locally.

Made with [Cursor](https://cursor.com)