### PR TITLE
docs(ops): Inventory §12 learning triggers compact index v0

### DIFF
--- a/docs/ops/specs/MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md
+++ b/docs/ops/specs/MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md
@@ -47,7 +47,7 @@ This inventory uses the following canonical categories:
 
 | category | canonical meaning | nearest repo evidence | what is confirmed | what remains unclear | authority visibility | confidence | ambiguity and gap |
 |---|---|---|---|---|---|---|---|
-| learning triggers | events that should start learning-related review or retraining flow | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md) | trigger-like governance conditions and re-entry guardrails are documented | one compact canonical trigger registry for Master V2 is not materialized | partial | partial | trigger semantics are distributed across governance and decision notes |
+| learning triggers | events that should start learning-related review or retraining flow | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md), **§12 learning triggers compact pointer index** | trigger-like governance conditions and re-entry guardrails are documented; **§12 materializes compact trigger→§10→§11 pointer index** | runtime trigger dispatch and auto-retrain enforcement remain out of scope | partial to strong | partial to high | **§12** consolidates review-entry triggers without new registry or runtime workflow |
 | training loops | closed-loop training process definitions and control boundaries | [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md), [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) | closed self-learning loops are explicitly disallowed in current guardrails | one canonical training-loop contract for Master V2 is not materialized | unclear | partial | boundary is mostly defined by prohibitions, not by one positive loop contract |
 | offline learning and retraining | bounded offline model improvement outside live hot path | [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md), [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) | offline-only direction is explicit in multiple documents | canonical retraining lifecycle with approval checkpoints is not consolidated | partial | partial | retraining semantics exist, but lifecycle ownership remains distributed |
 | online learning and adaptation | live-time adaptation that affects behavior | [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md), [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md) | online-learning influence on live behavior is explicitly blocked | approved exception path is intentionally absent | clear for prohibition | high | prohibition is strong, but no positive allowed path is specified |
@@ -73,6 +73,7 @@ This inventory uses the following canonical categories:
 - model orchestration versus strategy selection: model routing and strategy switching remain distinct and must not be collapsed.
 - offline retraining versus online adaptation: offline allowance exists, online adaptation in live influence remains prohibited.
 - evidence and registry artifacts versus actual learning authority: rich artifacts do not automatically prove consolidated authority ownership.
+- Master V2 learning triggers versus operator drill tooling: **§12** Stage-7 review-entry triggers must not be conflated with `src/trigger_training/`, InfoStream `trigger_training_sessions`, or offline drill scripts (orthogonal research/operator surfaces).
 
 ## 7) Non-Authorizing Constraint
 
@@ -103,6 +104,10 @@ Addressed in §10 (docs index only):
 Addressed in §11 (docs index only):
 
 - consolidated learning-change evidence index tied to explicit authority nodes and §10 states (pointer-only; no new approval spec)
+
+Addressed in §12 (docs index only):
+
+- consolidated learning triggers compact pointer index tied to §10 states and §11 evidence rows (pointer-only; no runtime trigger workflow)
 
 ## 9) Cross-References
 
@@ -281,3 +286,52 @@ Rows are **pointers** to canonical owners. This table does **not** implement sto
 - No runtime transition enforcement or model training workflow
 - No approval grant, live deploy path, scheduler unlock, or external gate bypass
 - No implication that indexed artifacts authorize model deploy, live capital, broker, or exchange activity
