### PR TITLE
test(shadow): add observation harness contract v0

### DIFF
--- a/src/shadow_no_order_proof/observation_harness_v0.py
+++ b/src/shadow_no_order_proof/observation_harness_v0.py
@@ -1,0 +1,150 @@
+# Shadow Observation Harness v0 — declarative evidence only (no runtime entrypoint).
+# Pure: dataclasses + stdlib hashing/json. No I/O, no network, no time lookups.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, cast
+
+from src.shadow_no_order_proof.bounded_adapter_v0 import (
+    BoundedShadowAdapterPlan,
+    build_bounded_shadow_adapter_plan_v0,
+)
+
+OBSERVATION_EVIDENCE_SCHEMA_V0 = "shadow_observation_evidence_record.v0"
+
+
+@dataclass(frozen=True)
+class ShadowObservationInputSnapshot:
+    """Caller-supplied observation inputs — no broker/exchange/client fields."""
+
+    symbol: str
+    observed_at_utc: str
+    source: str
+    payload: Mapping[str, object]
+
+
+@dataclass(frozen=True)
+class ShadowObservationEvidenceRecord:
+    """Deterministic evidence bridge: snapshot + bounded adapter plan (metadata only)."""
+
+    evidence_version: str
+    adapter_kind: str
+    source: str
+    observed_at_utc: str
+    evidence_id: str
+    evidence_hash: str
+    proof_version: str
+    allowed_actions: tuple[str, ...]
+    evidence_required: bool
+    proven_shadow_no_order_entrypoint_found: bool
+    executable_command_created: bool
+    shadow_mode_allowed: bool
+    order_submission_allowed: bool
+    broker_allowed: bool
+    exchange_allowed: bool
+    runtime_allowed: bool
+    scheduler_allowed: bool
+    live_allowed: bool
+    testnet_allowed: bool
+    paper_allowed: bool
+    broker_touched: bool
+    exchange_touched: bool
+    credentials_touched: bool
+    order_intent_created: bool
+    runtime_started: bool
+    scheduler_started: bool
+
+
+def _canonical_json_primitive(obj: object) -> object:
+    """Normalize nested structures for deterministic JSON (sorted dict keys, tuples as lists)."""
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return obj
+    if isinstance(obj, Mapping):
+        mapping = cast(Mapping[str, Any], obj)
+        return {k: _canonical_json_primitive(mapping[k]) for k in sorted(mapping)}
+    if isinstance(obj, (list, tuple)):
+        return [_canonical_json_primitive(x) for x in obj]
+    raise TypeError(f"Unsupported payload type for canonical JSON: {type(obj)!r}")
+
+
+def _fingerprint_bytes(
+    *, snapshot: ShadowObservationInputSnapshot, plan: BoundedShadowAdapterPlan
+) -> bytes:
+    """Stable UTF-8 bytes for hashing; no wall-clock inputs."""
+    body: dict[str, object] = {
+        "schema": OBSERVATION_EVIDENCE_SCHEMA_V0,
+        "snapshot": {
+            "symbol": snapshot.symbol,
+            "observed_at_utc": snapshot.observed_at_utc,
+            "source": snapshot.source,
+            "payload": _canonical_json_primitive(dict(snapshot.payload)),
+        },
+        "plan": {
+            "adapter_kind": plan.adapter_kind,
+            "source": plan.source,
+            "proof_version": plan.proof_version,
+            "allowed_actions": list(plan.allowed_actions),
+            "forbidden_actions": list(plan.forbidden_actions),
+            "evidence_required": plan.evidence_required,
+            "proven_shadow_no_order_entrypoint_found": plan.proven_shadow_no_order_entrypoint_found,
+            "executable_command_created": plan.executable_command_created,
+            "not_executable_declaration": plan.not_executable_declaration,
+            "not_approved_declaration": plan.not_approved_declaration,
+            "shadow_mode_allowed": plan.shadow_mode_allowed,
+            "order_submission_allowed": plan.order_submission_allowed,
+            "broker_allowed": plan.broker_allowed,
+            "exchange_allowed": plan.exchange_allowed,
+            "runtime_allowed": plan.runtime_allowed,
+            "scheduler_allowed": plan.scheduler_allowed,
+            "live_allowed": plan.live_allowed,
+            "testnet_allowed": plan.testnet_allowed,
+            "paper_allowed": plan.paper_allowed,
+        },
+    }
+    return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def build_shadow_observation_evidence_record_v0(
+    *,
+    snapshot: ShadowObservationInputSnapshot,
+    plan: Optional[BoundedShadowAdapterPlan] = None,
+) -> ShadowObservationEvidenceRecord:
+    """Combine a snapshot with a bounded adapter plan into a deterministic evidence record."""
+    resolved = (
+        plan if plan is not None else build_bounded_shadow_adapter_plan_v0(source=snapshot.source)
+    )
+    raw = _fingerprint_bytes(snapshot=snapshot, plan=resolved)
+    digest = hashlib.sha256(raw).hexdigest()
+    return ShadowObservationEvidenceRecord(
+        evidence_version=OBSERVATION_EVIDENCE_SCHEMA_V0,
+        adapter_kind=resolved.adapter_kind,
+        source=snapshot.source,
+        observed_at_utc=snapshot.observed_at_utc,
+        evidence_id=digest,
+        evidence_hash=digest,
+        proof_version=resolved.proof_version,
+        allowed_actions=resolved.allowed_actions,
+        evidence_required=resolved.evidence_required,
+        proven_shadow_no_order_entrypoint_found=resolved.proven_shadow_no_order_entrypoint_found,
+        executable_command_created=resolved.executable_command_created,
+        shadow_mode_allowed=resolved.shadow_mode_allowed,
+        order_submission_allowed=resolved.order_submission_allowed,
+        broker_allowed=resolved.broker_allowed,
+        exchange_allowed=resolved.exchange_allowed,
+        runtime_allowed=resolved.runtime_allowed,
+        scheduler_allowed=resolved.scheduler_allowed,
+        live_allowed=resolved.live_allowed,
+        testnet_allowed=resolved.testnet_allowed,
+        paper_allowed=resolved.paper_allowed,
+        broker_touched=False,
+        exchange_touched=False,
+        credentials_touched=False,
+        order_intent_created=False,
+        runtime_started=False,
+        scheduler_started=False,
+    )

