### PR TITLE
feat(shadow): add one-shot observation harness helper

### DIFF
--- a/src/shadow_no_order_proof/observation_harness_v0.py
+++ b/src/shadow_no_order_proof/observation_harness_v0.py
@@ -148,3 +148,10 @@ def build_shadow_observation_evidence_record_v0(
         runtime_started=False,
         scheduler_started=False,
     )
+
+
+def run_shadow_observation_one_shot_v0(
+    snapshot: ShadowObservationInputSnapshot,
+) -> ShadowObservationEvidenceRecord:
+    """One in-memory snapshot → one evidence record; bounded plan from `snapshot.source` only."""
+    return build_shadow_observation_evidence_record_v0(snapshot=snapshot, plan=None)

--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -602,6 +602,85 @@ def test_shadow_observation_harness_emits_no_order_like_allowed_actions() -> Non
         assert "order" not in low
 
 
+def test_run_shadow_observation_one_shot_v0_returns_same_as_default_plan_build() -> None:
+    """One-shot entry is sugar over evidence build with plan derived from snapshot.source."""
+    snapshot = observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol="ONE",
+        observed_at_utc="2026-05-16T14:00:00Z",
+        source="one_shot_equiv",
+        payload={"x": 1},
+    )
+    via_one_shot = observation_harness_v0.run_shadow_observation_one_shot_v0(snapshot)
+    via_build = observation_harness_v0.build_shadow_observation_evidence_record_v0(
+        snapshot=snapshot, plan=None
+    )
+    assert via_one_shot == via_build
+    assert isinstance(via_one_shot, observation_harness_v0.ShadowObservationEvidenceRecord)
+
+
+def test_run_shadow_observation_one_shot_v0_is_deterministic() -> None:
+    snapshot = observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol="TWO",
+        observed_at_utc="2026-05-16T14:01:00Z",
+        source="one_shot_det",
+        payload={"n": 2},
+    )
+    a = observation_harness_v0.run_shadow_observation_one_shot_v0(snapshot)
+    b = observation_harness_v0.run_shadow_observation_one_shot_v0(snapshot)
+    assert a.evidence_id == b.evidence_id
+
+
+def test_run_shadow_observation_one_shot_v0_hash_changes_when_snapshot_changes() -> None:
+    base = observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol="THR",
+        observed_at_utc="2026-05-16T14:02:00Z",
+        source="one_shot_hash",
+        payload={"p": 0},
+    )
+    rid0 = observation_harness_v0.run_shadow_observation_one_shot_v0(base).evidence_id
+    rid1 = observation_harness_v0.run_shadow_observation_one_shot_v0(
+        observation_harness_v0.ShadowObservationInputSnapshot(
+            symbol="THR",
+            observed_at_utc="2026-05-16T14:02:00Z",
+            source="one_shot_hash",
+            payload={"p": 1},
+        )
+    ).evidence_id
+    assert rid0 != rid1
+
+
+def test_run_shadow_observation_one_shot_v0_preserves_no_order_safety_flags() -> None:
+    snapshot = observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol="FOU",
+        observed_at_utc="2026-05-16T14:03:00Z",
+        source="one_shot_flags",
+        payload={},
+    )
+    rec = observation_harness_v0.run_shadow_observation_one_shot_v0(snapshot)
+    assert rec.allowed_actions == ()
+    assert rec.evidence_required is True
+    assert rec.proven_shadow_no_order_entrypoint_found is False
+    assert rec.executable_command_created is False
+    must_be_false = (
+        rec.broker_touched,
+        rec.exchange_touched,
+        rec.credentials_touched,
+        rec.order_intent_created,
+        rec.order_submission_allowed,
+        rec.runtime_started,
+        rec.scheduler_started,
+        rec.shadow_mode_allowed,
+        rec.live_allowed,
+        rec.testnet_allowed,
+        rec.paper_allowed,
+        rec.broker_allowed,
+        rec.exchange_allowed,
+        rec.runtime_allowed,
+        rec.scheduler_allowed,
+    )
+    assert not any(must_be_false), f"expected all operational flags false, got {must_be_false!r}"
+
+
 def test_observation_harness_module_isolates_from_mixed_risk_scripts_and_runtime_packages() -> None:
     path = Path(observation_harness_v0.__file__).resolve()
     text = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds a one-shot no-order Shadow Observation Harness helper as a pure local wrapper around the existing deterministic evidence builder.

Changed files:

- `src/shadow_no_order_proof/observation_harness_v0.py`
- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## What this adds

- `run_shadow_observation_one_shot_v0(snapshot)`
- Pure delegation to `build_shadow_observation_evidence_record_v0(snapshot=snapshot, plan=None)`
- Deterministic one-shot evidence behavior
- No CLI
- No file I/O
- No runtime/scheduler
- No broker/exchange/credentials/orders
- No mixed-risk candidate wrapping or imports
- Python 3.9-compatible

## Reuse-before-new

- Reuses existing `src/shadow_no_order_proof/observation_harness_v0.py`
- Extends the existing canonical Shadow no-order proof contract test
- No new docs
- No new runtime surface
- No duplicate readiness/evidence/planning surface
- Notion update remains draft-only; no Notion write was performed

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No mixed-risk candidate wrapping or imports
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This remains pure/local/deterministic. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 26 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- Python 3.9 compatibility scan — ok

## Machine-readable

VERDICT=SHADOW_OBSERVATION_HARNESS_ONE_SHOT_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
SHADOW_OBSERVATION_HARNESS_ONE_SHOT_ADDED=true
NOTION_WRITE_PERFORMED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)