### PR TITLE
feat(shadow): add local observation run result contract

### DIFF
--- a/src/shadow_no_order_proof/observation_harness_v0.py
+++ b/src/shadow_no_order_proof/observation_harness_v0.py
@@ -16,6 +16,7 @@ from src.shadow_no_order_proof.bounded_adapter_v0 import (
 OBSERVATION_EVIDENCE_SCHEMA_V0 = "shadow_observation_evidence_record.v0"
 OBSERVATION_BATCH_SUMMARY_SCHEMA_V0 = "shadow_observation_batch_summary.v0"
 TIMED_OBSERVATION_SUMMARY_SCHEMA_V0 = "shadow_observation_timed_summary.v0"
+LOCAL_OBSERVATION_RUN_RESULT_SCHEMA_V0 = "shadow_observation_local_run_result.v0"
 
 
 @dataclass(frozen=True)
@@ -108,6 +109,43 @@ class ShadowObservationTimedSummary:
     executable_command_created: bool
 
 
+@dataclass(frozen=True)
+class ShadowObservationLocalRunResult:
+    """Pure composition of batch + timed summaries with an explicit run boundary hash (no runtime)."""
+
+    run_version: str
+    run_id: str
+    source: str
+    cadence_source: str
+    started_at_utc: str
+    ended_at_utc: str
+    cadence_seconds: int
+    max_observations: int
+    record_count: int
+    evidence_ids: tuple[str, ...]
+    batch_hash: str
+    timed_hash: str
+    run_hash: str
+    records: tuple[ShadowObservationEvidenceRecord, ...]
+    batch_summary: ShadowObservationBatchSummary
+    timed_summary: ShadowObservationTimedSummary
+    all_no_order: bool
+    all_broker_touched_false: bool
+    all_exchange_touched_false: bool
+    all_credentials_touched_false: bool
+    all_order_intent_created_false: bool
+    all_runtime_started_false: bool
+    all_scheduler_started_false: bool
+    all_shadow_mode_allowed_false: bool
+    proven_shadow_no_order_entrypoint_found: bool
+    executable_command_created: bool
+    local_observation_run_approved: bool
+    shadow_mode_allowed: bool
+    runtime_allowed: bool
+    scheduler_allowed: bool
+    order_submission_allowed: bool
+
+
 def _record_satisfies_no_order_invariants(rec: ShadowObservationEvidenceRecord) -> bool:
     if rec.allowed_actions:
         return False
@@ -164,6 +202,37 @@ def _timed_summary_fingerprint_bytes(
         "max_observations": max_observations,
         "observed_at_utc_values": list(observed_at_utc_values),
         "started_at_utc": started_at_utc,
+    }
+    return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def _local_run_fingerprint_bytes(
+    *,
+    timed_hash: str,
+    batch_hash: str,
+    evidence_ids: tuple[str, ...],
+    run_id: str,
+    source: str,
+    cadence_source: str,
+    started_at_utc: str,
+    ended_at_utc: str,
+    cadence_seconds: int,
+    max_observations: int,
+) -> bytes:
+    body: dict[str, object] = {
+        "schema": LOCAL_OBSERVATION_RUN_RESULT_SCHEMA_V0,
+        "batch_hash": batch_hash,
+        "cadence_seconds": cadence_seconds,
+        "cadence_source": cadence_source,
+        "ended_at_utc": ended_at_utc,
+        "evidence_ids": list(evidence_ids),
+        "max_observations": max_observations,
+        "run_id": run_id,
+        "source": source,
+        "started_at_utc": started_at_utc,
+        "timed_hash": timed_hash,
     }
     return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
         "utf-8"
@@ -372,4 +441,77 @@ def build_shadow_observation_timed_summary_v0(
         all_shadow_mode_allowed_false=batch.all_shadow_mode_allowed_false,
         proven_shadow_no_order_entrypoint_found=False,
         executable_command_created=False,
+    )
+
+
+def run_shadow_observation_local_v0(
+    snapshots: Sequence[ShadowObservationInputSnapshot],
+    *,
+    started_at_utc: str,
+    ended_at_utc: str,
+    cadence_seconds: int,
+    max_observations: int,
+    run_id: str,
+    source: str = "caller_provided",
+    cadence_source: str = "caller_provided",
+) -> ShadowObservationLocalRunResult:
+    """Finite caller snapshots + metadata → records, batch summary, timed summary, deterministic run hash."""
+    ordered_snaps = tuple(snapshots)
+    if len(ordered_snaps) > max_observations:
+        raise ValueError("snapshot count exceeds max_observations")
+    records = run_shadow_observation_batch_v0(ordered_snaps)
+    batch_summary = build_shadow_observation_batch_summary_v0(records)
+    timed_summary = build_shadow_observation_timed_summary_v0(
+        records,
+        started_at_utc=started_at_utc,
+        ended_at_utc=ended_at_utc,
+        cadence_seconds=cadence_seconds,
+        max_observations=max_observations,
+        cadence_source=cadence_source,
+    )
+    raw = _local_run_fingerprint_bytes(
+        timed_hash=timed_summary.timed_hash,
+        batch_hash=batch_summary.batch_hash,
+        evidence_ids=batch_summary.evidence_ids,
+        run_id=run_id,
+        source=source,
+        cadence_source=cadence_source,
+        started_at_utc=started_at_utc,
+        ended_at_utc=ended_at_utc,
+        cadence_seconds=cadence_seconds,
+        max_observations=max_observations,
+    )
+    run_hash = hashlib.sha256(raw).hexdigest()
+    return ShadowObservationLocalRunResult(
+        run_version=LOCAL_OBSERVATION_RUN_RESULT_SCHEMA_V0,
+        run_id=run_id,
+        source=source,
+        cadence_source=cadence_source,
+        started_at_utc=started_at_utc,
+        ended_at_utc=ended_at_utc,
+        cadence_seconds=cadence_seconds,
+        max_observations=max_observations,
+        record_count=batch_summary.record_count,
+        evidence_ids=batch_summary.evidence_ids,
+        batch_hash=batch_summary.batch_hash,
+        timed_hash=timed_summary.timed_hash,
+        run_hash=run_hash,
+        records=records,
+        batch_summary=batch_summary,
+        timed_summary=timed_summary,
+        all_no_order=batch_summary.all_no_order,
+        all_broker_touched_false=batch_summary.all_broker_touched_false,
+        all_exchange_touched_false=batch_summary.all_exchange_touched_false,
+        all_credentials_touched_false=batch_summary.all_credentials_touched_false,
+        all_order_intent_created_false=batch_summary.all_order_intent_created_false,
+        all_runtime_started_false=batch_summary.all_runtime_started_false,
+        all_scheduler_started_false=batch_summary.all_scheduler_started_false,
+        all_shadow_mode_allowed_false=batch_summary.all_shadow_mode_allowed_false,
+        proven_shadow_no_order_entrypoint_found=False,
+        executable_command_created=False,
+        local_observation_run_approved=False,
+        shadow_mode_allowed=False,
+        runtime_allowed=False,
+        scheduler_allowed=False,
+        order_submission_allowed=False,
     )

--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -985,6 +985,152 @@ def test_shadow_observation_timed_summary_rejects_negative_cadence_or_max() -> N
         )
 
 
