### PR TITLE
chore(ops): validate shadow 247 futures config read-only

### DIFF
--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -14,9 +14,10 @@ import argparse
 import hashlib
 import json
 import sys
+import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Sequence, TextIO, Tuple
+from typing import Any, Mapping, MutableMapping, Sequence, TextIO, Tuple
 
 # -----------------------------------------------------------------------------
 # Safety / scope constants (documentation + static-test anchors; not authority)
@@ -47,6 +48,25 @@ PRESTART_MANIFEST_SHA256_V0 = "MANIFEST.sha256"
 _DRYCHECK_ALLOWED_ENTRIES = frozenset(
     {PRESTART_MARKDOWN_ARTIFACT_V0, PRESTART_MANIFEST_JSON_V0, PRESTART_MANIFEST_SHA256_V0},
 )
+
+_OPS_CFG_EXPECT_BOOLS: Mapping[str, bool] = {
+    "enabled": False,
+    "armed": False,
+    "dry_run": True,
+    "shadow_mode": True,
+    "live_allowed": False,
+    "testnet_allowed": False,
+    "network_allowed": False,
+    "broker_allowed": False,
+    "exchange_allowed": False,
+    "order_submission_allowed": False,
+    "private_exchange_endpoint_allowed": False,
+    "credentials_allowed": False,
+}
+_OPS_EXPECT_STR = {"instrument": "BTCUSDT", "market_type": "futures"}
+_OPS_EXPECT_SCRIPT = "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py"
+
+_SHADOW_FUTURES_SCHEDULER_JOB_V0 = "shadow_247_futures_prestart_evidence_drycheck_placeholder_v0"
 
 # Future-only gate token (explicit operator string). **Presence does NOT enable runtime.**
 FUTURE_OPERATOR_CONFIRMATION_TOKEN_V0 = (
@@ -101,7 +121,265 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
             "with `--prestart-evidence-drycheck`."
         ),
     )
+    parser.add_argument(
+        "--config",
+        metavar="PATH",
+        default="",
+        dest="ops_config_path",
+        help=(
+            "**With `--prestart-evidence-drycheck` only.** Read-only validate default-off Ops "
+            "skeleton (`shadow_247_futures_wrapper_skeleton`) invariants via stdlib tomllib "
+            "(path must lie under repo root)."
+        ),
+    )
+    parser.add_argument(
+        "--jobs-config",
+        metavar="PATH",
+        default="",
+        dest="jobs_config_path",
+        help=(
+            "**With `--prestart-evidence-drycheck` only.** Read-only validate the disabled "
+            "scheduler placeholder row (stdlib tomllib)."
+        ),
+    )
     return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def _resolve_repo_relative_file(repo_root: Path, path_str: str) -> Tuple[Path | None, str | None]:
