### PR TITLE
feat(ops): add readiness gate snapshot v0

### DIFF
--- a/scripts/ops/report_readiness_gate_snapshot_v0.py
+++ b/scripts/ops/report_readiness_gate_snapshot_v0.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Compose readiness ledger, preflight status, and mirror into one gate snapshot.
+
+Non-authorizing offline convenience CLI. Does not start runtime or grant authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "peak_trade.readiness_gate_snapshot.v0"
+
+VERDICT_PASS_BLOCKED_SAFE = "READINESS_GATE_SNAPSHOT_PASS_BLOCKED_SAFE"
+VERDICT_REVIEW_REQUIRED = "READINESS_GATE_SNAPSHOT_REVIEW_REQUIRED"
+VERDICT_FAIL_CLOSED = "READINESS_GATE_SNAPSHOT_FAIL_CLOSED"
+
+LEDGER_PASS = "READINESS_EVIDENCE_LEDGER_PASS_BLOCKED_SAFE"
+MIRROR_PASS = "READINESS_LEDGER_PREFLIGHT_MIRROR_PASS_BLOCKED_SAFE"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _ensure_repo_imports() -> None:
+    root = str(_repo_root())
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+
+def _summarize_ledger(full: dict[str, Any]) -> dict[str, Any]:
+    evidence = full.get("evidence") if isinstance(full.get("evidence"), dict) else {}
+    planning = full.get("planning") if isinstance(full.get("planning"), dict) else {}
+    governance = full.get("governance") if isinstance(full.get("governance"), dict) else {}
+    return {
+        "verdict": full.get("verdict"),
+        "triple_lane_primary_evidence": evidence.get("triple_lane_primary_evidence"),
+        "planning_chain_present": planning.get("planning_chain_present"),
+        "governance_blocked": governance.get("governance_blocked"),
+        "live_allowed": governance.get("live_allowed"),
+        "broker_exchange_allowed": governance.get("broker_exchange_allowed"),
+        "secret_values_included": governance.get("secret_values_included"),
+        "go_decision_granted": governance.get("go_decision_granted"),
+        "hold_no_paper_run_cleared": governance.get("hold_no_paper_run_cleared"),
+        "glb_014_cleared": governance.get("glb_014_cleared"),
+        "glb_015_cleared": governance.get("glb_015_cleared"),
+        "preflight_ready": governance.get("preflight_ready"),
+        "blockers": full.get("blockers") if isinstance(full.get("blockers"), list) else [],
+        "issues_count": len(full.get("issues") or []),
+    }
+
+
+def _summarize_preflight(full: dict[str, Any]) -> dict[str, Any]:
+    hold = full.get("hold_context_v0") if isinstance(full.get("hold_context_v0"), dict) else {}
+    dry = (
+        full.get("dry_activation_readiness")
+        if isinstance(full.get("dry_activation_readiness"), dict)
+        else {}
+    )
+    return {
+        "status": full.get("status"),
+        "dry_activation_readiness_ready": dry.get("ready"),
+        "hold_current_state": hold.get("current_state"),
+        "go_live_next_step": hold.get("go_live_next_step"),
+        "live_authorized": full.get("live_authorized"),
+        "testnet_authorized": full.get("testnet_authorized"),
+        "activation_authorized": full.get("activation_authorized"),
+        "blockers": full.get("blockers") if isinstance(full.get("blockers"), list) else [],
+    }
+
+
+def _summarize_mirror(full: dict[str, Any]) -> dict[str, Any]:
+    mirror = full.get("mirror") if isinstance(full.get("mirror"), dict) else {}
+    return {
+        "verdict": full.get("verdict"),
+        "mirror_check_pass": mirror.get("mirror_check_pass"),
+        "ledger_pass_blocked_safe": mirror.get("ledger_pass_blocked_safe"),
+        "preflight_blocked": mirror.get("preflight_blocked"),
+        "authorization_flags_false": mirror.get("authorization_flags_false"),
+        "governance_blocked_consistent": mirror.get("governance_blocked_consistent"),
+        "issues_count": len(full.get("issues") or []),
+    }
+
+
+def _derive_governance(
+    ledger_full: dict[str, Any],
+    preflight_full: dict[str, Any],
+) -> dict[str, Any]:
+    ledger_gov = (
+        ledger_full.get("governance") if isinstance(ledger_full.get("governance"), dict) else {}
+    )
+    return {
+        "governance_blocked": ledger_gov.get("governance_blocked"),
+        "live_allowed": ledger_gov.get("live_allowed"),
+        "broker_exchange_allowed": ledger_gov.get("broker_exchange_allowed"),
+        "secret_values_included": ledger_gov.get("secret_values_included"),
+        "go_decision_granted": ledger_gov.get("go_decision_granted"),
+        "hold_no_paper_run_cleared": ledger_gov.get("hold_no_paper_run_cleared"),
+        "glb_014_cleared": ledger_gov.get("glb_014_cleared"),
+        "glb_015_cleared": ledger_gov.get("glb_015_cleared"),
+        "preflight_ready": ledger_gov.get("preflight_ready"),
+        "preflight_status": preflight_full.get("status"),
+    }
+
+
+def _collect_issues(
+    ledger_full: dict[str, Any],
+    mirror_full: dict[str, Any],
+    extra: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    for item in ledger_full.get("issues") or []:
+        if isinstance(item, dict):
+            issues.append({"source": "ledger", **item})
+    for item in mirror_full.get("issues") or []:
+        if isinstance(item, dict):
+            issues.append({"source": "mirror", **item})
+    issues.extend(extra)
+    return issues
+
+
+def _derive_blockers(ledger_full: dict[str, Any], mirror_full: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    ledger_blockers = ledger_full.get("blockers")
+    if isinstance(ledger_blockers, list):
+        blockers.extend(str(x) for x in ledger_blockers)
+    mirror_blockers = mirror_full.get("blockers")
+    if isinstance(mirror_blockers, list):
+        blockers.extend(str(x) for x in mirror_blockers)
+    return sorted(set(blockers))
+
+
+def derive_gate_verdict(
+    ledger_full: dict[str, Any],
+    preflight_full: dict[str, Any],
+    mirror_full: dict[str, Any],
+    issues: list[dict[str, Any]],
+) -> str:
+    ledger_verdict = ledger_full.get("verdict")
+    mirror_verdict = mirror_full.get("verdict")
+    governance = (
+        ledger_full.get("governance") if isinstance(ledger_full.get("governance"), dict) else {}
+    )
+
+    if ledger_verdict == "READINESS_EVIDENCE_LEDGER_FAIL_CLOSED":
+        return VERDICT_FAIL_CLOSED
+    if mirror_verdict == "READINESS_LEDGER_PREFLIGHT_MIRROR_FAIL_CLOSED":
+        return VERDICT_FAIL_CLOSED
+    if governance.get("live_allowed") is True:
+        return VERDICT_FAIL_CLOSED
+    if governance.get("broker_exchange_allowed") is True:
+        return VERDICT_FAIL_CLOSED
+    if governance.get("secret_values_included") is True:
+        return VERDICT_FAIL_CLOSED
+    if governance.get("go_decision_granted") is True:
+        return VERDICT_FAIL_CLOSED
+    if governance.get("hold_no_paper_run_cleared") is True:
+        return VERDICT_FAIL_CLOSED
+    if governance.get("glb_014_cleared") is True or governance.get("glb_015_cleared") is True:
+        return VERDICT_FAIL_CLOSED
+    if preflight_full.get("status") in {"READY", "APPROVED", "GO", "LIVE", "AUTHORIZED", "CLEARED"}:
+        return VERDICT_FAIL_CLOSED
+    if (
+        preflight_full.get("live_authorized") is True
+        or preflight_full.get("testnet_authorized") is True
+    ):
+        return VERDICT_FAIL_CLOSED
+
+    if ledger_verdict == "READINESS_EVIDENCE_LEDGER_REVIEW_REQUIRED":
+        return VERDICT_REVIEW_REQUIRED
+    if mirror_verdict == "READINESS_LEDGER_PREFLIGHT_MIRROR_REVIEW_REQUIRED":
+        return VERDICT_REVIEW_REQUIRED
+    if issues:
+        return VERDICT_REVIEW_REQUIRED
+
+    if (
+        ledger_verdict == LEDGER_PASS
+        and mirror_verdict == MIRROR_PASS
+        and preflight_full.get("status") == "BLOCKED"
+        and governance.get("governance_blocked") is True
+        and governance.get("live_allowed") is False
+        and governance.get("broker_exchange_allowed") is False
+        and governance.get("secret_values_included") is False
+    ):
+        return VERDICT_PASS_BLOCKED_SAFE
+    return VERDICT_REVIEW_REQUIRED
+
+
+def build_readiness_gate_snapshot(
+    archive_root: Path,
+    *,
+    repo_root: Path | None = None,
+    fixed_generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    _ensure_repo_imports()
+    from scripts.ops.build_readiness_evidence_ledger_v0 import (
+        DEFAULT_PAPER_RUN_ID,
+        DEFAULT_SHADOW_RUN_ID,
+        DEFAULT_TESTNET_RUN_ID,
+        BuildContext,
+        build_ledger,
+    )
+    from scripts.ops.report_paper_shadow_247_preflight_status import (
+        build_paper_shadow_247_preflight_status,
+    )
+    from scripts.ops.report_readiness_ledger_preflight_mirror_v0 import (
+        build_mirror_from_payloads,
+    )
+
+    root = (repo_root or _repo_root()).resolve()
+    archive = archive_root.expanduser().resolve()
+
+    ledger_ctx = BuildContext(
+        archive_root=archive,
+        paper_run_id=DEFAULT_PAPER_RUN_ID,
+        shadow_run_id=DEFAULT_SHADOW_RUN_ID,
+        testnet_run_id=DEFAULT_TESTNET_RUN_ID,
+    )
+    ledger_full = build_ledger(ledger_ctx)
+    preflight_full = build_paper_shadow_247_preflight_status(repo_root=root)
+    mirror_full = build_mirror_from_payloads(
+        ledger_full,
+        preflight_full,
+        fixed_generated_at_utc=fixed_generated_at_utc,
+    )
+
+    extra_issues: list[dict[str, Any]] = []
+    issues = _collect_issues(ledger_full, mirror_full, extra_issues)
+    governance = _derive_governance(ledger_full, preflight_full)
+    verdict = derive_gate_verdict(ledger_full, preflight_full, mirror_full, issues)
+
+    generated_at = fixed_generated_at_utc or os.environ.get("PEAK_TRADE_FIXED_GENERATED_AT_UTC")
+    if not generated_at:
+        generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return {
+        "schema": SCHEMA,
+        "generated_at_utc": generated_at,
+        "archive_root": str(archive),
+        "ledger": _summarize_ledger(ledger_full),
+        "preflight": _summarize_preflight(preflight_full),
+        "mirror": _summarize_mirror(mirror_full),
+        "governance": governance,
+        "blockers": _derive_blockers(ledger_full, mirror_full),
+        "verdict": verdict,
+        "issues": issues,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive-root", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path)
+    parser.add_argument("--fixed-generated-at-utc")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_readiness_gate_snapshot(
+        args.archive_root,
+        repo_root=args.repo_root,
+        fixed_generated_at_utc=args.fixed_generated_at_utc,
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=False))
+    else:
+        print(f"verdict={payload['verdict']}")
+        print(f"issues={len(payload['issues'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/report_readiness_ledger_preflight_mirror_v0.py
+++ b/scripts/ops/report_readiness_ledger_preflight_mirror_v0.py
@@ -327,15 +327,41 @@ def derive_blockers(ledger_summary: dict[str, Any], preflight_summary: dict[str,
 def build_mirror(ctx: MirrorContext) -> dict[str, Any]:
     ledger = _load_json(ctx.ledger_path, ctx, label="ledger")
     preflight = _load_json(ctx.preflight_path, ctx, label="preflight")
+    return build_mirror_from_payloads(
+        ledger,
+        preflight,
+        ctx=ctx,
+        fixed_generated_at_utc=ctx.fixed_generated_at_utc,
+    )
 
-    ledger_summary = _check_ledger(ledger, ctx)
-    preflight_summary = _check_preflight(preflight, ctx)
+
+def build_mirror_from_payloads(
+    ledger: dict[str, Any] | None,
+    preflight: dict[str, Any] | None,
+    *,
+    ctx: MirrorContext | None = None,
+    fixed_generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    mirror_ctx = ctx or MirrorContext(
+        ledger_path=None,
+        preflight_path=None,
+        fixed_generated_at_utc=fixed_generated_at_utc,
+    )
+    if ledger is None:
+        mirror_ctx.add_issue("MISSING_LEDGER_JSON", "ledger payload missing")
+    if preflight is None:
+        mirror_ctx.add_issue("MISSING_PREFLIGHT_JSON", "preflight payload missing")
+
+    ledger_summary = _check_ledger(ledger, mirror_ctx)
+    preflight_summary = _check_preflight(preflight, mirror_ctx)
     mirror = _build_mirror_checks(ledger_summary, preflight_summary)
 
-    verdict = derive_verdict(ctx)
+    verdict = derive_verdict(mirror_ctx)
     mirror["mirror_check_pass"] = verdict == VERDICT_PASS_BLOCKED_SAFE
 
-    generated_at = ctx.fixed_generated_at_utc or os.environ.get("PEAK_TRADE_FIXED_GENERATED_AT_UTC")
+    generated_at = mirror_ctx.fixed_generated_at_utc or os.environ.get(
+        "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
+    )
     if not generated_at:
         generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -347,7 +373,7 @@ def build_mirror(ctx: MirrorContext) -> dict[str, Any]:
         "mirror": mirror,
         "blockers": derive_blockers(ledger_summary, preflight_summary),
         "verdict": verdict,
-        "issues": [issue.as_dict() for issue in ctx.issues],
+        "issues": [issue.as_dict() for issue in mirror_ctx.issues],
     }
 
 

--- a/tests/fixtures/ops/readiness_gate_snapshot_v0/README.md
+++ b/tests/fixtures/ops/readiness_gate_snapshot_v0/README.md
@@ -1,0 +1,1 @@
+# Synthetic fixtures are built dynamically in test_report_readiness_gate_snapshot_v0.py.

--- a/tests/ops/test_report_readiness_gate_snapshot_v0.py
+++ b/tests/ops/test_report_readiness_gate_snapshot_v0.py
@@ -1,0 +1,327 @@
+"""Tests for readiness gate snapshot v0."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ops" / "report_readiness_gate_snapshot_v0.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "ops" / "readiness_gate_snapshot_v0"
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+
+GATE_PASS = "READINESS_GATE_SNAPSHOT_PASS_BLOCKED_SAFE"
+GATE_FAIL = "READINESS_GATE_SNAPSHOT_FAIL_CLOSED"
+GATE_REVIEW = "READINESS_GATE_SNAPSHOT_REVIEW_REQUIRED"
+
+LEDGER_PASS = "READINESS_EVIDENCE_LEDGER_PASS_BLOCKED_SAFE"
+LEDGER_FAIL = "READINESS_EVIDENCE_LEDGER_FAIL_CLOSED"
+LEDGER_REVIEW = "READINESS_EVIDENCE_LEDGER_REVIEW_REQUIRED"
+
+MIRROR_PASS = "READINESS_LEDGER_PREFLIGHT_MIRROR_PASS_BLOCKED_SAFE"
+MIRROR_FAIL = "READINESS_LEDGER_PREFLIGHT_MIRROR_FAIL_CLOSED"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("report_readiness_gate_snapshot_v0", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["report_readiness_gate_snapshot_v0"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _safe_ledger(**overrides: object) -> dict:
+    base = {
+        "schema": "peak_trade.readiness_evidence_ledger.v0",
+        "verdict": LEDGER_PASS,
+        "evidence": {"triple_lane_primary_evidence": True},
+        "planning": {"planning_chain_present": True},
+        "governance": {
+            "governance_blocked": True,
+            "live_allowed": False,
+            "broker_exchange_allowed": False,
+            "secret_values_included": False,
+            "go_decision_granted": False,
+            "preflight_ready": False,
+            "hold_no_paper_run_cleared": False,
+            "glb_014_cleared": False,
+            "glb_015_cleared": False,
+        },
+        "blockers": ["PREFLIGHT_BLOCKED"],
+        "issues": [],
+    }
+    if "governance" in overrides and isinstance(overrides["governance"], dict):
+        base["governance"].update(overrides.pop("governance"))  # type: ignore[arg-type]
+    base.update(overrides)
+    return base
+
+
+def _safe_preflight(**overrides: object) -> dict:
+    base = {
+        "status": "BLOCKED",
+        "activation_authorized": False,
+        "testnet_authorized": False,
+        "live_authorized": False,
+        "dry_activation_readiness": {"ready": False},
+        "hold_context_v0": {
+            "current_state": "HOLD_NO_PAPER_RUN",
+            "go_live_next_step": "blocked",
+        },
+        "blockers": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _safe_mirror(**overrides: object) -> dict:
+    base = {
+        "schema": "peak_trade.readiness_ledger_preflight_mirror.v0",
+        "verdict": MIRROR_PASS,
+        "mirror": {
+            "mirror_check_pass": True,
+            "ledger_pass_blocked_safe": True,
+            "preflight_blocked": True,
+            "authorization_flags_false": True,
+            "governance_blocked_consistent": True,
+        },
+        "blockers": ["PREFLIGHT_BLOCKED"],
+        "issues": [],
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+def test_complete_safe_fixture_pass_blocked_safe(mod, monkeypatch) -> None:
+    ledger = _safe_ledger()
+    preflight = _safe_preflight()
+    mirror = _safe_mirror()
+
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: ledger,
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: preflight,
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: mirror,
+    )
+
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        fixed_generated_at_utc="2026-05-21T00:00:00Z",
+    )
+    assert payload["verdict"] == GATE_PASS
+    assert payload["ledger"]["verdict"] == LEDGER_PASS
+    assert payload["mirror"]["verdict"] == MIRROR_PASS
+    assert payload["preflight"]["status"] == "BLOCKED"
+    assert payload["governance"]["governance_blocked"] is True
+    assert payload["governance"]["live_allowed"] is False
+    assert len(payload["issues"]) == 0
+
+
+def test_ledger_fail_closed_propagates(mod, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: _safe_ledger(verdict=LEDGER_FAIL),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: _safe_preflight(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: _safe_mirror(verdict=MIRROR_FAIL),
+    )
+
+    assert mod.build_readiness_gate_snapshot(Path("/tmp/archive"))["verdict"] == GATE_FAIL
+
+
+def test_mirror_fail_closed_propagates(mod, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: _safe_ledger(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: _safe_preflight(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: _safe_mirror(verdict=MIRROR_FAIL),
+    )
+
+    assert mod.build_readiness_gate_snapshot(Path("/tmp/archive"))["verdict"] == GATE_FAIL
+
+
+def test_preflight_ready_fail_closed(mod, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: _safe_ledger(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: _safe_preflight(status="READY"),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: _safe_mirror(),
+    )
+
+    assert mod.build_readiness_gate_snapshot(Path("/tmp/archive"))["verdict"] == GATE_FAIL
+
+
+def test_live_allowed_fail_closed(mod, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: _safe_ledger(governance={"live_allowed": True}),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: _safe_preflight(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: _safe_mirror(),
+    )
+
+    assert mod.build_readiness_gate_snapshot(Path("/tmp/archive"))["verdict"] == GATE_FAIL
+
+
+def test_secret_values_fail_closed(mod, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: _safe_ledger(governance={"secret_values_included": True}),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: _safe_preflight(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: _safe_mirror(),
+    )
+
+    assert mod.build_readiness_gate_snapshot(Path("/tmp/archive"))["verdict"] == GATE_FAIL
+
+
+def test_missing_archive_root_review_required(mod, tmp_path: Path) -> None:
+    missing = tmp_path / "missing_archive"
+    payload = mod.build_readiness_gate_snapshot(missing)
+    assert payload["verdict"] == GATE_REVIEW
+    assert payload["ledger"]["verdict"] == LEDGER_REVIEW
+
+
+def test_cli_json_prints_json_only(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--archive-root",
+            str(tmp_path / "missing"),
+            "--fixed-generated-at-utc",
+            "2026-05-21T00:00:00Z",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.stderr.strip() == ""
+    payload = json.loads(proc.stdout)
+    assert payload["schema"] == "peak_trade.readiness_gate_snapshot.v0"
+    assert payload["generated_at_utc"] == "2026-05-21T00:00:00Z"
+
+
+def test_deterministic_timestamp_via_env(mod, monkeypatch) -> None:
+    monkeypatch.setenv("PEAK_TRADE_FIXED_GENERATED_AT_UTC", "2026-05-21T12:00:00Z")
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: _safe_ledger(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: _safe_preflight(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: _safe_mirror(),
+    )
+    payload = mod.build_readiness_gate_snapshot(Path("/tmp/archive"))
+    assert payload["generated_at_utc"] == "2026-05-21T12:00:00Z"
+
+
+def test_schema_stable(mod, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: _safe_ledger(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: _safe_preflight(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: _safe_mirror(),
+    )
+    payload = mod.build_readiness_gate_snapshot(Path("/tmp/archive"))
+    assert set(payload) == {
+        "schema",
+        "generated_at_utc",
+        "archive_root",
+        "ledger",
+        "preflight",
+        "mirror",
+        "governance",
+        "blockers",
+        "verdict",
+        "issues",
+    }
+
+
+def test_no_subprocess_or_network_in_module_source() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "subprocess" not in source
+    assert "urllib" not in source
+    assert "requests" not in source
+    assert "socket" not in source
+
+
+def test_fixtures_dir_exists() -> None:
+    FIXTURES.mkdir(parents=True, exist_ok=True)
+    assert FIXTURES.is_dir()
+
+
+@pytest.mark.skipif(not ARCHIVE_ROOT.is_dir(), reason="operator archive not present")
+def test_real_smoke_pass_blocked_safe() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--archive-root",
+            str(ARCHIVE_ROOT),
+            "--fixed-generated-at-utc",
+            "2026-05-21T00:00:00Z",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == GATE_PASS
+    assert payload["ledger"]["issues_count"] == 0
+    assert payload["mirror"]["issues_count"] == 0


### PR DESCRIPTION
## Summary
- Add `report_readiness_gate_snapshot_v0.py` composing ledger, preflight, and mirror into one JSON gate snapshot.
- Add minimal `build_mirror_from_payloads` helper for in-process composition without subprocess.
- Add offline tests covering PASS_BLOCKED_SAFE, fail-closed propagation, review-required, CLI JSON, and real-archive smoke.

## Test plan
- [x] `uv run pytest tests/ops/test_report_readiness_gate_snapshot_v0.py -q`
- [x] `uv run pytest tests/ops/test_report_readiness_ledger_preflight_mirror_v0.py -q`
- [x] `uv run ruff check` / `ruff format --check` on touched files
- [x] Real archive smoke → `READINESS_GATE_SNAPSHOT_PASS_BLOCKED_SAFE`


Made with [Cursor](https://cursor.com)