### PR TITLE
docs(webui): F5 contract Market Surface backlink v0

### DIFF
--- a/docs/ops/specs/FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md
+++ b/docs/ops/specs/FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md
@@ -306,6 +306,8 @@ This contract is the **canonical F5 read-only market dashboard** display boundar
 
 Dashboard ≠ Freigabe. Read-only status, diagnostic output, and bounded WebUI contract tests **do not** authorize Live, Testnet, broker, exchange, scheduler, or runtime execution.
 
+The broader **`GET &#47;market`** WebUI owner [Market Surface v0](../../webui/MARKET_SURFACE_V0.md) (Kraken/OHLCV/dummy SSR lineage) is **orthogonal** to this F5 contract. Market Surface v0 **does not replace** F5 futures-aware display semantics; this contract remains the canonical F5 read-only dashboard boundary. Market-Airport and parallel dashboard surfaces remain out of scope.
+
 ## Validation / future tests
 
 Future tests should prove:
@@ -324,6 +326,7 @@ Future tests should prove:
 ## References
 
 - [Runtime Lane Taxonomy + Authority Levels Contract v0](RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) — lane_id `dashboard`, non-authorizing display indexing (§7h)
+- [Market Surface v0](../../webui/MARKET_SURFACE_V0.md) — orthogonal WebUI owner for `&#47;market` and related read-only routes; does not replace F5 semantics
 - [Futures Capability Spec v0](FUTURES_CAPABILITY_SPEC_V0.md)
 - [Futures Instrument Metadata Contract v0](FUTURES_INSTRUMENT_METADATA_CONTRACT_V0.md)
 - [Futures Market Data Provenance Contract v0](FUTURES_MARKET_DATA_PROVENANCE_CONTRACT_V0.md)

--- a/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
+++ b/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
@@ -697,6 +697,23 @@ def test_market_surface_v0_taxonomy_cross_ref_aligned() -> None:
     assert "does not replace the F5 contract owner" in taxonomy or "F5 contract owner" in taxonomy
 
 
+def test_f5_contract_market_surface_bidirectional_crossref_v0() -> None:
+    """F5 contract and Market Surface v0 cross-reference each other; separation preserved."""
+    assert MARKET_DASHBOARD_SPEC.is_file()
+    assert MARKET_SURFACE_V0.is_file()
+    f5 = MARKET_DASHBOARD_SPEC.read_text(encoding="utf-8")
+    surface = MARKET_SURFACE_V0.read_text(encoding="utf-8")
+    assert "MARKET_SURFACE_V0.md" in f5
+    assert "orthogonal" in f5.lower()
+    assert "does not replace" in f5.lower()
+    assert "Market-Airport" in f5 or "market-airport" in f5.lower()
+    assert "FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md" in surface
+    assert "replace f5" in surface.lower()
+    assert "Guardrails" in surface
+    assert "Freigabe" in surface
+    assert "AI" in surface and "Authority" in surface
+
+
 def test_autonomy_stage_authority_crosswalk_section_present() -> None:
     text = _spec_text()
     assert "## 12. Autonomy stage authority crosswalk" in text


### PR DESCRIPTION
## Summary
- Add missing F5 → `MARKET_SURFACE_V0.md` backlink in `FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md`.
- Clarify orthogonal separation between F5 and Market Surface.
- Keep Market-Airport explicitly out of scope.
- Add `test_f5_contract_market_surface_bidirectional_crossref_v0`.

## Reuse-before-new
- Reuses existing canonical F5 contract and Market Surface docs.
- Reuses existing taxonomy authority levels contract test file.
- No new dashboard, route, API, template, readiness, evidence, or Market-Airport surface.

## Test plan
- [x] Focused pytest: 3 passed
- [x] Full taxonomy file: 48 passed
- [x] Docs token policy
- [x] Reference target verification
- [x] Ruff check/format

## Safety
- Docs + static tests only.
- No template, route, or API changes.
- No WebUI server start.
- No runtime, scheduler, supervisor, daemon, launchctl, paper, shadow, testnet, live, broker, exchange, P67/P72 workload, Notion, or automation.
- Guardrails remain non-authorizing; Market-Airport remains out of scope.

Made with [Cursor](https://cursor.com)