### PR TITLE
test(webui): F5 guardrails visibility contract v0

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -153,6 +153,18 @@ def test_market_dashboard_has_no_trade_action_affordance(client: TestClient) -> 
         assert term not in combined_html
 
 
+def test_market_dashboard_guardrails_visibility_v0(client: TestClient) -> None:
+    """Both market routes render shared Guardrails non-authority copy (MARKET_SURFACE_V0)."""
+    guardrails_core = (
+        "Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval"
+    )
+    for path in ("/market", "/market/double-play"):
+        html = _html(client, path)
+        assert "Guardrails:" in html
+        assert guardrails_core in html
+        assert "keine Broker-/Order-/Live-Autorität" in html
+
+
 def test_market_dashboard_readonly_banner_markers(client: TestClient) -> None:
     market_html = _html(client, "/market")
     assert 'data-market-readonly="true"' in market_html

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -155,9 +155,7 @@ def test_market_dashboard_has_no_trade_action_affordance(client: TestClient) -> 
 
 def test_market_dashboard_guardrails_visibility_v0(client: TestClient) -> None:
     """Both market routes render shared Guardrails non-authority copy (MARKET_SURFACE_V0)."""
-    guardrails_core = (
-        "Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval"
-    )
+    guardrails_core = "Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval"
     for path in ("/market", "/market/double-play"):
         html = _html(client, path)
         assert "Guardrails:" in html


### PR DESCRIPTION
## Summary
- Add `test_market_dashboard_guardrails_visibility_v0` to the canonical market dashboard structure contract module.
- Assert shared non-authorizing Guardrails copy on `/market` and `/market/double-play`.
- No template, route, docs, or runtime changes.
- Preserve F5 vs. Market Surface separation; Market-Airport remains out of scope.

## Reuse-before-new
- Canonical owner reused: `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`.
- No new dashboard, docs, route, API, template, readiness, or evidence surface created.

## Test plan
- [x] `python3 -m pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -k guardrails -q` — 1 passed
- [x] `python3 -m pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` — 37 passed
- [x] `python3 -m ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Safety
- Tests-only.
- No WebUI server start.
- No runtime, scheduler, supervisor, daemon, launchctl, paper, shadow, testnet, live, broker, exchange, P67/P72 workload, Notion, or automation.
- Guardrails remain non-authorizing: Dashboard ≠ Freigabe, AI ≠ Authority, Signal ≠ Trade, Docs ≠ Approval.

Made with [Cursor](https://cursor.com)