### PR TITLE
chore(ops): add p67 recorded price series adapter

### DIFF
--- a/scripts/ops/run_shadow_loop_v1.sh
+++ b/scripts/ops/run_shadow_loop_v1.sh
@@ -15,9 +15,16 @@ if [[ -z "$OUT_DIR" ]]; then
 fi
 
 cd "$(git rev-parse --show-toplevel)"
+
+REC_ARGS=()
+if [[ -n "${RECORDED_PRICE_SOURCE:-}" ]]; then
+  REC_ARGS=(--recorded-price-source "$RECORDED_PRICE_SOURCE")
+fi
+
 python3 -m src.ops.p67.shadow_session_scheduler_cli_v1 \
   --mode "$MODE" \
   --run-id "$RUN_ID" \
   --out-dir "$OUT_DIR" \
   --iterations "$ITERATIONS" \
-  --interval-seconds "$INTERVAL"
+  --interval-seconds "$INTERVAL" \
+  "${REC_ARGS[@]}"

--- a/src/ops/p67/recorded_price_series_v0.py
+++ b/src/ops/p67/recorded_price_series_v0.py
@@ -1,0 +1,195 @@
+"""v0: load simple return series from local recorded public REST JSON snapshots (no network).
+
+Reads a bounded scan of ``*.json`` under an operator directory, extracts Binance-style
+``bidPrice``/``askPrice`` (or captured ``bid``/``ask`` decimals), computes midpoints in file/name
+order, then simple returns: (mid_i / mid_{i-1}) - 1.
+
+Path hygiene mirrors recorded-public-rest gates: allowed under ``/tmp`` (``peak_trade_*`` or
+``pytest`` prefix segments) or under ``tempfile.gettempdir()`` when it is not the filesystem
+``/tmp``. Repository tree paths are rejected.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import tempfile
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+MAX_JSON_FILES_SCAN = 512
+# SwitchLayerConfigV1.require_min_samples defaults to 60; needs len(returns) >= 60.
+_MIN_MIDPOINTS = 61
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _is_allowed_recorded_price_source_root(path: Path) -> bool:
+    resolved = path.resolve()
+    tmp_root = Path("/tmp").resolve()
+    tempfile_root = Path(tempfile.gettempdir()).resolve()
+
+    try:
+        relative_to_tmp = resolved.relative_to(tmp_root)
+    except ValueError:
+        relative_to_tmp = None
+
+    if relative_to_tmp is not None:
+        if not relative_to_tmp.parts:
+            return False
+        top_segment = relative_to_tmp.parts[0].lower()
+        return top_segment.startswith("peak_trade_") or top_segment.startswith("pytest")
+
+    if tempfile_root == tmp_root:
+        return False
+
+    try:
+        resolved.relative_to(tempfile_root)
+    except ValueError:
+        return False
+    return True
+
+
+def validate_recorded_price_source_path(path_str: str) -> Tuple[Optional[Path], Optional[str]]:
+    trimmed = path_str.strip()
+    if not trimmed:
+        return None, "recorded price source path must be non-empty"
+    if ".." in Path(trimmed).parts:
+        return None, "recorded price source must not contain path traversal segments"
+
+    probe = Path(trimmed).expanduser()
+    if not probe.is_absolute():
+        return None, "recorded price source must be an absolute path"
+    try:
+        resolved = probe.resolve(strict=True)
+    except FileNotFoundError:
+        return None, "recorded price source path does not exist"
+    except (OSError, RuntimeError):
+        return None, "recorded price source cannot be resolved safely"
+
+    if not resolved.is_dir():
+        return None, "recorded price source must be a directory"
+
+    rr = _REPO_ROOT.resolve()
+    if resolved == rr or resolved.is_relative_to(rr):
+        return None, "recorded price source must not reside inside the repository tree"
+
+    if ".git" in resolved.parts:
+        return None, "recorded price source must not traverse a `.git` path segment"
+
+    if not _is_allowed_recorded_price_source_root(resolved):
+        return (
+            None,
+            "recorded price source must resolve under `/tmp` with a top-level segment starting "
+            "with `peak_trade_` or `pytest`, or resolve under the process temporary directory "
+            "(stdlib `tempfile`) when it is not the filesystem `/tmp`.",
+        )
+
+    return resolved, None
+
+
+def _to_decimal(s: Any) -> Optional[Decimal]:
+    if isinstance(s, (int, float)) and not isinstance(s, bool):
+        try:
+            return Decimal(str(s))
+        except (InvalidOperation, ValueError, TypeError):
+            return None
+    if isinstance(s, str):
+        try:
+            return Decimal(s.strip())
+        except (InvalidOperation, ValueError):
+            return None
+    return None
+
+
+def _mid_from_mapping(obj: dict[str, Any]) -> Optional[float]:
+    bp = obj.get("bidPrice")
+    ap = obj.get("askPrice")
+    if bp is not None and ap is not None:
+        b = _to_decimal(bp)
+        a = _to_decimal(ap)
+        if b is None or a is None:
+            return None
+        if not b.is_finite() or not a.is_finite():
+            raise ValueError("ERR: non-finite midpoint in recorded JSON")
+        if b <= 0 or a <= 0 or a <= b:
+            return None
+        mid = (b + a) / Decimal("2")
+        out = float(mid)
+        if not math.isfinite(out):
+            raise ValueError("ERR: non-finite midpoint in recorded JSON")
+        return out
+
+    bid = obj.get("bid")
+    ask = obj.get("ask")
+    if bid is not None and ask is not None:
+        b = _to_decimal(bid)
+        a = _to_decimal(ask)
+        if b is None or a is None:
+            return None
+        if not b.is_finite() or not a.is_finite():
+            raise ValueError("ERR: non-finite midpoint in recorded JSON")
+        if b <= 0 or a <= 0 or a <= b:
+            return None
+        mid = (b + a) / Decimal("2")
+        out = float(mid)
+        if not math.isfinite(out):
+            raise ValueError("ERR: non-finite midpoint in recorded JSON")
+        return out
+
+    return None
+
+
+def _walk_collect_mids(obj: Any, mids: List[float]) -> None:
+    if isinstance(obj, dict):
+        mid = _mid_from_mapping(obj)
+        if mid is not None:
+            mids.append(mid)
+            return
+        for v in obj.values():
+            _walk_collect_mids(v, mids)
+    elif isinstance(obj, list):
+        for item in obj:
+            _walk_collect_mids(item, mids)
+
+
+def _sorted_json_files(root: Path) -> List[Path]:
+    paths = [p for p in root.rglob("*.json") if p.is_file()]
+    paths.sort(key=lambda p: str(p))
+    return paths[:MAX_JSON_FILES_SCAN]
+
+
+def load_simple_returns_from_recorded_price_source(source_dir: Path) -> Tuple[List[float], int]:
+    """Return (simple_returns, mid_count_used)."""
+    files = _sorted_json_files(source_dir)
+    if not files:
+        raise ValueError("ERR: no JSON files found under recorded price source")
+
+    mids: List[float] = []
+    for fp in files:
+        try:
+            raw = fp.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as e:
+            raise ValueError(f"ERR: cannot read/parse JSON: {fp}: {e}") from e
+        _walk_collect_mids(data, mids)
+
+    if len(mids) < _MIN_MIDPOINTS:
+        raise ValueError(
+            f"ERR: need at least {_MIN_MIDPOINTS} bid/ask midpoints for returns series, "
+            f"got {len(mids)}",
+        )
+
+    returns: List[float] = []
+    for i in range(1, len(mids)):
+        prev = mids[i - 1]
+        cur = mids[i]
+        if prev == 0.0:
+            raise ValueError("ERR: zero midpoint in recorded series (division)")
+        r = (cur / prev) - 1.0
+        if not math.isfinite(r):
+            raise ValueError("ERR: non-finite simple return in recorded series")
+        returns.append(r)
+
+    return returns, len(mids)

--- a/src/ops/p67/shadow_session_scheduler_cli_v1.py
+++ b/src/ops/p67/shadow_session_scheduler_cli_v1.py
@@ -17,16 +17,23 @@ def main() -> int:
     ap.add_argument("--out-dir", default="", help="If set, write evidence under this directory.")
     ap.add_argument("--iterations", type=int, default=1)
     ap.add_argument("--interval-seconds", type=float, default=60.0)
+    ap.add_argument(
+        "--recorded-price-source",
+        default="",
+        help="Absolute path to local directory with recorded public REST JSON snapshots.",
+    )
     ap.add_argument("--json", action="store_true", help="Print JSON result.")
     args = ap.parse_args()
 
     out_dir = Path(args.out_dir) if args.out_dir else None
+    rec = args.recorded_price_source.strip()
     ctx = P67RunContextV1(
         mode=args.mode,
         run_id=args.run_id,
         out_dir=out_dir,
         iterations=args.iterations,
         interval_seconds=args.interval_seconds,
+        recorded_price_source=Path(rec) if rec else None,
     )
     res = run_shadow_session_scheduler_v1(ctx)
     if args.json:

--- a/src/ops/p67/shadow_session_scheduler_v1.py
+++ b/src/ops/p67/shadow_session_scheduler_v1.py
@@ -12,6 +12,10 @@ from src.ops.p66.run_online_readiness_operator_entrypoint_v1 import (
     P66RunContextV1,
     run_online_readiness_operator_entrypoint_v1,
 )
+from .recorded_price_series_v0 import (
+    load_simple_returns_from_recorded_price_source,
+    validate_recorded_price_source_path,
+)
 
 ModeV1 = Literal["paper", "shadow"]
 
@@ -26,6 +30,7 @@ class P67RunContextV1:
     out_dir: Optional[Path] = None
     iterations: int = 1
     interval_seconds: float = 60.0
+    recorded_price_source: Optional[Path] = None
 
 
 def _utc_ts() -> str:
@@ -52,6 +57,21 @@ def run_shadow_session_scheduler_v1(ctx: P67RunContextV1) -> dict:
     if ctx.interval_seconds < 0:
         raise ValueError("ERR: interval_seconds must be >= 0")
 
+    recorded_price_source_used = False
+    recorded_price_source_path: Optional[str] = None
+    recorded_price_series_count: Optional[int] = None
+
+    if ctx.recorded_price_source is not None:
+        src_resolved, src_err = validate_recorded_price_source_path(str(ctx.recorded_price_source))
+        if src_err or src_resolved is None:
+            raise ValueError(src_err or "recorded price source validation failed")
+        price_series, _mid_count = load_simple_returns_from_recorded_price_source(src_resolved)
+        recorded_price_source_used = True
+        recorded_price_source_path = str(src_resolved)
+        recorded_price_series_count = len(price_series)
+    else:
+        price_series = list(_DEFAULT_PRICES)
+
     events: list[dict] = []
     base_out_dir = ctx.out_dir
     scheduler_meta = {
@@ -61,6 +81,9 @@ def run_shadow_session_scheduler_v1(ctx: P67RunContextV1) -> dict:
         "iterations": ctx.iterations,
         "interval_seconds": ctx.interval_seconds,
         "ts_utc_start": _utc_ts(),
+        "recorded_price_source_used": recorded_price_source_used,
+        "recorded_price_source_path": recorded_price_source_path,
+        "recorded_price_series_count": recorded_price_series_count,
     }
 
     for i in range(ctx.iterations):
@@ -78,7 +101,7 @@ def run_shadow_session_scheduler_v1(ctx: P67RunContextV1) -> dict:
             iterations=1,
             sleep_seconds=0.0,
         )
-        out = run_online_readiness_operator_entrypoint_v1(_DEFAULT_PRICES, p66_ctx)
+        out = run_online_readiness_operator_entrypoint_v1(price_series, p66_ctx)
         out_jsonable = to_jsonable_v1(out)
 
         event = {

--- a/tests/ops/test_p67_recorded_price_series_adapter_v0.py
+++ b/tests/ops/test_p67_recorded_price_series_adapter_v0.py
@@ -1,0 +1,136 @@
+"""Tests for P67 recorded price series adapter v0 (local JSON → simple returns, no network)."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.ops.p67.recorded_price_series_v0 import (
+    load_simple_returns_from_recorded_price_source,
+    validate_recorded_price_source_path,
+)
+from src.ops.p67.shadow_session_scheduler_v1 import P67RunContextV1, run_shadow_session_scheduler_v1
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_ADAPTER = REPO_ROOT / "src" / "ops" / "p67" / "recorded_price_series_v0.py"
+_SHADOW_LOOP = REPO_ROOT / "scripts" / "ops" / "run_shadow_loop_v1.sh"
+
+
+def _write_book_ticker_mids(src: Path, n: int) -> None:
+    rows = []
+    for i in range(n):
+        bid = f"{100 + i}.00"
+        ask = f"{100 + i}.50"
+        rows.append({"bidPrice": bid, "askPrice": ask, "symbol": "BTCUSDT"})
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "mids.json").write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+
+
+def test_adapter_extracts_mids_and_returns(tmp_path: Path) -> None:
+    _write_book_ticker_mids(tmp_path, 61)
+    returns, _ = load_simple_returns_from_recorded_price_source(tmp_path)
+    assert len(returns) == 60
+    assert all(math.isfinite(r) for r in returns)
+    assert returns[0] > 0  # price increases each step
+
+
+def test_adapter_rejects_missing_path() -> None:
+    ok, err = validate_recorded_price_source_path("/tmp/peak_trade_nonexistent_dir_xyz_12345")
+    assert ok is None
+    assert err and "does not exist" in err
+
+
+def test_adapter_rejects_repo_path(tmp_path: Path) -> None:
+    inside = REPO_ROOT / "peak_trade_forbidden_recorded_src"
+    inside.mkdir(exist_ok=True)
+    try:
+        ok, err = validate_recorded_price_source_path(str(inside.resolve()))
+        assert ok is None
+        assert err and "repository" in err.lower()
+    finally:
+        inside.rmdir()
+
+
+def test_adapter_rejects_nonfinite_mid(tmp_path: Path) -> None:
+    rows = []
+    for i in range(61):
+        if i == 30:
+            rows.append({"bidPrice": "nan", "askPrice": "131.0"})
+        else:
+            bid = f"{100 + i}.00"
+            ask = f"{100 + i}.50"
+            rows.append({"bidPrice": bid, "askPrice": ask})
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "mids.json").write_text(json.dumps(rows), encoding="utf-8")
+    with pytest.raises(ValueError, match="non-finite"):
+        load_simple_returns_from_recorded_price_source(tmp_path)
+
+
+def test_adapter_has_no_network_import_patterns() -> None:
+    text = _ADAPTER.read_text(encoding="utf-8")
+    banned = re.compile(
+        r"(?m)^\s*(?:from\s+(requests|httpx|websocket|websockets|aiohttp|ccxt)\b"
+        r"|import\s+(requests|httpx|websocket|websockets|aiohttp|ccxt)\b"
+        r"|from\s+urllib\.request\b"
+        r"|import\s+urllib\.request\b)",
+    )
+    assert banned.search(text) is None
+
+
+def test_p67_uses_adapter_when_recorded_source_set(tmp_path: Path) -> None:
+    gate = tmp_path / "gate"
+    _write_book_ticker_mids(gate, 61)
+    out = run_shadow_session_scheduler_v1(
+        P67RunContextV1(
+            mode="shadow",
+            iterations=1,
+            interval_seconds=0.0,
+            recorded_price_source=gate,
+        ),
+    )
+    assert out["meta"]["recorded_price_source_used"] is True
+    assert out["meta"]["recorded_price_series_count"] == 60
+    assert out["meta"]["recorded_price_source_path"] == str(gate.resolve())
+
+
+def test_p67_default_prices_when_no_source(tmp_path: Path) -> None:
+    out = run_shadow_session_scheduler_v1(
+        P67RunContextV1(
+            mode="shadow",
+            iterations=1,
+            interval_seconds=0.0,
+            out_dir=tmp_path,
+            run_id="ndef",
+        ),
+    )
+    assert out["meta"]["recorded_price_source_used"] is False
+    assert out["meta"]["recorded_price_source_path"] is None
+    assert out["meta"]["recorded_price_series_count"] is None
+
+
+def test_cli_accepts_recorded_price_source() -> None:
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.ops.p67.shadow_session_scheduler_cli_v1",
+            "--help",
+        ],
+        cwd=str(REPO_ROOT),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "--recorded-price-source" in out.stdout
+
+
+def test_run_shadow_loop_passes_recorded_source_env() -> None:
+    text = _SHADOW_LOOP.read_text(encoding="utf-8")
+    assert "RECORDED_PRICE_SOURCE" in text
+    assert "--recorded-price-source" in text

