### PR TITLE
docs(ops): rewire Master V2 reuse inventory dataflow links

### DIFF
--- a/docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md
+++ b/docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md
@@ -1,7 +1,7 @@
 # MASTER V2 — Dataflow Map v1 (Canonical, Read-Only)
 
 status: ACTIVE
-last_updated: 2026-04-19
+last_updated: 2026-05-20
 owner: Peak_Trade
 purpose: Canonical docs-only, evidence-based dataflow mapping across Master V2 readiness framing, read-model grammar, report surface, and support surfaces
 docs_token: DOCS_TOKEN_MASTER_V2_DATAFLOW_MAP_V1
@@ -17,7 +17,7 @@ Scope:
 - map how information is transformed, interpreted, forwarded, or referenced
 - classify artifacts as evidence pointers, reporting carriers, or interpretation carriers
 - classify transition clarity as `explicit`, `implicit`, `unclear`, or `missing`
-- provide structural handoff points for later decision-authority mapping work, without performing that work here
+- provide structural handoff points to the canonical decision-authority map without performing authority mapping here
 
 This slice is docs-only, mapping-only, and non-authorizing.
 
@@ -30,8 +30,8 @@ This specification does not:
 - authorize live unlock, live entry, promotion, or runtime behavior
 - define runtime architecture or telemetry/evidence generation pipelines
 - mutate paper/shadow/live evidence data
-- replace canonical ladder, read-model, report-surface, vocabulary-lock, or reuse/rewire surfaces
-- provide a decision-authority map
+- replace canonical ladder, read-model, report-surface, vocabulary-lock, reuse/rewire, or decision-authority map surfaces
+- duplicate decision-authority mapping (canonical owner: `MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`)
 
 ## 3) Relationship to Canonical Master V2 Surfaces
 
@@ -54,6 +54,10 @@ Canonical vocabulary/boundary lock:
 Canonical reuse/rewire inventory:
 
 - `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md`
+
+Canonical decision-authority map (separate owner; subordinate consumer of this dataflow handoff):
+
+- `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`
 
 Relationship rule:
 
@@ -95,9 +99,9 @@ Surface categories used in this map:
 | C1: Reporting schema rendering | report surface / reporting outputs | read-model grammar + ladder level labels | status rows, evidence-pointer slots, blocker slots, required-authority slots, next-slice slots | render grammar into summary table contract and per-gate detail contract without changing semantics | report output schema and five additive single-gate fill carriers | readiness status reviews, additive mapping slices | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` | `explicit` |
 | C2: Single-gate fill materialization | single-gate fill carriers | report-surface fill sections (First to Fifth) + canonical gate/runbook/script pointers | one-gate scoped interpretation snapshots, evidence-pointer bundles, blockers, required authority domains | instantiate schema per single gate with claim discipline and non-authorization wording | additive gate-level interpretation carriers; no closure artifacts | reviewers comparing gate-level interpretation deltas | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` | `explicit` |
 | D1: Vocabulary boundary enforcement | bridge / vocabulary / inventory support surfaces | vocabulary/boundary lock surface + read-model claim discipline | term definitions, forbidden equalities, boundary-safe phrasing constraints | constrain wording and prevent semantic drift across map/report/fill artifacts | guarded interpretation language (`Gate Fill != Gate Closure`, etc.) reused by report/fill docs | report/fill authors and reviewers | `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md` | `explicit` |
-| D2: Reuse/rewire preparation handoff | bridge / vocabulary / inventory support surfaces | reuse/rewire inventory table + canonical surfaces | reusable blocks, minimally rewirable blocks, documented-only/partial areas, identified missing higher-order artifacts | map where future slices should attach without redefining current semantics | preparation pointers for dataflow/authority follow-up slices | future docs-only mapping slices | `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md` | `explicit` |
+| D2: Reuse/rewire preparation handoff | bridge / vocabulary / inventory support surfaces | reuse/rewire inventory table + canonical surfaces | reusable blocks, minimally rewirable blocks, documented-only/partial areas, materialized map owners | map where future slices should attach without redefining current semantics | preparation pointers to materialized dataflow and decision-authority map owners | reuse/rewire and map reviewers | `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md`; `docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md`; `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md` | `explicit` |
 | E1: Evidence provenance to closure inference | cross-surface transition | evidence pointers from read-model/report/fills | pointer provenance exists, but closure sufficiency criteria are external | none in current canonical surfaces (no closure engine in this map scope) | potential interpretation by reviewers; no canonical closure output in this layer | external authority domains only | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md` | `implicit` |
-| E2: Decision-authority consolidation handoff | cross-surface transition | required-authority fields + non-authorization clauses across ladder/read-model/report/vocabulary | authority remains external and named as required, but not consolidated as a map | none in this slice by design | future decision-authority mapping input set | future decision-authority slice only | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`; `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md` | `missing` |
+| E2: Decision-authority consolidation handoff | cross-surface transition | required-authority fields + non-authorization clauses across ladder/read-model/report/vocabulary | authority remains external and named as required; consolidated in separate canonical authority map | hand off to canonical decision-authority map without redefining dataflow semantics here | canonical decision-authority map artifact and stage table | `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md` | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`; `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md`; `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md` | `explicit` |
 
 ## 6) Explicit vs Implicit vs Unclear vs Missing Transitions
 
@@ -107,7 +111,8 @@ Surface categories used in this map:
 - `Read Model -> Report Surface` grammar-to-rendering coupling is explicit.
 - `Report Surface -> Single-Gate Fill carriers` bounded one-gate materialization pattern is explicit.
 - `Vocabulary Lock -> Report&#47;Fill wording` boundary/forbidden-equality constraints are explicit.
