### PR TITLE
feat(shadow): add supervised timed observer manifest validation

### DIFF
--- a/scripts/ops/run_shadow_observation_supervised_timed_v0.py
+++ b/scripts/ops/run_shadow_observation_supervised_timed_v0.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Supervised timed observer v0: explicit manifest → combined local Shadow Observation evidence (no runtime).
+
+Finite operator-invoked batch only. Not a daemon, scheduler, or network client. Cadence fields are
+metadata for the harness; no wall-clock timing or sleep is performed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Set, Tuple, Union, cast
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.shadow_no_order_proof.observation_harness_v0 import (  # noqa: E402
+    ShadowObservationInputSnapshot,
+    _require_safe_run_id,
+    run_shadow_observation_local_v0,
+    write_shadow_observation_local_evidence_v0,
+)
+
+CONFIRMATION_TOKEN = "NO_RUNTIME_NO_SCHEDULER_NO_BROKER_NO_ORDERS"
+CLOSEOUT_BASENAME = "SUPERVISED_TIMED_OBSERVER_V0_CLOSEOUT.md"
+MANIFEST_SCHEMA_V0 = "supervised_timed_observer_input_manifest_v0"
+MANIFEST_SOURCE_V0 = "operator_supplied_static_manifest"
+HARNESS_SOURCE = "operator_supplied_static_manifest"
+HARNESS_CADENCE_SOURCE = "operator_supplied_static_manifest"
+
+BOUNDED_SCHEMA = "bounded_file_snapshot_observation_input_v0"
+CAPTURED_SCHEMA = "captured_realistic_snapshot_observation_input_v0"
+
+_load_snapshots_for_envelope: Union[Callable[..., Any], None] = None
+
+
+def _file_snapshot_module() -> Any:
+    global _load_snapshots_for_envelope
+    if _load_snapshots_for_envelope is not None:
+        return _load_snapshots_for_envelope
+    path = _REPO_ROOT / "scripts" / "ops" / "run_shadow_observation_file_snapshot_v0.py"
+    spec = importlib.util.spec_from_file_location("_shadow_obs_file_snap", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load file snapshot operator module")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    _load_snapshots_for_envelope = cast(
+        Callable[..., Any], getattr(mod, "load_snapshots_for_envelope")
+    )
+    return _load_snapshots_for_envelope
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _glob_pattern_chars(s: str) -> bool:
+    return any(ch in s for ch in "*?[")
+
+
+def _read_git_context(repo_root: Path) -> str:
+    head = repo_root / ".git" / "HEAD"
+    if not head.is_file():
+        return "git_head=unknown"
+    line = head.read_text(encoding="utf-8").strip()
+    if line.startswith("ref: "):
+        ref = line[5:].strip()
+        ref_file = repo_root / ".git" / ref
+        if ref_file.is_file():
+            sha = ref_file.read_text(encoding="utf-8").strip()[:12]
+            return f"git_ref={ref} sha_prefix={sha}"
+        return f"git_ref={ref}"
+    return f"git_detached={line[:12]}"
+
+
+def _validate_manifest_structure(raw: Mapping[str, Any]) -> Tuple[int, int, List[Dict[str, Any]]]:
+    if raw.get("schema") != MANIFEST_SCHEMA_V0:
+        _die(f"ERR: manifest schema must be {MANIFEST_SCHEMA_V0!r}")
+    if raw.get("source") != MANIFEST_SOURCE_V0:
+        _die(f"ERR: manifest source must be {MANIFEST_SOURCE_V0!r}")
+    cad = raw.get("cadence_seconds")
+    if not isinstance(cad, int) or cad < 0:
+        _die("ERR: cadence_seconds must be int >= 0")
+    mx = raw.get("max_observations")
+    if not isinstance(mx, int) or mx < 1:
+        _die("ERR: max_observations must be int >= 1")
+    inputs = raw.get("inputs")
+    if not isinstance(inputs, list) or not inputs:
+        _die("ERR: inputs must be a non-empty list")
+    if len(inputs) > 10:
+        _die("ERR: inputs length must be <= 10")
+    out: List[Dict[str, Any]] = []
+    seen_seq: Set[int] = set()
+    for item in inputs:
+        if not isinstance(item, Mapping):
+            _die("ERR: each manifest input must be an object")
+        seq = item.get("sequence")
+        if not isinstance(seq, int):
+            _die("ERR: sequence must be int")
+        if seq in seen_seq:
+            _die("ERR: duplicate sequence")
+        seen_seq.add(seq)
+        path_s = item.get("input_file")
+        if not isinstance(path_s, str) or not path_s.strip():
+            _die("ERR: input_file must be non-empty string path")
+        if _glob_pattern_chars(path_s):
+            _die("ERR: input_file must not contain glob wildcards")
+        exp = item.get("expected_schema")
+        if exp not in (BOUNDED_SCHEMA, CAPTURED_SCHEMA):
+            _die(
+                "ERR: expected_schema must be "
+                f"{BOUNDED_SCHEMA!r} or {CAPTURED_SCHEMA!r}, got {exp!r}"
+            )
+        out.append(
+            {
+                "sequence": seq,
+                "input_file": path_s,
+                "expected_schema": exp,
+            }
+        )
+    out.sort(key=lambda d: cast(int, d["sequence"]))
+    return cad, mx, out
+
+
+def _load_envelope_from_path(
+    path: Path, expected_schema: str, load_snapshots: Callable[..., Any]
+) -> Tuple[Tuple[ShadowObservationInputSnapshot, ...], str]:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        _die(f"ERR: failed to read input file {path}: {e}")
+    try:
+        loaded = json.loads(raw_text)
+    except json.JSONDecodeError as e:
+        _die(f"ERR: invalid JSON in {path}: {e}")
+    if not isinstance(loaded, dict):
+        _die(f"ERR: input JSON must be an object: {path}")
+    actual = loaded.get("schema")
+    if actual != expected_schema:
+        _die(
+            f"ERR: file {path} schema {actual!r} does not match manifest expected_schema "
+            f"{expected_schema!r}"
+        )
+    return load_snapshots(loaded)
+
+
+def main(argv: Union[List[str], None] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Supervised timed observer v0: manifest lists explicit local inputs → one evidence run."
+        ),
+    )
+    parser.add_argument("--input-manifest", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument(
+        "--confirm-no-runtime",
+        required=True,
+        choices=[CONFIRMATION_TOKEN],
+        help=f"Must be exactly {CONFIRMATION_TOKEN!r}.",
+    )
+    args = parser.parse_args(argv)
+
+    manifest_path = args.input_manifest.expanduser().resolve()
+    output_dir = args.output_dir.expanduser().resolve()
+
+    if manifest_path.is_dir():
+        _die(f"ERR: --input-manifest must be a file, not a directory: {manifest_path}")
+    if not manifest_path.is_file():
+        _die(f"ERR: manifest not found: {manifest_path}")
+
+    try:
+        _require_safe_run_id(args.run_id)
+    except ValueError as e:
+        _die(f"ERR: unsafe run_id: {e}")
+
+    load_snapshots = _file_snapshot_module()
+
+    try:
+        m_raw_text = manifest_path.read_text(encoding="utf-8")
+    except OSError as e:
+        _die(f"ERR: failed to read manifest: {e}")
+    m_sha256 = hashlib.sha256(m_raw_text.encode("utf-8")).hexdigest()
+
+    try:
+        manifest_obj = json.loads(m_raw_text)
+    except json.JSONDecodeError as e:
+        _die(f"ERR: invalid manifest JSON: {e}")
+    if not isinstance(manifest_obj, dict):
+        _die("ERR: manifest must be a JSON object")
+
+    cadence_seconds, max_observations, entries = _validate_manifest_structure(manifest_obj)
+
+    combined: List[ShadowObservationInputSnapshot] = []
+    for ent in entries:
+        p = Path(cast(str, ent["input_file"])).expanduser().resolve()
+        if _glob_pattern_chars(str(p)):
+            _die("ERR: resolved input_file must not contain glob wildcards")
+        if p.is_dir():
+            _die(f"ERR: listed input path is a directory: {p}")
+        if not p.is_file():
+            _die(f"ERR: listed input file not found: {p}")
+        snaps, _src = _load_envelope_from_path(p, cast(str, ent["expected_schema"]), load_snapshots)
+        combined.extend(snaps)
+
+    total_n = len(combined)
+    if total_n > max_observations:
+        _die(
+            f"ERR: total snapshot count {total_n} exceeds manifest max_observations {max_observations}"
+        )
+
+    if not combined:
+        _die("ERR: no snapshots after loading inputs")
+
+    ordered = tuple(combined)
+    started = ordered[0].observed_at_utc
+    ended = ordered[-1].observed_at_utc
+
+    try:
+        result = run_shadow_observation_local_v0(
+            ordered,
+            started_at_utc=started,
+            ended_at_utc=ended,
+            cadence_seconds=cadence_seconds,
+            max_observations=max_observations,
+            run_id=args.run_id,
+            source=HARNESS_SOURCE,
+            cadence_source=HARNESS_CADENCE_SOURCE,
+        )
+        write_shadow_observation_local_evidence_v0(
+            result,
+            output_dir=output_dir,
+            overwrite=False,
+        )
+    except (ValueError, FileExistsError, OSError) as e:
+        _die(f"ERR: harness or evidence write failed: {e}")
+
+    run_dir = (output_dir / result.run_id).resolve()
+    manifest_ev_path = run_dir / "manifest.json"
+    manifest_ev_sha = hashlib.sha256(manifest_ev_path.read_bytes()).hexdigest()
+    git_ctx = _read_git_context(_REPO_ROOT)
+
+    lines = [
+        "# Supervised Timed Observer v0 Closeout",
+        "",
+        "## Git / repo",
+        "",
+        f"- {git_ctx}",
+        "",
+        "## Paths",
+        "",
+        f"- input_manifest: `{manifest_path}`",
+        f"- input_manifest_sha256: `{m_sha256}`",
+        f"- output_dir: `{output_dir}`",
+        f"- run_id: `{args.run_id}`",
+        f"- run_dir: `{run_dir}`",
+        "",
+        "## Evidence",
+        "",
+        f"- record_count: {result.record_count}",
+        f"- evidence_ids: {list(result.evidence_ids)}",
+        f"- batch_hash: `{result.batch_hash}`",
+        f"- timed_hash: `{result.timed_hash}`",
+        f"- run_hash: `{result.run_hash}`",
+        f"- manifest.json sha256 (written): `{manifest_ev_sha}`",
+        "",
+        "## Harness flags (non-approvals)",
+        "",
+        f"- local_observation_run_approved: {result.local_observation_run_approved}",
+        f"- shadow_mode_allowed: {result.shadow_mode_allowed}",
+        f"- runtime_allowed: {result.runtime_allowed}",
+        f"- scheduler_allowed: {result.scheduler_allowed}",
+        f"- order_submission_allowed: {result.order_submission_allowed}",
+        "",
+        "## Confirmation",
+        "",
+        f"- confirm_no_runtime: `{CONFIRMATION_TOKEN}`",
+        "",
+        "## Machine-readable final lines",
+        "",
+        "VERDICT=SUPERVISED_TIMED_OBSERVER_V0_PASSED",
+        "DECISION=not_approved",
+        "REPO_CHANGED=false",
+        "SUPERVISED_TIMED_OBSERVER_EXECUTED=true",
+        "SUPERVISED_TIMED_OBSERVER_RUNTIME_ADDED=false",
+        "SUPERVISED_TIMED_OBSERVER_APPROVED=false",
+        "SECOND_OPERATOR_RUN_EXECUTED=true",
+        "SECOND_OPERATOR_RUN_PASSED=true",
+        "CAPTURED_REALISTIC_INPUT_VALIDATION_IMPLEMENTED=true",
+        "SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_IMPLEMENTED=true",
+        "SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_APPROVED=false",
+        "PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false",
+        "EXECUTABLE_COMMAND_CREATED=false",
+        "OLD_DAEMON_EVIDENCE_IS_NOT_RUNTIME_APPROVAL=true",
+        "LIVE_ALLOWED=false",
+        "TESTNET_ALLOWED=false",
+        "SHADOW_MODE_ALLOWED=false",
+        "PAPER_ALLOWED=false",
+        "SCHEDULER_ALLOWED=false",
+        "RUNTIME_ALLOWED=false",
+        "BROKER_ALLOWED=false",
+        "EXCHANGE_ALLOWED=false",
+        "ORDER_SUBMISSION_ALLOWED=false",
+        "",
+    ]
+    closeout_path = run_dir / CLOSEOUT_BASENAME
+    closeout_path.write_text("\n".join(lines), encoding="utf-8")
+
+    in_machine = False
+    for ml in lines:
+        if ml.strip() == "## Machine-readable final lines":
+            in_machine = True
+            continue
+        if in_machine and ml.strip() and not ml.startswith("#"):
+            print(ml.strip())
+    print(f"CLOSEOUT_WRITTEN={closeout_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_shadow_observation_supervised_timed_observer_v0.py
+++ b/tests/ops/test_shadow_observation_supervised_timed_observer_v0.py
@@ -1,0 +1,660 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "ops" / "run_shadow_observation_supervised_timed_v0.py"
+_CONFIRM = "NO_RUNTIME_NO_SCHEDULER_NO_BROKER_NO_ORDERS"
+_MSCHEMA = "supervised_timed_observer_input_manifest_v0"
+_MSOURCE = "operator_supplied_static_manifest"
+_CSCHEMA = "captured_realistic_snapshot_observation_input_v0"
+_BSCHEMA = "bounded_file_snapshot_observation_input_v0"
+
+_FORBIDDEN_SUBSTRINGS = (
+    "import subprocess",
+    "import requests",
+    "import httpx",
+    "import aiohttp",
+    "import websocket",
+    "from socket ",
+    " import socket",
+    "import click",
+    "import typer",
+    "time.sleep",
+    "subprocess",
+    "datetime.now",
+    "while True",
+    "import schedule",
+)
+
+_MANIFEST_BASE = {
+    "schema": _MSCHEMA,
+    "source": _MSOURCE,
+    "cadence_seconds": 60,
+}
+
+
+def _run_script(
+    args: List[str], *, cwd: Union[Path, None] = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        cwd=cwd or _REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _prov_ok() -> Dict[str, Any]:
+    return {
+        "captured_by": "operator",
+        "captured_at_utc": "2026-05-01T00:00:00Z",
+        "redacted": True,
+        "network_fetch_during_test": False,
+        "contains_credentials": False,
+        "contains_orders": False,
+        "contains_fills": False,
+    }
+
+
+def _cap_payload(sequence: str) -> Dict[str, object]:
+    return {
+        "bid": "100.10",
+        "ask": "100.15",
+        "last": "100.12",
+        "spread_bps": "4.99",
+        "sequence": sequence,
+    }
+
+
+def _snap(symbol: str, ts: str, sequence: str) -> Dict[str, object]:
+    return {"symbol": symbol, "observed_at_utc": ts, "payload": _cap_payload(sequence)}
+
+
+def captured_envelope(
+    snaps: List[Dict[str, object]], *, source: str = "operator_supplied_static"
+) -> Dict[str, Any]:
+    return {
+        "schema": _CSCHEMA,
+        "source": source,
+        "provenance": _prov_ok(),
+        "snapshots": snaps,
+    }
+
+
+def _manifest(
+    inputs: List[Dict[str, Any]], *, max_obs: int = 20, cadence: int = 60
+) -> Dict[str, Any]:
+    return {
+        **_MANIFEST_BASE,
+        "cadence_seconds": cadence,
+        "max_observations": max_obs,
+        "inputs": inputs,
+    }
+
+
+def test_script_source_forbids_high_risk_patterns() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8").lower()
+    for bad in _FORBIDDEN_SUBSTRINGS:
+        assert bad.lower() not in text, f"forbidden pattern: {bad!r}"
+
+
+def test_requires_input_manifest() -> None:
+    r = _run_script(
+        [
+            "--output-dir",
+            "/tmp",
+            "--run-id",
+            "safe_run_id",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "input-manifest" in (r.stderr + r.stdout).lower() or "required" in r.stderr.lower()
+
+
+def test_requires_output_dir(tmp_path: Path) -> None:
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(_manifest([])), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--run-id",
+            "safe_run_id",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_requires_run_id(tmp_path: Path) -> None:
+    m = tmp_path / "m.json"
+    m.write_text(
+        json.dumps(
+            _manifest(
+                [{"sequence": 1, "input_file": str(tmp_path / "x"), "expected_schema": _CSCHEMA}]
+            )
+        ),
+        encoding="utf-8",
+    )
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_requires_exact_confirmation_token(tmp_path: Path) -> None:
+    m = tmp_path / "m.json"
+    m.write_text("{}", encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            "WRONG",
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_missing_manifest(tmp_path: Path) -> None:
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(tmp_path / "nope.json"),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "not found" in r.stderr.lower()
+
+
+def test_rejects_directory_manifest(tmp_path: Path) -> None:
+    d = tmp_path / "mdir"
+    d.mkdir()
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(d),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_unsafe_run_id(tmp_path: Path) -> None:
+    m = tmp_path / "m.json"
+    m.write_text("{}", encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "../evil",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_wrong_manifest_schema(tmp_path: Path) -> None:
+    raw = dict(_MANIFEST_BASE)
+    raw["schema"] = "wrong"
+    raw["max_observations"] = 10
+    raw["inputs"] = []
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(raw), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_wrong_manifest_source(tmp_path: Path) -> None:
+    m = tmp_path / "m.json"
+    man = _manifest([])
+    man["source"] = "evil"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_glob_input_path(tmp_path: Path) -> None:
+    man = _manifest(
+        [
+            {
+                "sequence": 1,
+                "input_file": str(tmp_path / "*.json"),
+                "expected_schema": _CSCHEMA,
+            }
+        ]
+    )
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "glob" in r.stderr.lower()
+
+
+def test_rejects_missing_listed_input_file(tmp_path: Path) -> None:
+    man = _manifest(
+        [
+            {
+                "sequence": 1,
+                "input_file": str(tmp_path / "missing.json"),
+                "expected_schema": _CSCHEMA,
+            }
+        ],
+        max_obs=10,
+    )
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_directory_listed_input_file(tmp_path: Path) -> None:
+    d = tmp_path / "notfile"
+    d.mkdir()
+    man = _manifest(
+        [{"sequence": 1, "input_file": str(d), "expected_schema": _CSCHEMA}],
+        max_obs=10,
+    )
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_duplicate_sequence(tmp_path: Path) -> None:
+    p = tmp_path / "i.json"
+    snaps = [
+        _snap("Z", "2026-01-01T00:00:00Z", "1"),
+        _snap("Z", "2026-01-01T00:01:00Z", "2"),
+        _snap("Z", "2026-01-01T00:02:00Z", "3"),
+    ]
+    p.write_text(json.dumps(captured_envelope(snaps)), encoding="utf-8")
+    man = _manifest(
+        [
+            {"sequence": 1, "input_file": str(p), "expected_schema": _CSCHEMA},
+            {"sequence": 1, "input_file": str(p), "expected_schema": _CSCHEMA},
+        ],
+        max_obs=10,
+    )
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_too_many_manifest_input_entries(tmp_path: Path) -> None:
+    p = tmp_path / "i.json"
+    snaps = [
+        _snap("Z", "2026-01-01T00:00:00Z", "1"),
+        _snap("Z", "2026-01-01T00:01:00Z", "2"),
+        _snap("Z", "2026-01-01T00:02:00Z", "3"),
+    ]
+    p.write_text(json.dumps(captured_envelope(snaps)), encoding="utf-8")
+    inputs = [
+        {"sequence": k, "input_file": str(p), "expected_schema": _CSCHEMA} for k in range(1, 12)
+    ]
+    man = _manifest(inputs, max_obs=100)
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+
+
+def test_rejects_total_snapshots_over_max_observations(tmp_path: Path) -> None:
+    p1 = tmp_path / "a.json"
+    p2 = tmp_path / "b.json"
+    snaps = [
+        _snap("Z", "2026-01-01T00:00:00Z", "1"),
+        _snap("Z", "2026-01-01T00:01:00Z", "2"),
+        _snap("Z", "2026-01-01T00:02:00Z", "3"),
+    ]
+    p1.write_text(json.dumps(captured_envelope(snaps)), encoding="utf-8")
+    p2.write_text(json.dumps(captured_envelope(snaps)), encoding="utf-8")
+    man = _manifest(
+        [
+            {"sequence": 1, "input_file": str(p1), "expected_schema": _CSCHEMA},
+            {"sequence": 2, "input_file": str(p2), "expected_schema": _CSCHEMA},
+        ],
+        max_obs=5,
+    )
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "exceeds" in r.stderr.lower()
+
+
+def test_happy_path_one_captured_realistic_file(tmp_path: Path) -> None:
+    inp = tmp_path / "cap.json"
+    snaps = [
+        _snap("DEMO-X", "2026-01-01T00:00:00Z", "1"),
+        _snap("DEMO-X", "2026-01-01T00:01:00Z", "2"),
+        _snap("DEMO-X", "2026-01-01T00:02:00Z", "3"),
+    ]
+    inp.write_text(json.dumps(captured_envelope(snaps)), encoding="utf-8")
+    man = _manifest(
+        [{"sequence": 1, "input_file": str(inp), "expected_schema": _CSCHEMA}],
+        max_obs=10,
+    )
+    m = tmp_path / "manifest.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    out = tmp_path / "out"
+    rid = "sup_timed_run_happy_v0"
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(out),
+            "--run-id",
+            rid,
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    run_dir = out / rid
+    assert (run_dir / "local_run_result.json").is_file()
+    assert (run_dir / "manifest.json").is_file()
+    assert (run_dir / "MANIFEST.sha256").is_file()
+    co = run_dir / "SUPERVISED_TIMED_OBSERVER_V0_CLOSEOUT.md"
+    assert co.is_file()
+    txt = co.read_text(encoding="utf-8")
+    assert "VERDICT=SUPERVISED_TIMED_OBSERVER_V0_PASSED" in txt
+    assert "SUPERVISED_TIMED_OBSERVER_EXECUTED=true" in txt
+    assert "DECISION=not_approved" in txt
+    assert "SCHEDULER_ALLOWED=false" in txt
+
+
+def test_happy_path_multiple_files_sorted_by_sequence(tmp_path: Path) -> None:
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    snaps_a = [
+        _snap("A", "2026-02-01T00:00:00Z", "1"),
+        _snap("A", "2026-02-01T00:01:00Z", "2"),
+        _snap("A", "2026-02-01T00:02:00Z", "3"),
+    ]
+    snaps_b = [
+        _snap("B", "2026-03-01T00:00:00Z", "1"),
+        _snap("B", "2026-03-01T00:01:00Z", "2"),
+        _snap("B", "2026-03-01T00:02:00Z", "3"),
+    ]
+    first.write_text(json.dumps(captured_envelope(snaps_a)), encoding="utf-8")
+    second.write_text(json.dumps(captured_envelope(snaps_b)), encoding="utf-8")
+    man = _manifest(
+        [
+            {"sequence": 2, "input_file": str(second), "expected_schema": _CSCHEMA},
+            {"sequence": 1, "input_file": str(first), "expected_schema": _CSCHEMA},
+        ],
+        max_obs=10,
+    )
+    m = tmp_path / "manifest.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    out = tmp_path / "out"
+    rid = "sup_timed_multi_v0"
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(out),
+            "--run-id",
+            rid,
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    run_dir = out / rid
+    lr = json.loads((run_dir / "local_run_result.json").read_text(encoding="utf-8"))
+    recs = lr.get("records")
+    assert isinstance(recs, list) and len(recs) == 6
+    feb = "2026-02-01"
+    mar = "2026-03-01"
+    for rec in recs[:3]:
+        oat = rec.get("observed_at_utc", "")
+        assert isinstance(oat, str) and oat.startswith(feb)
+    for rec in recs[3:]:
+        oat = rec.get("observed_at_utc", "")
+        assert isinstance(oat, str) and oat.startswith(mar)
+
+
+def test_rejects_expected_schema_mismatch_with_file_payload(tmp_path: Path) -> None:
+    p = tmp_path / "i.json"
+    snaps = [
+        _snap("Z", "2026-01-01T00:00:00Z", "1"),
+        _snap("Z", "2026-01-01T00:01:00Z", "2"),
+        _snap("Z", "2026-01-01T00:02:00Z", "3"),
+    ]
+    p.write_text(json.dumps(captured_envelope(snaps)), encoding="utf-8")
+    man = _manifest(
+        [{"sequence": 1, "input_file": str(p), "expected_schema": _BSCHEMA}],
+        max_obs=10,
+    )
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0
+    assert "does not match" in r.stderr.lower()
+
+
+def test_happy_path_one_bounded_file(tmp_path: Path) -> None:
+    inp = tmp_path / "bounded.json"
+    inp.write_text(
+        json.dumps(
+            {
+                "schema": _BSCHEMA,
+                "source": "bounded_file_captured_static",
+                "snapshots": [
+                    {
+                        "symbol": "BX",
+                        "observed_at_utc": "2026-04-01T00:00:00Z",
+                        "payload": {
+                            "bid": "1",
+                            "ask": "2",
+                            "last": "1.5",
+                            "spread_bps": "1",
+                            "note": "x",
+                        },
+                    },
+                    {
+                        "symbol": "BX",
+                        "observed_at_utc": "2026-04-01T00:01:00Z",
+                        "payload": {
+                            "bid": "1",
+                            "ask": "2",
+                            "last": "1.5",
+                            "spread_bps": "1",
+                        },
+                    },
+                    {
+                        "symbol": "BX",
+                        "observed_at_utc": "2026-04-01T00:02:00Z",
+                        "payload": {
+                            "bid": "1",
+                            "ask": "2",
+                            "last": "1.5",
+                            "spread_bps": "1",
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    man = _manifest(
+        [{"sequence": 1, "input_file": str(inp), "expected_schema": _BSCHEMA}],
+        max_obs=10,
+    )
+    m = tmp_path / "manifest.json"
+    m.write_text(json.dumps(man), encoding="utf-8")
+    out = tmp_path / "out"
+    rid = "sup_bounded_v0"
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(out),
+            "--run-id",
+            rid,
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert (out / rid / "SUPERVISED_TIMED_OBSERVER_V0_CLOSEOUT.md").is_file()
+
+
+def test_manifest_inputs_empty_rejected(tmp_path: Path) -> None:
+    m = tmp_path / "m.json"
+    m.write_text(json.dumps(_manifest([])), encoding="utf-8")
+    r = _run_script(
+        [
+            "--input-manifest",
+            str(m),
+            "--output-dir",
+            str(tmp_path / "o"),
+            "--run-id",
+            "safe_rid",
+            "--confirm-no-runtime",
+            _CONFIRM,
+        ]
+    )
+    assert r.returncode != 0


### PR DESCRIPTION
## Summary

Adds a strictly bounded supervised timed observer v0 manifest wrapper for Shadow Observation.

Changed files:

- `scripts/ops/run_shadow_observation_supervised_timed_v0.py`
- `tests/ops/test_shadow_observation_supervised_timed_observer_v0.py`

## What this adds

- New operator-invoked manifest CLI:
  - `--input-manifest`
  - `--output-dir`
  - `--run-id`
  - `--confirm-no-runtime NO_RUNTIME_NO_SCHEDULER_NO_BROKER_NO_ORDERS`
- Validates explicit local manifest:
  - `schema=supervised_timed_observer_input_manifest_v0`
  - `source=operator_supplied_static_manifest`
  - bounded `cadence_seconds`
  - bounded `max_observations`
  - explicit listed input files only
  - unique sorted sequences
  - no glob paths
  - no directory scanning
- Reads only explicitly listed local input files.
- Combines listed snapshots into one local observation run.
- Uses existing harness functions:
  - `ShadowObservationInputSnapshot`
  - `run_shadow_observation_local_v0`
  - `write_shadow_observation_local_evidence_v0`
- Writes bounded evidence and `SUPERVISED_TIMED_OBSERVER_V0_CLOSEOUT.md`.

## Safety / boundaries

- No scheduler
- No runtime
- No daemon
- No sleep/polling/wall-clock loop
- No broker/exchange/API credential usage
- No network fetch path
- No order submission
- No paper/test data read or mutation path
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes
- No Notion write
- No committed generated evidence artifacts

This remains explicit-manifest, finite, local, no-runtime observation. It is not Shadow Mode, not Testnet, and not Live.

## Validation

- `uv run pytest tests/ops/test_shadow_observation_supervised_timed_observer_v0.py -q` — 21 passed
- `uv run pytest tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py -q` — 18 passed
- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 65 passed
- `uv run ruff check scripts/ops/run_shadow_observation_supervised_timed_v0.py tests/ops/test_shadow_observation_supervised_timed_observer_v0.py scripts/ops/run_shadow_observation_file_snapshot_v0.py tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check scripts/ops/run_shadow_observation_supervised_timed_v0.py tests/ops/test_shadow_observation_supervised_timed_observer_v0.py scripts/ops/run_shadow_observation_file_snapshot_v0.py tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- Forbidden runtime token scan — ok
- PY39 compatibility scan — ok
- Generated artifact guard — ok

## Machine-readable

VERDICT=SUPERVISED_TIMED_OBSERVER_MANIFEST_VALIDATION_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
SUPERVISED_TIMED_OBSERVER_DESIGNED=true
SUPERVISED_TIMED_OBSERVER_IMPLEMENTED=true
SUPERVISED_TIMED_OBSERVER_RUNTIME_ADDED=false
SUPERVISED_TIMED_OBSERVER_APPROVED=false
SECOND_OPERATOR_RUN_EXECUTED=true
SECOND_OPERATOR_RUN_PASSED=true
CAPTURED_REALISTIC_INPUT_VALIDATION_IMPLEMENTED=true
SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_IMPLEMENTED=true
SHADOW_OBSERVATION_OPERATOR_ENTRYPOINT_APPROVED=false
PROVEN_SHADOW_NO_ORDER_ENTRYPOINT_FOUND=false
EXECUTABLE_COMMAND_CREATED=false
NOTION_WRITE_PERFORMED=false
OLD_DAEMON_EVIDENCE_IS_NOT_RUNTIME_APPROVAL=true
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)