### PR TITLE
webui: show market depth tile readmodel identity v0

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -77,7 +77,7 @@ Current marker families are consolidated as:
 - **Read-only / non-authority shell**: markers that prove the Market Dashboard remains display-only and cannot approve, arm, or submit trades.
 - **SSR metric and candle/OHLC surface**: markers for server-rendered market context, candle stack continuity, and supplemental chart framing.
 - **Depth / orderbook readmodel display**: markers for read-only bid/ask/top-N/depth summaries; these do not create broker, exchange, or order authority.
-- **Visual Cockpit tiles**: markers for grouped Market Snapshot, Chart/OHLCV, Depth, and Safety Rail presentation. These are IA/test anchors, not a separate dashboard surface.
+- **Visual Cockpit tiles**: markers for grouped Market Snapshot, Chart/OHLCV, Depth, and Safety Rail presentation. These are IA/test anchors, not a separate dashboard surface. **Visual Cockpit · Depth‑Tile Readmodel-/Bundle‑Fingerprint (**`GET` `/market`):** wenn der SSR‑Depth‑Kontext **`readmodel_id`** oder Bundle‑**`source`** (Diagnostics/Fixture‑Label) enthält, kompakte monospace Zeilen (**Readmodel / Bundle**) unter **`data-market-v0-depth-tile-readmodel-identity-v0="true"`** — **non-authoritäre** Spiegelung bestehender **`market_depth`‑Felder**, **ohne** neuen Datenpfad oder Producer.
 - **Ranking funnel empty-state / dynamic labels**: markers for producer-defined stages such as `Top Universe`, `Shortlist`, `Top Ranking`, and `Selected Candidates`; the funnel is not fixed to `Top 50&#47;20&#47;5`.
 - **Diagnostic/helper markers**: compact template anchors may exist without individual doc bullets when they are subordinate to the families above.
 

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -308,6 +308,25 @@
       >
         <p class="text-[9px] font-bold uppercase tracking-[0.12em] text-amber-200/80 m-0">Depth (SSR)</p>
         <p class="text-[11px] font-mono text-amber-100/90 m-0 leading-snug">{{ market_depth.display_status }}</p>
+        {% if market_depth.readmodel_id or market_depth.depth_bundle_source %}
+        <div
+          class="mt-0.5 space-y-0.5 rounded-md border border-slate-800/65 bg-slate-950/50 px-2 py-1.5 text-[9px] text-slate-500 leading-snug"
+          data-market-v0-depth-tile-readmodel-identity-v0="true"
+          role="note"
+        >
+          <span class="sr-only">Offline- bzw. Diagnose‑Identität des Markttiefen‑Readmodels und Bundle‑Quellenlabel — reine Darstellung, keine operative Freigabe.</span>
+          {% if market_depth.readmodel_id %}
+          <p class="m-0 font-mono tabular-nums text-slate-400">
+            Readmodel&nbsp;<span class="text-slate-300/95">{{ market_depth.readmodel_id|e }}</span>
+          </p>
+          {% endif %}
+          {% if market_depth.depth_bundle_source %}
+          <p class="m-0 font-mono tabular-nums text-slate-400">
+            Bundle&nbsp;<span class="text-slate-300/95">{{ market_depth.depth_bundle_source|e }}</span>
+          </p>
+          {% endif %}
+        </div>
+        {% endif %}
         {% if market_depth.has_depth_levels %}
         <div class="flex-1 flex items-end gap-2 mt-1" aria-hidden="true">
           <div class="flex-1 flex flex-col justify-end gap-0.5 h-14 rounded-md bg-slate-950/60 border border-slate-800/80 p-1">

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -260,6 +260,39 @@ def test_double_play_market_dashboard_excludes_market_depth_bundle_provenance_ma
     assert "data-market-v0-depth-bundle-provenance-v0" not in html
 
 
+def test_market_dashboard_depth_cockpit_tile_readmodel_identity_default_depth_disabled_v0(
+    client: TestClient,
+) -> None:
+    """Visual Cockpit Depth tile echoes readmodel + bundle diagnostics from SSR context."""
+    html = _html(client, "/market")
+    assert 'data-market-v0-depth-tile-readmodel-identity-v0="true"' in html
+    assert "market_depth_readmodel.v0" in html
+    assert "Readmodel" in html
+    assert "Bundle" in html
+    assert "unavailable" in html
+
+
+def test_market_dashboard_depth_cockpit_tile_readmodel_identity_fixture_bundle_v0(
+    client_depth_fixture_bundle_on: TestClient,
+) -> None:
+    """Fixture depth SSR exposes dummy bundle label in cockpit depth tile."""
+    html = _html(client_depth_fixture_bundle_on, "/market")
+    assert 'data-market-v0-depth-tile-readmodel-identity-v0="true"' in html
+    assert "market_depth_readmodel.v0" in html
+    anchor = html.index("data-market-v0-depth-tile-readmodel-identity-v0")
+    window = html[anchor : anchor + 900]
+    assert "Bundle" in window
+    assert "dummy" in window
+
+
+def test_double_play_market_dashboard_excludes_depth_cockpit_readmodel_identity_marker_v0(
+    client: TestClient,
+) -> None:
+    """`/market`-only cockpit-depth identity marker stays off Double-Play."""
+    html = _html(client, "/market/double-play")
+    assert "data-market-v0-depth-tile-readmodel-identity-v0" not in html
+
+
 def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClient) -> None:
     """Contract-first funnel panel: stable marker only; no ranking data wired on /market."""
     market_html = _html(client, "/market")


### PR DESCRIPTION
## Summary

Shows existing Depth readmodel / bundle identity in the `/market` Visual Cockpit Depth tile.

## Scope

- Reuses existing `/market` context.
- Adds a compact read-only identity cue to the existing Depth tile.
- Adds bounded WebUI contract coverage.
- Documents the marker family in the canonical Market Surface doc.

## Boundary confirmations

- Reuse-before-new confirmed.
- Existing context only.
- No Shadow247 status added.
- No Master V2 logic changes.
- No Double-Play logic changes.
- No Risk/KillSwitch changes.
- No Execution/Live gate changes.
- No new route or API.
- No new readmodel.
- No runtime/shadow/testnet/live process started.
- `/market/double-play` remains isolated from this `/market`-specific marker.

## Validation

- `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py tests/test_market_surface_api.py -q`
- `uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
