### PR TITLE
chore(ops): add shadow 247 futures start wrapper skeleton

### DIFF
--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Default-off skeleton for a future Shadow 24/7 Futures *perpetual* start wrapper.
+
+This module is intentionally **not** a daemon, does not touch the scheduler at runtime,
+does not open network or broker paths, and **always** exits fail-closed until a separate
+governance implementation replaces this placeholder.
+
+Importing this file has no side effects beyond loading this module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence, TextIO
+
+# -----------------------------------------------------------------------------
+# Safety / scope constants (documentation + static-test anchors; not authority)
+# -----------------------------------------------------------------------------
+
+BOUNDARY_NO_LIVE = "NO_LIVE"
+BOUNDARY_NO_TESTNET_UNLESS_APPROVED = "NO_TESTNET_UNLESS_SEPARATELY_APPROVED"
+BOUNDARY_NO_BROKER = "NO_BROKER"
+BOUNDARY_NO_PRIVATE_EXCHANGE = "NO_PRIVATE_EXCHANGE_ENDPOINT"
+BOUNDARY_NO_ORDER_SUBMISSION = "NO_ORDER_SUBMISSION"
+BOUNDARY_NO_NETWORK = "NO_NETWORK"
+BOUNDARY_FUTURES_PERP_SCOPE = "FUTURES_OR_PERPETUAL_SCOPE_REQUIRED"
+BOUNDARY_EVIDENCE_ROOT_TMP = "/tmp/peak_trade_* evidence root convention"
+BOUNDARY_SUPERVISOR_LATER = "SUPERVISOR_TIMEOUT_REQUIRED_IN_FUTURE_GATE"
+BOUNDARY_ABORT_LATER = "ABORT_STOP_CRITERIA_REQUIRED_IN_FUTURE_GATE"
+
+EXIT_FAIL_CLOSED_DEFAULT = 64
+
+# Future-only gate token (explicit operator string). **Presence does NOT enable runtime.**
+FUTURE_OPERATOR_CONFIRMATION_TOKEN_V0 = (
+    "I_EXPLICITLY_CONFIRM_SHADOW_247_FUTURES_START_WRAPPER_BEYOND_DEFAULT_OFF_SKELETON_V0"
+)
+
+_MACHINE_LINES_ALWAYS = """\
+RUN_STARTED=false
+SCHEDULER_STARTED=false
+RUNTIME_STARTED=false
+READY_TO_START_FUTURES_SHADOW_247_DAEMON=false
+SKELETON_ONLY=true
+NETWORK_USED=false
+BROKER_USED=false
+EXCHANGE_USED=false
+ORDER_SUBMISSION_USED=false
+"""
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=("Shadow 24/7 Futures start-wrapper **skeleton** (fail-closed, no runtime)."),
+    )
+    parser.add_argument(
+        "--inspect",
+        action="store_true",
+        help="Print documented boundaries and diagnostic machine lines only.",
+    )
+    parser.add_argument(
+        "--confirm-token",
+        metavar="TOKEN",
+        default="",
+        help=(
+            "Optional future governance token placeholder. Skeleton still exits "
+            f"{EXIT_FAIL_CLOSED_DEFAULT} and never starts workloads."
+        ),
+    )
+    parser.add_argument(
+        "--evidence-root",
+        metavar="PATH",
+        default="",
+        help=(
+            "Optional `/tmp/peak_trade_*`-style absolute path checked for conventions only "
+            "(this skeleton does not write files except stdout/stderr)."
+        ),
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def _validate_evidence_root(path_str: str) -> str | None:
+    """Return error message string if invalid, else None."""
+    if not path_str:
+        return None
+    normalized = path_str.strip()
+    if not normalized.startswith("/tmp/peak_trade"):
+        return "evidence-root must use /tmp/peak_trade_* operator convention when supplied"
+    if ".." in normalized:
+        return "evidence-root must not contain path traversal"
+    return None
+
+
+def _emit_banner(out: TextIO) -> None:
+    out.write(
+        "peak_trade shadow_247_futures_start_wrapper_skeleton_v0: "
+        "FAIL-CLOSED SKELETON — no scheduler, daemon, runtime, broker, exchange, orders, "
+        "or network in this artifact.\n"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    out = sys.stdout
+    err = sys.stderr
+
+    ev_err = _validate_evidence_root(args.evidence_root)
+    if ev_err:
+        err.write(ev_err + "\n")
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(f"EXIT_REASON=invalid_evidence_root\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n")
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    if args.inspect:
+        _emit_banner(out)
+        out.write("\nBoundary markers:\n")
+        boundary_rows = (
+            ("BOUNDARY_ABORT_LATER", BOUNDARY_ABORT_LATER),
+            ("BOUNDARY_EVIDENCE_ROOT_TMP", BOUNDARY_EVIDENCE_ROOT_TMP),
+            ("BOUNDARY_FUTURES_PERP_SCOPE", BOUNDARY_FUTURES_PERP_SCOPE),
+            ("BOUNDARY_NO_BROKER", BOUNDARY_NO_BROKER),
+            ("BOUNDARY_NO_LIVE", BOUNDARY_NO_LIVE),
+            ("BOUNDARY_NO_NETWORK", BOUNDARY_NO_NETWORK),
+            ("BOUNDARY_NO_ORDER_SUBMISSION", BOUNDARY_NO_ORDER_SUBMISSION),
+            ("BOUNDARY_NO_PRIVATE_EXCHANGE", BOUNDARY_NO_PRIVATE_EXCHANGE),
+            ("BOUNDARY_NO_TESTNET_UNLESS_APPROVED", BOUNDARY_NO_TESTNET_UNLESS_APPROVED),
+            ("BOUNDARY_SUPERVISOR_LATER", BOUNDARY_SUPERVISOR_LATER),
+        )
+        for label, marker in boundary_rows:
+            out.write(f"  {label}={marker}\n")
+        out.write("\nMachine summary:\n")
+        out.write(_MACHINE_LINES_ALWAYS)
+        out.write(
+            f"EXIT_REASON=inspect_mode_fail_closed_skeleton\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n"
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    token = args.confirm_token.strip()
+
+    _emit_banner(err)
+    if not token:
+        err.write(
+            "No --confirm-token provided. This skeleton does not execute any start path "
+            "(default-off).\n"
+        )
+    elif token != FUTURE_OPERATOR_CONFIRMATION_TOKEN_V0:
+        err.write(
+            "confirm-token mismatch: future governance gate not satisfied for any implementation "
+            "beyond skeleton (still fail-closed for this artifact).\n"
+        )
+    else:
+        err.write(
+            "Future confirmation token accepted for bookkeeping only — this PR skeleton still "
+            "does not schedule, supervise, network, broker, exchange, submit orders, "
+            "or mutate trading state.\n"
+        )
+
+    if args.evidence_root:
+        err.write(f"Validated evidence-root convention hint: '{args.evidence_root.strip()}'\n")
+
+    err.write(_MACHINE_LINES_ALWAYS)
+    err.write(
+        f"EXIT_REASON=default_fail_closed_skeleton_v0\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n"
+    )
+    return EXIT_FAIL_CLOSED_DEFAULT
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -1,0 +1,170 @@
+"""Static/offline guards for Shadow 247 Futures default-off start-wrapper skeleton v0."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ops" / "shadow_247_futures_start_wrapper_skeleton_v0.py"
+SRC_TEXT = SCRIPT.read_text(encoding="utf-8")
+
+
+def test_shadow_247_futures_wrapper_skeleton_script_exists() -> None:
+    assert SCRIPT.is_file(), "expected skeleton under scripts/ops/"
+
+
+@pytest.mark.parametrize(
+    "forbidden_snippet",
+    [
+        "ccxt",
+        "requests",
+        "aiohttp",
+        "websocket",
+        "binance",
+        "subprocess",
+        "os.system",
+        "Popen",
+        "urllib.request",
+        "socket",
+    ],
+)
+def test_shadow_247_futures_wrapper_skeleton_source_has_no_blocked_substrings(
+    forbidden_snippet: str,
+) -> None:
+    assert forbidden_snippet not in SRC_TEXT.lower()
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "BOUNDARY_NO_LIVE",
+        "BOUNDARY_NO_TESTNET_UNLESS_APPROVED",
+        "BOUNDARY_NO_BROKER",
+        "BOUNDARY_NO_PRIVATE_EXCHANGE",
+        "BOUNDARY_NO_ORDER_SUBMISSION",
+        "BOUNDARY_NO_NETWORK",
+        "BOUNDARY_FUTURES_PERP_SCOPE",
+        "/tmp/peak_trade",
+        "NO_ORDER_SUBMISSION",
+    ],
+)
+def test_shadow_247_futures_wrapper_skeleton_has_boundary_constants(marker: str) -> None:
+    assert marker in SRC_TEXT
+
+
+def test_shadow_247_futures_wrapper_skeleton_import_has_no_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PYTHONINSPECT", raising=False)
+
+    spec = importlib.util.spec_from_file_location(
+        "_skel_under_test_shadow_247",
+        SCRIPT,
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    assert hasattr(mod, "main")
+    assert mod.EXIT_FAIL_CLOSED_DEFAULT == 64
+
+
+def test_shadow_247_futures_wrapper_skeleton_default_returns_64(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 64
+    combo = proc.stderr + proc.stdout
+    assert "FAIL-CLOSED" in combo or "fail-closed" in combo.lower() or "SKELETON" in combo
+    assert "RUN_STARTED=false" in combo
+
+
+def test_shadow_247_futures_wrapper_skeleton_correct_token_still_returns_64(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    token = "I_EXPLICITLY_CONFIRM_SHADOW_247_FUTURES_START_WRAPPER_BEYOND_DEFAULT_OFF_SKELETON_V0"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--confirm-token", token],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 64
+
+
+def test_shadow_247_futures_wrapper_skeleton_evidence_root_invalid_returns_64(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--evidence-root",
+            "/var/tmp/forbidden_peak_trade_fake",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 64
+    assert "peak_trade" in (proc.stderr + proc.stdout)
+
+
+def test_shadow_247_futures_wrapper_skeleton_evidence_root_valid_prefix_still_returns_64(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--evidence-root",
+            "/tmp/peak_trade_shadow_247_skeleton_probe",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 64
+
+
+def test_shadow_247_futures_wrapper_skeleton_future_token_marker_in_source_only() -> None:
+    marker = "I_EXPLICITLY_CONFIRM_SHADOW_247_FUTURES_START_WRAPPER_BEYOND_DEFAULT_OFF_SKELETON_V0"
+    assert marker in SRC_TEXT
+    assert "FUTURE_OPERATOR_CONFIRMATION_TOKEN_V0" in SRC_TEXT
+
+
+def test_shadow_247_futures_wrapper_skeleton_machine_lines_include_flags() -> None:
+    monkeypatch_locals = subprocess.run(
+        [sys.executable, str(SCRIPT), "--inspect"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    combo = monkeypatch_locals.stdout + monkeypatch_locals.stderr
+    assert monkeypatch_locals.returncode == 64
+    assert "BOUNDARY_NO_LIVE" in combo
+    assert "RUN_STARTED=false" in combo
+    assert "SCHEDULER_STARTED=false" in combo


### PR DESCRIPTION
## Summary

Adds a default-off, fail-closed Shadow 24/7 Futures start-wrapper skeleton.

The wrapper is intentionally non-executing:

- default exit code: `64`
- no scheduler/runtime/daemon start
- no paper/shadow/testnet/live run
- no broker/exchange/private endpoint/order submission
- no network calls
- no Notion/KG update
- no immediate executable start path approval

It also adds an offline/static test contract for the wrapper.

## Scope

Changed files:

- `scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py`
- `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`

## Safety boundaries

This PR does **not** approve or start:

- scheduler/runtime/daemon
- paper/shadow/testnet/live run
- broker/exchange connection
- order submission
- network calls
- Notion/KG update

Preserved boundaries:

- Script skeleton ≠ executable daemon
- Tests ≠ Execution
- Docs ≠ Approval
- Signal ≠ Trade
- AI ≠ Authority
- Dashboard ≠ Freigabe
- Notion ≠ Approval
- Shadow run ≠ Testnet
- Testnet ≠ Live
- Live remains blocked

## Validation

- `uv run pytest tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_executable_start_path_contract_v0.py -q`
- `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
- `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
- `git diff --check`

## Follow-up

After merge/closeout, the next safe gate is:

`shadow_247_futures_start_wrapper_skeleton_merge_closeout_then_next_slice_planning_no_runtime`

A real executable start path still requires separate implementation/review gates.
