### PR TITLE
test(ops): invariant contract P93 wrapper hint sync v0

### DIFF
--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -15,6 +15,7 @@ SHARED_HELPER = REPO_ROOT / "scripts" / "ops" / "primary_evidence_retention_v0.p
 P79_SHELL = REPO_ROOT / "scripts" / "ops" / "p79_supervisor_health_gate_v1.sh"
 P79_VERIFY = REPO_ROOT / "scripts" / "ops" / "p79_supervisor_evidence_manifest_verify_v0.py"
 P101_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p101_stop_playbook_v1.sh"
+P93_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p93_online_readiness_status_dashboard_v1.sh"
 PACK_SCRIPT = REPO_ROOT / "scripts" / "ops" / "pack_online_readiness_supervisor_evidence_v0.py"
 
 
@@ -28,6 +29,10 @@ def _adapter_text() -> str:
 
 def _p101_text() -> str:
     return P101_SCRIPT.read_text(encoding="utf-8")
+
+
+def _p93_text() -> str:
+    return P93_SCRIPT.read_text(encoding="utf-8")
 
 
 def test_canonical_owner_exists() -> None:
@@ -253,6 +258,65 @@ def test_p101_stop_playbook_does_not_auto_execute_wrapper_pack_or_p79_archive_ve
 
 def test_p101_stop_playbook_no_new_launchctl_or_supervisor_start() -> None:
     text = _p101_text()
+    assert "launchctl bootstrap" not in text
+    assert "launchctl kickstart" not in text
+    assert "online_readiness_supervisor_v1.sh start" not in text
+    assert "online_readiness_daemon_v1.sh" not in text
+
+
+def test_p93_status_dashboard_post_stop_hint_references_wrapper_and_optional_p79() -> None:
+    assert P93_SCRIPT.is_file()
+    text = _p93_text()
+    assert "run_online_readiness_post_stop_pack_v0.sh" in text
+    assert "--p79-archive-verify" in text
+    assert "P93_POST_STOP_PRIMARY_EVIDENCE_OPERATOR_HINTS.txt" in text
+    assert "--primary-evidence-enforce" in text
+
+
+def test_p93_status_dashboard_post_stop_hint_markers_non_authorizing() -> None:
+    text = _p93_text()
+    for marker in (
+        "HINT_ONLY=true",
+        "WRAPPER_REFERENCED=true",
+        "WRAPPER_NOT_EXECUTED_BY_P93=true",
+        "PACK_NOT_EXECUTED_BY_P93=true",
+        "P79_ARCHIVE_VERIFY_NOT_EXECUTED_BY_P93=true",
+        "OPERATOR_MUST_RUN_EXPLICITLY=true",
+        "EVIDENCE_NON_AUTHORIZING=true",
+    ):
+        assert marker in text
+
+
+def test_p93_status_dashboard_does_not_auto_execute_wrapper_pack_or_p79_archive_verify() -> None:
+    lines = _p93_text().splitlines()
+    wrapper_offenders = [
+        line
+        for line in lines
+        if "run_online_readiness_post_stop_pack_v0.sh" in line
+        and not line.strip().startswith("#")
+        and not line.strip().startswith("echo")
+    ]
+    assert wrapper_offenders == []
+    pack_offenders = [
+        line
+        for line in lines
+        if "pack_online_readiness_supervisor_evidence_v0.py" in line
+        and not line.strip().startswith("#")
+        and not line.strip().startswith("echo")
+    ]
+    assert pack_offenders == []
+    p79_offenders = [
+        line
+        for line in lines
+        if "p79_supervisor_health_gate_v1.sh" in line
+        and "ARCHIVE_ROOT" in line
+        and not line.strip().startswith("echo")
+    ]
+    assert p79_offenders == []
+
+
+def test_p93_status_dashboard_no_new_launchctl_or_supervisor_start() -> None:
+    text = _p93_text()
     assert "launchctl bootstrap" not in text
     assert "launchctl kickstart" not in text
     assert "online_readiness_supervisor_v1.sh start" not in text


### PR DESCRIPTION
## Summary
- Extend `test_primary_evidence_retention_invariant_contract_v0.py` with P93 wrapper hint assertions mirroring P101 (#3601).
- Assert wrapper reference, optional `--p79-archive-verify`, non-execution markers, and no auto-execution of wrapper/pack/P79.
- Tests-only; no docs or runtime changes.

## Test plan
- [x] `uv run pytest tests/ops/test_primary_evidence_retention_invariant_contract_v0.py -q` — 35 passed
- [x] `uv run pytest tests/ops/test_p93_status_dashboard_post_stop_pack_operator_hint_contract_v0.py -q` — 7 passed
- [x] `uv run pytest tests/ops/test_p101_stop_playbook_post_stop_pack_operator_hint_contract_v0.py -q` — 7 passed
- [x] `uv run pytest tests/ops/test_online_daemon_post_stop_pack_wrapper_v0.py -q` — 6 passed
- [x] `uv run ruff check tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`
- [x] `uv run ruff format --check tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`

## Safety
- Tests-only.
- No runtime started.
- No scheduler started.
- No supervisor or daemon start/stop.
- No `launchctl`.
- No wrapper, pack, or P79 execution.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, P67, P72, or Notion action.
- Evidence remains non-authorizing; no gate clearance implied.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/primary_evidence_retention_invariant_contract_p93_wrapper_hint_sync_v0_20260521T171757Z/PRIMARY_EVIDENCE_RETENTION_INVARIANT_CONTRACT_P93_WRAPPER_HINT_SYNC_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/primary_evidence_retention_invariant_contract_p93_wrapper_hint_sync_v0_20260521T171757Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)