### PR TITLE
feat(ops): add generic evidence run registry v1

### DIFF
--- a/scripts/ops/build_generic_evidence_run_registry_v1.py
+++ b/scripts/ops/build_generic_evidence_run_registry_v1.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""Build a generic offline evidence run registry from a runtime evidence archive.
+
+Non-authorizing: indexes run metadata only. Does not start runtime, read secrets,
+grant Live/Testnet/Go, or imply scheduler/canary/live authority.
+
+Lane semantics: docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "peak_trade.generic_evidence_run_registry.v1"
+
+TAXONOMY_SPEC_REL = Path("docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md")
+
+VERDICT_PASS_BLOCKED_SAFE = "GENERIC_EVIDENCE_RUN_REGISTRY_PASS_BLOCKED_SAFE"
+VERDICT_REVIEW_REQUIRED = "GENERIC_EVIDENCE_RUN_REGISTRY_REVIEW_REQUIRED"
+VERDICT_FAIL_CLOSED = "GENERIC_EVIDENCE_RUN_REGISTRY_FAIL_CLOSED"
+
+BLOCKER_HOLD = "HOLD_NO_PAPER_RUN_NOT_CLEARED"
+BLOCKER_GLB_014 = "GLB_014_NOT_CLEARED"
+BLOCKER_GLB_015 = "GLB_015_NOT_CLEARED"
+BLOCKER_PREFLIGHT = "PREFLIGHT_BLOCKED"
+BLOCKER_LIVE = "LIVE_NOT_AUTHORIZED"
+BLOCKER_BROKER = "BROKER_EXCHANGE_NOT_AUTHORIZED"
+
+PRIMARY_EVIDENCE_LANES = ("paper", "shadow", "testnet")
+NON_RUN_LANES = frozenset({"dashboard", "ai_orchestrator", "notion", "docs"})
+
+UNSAFE_TRUE_KEYS: frozenset[str] = frozenset(
+    {
+        "SECRET_VALUES_INCLUDED",
+        "LIVE_ALLOWED",
+        "BROKER_EXCHANGE_ALLOWED",
+        "GO_DECISION_GRANTED",
+        "CAN_AUTHORIZE_LIVE",
+        "CAN_TOUCH_BROKER_EXCHANGE",
+        "HOLD_NO_PAPER_RUN_CLEARED",
+        "GLB_014_CLEARED",
+        "GLB_015_CLEARED",
+    }
+)
+
+UNSAFE_KEY_TO_CODE: dict[str, str] = {
+    "SECRET_VALUES_INCLUDED": "UNSAFE_SECRET_VALUES_INCLUDED",
+    "LIVE_ALLOWED": "UNSAFE_LIVE_AUTHORITY",
+    "BROKER_EXCHANGE_ALLOWED": "UNSAFE_BROKER_EXCHANGE_AUTHORITY",
+    "GO_DECISION_GRANTED": "UNSAFE_GO_DECISION_GRANTED",
+    "CAN_AUTHORIZE_LIVE": "UNSAFE_LIVE_AUTHORITY",
+    "CAN_TOUCH_BROKER_EXCHANGE": "UNSAFE_BROKER_EXCHANGE_AUTHORITY",
+}
+
+MACHINE_LINE_RE = re.compile(r"^([A-Z0-9_]+)=(true|false)\s*$")
+
+GOVERNANCE_KEYS = (
+    "go_decision_granted",
+    "hold_no_paper_run_cleared",
+    "glb_014_cleared",
+    "glb_015_cleared",
+    "preflight_ready",
+    "live_allowed",
+    "broker_exchange_allowed",
+    "secret_values_included",
+)
+
+LANE_DEFAULTS: dict[str, dict[str, Any]] = {
+    "paper": {
+        "lane_kind": "bounded_runtime_candidate",
+        "authority_level": "evidence_only",
+        "runtime_allowed_by_default": False,
+        "requires_approval_record": True,
+        "review_required": False,
+        "manifest_required": True,
+        "durable_retention_required": True,
+        "notion_link_allowed": "index_only",
+        "indexing_mode": "runs_directory",
+    },
+    "shadow": {
+        "lane_kind": "bounded_runtime_candidate",
+        "authority_level": "evidence_only",
+        "runtime_allowed_by_default": False,
+        "requires_approval_record": True,
+        "review_required": True,
+        "manifest_required": True,
+        "durable_retention_required": True,
+        "notion_link_allowed": "index_only",
+        "indexing_mode": "runs_directory",
+    },
+    "testnet": {
+        "lane_kind": "bounded_runtime_candidate",
+        "authority_level": "evidence_only",
+        "runtime_allowed_by_default": False,
+        "requires_approval_record": True,
+        "review_required": True,
+        "manifest_required": True,
+        "durable_retention_required": True,
+        "notion_link_allowed": "index_only",
+        "indexing_mode": "runs_directory",
+    },
+    "scheduler": {
+        "lane_kind": "infrastructure",
+        "authority_level": "planning_only",
+        "runtime_allowed_by_default": False,
+        "requires_approval_record": False,
+        "review_required": False,
+        "manifest_required": False,
+        "durable_retention_required": False,
+        "notion_link_allowed": "false",
+        "indexing_mode": "planning_only",
+    },
+    "canary": {
+        "lane_kind": "governance_docs",
+        "authority_level": "planning_only",
+        "runtime_allowed_by_default": False,
+        "requires_approval_record": False,
+        "review_required": False,
+        "manifest_required": False,
+        "durable_retention_required": False,
+        "notion_link_allowed": "false",
+        "indexing_mode": "absent",
+    },
+    "live_canary": {
+        "lane_kind": "governance_docs",
+        "authority_level": "live_authority_requires_separate_record",
+        "runtime_allowed_by_default": False,
+        "requires_approval_record": True,
+        "review_required": True,
+        "manifest_required": False,
+        "durable_retention_required": False,
+        "notion_link_allowed": "false",
+        "indexing_mode": "external_record_required",
+    },
+    "live_production": {
+        "lane_kind": "execution",
+        "authority_level": "live_authority_requires_separate_record",
+        "runtime_allowed_by_default": False,
+        "requires_approval_record": True,
+        "review_required": True,
+        "manifest_required": False,
+        "durable_retention_required": False,
+        "notion_link_allowed": "false",
+        "indexing_mode": "external_record_required",
+    },
+}
+
+
+@dataclass
+class Issue:
+    code: str
+    message: str
+    path: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.path is not None:
+            out["path"] = self.path
+        return out
+
+
+@dataclass
+class BuildContext:
+    archive_root: Path
+    repo_root: Path
+    fixed_generated_at_utc: str | None = None
+    issues: list[Issue] = field(default_factory=list)
+
+    def add_issue(self, code: str, message: str, path: Path | None = None) -> None:
+        rel = None
+        if path is not None:
+            try:
+                rel = str(path.relative_to(self.archive_root))
+            except ValueError:
+                rel = str(path)
+        self.issues.append(Issue(code=code, message=message, path=rel))
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _iter_machine_lines(text: str) -> list[tuple[str, bool]]:
+    out: list[tuple[str, bool]] = []
+    for raw in text.splitlines():
+        match = MACHINE_LINE_RE.match(raw.strip())
+        if match:
+            out.append((match.group(1), match.group(2) == "true"))
+    return out
+
+
+def _scan_texts(root: Path) -> str:
+    if not root.is_dir():
+        return ""
+    chunks: list[str] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in {".md", ".json", ".log", ".txt"}:
+            continue
+        if path.name in {"MANIFEST.sha256", "MANIFEST_VERIFY.log"}:
+            continue
+        try:
+            chunks.append(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+    return "\n".join(chunks)
+
+
+def _parse_machine_line(text: str, key: str) -> bool | None:
+    machine_key = key.upper()
+    values = [value for name, value in _iter_machine_lines(text) if name == machine_key]
+    if not values:
+        return None
+    return values[-1]
+
+
+def scan_unsafe_text(text: str, ctx: BuildContext, path: Path) -> None:
+    for key, value in _iter_machine_lines(text):
+        if not value:
+            continue
+        if key in UNSAFE_TRUE_KEYS:
+            code = UNSAFE_KEY_TO_CODE.get(key, "UNSAFE_PLANNING_MARKER")
+            ctx.add_issue(code, f"unsafe machine line {key}=true", path)
+        if key == "RUNTIME_ALLOWED_BY_DEFAULT" and value:
+            ctx.add_issue(
+                "UNSAFE_SCHEDULER_RUNTIME_DEFAULT",
+                "scheduler/runtime lane must not claim runtime_allowed_by_default=true",
+                path,
+            )
+
+
+def verify_manifest_directory(root: Path, ctx: BuildContext, label: str) -> bool:
+    manifest_path = root / "MANIFEST.sha256"
+    if not root.is_dir():
+        ctx.add_issue("MISSING_RUN_DIR", f"{label} run directory missing", root)
+        return False
+    if not manifest_path.is_file():
+        ctx.add_issue("MISSING_MANIFEST", f"{label} MANIFEST.sha256 missing", manifest_path)
+        return False
+
+    ok = True
+    for line_no, raw in enumerate(manifest_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            ctx.add_issue(
+                "MANIFEST_ENTRY_MISSING",
+                f"{label} MANIFEST line {line_no} invalid",
+                manifest_path,
+            )
+            ok = False
+            continue
+        expected_hash, rel_path = parts
+        target = root / rel_path
+        if not target.is_file():
+            ctx.add_issue(
+                "MANIFEST_ENTRY_MISSING",
+                f"{label} manifest entry missing file: {rel_path}",
+                target,
+            )
+            ok = False
+            continue
+        if _sha256_file(target) != expected_hash:
+            ctx.add_issue(
+                "MANIFEST_HASH_MISMATCH",
+                f"{label} hash mismatch for {rel_path}",
+                target,
+            )
+            ok = False
+    return ok
+
+
+def _load_review_verdict(review_path: Path) -> tuple[str | None, str | None]:
+    if not review_path.is_file():
+        return None, "missing"
+    try:
+        payload = json.loads(review_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"invalid JSON: {exc}"
+    verdict = payload.get("verdict")
+    if not isinstance(verdict, str):
+        return None, "verdict missing or not string"
+    return verdict, None
+
+
+def _discover_all_runs(archive_root: Path) -> list[tuple[str, Path]]:
+    runs_root = archive_root / "runs"
+    if not runs_root.is_dir():
+        return []
+    out: list[tuple[str, Path]] = []
+    for lane_dir in sorted(runs_root.iterdir()):
+        if not lane_dir.is_dir():
+            continue
+        lane_id = lane_dir.name
+        for run_dir in sorted(lane_dir.iterdir()):
+            if run_dir.is_dir():
+                out.append((lane_id, run_dir))
+    return out
+
+
+def _build_run_record(
+    run_dir: Path,
+    lane_id: str,
+    ctx: BuildContext,
+) -> dict[str, Any]:
+    run_issues: list[dict[str, Any]] = []
+
+    if lane_id in NON_RUN_LANES:
+        ctx.add_issue(
+            "UNSAFE_NON_RUN_SURFACE_AUTHORITY",
+            f"non-run lane {lane_id!r} must not appear as executable run evidence",
+            run_dir,
+        )
+        defaults = {
+            "lane_kind": "display",
+            "authority_level": "review_input_only",
+            "runtime_allowed_by_default": False,
+            "requires_approval_record": False,
+            "review_required": False,
+            "manifest_required": False,
+            "durable_retention_required": False,
+            "notion_link_allowed": "false",
+        }
+    elif lane_id not in LANE_DEFAULTS:
+        ctx.add_issue("UNKNOWN_LANE", f"unknown lane {lane_id!r}", run_dir)
+        defaults = LANE_DEFAULTS["paper"].copy()
+    else:
+        defaults = LANE_DEFAULTS[lane_id]
+
+    scan_unsafe_text(_scan_texts(run_dir), ctx, run_dir)
+
+    manifest_present = (run_dir / "MANIFEST.sha256").is_file()
+    if defaults.get("manifest_required") and not manifest_present:
+        ctx.add_issue(
+            "MISSING_MANIFEST",
+            f"{lane_id} MANIFEST.sha256 missing",
+            run_dir / "MANIFEST.sha256",
+        )
+    manifest_verified = (
+        verify_manifest_directory(run_dir, ctx, lane_id) if manifest_present else False
+    )
+
+    review_path = run_dir / "review" / "REVIEW_RESULT.json"
+    review_present = review_path.is_file()
+    review_verdict: str | None = None
+    if defaults["review_required"]:
+        verdict, err = _load_review_verdict(review_path)
+        if err == "missing":
+            ctx.add_issue(
+                "MISSING_REVIEW_JSON",
+                f"{lane_id} review/REVIEW_RESULT.json missing",
+                review_path,
+            )
+        elif err is not None:
+            ctx.add_issue(
+                "MISSING_REVIEW_JSON",
+                f"{lane_id} review invalid: {err}",
+                review_path,
+            )
+        else:
+            review_verdict = verdict
+            if verdict != "PASS":
+                ctx.add_issue(
+                    "REVIEW_VERDICT_NOT_PASS",
+                    f"{lane_id} review verdict must be PASS, got {verdict!r}",
+                    review_path,
+                )
+    elif review_present:
+        review_verdict, _ = _load_review_verdict(review_path)
+
+    if lane_id == "scheduler" and defaults["runtime_allowed_by_default"]:
+        ctx.add_issue(
+            "UNSAFE_SCHEDULER_RUNTIME_DEFAULT",
+            "scheduler lane runtime_allowed_by_default must be false",
+            run_dir,
+        )
+
+    if lane_id in {"live_canary", "live_production"}:
+        ctx.add_issue(
+            "MISSING_EXTERNAL_LIVE_RECORD",
+            f"{lane_id} run present without separate external live authority record",
+            run_dir,
+        )
+
+    evidence_status = "verified"
+    if not manifest_verified:
+        evidence_status = "incomplete"
+    elif defaults["review_required"] and review_verdict != "PASS":
+        evidence_status = "failed_review"
+
+    rel_archive = str(run_dir.relative_to(ctx.archive_root).as_posix())
+
+    return {
+        "run_id": run_dir.name,
+        "lane_id": lane_id,
+        "lane_kind": defaults["lane_kind"],
+        "archive_path": rel_archive,
+        "manifest_present": manifest_present,
+        "manifest_verified": manifest_verified,
+        "review_required": defaults["review_required"],
+        "review_present": review_present,
+        "review_verdict": review_verdict,
+        "durable_retention_required": defaults["durable_retention_required"],
+        "durable_retention_verified": manifest_verified and not str(run_dir).startswith("/tmp"),
+        "notion_link_allowed": defaults["notion_link_allowed"],
+        "notion_link_present": "notion" in _scan_texts(run_dir).lower(),
+        "authority_level": defaults["authority_level"],
+        "runtime_allowed_by_default": defaults["runtime_allowed_by_default"],
+        "requires_approval_record": defaults["requires_approval_record"],
+        "can_clear_hold": False,
+        "can_clear_glb": False,
+        "can_authorize_live": False,
+        "can_touch_broker_exchange": False,
+        "protected_master_v2_boundary": True,
+        "evidence_status": evidence_status,
+        "issues": run_issues,
+    }
+
+
+def _lane_catalog_entry(lane_id: str, discovered: int) -> dict[str, Any]:
+    defaults = LANE_DEFAULTS[lane_id]
+    mode = defaults["indexing_mode"]
+    if discovered == 0 and lane_id in PRIMARY_EVIDENCE_LANES:
+        mode = "runs_directory"
+    elif discovered == 0:
+        mode = defaults["indexing_mode"]
+    return {
+        "lane_id": lane_id,
+        "lane_kind": defaults["lane_kind"],
+        "discovered_run_count": discovered,
+        "default_authority_level": defaults["authority_level"],
+        "runtime_allowed_by_default": defaults["runtime_allowed_by_default"],
+        "indexing_mode": mode,
+    }
+
+
+def derive_governance(planning_root: Path) -> dict[str, bool]:
+    blob = _scan_texts(planning_root)
+    governance: dict[str, bool] = {}
+    for key in GOVERNANCE_KEYS:
+        parsed = _parse_machine_line(blob, key.upper())
+        governance[key] = parsed if parsed is not None else False
+    governance["governance_blocked"] = (
+        not governance.get("go_decision_granted", False)
+        and not governance.get("live_allowed", False)
+        and not governance.get("broker_exchange_allowed", False)
+        and (
+            not governance.get("hold_no_paper_run_cleared", False)
+            or not governance.get("glb_014_cleared", False)
+            or not governance.get("glb_015_cleared", False)
+            or not governance.get("preflight_ready", False)
+        )
+    )
+    governance["evidence_does_not_authorize_runtime"] = True
+    return governance
+
+
+def derive_blockers(governance: dict[str, bool]) -> list[str]:
+    blockers: list[str] = []
+    if not governance.get("hold_no_paper_run_cleared", False):
+        blockers.append(BLOCKER_HOLD)
+    if not governance.get("glb_014_cleared", False):
+        blockers.append(BLOCKER_GLB_014)
+    if not governance.get("glb_015_cleared", False):
+        blockers.append(BLOCKER_GLB_015)
+    if not governance.get("preflight_ready", False):
+        blockers.append(BLOCKER_PREFLIGHT)
+    if not governance.get("live_allowed", False):
+        blockers.append(BLOCKER_LIVE)
+    if not governance.get("broker_exchange_allowed", False):
+        blockers.append(BLOCKER_BROKER)
+    return sorted(set(blockers))
+
+
+def derive_verdict(ctx: BuildContext) -> str:
+    codes = {issue.code for issue in ctx.issues}
+    fail_codes = {
+        "UNSAFE_LIVE_AUTHORITY",
+        "UNSAFE_BROKER_EXCHANGE_AUTHORITY",
+        "UNSAFE_SECRET_VALUES_INCLUDED",
+        "UNSAFE_GO_DECISION_GRANTED",
+        "UNSAFE_SCHEDULER_RUNTIME_DEFAULT",
+        "UNSAFE_NON_RUN_SURFACE_AUTHORITY",
+        "UNSAFE_TESTNET_TO_LIVE_PROMOTION",
+        "MANIFEST_HASH_MISMATCH",
+        "REVIEW_VERDICT_NOT_PASS",
+        "MASTER_V2_DOUBLE_PLAY_BOUNDARY_NOT_PROTECTED",
+    }
+    if codes & fail_codes or any(c.startswith("UNSAFE_") for c in codes):
+        return VERDICT_FAIL_CLOSED
+    review_codes = {
+        "MISSING_ARCHIVE_ROOT",
+        "MISSING_TAXONOMY_SPEC",
+        "MISSING_RUN_DIR",
+        "MISSING_MANIFEST",
+        "MANIFEST_ENTRY_MISSING",
+        "MISSING_REVIEW_JSON",
+        "MISSING_EXTERNAL_LIVE_RECORD",
+    }
+    if codes & review_codes:
+        return VERDICT_REVIEW_REQUIRED
+    return VERDICT_PASS_BLOCKED_SAFE
+
+
+def build_registry(ctx: BuildContext) -> dict[str, Any]:
+    archive_root = ctx.archive_root
+    if not archive_root.is_dir():
+        ctx.add_issue("MISSING_ARCHIVE_ROOT", "archive root does not exist", archive_root)
+
+    taxonomy_path = ctx.repo_root / TAXONOMY_SPEC_REL
+    if not taxonomy_path.is_file():
+        ctx.add_issue("MISSING_TAXONOMY_SPEC", "taxonomy spec missing on main", taxonomy_path)
+
+    planning_root = archive_root / "planning"
+    scan_unsafe_text(_scan_texts(planning_root), ctx, planning_root)
+
+    runs: list[dict[str, Any]] = []
+    runs_by_lane: dict[str, int] = {lid: 0 for lid in LANE_DEFAULTS}
+
+    for lane_id, run_dir in _discover_all_runs(archive_root):
+        runs_by_lane[lane_id] = runs_by_lane.get(lane_id, 0) + 1
+        runs.append(_build_run_record(run_dir, lane_id, ctx))
+
+    # Testnet PASS must not imply live — check planning/run text for promotion markers
+    blob = _scan_texts(archive_root)
+    if _parse_machine_line(blob, "TESTNET_AUTHORIZED") is True:
+        ctx.add_issue(
+            "UNSAFE_TESTNET_TO_LIVE_PROMOTION",
+            "TESTNET_AUTHORIZED=true must not appear in archive evidence",
+            archive_root,
+        )
+
+    governance = derive_governance(planning_root)
+    if governance.get("live_allowed"):
+        ctx.add_issue("UNSAFE_LIVE_AUTHORITY", "live_allowed=true in planning", planning_root)
+    if governance.get("broker_exchange_allowed"):
+        ctx.add_issue(
+            "UNSAFE_BROKER_EXCHANGE_AUTHORITY",
+            "broker_exchange_allowed=true in planning",
+            planning_root,
+        )
+    if governance.get("secret_values_included"):
+        ctx.add_issue(
+            "UNSAFE_SECRET_VALUES_INCLUDED",
+            "secret_values_included=true in planning",
+            planning_root,
+        )
+    if governance.get("go_decision_granted"):
+        ctx.add_issue(
+            "UNSAFE_GO_DECISION_GRANTED",
+            "go_decision_granted=true in planning",
+            planning_root,
+        )
+
+    for run in runs:
+        if not run.get("protected_master_v2_boundary", True):
+            ctx.add_issue(
+                "MASTER_V2_DOUBLE_PLAY_BOUNDARY_NOT_PROTECTED",
+                "run record must protect Master V2 / Double Play boundary",
+                archive_root / run["archive_path"],
+            )
+
+    verified = sum(1 for r in runs if r["evidence_status"] == "verified")
+    review_required_runs = sum(1 for r in runs if r["review_required"])
+    fail_closed_runs = sum(1 for r in runs if r["evidence_status"] == "failed_review")
+
+    lanes = [_lane_catalog_entry(lid, runs_by_lane.get(lid, 0)) for lid in LANE_DEFAULTS]
+
+    generated_at = ctx.fixed_generated_at_utc or os.environ.get("PEAK_TRADE_FIXED_GENERATED_AT_UTC")
+    if not generated_at:
+        generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    blockers = derive_blockers(governance)
+    verdict = derive_verdict(ctx)
+
+    summaries = {
+        "total_runs": len(runs),
+        "runs_by_lane": {k: runs_by_lane.get(k, 0) for k in PRIMARY_EVIDENCE_LANES},
+        "verified_runs": verified,
+        "review_required_runs": review_required_runs,
+        "fail_closed_runs": fail_closed_runs,
+        "primary_evidence_lanes_present": all(
+            runs_by_lane.get(l, 0) > 0 for l in PRIMARY_EVIDENCE_LANES
+        ),
+        "scheduler_boundary_gap_acknowledged": True,
+        "live_authority_present": governance.get("live_allowed", False),
+        "broker_exchange_authority_present": governance.get("broker_exchange_allowed", False),
+    }
+
+    authority = {
+        **governance,
+        "scheduler_boundary_gap_acknowledged": True,
+        "master_v2_double_play_boundary_preserved": True,
+    }
+
+    return {
+        "schema": SCHEMA,
+        "generated_at_utc": generated_at,
+        "archive_root": str(archive_root.resolve()),
+        "lanes": lanes,
+        "runs": runs,
+        "summaries": summaries,
+        "authority": authority,
+        "blockers": blockers,
+        "verdict": verdict,
+        "issues": [issue.as_dict() for issue in ctx.issues],
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive-root", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, default=_repo_root())
+    parser.add_argument("--fixed-generated-at-utc")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ctx = BuildContext(
+        archive_root=args.archive_root.expanduser().resolve(),
+        repo_root=args.repo_root.expanduser().resolve(),
+        fixed_generated_at_utc=args.fixed_generated_at_utc,
+    )
+    registry = build_registry(ctx)
+    if args.json:
+        print(json.dumps(registry, indent=2, sort_keys=False))
+    else:
+        print(f"verdict={registry['verdict']}")
+        print(f"total_runs={registry['summaries']['total_runs']}")
+        print(f"issues={len(registry['issues'])}")
+    if registry["verdict"] == VERDICT_FAIL_CLOSED:
+        return 2
+    if registry["verdict"] == VERDICT_REVIEW_REQUIRED:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/ops/generic_evidence_run_registry_v1/README.md
+++ b/tests/fixtures/ops/generic_evidence_run_registry_v1/README.md
@@ -4,9 +4,9 @@ Synthetic archive roots for offline registry builder tests.
 
 Layout per archive:
 
-- `runs/paper/{run_id}/` — manifest required; review optional
-- `runs/shadow/{run_id}/` — manifest + review PASS required
-- `runs/testnet/{run_id}/` — manifest + review PASS required
-- `planning/` — optional governance machine lines
+- `runs&#47;paper&#47;{run_id}&#47;` — manifest required; review optional
+- `runs&#47;shadow&#47;{run_id}&#47;` — manifest + review PASS required
+- `runs&#47;testnet&#47;{run_id}&#47;` — manifest + review PASS required
+- `planning&#47;` — optional governance machine lines
 
 Fixtures are created programmatically in tests; this directory documents conventions only.

--- a/tests/fixtures/ops/generic_evidence_run_registry_v1/README.md
+++ b/tests/fixtures/ops/generic_evidence_run_registry_v1/README.md
@@ -1,0 +1,12 @@
+# Generic Evidence Run Registry v1 — test fixtures
+
+Synthetic archive roots for offline registry builder tests.
+
+Layout per archive:
+
+- `runs/paper/{run_id}/` — manifest required; review optional
+- `runs/shadow/{run_id}/` — manifest + review PASS required
+- `runs/testnet/{run_id}/` — manifest + review PASS required
+- `planning/` — optional governance machine lines
+
+Fixtures are created programmatically in tests; this directory documents conventions only.

--- a/tests/ops/test_build_generic_evidence_run_registry_v1.py
+++ b/tests/ops/test_build_generic_evidence_run_registry_v1.py
@@ -1,0 +1,339 @@
+"""Tests for offline generic evidence run registry v1 builder."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ops" / "build_generic_evidence_run_registry_v1.py"
+REAL_ARCHIVE = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+
+SAFE_GOVERNANCE = "\n".join(
+    [
+        "GO_DECISION_GRANTED=false",
+        "HOLD_NO_PAPER_RUN_CLEARED=false",
+        "GLB_014_CLEARED=false",
+        "GLB_015_CLEARED=false",
+        "PREFLIGHT_READY=false",
+        "LIVE_ALLOWED=false",
+        "BROKER_EXCHANGE_ALLOWED=false",
+        "SECRET_VALUES_INCLUDED=false",
+    ]
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("build_generic_evidence_run_registry_v1", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["build_generic_evidence_run_registry_v1"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _sha256_file(path: Path) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_manifest(directory: Path) -> None:
+    entries: list[str] = []
+    for path in sorted(directory.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name in {"MANIFEST.sha256", "MANIFEST_VERIFY.log"}:
+            continue
+        rel = path.relative_to(directory).as_posix()
+        entries.append(f"{_sha256_file(path)}  {rel}")
+    (directory / "MANIFEST.sha256").write_text("\n".join(entries) + "\n", encoding="utf-8")
+
+
+def _write_review(run_dir: Path, verdict: str) -> None:
+    review_dir = run_dir / "review"
+    review_dir.mkdir(parents=True, exist_ok=True)
+    (review_dir / "REVIEW_RESULT.json").write_text(
+        json.dumps({"verdict": verdict, "issues": []}) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_run(
+    archive: Path,
+    lane: str,
+    run_id: str,
+    *,
+    review_verdict: str | None = None,
+    extra_text: str = "",
+    write_manifest: bool = True,
+) -> Path:
+    run_dir = archive / "runs" / lane / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    content = f"{lane}:{run_id}\n"
+    if extra_text:
+        content += extra_text + "\n"
+    (run_dir / "evidence.txt").write_text(content, encoding="utf-8")
+    if review_verdict is not None:
+        _write_review(run_dir, review_verdict)
+    if write_manifest:
+        _write_manifest(run_dir)
+    return run_dir
+
+
+def _complete_archive(root: Path) -> None:
+    _write_run(root, "paper", "paper_run", review_verdict=None)
+    _write_run(root, "shadow", "shadow_run", review_verdict="PASS")
+    _write_run(root, "testnet", "testnet_run", review_verdict="PASS")
+    planning = root / "planning" / "governance_fixture_v0"
+    planning.mkdir(parents=True, exist_ok=True)
+    (planning / "GOVERNANCE.md").write_text(SAFE_GOVERNANCE + "\n", encoding="utf-8")
+    _write_manifest(planning)
+
+
+def _build(mod, archive: Path, *, fixed: str = "2026-05-21T00:00:00Z") -> dict:
+    ctx = mod.BuildContext(
+        archive_root=archive,
+        repo_root=ROOT,
+        fixed_generated_at_utc=fixed,
+    )
+    return mod.build_registry(ctx)
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file()
+
+
+def test_schema_constant(mod) -> None:
+    assert mod.SCHEMA == "peak_trade.generic_evidence_run_registry.v1"
+
+
+def test_help_works() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "--archive-root" in proc.stdout
+
+
+def test_complete_fixture_pass_blocked_safe(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _complete_archive(root)
+    payload = _build(mod, root)
+    assert payload["schema"] == "peak_trade.generic_evidence_run_registry.v1"
+    assert payload["verdict"] == mod.VERDICT_PASS_BLOCKED_SAFE
+    assert payload["summaries"]["total_runs"] == 3
+    assert payload["authority"]["live_allowed"] is False
+    assert payload["authority"]["scheduler_boundary_gap_acknowledged"] is True
+    assert payload["blockers"]
+    lane_ids = {r["lane_id"] for r in payload["runs"]}
+    assert lane_ids == {"paper", "shadow", "testnet"}
+
+
+def test_missing_manifest_review_required(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(root, "paper", "paper_run", write_manifest=False)
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_REVIEW_REQUIRED
+    codes = {i["code"] for i in payload["issues"]}
+    assert "MISSING_MANIFEST" in codes
+
+
+def test_manifest_hash_mismatch_fail_closed(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    run_dir = _write_run(root, "paper", "paper_run")
+    (run_dir / "MANIFEST.sha256").write_text("deadbeef  evidence.txt\n", encoding="utf-8")
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+    assert any(i["code"] == "MANIFEST_HASH_MISMATCH" for i in payload["issues"])
+
+
+def test_shadow_review_missing_review_required(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(root, "shadow", "shadow_run", review_verdict=None)
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_REVIEW_REQUIRED
+    assert any(i["code"] == "MISSING_REVIEW_JSON" for i in payload["issues"])
+
+
+def test_shadow_review_not_pass_fail_closed(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(root, "shadow", "shadow_run", review_verdict="FAIL")
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+    assert any(i["code"] == "REVIEW_VERDICT_NOT_PASS" for i in payload["issues"])
+
+
+def test_testnet_review_missing_review_required(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(root, "testnet", "testnet_run", review_verdict=None)
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_REVIEW_REQUIRED
+
+
+def test_testnet_review_not_pass_fail_closed(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(root, "testnet", "testnet_run", review_verdict="REVIEW_REQUIRED")
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+
+
+def test_scheduler_runtime_allowed_fail_closed(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(
+        root,
+        "scheduler",
+        "sched_run",
+        extra_text="RUNTIME_ALLOWED_BY_DEFAULT=true",
+    )
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+    assert any(i["code"] == "UNSAFE_SCHEDULER_RUNTIME_DEFAULT" for i in payload["issues"])
+
+
+def test_testnet_can_authorize_live_fail_closed(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(
+        root,
+        "testnet",
+        "testnet_run",
+        review_verdict="PASS",
+        extra_text="CAN_AUTHORIZE_LIVE=true",
+    )
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+    assert any(i["code"] == "UNSAFE_LIVE_AUTHORITY" for i in payload["issues"])
+
+
+def test_dashboard_lane_fail_closed(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(root, "dashboard", "dash_run")
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+    assert any(i["code"] == "UNSAFE_NON_RUN_SURFACE_AUTHORITY" for i in payload["issues"])
+
+
+def test_live_production_without_record_review_required(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _write_run(root, "live_production", "live_run")
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_REVIEW_REQUIRED
+    assert any(i["code"] == "MISSING_EXTERNAL_LIVE_RECORD" for i in payload["issues"])
+
+
+def test_secret_values_included_fail_closed(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _complete_archive(root)
+    planning = root / "planning" / "governance_fixture_v0" / "GOVERNANCE.md"
+    planning.write_text(SAFE_GOVERNANCE + "\nSECRET_VALUES_INCLUDED=true\n", encoding="utf-8")
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+    assert any(i["code"] == "UNSAFE_SECRET_VALUES_INCLUDED" for i in payload["issues"])
+
+
+def test_go_decision_granted_fail_closed(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _complete_archive(root)
+    planning = root / "planning" / "governance_fixture_v0" / "GOVERNANCE.md"
+    planning.write_text(SAFE_GOVERNANCE + "\nGO_DECISION_GRANTED=true\n", encoding="utf-8")
+    payload = _build(mod, root)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+
+
+def test_deterministic_timestamp(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _complete_archive(root)
+    payload = _build(mod, root, fixed="2026-05-21T00:00:00Z")
+    assert payload["generated_at_utc"] == "2026-05-21T00:00:00Z"
+
+
+def test_cli_json_only_stdout(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _complete_archive(root)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(
+            [
+                "--archive-root",
+                str(root),
+                "--repo-root",
+                str(ROOT),
+                "--fixed-generated-at-utc",
+                "2026-05-21T00:00:00Z",
+                "--json",
+            ]
+        )
+    assert rc == 0
+    payload = json.loads(buf.getvalue())
+    assert payload["verdict"] == mod.VERDICT_PASS_BLOCKED_SAFE
+
+
+def test_per_run_registry_fields_present(mod, tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    _complete_archive(root)
+    payload = _build(mod, root)
+    required = {
+        "run_id",
+        "lane_id",
+        "lane_kind",
+        "archive_path",
+        "manifest_present",
+        "manifest_verified",
+        "review_required",
+        "review_present",
+        "review_verdict",
+        "durable_retention_required",
+        "durable_retention_verified",
+        "notion_link_allowed",
+        "notion_link_present",
+        "authority_level",
+        "runtime_allowed_by_default",
+        "requires_approval_record",
+        "can_clear_hold",
+        "can_clear_glb",
+        "can_authorize_live",
+        "can_touch_broker_exchange",
+        "protected_master_v2_boundary",
+        "evidence_status",
+        "issues",
+    }
+    for run in payload["runs"]:
+        assert required <= set(run.keys())
+        assert run["can_authorize_live"] is False
+        assert run["protected_master_v2_boundary"] is True
+
+
+@pytest.mark.skipif(
+    os.environ.get("PEAK_TRADE_RUN_REGISTRY_REAL_ARCHIVE") != "1",
+    reason="set PEAK_TRADE_RUN_REGISTRY_REAL_ARCHIVE=1 to run real archive smoke",
+)
+def test_real_archive_smoke_pass_blocked_safe(mod) -> None:
+    if not REAL_ARCHIVE.is_dir():
+        pytest.skip("real archive not present")
+    payload = _build(mod, REAL_ARCHIVE)
+    assert payload["verdict"] == mod.VERDICT_PASS_BLOCKED_SAFE
+    assert payload["authority"]["live_allowed"] is False
+    assert payload["authority"]["broker_exchange_allowed"] is False
+    assert payload["summaries"]["scheduler_boundary_gap_acknowledged"] is True
+    lane_ids = {r["lane_id"] for r in payload["runs"]}
+    assert {"paper", "shadow", "testnet"} <= lane_ids


### PR DESCRIPTION
## Summary
- Add offline `build_generic_evidence_run_registry_v1.py` to index paper/shadow/testnet evidence runs under an archive root with taxonomy-aligned authority boundaries.
- Emit schema `peak_trade.generic_evidence_run_registry.v1` with fail-closed guards (no live/broker authority, scheduler boundary gap acknowledged, non-run surfaces blocked).
- Add synthetic fixture tests (19 passing) covering manifest/review paths, unsafe markers, schema stability, and deterministic timestamps.

## Test plan
- [x] `uv run pytest tests/ops/test_build_generic_evidence_run_registry_v1.py -q`
- [x] `uv run ruff check` / `ruff format --check` on new files
- [x] Regression: ledger v0 + gate snapshot v0 tests pass
- [x] Real archive smoke: `GENERIC_EVIDENCE_RUN_REGISTRY_PASS_BLOCKED_SAFE` (paper/shadow/testnet indexed; no live/broker authority)


Made with [Cursor](https://cursor.com)