### PR TITLE
test(ops): anchor Master V2 go-live blocker register

### DIFF
--- a/tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py
+++ b/tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py
@@ -1,0 +1,130 @@
+"""Offline contract tests for Master V2 Go-Live Blocker Register core doc (v0).
+
+Pins stable read-only anchors in the canonical blocker register without runtime,
+broker access, or doc edits.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPECS = REPO_ROOT / "docs" / "ops" / "specs"
+
+BLOCKER_REGISTER = SPECS / "MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md"
+LADDER = SPECS / "MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md"
+READ_MODEL = SPECS / "MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md"
+GATE_STATUS_INDEX = SPECS / "MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md"
+
+LADDER_NAME = "MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md"
+READ_MODEL_NAME = "MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_READ_MODEL_V1.md"
+GATE_STATUS_INDEX_NAME = "MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md"
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing canonical doc: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _plain(path: Path) -> str:
+    text = _read(path)
+    text = text.replace("&#47;", "/")
+    return re.sub(r"[`*]", "", text)
+
+
+def _register_table_row(blocker_id: str) -> str:
+    text = _read(BLOCKER_REGISTER)
+    for line in text.splitlines():
+        if line.startswith(f"| {blocker_id} |"):
+            return line
+    raise AssertionError(f"missing register table row for {blocker_id}")
+
+
+def test_go_live_blocker_register_doc_exists_v0() -> None:
+    assert BLOCKER_REGISTER.is_file()
+
+
+def test_glb006_implicit_session_selection_blocked_default_v0() -> None:
+    row = _register_table_row("GLB-006")
+    assert "Source-bound session selection implicit" in row
+    assert "| BLOCKED |" in row
+
+    text = _plain(BLOCKER_REGISTER)
+    assert "6.1 GLB-006" in text or "GLB-006 — Binding session selection scope" in text
+    assert "implicit selection is STOP" in text
+    assert "session_id" in text
+    assert "does not satisfy explicit session_id selection" in text
+
+
+def test_glb014_external_operator_go_no_go_blocked_v0() -> None:
+    row = _register_table_row("GLB-014")
+    assert "External/operator Go-No-Go owner unclear" in row
+    assert "| BLOCKED |" in row
+    assert "External/operator authority" in row
+
+    text = _plain(BLOCKER_REGISTER)
+    assert "external/operator authority is missing" in text
+
+
+def test_glb015_repo_docs_not_final_approval_blocked_v0() -> None:
+    row = _register_table_row("GLB-015")
+    assert "Repo docs treated as approval" in row
+    assert "| BLOCKED |" in row
+    assert "In-repo doc is used as final approval" in row
+
+
+def test_no_green_claim_rule_v0() -> None:
+    text = _plain(BLOCKER_REGISTER)
+    assert "7. No-Green Claim Rule" in text
+    assert "prevent accidental" in text.lower() and "green" in text.lower()
+    assert "Go-Live approved" in text
+    assert "live trading authorized" in text
+    assert "all gates passed" in text
+    assert "external signoff complete" in text
+    assert "Closing one blocker does not imply readiness for First Live" in text
+
+
+def test_repo_tests_and_docs_do_not_implicitly_clear_blockers_v0() -> None:
+    text = _plain(BLOCKER_REGISTER)
+    assert "does not close GLB-010" in text or "does not close GLB-008" in text
+    assert "by itself" in text
+    assert "not inferred solely from generic repository tests or CI success" in text
+    assert (
+        "Default posture: blockers are OPEN unless evidence and the correct authority explicitly close or accept them"
+        in text
+    )
+
+
+def test_register_distinguishes_evidence_readiness_and_authority_v0() -> None:
+    text = _plain(BLOCKER_REGISTER)
+    assert "make evidence and decision requirements visible" in text
+    assert "does not authorize live execution" in text
+    assert "external authority" in text
+    assert "No state in this table authorizes live trading by itself" in text
+    assert "Owner labels in this register are role categories, not approvals" in text
+
+
+def test_register_preserves_non_authorizing_live_semantics_v0() -> None:
+    text = _plain(BLOCKER_REGISTER)
+    lowered = text.lower()
+    assert "non-authorizing" in lowered
+    assert "does not mark peak_trade as ready for live trading" in lowered
+    assert "no live authorization" in lowered
+    assert "no external signoff claim" in lowered
+
+
+def test_blocker_register_crosslinks_readiness_ladder_and_gate_index_v0() -> None:
+    text = _read(BLOCKER_REGISTER)
+    assert LADDER_NAME in text
+    assert GATE_STATUS_INDEX_NAME in text
+    assert "Readiness, gates, and authority:" in text
+    assert LADDER.is_file()
+    assert GATE_STATUS_INDEX.is_file()
+
+
+def test_blocker_register_references_read_model_companion_surfaces_v0() -> None:
+    text = _read(BLOCKER_REGISTER)
+    assert "Decision Authority Map" in text
+    assert "Promotion State Machine" in text
+    assert READ_MODEL.is_file()


### PR DESCRIPTION
## Summary
- Add a tests-only contract for `MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md`.
- Anchor core blocker semantics for GLB-006, GLB-014, GLB-015, and the §7 No-Green rule.
- Verify docs/tests/CI do not implicitly clear blockers or approve Go-Live.
- Pin existing crosslinks to the Ladder, Gate Status Index, and Decision Authority Map.

## Notes
- The test intentionally anchors the current document semantics.
- GLB-006 is anchored as the SRP/session-selection blocker: implicit session selection remains STOP and explicit `session_id` is required.
- GLB-015 is anchored as the “repo docs treated as approval” blocker.
- No doc changes are included in this PR.

## Test plan
- [x] `uv run pytest tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py -q` (10 passed)
- [x] `uv run ruff check tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py`
- [x] `uv run ruff format --check tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py`

## Guardrails
- Tests-only.
- No docs changed.
- No runtime code changed.
- No new docs, maps, indexes, evidence/readiness/handoff/package/pointer surfaces created.
- Existing canonical Go-Live Blocker Register owner anchored by tests instead of adding parallel documentation.
- No runtime/scheduler/shadow/testnet/live/paper process started.
- No online readiness supervisor started.
- No broker/exchange/live authorization touched.
- Docs ≠ Approval. Signal ≠ Trade. Dashboard ≠ Freigabe. AI ≠ Authority.

Made with [Cursor](https://cursor.com)