### PR TITLE
ci: enforce checkout v5 workflow pin

### DIFF
--- a/.github/workflows/real-market-forward-evidence-smoke.yml
+++ b/.github/workflows/real-market-forward-evidence-smoke.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5

--- a/tests/ci/test_workflows_no_pull_request_target_contract_v0.py
+++ b/tests/ci/test_workflows_no_pull_request_target_contract_v0.py
@@ -13,6 +13,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_ROOT = REPO_ROOT / ".github" / "workflows"
+CHECKOUT_USES_PATTERN = re.compile(r"uses:\s*actions/checkout@v(\d+)\b")
+FORBIDDEN_CHECKOUT_VERSIONS = frozenset({"3", "4"})
+REQUIRED_CHECKOUT_VERSION = "5"
 
 
 def _workflow_files() -> list[Path]:
@@ -111,3 +114,34 @@ def test_workflows_no_pull_request_target_contract_covers_all_workflow_files() -
 
     assert len(workflows) >= 1
     assert any(name.endswith(".yml") or name.endswith(".yaml") for name in workflow_names)
+
+
+def _checkout_uses_by_workflow() -> dict[str, list[str]]:
+    by_workflow: dict[str, list[str]] = {}
+    for workflow in _workflow_files():
+        matches = CHECKOUT_USES_PATTERN.findall(_workflow_text(workflow))
+        if matches:
+            by_workflow[workflow.relative_to(REPO_ROOT).as_posix()] = matches
+    return by_workflow
+
+
+def test_workflows_checkout_pin_uniform_v5_contract_forbids_legacy_versions() -> None:
+    offenders: list[str] = []
+
+    for workflow_path, versions in _checkout_uses_by_workflow().items():
+        legacy = sorted({version for version in versions if version in FORBIDDEN_CHECKOUT_VERSIONS})
+        if legacy:
+            offenders.append(f"{workflow_path}: actions/checkout@v{', v'.join(legacy)}")
+
+    assert not offenders, f"legacy checkout pins are forbidden: {offenders}"
+
+
+def test_workflows_checkout_pin_uniform_v5_contract_requires_explicit_v5() -> None:
+    offenders: list[str] = []
+
+    for workflow_path, versions in _checkout_uses_by_workflow().items():
+        non_v5 = sorted({version for version in versions if version != REQUIRED_CHECKOUT_VERSION})
+        if non_v5:
+            offenders.append(f"{workflow_path}: actions/checkout@v{', v'.join(non_v5)}")
+
+    assert not offenders, f"checkout pins must use actions/checkout@v5: {offenders}"


### PR DESCRIPTION
## Summary

This PR makes the remaining workflow checkout pin consistent with the repo-wide checkout v5 posture and adds static CI contract coverage so future workflows do not drift back to older checkout pins.

## Scope

CI workflow + tests only.

Changed files:
- `.github/workflows/real-market-forward-evidence-smoke.yml`
- `tests/ci/test_workflows_no_pull_request_target_contract_v0.py`

## What changed

- Updates the remaining `actions/checkout@v4` usage to `actions/checkout@v5`
- Extends the existing CI workflow static-contract owner
- Adds static checks that:
  - no tracked `.github/workflows/*.yml` or `.yaml` uses `actions/checkout@v3` or `actions/checkout@v4`
  - all `actions/checkout` pins are explicit `actions/checkout@v5`
  - violating workflow paths are included in assertion messages

## Validation

Focused validation passed:

```text
grep -R "actions/checkout@v4" .github/workflows && exit 1 || true
uv run pytest tests/ci
uv run ruff check tests/ci
uv run ruff format --check tests/ci
```

## Safety boundaries

- No docs changes
- No runtime/scheduler/shadow/testnet/live changes
- No adapter execute or durable-run-root default-on changes
- HOLD and Preflight remain BLOCKED
- Evidence remains non-authorizing

## Context

Follow-up to repeated checkout-auth / 401 CI flakes on PR #3632 and PR #3633. This is pin-uniformity and static guard only — not a claim that infra flakes are fully eliminated.

## Test plan

- [ ] CI green on required checks
- [ ] No docs diff
- [ ] `tests/ci` passes including new checkout pin contract tests

Made with [Cursor](https://cursor.com)