### PR TITLE
feat(ops): gate shadow 247 candidate 24h validation v0

### DIFF
--- a/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
+++ b/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
@@ -37,6 +37,7 @@ This charter **does not replace** the preflight contract, ops TOMLs, scheduler c
 - **Wrapper skeleton (fail-closed):** `scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py`
   - **Standard bounded Shadow dry-run cap (default):** 10 minutes / 600 simulated steps — unchanged.
   - **Extended tier (governed, default-off):** optional CLI path up to 60 minutes / 3600 steps only with `--extended-bounded-shadow-validation` plus a **distinct** extended confirm token (separate from the base wrapper token). Still local dry-run Shadow only; still **non-authorizing**; does **not** satisfy Stage 3 or any Live/Testnet/broker/exchange/order path.
+  - **24h candidate tier (governed, default-off):** optional CLI path up to 1440 minutes / 86400 steps only with `--candidate-24h-bounded-shadow-validation` plus a **distinct** `--candidate-24h-confirm-token` (separate from base and extended tokens; mutually exclusive with the extended flag). Preparation for bounded dry-run **candidate** validation only — **non-authorizing**, requires separate operator GO for any execution, does **not** imply 24/7 readiness or Stage 3+.
 - **Static drift tests (non-authorizing):** e.g. `tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`, `tests/ops/test_offline_crosslink_invariant_contract_v0.py`, `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
 
 ---

--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -71,6 +71,13 @@ EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0 = (
     "I_EXPLICITLY_CONFIRM_SHADOW_247_EXTENDED_BOUNDED_SHADOW_60M_TIER_V0"
 )
 
+# Governed 24h candidate tier: capped bounded dry-run only (explicit flag + distinct token; default-off).
+BOUNDED_SHADOW_24H_CANDIDATE_DURATION_CAP_MINUTES = 1440
+BOUNDED_SHADOW_24H_CANDIDATE_MAX_STEPS_CAP = 86400
+CANDIDATE_24H_BOUNDED_SHADOW_CONFIRM_TOKEN_V0 = (
+    "I_EXPLICITLY_CONFIRM_SHADOW_247_CANDIDATE_24H_BOUNDED_SHADOW_TIER_V0"
+)
+
 BOUNDED_SHADOW_RECORDED_PUBLIC_REST_REPLAY_HEARTBEAT_KIND = (
     "bounded_shadow_dry_run_recorded_public_rest_replay_heartbeat"
 )
@@ -192,6 +199,8 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
             f"{BOUNDED_SHADOW_DURATION_CAP_MINUTES}). "
             "With `--bounded-shadow-dry-run` plus `--extended-bounded-shadow-validation`: duration (1–"
             f"{BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES}). "
+            "With `--bounded-shadow-dry-run` plus `--candidate-24h-bounded-shadow-validation`: duration (1–"
+            f"{BOUNDED_SHADOW_24H_CANDIDATE_DURATION_CAP_MINUTES}). "
             "Otherwise invalid."
         ),
     )
@@ -201,7 +210,8 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         default=None,
         help=(
             "With `--bounded-shadow-dry-run` only: step budget; default tier 1–"
-            f"{BOUNDED_SHADOW_MAX_STEPS_CAP}, extended tier 1–{BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP} "
+            f"{BOUNDED_SHADOW_MAX_STEPS_CAP}, extended tier 1–{BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP}, "
+            f"24h candidate tier 1–{BOUNDED_SHADOW_24H_CANDIDATE_MAX_STEPS_CAP} "
             "(default ~12× duration minutes, capped to active tier)."
         ),
     )
@@ -245,6 +255,27 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         help=(
             "With `--bounded-shadow-dry-run` + `--extended-bounded-shadow-validation` only. "
             "Must match the extended-tier governance literal (distinct from `--confirm-token`)."
+        ),
+    )
+    parser.add_argument(
+        "--candidate-24h-bounded-shadow-validation",
+        action="store_true",
+        dest="candidate_24h_bounded_shadow_validation",
+        help=(
+            "With `--bounded-shadow-dry-run` only: enable governed 24h **candidate** tier (dry-run only; "
+            f"duration ≤{BOUNDED_SHADOW_24H_CANDIDATE_DURATION_CAP_MINUTES}m; max-steps ≤"
+            f"{BOUNDED_SHADOW_24H_CANDIDATE_MAX_STEPS_CAP}). Mutually exclusive with "
+            "`--extended-bounded-shadow-validation`. Requires `--candidate-24h-confirm-token`."
+        ),
+    )
+    parser.add_argument(
+        "--candidate-24h-confirm-token",
+        metavar="TOKEN",
+        default="",
+        dest="candidate_24h_confirm_token",
+        help=(
+            "With `--bounded-shadow-dry-run` + `--candidate-24h-bounded-shadow-validation` only. "
+            "Must match the 24h-candidate-tier governance literal (distinct from other confirm tokens)."
         ),
     )
     parser.add_argument(
@@ -982,6 +1013,7 @@ def _bounded_shadow_markdown(
             f"- Duration requested (minutes): `{run_meta['duration_minutes']}`\n",
             f"- Duration cap enforced (minutes): `{run_meta['duration_minutes_cap_enforced']}`\n",
             f"- Extended bounded tier: `{run_meta.get('extended_bounded_shadow_validation', False)}`\n",
+            f"- Candidate 24h bounded tier: `{run_meta.get('candidate_24h_bounded_shadow_validation', False)}`\n",
             f"- Step budget: `{run_meta['max_steps']}`\n",
             f"- Step budget cap enforced: `{run_meta['max_steps_cap_enforced']}`\n",
             f"- Step interval (seconds): `{run_meta['step_interval_seconds']}`\n",
@@ -1017,6 +1049,9 @@ def _bounded_shadow_manifest(
         "duration_minutes_cap_enforced": int(run_meta["duration_minutes_cap_enforced"]),
         "extended_bounded_shadow_validation": bool(
             run_meta.get("extended_bounded_shadow_validation", False),
+        ),
+        "candidate_24h_bounded_shadow_validation": bool(
+            run_meta.get("candidate_24h_bounded_shadow_validation", False),
         ),
         "evidence_root_absolute": str(evidence_abs),
         "exchange_used": False,
@@ -1068,6 +1103,7 @@ def _execute_bounded_shadow_dry_run(
     duration_cap_minutes: int = BOUNDED_SHADOW_DURATION_CAP_MINUTES,
     max_steps_cap: int = BOUNDED_SHADOW_MAX_STEPS_CAP,
     extended_bounded_shadow_validation: bool = False,
+    candidate_24h_bounded_shadow_validation: bool = False,
 ) -> int:
     recorded_meta: dict[str, Any] | None = None
     if recorded_public_rest_source is not None:
@@ -1115,6 +1151,7 @@ def _execute_bounded_shadow_dry_run(
         "duration_minutes": duration_minutes,
         "duration_minutes_cap_enforced": int(duration_cap_minutes),
         "extended_bounded_shadow_validation": extended_bounded_shadow_validation,
+        "candidate_24h_bounded_shadow_validation": candidate_24h_bounded_shadow_validation,
         "max_steps": max_steps,
         "max_steps_cap_enforced": int(max_steps_cap),
         "step_interval_seconds": step_interval_seconds,
@@ -1157,7 +1194,9 @@ def _execute_bounded_shadow_dry_run(
     err.write(f"BOUNDED_SHADOW_DRY_RUN_STEPS_EMITTED={steps_emitted}\n")
     if recorded_meta is not None:
         err.write("RECORDED_PUBLIC_REST_REPLAY_SOURCE_ATTACHED=true\n")
-    if extended_bounded_shadow_validation:
+    if candidate_24h_bounded_shadow_validation:
+        err.write("CANDIDATE_24H_BOUNDED_SHADOW_VALIDATION_TIER=true\n")
+    elif extended_bounded_shadow_validation:
         err.write("EXTENDED_BOUNDED_SHADOW_VALIDATION_TIER=true\n")
     err.write("BOUNDED_SHADOW_DRY_RUN_WRITTEN=true\n")
     err.write(f"EXIT_CODE={EXIT_DRYCHECK_SUCCESS}\n")
@@ -1290,6 +1329,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return EXIT_FAIL_CLOSED_DEFAULT
 
+    if args.candidate_24h_bounded_shadow_validation and not args.bounded_shadow_dry_run:
+        err.write(
+            "`--candidate-24h-bounded-shadow-validation` requires `--bounded-shadow-dry-run`.\n",
+        )
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(
+            f"EXIT_REASON=candidate_24h_bounded_shadow_requires_bounded_shadow_mode\n"
+            f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
+    if args.candidate_24h_confirm_token.strip() and not args.bounded_shadow_dry_run:
+        err.write(
+            "`--candidate-24h-confirm-token` is only valid with `--bounded-shadow-dry-run`.\n"
+        )
+        _emit_banner(err)
+        err.write(_MACHINE_LINES_ALWAYS)
+        err.write(
+            f"EXIT_REASON=candidate_24h_confirm_requires_bounded_shadow_mode\n"
+            f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+        )
+        return EXIT_FAIL_CLOSED_DEFAULT
+
     repo_root = _REPO_ROOT_CALC.resolve()
 
     def _drycheck_from_valid_evidence(
@@ -1397,7 +1460,48 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return EXIT_FAIL_CLOSED_DEFAULT
 
+        cand_active = args.candidate_24h_bounded_shadow_validation
         ext_active = args.extended_bounded_shadow_validation
+
+        if cand_active and ext_active:
+            err.write(
+                "`--extended-bounded-shadow-validation` cannot be combined with "
+                "`--candidate-24h-bounded-shadow-validation`.\n",
+            )
+            _emit_banner(err)
+            err.write(_MACHINE_LINES_ALWAYS)
+            err.write(
+                f"EXIT_REASON=bounded_shadow_tier_mutex_violation\n"
+                f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+            )
+            return EXIT_FAIL_CLOSED_DEFAULT
+
+        if cand_active:
+            c24_tok = args.candidate_24h_confirm_token.strip()
+            if c24_tok != CANDIDATE_24H_BOUNDED_SHADOW_CONFIRM_TOKEN_V0:
+                err.write(
+                    "24h candidate bounded-shadow tier requires `--candidate-24h-confirm-token` matching "
+                    "the 24h candidate governance literal.\n",
+                )
+                _emit_banner(err)
+                err.write(_MACHINE_LINES_ALWAYS)
+                err.write(
+                    f"EXIT_REASON=bounded_shadow_candidate_24h_token_invalid\n"
+                    f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+                )
+                return EXIT_FAIL_CLOSED_DEFAULT
+        elif args.candidate_24h_confirm_token.strip():
+            err.write(
+                "`--candidate-24h-confirm-token` requires `--candidate-24h-bounded-shadow-validation`.\n",
+            )
+            _emit_banner(err)
+            err.write(_MACHINE_LINES_ALWAYS)
+            err.write(
+                f"EXIT_REASON=candidate_24h_confirm_requires_candidate_flag\n"
+                f"EXIT_CODE={EXIT_FAIL_CLOSED_DEFAULT}\n",
+            )
+            return EXIT_FAIL_CLOSED_DEFAULT
+
         if ext_active:
             ext_tok = args.extended_confirm_token.strip()
             if ext_tok != EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0:
@@ -1433,14 +1537,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return EXIT_FAIL_CLOSED_DEFAULT
         dm = args.duration_minutes
-        duration_cap = (
-            BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES
-            if ext_active
-            else BOUNDED_SHADOW_DURATION_CAP_MINUTES
-        )
-        max_steps_cap = (
-            BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP if ext_active else BOUNDED_SHADOW_MAX_STEPS_CAP
-        )
+        if cand_active:
+            duration_cap = BOUNDED_SHADOW_24H_CANDIDATE_DURATION_CAP_MINUTES
+            max_steps_cap = BOUNDED_SHADOW_24H_CANDIDATE_MAX_STEPS_CAP
+        elif ext_active:
+            duration_cap = BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES
+            max_steps_cap = BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP
+        else:
+            duration_cap = BOUNDED_SHADOW_DURATION_CAP_MINUTES
+            max_steps_cap = BOUNDED_SHADOW_MAX_STEPS_CAP
         if dm < 1 or dm > duration_cap:
             err.write(
                 "with `--bounded-shadow-dry-run`, `--duration-minutes` must be between 1 and "
@@ -1565,6 +1670,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             duration_cap_minutes=duration_cap,
             max_steps_cap=max_steps_cap,
             extended_bounded_shadow_validation=ext_active,
+            candidate_24h_bounded_shadow_validation=cand_active,
         )
 
     if args.prestart_evidence_drycheck:

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -31,6 +31,9 @@ _FUTURE_CONFIRM_TOKEN = (
 _EXTENDED_BOUNDED_CONFIRM_TOKEN = (
     "I_EXPLICITLY_CONFIRM_SHADOW_247_EXTENDED_BOUNDED_SHADOW_60M_TIER_V0"
 )
+_CANDIDATE_24H_BOUNDED_CONFIRM_TOKEN = (
+    "I_EXPLICITLY_CONFIRM_SHADOW_247_CANDIDATE_24H_BOUNDED_SHADOW_TIER_V0"
+)
 
 
 def test_shadow_247_futures_wrapper_skeleton_script_exists() -> None:
@@ -83,9 +86,14 @@ def test_shadow_247_futures_wrapper_skeleton_source_has_no_blocked_substrings(
         "BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES",
         "BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP",
         "EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0",
+        "BOUNDED_SHADOW_24H_CANDIDATE_DURATION_CAP_MINUTES",
+        "BOUNDED_SHADOW_24H_CANDIDATE_MAX_STEPS_CAP",
+        "CANDIDATE_24H_BOUNDED_SHADOW_CONFIRM_TOKEN_V0",
         "BOUNDED_SHADOW_STEP_INTERVAL_MAX_SECONDS",
         "--extended-bounded-shadow-validation",
         "--extended-confirm-token",
+        "--candidate-24h-bounded-shadow-validation",
+        "--candidate-24h-confirm-token",
         "--recorded-public-rest-source",
         "bounded_shadow_dry_run_recorded_public_rest_replay_heartbeat",
     ],
@@ -1132,6 +1140,7 @@ def test_shadow_247_extended_tier_accepts_duration_above_default_cap_when_gated(
         assert doc["duration_minutes_cap_enforced"] == 60
         assert doc["max_steps_cap_enforced"] == 3600
         assert doc["extended_bounded_shadow_validation"] is True
+        assert doc.get("candidate_24h_bounded_shadow_validation") is False
         assert doc["dry_run"] is True
         assert doc["live_started"] is False
         assert doc["testnet_started"] is False
@@ -1381,6 +1390,358 @@ def test_shadow_247_extended_tier_accepts_cli_ceiling_60_and_3600_without_long_r
         assert doc["duration_minutes_cap_enforced"] == 60
         assert doc["max_steps_cap_enforced"] == 3600
         assert doc["extended_bounded_shadow_validation"] is True
+        assert doc.get("candidate_24h_bounded_shadow_validation") is False
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_candidate_24h_flag_requires_bounded_shadow_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_mx_", dir="/tmp")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--candidate-24h-bounded-shadow-validation",
+                "--evidence-root",
+                root_str,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "candidate-24h-bounded-shadow-validation" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_candidate_24h_confirm_requires_bounded_shadow_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_ec_", dir="/tmp")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--candidate-24h-confirm-token",
+                _CANDIDATE_24H_BOUNDED_CONFIRM_TOKEN,
+                "--evidence-root",
+                root_str,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        low = (proc.stderr + proc.stdout).lower()
+        assert "candidate-24h-confirm-token" in low or "bounded-shadow-dry-run" in low
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_extended_and_candidate_24h_mutex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_mu_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--extended-bounded-shadow-validation",
+                "--candidate-24h-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "60",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--extended-confirm-token",
+                _EXTENDED_BOUNDED_CONFIRM_TOKEN,
+                "--candidate-24h-confirm-token",
+                _CANDIDATE_24H_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert not any(root.iterdir())
+        combo = (proc.stderr + proc.stdout).lower()
+        assert "cannot be combined" in combo or "mutex" in combo or "tier" in combo
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_candidate_24h_tier_accepts_cli_ceiling_1440_and_86400_fast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_cap_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--candidate-24h-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1440",
+                "--max-steps",
+                "3",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--candidate-24h-confirm-token",
+                _CANDIDATE_24H_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        assert proc.returncode == 0, proc.stderr + proc.stdout
+        combo = proc.stderr + proc.stdout
+        assert "CANDIDATE_24H_BOUNDED_SHADOW_VALIDATION_TIER=true" in combo
+        doc = json.loads((root / _DRY_MANIFEST_JSON).read_text(encoding="utf-8"))
+        assert doc["duration_minutes_requested"] == 1440
+        assert doc["max_steps_budget"] == 3
+        assert doc["duration_minutes_cap_enforced"] == 1440
+        assert doc["max_steps_cap_enforced"] == 86400
+        assert doc["candidate_24h_bounded_shadow_validation"] is True
+        assert doc["extended_bounded_shadow_validation"] is False
+        assert doc["dry_run"] is True
+        assert doc["live_started"] is False
+        assert doc["testnet_started"] is False
+        assert doc["broker_used"] is False
+        assert doc["exchange_used"] is False
+        assert doc["order_submission_used"] is False
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_candidate_24h_tier_rejects_without_confirm_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_nt_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--candidate-24h-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "10",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "candidate-24h-confirm-token" in (proc.stderr + proc.stdout).lower()
+        assert not any(root.iterdir())
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_candidate_24h_tier_rejects_mismatched_confirm_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_bad_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--candidate-24h-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "10",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--candidate-24h-confirm-token",
+                _EXTENDED_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert not any(root.iterdir())
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_candidate_24h_confirm_requires_flag_when_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_cfbf_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--candidate-24h-confirm-token",
+                _CANDIDATE_24H_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "candidate-24h-bounded-shadow-validation" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_candidate_24h_tier_rejects_duration_above_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_1441_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--candidate-24h-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1441",
+                "--max-steps",
+                "2",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--candidate-24h-confirm-token",
+                _CANDIDATE_24H_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "duration" in (proc.stderr + proc.stdout).lower()
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_candidate_24h_tier_rejects_max_steps_above_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_c24h_ms_", dir="/tmp")
+    root = Path(root_str)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--bounded-shadow-dry-run",
+                "--candidate-24h-bounded-shadow-validation",
+                "--evidence-root",
+                str(root),
+                "--duration-minutes",
+                "1",
+                "--max-steps",
+                "86401",
+                "--confirm-token",
+                _FUTURE_CONFIRM_TOKEN,
+                "--candidate-24h-confirm-token",
+                _CANDIDATE_24H_BOUNDED_CONFIRM_TOKEN,
+                "--config",
+                "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+                "--jobs-config",
+                "config/scheduler/jobs.toml",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 64
+        assert "max-steps" in (proc.stderr + proc.stdout).lower()
     finally:
         shutil.rmtree(root_str, ignore_errors=True)
 
@@ -1803,6 +2164,7 @@ def test_shadow_247_bounded_shadow_dry_run_writes_manifest_sha_md_and_steps(
         assert doc.get("duration_minutes_cap_enforced") == 10
         assert doc.get("max_steps_cap_enforced") == 600
         assert doc.get("extended_bounded_shadow_validation") is False
+        assert doc.get("candidate_24h_bounded_shadow_validation") is False
         assert doc.get("bounded_local_shadow_dry_run") is True
         assert doc.get("run_started") is True
         assert doc.get("shadow_started") is True

--- a/tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py
+++ b/tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py
@@ -147,6 +147,9 @@ def test_wrapper_source_has_fail_closed_and_prestart_cli_markers_v0() -> None:
     assert "--extended-bounded-shadow-validation" in src
     assert "--extended-confirm-token" in src
     assert "EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0" in src
+    assert "--candidate-24h-bounded-shadow-validation" in src
+    assert "--candidate-24h-confirm-token" in src
+    assert "CANDIDATE_24H_BOUNDED_SHADOW_CONFIRM_TOKEN_V0" in src
     assert "--step-interval-seconds" in src
     assert "--evidence-root" in src
     assert "--config" in src


### PR DESCRIPTION
## Summary
- Adds a separately gated 24h candidate bounded-shadow validation tier.
- Preserves the existing default bounded tier cap at `10m / 600` steps.
- Preserves the extended 60m tier cap at `60m / 3600` steps.
- Adds candidate 24h cap at `1440m / 86400` steps.
- Requires an explicit 24h candidate flag and distinct candidate confirm token.
- Rejects simultaneous extended-60m and candidate-24h tier flags.
- Updates wrapper tests and bounded-mode contract drift checks.
- Adds a minimal governance-charter note that the 24h candidate tier is non-authorizing preparation only.

## Safety
- No run is authorized by this PR.
- No scheduler/runtime/shadow/paper/testnet/live started.
- No live/testnet/broker/exchange/orders.
- Default bounded behavior remains unchanged.
- Extended 60m behavior remains unchanged.
- Candidate 24h tier remains capped, explicit, default-off, and gated.
- 24h candidate tier does not imply 24/7 readiness.

## Validation
- `uv run pytest tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py -q`
- `uv run pytest tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py tests/ops/test_offline_crosslink_invariant_contract_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py -q`
- `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py`
- `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_shadow_247_futures_wrapper_bounded_mode_contract_v0.py`
- `uv run python scripts/ops/validate_docs_token_policy.py --tracked-docs`
- `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`

## Local report
- PR package report written under `/tmp/peak_trade_shadow247_bounded_shadow_24h_candidate_gate_v0_pr_package_*`.

Made with [Cursor](https://cursor.com)