### PR TITLE
feat(shadow): add timed observation summary contract

### DIFF
--- a/src/shadow_no_order_proof/observation_harness_v0.py
+++ b/src/shadow_no_order_proof/observation_harness_v0.py
@@ -15,6 +15,7 @@ from src.shadow_no_order_proof.bounded_adapter_v0 import (
 
 OBSERVATION_EVIDENCE_SCHEMA_V0 = "shadow_observation_evidence_record.v0"
 OBSERVATION_BATCH_SUMMARY_SCHEMA_V0 = "shadow_observation_batch_summary.v0"
+TIMED_OBSERVATION_SUMMARY_SCHEMA_V0 = "shadow_observation_timed_summary.v0"
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,34 @@ class ShadowObservationBatchSummary:
     executable_command_created: bool
 
 
+@dataclass(frozen=True)
+class ShadowObservationTimedSummary:
+    """Deterministic summary: batch evidence + caller-provided cadence metadata (no wall-clock)."""
+
+    timed_version: str
+    batch_version: str
+    record_count: int
+    evidence_ids: tuple[str, ...]
+    batch_hash: str
+    timed_hash: str
+    started_at_utc: str
+    ended_at_utc: str
+    cadence_seconds: int
+    max_observations: int
+    observed_at_utc_values: tuple[str, ...]
+    cadence_source: str
+    all_no_order: bool
+    all_broker_touched_false: bool
+    all_exchange_touched_false: bool
+    all_credentials_touched_false: bool
+    all_order_intent_created_false: bool
+    all_runtime_started_false: bool
+    all_scheduler_started_false: bool
+    all_shadow_mode_allowed_false: bool
+    proven_shadow_no_order_entrypoint_found: bool
+    executable_command_created: bool
+
+
 def _record_satisfies_no_order_invariants(rec: ShadowObservationEvidenceRecord) -> bool:
     if rec.allowed_actions:
         return False
@@ -108,6 +137,33 @@ def _batch_summary_fingerprint_bytes(*, evidence_ids: tuple[str, ...]) -> bytes:
     body: dict[str, object] = {
         "schema": OBSERVATION_BATCH_SUMMARY_SCHEMA_V0,
         "evidence_ids": list(evidence_ids),
+    }
+    return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def _timed_summary_fingerprint_bytes(
+    *,
+    batch_hash: str,
+    evidence_ids: tuple[str, ...],
+    started_at_utc: str,
+    ended_at_utc: str,
+    cadence_seconds: int,
+    max_observations: int,
+    cadence_source: str,
+    observed_at_utc_values: tuple[str, ...],
+) -> bytes:
+    body: dict[str, object] = {
+        "schema": TIMED_OBSERVATION_SUMMARY_SCHEMA_V0,
+        "batch_hash": batch_hash,
+        "evidence_ids": list(evidence_ids),
+        "cadence_seconds": cadence_seconds,
+        "cadence_source": cadence_source,
+        "ended_at_utc": ended_at_utc,
+        "max_observations": max_observations,
+        "observed_at_utc_values": list(observed_at_utc_values),
+        "started_at_utc": started_at_utc,
     }
     return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
         "utf-8"
@@ -260,6 +316,60 @@ def build_shadow_observation_batch_summary_v0(
         all_runtime_started_false=all(not r.runtime_started for r in ordered),
         all_scheduler_started_false=all(not r.scheduler_started for r in ordered),
         all_shadow_mode_allowed_false=all(not r.shadow_mode_allowed for r in ordered),
+        proven_shadow_no_order_entrypoint_found=False,
+        executable_command_created=False,
+    )
+
+
+def build_shadow_observation_timed_summary_v0(
+    records: Sequence[ShadowObservationEvidenceRecord],
+    *,
+    started_at_utc: str,
+    ended_at_utc: str,
+    cadence_seconds: int,
+    max_observations: int,
+    cadence_source: str = "caller_provided",
+) -> ShadowObservationTimedSummary:
+    """Batch summary plus caller-supplied timing metadata → deterministic timed hash; no I/O or clocks."""
+    if cadence_seconds < 0:
+        raise ValueError("cadence_seconds must be >= 0")
+    if max_observations < 0:
+        raise ValueError("max_observations must be >= 0")
+    ordered = tuple(records)
+    batch = build_shadow_observation_batch_summary_v0(ordered)
+    observed_at_utc_values = tuple(rec.observed_at_utc for rec in ordered)
+    raw = _timed_summary_fingerprint_bytes(
+        batch_hash=batch.batch_hash,
+        evidence_ids=batch.evidence_ids,
+        started_at_utc=started_at_utc,
+        ended_at_utc=ended_at_utc,
+        cadence_seconds=cadence_seconds,
+        max_observations=max_observations,
+        cadence_source=cadence_source,
+        observed_at_utc_values=observed_at_utc_values,
+    )
+    timed_hash = hashlib.sha256(raw).hexdigest()
+    return ShadowObservationTimedSummary(
+        timed_version=TIMED_OBSERVATION_SUMMARY_SCHEMA_V0,
+        batch_version=batch.batch_version,
+        record_count=batch.record_count,
+        evidence_ids=batch.evidence_ids,
+        batch_hash=batch.batch_hash,
+        timed_hash=timed_hash,
+        started_at_utc=started_at_utc,
+        ended_at_utc=ended_at_utc,
+        cadence_seconds=cadence_seconds,
+        max_observations=max_observations,
+        observed_at_utc_values=observed_at_utc_values,
+        cadence_source=cadence_source,
+        all_no_order=batch.all_no_order,
+        all_broker_touched_false=batch.all_broker_touched_false,
+        all_exchange_touched_false=batch.all_exchange_touched_false,
+        all_credentials_touched_false=batch.all_credentials_touched_false,
+        all_order_intent_created_false=batch.all_order_intent_created_false,
+        all_runtime_started_false=batch.all_runtime_started_false,
+        all_scheduler_started_false=batch.all_scheduler_started_false,
+        all_shadow_mode_allowed_false=batch.all_shadow_mode_allowed_false,
         proven_shadow_no_order_entrypoint_found=False,
         executable_command_created=False,
     )

--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -802,6 +802,196 @@ def test_shadow_observation_batch_summary_flags_safe_for_nonempty() -> None:
     assert summary.executable_command_created is False
 
 
+def _timed_meta() -> dict[str, object]:
+    return {
+        "started_at_utc": "2026-05-16T16:00:00Z",
+        "ended_at_utc": "2026-05-16T17:00:00Z",
+        "cadence_seconds": 60,
+        "max_observations": 10,
+    }
+
+
+def test_build_shadow_observation_timed_summary_v0_accepts_records_and_metadata() -> None:
+    snaps = (
+        _snap("T1", "timed", {"i": 0}),
+        _snap("T2", "timed", {"i": 1}),
+    )
+    recs = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    meta = _timed_meta()
+    summary = observation_harness_v0.build_shadow_observation_timed_summary_v0(
+        recs,
+        started_at_utc=str(meta["started_at_utc"]),
+        ended_at_utc=str(meta["ended_at_utc"]),
+        cadence_seconds=int(meta["cadence_seconds"]),
+        max_observations=int(meta["max_observations"]),
+    )
+    assert summary.timed_version == observation_harness_v0.TIMED_OBSERVATION_SUMMARY_SCHEMA_V0
+    assert summary.record_count == 2
+    assert summary.observed_at_utc_values == tuple(r.observed_at_utc for r in recs)
+    assert len(summary.timed_hash) == 64
+    assert summary.cadence_source == "caller_provided"
+
+
+def test_shadow_observation_timed_summary_same_inputs_same_hash() -> None:
+    snaps = (_snap("S", "th", {"k": 1}),)
+    recs_a = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    recs_b = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    meta = _timed_meta()
+    kw = {
+        "started_at_utc": str(meta["started_at_utc"]),
+        "ended_at_utc": str(meta["ended_at_utc"]),
+        "cadence_seconds": int(meta["cadence_seconds"]),
+        "max_observations": int(meta["max_observations"]),
+    }
+    t_a = observation_harness_v0.build_shadow_observation_timed_summary_v0(recs_a, **kw)
+    t_b = observation_harness_v0.build_shadow_observation_timed_summary_v0(recs_b, **kw)
+    assert t_a.timed_hash == t_b.timed_hash
+    assert t_a.batch_hash == t_b.batch_hash
+
+
+def test_shadow_observation_timed_hash_changes_when_cadence_metadata_changes() -> None:
+    snaps = (_snap("C", "cad", {}),)
+    recs = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    base = _timed_meta()
+    kw1 = {
+        "started_at_utc": str(base["started_at_utc"]),
+        "ended_at_utc": str(base["ended_at_utc"]),
+        "cadence_seconds": 60,
+        "max_observations": int(base["max_observations"]),
+    }
+    kw2 = {**kw1, "cadence_seconds": 120}
+    h1 = observation_harness_v0.build_shadow_observation_timed_summary_v0(recs, **kw1).timed_hash
+    h2 = observation_harness_v0.build_shadow_observation_timed_summary_v0(recs, **kw2).timed_hash
+    assert h1 != h2
+
+
+def test_shadow_observation_timed_hash_changes_when_cadence_source_changes() -> None:
+    snaps = (_snap("CS", "cads", {}),)
+    recs = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    meta = _timed_meta()
+    kw = {
+        "started_at_utc": str(meta["started_at_utc"]),
+        "ended_at_utc": str(meta["ended_at_utc"]),
+        "cadence_seconds": int(meta["cadence_seconds"]),
+        "max_observations": int(meta["max_observations"]),
+    }
+    a = observation_harness_v0.build_shadow_observation_timed_summary_v0(
+        recs, cadence_source="caller_provided", **kw
+    )
+    b = observation_harness_v0.build_shadow_observation_timed_summary_v0(
+        recs, cadence_source="fixture", **kw
+    )
+    assert a.timed_hash != b.timed_hash
+
+
+def test_shadow_observation_timed_hash_changes_when_started_ended_change() -> None:
+    snaps = (_snap("E", "se", {}),)
+    recs = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    h1 = observation_harness_v0.build_shadow_observation_timed_summary_v0(
+        recs,
+        started_at_utc="2026-05-16T12:00:00Z",
+        ended_at_utc="2026-05-16T13:00:00Z",
+        cadence_seconds=30,
+        max_observations=5,
+    ).timed_hash
+    h2 = observation_harness_v0.build_shadow_observation_timed_summary_v0(
+        recs,
+        started_at_utc="2026-05-16T12:00:01Z",
+        ended_at_utc="2026-05-16T13:00:00Z",
+        cadence_seconds=30,
+        max_observations=5,
+    ).timed_hash
+    assert h1 != h2
+
+
+def test_shadow_observation_timed_hash_order_sensitive() -> None:
+    s1 = _snap("O1", "ordt", {"n": 1})
+    s2 = _snap("O2", "ordt", {"n": 2})
+    meta = _timed_meta()
+    kw = {
+        "started_at_utc": str(meta["started_at_utc"]),
+        "ended_at_utc": str(meta["ended_at_utc"]),
+        "cadence_seconds": int(meta["cadence_seconds"]),
+        "max_observations": int(meta["max_observations"]),
+    }
+    fwd = observation_harness_v0.run_shadow_observation_batch_v0((s1, s2))
+    rev = observation_harness_v0.run_shadow_observation_batch_v0((s2, s1))
+    assert (
+        observation_harness_v0.build_shadow_observation_timed_summary_v0(fwd, **kw).timed_hash
+        != observation_harness_v0.build_shadow_observation_timed_summary_v0(rev, **kw).timed_hash
+    )
+
+
+def test_shadow_observation_timed_summary_empty_is_deterministic() -> None:
+    empty: tuple[observation_harness_v0.ShadowObservationEvidenceRecord, ...] = ()
+    meta = _timed_meta()
+    kw = {
+        "started_at_utc": str(meta["started_at_utc"]),
+        "ended_at_utc": str(meta["ended_at_utc"]),
+        "cadence_seconds": int(meta["cadence_seconds"]),
+        "max_observations": int(meta["max_observations"]),
+    }
+    a = observation_harness_v0.build_shadow_observation_timed_summary_v0(empty, **kw)
+    b = observation_harness_v0.build_shadow_observation_timed_summary_v0(empty, **kw)
+    assert a == b
+    assert a.record_count == 0
+    assert a.observed_at_utc_values == ()
+    assert len(a.timed_hash) == 64
+
+
+def test_shadow_observation_timed_summary_flags_safe_for_nonempty() -> None:
+    snaps = (_snap("F1", "tsafe", {}), _snap("F2", "tsafe", {"a": 1}))
+    recs = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    meta = _timed_meta()
+    t = observation_harness_v0.build_shadow_observation_timed_summary_v0(
+        recs,
+        started_at_utc=str(meta["started_at_utc"]),
+        ended_at_utc=str(meta["ended_at_utc"]),
+        cadence_seconds=int(meta["cadence_seconds"]),
+        max_observations=int(meta["max_observations"]),
+    )
+    assert t.all_no_order is True
+    assert t.proven_shadow_no_order_entrypoint_found is False
+    assert t.executable_command_created is False
+    assert t.all_broker_touched_false is True
+    assert t.all_exchange_touched_false is True
+    assert t.all_credentials_touched_false is True
+    assert t.all_order_intent_created_false is True
+    assert t.all_runtime_started_false is True
+    assert t.all_scheduler_started_false is True
+    assert t.all_shadow_mode_allowed_false is True
+
+
+def test_shadow_observation_timed_summary_rejects_negative_cadence_or_max() -> None:
+    snaps = (_snap("V", "neg", {}),)
+    recs = observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    meta = _timed_meta()
+    base_kw = {
+        "started_at_utc": str(meta["started_at_utc"]),
+        "ended_at_utc": str(meta["ended_at_utc"]),
+        "max_observations": int(meta["max_observations"]),
+    }
+    with pytest.raises(ValueError, match="cadence_seconds"):
+        observation_harness_v0.build_shadow_observation_timed_summary_v0(
+            recs, cadence_seconds=-1, **base_kw
+        )
+    with pytest.raises(ValueError, match="max_observations"):
+        observation_harness_v0.build_shadow_observation_timed_summary_v0(
+            recs,
+            cadence_seconds=1,
+            max_observations=-3,
+            started_at_utc=str(meta["started_at_utc"]),
+            ended_at_utc=str(meta["ended_at_utc"]),
+        )
+
+
+def test_observation_harness_has_no_sleep_or_datetime_now_tokens() -> None:
+    path = Path(observation_harness_v0.__file__).resolve()
+    text = path.read_text(encoding="utf-8")
+    assert "time.sleep" not in text
+    assert "datetime.now" not in text
+
+
 def test_observation_harness_module_isolates_from_mixed_risk_scripts_and_runtime_packages() -> None:
     path = Path(observation_harness_v0.__file__).resolve()
     text = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds a pure timed observation summary contract on top of the existing Shadow Observation Harness batch evidence.

Changed files:

- `src/shadow_no_order_proof/observation_harness_v0.py`
- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## What this adds

- `TIMED_OBSERVATION_SUMMARY_SCHEMA_V0`
- `ShadowObservationTimedSummary`
- `build_shadow_observation_timed_summary_v0 (...)`
- deterministic timed summary/hash over caller-provided batch records and timing metadata
- validation for negative `cadence_seconds` / `max_observations`
- no runtime loop, no sleep, no scheduler, no wall-clock polling

## Reuse-before-new

- Reuses existing `src/shadow_no_order_proof/observation_harness_v0.py`
- Reuses the existing batch summary
- Extends the existing canonical Shadow no-order proof contract test
- No new docs
- No new runtime surface
- No duplicate readiness/evidence/planning surface
- No Notion write performed in this slice

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No mixed-risk candidate wrapping or imports
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This is a timed summary contract, not timed runtime. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 43 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- Python 3.9 compatibility scan — ok

## Machine-readable

VERDICT=SHADOW_OBSERVATION_TIMED_SUMMARY_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
TIMED_OBSERVATION_SUMMARY_ADDED=true
TIMED_OBSERVATION_RUNTIME_ADDED=false
NOTION_WRITE_PERFORMED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)