### PR TITLE
test(shadow): guard proof from config authority

### DIFF
--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -92,6 +92,17 @@ _WORKFLOW_FORBIDDEN_SHADOW_NO_ORDER_SUBSTR: tuple[str, ...] = (
     "src.shadow_no_order_proof",
 )
 
+# Canonical repo config trees — scheduler/runtime wiring must not reference declarative proof.
+_CONFIG_AUTHORITY_REL_ROOTS: tuple[str, ...] = ("config",)
+_CONFIG_AUTHORITY_FILE_SUFFIXES: frozenset[str] = frozenset(
+    {".toml", ".yaml", ".yml", ".json", ".ini", ".cfg"}
+)
+_CONFIG_FORBIDDEN_SHADOW_NO_ORDER_SUBSTR: tuple[str, ...] = (
+    "shadow_no_order_proof",
+    "src.shadow_no_order_proof",
+    "SHADOW_NO_ORDER_PROOF_V0",
+)
+
 _FORBIDDEN_SOURCE_MARKERS = (
     "requests",
     "httpx",
@@ -172,6 +183,21 @@ def _workflow_files() -> list[Path]:
     )
 
 
+def _config_authority_surface_files() -> list[Path]:
+    paths: list[Path] = []
+    for rel in _CONFIG_AUTHORITY_REL_ROOTS:
+        root = _REPO_ROOT / rel
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*"):
+            if not p.is_file() or "__pycache__" in p.parts:
+                continue
+            suf = p.suffix.lower()
+            if suf in _CONFIG_AUTHORITY_FILE_SUFFIXES or p.name.lower().endswith(".env.example"):
+                paths.append(p.resolve())
+    return sorted(set(paths))
+
+
 def _authority_surface_files_for_shadow_no_order_import_guard() -> list[Path]:
     paths: list[Path] = []
     for rel in _SRC_AUTHORITY_REL_DIRS:
@@ -249,6 +275,19 @@ def test_workflows_do_not_reference_shadow_no_order_proof_as_authority() -> None
             assert needle not in text, (
                 f"workflow {path} must not reference {needle!r} "
                 "(declarative shadow_no_order_proof is not CI/release authority)"
+            )
+
+
+def test_runtime_scheduler_configs_do_not_reference_shadow_no_order_proof_as_authority() -> None:
+    """Bounded config trees must not wire declarative proof as scheduler/runtime authority."""
+    paths = _config_authority_surface_files()
+    assert paths, "expected at least one config-like file under canonical config roots"
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for needle in _CONFIG_FORBIDDEN_SHADOW_NO_ORDER_SUBSTR:
+            assert needle not in text, (
+                f"config {path} must not reference {needle!r} "
+                "(shadow_no_order_proof is not scheduler/runtime config authority)"
             )
 
 


### PR DESCRIPTION
## Summary

Adds a tests-only guard ensuring canonical runtime/scheduler/job/config-like surfaces do not reference `shadow_no_order_proof` / `src.shadow_no_order_proof` / proof markers as wiring, approval, trigger, or execution authority.

Changed file:

- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Reuse-before-new

- Reused the existing canonical Shadow no-order proof contract test.
- No new test file.
- No new docs.
- No new runtime surface.
- No duplicate readiness/evidence/planning surface.

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This remains static/tests-only. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 8 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Machine-readable

VERDICT=SHADOW_NO_ORDER_PROOF_CONFIG_ABSENCE_GUARD_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
TESTS_ONLY=true
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
SHADOW_NO_ORDER_PROOF_CONFIG_ABSENCE_GUARD_ADDED=true
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)