### PR TITLE
fix(ops): align bounded shadow evidence review contract

### DIFF
--- a/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -1005,6 +1005,10 @@ def _bounded_shadow_markdown(
             "- No live, testnet, broker, exchange, private endpoints, credentials, or network I/O.\n",
             "- No scheduler or daemon spawned; no execution session; no order submission.\n",
             "- Simulated bounded step loop only — not an exchange/broker runtime.\n\n",
+            "## Safety boundary markers (canonical)\n\n",
+            f"- {BOUNDARY_NO_BROKER}\n",
+            f"- {BOUNDARY_NO_NETWORK}\n",
+            f"- {BOUNDARY_NO_ORDER_SUBMISSION}\n\n",
             "## Operator machine summary (verbatim keys)\n\n",
             "```text\n",
             _BOUNDED_SHADOW_MACHINE_LINES,
@@ -1040,6 +1044,10 @@ def _bounded_shadow_manifest(
 ) -> dict:
     manifest: dict[str, Any] = {
         "artifact": BOUNDED_SHADOW_DRY_RUN_SCHEMA_V0,
+        "schema": BOUNDED_SHADOW_DRY_RUN_SCHEMA_V0,
+        BOUNDARY_NO_BROKER: True,
+        BOUNDARY_NO_NETWORK: True,
+        BOUNDARY_NO_ORDER_SUBMISSION: True,
         "bounded_local_shadow_dry_run": True,
         "broker_used": False,
         "credentials_used": False,

--- a/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
@@ -505,6 +505,35 @@ def test_review_fails_invalid_manifest_schema(tmp_path: Path) -> None:
     assert result["verdict"] == review.REVIEW_REQUIRED
 
 
+def test_review_fails_missing_manifest_schema(tmp_path: Path) -> None:
+    review = _load_review()
+    staging = tmp_path / "staging"
+    _write_wrapper_bundle(staging)
+    manifest_path = staging / "wrapper_evidence" / "manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload.pop("schema", None)
+    manifest_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    result = review.review_evidence(staging)
+    assert result["verdict"] == review.REVIEW_REQUIRED
+    assert any("schema must be" in issue for issue in result["issues"])
+
+
+def test_review_fails_missing_safety_boundary_strings(tmp_path: Path) -> None:
+    review = _load_review()
+    staging = tmp_path / "staging"
+    _write_wrapper_bundle(staging)
+    md_path = staging / "wrapper_evidence" / "SHADOW_247_FUTURES_BOUNDED_SHADOW_DRY_RUN.md"
+    md_path.write_text("# Bounded Shadow Dry Run\n", encoding="utf-8")
+    manifest_path = staging / "wrapper_evidence" / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({"schema": "shadow_247_futures_bounded_shadow_dry_run.v0"}) + "\n",
+        encoding="utf-8",
+    )
+    result = review.review_evidence(staging)
+    assert result["verdict"] == review.REVIEW_REQUIRED
+    assert any("missing safety boundary strings" in issue for issue in result["issues"])
+
+
 def test_review_does_not_claim_gate_clearance(tmp_path: Path) -> None:
     review = _load_review()
     staging = tmp_path / "staging"

--- a/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
+++ b/tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py
@@ -2161,6 +2161,10 @@ def test_shadow_247_bounded_shadow_dry_run_writes_manifest_sha_md_and_steps(
         )
         doc = json.loads(manifest_bytes.decode("utf-8"))
         assert doc.get("artifact") == "shadow_247_futures_bounded_shadow_dry_run.v0"
+        assert doc.get("schema") == "shadow_247_futures_bounded_shadow_dry_run.v0"
+        assert doc.get("NO_BROKER") is True
+        assert doc.get("NO_NETWORK") is True
+        assert doc.get("NO_ORDER_SUBMISSION") is True
         assert doc.get("duration_minutes_cap_enforced") == 10
         assert doc.get("max_steps_cap_enforced") == 600
         assert doc.get("extended_bounded_shadow_validation") is False
@@ -2187,8 +2191,65 @@ def test_shadow_247_bounded_shadow_dry_run_writes_manifest_sha_md_and_steps(
         assert "LIVE_STARTED=false" in ms
         md_txt = (root / _SHADOW_DRY_MD).read_text(encoding="utf-8")
         assert "Bounded Shadow Dry-Run" in md_txt
+        assert "NO_BROKER" in md_txt
+        assert "NO_NETWORK" in md_txt
+        assert "NO_ORDER_SUBMISSION" in md_txt
         steps_txt = (root / _SHADOW_STEPS).read_text(encoding="utf-8").strip().splitlines()
         assert len(steps_txt) == 4
+    finally:
+        shutil.rmtree(root_str, ignore_errors=True)
+
+
+def test_shadow_247_bounded_shadow_dry_run_evidence_passes_review_script(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    review_spec = importlib.util.spec_from_file_location(
+        "review_shadow_bounded_observation_evidence_v0",
+        REPO_ROOT / "scripts" / "ops" / "review_shadow_bounded_observation_evidence_v0.py",
+    )
+    assert review_spec is not None and review_spec.loader is not None
+    review_mod = importlib.util.module_from_spec(review_spec)
+    review_spec.loader.exec_module(review_mod)
+
+    root_str = tempfile.mkdtemp(prefix="peak_trade_utest_shdw_review_", dir="/tmp")
+    root = Path(root_str)
+    staging = root / "staging"
+    evidence = staging / "wrapper_evidence"
+    evidence.mkdir(parents=True)
+    logs = staging / "logs"
+    logs.mkdir(parents=True)
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--bounded-shadow-dry-run",
+            "--evidence-root",
+            str(evidence),
+            "--duration-minutes",
+            "1",
+            "--max-steps",
+            "2",
+            "--confirm-token",
+            _FUTURE_CONFIRM_TOKEN,
+            "--config",
+            "config/ops/shadow_247_futures_wrapper_skeleton.toml",
+            "--jobs-config",
+            "config/scheduler/jobs.toml",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    try:
+        assert proc.returncode == 0, proc.stderr + proc.stdout
+        (logs / "wrapper_stdout.log").write_text(proc.stdout, encoding="utf-8")
+        (logs / "wrapper_stderr.log").write_text(proc.stderr, encoding="utf-8")
+        result = review_mod.review_evidence(staging)
+        assert result["verdict"] == review_mod.PASS, result["issues"]
     finally:
         shutil.rmtree(root_str, ignore_errors=True)
 


### PR DESCRIPTION
## Summary

Aligns the bounded Shadow dry-run wrapper evidence contract with the Shadow retention review script.

This fixes the REVIEW_REQUIRED result observed after the first bounded Shadow dry-run adapter execution:

- wrapper completed successfully
- adapter correctly failed closed
- review did not PASS
- no primary archive was created

## Root cause

The wrapper evidence did not match the stricter review contract added with the Shadow retention adapter:

- `manifest.json` used `artifact` but lacked `schema`
- evidence lacked canonical literal safety markers:
  - `NO_BROKER`
  - `NO_NETWORK`
  - `NO_ORDER_SUBMISSION`

## Changes

Wrapper evidence now emits:

- `schema="shadow_247_futures_bounded_shadow_dry_run.v0"`
- keeps `artifact="shadow_247_futures_bounded_shadow_dry_run.v0"` for compatibility
- manifest safety markers:
  - `NO_BROKER=true`
  - `NO_NETWORK=true`
  - `NO_ORDER_SUBMISSION=true`
- Markdown safety-boundary marker section with the same canonical tokens

## Tests

Adds/extends tests so real generated wrapper evidence passes the review script while review remains fail-closed:

- generated wrapper evidence passes review
- missing schema fails review
- missing safety markers fail review
- manifest and Markdown include canonical schema/safety markers

## Safety

This PR does not rerun the failed Shadow dry-run.

It does not execute:

- Shadow adapter `--execute`
- wrapper
- scheduler
- Paper
- Testnet
- Live
- broker/exchange

The failed run remains non-primary and unarchived:

- `PRIMARY_EVIDENCE_ARCHIVED=false`
- `RERUN_REQUIRED_AFTER_FIX=true`

Review was not weakened:

- `REVIEW_WEAKENED=false`

## Validation

- `uv run pytest tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py -q`
- `uv run pytest tests/ops/test_run_shadow_bounded_observation_adapter_v0.py -q`
- `uv run ruff check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py scripts/ops/review_shadow_bounded_observation_evidence_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_run_shadow_bounded_observation_adapter_v0.py`
- `uv run ruff format --check scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py scripts/ops/review_shadow_bounded_observation_evidence_v0.py tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py tests/ops/test_run_shadow_bounded_observation_adapter_v0.py`
