### PR TITLE
feat(ops): gate shadow 247 extended bounded validation v0

### DIFF
--- a/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
+++ b/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
@@ -35,6 +35,8 @@ This charter **does not replace** the preflight contract, ops TOMLs, scheduler c
 - **Scheduler jobs:** `config/scheduler/jobs.toml` — preflight reporter vs placeholder vs quarantined paper-runtime jobs (see contract and tests).
 - **Stop snapshot (read-only):** `scripts/ops/snapshot_operator_stop_signals.py` — `CONTRACT_ID` / `PT_STOP_KEYS`; does not authorize trading.
 - **Wrapper skeleton (fail-closed):** `scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py`
+  - **Standard bounded Shadow dry-run cap (default):** 10 minutes / 600 simulated steps — unchanged.
+  - **Extended tier (governed, default-off):** optional CLI path up to 60 minutes / 3600 steps only with `--extended-bounded-shadow-validation` plus a **distinct** extended confirm token (separate from the base wrapper token). Still local dry-run Shadow only; still **non-authorizing**; does **not** satisfy Stage 3 or any Live/Testnet/broker/exchange/order path.
 - **Static drift tests (non-authorizing):** e.g. `tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`, `tests/ops/test_offline_crosslink_invariant_contract_v0.py`, `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
 
 ---

--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -64,6 +64,13 @@ BOUNDED_SHADOW_DURATION_CAP_MINUTES = 10
 BOUNDED_SHADOW_MAX_STEPS_CAP = 600
 BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS = 60.0
 
+# Governed extended tier: longer wall-clock bounded dry-run only (explicit flags + token).
+BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES = 60
+BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP = 3600
+EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0 = (
+    "I_EXPLICITLY_CONFIRM_SHADOW_247_EXTENDED_BOUNDED_SHADOW_60M_TIER_V0"
+)
+
 BOUNDED_SHADOW_RECORDED_PUBLIC_REST_REPLAY_HEARTBEAT_KIND = (
     "bounded_shadow_dry_run_recorded_public_rest_replay_heartbeat"
 )
@@ -181,7 +188,10 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         help=(
             "With `--bounded-runtime-contract-check`: duration (1–"
             f"{BOUNDED_RUNTIME_CONTRACT_DURATION_CAP_MINUTES}). "
-            f"With `--bounded-shadow-dry-run`: duration (1–{BOUNDED_SHADOW_DURATION_CAP_MINUTES}). "
+            "With `--bounded-shadow-dry-run` (default tier): duration (1–"
+            f"{BOUNDED_SHADOW_DURATION_CAP_MINUTES}). "
+            "With `--bounded-shadow-dry-run` plus `--extended-bounded-shadow-validation`: duration (1–"
+            f"{BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES}). "
             "Otherwise invalid."
         ),
     )
@@ -190,8 +200,9 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         type=int,
         default=None,
         help=(
-            f"With `--bounded-shadow-dry-run` only: step budget 1–{BOUNDED_SHADOW_MAX_STEPS_CAP} "
-            "(default ~12× duration minutes, capped)."
+            "With `--bounded-shadow-dry-run` only: step budget; default tier 1–"
+            f"{BOUNDED_SHADOW_MAX_STEPS_CAP}, extended tier 1–{BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP} "
+            "(default ~12× duration minutes, capped to active tier)."
         ),
     )
     parser.add_argument(
@@ -213,6 +224,27 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
             "Optional future governance token placeholder. Skeleton still exits "
             f"{EXIT_FAIL_CLOSED_DEFAULT} unless a gated evidence / bounded-shadow mode succeeds. "
             "Bounded modes require an exact token match."
+        ),
+    )
+    parser.add_argument(
+        "--extended-bounded-shadow-validation",
+        action="store_true",
+        dest="extended_bounded_shadow_validation",
+        help=(
+            "With `--bounded-shadow-dry-run` only: enable governed extended tier (dry-run only; "
+            f"duration ≤{BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES}m; max-steps ≤"
+            f"{BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP}). Requires `--extended-confirm-token`. "
+            "Default-off; standard tier caps remain 10m / 600 steps when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--extended-confirm-token",
+        metavar="TOKEN",
+        default="",
+        dest="extended_confirm_token",
+        help=(
+            "With `--bounded-shadow-dry-run` + `--extended-bounded-shadow-validation` only. "
+            "Must match the extended-tier governance literal (distinct from `--confirm-token`)."
         ),
     )
     parser.add_argument(
@@ -947,8 +979,11 @@ def _bounded_shadow_markdown(
             _BOUNDED_SHADOW_MACHINE_LINES,
             "```\n\n",
             "## Run parameters\n\n",
