### PR TITLE
chore(ops): add paced bounded shadow dry-run option

### DIFF
--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import sys
 import time
 
@@ -60,6 +61,7 @@ BOUNDED_SHADOW_DRY_RUN_MARKDOWN_V0 = "SHADOW_247_FUTURES_BOUNDED_SHADOW_DRY_RUN.
 BOUNDED_SHADOW_STEPS_JSONL_V0 = "steps.jsonl"
 BOUNDED_SHADOW_DURATION_CAP_MINUTES = 10
 BOUNDED_SHADOW_MAX_STEPS_CAP = 600
+BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS = 60.0
 
 _BOUNDED_SHADOW_ALLOWED_ENTRIES = frozenset(
     {
@@ -184,6 +186,17 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         help=(
             f"With `--bounded-shadow-dry-run` only: step budget 1–{BOUNDED_SHADOW_MAX_STEPS_CAP} "
             "(default ~12× duration minutes, capped)."
+        ),
+    )
+    parser.add_argument(
+        "--step-interval-seconds",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        dest="step_interval_seconds",
+        help=(
+            "`--bounded-shadow-dry-run` only: wall-clock seconds between simulated steps "
+            f"(0–{BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS:g}; default 0 for fast local tests)."
         ),
     )
     parser.add_argument(
@@ -816,6 +829,7 @@ def _bounded_shadow_markdown(
             "## Run parameters\n\n",
             f"- Duration cap (minutes): `{run_meta['duration_minutes']}`\n",
             f"- Step budget: `{run_meta['max_steps']}`\n",
+            f"- Step interval (seconds): `{run_meta['step_interval_seconds']}`\n",
             f"- Steps emitted: `{run_meta['steps_emitted']}`\n",
             f"- UTC end: `{run_meta['utc_end']}`\n\n",
             *_readonly_validation_markdown_lines(readonly_cfg_block),
@@ -867,6 +881,7 @@ def _bounded_shadow_manifest(
         "scheduler_started": False,
         "shadow_mode": True,
         "shadow_started": True,
+        "step_interval_seconds": float(run_meta["step_interval_seconds"]),
         "steps_emitted": int(run_meta["steps_emitted"]),
         "steps_jsonl_filename": BOUNDED_SHADOW_STEPS_JSONL_V0,
         "testnet_started": False,
@@ -884,6 +899,7 @@ def _execute_bounded_shadow_dry_run(
     readonly_cfg_block: Mapping[str, Any],
     duration_minutes: int,
     max_steps: int,
+    step_interval_seconds: float,
 ) -> int:
     utc_started = datetime.now(timezone.utc)
     deadline = time.monotonic() + float(duration_minutes) * 60.0
@@ -899,11 +915,18 @@ def _execute_bounded_shadow_dry_run(
         }
         lines.append(json.dumps(payload, sort_keys=True) + "\n")
         steps_emitted += 1
+        if steps_emitted >= max_steps or time.monotonic() >= deadline:
+            break
+        if step_interval_seconds > 0.0:
+            remaining_deadline = deadline - time.monotonic()
+            if remaining_deadline > 0.0:
+                time.sleep(min(step_interval_seconds, remaining_deadline))
 
     utc_ended = datetime.now(timezone.utc)
     run_meta: dict[str, Any] = {
         "duration_minutes": duration_minutes,
         "max_steps": max_steps,
+        "step_interval_seconds": step_interval_seconds,
         "steps_emitted": steps_emitted,
         "utc_end": utc_ended.strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
@@ -937,6 +960,7 @@ def _execute_bounded_shadow_dry_run(
     err.write(_BOUNDED_SHADOW_MACHINE_LINES)
     err.write("READONLY_OPS_OR_JOBS_CONFIG_VALIDATED=true\n")
     err.write("READONLY_CONFIG_VALIDATION_OK=true\n")
+    err.write(f"STEP_INTERVAL_SECONDS={step_interval_seconds}\n")
     err.write(f"BOUNDED_SHADOW_DRY_RUN_STEPS_EMITTED={steps_emitted}\n")
     err.write("BOUNDED_SHADOW_DRY_RUN_WRITTEN=true\n")
     err.write(f"EXIT_CODE={EXIT_DRYCHECK_SUCCESS}\n")
@@ -1023,6 +1047,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         err.write(_MACHINE_LINES_ALWAYS)
         err.write(
             f"EXIT_REASON=max_steps_requires_bounded_shadow\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    if args.step_interval_seconds is not None and not args.bounded_shadow_dry_run:
+        err.write("`--step-interval-seconds` is only valid with `--bounded-shadow-dry-run`.\n")
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(
+            f"EXIT_REASON=step_interval_requires_bounded_shadow\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
         )
         return EXIT_FAIL_CLOSED_DEFAULT
 
@@ -1215,7 +1248,37 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return EXIT_FAIL_CLOSED_DEFAULT
 
-        return _execute_bounded_shadow_dry_run(validated, repo_root, err, cfg_block, dm, int(ms))
+        step_iv = 0.0 if args.step_interval_seconds is None else float(args.step_interval_seconds)
+        if not math.isfinite(step_iv):
+            err.write("`--step-interval-seconds` must be a finite number.\n")
+            _emit_banner(err)
+            err.write(_MACHINE_LINES_ALWAYS)
+            err.write(
+                f"EXIT_REASON=bounded_shadow_step_interval_non_finite\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+            )
+            return EXIT_FAIL_CLOSED_DEFAULT
+        if step_iv < 0.0 or step_iv > BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS:
+            err.write(
+                "`--step-interval-seconds` must be between 0 and "
+                f"{BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS:g} inclusive.\n",
+            )
+            _emit_banner(err)
+            err.write(_MACHINE_LINES_ALWAYS)
+            err.write(
+                f"EXIT_REASON=bounded_shadow_step_interval_out_of_range\n"
+                f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+            )
+            return EXIT_FAIL_CLOSED_DEFAULT
+
+        return _execute_bounded_shadow_dry_run(
+            validated,
+            repo_root,
+            err,
+            cfg_block,
+            dm,
+            int(ms),
+            step_iv,
+        )
 
     if args.prestart_evidence_drycheck:
         validated, ferr = _validate_evidence_root_for_drycheck(args.evidence_root, repo_root)

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -65,9 +65,11 @@ def test_shadow_247_futures_wrapper_skeleton_source_has_no_blocked_substrings(
         "--bounded-runtime-contract-check",
         "--bounded-shadow-dry-run",
         "--max-steps",
+        "--step-interval-seconds",
         "--duration-minutes",
         "BOUNDED_RUNTIME_CONTRACT_DURATION_CAP_MINUTES",
         "BOUNDED_SHADOW_DURATION_CAP_MINUTES",
+        "BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS",
     ],
 )
 def test_shadow_247_futures_wrapper_skeleton_has_boundary_constants(marker: str) -> None:
@@ -1071,6 +1073,7 @@ def test_shadow_247_bounded_shadow_dry_run_writes_manifest_sha_md_and_steps(
         assert proc.returncode == 0
         combo = proc.stderr + proc.stdout
         assert "BOUNDED_SHADOW_DRY_RUN_WRITTEN=true" in combo
+        assert "STEP_INTERVAL_SECONDS=0.0" in combo
         names = {p.name for p in root.iterdir()}
         assert names == {
             _DRY_MANIFEST_JSON,
@@ -1101,6 +1104,7 @@ def test_shadow_247_bounded_shadow_dry_run_writes_manifest_sha_md_and_steps(
         assert doc.get("execution_approved") is False
         assert doc.get("dry_run") is True
         assert doc.get("shadow_mode") is True
+        assert doc.get("step_interval_seconds") == pytest.approx(0.0)
         ms = doc["verbatim_machine_summary"]
         assert "RUN_STARTED=true" in ms
         assert "TESTNET_STARTED=false" in ms
@@ -1153,3 +1157,193 @@ def test_shadow_247_bounded_shadow_dry_run_unsafe_ops_config_fail_closed(
     finally:
         shutil.rmtree(root_str, ignore_errors=True)
         shutil.rmtree(mut_dir, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_dry_run_rejects_step_interval_without_shadow_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_pace_mx_", dir="/tmp")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--prestart-evidence-drycheck",
+                "--evidence-root",
+                root_str,
+                "--step-interval-seconds",
+                "1",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "step-interval-seconds" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_dry_run_rejects_negative_step_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_pace_neg_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "2",
+                "--step-interval-seconds",
+                "-0.01",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert not any(root.iterdir())
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_dry_run_rejects_step_interval_above_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_pace_61_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "2",
+                "--step-interval-seconds",
+                "60.0001",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert not any(root.iterdir())
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_dry_run_accepts_60_second_step_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_pace_60_", dir="/tmp")
+    root = Path(root_str)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--bounded-shadow-dry-run",
+            "--evidence-root",
+            str(root),
+            "--duration-minutes",
+            "10",
+            "--max-steps",
+            "1",
+            "--step-interval-seconds",
+            "60",
+            "--confirm-token",
+            _FUTURE_CONFIRM_TOKEN,
+            "--config",
+            "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+            "--jobs-config",
+            "config/scheduler/jobs.toml",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    try:
+        assert proc.returncode == 0
+        doc = json.loads((root / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        assert doc["step_interval_seconds"] == pytest.approx(60.0)
+        assert "STEP_INTERVAL_SECONDS=60.0" in proc.stderr + proc.stdout
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_step_interval_paces_with_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib.util
+
+    monkeypatch.chdir(REPO_ROOT)
+    spec = importlib.util.spec_from_file_location("_skel_pace_v0", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    sleeps: list[float] = []
+    monkeypatch.setattr(mod.time, "sleep", lambda s: sleeps.append(float(s)))
+
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_pace_sleep_", dir="/tmp")
+    try:
+        rc = mod.main(
+            [
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                root_str,
+                "--duration-minutes",
+                "10",
+                "--max-steps",
+                "3",
+                "--step-interval-seconds",
+                "0.25",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+        )
+        assert rc == 0
+        assert sleeps == [0.25, 0.25]
+        manifest = json.loads((Path(root_str) / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        assert manifest["step_interval_seconds"] == pytest.approx(0.25)
+        assert manifest["steps_emitted"] == 3
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)

--- a/tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py
+++ b/tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py
@@ -144,6 +144,7 @@ def test_wrapper_source_has_fail_closed_and_prestart_cli_markers_v0() -> None:
     src = _wrapper_source()
     assert "--prestart-evidence-drycheck" in src
     assert "--bounded-shadow-dry-run" in src
+    assert "--step-interval-seconds" in src
     assert "--evidence-root" in src
     assert "--config" in src
     assert "--jobs-config" in src


### PR DESCRIPTION
## Summary

- add optional `--step-interval-seconds` pacing to the existing bounded Shadow dry-run wrapper path
- keep default interval at `0.0` so existing fast tests and dry-runs remain unchanged
- record `step_interval_seconds` in manifest/Markdown/stderr evidence
- preserve default fail-closed behavior and existing evidence-only modes

## Safety / Boundaries

- no testnet
- no live
- no broker
- no exchange
- no private endpoint
- no order submission
- no credentials
- no external network
- no scheduler/runtime/daemon handoff
- local bounded wrapper loop only

## Reuse-before-new

- reuses existing wrapper skeleton and focused ops contract tests
- no parallel docs
- no parallel evidence/readiness/map/handoff surfaces

## Test plan

- [ ] `uv run pytest tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py tests/ops/test_shadow_247_futures_bounded_runtime_contract_v0.py -q`
- [ ] `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py`
- [ ] `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py`
- [ ] `git diff --check`

Made with [Cursor](https://cursor.com)