### PR TITLE
ops: Stage-7 model approval state machine §10 (learning inventory)

### DIFF
--- a/docs/ops/specs/MASTER_V2_GO_LIVE_ROADMAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_GO_LIVE_ROADMAP_V0.md
@@ -115,6 +115,7 @@ Further reading (same specs directory):
 
 - [Runtime Lane Taxonomy §12 Autonomy Stage Authority Crosswalk](./RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) — normative stage 0–7 authority crosswalk (non-authorizing)
 - [First Live Readiness Ladder](./MASTER_V2_FIRST_LIVE_ENABLEMENT_READINESS_LADDER.md)
+- [Learning AI Autonomy Inventory §10 Stage-7 Model/Policy Approval State Machine](./MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) — normative S0–S15 approval index (non-authorizing)
 - [Learning AI Autonomy Inventory](./MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md)
 - [Futures Class A Capability Contract](./MASTER_V2_FUTURES_CLASS_A_CAPABILITY_CONTRACT_V0.md) — §7 WP1B / futures wiring HOLD posture remains unchanged unless separately approved.
 

--- a/docs/ops/specs/MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md
+++ b/docs/ops/specs/MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md
@@ -1,7 +1,7 @@
 # MASTER V2 — Learning AI Autonomy Inventory v1 (Canonical, Read-Only)
 
 status: ACTIVE
-last_updated: 2026-04-19
+last_updated: 2026-05-22
 owner: Peak_Trade
 purpose: Canonical docs-only inventory of learning, AI, and autonomy surfaces for Master V2 clarification
 docs_token: DOCS_TOKEN_MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1
