### PR TITLE
docs(ops): clarify AI KI manual paid workflow posture

### DIFF
--- a/docs/governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md
+++ b/docs/governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md
@@ -98,6 +98,10 @@ AI **MUST NOT** sein:
 - Ausnahme-Entscheider (Overrides/Exceptions)
 - Live-Optimierer (Parameter-Tweaks on-the-fly im Live-Betrieb)
 
+### 4.3 CI / Hilfsautomatisierung (GitHub Actions — nicht handelsautorisierend)
+
+Workflows können optionale OpenAI-/LLM-Pfade enthalten (z. B. Market Outlook unter `.github/workflows/market_outlook_automation.yml`, InfoStream unter `.github/workflows/infostream-automation.yml`, Promptfoo unter `.github/workflows/aiops-promptfoo-evals.yml`). Diese Pfade sind **keine** Live-/Order-/Risk-Freigabe und **keine** Kostenermächtigung: Secret-Anwesenheit erteilt keine Ausgabenerlaubnis; posture (default-off, explizite Opt-ins) steht in [`docs/ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md`](../ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md).
+
 ---
 
 ## 5. Verhältnis zu Peak_Trade Layern (Architektur-Invariante)

--- a/docs/ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md
+++ b/docs/ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md
@@ -24,12 +24,21 @@ Peak_Trade keeps **kostenpflichtige AI/KI/LLM** usage **default-off** in CI and 
 | Surface | Current expected state | Paid / billable LLM allowed? | Notes |
 |--------|-------------------------|--------------------------------|-------|
 | **AI-Ops Promptfoo Evals** | Active; PR/push run cost-safe path | **Only** manual `workflow_dispatch` with `run_paid_openai_evals=true` **and** repo var `PEAK_TRADE_RUN_PAID_PROMPTFOO_EVALS=true` | After PR #3461; see also [`AI_EVALS_RUNBOOK.md`](../ai/AI_EVALS_RUNBOOK.md). |
-| **InfoStream Automation** | Schedule + manual | **Schedule:** only if affirmative repo variables (e.g. `PT_AI_MODELS_ENABLED`, `PT_PAPERTRAIL_READY`) and runtime gates allow; keep vars **absent/false** unless owner-approved. | Treat scheduled model clients as **high sensitivity**. |
-| **MarketSentinel – Daily Market Outlook** | Schedule + manual | **Schedule:** uses `--skip-llm` (placeholder path). **Manual dispatch:** review point — no dedicated “paid LLM” workflow input today; rely on runtime gates and avoid casual manual runs. | Prefer manual-only or explicit paid opt-in in a future guardrail slice. |
+| **InfoStream Automation** (`.github/workflows/infostream-automation.yml`) | Schedule + manual | **Schedule:** only if affirmative repo variables (e.g. `PT_AI_MODELS_ENABLED`, `PT_PAPERTRAIL_READY`) and runtime gates allow; keep vars **absent/false** unless owner-approved. | Treat scheduled model clients as **high sensitivity**. |
+| **MarketSentinel – Daily Market Outlook** (`.github/workflows/market_outlook_automation.yml`) | Schedule + manual | **Schedule:** uses `--skip-llm` (placeholder path; no billable outbound LLM on cron). **Manual `workflow_dispatch`:** runs the script **without** `--skip-llm` today — **operator-initiated only**, not schedule-default, **not** autonomous spend; still **Principle 2** (secret ≠ spend permission) + **Principle 5** (no trading/live authority). No dedicated “paid LLM” workflow input yet. | Outputs are advisory/reporting; optional explicit paid opt-in inputs are a future guardrail slice. |
 | **AIOps trend seed / ledger** | `workflow_run` / dispatch | **No** OpenAI secret in workflow (artifact chain) | Offline/deterministic chain. |
 | **Cursor Auto-PR / Auto-merge** | Push / PR automation | **No LLM cost**; uses `GITHUB_TOKEN` | **Repo autonomy** (PRs, labels, merge) — separate governance from LLM cost. |
 | **`ai-model-cards-validate`** | PR | **No** — local validation of docs | Safe. |
 | **Audit workflow** | Various | Dummy `OPENAI_API_KEY` in CI only where documented | No live key dependency for audit path. |
+
+## Market Outlook — manual `workflow_dispatch` (operator clarification)
+
+This section restates repo-verified behavior from `.github/workflows/market_outlook_automation.yml` only; it does **not** grant authority.
+
+- **Scheduled runs** always pass `--skip-llm` → placeholder path; routine automation does **not** turn on billable LLM by default.
+- **Manual runs** follow the workflow `else` path **without** `--skip-llm`; any outbound LLM therefore requires a deliberate operator action in GitHub plus whatever keys/vars exist — **not** silent or autonomous CI spend.
+- **Presence of `OPENAI_API_KEY`** (or other secrets) is **not** approval, **not** Freigabe, and **not** trading/live enablement; spending posture remains gated by operator intent, repo variables, and runtime/workflow rules elsewhere.
+- **Documentation** and CI outputs **must not** be interpreted as order placement, risk override, or execution gates (see [`AI_AUTONOMY_GO_NO_GO_OVERVIEW.md`](../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md)).
 
 ## Repository variables (cost-relevant)
 


### PR DESCRIPTION
## Summary

- Clarifies AI/KI cost/autonomy policy around Market Outlook manual `workflow_dispatch` posture.
- Records that scheduled Market Outlook runs stay `--skip-llm`, while manually triggered paid/external LLM usage is operator-initiated and not default-on.
- Clarifies that API secrets do not imply spend permission, approval, Freigabe, or trading/live authority.
- Adds a small governance cross-reference from `AI_AUTONOMY_GO_NO_GO_OVERVIEW.md`.
- Corrects/supports exact workflow naming, including `infostream-automation.yml`.

## Scope

Docs-only.

Changed:
- `docs/ops/AI_KI_COST_AUTONOMY_CI_POLICY_V0.md`
- `docs/governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md`

Not changed:
- `.github/workflows/**`
- `tests/**`
- `scripts/**`
- `src/**`
- configs/generated data
- runtime/scheduler/paper/testnet/live/broker/exchange/order paths

## Validation

- `git diff --check`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Boundaries

- WORKFLOWS_TOUCHED=false
- RUNTIME_TOUCHED=false
- PAID_CALLS_TRIGGERED=false
- NEW_POLICY_DOC_CREATED=false
- Docs do not grant approval or trading authority.
- AI/KI remains non-authorizing.

Made with [Cursor](https://cursor.com)