### PR TITLE
feat(ops): share primary evidence manifest verify helper v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -56,7 +56,7 @@ The following are **forbidden as primary evidence** (supporting or documentary o
 
 Future run selectors and adapters must **reject or block** a run plan when primary evidence retention cannot be guaranteed. **No gate clearance** may be inferred from degraded or documentary evidence alone. Completing one bounded Paper observation run (for example Paper120) does **not** impose an automatic **24h** or **72h** rerun requirement.
 
-Reference implementation: `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` (plan-only default; execute requires approval record; archive root outside `/tmp`).
+Reference implementation: `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` and shared manifest helpers in `scripts/ops/primary_evidence_retention_v0.py` (plan-only default; execute requires approval record; archive root outside `/tmp`; `MANIFEST.sha256` verified after durable copy).
 
 ## 2b. Planning artifact durable retention v0
 

--- a/scripts/ops/primary_evidence_retention_v0.py
+++ b/scripts/ops/primary_evidence_retention_v0.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Shared primary evidence manifest helpers (Preflight §2a; non-authorizing)."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+MANIFEST_FILENAME = "MANIFEST.sha256"
+
+
+def write_manifest_sha256(root: Path) -> None:
+    """Write MANIFEST.sha256 over all files under root (excluding the manifest itself)."""
+    lines: list[str] = []
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        if path.name == MANIFEST_FILENAME:
+            continue
+        rel = path.relative_to(root).as_posix()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        lines.append(f"{digest}  {rel}")
+    manifest = root / MANIFEST_FILENAME
+    manifest.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def verify_manifest_sha256(root: Path) -> tuple[bool, str]:
+    """Verify MANIFEST.sha256 against files under root. Fail closed on any mismatch."""
+    manifest = root / MANIFEST_FILENAME
+    if not manifest.is_file():
+        return False, "MANIFEST.sha256 missing"
+    for raw in manifest.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            return False, f"invalid manifest line: {line!r}"
+        digest, rel = parts
+        path = root / rel
+        if not path.is_file():
+            return False, f"missing manifest entry: {rel}"
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != digest:
+            return False, f"checksum mismatch: {rel}"
+    return True, ""

--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -8,7 +8,6 @@ Default mode emits a command plan only; no scheduler or paper runtime subprocess
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import shutil
@@ -18,6 +17,15 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    verify_manifest_sha256,
+    write_manifest_sha256 as _write_manifest_sha256,
+)
 
 ADAPTER_VERSION = "cli_adapter_scheduler_composition_v0"
 ALLOWED_JOB = "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0"
