### PR TITLE
feat(ops): scheduler completion primary evidence closeout v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -60,6 +60,8 @@ Reference implementation: `scripts/ops/run_paper_only_bounded_observation_adapte
 
 P67/P72 library paths (`run_shadow_session_scheduler_v1`, `run_shadowloop_pack_v1`) write partial evidence by default; opt-in `primary_evidence_enforce=True` calls shared `finalize_primary_evidence_root()` at library completion (non-authorizing; does not clear HOLD or grant Live/Testnet/broker authority; P67 CLI scheduler guard unchanged).
 
+Scheduler launcher (`scripts/run_scheduler.py`) supports opt-in completion retention via `--evidence-dir` and `--primary-evidence-enforce`, writing `scheduler_completion_closeout_v0.json` and calling shared `finalize_primary_evidence_root()` when enforcement is enabled (default off; dry-run remains planning-only; start boundary guard unchanged).
+
 ## 2b. Planning artifact durable retention v0
 
 `PLANNING_ARTIFACT_DURABLE_RETENTION_REQUIRED=true`

--- a/docs/ops/specs/SCHEDULER_BOUNDARY_HARD_BLOCK_CONTRACT_V0.md
+++ b/docs/ops/specs/SCHEDULER_BOUNDARY_HARD_BLOCK_CONTRACT_V0.md
@@ -78,6 +78,10 @@ Shared guard module: `scripts/ops/scheduler_start_boundary_guard_v0.py` exposes 
 
 Direct calls to `run_shadow_session_scheduler_v1()` (library API, unit tests, P72 pack) bypass the CLI guard. Operators must not treat library bypass as authorized scheduler activation under blocked preflight.
 
+## 7a. Scheduler completion evidence (opt-in)
+
+Scheduler run-completion primary evidence (`MANIFEST.sha256` via shared `finalize_primary_evidence_root()`) is **opt-in** on `scripts/run_scheduler.py` via `--primary-evidence-enforce` and `--evidence-dir`. Default off. Does not alter start guard rules in §3–§4. Completion evidence remains **non-authorizing**.
+
 ## 8. Master V2 / Double Play
 
 ```
@@ -89,3 +93,4 @@ This contract does not authorize Master V2 or Double Play selection or live exec
 ## 9. Revision
 
 - **v0** — Initial hard-block markers + launcher guard requirement.
+- **v0.1** — Document opt-in scheduler completion evidence closeout (§7a); start guard unchanged.

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -28,6 +28,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import signal
 import sys
 import time
@@ -71,6 +72,8 @@ from scripts.ops.scheduler_start_boundary_guard_v0 import (
     assert_scheduler_start_authorized,
 )
 
+SCHEDULER_COMPLETION_CLOSEOUT_FILENAME = "scheduler_completion_closeout_v0.json"
+
 # Globaler Flag für graceful shutdown
 _shutdown_requested = False
 
@@ -80,6 +83,106 @@ def signal_handler(signum, frame):
     global _shutdown_requested
     print("\n[SCHEDULER] Shutdown angefordert...")
     _shutdown_requested = True