+def _local_run_kw(
+    run_id: str = "run-1",
+    *,
+    source: str = "caller_provided",
+    cadence_source: str = "caller_provided",
+) -> dict[str, object]:
+    meta = _timed_meta()
+    return {
+        "started_at_utc": str(meta["started_at_utc"]),
+        "ended_at_utc": str(meta["ended_at_utc"]),
+        "cadence_seconds": int(meta["cadence_seconds"]),
+        "max_observations": int(meta["max_observations"]),
+        "run_id": run_id,
+        "source": source,
+        "cadence_source": cadence_source,
+    }
+
+
+def test_run_shadow_observation_local_v0_composes_records_batch_and_timed() -> None:
+    snaps = (
+        _snap("L1", "loc", {"i": 0}),
+        _snap("L2", "loc", {"i": 1}),
+    )
+    kw = _local_run_kw()
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    assert run.run_version == observation_harness_v0.LOCAL_OBSERVATION_RUN_RESULT_SCHEMA_V0
+    assert run.record_count == 2
+    assert run.records == observation_harness_v0.run_shadow_observation_batch_v0(snaps)
+    assert run.batch_summary == observation_harness_v0.build_shadow_observation_batch_summary_v0(
+        run.records
+    )
+    assert run.timed_summary == observation_harness_v0.build_shadow_observation_timed_summary_v0(
+        run.records,
+        started_at_utc=str(kw["started_at_utc"]),
+        ended_at_utc=str(kw["ended_at_utc"]),
+        cadence_seconds=int(kw["cadence_seconds"]),
+        max_observations=int(kw["max_observations"]),
+        cadence_source=str(kw["cadence_source"]),
+    )
+    assert len(run.run_hash) == 64
+
+
+def test_shadow_observation_local_run_same_inputs_same_run_hash() -> None:
+    snaps = (_snap("X", "lrh", {"k": 1}),)
+    kw = _local_run_kw()
+    a = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    b = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    assert a.run_hash == b.run_hash
+
+
+def test_shadow_observation_local_run_hash_changes_when_snapshot_payload_changes() -> None:
+    kw = _local_run_kw()
+    r1 = observation_harness_v0.run_shadow_observation_local_v0((_snap("P", "ch", {"k": 1}),), **kw)
+    r2 = observation_harness_v0.run_shadow_observation_local_v0((_snap("P", "ch", {"k": 2}),), **kw)
+    assert r1.run_hash != r2.run_hash
+
+
+def test_shadow_observation_local_run_hash_changes_when_run_id_or_sources_or_timing_change() -> (
+    None
+):
+    snaps = (_snap("Q", "meta", {}),)
+    base = _local_run_kw()
+    h0 = observation_harness_v0.run_shadow_observation_local_v0(snaps, **base).run_hash
+    assert (
+        observation_harness_v0.run_shadow_observation_local_v0(
+            snaps, **{**base, "run_id": "other-run"}
+        ).run_hash
+        != h0
+    )
+    assert (
+        observation_harness_v0.run_shadow_observation_local_v0(
+            snaps, **{**base, "source": "fixture_provenance"}
+        ).run_hash
+        != h0
+    )
+    assert (
+        observation_harness_v0.run_shadow_observation_local_v0(
+            snaps, **{**base, "cadence_source": "fixture"}
+        ).run_hash
+        != h0
+    )
+    assert (
+        observation_harness_v0.run_shadow_observation_local_v0(
+            snaps,
+            **{
+                **base,
+                "started_at_utc": "2026-05-16T10:00:00Z",
+            },
+        ).run_hash
+        != h0
+    )
+
+
+def test_shadow_observation_local_run_hash_order_sensitive() -> None:
+    s1 = _snap("A", "lord", {"n": 1})
+    s2 = _snap("B", "lord", {"n": 2})
+    kw = _local_run_kw()
+    h_fwd = observation_harness_v0.run_shadow_observation_local_v0((s1, s2), **kw).run_hash
+    h_rev = observation_harness_v0.run_shadow_observation_local_v0((s2, s1), **kw).run_hash
+    assert h_fwd != h_rev
+
+
+def test_shadow_observation_local_run_empty_is_deterministic() -> None:
+    snaps: tuple[observation_harness_v0.ShadowObservationInputSnapshot, ...] = ()
+    kw = _local_run_kw()
+    a = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    b = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    assert a == b
+    assert a.record_count == 0
+    assert len(a.run_hash) == 64
+
+
+def test_shadow_observation_local_run_flags_remain_not_approved() -> None:
+    snaps = (_snap("Z1", "nap", {}), _snap("Z2", "nap", {"x": 1}))
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **_local_run_kw())
+    assert run.local_observation_run_approved is False
+    assert run.proven_shadow_no_order_entrypoint_found is False
+    assert run.executable_command_created is False
+    assert run.shadow_mode_allowed is False
+    assert run.runtime_allowed is False
+    assert run.scheduler_allowed is False
+    assert run.order_submission_allowed is False
+    assert run.all_no_order is True
+    assert run.all_shadow_mode_allowed_false is True
+
+
+def test_shadow_observation_local_run_rejects_snapshot_count_over_max() -> None:
+    snaps = (
+        _snap("M0", "cap", {}),
+        _snap("M1", "cap", {}),
+        _snap("M2", "cap", {}),
+    )
+    meta = _timed_meta()
+    kw = {
+        "started_at_utc": str(meta["started_at_utc"]),
+        "ended_at_utc": str(meta["ended_at_utc"]),
+        "cadence_seconds": int(meta["cadence_seconds"]),
+        "max_observations": 2,
+        "run_id": "x",
+        "source": "caller_provided",
+        "cadence_source": "caller_provided",
+    }
+    with pytest.raises(ValueError, match="snapshot count exceeds"):
+        observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+
+
 def test_observation_harness_has_no_sleep_or_datetime_now_tokens() -> None:
     path = Path(observation_harness_v0.__file__).resolve()
     text = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds a pure local observation run result contract on top of the existing Shadow Observation Harness one-shot, batch, and timed-summary helpers.