-- `Reuse&#47;Rewire Inventory -> next higher-order slice targets` preparation intent is explicit.
+- `Reuse&#47;Rewire Inventory -> materialized map owners` crosslink rewire is explicit.
+- `Dataflow Map -> Decision Authority Map` handoff via row E2 is explicit; authority topology remains owned by `MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`.
 
 ### 6.2 Implicit transitions (documented-only linkage)
 
@@ -119,23 +124,27 @@ Surface categories used in this map:
 
 ### 6.4 Missing transitions (intentionally not yet materialized)
 
-- consolidated decision-authority map transition from `required_authority` fields to a canonical authority-node graph is missing and explicitly out of scope for this slice.
 - explicit canonical transition from interpretation/report outputs to any closure artifact remains absent in this docs-only mapping set.
+- note: consolidated decision-authority mapping is materialized separately in `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`; remaining `partial`, `unclear`, or `missing` authority nodes there do not reopen a missing dataflow-map transition in this file.
 
 ## 7) Implications for Later Decision-Authority Work
 
-This map prepares (but does not implement) later authority mapping by identifying stable upstream inputs:
+The canonical decision-authority map is materialized at:
+
+- `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`
+
+This dataflow map hands off to that separate owner without duplicating authority semantics. Stable upstream inputs remain:
 
 - `required_authority` fields on report surface rows/details
 - non-authorization clauses across ladder/read-model/report/vocabulary surfaces
 - single-gate fill blockers and open-items phrasing
-- reuse/rewire inventory identification of missing authority-map artifact
+- reuse/rewire inventory pointers to materialized map owners
 
-Recommended next authority-oriented slice boundary:
+Recommended next authority-oriented slice boundary (if pursued later):
 
 - consume existing `required_authority` and non-authorization clauses as immutable inputs
-- produce one docs-only authority-node mapping artifact
-- avoid any runtime or policy/risk/governance semantic changes
+- resolve only explicitly marked `partial`, `unclear`, or `missing` nodes inside the canonical decision-authority map
+- avoid any runtime or policy/risk/governance semantic changes and avoid creating a parallel authority-map surface
 
 ## 8) Explicit Non-Authorization Rule
 

--- a/docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md
+++ b/docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md
@@ -1,7 +1,7 @@
 # MASTER V2 — Reuse / Rewire Inventory v1 (Canonical, Read-Only)
 
 status: ACTIVE
-last_updated: 2026-04-19
+last_updated: 2026-05-20
 owner: Peak_Trade
 purpose: Evidence-based reuse/rewire inventory for existing Master V2 First Live Enablement readiness surfaces
 docs_token: DOCS_TOKEN_MASTER_V2_REUSE_REWIRE_INVENTORY_V1
@@ -16,7 +16,7 @@ Scope:
 - identify what can be rewired with minimal adaptation (no parallel rebuild)
 - identify what is documented-only, partial, or unclear
 - isolate genuinely missing inventory/mapping pieces
-- prepare structurally for later higher-order slices (dataflow/decision-authority), without implementing them
+- maintain pointers to materialized higher-order map surfaces (dataflow/decision-authority) without redefining them
 
 This document is mapping-only and non-authorizing.
 
@@ -49,6 +49,11 @@ Canonical report/rendering + existing single-gate fills:
 Canonical vocabulary/boundary lock for gate-fill semantics:
 
 - `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`
+
+Materialized higher-order map surfaces (subordinate; reuse pointers only):
+
+- `docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md`
+- `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`
 
 This inventory is subordinate to all above surfaces and only maps reuse/rewire opportunity across them.
 
@@ -97,31 +102,34 @@ Evidence discipline:
 
 | block / area | existing repo artifacts | reusable as-is | rewirable with minimal adaptation | documented-only / partial / unclear | genuinely missing | notes / evidence pointers |
 |---|---|---|---|---|---|---|