+
+## 12) Learning triggers compact pointer index (normative)
+
+```
+LEARNING_TRIGGERS_COMPACT_INDEX_V0=true
+LEARNING_TRIGGERS_POINTER_ONLY=true
+LEARNING_TRIGGERS_NON_AUTHORIZING=true
+EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true
+TRIGGER_DOES_NOT_AUTHORIZE_RETRAIN=true
+TRIGGER_DOES_NOT_AUTHORIZE_RUNTIME=true
+ONLINE_LEARNING_TO_LIVE_FORBIDDEN=true
+FORBIDDEN_AUTO_RETRAINING_FROM_TRIGGER=true
+MODEL_DEPLOY_NOT_AUTHORIZED=true
+GLB015_EVIDENCE_NOT_APPROVAL=true
+```
+
+This section is the **compact pointer index** for Master V2 **learning-related review-entry events** mapped to **§10** states and **§11** evidence rows. It consolidates visibility only — **not** a trigger registry implementation, runtime dispatcher, auto-retraining workflow, or approval spec.
+
+**Reuse-before-new:** Trigger semantics remain in [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md](../../governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md) (hard NO-GO conditions, TTL + Review Trigger on evidence packs) and [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md) (re-entry rule; **no** auto-retraining). State transitions remain indexed in **§10**; evidence artifacts remain indexed in **§11**. Stage-7 posture remains in [RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md](RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) §12.2 row `7`.
+
+**Critical inequality (unchanged):** `trigger_event ≠ approval_packet_complete ≠ operator_decision_granted ≠ go_decision_granted ≠ live_deploy_authorized`.
+
+**Orthogonal exclusion:** Master V2 learning triggers in this section are **not** `src/trigger_training/`, InfoStream `trigger_training_sessions`, offline trigger-training drill scripts, scheduler hooks, or model-deploy authorization paths.
+
+### 12.1 Pointer index (trigger event → §10 state → §11 evidence)
+
+| learning trigger event (review entry) | §10 state entry | §11 evidence ref | canonical source / owner | non-authority boundary |
+|---|---|---|---|---|
+| AI model recommendation captured | `S1_MODEL_RECOMMENDATION` | §11 S1 row | §10 `S0→S1`; AI evidence packs | Recommendation **≠** approval; **≠** live |
+| Operator promotes formal candidate | `S2_POLICY_CANDIDATE_DRAFT` | §11 S2 row | §10 `S1→S2` (**not automatic**) | Candidate **≠** approval |
+| Offline retrain run completed | `S3_OFFLINE_RETRAIN_COMPLETE` | §11 S3 row | [BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md](../decisions/BAYESIAN_EVIDENCE_LAYER_V0_DECISION.md) | Offline **≠** live; drift hint **≠** auto-retrain |
+| Monitored autonomy model/policy change | `S2` (re-entry from `S13`) | §11 S2 row | `MODEL_CHANGE_REQUIRES_REAPPROVAL=true`; §10 `S13→S2` | Re-approval required; **≠** hot-swap |
+| Bounded lane evidence ready (shadow/paper/testnet) | `S4` / `S5` / `S6` | §11 lane rows | Taxonomy §10 adapters; review scripts | PASS **≠** gate clear (**GLB-015**) |
+| Approval packet assembled | `S7_APPROVAL_PACKET_ASSEMBLED` | §11 S7 row | [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md](../../governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md) | Packet **≠** operator Go |
+| Governance review / TTL review due | `S8` / `S9` | §11 S8/S9 rows | Go/No-Go §10.2F TTL + Review Trigger | Review **≠** execution |
+| Drift/novelty/reliability hint (Bayesian parking) | review queue → `S1` or governance | pointer only | BAYESIAN re-entry rule | Observation-only; **no** auto-retrain trigger |
+| Online-learning live influence (NO-GO) | `S14_ROLLBACK_OR_VETO` | §11 S14 row | Go/No-Go §8 item 5 | Veto dominates |
+| KillSwitch / GLB / operator emergency veto | `S14_ROLLBACK_OR_VETO` | §11 S14 row | §10.5 vetoes; [MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md](MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md) | **No** auto-resume |
+
+Rows are **pointers** to canonical owners. This table does **not** implement trigger dispatch, retrain execution, transition enforcement, or storage.
+
+### 12.2 Non-goals
+
+- No parallel Stage-7 approval, autonomy, or trigger spec
+- No `src/trigger_training/`, InfoStream `trigger_training_sessions`, or offline drill scripts as canonical Stage-7 trigger owners
+- No runtime trigger dispatcher, scheduler hook, or auto-retraining workflow
+- No new evidence registry, readiness hub, or archive surface
+- No approval grant, live deploy path, Preflight unblock, HOLD clear, or external gate bypass
+- No implication that indexed trigger events authorize model deploy, live capital, broker, exchange, or runtime activity

--- a/tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py
+++ b/tests/ops/test_master_v2_learning_ai_autonomy_inventory_stage7_v0.py
@@ -246,3 +246,75 @@ def test_learning_change_evidence_index_non_authorizing_v0() -> None:
     assert "evidence_complete ≠ approval_packet_complete" in text
     assert "consolidated learning-change evidence index" in text.lower()
     assert "Addressed in §11" in text
