### PR TITLE
feat(shadow): validate captured realistic operator input

### DIFF
--- a/scripts/ops/run_shadow_observation_file_snapshot_v0.py
+++ b/scripts/ops/run_shadow_observation_file_snapshot_v0.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 import sys
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Tuple
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
@@ -27,8 +27,38 @@ from src.shadow_no_order_proof.observation_harness_v0 import (  # noqa: E402
 
 CONFIRMATION_TOKEN = "NO_RUNTIME_NO_SCHEDULER_NO_BROKER_NO_ORDERS"
 CLOSEOUT_BASENAME = "SHADOW_OBSERVATION_FILE_SNAPSHOT_OPERATOR_ENTRYPOINT_V0_CLOSEOUT.md"
-INPUT_SCHEMA_V0 = "bounded_file_snapshot_observation_input_v0"
-INPUT_SOURCE_EXPECTED = "bounded_file_captured_static"
+BOUNDED_SCHEMA_V0 = "bounded_file_snapshot_observation_input_v0"
+BOUNDED_SOURCE_V0 = "bounded_file_captured_static"
+CAPTURED_SCHEMA_V0 = "captured_realistic_snapshot_observation_input_v0"
+
+CAPTURED_SOURCES_ALLOWED_V0 = frozenset(
+    {
+        "operator_supplied_static",
+        "redacted_public_snapshot_static",
+        "synthetic_realistic_static",
+        "prior_allowed_tmp_artifact_static",
+    }
+)
+
+_CAPTURED_PAYLOAD_REQUIRED_KEYS_V0 = frozenset({"bid", "ask", "last", "spread_bps", "sequence"})
+
+# Match whole payload key names via substring rejection (ASCII keys only expected).
+_PAYLOAD_KEY_REJECT_SUBSTRINGS_V0 = (
+    "api_key",
+    "secret",
+    "private_key",
+    "credential",
+    "account_id",
+    "wallet",
+    "order_id",
+    "fill_id",
+    "client_order_id",
+    "private_trade_id",
+    "balance",
+    "position_size",
+    "leverage",
+    "pnl",
+)
 
 
 def _die(msg: str, code: int = 2) -> None:
@@ -36,37 +66,122 @@ def _die(msg: str, code: int = 2) -> None:
     raise SystemExit(code)
 
 
-def _load_snapshots(payload: Mapping[str, Any]) -> tuple[ShadowObservationInputSnapshot, ...]:
-    schema = payload.get("schema")
-    if schema != INPUT_SCHEMA_V0:
-        _die(f"ERR: input schema must be {INPUT_SCHEMA_V0!r}, got {schema!r}")
+def _non_empty_trimmed_str(val: Any) -> bool:
+    return isinstance(val, str) and val.strip() != ""
+
+
+def _validate_captured_provenance(prov: Any) -> None:
+    if prov is None or not isinstance(prov, Mapping):
+        _die("ERR: captured-realistic input requires provenance object")
+    if prov.get("redacted") is not True:
+        _die("ERR: provenance.redacted must be true")
+    for key in (
+        "network_fetch_during_test",
+        "contains_credentials",
+        "contains_orders",
+        "contains_fills",
+    ):
+        if prov.get(key) is not False:
+            _die(f"ERR: provenance.{key} must be false")
+    if not _non_empty_trimmed_str(prov.get("captured_by")):
+        _die("ERR: provenance.captured_by must be a non-empty string")
+    if not _non_empty_trimmed_str(prov.get("captured_at_utc")):
+        _die("ERR: provenance.captured_at_utc must be a non-empty string")
+
+
+def _reject_forbidden_payload_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        lk = key.lower()
+        for frag in _PAYLOAD_KEY_REJECT_SUBSTRINGS_V0:
+            if frag in lk:
+                _die(f"ERR: forbidden payload key pattern {frag!r} matched in field {key!r}")
+
+
+def _validate_bounded_snapshot_item(
+    item: Any, envelope_source: str
+) -> ShadowObservationInputSnapshot:
+    if not isinstance(item, Mapping):
+        _die("ERR: each snapshot must be an object")
+    try:
+        symbol = str(item["symbol"])
+        observed_at_utc = str(item["observed_at_utc"])
+        pl = item["payload"]
+    except (KeyError, TypeError) as e:
+        _die(f"ERR: snapshot missing required fields: {e}")
+    if not isinstance(pl, Mapping):
+        _die("ERR: payload must be an object")
+    if not symbol.strip():
+        _die("ERR: snapshot.symbol must be non-empty")
+    if not observed_at_utc.strip():
+        _die("ERR: snapshot.observed_at_utc must be non-empty")
+    return ShadowObservationInputSnapshot(
+        symbol=symbol,
+        observed_at_utc=observed_at_utc,
+        source=envelope_source,
+        payload=dict(pl),
+    )
+
+
+def _validate_captured_snapshot_item(
+    item: Any, envelope_source: str
+) -> ShadowObservationInputSnapshot:
+    snap = _validate_bounded_snapshot_item(item, envelope_source)
+    pl = snap.payload
+    missing = sorted(_CAPTURED_PAYLOAD_REQUIRED_KEYS_V0 - set(pl))
+    if missing:
+        _die(f"ERR: captured-realistic snapshot payload missing required keys {missing}")
+    _reject_forbidden_payload_keys(pl)
+    return snap
+
+
+def _load_bounded_snapshots(
+    payload: Mapping[str, Any],
+) -> Tuple[Tuple[ShadowObservationInputSnapshot, ...], str]:
     source = payload.get("source")
-    if source != INPUT_SOURCE_EXPECTED:
-        _die(f"ERR: input source must be {INPUT_SOURCE_EXPECTED!r}, got {source!r}")
+    if source != BOUNDED_SOURCE_V0:
+        _die(f"ERR: input source must be {BOUNDED_SOURCE_V0!r}, got {source!r}")
     raw = payload.get("snapshots")
     if not isinstance(raw, list) or not raw:
         _die("ERR: snapshots must be a non-empty list")
     out: list[ShadowObservationInputSnapshot] = []
     for item in raw:
-        if not isinstance(item, Mapping):
-            _die("ERR: each snapshot must be an object")
-        try:
-            symbol = str(item["symbol"])
-            observed_at_utc = str(item["observed_at_utc"])
-            pl = item["payload"]
-        except (KeyError, TypeError) as e:
-            _die(f"ERR: snapshot missing required fields: {e}")
-        if not isinstance(pl, Mapping):
-            _die("ERR: payload must be an object")
-        out.append(
-            ShadowObservationInputSnapshot(
-                symbol=symbol,
-                observed_at_utc=observed_at_utc,
-                source=str(source),
-                payload=dict(pl),
-            )
+        out.append(_validate_bounded_snapshot_item(item, BOUNDED_SOURCE_V0))
+    return tuple(out), BOUNDED_SOURCE_V0
+
+
+def _load_captured_snapshots(
+    payload: Mapping[str, Any],
+) -> Tuple[Tuple[ShadowObservationInputSnapshot, ...], str]:
+    source = payload.get("source")
+    if not isinstance(source, str) or source not in CAPTURED_SOURCES_ALLOWED_V0:
+        _die(
+            "ERR: captured-realistic source must be one of "
+            f"{sorted(CAPTURED_SOURCES_ALLOWED_V0)!r}, got {source!r}"
         )
-    return tuple(out)
+    _validate_captured_provenance(payload.get("provenance"))
+    raw = payload.get("snapshots")
+    if not isinstance(raw, list):
+        _die("ERR: snapshots must be a non-empty array for captured-realistic input")
+    n = len(raw)
+    if n < 3 or n > 20:
+        _die(f"ERR: captured-realistic requires between 3 and 20 snapshots, got {n}")
+    out: list[ShadowObservationInputSnapshot] = []
+    for item in raw:
+        out.append(_validate_captured_snapshot_item(item, source))
+    return tuple(out), source
+
+
+def load_snapshots_for_envelope(
+    payload: Mapping[str, Any],
+) -> Tuple[Tuple[ShadowObservationInputSnapshot, ...], str]:
+    schema = payload.get("schema")
+    if schema == BOUNDED_SCHEMA_V0:
+        return _load_bounded_snapshots(payload)
+    if schema == CAPTURED_SCHEMA_V0:
+        return _load_captured_snapshots(payload)
+    _die(
+        f"ERR: input schema must be {BOUNDED_SCHEMA_V0!r} or {CAPTURED_SCHEMA_V0!r}, got {schema!r}"
+    )
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -112,7 +227,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     if not isinstance(loaded, dict):
         _die("ERR: input JSON must be an object")
 
-    snapshots = _load_snapshots(loaded)
+    snapshots, harness_source = load_snapshots_for_envelope(loaded)
     ordered = tuple(sorted(snapshots, key=lambda s: s.observed_at_utc))
     started = ordered[0].observed_at_utc
     ended = ordered[-1].observed_at_utc
@@ -125,8 +240,8 @@ def main(argv: Optional[list[str]] = None) -> int:
             cadence_seconds=60,
             max_observations=len(ordered),
             run_id=args.run_id,
-            source=INPUT_SOURCE_EXPECTED,
-            cadence_source=INPUT_SOURCE_EXPECTED,
+            source=harness_source,
+            cadence_source=harness_source,
         )
         write_shadow_observation_local_evidence_v0(
             result,

--- a/tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py
+++ b/tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py
@@ -11,6 +11,9 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT = _REPO_ROOT / "scripts" / "ops" / "run_shadow_observation_file_snapshot_v0.py"
 _CONFIRM = "NO_RUNTIME_NO_SCHEDULER_NO_BROKER_NO_ORDERS"
+_bounded_schema = "bounded_file_snapshot_observation_input_v0"
+_bounded_source = "bounded_file_captured_static"
+_captured_schema = "captured_realistic_snapshot_observation_input_v0"
 
 _FORBIDDEN_SUBSTRINGS = (
     "import subprocess",
@@ -199,6 +202,58 @@ def valid_input() -> dict:
     }
 
 
+def _prov_ok(extra: Optional[dict] = None) -> dict:
+    p = {
+        "captured_by": "operator",
+        "captured_at_utc": "2026-05-01T00:00:00Z",
+        "redacted": True,
+        "network_fetch_during_test": False,
+        "contains_credentials": False,
+        "contains_orders": False,
+        "contains_fills": False,
+    }
+    if extra:
+        p.update(extra)
+    return p
+
+
+def _cap_payload(sequence: str) -> dict[str, object]:
+    return {
+        "bid": "100.10",
+        "ask": "100.15",
+        "last": "100.12",
+        "spread_bps": "4.99",
+        "sequence": sequence,
+        "volume": "12.5",
+        "state": "captured_realistic_static_like",
+    }
+
+
+def _snap(symbol: str, ts: str, sequence: str) -> dict[str, object]:
+    return {"symbol": symbol, "observed_at_utc": ts, "payload": _cap_payload(sequence)}
+
+
+def captured_envelope(
+    snaps: list[dict[str, object]], *, source: str = "operator_supplied_static"
+) -> dict:
+    return {
+        "schema": _captured_schema,
+        "source": source,
+        "provenance": _prov_ok(),
+        "snapshots": snaps,
+    }
+
+
+@pytest.fixture
+def valid_captured_input() -> dict:
+    snaps = [
+        _snap("DEMO-X", "2026-01-01T00:00:00Z", "1"),
+        _snap("DEMO-X", "2026-01-01T00:01:00Z", "2"),
+        _snap("DEMO-X", "2026-01-01T00:02:00Z", "3"),
+    ]
+    return captured_envelope(snaps)
+
+
 def test_happy_path_writes_evidence_and_closeout(tmp_path: Path, valid_input: dict) -> None:
     inp = tmp_path / "captured_snapshots.json"
     out = tmp_path / "evidence"
@@ -234,3 +289,184 @@ def test_happy_path_writes_evidence_and_closeout(tmp_path: Path, valid_input: di
     assert "LIVE_ALLOWED=false" in body
     assert "DECISION=not_approved" in r.stdout
     assert str(out.resolve()).startswith(str(tmp_path.resolve()))
+
+
+def test_captured_realistic_happy_path_writes_evidence(
+    tmp_path: Path, valid_captured_input: dict
+) -> None:
+    inp = tmp_path / "cap.json"
+    out = tmp_path / "ev"
+    inp.write_text(
+        json.dumps(valid_captured_input, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    run_id = "captured_operator_run_v0"
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(out),
+            "--run-id",
+            run_id,
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ],
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    run_dir = out / run_id
+    assert (run_dir / "local_run_result.json").is_file()
+
+
+def test_captured_requires_provenance(tmp_path: Path, valid_captured_input: dict) -> None:
+    del valid_captured_input["provenance"]
+    inp = tmp_path / "x.json"
+    inp.write_text(json.dumps(valid_captured_input), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "provenance" in r.stderr.lower()
+
+
+def test_captured_rejects_network_fetch_during_test(
+    tmp_path: Path, valid_captured_input: dict
+) -> None:
+    valid_captured_input["provenance"] = _prov_ok({"network_fetch_during_test": True})
+    inp = tmp_path / "x.json"
+    inp.write_text(json.dumps(valid_captured_input), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "network_fetch_during_test" in r.stderr
+
+
+@pytest.mark.parametrize("field", ["contains_credentials", "contains_orders", "contains_fills"])
+def test_captured_rejects_truthy_sensitive_flags(
+    tmp_path: Path, valid_captured_input: dict, field: str
+) -> None:
+    prov = _prov_ok()
+    prov[field] = True
+    valid_captured_input["provenance"] = prov
+    inp = tmp_path / "x.json"
+    inp.write_text(json.dumps(valid_captured_input), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert field in r.stderr
+
+
+def test_captured_rejects_too_few_snapshots(tmp_path: Path) -> None:
+    snaps = [_snap("A", "2026-01-01T00:00:00Z", "1"), _snap("A", "2026-01-01T00:01:00Z", "2")]
+    env = captured_envelope(snaps)
+    inp = tmp_path / "x.json"
+    inp.write_text(json.dumps(env), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "3 and 20" in r.stderr
+
+
+def test_captured_rejects_too_many_snapshots(tmp_path: Path) -> None:
+    snaps = [_snap("A", f"2026-05-02T{k:02d}:00:01Z", str(k)) for k in range(21)]
+    env = captured_envelope(snaps)
+    inp = tmp_path / "x.json"
+    inp.write_text(json.dumps(env), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "3 and 20" in r.stderr
+
+
+def test_captured_rejects_forbidden_payload_key(tmp_path: Path, valid_captured_input: dict) -> None:
+    snaps = valid_captured_input["snapshots"]
+    assert isinstance(snaps, list) and snaps
+    pl = snaps[0]["payload"]
+    assert isinstance(pl, dict)
+    pl["my_api_key"] = "bad"
+    inp = tmp_path / "x.json"
+    inp.write_text(json.dumps(valid_captured_input), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "forbidden payload key" in r.stderr.lower()
+
+
+def test_captured_rejects_forbidden_source_class(
+    tmp_path: Path, valid_captured_input: dict
+) -> None:
+    valid_captured_input["source"] = "live_exchange_api"
+    inp = tmp_path / "x.json"
+    inp.write_text(json.dumps(valid_captured_input), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-file",
+            str(inp),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0


### PR DESCRIPTION
## Summary

Adds captured-realistic static input validation to the bounded Shadow Observation file-snapshot operator entrypoint.

Changed files:

- `scripts/ops/run_shadow_observation_file_snapshot_v0.py`
- `tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py`

## What this adds

The operator entrypoint now supports:

- existing `bounded_file_snapshot_observation_input_v0`
- new `captured_realistic_snapshot_observation_input_v0`

Captured-realistic validation includes:

- allowed source classes:
  - `operator_supplied_static`
  - `redacted_public_snapshot_static`
  - `synthetic_realistic_static`
  - `prior_allowed_tmp_artifact_static`
- required provenance object
- required safe provenance flags:
  - `redacted=true`
  - `network_fetch_during_test=false`
  - `contains_credentials=false`
  - `contains_orders=false`
  - `contains_fills=false`
- snapshot count policy: 3–20
- required snapshot fields
- required payload keys:
  - `bid`
  - `ask`
  - `last`
  - `spread_bps`
  - `sequence`
- forbidden private/order/credential payload key substrings

## Safety / boundaries

- No scheduler
- No runtime
- No daemon
- No broker/exchange/API credential usage
- No network fetch path
- No order submission
- No paper/test data read or mutation path
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes
- No Notion write
- No committed generated evidence artifacts

This remains a bounded local operator input-validation path, not Shadow Mode, not Testnet, and not Live.

## Validation

- `uv run pytest tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py -q` — 18 passed
- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 65 passed
- `uv run ruff check scripts/ops/run_shadow_observation_file_snapshot_v0.py tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check scripts/ops/run_shadow_observation_file_snapshot_v0.py tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- PY39 compatibility scan — ok
- Forbidden runtime token scan — ok

## Machine-readable

VERDICT=CAPTURED_REALISTIC_OPS_VALIDATION_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
CAPTURED_REALISTIC_INPUT_POLICY_DESIGNED=true
CAPTURED_REALISTIC_INPUT_VALIDATION_IMPLEMENTED=true
SECOND_OPERATOR_RUN_EXECUTED=false
SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_IMPLEMENTED=true
SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_APPROVED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
NOTION_WRITE_PERFORMED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)