+
+
+def _is_under_tmp(path: Path) -> bool:
+    try:
+        resolved = path.resolve()
+        tmp_root = Path("/tmp").resolve()
+        return resolved == tmp_root or tmp_root in resolved.parents
+    except OSError:
+        return str(path).startswith("/tmp")
+
+
+def validate_scheduler_evidence_cli(
+    *,
+    evidence_dir: Optional[Path],
+    primary_evidence_enforce: bool,
+    dry_run: bool,
+) -> Optional[int]:
+    """Return exit code when CLI evidence options are invalid; else None."""
+    if primary_evidence_enforce and evidence_dir is None:
+        print("ERR: --primary-evidence-enforce requires --evidence-dir")
+        return 1
+    if primary_evidence_enforce and dry_run:
+        print("ERR: --primary-evidence-enforce is incompatible with --dry-run")
+        return 1
+    if primary_evidence_enforce and evidence_dir is not None and _is_under_tmp(evidence_dir):
+        print("ERR: --evidence-dir must be outside /tmp when --primary-evidence-enforce is set")
+        return 1
+    return None
+
+
+def write_scheduler_completion_closeout(
+    evidence_dir: Path,
+    *,
+    dry_run: bool,
+    once: bool,
+    config_path: Path,
+    iterations: int,
+    jobs_dispatched: int,
+    exit_status: int,
+) -> None:
+    """Write non-authorizing scheduler completion closeout JSON."""
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": "scheduler_completion_closeout_v0",
+        "evidence_non_authorizing": True,
+        "dry_run": dry_run,
+        "once": once,
+        "config_path": str(config_path),
+        "iterations": iterations,
+        "jobs_dispatched": jobs_dispatched,
+        "exit_status": exit_status,
+        "ts_utc_end": datetime.utcnow().strftime("%Y%m%dT%H%M%SZ"),
+    }
+    closeout_path = evidence_dir / SCHEDULER_COMPLETION_CLOSEOUT_FILENAME
+    closeout_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def finalize_scheduler_completion_evidence(
+    evidence_dir: Optional[Path],
+    *,
+    primary_evidence_enforce: bool,
+    dry_run: bool,
+    once: bool,
+    config_path: Path,
+    iterations: int,
+    jobs_dispatched: int,
+    exit_status: int,
+) -> int:
+    """Write closeout when evidence dir is set; finalize MANIFEST when enforce is on."""
+    if evidence_dir is None and not primary_evidence_enforce:
+        return exit_status
+
+    if evidence_dir is None:
+        print("ERR: --primary-evidence-enforce requires --evidence-dir")
+        return 1
+
+    write_scheduler_completion_closeout(
+        evidence_dir,
+        dry_run=dry_run,
+        once=once,
+        config_path=config_path,
+        iterations=iterations,
+        jobs_dispatched=jobs_dispatched,
+        exit_status=exit_status,
+    )
+
+    if not primary_evidence_enforce:
+        return exit_status
+
+    if dry_run:
+        print("ERR: --primary-evidence-enforce is incompatible with --dry-run")
+        return 1
+
+    from scripts.ops.primary_evidence_retention_v0 import finalize_primary_evidence_root
+
+    ok, msg = finalize_primary_evidence_root(evidence_dir)
+    if not ok:
+        print(f"ERR: primary evidence finalize failed: {msg}")
+        return 1
+    return exit_status
 
 
 def parse_args(argv=None):
@@ -145,6 +248,19 @@ Examples:
 
     parser.add_argument(
         "--alert-log", type=str, default="logs/scheduler_alerts.log", help="Pfad zur Alert-Logdatei"
+    )
+
+    parser.add_argument(
+        "--evidence-dir",
+        type=str,
+        default=None,
+        help="Optional directory for scheduler completion closeout artifacts",
+    )
+
+    parser.add_argument(
+        "--primary-evidence-enforce",
+        action="store_true",
+        help="Require MANIFEST.sha256 finalize at completion (requires --evidence-dir; non-dry-run only)",
     )
 
     return parser.parse_args(argv)
@@ -393,9 +509,15 @@ def run_scheduler_loop(
     verbose: bool,
     use_registry: bool,
     notifier,
+    evidence_dir: Optional[Path] = None,
+    primary_evidence_enforce: bool = False,
 ) -> int:
     """Hauptschleife des Schedulers."""
     global _shutdown_requested
+
+    exit_code = 0
+    iteration = 0
+    total_jobs_run = 0
 
     print("\n" + "=" * 70)
     print("PEAK_TRADE SCHEDULER")
