### PR TITLE
chore(ops): add shadow 247 prestart evidence drycheck

### DIFF
--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -11,8 +11,12 @@ Importing this file has no side effects beyond loading this module.
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import sys
-from typing import Sequence, TextIO
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence, TextIO, Tuple
 
 # -----------------------------------------------------------------------------
 # Safety / scope constants (documentation + static-test anchors; not authority)
@@ -33,11 +37,23 @@ BOUNDARY_ABORT_LATER = "ABORT_STOP_CRITERIA_REQUIRED_IN_FUTURE_GATE"
 
 EXIT_FAIL_CLOSED_DEFAULT = 64
 EXIT_CODE_FAIL_CLOSED = EXIT_FAIL_CLOSED_DEFAULT
+EXIT_DRYCHECK_SUCCESS = 0
+
+PRESTART_SCHEMA_V0 = "shadow_247_futures_prestart_evidence_drycheck_v0"
+PRESTART_MARKDOWN_ARTIFACT_V0 = "SHADOW_247_FUTURES_PRESTART_EVIDENCE_DRYCHECK.md"
+PRESTART_MANIFEST_JSON_V0 = "manifest.json"
+PRESTART_MANIFEST_SHA256_V0 = "MANIFEST.sha256"
+
+_DRYCHECK_ALLOWED_ENTRIES = frozenset(
+    {PRESTART_MARKDOWN_ARTIFACT_V0, PRESTART_MANIFEST_JSON_V0, PRESTART_MANIFEST_SHA256_V0},
+)
 
 # Future-only gate token (explicit operator string). **Presence does NOT enable runtime.**
 FUTURE_OPERATOR_CONFIRMATION_TOKEN_V0 = (
     "I_EXPLICITLY_CONFIRM_SHADOW_247_FUTURES_START_WRAPPER_BEYOND_DEFAULT_OFF_SKELETON_V0"
 )
