### PR TITLE
test(ops): bundle shadow 247 stop snapshot gate crosslinks v1

### DIFF
--- a/tests/ops/test_offline_crosslink_invariant_contract_v0.py
+++ b/tests/ops/test_offline_crosslink_invariant_contract_v0.py
@@ -10,6 +10,8 @@ neues supervised-observation-Bundle ein.
 
 Ergänzt zudem einen statischen Scheduler-Anker für Paper/Shadow-247 Jobs und das Futures-Wrapper-TOML
 (Pfade lösen unter ``REPO_ROOT``; keine Laufzeitfreigabe).
+
+Ergänzt stabile Offline-Anker für ``snapshot_operator_stop_signals`` (Contract-ID / PT_STOP_KEYS).
 """
 
 from __future__ import annotations
@@ -56,6 +58,7 @@ _OFFLINE_SHADOW247_SCHEDULER_JOB_NAMES = (
     "shadow_247_futures_prestart_evidence_drycheck_placeholder_v0",
     "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0",
 )
+_SNAPSHOT_OPERATOR_STOP_SCRIPT = REPO_ROOT / "scripts" / "ops" / "snapshot_operator_stop_signals.py"
 
 
 def _load_scripts_ops_module(fake_name: str, path: Path) -> Any:
@@ -192,6 +195,15 @@ def test_offline_jobs_shadow247_scripts_resolve_v0() -> None:
     ra = rt["args"]
     assert (REPO_ROOT / ra["script"]).is_file()
     assert (REPO_ROOT / ra["spec"]).is_file()
+
+
+def test_offline_crosslink_stop_snapshot_contract_ids_v0() -> None:
+    """Stable read-only anchors for operator stop snapshot (no runtime, no authority grant)."""
+    body = _SNAPSHOT_OPERATOR_STOP_SCRIPT.read_text(encoding="utf-8")
+    assert 'CONTRACT_ID = "operator_stop_signal_snapshot_v1"' in body
+    assert "PT_STOP_KEYS" in body
+    low = body.lower()
+    assert "does not authorize live trading" in low
 
 
 def test_p67_recorded_source_meta_matches_offline_crosslink_semantics(

--- a/tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py
@@ -4,6 +4,7 @@ Includes small drift hooks: scheduler placeholder relpath must match ops `wrappe
 preflight status job must stay on the read-only reporter (not the futures wrapper).
 Crosslinks `paper_shadow_247_preflight.toml` with `shadow_247_futures_wrapper_skeleton.toml`
 for shared default-off / non-authorizing posture (metadata only, not activation approval).
+Crosslinks preflight `stop_command` / `emergency_stop_command` to on-disk reporter/snapshot scripts.
 """
 
 from __future__ import annotations
@@ -37,6 +38,16 @@ def _load_paper_shadow_preflight_toml() -> dict:
 def _jobs() -> list[dict]:
     payload = tomllib.loads(JOBS_CONFIG.read_text(encoding="utf-8"))
     return payload.get("job", [])
+
+
+def _relative_repo_scripts_from_shell_command(cmd: str) -> list[str]:
+    """Extract repo-relative `scripts/...py` paths from a shell-ish TOML string (static parse only)."""
+    paths: list[str] = []
+    for raw in cmd.replace(";", " ").split():
+        tok = raw.strip().strip('"').strip("'")
+        if tok.startswith("scripts/") and tok.endswith(".py"):
+            paths.append(tok)
+    return paths
 
 
 def test_shadow_247_futures_ops_config_file_exists() -> None:
@@ -232,3 +243,18 @@ def test_paper_shadow247_runtime_fixture_job_stays_quarantined_v0() -> None:
     ):
         assert job.get(key) is False, key
     assert job.get("shadow_247_futures_placeholder") is not True
