### PR TITLE
test(shadow): add bounded adapter proof contract

### DIFF
--- a/src/shadow_no_order_proof/adapter_contract_v0.py
+++ b/src/shadow_no_order_proof/adapter_contract_v0.py
@@ -1,0 +1,22 @@
+# Declarative bounded Shadow adapter proof contract (v0).
+# This module MUST NOT perform I/O, network, broker, exchange, or order submission.
+# Not a runtime entrypoint; not an executable command surface.
+
+BOUNDED_SHADOW_ADAPTER_PROOF_V0 = "bounded_shadow_adapter_proof_v0"
+ADAPTER_KIND = "declarative_no_order_shadow_adapter_proof"
+
+PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND = False
+EXECUTABLE_COMMAND_CREATED = False
+
+SHADOW_MODE_ALLOWED = False
+ORDER_SUBMISSION_ALLOWED = False
+
+BROKER_ALLOWED = False
+EXCHANGE_ALLOWED = False
+
+RUNTIME_ALLOWED = False
+SCHEDULER_ALLOWED = False
+
+LIVE_ALLOWED = False
+TESTNET_ALLOWED = False
+PAPER_ALLOWED = False

--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from src.core.environment import EnvironmentConfig, TradingEnvironment
-from src.shadow_no_order_proof import markers_v0
+from src.shadow_no_order_proof import adapter_contract_v0, markers_v0
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -314,8 +314,33 @@ def test_shadow_no_order_markers_are_all_false_and_tagged() -> None:
     assert markers_v0.RUNTIME_ALLOWED is False
 
 
+def test_bounded_shadow_adapter_proof_contract_is_declarative_and_all_flags_false() -> None:
+    """Bounded adapter proof slice: constants only, no authority to run or trade."""
+    assert adapter_contract_v0.BOUNDED_SHADOW_ADAPTER_PROOF_V0 == "bounded_shadow_adapter_proof_v0"
+    assert adapter_contract_v0.ADAPTER_KIND == "declarative_no_order_shadow_adapter_proof"
+    assert adapter_contract_v0.PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND is False
+    assert adapter_contract_v0.EXECUTABLE_COMMAND_CREATED is False
+    assert adapter_contract_v0.SHADOW_MODE_ALLOWED is False
+    assert adapter_contract_v0.ORDER_SUBMISSION_ALLOWED is False
+    assert adapter_contract_v0.BROKER_ALLOWED is False
+    assert adapter_contract_v0.EXCHANGE_ALLOWED is False
+    assert adapter_contract_v0.RUNTIME_ALLOWED is False
+    assert adapter_contract_v0.SCHEDULER_ALLOWED is False
+    assert adapter_contract_v0.LIVE_ALLOWED is False
+    assert adapter_contract_v0.TESTNET_ALLOWED is False
+    assert adapter_contract_v0.PAPER_ALLOWED is False
+
+
 def test_markers_module_source_has_no_execution_or_network_tokens() -> None:
     path = Path(markers_v0.__file__).resolve()
+    text = path.read_text(encoding="utf-8")
+    low = text.lower()
+    for needle in _FORBIDDEN_SOURCE_MARKERS:
+        assert needle.lower() not in low, f"unexpected token {needle!r} in {path}"
+
+
+def test_adapter_contract_module_source_has_no_execution_or_network_tokens() -> None:
+    path = Path(adapter_contract_v0.__file__).resolve()
     text = path.read_text(encoding="utf-8")
     low = text.lower()
     for needle in _FORBIDDEN_SOURCE_MARKERS:


### PR DESCRIPTION
## Summary

Adds a bounded Shadow adapter proof contract as a declarative/no-order proof surface.

Changed files:

- `src/shadow_no_order_proof/adapter_contract_v0.py`
- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Reuse-before-new

- Reuses the existing `src/shadow_no_order_proof/` package.
- Extends the existing canonical Shadow no-order proof contract test.
- No new docs.
- No new runtime surface.
- No duplicate readiness/evidence/planning surface.

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This remains declarative/tests-only. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 10 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## Machine-readable

VERDICT=BOUNDED_SHADOW_ADAPTER_PROOF_SLICE_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
TESTS_ONLY_OR_DECLARATIVE_ONLY=true
BOUNDED_SHADOW_ADAPTER_PROOF_ADDED=true
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)