+
+
+LEARNING_TRIGGERS_COMPACT_INDEX_MARKERS = (
+    "LEARNING_TRIGGERS_COMPACT_INDEX_V0=true",
+    "LEARNING_TRIGGERS_POINTER_ONLY=true",
+    "LEARNING_TRIGGERS_NON_AUTHORIZING=true",
+    "EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true",
+    "TRIGGER_DOES_NOT_AUTHORIZE_RETRAIN=true",
+    "TRIGGER_DOES_NOT_AUTHORIZE_RUNTIME=true",
+    "FORBIDDEN_AUTO_RETRAINING_FROM_TRIGGER=true",
+    "MODEL_DEPLOY_NOT_AUTHORIZED=true",
+)
+
+LEARNING_TRIGGERS_SECTION10_STATE_IDS = (
+    "S1_MODEL_RECOMMENDATION",
+    "S2_POLICY_CANDIDATE_DRAFT",
+    "S3_OFFLINE_RETRAIN_COMPLETE",
+    "S4_SHADOW_EVIDENCE",
+    "S5_PAPER_EVIDENCE",
+    "S6_TESTNET_EVIDENCE",
+    "S7_APPROVAL_PACKET_ASSEMBLED",
+    "S8_GOVERNANCE_REVIEW",
+    "S9_OPERATOR_DECISION_PENDING",
+    "S14_ROLLBACK_OR_VETO",
+)
+
+
+def test_learning_triggers_compact_index_section_present_v0() -> None:
+    """Inventory §12 learning triggers compact pointer index exists."""
+    text = _spec_text()
+    assert "## 12) Learning triggers compact pointer index" in text
+    for marker in LEARNING_TRIGGERS_COMPACT_INDEX_MARKERS:
+        assert marker in text
+    assert "Reuse-before-new" in text
+    assert "No parallel Stage-7 approval" in text
+    assert "Addressed in §12" in text
+
+
+def test_learning_triggers_map_to_section10_and_section11_v0() -> None:
+    """§12 pointer table maps trigger events to §10 states and §11 evidence refs."""
+    text = _spec_text()
+    assert "### 12.1 Pointer index" in text
+    for state_id in LEARNING_TRIGGERS_SECTION10_STATE_IDS:
+        assert state_id in text
+    assert "§11 S1 row" in text
+    assert "§11 S14 row" in text
+    assert "MODEL_CHANGE_REQUIRES_REAPPROVAL=true" in text
+    assert "BAYESIAN re-entry rule" in text
+
+
+def test_learning_triggers_non_authorizing_v0() -> None:
+    """§12 is pointer-only; does not authorize runtime, retrain, or model deploy."""
+    text = _spec_text()
+    assert "pointer index" in text.lower()
+    assert "non-authorizing" in text.lower()
+    assert "TRIGGER_DOES_NOT_AUTHORIZE_RUNTIME=true" in text
+    assert "No approval grant" in text
+    assert "No runtime trigger dispatcher" in text
+    assert "trigger_event ≠ approval_packet_complete" in text
+    assert "consolidated learning triggers compact pointer index" in text.lower()
+
+
+def test_learning_triggers_excludes_trigger_training_module_v0() -> None:
+    """§12 excludes trigger_training drills and parallel Stage-7 specs."""
+    text = _spec_text()
+    assert "src/trigger_training/" in text
+    assert "trigger_training_sessions" in text
+    assert "offline trigger-training drill scripts" in text
+    specs_dir = REPO_ROOT / "docs" / "ops" / "specs"
+    for fragment in FORBIDDEN_DUPLICATE_SPEC_PATHS:
+        matches = list(specs_dir.glob(f"*{fragment}*"))
+        assert matches == [], f"duplicate spec surface: {matches}"


### PR DESCRIPTION
## Summary
- Add Inventory §12 learning triggers compact pointer index.
- Map trigger event classes to §10 states and §11 evidence references.
- Sync §4 learning-trigger row and §8 closure criteria.
- Explicitly exclude `src/trigger_training/`, InfoStream drills, runtime dispatch, scheduler paths, and model deploy authority.
- Add four static contract tests.

## Reuse-before-new
- Canonical owner reused: `MASTER_V2_LEARNING_AI_AUTONOMY_INVENTORY_V1.md`.
- Reuses §10, §11, Go/No-Go, and Bayesian Decision references as pointers only.
- No parallel Stage-7, trigger, approval, training workflow, registry, or runtime surface created.

## Test plan
- [x] Stage-7 pytest: 21 passed
- [x] Docs token policy
- [x] Reference target verification
- [x] Ruff check/format

## Safety
- Docs + static tests only.
- No runtime behavior changed.
- No Preflight unblock, no HOLD clear, no gate clear, no start command.
- No model deploy/live/runtime authorization.
- No scheduler, supervisor, daemon, launchctl, paper, shadow, testnet, live, broker, exchange, P67/P72 workload, WebUI server, Notion, or automation.
- Global HOLD remains active; Preflight remains BLOCKED; evidence remains non-authorizing.

Made with [Cursor](https://cursor.com)