### PR TITLE
test(live): finalize persisted testnet status v0

### DIFF
--- a/src/live/run_logging.py
+++ b/src/live/run_logging.py
@@ -642,6 +642,38 @@ def load_run_metadata(run_dir: str | Path) -> LiveRunMetadata:
     return LiveRunMetadata.from_dict(data)
 
 
+def finalize_persisted_run_metadata_if_unfinished(
+    run_dir: str | Path,
+    *,
+    ended_at: Optional[datetime] = None,
+) -> bool:
+    """
+    Setzt ``ended_at`` in ``meta.json``, falls die Datei existiert und noch kein Ende vermerkt ist.
+
+    Idempotent: Bei bereits gesetztem ``ended_at`` wird nichts geändert.
+
+    Returns:
+        ``True`` wenn geschrieben, sonst ``False`` (keine Datei, Parse-Fehler, oder schon final).
+    """
+    run_path = Path(run_dir)
+    meta_path = run_path / "meta.json"
+    if not meta_path.is_file():
+        return False
+    try:
+        md = load_run_metadata(run_path)
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return False
+    if md.ended_at is not None:
+        return False
+    md.ended_at = ended_at or datetime.now(timezone.utc)
+    try:
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump(md.to_dict(), f, indent=2, ensure_ascii=False)
+    except OSError:
+        return False
+    return True
+
+
 def load_run_events(run_dir: str | Path) -> pd.DataFrame:
     """
     Lädt Run-Events aus einem Run-Verzeichnis.

--- a/src/live/testnet_orchestrator.py
+++ b/src/live/testnet_orchestrator.py
@@ -602,6 +602,7 @@ class TestnetOrchestrator:
             run_info = self._runs[run_id]
 
             if run_info.state in (RunState.STOPPED, RunState.ERROR):
+                self._finalize_persisted_run_record(run_info)
                 logger.info(f"[ORCHESTRATOR] Run bereits gestoppt: {run_id}")
                 return
 
@@ -614,10 +615,6 @@ class TestnetOrchestrator:
                 elif run_info.session and hasattr(run_info.session, "_shutdown_requested"):
                     run_info.session._shutdown_requested = True
 
-                # Run-Logger finalisieren
-                if run_info.run_logger:
-                    run_info.run_logger.finalize()
-
                 run_info.state = RunState.STOPPED
                 run_info.stopped_at = datetime.now(timezone.utc)
 
@@ -627,6 +624,23 @@ class TestnetOrchestrator:
                 logger.error(f"[ORCHESTRATOR] Fehler beim Stoppen des Runs: {run_id}, {e}")
                 run_info.state = RunState.ERROR
                 run_info.last_error = str(e)
+                run_info.stopped_at = datetime.now(timezone.utc)
+
+            finally:
+                self._finalize_persisted_run_record(run_info)
+
+    def _finalize_persisted_run_record(self, run_info: RunInfo) -> None:
+        """
+        Schließt persistierte ``meta.json`` ab (``ended_at``), falls ein Logger oder eine Datei existiert.
+        """
+        from .run_logging import finalize_persisted_run_metadata_if_unfinished
+
+        if run_info.run_logger is not None:
+            run_info.run_logger.finalize()
+            return
+
+        run_dir = self._persisted_runs_base_dir() / run_info.run_id
+        finalize_persisted_run_metadata_if_unfinished(run_dir)
 
     def get_status(self, run_id: Optional[str] = None) -> RunInfo | List[RunInfo]:
         """

