### PR TITLE
feat(ops): online readiness post-stop pack wrapper v0

### DIFF
--- a/scripts/ops/run_online_readiness_post_stop_pack_v0.sh
+++ b/scripts/ops/run_online_readiness_post_stop_pack_v0.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Operator-invoked post-stop pack wrapper for Online Readiness supervisor/daemon evidence.
+# Delegates to pack_online_readiness_supervisor_evidence_v0.py; optional P79 ARCHIVE_ROOT verify.
+# Does not start/stop supervisor, daemon, or invoke launchctl.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+OUT_DIR=""
+ARCHIVE_ROOT=""
+RESOLVE=""
+P79_ARCHIVE_VERIFY=0
+PRIMARY_EVIDENCE_ENFORCE=0
+REQUIRE_OPTIONAL=0
+OPTIONAL_ARTIFACTS=()
+
+usage() {
+  cat <<'EOF'
+Usage: run_online_readiness_post_stop_pack_v0.sh --archive-root PATH (--out-dir PATH | --resolve MODE) [options]
+
+Operator-invoked after STOP. Non-authorizing; does not start/stop supervisor or daemon.
+
+Options:
+  --out-dir PATH                 Existing supervisor/daemon OUT_DIR to pack
+  --resolve MODE                 Resolve OUT_DIR: latest-supervisor | latest-daemon-tick
+  --archive-root PATH            Durable destination root for packed evidence (required)
+  --optional-artifact PATH       Optional pid/log/lock path (repeatable)
+  --primary-evidence-enforce     Pass through to pack script (MANIFEST.sha256 enforce)
+  --require-optional-artifacts Fail closed when optional artifacts are missing
+  --p79-archive-verify           Run P79 ARCHIVE_ROOT verify after pack (explicit opt-in)
+  -h, --help                     Show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --archive-root)
+      ARCHIVE_ROOT="$2"
+      shift 2
+      ;;
+    --resolve)
+      RESOLVE="$2"
+      shift 2
+      ;;
+    --optional-artifact)
+      OPTIONAL_ARTIFACTS+=("$2")
+      shift 2
+      ;;
+    --primary-evidence-enforce)
+      PRIMARY_EVIDENCE_ENFORCE=1
+      shift
+      ;;
+    --require-optional-artifacts)
+      REQUIRE_OPTIONAL=1
+      shift
+      ;;
+    --p79-archive-verify)
+      P79_ARCHIVE_VERIFY=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+{
+  echo "ONLINE_DAEMON_POST_STOP_PACK_WRAPPER_V0=true"
+  echo "OPERATOR_INVOKED_ONLY=true"
+  echo "DAEMON_NOT_STARTED=true"
+  echo "DAEMON_NOT_STOPPED=true"
+  echo "SUPERVISOR_NOT_STARTED=true"
+  echo "SUPERVISOR_NOT_STOPPED=true"
+  echo "LAUNCHCTL_CALLED=false"
+  echo "PACK_SCRIPT_DELEGATED=true"
+  echo "P79_ARCHIVE_VERIFY_EXPLICIT_ONLY=true"
+  echo "EVIDENCE_NON_AUTHORIZING=true"
+}
+
+if [ -z "${ARCHIVE_ROOT}" ]; then
+  echo "ERR: --archive-root is required" >&2
+  exit 2
+fi
+
+if [ -n "${RESOLVE}" ] && [ -n "${OUT_DIR}" ]; then
+  echo "ERR: --out-dir and --resolve are mutually exclusive" >&2
+  exit 2
+fi
+
+if [ -n "${RESOLVE}" ]; then
+  case "${RESOLVE}" in
+    latest-supervisor)
+      sup_base="out/ops/online_readiness_supervisor"
+      latest="$(ls -1 "${sup_base}" 2>/dev/null | grep '^run_' | LC_ALL=C sort | tail -n 1 || true)"
+      if [ -n "${latest}" ]; then
+        OUT_DIR="${sup_base}/${latest}"
+      else
+        OUT_DIR="out/ops/p78_supervisor"
+      fi
+      ;;
+    latest-daemon-tick)
+      daemon_base="out/ops/online_readiness_daemon"
+      latest="$(ls -1 "${daemon_base}" 2>/dev/null | LC_ALL=C sort | tail -n 1 || true)"
+      if [ -z "${latest}" ]; then
+        echo "ERR: no daemon tick directories under ${daemon_base}" >&2
+        exit 3
+      fi
+      OUT_DIR="${daemon_base}/${latest}"
+      ;;
+    *)
+      echo "ERR: unknown --resolve mode: ${RESOLVE} (latest-supervisor|latest-daemon-tick)" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+if [ -z "${OUT_DIR}" ]; then
+  echo "ERR: --out-dir or --resolve is required" >&2
+  exit 2
+fi
+
+if [ ! -d "${OUT_DIR}" ]; then
+  echo "ERR: out_dir_missing: ${OUT_DIR}" >&2
+  exit 3
+fi
+
+pack_cmd=(python3 scripts/ops/pack_online_readiness_supervisor_evidence_v0.py
+  --out-dir "${OUT_DIR}"
+  --archive-root "${ARCHIVE_ROOT}")
+for artifact in "${OPTIONAL_ARTIFACTS[@]+"${OPTIONAL_ARTIFACTS[@]}"}"; do
+  pack_cmd+=(--optional-artifact "${artifact}")
+done
+if [ "${PRIMARY_EVIDENCE_ENFORCE}" -eq 1 ]; then
+  pack_cmd+=(--primary-evidence-enforce)
+fi
+if [ "${REQUIRE_OPTIONAL}" -eq 1 ]; then
+  pack_cmd+=(--require-optional-artifacts)
+fi
+
+echo "WRAPPER_OUT_DIR=${OUT_DIR}"
+echo "WRAPPER_ARCHIVE_ROOT=${ARCHIVE_ROOT}"
+
+"${pack_cmd[@]}"
+pack_rc=$?
+
+p79_rc=0
+if [ "${P79_ARCHIVE_VERIFY}" -eq 1 ]; then
+  ARCHIVE_ROOT="${ARCHIVE_ROOT}" bash scripts/ops/p79_supervisor_health_gate_v1.sh
+  p79_rc=$?
+else
+  echo "P79_ARCHIVE_VERIFY_SKIPPED=true"
+fi
+
+wrapper_rc=0
+if [ "${pack_rc}" -ne 0 ] || [ "${p79_rc}" -ne 0 ]; then
+  wrapper_rc=1
+fi
+echo "POST_STOP_PACK_WRAPPER_RC=${wrapper_rc}"
+exit "${wrapper_rc}"

