### PR TITLE
feat(ops): P79 offline supervisor evidence manifest gate v0

### DIFF
--- a/docs/ops/ai/online_readiness_supervisor_health_gate_runbook_v1.md
+++ b/docs/ops/ai/online_readiness_supervisor_health_gate_runbook_v1.md
@@ -1,22 +1,53 @@
 # Online Readiness — Supervisor Health Gate v1 (P79)
 
 ## Purpose
-Validate that the P78 supervisor (or P77 daemon) is healthy: ticks are recent, pidfile is valid (if present), and P76 artifacts exist per tick.
+Validate supervisor health in one of two **mutually exclusive** modes:
 
-## Prerequisites
+1. **Runtime tick mode** — P78 supervisor (or P77 daemon) is healthy: ticks are recent, pidfile is valid (if present), and P76 artifacts exist per tick.
+2. **Offline archive mode** — packed supervisor evidence from `pack_online_readiness_supervisor_evidence_v0.py` has valid `supervisor_session_closeout_v0.json` and verifiable `MANIFEST.sha256` (non-authorizing; no supervisor/daemon start).
+
+## Runtime tick mode
+
+### Prerequisites
 - `OUT_DIR` contains `tick_*` subdirs (from P78 supervisor)
 - Each tick dir should have at least one of: `P76_RESULT.txt`, `ONLINE_READINESS_ENV.json`, `P71_GATE.log`, `P72_PACK.log`, `readiness_report.json`, `manifest.json`
 
-## Invocation
+### Invocation
 ```bash
 MODE=shadow OUT_DIR=/path/to/supervisor/out MAX_AGE_SEC=300 \
   bash scripts/ops/p79_supervisor_health_gate_v1.sh
 ```
 
+### Evidence
+- `OUT_DIR&#47;p79_health_gate_v1.json` — JSON with mode, newest_tick, age_sec, etc.
+
+## Offline archive evidence-pack mode
+
+### Prerequisites
+- `ARCHIVE_ROOT` is the durable archive root produced by `pack_online_readiness_supervisor_evidence_v0.py`
+- `supervisor_session_closeout_v0.json` present with successful pack `exit_code`
+- `MANIFEST.sha256` present and verifiable via shared `verify_manifest_sha256()`
+
+### Invocation
+```bash
+ARCHIVE_ROOT=/path/to/supervisor/evidence/archive \
+  bash scripts/ops/p79_supervisor_health_gate_v1.sh
+```
+
+Direct helper (same semantics):
+
+```bash
+python3 scripts/ops/p79_supervisor_evidence_manifest_verify_v0.py \
+  --archive-root /path/to/supervisor/evidence/archive
+```
+
+### Evidence
+- `ARCHIVE_ROOT&#47;p79_health_gate_v1.json` — JSON with `gate_mode: archive_evidence_pack`, `manifest_verified`, `evidence_non_authorizing: true`
+
 ## Exit Codes
 - `0` — gate OK
-- `2` — usage/config error (missing MODE, OUT_DIR, invalid mode)
-- `3` — gate failed (stale ticks, stale pidfile, missing artifacts)
+- `2` — usage/config error (missing MODE/OUT_DIR, invalid mode, ARCHIVE_ROOT + OUT_DIR both set)
+- `3` — gate failed (stale ticks, stale pidfile, missing artifacts, or archive manifest/closeout failure)
 
-## Evidence
-- `OUT_DIR&#47;p79_health_gate_v1.json` — JSON with mode, newest_tick, age_sec, etc.
+## Non-authorizing
+P79 success means structural health or evidence-pack integrity only. It does **not** clear HOLD, preflight BLOCKED, or grant Live/Testnet/broker authority.

