### PR TITLE
feat(ops): add optional registry section to readiness gate snapshot v0

### DIFF
--- a/scripts/ops/report_readiness_gate_snapshot_v0.py
+++ b/scripts/ops/report_readiness_gate_snapshot_v0.py
@@ -2,6 +2,10 @@
 """Compose readiness ledger, preflight status, and mirror into one gate snapshot.
 
 Non-authorizing offline convenience CLI. Does not start runtime or grant authority.
+
+Optional ``--include-registry`` attaches a summary-only Generic Evidence Run Registry
+v1 subsection. That subsection is non-authorizing and must not be interpreted as gate
+clearance.
 """
 
 from __future__ import annotations
@@ -22,6 +26,10 @@ VERDICT_FAIL_CLOSED = "READINESS_GATE_SNAPSHOT_FAIL_CLOSED"
 
 LEDGER_PASS = "READINESS_EVIDENCE_LEDGER_PASS_BLOCKED_SAFE"
 MIRROR_PASS = "READINESS_LEDGER_PREFLIGHT_MIRROR_PASS_BLOCKED_SAFE"
+
+REGISTRY_PASS = "GENERIC_EVIDENCE_RUN_REGISTRY_PASS_BLOCKED_SAFE"
+REGISTRY_REVIEW = "GENERIC_EVIDENCE_RUN_REGISTRY_REVIEW_REQUIRED"
+REGISTRY_FAIL = "GENERIC_EVIDENCE_RUN_REGISTRY_FAIL_CLOSED"
 
 
 def _repo_root() -> Path:
