### PR TITLE
docs: clarify shadow-247 24h candidate evidence semantics

### DIFF
--- a/docs/ops/registry/DOCS_TRUTH_MAP.md
+++ b/docs/ops/registry/DOCS_TRUTH_MAP.md
@@ -72,6 +72,7 @@ Kurzablauf, wenn **`src/orders/`** (Prefix-Regel) geändert wird:
 Wenn **`docs/ops/registry/TRUTH_BRANCH_PROTECTION.md`** geändert wird, muss im **selben Diff** **`docs/ops/registry/DOCS_TRUTH_MAP.md`** (diese Datei) einen kurzen Eintrag unter „Änderungsnachweis“ erhalten — damit bleibt die Registry-Landkarte mit der Branch-Protection-Referenz im Einklang (siehe Regel `truth-branch-protection-canonical` in `config/ops/docs_truth_map.yaml`).
 
 ## Änderungsnachweis (Slice A)
+- 2026-05-19 — `docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md` — Additiver Absatz **„24h bounded Shadow dry-run candidate — evidence semantics“**: dokumentarische `/tmp`-Evidence eines erfolgreichen **24h candidate tier**-Laufs ersetzt **Preflight BLOCKED / not_ready** nicht; **keine** Testnet-/Live-/Broker-/Order-Freigabe; Repo bleibt kanonisch; **docs-only / non-authorizing**.
 - 2026-05-18 — `docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md` — Shadow-247 **Governance Charter v0** (activation ladder, operator/stop/evidence **planning**; **non-authorizing**; `not_ready` / STOP_IDLE); Querverweis aus `PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md` + `RUNBOOK_INDEX.md`; **kein** Live-/Testnet-/Daemon-/Run-Unlock; **kein** Ersatz für Preflight-Contract oder TOMLs.
 - `docs/ops/runbooks/CANARY_LIVE_ENTRY_CRITERIA.md` → PR #3494 (Canary readiness crosslinks slice): pointer-only Verlinkung auf bestehende Readiness-/Bounded-Pilot-Runbooks; kein neuer Readiness-/Evidence-Surface, kein Live-Unlock, keine LB-APR-Abkürzung, NO-LIVE-Default unverändert.
 

--- a/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
+++ b/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
@@ -11,6 +11,8 @@
 
 This charter **does not replace** the preflight contract, ops TOMLs, scheduler config, or tests. It **points to** them and records what **must still be decided** before any future stage can be considered.
 
+**24h bounded Shadow dry-run candidate — evidence semantics (non-authorizing):** A completed **governed** run using the wrapper’s **24h candidate tier** (duration-capped local simulation; dry-run only; no network, broker, or **order submission**; evidence under a fresh `/tmp/peak_trade_…` root such as emitted manifest/steps) produces **documentary machine-readable evidence** only. That evidence may be cited as **input material** for future readiness or gap reviews; it **does not** satisfy the blocked [PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md](PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md) (status remains **BLOCKED**), **does not** move Shadow-247 / Paper-Shadow-247 readiness away from **`not_ready`**, **does not** authorize Testnet, Live, broker or exchange paths, credentials, daemon operation, or scheduler execution, and is **not** a substitute for an external operator approval record. Canonical gate definitions remain in **this repository**; out-of-repo narrative alone does not clear gates.
+
 ---
 
 ## Boundary statements (non-negotiable semantics)


### PR DESCRIPTION
## Summary

- Clarifies the Shadow-247 24h bounded dry-run candidate as documentary evidence only.
- Keeps the Shadow-247 governance charter `not_ready` / STOP_IDLE posture intact.
- Explicitly preserves blocked preflight, no testnet/live/broker/exchange/orders, and no daemon/scheduler authorization.
- Updates `DOCS_TRUTH_MAP` change evidence for the charter edit.

## Safety

- Docs-only.
- No runtime change.
- No Notion change.
- No testnet/live/broker/exchange/order authorization.
- No new docs surface; reuses the canonical charter owner.

## Checks

- `uv run pytest tests/ops/test_shadow247_governance_charter_doc_contract_v0.py`
- `python scripts/ops/check_docs_drift_guard.py --base origin/main`

## Evidence

- Report: `/tmp/peak_trade_shadow247_24h_charter_clarification_docs_only_20260519/SHADOW247_24H_CHARTER_CLARIFICATION_DOCS_ONLY_RESULT.md`

Made with [Cursor](https://cursor.com)