### PR TITLE
docs(ops): clarify shadow 247 futures proxy boundary

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -32,6 +32,29 @@ The following are **not** trading authority, readiness approval, evidence approv
 - CI shadow/paper smoke artifacts;
 - any future read-only preflight JSON emitted from this contract.
 
+## 3a. Futures / perpetual planning boundary (BTC/USD proxy evidence)
+
+Symbols and surfaces such as **BTC/USD**, **BTC-USD**, **Bitcoin USD**, or **BTCUSDT** may appear in this repository as WebUI defaults, spot-style fixtures, Class-A smoke paths, or **public REST market-data captures**. Treat that evidence as **technical proxy / spot-smoke instrumentation only**.
+
+Proxy-style BTC evidence may still help validate scheduler wiring, logging discipline, evidence roots, path hygiene, and other **non-trading-authority** mechanics. It must **not** be interpreted as:
+
+- Futures or perpetual (**perp**) readiness,
+- Futures Shadow 24/7 readiness,
+- approval of continuous daemon operation,
+- clearance for no-active-run preflight “done” by itself,
+- Testnet approval, Live approval, broker/exchange connectivity, or order submission.
+
+Futures / perpetual Shadow 24/7 readiness requires explicit Futures scope and command-contract coverage **before** any run-readiness claim, including at minimum: exchange-native Futures/perp instrument notation (for example a venue-specific **BTCUSDT perpetual** if that is the governed candidate), explicit **market type**, **venue/adapter** binding, **margin/leverage/contract metadata**, **position mode** and **long/short** behavior under derivatives semantics, **reduce-only / close-only / no-order-submission** constraints as applicable, **funding / liquidation / fees / slippage** assumptions, and mapped boundaries for **Risk / KillSwitch / Scope / Capital / Master V2 / Double Play**, plus Futures-specific **evidence collection and abort criteria** aligned to the canonical Futures specs.
+
+Acceptance of a Futures scope command contract is **preparation only** and remains **non-authorizing** for scheduler execution, daemon execution, Paper runtime, Shadow runtime, Testnet, Live, broker, exchange, REST/WebSocket trading paths, credentials, or orders. **No-active-run preflight** (read-only, separate gate) and **explicit operator run approval** remain mandatory before any future authorized start.
+
+Canonical Futures planning surfaces (read alongside this contract; **not** approval sources):
+
+- [Futures Trading Readiness Runbook v0](futures/FUTURES_TRADING_READINESS_RUNBOOK_V0.md)
+- [Futures Capability Spec v0](../specs/FUTURES_CAPABILITY_SPEC_V0.md)
+- [Futures Candidate Evidence Package Contract v0](../specs/FUTURES_CANDIDATE_EVIDENCE_PACKAGE_CONTRACT_V0.md)
+- [Master V2 Futures Class A Capability Contract v0](../specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md)
+
 ## 4. Status model
 
 Conservative states (future materializations must use one of these):
@@ -103,6 +126,7 @@ Field names and enums may be refined in a later contract version; v0 only fixes 
 - [SCHEDULER_DAEMON.md](../../SCHEDULER_DAEMON.md) — scheduler boundary and dry-run-only diagnostics.
 - Shadow session runbook: [runbook_shadow_session.md](../p6/runbook_shadow_session.md) (single-run, no daemon).
 - Paper trading runbook: [runbook_paper_trading.md](../p7/runbook_paper_trading.md).
+- Futures planning (non-authorizing pointers): [Futures Trading Readiness Runbook v0](futures/FUTURES_TRADING_READINESS_RUNBOOK_V0.md), [Futures Capability Spec v0](../specs/FUTURES_CAPABILITY_SPEC_V0.md), [Futures Candidate Evidence Package Contract v0](../specs/FUTURES_CANDIDATE_EVIDENCE_PACKAGE_CONTRACT_V0.md), [Master V2 Futures Class A Capability Contract v0](../specs/MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md).
 
 ## Paper/Shadow 24/7 Preflight Metadata v0
 


### PR DESCRIPTION
## Summary

Docs-only clarification for the Shadow 24/7 preflight contract.

This PR documents that BTC/USD or BTC-USD shadow evidence is technical proxy evidence only and is not sufficient for Futures/perpetual readiness. It adds the Futures/perpetual boundary requirements before any future Shadow 24/7 Futures daemon path can be considered.

## Scope

Changed file:

- `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`

## Safety boundaries

This PR does **not** approve:

- scheduler/runtime/daemon start
- paper/shadow/testnet/live run
- broker/exchange connection
- order submission
- network calls
- Notion/KG update
- Futures readiness

Preserved boundaries:

- Docs ≠ Approval
- Signal ≠ Trade
- AI ≠ Authority
- Dashboard ≠ Freigabe
- Notion ≠ Approval
- BTC/USD proxy evidence ≠ Futures readiness

## Validation

- `git diff --check -- docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Follow-up

After merge/closeout, the next safe gate is:

`shadow_247_no_active_run_preflight_no_runtime`

Notion/KG alignment remains a later separate read-only gate and is not an approval source.
