### PR TITLE
docs(ops): Incident state usage plan drift sync v0

### DIFF
--- a/docs/ops/reviews/incident_state_read_model_usage_plan/PLAN.md
+++ b/docs/ops/reviews/incident_state_read_model_usage_plan/PLAN.md
@@ -15,7 +15,7 @@ The contract defines the minimum incident-state fields. Consumer authority remai
 - **risk gate** — caller-provided `limits.kill_switch`
 - **risk hook** — kill-switch behavior remains future work
 
-Canonical implementation evidence: `tests/webui/test_ops_cockpit.py` (payload + HTML assertions). Wave closeout: `docs/ops/reviews/incident_state_read_model_ops_cockpit_closeout/CLOSEOUT.txt`.
+Canonical implementation evidence: `tests/webui/test_ops_cockpit.py` (payload + HTML assertions). Wave closeout: `docs/ops/reviews/incident_state_read_model_ops_cockpit_closeout&#47;CLOSEOUT.txt`.
 
 ## Primary Usage Questions
 1. Was incident-stop invoked?
@@ -88,7 +88,7 @@ Why later:
 Also present (rollup, not CONTRACT minimum): `status`, `blocked`, `degraded`, `requires_operator_attention`, `summary`.
 
 **Partial / optional follow-ons (not payload gaps):**
-- **4-section PLAN HTML IA** — fields render in HTML; explicit Section 1–4 layout per `incident_state_read_model_ops_cockpit_plan/PLAN.md` may still be refined (display-only).
+- **4-section PLAN HTML IA** — fields render in HTML; explicit Section 1–4 layout per `incident_state_read_model_ops_cockpit_plan&#47;PLAN.md` may still be refined (display-only).
 - **`safety_state` projection** — `src/ops/safety_state.py` exposes a **subset** of `incident_state` in `incident_signal_subset`; full contract field projection not required for observation.
 
 **Still out of scope / unchanged:**
@@ -108,6 +108,6 @@ Current authority:
 - none yet for kill switch; still future work
 
 ## Recommended Next Slice
-- Hold incident-state ops-cockpit payload stable unless a concrete follow-up need arises (see `incident_state_read_model_ops_cockpit_closeout/CLOSEOUT.txt`).
+- Hold incident-state ops-cockpit payload stable unless a concrete follow-up need arises (see `incident_state_read_model_ops_cockpit_closeout&#47;CLOSEOUT.txt`).
 - Optional docs-only: sync downstream review artifacts if drift reappears.
 - Optional bounded follow-ons (separate slices): 4-section HTML IA polish; `safety_state` full contract-field projection (read-only).

--- a/docs/ops/reviews/incident_state_read_model_usage_plan/PLAN.md
+++ b/docs/ops/reviews/incident_state_read_model_usage_plan/PLAN.md
@@ -9,11 +9,13 @@ Define where and how the incident-state read model should be used before any imp
 - no paper/shadow/testnet mutation
 
 ## Current Position
-The contract now defines the minimum incident-state fields, but current consumers remain split:
-- ops cockpit is kill-switch-centric
-- entry contract is PT_ARMED-centric
-- risk gate depends on caller-provided kill_switch state
-- risk hook kill-switch behavior remains future work
+The contract defines the minimum incident-state fields. Consumer authority remains **split by question** (non-authorizing read-model only):
+- **ops cockpit** — `incident_state` payload on main implements all 11 contract fields in `src/webui/ops_cockpit.py`; per-question authority visible in payload and partial HTML (see gap matrix below). Still observation-only; does not grant entry, Live, broker, or exchange permission.
+- **entry contract** — `PT_ARMED`-centric deny posture (separate authority)
+- **risk gate** — caller-provided `limits.kill_switch`
+- **risk hook** — kill-switch behavior remains future work
+
+Canonical implementation evidence: `tests/webui/test_ops_cockpit.py` (payload + HTML assertions). Wave closeout: `docs/ops/reviews/incident_state_read_model_ops_cockpit_closeout/CLOSEOUT.txt`.
 
 ## Primary Usage Questions
 1. Was incident-stop invoked?
