### PR TITLE
docs(ops): taxonomy ↔ inventory §11 cross-ref v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md
+++ b/docs/ops/specs/MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md
@@ -106,7 +106,7 @@ Addressed in §11 (docs index only):
 
 ## 9) Cross-References
 
-- [RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md](RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) — §12 autonomy crosswalk; stage 7 row; §12.3 permanent operator-only gates
+- [RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md](RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) — §12 autonomy crosswalk; stage 7 row cross-references **§10** (approval SM) and **§11** (learning-change evidence pointer index); §12.3 permanent operator-only gates
 - [MASTER_V2_GO_LIVE_ROADMAP_V0.md](MASTER_V2_GO_LIVE_ROADMAP_V0.md) — §3.1 stage vocabulary
 - [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md) — environment promotion visibility (orthogonal to §10)
 - [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md)

--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -117,7 +117,7 @@ Non-goals:
 | Credential boundaries | [RUNBOOK_OPERATOR_CREDENTIAL_BOUNDARIES_PLANNING_FIRST_V0.md](../runbooks/RUNBOOK_OPERATOR_CREDENTIAL_BOUNDARIES_PLANNING_FIRST_V0.md) |
 | Autonomy stages 0–7 vocabulary (informative) | [MASTER_V2_GO_LIVE_ROADMAP_V0.md](MASTER_V2_GO_LIVE_ROADMAP_V0.md) §3.1 |
 | Decision authority topology | [MASTER_V2_DECISION_AUTHORITY_MAP_V1.md](MASTER_V2_DECISION_AUTHORITY_MAP_V1.md) |
-| Learning/AI/autonomy inventory | [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) — **§10 Stage-7 model/policy approval state machine** |
+| Learning/AI/autonomy inventory | [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) — **§10** Stage-7 model/policy approval state machine; **§11** learning-change evidence pointer index (orthogonal; pointer-only) |
 | AI autonomy layer matrix (L0–L6) | [AI_AUTONOMY_CONTROL_CENTER.md](../control_center/AI_AUTONOMY_CONTROL_CENTER.md) |
 | Promotion state machine | [MASTER_V2_PROMOTION_STATE_MACHINE_V1.md](MASTER_V2_PROMOTION_STATE_MACHINE_V1.md) |
 
@@ -544,7 +544,7 @@ GO_DECISION_REQUIRES_EXTERNAL_RECORD=true
 | `4` | Testnet autonomous bounded loop | `scoped_runtime_exception` | L0–L3 (max PROP; **no L6 EXEC**) | `testnet` adapter + review scripts (§10) | Stage-3 approval; testnet-only charter | `FORBIDDEN_PROMOTION_TESTNET_PASS_TO_LIVE_BROKER_EXCHANGE` |
 | `5` | Gated Live pilot | `live_authority_requires_separate_record` | L0–L4 (no L6 EXEC) | readiness ladder/index; GLB register; Canary criteria | external LB-APR-001 class + Canary manifest | `FORBIDDEN_PROMOTION_CANARY_DOCS_TO_LIVE`; GLB-014/015 |
 | `6` | Bounded autonomous Live | `go_decision_granted` | L0–L4 (no L6 EXEC) | Canary manifest + session review surfaces | external Go within lease; KillSwitch path (GLB-008) | `FORBIDDEN_PROMOTION_GO_NO_GO_TEMPLATE_TO_GO_DECISION`; GLB-020 |
-| `7` | Self-improving monitored autonomy | `operator_decision_required` | L0–L5 (L6 EXEC **forbidden**) | [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) **§10**; AI evidence packs | model/policy change approval state machine §10; online learning → live **prohibited** | `FORBIDDEN_PROMOTION_DASHBOARD_NOTION_DOCS_AI_TO_APPROVAL` |
+| `7` | Self-improving monitored autonomy | `operator_decision_required` | L0–L5 (L6 EXEC **forbidden**) | [MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md](MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md) **§10** approval SM; **§11** learning-change evidence pointer index; AI evidence packs | approval state machine **§10**; evidence pointer index **§11** (non-authorizing); online learning → live **prohibited** | `FORBIDDEN_PROMOTION_DASHBOARD_NOTION_DOCS_AI_TO_APPROVAL` |
 
 **Stage number ≠ authority level.** Higher automation surface does **not** imply higher repo authority without explicit external/operator gates.
 
