### PR TITLE
docs(ops): add shadow 247 governance charter v0

### DIFF
--- a/docs/ops/RUNBOOK_INDEX.md
+++ b/docs/ops/RUNBOOK_INDEX.md
@@ -83,6 +83,7 @@ Für eine zentrale Workflow- und Runbook-Übersicht siehe:
 - Canonical incident-stop runbook: `docs/ops/runbooks/incident_stop_freeze_rollback.md`
 - Scheduler/preflight HOLD boundary: `docs/SCHEDULER_DAEMON.md`
 - Paper/Shadow-247 preflight contract: `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`
+- Shadow-247 governance charter (activation ladder, non-authorizing): `docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md`
 
 Use these as index pointers only. Under `HOLD_NO_PAPER_RUN`, `active` and `unknown`
 classifications keep runtime and go-live progression blocked. `stale_closed` requires

--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -72,6 +72,7 @@ Kurzablauf, wenn **`src/orders/`** (Prefix-Regel) geändert wird:
 Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im **selben Diff** **`docs/ops/registry/DOCS_TRUTH_MAP.md`** (diese Datei) einen kurzen Eintrag unter „Änderungsnachweis“ erhalten — damit bleibt die Registry-Landkarte mit der Branch-Protection-Referenz im Einklang (siehe Regel `truth-branch-protection-canonical` in `config/ops/docs_truth_map.yaml`).
 
 ## Änderungsnachweis (Slice A)
+- 2026-05-18 — `docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md` — Shadow-247 **Governance Charter v0** (activation ladder, operator/stop/evidence **planning**; **non-authorizing**; `not_ready` / STOP_IDLE); Querverweis aus `PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md` + `RUNBOOK_INDEX.md`; **kein** Live-/Testnet-/Daemon-/Run-Unlock; **kein** Ersatz für Preflight-Contract oder TOMLs.
 - `docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md` → PR #3494 (Canary readiness crosslinks slice): pointer-only Verlinkung auf bestehende Readiness-/Bounded-Pilot-Runbooks; kein neuer Readiness-/Evidence-Surface, kein Live-Unlock, keine LB-APR-Abkürzung, NO-LIVE-Default unverändert.
 
 - 2026-05-02 — `docs&#47;ops&#47;specs&#47;MASTER_V2_GO_LIVE_ROADMAP_V0.md` — Informative **`### 3.1 Autonomy stage crosswalk (informative only)`** (planning vocabulary vs §4–§10; distributed recurring verification; **kein** neuer **`24&#47;7 Paper-Test-Daemon`**); **docs-only / non-authorizing**; **keine** Live-&#47;Testnet-&#47;Execution-Freigabe; Gates &#47; KillSwitch &#47; Risk dominieren weiterhin.

--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -8,6 +8,10 @@ It does **not** authorize activation. It does **not** start a daemon. It does **
 
 Current status: **BLOCKED**.
 
+### Related: Shadow-247 governance charter (non-authorizing)
+
+For the **activation ladder**, operator-approval semantics, stop/evidence planning boundaries, and explicit **STOP_IDLE** posture, see **[SHADOW_247_GOVERNANCE_CHARTER_V0.md](SHADOW_247_GOVERNANCE_CHARTER_V0.md)**. That charter is governance-only and **does not** override this document’s **BLOCKED** status or constitute a runtime approval.
+
 ## 2. Canonical activation status
 
 There is no approved one-command Paper/Shadow 24/7 activation path in the repository.