--- a/tests/live/test_testnet_persisted_status_finalization_contract_v0.py
+++ b/tests/live/test_testnet_persisted_status_finalization_contract_v0.py
@@ -1,0 +1,214 @@
+# tests/live/test_testnet_persisted_status_finalization_contract_v0.py
+"""
+Offline-Vertrag: Finalisierung persistierter Testnet-Metadaten (meta.json / ended_at).
+
+Kein Testnet-Start, kein Netzwerk — nur tmp_path, PeakConfig und Orchestrierungs-APIs.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.core.peak_config import PeakConfig
+from src.live.run_logging import (
+    LiveRunMetadata,
+    create_run_logger_from_config,
+    finalize_persisted_run_metadata_if_unfinished,
+    load_run_metadata,
+)
+from src.live.testnet_orchestrator import (
+    PersistedRunStopNotApplicableError,
+    RunInfo,
+    RunNotFoundError,
+    RunState,
+    TestnetOrchestrator,
+)
+
+
+def _write_meta(run_dir: Path, md: LiveRunMetadata) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "meta.json").write_text(
+        json.dumps(md.to_dict()),
+        encoding="utf-8",
+    )
+
+
+def test_synthetic_meta_finalized_offline_sets_ended_at(tmp_path: Path) -> None:
+    run_id = "testnet_finalize_offline_v0"
+    run_dir = tmp_path / "logs" / run_id
+    _write_meta(
+        run_dir,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="testnet",
+            strategy_name="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1m",
+            started_at=datetime(2026, 5, 15, 10, 0, 0, tzinfo=timezone.utc),
+        ),
+    )
+    fake_end = datetime(2026, 5, 15, 11, 0, 0, tzinfo=timezone.utc)
+    assert finalize_persisted_run_metadata_if_unfinished(run_dir, ended_at=fake_end) is True
+    md = load_run_metadata(run_dir)
+    assert md.ended_at == fake_end
+    assert finalize_persisted_run_metadata_if_unfinished(run_dir) is False
+
+
+def test_fresh_orchestrator_sees_non_running_persisted_after_finalization(
+    tmp_path: Path,
+) -> None:
+    run_id = "testnet_finalize_fresh_orch_v0"
+    base = tmp_path / "logs"
+    _write_meta(
+        base / run_id,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="testnet",
+            strategy_name="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1m",
+            started_at=datetime(2026, 5, 15, 9, 0, 0, tzinfo=timezone.utc),
+        ),
+    )
+    assert finalize_persisted_run_metadata_if_unfinished(base / run_id) is True
+
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+    st = orch.get_status(run_id)
+    assert st.status_source == "persisted"
+    assert st.state == RunState.STOPPED
+    assert st.stopped_at is not None
+
+
+def test_in_memory_stop_with_run_logger_finalizes_meta(tmp_path: Path) -> None:
+    run_id = "testnet_stop_with_logger_v0"
+    base = tmp_path / "logs"
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    run_logger = create_run_logger_from_config(
+        cfg,
+        mode="testnet",
+        strategy_name="ma_crossover",
+        symbol="BTC/EUR",
+        timeframe="1m",
+        run_id=run_id,
+    )
+    run_logger.initialize()
+
+    class _Sess:
+        def stop(self) -> None:
+            pass
+
+    orch = TestnetOrchestrator(cfg)
+    orch._runs[run_id] = RunInfo(
+        run_id=run_id,
+        mode="testnet",
+        strategy_name="ma_crossover",
+        symbol="BTC/EUR",
+        timeframe="1m",
+        state=RunState.RUNNING,
+        started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        session=_Sess(),
+        run_logger=run_logger,
+        status_source="in_memory",
+    )
+    orch.stop_run(run_id)
+
+    md = load_run_metadata(base / run_id)
+    assert md.ended_at is not None
+
+
+def test_in_memory_stop_without_logger_finalizes_orphan_meta(tmp_path: Path) -> None:
+    run_id = "testnet_stop_orphan_meta_v0"
+    base = tmp_path / "logs"
+    _write_meta(
+        base / run_id,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="testnet",
+            strategy_name="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1m",
+            started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        ),
+    )
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+
+    class _Sess:
+        def stop(self) -> None:
+            pass
+
+    orch._runs[run_id] = RunInfo(
+        run_id=run_id,
+        mode="testnet",
+        strategy_name="ma_crossover",
+        symbol="BTC/EUR",
+        timeframe="1m",
+        state=RunState.RUNNING,
+        started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        session=_Sess(),
+        run_logger=None,
+        status_source="in_memory",
+    )
+    orch.stop_run(run_id)
+
+    md = load_run_metadata(base / run_id)
+    assert md.ended_at is not None
+    assert orch._runs[run_id].state == RunState.STOPPED
+
+
+def test_persisted_only_stop_still_classifies_without_process_stopped(
+    tmp_path: Path,
+) -> None:
+    run_id = "testnet_finalize_cross_class_v0"
+    base = tmp_path / "logs"
+    _write_meta(
+        base / run_id,
+        LiveRunMetadata(
+            run_id=run_id,
+            mode="testnet",
+            strategy_name="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1m",
+            started_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        ),
+    )
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "testnet"},
+            "shadow_paper_logging": {"base_dir": str(base), "enabled": True},
+        }
+    )
+    orch = TestnetOrchestrator(cfg)
+    with pytest.raises(PersistedRunStopNotApplicableError) as ei:
+        orch.stop_run(run_id)
+    assert ei.value.classification == "stale_persisted_running"
+    assert "process_stopped=False" in str(ei.value)
+
+
+def test_missing_run_id_stop_still_not_found(tmp_path: Path) -> None:
+    base = tmp_path / "empty"
+    base.mkdir()
+    cfg = PeakConfig(raw={"shadow_paper_logging": {"base_dir": str(base), "enabled": True}})
+    orch = TestnetOrchestrator(cfg)
+    with pytest.raises(RunNotFoundError, match="nicht gefunden"):
+        orch.stop_run("missing_finalize_v0")


### PR DESCRIPTION
## Summary
- add offline contract coverage for finalizing persisted Testnet run metadata
- add idempotent persisted metadata finalization for unfinished meta.json records
- ensure in-memory stop paths can finalize persisted metadata when available
- preserve persisted status lookup and cross-process persisted-only stop classification

## Safety
- no Testnet start in tests
- no Runtime/Scheduler/Daemon
- no network/Broker/Exchange
- no Live/order lifecycle changes
- no AI/paid evals
- no paper test data mutation

## Validation
- uv run pytest -q tests/live/test_testnet_persisted_status_finalization_contract_v0.py
- uv run pytest -q tests/live/test_testnet_status_persisted_artifacts_contract_v0.py
- uv run pytest -q tests/live/test_testnet_cross_process_stop_contract_v0.py
- uv run pytest -q tests/ops/test_testnet_orchestrator_cli_help.py
- uv run pytest -q tests/test_testnet_orchestrator_smoke.py -k "stop_run_not_found"
- uv run ruff check src/live/run_logging.py src/live/testnet_orchestrator.py tests/live/test_testnet_persisted_status_finalization_contract_v0.py
- uv run ruff format --check src/live/run_logging.py src/live/testnet_orchestrator.py tests/live/test_testnet_persisted_status_finalization_contract_v0.py

## Evidence
- Post-commit readiness: /tmp/peak_trade_postcommit_testnet_persisted_status_finalization_pr_readiness_20260515T104736Z/POSTCOMMIT_TESTNET_PERSISTED_STATUS_FINALIZATION_PR_READINESS.md

Made with [Cursor](https://cursor.com)