### PR TITLE
ops: repair latest phase m smoke registry pointer v0

### DIFF
--- a/docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer
+++ b/docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer
@@ -1,10 +1,10 @@
-rid=22156880821
-done=out/ops/done/PHASE_M_SMOKE_20260218T204532Z_RID_22156880821.txt
-snapshot=out/ops/snapshots/PHASE_M_SMOKE_20260218T204533Z_RID_22156880821.md
-pack=out/ops/evidence_packs/pack_phase_m_smoke_22156880821
+rid=26124538678
+done=out/ops/done/PHASE_M_SMOKE_20260519T205107Z_RID_26124538678.txt
+snapshot=out/ops/snapshots/PHASE_M_SMOKE_20260519T205108Z_RID_26124538678.md
+pack=out/ops/evidence_packs/pack_phase_m_smoke_26124538678
 index=out/ops/index_phase_m_smokes.md
 
 repo=rauterfrank-ui/Peak_Trade
 workflow=paper-tests-audit-evidence
-run_id=22156880821
+run_id=26124538678
 artifact_hint=download all artifacts for run_id (gh run download)


### PR DESCRIPTION
## Summary

Repairs `docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer` so Operator Verify can download valid artifacts again.

## Scope

- Updates the pointer from stale/non-downloadable run `22156880821`.
- Points to successful run `26124538678`, which has downloadable artifacts.
- Preserves the existing pointer format.
- Reuses the existing registry pointer and verifier.

## Boundary confirmations

- Dashboard code unchanged.
- PR #3557 code unchanged.
- No runtime/shadow/testnet/live process started.
- No new registry surface.
- No new docs/runbooks.
- Reuse-before-new confirmed.

## Validation

- `scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download`
- `scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer`
