### PR TITLE
test(webui): lock market depth SSR region role contract v0

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -59,6 +59,27 @@ def test_market_dashboard_keeps_depth_ssr_without_client_depth_fetch(
     assert "XMLHttpRequest" not in html
 
 
+def test_market_dashboard_depth_ssr_region_role_contract_v0(client: TestClient) -> None:
+    """SSR depth strip section exposes role=region and aria-labelledby to landmark h2."""
+    html = _html(client, "/market")
+    assert re.search(
+        r'id="market-v0-depth-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-depth-ssr-h2"',
+        html,
+    )
+    assert 'id="market-v0-landmark-depth-ssr-h2"' in html
+    assert 'data-market-v0-depth-landmark-heading-v0="true"' in html
+
+
+def test_double_play_market_dashboard_excludes_depth_ssr_region_role_contract_v0(
+    client: TestClient,
+) -> None:
+    html = _html(client, "/market/double-play")
+    assert not re.search(
+        r'id="market-v0-depth-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-depth-ssr-h2"',
+        html,
+    )
+
+
 def test_double_play_market_dashboard_does_not_embed_market_depth_api_fetch(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds a tests-only contract for the already-merged `/market` SSR depth landmark region.

## Scope

- Asserts `/market` exposes the SSR depth section as a labelled `role="region"` contract.
- Asserts the existing `market-v0-landmark-depth-ssr-h2` heading and `data-market-v0-depth-landmark-heading-v0` marker remain present.
- Adds a negative Double-Play assertion so `/market/double-play` does not pick up the `/market` SSR depth landmark contract.

## Boundary confirmations

- Tests-only.
- No production code changes.
- No Master V2 logic changes.
- No Double-Play logic changes.
- No Risk/KillSwitch changes.
- No Execution/Live gate changes.
- No new route or API.
- No new readmodel.
- No runtime/shadow/testnet/live process started.

## Validation

- `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py tests/test_market_surface_api.py -q`
- `uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
