### PR TITLE
test(shadow): guard no-order proof from execution surface

### DIFF
--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from src.core.environment import EnvironmentConfig, TradingEnvironment
@@ -17,6 +18,77 @@ _FORBIDDEN_SOURCE_MARKERS = (
     "aiohttp",
     "if __name__",
 )
+
+# Whole-package guard: declarative surface only (no I/O, CLI, runtime, or trading clients).
+_PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "src" / "shadow_no_order_proof"
+_NO_EXEC_SURFACE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"if\s+__name__\s*==\s*[\"']__main__[\"']"), "__main__ guard"),
+    (re.compile(r"\bdef\s+main\s*\("), "def main("),
+    (re.compile(r"\b(import|from)\s+argparse\b"), "argparse import"),
+    (re.compile(r"argparse\."), "argparse usage"),
+    (re.compile(r"\b(import|from)\s+click\b"), "click import"),
+    (re.compile(r"click\."), "click usage"),
+    (re.compile(r"\b(import|from)\s+typer\b"), "typer import"),
+    (re.compile(r"typer\."), "typer usage"),
+    (re.compile(r"\buvicorn\b"), "uvicorn"),
+    (re.compile(r"\brun_scheduler\b"), "run_scheduler"),
+    (re.compile(r"\brun_with_timeout\b"), "run_with_timeout"),
+    (re.compile(r"\b(import|from)\s+subprocess\b"), "subprocess import"),
+    (re.compile(r"\bsubprocess\."), "subprocess call"),
+    (re.compile(r"\bos\.system\s*\("), "os.system"),
+    (re.compile(r"\bos\.popen\s*\("), "os.popen"),
+    (re.compile(r"\b(import|from)\s+socket\b"), "socket import"),
+    (re.compile(r"\bsocket\."), "socket usage"),
+    (re.compile(r"\b(import|from)\s+multiprocessing\b"), "multiprocessing import"),
+    (re.compile(r"\b(import|from)\s+threading\b"), "threading import"),
+    (re.compile(r"\brequests\."), "requests usage"),
+    (re.compile(r"\b(import|from)\s+requests\b"), "requests import"),
+    (re.compile(r"\bhttpx\."), "httpx usage"),
+    (re.compile(r"\b(import|from)\s+httpx\b"), "httpx import"),
+    (re.compile(r"\b(import|from)\s+urllib\b"), "urllib import"),
+    (re.compile(r"\burllib\.request\b"), "urllib.request"),
+    (re.compile(r"\b(import|from)\s+aiohttp\b"), "aiohttp import"),
+    (re.compile(r"\baiohttp\."), "aiohttp usage"),
+    (re.compile(r"\bwebsocket"), "websocket"),
+    (re.compile(r"\bccxt\b"), "ccxt"),
+    (re.compile(r"\bcreate_order\b"), "create_order"),
+    (re.compile(r"\bplace_order\b"), "place_order"),
+    (re.compile(r"\bsend_order\b"), "send_order"),
+    (re.compile(r"\bsubmit_order\b"), "submit_order"),
+    (re.compile(r"\border_submission\b"), "order_submission"),
+    (re.compile(r"\bapi_key\s*="), "api_key assignment"),
+    (re.compile(r"\bsecret\s*="), "secret assignment"),
+    (re.compile(r"\bprivate_key\s*="), "private_key assignment"),
+    (re.compile(r"\bcredential\s*="), "credential assignment"),
+    (re.compile(r"SHADOW_MODE_ALLOWED\s*=\s*True"), "SHADOW_MODE_ALLOWED true"),
+    (re.compile(r"ORDER_SUBMISSION_ALLOWED\s*=\s*True"), "ORDER_SUBMISSION_ALLOWED true"),
+    (re.compile(r"BROKER_ALLOWED\s*=\s*True"), "BROKER_ALLOWED true"),
+    (re.compile(r"EXCHANGE_ALLOWED\s*=\s*True"), "EXCHANGE_ALLOWED true"),
+    (re.compile(r"LIVE_ALLOWED\s*=\s*True"), "LIVE_ALLOWED true"),
+    (re.compile(r"TESTNET_ALLOWED\s*=\s*True"), "TESTNET_ALLOWED true"),
+    (re.compile(r"PAPER_ORDER_PATH_ALLOWED\s*=\s*True"), "PAPER_ORDER_PATH_ALLOWED true"),
+    (re.compile(r"SCHEDULER_ALLOWED\s*=\s*True"), "SCHEDULER_ALLOWED true"),
+    (re.compile(r"RUNTIME_ALLOWED\s*=\s*True"), "RUNTIME_ALLOWED true"),
+    (re.compile(r"EXECUTABLE_COMMAND_CREATED\s*=\s*True"), "EXECUTABLE_COMMAND_CREATED true"),
+)
+
+
+def _shadow_no_order_proof_py_files() -> list[Path]:
+    assert _PACKAGE_ROOT.is_dir(), f"missing package: {_PACKAGE_ROOT}"
+    paths = sorted(
+        p for p in _PACKAGE_ROOT.rglob("*.py") if p.is_file() and "__pycache__" not in p.parts
+    )
+    assert paths, "expected at least one Python file under shadow_no_order_proof"
+    return paths
+
+
+def test_shadow_no_order_proof_package_is_non_execution_surface() -> None:
+    """Scan only `src/shadow_no_order_proof/` — no whole-repo walk."""
+    for path in _shadow_no_order_proof_py_files():
+        text = path.read_text(encoding="utf-8")
+        for pattern, label in _NO_EXEC_SURFACE_PATTERNS:
+            match = pattern.search(text)
+            assert match is None, f"{label!r} matched in {path}: {match.group(0)!r}"
 
 
 def test_shadow_no_order_markers_are_all_false_and_tagged() -> None:


### PR DESCRIPTION
## Summary

Adds a tests-only package-wide guard ensuring `src/shadow_no_order_proof/` remains a declarative no-order proof surface and cannot drift into an execution/runtime/scheduler/broker/exchange/order-submission surface.

Changed file:

- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Reuse-before-new

- Reused the existing canonical Shadow no-order proof contract test.
- No new test file.
- No new docs.
- No new runtime surface.
- No duplicate readiness/evidence/planning surface.

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This remains a static/tests-only proof. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 4 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Machine-readable

VERDICT=SHADOW_NO_ORDER_NO_EXECUTION_SURFACE_GUARD_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
TESTS_ONLY=true
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
SHADOW_NO_ORDER_PROOF_ADDED=true
NO_EXECUTION_SURFACE_GUARD_ADDED=true
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)