### PR TITLE
ops: add paper adapter 24h profile contract

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -26,6 +26,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from scripts.ops import bounded_daemon_paper_shadow_24h_approval_v0 as contract_24h
 from scripts.ops.primary_evidence_retention_v0 import (
     verify_manifest_sha256,
     write_manifest_sha256 as _write_manifest_sha256,
@@ -92,6 +93,7 @@ class AdapterPlan:
     commands: dict[str, list[str]]
     retention_steps: list[str]
     expected_artifacts: list[str]
+    contract_profile: str = ""
     forbidden_paths_absent: bool = True
 
     def to_dict(self) -> dict[str, Any]:
@@ -142,8 +144,31 @@ def load_approval_record(path: Path) -> dict[str, str]:
     return parse_machine_lines(path.read_text(encoding="utf-8"))
 
 
-def validate_approval_record(fields: Mapping[str, str]) -> list[str]:
+def normalize_profile(profile: str | None) -> str:
+    return (profile or "").strip()
+
+
+def validate_profile_name(profile: str) -> list[str]:
+    if profile and profile != contract_24h.CONTRACT_PROFILE:
+        return [f"unknown profile: {profile!r}"]
+    return []
+
+
+def validate_approval_record(
+    fields: Mapping[str, str],
+    *,
+    profile: str = "",
+    approved_run_id: str = "",
+) -> list[str]:
     issues: list[str] = []
+    if profile == contract_24h.CONTRACT_PROFILE:
+        issues.extend(
+            contract_24h.validate_approval_record(fields, approved_run_id=approved_run_id)
+        )
+        for key in FORBIDDEN_APPROVAL_TRUE:
+            if fields.get(key, "false").lower() == "true":
+                issues.append(f"approval record forbids {key}=true")
+        return issues
     for key, expected in REQUIRED_APPROVAL.items():
         if fields.get(key, "").lower() != expected:
             issues.append(f"approval record missing or invalid: {key}={expected}")
@@ -208,6 +233,7 @@ def build_plan(
     duration_seconds: int,
     poll_interval_seconds: int,
     run_id: str,
+    contract_profile: str = "",
 ) -> AdapterPlan:
     paths = _plan_paths(staging_root, run_id)
     runtime_out = paths["runtime_out"]
@@ -304,6 +330,7 @@ def build_plan(
         commands=commands,
         retention_steps=retention_steps,
         expected_artifacts=expected_artifacts,
+        contract_profile=contract_profile,
         forbidden_paths_absent=forbidden_absent,
     )
 
@@ -320,8 +347,10 @@ def render_plan(plan: AdapterPlan, as_json: bool) -> str:
         f"POLL_INTERVAL_SECONDS={plan.poll_interval_seconds}",
         f"STAGING_ROOT={plan.staging_root}",
         f"ARCHIVE_ROOT={plan.archive_root}",
-        "COMMANDS:",
     ]
+    if plan.contract_profile:
+        lines.append(f"CONTRACT_PROFILE={plan.contract_profile}")
+    lines.append("COMMANDS:")
     for name, argv in plan.commands.items():
         lines.append(f"  {name}: {' '.join(argv)}")
     lines.append("RETENTION_STEPS:")
