### PR TITLE
feat(shadow): add batch observation harness helper

### DIFF
--- a/src/shadow_no_order_proof/observation_harness_v0.py
+++ b/src/shadow_no_order_proof/observation_harness_v0.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional, cast
+from typing import Any, Mapping, Optional, Sequence, cast
 
 from src.shadow_no_order_proof.bounded_adapter_v0 import (
     BoundedShadowAdapterPlan,
@@ -14,6 +14,7 @@ from src.shadow_no_order_proof.bounded_adapter_v0 import (
 )
 
 OBSERVATION_EVIDENCE_SCHEMA_V0 = "shadow_observation_evidence_record.v0"
+OBSERVATION_BATCH_SUMMARY_SCHEMA_V0 = "shadow_observation_batch_summary.v0"
 
 
 @dataclass(frozen=True)
@@ -56,6 +57,61 @@ class ShadowObservationEvidenceRecord:
     order_intent_created: bool
     runtime_started: bool
     scheduler_started: bool
+
+
+@dataclass(frozen=True)
+class ShadowObservationBatchSummary:
+    """Deterministic aggregate over ordered evidence records (metadata only)."""
+
+    batch_version: str
+    record_count: int
+    evidence_ids: tuple[str, ...]
+    batch_hash: str
+    all_no_order: bool
+    all_broker_touched_false: bool
+    all_exchange_touched_false: bool
+    all_credentials_touched_false: bool
+    all_order_intent_created_false: bool
+    all_runtime_started_false: bool
+    all_scheduler_started_false: bool
+    all_shadow_mode_allowed_false: bool
+    proven_shadow_no_order_entrypoint_found: bool
+    executable_command_created: bool
+
+
+def _record_satisfies_no_order_invariants(rec: ShadowObservationEvidenceRecord) -> bool:
+    if rec.allowed_actions:
+        return False
+    flags = (
+        rec.broker_touched,
+        rec.exchange_touched,
+        rec.credentials_touched,
+        rec.order_intent_created,
+        rec.order_submission_allowed,
+        rec.runtime_started,
+        rec.scheduler_started,
+        rec.shadow_mode_allowed,
+        rec.live_allowed,
+        rec.testnet_allowed,
+        rec.paper_allowed,
+        rec.broker_allowed,
+        rec.exchange_allowed,
+        rec.runtime_allowed,
+        rec.scheduler_allowed,
+        rec.proven_shadow_no_order_entrypoint_found,
+        rec.executable_command_created,
+    )
+    return not any(flags)
+
+
+def _batch_summary_fingerprint_bytes(*, evidence_ids: tuple[str, ...]) -> bytes:
+    body: dict[str, object] = {
+        "schema": OBSERVATION_BATCH_SUMMARY_SCHEMA_V0,
+        "evidence_ids": list(evidence_ids),
+    }
+    return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
 
 
 def _canonical_json_primitive(obj: object) -> object:
@@ -155,3 +211,55 @@ def run_shadow_observation_one_shot_v0(
 ) -> ShadowObservationEvidenceRecord:
     """One in-memory snapshot → one evidence record; bounded plan from `snapshot.source` only."""
     return build_shadow_observation_evidence_record_v0(snapshot=snapshot, plan=None)
+
+
+def run_shadow_observation_batch_v0(
+    snapshots: Sequence[ShadowObservationInputSnapshot],
+) -> tuple[ShadowObservationEvidenceRecord, ...]:
+    """Ordered snapshots → ordered evidence records; one one-shot evaluation per snapshot."""
+    return tuple(run_shadow_observation_one_shot_v0(s) for s in snapshots)
+
+
+def build_shadow_observation_batch_summary_v0(
+    records: Sequence[ShadowObservationEvidenceRecord],
+) -> ShadowObservationBatchSummary:
+    """Derive a deterministic batch summary and hash from an ordered evidence sequence."""
+    ordered = tuple(records)
+    evidence_ids = tuple(r.evidence_id for r in ordered)
+    raw = _batch_summary_fingerprint_bytes(evidence_ids=evidence_ids)
+    batch_hash = hashlib.sha256(raw).hexdigest()
+
+    if not ordered:
+        return ShadowObservationBatchSummary(
+            batch_version=OBSERVATION_BATCH_SUMMARY_SCHEMA_V0,
+            record_count=0,
+            evidence_ids=evidence_ids,
+            batch_hash=batch_hash,
+            all_no_order=True,
+            all_broker_touched_false=True,
+            all_exchange_touched_false=True,
+            all_credentials_touched_false=True,
+            all_order_intent_created_false=True,
+            all_runtime_started_false=True,
+            all_scheduler_started_false=True,
+            all_shadow_mode_allowed_false=True,
+            proven_shadow_no_order_entrypoint_found=False,
+            executable_command_created=False,
+        )
+
+    return ShadowObservationBatchSummary(
+        batch_version=OBSERVATION_BATCH_SUMMARY_SCHEMA_V0,
+        record_count=len(ordered),
+        evidence_ids=evidence_ids,
+        batch_hash=batch_hash,
+        all_no_order=all(_record_satisfies_no_order_invariants(r) for r in ordered),
+        all_broker_touched_false=all(not r.broker_touched for r in ordered),
+        all_exchange_touched_false=all(not r.exchange_touched for r in ordered),
+        all_credentials_touched_false=all(not r.credentials_touched for r in ordered),
+        all_order_intent_created_false=all(not r.order_intent_created for r in ordered),
+        all_runtime_started_false=all(not r.runtime_started for r in ordered),
+        all_scheduler_started_false=all(not r.scheduler_started for r in ordered),
+        all_shadow_mode_allowed_false=all(not r.shadow_mode_allowed for r in ordered),
+        proven_shadow_no_order_entrypoint_found=False,
+        executable_command_created=False,
+    )

--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -681,6 +681,127 @@ def test_run_shadow_observation_one_shot_v0_preserves_no_order_safety_flags() ->
     assert not any(must_be_false), f"expected all operational flags false, got {must_be_false!r}"
 
 
+def _snap(
+    symbol: str, source: str, payload: dict[str, object]
+) -> observation_harness_v0.ShadowObservationInputSnapshot:
+    return observation_harness_v0.ShadowObservationInputSnapshot(
+        symbol=symbol,
+        observed_at_utc="2026-05-16T15:00:00Z",
+        source=source,
+        payload=payload,
+    )
+
+
+def test_run_shadow_observation_batch_v0_one_record_per_snapshot_ordered() -> None:
+    snaps = (
+        _snap("A", "batch_src", {"i": 0}),
+        _snap("B", "batch_src", {"i": 1}),
+    )
+    records = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    assert len(records) == 2
+    assert records[0] == observation_harness_v0.run_shadow_observation_one_shot_v0(snaps[0])
+    assert records[1] == observation_harness_v0.run_shadow_observation_one_shot_v0(snaps[1])
+
+
+def test_run_shadow_observation_batch_v0_empty_is_deterministic() -> None:
+    r1 = observation_harness_v0.run_shadow_observation_batch_v0(())
+    r2 = observation_harness_v0.run_shadow_observation_batch_v0(())
+    assert r1 == () == r2
+    s1 = observation_harness_v0.build_shadow_observation_batch_summary_v0(r1)
+    s2 = observation_harness_v0.build_shadow_observation_batch_summary_v0(r2)
+    assert s1 == s2
+    assert s1.record_count == 0
+    assert s1.evidence_ids == ()
+    assert len(s1.batch_hash) == 64
+
+
+def test_shadow_observation_batch_summary_same_order_same_hash() -> None:
+    snaps = (
+        _snap("X", "batch_hash", {"k": 1}),
+        _snap("Y", "batch_hash", {"k": 2}),
+    )
+    recs_a = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    recs_b = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    su_a = observation_harness_v0.build_shadow_observation_batch_summary_v0(recs_a)
+    su_b = observation_harness_v0.build_shadow_observation_batch_summary_v0(recs_b)
+    assert su_a.batch_hash == su_b.batch_hash
+    assert su_a.evidence_ids == su_b.evidence_ids
+
+
+def test_shadow_observation_batch_hash_changes_when_snapshot_changes() -> None:
+    snaps1 = (
+        _snap("X", "bh", {"k": 1}),
+        _snap("Y", "bh", {"k": 2}),
+    )
+    snaps2 = (
+        _snap("X", "bh", {"k": 1}),
+        _snap("Y", "bh", {"k": 99}),
+    )
+    h1 = observation_harness_v0.build_shadow_observation_batch_summary_v0(
+        observation_harness_v0.run_shadow_observation_batch_v0(snaps1)
+    ).batch_hash
+    h2 = observation_harness_v0.build_shadow_observation_batch_summary_v0(
+        observation_harness_v0.run_shadow_observation_batch_v0(snaps2)
+    ).batch_hash
+    assert h1 != h2
+
+
+def test_shadow_observation_batch_hash_order_sensitive() -> None:
+    s1 = _snap("P", "ord", {"n": 1})
+    s2 = _snap("Q", "ord", {"n": 2})
+    h_forward = observation_harness_v0.build_shadow_observation_batch_summary_v0(
+        observation_harness_v0.run_shadow_observation_batch_v0((s1, s2))
+    ).batch_hash
+    h_reverse = observation_harness_v0.build_shadow_observation_batch_summary_v0(
+        observation_harness_v0.run_shadow_observation_batch_v0((s2, s1))
+    ).batch_hash
+    assert h_forward != h_reverse
+
+
+def test_shadow_observation_batch_records_remain_no_order() -> None:
+    snaps = (
+        _snap("N1", "no_order_batch", {}),
+        _snap("N2", "no_order_batch", {"z": 3}),
+    )
+    for rec in observation_harness_v0.run_shadow_observation_batch_v0(snaps):
+        assert rec.allowed_actions == ()
+        must_be_false = (
+            rec.broker_touched,
+            rec.exchange_touched,
+            rec.credentials_touched,
+            rec.order_intent_created,
+            rec.order_submission_allowed,
+            rec.runtime_started,
+            rec.scheduler_started,
+            rec.shadow_mode_allowed,
+            rec.live_allowed,
+            rec.testnet_allowed,
+            rec.paper_allowed,
+            rec.broker_allowed,
+            rec.exchange_allowed,
+            rec.runtime_allowed,
+            rec.scheduler_allowed,
+        )
+        assert not any(must_be_false)
+
+
+def test_shadow_observation_batch_summary_flags_safe_for_nonempty() -> None:
+    snaps = (_snap("S1", "sum_safe", {}), _snap("S2", "sum_safe", {"a": 1}))
+    summary = observation_harness_v0.build_shadow_observation_batch_summary_v0(
+        observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    )
+    assert summary.all_no_order is True
+    assert summary.all_broker_touched_false is True
+    assert summary.all_exchange_touched_false is True
+    assert summary.all_credentials_touched_false is True
+    assert summary.all_order_intent_created_false is True
+    assert summary.all_runtime_started_false is True
+    assert summary.all_scheduler_started_false is True
+    assert summary.all_shadow_mode_allowed_false is True
+    assert summary.proven_shadow_no_order_entrypoint_found is False
+    assert summary.executable_command_created is False
+
+
 def test_observation_harness_module_isolates_from_mixed_risk_scripts_and_runtime_packages() -> None:
     path = Path(observation_harness_v0.__file__).resolve()
     text = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds a batch no-order Shadow Observation Harness helper on top of the existing one-shot observation harness.

Changed files:

- `src/shadow_no_order_proof/observation_harness_v0.py`
- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## What this adds

- `OBSERVATION_BATCH_SUMMARY_SCHEMA_V0`
- `ShadowObservationBatchSummary`
- `run_shadow_observation_batch_v0(snapshots)`
- `build_shadow_observation_batch_summary_v0(records)`
- deterministic order-sensitive batch hash over evidence IDs
- explicit deterministic empty-batch behavior
- batch-level no-order safety flags

## Reuse-before-new

- Reuses existing `src/shadow_no_order_proof/observation_harness_v0.py`
- Reuses the existing one-shot helper
- Extends the existing canonical Shadow no-order proof contract test
- No new docs
- No new runtime surface
- No duplicate readiness/evidence/planning surface
- Notion update remains unchanged; no Notion write was performed in this slice

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No mixed-risk candidate wrapping or imports
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This remains pure/local/deterministic. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 33 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- Python 3.9 compatibility scan — ok

## Machine-readable

VERDICT=SHADOW_OBSERVATION_HARNESS_BATCH_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
SHADOW_OBSERVATION_HARNESS_BATCH_ADDED=true
NOTION_WRITE_PERFORMED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)