--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import re
+from dataclasses import fields
 from pathlib import Path
 
 import pytest
 
 from src.core.environment import EnvironmentConfig, TradingEnvironment
-from src.shadow_no_order_proof import adapter_contract_v0, bounded_adapter_v0, markers_v0
+from src.shadow_no_order_proof import (
+    adapter_contract_v0,
+    bounded_adapter_v0,
+    markers_v0,
+    observation_harness_v0,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -455,6 +461,165 @@ def test_bounded_adapter_module_isolates_from_mixed_risk_scripts_and_runtime_pac
 
 def test_bounded_adapter_module_source_has_no_execution_or_network_tokens() -> None:
     path = Path(bounded_adapter_v0.__file__).resolve()
+    text = path.read_text(encoding="utf-8")
+    low = text.lower()
+    for needle in _FORBIDDEN_SOURCE_MARKERS:
+        assert needle.lower() not in low, f"unexpected token {needle!r} in {path}"
+
+
+def test_shadow_observation_input_snapshot_has_only_safe_fields() -> None:
+    """Contract: snapshot carries symbol/time/source/payload only — no broker/exchange/client fields."""
+    expected = {"symbol", "observed_at_utc", "source", "payload"}
+    assert {
+        f.name for f in fields(observation_harness_v0.ShadowObservationInputSnapshot)
+    } == expected
+    forbidden_substrings = ("exchange", "broker", "client", "credential")
+    for f in fields(observation_harness_v0.ShadowObservationInputSnapshot):
+        lower = f.name.lower()
+        for sub in forbidden_substrings:
+            assert sub not in lower, f"field {f.name!r} must not contain {sub!r}"
+
+
+def test_shadow_observation_evidence_record_shapes_and_safety_flags() -> None:
+    """Contract: evidence record mirrors plan metadata; operational safety flags stay false."""
+    snapshot = observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol="TEST",
+        observed_at_utc="2026-01-02T00:00:00Z",
+        source="contract_observation_v0",
+        payload={"mid": 1.0},
+    )
+    plan = bounded_adapter_v0.build_bounded_shadow_adapter_plan_v0(source=snapshot.source)
+    rec = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=snapshot, plan=plan
+    )
+    assert rec.evidence_version == observation_harness_v0.OBSERVATION_EVIDENCE_SCHEMA_V0
+    assert rec.adapter_kind == plan.adapter_kind
+    assert rec.source == snapshot.source
+    assert rec.observed_at_utc == snapshot.observed_at_utc
+    assert rec.evidence_id == rec.evidence_hash
+    assert len(rec.evidence_id) == 64
+    assert rec.proof_version == plan.proof_version
+    assert rec.allowed_actions == ()
+    assert rec.evidence_required is True
+    assert rec.proven_shadow_no_order_entrypoint_found is False
+    assert rec.executable_command_created is False
+    must_be_false = (
+        rec.broker_touched,
+        rec.exchange_touched,
+        rec.credentials_touched,
+        rec.order_intent_created,
+        rec.order_submission_allowed,
+        rec.runtime_started,
+        rec.scheduler_started,
+        rec.shadow_mode_allowed,
+        rec.live_allowed,
+        rec.testnet_allowed,
+        rec.paper_allowed,
+        rec.broker_allowed,
+        rec.exchange_allowed,
+        rec.runtime_allowed,
+        rec.scheduler_allowed,
+    )
+    assert not any(must_be_false), f"expected all operational flags false, got {must_be_false!r}"
+
+
+def test_shadow_observation_evidence_is_deterministic_for_same_inputs() -> None:
+    snapshot = observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol="AAA",
+        observed_at_utc="2026-05-16T12:00:00Z",
+        source="det_test",
+        payload={"a": 1, "nested": {"z": 3, "y": 2}},
+    )
+    plan = bounded_adapter_v0.build_bounded_shadow_adapter_plan_v0(source="det_test")
+    r1 = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=snapshot, plan=plan
+    )
+    r2 = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=snapshot, plan=plan
+    )
+    assert r1.evidence_id == r2.evidence_id
+
+
+def test_shadow_observation_evidence_id_changes_when_snapshot_or_plan_differs() -> None:
+    base_snap = observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol="BBB",
+        observed_at_utc="2026-05-16T12:00:00Z",
+        source="id_change",
+        payload={"k": 1},
+    )
+    plan_a = bounded_adapter_v0.build_bounded_shadow_adapter_plan_v0(source="id_change")
+    plan_b = bounded_adapter_v0.build_bounded_shadow_adapter_plan_v0(source="other_source")
+    rid1 = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=base_snap, plan=plan_a
+    ).evidence_id
+    rid2 = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=observation_harness_v0.ShadowObservationInputSnapshot(
+            symbol="BBB",
+            observed_at_utc="2026-05-16T12:00:01Z",
+            source="id_change",
+            payload={"k": 1},
+        ),
+        plan=plan_a,
+    ).evidence_id
+    rid3 = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=observation_harness_v0.ShadowObservationInputSnapshot(
+            symbol="BBB",
+            observed_at_utc="2026-05-16T12:00:00Z",
+            source="id_change",
+            payload={"k": 2},
+        ),
+        plan=plan_a,
+    ).evidence_id
+    rid4 = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=observation_harness_v0.ShadowObservationInputSnapshot(
+            symbol="BBB",
+            observed_at_utc="2026-05-16T12:00:00Z",
+            source="other",
+            payload={"k": 1},
+        ),
+        plan=plan_a,
+    ).evidence_id
+    rid5 = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=base_snap, plan=plan_b
+    ).evidence_id
+    assert len({rid1, rid2, rid3, rid4, rid5}) == 5
+
+
+def test_shadow_observation_harness_emits_no_order_like_allowed_actions() -> None:
+    snapshot = observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol="CCC",
+        observed_at_utc="2026-05-16T12:00:00Z",
+        source="no_order_actions",
+        payload={},
+    )
+    plan = bounded_adapter_v0.build_bounded_shadow_adapter_plan_v0(source=snapshot.source)
+    rec = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=snapshot, plan=plan
+    )
+    assert not rec.allowed_actions
+    for action in rec.allowed_actions:
+        low = action.lower()
+        assert "order" not in low
+
+
+def test_observation_harness_module_isolates_from_mixed_risk_scripts_and_runtime_packages() -> None:
+    path = Path(observation_harness_v0.__file__).resolve()
+    text = path.read_text(encoding="utf-8")
+    for needle in ("scripts/run_shadow_execution.py", "scripts/testnet_orchestrator_cli.py"):
+        assert needle not in text, f"{path} must not reference mixed-risk script path {needle!r}"
+    for pattern in (
+        re.compile(
+            r"(?m)^\s*from\s+src\.(execution|live|scheduler|strategies|ops|data|orders|backtest)\b"
+        ),
+        re.compile(
+            r"(?m)^\s*import\s+src\.(execution|live|scheduler|strategies|ops|data|orders|backtest)\b"
+        ),
+    ):
+        assert pattern.search(text) is None, f"{path} must not import runtime-like src packages"
+
+
+def test_observation_harness_module_source_has_no_execution_or_network_tokens() -> None:
+    path = Path(observation_harness_v0.__file__).resolve()
     text = path.read_text(encoding="utf-8")
     low = text.lower()
     for needle in _FORBIDDEN_SOURCE_MARKERS:


### PR DESCRIPTION
## Summary

Adds Shadow Observation Harness v0 as a pure no-order evidence contract and deterministic evidence builder.

Changed files:

- `src/shadow_no_order_proof/observation_harness_v0.py`
- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## What this adds

- `ShadowObservationInputSnapshot`
- `ShadowObservationEvidenceRecord`
- `build_shadow_observation_evidence_record_v0(...)`
- Deterministic canonical JSON + SHA-256 evidence hash
- No broker/exchange/credentials/order/runtime/scheduler flags
- Python 3.9-compatible typing

## Reuse-before-new

- Reuses existing `src/shadow_no_order_proof/` as canonical owner.
- Extends the existing canonical Shadow no-order proof contract test.
- No new docs.
- No new runtime surface.
- No duplicate readiness/evidence/planning surface.
- Notion update remains draft-only; no Notion write was performed.

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No mixed-risk candidate wrapping or imports
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This remains pure/local/deterministic. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 22 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- Python 3.9 compatibility scan — ok

## Machine-readable

VERDICT=SHADOW_OBSERVATION_HARNESS_CONTRACT_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
TESTS_ONLY_OR_PURE_IMPLEMENTATION_ONLY=true
SHADOW_OBSERVATION_HARNESS_CONTRACT_ADDED=true
SHADOW_OBSERVATION_HARNESS_IMPLEMENTED=true
NOTION_WRITE_PERFORMED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)