### PR TITLE
test(live): classify persisted testnet stop state v0

### DIFF
--- a/scripts/testnet_orchestrator_cli.py
+++ b/scripts/testnet_orchestrator_cli.py
@@ -40,6 +40,7 @@ from src.live.testnet_orchestrator import (
     TestnetOrchestrator,
     RunInfo,
     RunNotFoundError,
+    PersistedRunStopNotApplicableError,
     ReadinessCheckFailedError,
     InvalidModeError,
     OrchestratorError,
@@ -414,9 +415,15 @@ def cmd_stop(args: argparse.Namespace, orchestrator: TestnetOrchestrator) -> int
                 return 1
 
             orchestrator.stop_run(args.run_id)
-            print(f"✅ Run gestoppt: {args.run_id}")
+            print(f"✅ Run gestoppt (in_memory): {args.run_id}")
             return 0
 
+    except PersistedRunStopNotApplicableError as e:
+        print(
+            f"⚠️ Stop nicht möglich — nur persistierte Metadaten (kein aktiver Orchestrator-Prozess): {e}",
+            file=sys.stderr,
+        )
+        return 2
     except RunNotFoundError as e:
         print(f"❌ Fehler: {e}", file=sys.stderr)
         return 1

--- a/src/live/testnet_orchestrator.py
+++ b/src/live/testnet_orchestrator.py
@@ -117,6 +117,23 @@ class RunNotFoundError(OrchestratorError):
     pass
 
 
+class PersistedRunStopNotApplicableError(OrchestratorError):
+    """
+    Stop angefordert, aber nur persistierte Metadaten vorhanden (kein In-Prozess-Run).
+
+    Tritt auf, wenn ``stop_run`` aus einem neuen Prozess aufgerufen wird, während der
+    Run nur als ``meta.json`` existiert — ein aktiver Worker kann nicht gestoppt werden.
+    """
+
+    def __init__(self, classification: str, run_id: str) -> None:
+        self.classification = classification
+        self.run_id = run_id
+        super().__init__(
+            f"stop_classification={classification}; persisted_only=True; "
+            f"process_stopped=False; run_id={run_id}"
+        )
+
+
 class InvalidModeError(OrchestratorError):
     """Ungültiger Mode (z.B. 'live' nicht erlaubt)."""
 
@@ -564,11 +581,23 @@ class TestnetOrchestrator:
             run_id: Run-ID
 
         Raises:
-            RunNotFoundError: Wenn Run-ID nicht gefunden
+            RunNotFoundError: Wenn Run-ID weder im Orchestrator noch auf der Platte (testnet/shadow-meta)
+            PersistedRunStopNotApplicableError: Wenn nur ``meta.json`` existiert, kein In-Prozess-Run
         """
         with self._lock:
             if run_id not in self._runs:
-                raise RunNotFoundError(f"Run-ID nicht gefunden: {run_id}")
+                persisted = self._try_build_run_info_from_persisted_metadata(run_id)
+                if persisted is None:
+                    raise RunNotFoundError(f"Run-ID nicht gefunden: {run_id}")
+                if persisted.state == RunState.RUNNING:
+                    raise PersistedRunStopNotApplicableError(
+                        "stale_persisted_running",
+                        run_id,
+                    )
+                raise PersistedRunStopNotApplicableError(
+                    "persisted_only_already_stopped",
+                    run_id,
+                )
 
             run_info = self._runs[run_id]
 

--- a/tests/live/test_testnet_cross_process_stop_contract_v0.py
+++ b/tests/live/test_testnet_cross_process_stop_contract_v0.py
@@ -1,0 +1,211 @@
+# tests/live/test_testnet_cross_process_stop_contract_v0.py
+"""
+Offline-Vertrag: Cross-Process-Stop-Semantik für Testnet-Orchestrator.
+
+Kein Testnet-Start, kein Netzwerk — nur tmp_path, PeakConfig und CLI-Funktionen.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from argparse import Namespace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.core.peak_config import PeakConfig
+from src.live.run_logging import LiveRunMetadata
+from src.live.testnet_orchestrator import (
+    PersistedRunStopNotApplicableError,
+    RunInfo,
+    RunNotFoundError,
+    RunState,
+    TestnetOrchestrator,
+)
+
+
+def _write_meta(run_dir: Path, md: LiveRunMetadata) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "meta.json").write_text(json.dumps(md.to_dict()), encoding="utf-8")
+
+
+def _load_cli_module():
+    root = Path(__file__).resolve().parents[2]
+    path = root / "scripts" / "testnet_orchestrator_cli.py"
+    spec = importlib.util.spec_from_file_location("_testnet_orchestrator_cli", path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_testnet_orchestrator_cli"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_stop_run_in_memory_still_stops_same_process_run(tmp_path: Path) -> None:
+    """In-Prozess: ``stop_run`` beendet einen Eintrag in ``_runs`` wie bisher."""
+
+    class _DummySession:
+        def __init__(self) -> None:
+            self.stop_called = False
+
+        def stop(self) -> None:
+            self.stop_called = True
+
+    run_id = "testnet_cross_stop_mem_v0"
+    base = tmp_path / "runs"
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+    sess = _DummySession()
+    orch._runs[run_id] = RunInfo(
+        run_id=run_id,
+        mode="testnet",
+        strategy_name="ma_crossover",
+        symbol="BTC/EUR",
+        timeframe="1m",
+        state=RunState.RUNNING,
+        started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        session=sess,
+        status_source="in_memory",
+    )
+
+    orch.stop_run(run_id)
+
+    assert sess.stop_called
+    assert orch._runs[run_id].state == RunState.STOPPED
+    assert orch._runs[run_id].stopped_at is not None
+
+
+def test_stop_run_persisted_only_running_raises_stale_classification(tmp_path: Path) -> None:
+    """Nur ``meta.json`` (running): keine Ausnahme „nicht gefunden“, sondern Persistenz-Klasse."""
+    run_id = "testnet_cross_stop_stale_v0"
+    base = tmp_path / "runs"
+    _write_meta(
+        base / run_id,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="testnet",
+            strategy_name="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1m",
+            started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        ),
+    )
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+
+    with pytest.raises(PersistedRunStopNotApplicableError) as ei:
+        orch.stop_run(run_id)
+
+    assert ei.value.classification == "stale_persisted_running"
+    assert "stop_classification=stale_persisted_running" in str(ei.value)
+    assert "persisted_only=True" in str(ei.value)
+    assert "process_stopped=False" in str(ei.value)
+
+
+def test_stop_run_persisted_only_already_stopped_classification(tmp_path: Path) -> None:
+    """Persistiert mit ``ended_at``: ebenfalls kein In-Prozess-Stopp möglich."""
+    run_id = "testnet_cross_stop_done_v0"
+    base = tmp_path / "runs"
+    _write_meta(
+        base / run_id,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="testnet",
+            strategy_name="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1m",
+            started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 5, 15, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+    )
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+
+    with pytest.raises(PersistedRunStopNotApplicableError) as ei:
+        orch.stop_run(run_id)
+
+    assert ei.value.classification == "persisted_only_already_stopped"
+
+
+def test_stop_run_missing_run_id_still_not_found(tmp_path: Path) -> None:
+    base = tmp_path / "empty"
+    base.mkdir()
+    cfg = PeakConfig(raw={"shadow_paper_logging": {"base_dir": str(base), "enabled": True}})
+    orch = TestnetOrchestrator(cfg)
+    with pytest.raises(RunNotFoundError, match="nicht gefunden"):
+        orch.stop_run("does_not_exist_cross_stop_v0")
+
+
+def test_cmd_stop_messages_distinguish_paths(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI: unterscheidbare Ausgaben für in-memory vs persisted-only vs nicht gefunden."""
+    cli = _load_cli_module()
+    base = tmp_path / "runs"
+    run_stale = "testnet_cli_stale_v0"
+    run_mem = "testnet_cli_mem_v0"
+    _write_meta(
+        base / run_stale,
+        LiveRunMetadata(
+            run_id=run_stale,
+            mode="testnet",
+            strategy_name="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1m",
+            started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        ),
+    )
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+
+    assert cli.cmd_stop(Namespace(all=False, run_id=run_stale), orch) == 2
+    err = capsys.readouterr().err
+    assert "stop_classification=stale_persisted_running" in err
+    assert "persisted_only=True" in err
+    assert "process_stopped=False" in err
+
+    class _S:
+        def stop(self) -> None:
+            pass
+
+    orch._runs[run_mem] = RunInfo(
+        run_id=run_mem,
+        mode="testnet",
+        strategy_name="ma_crossover",
+        symbol="BTC/EUR",
+        timeframe="1m",
+        state=RunState.RUNNING,
+        started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        session=_S(),
+        status_source="in_memory",
+    )
+    assert cli.cmd_stop(Namespace(all=False, run_id=run_mem), orch) == 0
+    out = capsys.readouterr().out
+    assert "✅ Run gestoppt (in_memory)" in out
+
+    assert cli.cmd_stop(Namespace(all=False, run_id="missing_cli_v0"), orch) == 1
+    err_nf = capsys.readouterr().err
+    assert "❌ Fehler" in err_nf
+    assert "Run-ID nicht gefunden" in err_nf


### PR DESCRIPTION
## Summary
- add offline contract coverage for cross-process stop behavior on persisted Testnet metadata
- preserve same-process in-memory stop behavior
- classify persisted-only/stale persisted Testnet runs explicitly instead of reporting plain not found
- expose clearer CLI stop output for in-memory vs persisted-only vs missing run states

## Safety
- no Testnet start in tests
- no Runtime/Scheduler/Daemon
- no network/Broker/Exchange
- no Live/order lifecycle changes
- no AI/paid evals
- no paper test data mutation
- persisted-only stop does not pretend that a process was stopped

## Validation
- uv run pytest -q tests/live/test_testnet_cross_process_stop_contract_v0.py
- uv run pytest -q tests/live/test_testnet_status_persisted_artifacts_contract_v0.py
- uv run pytest -q tests/ops/test_testnet_orchestrator_cli_help.py
- uv run pytest -q tests/test_testnet_orchestrator_smoke.py -k "stop_run_not_found"
- uv run ruff check src/live/testnet_orchestrator.py scripts/testnet_orchestrator_cli.py tests/live/test_testnet_cross_process_stop_contract_v0.py
- uv run ruff format --check src/live/testnet_orchestrator.py scripts/testnet_orchestrator_cli.py tests/live/test_testnet_cross_process_stop_contract_v0.py

## Evidence
- Post-commit readiness: /tmp/peak_trade_postcommit_testnet_cross_process_stop_pr_readiness_20260515T101815Z/POSTCOMMIT_TESTNET_CROSS_PROCESS_STOP_PR_READINESS.md

Made with [Cursor](https://cursor.com)