### PR TITLE
ops: align paper shadow 247 preflight job set

### DIFF
--- a/config/ops/paper_shadow_247_preflight.toml
+++ b/config/ops/paper_shadow_247_preflight.toml
@@ -6,17 +6,12 @@
 schema_version = "paper_shadow_247_preflight.v0"
 canonical_owner = "ops-paper-shadow-247-readiness"
 
+# Canonical scheduler-visible paper jobs only (see config/scheduler/jobs.toml).
+# P7 paper_runner_*_contract_v0 fixtures live under tests/aiops/p7/ — not scheduler jobs.
 paper_jobs = [
   "paper_shadow_247_paper_only_runtime_min_v0",
   "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0",
   "paper_shadow_247_paper_only_preflight_status_v0",
-  "paper_runner_no_order_no_fill_contract_v0",
-  "paper_runner_single_order_contract_v0",
-  "paper_runner_two_order_roundtrip_contract_v0",
-  "paper_runner_fail_closed_contract_v0",
-  "paper_runner_insufficient_cash_contract_v0",
-  "paper_runner_multisymbol_contract_v0",
-  "paper_runner_partial_sell_contract_v0",
 ]
 
 shadow_jobs = [

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -196,11 +196,9 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
         == "out/paper_shadow_247/runtime/high_vol_no_trade/__DRY_RUN_PLACEHOLDER__"
     )
 
-    assert any(str(c["name"]).startswith("paper_runner_") and c["found"] is False for c in commands)
-    for c in commands:
-        if str(c["name"]).startswith("paper_runner_") and c["found"] is False:
-            assert "safety_classification" not in c
-            break
+    assert not any(str(c["name"]).startswith("paper_runner_") for c in commands)
+    for name in paper:
+        assert by_name[name]["found"] is True, name
     shadow_entry = by_name["p7_shadow_high_vol_no_trade_runner_manual_v0"]
     assert shadow_entry["source"] == "shadow"
     assert shadow_entry["found"] is False
@@ -499,6 +497,24 @@ def test_preflight_cli_operator_decision_record_missing_file_exits_2(tmp_path: P
         "hold_testnet_authorized=false",
         "hold_live_authorized=false",
     ]
+
+
+def test_paper_shadow_247_preflight_paper_jobs_align_with_scheduler_inventory() -> None:
+    """P7 paper_runner_* contract fixtures must not be canonical scheduler job expectations."""
+
+    meta = tomllib.loads(PREFLIGHT_CONFIG.read_text(encoding="utf-8"))
+    paper_jobs = [str(x) for x in meta["paper_jobs"]]
+    assert paper_jobs == [
+        "paper_shadow_247_paper_only_runtime_min_v0",
+        "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0",
+        "paper_shadow_247_paper_only_preflight_status_v0",
+    ]
+    assert not any(name.startswith("paper_runner_") for name in paper_jobs)
+
+    payload = _run_json()
+    by_name = {str(c["name"]): c for c in payload["commands"]}
+    for name in paper_jobs:
+        assert by_name[name]["found"] is True, name
 
 
 def test_paper_shadow_247_preflight_metadata_config_is_materialized() -> None:


### PR DESCRIPTION
## Summary

Aligns `config/ops/paper_shadow_247_preflight.toml` with the scheduler-visible paper job set.

The previous §5 audit found TOML–Scheduler drift: the preflight TOML listed seven `paper_runner_*_contract_v0` P7 test fixtures as if they were scheduler jobs. Those fixtures are not declared in `jobs.toml`, so the readiness audit reported a false job-set/command BLOCKED state.

This PR trims those phantom P7 fixture entries from the canonical paper job-set expectation and adds/updates tests to keep the TOML aligned with scheduler inventory.

## Scope

Changed files:

- `config/ops/paper_shadow_247_preflight.toml`
- `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py`

## Result

- Paper jobs in TOML: 10 → 3
- Paper jobs found in scheduler inventory: 3/10 → 3/3
- `jobs.toml` unchanged
- Shadow job scheduler declaration unchanged
- Docs unchanged
- Archives unchanged except durable report copy before commit

## Durable report archive

The implementation report was copied out of `/tmp` before commit:

- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/paper_shadow_247_toml_canonical_job_set_alignment_slice_v0_20260524T075319Z`
- `MANIFEST.sha256` verified OK
- Archived report: `PAPER_SHADOW_247_TOML_CANONICAL_JOB_SET_ALIGNMENT_SLICE_V0_RESULT.md`

## Safety

- Config/test-only alignment
- No runtime started
- No scheduler/supervisor/paper/shadow/testnet/live process started
- No broker/exchange access
- No executing start command generated
- No run OUTROOT created
- No start permission changed
- `READY_TO_START_RUN_NOW=false`
- Reuse-before-new respected
- No parallel docs/surfaces created

## Checks

- `git diff --check` ✅
- TOML parse ✅
- `uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py` ✅

## Follow-up

Recommended next token remains:

`paper_shadow_247_shadow_job_scheduler_declaration_slice_v0`

This PR does not resolve the separate Shadow job scheduler declaration blocker.

Made with [Cursor](https://cursor.com)