### PR TITLE
test(ops): bundle shadow 247 governance scheduler crosslinks v1

### DIFF
--- a/tests/ops/test_offline_crosslink_invariant_contract_v0.py
+++ b/tests/ops/test_offline_crosslink_invariant_contract_v0.py
@@ -7,6 +7,9 @@ ohne Netzwerk. Erzeugt keine Laufzeitfreigabe und keine parallele Evidenz-Oberfl
 Ergänzt die statische Offline-Grenze zwischen ``build_static_market_capture_package_v0`` und
 ``build_public_rest_to_supervised_observer_bridge_v0`` (gemeinsames CONFIRM_TOKEN); schließt **kein**
 neues supervised-observation-Bundle ein.
+
+Ergänzt zudem einen statischen Scheduler-Anker für Paper/Shadow-247 Jobs und das Futures-Wrapper-TOML
+(Pfade lösen unter ``REPO_ROOT``; keine Laufzeitfreigabe).
 """
 
 from __future__ import annotations
@@ -20,6 +23,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef,import-not-found]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -37,6 +45,16 @@ _WRAPPER_OWNER_TEST = REPO_ROOT / "tests/ops/test_shadow_247_futures_start_wrapp
 _PREFLIGHT = REPO_ROOT / "docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
 _SUPERVISED_OBSERVER_TEST = (
     REPO_ROOT / "tests/ops/test_shadow_observation_supervised_timed_observer_v0.py"
+)
+_JOBS_TOML = REPO_ROOT / "config" / "scheduler" / "jobs.toml"
+_SHADOW247_WRAPPER_OPS_TOML = (
+    REPO_ROOT / "config" / "ops" / "shadow_247_futures_wrapper_skeleton.toml"
+)
+# Stable scheduler names; static path contract only (preflight reporter may stay enabled elsewhere).
+_OFFLINE_SHADOW247_SCHEDULER_JOB_NAMES = (
+    "paper_shadow_247_paper_only_preflight_status_v0",
+    "shadow_247_futures_prestart_evidence_drycheck_placeholder_v0",
+    "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0",
 )
 
 
@@ -150,6 +168,30 @@ def test_supervised_observer_is_optional_test_surface_not_p67_gate() -> None:
     assert _SUPERVISED_OBSERVER_TEST.is_file()
     p67_txt = _P67_SCHEDULER.read_text(encoding="utf-8").lower()
     assert "supervised" not in p67_txt
+
+
+def test_offline_jobs_shadow247_scripts_resolve_v0() -> None:
+    """Scheduler anchors for Paper/Shadow-247: on-disk scripts match wrapper TOML (static only)."""
+    ops = tomllib.loads(_SHADOW247_WRAPPER_OPS_TOML.read_text(encoding="utf-8"))
+    wrapper_script = ops["wrapper_script"]
+    jobs = tomllib.loads(_JOBS_TOML.read_text(encoding="utf-8")).get("job", [])
+    by_name = {j["name"]: j for j in jobs if isinstance(j, dict) and "name" in j}
+
+    for name in _OFFLINE_SHADOW247_SCHEDULER_JOB_NAMES:
+        assert name in by_name, f"missing scheduler job: {name!r}"
+
+    pre = by_name["paper_shadow_247_paper_only_preflight_status_v0"]
+    script_rel = pre["args"]["script"]
+    assert (REPO_ROOT / script_rel).is_file()
+
+    ph = by_name["shadow_247_futures_prestart_evidence_drycheck_placeholder_v0"]
+    assert ph["args"]["script"] == wrapper_script
+    assert (REPO_ROOT / ph["args"]["script"]).is_file()
+
+    rt = by_name["paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0"]
+    ra = rt["args"]
+    assert (REPO_ROOT / ra["script"]).is_file()
+    assert (REPO_ROOT / ra["spec"]).is_file()
 
 
 def test_p67_recorded_source_meta_matches_offline_crosslink_semantics(

--- a/tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py
@@ -23,6 +23,7 @@ JOBS_CONFIG = REPO_ROOT / "config" / "scheduler" / "jobs.toml"
 PLACEHOLDER_JOB_NAME = "shadow_247_futures_prestart_evidence_drycheck_placeholder_v0"
 PREFLIGHT_STATUS_JOB_NAME = "paper_shadow_247_paper_only_preflight_status_v0"
 PREFLIGHT_REPORTER_SCRIPT = "scripts/ops/report_paper_shadow_247_preflight_status.py"
+RUNTIME_HIGH_VOL_JOB_NAME = "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0"
 
 
 def _load_ops_config() -> dict:
@@ -142,6 +143,30 @@ def test_paper_shadow_247_preflight_status_job_is_readonly_reporter_not_futures_
     assert job.get("live_authorized") is False
 
 
+def test_paper_preflight_job_shape_vs_toml_crosslink_v0() -> None:
+    """Crosslink read-only preflight reporter job with paper_shadow_247_preflight.toml (no activation)."""
+    pf = _load_paper_shadow_preflight_toml()
+    job = next(j for j in _jobs() if j.get("name") == PREFLIGHT_STATUS_JOB_NAME)
+    assert PREFLIGHT_STATUS_JOB_NAME in pf.get("paper_jobs", [])
+    assert job["args"]["script"] == PREFLIGHT_REPORTER_SCRIPT
+    assert job["args"]["script"] != "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py"
+    tags = set(job.get("tags", []))
+    assert tags >= {"paper_shadow_247", "preflight", "readonly"}
+    assert job.get("paper_only") is True
+    assert job.get("dry_run_visible") is True
+    for key in (
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert job.get(key) is False, key
+    assert pf["scheduler_execution_authorized"] is False
+    assert pf["daemon_activation_authorized"] is False
+    assert pf["shadow_runtime_authorized"] is False
+
+
 def test_paper_shadow_247_preflight_toml_exists_parseable_and_default_off() -> None:
     """Read-only preflight metadata must stay default-off; does not authorize any activation path."""
     assert PAPER_SHADOW_PREFLIGHT_TOML.is_file()
@@ -182,3 +207,28 @@ def test_paper_shadow247_preflight_toml_and_futures_wrapper_toml_default_off_cro
         "order_submission_authorized",
     ):
         assert pf[key] is False and wrap[key.replace("_authorized", "_allowed")] is False, key
+
+
+def test_paper_shadow247_runtime_fixture_job_stays_quarantined_v0() -> None:
+    """Paper runtime fixture job stays disabled and off wrapper/reporter activation paths."""
+    job = next(j for j in _jobs() if j.get("name") == RUNTIME_HIGH_VOL_JOB_NAME)
+    assert job["enabled"] is False
+    assert job.get("paper_only") is True
+    assert job.get("paper_runtime_job") is True
+    assert job.get("dry_run_visible") is True
+    script = job["args"]["script"]
+    assert script == "scripts/aiops/run_paper_trading_session.py"
+    assert script != "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py"
+    assert script != PREFLIGHT_REPORTER_SCRIPT
+    tags = set(job.get("tags", []))
+    assert "disabled_by_default" in tags
+    assert "paper_runtime" in tags
+    for key in (
+        "testnet_authorized",
+        "live_authorized",
+        "broker_authorized",
+        "exchange_authorized",
+        "order_submission_authorized",
+    ):
+        assert job.get(key) is False, key
+    assert job.get("shadow_247_futures_placeholder") is not True


### PR DESCRIPTION
## Summary
Bundled Shadow-247 governance/scheduler tests-only package.

Adds 3 static/offline hooks across existing canonical test owners:

1. `offline_jobs_shadow247_scripts_resolve_v0`
   - Loads scheduler jobs and Shadow-247 wrapper TOML.
   - Verifies relevant job script paths resolve under the repo.
   - Verifies placeholder script alignment with the wrapper script path.

2. `paper_preflight_job_shape_vs_toml_crosslink_v0`
   - Crosslinks Paper/Shadow-247 preflight status job shape with preflight TOML.
   - Keeps the job read-only / non-authorizing.
   - Avoids incorrectly treating reporter enablement as runtime authorization.

3. `paper_shadow247_runtime_fixture_job_stays_quarantined_v0`
   - Verifies the paper runtime fixture job remains disabled/quarantined.
   - Keeps it separate from preflight and wrapper activation paths.
   - Locks no-testnet/no-live/no-broker/no-exchange/no-orders posture.

## Safety
- Bundled tests-only change.
- No docs changes.
- No src/config/workflow/template changes.
- No new readiness, evidence, handoff, package, or pointer surface.
- No runtime, scheduler, Shadow, Paper, Testnet, Live, broker, exchange, or network usage.
- This does not authorize 24/7 Shadow daemon operation.

## Validation
- `uv run pytest tests/ops/test_offline_crosslink_invariant_contract_v0.py tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py -q`
- `uv run ruff check tests/ops/test_offline_crosslink_invariant_contract_v0.py tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`
- `uv run ruff format --check tests/ops/test_offline_crosslink_invariant_contract_v0.py tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`

## Workflow note
This PR intentionally bundles several small Shadow-247 governance hooks to avoid repeated micro-PR CI cycles.

Made with [Cursor](https://cursor.com)