### PR TITLE
webui: refine market readonly banner chip rhythm v0

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -23,32 +23,52 @@
   <section
     role="region"
     aria-labelledby="market-v0-landmark-readonly-constraints-h2"
-    class="rounded-xl border border-slate-700/60 bg-slate-900/55 px-3 py-2.5 sm:px-4"
+    class="rounded-xl border border-slate-700/60 bg-slate-900/55 px-3 py-2.5 sm:px-4 sm:py-3"
     data-market-v1-readonly-banner="true"
+    data-market-v0-readonly-banner-chip-rhythm-v0="true"
   >
     <h2 id="market-v0-landmark-readonly-constraints-h2" class="sr-only">Read-only market constraints</h2>
-    <ul class="m-0 p-0 list-none flex flex-wrap gap-2">
-      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
-        <span class="h-1.5 w-1.5 rounded-full bg-emerald-400/90 shrink-0" aria-hidden="true"></span>
-        Read-only market display
-      </li>
-      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
-        <span class="h-1.5 w-1.5 rounded-full bg-slate-500 shrink-0" aria-hidden="true"></span>
-        No orders
-      </li>
-      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
-        <span class="h-1.5 w-1.5 rounded-full bg-slate-500 shrink-0" aria-hidden="true"></span>
-        No strategy authority
-      </li>
-      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
-        <span class="h-1.5 w-1.5 rounded-full bg-amber-400/85 shrink-0" aria-hidden="true"></span>
-        No Live/Testnet action
-      </li>
-      <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
-        <span class="h-1.5 w-1.5 rounded-full bg-rose-400/80 shrink-0" aria-hidden="true"></span>
-        No Risk/KillSwitch override
-      </li>
-    </ul>
+    <div
+      class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-4 sm:gap-y-2.5"
+      data-market-v0-readonly-banner-chip-rows-v0="true"
+    >
+      <ul
+        class="m-0 p-0 list-none flex flex-wrap gap-2 sm:gap-2.5"
+        aria-label="Read-only posture"
+      >
+        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+          <span class="h-1.5 w-1.5 rounded-full bg-emerald-400/90 shrink-0" aria-hidden="true"></span>
+          Read-only market display
+        </li>
+        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+          <span class="h-1.5 w-1.5 rounded-full bg-slate-500 shrink-0" aria-hidden="true"></span>
+          No orders
+        </li>
+        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+          <span class="h-1.5 w-1.5 rounded-full bg-slate-500 shrink-0" aria-hidden="true"></span>
+          No strategy authority
+        </li>
+      </ul>
+      <div
+        role="presentation"
+        class="hidden sm:block sm:self-stretch w-px min-h-[1.75rem] bg-slate-600/35 shrink-0"
+        aria-hidden="true"
+        data-market-v0-readonly-banner-chip-divider-v0="true"
+      ></div>
+      <ul
+        class="m-0 p-0 list-none flex flex-wrap gap-2 sm:gap-2.5"
+        aria-label="Execution and risk boundaries"
+      >
+        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+          <span class="h-1.5 w-1.5 rounded-full bg-amber-400/85 shrink-0" aria-hidden="true"></span>
+          No Live/Testnet action
+        </li>
+        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/60 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums">
+          <span class="h-1.5 w-1.5 rounded-full bg-rose-400/80 shrink-0" aria-hidden="true"></span>
+          No Risk/KillSwitch override
+        </li>
+      </ul>
+    </div>
   </section>
 
   <section

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -159,6 +159,24 @@ def test_market_dashboard_readonly_banner_markers(client: TestClient) -> None:
     assert 'data-market-non-authorizing="true"' in market_html
 
 
+def test_market_dashboard_readonly_banner_chip_rhythm_v0(client: TestClient) -> None:
+    """Top read-only banner uses grouped chip rows + rhythm marker; /market only."""
+    html = _html(client, "/market")
+    assert 'data-market-v0-readonly-banner-chip-rhythm-v0="true"' in html
+    assert 'data-market-v0-readonly-banner-chip-rows-v0="true"' in html
+    assert 'data-market-v0-readonly-banner-chip-divider-v0="true"' in html
+
+
+def test_double_play_market_dashboard_excludes_market_readonly_banner_chip_rhythm_v0(
+    client: TestClient,
+) -> None:
+    """Double-Play must not carry `/market` read-only banner rhythm contract markers."""
+    html = _html(client, "/market/double-play")
+    assert "data-market-v0-readonly-banner-chip-rhythm-v0" not in html
+    assert "data-market-v0-readonly-banner-chip-rows-v0" not in html
+    assert "data-market-v0-readonly-banner-chip-divider-v0" not in html
+
+
 def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClient) -> None:
     """Contract-first funnel panel: stable marker only; no ranking data wired on /market."""
     market_html = _html(client, "/market")


### PR DESCRIPTION
## Summary

Refines the `/market` read-only banner chip rhythm by grouping the existing five chips into clearer rows for readability.

## Scope

- `/market` template-only visual/readability refinement.
- Adds stable structure markers for the read-only banner chip rhythm contract.
- Adds bounded WebUI contract coverage.
- Keeps existing chip text unchanged.

## Boundary confirmations

- No Shadow247 status added.
- No Master V2 logic changes.
- No Double-Play logic changes.
- No Risk/KillSwitch changes.
- No Execution/Live gate changes.
- No new route or API.
- No new readmodel.
- No runtime/shadow/testnet/live process started.
- `/market/double-play` remains isolated from this `/market`-specific marker.

## Validation

- `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py tests/test_market_surface_api.py -q`
- `uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