@@ -54,8 +54,8 @@ This inventory uses the following canonical categories:
 | knowledge base and memory-like layer | documented knowledge surfaces used for context and review continuity | [KNOWLEDGE_BASE_INDEX.md](../../KNOWLEDGE_BASE_INDEX.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | a broad knowledge index and canonical vocabulary layer exist | one Master V2-specific memory contract tied to authority boundaries is not materialized | partial | partial | knowledge indexing exists without one consolidated Master V2 memory contract |
 | AI-layer orchestration | AI coordination layer above execution and risk hot path | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | AI orchestration is documented as advisory and non-execution authority | one compact Master V2 orchestration capability map is not materialized | partial | partial | role boundaries are explicit but spread across governance and vocabulary docs |
 | model orchestration and routing | proposer, fallback, critic model assignment and separation of duties | [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | proposer and critic separation plus model-assignment fields are documented | canonical runtime-routing contract for Master V2 remains outside this inventory | partial | partial | template fields are clear but do not assert one authoritative runtime router |
-| approval logic for updated models | process and sign-off requirements before stronger autonomy states | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md) | evidence pack and sign-off obligations are explicit | one compact model-update approval state machine is not materialized | partial | partial | approval requirements exist without one canonical state-machine artifact |
-| decision authority for model and policy changes | who can approve, veto, or stop changes | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | decision-authority map marks learning/model/policy chain as missing or partial | single consolidated authoritative approval chain remains open | unclear to partial | partial | authority topology is visible, but consolidation is still missing |
+| approval logic for updated models | process and sign-off requirements before stronger autonomy states | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md), **§10 Stage-7 approval state machine** | evidence pack and sign-off obligations are explicit; **§10 materializes model/policy approval state machine index** | runtime enforcement of transitions remains out of scope | partial | partial | approval chain indexed in §10; runtime router still outside inventory |
+| decision authority for model and policy changes | who can approve, veto, or stop changes | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md), **§10** | decision-authority map marks learning/model/policy chain as missing or partial; **§10 indexes operator/external gates** | single runtime approver enforcement remains open | partial | partial | authority topology cross-linked; consolidation is docs-index only |
 | feedback loops from outcomes to learning | how outcomes inform future learning or policy updates | [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | read-only and offline-first feedback intent is explicit | canonical bounded feedback protocol is not materialized | unclear | partial | distributed references, no single Master V2 feedback contract |
 | evidence, audit, and replay trail for learning and model changes | artifacts proving what changed, why, and under which authority | [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | evidence, replay, provenance, and sign-off fields are strongly documented | one compact Master V2 learning-change evidence index is not materialized | partial to strong | partial to high | evidence primitives are strong; consolidation as one index remains open |
 
@@ -94,16 +94,22 @@ Confirmed by this specification:
 
 Still open:
 
-- a consolidated approval-chain map for model and policy updates
-- a compact Master V2 promotion and state-machine artifact for autonomy transitions
 - one consolidated learning-change evidence index tied to explicit authority nodes
+- runtime enforcement of Stage-7 approval transitions (explicitly out of scope)
+
+Addressed in §10 (docs index only):
+
+- consolidated approval-chain map for model and policy updates at Stage 7
 
 Potential next follow-up slice (separate topic):
 
-- a dedicated promotion and state-machine clarification slice focused on transition and approval semantics
+- learning-change evidence index consolidation (no new approval spec)
 
 ## 9) Cross-References
 
+- [RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md](RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) — §12 autonomy crosswalk; stage 7 row; §12.3 permanent operator-only gates
+- [MASTER_V2_GO_LIVE_ROADMAP_V0.md](MASTER_V2_GO_LIVE_ROADMAP_V0.md) — §3.1 stage vocabulary
+- [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md) — environment promotion visibility (orthogonal to §10)
 - [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)
 - [MASTER_V2_DATAFLOW_MAP_V1.md](MASTER_V2_DATAFLOW_MAP_V1.md)
 - [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md)
@@ -114,3 +120,117 @@ Potential next follow-up slice (separate topic):
 - [POLICY_CRITIC_STATUS.md](../../governance/POLICY_CRITIC_STATUS.md)
 - [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md)
 - [KNOWLEDGE_BASE_INDEX.md](../../KNOWLEDGE_BASE_INDEX.md)
+- [AI_AUTONOMY_CONTROL_CENTER.md](../control_center/AI_AUTONOMY_CONTROL_CENTER.md)
+- [CANARY_LIVE_ENTRY_CRITERIA.md](../runbooks/CANARY_LIVE_ENTRY_CRITERIA.md)
+
+## 10) Stage-7 model/policy approval state machine (normative index)
+
+```
+STAGE_7_MODEL_APPROVAL_STATE_MACHINE_V0=true
+STAGE_7_APPROVAL_STATE_COUNT=16
+MODEL_RECOMMENDATION_NON_AUTHORIZING=true
+POLICY_CANDIDATE_NON_EXECUTING=true
+APPROVAL_PACKET_REVIEW_INPUT_ONLY=true
+ONLINE_LEARNING_TO_LIVE_FORBIDDEN=true
+MODEL_CHANGE_REQUIRES_REAPPROVAL=true
+FORBIDDEN_AUTO_PROMOTION_RECOMMENDATION_TO_LIVE=true
+FORBIDDEN_AUTO_PROMOTION_EVIDENCE_PASS_TO_LIVE=true
+FORBIDDEN_AUTO_PROMOTION_PACKET_TO_GO_DECISION=true
+EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true
+TESTNET_PASS_DOES_NOT_AUTHORIZE_LIVE=true
+GO_DECISION_REQUIRES_EXTERNAL_RECORD=true
+AI_L6_EXEC_FORBIDDEN=true
+KILLSWITCH_SAFETY_VETO_DOMINATES=true
+```
+
+This section is the **normative index** for Stage-7 model/policy change approval near [MASTER_V2_GO_LIVE_ROADMAP_V0.md](MASTER_V2_GO_LIVE_ROADMAP_V0.md) §3.1 stage 7 and [RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md](RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) §12.2 row `7`. It does **not** authorize runtime, live deploy, scheduler unlock, or model release by assertion.
+
+**Reuse-before-new:** Environment promotion visibility remains in [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md). Permanent operator-only gates remain indexed in taxonomy §12.3 — **not re-listed here** (pointer only).
+
+**Critical inequality:** `approval_packet_complete ≠ operator_decision_granted ≠ go_decision_granted ≠ live_deploy_authorized`.
+
+### 10.1 Semantic distinctions
+
+| term | authority | may authorize runtime/live? |
+|---|---|---|
+| Model recommendation | AI L0–L3 advisory (REC/PROP) | **No** |
+| Policy candidate | Versioned proposal artifact | **No** |
+| Shadow / paper / testnet evidence | Bounded lanes (taxonomy §10) | **No** |
+| Approval packet | [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md) | **No** (review input only) |
+| Governance review outcome | L4 critic + human governance | **No** |
+| Operator decision record | `operator_decision_required` | **No** for live; bounded non-live only |
+| Canary / pilot gate | Readiness + GLB + LB-APR-001 class | **No** repo auto-clear |
+| Live deploy approval | External `go_decision_granted` | **Only** external path to live capital |
+| Monitored autonomy (Stage 7) | Locked approved model/policy within prior Go | Model change **re-enters** at `S2` |
+
+### 10.2 State machine table (S0–S15)
+
+| state_id | description | max AI layer | evidence owner (canonical) |
+|---|---|---|---|
+| `S0_IDLE` | No pending model/policy change | L0–L2 RO/REC | N/A |
+| `S1_MODEL_RECOMMENDATION` | AI advisory output captured | L0–L3 max PROP | AI evidence packs; [AI_AUTONOMY_LAYER_MAP_MODEL_MATRIX.md](../../governance/matrix/AI_AUTONOMY_LAYER_MAP_MODEL_MATRIX.md) |
+| `S2_POLICY_CANDIDATE_DRAFT` | Versioned change proposal | L0–L3 | Policy/version refs; artifact hashes |
+| `S3_OFFLINE_RETRAIN_COMPLETE` | Offline retrain artifact (non-live) | L0–L3 | Offline run logs; [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md) |
+| `S4_SHADOW_EVIDENCE` | Shadow bounded observation | L0–L2 | Shadow adapter + review (taxonomy §10) |
+| `S5_PAPER_EVIDENCE` | Paper bounded observation | L0–L3 | Paper adapter; preflight §2a retention |
+| `S6_TESTNET_EVIDENCE` | Optional testnet validation | L0–L3 | Testnet adapter + review (taxonomy §10) |
+| `S7_APPROVAL_PACKET_ASSEMBLED` | EVP v2 complete; SoD PASS | L4 review input | `AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2` |
+| `S8_GOVERNANCE_REVIEW` | L4 critic + human governance review | L4 RO/REC | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) |
+| `S9_OPERATOR_DECISION_PENDING` | Awaiting operator accept/reject | — | Operator decision record |
+| `S10_OPERATOR_ACCEPTED_BOUNDED` | Accepted for **bounded non-live** only | L0–L5 | Decision record + evidence chain |
+| `S11_CANARY_PILOT_ELIGIBLE` | Separate Canary/pilot readiness (stage 5) | L0–L4 | Readiness ladder; GLB; [CANARY_LIVE_ENTRY_CRITERIA.md](../runbooks/CANARY_LIVE_ENTRY_CRITERIA.md) |
+| `S12_LIVE_DEPLOY_PENDING_EXTERNAL` | Awaiting external Go (not auto from S10/S11) | — | LB-APR-001 class; Canary manifest |
+| `S13_MONITORED_AUTONOMY_LOCKED` | Stage 7 runtime; model/policy version **locked** | L0–L5; L6 forbidden | Session review; this inventory |
+| `S14_ROLLBACK_OR_VETO` | KillSwitch, safety, GLB, operator revoke | L5 veto | Incident + stop playbooks |
+| `S15_RETIRED` | Policy superseded | — | Archive evidence |
+
+States `S4`–`S6` are **parallel evidence lanes**, not strict serial requirements for every change.
+
+### 10.3 Allowed transitions (index)
+
+- `S0 → S1` — AI recommendation (non-authorizing)
+- `S1 → S2` — operator promotes to formal candidate (**not automatic**)
+- `S2 → S3` — offline retrain (offline only)
+- `S3 → S4|S5|S6` — bounded evidence (Stage-3 gated adapter execute)
+- `S4|S5|S6 → S7` — packet assembly (review PASS ≠ execute auth)
+- `S7 → S8 → S9` — governance review → operator decision pending
+- `S9 → S10` (accept bounded) | `S0` (reject)
+- `S10 → S11` (optional Canary readiness)
+- `S11 → S12` — external Go still required
+- `S12 → S13` — external `go_decision_granted` + Canary + KillSwitch path
+- `S13 → S2` — **any** model/policy change (`MODEL_CHANGE_REQUIRES_REAPPROVAL=true`)
+- `ANY → S14` — veto / KillSwitch / GLB / operator emergency
+- `S14 → S0|S13` — explicit operator closeout only (not automatic)
+
+### 10.4 Forbidden auto-promotions
+
+| forbidden transition | literal / ref |
+|---|---|
+| Recommendation → live deploy | `FORBIDDEN_AUTO_PROMOTION_RECOMMENDATION_TO_LIVE` |
+| Evidence PASS → live | `FORBIDDEN_AUTO_PROMOTION_EVIDENCE_PASS_TO_LIVE`; `EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true` |
+| Testnet pass → live | `TESTNET_PASS_DOES_NOT_AUTHORIZE_LIVE=true` |
+| Packet/review → Go | `FORBIDDEN_AUTO_PROMOTION_PACKET_TO_GO_DECISION` |
+| Skip external Go → monitored live | `GO_DECISION_REQUIRES_EXTERNAL_RECORD=true` |
+| Offline retrain → monitored live direct | `ONLINE_LEARNING_TO_LIVE_FORBIDDEN=true` |
+| Dashboard/Notion/docs/AI → approval | `FORBIDDEN_PROMOTION_DASHBOARD_NOTION_DOCS_AI_TO_APPROVAL` (taxonomy §5) |
+| Online learning on live path | taxonomy §12.4; online-learning inventory row |
+
+### 10.5 Vetoes (always dominate)
+
+KillSwitch/safety (GLB-008 class), L5 Risk Gate, **L6 EXEC forbidden**, strategic switch-gate, GLB blockers, scheduler hard-block (taxonomy §7), scope/capital envelope breach — all force or block toward `S14`.
+
+### 10.6 AI may recommend vs gates may authorize
+
+- **L0–L3 AI:** may recommend; **must not** authorize live, Go, promotion, or scheduler unlock.
+- **L4 Policy Critic:** governance review on packet only; **not** execution or live.
+- **L5 Risk Gate:** deterministic hard-limit checks only.
+- **Evidence / readiness / dashboard:** **must not** authorize runtime or live.
+- **Operator:** bounded non-live acceptance; live requires external Go.
+- **External governance:** sole source of `go_decision_granted`.
+
+### 10.7 Non-goals
+
+- No parallel Stage-7 approval spec
+- No new readiness/evidence registry
+- No runtime transition enforcement
+- No scheduler/live/testnet execute enablement

--- a/docs/ops/specs/MASTER_V2_PROMOTION_STATE_MACHINE_V1.md
+++ b/docs/ops/specs/MASTER_V2_PROMOTION_STATE_MACHINE_V1.md
@@ -65,6 +65,7 @@ State semantics are interpretation and governance visibility only. They are not 
 - [MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md](MASTER_V2_FIRST_LIVE_GATE_STATUS_INDEX_V1.md): compact gate visibility and conservative status posture.
 - [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md): authority topology and unresolved approval-chain nodes.
 - [MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md](MASTER_V2_SCOPE_CAPITAL_ENVELOPE_CLARIFICATION_V1.md): upstream scope and capital semantics adjacent to promotion logic.
+- [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md): Stage-7 model/policy approval state machine §10 (orthogonal to environment states in this spec).
 - [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md): non-equality and authority-boundary language lock.
 
 This specification only cross-links these artifacts and does not modify them.

--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -109,7 +109,7 @@ Non-goals:
 | Credential boundaries | [RUNBOOK_OPERATOR_CREDENTIAL_BOUNDARIES_PLANNING_FIRST_V0.md](../runbooks/RUNBOOK_OPERATOR_CREDENTIAL_BOUNDARIES_PLANNING_FIRST_V0.md) |
 | Autonomy stages 0–7 vocabulary (informative) | [MASTER_V2_GO_LIVE_ROADMAP_V0.md](MASTER_V2_GO_LIVE_ROADMAP_V0.md) §3.1 |
 | Decision authority topology | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) |
