### PR TITLE
chore(ops): add recorded public rest replay input

### DIFF
--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import math
 import sys
+import tempfile
 import time
 
 try:
@@ -62,6 +63,11 @@ BOUNDED_SHADOW_STEPS_JSONL_V0 = "steps.jsonl"
 BOUNDED_SHADOW_DURATION_CAP_MINUTES = 10
 BOUNDED_SHADOW_MAX_STEPS_CAP = 600
 BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS = 60.0
+
+BOUNDED_SHADOW_RECORDED_PUBLIC_REST_REPLAY_HEARTBEAT_KIND = (
+    "bounded_shadow_dry_run_recorded_public_rest_replay_heartbeat"
+)
+_RECORDED_PUBLIC_REST_SOURCE_JSON_SCAN_CAP = 512
 
 _BOUNDED_SHADOW_ALLOWED_ENTRIES = frozenset(
     {
@@ -240,6 +246,17 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
             "**With `--prestart-evidence-drycheck`, `--bounded-runtime-contract-check`, or "
             "`--bounded-shadow-dry-run`.** "
             "Read-only validate the disabled scheduler placeholder row (stdlib tomllib)."
+        ),
+    )
+    parser.add_argument(
+        "--recorded-public-rest-source",
+        metavar="PATH",
+        default="",
+        dest="recorded_public_rest_source",
+        help=(
+            "`--bounded-shadow-dry-run` only: absolute path to an existing directory of local "
+            "public-REST gate artefacts (read-only inventory; no network, capture, bridge, "
+            "nor supervised observer)."
         ),
     )
     return parser.parse_args(list(argv) if argv is not None else None)