--- a/tests/ops/test_p67_shadow_loop_no_network_contract_v0.py
+++ b/tests/ops/test_p67_shadow_loop_no_network_contract_v0.py
@@ -24,6 +24,7 @@ _P67_CHAIN_SOURCE_RELPATHS: tuple[str, ...] = (
     "scripts/ops/run_shadow_loop_v1.sh",
     "src/ops/p67/shadow_session_scheduler_cli_v1.py",
     "src/ops/p67/shadow_session_scheduler_v1.py",
+    "src/ops/p67/recorded_price_series_v0.py",
     "src/ops/p66/run_online_readiness_operator_entrypoint_v1.py",
     "src/ops/p65/run_online_readiness_loop_runner_v1.py",
     "src/ops/p64/run_online_readiness_runner_v1.py",


### PR DESCRIPTION
## Summary
- add local recorded price-series adapter for the P67 shadow scheduler path
- convert recorded public REST bookTicker-style mids into simple returns for P66/P57 input
- add optional `--recorded-price-source` CLI hook and `RECORDED_PRICE_SOURCE` shell env wiring
- preserve existing `_DEFAULT_PRICES` behavior when no recorded source is provided
- record source metadata in scheduler meta

## Safety / Boundaries
- local filesystem reads only
- no network
- no broker/exchange/private endpoint
- no order submission
- no credentials
- no testnet/live
- no shadow loop execution in this slice
- no docs or parallel evidence surfaces

## Validation
- `uv run pytest tests/ops/test_p67_recorded_price_series_adapter_v0.py -q`
- `uv run pytest tests/ops/test_p67_shadow_loop_no_network_contract_v0.py -q`
- `uv run pytest tests/ops/test_p67_recorded_price_series_adapter_v0.py tests/ops/test_p67_shadow_loop_no_network_contract_v0.py -q`
- `uv run ruff check src/ops/p67/recorded_price_series_v0.py src/ops/p67/shadow_session_scheduler_v1.py src/ops/p67/shadow_session_scheduler_cli_v1.py tests/ops/test_p67_recorded_price_series_adapter_v0.py tests/ops/test_p67_shadow_loop_no_network_contract_v0.py`
- `uv run ruff format --check src/ops/p67/recorded_price_series_v0.py src/ops/p67/shadow_session_scheduler_v1.py src/ops/p67/shadow_session_scheduler_cli_v1.py tests/ops/test_p67_recorded_price_series_adapter_v0.py tests/ops/test_p67_shadow_loop_no_network_contract_v0.py`
- `git diff --check`

Made with [Cursor](https://cursor.com)