### PR TITLE
docs(ops): Readiness script taxonomy reciprocal pointer v0

### DIFF
--- a/scripts/ops/build_readiness_evidence_ledger_v0.py
+++ b/scripts/ops/build_readiness_evidence_ledger_v0.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
 """Build an offline readiness/evidence ledger from a runtime evidence archive root.
 
-Non-authorizing: does not start runtime, read secrets, or grant Live/Testnet/Go.
+Taxonomy cross-reference (review-input-only): indexed in
+``docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md`` §10.
+
+Non-authorizing: review-input-only; does not start runtime, read secrets, or grant
+Live/Testnet/broker/exchange approval or trading authorization. Does not override
+scheduler boundary guards, preflight BLOCKED, or operator-explicit approval.
 """
 
 from __future__ import annotations

--- a/scripts/ops/report_readiness_gate_snapshot_v0.py
+++ b/scripts/ops/report_readiness_gate_snapshot_v0.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """Compose readiness ledger, preflight status, and mirror into one gate snapshot.
 
-Non-authorizing offline convenience CLI. Does not start runtime or grant authority.
+Taxonomy cross-reference (review-input-only): indexed in
+``docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md`` §10.
+
+Non-authorizing offline convenience CLI. Review-input-only; does not start runtime or
+grant approval, gate clearance, Live/Testnet/broker/exchange permission, or trading
+authorization. Does not override scheduler boundary guards, preflight BLOCKED, or
+operator-explicit approval.
 
 Optional ``--include-registry`` attaches a summary-only Generic Evidence Run Registry
 v1 subsection. That subsection is non-authorizing and must not be interpreted as gate

--- a/scripts/ops/report_readiness_ledger_preflight_mirror_v0.py
+++ b/scripts/ops/report_readiness_ledger_preflight_mirror_v0.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """Compare Readiness Evidence Ledger v0 JSON with Preflight status JSON.
 
-Non-authorizing mirror check only. Does not start runtime or grant authority.
+Taxonomy cross-reference (review-input-only): indexed in
+``docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md`` §10.
+
+Non-authorizing mirror check only. Review-input-only; does not start runtime or grant
+approval, gate clearance, Live/Testnet/broker/exchange permission, or trading
+authorization. Does not override scheduler boundary guards, preflight BLOCKED, or
+operator-explicit approval.
 """
 
 from __future__ import annotations

--- a/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
+++ b/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
@@ -317,6 +317,26 @@ def test_readiness_tooling_taxonomy_cross_ref_aligned() -> None:
     assert "FORBIDDEN_PROMOTION" in text
 
 
+def test_readiness_script_taxonomy_reciprocal_pointer_aligned() -> None:
+    taxonomy_ref = "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md"
+    for script in (
+        READINESS_LEDGER_SCRIPT,
+        READINESS_MIRROR_SCRIPT,
+        READINESS_GATE_SNAPSHOT_SCRIPT,
+    ):
+        assert script.is_file()
+        text = script.read_text(encoding="utf-8")
+        assert taxonomy_ref in text
+        assert "§10" in text or "section 10" in text.lower()
+        assert "review-input-only" in text.lower() or "review input only" in text.lower()
+        assert "non-authorizing" in text.lower()
+        assert "broker" in text.lower() or "exchange" in text.lower()
+        assert "live" in text.lower()
+        assert "preflight" in text.lower()
+        assert "scheduler" in text.lower() or "operator" in text.lower()
+        assert "does not override" in text.lower() or "do not override" in text.lower()
+
+
 def test_scheduler_completion_closeout_marker_aligned() -> None:
     assert SCHEDULER_LAUNCHER.is_file()
     text = _spec_text()


### PR DESCRIPTION
## Summary
- Add reciprocal Taxonomy §10 pointers in readiness ledger, preflight mirror, and gate snapshot module docstrings.
- Assert review-input-only / non-authorizing semantics and scheduler/preflight/operator boundaries.
- Extend taxonomy contract test.
- Docstring-only; no script execution.

## Test plan
- [x] `uv run pytest tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py -q` — 34 passed
- [x] `uv run ruff check scripts/ops/build_readiness_evidence_ledger_v0.py scripts/ops/report_readiness_ledger_preflight_mirror_v0.py scripts/ops/report_readiness_gate_snapshot_v0.py tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py`
- [x] `uv run ruff format --check scripts/ops/build_readiness_evidence_ledger_v0.py scripts/ops/report_readiness_ledger_preflight_mirror_v0.py scripts/ops/report_readiness_gate_snapshot_v0.py tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py`

## Safety
- Docstring + static test only.
- No readiness tooling execution.
- No runtime started.
- No scheduler started.
- No supervisor or daemon start/stop.
- No `launchctl`.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, P67, P72, or Notion action.
- Readiness outputs remain review-input-only and non-authorizing.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/readiness_script_taxonomy_reciprocal_pointer_v0_20260521T205139Z/READINESS_SCRIPT_TAXONOMY_RECIPROCAL_POINTER_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/readiness_script_taxonomy_reciprocal_pointer_v0_20260521T205139Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)