@@ -659,6 +676,88 @@ def _validate_evidence_root_for_bounded_shadow(
     return resolved, None
 
 
+def _validate_recorded_public_rest_source(
+    path_str: str, repo_root: Path
+) -> Tuple[Path | None, str | None]:
+    """Local directory only: under `/tmp` (`peak_trade_*` / `pytest-*`) or stdlib temp dir."""
+    trimmed = path_str.strip()
+    if not trimmed:
+        return None, "`--recorded-public-rest-source` must be non-empty when provided"
+    if ".." in Path(trimmed).parts:
+        return None, "recorded-public-rest-source must not contain path traversal segments"
+
+    probe = Path(trimmed).expanduser()
+    if not probe.is_absolute():
+        return None, "recorded-public-rest-source must be an absolute path"
+    try:
+        resolved = probe.resolve(strict=True)
+    except FileNotFoundError:
+        return None, "recorded-public-rest-source path does not exist"
+    except (OSError, RuntimeError):
+        return None, "recorded-public-rest-source cannot be resolved safely"
+
+    if not resolved.is_dir():
+        return None, "recorded-public-rest-source must be a directory"
+
+    rr = repo_root.resolve()
+    if resolved == rr or resolved.is_relative_to(rr):
+        return None, "recorded-public-rest-source must not reside inside the repository tree"
+
+    if ".git" in resolved.parts:
+        return None, "recorded-public-rest-source must not traverse a `.git` path segment"
+
+    tmp_anchor = Path("/tmp").resolve()
+    temp_anchor = Path(tempfile.gettempdir()).resolve()
+    allowed_under_tmp = False
+    allowed_under_tempfile = False
+    try:
+        rel_tmp = resolved.relative_to(tmp_anchor)
+        if rel_tmp.parts:
+            top = rel_tmp.parts[0].lower()
+            if top.startswith("peak_trade_") or top.startswith("pytest-"):
+                allowed_under_tmp = True
+    except ValueError:
+        pass
+    if not allowed_under_tmp:
+        try:
+            resolved.relative_to(temp_anchor)
+            allowed_under_tempfile = True
+        except ValueError:
+            pass
+
+    if not (allowed_under_tmp or allowed_under_tempfile):
+        return (
+            None,
+            "recorded-public-rest-source must resolve under `/tmp` with a top-level segment "
+            "starting with `peak_trade_` or `pytest-`, or resolve under the process temporary "
+            "directory (stdlib `tempfile`).",
+        )
+
+    return resolved, None
+
+
+def _inventory_recorded_public_rest_source(source_dir: Path) -> dict[str, Any]:
+    manifest_paths = sorted({p for p in source_dir.rglob("manifest.json") if p.is_file()})
+    json_paths = sorted({p for p in source_dir.rglob("*.json") if p.is_file()})
+    truncated = len(json_paths) > _RECORDED_PUBLIC_REST_SOURCE_JSON_SCAN_CAP
+    subset = json_paths[:_RECORDED_PUBLIC_REST_SOURCE_JSON_SCAN_CAP]
+    rows: list[dict[str, str]] = []
+    for p in subset:
+        rel = p.relative_to(source_dir).as_posix()
+        digest = hashlib.sha256(p.read_bytes()).hexdigest()
+        rows.append({"relative_path": rel, "sha256": digest})
+    rows.sort(key=lambda r: r["relative_path"])
+    files_digest = hashlib.sha256(json.dumps(rows, sort_keys=True).encode("utf-8")).hexdigest()
+    return {
+        "recorded_public_rest_source_path": str(source_dir),
+        "recorded_public_rest_source_exists": True,
+        "recorded_public_rest_source_manifest_count": len(manifest_paths),
+        "recorded_public_rest_source_json_count": len(json_paths),
+        "recorded_public_rest_source_json_scan_truncated": truncated,
+        "recorded_public_rest_source_files_digest_sha256": files_digest,
+    }
+
+
 def _canonical_json_bytes(payload: dict) -> bytes:
     return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
 
@@ -811,7 +910,20 @@ def _bounded_shadow_markdown(
     repo_sha: str,
     readonly_cfg_block: Mapping[str, Any],
     run_meta: Mapping[str, Any],
+    recorded_meta: Mapping[str, Any] | None = None,
 ) -> str:
+    recorded_block: tuple[str, ...] = ()
+    if recorded_meta is not None:
+        recorded_block = (
+            "## Recorded public REST replay source (local cross-link; read-only)\n\n",
+            f"- Source path: `{recorded_meta['recorded_public_rest_source_path']}`  \n",
+            f"- Exists: `{recorded_meta['recorded_public_rest_source_exists']}`\n",
+            f"- `manifest.json` files found: `{recorded_meta['recorded_public_rest_source_manifest_count']}`\n",
+            f"- JSON files found: `{recorded_meta['recorded_public_rest_source_json_count']}`\n",
+            f"- JSON inventory scan truncated: `{recorded_meta['recorded_public_rest_source_json_scan_truncated']}`\n",
+            f"- Per-file digest summary SHA-256: `{recorded_meta['recorded_public_rest_source_files_digest_sha256']}`\n",
+            "- No network, capture, bridge, nor supervised-observer scripts are invoked in this mode.\n\n",
+        )
     return "".join(
         (
             "# Shadow 24-7 Futures — Bounded Shadow Dry-Run (Local Simulation)\n\n",
@@ -832,6 +944,7 @@ def _bounded_shadow_markdown(
             f"- Step interval (seconds): `{run_meta['step_interval_seconds']}`\n",
             f"- Steps emitted: `{run_meta['steps_emitted']}`\n",
             f"- UTC end: `{run_meta['utc_end']}`\n\n",
+            *recorded_block,
             *_readonly_validation_markdown_lines(readonly_cfg_block),
             "## Appendix\n\n",
             "Artefacts: `manifest.json`, `MANIFEST.sha256`, "
@@ -848,8 +961,9 @@ def _bounded_shadow_manifest(
     utc_ended: datetime,
     readonly_cfg_block: Mapping[str, Any],
     run_meta: Mapping[str, Any],
+    recorded_meta: Mapping[str, Any] | None = None,
 ) -> dict:
-    return {
+    manifest: dict[str, Any] = {
         "artifact": BOUNDED_SHADOW_DRY_RUN_SCHEMA_V0,
         "bounded_local_shadow_dry_run": True,
         "broker_used": False,
@@ -890,6 +1004,9 @@ def _bounded_shadow_manifest(
         "verbatim_machine_summary": _BOUNDED_SHADOW_MACHINE_LINES.rstrip("\n"),
         "wrapper_requires_future_gate_before_execution": True,
     }
+    if recorded_meta is not None:
+        manifest.update(dict(recorded_meta))
+    return manifest
 
 
 def _execute_bounded_shadow_dry_run(
@@ -900,7 +1017,12 @@ def _execute_bounded_shadow_dry_run(
     duration_minutes: int,
     max_steps: int,
     step_interval_seconds: float,
+    recorded_public_rest_source: Path | None = None,
 ) -> int:
+    recorded_meta: dict[str, Any] | None = None
+    if recorded_public_rest_source is not None:
+        recorded_meta = _inventory_recorded_public_rest_source(recorded_public_rest_source)
+
     utc_started = datetime.now(timezone.utc)
     deadline = time.monotonic() + float(duration_minutes) * 60.0
     steps_emitted = 0
@@ -908,11 +1030,27 @@ def _execute_bounded_shadow_dry_run(
 
     while steps_emitted < max_steps and time.monotonic() < deadline:
         step_ts = datetime.now(timezone.utc)
-        payload = {
-            "step_index": steps_emitted + 1,
-            "utc": step_ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "kind": "bounded_shadow_dry_run_simulated_heartbeat",
-        }
+        if steps_emitted == 0 and recorded_meta is not None:
+            payload = {
+                "kind": BOUNDED_SHADOW_RECORDED_PUBLIC_REST_REPLAY_HEARTBEAT_KIND,
+                "recorded_public_rest_source_files_digest_sha256": recorded_meta[
+                    "recorded_public_rest_source_files_digest_sha256"
+                ],
+                "recorded_public_rest_source_manifest_count": recorded_meta[
+                    "recorded_public_rest_source_manifest_count"
+                ],
+                "recorded_public_rest_source_path": recorded_meta[
+                    "recorded_public_rest_source_path"
+                ],
+                "step_index": steps_emitted + 1,
+                "utc": step_ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+        else:
+            payload = {
+                "step_index": steps_emitted + 1,
+                "utc": step_ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "kind": "bounded_shadow_dry_run_simulated_heartbeat",
+            }
         lines.append(json.dumps(payload, sort_keys=True) + "\n")
         steps_emitted += 1
         if steps_emitted >= max_steps or time.monotonic() >= deadline:
@@ -938,6 +1076,7 @@ def _execute_bounded_shadow_dry_run(
         utc_ended,
         readonly_cfg_block,
         run_meta,
+        recorded_meta,
     )
     manifest_bytes = _canonical_json_bytes(manifest)
     digest_hex = hashlib.sha256(manifest_bytes).hexdigest()
@@ -947,6 +1086,7 @@ def _execute_bounded_shadow_dry_run(
         repo_sha,
         readonly_cfg_block,
         run_meta,
+        recorded_meta,
     )
 
     evidence_root_abs.mkdir(parents=True, exist_ok=True)
@@ -962,6 +1102,8 @@ def _execute_bounded_shadow_dry_run(
     err.write("READONLY_CONFIG_VALIDATION_OK=true\n")
     err.write(f"STEP_INTERVAL_SECONDS={step_interval_seconds}\n")
     err.write(f"BOUNDED_SHADOW_DRY_RUN_STEPS_EMITTED={steps_emitted}\n")
+    if recorded_meta is not None:
+        err.write("RECORDED_PUBLIC_REST_REPLAY_SOURCE_ATTACHED=true\n")
     err.write("BOUNDED_SHADOW_DRY_RUN_WRITTEN=true\n")
     err.write(f"EXIT_CODE={EXIT_DRYCHECK_SUCCESS}\n")
     return EXIT_DRYCHECK_SUCCESS
@@ -1056,6 +1198,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         err.write(_MACHINE_LINES_ALWAYS)
         err.write(
             f"EXIT_REASON=step_interval_requires_bounded_shadow\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    if args.recorded_public_rest_source.strip() and not args.bounded_shadow_dry_run:
+        err.write(
+            "`--recorded-public-rest-source` is only valid with `--bounded-shadow-dry-run`.\n",
+        )
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(
+            f"EXIT_REASON=recorded_public_rest_source_requires_bounded_shadow\n"
+            f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
         )
         return EXIT_FAIL_CLOSED_DEFAULT
 
@@ -1248,6 +1402,23 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return EXIT_FAIL_CLOSED_DEFAULT
 
+        recorded_resolved: Path | None = None
+        if args.recorded_public_rest_source.strip():
+            rec_val, rec_err = _validate_recorded_public_rest_source(
+                args.recorded_public_rest_source, repo_root
+            )
+            if rec_err or rec_val is None:
+                assert rec_err is not None
+                err.write(rec_err + "\n")
+                _emit_banner(err)
+                err.write(_MACHINE_LINES_ALWAYS)
+                err.write(
+                    f"EXIT_REASON=invalid_recorded_public_rest_source\n"
+                    f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+                )
+                return EXIT_FAIL_CLOSED_DEFAULT
+            recorded_resolved = rec_val
+
         step_iv = 0.0 if args.step_interval_seconds is None else float(args.step_interval_seconds)
         if not math.isfinite(step_iv):
             err.write("`--step-interval-seconds` must be a finite number.\n")
@@ -1278,6 +1449,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             dm,
             int(ms),
             step_iv,
+            recorded_resolved,
         )
 
     if args.prestart_evidence_drycheck:

--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -676,6 +676,33 @@ def _validate_evidence_root_for_bounded_shadow(
     return resolved, None
 
 
+def _is_allowed_recorded_public_rest_source_root(path: Path) -> bool:
+    """Allow `/tmp/peak_trade_*` and `/tmp/pytest-*`, else non-`/tmp` paths under `tempfile`."""
+    resolved = path.resolve()
+    tmp_root = Path("/tmp").resolve()
+    tempfile_root = Path(tempfile.gettempdir()).resolve()
+
+    try:
+        relative_to_tmp = resolved.relative_to(tmp_root)
+    except ValueError:
+        relative_to_tmp = None
+
+    if relative_to_tmp is not None:
+        if not relative_to_tmp.parts:
+            return False
+        top_segment = relative_to_tmp.parts[0].lower()
+        return top_segment.startswith("peak_trade_") or top_segment.startswith("pytest-")
+
+    if tempfile_root == tmp_root:
+        return False
+
+    try:
+        resolved.relative_to(tempfile_root)
+    except ValueError:
+        return False
+    return True
+
+
 def _validate_recorded_public_rest_source(
     path_str: str, repo_root: Path
 ) -> Tuple[Path | None, str | None]:
@@ -706,31 +733,12 @@ def _validate_recorded_public_rest_source(
     if ".git" in resolved.parts:
         return None, "recorded-public-rest-source must not traverse a `.git` path segment"
 
-    tmp_anchor = Path("/tmp").resolve()
-    temp_anchor = Path(tempfile.gettempdir()).resolve()
-    allowed_under_tmp = False
-    allowed_under_tempfile = False
-    try:
-        rel_tmp = resolved.relative_to(tmp_anchor)
-        if rel_tmp.parts:
-            top = rel_tmp.parts[0].lower()
-            if top.startswith("peak_trade_") or top.startswith("pytest-"):
-                allowed_under_tmp = True
-    except ValueError:
-        pass
-    if not allowed_under_tmp:
-        try:
-            resolved.relative_to(temp_anchor)
-            allowed_under_tempfile = True
-        except ValueError:
-            pass
-
-    if not (allowed_under_tmp or allowed_under_tempfile):
+    if not _is_allowed_recorded_public_rest_source_root(resolved):
         return (
             None,
             "recorded-public-rest-source must resolve under `/tmp` with a top-level segment "
             "starting with `peak_trade_` or `pytest-`, or resolve under the process temporary "
-            "directory (stdlib `tempfile`).",
+            "directory (stdlib `tempfile`) when it is not the filesystem `/tmp`.",
         )
 
     return resolved, None

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -70,6 +70,8 @@ def test_shadow_247_futures_wrapper_skeleton_source_has_no_blocked_substrings(
         "BOUNDED_RUNTIME_CONTRACT_DURATION_CAP_MINUTES",
         "BOUNDED_SHADOW_DURATION_CAP_MINUTES",
         "BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS",
+        "--recorded-public-rest-source",
+        "bounded_shadow_dry_run_recorded_public_rest_replay_heartbeat",
     ],
 )
 def test_shadow_247_futures_wrapper_skeleton_has_boundary_constants(marker: str) -> None:
@@ -1019,6 +1021,265 @@ def test_shadow_247_prestart_drycheck_rejects_duration_minutes_flag(
         )
         assert proc.returncode == 64
         assert "duration-minutes" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+_SHADOW_RECORDED_REPLAY_KIND = "bounded_shadow_dry_run_recorded_public_rest_replay_heartbeat"
+
+
+def test_shadow_247_recorded_public_rest_source_rejected_without_bounded_shadow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--prestart-evidence-drycheck",
+            "--evidence-root",
+            tempfile.mkdtemp(prefix="peak_trade_utest_rec_pre_", dir="/tmp"),
+            "--recorded-public-rest-source",
+            "/tmp/peak_trade_utest_rec_dummy_gate",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    root = Path(proc.args[4])
+    try:
+        assert proc.returncode == 64
+        assert "recorded-public-rest-source" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_shadow_247_recorded_public_rest_source_rejects_missing_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_rec_", dir="/tmp")
+    missing = Path(root_str) / "nope_not_here"
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+                "--recorded-public-rest-source",
+                str(missing),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "does not exist" in (proc.stderr + proc.stdout).lower()
+        assert not any(root.iterdir())
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_recorded_public_rest_source_rejects_disallowed_tmp_top_segment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    bad_gate = tempfile.mkdtemp(prefix="forbidden_not_peak_trade_", dir="/tmp")
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_recbad_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "1",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+                "--recorded-public-rest-source",
+                bad_gate,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        combo = proc.stderr + proc.stdout
+        assert "recorded-public-rest-source" in combo.lower() or "peak_trade_" in combo
+        assert not any(root.iterdir())
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+        shutil.rmtree(bad_gate, ignore_errors=True)
+
+
+def test_shadow_247_recorded_public_rest_source_rejects_repo_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_rec_repo_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "1",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+                "--recorded-public-rest-source",
+                str(REPO_ROOT),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "repository" in (proc.stderr + proc.stdout).lower()
+        assert not any(root.iterdir())
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_dry_run_with_recorded_public_rest_source_writes_crosslink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    gate_str = tempfile.mkdtemp(prefix="peak_trade_utest_pubrest_gate_", dir="/tmp")
+    gate = Path(gate_str)
+    sub = gate / "nested"
+    sub.mkdir(parents=True)
+    (sub / "manifest.json").write_text('{"probe": true}\n', encoding="utf-8")
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_rec_ok_", dir="/tmp")
+    root = Path(root_str)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--bounded-shadow-dry-run",
+            "--evidence-root",
+            str(root),
+            "--duration-minutes",
+            "1",
+            "--max-steps",
+            "3",
+            "--confirm-token",
+            _FUTURE_CONFIRM_TOKEN,
+            "--config",
+            "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+            "--jobs-config",
+            "config/scheduler/jobs.toml",
+            "--recorded-public-rest-source",
+            str(gate),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    try:
+        assert proc.returncode == 0
+        combo = proc.stderr + proc.stdout
+        assert "RECORDED_PUBLIC_REST_REPLAY_SOURCE_ATTACHED=true" in combo
+        doc = json.loads((root / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        assert doc["recorded_public_rest_source_exists"] is True
+        assert doc["recorded_public_rest_source_path"] == str(gate.resolve())
+        assert doc["recorded_public_rest_source_manifest_count"] >= 1
+        assert doc["recorded_public_rest_source_json_count"] >= 1
+        assert "recorded_public_rest_source_files_digest_sha256" in doc
+        assert doc["network_used"] is False
+        md_txt = (root / _SHADOW_DRY_MD).read_text(encoding="utf-8")
+        assert "Recorded public REST replay source" in md_txt
+        assert str(gate.resolve()) in md_txt
+        lines = (root / _SHADOW_STEPS).read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 3
+        step0 = json.loads(lines[0])
+        step1 = json.loads(lines[1])
+        assert step0["kind"] == _SHADOW_RECORDED_REPLAY_KIND
+        assert step1["kind"] == "bounded_shadow_dry_run_simulated_heartbeat"
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+        shutil.rmtree(gate_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_dry_run_accepts_recorded_source_under_pytest_tmp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    (tmp_path / "manifest.json").write_text("{}", encoding="utf-8")
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_evtmp_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "1",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+                "--recorded-public-rest-source",
+                str(tmp_path),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        assert proc.returncode == 0, proc.stderr + proc.stdout
+        doc = json.loads((root / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        assert doc["recorded_public_rest_source_manifest_count"] == 1
     finally:
         shutil.rmtree(root_str, ignore_errors=True)
 

--- a/tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py
+++ b/tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py
@@ -144,6 +144,7 @@ def test_wrapper_source_has_fail_closed_and_prestart_cli_markers_v0() -> None:
     src = _wrapper_source()
     assert "--prestart-evidence-drycheck" in src
     assert "--bounded-shadow-dry-run" in src
+    assert "--recorded-public-rest-source" in src
     assert "--step-interval-seconds" in src
     assert "--evidence-root" in src
     assert "--config" in src


### PR DESCRIPTION
## Summary
- add `--recorded-public-rest-source PATH` to the bounded Shadow dry-run wrapper path
- allow local recorded public REST gate artefacts to be inventoried/cross-linked into bounded Shadow evidence
- record source metadata in manifest, Markdown evidence, stderr, and steps.jsonl
- distinguish recorded replay/crosslink heartbeat from pure simulated heartbeat

## Safety / Boundaries
- no network
- no capture invocation
- no bridge invocation
- no supervised observer invocation
- no broker
- no exchange/private endpoint
- no order submission
- no credentials
- no testnet/live
- bounded Shadow path remains local, dry-run, evidence-only

## Reuse-before-new
- reuses existing wrapper skeleton and focused ops contract tests
- no parallel docs
- no parallel evidence/readiness/map/handoff surfaces

## Validation
- `uv run pytest tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py tests/ops/test_shadow_247_futures_bounded_runtime_contract_v0.py -q`
- `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py`
- `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py`
- `git diff --check`

Made with [Cursor](https://cursor.com)