### PR TITLE
test: crosslink primary evidence invariant to mandatory wiring

### DIFF
--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -18,10 +18,20 @@ P101_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p101_stop_playbook_v1.sh"
 P93_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p93_online_readiness_status_dashboard_v1.sh"
 P91_SCRIPT = REPO_ROOT / "scripts" / "ops" / "p91_audit_snapshot_runner_v1.sh"
 PACK_SCRIPT = REPO_ROOT / "scripts" / "ops" / "pack_online_readiness_supervisor_evidence_v0.py"
+SHADOW_REVIEW = REPO_ROOT / "scripts" / "ops" / "review_shadow_bounded_observation_evidence_v0.py"
+TESTNET_REVIEW = REPO_ROOT / "scripts" / "ops" / "review_testnet_bounded_observation_evidence_v0.py"
+HARD_GATE_CONTRACT_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_run_primary_evidence_retention_hard_gate_v0.py"
+)
+MANDATORY_CLOSEOUT_WIRING_TOKEN = "DURABLE_PRIMARY_EVIDENCE_MANDATORY_CLOSEOUT_WIRING_V0=true"
 
 
 def _owner_text() -> str:
     return CANONICAL_OWNER.read_text(encoding="utf-8")
+
+
+def _section_2a1() -> str:
+    return _owner_text().split("## 2a.1", 1)[1].split("## 2b.", 1)[0]
 
 
 def _adapter_text() -> str:
@@ -423,6 +433,63 @@ def test_bounded_adapters_import_shared_helper_not_duplicate_verify() -> None:
         text = path.read_text(encoding="utf-8")
         assert "primary_evidence_retention_v0" in text
         assert "def verify_manifest_sha256" not in text
+
+
+def test_section_2a1_contains_mandatory_closeout_wiring_token() -> None:
+    text = _owner_text()
+    section = _section_2a1()
+    assert "## 2a. Primary evidence retention invariant v0" in text
+    assert "## 2a.1 Future-run primary evidence hard gate v0" in text
+    assert text.index("## 2a.") < text.index("## 2a.1") < text.index("## 2b.")
+    assert MANDATORY_CLOSEOUT_WIRING_TOKEN in section
+
+
+def test_invariant_owner_crosslinks_mandatory_wiring_with_bounded_review_durable_run_root() -> None:
+    section = _section_2a1()
+    for review_path in (SHADOW_REVIEW, TESTNET_REVIEW):
+        text = review_path.read_text(encoding="utf-8")
+        assert review_path.name in section
+        assert "--durable-run-root" in text
+        assert "validate_durable_primary_evidence_root" in text
+        assert "default=None" in text
+    assert MANDATORY_CLOSEOUT_WIRING_TOKEN in section
+
+
+def test_invariant_owner_crosslinks_bounded_adapters_with_mandatory_wiring_review_owners() -> None:
+    section = _section_2a1()
+    for adapter_path, review_name in (
+        (SHADOW_ADAPTER, SHADOW_REVIEW.name),
+        (TESTNET_ADAPTER, TESTNET_REVIEW.name),
+    ):
+        adapter_text = adapter_path.read_text(encoding="utf-8")
+        assert review_name in adapter_text
+        assert review_name in section
+        assert "primary_evidence_retention_v0" in adapter_text
+    assert MANDATORY_CLOSEOUT_WIRING_TOKEN in section
+
+
+def test_invariant_owner_preserves_durable_run_root_default_off_on_adapter_execute() -> None:
+    for adapter_path in (SHADOW_ADAPTER, TESTNET_ADAPTER):
+        text = adapter_path.read_text(encoding="utf-8")
+        assert "--durable-run-root" not in text
+        assert "durable_run_root" not in text
+        review_cmd_region = text.split("review_cmd =", 1)[1].split("]", 1)[0]
+        assert "--staging-root" in review_cmd_region
+        assert "--durable-run-root" not in review_cmd_region
+    section = _section_2a1()
+    collapsed = section.replace("**", "").lower()
+    assert "default off" in collapsed or "opt-in (default off)" in collapsed
+
+
+def test_invariant_owner_mandatory_wiring_chain_preserves_non_authorizing_boundary() -> None:
+    invariant_section = _owner_text().split("## 2a.1", 1)[0]
+    mandatory_section = _section_2a1()
+    for section in (invariant_section, mandatory_section):
+        collapsed = section.replace("**", "").lower()
+        assert "non-authorizing" in collapsed or "evidence ≠ approval" in section
+        assert "blocked" in collapsed
+    assert "EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true" in mandatory_section
+    assert HARD_GATE_CONTRACT_TESTS.name in Path(__file__).read_text(encoding="utf-8")
 
 
 def test_paper_adapter_verifies_manifest_after_archive_copy() -> None:


### PR DESCRIPTION
## Summary

This PR adds tests-only crosslink coverage from the primary evidence retention invariant owner to the durable mandatory closeout wiring chain hardened by PR #3632, PR #3633, and PR #3635.

It verifies the invariant chain without changing docs, scripts, adapters, workflows, or runtime behavior:

`Primary evidence invariant → Preflight §2a.1 mandatory token → bounded review --durable-run-root availability → adapter execute/default-off boundary`

## Scope

Tests only.

Changed file:
- `tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`

No docs, scripts, adapters, or workflows changed.

## What is covered

The new static tests assert:
- §2a.1 contains `DURABLE_PRIMARY_EVIDENCE_MANDATORY_CLOSEOUT_WIRING_V0=true`
- mandatory wiring crosslinks to bounded review `--durable-run-root` availability
- adapter/review ownership and shared-helper reuse remain visible from the invariant owner
- adapter execute does not make `--durable-run-root` required/default-on
- evidence/review remains non-authorizing
- the hard-gate owner remains anchored to the same mandatory wiring chain

## Validation

Focused validation passed:

```text
uv run pytest tests/ops/test_primary_evidence_retention_invariant_contract_v0.py tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py tests/ops/test_bounded_observation_review_durable_primary_evidence_contract_v0.py
uv run ruff check tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
uv run ruff format --check tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
```

## Safety boundaries

- No docs changes
- No script/adapter/workflow changes
- No adapter execute behavior change
- `--durable-run-root` remains opt-in/default-off
- No runtime/scheduler/shadow/testnet/live/broker start
- HOLD and Preflight remain BLOCKED
- Evidence remains non-authorizing

## Context

Follow-up to PR #3635 bounded adapter crosslink tests and the post-PR #3635 reuse-first scope scan. Extends the existing §2a invariant test owner only; complements hard-gate owner coverage without duplicating assertions.

## Test plan

- [ ] CI green on required checks
- [ ] No docs/scripts/workflows diff
- [ ] Invariant + hard-gate + bounded-review regression tests pass

Made with [Cursor](https://cursor.com)