+
+_REPO_ROOT_CALC = Path(__file__).resolve().parents[2]
 
 _MACHINE_LINES_ALWAYS = """\
 RUN_STARTED=false
@@ -62,12 +78,18 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         help="Print documented boundaries and diagnostic machine lines only.",
     )
     parser.add_argument(
+        "--prestart-evidence-drycheck",
+        action="store_true",
+        dest="prestart_evidence_drycheck",
+        help=("Write local prestart evidence under --evidence-root only (still no daemon start)."),
+    )
+    parser.add_argument(
         "--confirm-token",
         metavar="TOKEN",
         default="",
         help=(
             "Optional future governance token placeholder. Skeleton still exits "
-            f"{EXIT_FAIL_CLOSED_DEFAULT} and never starts workloads."
+            f"{EXIT_FAIL_CLOSED_DEFAULT} unless prestart-evidence-drycheck succeeds."
         ),
     )
     parser.add_argument(
@@ -75,23 +97,213 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         metavar="PATH",
         default="",
         help=(
-            "Optional `/tmp/peak_trade_*`-style absolute path checked for conventions only "
-            "(this skeleton does not write files except stdout/stderr)."
+            "Optional `/tmp/peak_trade_*`-style absolute path (convention-only), or required "
+            "with `--prestart-evidence-drycheck`."
         ),
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 
 
 def _validate_evidence_root(path_str: str) -> str | None:
-    """Return error message string if invalid, else None."""
+    """Return error message string if invalid for non-starting modes, else None."""
     if not path_str:
         return None
     normalized = path_str.strip()
-    if not normalized.startswith("/tmp/peak_trade"):
-        return "evidence-root must use /tmp/peak_trade_* operator convention when supplied"
     if ".." in normalized:
         return "evidence-root must not contain path traversal"
+    probe = Path(normalized).expanduser()
+    if not probe.is_absolute():
+        return "evidence-root must be absolute for convention checks when supplied"
+    try:
+        resolved = probe.resolve()
+        tmp_anchor = Path("/tmp").resolve()
+        rel = resolved.relative_to(tmp_anchor)
+    except (ValueError, OSError, RuntimeError):
+        return "evidence-root must use /tmp/peak_trade_* operator convention when supplied"
+    if not rel.parts or not rel.parts[0].lower().startswith("peak_trade"):
+        return "evidence-root must use /tmp/peak_trade_* operator convention when supplied"
     return None
+
+
+def _read_git_sha_prefix(repo_root: Path, maxlen: int = 12) -> str:
+    head_file = repo_root / ".git" / "HEAD"
+    if not head_file.is_file():
+        return "UNKNOWN"
+    raw = head_file.read_text(encoding="utf-8", errors="replace").strip()
+    if raw.startswith("ref: "):
+        ref = raw[5:].strip()
+        ref_path = repo_root / ".git" / ref
+        if ref_path.is_file():
+            sha = ref_path.read_text(encoding="utf-8", errors="replace").strip()
+            return sha[:maxlen] if sha else "UNKNOWN_REF_EMPTY"
+        return "UNKNOWN_REF_MISSING"
+    # Detached HEAD or direct SHA digest string.
+    cand40 = raw[:40].lower()
+    if len(cand40) == 40 and all(ch in "0123456789abcdef" for ch in cand40):
+        return raw[:maxlen]
+    return "UNKNOWN_RAW_HEAD_LAYOUT"
+
+
+def _evidence_has_paper_or_test_hints(path_chars: str) -> bool:
+    lower = path_chars.lower()
+    hints = (
+        "/paper/",
+        "/paper_trade",
+        "paper_trading/",
+        "/test_data/",
+        "/testdata/",
+        "/fixtures/",
+        "pytest_legacy",
+        "live_trading",
+    )
+    return any(part in lower for part in hints)
+
+
+def _validate_evidence_root_for_drycheck(
+    path_str: str, repo_root: Path
+) -> Tuple[Path | None, str | None]:
+    trimmed = path_str.strip()
+    if not trimmed:
+        return None, "prestart-evidence-drycheck requires a non-empty --evidence-root"
+    probe = Path(trimmed).expanduser()
+    if not probe.is_absolute():
+        return None, "evidence-root must be an absolute path for prestart-evidence-drycheck"
+    try:
+        resolved = probe.resolve()
+    except (OSError, RuntimeError):
+        return None, "evidence-root cannot be resolved safely"
+
+    rr = repo_root.resolve()
+    try:
+        tmp_anchor = Path("/tmp").resolve()
+        rel_to_tmp = resolved.relative_to(tmp_anchor)
+    except (ValueError, OSError, RuntimeError):
+        return None, (
+            "evidence-root must resolve somewhere under filesystem `/tmp` after symlink normalization."
+        )
+    if not rel_to_tmp.parts:
+        return None, "evidence-root has empty relative path under `/tmp`."
+    top_seg = rel_to_tmp.parts[0].lower()
+    if not top_seg.startswith("peak_trade_"):
+        return (
+            None,
+            "evidence-root first directory segment under `/tmp` must start with "
+            "`peak_trade_` for prestart-evidence-drycheck.",
+        )
+    rstr = str(resolved)
+
+    if resolved == rr:
+        return None, "evidence-root must not equal the Peak_Trade repository root"
+    if resolved.is_relative_to(rr):
+        return None, "evidence-root must not reside inside the repository tree"
+
+    if ".git" in resolved.parts:
+        return None, "evidence-root must not traverse a `.git` path segment"
+
+    if _evidence_has_paper_or_test_hints(rstr):
+        return None, "evidence-root path hints at paper/test fixtures — forbidden for this drycheck"
+
+    if resolved.is_file():
+        return None, "evidence-root must be a directory, not an existing file"
+
+    if resolved.exists():
+        entries = sorted(p.name for p in resolved.iterdir())
+        if entries and set(entries) != _DRYCHECK_ALLOWED_ENTRIES:
+            bad = sorted(set(entries) - _DRYCHECK_ALLOWED_ENTRIES)
+            return (
+                None,
+                f"evidence-root directory is non-empty with unexpected entries: {bad!r}",
+            )
+
+    return resolved, None
+
+
+def _canonical_json_bytes(payload: dict) -> bytes:
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _drycheck_manifest(
+    evidence_abs: Path,
+    repo_sha: str,
+    utc_now: datetime,
+) -> dict:
+    return {
+        "artifact": PRESTART_SCHEMA_V0,
+        "broker_used": False,
+        "daemon_run_approved": False,
+        "evidence_root_absolute": str(evidence_abs),
+        "exchange_used": False,
+        "executor": "peak_trade/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py",
+        "futures_perpetual_planning_scope_only": True,
+        "git_sha_prefix": repo_sha,
+        "markdown_artifact_filename": PRESTART_MARKDOWN_ARTIFACT_V0,
+        "network_used": False,
+        "order_submission_used": False,
+        "prestart_claims_summary": (
+            "No run, scheduler, daemon, network, broker, exchange, orders, shadow/paper/testnet/"
+            "live workloads — evidence only."
+        ),
+        "ready_to_start_futures_shadow_247_daemon": False,
+        "run_started": False,
+        "runtime_started": False,
+        "scheduler_started": False,
+        "utc_generated": utc_now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "verbatim_machine_summary": _MACHINE_LINES_ALWAYS.rstrip("\n"),
+        "wrapper_requires_future_gate_before_execution": True,
+    }
+
+
+def _drycheck_markdown(
+    utc_now: datetime,
+    evidence_abs: Path,
+    repo_sha: str,
+) -> str:
+    lines = (
+        "# Shadow 24-7 Futures — Prestart Evidence Drycheck (Local)\n\n",
+        f"UTC: `{utc_now.strftime('%Y-%m-%dT%H:%M:%SZ')}`  \n",
+        f"Evidence root: `{evidence_abs}`  \n",
+        f"Repository git SHA prefix hint: `{repo_sha}` (best-effort, filesystem read).\n\n",
+        "## Statements (non-binding; planning evidence only)\n\n",
+        "- No live, testnet, paper, shadow, or production runtime started.\n",
+        "- No scheduler or daemon spawned.\n",
+        "- No network, broker API, exchange private endpoint access, nor order submission.\n",
+        "- Futures/perpetual execution scope remains planning-only pending future gates.\n",
+        "- Wrapper is **not** `READY_TO_START` for Futures Shadow 24/7 daemon.\n\n",
+        "## Operator machine summary (verbatim keys)\n\n",
+        "```text\n",
+        _MACHINE_LINES_ALWAYS,
+        "```\n\n",
+        "## Appendix\n\n",
+        "Drycheck artefacts: `manifest.json`, `MANIFEST.sha256`. "
+        "`MANIFEST.sha256` covers canonical UTF-8 bytes of sorted-key pretty JSON manifest.\n",
+    )
+    return "".join(lines)
+
+
+def _execute_prestart_drycheck(evidence_root_abs: Path, repo_root: Path, err: TextIO) -> int:
+    utc_now = datetime.now(timezone.utc)
+    repo_sha = _read_git_sha_prefix(repo_root)
+    manifest = _drycheck_manifest(evidence_root_abs, repo_sha, utc_now)
+
+    manifest_bytes = _canonical_json_bytes(manifest)
+    digest_hex = hashlib.sha256(manifest_bytes).hexdigest()
+
+    md_text = _drycheck_markdown(utc_now, evidence_root_abs, repo_sha)
+
+    evidence_root_abs.mkdir(parents=True, exist_ok=True)
+    md_path = evidence_root_abs / PRESTART_MARKDOWN_ARTIFACT_V0
+    mj_path = evidence_root_abs / PRESTART_MANIFEST_JSON_V0
+    sh_path = evidence_root_abs / PRESTART_MANIFEST_SHA256_V0
+
+    md_path.write_text(md_text, encoding="utf-8")
+    mj_path.write_bytes(manifest_bytes)
+    sh_path.write_text(digest_hex + "\n", encoding="utf-8")
+
+    err.write(_MACHINE_LINES_ALWAYS)
+    err.write(
+        "PRESTART_EVIDENCE_DRYCHECK_WRITTEN=true\nEXIT_CODE={}\n".format(EXIT_DRYCHECK_SUCCESS)
+    )
+    return EXIT_DRYCHECK_SUCCESS
 
 
 def _emit_banner(out: TextIO) -> None:
@@ -107,6 +319,30 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     out = sys.stdout
     err = sys.stderr
+
+    if args.inspect and args.prestart_evidence_drycheck:
+        err.write("--inspect combined with --prestart-evidence-drycheck is not allowed.\n")
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(f"EXIT_REASON=mutually_exclusive_flags\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n")
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    repo_root = _REPO_ROOT_CALC.resolve()
+
+    if args.prestart_evidence_drycheck:
+        validated, ferr = _validate_evidence_root_for_drycheck(args.evidence_root, repo_root)
+        if ferr or validated is None:
+            assert ferr is not None
+            err.write(ferr + "\n")
+            _emit_banner(err)
+            err.write(_MACHINE_LINES_ALWAYS)
+            err.write(
+                f"EXIT_REASON=invalid_evidence_root_drycheck\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n"
+            )
+            return EXIT_FAIL_CLOSED_DEFAULT
+
+        path_v = validated
+        return _execute_prestart_drycheck(path_v, repo_root, err)
 
     ev_err = _validate_evidence_root(args.evidence_root)
     if ev_err:

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import json
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -53,6 +57,7 @@ def test_shadow_247_futures_wrapper_skeleton_source_has_no_blocked_substrings(
         "BOUNDARY_FUTURES_PERP_SCOPE",
         "/tmp/peak_trade",
         "NO_ORDER_SUBMISSION",
+        "PRESTART_SCHEMA_V0",
     ],
 )
 def test_shadow_247_futures_wrapper_skeleton_has_boundary_constants(marker: str) -> None:
@@ -170,3 +175,216 @@ def test_shadow_247_futures_wrapper_skeleton_machine_lines_include_flags() -> No
     assert "BOUNDARY_NO_LIVE" in combo
     assert "RUN_STARTED=false" in combo
     assert "SCHEDULER_STARTED=false" in combo
+
+
+_DRY_ART_MD = "SHADOW_247_FUTURES_PRESTART_EVIDENCE_DRYCHECK.md"
+_DRY_MANIFEST_JSON = "manifest.json"
+_DRY_SHA = "MANIFEST.sha256"
+
+
+def _drycheck_machine_needles() -> tuple[str, ...]:
+    return (
+        "RUN_STARTED=false",
+        "SCHEDULER_STARTED=false",
+        "RUNTIME_STARTED=false",
+        "NETWORK_USED=false",
+        "BROKER_USED=false",
+        "EXCHANGE_USED=false",
+        "ORDER_SUBMISSION_USED=false",
+        "READY_TO_START_FUTURES_SHADOW_247_DAEMON=false",
+    )
+
+
+def test_shadow_247_prestart_evidence_drycheck_writes_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_ev_", dir="/tmp")
+    root = Path(root_str)
+    assert str(root).startswith("/tmp/peak_trade_")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--prestart-evidence-drycheck",
+            "--evidence-root",
+            str(root),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    try:
+        assert proc.returncode == 0
+        combo = proc.stderr + proc.stdout
+        for ln in _drycheck_machine_needles():
+            assert ln in combo
+        assert _DRY_ART_MD in {p.name for p in root.iterdir()}
+        manifest_path = root / _DRY_MANIFEST_JSON
+        manifest_bytes = manifest_path.read_bytes()
+        got_hex = hashlib.sha256(manifest_bytes).hexdigest()
+        sha_file = root / _DRY_SHA
+        assert sha_file.read_text(encoding="utf-8").strip() == got_hex
+        md_txt = (root / _DRY_ART_MD).read_text(encoding="utf-8")
+        for ln in _drycheck_machine_needles():
+            assert ln in md_txt
+        doc = json.loads(manifest_bytes.decode("utf-8"))
+        ms = doc["verbatim_machine_summary"]
+        for ln in _drycheck_machine_needles():
+            assert ln in ms
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_prestart_evidence_drycheck_repeat_overwrites(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_repeat_", dir="/tmp")
+    cli = [
+        sys.executable,
+        str(SCRIPT),
+        "--prestart-evidence-drycheck",
+        "--evidence-root",
+        root_str,
+    ]
+    try:
+        first = subprocess.run(
+            cli, cwd=REPO_ROOT, capture_output=True, text=True, check=False, timeout=10
+        )
+        second = subprocess.run(
+            cli, cwd=REPO_ROOT, capture_output=True, text=True, check=False, timeout=10
+        )
+        assert first.returncode == 0 and second.returncode == 0
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_prestart_evidence_drycheck_requires_strict_tmp_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--prestart-evidence-drycheck",
+            "--evidence-root",
+            "/tmp/does_not_start_with_peak_trade_convention_xx",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 64
+
+
+def test_shadow_247_prestart_evidence_drycheck_rejects_repo_internal_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    inner = REPO_ROOT / "_utest_inside_repo_peak_evidence_drychk"
+    inner.mkdir(parents=True, exist_ok=True)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                str(inner.resolve()),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+    finally:
+        shutil.rmtree(inner, ignore_errors=True)
+
+
+def test_shadow_247_prestart_evidence_drycheck_rejects_nonempty_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_nonempty_", dir="/tmp")
+    root_path = Path(root_str)
+    (root_path / "unexpected.txt").write_text("junk", encoding="utf-8")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                root_str,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_prestart_evidence_drycheck_rejects_paper_named_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    parent_str = tempfile.mkdtemp(prefix="peak_trade_utest_paren_", dir="/tmp")
+    paper_nested = Path(parent_str) / "paper_trade_only"
+    paper_nested.mkdir(parents=True)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                str(paper_nested.resolve()),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+    finally:
+        shutil.rmtree(parent_str, ignore_errors=True)
+
+
+def test_shadow_247_prestart_evidence_drycheck_mutually_exclusive_with_inspect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_mutex_", dir="/tmp")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--inspect",
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                root_str,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "not allowed" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)


### PR DESCRIPTION
## Summary

Adds a default-off prestart evidence drycheck mode to the Shadow 24/7 Futures wrapper skeleton.

The wrapper can now write local prestart evidence artifacts under a validated `/tmp/peak_trade_*` evidence root:

- `SHADOW_247_FUTURES_PRESTART_EVIDENCE_DRYCHECK.md`
- `manifest.json`
- `MANIFEST.sha256`

The wrapper still does **not** start scheduler/runtime/daemon/shadow/testnet/live, does not use network, and does not touch broker/exchange/order paths.

## Scope

Changed files:

- `scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py`
- `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`

## Safety boundaries

This PR does **not** approve or start:

- scheduler/runtime/daemon
- paper/shadow/testnet/live run
- broker/exchange connection
- order submission
- network calls
- Notion/KG update

Preserved boundaries:

- Prestart drycheck ≠ daemon start
- Script skeleton ≠ executable trading path
- Tests ≠ Execution
- Docs ≠ Approval
- Signal ≠ Trade
- AI ≠ Authority
- Dashboard ≠ Freigabe
- Notion ≠ Approval
- Shadow run ≠ Testnet
- Testnet ≠ Live

## Validation

- `uv run pytest tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_executable_start_path_contract_v0.py -q`
- `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
- `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
- `git diff --check`

## Follow-up

After merge/closeout, the next safe gate is:

`shadow_247_futures_prestart_evidence_drycheck_merge_closeout_then_config_job_skeleton_planning_no_runtime`

A real executable daemon start path still requires separate future implementation/review gates.
