### PR TITLE
test(shadow): add no-order proof contract v0

### DIFF
--- a/src/shadow_no_order_proof/__init__.py
+++ b/src/shadow_no_order_proof/__init__.py
@@ -1,0 +1,1 @@
+"""Shadow no-order proof slice v0: declarative markers only (not a runtime entrypoint)."""

--- a/src/shadow_no_order_proof/markers_v0.py
+++ b/src/shadow_no_order_proof/markers_v0.py
@@ -1,0 +1,14 @@
+# Declarative markers for Shadow / no-order planning proofs (v0).
+# This module MUST NOT perform I/O, network, broker, exchange, or order submission.
+
+SHADOW_NO_ORDER_PROOF_V0 = "shadow_no_order_proof_v0"
+SHADOW_MODE_ALLOWED = False
+ORDER_SUBMISSION_ALLOWED = False
+BROKER_ALLOWED = False
+EXCHANGE_ALLOWED = False
+EXECUTABLE_COMMAND_CREATED = False
+LIVE_ALLOWED = False
+TESTNET_ALLOWED = False
+PAPER_ORDER_PATH_ALLOWED = False
+SCHEDULER_ALLOWED = False
+RUNTIME_ALLOWED = False

--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -1,0 +1,51 @@
+"""v0 contract: Shadow no-order proof markers stay declarative; canonical env defaults stay safe."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.core.environment import EnvironmentConfig, TradingEnvironment
+from src.shadow_no_order_proof import markers_v0
+
+_FORBIDDEN_SOURCE_MARKERS = (
+    "requests",
+    "httpx",
+    "urllib.request",
+    "socket",
+    "subprocess",
+    "ccxt",
+    "aiohttp",
+    "if __name__",
+)
+
+
+def test_shadow_no_order_markers_are_all_false_and_tagged() -> None:
+    assert markers_v0.SHADOW_NO_ORDER_PROOF_V0 == "shadow_no_order_proof_v0"
+    assert markers_v0.SHADOW_MODE_ALLOWED is False
+    assert markers_v0.ORDER_SUBMISSION_ALLOWED is False
+    assert markers_v0.BROKER_ALLOWED is False
+    assert markers_v0.EXCHANGE_ALLOWED is False
+    assert markers_v0.EXECUTABLE_COMMAND_CREATED is False
+    assert markers_v0.LIVE_ALLOWED is False
+    assert markers_v0.TESTNET_ALLOWED is False
+    assert markers_v0.PAPER_ORDER_PATH_ALLOWED is False
+    assert markers_v0.SCHEDULER_ALLOWED is False
+    assert markers_v0.RUNTIME_ALLOWED is False
+
+
+def test_markers_module_source_has_no_execution_or_network_tokens() -> None:
+    path = Path(markers_v0.__file__).resolve()
+    text = path.read_text(encoding="utf-8")
+    low = text.lower()
+    for needle in _FORBIDDEN_SOURCE_MARKERS:
+        assert needle.lower() not in low, f"unexpected token {needle!r} in {path}"
+
+
+def test_environment_config_defaults_remain_paper_and_gated() -> None:
+    """Canonical owner: src.core.environment.EnvironmentConfig defaults."""
+    cfg = EnvironmentConfig()
+    assert cfg.environment == TradingEnvironment.PAPER
+    assert cfg.enable_live_trading is False
+    assert cfg.testnet_dry_run is True
+    assert cfg.live_mode_armed is False
+    assert cfg.live_dry_run_mode is True


### PR DESCRIPTION
## Summary

Adds a small static proof contract for Shadow no-order boundaries.

Changed files:

- `src/shadow_no_order_proof/__init__.py`
- `src/shadow_no_order_proof/markers_v0.py`
- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This slice is declarative/static only. It does not identify or approve a proven Shadow runtime entry point.

## Reuse-before-new

The prior read-only entrypoint search found no proven canonical Shadow no-order entry point:

- `PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false`
- `EXPLICIT_BOUNDARY_CANDIDATES_FOUND=false`
- `UNPROVEN_MIXED_RISK_CANDIDATES_FOUND=true`

This PR therefore adds the smallest explicit static proof surface instead of creating a run command or new runtime path.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q`
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Machine-readable

VERDICT=SHADOW_NO_ORDER_PROOF_SLICE_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
SHADOW_NO_ORDER_PROOF_ADDED=true
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)