### PR TITLE
docs(ops): link canary readiness criteria to canonical runbooks

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -72,6 +72,7 @@ Kurzablauf, wenn **`src/orders/`** (Prefix-Regel) geändert wird:
 Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im **selben Diff** **`docs/ops/registry/DOCS_TRUTH_MAP.md`** (diese Datei) einen kurzen Eintrag unter „Änderungsnachweis“ erhalten — damit bleibt die Registry-Landkarte mit der Branch-Protection-Referenz im Einklang (siehe Regel `truth-branch-protection-canonical` in `config/ops/docs_truth_map.yaml`).
 
 ## Änderungsnachweis (Slice A)
+- `docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md` → PR #3494 (Canary readiness crosslinks slice): pointer-only Verlinkung auf bestehende Readiness-/Bounded-Pilot-Runbooks; kein neuer Readiness-/Evidence-Surface, kein Live-Unlock, keine LB-APR-Abkürzung, NO-LIVE-Default unverändert.
 
 - 2026-05-02 — `docs&#47;ops&#47;specs&#47;MASTER_V2_GO_LIVE_ROADMAP_V0.md` — Informative **`### 3.1 Autonomy stage crosswalk (informative only)`** (planning vocabulary vs §4–§10; distributed recurring verification; **kein** neuer **`24&#47;7 Paper-Test-Daemon`**); **docs-only / non-authorizing**; **keine** Live-&#47;Testnet-&#47;Execution-Freigabe; Gates &#47; KillSwitch &#47; Risk dominieren weiterhin.
 

--- a/docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md
+++ b/docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md
@@ -139,6 +139,12 @@ Nur interne Referenzen; Pfade relativ zum Repository-Root `docs/`.
 | Stop / Freeze / Rollback | [incident_stop_freeze_rollback.md](./incident_stop_freeze_rollback.md) |
 | Risk-Limit-Verletzung | [risk_limit_breach.md](./risk_limit_breach.md) |
 | Offene Features / Triage | [RUNBOOK_UNIMPLEMENTED_FEATURES_ORDERED.md](./RUNBOOK_UNIMPLEMENTED_FEATURES_ORDERED.md) |
+| Master V2 First Live — Readiness Ladder (Navigation; non-authorizing) | [MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md](../specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md) |
+| Bounded real-money pilot — Entry Contract (DRAFT) | [BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md](../specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md) |
+| Bounded pilot — Dry Validation Runbook | [RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md](RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md) |
+| Bounded pilot — Live Entry Runbook | [RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md](RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md) |
+
+**Hinweis (Pointer-only):** Die vier Zusatzzeilen sind **Lesepfade** zu kanonischen Specs/Runbooks; sie begründen **keine** Freigabe, **keinen** Live-Unlock, **keine** Abkürzung des externen LB-APR-001-Nachweises und **keine** Autorisierung von Runtime, Scheduler, Paper, Testnet, Live, Broker oder Exchange. **Docs ≠ Approval** · **Signal ≠ Trade** · NO-LIVE-Default unverändert.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds pointer-only cross-links from `CANARY_LIVE_ENTRY_CRITERIA.md` to existing canonical readiness/runbook surfaces.
- Reuses existing docs instead of creating a parallel readiness/evidence/index surface.
- Keeps the canary criteria non-authorizing: docs do not approve Live, testnet success does not unlock Live, and LB-APR/gate requirements remain intact.

## Validation

- `git diff --check`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Safety

- Docs-only.
- No runtime/scheduler/testnet/live started.
- No broker/exchange access.
- No Master V2 / Double Play touch.
- No Risk/KillSwitch behavior change.
- No Scope/Capital logic change.
- No Market Dashboard touch.
- No new readiness/evidence surface.
- Pointer-only reuse of existing canonical docs.
- NO-LIVE default remains unchanged.

Made with [Cursor](https://cursor.com)