@@ -382,18 +390,6 @@ def _default_subprocess_runner(
     return int(proc.returncode or 0)
 
 
-def _write_manifest_sha256(staging_root: Path) -> None:
-    lines: list[str] = []
-    for path in sorted(p for p in staging_root.rglob("*") if p.is_file()):
-        if path.name == "MANIFEST.sha256":
-            continue
-        rel = path.relative_to(staging_root).as_posix()
-        digest = hashlib.sha256(path.read_bytes()).hexdigest()
-        lines.append(f"{digest}  {rel}")
-    manifest = staging_root / "MANIFEST.sha256"
-    manifest.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
-
-
 def execute_plan(
     ctx: ExecuteContext,
     plan: AdapterPlan,
@@ -449,6 +445,11 @@ def execute_plan(
         else:
             shutil.copy2(item, dest)
 
+    ok, reason = verify_manifest_sha256(archive_dest)
+    if not ok:
+        print(reason, file=sys.stderr)
+        return VALIDATION_EXIT
+
     pointer = ctx.staging_root / "ARCHIVE_POINTER.md"
     pointer.write_text(
         "\n".join(
@@ -457,6 +458,7 @@ def execute_plan(
                 f"ARCHIVE_PATH={archive_dest}",
                 f"COPY_UTC={datetime.now(timezone.utc).isoformat()}",
                 "ARCHIVE_COPY_COMPLETE=true",
+                "MANIFEST_VERIFY_RC=0",
             ]
         )
         + "\n",

--- a/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
@@ -8,7 +8,6 @@ Default mode emits a command plan only; no wrapper or Shadow runtime subprocess.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import shutil
@@ -18,6 +17,15 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    verify_manifest_sha256,
+    write_manifest_sha256 as _write_manifest_sha256,
+)
 
 ADAPTER_VERSION = "cli_adapter_wrapper_composition_v0"
 WRAPPER_SCRIPT = "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py"
@@ -379,39 +387,6 @@ def _default_subprocess_runner(
         if stderr not in (None, subprocess.DEVNULL):
             stderr.close()
     return int(proc.returncode or 0)
-
-
-def _write_manifest_sha256(staging_root: Path) -> None:
-    lines: list[str] = []
-    for path in sorted(p for p in staging_root.rglob("*") if p.is_file()):
-        if path.name == "MANIFEST.sha256":
-            continue
-        rel = path.relative_to(staging_root).as_posix()
-        digest = hashlib.sha256(path.read_bytes()).hexdigest()
-        lines.append(f"{digest}  {rel}")
-    manifest = staging_root / "MANIFEST.sha256"
-    manifest.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
-
-
-def verify_manifest_sha256(root: Path) -> tuple[bool, str]:
-    manifest = root / "MANIFEST.sha256"
-    if not manifest.is_file():
-        return False, "MANIFEST.sha256 missing"
-    for raw in manifest.read_text(encoding="utf-8").splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        parts = line.split(None, 1)
-        if len(parts) != 2:
-            return False, f"invalid manifest line: {line!r}"
-        digest, rel = parts
-        path = root / rel
-        if not path.is_file():
-            return False, f"missing manifest entry: {rel}"
-        actual = hashlib.sha256(path.read_bytes()).hexdigest()
-        if actual != digest:
-            return False, f"checksum mismatch: {rel}"
-    return True, ""
 
 
 def _write_closeout_artifacts(

--- a/scripts/ops/run_testnet_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_testnet_bounded_observation_adapter_v0.py
@@ -8,7 +8,6 @@ Default mode emits a command plan only; no Testnet runtime subprocess.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import shutil
@@ -18,6 +17,15 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    verify_manifest_sha256,
+    write_manifest_sha256 as _write_manifest_sha256,
+)
 
 ADAPTER_VERSION = "cli_testnet_evidence_flow_composition_v0"
 STAGING_SCRIPT = "scripts/ops/run_testnet_bounded_evidence_staging_v0.sh"
@@ -400,40 +408,6 @@ def _default_subprocess_runner(
         if stderr not in (None, subprocess.DEVNULL):
             stderr.close()
     return int(proc.returncode or 0)
-
-
-def _write_manifest_sha256(staging_root: Path) -> None:
-    lines: list[str] = []
-    for path in sorted(p for p in staging_root.rglob("*") if p.is_file()):
-        if path.name == "MANIFEST.sha256":
-            continue
-        rel = path.relative_to(staging_root).as_posix()
-        digest = hashlib.sha256(path.read_bytes()).hexdigest()
-        lines.append(f"{digest}  {rel}")
-    (staging_root / "MANIFEST.sha256").write_text(
-        "\n".join(lines) + ("\n" if lines else ""),
-        encoding="utf-8",
-    )
-
-
-def verify_manifest_sha256(root: Path) -> tuple[bool, str]:
-    manifest = root / "MANIFEST.sha256"
-    if not manifest.is_file():
-        return False, "MANIFEST.sha256 missing"
-    for raw in manifest.read_text(encoding="utf-8").splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        parts = line.split(None, 1)
-        if len(parts) != 2:
-            return False, f"invalid manifest line: {line!r}"
-        digest, rel = parts
-        path = root / rel
-        if not path.is_file():
-            return False, f"missing manifest entry: {rel}"
-        if hashlib.sha256(path.read_bytes()).hexdigest() != digest:
-            return False, f"checksum mismatch: {rel}"
-    return True, ""
 
 
 def _write_closeout_artifacts(

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -9,6 +9,9 @@ CANONICAL_OWNER = (
     REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
 )
 PAPER_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_paper_only_bounded_observation_adapter_v0.py"
+SHADOW_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_shadow_bounded_observation_adapter_v0.py"
+TESTNET_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_testnet_bounded_observation_adapter_v0.py"
+SHARED_HELPER = REPO_ROOT / "scripts" / "ops" / "primary_evidence_retention_v0.py"
 
 
 def _owner_text() -> str:
@@ -112,5 +115,74 @@ def test_paper_adapter_archive_root_must_be_outside_tmp() -> None:
 def test_canonical_owner_references_paper_adapter_implementation() -> None:
     text = _owner_text()
     assert "run_paper_only_bounded_observation_adapter_v0.py" in text
+    assert "primary_evidence_retention_v0.py" in text
     assert "plan-only default" in text
     assert "archive root outside `/tmp`" in text
+
+
+def test_shared_helper_module_exists() -> None:
+    assert SHARED_HELPER.is_file()
+    text = SHARED_HELPER.read_text(encoding="utf-8")
+    assert "def write_manifest_sha256" in text
+    assert "def verify_manifest_sha256" in text
+
+
+def test_bounded_adapters_import_shared_helper_not_duplicate_verify() -> None:
+    for path in (PAPER_ADAPTER, SHADOW_ADAPTER, TESTNET_ADAPTER):
+        text = path.read_text(encoding="utf-8")
+        assert "primary_evidence_retention_v0" in text
+        assert "def verify_manifest_sha256" not in text
+
+
+def test_paper_adapter_verifies_manifest_after_archive_copy() -> None:
+    text = PAPER_ADAPTER.read_text(encoding="utf-8")
+    execute = text.split("def execute_plan", 1)[1].split("\ndef build_arg_parser", 1)[0]
+    assert "verify_manifest_sha256(archive_dest)" in execute
+    assert execute.index("verify_manifest_sha256(archive_dest)") > execute.rindex("shutil.copy")
+    assert "MANIFEST_VERIFY_RC=0" in execute
+
+
+def test_verify_manifest_sha256_fails_closed_on_missing(tmp_path) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+
+    ok, reason = verify_manifest_sha256(tmp_path)
+    assert ok is False
+    assert reason == "MANIFEST.sha256 missing"
+
+
+def test_verify_manifest_sha256_detects_checksum_mismatch(tmp_path) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import (
+        verify_manifest_sha256,
+        write_manifest_sha256,
+    )
+
+    data = tmp_path / "data.txt"
+    data.write_text("hello", encoding="utf-8")
+    write_manifest_sha256(tmp_path)
+    data.write_text("tampered", encoding="utf-8")
+    ok, reason = verify_manifest_sha256(tmp_path)
+    assert ok is False
+    assert "checksum mismatch" in reason
+
+
+def test_write_and_verify_manifest_roundtrip(tmp_path) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import (
+        verify_manifest_sha256,
+        write_manifest_sha256,
+    )
+
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    write_manifest_sha256(tmp_path)
+    ok, reason = verify_manifest_sha256(tmp_path)
+    assert ok is True, reason


### PR DESCRIPTION
## Summary
- Add `scripts/ops/primary_evidence_retention_v0.py` with shared `write_manifest_sha256` / `verify_manifest_sha256`.
- Wire Paper, Shadow, and Testnet bounded observation adapters to reuse the helper.
- Close Paper adapter gap: verify manifest after durable archive copy.
- Update Preflight §2a reference line only.

## Test plan
- [x] `uv run pytest tests/ops/test_primary_evidence_retention_invariant_contract_v0.py -q` — 19 passed
- [x] `uv run pytest tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py -q` — 28 passed
- [x] `uv run pytest tests/ops/test_run_shadow_bounded_observation_adapter_v0.py -q` — 34 passed
- [x] `uv run pytest tests/ops/test_run_testnet_bounded_observation_adapter_v0.py -q` — 19 passed
- [x] ruff check + ruff format --check on changed Python files

## Safety
- No runtime started.
- No scheduler started.
- No Paper, Shadow, Testnet, P67, P72, Live, Broker, Exchange, Supervisor, or Notion action.
- Non-authorizing retention helpers only.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/primary_evidence_retention_shared_verify_helper_v0_20260521T045012Z/PRIMARY_EVIDENCE_RETENTION_SHARED_VERIFY_HELPER_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/primary_evidence_retention_shared_verify_helper_v0_20260521T045012Z/MANIFEST.sha256`

## Residual risk
This slice only closes the bounded Paper reference gap and consolidates bounded Paper/Shadow/Testnet manifest verification. P67/P72 libraries, scheduler completion, live-pilot session, and online-daemon retention enforcement remain separate follow-up surfaces and must not be solved by parallel contract creation.

Made with [Cursor](https://cursor.com)