### PR TITLE
docs: add shadow wall-clock staging log hygiene contract

### DIFF
--- a/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
+++ b/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
@@ -41,8 +41,8 @@ This charter **does not replace** the preflight contract, ops TOMLs, scheduler c
   - **Extended tier (governed, default-off):** optional CLI path up to 60 minutes / 3600 steps only with `--extended-bounded-shadow-validation` plus a **distinct** extended confirm token (separate from the base wrapper token). Still local dry-run Shadow only; still **non-authorizing**; does **not** satisfy Stage 3 or any Live/Testnet/broker/exchange/order path.
   - **24h candidate tier (governed, default-off):** optional CLI path up to 1440 minutes / 86400 steps only with `--candidate-24h-bounded-shadow-validation` plus a **distinct** `--candidate-24h-confirm-token` (separate from base and extended tokens; mutually exclusive with the extended flag). Preparation for bounded dry-run **candidate** validation only — **non-authorizing**, requires separate operator GO for any execution, does **not** imply 24/7 readiness or Stage 3+.
 - **Static drift tests (non-authorizing):** e.g. `tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`, `tests/ops/test_offline_crosslink_invariant_contract_v0.py`, `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`, `tests/ops/test_shadow_bounded_observation_staging_log_contract_v0.py`
-- **Shadow bounded observation adapter (execute reference):** `scripts/ops/run_shadow_bounded_observation_adapter_v0.py` — writes wrapper stdout/stderr under `{staging_root}/logs/` before review.
-- **Shadow bounded observation review (enforcer):** `scripts/ops/review_shadow_bounded_observation_evidence_v0.py` — offline review only; requires `logs/wrapper_stdout.log` and `logs/wrapper_stderr.log`.
+- **Shadow bounded observation adapter (execute reference):** `scripts/ops/run_shadow_bounded_observation_adapter_v0.py` — writes wrapper stdout/stderr under `{staging_root}&#47;logs&#47;` before review.
+- **Shadow bounded observation review (enforcer):** `scripts/ops/review_shadow_bounded_observation_evidence_v0.py` — offline review only; requires `logs&#47;wrapper_stdout.log` and `logs&#47;wrapper_stderr.log`.
 
 ---
 
@@ -50,12 +50,12 @@ This charter **does not replace** the preflight contract, ops TOMLs, scheduler c
 
 Any **detached**, **manual**, or **archive-only** operator start path that later invokes `scripts/ops/review_shadow_bounded_observation_evidence_v0.py` **must** populate these canonical staging paths **before** post-run review:
 
-- `{staging_root}/logs/wrapper_stdout.log`
-- `{staging_root}/logs/wrapper_stderr.log`
+- `{staging_root}&#47;logs&#47;wrapper_stdout.log`
+- `{staging_root}&#47;logs&#47;wrapper_stderr.log`
 
 The wrapper skeleton emits evidence under `--evidence-root`; stdout/stderr capture is **caller-owned**. The canonical execute reference is `scripts/ops/run_shadow_bounded_observation_adapter_v0.py` (`expected_artifacts` includes both log files). The review script **hard-fails** when either path is missing — **do not** weaken review to accept detached-only alternate log locations.
 