-            f"- Duration cap (minutes): `{run_meta['duration_minutes']}`\n",
+            f"- Duration requested (minutes): `{run_meta['duration_minutes']}`\n",
+            f"- Duration cap enforced (minutes): `{run_meta['duration_minutes_cap_enforced']}`\n",
+            f"- Extended bounded tier: `{run_meta.get('extended_bounded_shadow_validation', False)}`\n",
             f"- Step budget: `{run_meta['max_steps']}`\n",
+            f"- Step budget cap enforced: `{run_meta['max_steps_cap_enforced']}`\n",
             f"- Step interval (seconds): `{run_meta['step_interval_seconds']}`\n",
             f"- Steps emitted: `{run_meta['steps_emitted']}`\n",
             f"- UTC end: `{run_meta['utc_end']}`\n\n",
@@ -979,7 +1014,10 @@ def _bounded_shadow_manifest(
         "daemon_run_approved": False,
         "dry_run": True,
         "duration_minutes_requested": int(run_meta["duration_minutes"]),
-        "duration_minutes_cap_enforced": int(BOUNDED_SHADOW_DURATION_CAP_MINUTES),
+        "duration_minutes_cap_enforced": int(run_meta["duration_minutes_cap_enforced"]),
+        "extended_bounded_shadow_validation": bool(
+            run_meta.get("extended_bounded_shadow_validation", False),
+        ),
         "evidence_root_absolute": str(evidence_abs),
         "exchange_used": False,
         "execution_approved": False,
@@ -989,7 +1027,7 @@ def _bounded_shadow_manifest(
         "live_started": False,
         "markdown_artifact_filename": BOUNDED_SHADOW_DRY_RUN_MARKDOWN_V0,
         "max_steps_budget": int(run_meta["max_steps"]),
-        "max_steps_cap_enforced": int(BOUNDED_SHADOW_MAX_STEPS_CAP),
+        "max_steps_cap_enforced": int(run_meta["max_steps_cap_enforced"]),
         "network_used": False,
         "order_submission_used": False,
         "prestart_claims_summary": (
@@ -1026,6 +1064,10 @@ def _execute_bounded_shadow_dry_run(
     max_steps: int,
     step_interval_seconds: float,
     recorded_public_rest_source: Path | None = None,
+    *,
+    duration_cap_minutes: int = BOUNDED_SHADOW_DURATION_CAP_MINUTES,
+    max_steps_cap: int = BOUNDED_SHADOW_MAX_STEPS_CAP,
+    extended_bounded_shadow_validation: bool = False,
 ) -> int:
     recorded_meta: dict[str, Any] | None = None
     if recorded_public_rest_source is not None:
@@ -1071,7 +1113,10 @@ def _execute_bounded_shadow_dry_run(
     utc_ended = datetime.now(timezone.utc)
     run_meta: dict[str, Any] = {
         "duration_minutes": duration_minutes,
+        "duration_minutes_cap_enforced": int(duration_cap_minutes),
+        "extended_bounded_shadow_validation": extended_bounded_shadow_validation,
         "max_steps": max_steps,
+        "max_steps_cap_enforced": int(max_steps_cap),
         "step_interval_seconds": step_interval_seconds,
         "steps_emitted": steps_emitted,
         "utc_end": utc_ended.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -1112,6 +1157,8 @@ def _execute_bounded_shadow_dry_run(
     err.write(f"BOUNDED_SHADOW_DRY_RUN_STEPS_EMITTED={steps_emitted}\n")
     if recorded_meta is not None:
         err.write("RECORDED_PUBLIC_REST_REPLAY_SOURCE_ATTACHED=true\n")
+    if extended_bounded_shadow_validation:
+        err.write("EXTENDED_BOUNDED_SHADOW_VALIDATION_TIER=true\n")
     err.write("BOUNDED_SHADOW_DRY_RUN_WRITTEN=true\n")
     err.write(f"EXIT_CODE={EXIT_DRYCHECK_SUCCESS}\n")
     return EXIT_DRYCHECK_SUCCESS
@@ -1217,6 +1264,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         err.write(_MACHINE_LINES_ALWAYS)
         err.write(
             f"EXIT_REASON=recorded_public_rest_source_requires_bounded_shadow\n"
+            f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    if args.extended_bounded_shadow_validation and not args.bounded_shadow_dry_run:
+        err.write(
+            "`--extended-bounded-shadow-validation` requires `--bounded-shadow-dry-run`.\n",
+        )
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(
+            f"EXIT_REASON=extended_bounded_shadow_requires_bounded_shadow_mode\n"
+            f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    if args.extended_confirm_token.strip() and not args.bounded_shadow_dry_run:
+        err.write("`--extended-confirm-token` is only valid with `--bounded-shadow-dry-run`.\n")
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(
+            f"EXIT_REASON=extended_confirm_requires_bounded_shadow_mode\n"
             f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
         )
         return EXIT_FAIL_CLOSED_DEFAULT
@@ -1327,6 +1396,34 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"EXIT_REASON=bounded_shadow_token_invalid\nEXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
             )
             return EXIT_FAIL_CLOSED_DEFAULT
+
+        ext_active = args.extended_bounded_shadow_validation
+        if ext_active:
+            ext_tok = args.extended_confirm_token.strip()
+            if ext_tok != EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0:
+                err.write(
+                    "extended bounded-shadow tier requires `--extended-confirm-token` matching "
+                    "the extended governance literal.\n",
+                )
+                _emit_banner(err)
+                err.write(_MACHINE_LINES_ALWAYS)
+                err.write(
+                    f"EXIT_REASON=bounded_shadow_extended_token_invalid\n"
+                    f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+                )
+                return EXIT_FAIL_CLOSED_DEFAULT
+        elif args.extended_confirm_token.strip():
+            err.write(
+                "`--extended-confirm-token` requires `--extended-bounded-shadow-validation`.\n",
+            )
+            _emit_banner(err)
+            err.write(_MACHINE_LINES_ALWAYS)
+            err.write(
+                f"EXIT_REASON=extended_confirm_requires_extended_flag\n"
+                f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+            )
+            return EXIT_FAIL_CLOSED_DEFAULT
+
         if args.duration_minutes is None:
             err.write("`--duration-minutes` is required with `--bounded-shadow-dry-run`.\n")
             _emit_banner(err)
@@ -1336,10 +1433,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return EXIT_FAIL_CLOSED_DEFAULT
         dm = args.duration_minutes
-        if dm < 1 or dm > BOUNDED_SHADOW_DURATION_CAP_MINUTES:
+        duration_cap = (
+            BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES
+            if ext_active
+            else BOUNDED_SHADOW_DURATION_CAP_MINUTES
+        )
+        max_steps_cap = (
+            BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP if ext_active else BOUNDED_SHADOW_MAX_STEPS_CAP
+        )
+        if dm < 1 or dm > duration_cap:
             err.write(
                 "with `--bounded-shadow-dry-run`, `--duration-minutes` must be between 1 and "
-                f"{BOUNDED_SHADOW_DURATION_CAP_MINUTES} inclusive.\n",
+                f"{duration_cap} inclusive for the active tier.\n",
             )
             _emit_banner(err)
             err.write(_MACHINE_LINES_ALWAYS)
@@ -1349,10 +1454,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             return EXIT_FAIL_CLOSED_DEFAULT
         if args.max_steps is not None:
             ms = args.max_steps
-            if ms < 1 or ms > BOUNDED_SHADOW_MAX_STEPS_CAP:
+            if ms < 1 or ms > max_steps_cap:
                 err.write(
-                    "`--max-steps` must be between 1 and "
-                    f"{BOUNDED_SHADOW_MAX_STEPS_CAP} inclusive.\n",
+                    f"`--max-steps` must be between 1 and {max_steps_cap} inclusive.\n",
                 )
                 _emit_banner(err)
                 err.write(_MACHINE_LINES_ALWAYS)
@@ -1362,7 +1466,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 return EXIT_FAIL_CLOSED_DEFAULT
         else:
-            ms = min(12 * dm, BOUNDED_SHADOW_MAX_STEPS_CAP)
+            ms = min(12 * dm, max_steps_cap)
 
         if not args.ops_config_path.strip() or not args.jobs_config_path.strip():
             err.write(
@@ -1458,6 +1562,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             int(ms),
             step_iv,
             recorded_resolved,
+            duration_cap_minutes=duration_cap,
+            max_steps_cap=max_steps_cap,
+            extended_bounded_shadow_validation=ext_active,
         )
 
     if args.prestart_evidence_drycheck:

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -28,6 +28,9 @@ SRC_TEXT = SCRIPT.read_text(encoding="utf-8")
 _FUTURE_CONFIRM_TOKEN = (
     "I_EXPLICITLY_CONFIRM_SHADOW_247_FUTURES_START_WRAPPER_BEYOND_DEFAULT_OFF_SKELETON_V0"
 )
+_EXTENDED_BOUNDED_CONFIRM_TOKEN = (
+    "I_EXPLICITLY_CONFIRM_SHADOW_247_EXTENDED_BOUNDED_SHADOW_60M_TIER_V0"
+)
 
 
 def test_shadow_247_futures_wrapper_skeleton_script_exists() -> None:
@@ -77,7 +80,12 @@ def test_shadow_247_futures_wrapper_skeleton_source_has_no_blocked_substrings(
         "--duration-minutes",
         "BOUNDED_RUNTIME_CONTRACT_DURATION_CAP_MINUTES",
         "BOUNDED_SHADOW_DURATION_CAP_MINUTES",
+        "BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES",
+        "BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP",
+        "EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0",
         "BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS",
+        "--extended-bounded-shadow-validation",
+        "--extended-confirm-token",
         "--recorded-public-rest-source",
         "bounded_shadow_dry_run_recorded_public_rest_replay_heartbeat",
     ],
@@ -955,6 +963,428 @@ def test_shadow_247_bounded_shadow_dry_run_rejects_duration_above_shadow_cap(
         shutil.rmtree(root_str, ignore_errors=True)
 
 
+def test_shadow_247_bounded_shadow_dry_run_rejects_max_steps_above_default_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_ms601_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "10",
+                "--max-steps",
+                "601",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "max-steps" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_dry_run_rejects_duration_above_default_cap_even_if_steps_small(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_dm60_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "60",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "duration" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_bounded_shadow_flag_requires_bounded_shadow_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_extmx_", dir="/tmp")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--extended-bounded-shadow-validation",
+                "--evidence-root",
+                root_str,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "extended-bounded-shadow-validation" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_confirm_token_requires_bounded_shadow_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_ecfm_", dir="/tmp")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--extended-confirm-token",
+                _EXTENDED_BOUNDED_CONFIRM_TOKEN,
+                "--evidence-root",
+                root_str,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        low = (proc.stderr + proc.stdout).lower()
+        assert "extended-confirm-token" in low or "bounded-shadow-dry-run" in low
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_tier_accepts_duration_above_default_cap_when_gated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_ext11_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--extended-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "11",
+                "--max-steps",
+                "3",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--extended-confirm-token",
+                _EXTENDED_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        assert proc.returncode == 0, proc.stderr + proc.stdout
+        combo = proc.stderr + proc.stdout
+        assert "EXTENDED_BOUNDED_SHADOW_VALIDATION_TIER=true" in combo
+        doc = json.loads((root / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        assert doc["duration_minutes_cap_enforced"] == 60
+        assert doc["max_steps_cap_enforced"] == 3600
+        assert doc["extended_bounded_shadow_validation"] is True
+        assert doc["dry_run"] is True
+        assert doc["live_started"] is False
+        assert doc["testnet_started"] is False
+        assert doc["broker_used"] is False
+        assert doc["exchange_used"] is False
+        assert doc["order_submission_used"] is False
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_tier_rejects_without_extended_confirm_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_extnt_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--extended-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "11",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "extended-confirm-token" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_tier_rejects_mismatched_extended_confirm_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_extbad_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--extended-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "11",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--extended-confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert not any(root.iterdir())
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_confirm_token_requires_extended_flag_when_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_ecfbf_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--extended-confirm-token",
+                _EXTENDED_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "extended-bounded-shadow-validation" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_tier_rejects_duration_above_extended_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_ext61_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--extended-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "61",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--extended-confirm-token",
+                _EXTENDED_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "duration" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_tier_rejects_max_steps_above_extended_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_ms3601_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--extended-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "3601",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--extended-confirm-token",
+                _EXTENDED_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "max-steps" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_extended_tier_accepts_cli_ceiling_60_and_3600_without_long_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caps allow duration=60 and max_steps=3600; finish early via small max_steps budget."""
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_ext60_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--extended-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "60",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--extended-confirm-token",
+                _EXTENDED_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        assert proc.returncode == 0, proc.stderr + proc.stdout
+        doc = json.loads((root / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        assert doc["duration_minutes_requested"] == 60
+        assert doc["max_steps_budget"] == 2
+        assert doc["duration_minutes_cap_enforced"] == 60
+        assert doc["max_steps_cap_enforced"] == 3600
+        assert doc["extended_bounded_shadow_validation"] is True
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
 def test_shadow_247_bounded_runtime_contract_check_allows_30_minutes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1370,6 +1800,9 @@ def test_shadow_247_bounded_shadow_dry_run_writes_manifest_sha_md_and_steps(
         )
         doc = json.loads(manifest_bytes.decode("utf-8"))
         assert doc.get("artifact") == "shadow_247_futures_bounded_shadow_dry_run.v0"
+        assert doc.get("duration_minutes_cap_enforced") == 10
+        assert doc.get("max_steps_cap_enforced") == 600
+        assert doc.get("extended_bounded_shadow_validation") is False
         assert doc.get("bounded_local_shadow_dry_run") is True
         assert doc.get("run_started") is True
         assert doc.get("shadow_started") is True

--- a/tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py
+++ b/tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py
@@ -144,7 +144,9 @@ def test_wrapper_source_has_fail_closed_and_prestart_cli_markers_v0() -> None:
     src = _wrapper_source()
     assert "--prestart-evidence-drycheck" in src
     assert "--bounded-shadow-dry-run" in src
-    assert "--recorded-public-rest-source" in src
+    assert "--extended-bounded-shadow-validation" in src
+    assert "--extended-confirm-token" in src
+    assert "EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0" in src
     assert "--step-interval-seconds" in src
     assert "--evidence-root" in src
     assert "--config" in src


### PR DESCRIPTION
## Summary
- Adds a separately gated extended bounded-shadow validation tier.
- Preserves the existing default bounded tier cap at `10m / 600` steps.
- Adds an explicit extended tier cap at `60m / 3600` steps.
- Requires an explicit extended flag and distinct extended confirm token.
- Keeps the feature default-off and dry-run only.
- Updates wrapper tests and bounded-mode contract drift checks.
- Adds a minimal governance-charter note that the extended tier is non-authorizing preparation only.

## Safety
- No run is authorized by this PR.
- No scheduler/runtime/shadow/paper/testnet/live started.
- No live/testnet/broker/exchange/orders.
- Default bounded behavior remains unchanged.
- Extended tier remains capped, explicit, and gated.

## Validation
- `uv run pytest tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py -q`
- `uv run pytest tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py tests/ops/test_offline_crosslink_invariant_contract_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py -q`
- `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py`
- `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Local report
- PR package report written under `/tmp/peak_trade_shadow247_bounded_shadow_extended_60m_gate_v0_pr_package_*`.

Made with [Cursor](https://cursor.com)