### PR TITLE
ops: declare paper shadow 247 shadow scheduler job

### DIFF
--- a/config/scheduler/jobs.toml
+++ b/config/scheduler/jobs.toml
@@ -265,6 +265,31 @@ spec = "tests/fixtures/p7/paper_run_min_v0.json"
 outdir = "out/paper_shadow_247/runtime/min/__DRY_RUN_PLACEHOLDER__"
 
 # =============================================================================
+# Paper-Shadow 247 — shadow high-vol no-trade manual runner (disabled by default)
+# =============================================================================
+# Scheduler-visible Shadow command shape for a later explicit bounded run.
+# Not Testnet/Live/Broker/Exchange/order authorization.
+[[job]]
+name = "p7_shadow_high_vol_no_trade_runner_manual_v0"
+enabled = false
+schedule_type = "once"
+command = "python"
+args = { script = "scripts/aiops/run_shadow_session.py", spec = "tests/fixtures/p6/shadow_session_high_vol_no_trade_v0.json", run_id = "__DRY_RUN_PLACEHOLDER__", outdir = "out/paper_shadow_247/shadow/high_vol_no_trade/__DRY_RUN_PLACEHOLDER__", p7_enable = "1", p7_evidence = "0", dry_run = true }
+description = "Shadow high-vol no-trade manual runner; disabled until explicit bounded gate."
+tags = ["paper_shadow_247", "shadow_runtime", "readonly", "disabled_by_default"]
+timeout_seconds = 600
+paper_only = false
+paper_runtime_job = false
+dry_run_visible = true
+runtime_fixture = "tests/fixtures/p6/shadow_session_high_vol_no_trade_v0.json"
+runtime_outdir_template = "out/paper_shadow_247/shadow/high_vol_no_trade/{timestamp}"
+testnet_authorized = false
+live_authorized = false
+broker_authorized = false
+exchange_authorized = false
+order_submission_authorized = false
+
+# =============================================================================
 # Shadow 24/7 Futures wrapper — scheduler placeholder (disabled, non-authorizing)
 # =============================================================================
 # Invokes only the default-off wrapper entrypoint shape when enabled in a future gate.

--- a/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
+++ b/tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py
@@ -201,8 +201,33 @@ def _assert_command_inventory_shape(payload: dict[str, object]) -> None:
         assert by_name[name]["found"] is True, name
     shadow_entry = by_name["p7_shadow_high_vol_no_trade_runner_manual_v0"]
     assert shadow_entry["source"] == "shadow"
-    assert shadow_entry["found"] is False
-    assert "safety_classification" not in shadow_entry
+    assert shadow_entry["found"] is True
+    assert shadow_entry["enabled"] is False
+    assert shadow_entry["command"] == "python"
+    safety_shadow = shadow_entry["safety_classification"]
+    assert isinstance(safety_shadow, dict)
+    assert safety_shadow["paper_only"] is False
+    assert safety_shadow["dry_run_visible"] is True
+    assert safety_shadow["paper_runtime_job"] is False
+    assert safety_shadow["enabled"] is False
+    assert safety_shadow["disabled_by_default"] is True
+    assert safety_shadow["authorization_flags"] == {
+        "testnet_authorized": False,
+        "live_authorized": False,
+        "broker_authorized": False,
+        "exchange_authorized": False,
+        "order_submission_authorized": False,
+    }
+    assert safety_shadow["non_authorizing"] is True
+    args_shadow = shadow_entry["args"]
+    assert isinstance(args_shadow, dict)
+    assert args_shadow["script"] == "scripts/aiops/run_shadow_session.py"
+    assert args_shadow["spec"] == "tests/fixtures/p6/shadow_session_high_vol_no_trade_v0.json"
+    assert (
+        args_shadow["outdir"]
+        == "out/paper_shadow_247/shadow/high_vol_no_trade/__DRY_RUN_PLACEHOLDER__"
+    )
+    assert args_shadow["dry_run"] is True
 
 
 def _assert_hold_context_v0(payload: dict[str, object]) -> None:
@@ -497,6 +522,26 @@ def test_preflight_cli_operator_decision_record_missing_file_exits_2(tmp_path: P
         "hold_testnet_authorized=false",
         "hold_live_authorized=false",
     ]
+
+
+def test_paper_shadow_247_preflight_shadow_jobs_align_with_scheduler_inventory() -> None:
+    """Shadow jobs declared in preflight metadata must resolve in jobs.toml."""
+
+    meta = tomllib.loads(PREFLIGHT_CONFIG.read_text(encoding="utf-8"))
+    shadow_jobs = [str(x) for x in meta["shadow_jobs"]]
+    assert shadow_jobs == ["p7_shadow_high_vol_no_trade_runner_manual_v0"]
+
+    payload = _run_json()
+    by_name = {str(c["name"]): c for c in payload["commands"]}
+    for name in shadow_jobs:
+        entry = by_name[name]
+        assert entry["found"] is True, name
+        assert entry["source"] == "shadow"
+        assert entry["enabled"] is False
+        args = entry["args"]
+        assert isinstance(args, dict)
+        assert args["script"] == "scripts/aiops/run_shadow_session.py"
+        assert args["spec"] == "tests/fixtures/p6/shadow_session_high_vol_no_trade_v0.json"
 
 
 def test_paper_shadow_247_preflight_paper_jobs_align_with_scheduler_inventory() -> None:


### PR DESCRIPTION
## Summary

Declares the missing scheduler-visible Shadow job for the Paper/Shadow 247 preflight path.

This resolves the Shadow command/argv inventory gap without starting runtime or changing authorization gates.

## Scope

Changed files:

- `config/scheduler/jobs.toml`
- `tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py`

New scheduler job:

- `p7_shadow_high_vol_no_trade_runner_manual_v0`

Safety properties:

- `enabled=false`
- `dry_run_visible=true`
- auth/start/live/testnet flags remain false
- command uses `run_shadow_session.py` with fixture `shadow_session_high_vol_no_trade_v0.json`
- outdir uses dry-run placeholder:
  `out/paper_shadow_247/shadow/high_vol_no_trade/__DRY_RUN_PLACEHOLDER__`

## Result

- Commands total: 4
- Commands found: 3/4 → 4/4
- Shadow job resolved: false → true
- `paper_shadow_247_preflight.toml` unchanged
- Dry-run proof not captured in this PR
- `READY_TO_START_RUN_NOW=false`

## Durable report archive

The implementation report was copied out of `/tmp` before commit:

- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/paper_shadow_247_shadow_job_scheduler_declaration_slice_v0_20260524T081718Z`
- `MANIFEST.sha256` verified OK
- Archived report: `PAPER_SHADOW_247_SHADOW_JOB_SCHEDULER_DECLARATION_SLICE_V0_RESULT.md`

## Safety

- Config/test-only
- No runtime started
- No scheduler/supervisor/paper/shadow/testnet/live process started
- No broker/exchange access
- No executing start command generated
- No run OUTROOT created
- No start permission changed
- Reuse-before-new respected
- No parallel docs/surfaces created

## Checks

- `git diff --check` ✅
- TOML parse ✅
- `uv run pytest tests/ops/test_report_paper_shadow_247_preflight_status_cli_v0.py` ✅

## Follow-up

Recommended next token:

`paper_shadow_247_scheduler_dry_run_proof_capture_archive_only_v0`

This PR does not capture dry-run proof and does not authorize any run.

Made with [Cursor](https://cursor.com)