### PR TITLE
feat(shadow): add file snapshot observation operator entrypoint

### DIFF
--- a/scripts/ops/run_shadow_observation_file_snapshot_v0.py
+++ b/scripts/ops/run_shadow_observation_file_snapshot_v0.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Bounded local operator entrypoint: file snapshot → Shadow Observation evidence (no runtime authority).
+
+This script is an ops-only wrapper. It does not approve Shadow Mode, runtime, scheduler, broker,
+exchange, or orders. It invokes the existing harness and evidence writer only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.shadow_no_order_proof.observation_harness_v0 import (  # noqa: E402
+    ShadowObservationInputSnapshot,
+    _require_safe_run_id,
+    run_shadow_observation_local_v0,
+    write_shadow_observation_local_evidence_v0,
+)
+
+CONFIRMATION_TOKEN = "NO_RUNTIME_NO_SCHEDULER_NO_BROKER_NO_ORDERS"
+CLOSEOUT_BASENAME = "SHADOW_OBSERVATION_FILE_SNAPSHOT_OPERATOR_ENTRYPOINT_V0_CLOSEOUT.md"
+INPUT_SCHEMA_V0 = "bounded_file_snapshot_observation_input_v0"
+INPUT_SOURCE_EXPECTED = "bounded_file_captured_static"
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_snapshots(payload: Mapping[str, Any]) -> tuple[ShadowObservationInputSnapshot, ...]:
+    schema = payload.get("schema")
+    if schema != INPUT_SCHEMA_V0:
+        _die(f"ERR: input schema must be {INPUT_SCHEMA_V0!r}, got {schema!r}")
+    source = payload.get("source")
+    if source != INPUT_SOURCE_EXPECTED:
+        _die(f"ERR: input source must be {INPUT_SOURCE_EXPECTED!r}, got {source!r}")
+    raw = payload.get("snapshots")
+    if not isinstance(raw, list) or not raw:
+        _die("ERR: snapshots must be a non-empty list")
+    out: list[ShadowObservationInputSnapshot] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            _die("ERR: each snapshot must be an object")
+        try:
+            symbol = str(item["symbol"])
+            observed_at_utc = str(item["observed_at_utc"])
+            pl = item["payload"]
+        except (KeyError, TypeError) as e:
+            _die(f"ERR: snapshot missing required fields: {e}")
+        if not isinstance(pl, Mapping):
+            _die("ERR: payload must be an object")
+        out.append(
+            ShadowObservationInputSnapshot(
+                symbol=symbol,
+                observed_at_utc=observed_at_utc,
+                source=str(source),
+                payload=dict(pl),
+            )
+        )
+    return tuple(out)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run bounded file-snapshot Shadow Observation evidence (local / caller paths only)."
+        ),
+    )
+    parser.add_argument("--input-file", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument(
+        "--confirm-no-runtime",
+        required=True,
+        choices=[CONFIRMATION_TOKEN],
+        help=f"Must be exactly {CONFIRMATION_TOKEN!r}.",
+    )
+    args = parser.parse_args(argv)
+
+    input_path = args.input_file.expanduser().resolve()
+    output_dir = args.output_dir.expanduser().resolve()
+
+    if input_path.is_dir():
+        _die(f"ERR: --input-file must be a file, not a directory: {input_path}")
+    if not input_path.is_file():
+        _die(f"ERR: input file not found: {input_path}")
+
+    try:
+        _require_safe_run_id(args.run_id)
+    except ValueError as e:
+        _die(f"ERR: unsafe run_id: {e}")
+
+    try:
+        raw_text = input_path.read_text(encoding="utf-8")
+    except OSError as e:
+        _die(f"ERR: failed to read input file: {e}")
+    input_sha256 = hashlib.sha256(raw_text.encode("utf-8")).hexdigest()
+
+    try:
+        loaded = json.loads(raw_text)
+    except json.JSONDecodeError as e:
+        _die(f"ERR: invalid JSON: {e}")
+    if not isinstance(loaded, dict):
+        _die("ERR: input JSON must be an object")
+
+    snapshots = _load_snapshots(loaded)
+    ordered = tuple(sorted(snapshots, key=lambda s: s.observed_at_utc))
+    started = ordered[0].observed_at_utc
+    ended = ordered[-1].observed_at_utc
+
+    try:
+        result = run_shadow_observation_local_v0(
+            ordered,
+            started_at_utc=started,
+            ended_at_utc=ended,
+            cadence_seconds=60,
+            max_observations=len(ordered),
+            run_id=args.run_id,
+            source=INPUT_SOURCE_EXPECTED,
+            cadence_source=INPUT_SOURCE_EXPECTED,
+        )
+        write_shadow_observation_local_evidence_v0(
+            result,
+            output_dir=output_dir,
+            overwrite=False,
+        )
+    except (ValueError, FileExistsError, OSError) as e:
+        _die(f"ERR: harness or evidence write failed: {e}")
+
+    run_dir = (output_dir / result.run_id).resolve()
+    manifest_path = run_dir / "manifest.json"
+    manifest_sha256 = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+    lines = [
+        "# Shadow Observation File Snapshot Operator Entrypoint v0 Closeout",
+        "",
+        "## Scope",
+        "",
+        "- Bounded local operator entrypoint (no Shadow Mode / runtime / scheduler / broker / orders).",
+        "",
+        "## Paths",
+        "",
+        f"- input_file: `{input_path}`",
+        f"- output_dir: `{output_dir}`",
+        f"- run_dir: `{run_dir}`",
+        "",
+        "## Hashes",
+        "",
+        f"- input_sha256: `{input_sha256}`",
+        f"- manifest_sha256: `{manifest_sha256}`",
+        "",
+        "## Harness flags (all must remain non-approvals)",
+        "",
+        f"- local_observation_run_approved: {result.local_observation_run_approved}",
+        f"- proven_shadow_no_order_entrypoint_found: {result.proven_shadow_no_order_entrypoint_found}",
+        f"- executable_command_created: {result.executable_command_created}",
+        f"- shadow_mode_allowed: {result.shadow_mode_allowed}",
+        f"- runtime_allowed: {result.runtime_allowed}",
+        f"- scheduler_allowed: {result.scheduler_allowed}",
+        f"- order_submission_allowed: {result.order_submission_allowed}",
+        "",
+        "## Machine-readable final lines",
+        "",
+        "VERDICT=SHADOW_OBSERVATION_FILE_SNAPSHOT_OPERATOR_ENTRYPOINT_V0_PASSED_LOCAL_OPERATOR_ONLY",
+        "DECISION=not_approved",
+        "REPO_CHANGED=false",
+        "SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_IMPLEMENTED=true",
+        "SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_APPROVED=false",
+        "LOCAL_OBSERVATION_RUN_APPROVED=false",
+        "PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false",
+        "EXECUTABLE_COMMAND_CREATED=false",
+        "LIVE_ALLOWED=false",
+        "TESTNET_ALLOWED=false",
+        "SHADOW_MODE_ALLOWED=false",
+        "PAPER_ALLOWED=false",
+        "SCHEDULER_ALLOWED=false",
+        "RUNTIME_ALLOWED=false",
+        "BROKER_ALLOWED=false",
+        "EXCHANGE_ALLOWED=false",
+        "ORDER_SUBMISSION_ALLOWED=false",
+        "BOUNDED_FILE_SNAPSHOT_OBSERVATION_TEST_PASSED=true",
+        "",
+    ]
+    closeout_path = run_dir / CLOSEOUT_BASENAME
+    closeout_path.write_text("\n".join(lines), encoding="utf-8")
+
+    in_machine = False
+    for ml in lines:
+        if ml.strip() == "## Machine-readable final lines":
+            in_machine = True
+            continue
+        if in_machine and ml.strip() and not ml.startswith("#"):
+            print(ml.strip())
+    print(f"CLOSEOUT_WRITTEN={closeout_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py
+++ b/tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "ops" / "run_shadow_observation_file_snapshot_v0.py"
+_CONFIRM = "NO_RUNTIME_NO_SCHEDULER_NO_BROKER_NO_ORDERS"
+
+_FORBIDDEN_SUBSTRINGS = (
+    "import subprocess",
+    "import requests",
+    "import httpx",
+    "import aiohttp",
+    "import websocket",
+    "from socket ",
+    " import socket",
+    "import click",
+    "import typer",
+)
+
+
+def _run_script(args: list[str], *, cwd: Optional[Path] = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        cwd=cwd or _REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_script_source_forbids_high_risk_imports() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    lowered = text.lower()
+    for bad in _FORBIDDEN_SUBSTRINGS:
+        assert bad.lower() not in lowered, f"forbidden pattern: {bad!r}"
+
+
+def test_requires_input_file() -> None:
+    r = _run_script(
+        [
+            "--output-dir",
+            "/tmp",
+            "--run-id",
+            "safe_run_id",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "--input-file" in (r.stderr + r.stdout) or "required" in r.stderr.lower()
+
+
+def test_requires_output_dir(tmp_path: Path) -> None:
+    p = tmp_path / "in.json"
+    p.write_text("{}", encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(p),
+            "--run-id",
+            "safe_run_id",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_requires_run_id(tmp_path: Path) -> None:
+    p = tmp_path / "in.json"
+    p.write_text(
+        '{"schema":"bounded_file_snapshot_observation_input_v0","source":"bounded_file_captured_static","snapshots":[]}',
+        encoding="utf-8",
+    )
+    r = _run_script(
+        [
+            "--input-file",
+            str(p),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_requires_exact_confirmation_token(tmp_path: Path) -> None:
+    p = tmp_path / "in.json"
+    p.write_text('{"schema":"x"}', encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(p),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--run-id",
+            "operator_run_v0",
+            "--confirm-no-runtime",
+            "WRONG",
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_directory_input(tmp_path: Path) -> None:
+    d = tmp_path / "notafile"
+    d.mkdir()
+    r = _run_script(
+        [
+            "--input-file",
+            str(d),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--run-id",
+            "operator_run_v0",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "directory" in r.stderr.lower() or "directory" in r.stdout.lower()
+
+
+def test_rejects_unsafe_run_id(tmp_path: Path) -> None:
+    p = tmp_path / "in.json"
+    p.write_text(
+        '{"schema":"bounded_file_snapshot_observation_input_v0","source":"bounded_file_captured_static","snapshots":[]}',
+        encoding="utf-8",
+    )
+    r = _run_script(
+        [
+            "--input-file",
+            str(p),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--run-id",
+            "../evil",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+@pytest.fixture
+def valid_input() -> dict:
+    return {
+        "schema": "bounded_file_snapshot_observation_input_v0",
+        "source": "bounded_file_captured_static",
+        "snapshots": [
+            {
+                "symbol": "FILE-CAPTURED-OBS",
+                "observed_at_utc": "2026-01-01T00:00:00Z",
+                "payload": {
+                    "bid": "100.10",
+                    "ask": "100.15",
+                    "last": "100.12",
+                    "volume": "12.5",
+                    "spread_bps": "4.99",
+                    "state": "bounded_file_captured_static",
+                    "sequence": "1",
+                },
+            },
+            {
+                "symbol": "FILE-CAPTURED-OBS",
+                "observed_at_utc": "2026-01-01T00:01:00Z",
+                "payload": {
+                    "bid": "100.18",
+                    "ask": "100.23",
+                    "last": "100.20",
+                    "volume": "14.0",
+                    "spread_bps": "4.98",
+                    "state": "bounded_file_captured_static",
+                    "sequence": "2",
+                },
+            },
+            {
+                "symbol": "FILE-CAPTURED-OBS",
+                "observed_at_utc": "2026-01-01T00:02:00Z",
+                "payload": {
+                    "bid": "100.05",
+                    "ask": "100.11",
+                    "last": "100.09",
+                    "volume": "11.7",
+                    "spread_bps": "5.99",
+                    "state": "bounded_file_captured_static",
+                    "sequence": "3",
+                },
+            },
+        ],
+    }
+
+
+def test_happy_path_writes_evidence_and_closeout(tmp_path: Path, valid_input: dict) -> None:
+    inp = tmp_path / "captured_snapshots.json"
+    out = tmp_path / "evidence"
+    inp.write_text(
+        json.dumps(valid_input, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8"
+    )
+    run_id = "operator_file_snapshot_observation_v0"
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(out),
+            "--run-id",
+            run_id,
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    run_dir = out / run_id
+    assert (run_dir / "local_run_result.json").is_file()
+    assert (run_dir / "manifest.json").is_file()
+    assert (run_dir / "MANIFEST.sha256").is_file()
+    co = run_dir / "SHADOW_OBSERVATION_FILE_SNAPSHOT_OPERATOR_ENTRYPOINT_V0_CLOSEOUT.md"
+    assert co.is_file()
+    body = co.read_text(encoding="utf-8")
+    assert "DECISION=not_approved" in body
+    assert "LOCAL_OBSERVATION_RUN_APPROVED=false" in body
+    assert "PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false" in body
+    assert "EXECUTABLE_COMMAND_CREATED=false" in body
+    assert "SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_IMPLEMENTED=true" in body
+    assert "LIVE_ALLOWED=false" in body
+    assert "DECISION=not_approved" in r.stdout
+    assert str(out.resolve()).startswith(str(tmp_path.resolve()))


### PR DESCRIPTION
## Summary

Adds the first bounded operator-facing Shadow Observation entrypoint for explicit local file snapshot observation.

Changed files:

- `scripts/ops/run_shadow_observation_file_snapshot_v0.py`
- `tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py`

## What this adds

- Ops script requiring explicit:
  - `--input-file`
  - `--output-dir`
  - `--run-id`
  - `--confirm-no-runtime NO_RUNTIME_NO_SCHEDULER_NO_BROKER_NO_ORDERS`
- Reads only the explicit JSON input file.
- Uses existing Shadow Observation Harness functions.
- Writes evidence only under explicit `output_dir / run_id`.
- Writes a closeout:
  - `SHADOW_OBSERVATION_FILE_SNAPSHOT_OPERATOR_ENTRYPOINT_V0_CLOSEOUT.md`
- Keeps Python 3.9-compatible signatures via `Optional[...]`.

## Safety / boundaries

- No scheduler
- No runtime
- No daemon
- No broker/exchange/API credential usage
- No order submission
- No network client integration
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes
- No Notion write
- No committed generated evidence artifacts

This is a bounded local operator wrapper, not Shadow Mode, not Testnet, and not Live.

## Validation

- `uv run pytest tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py -q` — 8 passed
- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 65 passed
- `uv run ruff check scripts/ops/run_shadow_observation_file_snapshot_v0.py tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check scripts/ops/run_shadow_observation_file_snapshot_v0.py tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- PY39 compatibility scan — ok
- Forbidden runtime token scan — ok

## Machine-readable

VERDICT=SHADOW_OBSERVATION_FILE_SNAPSHOT_OPERATOR_ENTRYPOINT_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_IMPLEMENTED=true
SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_APPROVED=false
LOCAL_OBSERVATION_RUN_APPROVED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
NOTION_WRITE_PERFORMED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)