### PR TITLE
feat(ops): supervisor evidence pack closeout v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -62,6 +62,8 @@ P67/P72 library paths (`run_shadow_session_scheduler_v1`, `run_shadowloop_pack_v
 
 Scheduler launcher (`scripts/run_scheduler.py`) supports opt-in completion retention via `--evidence-dir` and `--primary-evidence-enforce`, writing `scheduler_completion_closeout_v0.json` and calling shared `finalize_primary_evidence_root()` when enforcement is enabled (default off; dry-run remains planning-only; start boundary guard unchanged).
 
+Offline supervisor/daemon evidence pack: `scripts/ops/pack_online_readiness_supervisor_evidence_v0.py` copies an existing supervisor `OUT_DIR` and optional pid/log artifacts into a durable archive root, writes `supervisor_session_closeout_v0.json`, and may call shared `finalize_primary_evidence_root()` when `--primary-evidence-enforce` is set (operator-invoked after STOP; does not start/stop supervisor, daemon, or launchctl; non-authorizing).
+
 ## 2b. Planning artifact durable retention v0
 
 `PLANNING_ARTIFACT_DURABLE_RETENTION_REQUIRED=true`

--- a/scripts/ops/pack_online_readiness_supervisor_evidence_v0.py
+++ b/scripts/ops/pack_online_readiness_supervisor_evidence_v0.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Offline pack closeout for Online Readiness Supervisor/Daemon evidence (Preflight §2a; non-authorizing).
+
+Operator-invoked after STOP. Does not start/stop supervisor, daemon, or launchctl.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import finalize_primary_evidence_root
+
+CLOSEOUT_FILENAME = "supervisor_session_closeout_v0.json"
+SUPERVISOR_SESSION_DIR = "supervisor_session"
+SUPPORTING_DIR = "supporting"
+
+
+@dataclass
+class OptionalArtifactResult:
+    source: str
+    dest: str
+    status: str
+    reason: str = ""
+
+
+@dataclass
+class PackResult:
+    out_dir: str
+    archive_root: str
+    closeout_path: str
+    supervisor_session_dest: str
+    optional_artifacts: list[OptionalArtifactResult] = field(default_factory=list)
+    primary_evidence_enforce: bool = False
+    manifest_verified: bool = False
+    exit_code: int = 0
+    error: str = ""
+
+
+def _utc_ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _is_under_tmp(path: Path) -> bool:
+    try:
+        resolved = path.resolve()
+        tmp_root = Path("/tmp").resolve()
+        return resolved == tmp_root or tmp_root in resolved.parents
+    except OSError:
+        return str(path).startswith("/tmp")
+
+
+def _copy_file_or_tree(source: Path, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_dir():
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(source, dest)
+    else:
+        shutil.copy2(source, dest)
+
+
+def _copy_optional_artifact(source: Path, supporting_root: Path) -> OptionalArtifactResult:
+    dest = supporting_root / source.name
+    rel_dest = f"{SUPPORTING_DIR}/{source.name}"
+    if not source.exists():
+        return OptionalArtifactResult(
+            source=str(source),
+            dest=rel_dest,
+            status="missing",
+            reason="source path does not exist",
+        )
+    _copy_file_or_tree(source, dest)
+    return OptionalArtifactResult(
+        source=str(source),
+        dest=rel_dest,
+        status="copied",
+    )
+
+
+def pack_supervisor_evidence(
+    *,
+    out_dir: Path,
+    archive_root: Path,
+    optional_artifacts: Sequence[Path] = (),
+    primary_evidence_enforce: bool = False,
+    require_optional_artifacts: bool = False,
+) -> PackResult:
+    """Copy supervisor OUT_DIR and optional artifacts into archive_root; optional MANIFEST finalize."""
+    result = PackResult(
+        out_dir=str(out_dir),
+        archive_root=str(archive_root),
+        closeout_path=str(archive_root / CLOSEOUT_FILENAME),
+        supervisor_session_dest=str(archive_root / SUPERVISOR_SESSION_DIR),
+        primary_evidence_enforce=primary_evidence_enforce,
+    )
+
+    if not out_dir.is_dir():
+        result.exit_code = 1
+        result.error = f"out_dir missing or not a directory: {out_dir}"
+        return result
+
+    if primary_evidence_enforce and _is_under_tmp(archive_root):
+        result.exit_code = 1
+        result.error = "archive_root must be outside /tmp when --primary-evidence-enforce is set"
+        return result
+
+    archive_root.mkdir(parents=True, exist_ok=True)
+    session_dest = archive_root / SUPERVISOR_SESSION_DIR
+    if session_dest.exists():
+        shutil.rmtree(session_dest)
+    shutil.copytree(out_dir, session_dest)
+
+    supporting_root = archive_root / SUPPORTING_DIR
+    supporting_root.mkdir(parents=True, exist_ok=True)
+    for src in optional_artifacts:
+        artifact = _copy_optional_artifact(src, supporting_root)
+        result.optional_artifacts.append(artifact)
+        if require_optional_artifacts and artifact.status == "missing":
+            result.exit_code = 1
+            result.error = f"required optional artifact missing: {src}"
+            _write_closeout(archive_root, result)
+            return result
+
+    _write_closeout(archive_root, result)
+
+    if primary_evidence_enforce:
+        ok, msg = finalize_primary_evidence_root(archive_root)
+        result.manifest_verified = ok
+        if not ok:
+            result.exit_code = 1
+            result.error = f"primary evidence finalize failed: {msg}"
+            _write_closeout(archive_root, result)
+            return result
+
+    return result
+
+
+def _write_closeout(archive_root: Path, result: PackResult) -> None:
+    payload = {
+        "version": "supervisor_session_closeout_v0",
+        "evidence_non_authorizing": True,
+        "ts_utc": _utc_ts(),
+        "out_dir": result.out_dir,
+        "archive_root": result.archive_root,
+        "supervisor_session_dest": result.supervisor_session_dest,
+        "primary_evidence_enforce": result.primary_evidence_enforce,
+        "manifest_verified": result.manifest_verified,
+        "optional_artifacts": [
+            {
+                "source": a.source,
+                "dest": a.dest,
+                "status": a.status,
+                "reason": a.reason,
+            }
+            for a in result.optional_artifacts
+        ],
+        "exit_code": result.exit_code,
+        "error": result.error or None,
+    }
+    closeout = archive_root / CLOSEOUT_FILENAME
+    closeout.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    result.closeout_path = str(closeout)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Pack Online Readiness Supervisor/Daemon evidence into a durable archive "
+            "(non-authorizing; operator-invoked after STOP)."
+        ),
+    )
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        type=Path,
+        help="Existing supervisor OUT_DIR under out/ops/ containing tick artifacts",
+    )
+    parser.add_argument(
+        "--archive-root",
+        required=True,
+        type=Path,
+        help="Durable destination root for packed evidence",
+    )
+    parser.add_argument(
+        "--optional-artifact",
+        action="append",
+        default=[],
+        type=Path,
+        help="Optional pid/log/lock/stdout/stderr source path (repeatable)",
+    )
+    parser.add_argument(
+        "--primary-evidence-enforce",
+        action="store_true",
+        help="Write and verify MANIFEST.sha256 via shared helper (archive-root outside /tmp)",
+    )
+    parser.add_argument(
+        "--require-optional-artifacts",
+        action="store_true",
+        help="Fail closed when any --optional-artifact path is missing",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(list(argv) if argv is not None else None)
+    result = pack_supervisor_evidence(
+        out_dir=args.out_dir,
+        archive_root=args.archive_root,
+        optional_artifacts=tuple(args.optional_artifact or []),
+        primary_evidence_enforce=bool(args.primary_evidence_enforce),
+        require_optional_artifacts=bool(args.require_optional_artifacts),
+    )
+    if result.error:
+        print(f"ERR: {result.error}", file=sys.stderr)
+    print(f"SUPERVISOR_EVIDENCE_PACK_RC={result.exit_code}")
+    print(f"CLOSEOUT_PATH={result.closeout_path}")
+    print(f"MANIFEST_VERIFIED={str(result.manifest_verified).lower()}")
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py
+++ b/tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py
@@ -1,0 +1,177 @@
+"""Contract tests for offline supervisor evidence pack closeout (no runtime workloads)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACK_SCRIPT = REPO_ROOT / "scripts" / "ops" / "pack_online_readiness_supervisor_evidence_v0.py"
+SHARED_HELPER = REPO_ROOT / "scripts" / "ops" / "primary_evidence_retention_v0.py"
+PREFLIGHT = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.ops.pack_online_readiness_supervisor_evidence_v0 import (
+    CLOSEOUT_FILENAME,
+    pack_supervisor_evidence,
+)
+
+
+def test_pack_script_exists_and_reuses_shared_helper() -> None:
+    text = PACK_SCRIPT.read_text(encoding="utf-8")
+    assert "finalize_primary_evidence_root" in text
+    assert "subprocess" not in text
+    assert "launchctl " not in text
+    assert "def verify_manifest_sha256" not in text
+
+
+def test_pack_copies_out_dir_and_writes_closeout(tmp_path: Path) -> None:
+    out_dir = tmp_path / "supervisor_out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text('{"version":"test"}\n', encoding="utf-8")
+    tick = out_dir / "tick_20260101T000000Z"
+    tick.mkdir()
+    (tick / "P76_RESULT.txt").write_text("P76_READY\n", encoding="utf-8")
+
+    archive = tmp_path / "archive"
+    result = pack_supervisor_evidence(out_dir=out_dir, archive_root=archive)
+
+    assert result.exit_code == 0
+    assert (archive / "supervisor_session" / "supervisor_meta.json").is_file()
+    assert (archive / "supervisor_session" / "tick_20260101T000000Z" / "P76_RESULT.txt").is_file()
+    closeout = json.loads((archive / CLOSEOUT_FILENAME).read_text(encoding="utf-8"))
+    assert closeout["evidence_non_authorizing"] is True
+    assert closeout["manifest_verified"] is False
+    assert not (archive / "MANIFEST.sha256").exists()
+
+
+def test_pack_records_missing_optional_artifact_without_enforce(tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text("{}\n", encoding="utf-8")
+
+    missing = tmp_path / "missing.pid"
+    archive = tmp_path / "archive"
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=archive,
+        optional_artifacts=(missing,),
+    )
+
+    assert result.exit_code == 0
+    assert len(result.optional_artifacts) == 1
+    assert result.optional_artifacts[0].status == "missing"
+    closeout = json.loads((archive / CLOSEOUT_FILENAME).read_text(encoding="utf-8"))
+    assert closeout["optional_artifacts"][0]["status"] == "missing"
+
+
+def test_pack_copies_optional_artifact_when_present(tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "P78_SUPERVISOR.ndjson").write_text('{"tick":1}\n', encoding="utf-8")
+
+    pidfile = tmp_path / "supervisor.pid"
+    pidfile.write_text("12345\n", encoding="utf-8")
+
+    archive = tmp_path / "archive"
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=archive,
+        optional_artifacts=(pidfile,),
+    )
+
+    assert result.exit_code == 0
+    assert (archive / "supporting" / "supervisor.pid").read_text(encoding="utf-8") == "12345\n"
+    assert result.optional_artifacts[0].status == "copied"
+
+
+def test_pack_enforce_writes_and_verifies_manifest(tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text("{}\n", encoding="utf-8")
+
+    archive = tmp_path / "archive"
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=archive,
+        primary_evidence_enforce=True,
+    )
+
+    assert result.exit_code == 0
+    assert result.manifest_verified is True
+    assert (archive / "MANIFEST.sha256").is_file()
+
+    from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+
+    ok, msg = verify_manifest_sha256(archive)
+    assert ok is True, msg
+
+
+def test_pack_enforce_fails_closed_on_missing_out_dir(tmp_path: Path) -> None:
+    result = pack_supervisor_evidence(
+        out_dir=tmp_path / "missing",
+        archive_root=tmp_path / "archive",
+        primary_evidence_enforce=True,
+    )
+    assert result.exit_code == 1
+    assert "out_dir missing" in result.error
+
+
+def test_pack_enforce_fails_closed_on_finalize_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "meta.json").write_text("{}\n", encoding="utf-8")
+
+    def _fail(_root: Path) -> tuple[bool, str]:
+        return False, "checksum mismatch"
+
+    monkeypatch.setattr(
+        "scripts.ops.pack_online_readiness_supervisor_evidence_v0.finalize_primary_evidence_root",
+        _fail,
+    )
+
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=tmp_path / "archive",
+        primary_evidence_enforce=True,
+    )
+    assert result.exit_code == 1
+    assert "finalize failed" in result.error
+
+
+def test_pack_enforce_rejects_tmp_archive_root(tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "meta.json").write_text("{}\n", encoding="utf-8")
+
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=Path("/tmp/supervisor_pack_test"),
+        primary_evidence_enforce=True,
+    )
+    assert result.exit_code == 1
+    assert "outside /tmp" in result.error
+
+
+def test_cli_main_parses_without_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import scripts.ops.pack_online_readiness_supervisor_evidence_v0 as mod
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text("{}\n", encoding="utf-8")
+    archive = tmp_path / "archive"
+
+    rc = mod.main(["--out-dir", str(out_dir), "--archive-root", str(archive)])
+    assert rc == 0
+
+
+def test_preflight_documents_supervisor_pack_closeout() -> None:
+    text = PREFLIGHT.read_text(encoding="utf-8")
+    assert "pack_online_readiness_supervisor_evidence_v0.py" in text

--- a/tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py
+++ b/tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -20,6 +21,21 @@ from scripts.ops.pack_online_readiness_supervisor_evidence_v0 import (
     CLOSEOUT_FILENAME,
     pack_supervisor_evidence,
 )
+
+
+def _durable_archive(tmp_path: Path) -> Path:
+    # pytest tmp_path on Linux CI lives under /tmp; pack rejects archive roots there.
+    path = REPO_ROOT / "tests" / ".pytest_archive_roots" / tmp_path.name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_durable_archive_dirs() -> None:
+    yield
+    archive_roots = REPO_ROOT / "tests" / ".pytest_archive_roots"
+    if archive_roots.is_dir():
+        shutil.rmtree(archive_roots, ignore_errors=True)
 
 
 def test_pack_script_exists_and_reuses_shared_helper() -> None:
@@ -95,7 +111,7 @@ def test_pack_enforce_writes_and_verifies_manifest(tmp_path: Path) -> None:
     out_dir.mkdir()
     (out_dir / "supervisor_meta.json").write_text("{}\n", encoding="utf-8")
 
-    archive = tmp_path / "archive"
+    archive = _durable_archive(tmp_path)
     result = pack_supervisor_evidence(
         out_dir=out_dir,
         archive_root=archive,
@@ -139,7 +155,7 @@ def test_pack_enforce_fails_closed_on_finalize_failure(
 
     result = pack_supervisor_evidence(
         out_dir=out_dir,
-        archive_root=tmp_path / "archive",
+        archive_root=_durable_archive(tmp_path),
         primary_evidence_enforce=True,
     )
     assert result.exit_code == 1

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -135,6 +135,12 @@ def test_canonical_owner_references_scheduler_completion_opt_in() -> None:
     assert "scheduler_completion_closeout_v0" in text
 
 
+def test_canonical_owner_references_supervisor_pack_closeout() -> None:
+    text = _owner_text()
+    assert "pack_online_readiness_supervisor_evidence_v0.py" in text
+    assert "supervisor_session_closeout_v0" in text
+
+
 def test_canonical_owner_references_p67_p72_opt_in_enforce() -> None:
     text = _owner_text()
     assert "primary_evidence_enforce=True" in text


### PR DESCRIPTION
## Summary
- Add offline `pack_online_readiness_supervisor_evidence_v0.py` for operator-invoked supervisor evidence packing after STOP.
- Copy supervisor `OUT_DIR` and optional pid/log artifacts into a durable archive root.
- Write `supervisor_session_closeout_v0.json`.
- Support opt-in `finalize_primary_evidence_root()` through the shared primary evidence helper.
- Document the packer in Preflight §2a.
- No supervisor, daemon, or launchctl behavior changes.

## Test plan
- [x] `uv run pytest tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py tests/ops/test_primary_evidence_retention_invariant_contract_v0.py -q` — 32 passed
- [x] `uv run ruff check` on changed Python files
- [x] `uv run ruff format --check` on changed Python files
- [x] `uv run python scripts/ops/validate_docs_token_policy.py`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh`

## Safety
- No runtime started.
- No scheduler started.
- No supervisor or daemon start/stop.
- No `launchctl`.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, P67, P72, or Notion action.
- Copy-only; source artifacts are preserved.
- Evidence remains non-authorizing; no gate clearance implied.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/supervisor_evidence_pack_closeout_v0_20260521T062923Z/SUPERVISOR_EVIDENCE_PACK_CLOSEOUT_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/supervisor_evidence_pack_closeout_v0_20260521T062923Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)