### PR TITLE
docs(ops): link dry validation runbook to canary criteria

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md
@@ -164,3 +164,7 @@ State **UTC window**, **step** that failed, and whether cockpit posture is **kno
 - no new gates;
 - no replacement for operator judgment;
 - no claim of pilot readiness **beyond** documenting this dry-validation sequence.
+
+## Siehe auch
+
+- [CANARY_LIVE_ENTRY_CRITERIA.md](CANARY_LIVE_ENTRY_CRITERIA.md) — kanonische Canary-Live-Entry-Kriterien; dieser Dry-Validation-Runbook-Pointer ist rein navigierend und begründet keine Freigabe, keinen Live-Unlock, keine LB-APR-Abkürzung und keine Autorisierung von Runtime, Scheduler, Paper, Testnet, Live, Broker oder Exchange. **Docs ≠ Approval** · **Signal ≠ Trade** · NO-LIVE-Default unverändert.


### PR DESCRIPTION
## Summary

- Adds a pointer-only `Siehe auch` link from `RUNBOOK_BOUNDED_PILOT_DRY_VALIDATION.md` to the canonical `CANARY_LIVE_ENTRY_CRITERIA.md`.
- Reuses the existing canary criteria owner instead of creating a parallel readiness/evidence/index surface.
- Keeps the dry-validation runbook non-authorizing: this link does not approve Live, unlock Live, shortcut LB-APR, or authorize runtime/scheduler/paper/testnet/live/broker/exchange activity.

## Validation

- `git diff --check`
- `uv run python scripts/ops/check_docs_drift_guard.py --base origin/main`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Safety

- Docs-only.
- No runtime/scheduler/testnet/live started.
- No broker/exchange access.
- No Master V2 / Double Play touch.
- No Risk/KillSwitch behavior change.
- No Scope/Capital logic change.
- No Market Dashboard touch.
- No new readiness/evidence surface.
- Pointer-only reuse of existing canonical docs.
- NO-LIVE default remains unchanged.

Made with [Cursor](https://cursor.com)