### PR TITLE
docs(ops): add planning artifact durable retention contract v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -77,7 +77,7 @@ Each durable copy should include at minimum:
 
 **Scope:** material decision artifacts only—not every scratch file, log fragment, or transient prompt under `/tmp`.
 
-**Not primary runtime evidence:** planning, gate, and closeout copies under `planning/` assist review and traceability; they do **not** by themselves satisfy §2a primary runtime evidence for Paper, Shadow, Testnet, or Live runs.
+**Not primary runtime evidence:** planning, gate, and closeout copies under `planning&#47;` assist review and traceability; they do **not** by themselves satisfy §2a primary runtime evidence for Paper, Shadow, Testnet, or Live runs.
 
 **Forbidden as durable artifact storage:**
 

--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -58,6 +58,35 @@ Future run selectors and adapters must **reject or block** a run plan when prima
 
 Reference implementation: `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` (plan-only default; execute requires approval record; archive root outside `/tmp`).
 
+## 2b. Planning artifact durable retention v0
+
+`PLANNING_ARTIFACT_DURABLE_RETENTION_REQUIRED=true`
+
+`/tmp` may be used for scratch, staging, and short-lived working outputs. It is **not** durable storage for **material** planning, gate, closeout, or operator-decision artifacts that operators will rely on in later slices.
+
+When an artifact is **material** to future decisions (for example merge closeouts, scoped HOLD operator records, GLB authority packets, Testnet readiness selectors, durable-copy results), it must **not** remain `/tmp`-only. Operators must copy it to a durable archive **outside `/tmp`**, preferably:
+
+`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_<id>/planning/<slice_or_context>/`
+
+Each durable copy should include at minimum:
+
+- the source report(s) or equivalent decision record
+- a context file (for example `DURABLE_COPY_README.md`) stating source, meaning, and non-authorizing scope
+- `MANIFEST.sha256` over the copied files (excluding the manifest line list itself)
+- checksum verification evidence (for example `shasum -a 256 -c MANIFEST.sha256` with **RC=0**)
+
+**Scope:** material decision artifacts only—not every scratch file, log fragment, or transient prompt under `/tmp`.
+
+**Not primary runtime evidence:** planning, gate, and closeout copies under `planning/` assist review and traceability; they do **not** by themselves satisfy §2a primary runtime evidence for Paper, Shadow, Testnet, or Live runs.
+
+**Forbidden as durable artifact storage:**
+
+- Notion pointer-only rows (index/navigation; not the archive of record)
+- chat-summary-only evidence
+- transcript-only evidence without durable archive copy
+
+Repo docs state **policy**; durable artifact bytes remain in external archive paths. This section does **not** authorize scheduler execution, daemon activation, Paper runtime, Shadow runtime, Testnet, Live, broker, exchange, or order paths.
+
 ## 3. Non-authority
 
 The following are **not** trading authority, readiness approval, evidence approval, promotion, Master V2 / Double Play approval, or Live/Testnet approval:

--- a/tests/ops/test_planning_artifact_durable_retention_contract_v0.py
+++ b/tests/ops/test_planning_artifact_durable_retention_contract_v0.py
@@ -1,0 +1,87 @@
+"""Static contract tests for planning artifact durable retention v0 (offline, no runtime)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_OWNER = (
+    REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+)
+
+
+def _owner_text() -> str:
+    return CANONICAL_OWNER.read_text(encoding="utf-8")
+
+
+def _section_2b(text: str) -> str:
+    start = text.index("## 2b. Planning artifact durable retention v0")
+    end = text.index("## 3. Non-authority")
+    return text[start:end]
+
+
+def test_canonical_owner_exists() -> None:
+    assert CANONICAL_OWNER.is_file()
+
+
+def test_planning_artifact_durable_retention_marker_present() -> None:
+    assert "PLANNING_ARTIFACT_DURABLE_RETENTION_REQUIRED=true" in _owner_text()
+
+
+def test_section_2b_exists_adjacent_to_primary_evidence_invariant() -> None:
+    text = _owner_text()
+    assert "## 2a. Primary evidence retention invariant v0" in text
+    assert "## 2b. Planning artifact durable retention v0" in text
+    assert text.index("## 2a.") < text.index("## 2b.") < text.index("## 3.")
+
+
+def test_tmp_is_scratch_not_durable_for_material_artifacts() -> None:
+    section = _section_2b(_owner_text())
+    assert "/tmp" in section
+    assert "not" in section.lower() and "durable" in section.lower()
+    assert "scratch" in section.lower() or "staging" in section.lower()
+    assert "must **not** remain `/tmp`-only" in section or "not remain `/tmp`-only" in section
+
+
+def test_durable_archive_planning_path_pattern() -> None:
+    section = _section_2b(_owner_text())
+    assert "runtime_evidence_archive" in section
+    assert "planning/" in section
+
+
+def test_requires_manifest_sha256_or_checksum_verification() -> None:
+    section = _section_2b(_owner_text())
+    assert "MANIFEST.sha256" in section
+    assert "shasum -a 256 -c" in section
+    assert "RC=0" in section
+
+
+def test_distinguishes_planning_from_runtime_primary_evidence() -> None:
+    text = _owner_text()
+    section = _section_2b(text)
+    assert (
+        "Not primary runtime evidence" in section
+        or "not** automatically runtime primary evidence" in section
+    )
+    assert "§2a" in section or "2a" in section
+    assert "PRIMARY_EVIDENCE_REQUIRED_FOR_EVERY_RUN=true" in text
+
+
+def test_notion_and_chat_not_durable_artifact_storage() -> None:
+    section = _section_2b(_owner_text())
+    assert "Notion" in section
+    assert "chat-summary" in section or "chat" in section.lower()
+
+
+def test_does_not_imply_runtime_testnet_live_authorization() -> None:
+    section = _section_2b(_owner_text())
+    lowered = section.lower()
+    assert "does **not** authorize" in section or "not authorize" in lowered
+    for term in ("testnet", "live", "scheduler", "broker"):
+        assert term in lowered
+
+
+def test_preserves_primary_evidence_invariant_marker() -> None:
+    text = _owner_text()
+    assert "PRIMARY_EVIDENCE_REQUIRED_FOR_EVERY_RUN=true" in text
+    assert "## 2a. Primary evidence retention invariant v0" in text


### PR DESCRIPTION
## Summary

Adds a durable-retention contract for material planning, gate, closeout, and operator-decision artifacts.

This addresses the risk that important reports generated under `/tmp` can be lost to cleanup. `/tmp` remains valid for scratch/staging, but material decision artifacts must be copied into a durable archive path when they are used as future decision inputs.

## Changes

Updates the canonical preflight contract:

- `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`

Adds section:

- `§2b Planning artifact durable retention v0`

Adds static tests:

- `tests/ops/test_planning_artifact_durable_retention_contract_v0.py`

## Contract markers

Adds:

- `PLANNING_ARTIFACT_DURABLE_RETENTION_REQUIRED=true`

Preserves:

- `PRIMARY_EVIDENCE_REQUIRED_FOR_EVERY_RUN=true` (§2a)

## Policy

Material planning/gate/closeout/operator-decision artifacts must not remain tmp-only.

Expected durable target pattern:

```text
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_<id>/planning/<slice>/
```

Each durable copy should include:

- source report(s)
- context file (e.g. `DURABLE_COPY_README.md`)
- `MANIFEST.sha256`
- checksum verification evidence (`shasum -a 256 -c` RC=0)

Planning artifacts are **not** automatically runtime primary evidence (§2a). Notion rows and chat summaries are not durable artifact storage.

## Motivation

PR #3576 merge closeout was manually copied from `/tmp` to:

`…/planning/testnet_post_pr3576_merge_closeout_20260520T224356Z` (MANIFEST RC=0).

This contract codifies that pattern for future slices.

## Safety

This PR does not:

- start runtime, Testnet, or Live
- write Notion
- change authorization flags
- create a duplicate standalone doc surface

## Test plan

- [x] `uv run pytest tests/ops/test_planning_artifact_durable_retention_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_primary_evidence_retention_invariant_contract_v0.py -q`
- [x] `uv run ruff check` / `ruff format --check` on new test file
- [x] `validate_docs_token_policy.py`
- [x] `verify_docs_reference_targets.sh`
