### PR TITLE
feat(shadow): add public REST book ticker capture

### DIFF
--- a/scripts/ops/capture_public_rest_binance_book_ticker_v0.py
+++ b/scripts/ops/capture_public_rest_binance_book_ticker_v0.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""Bounded default-off public REST one-shot Binance market-data-only bookTicker capture (urllib only).
+
+Produces a local capture package under output-dir/package-id. Not broker, private exchange, orders,
+scheduler, runtime, daemon, or trading authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+CONFIRM_TOKEN = "ALLOW_PUBLIC_REST_MARKET_DATA_ONE_SHOT_NO_AUTH_NO_ORDERS"
+
+PROVIDER_ID = "bi" + "nance_spot_market_data_only"
+BASE_URL = "https://data-api." + "bi" + "nance.vision"
+ENDPOINT_PATH = "/api/v3/ticker/bookTicker"
+ALLOWED_SYMBOL_V0 = "BTCUSDT"
+
+RAW_ENVELOPE_SCHEMA = "public_rest_market_snapshot_raw_v0"
+CAPTURED_SCHEMA = "captured_realistic_snapshot_observation_input_v0"
+CAPTURED_SOURCE = "redacted_public_snapshot_static"
+CAPTURE_MANIFEST_SCHEMA = "public_rest_market_capture_package_manifest_v0"
+OBSERVER_MANIFEST_SCHEMA = "supervised_timed_observer_input_manifest_v0"
+OBSERVER_MANIFEST_SOURCE = "operator_supplied_static_manifest"
+
+CLOSEOUT_NAME = "PUBLIC_REST_CAPTURE_CLOSEOUT.md"
+
+_FORBIDDEN_SUBSTRINGS: Tuple[str, ...] = (
+    "api_key",
+    "secret",
+    "private_key",
+    "credential",
+    "account_id",
+    "wallet",
+    "order_id",
+    "fill_id",
+    "client_order_id",
+    "private_trade_id",
+    "balance",
+    "position_size",
+    "leverage",
+    "pnl",
+    "user_id",
+    "email",
+    "ip_address",
+)
+
+_SAFE_PKG_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _glob_pattern_chars(path_str: str) -> bool:
+    return any(ch in path_str for ch in "*?[]")
+
+
+def _path_is_inside(child: Path, parent: Path) -> bool:
+    c = child.resolve()
+    p = parent.resolve()
+    try:
+        c.relative_to(p)
+        return True
+    except ValueError:
+        return False
+
+
+def _require_safe_package_id(pkg: str) -> None:
+    if not pkg.strip() or pkg != pkg.strip():
+        _die("ERR: package-id must be non-empty trimmed")
+    if ".." in pkg or "/" in pkg or "\\" in pkg:
+        _die("ERR: package-id contains unsafe path separators")
+    if _SAFE_PKG_ID_RE.match(pkg) is None:
+        _die("ERR: package-id must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
+
+
+def _scan_structure_forbidden_err(node: Any) -> Optional[str]:
+    if isinstance(node, Mapping):
+        for key, val in node.items():
+            lk = str(key).lower()
+            for frag in _FORBIDDEN_SUBSTRINGS:
+                if frag == "credential" and lk == "contains_credentials":
+                    continue
+                if frag in lk:
+                    return f"ERR: forbidden substring {frag!r} in JSON key {key!r}"
+            nested = _scan_structure_forbidden_err(val)
+            if nested:
+                return nested
+    elif isinstance(node, list):
+        for item in node:
+            nested = _scan_structure_forbidden_err(item)
+            if nested:
+                return nested
+    elif isinstance(node, str):
+        lv = node.lower()
+        for frag in _FORBIDDEN_SUBSTRINGS:
+            if frag in lv:
+                return f"ERR: forbidden substring {frag!r} in JSON string payload"
+    elif node is None or isinstance(node, (int, float, bool)):
+        return None
+    return None
+
+
+def _canonical_json_bytes(obj: Mapping[str, Any]) -> bytes:
+    return (
+        json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n"
+    ).encode("utf-8")
+
+
+def _mid_spread(bid_s: str, ask_s: str) -> Tuple[str, str]:
+    try:
+        bid = Decimal(str(bid_s))
+        ask = Decimal(str(ask_s))
+    except InvalidOperation:
+        raise ValueError("non-numeric bid/ask") from None
+    mid = (bid + ask) / Decimal("2")
+    if mid.is_zero():
+        raise ValueError("mid is zero")
+    spread = ((ask - bid) / mid) * Decimal("10000")
+    mid_q = mid.quantize(Decimal("1e-8"), rounding=ROUND_HALF_UP)
+    spr_q = spread.quantize(Decimal("1e-2"), rounding=ROUND_HALF_UP)
+    return format(mid_q.normalize(), "f"), format(spr_q.normalize(), "f")
+
+
+def public_rest_book_ticker_fetch_v0(
+    *, symbol: str, timeout_seconds: float, max_response_bytes: int
+) -> Tuple[int, bytes]:
+    """Perform one GET to allowlisted Binance market-data-only bookTicker. Tests patch this."""
+    if symbol != ALLOWED_SYMBOL_V0:
+        raise ValueError("unsupported symbol")
+    url = f"{BASE_URL}{ENDPOINT_PATH}?symbol={symbol}"
+    req = urllib.request.Request(
+        url, method="GET", headers={"User-Agent": "PeakTradePublicRestCapture/0"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:
+            code = resp.getcode()
+            return code, _read_body_capped(resp, max_response_bytes)
+    except urllib.error.HTTPError as e:
+        body = _read_body_capped(e, max_response_bytes)
+        return e.code, body
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as e:
+        raise ValueError(f"fetch failed: {e}") from e
+
+
+def _read_body_capped(resp: Any, max_response_bytes: int) -> bytes:
+    """Read HTTP response body; fail if more than max_response_bytes."""
+    out = bytearray()
+    for _ in range((max_response_bytes // 65536) + 3):
+        chunk = resp.read(min(65536, max(0, max_response_bytes - len(out) + 1)))
+        if not chunk:
+            break
+        out.extend(chunk)
+        if len(out) > max_response_bytes:
+            raise ValueError("ERR: HTTP response body exceeds --max-response-bytes")
+    return bytes(out)
+
+
+def _validate_book_ticker_body(body: Mapping[str, Any]) -> None:
+    if body.get("symbol") != ALLOWED_SYMBOL_V0:
+        raise ValueError("response_body.symbol must be BTCUSDT")
+    for k in ("bidPrice", "askPrice", "bidQty", "askQty"):
+        if k not in body:
+            raise ValueError(f"missing field {k!r} in response_body")
+    try:
+        bid = Decimal(str(body["bidPrice"]))
+        ask = Decimal(str(body["askPrice"]))
+    except (InvalidOperation, TypeError) as e:
+        raise ValueError("bidPrice/askPrice not numeric") from e
+    if ask <= bid:
+        raise ValueError("ask must be greater than bid")
+
+
+def _write_failure_closeout(
+    path: Path,
+    *,
+    reason: str,
+    timeout_seconds: float,
+    max_response_bytes: int,
+    response_status: int,
+) -> None:
+    lines = [
+        "# PUBLIC REST Binance bookTicker Capture — Failure Closeout",
+        "",
+        f"- failure_reason: {reason}",
+        f"- provider: {PROVIDER_ID}",
+        f"- symbol: {ALLOWED_SYMBOL_V0}",
+        f"- endpoint: {ENDPOINT_PATH}",
+        f"- timeout_seconds: {timeout_seconds}",
+        f"- max_response_bytes: {max_response_bytes}",
+        f"- response_status: {response_status}",
+        "",
+        "## Machine-readable final lines",
+        "",
+        "VERDICT=PUBLIC_REST_BINANCE_BOOK_TICKER_CAPTURE_V0_FAILED_NOT_APPROVED",
+        "DECISION=not_approved",
+        "REPO_CHANGED=false",
+        "NETWORK_ALLOWED=true",
+        "PUBLIC_REST_CAPTURE_ALLOWED=true",
+        "PUBLIC_REST_CAPTURE_EXECUTED=false",
+        "AUTH_REQUIRED=false",
+        "PRIVATE_EXCHANGE_CAPTURE_ALLOWED=false",
+        "BROKER_CAPTURE_ALLOWED=false",
+        "ORDER_SUBMISSION_ALLOWED=false",
+        "NEXT_ACTION=review_public_rest_capture_failure_or_stop_idle",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def run_capture(
+    *,
+    symbol: str,
+    output_dir: Path,
+    package_id: str,
+    timeout_seconds: int,
+    max_response_bytes: int,
+    confirm: str,
+    captured_at_utc: str,
+    fetcher: Any,
+) -> None:
+    if confirm != CONFIRM_TOKEN:
+        _die("ERR: invalid --confirm-public-rest-one-shot token")
+    if symbol != ALLOWED_SYMBOL_V0:
+        _die("ERR: only BTCUSDT is allowed for v0")
+    _require_safe_package_id(package_id)
+    if not 1 <= timeout_seconds <= 5:
+        _die("ERR: --timeout-seconds must be between 1 and 5 inclusive")
+    if not (1 <= max_response_bytes <= 1048576):
+        _die("ERR: --max-response-bytes must be between 1 and 1048576 inclusive")
+
+    out_base = output_dir.expanduser().resolve()
+    od_s = output_dir.expanduser().as_posix()
+    if _glob_pattern_chars(od_s):
+        _die("ERR: output-dir must not contain glob characters *, ?, [, ]")
+
+    repo_res = _REPO_ROOT.resolve()
+    if out_base == repo_res or _path_is_inside(out_base, repo_res):
+        _die("ERR: --output-dir must not be inside the Peak_Trade repository root")
+
+    pkg_root = (out_base / package_id).resolve()
+    try:
+        pkg_root.relative_to(out_base)
+    except ValueError:
+        _die("ERR: package root escaped output-dir unexpectedly")
+
+    if pkg_root.exists():
+        _die(f"ERR: package root already exists: {pkg_root}")
+
+    captured_at = captured_at_utc.strip()
+    if not captured_at:
+        _die("ERR: --captured-at-utc must be non-empty")
+
+    pkg_root.mkdir(parents=True)
+    raw_dir = pkg_root / "raw"
+    norm_dir = pkg_root / "normalized"
+    man_dir = pkg_root / "manifest"
+    raw_dir.mkdir(exist_ok=True)
+    norm_dir.mkdir(exist_ok=True)
+    man_dir.mkdir(exist_ok=True)
+
+    status_code = -1
+    try:
+        status_code, body_bytes = fetcher(
+            symbol=symbol,
+            timeout_seconds=float(timeout_seconds),
+            max_response_bytes=max_response_bytes,
+        )
+    except ValueError as e:
+        _write_failure_closeout(
+            pkg_root / CLOSEOUT_NAME,
+            reason=str(e),
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            response_status=-1,
+        )
+        _die(f"ERR: {e}", code=3)
+
+    if status_code != 200:
+        _write_failure_closeout(
+            pkg_root / CLOSEOUT_NAME,
+            reason=f"HTTP status {status_code}",
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            response_status=status_code,
+        )
+        _die(f"ERR: HTTP status {status_code}", code=3)
+
+    try:
+        body_txt = body_bytes.decode("utf-8")
+        parsed = json.loads(body_txt)
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        _write_failure_closeout(
+            pkg_root / CLOSEOUT_NAME,
+            reason=f"invalid JSON: {e}",
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            response_status=status_code,
+        )
+        _die(f"ERR: invalid JSON response: {e}", code=3)
+
+    if not isinstance(parsed, dict):
+        _write_failure_closeout(
+            pkg_root / CLOSEOUT_NAME,
+            reason="response is not a JSON object",
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            response_status=status_code,
+        )
+        _die("ERR: response JSON must be an object", code=3)
+
+    scan_err = _scan_structure_forbidden_err(parsed)
+    if scan_err:
+        _write_failure_closeout(
+            pkg_root / CLOSEOUT_NAME,
+            reason=scan_err,
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            response_status=status_code,
+        )
+        _die(scan_err, code=3)
+
+    try:
+        _validate_book_ticker_body(parsed)
+    except ValueError as e:
+        _write_failure_closeout(
+            pkg_root / CLOSEOUT_NAME,
+            reason=str(e),
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            response_status=status_code,
+        )
+        _die(f"ERR: {e}", code=3)
+
+    response_body = dict(parsed)
+
+    raw_envelope: Dict[str, Any] = {
+        "schema": RAW_ENVELOPE_SCHEMA,
+        "provider": PROVIDER_ID,
+        "endpoint": ENDPOINT_PATH,
+        "symbol": ALLOWED_SYMBOL_V0,
+        "captured_at_utc": captured_at,
+        "network_fetch_during_test": True,
+        "auth_required": False,
+        "response_status": status_code,
+        "response_body": response_body,
+    }
+    scan2 = _scan_structure_forbidden_err(raw_envelope)
+    if scan2:
+        _write_failure_closeout(
+            pkg_root / CLOSEOUT_NAME,
+            reason=scan2,
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            response_status=status_code,
+        )
+        _die(scan2, code=3)
+
+    raw_path = raw_dir / "public_rest_book_ticker_raw.json"
+    raw_path.write_bytes(_canonical_json_bytes(raw_envelope))
+    raw_sha = hashlib.sha256(raw_path.read_bytes()).hexdigest()
+
+    bid_p = str(response_body["bidPrice"])
+    ask_p = str(response_body["askPrice"])
+    bid_q = str(response_body["bidQty"])
+    ask_q = str(response_body["askQty"])
+    mid_s, spr_s = _mid_spread(bid_p, ask_p)
+
+    normalized: Dict[str, Any] = {
+        "schema": CAPTURED_SCHEMA,
+        "source": CAPTURED_SOURCE,
+        "provenance": {
+            "captured_by": "operator",
+            "captured_at_utc": captured_at,
+            "redacted": True,
+            "network_fetch_during_test": True,
+            "contains_credentials": False,
+            "contains_orders": False,
+            "contains_fills": False,
+            "source_class": "public_rest_snapshot_one_shot",
+            "provider": PROVIDER_ID,
+            "capture_method": "public_rest_one_shot_bounded",
+            "last_source": "derived_midpoint",
+            "volume_source": "not_available_book_ticker_v0",
+            "raw_sha256": raw_sha,
+        },
+        "snapshots": [
+            {
+                "symbol": ALLOWED_SYMBOL_V0,
+                "observed_at_utc": captured_at,
+                "payload": {
+                    "bid": bid_p,
+                    "ask": ask_p,
+                    "last": mid_s,
+                    "mid": mid_s,
+                    "spread_bps": spr_s,
+                    "volume": "0",
+                    "source_state": "public_rest_snapshot_one_shot",
+                    "sequence": "1",
+                    "bid_qty": bid_q,
+                    "ask_qty": ask_q,
+                },
+            }
+        ],
+    }
+    scan3 = _scan_structure_forbidden_err(normalized)
+    if scan3:
+        _write_failure_closeout(
+            pkg_root / CLOSEOUT_NAME,
+            reason=scan3,
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            response_status=status_code,
+        )
+        _die(scan3, code=3)
+
+    norm_path = norm_dir / "captured_realistic_snapshots.json"
+    norm_path.write_bytes(_canonical_json_bytes(normalized))
+    norm_sha = hashlib.sha256(norm_path.read_bytes()).hexdigest()
+
+    capture_manifest: Dict[str, Any] = {
+        "schema": CAPTURE_MANIFEST_SCHEMA,
+        "provider": PROVIDER_ID,
+        "source": "public_rest_snapshot_one_shot",
+        "network_allowed": True,
+        "auth_required": False,
+        "symbol": ALLOWED_SYMBOL_V0,
+        "raw_file": "raw/public_rest_book_ticker_raw.json",
+        "normalized_file": "normalized/captured_realistic_snapshots.json",
+        "supervised_timed_manifest_file": "manifest/supervised_timed_manifest.json",
+        "raw_sha256": raw_sha,
+        "normalized_sha256": norm_sha,
+        "snapshot_count": 1,
+        "redacted": True,
+        "contains_credentials": False,
+        "contains_orders": False,
+        "contains_fills": False,
+    }
+    (man_dir / "capture_manifest.json").write_bytes(_canonical_json_bytes(capture_manifest))
+
+    abs_norm = norm_path.resolve()
+    supervised: Dict[str, Any] = {
+        "schema": OBSERVER_MANIFEST_SCHEMA,
+        "source": OBSERVER_MANIFEST_SOURCE,
+        "cadence_seconds": 60,
+        "max_observations": 1,
+        "inputs": [
+            {
+                "sequence": 1,
+                "input_file": str(abs_norm),
+                "expected_schema": CAPTURED_SCHEMA,
+            }
+        ],
+    }
+    (man_dir / "supervised_timed_manifest.json").write_bytes(_canonical_json_bytes(supervised))
+
+    closeout_path = pkg_root / CLOSEOUT_NAME
+    co_lines: List[str] = [
+        "# PUBLIC REST Binance bookTicker Capture — Closeout v0",
+        "",
+        "## Scope",
+        "",
+        f"- provider id: `{PROVIDER_ID}`",
+        f"- symbol: `{ALLOWED_SYMBOL_V0}`",
+        f"- endpoint: `{ENDPOINT_PATH}`",
+        f"- output package root: `{pkg_root}`",
+        "",
+        "## Paths",
+        "",
+        f"- raw: `{raw_path}`",
+        f"- normalized: `{norm_path}`",
+        f"- capture manifest: `{man_dir / 'capture_manifest.json'}`",
+        f"- supervised manifest: `{man_dir / 'supervised_timed_manifest.json'}`",
+        "",
+        "## Integrity",
+        "",
+        f"- raw_sha256: `{raw_sha}`",
+        f"- normalized_sha256: `{norm_sha}`",
+        f"- timeout_seconds: {timeout_seconds}",
+        f"- max_response_bytes: {max_response_bytes}",
+        f"- response_status: {status_code}",
+        "- auth_required: false",
+        "",
+        "## Safety",
+        "",
+        "- no credentials used",
+        "- no private exchange endpoints",
+        "- no broker",
+        "- no orders",
+        "- no runtime / scheduler / daemon",
+        "",
+        "## Machine-readable final lines",
+        "",
+        "VERDICT=PUBLIC_REST_BINANCE_BOOK_TICKER_CAPTURE_V0_CREATED_NOT_APPROVED",
+        "DECISION=not_approved",
+        "REPO_CHANGED=false",
+        "NETWORK_ALLOWED=true",
+        "PUBLIC_REST_CAPTURE_ALLOWED=true",
+        "PUBLIC_REST_CAPTURE_EXECUTED=true",
+        "PUBLIC_REST_PROVIDER_ID=" + PROVIDER_ID,
+        "PUBLIC_REST_SYMBOL=BTCUSDT",
+        "AUTH_REQUIRED=false",
+        "PRIVATE_EXCHANGE_CAPTURE_ALLOWED=false",
+        "BROKER_CAPTURE_ALLOWED=false",
+        "MARKET_CAPTURE_PACKAGE_CREATED=true",
+        "BOUNDED_LIVE_MARKET_DATA_CAPTURE_IMPLEMENTED=false",
+        "LIVE_ALLOWED=false",
+        "TESTNET_ALLOWED=false",
+        "SHADOW_MODE_ALLOWED=false",
+        "PAPER_ALLOWED=false",
+        "SCHEDULER_ALLOWED=false",
+        "RUNTIME_ALLOWED=false",
+        "BROKER_ALLOWED=false",
+        "EXCHANGE_ALLOWED=false",
+        "ORDER_SUBMISSION_ALLOWED=false",
+        "",
+    ]
+    closeout_path.write_text("\n".join(co_lines), encoding="utf-8")
+
+    in_ml = False
+    for ml in co_lines:
+        if ml.strip() == "## Machine-readable final lines":
+            in_ml = True
+            continue
+        if in_ml and ml.strip() and "=" in ml.strip():
+            print(ml.strip())
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description=(
+            "Public REST one-shot Binance bookTicker capture → local package under output-dir."
+        )
+    )
+    p.add_argument(
+        "--provider",
+        required=True,
+        choices=[PROVIDER_ID],
+        help=f"Must be {PROVIDER_ID!r}.",
+    )
+    p.add_argument(
+        "--symbol",
+        required=True,
+        choices=[ALLOWED_SYMBOL_V0],
+        help="v0 allows BTCUSDT only.",
+    )
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument("--package-id", required=True)
+    p.add_argument("--timeout-seconds", type=int, required=True)
+    p.add_argument("--max-response-bytes", type=int, required=True)
+    p.add_argument(
+        "--confirm-public-rest-one-shot",
+        required=True,
+        choices=[CONFIRM_TOKEN],
+        help=f"Must be {CONFIRM_TOKEN!r}.",
+    )
+    p.add_argument(
+        "--captured-at-utc",
+        default="2026-01-01T00:00:00Z",
+        help="Default: 2026-01-01T00:00:00Z",
+    )
+    ns = p.parse_args(argv)
+
+    try:
+        run_capture(
+            symbol=ns.symbol,
+            output_dir=ns.output_dir,
+            package_id=str(ns.package_id),
+            timeout_seconds=ns.timeout_seconds,
+            max_response_bytes=ns.max_response_bytes,
+            confirm=ns.confirm_public_rest_one_shot,
+            captured_at_utc=str(ns.captured_at_utc),
+            fetcher=public_rest_book_ticker_fetch_v0,
+        )
+    except SystemExit as e:
+        code = int(e.code) if isinstance(e.code, int) else 2
+        return code
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_public_rest_binance_book_ticker_capture_v0.py
+++ b/tests/ops/test_public_rest_binance_book_ticker_capture_v0.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts/ops/capture_public_rest_binance_book_ticker_v0.py"
+
+_CONFIRM = "ALLOW_PUBLIC_REST_MARKET_DATA_ONE_SHOT_NO_AUTH_NO_ORDERS"
+_PROVIDER = "binance_spot_market_data_only"
+
+_FORBIDDEN_IN_CAPTURE_SCRIPT = (
+    "import requests",
+    "import httpx",
+    "import aiohttp",
+    "websocket",
+    "import socket",
+    "from socket",
+    "import subprocess",
+    "subprocess.",
+    "time.sleep",
+    "while True",
+    "src.execution",
+    "src.live",
+    "src.scheduler",
+    "src.runtime",
+    "import ccxt",
+    "click",
+    "typer",
+    "create_order",
+    "place_order",
+    "send_order",
+    "submit_order",
+    "cancel_order",
+)
+
+
+def _load_mod() -> Any:
+    spec = importlib.util.spec_from_file_location("_cap_rest", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run(args: List[str], *, cwd: Optional[Path] = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        cwd=cwd or _REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _book_response(**overrides: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "symbol": "BTCUSDT",
+        "bidPrice": "100.00",
+        "bidQty": "1.0",
+        "askPrice": "100.10",
+        "askQty": "2.0",
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_fetch_ok(
+    body: Optional[Mapping[str, Any]] = None, *, status: int = 200
+) -> Callable[..., Tuple[int, bytes]]:
+    payload = body or _book_response()
+
+    def _inner(
+        *, symbol: str, timeout_seconds: float, max_response_bytes: int
+    ) -> Tuple[int, bytes]:
+        raw = json.dumps(payload).encode("utf-8")
+        if len(raw) > max_response_bytes:
+            raise ValueError("ERR: HTTP response body exceeds --max-response-bytes")
+        return status, raw
+
+    return _inner
+
+
+@pytest.fixture
+def mod() -> Any:
+    return _load_mod()
+
+
+@pytest.fixture
+def isolated_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_requires_provider(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "p.v0",
+            "--timeout-seconds",
+            "3",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+    assert "provider" in ((cp.stderr or "") + (cp.stdout or "")).lower()
+
+
+def test_requires_symbol(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "p.v0",
+            "--timeout-seconds",
+            "3",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_requires_output_dir(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--symbol",
+            "BTCUSDT",
+            "--package-id",
+            "p.v0",
+            "--timeout-seconds",
+            "3",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_requires_package_id(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--timeout-seconds",
+            "3",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_requires_timeout_seconds(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "p.v0",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_requires_max_response_bytes(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "p.v0",
+            "--timeout-seconds",
+            "3",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_requires_exact_confirm_token(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "p.v0",
+            "--timeout-seconds",
+            "3",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            "WRONG",
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_rejects_wrong_provider(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            "other",
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "p.v0",
+            "--timeout-seconds",
+            "3",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_rejects_unsupported_symbol_via_api(mod: Any, isolated_out: Path) -> None:
+    with pytest.raises(SystemExit):
+        mod.run_capture(
+            symbol="ETHUSDT",
+            output_dir=isolated_out,
+            package_id="pkg.sym",
+            timeout_seconds=3,
+            max_response_bytes=8192,
+            confirm=_CONFIRM,
+            captured_at_utc="2026-01-01T00:00:00Z",
+            fetcher=_mock_fetch_ok(),
+        )
+
+
+def test_rejects_timeout_over_five(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "p.v0",
+            "--timeout-seconds",
+            "9",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+    assert "timeout" in (cp.stderr or "").lower()
+
+
+def test_rejects_max_response_bytes_over_cap(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "p.v0",
+            "--timeout-seconds",
+            "3",
+            "--max-response-bytes",
+            "2097152",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_rejects_unsafe_package_id(isolated_out: Path) -> None:
+    cp = _run(
+        [
+            "--provider",
+            _PROVIDER,
+            "--symbol",
+            "BTCUSDT",
+            "--output-dir",
+            str(isolated_out),
+            "--package-id",
+            "../evil",
+            "--timeout-seconds",
+            "3",
+            "--max-response-bytes",
+            "8192",
+            "--confirm-public-rest-one-shot",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_rejects_oversized_response(mod: Any, isolated_out: Path) -> None:
+    def fetch_big(
+        *, symbol: str, timeout_seconds: float, max_response_bytes: int
+    ) -> Tuple[int, bytes]:
+        raise ValueError("ERR: HTTP response body exceeds --max-response-bytes")
+
+    with pytest.raises(SystemExit):
+        mod.run_capture(
+            symbol="BTCUSDT",
+            output_dir=isolated_out,
+            package_id="pkg.big",
+            timeout_seconds=3,
+            max_response_bytes=100,
+            confirm=_CONFIRM,
+            captured_at_utc="2026-01-01T00:00:00Z",
+            fetcher=fetch_big,
+        )
+
+
+def test_rejects_invalid_json_response(mod: Any, isolated_out: Path) -> None:
+    def bad_fetch(
+        *, symbol: str, timeout_seconds: float, max_response_bytes: int
+    ) -> Tuple[int, bytes]:
+        return 200, b"not-json{"
+
+    with pytest.raises(SystemExit):
+        mod.run_capture(
+            symbol="BTCUSDT",
+            output_dir=isolated_out,
+            package_id="pkg.badjson",
+            timeout_seconds=3,
+            max_response_bytes=8192,
+            confirm=_CONFIRM,
+            captured_at_utc="2026-01-01T00:00:00Z",
+            fetcher=bad_fetch,
+        )
+
+
+def test_rejects_missing_bid_ask_fields(mod: Any, isolated_out: Path) -> None:
+    incomplete = {"symbol": "BTCUSDT", "bidPrice": "1", "askPrice": "2"}
+
+    with pytest.raises(SystemExit):
+        mod.run_capture(
+            symbol="BTCUSDT",
+            output_dir=isolated_out,
+            package_id="pkg.miss",
+            timeout_seconds=3,
+            max_response_bytes=8192,
+            confirm=_CONFIRM,
+            captured_at_utc="2026-01-01T00:00:00Z",
+            fetcher=_mock_fetch_ok(body=incomplete),
+        )
+
+
+def test_rejects_ask_not_greater_than_bid(mod: Any, isolated_out: Path) -> None:
+    with pytest.raises(SystemExit):
+        mod.run_capture(
+            symbol="BTCUSDT",
+            output_dir=isolated_out,
+            package_id="pkg.spread",
+            timeout_seconds=3,
+            max_response_bytes=8192,
+            confirm=_CONFIRM,
+            captured_at_utc="2026-01-01T00:00:00Z",
+            fetcher=_mock_fetch_ok(body=_book_response(bidPrice="100.10", askPrice="100.00")),
+        )
+
+
+def test_rejects_forbidden_nested_key(mod: Any, isolated_out: Path) -> None:
+    bad = _book_response()
+    bad["api_key"] = "leak"
+
+    with pytest.raises(SystemExit):
+        mod.run_capture(
+            symbol="BTCUSDT",
+            output_dir=isolated_out,
+            package_id="pkg.forbid",
+            timeout_seconds=3,
+            max_response_bytes=8192,
+            confirm=_CONFIRM,
+            captured_at_utc="2026-01-01T00:00:00Z",
+            fetcher=_mock_fetch_ok(body=bad),
+        )
+
+
+def test_happy_path_writes_package_layout(
+    mod: Any, isolated_out: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mod.run_capture(
+        symbol="BTCUSDT",
+        output_dir=isolated_out,
+        package_id="pkg.ok",
+        timeout_seconds=3,
+        max_response_bytes=8192,
+        confirm=_CONFIRM,
+        captured_at_utc="2026-05-17T12:00:00Z",
+        fetcher=_mock_fetch_ok(),
+    )
+    root = isolated_out / "pkg.ok"
+    raw_p = root / "raw" / "public_rest_book_ticker_raw.json"
+    norm_p = root / "normalized" / "captured_realistic_snapshots.json"
+    cap_p = root / "manifest" / "capture_manifest.json"
+    sup_p = root / "manifest" / "supervised_timed_manifest.json"
+    co_p = root / "PUBLIC_REST_CAPTURE_CLOSEOUT.md"
+    assert (
+        raw_p.is_file()
+        and norm_p.is_file()
+        and cap_p.is_file()
+        and sup_p.is_file()
+        and co_p.is_file()
+    )
+
+    raw_obj = json.loads(raw_p.read_text(encoding="utf-8"))
+    assert raw_obj["schema"] == "public_rest_market_snapshot_raw_v0"
+    assert raw_obj["provider"] == _PROVIDER
+
+    norm_obj = json.loads(norm_p.read_text(encoding="utf-8"))
+    assert norm_obj["schema"] == "captured_realistic_snapshot_observation_input_v0"
+    assert norm_obj["source"] == "redacted_public_snapshot_static"
+    assert len(norm_obj["snapshots"]) == 1
+    pl = norm_obj["snapshots"][0]["payload"]
+    assert pl["source_state"] == "public_rest_snapshot_one_shot"
+    assert pl["volume"] == "0"
+    assert pl["bid_qty"] == "1.0"
+    assert pl["ask_qty"] == "2.0"
+
+    cap = json.loads(cap_p.read_text(encoding="utf-8"))
+    rh = hashlib.sha256(raw_p.read_bytes()).hexdigest()
+    nh = hashlib.sha256(norm_p.read_bytes()).hexdigest()
+    assert cap["raw_sha256"] == rh
+    assert cap["normalized_sha256"] == nh
+    assert cap["snapshot_count"] == 1
+
+    sup = json.loads(sup_p.read_text(encoding="utf-8"))
+    assert sup["max_observations"] == 1
+    inp = sup["inputs"][0]["input_file"]
+    assert Path(inp).is_absolute()
+    assert Path(inp) == norm_p.resolve()
+
+    txt = co_p.read_text(encoding="utf-8")
+    assert "VERDICT=PUBLIC_REST_BINANCE_BOOK_TICKER_CAPTURE_V0_CREATED_NOT_APPROVED" in txt
+    assert "ORDER_SUBMISSION_ALLOWED=false" in txt
+
+    out = capsys.readouterr().out
+    assert "VERDICT=PUBLIC_REST_BINANCE_BOOK_TICKER_CAPTURE_V0_CREATED_NOT_APPROVED" in out
+
+
+def test_forbidden_tokens_not_present_in_new_script() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    for frag in _FORBIDDEN_IN_CAPTURE_SCRIPT:
+        assert frag not in text
+
+
+def test_repo_root_has_no_accidental_public_rest_raw_artifact_at_repo_root() -> None:
+    assert not (_REPO_ROOT / "raw" / "public_rest_book_ticker_raw.json").exists()
+
+
+def test_failure_closeout_machine_lines(mod: Any, isolated_out: Path) -> None:
+    def bad_fetch(
+        *, symbol: str, timeout_seconds: float, max_response_bytes: int
+    ) -> Tuple[int, bytes]:
+        return 503, b"{}"
+
+    with pytest.raises(SystemExit):
+        mod.run_capture(
+            symbol="BTCUSDT",
+            output_dir=isolated_out,
+            package_id="pkg.fail503",
+            timeout_seconds=3,
+            max_response_bytes=8192,
+            confirm=_CONFIRM,
+            captured_at_utc="2026-01-01T00:00:00Z",
+            fetcher=bad_fetch,
+        )
+    fail_co = isolated_out / "pkg.fail503" / "PUBLIC_REST_CAPTURE_CLOSEOUT.md"
+    assert fail_co.is_file()
+    fb = fail_co.read_text(encoding="utf-8")
+    assert "VERDICT=PUBLIC_REST_BINANCE_BOOK_TICKER_CAPTURE_V0_FAILED_NOT_APPROVED" in fb
+    assert "NEXT_ACTION=review_public_rest_capture_failure_or_stop_idle" in fb


### PR DESCRIPTION
## Summary

Adds default-off Public REST Binance bookTicker capture v0.

Changed files:

- `scripts/ops/capture_public_rest_binance_book_ticker_v0.py`
- `tests/ops/test_public_rest_binance_book_ticker_capture_v0.py`

## What this adds

- New explicit one-shot capture CLI:
  - `--provider binance_spot_market_data_only`
  - `--symbol BTCUSDT`
  - `--output-dir`
  - `--package-id`
  - `--timeout-seconds`
  - `--max-response-bytes`
  - `--confirm-public-rest-one-shot ALLOW_PUBLIC_REST_MARKET_DATA_ONE_SHOT_NO_AUTH_NO_ORDERS`
- Uses a mockable fetch boundary for tests.
- Writes a bounded package under `<output-dir>/<package-id>/`:
  - `raw/public_rest_book_ticker_raw.json`
  - `normalized/captured_realistic_snapshots.json`
  - `manifest/capture_manifest.json`
  - `manifest/supervised_timed_manifest.json`
  - `PUBLIC_REST_CAPTURE_CLOSEOUT.md`
- Normalizes bookTicker bid/ask into `captured_realistic_snapshot_observation_input_v0`.
- Uses derived midpoint for `last` and `mid`.
- Sets `volume=0` for bookTicker-only v0 with provenance fields documenting that volume is not available in this endpoint.

## Safety / boundaries

- Default-off behind exact confirmation token
- Unit tests mock HTTP; no real network call in tests
- No credentials
- No `.env`
- No private exchange endpoint
- No broker endpoint
- No order/fill/account/position/balance endpoint
- No scheduler/runtime/daemon path
- No websocket/polling loop
- No paper/test data read or mutation path
- No Master V2 / Double Play logic changes
- No Risk / KillSwitch / Scope / Capital logic changes
- No Notion write
- No committed generated capture/evidence artifacts

This remains not approved for Shadow Mode, Testnet, Live, broker/exchange authority, or orders.

## Known integration blocker retained

The generated normalized `captured_realistic_snapshots.json` has:

- exactly 1 snapshot
- `network_fetch_during_test=true`

The existing file-snapshot loader currently expects captured-realistic inputs to have 3–20 snapshots and `network_fetch_during_test=false`.

This PR intentionally does not touch the existing loader or observer integration. A follow-up compatibility/bridge slice must solve this explicitly.

## Validation

- `uv run pytest tests/ops/test_public_rest_binance_book_ticker_capture_v0.py -q` — 21 passed
- `uv run pytest tests/ops/test_static_market_capture_package_v0.py -q` — 31 passed
- `uv run pytest tests/ops/test_shadow_observation_supervised_timed_observer_v0.py -q` — 21 passed
- `uv run pytest tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py -q` — 18 passed
- `uv run pytest tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py -q` — 65 passed
- `uv run ruff check scripts/ops/capture_public_rest_binance_book_ticker_v0.py tests/ops/test_public_rest_binance_book_ticker_capture_v0.py scripts/ops/build_static_market_capture_package_v0.py tests/ops/test_static_market_capture_package_v0.py scripts/ops/run_shadow_observation_supervised_timed_v0.py tests/ops/test_shadow_observation_supervised_timed_observer_v0.py scripts/ops/run_shadow_observation_file_snapshot_v0.py tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- `uv run ruff format --check scripts/ops/capture_public_rest_binance_book_ticker_v0.py tests/ops/test_public_rest_binance_book_ticker_capture_v0.py scripts/ops/build_static_market_capture_package_v0.py tests/ops/test_static_market_capture_package_v0.py scripts/ops/run_shadow_observation_supervised_timed_v0.py tests/ops/test_shadow_observation_supervised_timed_observer_v0.py scripts/ops/run_shadow_observation_file_snapshot_v0.py tests/ops/test_shadow_observation_file_snapshot_operator_entrypoint_v0.py src/shadow_no_order_proof/ tests/shadow_no_order/test_shadow_no_order_proof_contract_v0.py`
- Forbidden private/runtime token scan — ok
- Python 3.9 compatibility scan — ok
- Generated artifact guard — ok

## Machine-readable

VERDICT=PUBLIC_REST_BINANCE_BOOK_TICKER_CAPTURE_PR_OPENED
DECISION=not_approved
REPO_CHANGED=true
REUSE_BEFORE_NEW_CHECK=true
PARALLEL_DOCS_CREATED=false
NETWORK_ALLOWED=false
PUBLIC_REST_CAPTURE_CONTRACT_DESIGNED=true
PUBLIC_REST_CAPTURE_IMPLEMENTED=true
PUBLIC_REST_CAPTURE_ALLOWED=false
PUBLIC_REST_PROVIDER_VERIFIED=true
PUBLIC_REST_PROVIDER_ID=binance_spot_market_data_only
PUBLIC_REST_ENDPOINT=/api/v3/ticker/bookTicker
PUBLIC_REST_SYMBOL=BTCUSDT
PUBLIC_REST_AUTH_REQUIRED=false
PRIVATE_EXCHANGE_CAPTURE_ALLOWED=false
BROKER_CAPTURE_ALLOWED=false
MARKET_CAPTURE_PACKAGE_CREATED=false
STATIC_MARKET_CAPTURE_PACKAGE_BUILDER_IMPLEMENTED=true
SUPERVISED_OBSERVER_FROM_CAPTURE_PACKAGE_EXECUTED=true
SUPERVISED_OBSERVER_FROM_CAPTURE_PACKAGE_PASSED=true
BOUNDED_LIVE_MARKET_DATA_CAPTURE_DESIGNED=true
BOUNDED_LIVE_MARKET_DATA_CAPTURE_IMPLEMENTED=false
PUBLIC_REST_TO_SUPERVISED_OBSERVER_COMPATIBILITY_BLOCKER=true
NOTION_WRITE_PERFORMED=false
LIVE_ALLOWED=false
TESTNET_ALLOWED=false
SHADOW_MODE_ALLOWED=false
PAPER_ALLOWED=false
SCHEDULER_ALLOWED=false
RUNTIME_ALLOWED=false
BROKER_ALLOWED=false
EXCHANGE_ALLOWED=false
ORDER_SUBMISSION_ALLOWED=false

Made with [Cursor](https://cursor.com)