### PR TITLE
test(ops): anchor preflight 24h evidence charter crosslink (#3562)

### DIFF
--- a/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
+++ b/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
@@ -36,6 +36,20 @@ def test_paper_shadow_247_contract_links_governance_charter_without_overriding_b
     assert "runtime approval" in text
 
 
+def test_paper_shadow_247_contract_links_charter_24h_evidence_semantics_without_changing_blocked_v0() -> None:
+    """Regression anchor for PR #3562 — preflight navigation to charter 24h tier only."""
+    text = _read_contract()
+    assert CHARTER.is_file()
+    assert "24h bounded Shadow dry-run candidate" in text
+    assert CHARTER_NAME in text
+    assert "Status and scope" in text
+    assert "**documentary**" in text
+    assert "**non-authorizing**" in text
+    assert "**does not** change this contract" in text
+    assert "**BLOCKED** status" in text
+    assert "assists navigation only" in text
+
+
 def test_paper_shadow_247_contract_is_blocked_and_non_authorizing() -> None:
     text = _read_contract()
 

--- a/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
+++ b/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
@@ -36,7 +36,9 @@ def test_paper_shadow_247_contract_links_governance_charter_without_overriding_b
     assert "runtime approval" in text
 
 
-def test_paper_shadow_247_contract_links_charter_24h_evidence_semantics_without_changing_blocked_v0() -> None:
+def test_paper_shadow_247_contract_links_charter_24h_evidence_semantics_without_changing_blocked_v0() -> (
+    None
+):
     """Regression anchor for PR #3562 — preflight navigation to charter 24h tier only."""
     text = _read_contract()
     assert CHARTER.is_file()


### PR DESCRIPTION
## Summary
- Add regression test anchoring the #3562 Preflight→Charter navigation sentence for 24h bounded Shadow dry-run documentary evidence semantics.
- Completes the test pair started in #3561 (charter-side) with the preflight-side anchor.
- Tests-only; no docs, runtime, or authority changes.

## Test plan
- [x] `uv run pytest tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q` (8 passed)
- [x] `uv run pytest tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/ops/test_shadow247_governance_charter_doc_contract_v0.py -q` (20 passed)
- [x] `uv run ruff check tests/ops/test_paper_shadow_247_preflight_contract_v0.py`

## Packaging decision
- Standalone PR.
- Market Dashboard work intentionally not bundled.
- #3563 REC_ARGS regression intentionally not bundled.
- Reuse-before-new checked; no parallel docs or parallel build surfaces created.

Made with [Cursor](https://cursor.com)