### PR TITLE
test(ops): add P91 post-stop hints to primary evidence invariant contract

### DIFF
--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -16,6 +16,7 @@ P79_SHELL = REPO_ROOT / "scripts" / "ops" / "p79_supervisor_health_gate_v1.sh"
 P79_VERIFY = REPO_ROOT / "scripts" / "ops" / "p79_supervisor_evidence_manifest_verify_v0.py"
 P101_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p101_stop_playbook_v1.sh"
 P93_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p93_online_readiness_status_dashboard_v1.sh"
+P91_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p91_audit_snapshot_runner_v1.sh"
 PACK_SCRIPT = REPO_ROOT / "scripts" / "ops" / "pack_online_readiness_supervisor_evidence_v0.py"
 
 
@@ -33,6 +34,10 @@ def _p101_text() -> str:
 
 def _p93_text() -> str:
     return P93_SCRIPT.read_text(encoding="utf-8")
+
+
+def _p91_text() -> str:
+    return P91_SCRIPT.read_text(encoding="utf-8")
 
 
 def test_canonical_owner_exists() -> None:
@@ -172,6 +177,18 @@ def test_canonical_owner_references_p101_post_stop_operator_hints() -> None:
     assert "run_online_readiness_post_stop_pack_v0.sh" in text
     assert "--p79-archive-verify" in text
     assert "does not execute wrapper" in text.lower() or "does not execute pack" in text.lower()
+    assert "operator must" in text.lower()
+    assert "non-authorizing" in text
+    assert "In-process online-daemon automatic pack remains unimplemented" in text
+
+
+def test_canonical_owner_references_p91_post_stop_operator_hints() -> None:
+    text = _owner_text()
+    assert "p91_audit_snapshot_runner_v1.sh" in text
+    assert "P93 status dashboard" in text or "p93" in text.lower()
+    assert "run_online_readiness_post_stop_pack_v0.sh" in text
+    assert "--p79-archive-verify" in text
+    assert "does not execute wrapper" in text.lower() or "non-executing" in text.lower()
     assert "operator must" in text.lower()
     assert "non-authorizing" in text
     assert "In-process online-daemon automatic pack remains unimplemented" in text
@@ -329,6 +346,66 @@ def test_p93_status_dashboard_does_not_auto_execute_wrapper_pack_or_p79_archive_
 
 def test_p93_status_dashboard_no_new_launchctl_or_supervisor_start() -> None:
     text = _p93_text()
+    assert "launchctl bootstrap" not in text
+    assert "launchctl kickstart" not in text
+    assert "online_readiness_supervisor_v1.sh start" not in text
+    assert "online_readiness_daemon_v1.sh" not in text
+
+
+def test_p91_audit_snapshot_post_stop_hint_references_wrapper_and_optional_p79() -> None:
+    assert P91_SCRIPT.is_file()
+    text = _p91_text()
+    assert "run_online_readiness_post_stop_pack_v0.sh" in text
+    assert "--p79-archive-verify" in text
+    assert "P91_POST_STOP_PRIMARY_EVIDENCE_OPERATOR_HINTS.txt" in text
+    assert "--primary-evidence-enforce" in text
+
+
+def test_p91_audit_snapshot_post_stop_hint_markers_non_authorizing() -> None:
+    text = _p91_text()
+    for marker in (
+        "HINT_ONLY=true",
+        "WRAPPER_REFERENCED=true",
+        "WRAPPER_NOT_EXECUTED_BY_P91=true",
+        "PACK_NOT_EXECUTED_BY_P91=true",
+        "P79_ARCHIVE_VERIFY_NOT_EXECUTED_BY_P91=true",
+        "OPERATOR_MUST_RUN_EXPLICITLY=true",
+        "EVIDENCE_NON_AUTHORIZING=true",
+        "P91_AUDIT_SNAPSHOT_NOT_POST_STOP_AUTHORITY=true",
+    ):
+        assert marker in text
+
+
+def test_p91_audit_snapshot_does_not_auto_execute_wrapper_pack_or_p79_archive_verify() -> None:
+    lines = _p91_text().splitlines()
+    wrapper_offenders = [
+        line
+        for line in lines
+        if "run_online_readiness_post_stop_pack_v0.sh" in line
+        and not line.strip().startswith("#")
+        and not line.strip().startswith("echo")
+    ]
+    assert wrapper_offenders == []
+    pack_offenders = [
+        line
+        for line in lines
+        if "pack_online_readiness_supervisor_evidence_v0.py" in line
+        and not line.strip().startswith("#")
+        and not line.strip().startswith("echo")
+    ]
+    assert pack_offenders == []
+    p79_offenders = [
+        line
+        for line in lines
+        if "p79_supervisor_health_gate_v1.sh" in line
+        and "ARCHIVE_ROOT" in line
+        and not line.strip().startswith("echo")
+    ]
+    assert p79_offenders == []
+
+
+def test_p91_audit_snapshot_no_new_launchctl_or_supervisor_start() -> None:
+    text = _p91_text()
     assert "launchctl bootstrap" not in text
     assert "launchctl kickstart" not in text
     assert "online_readiness_supervisor_v1.sh start" not in text


### PR DESCRIPTION
## Summary
- Extend shared primary evidence retention invariant contract with P91 post-stop hint coverage.
- Mirror P101/P93 invariant coverage for P91.
- Assert P91 hints remain non-executing and non-authorizing.
- Assert P91 does not clear HOLD, authorize runtime, or alter launchctl/supervisor behavior.

## Reuse-before-new
- Reuses existing shared invariant test owner: `tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`.
- No new docs, specs, runbooks, scripts, wrappers, launchctl, readiness, or evidence surfaces.

## Test plan
- [x] 50/50 focused tests passed
- [x] Ruff check/format
- [x] `bash -n scripts/ops/p91_audit_snapshot_runner_v1.sh`

## Safety
- Static tests only.
- No runtime behavior changed.
- No docs changes.
- No scheduler, supervisor, daemon, launchctl, paper, shadow, testnet, live, broker, exchange, P67/P72 workload, WebUI server, Notion, or automation.
- Global HOLD remains active.
- Preflight remains BLOCKED.
- Evidence remains non-authorizing.

Made with [Cursor](https://cursor.com)