### PR TITLE
test(live): persist testnet status lookup contract v0

### DIFF
--- a/scripts/testnet_orchestrator_cli.py
+++ b/scripts/testnet_orchestrator_cli.py
@@ -372,6 +372,7 @@ def cmd_status(args: argparse.Namespace, orchestrator: TestnetOrchestrator) -> i
                     print(f"Last Error: {status.last_error}")
                 if status.notes:
                     print(f"Notes: {status.notes}")
+                print(f"status_source: {status.status_source}")
 
         return 0
 

--- a/src/live/testnet_orchestrator.py
+++ b/src/live/testnet_orchestrator.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 import threading
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -73,6 +73,8 @@ class RunInfo:
     notes: str = ""
     session: Optional[Any] = None  # ShadowPaperSession oder Testnet-Session
     run_logger: Optional["LiveRunLogger"] = None
+    #: ``in_memory`` für den aktuellen Prozess; ``persisted`` aus ``meta.json`` / Run-Log
+    status_source: str = "in_memory"
 
     def to_dict(self) -> Dict[str, Any]:
         """Konvertiert zu Dictionary."""
@@ -88,6 +90,7 @@ class RunInfo:
             "last_event_time": self.last_event_time.isoformat() if self.last_event_time else None,
             "last_error": self.last_error,
             "notes": self.notes,
+            "status_source": self.status_source,
         }
 
 
@@ -158,6 +161,49 @@ class TestnetOrchestrator:
         self._lock = threading.RLock()
 
         logger.info("[ORCHESTRATOR] Initialisiert")
