### PR TITLE
feat(shadow): add local observation evidence output

### DIFF
--- a/src/shadow_no_order_proof/observation_harness_v0.py
+++ b/src/shadow_no_order_proof/observation_harness_v0.py
@@ -1,12 +1,15 @@
 # Shadow Observation Harness v0 — declarative evidence only (no runtime entrypoint).
-# Pure: dataclasses + stdlib hashing/json. No I/O, no network, no time lookups.
+# Core helpers: dataclasses + stdlib hashing/json (no network, no wall-clock reads).
+# Bounded filesystem output exists only in write_shadow_observation_local_evidence_v0.
 
 from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
-from typing import Any, Mapping, Optional, Sequence, cast
+import re
+from dataclasses import dataclass, fields, is_dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence, Union, cast
 
 from src.shadow_no_order_proof.bounded_adapter_v0 import (
     BoundedShadowAdapterPlan,
@@ -17,6 +20,13 @@ OBSERVATION_EVIDENCE_SCHEMA_V0 = "shadow_observation_evidence_record.v0"
 OBSERVATION_BATCH_SUMMARY_SCHEMA_V0 = "shadow_observation_batch_summary.v0"
 TIMED_OBSERVATION_SUMMARY_SCHEMA_V0 = "shadow_observation_timed_summary.v0"
 LOCAL_OBSERVATION_RUN_RESULT_SCHEMA_V0 = "shadow_observation_local_run_result.v0"
+LOCAL_OBSERVATION_EVIDENCE_OUTPUT_SCHEMA_V0 = "shadow_observation_local_evidence_manifest.v0"
+
+_LOCAL_RUN_RESULT_BASENAME = "local_run_result.json"
+_MANIFEST_BASENAME = "manifest.json"
+_MANIFEST_SHA256_BASENAME = "MANIFEST.sha256"
+
+_SAFE_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
 
 
 @dataclass(frozen=True)
@@ -146,6 +156,36 @@ class ShadowObservationLocalRunResult:
     order_submission_allowed: bool
 
 
+@dataclass(frozen=True)
+class ShadowObservationLocalEvidenceBundleV0:
+    """Deterministic JSON payloads for a local run evidence folder (no filesystem access)."""
+
+    local_run_result_json_bytes: bytes
+    manifest_json_bytes: bytes
+
+
+@dataclass(frozen=True)
+class ShadowObservationEvidenceOutputReceipt:
+    """Receipt for a bounded write under caller-provided output_dir/run_id (not an approval)."""
+
+    output_root: str
+    run_id: str
+    local_run_result_path: str
+    manifest_path: str
+    manifest_sha256_path: str
+    local_run_result_sha256: str
+    manifest_sha256: str
+    manifest_body_sha256_hex: str
+    local_observation_evidence_output_approved: bool
+    local_observation_run_approved: bool
+    proven_shadow_no_order_entrypoint_found: bool
+    executable_command_created: bool
+    shadow_mode_allowed: bool
+    runtime_allowed: bool
+    scheduler_allowed: bool
+    order_submission_allowed: bool
+
+
 def _record_satisfies_no_order_invariants(rec: ShadowObservationEvidenceRecord) -> bool:
     if rec.allowed_actions:
         return False
@@ -249,6 +289,132 @@ def _canonical_json_primitive(obj: object) -> object:
     if isinstance(obj, (list, tuple)):
         return [_canonical_json_primitive(x) for x in obj]
     raise TypeError(f"Unsupported payload type for canonical JSON: {type(obj)!r}")
+
+
+def _observation_value_to_json_obj(obj: object) -> object:
+    """Turn observation harness dataclasses/mappings into JSON-compatible trees."""
+    if is_dataclass(obj) and not isinstance(obj, type):
+        dc_any = cast(Any, obj)
+        return {
+            f.name: _observation_value_to_json_obj(getattr(dc_any, f.name)) for f in fields(dc_any)
+        }
+    if isinstance(obj, Mapping):
+        mapping = cast(Mapping[str, Any], obj)
+        return {k: _observation_value_to_json_obj(mapping[k]) for k in sorted(mapping)}
+    if isinstance(obj, (list, tuple)):
+        seq = cast(Sequence[object], obj)
+        return [_observation_value_to_json_obj(x) for x in seq]
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return obj
+    raise TypeError(f"Unsupported observation export type: {type(obj)!r}")
+
+
+def _require_safe_run_id(run_id: str) -> None:
+    if run_id != run_id.strip() or not run_id:
+        raise ValueError("run_id must be a non-empty trimmed string")
+    if ".." in run_id:
+        raise ValueError("run_id must not contain '..'")
+    if _SAFE_RUN_ID_RE.match(run_id) is None:
+        raise ValueError("run_id has unsafe characters")
+
+
+def _dump_canonical_json_bytes(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def build_shadow_observation_local_evidence_bundle_v0(
+    result: ShadowObservationLocalRunResult,
+) -> ShadowObservationLocalEvidenceBundleV0:
+    """Serialize a local run result + deterministic manifest bytes (pure; no filesystem)."""
+    body_obj = _observation_value_to_json_obj(result)
+    body = cast(Mapping[str, object], body_obj)
+    payload_bytes = _dump_canonical_json_bytes(body)
+    payload_sha256 = hashlib.sha256(payload_bytes).hexdigest()
+    manifest_body: dict[str, object] = {
+        "schema": LOCAL_OBSERVATION_EVIDENCE_OUTPUT_SCHEMA_V0,
+        "created_by": "shadow_observation_harness_v0",
+        "run_id": result.run_id,
+        "run_hash": result.run_hash,
+        "files": [
+            {
+                "path": _LOCAL_RUN_RESULT_BASENAME,
+                "sha256": payload_sha256,
+                "bytes": len(payload_bytes),
+            }
+        ],
+    }
+    manifest_bytes = _dump_canonical_json_bytes(manifest_body)
+    return ShadowObservationLocalEvidenceBundleV0(
+        local_run_result_json_bytes=payload_bytes,
+        manifest_json_bytes=manifest_bytes,
+    )
+
+
+def write_shadow_observation_local_evidence_v0(
+    result: ShadowObservationLocalRunResult,
+    *,
+    output_dir: Union[str, Path],
+    overwrite: bool = False,
+) -> ShadowObservationEvidenceOutputReceipt:
+    """Write bounded evidence files under output_dir/run_id (caller-owned paths only)."""
+    _require_safe_run_id(result.run_id)
+    base = Path(output_dir).expanduser().resolve()
+    base.mkdir(parents=True, exist_ok=True)
+    dest = (base / result.run_id).resolve()
+    if not dest.is_relative_to(base):
+        raise ValueError("run_id resolves outside output_dir")
+    dest.mkdir(parents=True, exist_ok=True)
+
+    bundle = build_shadow_observation_local_evidence_bundle_v0(result)
+    payload_bytes = bundle.local_run_result_json_bytes
+    manifest_bytes = bundle.manifest_json_bytes
+    manifest_body_hex = hashlib.sha256(manifest_bytes).hexdigest()
+    digest_bytes = f"{manifest_body_hex}\n".encode("utf-8")
+
+    p_payload = dest / _LOCAL_RUN_RESULT_BASENAME
+    p_manifest = dest / _MANIFEST_BASENAME
+    p_digest = dest / _MANIFEST_SHA256_BASENAME
+
+    targets = (p_payload, p_manifest, p_digest)
+    if not overwrite:
+        for p in targets:
+            if p.exists():
+                raise FileExistsError(str(p))
+    else:
+        for p in targets:
+            if p.exists():
+                p.unlink()
+
+    p_payload.write_bytes(payload_bytes)
+    p_manifest.write_bytes(manifest_bytes)
+    p_digest.write_bytes(digest_bytes)
+
+    payload_written_hash = hashlib.sha256(p_payload.read_bytes()).hexdigest()
+    manifest_written_hash = hashlib.sha256(p_manifest.read_bytes()).hexdigest()
+
+    return ShadowObservationEvidenceOutputReceipt(
+        output_root=str(dest),
+        run_id=result.run_id,
+        local_run_result_path=str(p_payload),
+        manifest_path=str(p_manifest),
+        manifest_sha256_path=str(p_digest),
+        local_run_result_sha256=payload_written_hash,
+        manifest_sha256=manifest_written_hash,
+        manifest_body_sha256_hex=manifest_body_hex,
+        local_observation_evidence_output_approved=False,
+        local_observation_run_approved=result.local_observation_run_approved,
+        proven_shadow_no_order_entrypoint_found=result.proven_shadow_no_order_entrypoint_found,
+        executable_command_created=result.executable_command_created,
+        shadow_mode_allowed=result.shadow_mode_allowed,
+        runtime_allowed=result.runtime_allowed,
+        scheduler_allowed=result.scheduler_allowed,
+        order_submission_allowed=result.order_submission_allowed,
+    )
 
 
 def _fingerprint_bytes(

--- a/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
+++ b/tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from dataclasses import fields
 from pathlib import Path
@@ -1129,6 +1131,172 @@ def test_shadow_observation_local_run_rejects_snapshot_count_over_max() -> None:
     }
     with pytest.raises(ValueError, match="snapshot count exceeds"):
         observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+
+
+def test_build_shadow_observation_local_evidence_bundle_v0_is_deterministic() -> None:
+    snaps = (_snap("E1", "evb", {"n": 1}),)
+    kw = _local_run_kw(run_id="evidence-run-1")
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    a = observation_harness_v0.build_shadow_observation_local_evidence_bundle_v0(run)
+    b = observation_harness_v0.build_shadow_observation_local_evidence_bundle_v0(run)
+    assert a == b
+    assert (
+        hashlib.sha256(a.local_run_result_json_bytes).hexdigest()
+        == hashlib.sha256(b.local_run_result_json_bytes).hexdigest()
+    )
+
+
+def test_evidence_bundle_manifest_reflects_payload_hash_and_schema() -> None:
+    snaps = (_snap("E2", "evm", {}),)
+    kw = _local_run_kw(run_id="manifest-run")
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    bundle = observation_harness_v0.build_shadow_observation_local_evidence_bundle_v0(run)
+    payload_hash = hashlib.sha256(bundle.local_run_result_json_bytes).hexdigest()
+    manifest = json.loads(bundle.manifest_json_bytes.decode("utf-8"))
+    assert manifest["schema"] == observation_harness_v0.LOCAL_OBSERVATION_EVIDENCE_OUTPUT_SCHEMA_V0
+    assert manifest["created_by"] == "shadow_observation_harness_v0"
+    assert manifest["run_id"] == run.run_id
+    assert manifest["run_hash"] == run.run_hash
+    assert manifest["files"] == [
+        {
+            "path": "local_run_result.json",
+            "sha256": payload_hash,
+            "bytes": len(bundle.local_run_result_json_bytes),
+        }
+    ]
+
+
+def test_evidence_bundle_bytes_change_when_local_run_payload_changes() -> None:
+    kw = _local_run_kw(run_id="delta-run")
+    r1 = observation_harness_v0.run_shadow_observation_local_v0(
+        (_snap("D", "evd", {"k": 1}),), **kw
+    )
+    r2 = observation_harness_v0.run_shadow_observation_local_v0(
+        (_snap("D", "evd", {"k": 2}),), **kw
+    )
+    b1 = observation_harness_v0.build_shadow_observation_local_evidence_bundle_v0(r1)
+    b2 = observation_harness_v0.build_shadow_observation_local_evidence_bundle_v0(r2)
+    assert b1.local_run_result_json_bytes != b2.local_run_result_json_bytes
+    assert b1.manifest_json_bytes != b2.manifest_json_bytes
+
+
+def test_write_shadow_observation_local_evidence_writes_three_files(tmp_path: Path) -> None:
+    snaps = (_snap("W1", "wrt", {}),)
+    kw = _local_run_kw(run_id="write-run-a")
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    receipt = observation_harness_v0.write_shadow_observation_local_evidence_v0(
+        run,
+        output_dir=tmp_path / "evidence_root",
+        overwrite=False,
+    )
+    root = Path(receipt.output_root)
+    names = {p.name for p in root.iterdir()}
+    assert names == {
+        "local_run_result.json",
+        "manifest.json",
+        "MANIFEST.sha256",
+    }
+    bundle = observation_harness_v0.build_shadow_observation_local_evidence_bundle_v0(run)
+    assert (root / "local_run_result.json").read_bytes() == bundle.local_run_result_json_bytes
+    assert (root / "manifest.json").read_bytes() == bundle.manifest_json_bytes
+    digest = (root / "MANIFEST.sha256").read_bytes().decode("utf-8")
+    assert digest == hashlib.sha256(bundle.manifest_json_bytes).hexdigest() + "\n"
+    assert (
+        receipt.local_run_result_sha256
+        == hashlib.sha256(bundle.local_run_result_json_bytes).hexdigest()
+    )
+    assert receipt.manifest_sha256 == hashlib.sha256(bundle.manifest_json_bytes).hexdigest()
+    assert (
+        receipt.manifest_body_sha256_hex == hashlib.sha256(bundle.manifest_json_bytes).hexdigest()
+    )
+
+
+def test_write_shadow_observation_local_evidence_refuses_overwrite(tmp_path: Path) -> None:
+    snaps = (_snap("W2", "novr", {}),)
+    kw = _local_run_kw(run_id="write-run-b")
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    out = tmp_path / "out_b"
+    observation_harness_v0.write_shadow_observation_local_evidence_v0(
+        run, output_dir=out, overwrite=False
+    )
+    with pytest.raises(FileExistsError):
+        observation_harness_v0.write_shadow_observation_local_evidence_v0(
+            run, output_dir=out, overwrite=False
+        )
+
+
+def test_write_shadow_observation_local_evidence_overwrite_true_replaces(tmp_path: Path) -> None:
+    snaps = (_snap("W3", "ovr", {}),)
+    kw = _local_run_kw(run_id="write-run-c")
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    out = tmp_path / "out_c"
+    observation_harness_v0.write_shadow_observation_local_evidence_v0(
+        run, output_dir=out, overwrite=False
+    )
+    first_payload = (Path(out) / run.run_id / "local_run_result.json").read_bytes()
+    observation_harness_v0.write_shadow_observation_local_evidence_v0(
+        run, output_dir=out, overwrite=True
+    )
+    second_payload = (Path(out) / run.run_id / "local_run_result.json").read_bytes()
+    assert first_payload == second_payload
+
+
+def test_write_shadow_observation_local_evidence_overwrite_preserves_extra_files(
+    tmp_path: Path,
+) -> None:
+    snaps = (_snap("W4", "xtra", {}),)
+    kw = _local_run_kw(run_id="write-run-d")
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    out = tmp_path / "out_d"
+    observation_harness_v0.write_shadow_observation_local_evidence_v0(
+        run, output_dir=out, overwrite=False
+    )
+    dest = Path(out) / run.run_id
+    (dest / "extra.txt").write_text("keep", encoding="utf-8")
+    observation_harness_v0.write_shadow_observation_local_evidence_v0(
+        run, output_dir=out, overwrite=True
+    )
+    assert (dest / "extra.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_evidence_output_receipt_authority_flags_remain_false(tmp_path: Path) -> None:
+    snaps = (_snap("W5", "rcp", {}), _snap("W6", "rcp", {"z": 9}))
+    kw = _local_run_kw(run_id="receipt-run")
+    run = observation_harness_v0.run_shadow_observation_local_v0(snaps, **kw)
+    receipt = observation_harness_v0.write_shadow_observation_local_evidence_v0(
+        run,
+        output_dir=tmp_path / "out_e",
+        overwrite=False,
+    )
+    assert receipt.local_observation_evidence_output_approved is False
+    assert receipt.local_observation_run_approved is False
+    assert receipt.proven_shadow_no_order_entrypoint_found is False
+    assert receipt.executable_command_created is False
+    assert receipt.shadow_mode_allowed is False
+    assert receipt.runtime_allowed is False
+    assert receipt.scheduler_allowed is False
+    assert receipt.order_submission_allowed is False
+
+
+def test_write_evidence_rejects_unsafe_run_id(tmp_path: Path) -> None:
+    snaps = (_snap("U", "unsafe", {}),)
+    meta = _timed_meta()
+    run = observation_harness_v0.run_shadow_observation_local_v0(
+        snaps,
+        started_at_utc=str(meta["started_at_utc"]),
+        ended_at_utc=str(meta["ended_at_utc"]),
+        cadence_seconds=int(meta["cadence_seconds"]),
+        max_observations=int(meta["max_observations"]),
+        run_id="trick/../../../escape",
+        source="caller_provided",
+        cadence_source="caller_provided",
+    )
+    with pytest.raises(ValueError, match="run_id"):
+        observation_harness_v0.write_shadow_observation_local_evidence_v0(
+            run,
+            output_dir=tmp_path / "bad",
+            overwrite=False,
+        )
 
 
 def test_observation_harness_has_no_sleep_or_datetime_now_tokens() -> None:


### PR DESCRIPTION
## Summary

Adds bounded local observation evidence output for an already-built `ShadowObservationLocalRunResult`.

Changed files:

- `src/shadow_no_order_proof/observation_harness_v0.py`
- `tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`

## What this adds

- `LOCAL_OBSERVATION_EVIDENCE_OUTPUT_SCHEMA_V0`
- `ShadowObservationLocalEvidenceBundleV0`
- `ShadowObservationEvidenceOutputReceipt`
- `build_shadow_observation_local_evidence_bundle_v0(result)`
- `write_shadow_observation_local_evidence_v0(result, *, output_dir, overwrite=False)`

Output layout under explicit caller-provided `output_dir / run_id`:

- `local_run_result.json`
- `manifest.json`
- `MANIFEST.sha256`

## Safety / boundaries

- Caller-provided result only
- Caller-provided output directory only
- No implicit production path
- No input file reads
- No directory scans as input
- No CLI
- No scheduler
- No runtime
- No network
- No broker/exchange/API credential usage
- No order submission
- No mixed-risk candidate wrapping or imports
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes

This is bounded evidence file output, not Shadow Mode, not runtime, not Testnet, and not Live.

## Path / overwrite behavior

- Strict `run_id` validation
- Writes only under resolved `output_dir / run_id`
- `overwrite=False` raises `FileExistsError` if expected files already exist
- `overwrite=True` replaces only expected files
- Other files in the run directory are preserved

## Validation

- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 60 passed
- `uv run ruff check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- Python 3.9 compatibility scan — ok

## Machine-readable

VERDICT=LOCAL_OBSERVATION_EVIDENCE_OUTPUT_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
LOCAL_OBSERVATION_EVIDENCE_OUTPUT_IMPLEMENTED=true
LOCAL_OBSERVATION_RUN_APPROVED=false
TIMED_OBSERVATION_RUNTIME_ADDED=false
NOTION_WRITE_PERFORMED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)