### PR TITLE
chore(ops): add shadow 247 futures config job skeleton

### DIFF
--- a/config/ops/shadow_247_futures_wrapper_skeleton.toml
+++ b/config/ops/shadow_247_futures_wrapper_skeleton.toml
@@ -1,0 +1,47 @@
+# Shadow 24/7 Futures wrapper skeleton — read-only ops metadata v0
+#
+# Non-authorizing: documents planning defaults only. Does not enable scheduler, daemon,
+# testnet, live, broker, exchange, network, or order submission.
+# Aligns with config/ops/paper_shadow_247_preflight.toml boolean discipline.
+
+schema_version = "shadow_247_futures_wrapper_skeleton.v0"
+canonical_owner = "ops-shadow-247-futures-wrapper-skeleton"
+
+# Default-off operator posture (config-only; not runtime authority)
+enabled = false
+armed = false
+dry_run = true
+shadow_mode = true
+
+# Capability gates — must remain false until separate explicit governance PRs
+testnet_allowed = false
+live_allowed = false
+paper_allowed = false
+network_allowed = false
+broker_allowed = false
+exchange_allowed = false
+order_submission_allowed = false
+private_exchange_endpoint_allowed = false
+credentials_allowed = false
+
+# Futures / perpetual planning scope (not a trading approval)
+instrument = "BTCUSDT"
+market_type = "futures"
+perpetual_scope = true
+
+# Evidence + wrapper linkage
+evidence_root_convention = "/tmp/peak_trade_*"
+wrapper_script = "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py"
+wrapper_modes_allowed = [
+  "prestart_evidence_drycheck",
+  "inspect",
+  "default_fail_closed",
+]
+wrapper_daemon_start_allowed = false
+
+# Future gates — documented as required, not satisfiable from this file alone
+supervisor_timeout_future_gate_required = true
+abort_stop_criteria_future_gate_required = true
+final_operator_confirmation_gate_required = true
+
+immediate_execution_approved = false

--- a/config/scheduler/jobs.toml
+++ b/config/scheduler/jobs.toml
@@ -264,3 +264,27 @@ script = "scripts/aiops/run_paper_trading_session.py"
 spec = "tests/fixtures/p7/paper_run_min_v0.json"
 outdir = "out/paper_shadow_247/runtime/min/__DRY_RUN_PLACEHOLDER__"
 
+# =============================================================================
+# Shadow 24/7 Futures wrapper — scheduler placeholder (disabled, non-authorizing)
+# =============================================================================
+# Invokes only the default-off wrapper entrypoint shape when enabled in a future gate.
+# Not Testnet/Live/Broker/Exchange/order authorization. Keep enabled=false until separately approved.
+[[job]]
+name = "shadow_247_futures_prestart_evidence_drycheck_placeholder_v0"
+enabled = false
+schedule_type = "once"
+command = "python"
+args = { script = "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py" }
+description = "Placeholder: Futures wrapper fail-closed / prestart-drycheck command shape; disabled; non-authorizing."
+tags = ["shadow_247_futures", "futures_wrapper", "readonly", "disabled_by_default", "prestart_only"]
+timeout_seconds = 120
+paper_only = false
+paper_runtime_job = false
+dry_run_visible = true
+shadow_247_futures_placeholder = true
+testnet_authorized = false
+live_authorized = false
+broker_authorized = false
+exchange_authorized = false
+order_submission_authorized = false
+