-| Learning/AI/autonomy inventory | [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) |
+| Learning/AI/autonomy inventory | [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) — **§10 Stage-7 model/policy approval state machine** |
 | AI autonomy layer matrix (L0–L6) | [AI_AUTONOMY_CONTROL_CENTER.md](../control_center/AI_AUTONOMY_CONTROL_CENTER.md) |
 | Promotion state machine | [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md) |
 
@@ -510,7 +510,7 @@ GO_DECISION_REQUIRES_EXTERNAL_RECORD=true
 | `4` | Testnet autonomous bounded loop | `scoped_runtime_exception` | L0–L3 (max PROP; **no L6 EXEC**) | `testnet` adapter + review scripts (§10) | Stage-3 approval; testnet-only charter | `FORBIDDEN_PROMOTION_TESTNET_PASS_TO_LIVE_BROKER_EXCHANGE` |
 | `5` | Gated Live pilot | `live_authority_requires_separate_record` | L0–L4 (no L6 EXEC) | readiness ladder/index; GLB register; Canary criteria | external LB-APR-001 class + Canary manifest | `FORBIDDEN_PROMOTION_CANARY_DOCS_TO_LIVE`; GLB-014/015 |
 | `6` | Bounded autonomous Live | `go_decision_granted` | L0–L4 (no L6 EXEC) | Canary manifest + session review surfaces | external Go within lease; KillSwitch path (GLB-008) | `FORBIDDEN_PROMOTION_GO_NO_GO_TEMPLATE_TO_GO_DECISION`; GLB-020 |
