### PR TITLE
test: guard double play from market ranking markers

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -534,6 +534,48 @@ def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> No
     assert "market-v0-order-form" not in lowered
 
 
+def test_market_dashboard_ranking_funnel_and_pro_shell_marker_families_v0(
+    client: TestClient,
+) -> None:
+    """Positive pairing: /market carries ranking funnel and pro-shell IA marker families."""
+    html = _html(client, "/market")
+    assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-dynamic-labels-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-stages-v0="true"' in html
+    assert 'id="market-v0-landmark-ranking-funnel-h2"' in html
+    assert 'data-market-v0-pro-shell="true"' in html
+    assert 'data-market-v0-pro-grid="true"' in html
+    assert 'data-market-v0-pro-boundary="true"' in html
+    assert 'data-market-v0-visual-cockpit="true"' in html
+
+
+def test_double_play_market_dashboard_excludes_ranking_funnel_markers_v0(
+    client: TestClient,
+) -> None:
+    """Double-Play must not carry `/market`-only ranking funnel contract markers."""
+    html = _html(client, "/market/double-play")
+    assert "data-market-v0-ranking-funnel-empty-state-v0" not in html
+    assert "data-market-v0-ranking-funnel-dynamic-labels-v0" not in html
+    assert "data-market-v0-ranking-funnel-stages-v0" not in html
+    assert "market-v0-landmark-ranking-funnel-h2" not in html
+    assert "data-market-v0-" not in html
+    assert 'data-market-readonly="true"' in html
+
+
+def test_double_play_market_dashboard_excludes_pro_shell_markers_v0(
+    client: TestClient,
+) -> None:
+    """Double-Play must not carry `/market`-only pro-shell / visual-cockpit IA markers."""
+    html = _html(client, "/market/double-play")
+    assert "data-market-v0-pro-shell" not in html
+    assert "data-market-v0-pro-grid" not in html
+    assert "data-market-v0-pro-boundary" not in html
+    assert "data-market-v0-visual-cockpit" not in html
+    assert "market-v0-landmark-visual-cockpit-h2" not in html
+    assert "data-market-v0-" not in html
+    assert 'data-market-readonly="true"' in html
+
+
 def test_market_dashboard_landmarks_and_labelled_regions_v0(client: TestClient) -> None:
     """Stable region landmarks + aria-labelledby hooks; read-only markers unchanged."""
     html = _html(client, "/market")


### PR DESCRIPTION
## Summary

This PR adds tests-only exclusion coverage to protect `/market/double-play` from `/market`-only marker families.

It closes the gap identified after PR #3646: ranking funnel and pro-shell/pro-grid markers had positive `/market` coverage, but no explicit Double-Play exclusion coverage.

## Scope

Tests only.

Changed file:
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## What changed

Adds 3 tests:

- Positive marker coverage for /market ranking funnel and pro-shell marker families
- Negative /market/double-play assertion for ranking funnel markers
- Negative /market/double-play assertion for pro-shell / visual-cockpit markers

Allowed exception preserved:
- `data-market-readonly="true"` remains allowed on the embedded OHLC block in Double-Play.

## Validation

Focused validation passed:

```text
uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py tests/test_market_surface_api.py
uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
uv run ruff format --check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
```

Result:
- pytest: `54 passed`
- ruff check/format: PASS

## Durable evidence archive

Pre-PR implementation evidence is archived at:

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/market_dashboard_double_play_ranking_pro_shell_exclusion_tests_v0_20260524T005437Z`

Archive contents:
- `MARKET_DASHBOARD_DOUBLE_PLAY_RANKING_PRO_SHELL_EXCLUSION_TESTS_V0_RESULT.md`
- `CURSOR_MARKET_DASHBOARD_DOUBLE_PLAY_RANKING_PRO_SHELL_EXCLUSION_TESTS_V0_OUTPUT.log`
- `ARCHIVE_POINTER.md`
- `MANIFEST.sha256`
- `MANIFEST_VERIFY.log`

Archive manifest verification: `RC=0`.

## Safety boundaries

- Tests-only
- No docs changed
- No template changed
- No scripts changed
- No workflows changed
- No adapter execute behavior changed
- No new route
- No new template
- No new readmodel
- No new API
- No polling
- No WebUI server start
- No runtime start
- No scheduler start
- No Paper/Shadow/24h-Shadow/Testnet/Live start
- No broker/exchange access
- No Market-Airport work
- Dashboard authority unchanged
- Master V2 untouched
- Double-Play trading logic untouched
- No Double-Play markers added
- Evidence remains non-authorizing
- Global HOLD remains active
- Preflight remains BLOCKED

Machine lines:

```text
MARKET_DASHBOARD_DOUBLE_PLAY_RANKING_PRO_SHELL_EXCLUSION_TESTS_IMPLEMENTED=true
MARKET_DASHBOARD_DOUBLE_PLAY_RANKING_PRO_SHELL_EXCLUSION_TESTS_REPORT_ARCHIVED=true
TESTS_ONLY=true
DOCS_CHANGED=false
TEMPLATE_CHANGED=false
SCRIPTS_CHANGED=false
WORKFLOWS_CHANGED=false
ADAPTER_EXECUTE_CHANGED=false
NEW_ROUTE_CREATED=false
NEW_TEMPLATE_CREATED=false
NEW_READMODEL_CREATED=false
NEW_API_CREATED=false
WEBUI_SERVER_STARTED=false
DASHBOARD_AUTHORITY_CHANGED=false
MASTER_V2_TOUCHED=false
DOUBLE_PLAY_TOUCHED=false
DOUBLE_PLAY_MARKERS_ADDED=false
MARKET_AIRPORT_EXCLUDED=true
NEW_SURFACE_CREATED=false
NEW_RUN_STARTED=false
RUNTIME_STARTED=false
SCHEDULER_STARTED=false
SHADOW_STARTED=false
TWENTY_FOUR_HOUR_SHADOW_STARTED=false
TESTNET_STARTED=false
LIVE_ALLOWED=false
BROKER_EXCHANGE_ALLOWED=false
REUSE_BEFORE_NEW_CONFIRMED=true
NO_PARALLEL_SURFACE_CREATED=true
GLOBAL_HOLD_REMAINS_ACTIVE=true
PREFLIGHT_REMAINS_BLOCKED=true
EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true
VALIDATION_PASSED=true
MANIFEST_VERIFY_RC=0
NEXT_ACTION=review_pr_checks
```

Made with [Cursor](https://cursor.com)