@@ -24,12 +26,14 @@ The contract now defines the minimum incident-state fields, but current consumer
 
 ## First Consumer Priority
 ### Phase 1 — Ops Cockpit Read-Model Mapping
-Why first:
+Status on main: **implemented (payload)** — all target contract fields present in `incident_state`; tests in `tests/webui/test_ops_cockpit.py`.
+
+Why first (historical):
 - already operator-facing
 - already consumes kill-switch-centric state
 - safest place to make per-question authority explicit without changing runtime gates
 
-Target contract fields to surface or map:
+Target contract fields surfaced in ops cockpit payload (`incident_state`):
 - `incident_stop_invoked`
 - `incident_stop_source`
 - `pt_force_no_trade`
@@ -73,17 +77,23 @@ Why later:
 
 ## Current Gap Matrix Summary
 ### Ops Cockpit
-Missing today:
-- `incident_stop_invoked`
+**Implemented on main (payload, read-model / non-authorizing):**
+- `incident_stop_invoked` — `_detect_incident_stop` in `src/webui/ops_cockpit.py`
 - `incident_stop_source`
-- `pt_force_no_trade`
-- env-based `pt_enabled`
-- env-based `pt_armed`
-- `kill_switch_source`
-- `entry_permitted`
-- `risk_gate_kill_switch_active`
-- `operator_authoritative_state`
-- `operator_state_reason`
+- `pt_force_no_trade`, `pt_enabled`, `pt_armed` — env observation
+- `kill_switch_active`, `kill_switch_source`
+- `entry_permitted`, `risk_gate_kill_switch_active`
+- `operator_authoritative_state`, `operator_state_reason`
+
+Also present (rollup, not CONTRACT minimum): `status`, `blocked`, `degraded`, `requires_operator_attention`, `summary`.
+
+**Partial / optional follow-ons (not payload gaps):**
+- **4-section PLAN HTML IA** — fields render in HTML; explicit Section 1–4 layout per `incident_state_read_model_ops_cockpit_plan/PLAN.md` may still be refined (display-only).
+- **`safety_state` projection** — `src/ops/safety_state.py` exposes a **subset** of `incident_state` in `incident_signal_subset`; full contract field projection not required for observation.
+
+**Still out of scope / unchanged:**
+- Cockpit observation does **not** authorize Live, broker, exchange, scheduler, or runtime execution.
+- Entry/risk/risk-hook authority split unchanged (see below).
 
 ### Entry Contract
 Current authority:
@@ -98,4 +108,6 @@ Current authority:
 - none yet for kill switch; still future work
 
 ## Recommended Next Slice
-- `incident_state_read_model_ops_cockpit_plan`
+- Hold incident-state ops-cockpit payload stable unless a concrete follow-up need arises (see `incident_state_read_model_ops_cockpit_closeout/CLOSEOUT.txt`).
+- Optional docs-only: sync downstream review artifacts if drift reappears.
+- Optional bounded follow-ons (separate slices): 4-section HTML IA polish; `safety_state` full contract-field projection (read-only).


### PR DESCRIPTION
## Summary
- Sync `incident_state_read_model_usage_plan/PLAN.md` gap matrix with main implementation.
- Document all 11 contract fields as present in the ops-cockpit `incident_state` payload.
- Keep partial follow-ons explicit: 4-section HTML IA and `safety_state` subset remain separate/optional.
- Docs-only; no WebUI/runtime changes.

## Test plan
- [x] `uv run python scripts/ops/validate_docs_token_policy.py`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh`

## Safety
- Docs-only.
- No WebUI server, route, template, API, or readmodel code changes.
- No runtime started.
- No scheduler started.
- No supervisor or daemon start/stop.
- No `launchctl`.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, P67, P72, or Notion action.
- Incident-state/Ops-Cockpit remains read-model / review-input-only and non-authorizing.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/incident_state_usage_plan_drift_sync_v0_20260521T211755Z/INCIDENT_STATE_USAGE_PLAN_DRIFT_SYNC_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/incident_state_usage_plan_drift_sync_v0_20260521T211755Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)