+    """Resolve a filesystem path strictly under ``repo_root``; return (path, None) or (None, err)."""
+    trimmed = path_str.strip()
+    if not trimmed:
+        return None, "empty configuration path argument"
+    if ".." in Path(trimmed).parts:
+        return None, "config path must not contain path traversal segments"
+    candidate = Path(trimmed).expanduser()
+    repo_resolved = repo_root.resolve()
+    merged = candidate if candidate.is_absolute() else (repo_resolved / candidate)
+    try:
+        resolved = merged.resolve(strict=True)
+    except (FileNotFoundError, OSError, RuntimeError):
+        return None, f"cannot resolve readable file under repo: {candidate}"
+    if not resolved.is_relative_to(repo_resolved):
+        return None, "config files must reside under the repository checkout root"
+    if not resolved.is_file():
+        return None, "config path must be a regular existing file inside the repo"
+    return resolved, None
+
+
+def _validate_shadow_futures_ops_doc(doc: Mapping[str, Any]) -> list[str]:
+    errs: list[str] = []
+    if not isinstance(doc, Mapping):
+        return ["ops config root document is not a TOML table"]
+
+    if doc.get("schema_version") != "shadow_247_futures_wrapper_skeleton.v0":
+        errs.append(
+            f"schema_version must be shadow_247_futures_wrapper_skeleton.v0 "
+            f"(got {doc.get('schema_version')!r})"
+        )
+
+    for key, expect in _OPS_CFG_EXPECT_BOOLS.items():
+        if key not in doc:
+            errs.append(f"missing ops key `{key}`")
+            continue
+        obs = doc[key]
+        if not isinstance(obs, bool):
+            errs.append(f"expected boolean for `{key}` (got `{type(obs).__name__}`)")
+            continue
+        if obs != expect:
+            errs.append(f"`{key}` mismatch: requires {expect!r}, observed {obs!r}")
+
+    if "paper_allowed" in doc:
+        pa = doc["paper_allowed"]
+        if isinstance(pa, bool):
+            if pa is not False:
+                errs.append("`paper_allowed` must be false when present")
+        else:
+            errs.append("`paper_allowed` must be boolean when present")
+
+    for key, expect in _OPS_EXPECT_STR.items():
+        obs = doc.get(key)
+        if not isinstance(obs, str):
+            errs.append(f"expected string for `{key}` (got {type(obs).__name__})")
+        elif obs != expect:
+            errs.append(f"`{key}` mismatch: requires {expect!r}, observed {obs!r}")
+
+    if doc.get("perpetual_scope") is not True:
+        errs.append(f"`perpetual_scope` must be true (got {doc.get('perpetual_scope')!r})")
+
+    obs_script = doc.get("wrapper_script")
+    if obs_script != _OPS_EXPECT_SCRIPT:
+        errs.append(
+            f"`wrapper_script` mismatch: requires {_OPS_EXPECT_SCRIPT!r}, observed {obs_script!r}",
+        )
+
+    if "wrapper_daemon_start_allowed" in doc:
+        wds = doc["wrapper_daemon_start_allowed"]
+        if isinstance(wds, bool):
+            if wds is not False:
+                errs.append("`wrapper_daemon_start_allowed` must be false when present")
+        else:
+            errs.append("`wrapper_daemon_start_allowed` must be boolean when present")
+
+    if "immediate_execution_approved" in doc:
+        ie = doc["immediate_execution_approved"]
+        if isinstance(ie, bool):
+            if ie is not False:
+                errs.append("`immediate_execution_approved` must be false when present")
+        else:
+            errs.append("`immediate_execution_approved` must be boolean when present")
+
+    conv = doc.get("evidence_root_convention")
+    if not isinstance(conv, str) or "/tmp/peak_trade_" not in conv:
+        errs.append("`evidence_root_convention` must mention `/tmp/peak_trade_*` convention")
+
+    return errs
+
+
+def _validate_shadow_futures_jobs_placeholder(doc: Mapping[str, Any]) -> list[str]:
+    errs: list[str] = []
+    rows = doc.get("job")
+    if rows is None:
+        return ["`jobs.toml` missing `job` tables"]
+    if not isinstance(rows, list):
+        return [f"`job` tables must decode to a list (got `{type(rows).__name__}`)"]
+
+    found: Mapping[str, Any] | None = None
+    for row in rows:
+        if isinstance(row, Mapping) and row.get("name") == _SHADOW_FUTURES_SCHEDULER_JOB_V0:
+            found = row
+            break
+    if found is None:
+        return [
+            (
+                "scheduler placeholder job "
+                f"{_SHADOW_FUTURES_SCHEDULER_JOB_V0!r} not present in `--jobs-config` tables"
+            ),
+        ]
+
+    if found.get("enabled") is not False:
+        errs.append(
+            "`enabled` mismatch for Futures placeholder job: requires false, observed "
+            f"{found.get('enabled')!r}",
+        )
+
+    args = found.get("args")
+    if not isinstance(args, Mapping):
+        errs.append("placeholder job `args` missing or not a table")
+        return errs
+    scr = args.get("script")
+    if scr != _OPS_EXPECT_SCRIPT:
+        errs.append(
+            f"placeholder args.script mismatch: requires {_OPS_EXPECT_SCRIPT!r}, observed {scr!r}",
+        )
+    return errs
+
+
+def _build_readonly_validation_block(
+    repo_root: Path,
+    ops_path_arg: str,
+    jobs_path_arg: str,
+) -> Tuple[dict[str, Any], list[str]]:
+    """Produce JSON-serializable validation summary plus combined blocking errors."""
+
+    blk: dict[str, Any] = {
+        "ops_config_provided": bool(ops_path_arg.strip()),
+        "ops_config_absolute": None,
+        "ops_validation_errors": [],
+        "jobs_config_provided": bool(jobs_path_arg.strip()),
+        "jobs_config_absolute": None,
+        "jobs_validation_errors": [],
+        "combined_validation_ok": True,
+    }
+    errs: list[str] = []
+
+    if blk["ops_config_provided"]:
+        p, perr = _resolve_repo_relative_file(repo_root, ops_path_arg)
+        if perr or p is None:
+            assert perr is not None
+            blk["ops_validation_errors"] = [perr]
+            errs.append(perr)
+            blk["combined_validation_ok"] = False
+        else:
+            blk["ops_config_absolute"] = str(p)
+            raw = p.read_bytes()
+            try:
+                doc = tomllib.loads(raw.decode("utf-8"))
+            except tomllib.TOMLDecodeError as exc:
+                msg = f"ops TOML decode error: {exc}"
+                blk["ops_validation_errors"] = [msg]
+                errs.append(msg)
+                blk["combined_validation_ok"] = False
+            else:
+                oerrs = _validate_shadow_futures_ops_doc(doc)
+                blk["ops_validation_errors"] = oerrs
+                if oerrs:
+                    errs.extend(oerrs)
+                    blk["combined_validation_ok"] = False
+
+    if blk["jobs_config_provided"]:
+        p, perr = _resolve_repo_relative_file(repo_root, jobs_path_arg)
+        if perr or p is None:
+            assert perr is not None
+            blk["jobs_validation_errors"] = [perr]
+            errs.append(perr)
+            blk["combined_validation_ok"] = False
+        else:
+            blk["jobs_config_absolute"] = str(p)
+            raw = p.read_bytes()
+            try:
+                doc = tomllib.loads(raw.decode("utf-8"))
+            except tomllib.TOMLDecodeError as exc:
+                msg = f"jobs TOML decode error: {exc}"
+                blk["jobs_validation_errors"] = [msg]
+                errs.append(msg)
+                blk["combined_validation_ok"] = False
+            else:
+                jerrs = _validate_shadow_futures_jobs_placeholder(doc)
+                blk["jobs_validation_errors"] = jerrs
+                if jerrs:
+                    errs.extend(jerrs)
+                    blk["combined_validation_ok"] = False
+
+    return blk, errs
+
+
+def _readonly_validation_markdown_lines(val: Mapping[str, Any]) -> list[str]:
+    lines: list[str] = [
+        "## Read-only config validation (local; not an execution approval)\n\n",
+    ]
+    if not val["ops_config_provided"] and not val["jobs_config_provided"]:
+        lines.append(
+            "- Config paths not supplied — validation **skipped** (drycheck evidence only).\n\n",
+        )
+        return lines
+
+    if val["ops_config_provided"]:
+        ap = val["ops_config_absolute"]
+        oerrs = val["ops_validation_errors"]
+        state = "PASS" if not oerrs else "FAIL"
+        lines.append(f"- Ops skeleton (`--config`): **{state}** — `{ap}`\n")
+        if oerrs:
+            for e in oerrs:
+                lines.append(f"  - Error: `{e}`\n")
+        lines.append("\n")
+
+    if val["jobs_config_provided"]:
+        jp = val["jobs_config_absolute"]
+        jerrs = val["jobs_validation_errors"]
+        state = "PASS" if not jerrs else "FAIL"
+        lines.append(
+            f"- Scheduler placeholder (`--jobs-config`): **{state}** — `{jp}`\n",
+        )
+        if jerrs:
+            for e in jerrs:
+                lines.append(f"  - Error: `{e}`\n")
+        lines.append("\n")
+
+    assert isinstance(val["combined_validation_ok"], bool)
+    lines.append(
+        f"- Combined validation OK: **{str(val['combined_validation_ok']).lower()}**\n\n",
+    )
+    return lines
 
 
 def _validate_evidence_root(path_str: str) -> str | None:
@@ -226,8 +504,22 @@ def _drycheck_manifest(
     evidence_abs: Path,
     repo_sha: str,
     utc_now: datetime,
+    readonly_cfg_block: Mapping[str, Any],
 ) -> dict:
-    return {
+    base_claim = (
+        "No run, scheduler, daemon, network, broker, exchange, orders, shadow/paper/testnet/live "
+        "workloads — evidence only."
+    )
+    if readonly_cfg_block.get("ops_config_provided") or readonly_cfg_block.get(
+        "jobs_config_provided"
+    ):
+        claim = (
+            base_claim + " Read-only Ops / scheduler-placeholder TOML invariants asserted locally."
+        )
+    else:
+        claim = base_claim
+
+    manifest: MutableMapping[str, Any] = {
         "artifact": PRESTART_SCHEMA_V0,
         "broker_used": False,
         "daemon_run_approved": False,
@@ -239,10 +531,8 @@ def _drycheck_manifest(
         "markdown_artifact_filename": PRESTART_MARKDOWN_ARTIFACT_V0,
         "network_used": False,
         "order_submission_used": False,
-        "prestart_claims_summary": (
-            "No run, scheduler, daemon, network, broker, exchange, orders, shadow/paper/testnet/"
-            "live workloads — evidence only."
-        ),
+        "prestart_claims_summary": claim,
+        "readonly_local_config_skeleton_validation": dict(readonly_cfg_block),
         "ready_to_start_futures_shadow_247_daemon": False,
         "run_started": False,
         "runtime_started": False,
@@ -251,12 +541,14 @@ def _drycheck_manifest(
         "verbatim_machine_summary": _MACHINE_LINES_ALWAYS.rstrip("\n"),
         "wrapper_requires_future_gate_before_execution": True,
     }
+    return manifest
 
 
 def _drycheck_markdown(
     utc_now: datetime,
     evidence_abs: Path,
     repo_sha: str,
+    readonly_cfg_block: Mapping[str, Any],
 ) -> str:
     lines = (
         "# Shadow 24-7 Futures — Prestart Evidence Drycheck (Local)\n\n",
@@ -273,6 +565,7 @@ def _drycheck_markdown(
         "```text\n",
         _MACHINE_LINES_ALWAYS,
         "```\n\n",
+        *_readonly_validation_markdown_lines(readonly_cfg_block),
         "## Appendix\n\n",
         "Drycheck artefacts: `manifest.json`, `MANIFEST.sha256`. "
         "`MANIFEST.sha256` covers canonical UTF-8 bytes of sorted-key pretty JSON manifest.\n",
@@ -280,15 +573,20 @@ def _drycheck_markdown(
     return "".join(lines)
 
 
-def _execute_prestart_drycheck(evidence_root_abs: Path, repo_root: Path, err: TextIO) -> int:
+def _execute_prestart_drycheck(
+    evidence_root_abs: Path,
+    repo_root: Path,
+    err: TextIO,
+    readonly_cfg_block: Mapping[str, Any],
+) -> int:
     utc_now = datetime.now(timezone.utc)
     repo_sha = _read_git_sha_prefix(repo_root)
-    manifest = _drycheck_manifest(evidence_root_abs, repo_sha, utc_now)
+    manifest = _drycheck_manifest(evidence_root_abs, repo_sha, utc_now, readonly_cfg_block)
 
     manifest_bytes = _canonical_json_bytes(manifest)
     digest_hex = hashlib.sha256(manifest_bytes).hexdigest()
 
-    md_text = _drycheck_markdown(utc_now, evidence_root_abs, repo_sha)
+    md_text = _drycheck_markdown(utc_now, evidence_root_abs, repo_sha, readonly_cfg_block)
 
     evidence_root_abs.mkdir(parents=True, exist_ok=True)
     md_path = evidence_root_abs / PRESTART_MARKDOWN_ARTIFACT_V0
@@ -300,6 +598,15 @@ def _execute_prestart_drycheck(evidence_root_abs: Path, repo_root: Path, err: Te
     sh_path.write_text(digest_hex + "\n", encoding="utf-8")
 
     err.write(_MACHINE_LINES_ALWAYS)
+    if readonly_cfg_block.get("ops_config_provided") or readonly_cfg_block.get(
+        "jobs_config_provided"
+    ):
+        err.write("READONLY_OPS_OR_JOBS_CONFIG_VALIDATED=true\n")
+        err.write("READONLY_CONFIG_VALIDATION_OK=true\n")
+    else:
+        err.write("READONLY_OPS_OR_JOBS_CONFIG_VALIDATED=false\n")
+        err.write("READONLY_CONFIG_VALIDATION_OK=skipped\n")
+
     err.write(
         "PRESTART_EVIDENCE_DRYCHECK_WRITTEN=true\nEXIT_CODE={}\n".format(EXIT_DRYCHECK_SUCCESS)
     )
@@ -327,6 +634,29 @@ def main(argv: Sequence[str] | None = None) -> int:
         err.write(f"EXIT_REASON=mutually_exclusive_flags\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n")
         return EXIT_FAIL_CLOSED_DEFAULT
 
+    if args.inspect and (args.ops_config_path.strip() or args.jobs_config_path.strip()):
+        err.write("--inspect cannot be combined with --config/--jobs-config.\n")
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(
+            f"EXIT_REASON=mutually_exclusive_inspect_vs_config_validate\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n"
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    if (args.ops_config_path.strip() or args.jobs_config_path.strip()) and (
+        not args.prestart_evidence_drycheck
+    ):
+        err.write(
+            "`--config` / `--jobs-config` are invalid without `--prestart-evidence-drycheck` "
+            "(read-only skeleton validation emits evidence only).\n",
+        )
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(
+            f"EXIT_REASON=config_validate_requires_drycheck\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
     repo_root = _REPO_ROOT_CALC.resolve()
 
     if args.prestart_evidence_drycheck:
@@ -342,7 +672,32 @@ def main(argv: Sequence[str] | None = None) -> int:
             return EXIT_FAIL_CLOSED_DEFAULT
 
         path_v = validated
-        return _execute_prestart_drycheck(path_v, repo_root, err)
+
+        cfg_block, ferr_list = _build_readonly_validation_block(
+            repo_root,
+            args.ops_config_path,
+            args.jobs_config_path,
+        )
+        if not cfg_block["combined_validation_ok"]:
+            err.write(
+                "Read-only shadow futures ops/jobs TOML validation failed — evidence artefacts "
+                "were not written.\n",
+            )
+            for msg in ferr_list:
+                err.write(f"- {msg}\n")
+            _emit_banner(err)
+            err.write(_MACHINE_LINES_ALWAYS)
+            err.write(
+                "READONLY_OPS_OR_JOBS_CONFIG_VALIDATED="
+                + str(cfg_block["ops_config_provided"] or cfg_block["jobs_config_provided"]).lower()
+                + "\n",
+            )
+            err.write(
+                f"EXIT_REASON=readonly_config_skeleton_validation_failed\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n"
+            )
+            return EXIT_FAIL_CLOSED_DEFAULT
+
+        return _execute_prestart_drycheck(path_v, repo_root, err, cfg_block)
 
     ev_err = _validate_evidence_root(args.evidence_root)
     if ev_err:

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -221,6 +221,8 @@ def test_shadow_247_prestart_evidence_drycheck_writes_artifacts(
         combo = proc.stderr + proc.stdout
         for ln in _drycheck_machine_needles():
             assert ln in combo
+        assert "READONLY_OPS_OR_JOBS_CONFIG_VALIDATED=false" in combo
+        assert "READONLY_CONFIG_VALIDATION_OK=skipped" in combo
         assert _DRY_ART_MD in {p.name for p in root.iterdir()}
         manifest_path = root / _DRY_MANIFEST_JSON
         manifest_bytes = manifest_path.read_bytes()
@@ -230,10 +232,16 @@ def test_shadow_247_prestart_evidence_drycheck_writes_artifacts(
         md_txt = (root / _DRY_ART_MD).read_text(encoding="utf-8")
         for ln in _drycheck_machine_needles():
             assert ln in md_txt
+        assert "## Read-only config validation" in md_txt
+        assert "skipped" in md_txt.lower()
         doc = json.loads(manifest_bytes.decode("utf-8"))
         ms = doc["verbatim_machine_summary"]
         for ln in _drycheck_machine_needles():
             assert ln in ms
+        blk = doc["readonly_local_config_skeleton_validation"]
+        assert blk["ops_config_provided"] is False
+        assert blk["jobs_config_provided"] is False
+        assert blk["combined_validation_ok"] is True
     finally:
         shutil.rmtree(root_str, ignore_errors=True)
 
@@ -388,3 +396,281 @@ def test_shadow_247_prestart_evidence_drycheck_mutually_exclusive_with_inspect(
         assert "not allowed" in (proc.stderr + proc.stdout).lower()
     finally:
         shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_wrapper_config_validate_requires_prestart_drycheck(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--config",
+            "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 64
+    assert "drycheck" in (proc.stderr + proc.stdout).lower()
+
+
+def test_shadow_247_wrapper_inspect_rejects_paired_config_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--inspect",
+            "--config",
+            "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert proc.returncode == 64
+
+
+def test_shadow_247_prestart_drycheck_with_valid_ops_config_writes_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_ro_cfg_", dir="/tmp")
+    root = Path(root_str)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--prestart-evidence-drycheck",
+            "--evidence-root",
+            str(root),
+            "--config",
+            "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    try:
+        assert proc.returncode == 0
+        combo = proc.stderr + proc.stdout
+        assert "READONLY_OPS_OR_JOBS_CONFIG_VALIDATED=true" in combo
+        assert "READONLY_CONFIG_VALIDATION_OK=true" in combo
+        md_txt = (root / _DRY_ART_MD).read_text(encoding="utf-8")
+        assert "**PASS**" in md_txt
+        doc = json.loads((root / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        blk = doc["readonly_local_config_skeleton_validation"]
+        assert blk["ops_config_provided"] is True
+        assert blk["jobs_config_provided"] is False
+        assert blk["combined_validation_ok"] is True
+        assert not blk["ops_validation_errors"]
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_prestart_drycheck_with_ops_and_scheduler_jobs_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_ro_dual_", dir="/tmp")
+    root = Path(root_str)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--prestart-evidence-drycheck",
+            "--evidence-root",
+            str(root),
+            "--config",
+            "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+            "--jobs-config",
+            "config/scheduler/jobs.toml",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    try:
+        assert proc.returncode == 0
+        doc = json.loads((root / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        blk = doc["readonly_local_config_skeleton_validation"]
+        assert blk["ops_config_provided"] is True
+        assert blk["jobs_config_provided"] is True
+        assert blk["combined_validation_ok"] is True
+        tail = Path(blk["jobs_config_absolute"]).as_posix()
+        assert tail.endswith("config/scheduler/jobs.toml")
+        assert not blk["ops_validation_errors"] and not blk["jobs_validation_errors"]
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def _mutate_ops_fixture(text: str, rel_name: str) -> Path:
+    mut_dir = REPO_ROOT / "_utest_shadow_247_ops_cfg_mut"
+    mut_dir.mkdir(exist_ok=True)
+    p = mut_dir / rel_name
+    p.write_text(text, encoding="utf-8")
+    return p.relative_to(REPO_ROOT)
+
+
+def test_shadow_247_prestart_drycheck_mutated_ops_config_fail_closed_no_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    good = (REPO_ROOT / "config/ops/shadow_247_futures_wrapper_skeleton.toml").read_text(
+        encoding="utf-8",
+    )
+    bad = good.replace("enabled = false", "enabled = true", 1)
+    rel = _mutate_ops_fixture(bad, "unsafe_enabled_true.toml")
+    mut_dir = REPO_ROOT / "_utest_shadow_247_ops_cfg_mut"
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_ro_bad_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                str(root),
+                "--config",
+                str(rel),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        combo = proc.stderr + proc.stdout
+        assert "validation failed" in combo.lower()
+        assert not (root / _DRY_ART_MD).exists()
+        assert "READY_TO_START_FUTURES_SHADOW_247_DAEMON=true" not in combo
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+        shutil.rmtree(mut_dir, ignore_errors=True)
+
+
+def test_shadow_247_prestart_drycheck_mutated_live_allowed_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    good = (REPO_ROOT / "config/ops/shadow_247_futures_wrapper_skeleton.toml").read_text(
+        encoding="utf-8",
+    )
+    bad = good.replace("live_allowed = false", "live_allowed = true", 1)
+    rel = _mutate_ops_fixture(bad, "unsafe_live.toml")
+    mut_dir = REPO_ROOT / "_utest_shadow_247_ops_cfg_mut"
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_ro_bad2_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                str(root),
+                "--config",
+                str(rel),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert not (root / _DRY_ART_MD).exists()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+        shutil.rmtree(mut_dir, ignore_errors=True)
+
+
+def test_shadow_247_prestart_drycheck_mutated_order_submission_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    good = (REPO_ROOT / "config/ops/shadow_247_futures_wrapper_skeleton.toml").read_text(
+        encoding="utf-8",
+    )
+    bad = good.replace(
+        "order_submission_allowed = false",
+        "order_submission_allowed = true",
+        1,
+    )
+    rel = _mutate_ops_fixture(bad, "unsafe_orders.toml")
+    mut_dir = REPO_ROOT / "_utest_shadow_247_ops_cfg_mut"
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_ro_bad3_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                str(root),
+                "--config",
+                str(rel),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert not (root / _DRY_ART_MD).exists()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+        shutil.rmtree(mut_dir, ignore_errors=True)
+
+
+def test_shadow_247_prestart_drycheck_mutated_instrument_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    good = (REPO_ROOT / "config/ops/shadow_247_futures_wrapper_skeleton.toml").read_text(
+        encoding="utf-8",
+    )
+    bad = good.replace('instrument = "BTCUSDT"', 'instrument = "ETHUSDT"', 1)
+    rel = _mutate_ops_fixture(bad, "unsafe_instrument.toml")
+    mut_dir = REPO_ROOT / "_utest_shadow_247_ops_cfg_mut"
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_ro_bad4_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                str(root),
+                "--config",
+                str(rel),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert not (root / _DRY_ART_MD).exists()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+        shutil.rmtree(mut_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Extends the Shadow 24/7 Futures wrapper skeleton with read-only config/job validation during prestart evidence drycheck.

The wrapper can now validate the inert/default-off config skeleton and disabled scheduler placeholder without starting anything.

## Scope

Changed files:

- `scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py`
- `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`

## Behavior

New flags:

- `--config config/ops/shadow_247_futures_wrapper_skeleton.toml`
- `--jobs-config config/scheduler/jobs.toml`

These are only valid with:

- `--prestart-evidence-drycheck`
- `--evidence-root /tmp/peak_trade_*`

The wrapper validates:

- default-off / fail-closed flags
- BTCUSDT futures/perpetual scope
- wrapper path
- disabled scheduler placeholder
- no live/testnet/broker/exchange/order/network authority

Successful drycheck writes only local evidence artifacts under the supplied `/tmp/peak_trade_*` root.

## Safety boundaries

This PR does **not** approve or start:

- scheduler/runtime/daemon
- paper/shadow/testnet/live run
- broker/exchange connection
- order submission
- network calls
- Notion/KG update

Preserved boundaries:

- Config validation ≠ runtime start
- Prestart drycheck ≠ daemon start
- Tests ≠ Execution
- Docs ≠ Approval
- Signal ≠ Trade
- AI ≠ Authority
- Dashboard ≠ Freigabe
- Notion ≠ Approval
- Shadow run ≠ Testnet
- Testnet ≠ Live

## Validation

- `uv run pytest tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py tests/ops/test_shadow_247_futures_executable_start_path_contract_v0.py -q`
- `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
- `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
- `git diff --check`

## Follow-up

After merge/closeout, the next safe gate is:

`shadow_247_futures_wrapper_config_validation_merge_closeout_then_wrapper_drycheck_operator_probe_no_runtime`

A real executable daemon start path still requires separate future implementation/review gates.