+
+    def _persisted_runs_base_dir(self) -> Path:
+        """Basisverzeichnis für Run-Logs (meta.json unter ``{base}/{run_id}/``)."""
+        from .run_logging import load_shadow_paper_logging_config
+
+        return Path(load_shadow_paper_logging_config(self._config).base_dir)
+
+    def _try_build_run_info_from_persisted_metadata(self, run_id: str) -> Optional[RunInfo]:
+        """
+        Rekonstruiert ``RunInfo`` aus persistiertem ``meta.json`` (ohne laufenden Prozess).
+
+        Nur Modi ``shadow`` / ``testnet`` (Orchestrierungs-Domäne).
+        """
+        from .run_logging import load_run_metadata
+
+        run_dir = self._persisted_runs_base_dir() / run_id
+        if not (run_dir / "meta.json").is_file():
+            return None
+        try:
+            md = load_run_metadata(run_dir)
+        except (FileNotFoundError, OSError, ValueError, KeyError, TypeError):
+            return None
+
+        if md.mode not in ("shadow", "testnet"):
+            return None
+
+        state = RunState.STOPPED if md.ended_at else RunState.RUNNING
+        started_at = md.started_at or datetime.now(timezone.utc)
+
+        return RunInfo(
+            run_id=md.run_id,
+            mode=md.mode,
+            strategy_name=md.strategy_name,
+            symbol=md.symbol,
+            timeframe=md.timeframe,
+            state=state,
+            started_at=started_at,
+            stopped_at=md.ended_at,
+            notes=md.notes,
+            session=None,
+            run_logger=None,
+            status_source="persisted",
+        )
 
     def _ensure_readiness(self, mode: str) -> None:
         """
@@ -343,6 +389,7 @@ class TestnetOrchestrator:
                     timeframe=timeframe,
                     run_id=run_id,
                 )
+                run_logger.initialize()
 
                 # Session bauen
                 session = self._build_shadow_session(
@@ -448,6 +495,7 @@ class TestnetOrchestrator:
                     timeframe=timeframe,
                     run_id=run_id,
                 )
+                run_logger.initialize()
 
                 # Für v1: Testnet-Runs nutzen ShadowPaperSession mit Testnet-Environment
                 # Später kann hier echte Testnet-Session erstellt werden
@@ -568,10 +616,14 @@ class TestnetOrchestrator:
             if run_id is None:
                 return list(self._runs.values())
 
-            if run_id not in self._runs:
-                raise RunNotFoundError(f"Run-ID nicht gefunden: {run_id}")
+            if run_id in self._runs:
+                return replace(self._runs[run_id], status_source="in_memory")
 
-            return self._runs[run_id]
+            persisted = self._try_build_run_info_from_persisted_metadata(run_id)
+            if persisted is not None:
+                return persisted
+
+            raise RunNotFoundError(f"Run-ID nicht gefunden: {run_id}")
 
     def tail_events(
         self,

--- a/tests/live/test_testnet_status_persisted_artifacts_contract_v0.py
+++ b/tests/live/test_testnet_status_persisted_artifacts_contract_v0.py
@@ -1,0 +1,138 @@
+# tests/live/test_testnet_status_persisted_artifacts_contract_v0.py
+"""
+Offline-Vertrag: Status zu Testnet-Runs aus persistiertem ``meta.json``.
+
+Kein Testnet-Start, kein Netzwerk, kein Broker — nur tmp_path + PeakConfig.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.core.peak_config import PeakConfig
+from src.live.run_logging import LiveRunMetadata
+from src.live.testnet_orchestrator import (
+    RunInfo,
+    RunNotFoundError,
+    RunState,
+    TestnetOrchestrator,
+)
+
+
+def _write_meta(run_dir: Path, md: LiveRunMetadata) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "meta.json").write_text(
+        json.dumps(md.to_dict()),
+        encoding="utf-8",
+    )
+
+
+def test_get_status_resolves_persisted_testnet_run_from_meta_json(tmp_path: Path) -> None:
+    run_id = "testnet_persisted_contract_v0_001"
+    base = tmp_path / "run_logs"
+    _write_meta(
+        base / run_id,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="testnet",
+            strategy_name="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1m",
+            started_at=datetime(2026, 5, 15, 7, 28, 38, tzinfo=timezone.utc),
+        ),
+    )
+
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+    assert orch.get_status().__class__ is list
+    assert len(orch._runs) == 0
+
+    st = orch.get_status(run_id)
+    assert st.run_id == run_id
+    assert st.status_source == "persisted"
+    assert st.mode == "testnet"
+    assert st.strategy_name == "ma_crossover"
+    assert st.to_dict()["status_source"] == "persisted"
+
+
+def test_get_status_missing_run_id_raises(tmp_path: Path) -> None:
+    base = tmp_path / "empty_runs"
+    base.mkdir()
+    cfg = PeakConfig(
+        raw={
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+    with pytest.raises(RunNotFoundError, match="nicht gefunden"):
+        orch.get_status("does_not_exist_000")
+
+
+def test_in_memory_run_takes_precedence_over_persisted_meta(tmp_path: Path) -> None:
+    """Gleicher Prozess: Eintrag in ``_runs`` gewinnt; Quelle wird als in_memory markiert."""
+    run_id = "testnet_precedence_contract_v0_002"
+    base = tmp_path / "both"
+    _write_meta(
+        base / run_id,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="testnet",
+            strategy_name="from_disk",
+            symbol="ETH/EUR",
+            timeframe="5m",
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+    cfg = PeakConfig(
+        raw={
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+
+    memory_started = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    orch._runs[run_id] = RunInfo(
+        run_id=run_id,
+        mode="testnet",
+        strategy_name="from_memory",
+        symbol="BTC/EUR",
+        timeframe="1m",
+        state=RunState.RUNNING,
+        started_at=memory_started,
+        status_source="in_memory",
+    )
+
+    st = orch.get_status(run_id)
+    assert st.strategy_name == "from_memory"
+    assert st.symbol == "BTC/EUR"
+    assert st.timeframe == "1m"
+    assert st.status_source == "in_memory"
+
+
+def test_paper_mode_meta_is_not_loaded_as_orchestrator_run(tmp_path: Path) -> None:
+    """Nur Modi shadow/testnet sind für die Persistenz-Rekonstruktion zulässig."""
+    run_id = "paper_meta_ignored_003"
+    base = tmp_path / "paperish"
+    _write_meta(
+        base / run_id,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="paper",
+            strategy_name="x",
+            symbol="BTC/EUR",
+            timeframe="1m",
+        ),
+    )
+    cfg = PeakConfig(raw={"shadow_paper_logging": {"base_dir": str(base), "enabled": True}})
+    orch = TestnetOrchestrator(cfg)
+    with pytest.raises(RunNotFoundError):
+        orch.get_status(run_id)


### PR DESCRIPTION
## Summary
- add offline contract coverage for resolving Testnet status from persisted run artifacts after the original process exits
- add status_source to RunInfo/to_dict and CLI text output
- keep in-memory status behavior first, with persisted metadata fallback

## Safety
- no Testnet start in tests
- no Runtime/Scheduler/Daemon
- no network/Broker/Exchange
- no Live/order lifecycle changes
- no AI/paid evals
- no paper test data mutation

## Validation
- uv run pytest -q tests/live/test_testnet_status_persisted_artifacts_contract_v0.py
- uv run pytest -q tests/ops/test_testnet_orchestrator_cli_help.py
- uv run ruff check scripts/testnet_orchestrator_cli.py src/live/testnet_orchestrator.py tests/live/test_testnet_status_persisted_artifacts_contract_v0.py
- uv run ruff format --check scripts/testnet_orchestrator_cli.py src/live/testnet_orchestrator.py tests/live/test_testnet_status_persisted_artifacts_contract_v0.py

## Evidence
- Post-commit readiness: /tmp/peak_trade_postcommit_testnet_status_persisted_pr_readiness_20260515T075428Z/POSTCOMMIT_TESTNET_STATUS_PERSISTED_PR_READINESS.md

Made with [Cursor](https://cursor.com)