### PR TITLE
test(ops): add shadow247 governance charter contract

### DIFF
--- a/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
+++ b/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTRACT = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+CHARTER = REPO_ROOT / "docs" / "ops" / "runbooks" / "SHADOW_247_GOVERNANCE_CHARTER_V0.md"
+CHARTER_NAME = "SHADOW_247_GOVERNANCE_CHARTER_V0.md"
 SCHEDULER_DAEMON = REPO_ROOT / "docs" / "SCHEDULER_DAEMON.md"
 JOBS_TOML = REPO_ROOT / "config" / "scheduler" / "jobs.toml"
 
@@ -20,6 +22,18 @@ def _extract_json_example(markdown: str) -> dict[str, object]:
     match = re.search(r"```json\n(.*?)\n```", markdown, re.DOTALL)
     assert match is not None
     return json.loads(match.group(1))
+
+
+def test_paper_shadow_247_contract_links_governance_charter_without_overriding_blocked_v0() -> None:
+    text = _read_contract()
+    assert CHARTER.is_file()
+    assert f"]({CHARTER_NAME})" in text
+    assert "Shadow-247 governance charter" in text
+    assert "**STOP_IDLE**" in text
+    assert "**does not** override this document" in text
+    assert "**BLOCKED** status" in text
+    assert "governance-only" in text
+    assert "runtime approval" in text
 
 
 def test_paper_shadow_247_contract_is_blocked_and_non_authorizing() -> None:

--- a/tests/ops/test_shadow247_governance_charter_doc_contract_v0.py
+++ b/tests/ops/test_shadow247_governance_charter_doc_contract_v0.py
@@ -1,0 +1,99 @@
+"""Contract tests for Shadow-247 Governance Charter v0 (read-only doc anchors, no runtime)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHARTER = REPO_ROOT / "docs" / "ops" / "runbooks" / "SHADOW_247_GOVERNANCE_CHARTER_V0.md"
+PREFLIGHT_NAME = "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+
+EXPECTED_HEADINGS: tuple[str, ...] = (
+    "## Status and scope",
+    "## Boundary statements (non-negotiable semantics)",
+    "## Activation ladder",
+    "## Explicit next-state",
+    "## Document control",
+)
+
+
+def _read() -> str:
+    assert CHARTER.is_file(), f"missing canonical charter: {CHARTER}"
+    return CHARTER.read_text(encoding="utf-8")
+
+
+def test_shadow247_governance_charter_doc_exists_v0() -> None:
+    assert CHARTER.is_file()
+
+
+def test_shadow247_governance_charter_doc_has_stable_outline_v0() -> None:
+    text = _read()
+    for heading in EXPECTED_HEADINGS:
+        assert heading in text, f"missing section heading {heading!r}"
+
+
+def test_shadow247_governance_charter_doc_states_non_authorizing_posture_v0() -> None:
+    text = _read()
+    assert "`not_ready`" in text
+    assert "**STOP_IDLE**" in text
+    assert "**non-authorizing**" in text
+    assert "planning only" in text
+    assert "governance and activation-path **planning only**" in text
+
+
+def test_shadow247_governance_charter_doc_forbids_runtime_authority_paths_v0() -> None:
+    text = _read()
+    lowered = text.lower()
+    for phrase in (
+        "testnet",
+        "live",
+        "broker",
+        "exchange",
+        "order submission",
+        "daemon operation",
+        "scheduler execution",
+    ):
+        assert phrase in lowered, f"expected boundary mention of {phrase!r}"
+    assert "**It does not:**" in text
+    assert "approve bounded Shadow smoke" in text
+
+
+def test_shadow247_governance_charter_doc_forbids_runtime_authorization_payloads_v0() -> None:
+    text = _read()
+    assert '"activation_authorized": true' not in text
+    assert '"activation_authorized":true' not in text
+
+
+def test_shadow247_governance_charter_doc_links_preflight_not_parallel_owner_v0() -> None:
+    text = _read()
+    assert f"]({PREFLIGHT_NAME})" in text
+    assert PREFLIGHT_NAME in text
+    assert "**does not replace** the preflight contract" in text
+    assert "do not fork parallel" in text
+
+
+def test_shadow247_governance_charter_doc_rejects_duplicate_approval_surfaces_v0() -> None:
+    text = _read()
+    assert "**Docs ≠ Approval**" in text
+    assert "**Evidence ≠ Approval**" in text
+    assert "**Dashboard ≠ Approval**" in text
+    assert "EVIDENCE_INDEX" not in text
+    assert "HANDOFF" not in text
+
+
+def test_shadow247_governance_charter_doc_does_not_name_notion_as_authority_v0() -> None:
+    assert "notion" not in _read().lower()
+
+
+def test_shadow247_governance_charter_doc_references_shadow247_bounded_test_anchors_v0() -> None:
+    text = _read()
+    assert "Shadow-247" in text
+    assert "24h" in text
+    assert "test_offline_crosslink_invariant_contract_v0.py" in text
+    assert "test_shadow_247_futures_config_job_skeleton_v0.py" in text
+
+
+def test_shadow247_governance_charter_doc_stage_zero_is_stop_idle_v0() -> None:
+    text = _read()
+    assert "### Stage 0 — STOP_IDLE / blocked (current)" in text
+    assert "preflight **BLOCKED**" in text


### PR DESCRIPTION
## Summary

- Add read-only doc contract tests for `SHADOW_247_GOVERNANCE_CHARTER_V0.md` (mirror P7 governance contract pattern).
- Extend `test_paper_shadow_247_preflight_contract_v0.py` with one Preflight↔Charter crosslink assert (BLOCKED status not overridden).

## Test plan

- [x] `uv run pytest tests/ops/test_shadow247_governance_charter_doc_contract_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/ops/test_p7_shadow_repeated_one_shot_governance_doc_contract_v0.py`
- [x] `uv run ruff check` / `ruff format --check` on changed test files

## Safety

- tests-only; no `src/`, docs, configs, scheduler, wrapper, or runtime paths
- does not authorize Shadow/Live/Testnet execution