@@ -346,7 +375,14 @@ def validate_execute_preconditions(
             issues.append(str(exc))
         else:
             ctx.approval_fields = fields
-            issues.extend(validate_approval_record(fields))
+            profile = normalize_profile(getattr(ctx.args, "profile", ""))
+            issues.extend(
+                validate_approval_record(
+                    fields,
+                    profile=profile,
+                    approved_run_id=ctx.run_id,
+                )
+            )
     if not ctx.archive_root.is_dir():
         issues.append(f"archive root must exist: {ctx.archive_root}")
     elif not os.access(ctx.archive_root, os.W_OK):
@@ -494,7 +530,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--duration-seconds",
         type=int,
-        default=DEFAULT_DURATION_SECONDS,
+        default=None,
     )
     parser.add_argument(
         "--poll-interval",
@@ -505,6 +541,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--source-jobs-toml", type=Path, default=None)
     parser.add_argument("--approval-record", type=Path, default=None)
     parser.add_argument("--run-id", type=str, default="")
+    parser.add_argument(
+        "--profile",
+        type=str,
+        default="",
+        help=(
+            "Optional approval contract profile. "
+            f"Supported: {contract_24h.CONTRACT_PROFILE!r} (default: 120min paper-only)."
+        ),
+    )
     parser.add_argument(
         "--strict-repo-clean",
         action="store_true",
@@ -536,6 +581,27 @@ def main(
             raise
         return USAGE_EXIT
 
+    profile = normalize_profile(args.profile)
+    profile_issues = validate_profile_name(profile)
+    if profile_issues:
+        for issue in profile_issues:
+            print(issue, file=sys.stderr)
+        return USAGE_EXIT
+
+    if profile == contract_24h.CONTRACT_PROFILE:
+        if not args.run_id.strip():
+            print("--run-id is required for 24h profile", file=sys.stderr)
+            return USAGE_EXIT
+        if args.duration_seconds is None:
+            args.duration_seconds = contract_24h.DAEMON_PAPER_SHADOW_24H_DURATION_SECONDS
+        duration_issues = contract_24h.validate_paper_duration_seconds(args.duration_seconds)
+        if duration_issues:
+            for issue in duration_issues:
+                print(issue, file=sys.stderr)
+            return VALIDATION_EXIT
+    elif args.duration_seconds is None:
+        args.duration_seconds = DEFAULT_DURATION_SECONDS
+
     if args.duration_seconds <= 0 or args.poll_interval <= 0:
         print("duration and poll interval must be > 0", file=sys.stderr)
         return USAGE_EXIT
@@ -559,6 +625,7 @@ def main(
         duration_seconds=args.duration_seconds,
         poll_interval_seconds=args.poll_interval,
         run_id=run_id,
+        contract_profile=profile,
     )
 
     if args.execute:

--- a/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
@@ -19,6 +19,11 @@ SCRIPT = ROOT / "scripts" / "ops" / "run_paper_only_bounded_observation_adapter_
 APPROVAL_FIXTURE = (
     ROOT / "tests" / "fixtures" / "ops" / "paper_only_adapter_stage3_approval_sample.md"
 )
+APPROVAL_FIXTURE_24H = (
+    ROOT / "tests" / "fixtures" / "ops" / "daemon_paper_shadow_24h_adapter_approval_sample.md"
+)
+RUN_ID_24H = "daemon_paper_24h_20260524T093549Z"
+PROFILE_24H = "daemon_paper_shadow_24h_v0"
 ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
 
 
@@ -44,6 +49,15 @@ def _base_argv(staging: Path, archive: Path | None = None) -> list[str]:
         str(archive or ARCHIVE_ROOT),
         "--repo-root",
         str(ROOT),
+    ]
+
+
+def _base_argv_24h(staging: Path, archive: Path | None = None) -> list[str]:
+    return _base_argv(staging, archive) + [
+        "--profile",
+        PROFILE_24H,
+        "--run-id",
+        RUN_ID_24H,
     ]
 
 
@@ -416,3 +430,179 @@ def test_module_build_plan_forbidden_paths_absent(tmp_path: Path) -> None:
         run_id="test_run",
     )
     assert plan.forbidden_paths_absent is True
+
+
+def test_default_profile_unchanged_still_7200(tmp_path: Path) -> None:
+    plan = _plan_dict(_staging(tmp_path))
+    assert plan["duration_seconds"] == 7200
+    assert plan.get("contract_profile", "") == ""
+
+
+def test_24h_profile_plan_only_default_duration_86400(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(_base_argv_24h(staging) + ["--json"])
+    assert rc == 0, buf.getvalue()
+    plan = json.loads(buf.getvalue())
+    assert plan["duration_seconds"] == 86400
+    assert plan["contract_profile"] == PROFILE_24H
+    assert plan["run_id"] == RUN_ID_24H
+
+
+def test_24h_profile_rejects_7200_duration(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    rc = mod.main(
+        _base_argv_24h(staging) + ["--duration-seconds", "7200"],
+    )
+    assert rc != 0
+
+
+def test_24h_profile_requires_run_id(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    rc = mod.main(
+        _base_argv(staging) + ["--profile", PROFILE_24H],
+    )
+    assert rc != 0
+
+
+def test_unknown_profile_rejected(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    rc = mod.main(
+        _base_argv(staging) + ["--profile", "unknown_profile_v0"],
+    )
+    assert rc != 0
+
+
+def test_24h_profile_execute_rejects_120min_approval_fixture(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(APPROVAL_FIXTURE),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+def test_24h_profile_execute_rejects_run_id_mismatch(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    rc = mod.main(
+        _base_argv(staging, archive)
+        + [
+            "--profile",
+            PROFILE_24H,
+            "--run-id",
+            "other_run_id",
+            "--execute",
+            "--approval-record",
+            str(APPROVAL_FIXTURE_24H),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+@pytest.mark.parametrize("key", ["PAPER_LANE_AUTHORIZED", "SHADOW_LANE_AUTHORIZED"])
+def test_24h_profile_execute_rejects_missing_lane_key(tmp_path: Path, key: str) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    text = APPROVAL_FIXTURE_24H.read_text(encoding="utf-8")
+    lines = [line for line in text.splitlines() if not line.strip().startswith(f"{key}=")]
+    bad = tmp_path / "bad_approval.md"
+    bad.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(bad),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("START_TESTNET_NOW", "true"),
+        ("START_LIVE_NOW", "true"),
+        ("LIVE_ALLOWED", "true"),
+        ("BROKER_EXCHANGE_ALLOWED", "true"),
+    ],
+)
+def test_24h_profile_execute_rejects_forbidden_flags(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    text = APPROVAL_FIXTURE_24H.read_text(encoding="utf-8").replace(
+        f"{field}=false", f"{field}={value}"
+    )
+    bad = tmp_path / f"bad_{field}.md"
+    bad.write_text(text, encoding="utf-8")
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(bad),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+def test_24h_profile_execute_accepts_sample_fixture_mocked(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    calls: list[str] = []
+
+    def _runner(argv: Sequence[str], _cwd, _stdout, _stderr) -> int:
+        calls.append(" ".join(argv))
+        if "review_scheduler_paper_runtime_evidence.py" in " ".join(argv):
+            review_dir = staging / "review"
+            review_dir.mkdir(parents=True, exist_ok=True)
+            (review_dir / "REVIEW_RESULT.json").write_text(
+                json.dumps({"verdict": "PASS", "metrics": {}, "issues": []}),
+                encoding="utf-8",
+            )
+            return 0
+        if "run_with_timeout.py" in " ".join(argv):
+            return mod.TIMEOUT_EXIT
+        return 0
+
+    archive = _durable_archive(tmp_path)
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(APPROVAL_FIXTURE_24H),
+            "--no-strict-repo-clean",
+        ],
+        subprocess_runner=_runner,
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc == 0
+    assert calls
+    timeout_cmd = next(cmd for cmd in calls if "run_with_timeout.py" in cmd)
+    assert "--timeout-seconds 86400" in timeout_cmd


### PR DESCRIPTION
## Summary

Adds optional `daemon_paper_shadow_24h_v0` profile to the paper-only bounded observation adapter.

- Reuses merged validator from PR #3663 (`bounded_daemon_paper_shadow_24h_approval_v0.py`).
- Requires 86400s paper duration, explicit `--run-id`, and `APPROVED_RUN_ID` binding for 24h profile.
- Requires both `PAPER_LANE_AUTHORIZED` and `SHADOW_LANE_AUTHORIZED` in approval record (pair contract; paper lane only executes).
- Existing 120min default behavior and tests preserved.

## Safety

- Paper adapter 24h profile only.
- No Shadow path changes.
- No staging bridge.
- No HOLD clearance.
- No runtime execution in tests.
- `READY_TO_START_RUN_NOW=false`.

## Checks

- `git diff --check`
- `uv run python -m py_compile` (adapter + validator)
- `uv run pytest` (24h contract + paper adapter tests — 52 passed)
- `uv run ruff check` / `ruff format --check`

## Out of scope

- Shadow 247 path integration
- Staging bridge
- HOLD/governance clearance
- Preflight unblock
- Execution retry

Made with [Cursor](https://cursor.com)