@@ -412,14 +534,33 @@ def run_scheduler_loop(
         all_jobs = load_jobs_from_toml(config_path)
     except FileNotFoundError as e:
         print(f"\nERROR: {e}")
-        return 1
+        exit_code = 1
+        return finalize_scheduler_completion_evidence(
+            evidence_dir,
+            primary_evidence_enforce=primary_evidence_enforce,
+            dry_run=dry_run,
+            once=once,
+            config_path=config_path,
+            iterations=iteration,
+            jobs_dispatched=total_jobs_run,
+            exit_status=exit_code,
+        )
 
     # Jobs filtern
     jobs = filter_jobs_by_tags(all_jobs, include_tags, exclude_tags)
 
     if not jobs:
         print("\nKeine passenden Jobs gefunden.")
-        return 0
+        return finalize_scheduler_completion_evidence(
+            evidence_dir,
+            primary_evidence_enforce=primary_evidence_enforce,
+            dry_run=dry_run,
+            once=once,
+            config_path=config_path,
+            iterations=iteration,
+            jobs_dispatched=total_jobs_run,
+            exit_status=exit_code,
+        )
 
     # Validierung
     for job in jobs:
@@ -437,9 +578,6 @@ def run_scheduler_loop(
     print_job_summary(jobs, now)
 
     # Schleife
-    iteration = 0
-    total_jobs_run = 0
-
     while not _shutdown_requested:
         iteration += 1
         now = datetime.utcnow()
@@ -506,12 +644,32 @@ def run_scheduler_loop(
     print(f"Jobs ausgeführt: {total_jobs_run}")
     print("=" * 70 + "\n")
 
-    return 0
+    return finalize_scheduler_completion_evidence(
+        evidence_dir,
+        primary_evidence_enforce=primary_evidence_enforce,
+        dry_run=dry_run,
+        once=once,
+        config_path=config_path,
+        iterations=iteration,
+        jobs_dispatched=total_jobs_run,
+        exit_status=exit_code,
+    )
 
 
 def main(argv=None) -> int:
     """Main entry point."""
     args = parse_args(argv)
+
+    evidence_dir = Path(args.evidence_dir) if args.evidence_dir else None
+    primary_evidence_enforce = bool(args.primary_evidence_enforce)
+
+    cli_rc = validate_scheduler_evidence_cli(
+        evidence_dir=evidence_dir,
+        primary_evidence_enforce=primary_evidence_enforce,
+        dry_run=args.dry_run,
+    )
+    if cli_rc is not None:
+        return cli_rc
 
     # Signal-Handler registrieren
     signal.signal(signal.SIGINT, signal_handler)
@@ -548,6 +706,8 @@ def main(argv=None) -> int:
         verbose=args.verbose,
         use_registry=use_registry,
         notifier=notifier,
+        evidence_dir=evidence_dir,
+        primary_evidence_enforce=primary_evidence_enforce,
     )
 
 

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -128,6 +128,13 @@ def test_shared_helper_module_exists() -> None:
     assert "def finalize_primary_evidence_root" in text
 
 
+def test_canonical_owner_references_scheduler_completion_opt_in() -> None:
+    text = _owner_text()
+    assert "run_scheduler.py" in text
+    assert "primary-evidence-enforce" in text or "primary_evidence_enforce" in text
+    assert "scheduler_completion_closeout_v0" in text
+
+
 def test_canonical_owner_references_p67_p72_opt_in_enforce() -> None:
     text = _owner_text()
     assert "primary_evidence_enforce=True" in text

--- a/tests/ops/test_scheduler_completion_primary_evidence_closeout_v0.py
+++ b/tests/ops/test_scheduler_completion_primary_evidence_closeout_v0.py
@@ -1,0 +1,222 @@
+"""Contract tests for scheduler completion primary evidence closeout v0."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_SCHEDULER = REPO_ROOT / "scripts" / "run_scheduler.py"
+SHARED_HELPER = REPO_ROOT / "scripts" / "ops" / "primary_evidence_retention_v0.py"
+PREFLIGHT = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+
+
+def _load_run_scheduler():
+    spec = importlib.util.spec_from_file_location("run_scheduler", RUN_SCHEDULER)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["run_scheduler"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def rs():
+    return _load_run_scheduler()
+
+
+def test_cli_flags_present_in_parser(rs) -> None:
+    text = RUN_SCHEDULER.read_text(encoding="utf-8")
+    assert "--evidence-dir" in text
+    assert "--primary-evidence-enforce" in text
+    assert "scheduler_completion_closeout_v0.json" in text
+    assert "finalize_primary_evidence_root" in text
+    assert (
+        "def verify_manifest_sha256"
+        not in text.split("finalize_scheduler_completion_evidence", 1)[0]
+    )
+
+
+def test_validate_enforce_requires_evidence_dir(rs) -> None:
+    assert (
+        rs.validate_scheduler_evidence_cli(
+            evidence_dir=None,
+            primary_evidence_enforce=True,
+            dry_run=False,
+        )
+        == 1
+    )
+
+
+def test_validate_enforce_incompatible_with_dry_run(rs) -> None:
+    assert (
+        rs.validate_scheduler_evidence_cli(
+            evidence_dir=Path("/var/tmp/evidence"),
+            primary_evidence_enforce=True,
+            dry_run=True,
+        )
+        == 1
+    )
+
+
+def test_main_enforce_without_evidence_dir_fails_before_loop(rs, monkeypatch) -> None:
+    loop_calls: list[object] = []
+    monkeypatch.setattr(rs, "run_scheduler_loop", lambda **kwargs: loop_calls.append(kwargs) or 0)
+
+    rc = rs.main(["--once", "--config", "config/scheduler/jobs.toml", "--primary-evidence-enforce"])
+    assert rc == 1
+    assert loop_calls == []
+
+
+def test_main_enforce_with_dry_run_fails_before_loop(rs, monkeypatch) -> None:
+    loop_calls: list[object] = []
+    monkeypatch.setattr(rs, "run_scheduler_loop", lambda **kwargs: loop_calls.append(kwargs) or 0)
+
+    rc = rs.main(
+        [
+            "--dry-run",
+            "--once",
+            "--config",
+            "config/scheduler/jobs.toml",
+            "--evidence-dir",
+            "/var/tmp/evidence",
+            "--primary-evidence-enforce",
+        ],
+    )
+    assert rc == 1
+    assert loop_calls == []
+
+
+def test_main_default_backward_compatible(rs, monkeypatch) -> None:
+    loop_calls: list[dict] = []
+    monkeypatch.setattr(rs, "assert_scheduler_start_authorized", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        rs,
+        "run_scheduler_loop",
+        lambda **kwargs: loop_calls.append(kwargs) or 0,
+    )
+
+    rc = rs.main(["--once", "--config", "config/scheduler/jobs.toml"])
+    assert rc == 0
+    assert len(loop_calls) == 1
+    assert loop_calls[0].get("evidence_dir") is None
+    assert loop_calls[0].get("primary_evidence_enforce") is False
+
+
+def test_loop_enforce_writes_closeout_and_manifest(rs, monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(rs, "load_jobs_from_toml", lambda _path: [])
+    monkeypatch.setattr(rs, "filter_jobs_by_tags", lambda jobs, *_args, **_kwargs: [])
+
+    rc = rs.run_scheduler_loop(
+        Path("config/scheduler/jobs.toml"),
+        poll_interval=30,
+        once=True,
+        include_tags=None,
+        exclude_tags=None,
+        dry_run=False,
+        verbose=False,
+        use_registry=False,
+        notifier=None,
+        evidence_dir=tmp_path,
+        primary_evidence_enforce=True,
+    )
+    assert rc == 0
+    closeout = tmp_path / "scheduler_completion_closeout_v0.json"
+    assert closeout.is_file()
+    payload = json.loads(closeout.read_text(encoding="utf-8"))
+    assert payload["evidence_non_authorizing"] is True
+    assert payload["dry_run"] is False
+    assert (tmp_path / "MANIFEST.sha256").is_file()
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+
+    ok, msg = verify_manifest_sha256(tmp_path)
+    assert ok is True, msg
+
+
+def test_loop_enforce_fails_closed_on_finalize_failure(rs, monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(rs, "load_jobs_from_toml", lambda _path: [])
+    monkeypatch.setattr(rs, "filter_jobs_by_tags", lambda jobs, *_args, **_kwargs: [])
+
+    def _fail(_root: Path) -> tuple[bool, str]:
+        return False, "checksum mismatch: scheduler_completion_closeout_v0.json"
+
+    monkeypatch.setattr(
+        "scripts.ops.primary_evidence_retention_v0.finalize_primary_evidence_root",
+        _fail,
+    )
+
+    rc = rs.run_scheduler_loop(
+        Path("config/scheduler/jobs.toml"),
+        poll_interval=30,
+        once=True,
+        include_tags=None,
+        exclude_tags=None,
+        dry_run=False,
+        verbose=False,
+        use_registry=False,
+        notifier=None,
+        evidence_dir=tmp_path,
+        primary_evidence_enforce=True,
+    )
+    assert rc == 1
+
+
+def test_dry_run_main_skips_guard_and_does_not_enforce(rs, monkeypatch, tmp_path: Path) -> None:
+    guard_calls: list[object] = []
+
+    def _guard(**kwargs):
+        guard_calls.append(kwargs)
+        raise AssertionError("guard must not run for dry-run")
+
+    monkeypatch.setattr(rs, "assert_scheduler_start_authorized", _guard)
+    monkeypatch.setattr(rs, "load_jobs_from_toml", lambda _path: [])
+    monkeypatch.setattr(rs, "filter_jobs_by_tags", lambda jobs, *_args, **_kwargs: [])
+
+    rc = rs.main(
+        [
+            "--dry-run",
+            "--once",
+            "--config",
+            "config/scheduler/jobs.toml",
+            "--evidence-dir",
+            str(tmp_path),
+        ],
+    )
+    assert rc == 0
+    assert guard_calls == []
+    assert (tmp_path / "scheduler_completion_closeout_v0.json").is_file()
+    assert not (tmp_path / "MANIFEST.sha256").exists()
+
+
+def test_non_dry_run_blocked_under_hold_still_exits_2(rs, monkeypatch) -> None:
+    monkeypatch.setattr(
+        rs,
+        "assert_scheduler_start_authorized",
+        lambda **kwargs: (_ for _ in ()).throw(SystemExit(rs.SCHEDULER_START_BLOCKED_EXIT)),
+    )
+    monkeypatch.setattr(rs, "run_scheduler_loop", lambda **kwargs: pytest.fail("loop must not run"))
+
+    with pytest.raises(SystemExit) as exc:
+        rs.main(
+            [
+                "--once",
+                "--config",
+                "config/scheduler/jobs.toml",
+                "--evidence-dir",
+                "/var/tmp/evidence",
+                "--primary-evidence-enforce",
+            ],
+        )
+    assert exc.value.code == rs.SCHEDULER_START_BLOCKED_EXIT
+
+
+def test_preflight_documents_scheduler_completion_opt_in() -> None:
+    text = PREFLIGHT.read_text(encoding="utf-8")
+    assert "scheduler_completion_closeout_v0" in text or "run_scheduler.py" in text
+    assert "primary-evidence-enforce" in text or "primary_evidence_enforce" in text


### PR DESCRIPTION
## Summary
- Add opt-in `--evidence-dir` and `--primary-evidence-enforce` to `scripts/run_scheduler.py`.
- Write `scheduler_completion_closeout_v0.json` and reuse `finalize_primary_evidence_root()` when enforcement is enabled.
- Preserve default backward compatibility.
- Preserve dry-run planning-only behavior.
- Preserve unchanged non-dry-run start boundary guard and HOLD exit 2 behavior.
- Document opt-in hook in Preflight §2a and scheduler boundary spec §7a.

## Test plan
- [x] `uv run pytest tests/ops/test_scheduler_completion_primary_evidence_closeout_v0.py tests/ops/test_scheduler_boundary_hard_block_contract_v0.py tests/test_scheduler_smoke.py tests/ops/test_primary_evidence_retention_invariant_contract_v0.py -q` — 81 passed
- [x] `uv run ruff check` on changed Python files
- [x] `uv run ruff format --check` on changed Python files
- [x] `uv run python scripts/ops/validate_docs_token_policy.py`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh`

## Safety
- No scheduler workload/runtime execution.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, Supervisor, P67, P72, or Notion action.
- Evidence remains non-authorizing; no gate clearance implied.
- Start guard and HOLD exit 2 behavior preserved.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/scheduler_completion_primary_evidence_closeout_v0_20260521T060314Z/SCHEDULER_COMPLETION_PRIMARY_EVIDENCE_CLOSEOUT_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/scheduler_completion_primary_evidence_closeout_v0_20260521T060314Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

## Residual risk
This PR only covers opt-in scheduler completion primary evidence closeout. It does not authorize scheduler starts, runtime starts, live trading, broker/exchange access, online-daemon retention, or any dashboard authority.

Made with [Cursor](https://cursor.com)