--- a/tests/ops/test_online_daemon_post_stop_pack_wrapper_v0.py
+++ b/tests/ops/test_online_daemon_post_stop_pack_wrapper_v0.py
@@ -1,0 +1,114 @@
+"""Contract tests for online readiness post-stop pack wrapper (no runtime workloads)."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "scripts" / "ops" / "run_online_readiness_post_stop_pack_v0.sh"
+PACK_SCRIPT = "pack_online_readiness_supervisor_evidence_v0.py"
+P79_SCRIPT = "p79_supervisor_health_gate_v1.sh"
+
+MARKERS = (
+    "ONLINE_DAEMON_POST_STOP_PACK_WRAPPER_V0=true",
+    "OPERATOR_INVOKED_ONLY=true",
+    "DAEMON_NOT_STARTED=true",
+    "DAEMON_NOT_STOPPED=true",
+    "SUPERVISOR_NOT_STARTED=true",
+    "SUPERVISOR_NOT_STOPPED=true",
+    "LAUNCHCTL_CALLED=false",
+    "PACK_SCRIPT_DELEGATED=true",
+    "P79_ARCHIVE_VERIFY_EXPLICIT_ONLY=true",
+    "EVIDENCE_NON_AUTHORIZING=true",
+)
+
+
+def _script_lines() -> list[str]:
+    return WRAPPER.read_text(encoding="utf-8").splitlines()
+
+
+def _durable_archive(tmp_path: Path) -> Path:
+    path = REPO_ROOT / "tests" / ".pytest_archive_roots" / tmp_path.name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_durable_archive_dirs() -> None:
+    yield
+    archive_roots = REPO_ROOT / "tests" / ".pytest_archive_roots"
+    if archive_roots.is_dir():
+        shutil.rmtree(archive_roots, ignore_errors=True)
+
+
+def test_wrapper_exists_and_contains_operator_markers() -> None:
+    assert WRAPPER.is_file()
+    text = WRAPPER.read_text(encoding="utf-8")
+    for marker in MARKERS:
+        assert marker in text
+
+
+def test_wrapper_references_pack_and_p79_archive_root() -> None:
+    text = WRAPPER.read_text(encoding="utf-8")
+    assert PACK_SCRIPT in text
+    assert P79_SCRIPT in text
+    assert "ARCHIVE_ROOT=" in text
+    assert "--p79-archive-verify" in text
+    assert "P79_ARCHIVE_VERIFY_SKIPPED=true" in text
+
+
+def test_wrapper_does_not_invoke_launchctl_or_start_daemon_supervisor() -> None:
+    text = WRAPPER.read_text(encoding="utf-8")
+    assert "launchctl " not in text
+    assert "online_readiness_supervisor_v1.sh" not in text
+    assert "online_readiness_daemon_v1.sh" not in text
+
+
+def test_wrapper_delegates_pack_does_not_reimplement_manifest_logic() -> None:
+    text = WRAPPER.read_text(encoding="utf-8")
+    assert "pack_online_readiness_supervisor_evidence_v0.py" in text
+    assert "verify_manifest_sha256" not in text
+    assert "finalize_primary_evidence_root" not in text
+
+
+def test_p79_verify_gated_behind_explicit_flag() -> None:
+    lines = _script_lines()
+    p79_invocations = [
+        line
+        for line in lines
+        if P79_SCRIPT in line
+        and not line.strip().startswith("#")
+        and not line.strip().startswith("echo")
+    ]
+    assert len(p79_invocations) == 1
+    assert 'if [ "${P79_ARCHIVE_VERIFY}" -eq 1 ]' in WRAPPER.read_text(encoding="utf-8")
+
+
+def test_wrapper_delegates_to_pack_on_temp_dirs_without_p79_verify(tmp_path: Path) -> None:
+    out_dir = tmp_path / "supervisor_out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text('{"version":"test"}\n', encoding="utf-8")
+
+    archive = _durable_archive(tmp_path)
+    result = subprocess.run(
+        [
+            "bash",
+            str(WRAPPER),
+            "--out-dir",
+            str(out_dir),
+            "--archive-root",
+            str(archive),
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "P79_ARCHIVE_VERIFY_SKIPPED=true" in result.stdout
+    assert (archive / "supervisor_session_closeout_v0.json").is_file()
+    assert "POST_STOP_PACK_WRAPPER_RC=0" in result.stdout


### PR DESCRIPTION
## Summary
- Add `run_online_readiness_post_stop_pack_v0.sh` as an operator-invoked post-stop wrapper.
- Delegate to the existing supervisor evidence pack script instead of duplicating pack/manifest logic.
- Support optional `--p79-archive-verify`, which runs the P79 `ARCHIVE_ROOT` gate only when explicitly requested.
- Preserve daemon/supervisor/launchctl behavior: no start, stop, or runtime control changes.
- Add static and temp-dir contract tests.

## Test plan
- [x] `bash -n scripts/ops/run_online_readiness_post_stop_pack_v0.sh`
- [x] `uv run pytest tests/ops/test_online_daemon_post_stop_pack_wrapper_v0.py -q` — 6 passed
- [x] `uv run pytest tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py -q` — 10 passed
- [x] `uv run pytest tests/ops/test_p79_supervisor_primary_evidence_manifest_gate_v0.py -q` — 11 passed
- [x] `uv run pytest tests/ops/test_p101_stop_playbook_post_stop_pack_operator_hint_contract_v0.py -q` — 6 passed
- [x] `uv run pytest tests/ops/test_p93_status_dashboard_post_stop_pack_operator_hint_contract_v0.py -q` — 6 passed
- [x] `uv run ruff check tests/ops/test_online_daemon_post_stop_pack_wrapper_v0.py`
- [x] `uv run ruff format --check tests/ops/test_online_daemon_post_stop_pack_wrapper_v0.py`

## Safety
- No runtime started.
- No scheduler started.
- No supervisor or daemon start/stop.
- No `launchctl`.
- No live path pack execution in tests.
- No automatic P79 archive verification.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, P67, P72, or Notion action.
- Evidence remains non-authorizing; no gate clearance implied.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/online_daemon_post_stop_pack_wrapper_v0_20260521T162749Z/ONLINE_DAEMON_POST_STOP_PACK_WRAPPER_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/online_daemon_post_stop_pack_wrapper_v0_20260521T162749Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)