-| `7` | Self-improving monitored autonomy | `operator_decision_required` | L0–L5 (L6 EXEC **forbidden**) | [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md); AI evidence packs | model/policy change approval; online learning → live **prohibited** | `FORBIDDEN_PROMOTION_DASHBOARD_NOTION_DOCS_AI_TO_APPROVAL` |
+| `7` | Self-improving monitored autonomy | `operator_decision_required` | L0–L5 (L6 EXEC **forbidden**) | [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) **§10**; AI evidence packs | model/policy change approval state machine §10; online learning → live **prohibited** | `FORBIDDEN_PROMOTION_DASHBOARD_NOTION_DOCS_AI_TO_APPROVAL` |
 
 **Stage number ≠ authority level.** Higher automation surface does **not** imply higher repo authority without explicit external/operator gates.
 

--- a/tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py
+++ b/tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py
@@ -1,0 +1,140 @@
+"""Static contract tests for Stage-7 model/policy approval state machine (Learning Inventory §10)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_OWNER = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md"
+)
+TAXONOMY_SPEC = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md"
+)
+ROADMAP_SPEC = REPO_ROOT / "docs" / "ops" / "specs" / "MASTER_V2_GO_LIVE_ROADMAP_V0.md"
+PROMOTION_SM = REPO_ROOT / "docs" / "ops" / "specs" / "MASTER_V2_PROMOTION_STATE_MACHINE_V1.md"
+
+FORBIDDEN_DUPLICATE_SPEC_PATHS = (
+    "STAGE_7_MODEL_APPROVAL",
+    "MODEL_APPROVAL_STATE_MACHINE",
+    "STAGE_7_MODEL_POLICY_APPROVAL",
+)
+
+REQUIRED_STATE_IDS = (
+    "S0_IDLE",
+    "S1_MODEL_RECOMMENDATION",
+    "S2_POLICY_CANDIDATE_DRAFT",
+    "S3_OFFLINE_RETRAIN_COMPLETE",
+    "S4_SHADOW_EVIDENCE",
+    "S5_PAPER_EVIDENCE",
+    "S6_TESTNET_EVIDENCE",
+    "S7_APPROVAL_PACKET_ASSEMBLED",
+    "S8_GOVERNANCE_REVIEW",
+    "S9_OPERATOR_DECISION_PENDING",
+    "S10_OPERATOR_ACCEPTED_BOUNDED",
+    "S11_CANARY_PILOT_ELIGIBLE",
+    "S12_LIVE_DEPLOY_PENDING_EXTERNAL",
+    "S13_MONITORED_AUTONOMY_LOCKED",
+    "S14_ROLLBACK_OR_VETO",
+    "S15_RETIRED",
+)
+
+STAGE_7_MACHINE_MARKERS = (
+    "STAGE_7_MODEL_APPROVAL_STATE_MACHINE_V0=true",
+    "STAGE_7_APPROVAL_STATE_COUNT=16",
+    "MODEL_RECOMMENDATION_NON_AUTHORIZING=true",
+    "POLICY_CANDIDATE_NON_EXECUTING=true",
+    "APPROVAL_PACKET_REVIEW_INPUT_ONLY=true",
+    "ONLINE_LEARNING_TO_LIVE_FORBIDDEN=true",
+    "MODEL_CHANGE_REQUIRES_REAPPROVAL=true",
+    "FORBIDDEN_AUTO_PROMOTION_RECOMMENDATION_TO_LIVE=true",
+    "FORBIDDEN_AUTO_PROMOTION_EVIDENCE_PASS_TO_LIVE=true",
+    "FORBIDDEN_AUTO_PROMOTION_PACKET_TO_GO_DECISION=true",
+    "EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true",
+    "TESTNET_PASS_DOES_NOT_AUTHORIZE_LIVE=true",
+    "GO_DECISION_REQUIRES_EXTERNAL_RECORD=true",
+    "AI_L6_EXEC_FORBIDDEN=true",
+    "KILLSWITCH_SAFETY_VETO_DOMINATES=true",
+)
+
+
+def _spec_text() -> str:
+    return CANONICAL_OWNER.read_text(encoding="utf-8")
+
+
+def test_canonical_owner_exists() -> None:
+    assert CANONICAL_OWNER.is_file()
+
+
+def test_stage_7_section_present() -> None:
+    text = _spec_text()
+    assert "## 10) Stage-7 model/policy approval state machine" in text
+    assert "Reuse-before-new" in text
+
+
+def test_all_stage_7_machine_markers_present() -> None:
+    text = _spec_text()
+    for marker in STAGE_7_MACHINE_MARKERS:
+        assert marker in text
+
+
+def test_all_s0_through_s15_state_ids_present() -> None:
+    text = _spec_text()
+    assert "STAGE_7_APPROVAL_STATE_COUNT=16" in text
+    for state_id in REQUIRED_STATE_IDS:
+        assert f"`{state_id}`" in text, f"missing state_id {state_id!r}"
+
+
+def test_forbidden_auto_promotion_literals_present() -> None:
+    text = _spec_text()
+    for literal in (
+        "FORBIDDEN_AUTO_PROMOTION_RECOMMENDATION_TO_LIVE",
+        "FORBIDDEN_AUTO_PROMOTION_EVIDENCE_PASS_TO_LIVE",
+        "FORBIDDEN_AUTO_PROMOTION_PACKET_TO_GO_DECISION",
+        "FORBIDDEN_PROMOTION_DASHBOARD_NOTION_DOCS_AI_TO_APPROVAL",
+    ):
+        assert literal in text
+
+
+def test_semantic_distinctions_and_critical_inequality_present() -> None:
+    text = _spec_text()
+    assert "approval_packet_complete ≠ operator_decision_granted ≠ go_decision_granted" in text
+    assert "Model recommendation" in text
+    assert "Policy candidate" in text
+    assert "Monitored autonomy" in text or "Monitored autonomy (Stage 7)" in text
+
+
+def test_vetoes_and_non_goals_present() -> None:
+    text = _spec_text()
+    assert "S14_ROLLBACK_OR_VETO" in text
+    assert "KillSwitch" in text
+    assert "No parallel Stage-7 approval spec" in text
+    assert "non-authorizing" in text.lower()
+
+
+def test_no_duplicate_stage_7_approval_spec_introduced() -> None:
+    specs_dir = REPO_ROOT / "docs" / "ops" / "specs"
+    for fragment in FORBIDDEN_DUPLICATE_SPEC_PATHS:
+        matches = list(specs_dir.glob(f"*{fragment}*"))
+        assert matches == [], f"duplicate spec surface: {matches}"
+
+
+def test_taxonomy_crosslinks_learning_inventory_section_10() -> None:
+    taxonomy = TAXONOMY_SPEC.read_text(encoding="utf-8")
+    inventory = _spec_text()
+    assert "MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md" in taxonomy
+    assert "§10" in taxonomy
+    assert "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md" in inventory
+    assert "§12" in inventory
+
+
+def test_roadmap_crosslinks_learning_inventory_section_10() -> None:
+    roadmap = ROADMAP_SPEC.read_text(encoding="utf-8")
+    assert "MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md" in roadmap
+    assert "§10" in roadmap or "Stage-7" in roadmap
+
+
+def test_promotion_sm_crosslinks_learning_inventory_section_10() -> None:
+    promotion = PROMOTION_SM.read_text(encoding="utf-8")
+    assert "MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md" in promotion
+    assert "§10" in promotion


### PR DESCRIPTION
## Summary
- Extend `MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md` with normative §10 Stage-7 model/policy approval state machine (S0–S15).
- Index allowed/forbidden transitions, vetoes, rollback/kill paths, and semantic distinctions without a parallel approval spec.
- Add minimal cross-links from Runtime Lane Taxonomy §12, Master V2 Go-Live Roadmap, and Promotion State Machine.
- Add static contract tests with duplicate-spec guard.

## Reuse-before-new
- Canonical owner reused: `MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md` §10.
- No `STAGE_7_MODEL_APPROVAL_*` parallel spec created.
- Existing taxonomy/roadmap/promotion surfaces only cross-link to the canonical owner.

## Test plan
- [x] `python3 -m pytest tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py -q` — 11 passed
- [x] `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh --docs-root docs`
- [x] `python3 -m ruff check tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py`
- [x] `python3 -m ruff format --check tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py`

## Safety
- Docs + static contract tests only.
- No runtime, scheduler, supervisor, daemon, launchctl, paper, shadow, testnet, live, broker, exchange, P67/P72 workload, WebUI server, Notion, or automation.
- Preserves non-authorizing semantics: AI may recommend; gates may validate; external/operator approval remains required where defined.
- Preserves permanent blocks: L6 EXEC forbidden, external `go_decision_granted` for live, KillSwitch/Safety veto dominance, no automatic model live deploy, no automatic capital/scope increase, no automatic pilot promotion.

Made with [Cursor](https://cursor.com)