--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -64,6 +64,8 @@ Scheduler launcher (`scripts/run_scheduler.py`) supports opt-in completion reten
 
 Offline supervisor/daemon evidence pack: `scripts/ops/pack_online_readiness_supervisor_evidence_v0.py` copies an existing supervisor `OUT_DIR` and optional pid/log artifacts into a durable archive root, writes `supervisor_session_closeout_v0.json`, and may call shared `finalize_primary_evidence_root()` when `--primary-evidence-enforce` is set (operator-invoked after STOP; does not start/stop supervisor, daemon, or launchctl; non-authorizing).
 
+P79 offline archive manifest gate: `scripts/ops/p79_supervisor_health_gate_v1.sh` with `ARCHIVE_ROOT` (or `scripts/ops/p79_supervisor_evidence_manifest_verify_v0.py`) validates packed supervisor evidence (`supervisor_session_closeout_v0.json` + `MANIFEST.sha256` via shared `verify_manifest_sha256()`); mutually exclusive with runtime tick mode; non-authorizing; does not start/stop supervisor, daemon, or launchctl.
+
 ## 2b. Planning artifact durable retention v0
 
 `PLANNING_ARTIFACT_DURABLE_RETENTION_REQUIRED=true`

--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -221,6 +221,7 @@ Normative state (post supervisor evidence pack closeout #3590):
 - Live-pilot / production retention hooks remain out of scope for this taxonomy index.
 - Direct library calls to `run_shadow_session_scheduler_v1()` still bypass CLI scheduler guard (`SCHEDULER_LIBRARY_BYPASS_RESIDUAL=true`).
 - Registry PASS, dashboard status, and readiness aggregate verdicts remain **non-authorizing**.
+- P79 offline archive mode (`ARCHIVE_ROOT` on `p79_supervisor_health_gate_v1.sh`) validates pack closeout + `MANIFEST.sha256`; runtime tick mode unchanged.
 
 ## 8. Canary and Live-Canary lanes
 

--- a/scripts/ops/p79_supervisor_evidence_manifest_verify_v0.py
+++ b/scripts/ops/p79_supervisor_evidence_manifest_verify_v0.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Offline P79 archive manifest verification for supervisor evidence packs (non-authorizing)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.pack_online_readiness_supervisor_evidence_v0 import CLOSEOUT_FILENAME
+from scripts.ops.primary_evidence_retention_v0 import MANIFEST_FILENAME, verify_manifest_sha256
+
+GATE_EVIDENCE_FILENAME = "p79_health_gate_v1.json"
+ARCHIVE_GATE_MODE = "archive_evidence_pack"
+
+
+@dataclass
+class ArchiveGateResult:
+    archive_root: str
+    closeout_path: str
+    evidence_path: str
+    gate_mode: str
+    closeout_parse_ok: bool
+    manifest_verified: bool
+    evidence_non_authorizing: bool
+    exit_code: int
+    error: str = ""
+
+
+def verify_supervisor_evidence_archive(archive_root: Path) -> ArchiveGateResult:
+    """Validate packed supervisor evidence: closeout JSON + MANIFEST.sha256 via shared helper."""
+    result = ArchiveGateResult(
+        archive_root=str(archive_root),
+        closeout_path=str(archive_root / CLOSEOUT_FILENAME),
+        evidence_path=str(archive_root / GATE_EVIDENCE_FILENAME),
+        gate_mode=ARCHIVE_GATE_MODE,
+        closeout_parse_ok=False,
+        manifest_verified=False,
+        evidence_non_authorizing=True,
+        exit_code=0,
+    )
+
+    if not archive_root.is_dir():
+        result.exit_code = 1
+        result.error = f"archive_root missing or not a directory: {archive_root}"
+        return result
+
+    closeout_path = archive_root / CLOSEOUT_FILENAME
+    if not closeout_path.is_file():
+        result.exit_code = 1
+        result.error = f"{CLOSEOUT_FILENAME} missing"
+        return result
+
+    try:
+        closeout = json.loads(closeout_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        result.exit_code = 1
+        result.error = f"{CLOSEOUT_FILENAME} not parseable: {exc}"
+        return result
+
+    result.closeout_parse_ok = True
+
+    if closeout.get("version") != "supervisor_session_closeout_v0":
+        result.exit_code = 1
+        result.error = "closeout version mismatch (expected supervisor_session_closeout_v0)"
+        return result
+
+    if closeout.get("exit_code", 0) != 0:
+        result.exit_code = 1
+        result.error = f"closeout records pack failure: {closeout.get('error') or 'unknown'}"
+        return result
+
+    if closeout.get("error"):
+        result.exit_code = 1
+        result.error = f"closeout records error: {closeout['error']}"
+        return result
+
+    manifest_path = archive_root / MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        result.exit_code = 1
+        result.error = f"{MANIFEST_FILENAME} missing"
+        return result
+
+    ok, msg = verify_manifest_sha256(archive_root)
+    result.manifest_verified = ok
+    if not ok:
+        result.exit_code = 1
+        result.error = f"manifest verify failed: {msg}"
+        return result
+
+    return result
+
+
+def write_archive_gate_evidence(archive_root: Path, result: ArchiveGateResult) -> None:
+    payload = {
+        "version": "p79_health_gate_v1",
+        "gate_mode": result.gate_mode,
+        "ts_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "archive_root": result.archive_root,
+        "closeout_path": result.closeout_path,
+        "closeout_parse_ok": result.closeout_parse_ok,
+        "manifest_verified": result.manifest_verified,
+        "evidence_non_authorizing": result.evidence_non_authorizing,
+        "overall_ok": result.exit_code == 0,
+        "exit_code": result.exit_code,
+        "error": result.error or None,
+    }
+    evidence_path = archive_root / GATE_EVIDENCE_FILENAME
+    evidence_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    result.evidence_path = str(evidence_path)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline P79 verification of supervisor evidence pack archive "
+            "(closeout JSON + MANIFEST.sha256; non-authorizing)."
+        ),
+    )
+    parser.add_argument(
+        "--archive-root",
+        required=True,
+        type=Path,
+        help="Packed supervisor evidence archive root from pack_online_readiness_supervisor_evidence_v0.py",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    result = verify_supervisor_evidence_archive(args.archive_root)
+    write_archive_gate_evidence(args.archive_root, result)
+    if result.error:
+        print(f"P79_GATE_FAIL: {result.error}", file=sys.stderr)
+        print(f"P79_ARCHIVE_GATE_RC=3")
+        return 3
+
+    print(f"P79_GATE_OK archive_root={result.archive_root} manifest_verified=true")
+    print("P79_ARCHIVE_GATE_RC=0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/p79_supervisor_health_gate_v1.sh
+++ b/scripts/ops/p79_supervisor_health_gate_v1.sh
@@ -1,35 +1,50 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# P79 — Supervisor Health Gate v1 (paper/shadow only)
+# P79 — Supervisor Health Gate v1 (paper/shadow runtime OR offline archive evidence pack)
 #
 # Exit codes:
 #   0 = OK
 #   2 = usage / config error
-#   3 = gate failed
+#   3 = gate failed (runtime mode)
 #
-# Env:
+# Runtime mode env:
 #   MODE                (required) paper|shadow
 #   OUT_DIR             (required) supervisor output dir (contains tick_*/)
 #   PIDFILE             (optional) pidfile path to validate (must be live if present)
 #   MAX_AGE_SEC         (optional) max allowed age for newest tick dir (default 300)
 #   REQUIRE_P76_FILES   (optional) 1 to require P76 artifacts per tick (default 1)
 #
+# Offline archive mode env (mutually exclusive with OUT_DIR runtime mode):
+#   ARCHIVE_ROOT        packed supervisor evidence directory (closeout + MANIFEST.sha256)
+#
 # Evidence:
-#   Writes to OUT_DIR/p79_health_gate_v1.json (json) and prints P79_GATE_OK / P79_GATE_FAIL
+#   Runtime: OUT_DIR/p79_health_gate_v1.json
+#   Archive: ARCHIVE_ROOT/p79_health_gate_v1.json
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 die_usage() { echo "P79_USAGE: $*" >&2; exit 2; }
 fail_gate()  { echo "P79_GATE_FAIL: $*" >&2; exit 3; }
 
 MODE="${MODE:-}"
 OUT_DIR="${OUT_DIR:-}"
+ARCHIVE_ROOT="${ARCHIVE_ROOT:-}"
 PIDFILE="${PIDFILE:-}"
 MAX_AGE_SEC="${MAX_AGE_SEC:-300}"
 REQUIRE_P76_FILES="${REQUIRE_P76_FILES:-1}"
 
-[ -n "${MODE}" ] || die_usage "MODE required (paper|shadow)"
+if [ -n "${ARCHIVE_ROOT}" ]; then
+  [ -z "${OUT_DIR}" ] || die_usage "ARCHIVE_ROOT mode is mutually exclusive with OUT_DIR runtime mode"
+  [ -d "${ARCHIVE_ROOT}" ] || fail_gate "archive_root_missing: ${ARCHIVE_ROOT}"
+  rc=0
+  python3 "${ROOT}/scripts/ops/p79_supervisor_evidence_manifest_verify_v0.py" \
+    --archive-root "${ARCHIVE_ROOT}" || rc=$?
+  exit "${rc}"
+fi
+
+[ -n "${MODE}" ] || die_usage "MODE required (paper|shadow) unless ARCHIVE_ROOT is set"
 [ "${MODE}" = "paper" ] || [ "${MODE}" = "shadow" ] || fail_gate "mode_not_allowed: ${MODE} (paper|shadow only)"
-[ -n "${OUT_DIR}" ] || die_usage "OUT_DIR required"
+[ -n "${OUT_DIR}" ] || die_usage "OUT_DIR required unless ARCHIVE_ROOT is set"
 [ -d "${OUT_DIR}" ] || fail_gate "out_dir_missing: ${OUT_DIR}"
 
 # pidfile validation (if provided + exists)
@@ -107,6 +122,7 @@ import time
 path, mode, out_dir, pidfile, pid, max_age, age, newest, miss = sys.argv[1:10]
 doc = {
     "version": "p79_health_gate_v1",
+    "gate_mode": "runtime_ticks",
     "ts_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     "mode": mode,
     "out_dir": out_dir,
@@ -116,6 +132,7 @@ doc = {
     "newest_tick": newest,
     "newest_tick_age_sec": int(age),
     "missing_tick_artifacts": int(miss),
+    "evidence_non_authorizing": True,
     "overall_ok": True,
 }
 parent = os.path.dirname(path)

--- a/tests/ops/test_p79_supervisor_primary_evidence_manifest_gate_v0.py
+++ b/tests/ops/test_p79_supervisor_primary_evidence_manifest_gate_v0.py
@@ -1,0 +1,171 @@
+"""Contract tests for P79 offline supervisor evidence pack manifest gate (no runtime workloads)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+P79_SHELL = REPO_ROOT / "scripts" / "ops" / "p79_supervisor_health_gate_v1.sh"
+P79_VERIFY = REPO_ROOT / "scripts" / "ops" / "p79_supervisor_evidence_manifest_verify_v0.py"
+PACK_SCRIPT = REPO_ROOT / "scripts" / "ops" / "pack_online_readiness_supervisor_evidence_v0.py"
+PREFLIGHT = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.ops.pack_online_readiness_supervisor_evidence_v0 import (
+    CLOSEOUT_FILENAME,
+    pack_supervisor_evidence,
+)
+from scripts.ops.p79_supervisor_evidence_manifest_verify_v0 import (
+    ARCHIVE_GATE_MODE,
+    verify_supervisor_evidence_archive,
+)
+from scripts.ops.primary_evidence_retention_v0 import MANIFEST_FILENAME
+
+
+def _durable_archive(tmp_path: Path) -> Path:
+    path = REPO_ROOT / "tests" / ".pytest_archive_roots" / tmp_path.name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_durable_archive_dirs() -> None:
+    yield
+    archive_roots = REPO_ROOT / "tests" / ".pytest_archive_roots"
+    if archive_roots.is_dir():
+        shutil.rmtree(archive_roots, ignore_errors=True)
+
+
+def _build_valid_pack(tmp_path: Path) -> Path:
+    out_dir = tmp_path / "supervisor_out"
+    out_dir.mkdir()
+    tick = out_dir / "tick_20260101T000000Z"
+    tick.mkdir()
+    (tick / "manifest.json").write_text("{}\n", encoding="utf-8")
+    (tick / "P76_RESULT.txt").write_text("P76_READY\n", encoding="utf-8")
+
+    archive = _durable_archive(tmp_path)
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=archive,
+        primary_evidence_enforce=True,
+    )
+    assert result.exit_code == 0, result.error
+    return archive
+
+
+def test_verify_module_reuses_shared_helper_not_duplicate() -> None:
+    text = P79_VERIFY.read_text(encoding="utf-8")
+    assert "verify_manifest_sha256" in text
+    assert "primary_evidence_retention_v0" in text
+    assert "def verify_manifest_sha256" not in text
+    assert "launchctl" not in text
+    assert "subprocess" not in text
+
+
+def test_shell_documents_archive_root_mode() -> None:
+    text = P79_SHELL.read_text(encoding="utf-8")
+    assert "ARCHIVE_ROOT" in text
+    assert "mutually exclusive" in text
+    assert "p79_supervisor_evidence_manifest_verify_v0.py" in text
+
+
+def test_archive_mode_accepts_valid_pack(tmp_path: Path) -> None:
+    archive = _build_valid_pack(tmp_path)
+    result = verify_supervisor_evidence_archive(archive)
+    assert result.exit_code == 0
+    assert result.manifest_verified is True
+    assert result.closeout_parse_ok is True
+    assert result.gate_mode == ARCHIVE_GATE_MODE
+    assert (archive / CLOSEOUT_FILENAME).is_file()
+    assert (archive / MANIFEST_FILENAME).is_file()
+
+
+def test_archive_mode_fails_missing_manifest(tmp_path: Path) -> None:
+    archive = _build_valid_pack(tmp_path)
+    (archive / MANIFEST_FILENAME).unlink()
+    result = verify_supervisor_evidence_archive(archive)
+    assert result.exit_code != 0
+    assert result.manifest_verified is False
+    assert "MANIFEST.sha256 missing" in result.error
+
+
+def test_archive_mode_fails_manifest_mismatch(tmp_path: Path) -> None:
+    archive = _build_valid_pack(tmp_path)
+    session_file = archive / "supervisor_session" / "tick_20260101T000000Z" / "P76_RESULT.txt"
+    session_file.write_text("tampered\n", encoding="utf-8")
+    result = verify_supervisor_evidence_archive(archive)
+    assert result.exit_code != 0
+    assert result.manifest_verified is False
+    assert "manifest verify failed" in result.error
+
+
+def test_archive_mode_fails_missing_closeout(tmp_path: Path) -> None:
+    archive = _build_valid_pack(tmp_path)
+    (archive / CLOSEOUT_FILENAME).unlink()
+    result = verify_supervisor_evidence_archive(archive)
+    assert result.exit_code != 0
+    assert "supervisor_session_closeout_v0.json missing" in result.error
+
+
+def test_archive_mode_fails_closeout_pack_failure(tmp_path: Path) -> None:
+    archive = _build_valid_pack(tmp_path)
+    closeout = json.loads((archive / CLOSEOUT_FILENAME).read_text(encoding="utf-8"))
+    closeout["exit_code"] = 1
+    closeout["error"] = "pack failed"
+    (archive / CLOSEOUT_FILENAME).write_text(json.dumps(closeout) + "\n", encoding="utf-8")
+    result = verify_supervisor_evidence_archive(archive)
+    assert result.exit_code != 0
+    assert "pack failure" in result.error
+
+
+def test_missing_optional_supporting_does_not_false_pass_on_closeout_error(tmp_path: Path) -> None:
+    archive = _build_valid_pack(tmp_path)
+    closeout = json.loads((archive / CLOSEOUT_FILENAME).read_text(encoding="utf-8"))
+    closeout["optional_artifacts"] = [
+        {
+            "source": "/tmp/missing.pid",
+            "dest": "supporting/missing.pid",
+            "status": "missing",
+            "reason": "x",
+        }
+    ]
+    closeout["error"] = "required optional artifact missing"
+    closeout["exit_code"] = 1
+    (archive / CLOSEOUT_FILENAME).write_text(json.dumps(closeout) + "\n", encoding="utf-8")
+    result = verify_supervisor_evidence_archive(archive)
+    assert result.exit_code != 0
+
+
+def test_cli_main_writes_non_authorizing_evidence(tmp_path: Path) -> None:
+    import scripts.ops.p79_supervisor_evidence_manifest_verify_v0 as mod
+
+    archive = _build_valid_pack(tmp_path)
+    rc = mod.main(["--archive-root", str(archive)])
+    assert rc == 0
+    evidence = json.loads((archive / "p79_health_gate_v1.json").read_text(encoding="utf-8"))
+    assert evidence["evidence_non_authorizing"] is True
+    assert evidence["gate_mode"] == ARCHIVE_GATE_MODE
+    assert evidence["manifest_verified"] is True
+    assert evidence["overall_ok"] is True
+
+
+def test_runtime_tick_manifest_path_unchanged_in_shell() -> None:
+    text = P79_SHELL.read_text(encoding="utf-8")
+    assert "manifest.json" in text
+    assert "runtime_ticks" in text or "gate_mode" in text
+
+
+def test_preflight_documents_p79_archive_manifest_check() -> None:
+    text = PREFLIGHT.read_text(encoding="utf-8")
+    assert (
+        "p79_supervisor_evidence_manifest_verify_v0.py" in text
+        or "p79_supervisor_health_gate_v1.sh" in text
+    )


### PR DESCRIPTION
## Summary
- Add offline `ARCHIVE_ROOT` mode to P79 validating supervisor pack closeout and `MANIFEST.sha256` via shared `verify_manifest_sha256()`.
- Preserve runtime tick/pidfile/P76 mode unchanged.
- Preserve non-authorizing semantics in both modes.
- Add contract tests with fake pack output.
- Update existing runbook, Preflight §2a, and taxonomy §7c.
- No new docs surface.

## Test plan
- [x] `uv run pytest tests/ops/test_p79_supervisor_primary_evidence_manifest_gate_v0.py tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py tests/ops/test_primary_evidence_retention_invariant_contract_v0.py -q` — 43 passed
- [x] `uv run ruff check` on changed Python files
- [x] `uv run ruff format --check` on changed Python files
- [x] `uv run python scripts/ops/validate_docs_token_policy.py`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh`

## Safety
- No runtime started.
- No scheduler started.
- No supervisor or daemon start/stop.
- No `launchctl`.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, P67, P72, or Notion action.
- Offline archive validation only.
- Evidence remains non-authorizing; no gate clearance implied.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/p79_supervisor_primary_evidence_manifest_gate_v0_20260521T083646Z/P79_SUPERVISOR_PRIMARY_EVIDENCE_MANIFEST_GATE_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/p79_supervisor_primary_evidence_manifest_gate_v0_20260521T083646Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)