+
+
+def test_shadow247_preflight_stop_commands_resolve_v0() -> None:
+    """Preflight TOML stop/emergency commands reference existing scripts; stays non-authorizing."""
+    pf = _load_paper_shadow_preflight_toml()
+    stop_cmd = pf["stop_command"]
+    emerg_cmd = pf["emergency_stop_command"]
+    assert "report_paper_shadow_247_preflight_status.py" in stop_cmd
+    assert "snapshot_operator_stop_signals.py" in emerg_cmd
+    for cmd in (stop_cmd, emerg_cmd):
+        for rel in _relative_repo_scripts_from_shell_command(cmd):
+            assert (REPO_ROOT / rel).is_file(), rel
+    assert pf["activation_authorized"] is False
+    assert pf["daemon_activation_authorized"] is False
+    assert pf["scheduler_execution_authorized"] is False

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -13,8 +13,16 @@ from pathlib import Path
 
 import pytest
 
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef,import-not-found]
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "ops" / "shadow_247_futures_start_wrapper_skeleton_v0.py"
+_OPS_SHADOW247_WRAPPER_TOML = (
+    REPO_ROOT / "config" / "ops" / "shadow_247_futures_wrapper_skeleton.toml"
+)
 SRC_TEXT = SCRIPT.read_text(encoding="utf-8")
 
 _FUTURE_CONFIRM_TOKEN = (
@@ -76,6 +84,18 @@ def test_shadow_247_futures_wrapper_skeleton_source_has_no_blocked_substrings(
 )
 def test_shadow_247_futures_wrapper_skeleton_has_boundary_constants(marker: str) -> None:
     assert marker in SRC_TEXT
+
+
+def test_wrapper_operator_gate_fail_closed_crosslink_v0() -> None:
+    """Ops TOML operator/future gates align with fail-closed wrapper source markers (static)."""
+    cfg = tomllib.loads(_OPS_SHADOW247_WRAPPER_TOML.read_text(encoding="utf-8"))
+    assert cfg["final_operator_confirmation_gate_required"] is True
+    assert cfg["supervisor_timeout_future_gate_required"] is True
+    assert cfg["wrapper_daemon_start_allowed"] is False
+    assert cfg["enabled"] is False
+    assert cfg["armed"] is False
+    for token in ("EXIT_FAIL_CLOSED_DEFAULT", "EXIT_CODE_FAIL_CLOSED", "default_fail_closed"):
+        assert token in SRC_TEXT, token
 
 
 def test_shadow_247_futures_wrapper_skeleton_import_has_no_side_effects(


### PR DESCRIPTION
## Summary
Bundled Shadow-247 stop/snapshot/operator-gate tests-only package.

Adds 3 static/offline hooks across existing canonical test owners:

1. `shadow247_preflight_stop_commands_resolve_v0`
   - Crosslinks Paper/Shadow-247 preflight stop-command fields to existing repo-local script paths.
   - Verifies stop commands are inspected statically only and are not executed.

2. `offline_crosslink_stop_snapshot_contract_ids_v0`
   - Locks offline visibility for stable stop/snapshot contract anchors.
   - Verifies stop/snapshot markers remain reachable without runtime authority.

3. `wrapper_operator_gate_fail_closed_crosslink_v0`
   - Crosslinks wrapper TOML and wrapper source around operator/fail-closed gates.
   - Verifies default-off / not-armed / not-enabled posture remains intact.
   - Confirms config alone cannot authorize daemon start.

## Safety
- Bundled tests-only change.
- No docs changes.
- No src/config/workflow/template changes.
- No new readiness, evidence, handoff, package, or pointer surface.
- No runtime, scheduler, Shadow, Paper, Testnet, Live, broker, exchange, or network usage.
- This does not authorize 24/7 Shadow daemon operation.

## Validation
- `uv run pytest tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py tests/ops/test_offline_crosslink_invariant_contract_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py -q`
- `uv run ruff check tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py tests/ops/test_offline_crosslink_invariant_contract_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
- `uv run ruff format --check tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py tests/ops/test_offline_crosslink_invariant_contract_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`

## Workflow note
This PR intentionally bundles several small Shadow-247 governance hooks to avoid repeated micro-PR CI cycles.

Made with [Cursor](https://cursor.com)