### PR TITLE
fix(ops): support tomli fallback for shadow 247 wrapper

### DIFF
--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -14,7 +14,11 @@ import argparse
 import hashlib
 import json
 import sys
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python < 3.11 in CI
+    import tomli as tomllib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping, Sequence, TextIO, Tuple


### PR DESCRIPTION
## Summary

Cherry-picks the Python 3.9 / 3.10 compatibility fix that was not included in the squash merge of PR #3528.

The Shadow 24/7 Futures wrapper currently imports `tomllib`, which is stdlib only on Python 3.11+. This PR adds the intended fallback:

- Python 3.11+: `tomllib`
- Python 3.9 / 3.10: `tomli as tomllib`

## Scope

Changed file:

- `scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py`

## Why this is needed

PR #3528 merged the bounded runtime contract test, but the later compatibility commit from the PR branch was not part of the squash/merge result on `main`.

Without this fix, Python 3.9 / 3.10 CI paths that import or execute the wrapper can fail with:

`ModuleNotFoundError: No module named 'tomllib'`

## Safety boundaries

This PR does **not** approve or start:

- scheduler/runtime/daemon
- paper/shadow/testnet/live run
- broker/exchange connection
- order submission
- network calls
- Notion/KG update

Preserved boundaries:

- Compatibility fix ≠ execution
- Tests ≠ Execution
- Contract ≠ Approval
- Shadow run ≠ Testnet
- Testnet ≠ Live

## Validation

- `uv run pytest tests/ops/test_shadow_247_futures_bounded_runtime_contract_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py tests/ops/test_shadow_247_futures_executable_start_path_contract_v0.py -q`
- `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_bounded_runtime_contract_v0.py tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`
- `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_bounded_runtime_contract_v0.py tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`
- `git diff --check`

## Follow-up

After merge/closeout, rerun the PR #3528 closeout marker that checks `TOMLLIB_FALLBACK_ON_MAIN=true`.

No runtime execution is approved by this PR.
