### PR TITLE
docs(ops): Readiness ledger bounded observation adapter cross-ref v0

### DIFF
--- a/scripts/ops/build_readiness_evidence_ledger_v0.py
+++ b/scripts/ops/build_readiness_evidence_ledger_v0.py
@@ -2,7 +2,13 @@
 """Build an offline readiness/evidence ledger from a runtime evidence archive root.
 
 Taxonomy cross-reference (review-input-only): indexed in
-``docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md`` §10.
+``docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md`` §10
+(readiness aggregate and bounded observation retention adapters).
+
+Default shadow/testnet run IDs use the bounded observation evidence family
+(``shadow_bounded_observation_*``, ``testnet_bounded_observation_*``) as
+review-input-only archive inputs — ledger PASS does not authorize adapter
+``--execute``, Stage-3 escalation, or runtime start.
 
 Non-authorizing: review-input-only; does not start runtime, read secrets, or grant
 Live/Testnet/broker/exchange approval or trading authorization. Does not override

--- a/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
+++ b/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
@@ -346,6 +346,28 @@ def test_readiness_script_taxonomy_reciprocal_pointer_aligned() -> None:
         assert "does not override" in text.lower() or "do not override" in text.lower()
 
 
+def test_readiness_ledger_bounded_observation_adapter_cross_ref_aligned() -> None:
+    assert READINESS_LEDGER_SCRIPT.is_file()
+    text = READINESS_LEDGER_SCRIPT.read_text(encoding="utf-8")
+    assert "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md" in text
+    assert "§10" in text or "section 10" in text.lower()
+    assert "bounded observation" in text.lower()
+    assert "run_paper_only_bounded_observation_adapter_v0.py" in text or (
+        "shadow_bounded_observation_" in text and "testnet_bounded_observation_" in text
+    )
+    assert "shadow_bounded_observation_" in text
+    assert "testnet_bounded_observation_" in text
+    assert "review-input-only" in text.lower() or "review input only" in text.lower()
+    assert "non-authorizing" in text.lower()
+    assert "broker" in text.lower() or "exchange" in text.lower()
+    assert "live" in text.lower()
+    assert "preflight" in text.lower()
+    assert "scheduler" in text.lower() or "operator" in text.lower()
+    assert "does not override" in text.lower() or "do not override" in text.lower()
+    assert "--execute" in text or "adapter" in text.lower()
+    assert "stage-3" in text.lower() or "stage 3" in text.lower()
+
+
 def test_bounded_observation_adapters_taxonomy_cross_ref_aligned() -> None:
     text = _spec_text()
     for marker in (


### PR DESCRIPTION
## Summary
- Extend readiness ledger docstring to reference Taxonomy §10 bounded observation adapter indexing.
- Clarify default `shadow_bounded_observation_*` and `testnet_bounded_observation_*` run ID families as review-input-only archive inputs.
- Add static contract test.
- No functional or execution behavior changes.

## Test plan
- [x] `uv run pytest tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py -q` — 37 passed
- [x] `uv run ruff check scripts/ops/build_readiness_evidence_ledger_v0.py tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py`
- [x] `uv run ruff format --check scripts/ops/build_readiness_evidence_ledger_v0.py tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py`

## Safety
- Docstring + static test only.
- No readiness ledger execution.
- No adapter `--execute`.
- No runtime started.
- No scheduler started.
- No supervisor or daemon start/stop.
- No `launchctl`.
- No Paper, Shadow, Testnet, Live, Broker, Exchange, P67, P72, or Notion action.
- Readiness ledger and bounded observation adapters remain review-input-only and non-authorizing.

## Durable evidence
- Implementation result: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/readiness_bounded_observation_adapter_ledger_cross_ref_v0_20260521T215439Z/READINESS_BOUNDED_OBSERVATION_ADAPTER_LEDGER_CROSS_REF_V0_IMPLEMENTATION_RESULT.md`
- Manifest: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/readiness_bounded_observation_adapter_ledger_cross_ref_v0_20260521T215439Z/MANIFEST.sha256`
- Manifest verify: `MANIFEST_VERIFY_RC=0`

Made with [Cursor](https://cursor.com)