### PR TITLE
test(scheduler): prove bounded single tick dry run v0

### DIFF
--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -31,9 +31,10 @@ import argparse
 import signal
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Any, Callable, List, Optional, Set
 
 # Projekt-Root zum Python-Path hinzufügen
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -272,6 +273,109 @@ def log_job_to_registry(result: JobResult, job: JobDefinition) -> Optional[str]:
     except Exception as e:
         print(f"[WARNING] Registry-Logging fehlgeschlagen: {e}")
         return None
+
+
+@dataclass
+class SchedulerTickSummary:
+    """Zählerstands-Snapshot eines einzelnen Scheduler-Ticks."""
+
+    loaded: int = 0
+    eligible_after_tags: int = 0
+    skipped_not_due: int = 0
+    due: int = 0
+    dispatched: int = 0
+    succeeded: int = 0
+    failed: int = 0
+
+
+def run_scheduler_tick_once(
+    config_path: Path | str,
+    *,
+    now: Optional[datetime] = None,
+    dry_run: bool = False,
+    include_tags: Optional[Set[str]] = None,
+    exclude_tags: Optional[Set[str]] = None,
+    verbose: bool = False,
+    use_registry: bool = False,
+    notifier: Any | None = None,
+    subprocess_run: Optional[Any] = None,
+    utcnow: Optional[Callable[[], datetime]] = None,
+) -> SchedulerTickSummary:
+    """
+    Führt genau einen Scheduler-«Tick» aus: Jobs laden, fällige auswählen, ausführen, Schedule aktualisieren.
+
+    Kein ``while``-Loop, kein ``sleep``, kein Daemon. Spiegelt die Kernlogik eines
+    Loop-Durchlaufs von ``run_scheduler_loop`` (ohne Warten/Wiederholen).
+    """
+    path = Path(config_path)
+    summary = SchedulerTickSummary()
+
+    all_jobs = load_jobs_from_toml(path)
+    summary.loaded = len(all_jobs)
+
+    jobs = filter_jobs_by_tags(all_jobs, include_tags, exclude_tags)
+    summary.eligible_after_tags = len(jobs)
+
+    if not jobs:
+        summary.skipped_not_due = 0
+        return summary
+
+    for job in jobs:
+        warnings = validate_job_config(job)
+        for w in warnings:
+            if verbose:
+                print(f"[WARNING] {w}")
+
+    tick_now = now if now is not None else datetime.utcnow()
+
+    for job in jobs:
+        if job.schedule.next_run_at is None:
+            job.schedule.next_run_at = compute_next_run_at(job.schedule, now=tick_now)
+
+    if verbose:
+        print_job_summary(jobs, tick_now)
+
+    due_jobs = get_due_jobs(jobs, now=tick_now)
+    summary.due = len(due_jobs)
+    summary.skipped_not_due = summary.eligible_after_tags - summary.due
+
+    for job in due_jobs:
+        if verbose:
+            print(f"\n  -> Starte: {job.name}")
+
+        summary.dispatched += 1
+        result = run_job(
+            job,
+            dry_run=dry_run,
+            subprocess_run=subprocess_run,
+            utcnow=utcnow,
+        )
+
+        update_job_schedule_after_run(job, result)
+
+        if result.success:
+            summary.succeeded += 1
+            if verbose:
+                print(f"     ✅ Erfolgreich ({result.duration_seconds:.1f}s)")
+                if verbose and result.stdout:
+                    print(f"     stdout: {result.stdout[:200]}...")
+            send_job_alert(notifier, result, level="info")
+        else:
+            summary.failed += 1
+            if verbose:
+                print(f"     ❌ Fehlgeschlagen (return_code={result.return_code})")
+                if result.exception:
+                    print(f"     Exception: {result.exception}")
+                if result.stderr:
+                    print(f"     stderr: {result.stderr[:200]}...")
+            send_job_alert(notifier, result, level="critical")
+
+        if use_registry and not dry_run:
+            run_id = log_job_to_registry(result, job)
+            if run_id and verbose:
+                print(f"     Registry: {run_id[:8]}...")
+
+    return summary
 
 
 def run_scheduler_loop(

--- a/tests/test_scheduler_single_tick_dry_run_contract_v0.py
+++ b/tests/test_scheduler_single_tick_dry_run_contract_v0.py
@@ -1,0 +1,324 @@
+# tests/test_scheduler_single_tick_dry_run_contract_v0.py
+"""
+Bounded single-tick contract: scripts.run_scheduler.run_scheduler_tick_once.
+
+No daemon, no ``run_scheduler_loop``, no sleeps in assertions.
+Uses tmp_path TOML, deterministic ``now`` / ``utcnow``, and fake ``subprocess_run``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+NOW = datetime(2026, 5, 15, 19, 0, 0)
+
+
+def _utc() -> datetime:
+    return NOW
+
+
+def _three_jobs_toml() -> str:
+    return """
+[[job]]
+name = "due_once"
+enabled = true
+command = "python"
+args = { script = "scripts/offline_tick.py", lane = "due" }
+schedule_type = "once"
+
+[[job]]
+name = "future_iv"
+enabled = true
+command = "python"
+args = { script = "scripts/offline_tick.py", lane = "future" }
+schedule_type = "interval"
+interval_seconds = 3600
+
+[[job]]
+name = "disabled_once"
+enabled = false
+command = "python"
+args = { script = "scripts/offline_tick.py", lane = "off" }
+schedule_type = "once"
+"""
+
+
+@pytest.fixture()
+def patched_tick_loader(monkeypatch: pytest.MonkeyPatch):
+    """Patch loader so future_iv is not-yet-due; due_once is due."""
+
+    import scripts.run_scheduler as rs
+
+    real_load = rs.load_jobs_from_toml
+
+    def _wrap(path):  # noqa: ARG001
+        jobs = real_load(path)
+        due_once = next(j for j in jobs if j.name == "due_once")
+        fut = next(j for j in jobs if j.name == "future_iv")
+        due_once.schedule.next_run_at = NOW - timedelta(seconds=2)
+        fut.schedule.next_run_at = NOW + timedelta(hours=2)
+        return jobs
+
+    monkeypatch.setattr(rs, "load_jobs_from_toml", _wrap)
+    return rs
+
+
+def test_tick_loads_dispatches_one_due_job_once(tmp_path: Path, patched_tick_loader) -> None:
+    cfg = tmp_path / "tick.toml"
+    cfg.write_text(_three_jobs_toml(), encoding="utf-8")
+
+    invocations: list[int] = []
+
+    def fake_run(cmd, **_kwargs):
+        invocations.append(1)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    summary = patched_tick_loader.run_scheduler_tick_once(
+        cfg,
+        now=NOW,
+        dry_run=False,
+        subprocess_run=fake_run,
+        utcnow=_utc,
+    )
+
+    assert summary.loaded == 3
+    assert summary.eligible_after_tags == 3
+    assert summary.due == 1
+    assert summary.dispatched == 1
+    assert summary.succeeded == 1
+    assert summary.failed == 0
+    assert summary.skipped_not_due == 2
+    assert len(invocations) == 1
+
+
+def test_tick_skips_not_due_job(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "tick.toml"
+    cfg.write_text(_three_jobs_toml(), encoding="utf-8")
+
+    import scripts.run_scheduler as rs
+
+    real_load = rs.load_jobs_from_toml
+
+    def wrap(p):
+        jobs = real_load(p)
+        for j in jobs:
+            j.schedule.next_run_at = NOW + timedelta(days=1)
+        return jobs
+
+    monkeypatch.setattr(rs, "load_jobs_from_toml", wrap)
+
+    called: list[int] = []
+
+    def fake_run(*_a, **_k):
+        called.append(1)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    summary = rs.run_scheduler_tick_once(
+        cfg,
+        now=NOW,
+        subprocess_run=fake_run,
+        utcnow=_utc,
+    )
+    assert summary.due == 0
+    assert summary.dispatched == 0
+    assert summary.skipped_not_due == 3
+    assert called == []
+
+
+def test_tick_skips_disabled_job(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "tick.toml"
+    cfg.write_text(_three_jobs_toml(), encoding="utf-8")
+
+    import scripts.run_scheduler as rs
+
+    real_load = rs.load_jobs_from_toml
+
+    def wrap(p):
+        jobs = real_load(p)
+        for j in jobs:
+            if j.name != "disabled_once":
+                j.schedule.next_run_at = NOW + timedelta(days=7)
+            else:
+                j.schedule.next_run_at = NOW - timedelta(seconds=9)
+        return jobs
+
+    monkeypatch.setattr(rs, "load_jobs_from_toml", wrap)
+
+    summary = rs.run_scheduler_tick_once(
+        cfg,
+        now=NOW,
+        subprocess_run=lambda *_a, **_k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        utcnow=_utc,
+    )
+    assert summary.due == 0
+    assert summary.dispatched == 0
+
+
+def test_tick_records_failed_fake_dispatch_without_network(
+    tmp_path: Path, patched_tick_loader
+) -> None:
+    cfg = tmp_path / "tick.toml"
+    cfg.write_text(_three_jobs_toml(), encoding="utf-8")
+
+    def bad_run(cmd, **_kwargs):  # noqa: ARG001
+        return SimpleNamespace(returncode=3, stdout="", stderr="offline-fatal")
+
+    summary = patched_tick_loader.run_scheduler_tick_once(
+        cfg,
+        now=NOW,
+        subprocess_run=bad_run,
+        utcnow=_utc,
+    )
+    assert summary.due == 1
+    assert summary.dispatched == 1
+    assert summary.succeeded == 0
+    assert summary.failed == 1
+
+
+def test_tick_updates_schedule_after_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = tmp_path / "tick.toml"
+    cfg.write_text(
+        """
+[[job]]
+name = "iv_only"
+enabled = true
+command = "python"
+args = { script = "scripts/offline_tick.py" }
+schedule_type = "interval"
+interval_seconds = 90
+""",
+        encoding="utf-8",
+    )
+
+    import scripts.run_scheduler as rs
+
+    iv_job_holder: dict[str, object] = {}
+
+    real_load = rs.load_jobs_from_toml
+
+    def wrap(p):
+        jobs = real_load(p)
+        job = jobs[0]
+        job.schedule.last_run_at = None
+        job.schedule.next_run_at = NOW - timedelta(seconds=2)
+        iv_job_holder["job"] = job
+        return jobs
+
+    monkeypatch.setattr(rs, "load_jobs_from_toml", wrap)
+
+    fake_res = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    summary = rs.run_scheduler_tick_once(
+        cfg,
+        now=NOW,
+        subprocess_run=lambda *_a, **_k: fake_res,
+        utcnow=_utc,
+    )
+
+    job = iv_job_holder["job"]
+    assert summary.succeeded == 1
+    assert job.schedule.last_run_at is not None
+    assert job.schedule.next_run_at == job.schedule.last_run_at + timedelta(seconds=90)
+
+
+def test_tick_summary_counts_stable_shape(tmp_path: Path, patched_tick_loader) -> None:
+    cfg = tmp_path / "tick.toml"
+    cfg.write_text(_three_jobs_toml(), encoding="utf-8")
+
+    summary = patched_tick_loader.run_scheduler_tick_once(
+        cfg,
+        now=NOW,
+        subprocess_run=lambda *_a, **_k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        utcnow=_utc,
+    )
+    dispatch_total = summary.succeeded + summary.failed
+    assert summary.dispatched == dispatch_total
+
+
+def test_tick_does_not_call_sleep(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import scripts.run_scheduler as rs
+
+    def boom_sleep(_secs=None):
+        raise AssertionError("time.sleep must not be used in bounded tick")
+
+    monkeypatch.setattr(rs.time, "sleep", boom_sleep)
+
+    cfg = tmp_path / "solo.toml"
+    cfg.write_text(
+        """
+[[job]]
+name = "solo"
+args = { script = "scripts/solo.py" }
+schedule_type = "once"
+""",
+        encoding="utf-8",
+    )
+
+    real_load = rs.load_jobs_from_toml
+
+    def wrap(p):
+        jobs = real_load(p)
+        jobs[0].schedule.next_run_at = NOW - timedelta(seconds=1)
+        return jobs
+
+    monkeypatch.setattr(rs, "load_jobs_from_toml", wrap)
+
+    rs.run_scheduler_tick_once(
+        cfg,
+        now=NOW,
+        subprocess_run=lambda *_a, **_k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        utcnow=_utc,
+    )
+
+
+def test_tick_does_not_invoke_run_scheduler_loop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import scripts.run_scheduler as rs
+
+    def crash_loop(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("run_scheduler_loop must not run in bounded tick contract")
+
+    monkeypatch.setattr(rs, "run_scheduler_loop", crash_loop)
+
+    cfg = tmp_path / "solo2.toml"
+    cfg.write_text(
+        """
+[[job]]
+name = "solo2"
+args = { script = "scripts/solo.py" }
+schedule_type = "once"
+""",
+        encoding="utf-8",
+    )
+
+    real_load = rs.load_jobs_from_toml
+
+    def wrap(p):
+        jobs = real_load(p)
+        jobs[0].schedule.next_run_at = NOW - timedelta(seconds=1)
+        return jobs
+
+    monkeypatch.setattr(rs, "load_jobs_from_toml", wrap)
+
+    summary = rs.run_scheduler_tick_once(
+        cfg,
+        now=NOW,
+        subprocess_run=lambda *_a, **_k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        utcnow=_utc,
+    )
+    assert summary.dispatched == 1
+
+
+def test_scheduler_tick_summary_dataclass_defaults() -> None:
+    import scripts.run_scheduler as rs
+
+    s = rs.SchedulerTickSummary()
+    assert s.loaded == 0
+    assert s.due == 0


### PR DESCRIPTION
## Summary
- add a bounded scheduler single-tick dry-run contract
- add SchedulerTickSummary and run_scheduler_tick_once to compose config loading, due selection, dispatch, and schedule update once
- prove due dispatch, not-due skip, disabled skip, failure classification, summary counts, and no sleep/runtime-loop behavior
- preserve run_scheduler_loop behavior

## Safety
- no Testnet start
- no Paper/Shadow run
- no scheduler daemon
- no unbounded runtime loop
- no sleep loop in tests
- no network/Broker/Exchange
- no Live/order lifecycle changes
- no AI/paid evals
- no parameter tuning
- no paper test data mutation

## Validation
- uv run pytest -q tests/test_scheduler_single_tick_dry_run_contract_v0.py tests/test_scheduler_config_to_due_dispatch_contract_v0.py tests/test_scheduler_due_dispatch_contract_v0.py tests/test_scheduler_smoke.py
- uv run ruff check scripts/run_scheduler.py tests/test_scheduler_single_tick_dry_run_contract_v0.py
- uv run ruff format --check scripts/run_scheduler.py tests/test_scheduler_single_tick_dry_run_contract_v0.py

## Evidence
- Pre-commit audit: /tmp/peak_trade_precommit_bounded_scheduler_single_tick_dry_run_contract_20260515T194656Z/PRECOMMIT_BOUNDED_SCHEDULER_SINGLE_TICK_DRY_RUN_CONTRACT.md
- Post-commit readiness: /tmp/peak_trade_postcommit_bounded_scheduler_single_tick_pr_readiness_20260515T194923Z/POSTCOMMIT_BOUNDED_SCHEDULER_SINGLE_TICK_PR_READINESS.md

Made with [Cursor](https://cursor.com)