### PR TITLE
test(webui): anchor market depth placeholder fixture contract

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -361,6 +361,34 @@ def test_double_play_market_dashboard_excludes_depth_cockpit_freshness_mirror_ma
     assert "data-market-v0-depth-tile-freshness-mirror-v0" not in html
 
 
+def test_market_dashboard_depth_chart_placeholder_fixture_mini_bars_contract_v0(
+    client_depth_fixture_bundle_on: TestClient,
+) -> None:
+    """Fixture SSR locks depth-chart placeholder mini bid/ask bars from offline bundle."""
+    html = _html(client_depth_fixture_bundle_on, "/market")
+    assert 'data-market-v0-depth-chart-placeholder="true"' in html
+    placeholder_idx = html.index('data-market-v0-depth-chart-placeholder="true"')
+    window = html[placeholder_idx : placeholder_idx + 6000]
+    assert "Displayed top-level depth (static)" in window
+    assert "Not cumulative" in window
+    assert 'aria-label="Miniature SSR bid versus ask displayed sizes, top levels only"' in window
+    assert "Bids (display)" in window
+    assert "Asks (display)" in window
+    assert "63000" in window
+    assert "63030" in window
+    assert "data-market-v0-depth-chart-disabled-envelope" not in window
+    assert "fetch(" not in html
+    assert "/api/market/depth" not in html
+
+
+def test_double_play_market_dashboard_excludes_depth_chart_placeholder_marker_v0(
+    client: TestClient,
+) -> None:
+    """`/market`-only depth-chart placeholder marker stays off Double-Play."""
+    html = _html(client, "/market/double-play")
+    assert 'data-market-v0-depth-chart-placeholder="true"' not in html
+
+
 def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClient) -> None:
     """Contract-first funnel panel: stable marker only; no ranking data wired on /market."""
     market_html = _html(client, "/market")


### PR DESCRIPTION
## Summary
- Add fixture-based structure coverage for the `/market` depth-chart placeholder mini-bar contract.
- Assert existing static top-level depth / non-cumulative placeholder semantics with fixture prices.
- Add Double-Play exclusion coverage so `/market/double-play` does not inherit the `/market` placeholder marker.

## Test plan
- [x] `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` (34 passed)
- [x] `uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- [x] `uv run ruff format --check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Guardrails
- Tests-only.
- Existing canonical test owner extended.
- No template or docs changes.
- No new routes, endpoints, APIs, readmodels, JS bundles, polling, runtime behavior, or dashboard surfaces.
- No runtime/scheduler/shadow/testnet/live/paper process started.
- Market Dashboard only; Master V2 / Double Play authority boundaries preserved.

Made with [Cursor](https://cursor.com)