@@ -192,11 +200,80 @@ def derive_gate_verdict(
     return VERDICT_REVIEW_REQUIRED
 
 
+def _summarize_registry(full: dict[str, Any]) -> dict[str, Any]:
+    summaries = full.get("summaries") if isinstance(full.get("summaries"), dict) else {}
+    blockers = full.get("blockers") if isinstance(full.get("blockers"), list) else []
+    return {
+        "included": True,
+        "non_authorizing": True,
+        "schema": full.get("schema"),
+        "verdict": full.get("verdict"),
+        "total_runs": summaries.get("total_runs"),
+        "verified_runs": summaries.get("verified_runs"),
+        "runs_by_lane": summaries.get("runs_by_lane"),
+        "scheduler_boundary_gap_acknowledged": summaries.get("scheduler_boundary_gap_acknowledged"),
+        "live_authority_present": summaries.get("live_authority_present"),
+        "broker_exchange_authority_present": summaries.get("broker_exchange_authority_present"),
+        "issues_count": len(full.get("issues") or []),
+        "blockers": blockers,
+    }
+
+
+def _registry_build_failed_section() -> dict[str, Any]:
+    return {
+        "included": False,
+        "non_authorizing": True,
+    }
+
+
+def _registry_unsafe_for_gate(full: dict[str, Any]) -> bool:
+    summaries = full.get("summaries") if isinstance(full.get("summaries"), dict) else {}
+    authority = full.get("authority") if isinstance(full.get("authority"), dict) else {}
+    if summaries.get("live_authority_present") is True:
+        return True
+    if summaries.get("broker_exchange_authority_present") is True:
+        return True
+    if authority.get("live_allowed") is True:
+        return True
+    if authority.get("broker_exchange_allowed") is True:
+        return True
+    if authority.get("secret_values_included") is True:
+        return True
+    return False
+
+
+def _apply_registry_verdict_escalation(
+    gate_verdict: str,
+    registry_full: dict[str, Any] | None,
+    *,
+    build_failed: bool,
+) -> str:
+    if build_failed:
+        if gate_verdict == VERDICT_FAIL_CLOSED:
+            return gate_verdict
+        return VERDICT_REVIEW_REQUIRED
+
+    if registry_full is None:
+        return gate_verdict
+
+    if _registry_unsafe_for_gate(registry_full):
+        return VERDICT_FAIL_CLOSED
+
+    reg_verdict = registry_full.get("verdict")
+    if reg_verdict == REGISTRY_FAIL:
+        return VERDICT_FAIL_CLOSED
+    if reg_verdict == REGISTRY_REVIEW and gate_verdict == VERDICT_PASS_BLOCKED_SAFE:
+        return VERDICT_REVIEW_REQUIRED
+
+    return gate_verdict
+
+
 def build_readiness_gate_snapshot(
     archive_root: Path,
     *,
     repo_root: Path | None = None,
     fixed_generated_at_utc: str | None = None,
+    include_registry: bool = False,
 ) -> dict[str, Any]:
     _ensure_repo_imports()
     from scripts.ops.build_readiness_evidence_ledger_v0 import (
@@ -235,11 +312,70 @@ def build_readiness_gate_snapshot(
     governance = _derive_governance(ledger_full, preflight_full)
     verdict = derive_gate_verdict(ledger_full, preflight_full, mirror_full, issues)
 
+    registry_section: dict[str, Any] | None = None
+    if include_registry:
+        try:
+            from scripts.ops.build_generic_evidence_run_registry_v1 import (
+                BuildContext as RegistryBuildContext,
+                build_registry,
+            )
+
+            registry_ctx = RegistryBuildContext(
+                archive_root=archive,
+                repo_root=root,
+                fixed_generated_at_utc=fixed_generated_at_utc,
+            )
+            registry_full = build_registry(registry_ctx)
+            registry_section = _summarize_registry(registry_full)
+            if _registry_unsafe_for_gate(registry_full):
+                issues.append(
+                    {
+                        "source": "registry",
+                        "code": "REGISTRY_SECTION_UNSAFE_AUTHORITY_SIGNAL",
+                        "message": "registry summary reported unsafe authority signal",
+                    }
+                )
+            elif registry_full.get("verdict") == REGISTRY_REVIEW:
+                issues.append(
+                    {
+                        "source": "registry",
+                        "code": "REGISTRY_SECTION_REVIEW_REQUIRED",
+                        "message": "registry verdict requires review",
+                    }
+                )
+            elif registry_full.get("verdict") == REGISTRY_FAIL:
+                issues.append(
+                    {
+                        "source": "registry",
+                        "code": "REGISTRY_SECTION_FAIL_CLOSED",
+                        "message": "registry verdict is fail closed",
+                    }
+                )
+            verdict = _apply_registry_verdict_escalation(
+                verdict,
+                registry_full,
+                build_failed=False,
+            )
+        except Exception as exc:
+            registry_section = _registry_build_failed_section()
+            issues.append(
+                {
+                    "source": "registry",
+                    "code": "REGISTRY_SECTION_BUILD_FAILED",
+                    "message": str(exc),
+                }
+            )
+            verdict = _apply_registry_verdict_escalation(
+                verdict,
+                None,
+                build_failed=True,
+            )
+
     generated_at = fixed_generated_at_utc or os.environ.get("PEAK_TRADE_FIXED_GENERATED_AT_UTC")
     if not generated_at:
         generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    return {
+    payload: dict[str, Any] = {
         "schema": SCHEMA,
         "generated_at_utc": generated_at,
         "archive_root": str(archive),
@@ -251,6 +387,9 @@ def build_readiness_gate_snapshot(
         "verdict": verdict,
         "issues": issues,
     }
+    if include_registry and registry_section is not None:
+        payload["registry"] = registry_section
+    return payload
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -258,6 +397,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--archive-root", type=Path, required=True)
     parser.add_argument("--repo-root", type=Path)
     parser.add_argument("--fixed-generated-at-utc")
+    parser.add_argument("--include-registry", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
 
@@ -268,6 +408,7 @@ def main(argv: list[str] | None = None) -> int:
         args.archive_root,
         repo_root=args.repo_root,
         fixed_generated_at_utc=args.fixed_generated_at_utc,
+        include_registry=args.include_registry,
     )
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=False))

--- a/tests/ops/test_report_readiness_gate_snapshot_v0.py
+++ b/tests/ops/test_report_readiness_gate_snapshot_v0.py
@@ -26,6 +26,10 @@ LEDGER_REVIEW = "READINESS_EVIDENCE_LEDGER_REVIEW_REQUIRED"
 MIRROR_PASS = "READINESS_LEDGER_PREFLIGHT_MIRROR_PASS_BLOCKED_SAFE"
 MIRROR_FAIL = "READINESS_LEDGER_PREFLIGHT_MIRROR_FAIL_CLOSED"
 
+REGISTRY_PASS = "GENERIC_EVIDENCE_RUN_REGISTRY_PASS_BLOCKED_SAFE"
+REGISTRY_REVIEW = "GENERIC_EVIDENCE_RUN_REGISTRY_REVIEW_REQUIRED"
+REGISTRY_FAIL = "GENERIC_EVIDENCE_RUN_REGISTRY_FAIL_CLOSED"
+
 
 def _load_module():
     spec = importlib.util.spec_from_file_location("report_readiness_gate_snapshot_v0", SCRIPT)
@@ -95,6 +99,54 @@ def _safe_mirror(**overrides: object) -> dict:
     }
     base.update(overrides)
     return base
+
+
+def _safe_registry(**overrides: object) -> dict:
+    base = {
+        "schema": "peak_trade.generic_evidence_run_registry.v1",
+        "verdict": REGISTRY_PASS,
+        "summaries": {
+            "total_runs": 3,
+            "verified_runs": 3,
+            "runs_by_lane": {"paper": 1, "shadow": 1, "testnet": 1},
+            "scheduler_boundary_gap_acknowledged": True,
+            "live_authority_present": False,
+            "broker_exchange_authority_present": False,
+        },
+        "authority": {
+            "live_allowed": False,
+            "broker_exchange_allowed": False,
+            "secret_values_included": False,
+        },
+        "blockers": ["LIVE_NOT_AUTHORIZED"],
+        "issues": [],
+    }
+    if "summaries" in overrides and isinstance(overrides["summaries"], dict):
+        base["summaries"].update(overrides.pop("summaries"))  # type: ignore[arg-type]
+    if "authority" in overrides and isinstance(overrides["authority"], dict):
+        base["authority"].update(overrides.pop("authority"))  # type: ignore[arg-type]
+    base.update(overrides)
+    return base
+
+
+def _patch_safe_stack(monkeypatch, mod, *, registry: dict | None = None) -> None:
+    monkeypatch.setattr(
+        "scripts.ops.build_readiness_evidence_ledger_v0.build_ledger",
+        lambda ctx: _safe_ledger(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_paper_shadow_247_preflight_status.build_paper_shadow_247_preflight_status",
+        lambda **kwargs: _safe_preflight(),
+    )
+    monkeypatch.setattr(
+        "scripts.ops.report_readiness_ledger_preflight_mirror_v0.build_mirror_from_payloads",
+        lambda *a, **k: _safe_mirror(),
+    )
+    if registry is not None:
+        monkeypatch.setattr(
+            "scripts.ops.build_generic_evidence_run_registry_v1.build_registry",
+            lambda ctx: registry,
+        )
 
 
 @pytest.fixture
@@ -290,6 +342,157 @@ def test_schema_stable(mod, monkeypatch) -> None:
         "verdict",
         "issues",
     }
+    assert "registry" not in payload
+
+
+def test_default_output_has_no_registry_key(mod, monkeypatch) -> None:
+    _patch_safe_stack(monkeypatch, mod)
+    payload = mod.build_readiness_gate_snapshot(Path("/tmp/archive"))
+    assert "registry" not in payload
+
+
+def test_include_registry_adds_summary_section(mod, monkeypatch) -> None:
+    _patch_safe_stack(monkeypatch, mod, registry=_safe_registry())
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    reg = payload["registry"]
+    assert reg["included"] is True
+    assert reg["schema"] == "peak_trade.generic_evidence_run_registry.v1"
+    assert reg["total_runs"] == 3
+    assert reg["verified_runs"] == 3
+    assert reg["runs_by_lane"] == {"paper": 1, "shadow": 1, "testnet": 1}
+
+
+def test_registry_non_authorizing_flag(mod, monkeypatch) -> None:
+    _patch_safe_stack(monkeypatch, mod, registry=_safe_registry())
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    assert payload["registry"]["non_authorizing"] is True
+
+
+def test_registry_pass_does_not_change_gate_verdict(mod, monkeypatch) -> None:
+    _patch_safe_stack(monkeypatch, mod, registry=_safe_registry())
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    assert payload["verdict"] == GATE_PASS
+
+
+def test_registry_review_required_escalates_gate_from_pass(mod, monkeypatch) -> None:
+    _patch_safe_stack(monkeypatch, mod, registry=_safe_registry(verdict=REGISTRY_REVIEW))
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    assert payload["verdict"] == GATE_REVIEW
+
+
+def test_registry_fail_closed_escalates_gate(mod, monkeypatch) -> None:
+    _patch_safe_stack(monkeypatch, mod, registry=_safe_registry(verdict=REGISTRY_FAIL))
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    assert payload["verdict"] == GATE_FAIL
+
+
+def test_registry_live_authority_present_fail_closed(mod, monkeypatch) -> None:
+    _patch_safe_stack(
+        monkeypatch,
+        mod,
+        registry=_safe_registry(
+            summaries={"live_authority_present": True},
+        ),
+    )
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    assert payload["verdict"] == GATE_FAIL
+    assert any(
+        i.get("code") == "REGISTRY_SECTION_UNSAFE_AUTHORITY_SIGNAL" for i in payload["issues"]
+    )
+
+
+def test_registry_broker_exchange_authority_present_fail_closed(mod, monkeypatch) -> None:
+    _patch_safe_stack(
+        monkeypatch,
+        mod,
+        registry=_safe_registry(
+            summaries={"broker_exchange_authority_present": True},
+        ),
+    )
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    assert payload["verdict"] == GATE_FAIL
+
+
+def test_registry_build_failure_review_required(mod, monkeypatch) -> None:
+    _patch_safe_stack(monkeypatch, mod)
+
+    def _boom(ctx):
+        raise RuntimeError("registry build failed")
+
+    monkeypatch.setattr(
+        "scripts.ops.build_generic_evidence_run_registry_v1.build_registry",
+        _boom,
+    )
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    assert payload["verdict"] == GATE_REVIEW
+    assert payload["registry"]["included"] is False
+    assert any(i.get("code") == "REGISTRY_SECTION_BUILD_FAILED" for i in payload["issues"])
+
+
+def test_include_registry_schema_stable(mod, monkeypatch) -> None:
+    _patch_safe_stack(monkeypatch, mod, registry=_safe_registry())
+    payload = mod.build_readiness_gate_snapshot(
+        Path("/tmp/archive"),
+        include_registry=True,
+    )
+    assert set(payload) == {
+        "schema",
+        "generated_at_utc",
+        "archive_root",
+        "ledger",
+        "preflight",
+        "mirror",
+        "governance",
+        "blockers",
+        "verdict",
+        "issues",
+        "registry",
+    }
+
+
+def test_cli_include_registry_json_prints_json_only(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--archive-root",
+            str(tmp_path / "missing"),
+            "--fixed-generated-at-utc",
+            "2026-05-21T00:00:00Z",
+            "--include-registry",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.stderr.strip() == ""
+    payload = json.loads(proc.stdout)
+    assert "registry" in payload
 
 
 def test_no_subprocess_or_network_in_module_source() -> None:
@@ -325,3 +528,32 @@ def test_real_smoke_pass_blocked_safe() -> None:
     assert payload["verdict"] == GATE_PASS
     assert payload["ledger"]["issues_count"] == 0
     assert payload["mirror"]["issues_count"] == 0
+    assert "registry" not in payload
+
+
+@pytest.mark.skipif(not ARCHIVE_ROOT.is_dir(), reason="operator archive not present")
+def test_real_smoke_include_registry_pass_blocked_safe() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--archive-root",
+            str(ARCHIVE_ROOT),
+            "--fixed-generated-at-utc",
+            "2026-05-21T00:00:00Z",
+            "--include-registry",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == GATE_PASS
+    assert payload["registry"]["included"] is True
+    assert payload["registry"]["non_authorizing"] is True
+    assert payload["registry"]["verdict"] == REGISTRY_PASS
+    assert payload["governance"]["live_allowed"] is False
+    assert payload["governance"]["broker_exchange_allowed"] is False
+    assert payload["governance"]["secret_values_included"] is False
+    assert payload["registry"]["issues_count"] == 0


### PR DESCRIPTION
## Summary
- Add `--include-registry` flag to `report_readiness_gate_snapshot_v0.py`.
- When set, attach a summary-only, non-authorizing Registry v1 subsection under top-level `registry`.
- Default Gate Snapshot output and verdict derivation unchanged (ledger/mirror/preflight only).
- Registry unsafe authority signals escalate gate to `FAIL_CLOSED`; registry build/REVIEW/FAIL issues escalate from `PASS_BLOCKED_SAFE` per contract.

## Test plan
- [x] `uv run pytest tests/ops/test_report_readiness_gate_snapshot_v0.py -q` (25 passed)
- [x] `uv run pytest tests/ops/test_build_generic_evidence_run_registry_v1.py -q` (regression)
- [x] ruff check/format on touched files
- [x] Real archive smoke: gate PASS_BLOCKED_SAFE, registry PASS_BLOCKED_SAFE, no live/broker authority


Made with [Cursor](https://cursor.com)