--- a/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
+++ b/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
@@ -1,0 +1,178 @@
+# Shadow-247 Governance Charter v0
+
+## Status and scope
+
+- **Shadow-247 / Paper-Shadow-247 readiness:** `not_ready`.
+- **This document:** governance and activation-path **planning only**. It is **non-authorizing**.
+- **It does not:** approve bounded Shadow smoke, 24h Shadow, 24/7 Shadow, daemon operation, scheduler execution, Paper runtime, Testnet, Live, broker, exchange, credentials, or order submission.
+- **Current operational posture:** **STOP_IDLE** — no run is authorized by this file or by its mere existence in the repository.
+
+**Companion (blocked preflight contract, field-level):** [PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md](PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md) — remains **BLOCKED** unless a **separate**, explicitly reviewed governance update says otherwise.
+
+This charter **does not replace** the preflight contract, ops TOMLs, scheduler config, or tests. It **points to** them and records what **must still be decided** before any future stage can be considered.
+
+---
+
+## Boundary statements (non-negotiable semantics)
+
+| Surface | Meaning |
+|--------|---------|
+| **Docs ≠ Approval** | No document in-repo (including this charter) grants execution or promotion. |
+| **Config ≠ Approval** | `paper_shadow_247_preflight.toml` and `shadow_247_futures_wrapper_skeleton.toml` are metadata/default-off planning; they do not authorize runs. |
+| **Scheduler job ≠ Approval** | Entries in `config/scheduler/jobs.toml` are visibility/shape; `enabled` or `readonly` does not imply go-ahead (see preflight contract). |
+| **Evidence ≠ Approval** | Logs, JSON, CI artifacts, or dashboards do not clear Live/Testnet/Shadow daemon paths. |
+| **Dashboard ≠ Approval** | WebUI/read models are observability only unless a **separate** gate explicitly says otherwise. |
+| **AI ≠ Authority** | No AI/LLM/coding agent is execution, risk, or governance authority. |
+| **Signal ≠ Trade** | Strategy signals and forward tests are not order or Live authority. |
+
+---
+
+## Canonical references (read before any future stage)
+
+- **Preflight contract (blocked):** [PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md](PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md)
+- **Preflight metadata TOML:** `config/ops/paper_shadow_247_preflight.toml` — `activation_authorized`, `daemon_activation_authorized`, `scheduler_execution_authorized`, `shadow_runtime_authorized`, etc. must remain **false** until an explicit operator-governed update.
+- **Futures wrapper skeleton TOML:** `config/ops/shadow_247_futures_wrapper_skeleton.toml` — default-off (`enabled`, `armed`, `wrapper_daemon_start_allowed`, capability flags false); future gates (`final_operator_confirmation_gate_required`, …) document **requirements**, not satisfied approval.
+- **Scheduler jobs:** `config/scheduler/jobs.toml` — preflight reporter vs placeholder vs quarantined paper-runtime jobs (see contract and tests).
+- **Stop snapshot (read-only):** `scripts/ops/snapshot_operator_stop_signals.py` — `CONTRACT_ID` / `PT_STOP_KEYS`; does not authorize trading.
+- **Wrapper skeleton (fail-closed):** `scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py`
+- **Static drift tests (non-authorizing):** e.g. `tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`, `tests/ops/test_offline_crosslink_invariant_contract_v0.py`, `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
+
+---
+
+## Activation ladder
+
+Each stage requires **operator approval** recorded **outside** this document (e.g. ticket, LB-APR-style artifact, or other **explicit** org process). **Implied approval is invalid.**
+
+### Stage 0 — STOP_IDLE / blocked (current)
+
+| Dimension | Requirement |
+|-----------|-------------|
+| **Entry** | Default; matches preflight **BLOCKED** and TOML all-false authorization flags. |
+| **Forbidden** | Any Shadow/Paper-247 **run**, daemon, bounded smoke, Testnet, Live, broker, exchange, orders, credential use for trading. |
+| **Evidence** | N/A (no run). |
+| **Stop** | N/A. |
+| **Operator approval** | None for runs; **STOP** remains until Stage 1+ explicitly approved for **planning only**. |
+
+### Stage 1 — Governance charter absorbed, **no run**
+
+| Dimension | Requirement |
+|-----------|-------------|
+| **Entry** | Org acknowledges this charter + preflight contract; activation path and owners documented; **still zero runs**. |
+| **Forbidden** | Same as Stage 0 for any executable path. |
+| **Evidence** | Charter + contract reviewed; decision record that Stage 1 is satisfied **without** conflating review with run approval. |
+| **Stop** | Revert to Stage 0 if ambiguity remains on authority boundaries. |
+| **Operator approval** | **Required** to exit Stage 0 for planning discipline only — **not** a run approval. |
+
+### Stage 2 — Bounded dry Shadow **planning only** (no execution)
+
+| Dimension | Requirement |
+|-----------|-------------|
+| **Entry** | Stage 1 complete; written plan: duration caps, mode (dry/bounded), abort criteria, evidence locations, **no-order** posture; Futures/perp scope per preflight §3/§3b if applicable. |
+| **Forbidden** | Actual smoke execution, daemon, Testnet, Live, real broker/exchange, order submission. |
+| **Evidence** | Plan document + checklists; config snapshot **as planning**; **no** runtime evidence claims. |
+| **Stop** | Any drift from default-off TOML or blocked contract without a new governed change. |
+| **Operator approval** | **Required** for the **plan** — explicitly **not** execution approval. |
+
+### Stage 3 — Bounded Shadow smoke (**future-only**, explicit approval per event)
+
+| Dimension | Requirement |
+|-----------|-------------|
+| **Entry** | Stage 2 plan approved; **separate explicit go** for **one** bounded attempt; kill/stop path rehearsed; evidence and closeout owners named. |
+| **Forbidden** | 24h or 24/7 operation; expanding scope without new approval; Testnet/Live/broker unless future charter amend. |
+| **Evidence** | Events, logs, heartbeats/stale rules as defined in plan; config snapshot; operator decision record per run; closeout/postrun analysis **as specified before start**. |
+| **Stop** | Emergency stop; stale process; heartbeat failure; unexpected orders/fills; network/API degradation; **fail-closed** behavior per wrapper/preflight/runbooks. |
+| **Operator approval** | **Required per run** — no standing approval. |
+
+### Stage 4 — 24h Shadow **candidate** (future)
+
+| Dimension | Requirement |
+|-----------|-------------|
+| **Entry** | Repeated successful **bounded** runs; on-call; incident path; SLOs for heartbeat/stale; **separate** governance package. |
+| **Forbidden** | Treating 24h as “soft launch” Live; credential expansion without gate. |
+| **Evidence** | 24h evidence pack; postrun sign-off; incident replay capability. |
+| **Stop** | Same as Stage 3 + escalation for sustained degradation. |
+| **Operator approval** | **Explicit** promotion decision — not implied by Stage 3 success alone. |
+
+### Stage 5 — 24/7 Shadow **candidate** (future)
+
+| Dimension | Requirement |
+|-----------|-------------|
+| **Entry** | Daemon lifecycle defined (start/stop/upgrade/orphan recovery); 24h path stable; security and capacity reviewed; **heavyweight** governance sign-off. |
+| **Forbidden** | Permanent operation without runbooked maintenance and STOP semantics. |
+| **Evidence** | Long-horizon logs/metrics; audit trail; periodic re-certification process (org-defined). |
+| **Stop** | Org-wide STOP / incident commander per runbooks. |
+| **Operator approval** | **Highest tier** — explicit 24/7 charter amendment; not derivable from tests or CI. |
+
+---
+
+## Preconditions before **any** bounded Shadow smoke (Stage 3)
+
+- **Explicit operator decision record** for **that** attempt (scope, timebox, rollback).
+- **Duration and scope** caps fixed in writing; **no-order** / dry posture as applicable.
+- **Instrument / universe** consistent with Futures/perp planning boundary in preflight contract if derivatives context applies.
+- **Stop command availability** understood — see `paper_shadow_247_preflight.toml` `stop_command` / `emergency_stop_command` (paths only; execution is operator responsibility when and if ever allowed).
+- **Heartbeat / stale-process handling** defined operationally (not merely “tests pass”).
+- **Evidence output paths** and retention agreed.
+- **Closeout / postrun analysis** owner and checklist defined **before** start.
+- **No** Live / Testnet / broker / exchange / order permissions unless a **future** governed layer explicitly permits (currently default **denied** in TOMLs).
+
+---
+
+## Preconditions before **24h** Shadow (Stage 4)
+
+- Repeatable bounded runs with **documented** abort outcomes.
+- Heartbeat/stale semantics **operationally** owned, not only config-coded.
+- On-call / incident alignment with `incident_stop_freeze_rollback` and kill-switch policy as applicable.
+- Futures/perp evidence gaps (preflight §3b) addressed **if** Futures Shadow is in scope.
+
+---
+
+## Preconditions before **24/7** Shadow (Stage 5)
+
+- Daemon model: orphan detection, restart policy, resource limits, security boundary.
+- Long-term evidence, patching, and **re-charter** cadence defined.
+- **No** implication that CI or static tests substitute for org sign-off.
+
+---
+
+## Stop and incident semantics (planning requirements)
+
+Organizational clarity (not just repo flags) is required for:
+
+- **Emergency stop** — who invokes, what tools (`snapshot_operator_stop_signals`, kill switch, env flags).
+- **Stale process** — definition of “stuck” vs “slow”; escalation.
+- **Heartbeat failure** — measurement and timeout policy.
+- **Missing evidence** — treat as **failure**, not **skip**.
+- **Unexpected fills or orders** — in no-order paths, **immediate STOP** and incident posture.
+- **Network/API degradation** — fail-closed vs degrade rules **per org**, aligned with default-off repo posture.
+- **Fail-closed** — default remains **deny/exit** (wrapper skeleton philosophy); **no** silent continuation.
+
+---
+
+## Evidence requirements (categories)
+
+For any **future** authorized run stage, the org should specify how these are satisfied; this list is **not** approval:
+
+- **Events** — structured run/event stream where applicable.
+- **Logs** — correlation IDs, run id, time bounds.
+- **Fills** — if any execution path exists in scope; **unexpected fills** = incident.
+- **Metrics / heartbeats** — as defined for that stage.
+- **Config snapshot** — TOML/job list relevant to the attempt (read-only capture).
+- **Operator decision record** — per Stage 3+.
+- **Closeout report** — end-state, anomalies, sign-off.
+- **Postrun analysis** — retrospective against plan; feeds **next** approval only.
+
+---
+
+## Explicit next-state
+
+- **Repository and org state after merging this document:** **STOP_IDLE** for Shadow-247 execution. Readiness remains **`not_ready`**.
+- **Next implementation** (config, code, scheduler enablement, or run) requires a **separately approved** slice; **not** implied by this charter PR.
+- **No run** is authorized by this document.
+
+---
+
+## Document control
+
+- **Canonical owner:** ops governance / paper-shadow-247 readiness (align with `canonical_owner` in `paper_shadow_247_preflight.toml` for process ownership).
+- **Version:** v0 — amend only via reviewed docs PR; do not fork parallel “charter” documents.


### PR DESCRIPTION
## Summary
- Adds the canonical Shadow-247 Governance Charter v0.
- Records current readiness as `not_ready` / `STOP_IDLE`.
- Defines the non-authorizing boundaries:
  - Docs ≠ Approval
  - Config ≠ Approval
  - Scheduler job ≠ Approval
  - Evidence ≠ Approval
  - Dashboard ≠ Approval
  - AI ≠ Authority
  - Signal ≠ Trade
- Defines the activation ladder from STOP_IDLE through bounded smoke, 24h Shadow, and 24/7 Shadow candidate.
- Captures preconditions, evidence requirements, stop/incident semantics, and operator approval requirements.
- Adds minimal crosslinks to the existing Paper/Shadow-247 preflight contract, runbook index, and docs truth map.

## Safety
- Docs-only change.
- No src/config/script/workflow/runtime behavior changes.
- No scheduler/runtime/Shadow/Paper/Testnet/Live started.
- No broker/exchange/API usage.
- This charter does not authorize bounded Shadow smoke, 24h Shadow, or 24/7 Shadow operation.

## Validation
- Token-policy check on changed Markdown files via `DocsTokenPolicyValidator.scan_file`.
- `bash scripts/ops/verify_docs_reference_targets.sh`
- `uv run pytest tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q`

## Workflow note
This is the governance/activation-path layer identified after the recent bundled Shadow-247 static guard PRs.

Made with [Cursor](https://cursor.com)