### PR TITLE
ops: add paper lane closeout parity v0

### DIFF
--- a/scripts/ops/primary_evidence_retention_v0.py
+++ b/scripts/ops/primary_evidence_retention_v0.py
@@ -35,6 +35,16 @@ BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS = (
     MANIFEST_FILENAME,
 )
 
+# Paper bounded observation durable run roots (scheduler composition; Preflight §2a.1).
+PAPER_BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS = (
+    "RUN_METADATA.json",
+    "review/REVIEW_RESULT.json",
+    "runtime_out/evidence_manifest.json",
+    "logs/scheduler_stdout.log",
+    "logs/scheduler_stderr.log",
+    MANIFEST_FILENAME,
+)
+
 # Closeout filenames referenced by §2a.1 hard gate (index only; owners remain canonical).
 KNOWN_CLOSEOUT_FILENAMES = (
     "scheduler_completion_closeout_v0.json",

--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -302,6 +302,7 @@ def build_plan(
         "logs/scheduler_stdout.log",
         "logs/scheduler_stderr.log",
         "review/REVIEW_RESULT.json",
+        "RUN_METADATA.json",
         "MANIFEST.sha256",
         "CLOSEOUT.md",
         "POSTRUN_ANALYSIS.md",
@@ -447,6 +448,67 @@ def _default_subprocess_runner(
     return int(proc.returncode or 0)
 
 
+def _write_closeout_artifacts(
+    ctx: ExecuteContext,
+    plan: AdapterPlan,
+    archive_dest: Path,
+    review_payload: Mapping[str, Any],
+) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    run_metadata = {
+        "run_id": ctx.run_id,
+        "adapter_version": plan.adapter_version,
+        "staging_root": str(ctx.staging_root),
+        "archive_path": str(archive_dest),
+        "duration_seconds": plan.duration_seconds,
+        "poll_interval_seconds": plan.poll_interval_seconds,
+        "review_verdict": review_payload.get("verdict"),
+        "live_authority": False,
+        "testnet_authority": False,
+        "broker_authority": False,
+        "utc": now,
+    }
+    (ctx.staging_root / "RUN_METADATA.json").write_text(
+        json.dumps(run_metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    closeout_lines = [
+        "# Paper Bounded Observation Adapter Closeout",
+        "",
+        f"RUN_ID={ctx.run_id}",
+        f"STAGING_PATH={ctx.staging_root}",
+        f"ARCHIVE_PATH={archive_dest}",
+        f"REVIEW_VERDICT={review_payload.get('verdict')}",
+        "EXECUTION_PERFORMED=true",
+        "PAPER_RUNTIME_APPROVAL_GRANTED=false",
+        "SHADOW_STARTED=false",
+        "TESTNET_STARTED=false",
+        "LIVE_ALLOWED=false",
+        "live_authority=false",
+        "testnet_authority=false",
+        "broker_authority=false",
+        "PREFLIGHT_BLOCKED=true",
+        "NOTION_WRITES=false",
+        "PRIMARY_EVIDENCE_TIER=achieved",
+        "NO_AUTOMATIC_24H_72H_RERUN_REQUIRED=true",
+    ]
+    (ctx.staging_root / "CLOSEOUT.md").write_text(
+        "\n".join(closeout_lines) + "\n",
+        encoding="utf-8",
+    )
+    postrun_lines = [
+        "# Paper Bounded Observation Postrun Analysis",
+        "",
+        f"Generated UTC: {now}",
+        f"Review issues: {review_payload.get('issues', [])}",
+        "Non-authorizing adapter execute; no gate clearance claimed.",
+    ]
+    (ctx.staging_root / "POSTRUN_ANALYSIS.md").write_text(
+        "\n".join(postrun_lines) + "\n",
+        encoding="utf-8",
+    )
+
+
 def execute_plan(
     ctx: ExecuteContext,
     plan: AdapterPlan,
@@ -507,8 +569,9 @@ def execute_plan(
     if review_payload.get("verdict") != "PASS":
         return VALIDATION_EXIT
 
-    _write_manifest_sha256(ctx.staging_root)
     archive_dest = ctx.archive_root / "runs" / "paper" / ctx.run_id
+    _write_closeout_artifacts(ctx, plan, archive_dest, review_payload)
+    _write_manifest_sha256(ctx.staging_root)
     archive_dest.mkdir(parents=True, exist_ok=True)
     for item in ctx.staging_root.iterdir():
         dest = archive_dest / item.name

--- a/tests/ops/test_paper_lane_closeout_parity_v0.py
+++ b/tests/ops/test_paper_lane_closeout_parity_v0.py
@@ -1,0 +1,220 @@
+"""Contract tests for paper-lane bounded observation closeout parity v0."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PAPER_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_paper_only_bounded_observation_adapter_v0.py"
+REGISTRY_SCRIPT = REPO_ROOT / "scripts" / "ops" / "build_generic_evidence_run_registry_v1.py"
+APPROVAL_FIXTURE = (
+    REPO_ROOT / "tests" / "fixtures" / "ops" / "paper_only_adapter_stage3_approval_sample.md"
+)
+RUN_ID = "paper_lane_closeout_parity_fixture_v0"
+
+
+def _load_paper_adapter():
+    spec = importlib.util.spec_from_file_location(
+        "run_paper_only_bounded_observation_adapter_v0_parity",
+        PAPER_ADAPTER,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_registry():
+    spec = importlib.util.spec_from_file_location(
+        "build_generic_evidence_run_registry_v1_parity",
+        REGISTRY_SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _staging(tmp_path: Path) -> Path:
+    return Path("/tmp") / f"peak_trade_paper_closeout_parity_{tmp_path.name}"
+
+
+def _durable_archive(tmp_path: Path) -> Path:
+    path = REPO_ROOT / "tests" / ".pytest_archive_roots" / tmp_path.name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_minimal_paper_runtime_bundle(staging: Path) -> None:
+    runtime_out = staging / "runtime_out"
+    runtime_out.mkdir(parents=True, exist_ok=True)
+    (runtime_out / "account.json").write_text("{}\n", encoding="utf-8")
+    (runtime_out / "fills.json").write_text("[]\n", encoding="utf-8")
+    (runtime_out / "evidence_manifest.json").write_text(
+        json.dumps({"schema": "paper_runtime_evidence.v0"}) + "\n",
+        encoding="utf-8",
+    )
+    logs = staging / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    (logs / "scheduler_stdout.log").write_text("stdout\n", encoding="utf-8")
+    (logs / "scheduler_stderr.log").write_text("stderr\n", encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_durable_archive_dirs():
+    yield
+    archive_roots = REPO_ROOT / "tests" / ".pytest_archive_roots"
+    if archive_roots.is_dir():
+        shutil.rmtree(archive_roots, ignore_errors=True)
+
+
+def test_paper_adapter_exposes_write_closeout_artifacts() -> None:
+    text = PAPER_ADAPTER.read_text(encoding="utf-8")
+    assert "_write_closeout_artifacts" in text
+    assert "RUN_METADATA.json" in text
+    assert "CLOSEOUT.md" in text
+
+
+def test_execute_emits_closeout_artifacts_with_non_authority_markers(tmp_path: Path) -> None:
+    mod = _load_paper_adapter()
+    staging = _staging(tmp_path)
+    archive = _durable_archive(tmp_path)
+
+    def _runner(
+        argv: Sequence[str],
+        _cwd,
+        _stdout,
+        _stderr,
+        *,
+        extra_env: Mapping[str, str] | None = None,
+    ) -> int:
+        if "run_with_timeout.py" in " ".join(argv):
+            _write_minimal_paper_runtime_bundle(staging)
+            return mod.TIMEOUT_EXIT
+        if "review_scheduler_paper_runtime_evidence.py" in " ".join(argv):
+            review_dir = staging / "review"
+            review_dir.mkdir(parents=True, exist_ok=True)
+            (review_dir / "REVIEW_RESULT.json").write_text(
+                json.dumps({"verdict": "PASS", "metrics": {}, "issues": []}),
+                encoding="utf-8",
+            )
+            return 0
+        return 0
+
+    rc = mod.main(
+        [
+            "--staging-root",
+            str(staging),
+            "--archive-root",
+            str(archive),
+            "--repo-root",
+            str(REPO_ROOT),
+            "--run-id",
+            RUN_ID,
+            "--execute",
+            "--approval-record",
+            str(APPROVAL_FIXTURE),
+            "--no-strict-repo-clean",
+        ],
+        subprocess_runner=_runner,
+        repo_clean_checker=lambda _root: (True, ""),
+    )
+    assert rc == 0
+
+    archive_dest = archive / "runs" / "paper" / RUN_ID
+    for rel in (
+        "CLOSEOUT.md",
+        "RUN_METADATA.json",
+        "POSTRUN_ANALYSIS.md",
+        "review/REVIEW_RESULT.json",
+        "MANIFEST.sha256",
+    ):
+        assert (archive_dest / rel).is_file(), rel
+
+    metadata = json.loads((archive_dest / "RUN_METADATA.json").read_text(encoding="utf-8"))
+    assert metadata["live_authority"] is False
+    assert metadata["testnet_authority"] is False
+    assert metadata["broker_authority"] is False
+
+    closeout = (archive_dest / "CLOSEOUT.md").read_text(encoding="utf-8")
+    assert "live_authority=false" in closeout
+    assert "testnet_authority=false" in closeout
+    assert "broker_authority=false" in closeout
+    assert "LIVE_ALLOWED=false" in closeout
+
+
+def test_validate_durable_primary_evidence_root_passes_for_paper_fixture(tmp_path: Path) -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import (
+        PAPER_BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS,
+        validate_durable_primary_evidence_root,
+        write_manifest_sha256,
+    )
+
+    durable = _durable_archive(tmp_path) / "runs" / "paper" / RUN_ID
+    _write_minimal_paper_runtime_bundle(durable)
+    review_dir = durable / "review"
+    review_dir.mkdir(parents=True, exist_ok=True)
+    (review_dir / "REVIEW_RESULT.json").write_text(
+        json.dumps({"verdict": "PASS", "issues": []}) + "\n",
+        encoding="utf-8",
+    )
+    (durable / "RUN_METADATA.json").write_text(
+        json.dumps(
+            {
+                "run_id": RUN_ID,
+                "live_authority": False,
+                "testnet_authority": False,
+                "broker_authority": False,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (durable / "CLOSEOUT.md").write_text(
+        "live_authority=false\ntestnet_authority=false\nbroker_authority=false\n",
+        encoding="utf-8",
+    )
+    write_manifest_sha256(durable)
+
+    ok, reason, detail = validate_durable_primary_evidence_root(
+        durable,
+        required_rel_paths=PAPER_BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS,
+    )
+    assert ok is True, reason
+    assert detail["checks"]["durable_review_verdict_pass"] is True
+    assert detail["checks"]["manifest_sha256_verify"] is True
+
+
+def test_registry_v1_indexes_paper_lane_not_new_lane_id(tmp_path: Path) -> None:
+    archive = _durable_archive(tmp_path)
+    run_dir = archive / "runs" / "paper" / RUN_ID
+    _write_minimal_paper_runtime_bundle(run_dir)
+    review_dir = run_dir / "review"
+    review_dir.mkdir(parents=True, exist_ok=True)
+    (review_dir / "REVIEW_RESULT.json").write_text(
+        json.dumps({"verdict": "PASS", "issues": []}) + "\n",
+        encoding="utf-8",
+    )
+    (run_dir / "RUN_METADATA.json").write_text('{"run_id": "' + RUN_ID + '"}\n', encoding="utf-8")
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+    write_manifest_sha256(run_dir)
+
+    mod = _load_registry()
+    registry = mod.build_registry(mod.BuildContext(archive_root=archive, repo_root=REPO_ROOT))
+    lane_ids = {row["lane_id"] for row in registry["runs"]}
+    assert lane_ids == {"paper"}
+    assert registry["runs"][0]["lane_id"] == "paper"
+    assert "daemon_paper_24h" not in lane_ids
+    assert "remote_runtime" not in lane_ids

--- a/tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py
+++ b/tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py
@@ -177,15 +177,12 @@ def test_bounded_adapters_reject_tmp_archive_root_on_execute() -> None:
 
 
 def test_bounded_adapters_write_closeout_and_review_on_execute() -> None:
-    for path in (SHADOW_ADAPTER, TESTNET_ADAPTER):
+    for path in (PAPER_ADAPTER, SHADOW_ADAPTER, TESTNET_ADAPTER):
         text = path.read_text(encoding="utf-8")
         assert "_write_closeout_artifacts" in text
         assert "REVIEW_RESULT.json" in text
         assert "verify_manifest_sha256" in text
-    paper_text = PAPER_ADAPTER.read_text(encoding="utf-8")
-    assert "REVIEW_RESULT.json" in paper_text
-    assert "verify_manifest_sha256" in paper_text
-    assert "archive root must be outside /tmp" in paper_text
+        assert "archive root must be outside /tmp" in text
 
 
 def test_p67_p72_reference_finalize_primary_evidence_root() -> None:


### PR DESCRIPTION
## Summary

Adds paper-lane closeout parity v0 by making the paper bounded observation adapter emit the same essential durable closeout artifacts expected by the primary evidence retention flow.

This closes the known paper-lane gap found after the durable 24h daemon closeout and the Generic Evidence Registry v1 read-only analysis.

## Scope

- Adds paper-lane `CLOSEOUT.md` generation.
- Adds paper-lane `RUN_METADATA.json` generation.
- Ensures closeout artifacts are written before `MANIFEST.sha256`.
- Adds paper-specific durable validation required paths.
- Adds focused offline contract tests.
- Extends hard-gate assertion coverage.

## Safety Boundaries

- No new lane.
- No new evidence standard.
- No new closeout standard.
- No runtime start.
- No scheduler/daemon/paper/shadow/testnet/live execution.
- No AWS/rclone calls.
- No Notion writes.
- No Market Dashboard changes.
- No Master V2 / Double Play authority changes.
- Live authority remains false.
- Testnet authority remains false.
- Historical durable archive is not modified.

## Validation

- `pytest` relevant ops/evidence/adapter/registry tests:
  - 175 passed, 1 skipped
- `ruff format`
  - clean
- `ruff check`
  - clean
- `validate_durable_primary_evidence_root`
  - passes for paper fixtures using paper-specific required paths

## Context

This follows:

- Durable 24h daemon closeout:
  - `RUN_ID=daemon_paper_24h_20260524T205447Z`
  - `DURABLE_ARCHIVE_ROOT=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260525T210741Z`
  - `MANIFEST_VERIFY_RC=0`
- PR #3670:
  - Remote Runtime Host Metadata Contract v0 merged.
- Registry v1 read-only analysis:
  - Paper row was indexable but paper primary evidence lacked closeout parity.

This PR improves future Paper evidence reusability before Notion/Dashboard/S3/AWS work proceeds.

## Machine Lines

PAPER_LANE_CLOSEOUT_PARITY_MODE=minimal_implementation_contract_tests
PAPER_CLOSEOUT_MD_EMITTED=true
PAPER_RUN_METADATA_JSON_EMITTED=true
PAPER_VALIDATE_DURABLE_PRIMARY_EVIDENCE_ROOT_PASSES=true
NEW_EVIDENCE_STANDARD_CREATED=false
NEW_CLOSEOUT_STANDARD_CREATED=false
NEW_LANE_CREATED=false
RUNTIME_COMMANDS_CALLED=false
AWS_CLI_CALLED=false
RCLONE_CALLED=false
NOTION_WRITE_CALLED=false
MARKET_DASHBOARD_CHANGED=false
LIVE_AUTHORITY=false
TESTNET_AUTHORITY=false

Made with [Cursor](https://cursor.com)