-Detached `nohup` launches may mirror logs under a bundle `detached/` directory (symlink or copy) for operator monitoring, but **`staging/logs/`** paths are authoritative for review and durable archive closeout.
+Detached `nohup` launches may mirror logs under a bundle `detached&#47;` directory (symlink or copy) for operator monitoring, but **`staging&#47;logs&#47;`** paths are authoritative for review and durable archive closeout.
 
 ```text
 SHADOW_BOUNDED_STAGING_LOG_CONTRACT_V0=true

--- a/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
+++ b/docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md
@@ -40,7 +40,30 @@ This charter **does not replace** the preflight contract, ops TOMLs, scheduler c
   - **Standard bounded Shadow dry-run cap (default):** 10 minutes / 600 simulated steps — unchanged.
   - **Extended tier (governed, default-off):** optional CLI path up to 60 minutes / 3600 steps only with `--extended-bounded-shadow-validation` plus a **distinct** extended confirm token (separate from the base wrapper token). Still local dry-run Shadow only; still **non-authorizing**; does **not** satisfy Stage 3 or any Live/Testnet/broker/exchange/order path.
   - **24h candidate tier (governed, default-off):** optional CLI path up to 1440 minutes / 86400 steps only with `--candidate-24h-bounded-shadow-validation` plus a **distinct** `--candidate-24h-confirm-token` (separate from base and extended tokens; mutually exclusive with the extended flag). Preparation for bounded dry-run **candidate** validation only — **non-authorizing**, requires separate operator GO for any execution, does **not** imply 24/7 readiness or Stage 3+.
-- **Static drift tests (non-authorizing):** e.g. `tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`, `tests/ops/test_offline_crosslink_invariant_contract_v0.py`, `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`
+- **Static drift tests (non-authorizing):** e.g. `tests/ops/test_shadow_247_futures_config_job_skeleton_v0.py`, `tests/ops/test_offline_crosslink_invariant_contract_v0.py`, `tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py`, `tests/ops/test_shadow_bounded_observation_staging_log_contract_v0.py`
+- **Shadow bounded observation adapter (execute reference):** `scripts/ops/run_shadow_bounded_observation_adapter_v0.py` — writes wrapper stdout/stderr under `{staging_root}/logs/` before review.
+- **Shadow bounded observation review (enforcer):** `scripts/ops/review_shadow_bounded_observation_evidence_v0.py` — offline review only; requires `logs/wrapper_stdout.log` and `logs/wrapper_stderr.log`.
+
+---
+
+## Detached / manual bounded Shadow launch — staging log contract (v0)
+
+Any **detached**, **manual**, or **archive-only** operator start path that later invokes `scripts/ops/review_shadow_bounded_observation_evidence_v0.py` **must** populate these canonical staging paths **before** post-run review:
+
+- `{staging_root}/logs/wrapper_stdout.log`
+- `{staging_root}/logs/wrapper_stderr.log`
+
+The wrapper skeleton emits evidence under `--evidence-root`; stdout/stderr capture is **caller-owned**. The canonical execute reference is `scripts/ops/run_shadow_bounded_observation_adapter_v0.py` (`expected_artifacts` includes both log files). The review script **hard-fails** when either path is missing — **do not** weaken review to accept detached-only alternate log locations.
+
+Detached `nohup` launches may mirror logs under a bundle `detached/` directory (symlink or copy) for operator monitoring, but **`staging/logs/`** paths are authoritative for review and durable archive closeout.
+
+```text
+SHADOW_BOUNDED_STAGING_LOG_CONTRACT_V0=true
+NON_AUTHORIZING=true
+REVIEW_INPUT_ONLY=true
+```
+
+**Non-authorizing:** evidence layout only; does not authorize runs, clear HOLD, or unblock Preflight.
 
 ---
 

--- a/tests/ops/test_shadow_bounded_observation_staging_log_contract_v0.py
+++ b/tests/ops/test_shadow_bounded_observation_staging_log_contract_v0.py
@@ -10,18 +10,17 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHARTER = REPO_ROOT / "docs" / "ops" / "runbooks" / "SHADOW_247_GOVERNANCE_CHARTER_V0.md"
-REVIEW_SCRIPT = (
-    REPO_ROOT / "scripts" / "ops" / "review_shadow_bounded_observation_evidence_v0.py"
-)
-ADAPTER_SCRIPT = (
-    REPO_ROOT / "scripts" / "ops" / "run_shadow_bounded_observation_adapter_v0.py"
-)
+REVIEW_SCRIPT = REPO_ROOT / "scripts" / "ops" / "review_shadow_bounded_observation_evidence_v0.py"
+ADAPTER_SCRIPT = REPO_ROOT / "scripts" / "ops" / "run_shadow_bounded_observation_adapter_v0.py"
 
 STAGING_LOG_SECTION_HEADING = (
     "## Detached / manual bounded Shadow launch — staging log contract (v0)"
 )
-STAGING_STDOUT = "logs/wrapper_stdout.log"
-STAGING_STDERR = "logs/wrapper_stderr.log"
+# Docs token policy: illustrative paths in charter use &#47; encoding.
+STAGING_STDOUT_CHARTER = "logs&#47;wrapper_stdout.log"
+STAGING_STDERR_CHARTER = "logs&#47;wrapper_stderr.log"
+STAGING_STDOUT_LITERAL = "logs/wrapper_stdout.log"
+STAGING_STDERR_LITERAL = "logs/wrapper_stderr.log"
 CONTRACT_TOKEN = "SHADOW_BOUNDED_STAGING_LOG_CONTRACT_V0=true"
 
 
@@ -34,8 +33,11 @@ def _staging_log_section() -> str:
 
 def test_staging_log_contract_section_exists_in_governance_charter_v0() -> None:
     section = _staging_log_section()
-    assert STAGING_STDOUT in section
-    assert STAGING_STDERR in section
+    assert STAGING_STDOUT_CHARTER in section
+    assert STAGING_STDERR_CHARTER in section
+    assert "{staging_root}&#47;logs&#47;wrapper_stdout.log" in section
+    assert "detached&#47;" in section
+    assert "staging&#47;logs&#47;" in section
     assert "review_shadow_bounded_observation_evidence_v0.py" in section
     assert "run_shadow_bounded_observation_adapter_v0.py" in section
     assert CONTRACT_TOKEN in section
@@ -59,6 +61,6 @@ def test_review_enforcer_references_wrapper_staging_log_paths_v0() -> None:
 
 def test_adapter_expected_artifacts_include_staging_log_paths_v0() -> None:
     text = ADAPTER_SCRIPT.read_text(encoding="utf-8")
-    assert STAGING_STDOUT in text
-    assert STAGING_STDERR in text
+    assert STAGING_STDOUT_LITERAL in text
+    assert STAGING_STDERR_LITERAL in text
     assert "expected_artifacts" in text

--- a/tests/ops/test_shadow_bounded_observation_staging_log_contract_v0.py
+++ b/tests/ops/test_shadow_bounded_observation_staging_log_contract_v0.py
@@ -1,0 +1,64 @@
+"""Static contract tests for Shadow bounded observation staging log paths (v0).
+
+Verankert die Staging-Log-Pfade für detached/manuelle Shadow-Starts an der Governance-Charter-
+Sektion und am Review-Enforcer — ohne Laufzeit, ohne Adapter-Execute, ohne Gate-Freigabe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHARTER = REPO_ROOT / "docs" / "ops" / "runbooks" / "SHADOW_247_GOVERNANCE_CHARTER_V0.md"
+REVIEW_SCRIPT = (
+    REPO_ROOT / "scripts" / "ops" / "review_shadow_bounded_observation_evidence_v0.py"
+)
+ADAPTER_SCRIPT = (
+    REPO_ROOT / "scripts" / "ops" / "run_shadow_bounded_observation_adapter_v0.py"
+)
+
+STAGING_LOG_SECTION_HEADING = (
+    "## Detached / manual bounded Shadow launch — staging log contract (v0)"
+)
+STAGING_STDOUT = "logs/wrapper_stdout.log"
+STAGING_STDERR = "logs/wrapper_stderr.log"
+CONTRACT_TOKEN = "SHADOW_BOUNDED_STAGING_LOG_CONTRACT_V0=true"
+
+
+def _staging_log_section() -> str:
+    text = CHARTER.read_text(encoding="utf-8")
+    start = text.index(STAGING_LOG_SECTION_HEADING)
+    end = text.index("## Activation ladder", start)
+    return text[start:end]
+
+
+def test_staging_log_contract_section_exists_in_governance_charter_v0() -> None:
+    section = _staging_log_section()
+    assert STAGING_STDOUT in section
+    assert STAGING_STDERR in section
+    assert "review_shadow_bounded_observation_evidence_v0.py" in section
+    assert "run_shadow_bounded_observation_adapter_v0.py" in section
+    assert CONTRACT_TOKEN in section
+    assert "**Non-authorizing:**" in section
+
+
+def test_staging_log_contract_forbids_weakening_review_enforcer_v0() -> None:
+    section = _staging_log_section()
+    collapsed = section.replace("**", "")
+    assert "hard-fails" in section
+    assert "do not weaken review" in collapsed
+
+
+def test_review_enforcer_references_wrapper_staging_log_paths_v0() -> None:
+    text = REVIEW_SCRIPT.read_text(encoding="utf-8")
+    assert "wrapper_stdout.log" in text
+    assert "wrapper_stderr.log" in text
+    assert "missing logs/wrapper_stdout.log" in text
+    assert "missing logs/wrapper_stderr.log" in text
+
+
+def test_adapter_expected_artifacts_include_staging_log_paths_v0() -> None:
+    text = ADAPTER_SCRIPT.read_text(encoding="utf-8")
+    assert STAGING_STDOUT in text
+    assert STAGING_STDERR in text
+    assert "expected_artifacts" in text


### PR DESCRIPTION
## Summary
- document detached/manual bounded Shadow launch staging-log contract
- require future wall-clock/manual starts to populate staging/logs/wrapper_stdout.log and wrapper_stderr.log directly
- add static tests covering the governance contract and review-enforcer expectations

## Safety
- no new run
- no scheduler/supervisor/daemon changes
- no wrapper runtime change
- no adapter runtime change
- no review-enforcer change
- no Testnet/Live/Paper/Broker authority
- completed Wall-Clock 12h arc remains STOP_IDLE

## Tests
- uv run pytest tests/ops/test_shadow_bounded_observation_staging_log_contract_v0.py tests/ops/test_shadow247_governance_charter_doc_contract_v0.py
- uv run ruff check tests/ops/test_shadow_bounded_observation_staging_log_contract_v0.py

Made with [Cursor](https://cursor.com)