-| dataflow mapping preparation | read-model evidence pointer semantics and report surface row/detail schema | yes: reuse evidence-pointer and field schema as stable input vocabulary | yes: rewire by adding a docs-only dataflow map that references existing fields without changing semantics | currently documented only as interpretation pointers, not full source-to-decision flow | canonical cross-surface dataflow map (docs-only) | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` |
-| decision-authority mapping preparation | required-authority field and non-authorization clauses already exist | yes: authority boundary language reusable as-is | yes: rewire by mapping decision nodes to existing authority-safe wording and required-authority field | partial: authority ownership is referenced but not consolidated as a single map artifact | canonical decision-authority map surface (docs-only) | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` |
+| dataflow mapping preparation | read-model evidence pointer semantics and report surface row/detail schema; materialized dataflow map | yes: reuse evidence-pointer and field schema as stable input vocabulary | yes: rewire discoverability through existing dataflow map cross-references without changing semantics | partial: some cross-gate evidence-bundle aggregation remains documented-only | no new dataflow map required; canonical owner is materialized | `docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md` |
+| decision-authority mapping preparation | required-authority field and non-authorization clauses; materialized decision-authority map | yes: authority boundary language reusable as-is | yes: rewire discoverability through existing authority map cross-references without changing authority | partial: several authority nodes remain `partial`, `unclear`, or `missing` inside the map by design | no new decision-authority map required; canonical owner is materialized | `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_GATE_FILL_VOCABULARY_BOUNDARY_LOCK_V1.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md` |
 | cross-gate inventory maintenance | five single-gate fills plus canonical ladder levels | yes: gate labels (`L0` to `L5`) and single-gate pattern reusable | yes: rewire by maintaining one canonical cross-gate inventory table instead of parallel notes | partial visibility if readers inspect only per-gate sections | this canonical inventory file is the missing artifact now materialized in v1 | `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md`; `docs/ops/specs/MASTER_V2_FIRST_LIVE_ENABLEMENT_GATE_STATUS_REPORT_SURFACE_V1.md`; `docs/ops/specs/MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md` |
 
 ## 6) Genuinely Missing / Unclear Areas
 
 Genuinely missing (for later slices, not implemented here):
 
-- canonical docs-only cross-surface dataflow map (source -> interpretation field -> report surface cell -> decision touchpoint)
-- canonical docs-only decision-authority map that consolidates authority domains referenced across readiness surfaces
 - optional claim-discipline review aid (lint/checklist) to reduce accidental claim-class drift in future additive docs slices
+
+Materialized / rewired (no new parallel map surface required):
+
+- canonical cross-surface dataflow map: `docs/ops/specs/MASTER_V2_DATAFLOW_MAP_V1.md`
+- canonical decision-authority map: `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`
 
 Unclear or partial (kept explicit, non-upgraded):
 
 - candidate-scoped evidence bundles are intentionally open in multiple existing single-gate fills
 - discoverability can degrade if readers skip canonical reader order and consume isolated sections
-- higher-order mapping work is prepared structurally but not yet consolidated in dedicated artifacts
+- authority-map stage rows may remain `partial`, `unclear`, or `missing` without implying live authorization or gate closure
 
 ## 7) Implications for Next Higher-Order Slices
 
 This inventory suggests a minimal, low-drift sequence for later work:
 
-1. Dataflow Map Slice (docs-only): reuse read-model/report fields as nodes, map provenance paths end-to-end.
-2. Decision-Authority Map Slice (docs-only): consolidate required-authority anchors and authority boundaries without changing authority.
-3. Optional Review Hygiene Slice (docs/process-only): lightweight claim-class and pointer-consistency checklist.
+1. Reuse/rewire maintenance only: keep this inventory aligned with materialized map owners (`MASTER_V2_DATAFLOW_MAP_V1.md`, `MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`) via cross-references; do not create parallel map surfaces.
+2. Optional Review Hygiene Slice (docs/process-only): lightweight claim-class and pointer-consistency checklist.
+3. Optional authority-gap closure slices (docs-only, separate): may resolve explicitly marked `partial`, `unclear`, or `missing` nodes inside `MASTER_V2_DECISION_AUTHORITY_MAP_V1.md` without mixing runtime implementation or live authorization.
 
 Guardrails for all above:
 


### PR DESCRIPTION
## Summary
- Rewire stale Master V2 reuse-inventory references now that the Dataflow and Decision Authority maps already exist as ACTIVE canonical owners.
- Update `MASTER_V2_REUSE_REWIRE_INVENTORY_V1.md` so Dataflow and Authority maps are no longer described as genuinely missing.
- Update `MASTER_V2_DATAFLOW_MAP_V1.md` so E2 / authority-map references point to the existing canonical Decision Authority Map.

## Test plan
- [x] `uv run python scripts/ops/validate_docs_token_policy.py`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh`
- [x] `git diff --check`

## Guardrails
- Docs-only.
- Existing canonical owner files updated only.
- No new Master V2 maps, indexes, packages, handoffs, readiness/evidence surfaces, or overview docs created.
- Reuse-before-new checked; stale references were consolidated/rewired into existing owners.
- No runtime/scheduler/shadow/testnet/live/paper process started.
- No broker/exchange/live authorization touched.
- Docs ≠ Approval. Signal ≠ Trade. Dashboard ≠ Freigabe. AI ≠ Authority.

Made with [Cursor](https://cursor.com)