### PR TITLE
ops: add shadow adapter 24h profile contract

### DIFF
--- a/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
@@ -26,6 +26,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from scripts.ops import bounded_daemon_paper_shadow_24h_approval_v0 as contract_24h
 from scripts.ops.primary_evidence_retention_v0 import (
     verify_manifest_sha256,
     write_manifest_sha256 as _write_manifest_sha256,
@@ -45,6 +46,10 @@ DEFAULT_MAX_STEPS = 120
 DEFAULT_STEP_INTERVAL_SECONDS = 0.0
 MAX_DURATION_MINUTES = 10
 MAX_STEPS_CAP = 600
+CANDIDATE_24H_MAX_STEPS_CAP = 86400
+CANDIDATE_24H_BOUNDED_SHADOW_CONFIRM_TOKEN_V0 = (
+    "I_EXPLICITLY_CONFIRM_SHADOW_247_CANDIDATE_24H_BOUNDED_SHADOW_TIER_V0"
+)
 
 FORBIDDEN_APPROVAL_TRUE = frozenset(
     {
@@ -106,6 +111,7 @@ class AdapterPlan:
     commands: dict[str, list[str]]
     retention_steps: list[str]
     expected_artifacts: list[str]
+    contract_profile: str = ""
     forbidden_paths_absent: bool = True
 
     def to_dict(self) -> dict[str, Any]:
@@ -155,8 +161,31 @@ def load_approval_record(path: Path) -> dict[str, str]:
     return parse_machine_lines(path.read_text(encoding="utf-8"))
 
 
-def validate_approval_record(fields: Mapping[str, str]) -> list[str]:
+def normalize_profile(profile: str | None) -> str:
+    return (profile or "").strip()
+
+
+def validate_profile_name(profile: str) -> list[str]:
+    if profile and profile != contract_24h.CONTRACT_PROFILE:
+        return [f"unknown profile: {profile!r}"]
+    return []
+
+
+def validate_approval_record(
+    fields: Mapping[str, str],
+    *,
+    profile: str = "",
+    approved_run_id: str = "",
+) -> list[str]:
     issues: list[str] = []
+    if profile == contract_24h.CONTRACT_PROFILE:
+        issues.extend(
+            contract_24h.validate_approval_record(fields, approved_run_id=approved_run_id)
+        )
+        for key in FORBIDDEN_APPROVAL_TRUE:
+            if fields.get(key, "false").lower() == "true":
+                issues.append(f"approval record forbids {key}=true")
+        return issues
     for key, expected in REQUIRED_APPROVAL.items():
         if fields.get(key, "").lower() != expected:
             issues.append(f"approval record missing or invalid: {key}={expected}")
@@ -217,6 +246,7 @@ def build_plan(
     max_steps: int,
     step_interval_seconds: float,
     run_id: str,
+    contract_profile: str = "",
 ) -> AdapterPlan:
     wrapper_evidence = staging_root / WRAPPER_EVIDENCE_DIR
     review_out = staging_root / "review" / "REVIEW_RESULT.json"
@@ -238,6 +268,14 @@ def build_plan(
         "--jobs-config",
         JOBS_CONFIG,
     ]
+    if contract_profile == contract_24h.CONTRACT_PROFILE:
+        wrapper_cmd.extend(
+            [
+                "--candidate-24h-bounded-shadow-validation",
+                "--candidate-24h-confirm-token",
+                CANDIDATE_24H_BOUNDED_SHADOW_CONFIRM_TOKEN_V0,
+            ]
+        )
     review_cmd = _python_cmd(repo_root, REVIEW_SCRIPT) + [
         "--staging-root",
         str(staging_root.resolve()),
@@ -299,6 +337,7 @@ def build_plan(
         commands=commands,
         retention_steps=retention_steps,
         expected_artifacts=expected_artifacts,
+        contract_profile=contract_profile,
         forbidden_paths_absent=forbidden_absent,
     )
 
@@ -317,8 +356,10 @@ def render_plan(plan: AdapterPlan, as_json: bool) -> str:
         f"STAGING_ROOT={plan.staging_root}",
         f"ARCHIVE_ROOT={plan.archive_root}",
         f"RUN_ID={plan.run_id}",
-        "COMMANDS:",
     ]
+    if plan.contract_profile:
+        lines.append(f"CONTRACT_PROFILE={plan.contract_profile}")
+    lines.append("COMMANDS:")
     for name, argv in plan.commands.items():
         lines.append(f"  {name}: {' '.join(argv)}")
     lines.append("RETENTION_STEPS:")
@@ -343,7 +384,14 @@ def validate_execute_preconditions(
             issues.append(str(exc))
         else:
             ctx.approval_fields = fields
-            issues.extend(validate_approval_record(fields))
+            profile = normalize_profile(getattr(ctx.args, "profile", ""))
+            issues.extend(
+                validate_approval_record(
+                    fields,
+                    profile=profile,
+                    approved_run_id=ctx.run_id,
+                )
+            )
     if not ctx.archive_root.is_dir():
         issues.append(f"archive root must exist: {ctx.archive_root}")
     elif not os.access(ctx.archive_root, os.W_OK):
@@ -541,7 +589,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--staging-root", type=Path, required=True)
     parser.add_argument("--archive-root", type=Path, required=True)
-    parser.add_argument("--duration-minutes", type=int, default=DEFAULT_DURATION_MINUTES)
+    parser.add_argument("--duration-minutes", type=int, default=None)
     parser.add_argument("--max-steps", type=int, default=None)
     parser.add_argument(
         "--step-interval-seconds",
@@ -551,6 +599,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo-root", type=Path, default=None)
     parser.add_argument("--approval-record", type=Path, default=None)
     parser.add_argument("--run-id", type=str, default="")
+    parser.add_argument(
+        "--profile",
+        type=str,
+        default="",
+        help=(
+            "Optional approval contract profile. "
+            f"Supported: {contract_24h.CONTRACT_PROFILE!r} (default: 10min bounded shadow)."
+        ),
+    )
     parser.add_argument(
         "--strict-repo-clean",
         action="store_true",
@@ -582,16 +639,45 @@ def main(
             raise
         return USAGE_EXIT
 
-    if args.duration_minutes <= 0 or args.duration_minutes > MAX_DURATION_MINUTES:
-        print(
-            f"duration-minutes must be between 1 and {MAX_DURATION_MINUTES} inclusive",
-            file=sys.stderr,
-        )
+    profile = normalize_profile(args.profile)
+    profile_issues = validate_profile_name(profile)
+    if profile_issues:
+        for issue in profile_issues:
+            print(issue, file=sys.stderr)
+        return USAGE_EXIT
+
+    if profile == contract_24h.CONTRACT_PROFILE:
+        if not args.run_id.strip():
+            print("--run-id is required for 24h profile", file=sys.stderr)
+            return USAGE_EXIT
+        if args.duration_minutes is None:
+            args.duration_minutes = contract_24h.DAEMON_PAPER_SHADOW_24H_DURATION_MINUTES
+        duration_issues = contract_24h.validate_shadow_duration_minutes(args.duration_minutes)
+        if duration_issues:
+            for issue in duration_issues:
+                print(issue, file=sys.stderr)
+            return VALIDATION_EXIT
+        max_steps_cap = CANDIDATE_24H_MAX_STEPS_CAP
+    else:
+        if args.duration_minutes is None:
+            args.duration_minutes = DEFAULT_DURATION_MINUTES
+        if args.duration_minutes <= 0 or args.duration_minutes > MAX_DURATION_MINUTES:
+            print(
+                f"duration-minutes must be between 1 and {MAX_DURATION_MINUTES} inclusive",
+                file=sys.stderr,
+            )
+            return USAGE_EXIT
+        max_steps_cap = MAX_STEPS_CAP
+
+    if args.duration_minutes <= 0:
+        print("duration-minutes must be > 0", file=sys.stderr)
         return USAGE_EXIT
 
     max_steps = _default_max_steps(args.duration_minutes, args.max_steps)
-    if max_steps <= 0 or max_steps > MAX_STEPS_CAP:
-        print(f"max-steps must be between 1 and {MAX_STEPS_CAP} inclusive", file=sys.stderr)
+    if profile == contract_24h.CONTRACT_PROFILE and args.max_steps is None:
+        max_steps = min(CANDIDATE_24H_MAX_STEPS_CAP, max(1, args.duration_minutes * 12))
+    if max_steps <= 0 or max_steps > max_steps_cap:
+        print(f"max-steps must be between 1 and {max_steps_cap} inclusive", file=sys.stderr)
         return USAGE_EXIT
 
     if args.step_interval_seconds < 0:
@@ -616,6 +702,7 @@ def main(
         max_steps=max_steps,
         step_interval_seconds=args.step_interval_seconds,
         run_id=run_id,
+        contract_profile=profile,
     )
 
     if args.execute:

--- a/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
@@ -18,6 +18,11 @@ ROOT = Path(__file__).resolve().parent.parent.parent
 ADAPTER_SCRIPT = ROOT / "scripts" / "ops" / "run_shadow_bounded_observation_adapter_v0.py"
 REVIEW_SCRIPT = ROOT / "scripts" / "ops" / "review_shadow_bounded_observation_evidence_v0.py"
 APPROVAL_FIXTURE = ROOT / "tests" / "fixtures" / "ops" / "shadow_adapter_stage3_approval_sample.md"
+APPROVAL_FIXTURE_24H = (
+    ROOT / "tests" / "fixtures" / "ops" / "daemon_paper_shadow_24h_adapter_approval_sample.md"
+)
+RUN_ID_24H = "daemon_paper_24h_20260524T093549Z"
+PROFILE_24H = "daemon_paper_shadow_24h_v0"
 ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
 
 
@@ -50,6 +55,15 @@ def _base_argv(staging: Path, archive: Path | None = None) -> list[str]:
         str(archive or ARCHIVE_ROOT),
         "--repo-root",
         str(ROOT),
+    ]
+
+
+def _base_argv_24h(staging: Path, archive: Path | None = None) -> list[str]:
+    return _base_argv(staging, archive) + [
+        "--profile",
+        PROFILE_24H,
+        "--run-id",
+        RUN_ID_24H,
     ]
 
 
@@ -542,6 +556,224 @@ def test_review_does_not_claim_gate_clearance(tmp_path: Path) -> None:
     blob = json.dumps(result)
     assert "SHADOW_READY" not in blob
     assert result["non_authorizing"] is True
+
+
+def test_default_profile_unchanged_still_10_minutes(tmp_path: Path) -> None:
+    plan = _plan_dict(_staging(tmp_path))
+    assert plan["duration_minutes"] == 10
+    assert plan.get("contract_profile", "") == ""
+
+
+def test_default_profile_rejects_duration_11(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    rc = mod.main(_base_argv(staging) + ["--duration-minutes", "11"])
+    assert rc != 0
+
+
+def test_24h_profile_plan_only_default_duration_1440(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(_base_argv_24h(staging) + ["--json"])
+    assert rc == 0, buf.getvalue()
+    plan = json.loads(buf.getvalue())
+    assert plan["duration_minutes"] == 1440
+    assert plan["contract_profile"] == PROFILE_24H
+    assert plan["run_id"] == RUN_ID_24H
+
+
+def test_24h_profile_plan_includes_candidate_24h_wrapper_flags(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(_base_argv_24h(staging) + ["--json"])
+    assert rc == 0
+    plan = json.loads(buf.getvalue())
+    joined = json.dumps(plan["commands"]).lower()
+    assert "candidate-24h-bounded-shadow-validation" in joined
+    assert "candidate-24h-confirm-token" in joined
+
+
+def test_24h_profile_rejects_10_minutes_explicit(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    rc = mod.main(_base_argv_24h(staging) + ["--duration-minutes", "10"])
+    assert rc != 0
+
+
+def test_24h_profile_requires_run_id(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    rc = mod.main(_base_argv(staging) + ["--profile", PROFILE_24H])
+    assert rc != 0
+
+
+def test_unknown_profile_rejected(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    rc = mod.main(_base_argv(staging) + ["--profile", "unknown_profile_v0"])
+    assert rc != 0
+
+
+def test_24h_profile_execute_rejects_shadow_only_approval_fixture(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(APPROVAL_FIXTURE),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+def test_24h_profile_execute_rejects_120min_paper_approval_fixture(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    paper_fixture = (
+        ROOT / "tests" / "fixtures" / "ops" / "paper_only_adapter_stage3_approval_sample.md"
+    )
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(paper_fixture),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+def test_24h_profile_execute_rejects_run_id_mismatch(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    rc = mod.main(
+        _base_argv(staging, archive)
+        + [
+            "--profile",
+            PROFILE_24H,
+            "--run-id",
+            "other_run_id",
+            "--execute",
+            "--approval-record",
+            str(APPROVAL_FIXTURE_24H),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+@pytest.mark.parametrize("key", ["PAPER_LANE_AUTHORIZED", "SHADOW_LANE_AUTHORIZED"])
+def test_24h_profile_execute_rejects_missing_lane_key(tmp_path: Path, key: str) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    text = APPROVAL_FIXTURE_24H.read_text(encoding="utf-8")
+    lines = [line for line in text.splitlines() if not line.strip().startswith(f"{key}=")]
+    bad = tmp_path / "bad_approval.md"
+    bad.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(bad),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("START_TESTNET_NOW", "true"),
+        ("START_LIVE_NOW", "true"),
+        ("LIVE_ALLOWED", "true"),
+        ("BROKER_EXCHANGE_ALLOWED", "true"),
+    ],
+)
+def test_24h_profile_execute_rejects_forbidden_flags(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    text = APPROVAL_FIXTURE_24H.read_text(encoding="utf-8").replace(
+        f"{field}=false", f"{field}={value}"
+    )
+    bad = tmp_path / f"bad_{field}.md"
+    bad.write_text(text, encoding="utf-8")
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(bad),
+            "--no-strict-repo-clean",
+        ],
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc != 0
+
+
+def test_24h_profile_execute_accepts_shared_fixture_mocked(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+    calls: list[str] = []
+
+    def _runner(argv: Sequence[str], _cwd, stdout_path, stderr_path) -> int:
+        joined = " ".join(argv)
+        calls.append(joined)
+        if "shadow_247_futures_start_wrapper_skeleton_v0.py" in joined:
+            assert "candidate-24h-bounded-shadow-validation" in joined
+            assert "--duration-minutes 1440" in joined
+            _write_wrapper_bundle(staging)
+            if stdout_path is not None:
+                stdout_path.write_text("mock wrapper stdout\n", encoding="utf-8")
+            if stderr_path is not None:
+                stderr_path.write_text("mock wrapper stderr\n", encoding="utf-8")
+            return 0
+        if "review_shadow_bounded_observation_evidence_v0.py" in joined:
+            review_mod = _load_review()
+            result = review_mod.review_evidence(staging)
+            if stdout_path is not None:
+                stdout_path.parent.mkdir(parents=True, exist_ok=True)
+                stdout_path.write_text(
+                    json.dumps(result, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+            return 0 if result["verdict"] == review_mod.PASS else 1
+        return 0
+
+    rc = mod.main(
+        _base_argv_24h(staging, archive)
+        + [
+            "--execute",
+            "--approval-record",
+            str(APPROVAL_FIXTURE_24H),
+            "--no-strict-repo-clean",
+        ],
+        subprocess_runner=_runner,
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc == 0
+    assert calls
 
 
 def test_review_json_output_parseable(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds optional `daemon_paper_shadow_24h_v0` profile to the shadow bounded observation adapter.

- Reuses merged validator from PR #3663 (`bounded_daemon_paper_shadow_24h_approval_v0.py`).
- Requires 1440min shadow duration, explicit `--run-id`, and `APPROVED_RUN_ID` binding for 24h profile.
- Requires both `PAPER_LANE_AUTHORIZED` and `SHADOW_LANE_AUTHORIZED` in shared approval record.
- Wires wrapper 24h candidate flags only under 24h profile.
- Existing 10min shadow default behavior and tests preserved.

## Safety

- Shadow adapter 24h profile only.
- Paper adapter untouched.
- No staging bridge.
- No HOLD clearance.
- No runtime execution in tests.
- `READY_TO_START_RUN_NOW=false`.

## Checks

- `git diff --check`
- `uv run python -m py_compile` (shadow adapter + validator)
- `uv run pytest` (24h contract + shadow adapter tests — 61 passed)
- `uv run ruff check` / `ruff format --check`

## Out of scope

- Staging bridge
- HOLD/governance clearance
- Preflight unblock
- Execution retry

Made with [Cursor](https://cursor.com)