### PR TITLE
test(webui): anchor market orderbook fixture levels contract

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -381,12 +381,53 @@ def test_market_dashboard_depth_chart_placeholder_fixture_mini_bars_contract_v0(
     assert "/api/market/depth" not in html
 
 
+def test_market_dashboard_orderbook_fixture_levels_contract_v0(
+    client_depth_fixture_bundle_on: TestClient,
+) -> None:
+    """Fixture SSR renders lower orderbook ladder with bid/ask rows from complete_minimal."""
+    html = _html(client_depth_fixture_bundle_on, "/market")
+    assert 'data-market-v0-orderbook-placeholder="true"' in html
+    assert 'data-market-v0-lower-depth-orderbook-visuals-v1="true"' in html
+    assert 'data-market-v0-orderbook-topn="true"' in html
+    assert 'data-market-v0-orderbook-has-levels="true"' in html
+    assert 'data-market-v0-orderbook-bids="true"' in html
+    assert 'data-market-v0-orderbook-asks="true"' in html
+    assert 'data-market-v0-orderbook-empty="true"' not in html
+
+    topn_idx = html.index('data-market-v0-orderbook-topn="true"')
+    window = html[topn_idx : topn_idx + 8000]
+    placeholder_idx = html.index('data-market-v0-orderbook-placeholder="true"')
+    header_window = html[placeholder_idx : topn_idx + 200]
+    assert "Read-only · offline depth bundle" in header_window
+    assert "63010" in window
+    assert "63020" in window
+    assert "63000" in window
+    assert "63030" in window
+    assert "Levels · bid-side (display only)" in window
+    assert "Levels · ask-side (display only)" in window
+    assert "Horizontal bars = displayed size" in window
+    assert "fetch(" not in html
+    assert "/api/market/depth" not in html
+    assert 'data-market-readonly="true"' in html
+    assert 'data-market-non-authorizing="true"' in html
+
+
 def test_double_play_market_dashboard_excludes_depth_chart_placeholder_marker_v0(
     client: TestClient,
 ) -> None:
     """`/market`-only depth-chart placeholder marker stays off Double-Play."""
     html = _html(client, "/market/double-play")
     assert 'data-market-v0-depth-chart-placeholder="true"' not in html
+
+
+def test_double_play_market_dashboard_excludes_orderbook_fixture_levels_markers_v0(
+    client: TestClient,
+) -> None:
+    """`/market`-only fixture orderbook level markers stay off Double-Play."""
+    html = _html(client, "/market/double-play")
+    assert 'data-market-v0-orderbook-has-levels="true"' not in html
+    assert 'data-market-v0-orderbook-bids="true"' not in html
+    assert 'data-market-v0-orderbook-asks="true"' not in html
 
 
 def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Add fixture-based structure coverage for the `/market` lower orderbook levels path.
- Assert fixture-enabled orderbook levels render with bid/ask panels and expected fixture prices.
- Add Double-Play exclusion coverage so `/market/double-play` does not inherit `/market` orderbook fixture-level markers.
- Preserve static SSR/no-polling semantics.

## Test plan
- [x] `uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` (36 passed)
- [x] `uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- [x] `uv run ruff format --check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Guardrails
- Tests-only.
- Existing canonical Market Dashboard structure-contract test owner extended.
- No template changes.
- No docs changes.
- No new routes, endpoints, APIs, readmodels, JS bundles, polling, runtime behavior, or dashboard surfaces.
- No runtime/scheduler/shadow/testnet/live/paper process started.
- Master V2 / Double Play authority boundaries preserved.

Made with [Cursor](https://cursor.com)