### PR TITLE
test(shadow): guard workflows from proof authority

### DIFF
--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 from src.core.environment import EnvironmentConfig, TradingEnvironment
 from src.shadow_no_order_proof import markers_v0
 
@@ -82,6 +84,12 @@ _NO_ORDER_ENTRYPOINT_FORBIDDEN_APPROVAL: tuple[tuple[re.Pattern[str], str], ...]
         re.compile(r"EXECUTABLE_COMMAND_CREATED\s*=\s*(?i:True)"),
         "EXECUTABLE_COMMAND_CREATED true",
     ),
+)
+
+# Workflows must not treat declarative proof metadata as CI/release/execution authority.
+_WORKFLOW_FORBIDDEN_SHADOW_NO_ORDER_SUBSTR: tuple[str, ...] = (
+    "shadow_no_order_proof",
+    "src.shadow_no_order_proof",
 )
 
 _FORBIDDEN_SOURCE_MARKERS = (
@@ -225,6 +233,23 @@ def test_known_shadow_runtime_candidates_are_not_approved_no_order_entrypoints()
                 f"{label!r} must not appear in candidate {path} (matched {match.group(0)!r})"
             )
     assert checked > 0, "expected at least one known shadow/runtime candidate file to exist"
+
+
+def test_workflows_do_not_reference_shadow_no_order_proof_as_authority() -> None:
+    """GitHub Actions YAML must not reference declarative proof as CI/release/execution authority."""
+    wf_root = _REPO_ROOT / ".github" / "workflows"
+    if not wf_root.is_dir():
+        pytest.skip(".github/workflows not present")
+    paths = _workflow_files()
+    if not paths:
+        pytest.skip("no .yml/.yaml workflow files under .github/workflows")
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for needle in _WORKFLOW_FORBIDDEN_SHADOW_NO_ORDER_SUBSTR:
+            assert needle not in text, (
+                f"workflow {path} must not reference {needle!r} "
+                "(declarative shadow_no_order_proof is not CI/release authority)"
+            )
 
 
 def test_shadow_no_order_proof_package_is_non_execution_surface() -> None:


### PR DESCRIPTION
## Summary

Adds a tests-only guard ensuring GitHub Actions workflows do not reference `shadow_no_order_proof` / `src.shadow_no_order_proof` as CI, release, execution, approval, or authority surface.

Changed file:

- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Reuse-before-new

- Reused the existing canonical Shadow no-order proof contract test.
- No new test file.
- No new docs.
- No new runtime surface.
- No duplicate readiness/evidence/planning surface.

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This remains static/tests-only. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 7 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Machine-readable

VERDICT=WORKFLOW_SHADOW_NO_ORDER_PROOF_NO_AUTHORITY_REFERENCE_GUARD_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
TESTS_ONLY=true
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
WORKFLOW_SHADOW_NO_ORDER_PROOF_NO_AUTHORITY_REFERENCE_GUARD_ADDED=true
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)