### PR TITLE
feat(ops): P67/P72 opt-in primary evidence closeout v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -58,6 +58,8 @@ Future run selectors and adapters must **reject or block** a run plan when prima
 
 Reference implementation: `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` and shared manifest helpers in `scripts/ops/primary_evidence_retention_v0.py` (plan-only default; execute requires approval record; archive root outside `/tmp`; `MANIFEST.sha256` verified after durable copy).
 
+P67/P72 library paths (`run_shadow_session_scheduler_v1`, `run_shadowloop_pack_v1`) write partial evidence by default; opt-in `primary_evidence_enforce=True` calls shared `finalize_primary_evidence_root()` at library completion (non-authorizing; does not clear HOLD or grant Live/Testnet/broker authority; P67 CLI scheduler guard unchanged).
+
 ## 2b. Planning artifact durable retention v0
 
 `PLANNING_ARTIFACT_DURABLE_RETENTION_REQUIRED=true`

--- a/scripts/ops/primary_evidence_retention_v0.py
+++ b/scripts/ops/primary_evidence_retention_v0.py
@@ -42,3 +42,9 @@ def verify_manifest_sha256(root: Path) -> tuple[bool, str]:
         if actual != digest:
             return False, f"checksum mismatch: {rel}"
     return True, ""
+
+
+def finalize_primary_evidence_root(root: Path) -> tuple[bool, str]:
+    """Write MANIFEST.sha256 then verify. Fail closed on verify failure."""
+    write_manifest_sha256(root)
+    return verify_manifest_sha256(root)

--- a/src/ops/p67/shadow_session_scheduler_v1.py
+++ b/src/ops/p67/shadow_session_scheduler_v1.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -31,6 +32,29 @@ class P67RunContextV1:
     iterations: int = 1
     interval_seconds: float = 60.0
     recorded_price_source: Optional[Path] = None
+    primary_evidence_enforce: bool = False
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _maybe_finalize_primary_evidence(ctx: P67RunContextV1) -> None:
+    if not ctx.primary_evidence_enforce:
+        return
+    if ctx.out_dir is None:
+        raise RuntimeError("ERR: primary_evidence_enforce requires out_dir (non-authorizing §2a)")
+    root = ctx.out_dir / f"p67_shadow_session_{ctx.run_id}"
+    if not root.is_dir():
+        raise RuntimeError(f"ERR: primary evidence root missing: {root}")
+    repo_root = _repo_root()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from scripts.ops.primary_evidence_retention_v0 import finalize_primary_evidence_root
+
+    ok, msg = finalize_primary_evidence_root(root)
+    if not ok:
+        raise RuntimeError(f"ERR: primary evidence finalize failed: {msg}")
 
 
 def _utc_ts() -> str:
@@ -131,5 +155,6 @@ def run_shadow_session_scheduler_v1(ctx: P67RunContextV1) -> dict:
             time.sleep(ctx.interval_seconds)
 
     scheduler_meta["ts_utc_end"] = _utc_ts()
+    _maybe_finalize_primary_evidence(ctx)
     res = {"meta": scheduler_meta, "events": events}
     return to_jsonable_v1(res)

--- a/src/ops/p72/run_shadowloop_pack_v1.py
+++ b/src/ops/p72/run_shadowloop_pack_v1.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -20,6 +21,26 @@ class P72PackContextV1:
     allow_bear_strategies: Optional[list[str]] = None
     iterations: int = 1
     interval_seconds: float = 0.0
+    primary_evidence_enforce: bool = False
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _maybe_finalize_pack_primary_evidence(ctx: P72PackContextV1) -> None:
+    if not ctx.primary_evidence_enforce:
+        return
+    if not ctx.out_dir.is_dir():
+        raise RuntimeError(f"ERR: primary evidence pack root missing: {ctx.out_dir}")
+    repo_root = _repo_root()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from scripts.ops.primary_evidence_retention_v0 import finalize_primary_evidence_root
+
+    ok, msg = finalize_primary_evidence_root(ctx.out_dir)
+    if not ok:
+        raise RuntimeError(f"ERR: primary evidence pack finalize failed: {msg}")
 
 
 def run_shadowloop_pack_v1(ctx: P72PackContextV1) -> Dict[str, Any]:
@@ -52,12 +73,15 @@ def run_shadowloop_pack_v1(ctx: P72PackContextV1) -> Dict[str, Any]:
         out_dir=ctx.out_dir,
         iterations=ctx.iterations,
         interval_seconds=ctx.interval_seconds,
+        primary_evidence_enforce=ctx.primary_evidence_enforce,
     )
     loop_out = run_shadow_session_scheduler_v1(p67_ctx)
 
-    return {
+    result = {
         "p72_version": "v1",
         "gate_ok": True,
         "gate_report": gate_report,
         "loop_run": loop_out,
     }
+    _maybe_finalize_pack_primary_evidence(ctx)
+    return result

--- a/tests/ops/test_p67_primary_evidence_closeout_v0.py
+++ b/tests/ops/test_p67_primary_evidence_closeout_v0.py
@@ -1,0 +1,143 @@
+"""Contract tests for P67/P72 opt-in primary evidence closeout (no runtime workloads)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+P67_LIBRARY = REPO_ROOT / "src" / "ops" / "p67" / "shadow_session_scheduler_v1.py"
+P67_CLI = REPO_ROOT / "src" / "ops" / "p67" / "shadow_session_scheduler_cli_v1.py"
+P72_LIBRARY = REPO_ROOT / "src" / "ops" / "p72" / "run_shadowloop_pack_v1.py"
+SHARED_HELPER = REPO_ROOT / "scripts" / "ops" / "primary_evidence_retention_v0.py"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.ops.p67.shadow_session_scheduler_v1 import (
+    P67RunContextV1,
+    run_shadow_session_scheduler_v1,
+)
+from src.ops.p72 import P72PackContextV1, run_shadowloop_pack_v1
+
+
+def test_shared_helper_exposes_finalize_primary_evidence_root() -> None:
+    text = SHARED_HELPER.read_text(encoding="utf-8")
+    assert "def finalize_primary_evidence_root" in text
+    assert "write_manifest_sha256" in text
+    assert "verify_manifest_sha256" in text
+
+
+def test_p67_library_wires_opt_in_enforce_and_shared_helper() -> None:
+    text = P67_LIBRARY.read_text(encoding="utf-8")
+    assert "primary_evidence_enforce: bool = False" in text
+    assert "finalize_primary_evidence_root" in text
+    assert "def verify_manifest_sha256" not in text
+
+
+def test_p72_library_wires_opt_in_enforce_and_passes_through_to_p67() -> None:
+    text = P72_LIBRARY.read_text(encoding="utf-8")
+    assert "primary_evidence_enforce: bool = False" in text
+    assert "primary_evidence_enforce=ctx.primary_evidence_enforce" in text
+    assert "finalize_primary_evidence_root" in text
+
+
+def test_p67_cli_scheduler_guard_preserved() -> None:
+    text = P67_CLI.read_text(encoding="utf-8")
+    guard_idx = text.index("assert_scheduler_start_authorized")
+    run_idx = text.index("run_shadow_session_scheduler_v1(ctx)")
+    assert guard_idx < run_idx
+    assert "scheduler_start_boundary_guard_v0" in text
+
+
+def test_p67_default_backward_compatible_no_manifest_sha256(tmp_path: Path) -> None:
+    run_shadow_session_scheduler_v1(
+        P67RunContextV1(
+            mode="shadow",
+            run_id="compat",
+            out_dir=tmp_path,
+            iterations=1,
+            interval_seconds=0.0,
+        ),
+    )
+    root = tmp_path / "p67_shadow_session_compat"
+    assert (root / "manifest.json").exists()
+    assert not (root / "MANIFEST.sha256").exists()
+
+
+def test_p67_enforce_without_out_dir_fails_closed() -> None:
+    with pytest.raises(RuntimeError, match="primary_evidence_enforce requires out_dir"):
+        run_shadow_session_scheduler_v1(
+            P67RunContextV1(
+                mode="shadow",
+                iterations=1,
+                interval_seconds=0.0,
+                primary_evidence_enforce=True,
+            ),
+        )
+
+
+def test_p67_enforce_writes_and_verifies_manifest_sha256(tmp_path: Path) -> None:
+    run_shadow_session_scheduler_v1(
+        P67RunContextV1(
+            mode="shadow",
+            run_id="enforce",
+            out_dir=tmp_path,
+            iterations=1,
+            interval_seconds=0.0,
+            primary_evidence_enforce=True,
+        ),
+    )
+    root = tmp_path / "p67_shadow_session_enforce"
+    manifest = root / "MANIFEST.sha256"
+    assert manifest.is_file()
+    from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+
+    ok, msg = verify_manifest_sha256(root)
+    assert ok is True, msg
+
+
+def test_p67_enforce_fails_closed_on_finalize_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fail(_root: Path) -> tuple[bool, str]:
+        return False, "checksum mismatch: meta.json"
+
+    monkeypatch.setattr(
+        "scripts.ops.primary_evidence_retention_v0.finalize_primary_evidence_root",
+        _fail,
+    )
+    with pytest.raises(RuntimeError, match="primary evidence finalize failed"):
+        run_shadow_session_scheduler_v1(
+            P67RunContextV1(
+                mode="shadow",
+                run_id="fail",
+                out_dir=tmp_path,
+                iterations=1,
+                interval_seconds=0.0,
+                primary_evidence_enforce=True,
+            ),
+        )
+
+
+def test_p72_enforce_finalizes_pack_root(tmp_path: Path) -> None:
+    out = run_shadowloop_pack_v1(
+        P72PackContextV1(
+            mode="shadow",
+            run_id="pack",
+            out_dir=tmp_path,
+            allow_bull_strategies=["s1"],
+            allow_bear_strategies=["s1"],
+            iterations=1,
+            interval_seconds=0.0,
+            primary_evidence_enforce=True,
+        ),
+    )
+    assert out["gate_ok"] is True
+    assert (tmp_path / "MANIFEST.sha256").is_file()
+    from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+
+    ok, msg = verify_manifest_sha256(tmp_path)
+    assert ok is True, msg

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -125,6 +125,13 @@ def test_shared_helper_module_exists() -> None:
     text = SHARED_HELPER.read_text(encoding="utf-8")
     assert "def write_manifest_sha256" in text
     assert "def verify_manifest_sha256" in text
+    assert "def finalize_primary_evidence_root" in text
+
+
+def test_canonical_owner_references_p67_p72_opt_in_enforce() -> None:
+    text = _owner_text()
+    assert "primary_evidence_enforce=True" in text
+    assert "finalize_primary_evidence_root" in text
 
 
 def test_bounded_adapters_import_shared_helper_not_duplicate_verify() -> None:


### PR DESCRIPTION
## Summary
- Add `finalize_primary_evidence_root()` to the shared primary evidence helper.
- Wire opt-in `primary_evidence_enforce` on P67/P72 library completion paths.
- Preserve backward compatibility with default `primary_evidence_enforce=False`.
- When `primary_evidence_enforce=True`, write and verify `MANIFEST.sha256` fail-closed.
- Document the opt-in hook in Preflight §2a.
- Keep the P67 CLI scheduler boundary guard unchanged.

## Test plan
- [x] `uv run pytest tests/ops/test_p67_primary_evidence_closeout_v0.py tests/ops/test_primary_evidence_retention_invariant_contract_v0.py tests/p67/test_shadow_session_scheduler_v1.py tests/p72/test_p72_smoke.py -q` — 38 passed
- [x] `uv run ruff check` on changed Python files
- [x] `uv run ruff format --check` on changed Python files
- [x] `uv run python scripts/ops/validate_docs_token_policy.py`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh`

## Safety
- No runtime started.
- No scheduler started.
- No P67/P72 workload execution.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, Supervisor, or Notion action.
- Evidence remains non-authorizing; no gate clearance implied.
- Scheduler library bypass remains documented out-of-scope.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/p67_p72_library_primary_evidence_closeout_v0_20260521T054048Z/P67_P72_LIBRARY_PRIMARY_EVIDENCE_CLOSEOUT_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/p67_p72_library_primary_evidence_closeout_v0_20260521T054048Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)