### PR TITLE
fix(ops): avoid empty REC_ARGS expansion on bash 3.2

### DIFF
--- a/scripts/ops/run_shadow_loop_v1.sh
+++ b/scripts/ops/run_shadow_loop_v1.sh
@@ -21,10 +21,16 @@ if [[ -n "${RECORDED_PRICE_SOURCE:-}" ]]; then
   REC_ARGS=(--recorded-price-source "$RECORDED_PRICE_SOURCE")
 fi
 
-python3 -m src.ops.p67.shadow_session_scheduler_cli_v1 \
-  --mode "$MODE" \
-  --run-id "$RUN_ID" \
-  --out-dir "$OUT_DIR" \
-  --iterations "$ITERATIONS" \
-  --interval-seconds "$INTERVAL" \
-  "${REC_ARGS[@]}"
+PY_ARGS=(
+  --mode "$MODE"
+  --run-id "$RUN_ID"
+  --out-dir "$OUT_DIR"
+  --iterations "$ITERATIONS"
+  --interval-seconds "$INTERVAL"
+)
+
+if [[ ${#REC_ARGS[@]} -gt 0 ]]; then
+  python3 -m src.ops.p67.shadow_session_scheduler_cli_v1 "${PY_ARGS[@]}" "${REC_ARGS[@]}"
+else
+  python3 -m src.ops.p67.shadow_session_scheduler_cli_v1 "${PY_ARGS[@]}"
+fi


### PR DESCRIPTION
## Summary

Fixes a macOS `/bin/bash` 3.2 + `set -u` failure in `scripts/ops/run_shadow_loop_v1.sh`.

The script previously expanded an empty `REC_ARGS[@]` array when `RECORDED_PRICE_SOURCE` was unset. On bash 3.2 this fails with:

```text
REC_ARGS[@]: unbound variable
```

That blocked the p76 path inside the online readiness supervisor (p86 gate reported `p76_not_ready` / `p72_pack_failed`).

This change builds fixed scheduler args in `PY_ARGS` and only appends `REC_ARGS` when non-empty.

## Test plan

- [x] `/bin/bash -n scripts/ops/run_shadow_loop_v1.sh`
- [x] bash 3.2 smoke: empty `REC_ARGS` no longer triggers `set -u` failure
- [x] `uv run pytest tests/ops/test_p67_shadow_loop_no_network_contract_v0.py tests/ops/test_p67_recorded_price_series_adapter_v0.py tests/ops/test_online_readiness_supervisor_v1_script_contract_v0.py -q` (31 passed)
- [x] `uv run pytest tests/ops -q -k 'p67 or shadow_loop or readiness'` (151 passed, 1 skipped)
- [ ] After merge: optionally restart launchd supervisor smoke and confirm p76 ticks no longer fail on `REC_ARGS`

Made with [Cursor](https://cursor.com)