--- a/tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py
@@ -1,0 +1,104 @@
+"""Static contract tests for Shadow 24/7 Futures config/job skeleton (no runtime)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef,import-not-found]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPS_CONFIG = REPO_ROOT / "config" / "ops" / "shadow_247_futures_wrapper_skeleton.toml"
+JOBS_CONFIG = REPO_ROOT / "config" / "scheduler" / "jobs.toml"
+
+PLACEHOLDER_JOB_NAME = "shadow_247_futures_prestart_evidence_drycheck_placeholder_v0"
+
+
+def _load_ops_config() -> dict:
+    return tomllib.loads(OPS_CONFIG.read_text(encoding="utf-8"))
+
+
+def _jobs() -> list[dict]:
+    payload = tomllib.loads(JOBS_CONFIG.read_text(encoding="utf-8"))
+    return payload.get("job", [])
+
+
+def test_shadow_247_futures_ops_config_file_exists() -> None:
+    assert OPS_CONFIG.is_file()
+
+
+def test_shadow_247_futures_ops_config_schema_and_wrapper_path() -> None:
+    cfg = _load_ops_config()
+    assert cfg["schema_version"] == "shadow_247_futures_wrapper_skeleton.v0"
+    assert cfg["wrapper_script"] == "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py"
+    assert "/tmp/peak_trade_" in cfg["evidence_root_convention"]
+
+
+def test_shadow_247_futures_ops_config_default_off_core() -> None:
+    cfg = _load_ops_config()
+    assert cfg["enabled"] is False
+    assert cfg["armed"] is False
+    assert cfg["dry_run"] is True
+    assert cfg["shadow_mode"] is True
+    assert cfg["immediate_execution_approved"] is False
+    assert cfg["wrapper_daemon_start_allowed"] is False
+
+
+def test_shadow_247_futures_ops_config_futures_scope_explicit() -> None:
+    cfg = _load_ops_config()
+    assert cfg["instrument"] == "BTCUSDT"
+    assert cfg["market_type"] == "futures"
+    assert cfg["perpetual_scope"] is True
+
+
+def test_shadow_247_futures_ops_config_all_runtime_flags_false() -> None:
+    cfg = _load_ops_config()
+    for key in (
+        "testnet_allowed",
+        "live_allowed",
+        "paper_allowed",
+        "network_allowed",
+        "broker_allowed",
+        "exchange_allowed",
+        "order_submission_allowed",
+        "private_exchange_endpoint_allowed",
+        "credentials_allowed",
+    ):
+        assert cfg[key] is False, key
+
+
+def test_shadow_247_futures_ops_config_future_gates_required_flags() -> None:
+    cfg = _load_ops_config()
+    assert cfg["supervisor_timeout_future_gate_required"] is True
+    assert cfg["abort_stop_criteria_future_gate_required"] is True
+    assert cfg["final_operator_confirmation_gate_required"] is True
+
+
+def test_shadow_247_futures_ops_config_wrapper_modes_include_prestart_only() -> None:
+    cfg = _load_ops_config()
+    modes = cfg["wrapper_modes_allowed"]
+    assert "prestart_evidence_drycheck" in modes
+    assert "inspect" in modes
+    assert "default_fail_closed" in modes
+
+
+def test_shadow_247_futures_scheduler_placeholder_is_disabled_and_safe() -> None:
+    job = next(j for j in _jobs() if j.get("name") == PLACEHOLDER_JOB_NAME)
+    assert job["enabled"] is False
+    assert job["args"]["script"] == "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py"
+    assert job.get("paper_only") is False
+    assert job.get("paper_runtime_job") is False
+    for key in (
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert job[key] is False
+    tags = job.get("tags", [])
+    assert "disabled_by_default" in tags
+    assert "shadow_247_futures" in tags
+    assert "prestart_only" in tags


### PR DESCRIPTION
## Summary

Adds a default-off Shadow 24/7 Futures config/job skeleton and static tests.

This PR creates an inert ops config and disabled scheduler placeholder for the Shadow 24/7 Futures prestart-evidence-drycheck path. It does not enable runtime execution.

## Scope

Changed files:

- `config/ops/shadow_247_futures_wrapper_skeleton.toml`
- `config/scheduler/jobs.toml`
- `tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`

## Safety boundaries

This PR does **not** approve or start:

- scheduler/runtime/daemon
- paper/shadow/testnet/live run
- broker/exchange connection
- order submission
- network calls
- Notion/KG update

Preserved boundaries:

- Config skeleton ≠ runtime start
- Scheduler placeholder is disabled/default-off
- Tests ≠ Execution
- Docs ≠ Approval
- Signal ≠ Trade
- AI ≠ Authority
- Dashboard ≠ Freigabe
- Notion ≠ Approval
- Shadow run ≠ Testnet
- Testnet ≠ Live

## Validation

- `uv run pytest tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_executable_start_path_contract_v0.py -q`
- `uv run ruff check tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`
- `uv run ruff format --check tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`
- `git diff --check`

## Follow-up

After merge/closeout, the next safe gate is:

`shadow_247_futures_config_job_skeleton_merge_closeout_then_wrapper_config_validation_no_runtime`

A real executable daemon start path still requires separate future implementation/review gates.