@@ -590,3 +590,4 @@ The following remain **operator-only** or **external-gated** regardless of stage
 - **v1.0** — Bounded observation adapter cross-ref: §10 subsection indexes paper/shadow/testnet retention adapters; plan-only default; Stage-3 gated execute; review-input-only semantics.
 - **v1.1** — Bounded observation review script cross-ref: §10 indexes shadow/testnet evidence review scripts; offline; non-executing; review-input-only semantics.
 - **v1.2** — Autonomy stage authority crosswalk §12: stages 0–7 → max authority, AI layer caps, evidence owners, external/operator gates, forbidden promotions; reuse roadmap §3.1 vocabulary; no parallel autonomy spec.
+- **v1.3** — Inventory §11 learning-change evidence index cross-ref: §12.2 stage-7 row and owner table index **§11** pointer index alongside **§10** approval SM; pointer-only; non-authorizing.

--- a/tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py
+++ b/tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py
@@ -131,6 +131,23 @@ def test_taxonomy_crosslinks_learning_inventory_section_10() -> None:
     assert "§12" in inventory
 
 
+def test_taxonomy_crosslinks_learning_inventory_section_11_v0() -> None:
+    """Taxonomy §12 stage-7 indexes Inventory §11 evidence pointer; §10 approval owner preserved."""
+    taxonomy = TAXONOMY_SPEC.read_text(encoding="utf-8")
+    inventory = _spec_text()
+    assert "MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md" in taxonomy
+    assert "§10" in taxonomy
+    assert "§11" in taxonomy
+    assert "learning-change evidence pointer index" in taxonomy.lower()
+    assert "approval SM" in taxonomy or "approval state machine" in taxonomy.lower()
+    assert "non-authorizing" in taxonomy.lower()
+    assert "§11" in inventory
+    assert "§10" in inventory
+    assert "stage 7" in inventory.lower() or "§12" in inventory
+    assert "LEARNING_CHANGE_EVIDENCE_INDEX_POINTER_ONLY=true" in inventory
+    assert "## 10) Stage-7 model/policy approval state machine" in inventory
+
+
 def test_roadmap_crosslinks_learning_inventory_section_10() -> None:
     roadmap = ROADMAP_SPEC.read_text(encoding="utf-8")
     assert "MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md" in roadmap


### PR DESCRIPTION
## Summary
- Extend taxonomy owner table and §12.2 Stage-7 row to reference both Inventory §10 and §11.
- Preserve §10 as the approval state-machine owner.
- Add §11 as the learning-change evidence pointer index.
- Add Inventory §9 backlink for taxonomy Stage-7 cross-reference.
- Add static test for §10/§11 separation and bidirectional cross-linking.

## Reuse-before-new
- Canonical owners reused:
  - `RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md` §12
  - `MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md` §10/§11
- No parallel Stage-7, Autonomy, approval, evidence, or registry surface created.

## Test plan
- [x] Stage-7 pytest: 17 passed
- [x] Taxonomy autonomy crosswalk pytest: 4 passed
- [x] Docs token policy
- [x] Reference target verification
- [x] Ruff check/format

## Safety
- Docs + static test only.
- No runtime behavior changed.
- No Preflight unblock, no HOLD clear, no gate clear, no start command.
- No model deploy/live/runtime authorization.
- No scheduler, supervisor, daemon, launchctl, paper, shadow, testnet, live, broker, exchange, P67/P72 workload, WebUI server, Notion, or automation.
- Global HOLD remains active; Preflight remains BLOCKED; evidence remains non-authorizing.

Made with [Cursor](https://cursor.com)