Changed files:

- `src/shadow_no_order_proof/observation_harness_v0.py`
- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## What this adds

- `LOCAL_OBSERVATION_RUN_RESULT_SCHEMA_V0`
- `ShadowObservationLocalRunResult`
- `run_shadow_observation_local_v0(...)`
- deterministic run hash over caller-provided snapshots and metadata
- explicit separation of `source` and `cadence_source`
- deterministic composition:
  - one-shot evidence records
  - batch summary
  - timed summary
  - local run result
- max snapshot cap validation via `max_observations`

## Reuse-before-new

- Reuses existing `src/shadow_no_order_proof/observation_harness_v0.py`
- Reuses one-shot, batch, and timed-summary helpers
- Extends the existing canonical Shadow no-order proof contract test
- No new docs
- No new runtime surface
- No duplicate readiness/evidence/planning surface
- No Notion write performed in this slice

## Safety / boundaries

- No runtime start
- No scheduler start
- No Shadow Mode start
- No Testnet start
- No Live authorization
- No broker/exchange/API credential usage
- No order submission
- No mixed-risk candidate wrapping or imports
- No file I/O
- No CLI
- No wall-clock loop
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This is a local observation result contract, not a runtime, scheduler, or executable Shadow command. It does not establish or approve a Shadow runtime entry point.

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 51 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- Python 3.9 compatibility scan — ok

## Machine-readable

VERDICT=SHADOW_OBSERVATION_LOCAL_RUN_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
LOCAL_OBSERVATION_RUN_IMPLEMENTED=true
LOCAL_OBSERVATION_RUN_APPROVED=false
TIMED_OBSERVATION_RUNTIME_ADDED=false
NOTION_WRITE_PERFORMED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)