### PR TITLE
test(ops): anchor primary evidence retention invariant

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -28,6 +28,36 @@ That command is for planning and diagnostics. It must not be interpreted as daem
 
 Operator decision until a future reviewed slice completes all mandatory contract items: **STOP — do not activate Paper/Shadow 24/7.**
 
+## 2a. Primary evidence retention invariant v0 (all run types)
+
+`PRIMARY_EVIDENCE_REQUIRED_FOR_EVERY_RUN=true`
+
+Every governed run—**Paper**, **Shadow**, **Testnet**, **Live/Canary**, **Scheduler**, **Supervisor**, **Daemon**, **Smoke**, **bounded trial**, and **runtime adapter** paths—must produce **durable primary evidence** before the run may be treated as complete.
+
+A run is **not complete** until **archive verification passes**, including at minimum:
+
+- durable archive outside `/tmp`
+- `MANIFEST.sha256` present and verifiable (`shasum -a 256 -c` RC=0)
+- required runtime artifacts present (for example account, fills, events, steps as applicable)
+- config snapshot with secrets redacted when applicable
+- stdout/stderr or scheduler logs present
+- closeout present
+- postrun/review present (for example `REVIEW_RESULT.json` with explicit verdict)
+- archive copy verified against staging
+- source path usable later for operator retrieval
+
+The following are **forbidden as primary evidence** (supporting or documentary only):
+
+- `/tmp`-only artifacts without durable archive
+- transcript-only evidence
+- Notion pointer-only evidence
+- chat-summary-only evidence
+- unverified archive copies
+
+Future run selectors and adapters must **reject or block** a run plan when primary evidence retention cannot be guaranteed. **No gate clearance** may be inferred from degraded or documentary evidence alone. Completing one bounded Paper observation run (for example Paper120) does **not** impose an automatic **24h** or **72h** rerun requirement.
+
+Reference implementation: `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` (plan-only default; execute requires approval record; archive root outside `/tmp`).
+
 ## 3. Non-authority
 
 The following are **not** trading authority, readiness approval, evidence approval, promotion, Master V2 / Double Play approval, or Live/Testnet approval:

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -1,0 +1,116 @@
+"""Static contract tests for primary evidence retention invariant v0 (offline, no runtime)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_OWNER = (
+    REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+)
+PAPER_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_paper_only_bounded_observation_adapter_v0.py"
+
+
+def _owner_text() -> str:
+    return CANONICAL_OWNER.read_text(encoding="utf-8")
+
+
+def _adapter_text() -> str:
+    return PAPER_ADAPTER.read_text(encoding="utf-8")
+
+
+def test_canonical_owner_exists() -> None:
+    assert CANONICAL_OWNER.is_file()
+
+
+def test_canonical_owner_declares_primary_evidence_required_for_every_run() -> None:
+    text = _owner_text()
+    assert "PRIMARY_EVIDENCE_REQUIRED_FOR_EVERY_RUN=true" in text
+    assert "## 2a. Primary evidence retention invariant v0" in text
+
+
+def test_canonical_owner_applies_to_all_run_types() -> None:
+    text = _owner_text()
+    for run_type in (
+        "Paper",
+        "Shadow",
+        "Testnet",
+        "Live/Canary",
+        "Scheduler",
+        "Supervisor",
+        "Daemon",
+        "Smoke",
+        "bounded trial",
+        "runtime adapter",
+    ):
+        assert run_type in text
+
+
+def test_canonical_owner_requires_durable_archive_outside_tmp() -> None:
+    text = _owner_text()
+    assert "durable archive outside `/tmp`" in text
+    assert "archive verification passes" in text
+
+
+def test_canonical_owner_requires_manifest_and_sha256_verification() -> None:
+    text = _owner_text()
+    assert "MANIFEST.sha256" in text
+    assert "shasum -a 256 -c" in text
+    assert "RC=0" in text
+
+
+def test_canonical_owner_requires_closeout_and_postrun_review() -> None:
+    text = _owner_text()
+    assert "closeout present" in text
+    assert "postrun/review present" in text
+    assert "REVIEW_RESULT.json" in text
+
+
+def test_canonical_owner_rejects_non_primary_evidence_sources() -> None:
+    text = _owner_text()
+    forbidden = (
+        "/tmp`-only artifacts",
+        "transcript-only evidence",
+        "Notion pointer-only evidence",
+        "chat-summary-only evidence",
+        "unverified archive copies",
+    )
+    for phrase in forbidden:
+        assert phrase in text
+
+
+def test_canonical_owner_forbids_gate_clearance_from_documentary_only() -> None:
+    text = _owner_text()
+    assert "No gate clearance" in text
+    assert "degraded or documentary evidence alone" in text
+
+
+def test_canonical_owner_no_automatic_24h_72h_rerun_after_paper120() -> None:
+    text = _owner_text()
+    assert "automatic **24h** or **72h** rerun requirement" in text
+    assert "Paper120" in text
+
+
+def test_canonical_owner_run_not_complete_until_archive_verification() -> None:
+    text = _owner_text()
+    assert "A run is **not complete** until **archive verification passes**" in text
+
+
+def test_paper_adapter_plan_only_default_and_execute_gated() -> None:
+    text = _adapter_text()
+    assert "plan-only default" in text
+    assert "--plan-only" in text or '"plan-only"' in text
+    assert "--execute" in text
+    assert "requires --approval-record" in text or "execute requires --approval-record" in text
+
+
+def test_paper_adapter_archive_root_must_be_outside_tmp() -> None:
+    text = _adapter_text()
+    assert "archive root must be outside /tmp" in text
+
+
+def test_canonical_owner_references_paper_adapter_implementation() -> None:
+    text = _owner_text()
+    assert "run_paper_only_bounded_observation_adapter_v0.py" in text
+    assert "plan-only default" in text
+    assert "archive root outside `/tmp`" in text


### PR DESCRIPTION
## Summary

Anchors the Primary Evidence Retention invariant in the existing canonical preflight owner instead of creating a new parallel surface.

Canonical owner reused:

- `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`

Adds static/offline contract tests:

- `tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`

## Invariant pinned

Future runs are not considered complete unless primary evidence is:

- produced
- archived outside `/tmp`
- checksummed
- verified
- closeout/review/postrun available
- usable later via durable source path

This applies to Paper, Shadow, Testnet, Live/Canary, Scheduler, Supervisor, Daemon, Smoke, bounded trial, and runtime adapter flows.

Forbidden as primary evidence:

- `/tmp`-only artifacts
- transcript-only traces
- Notion-only pointers
- chat-summary-only evidence
- unverified archive copies

Also pinned:

- no gate clearance from documentary/degraded evidence only
- no automatic 24h/72h rerun requirement after Paper120
- paper-only adapter v0 retains archive-root requirement and inert plan-only default

## Safety

This PR does not start runtime and does not approve Paper, Shadow, Testnet, Live, broker/exchange, scheduler, or supervisor execution.

It does not clear:

- `HOLD_NO_PAPER_RUN`
- GLB-014 / GLB-015
- Shadow readiness
- Testnet readiness
- Live readiness

## Validation

- `uv run pytest tests/ops/test_primary_evidence_retention_invariant_contract_v0.py -q`
- `uv run pytest tests/ops/test_paper_shadow_247_preflight_contract_v0.py -q`
- `uv run ruff check tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`
- `uv run ruff format --check tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`
- `uv run python scripts/ops/validate_docs_token_policy.py`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Runtime

Runtime was not started. Scheduler was not started. Paper/Shadow/Testnet/Live were not started.
