### PR TITLE
test(ops): assert P101 post-stop hints in primary evidence invariant contract

### DIFF
--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -14,6 +14,8 @@ TESTNET_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_testnet_bounded_observati
 SHARED_HELPER = REPO_ROOT / "scripts" / "ops" / "primary_evidence_retention_v0.py"
 P79_SHELL = REPO_ROOT / "scripts" / "ops" / "p79_supervisor_health_gate_v1.sh"
 P79_VERIFY = REPO_ROOT / "scripts" / "ops" / "p79_supervisor_evidence_manifest_verify_v0.py"
+P101_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p101_stop_playbook_v1.sh"
+PACK_SCRIPT = REPO_ROOT / "scripts" / "ops" / "pack_online_readiness_supervisor_evidence_v0.py"
 
 
 def _owner_text() -> str:
@@ -22,6 +24,10 @@ def _owner_text() -> str:
 
 def _adapter_text() -> str:
     return PAPER_ADAPTER.read_text(encoding="utf-8")
+
+
+def _p101_text() -> str:
+    return P101_SCRIPT.read_text(encoding="utf-8")
 
 
 def test_canonical_owner_exists() -> None:
@@ -180,6 +186,57 @@ def test_p79_verifier_checks_closeout_and_manifest_non_authorizing() -> None:
     assert "evidence_non_authorizing" in text
     assert "LIVE_ALLOWED" not in text
     assert "BROKER_EXCHANGE_ALLOWED" not in text
+
+
+def test_p101_stop_playbook_post_stop_hint_references_pack_and_p79_archive() -> None:
+    assert P101_SCRIPT.is_file()
+    assert PACK_SCRIPT.is_file()
+    text = _p101_text()
+    assert "pack_online_readiness_supervisor_evidence_v0.py" in text
+    assert "p79_supervisor_health_gate_v1.sh" in text
+    assert "ARCHIVE_ROOT=" in text
+    assert "P101_POST_STOP_PRIMARY_EVIDENCE_OPERATOR_HINTS.txt" in text
+    assert "--primary-evidence-enforce" in text
+
+
+def test_p101_stop_playbook_post_stop_hint_markers_non_authorizing() -> None:
+    text = _p101_text()
+    for marker in (
+        "HINT_ONLY=true",
+        "PACK_NOT_EXECUTED_BY_P101=true",
+        "P79_ARCHIVE_VERIFY_NOT_EXECUTED_BY_P101=true",
+        "OPERATOR_MUST_RUN_EXPLICITLY=true",
+        "EVIDENCE_NON_AUTHORIZING=true",
+    ):
+        assert marker in text
+
+
+def test_p101_stop_playbook_does_not_auto_execute_pack_or_p79_archive_verify() -> None:
+    lines = _p101_text().splitlines()
+    pack_offenders = [
+        line
+        for line in lines
+        if "pack_online_readiness_supervisor_evidence_v0.py" in line
+        and not line.strip().startswith("#")
+        and not line.strip().startswith("echo")
+    ]
+    assert pack_offenders == []
+    p79_offenders = [
+        line
+        for line in lines
+        if "p79_supervisor_health_gate_v1.sh" in line
+        and "ARCHIVE_ROOT" in line
+        and not line.strip().startswith("echo")
+    ]
+    assert p79_offenders == []
+
+
+def test_p101_stop_playbook_no_new_launchctl_or_supervisor_start() -> None:
+    text = _p101_text()
+    assert "launchctl bootstrap" not in text
+    assert "launchctl kickstart" not in text
+    assert "online_readiness_supervisor_v1.sh start" not in text
+    assert "online_readiness_daemon_v1.sh" not in text
 
 
 def test_canonical_owner_references_p67_p72_opt_in_enforce() -> None:


### PR DESCRIPTION
## Summary
- Extend `test_primary_evidence_retention_invariant_contract_v0.py` with four static P101 post-stop hint assertions.
- Assert supervisor pack and P79 `ARCHIVE_ROOT` references.
- Assert non-authorizing markers and non-execution guarantees.
- Tests-only; no runtime or docs changes.

## Test plan
- [x] `uv run pytest tests/ops/test_primary_evidence_retention_invariant_contract_v0.py -q` — 30 passed
- [x] `uv run pytest tests/ops/test_p101_stop_playbook_post_stop_pack_operator_hint_contract_v0.py -q` — 6 passed
- [x] `uv run pytest tests/p101/test_p101_stop_playbook_exists.py -q` — 3 passed
- [x] `uv run pytest tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py -q` — 10 passed
- [x] `uv run pytest tests/ops/test_p79_supervisor_primary_evidence_manifest_gate_v0.py -q` — 11 passed
- [x] `uv run ruff check tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`
- [x] `uv run ruff format --check tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`

## Safety
- Tests-only.
- No runtime started.
- No scheduler started.
- No supervisor or daemon start/stop.
- No `launchctl`.
- No pack/P79 execution.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, P67, P72, or Notion action.
- Evidence remains non-authorizing; no gate clearance implied.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/primary_evidence_retention_invariant_contract_p101_hint_sync_v0_20260521T134905Z/PRIMARY_EVIDENCE_RETENTION_INVARIANT_CONTRACT_P101_HINT_SYNC_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/primary_evidence_retention_invariant_contract_p101_hint_sync_v0_20260521T134905Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)