### PR TITLE
docs(ops): link live entry runbook to canary criteria

### DIFF
--- a/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
+++ b/docs/ops/runbooks/RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md
@@ -225,6 +225,8 @@ Bei Anomalien **sofort** stoppen und dokumentieren:
 
 ## 8. Verwandte Dokumente
 
+- [CANARY_LIVE_ENTRY_CRITERIA.md](CANARY_LIVE_ENTRY_CRITERIA.md) — kanonische Canary-Live-Entry-Kriterien; dieser Live-Entry-Runbook-Pointer ist rein navigierend und begründet keine Freigabe, keinen Live-Unlock, keine LB-APR-Abkürzung und keine Autorisierung von Runtime, Scheduler, Paper, Testnet, Live, Broker oder Exchange. **Docs ≠ Approval** · **Signal ≠ Trade** · NO-LIVE-Default unverändert.
+
 | Dokument | Rolle |
 |----------|--------|
 | `docs/ops/specs/BOUNDED_REAL_MONEY_PILOT_ENTRY_CONTRACT.md` | Kanonischer Entry-Vertrag |


### PR DESCRIPTION
## Summary

- Adds a pointer-only `CANARY_LIVE_ENTRY_CRITERIA.md` link to `RUNBOOK_BOUNDED_PILOT_LIVE_ENTRY.md`.
- Closes the existing Canary ↔ Dry Validation ↔ Live Entry navigation loop using existing canonical runbooks.
- Reuses existing readiness surfaces instead of creating a parallel readiness/evidence/index document.

## Validation

- `git diff --check`
- `uv run python scripts/ops/check_docs_drift_guard.py --base origin/main`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Safety

- Docs-only.
- No runtime/scheduler/testnet/live started.
- No broker/exchange access.
- No Master V2 / Double Play touch.
- No Risk/KillSwitch behavior change.
- No Scope/Capital logic change.
- No Market Dashboard touch.
- No new readiness/evidence surface.
- Pointer-only reuse of existing canonical docs.
- NO-LIVE default remains unchanged.
- No LB-APR short-circuit.

Made with [Cursor](https://cursor.com)