### PR TITLE
ops: add combined outroot composition index v0

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -58,7 +58,7 @@ Future run selectors and adapters must **reject or block** a run plan when prima
 
 Reference implementation: `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` and shared manifest helpers in `scripts/ops/primary_evidence_retention_v0.py` (plan-only default; execute requires approval record; archive root outside `/tmp`; `MANIFEST.sha256` verified after durable copy).
 
-Combined daemon paper+shadow OUTROOTs are **composition/index** wrappers indexed in Generic Evidence Run Registry v1 `compositions[]` (taxonomy §6b); per-lane `MANIFEST.sha256` at `runs/{paper,shadow,testnet}/{run_id}/` remains canonical primary evidence.
+Combined daemon paper+shadow OUTROOTs are **composition/index** wrappers indexed in Generic Evidence Run Registry v1 `compositions[]` (taxonomy §6b); per-lane `MANIFEST.sha256` at `runs&#47;{paper,shadow,testnet}&#47;{run_id}&#47;` remains canonical primary evidence.
 
 P67/P72 library paths (`run_shadow_session_scheduler_v1`, `run_shadowloop_pack_v1`) write partial evidence by default; opt-in `primary_evidence_enforce=True` calls shared `finalize_primary_evidence_root()` at library completion (non-authorizing; does not clear HOLD or grant Live/Testnet/broker authority; P67 CLI scheduler guard unchanged).
 

--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -58,6 +58,8 @@ Future run selectors and adapters must **reject or block** a run plan when prima
 
 Reference implementation: `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` and shared manifest helpers in `scripts/ops/primary_evidence_retention_v0.py` (plan-only default; execute requires approval record; archive root outside `/tmp`; `MANIFEST.sha256` verified after durable copy).
 
+Combined daemon paper+shadow OUTROOTs are **composition/index** wrappers indexed in Generic Evidence Run Registry v1 `compositions[]` (taxonomy §6b); per-lane `MANIFEST.sha256` at `runs/{paper,shadow,testnet}/{run_id}/` remains canonical primary evidence.
+
 P67/P72 library paths (`run_shadow_session_scheduler_v1`, `run_shadowloop_pack_v1`) write partial evidence by default; opt-in `primary_evidence_enforce=True` calls shared `finalize_primary_evidence_root()` at library completion (non-authorizing; does not clear HOLD or grant Live/Testnet/broker authority; P67 CLI scheduler guard unchanged).
 
 Scheduler launcher (`scripts/run_scheduler.py`) supports opt-in completion retention via `--evidence-dir` and `--primary-evidence-enforce`, writing `scheduler_completion_closeout_v0.json` and calling shared `finalize_primary_evidence_root()` when enforcement is enabled (default off; dry-run remains planning-only; start boundary guard unchanged).

--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -85,6 +85,11 @@ NOTION_PROJECTION_NON_AUTHORIZING=true
 MARKET_DASHBOARD_PROJECTION_READONLY=true
 REMOTE_RUNTIME_V0_LIVE_AUTHORITY=false
 REMOTE_RUNTIME_V0_TESTNET_AUTHORITY=false
+COMBINED_OUTROOT_COMPOSITION_INDEX_V0=true
+COMPOSITION_INDEX_IS_NOT_LANE=true
+LANE_ID_DAEMON_PAPER_24H_FORBIDDEN=true
+LANE_ID_REMOTE_RUNTIME_FORBIDDEN=true
+COMPOSITION_INDEX_AUTHORITY=false
 ```
 
 Non-goals:
@@ -339,6 +344,71 @@ Completed bounded dry-run (example context for field semantics only):
 ### Reuse-before-new
 
 Do **not** add a parallel remote-runtime runbook, remote lane, remote evidence manifest, remote closeout standard, or remote scheduler authority. Extend this §6a, Generic Evidence Run Registry v1 optional fields, and existing Phase T/W export consumer planning only.
+
+### 6b. Combined OUTROOT composition-index v0 (not a lane)
+
+```
+COMBINED_OUTROOT_COMPOSITION_INDEX_V0=true
+COMPOSITION_INDEX_IS_NOT_LANE=true
+LANE_ID_DAEMON_PAPER_24H_FORBIDDEN=true
+LANE_ID_REMOTE_RUNTIME_FORBIDDEN=true
+COMPOSITION_INDEX_AUTHORITY=false
+composition_index_authority=false
+live_authority=false
+testnet_authority=false
+s3_authority=false
+notion_authority=false
+market_dashboard_authority=false
+REGISTRY_V1_COMPOSITION_RECORD_KIND=composition_index
+PER_LANE_MANIFEST_SHA256_REMAINS_CANONICAL=true
+```
+
+**Purpose:** Represent combined daemon paper+shadow OUTROOTs as **composition/index metadata** in Generic Evidence Run Registry v1 without promoting `runs/daemon_paper_24h/` to a taxonomy lane or introducing `lane_id=daemon_paper_24h`.
+
+**Normative rule:** `paper`, `shadow`, and `testnet` remain the only bounded primary-evidence **lanes** (§3). A combined OUTROOT under `runs/daemon_paper_24h/{run_id}/` is a **composition wrapper** that references child lane rows; it is **not** a runtime lane, approval lane, evidence standard, or closeout standard.
+
+Implementation index:
+
+- Registry builder: [build_generic_evidence_run_registry_v1.py](../../../scripts/ops/build_generic_evidence_run_registry_v1.py) — `compositions[]` records with `record_kind=composition_index`; lane rows remain in `runs[]`.
+- Per-lane primary evidence owner unchanged: [primary_evidence_retention_v0.py](../../../scripts/ops/primary_evidence_retention_v0.py) — `MANIFEST.sha256` at `runs/{paper,shadow,testnet}/{run_id}/`.
+- Preflight §2a anchor: [PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md](../runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md) — per-lane manifest verify remains canonical.
+
+#### composition_index vs lane_id
+
+| Surface | Role | Authority |
+|---|---|---|
+| `lane_id` ∈ {`paper`, `shadow`, `testnet`} | Canonical bounded primary-evidence lane | `evidence_only` (§3) |
+| `composition_id=daemon_paper_24h` | Combined OUTROOT index wrapper | **none** (`composition_index_authority=false`) |
+| `lane_id=daemon_paper_24h` | **Forbidden** | must not appear in registry lane catalog |
+| `lane_id=remote_runtime` | **Forbidden** (§6a) | backend metadata only |
+
+#### paper_then_shadow composition semantics
+
+- `runtime_mode=paper_then_shadow` on a composition record documents sequencing context only.
+- Composition record **`child_lane_refs`** point at canonical lane run roots: `runs/paper/{run_id}/`, `runs/shadow/{run_id}/`.
+- Child lane rows in `runs[]` remain authoritative for lane primary evidence, review verdicts, and closeout artifacts.
+- Composition record may carry governance/context pointers; it does **not** substitute for per-lane evidence or clear gates.
+
+#### Manifest resolution
+
+- **Per-lane primary:** `runs/{lane}/{run_id}/MANIFEST.sha256` — sole canonical primary evidence manifest for that lane (Preflight §2a; unchanged).
+- **Composition rollup (optional):** `runs/daemon_paper_24h/{run_id}/manifests/MANIFEST.sha256` — composition rollup only; paths relative to the composition root.
+- Composition rollup manifest **does not replace** per-lane `MANIFEST.sha256`.
+- Root-level `MANIFEST.sha256` on a composition OUTROOT is **not** primary evidence; registry emits `COMPOSITION_ROOT_MANIFEST_NOT_PRIMARY` when present.
+
+#### Forbidden promotions
+
+- `lane_id=daemon_paper_24h` — forbidden
+- `lane_id=remote_runtime` — forbidden
+- `composition_index_authority=true` — forbidden
+- Treating composition rollup manifest as lane primary evidence — forbidden
+- Introducing `SHA256SUMS.stable.txt` as competing truth — forbidden (reuse `MANIFEST.sha256` only)
+
+#### Illustrative anchor (non-authorizing)
+
+- `RUN_ID=daemon_paper_24h_20260524T205447Z`
+- Combined OUTROOT: `runs/daemon_paper_24h/{run_id}/` with optional `manifests/MANIFEST.sha256`
+- Child lanes: `runs/paper/{run_id}/`, `runs/shadow/{run_id}/` — canonical per-lane evidence
 
 ## 7. Scheduler lane — launcher and CLI hard-block (partial verification)
 

--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -363,14 +363,14 @@ REGISTRY_V1_COMPOSITION_RECORD_KIND=composition_index
 PER_LANE_MANIFEST_SHA256_REMAINS_CANONICAL=true
 ```
 
-**Purpose:** Represent combined daemon paper+shadow OUTROOTs as **composition/index metadata** in Generic Evidence Run Registry v1 without promoting `runs/daemon_paper_24h/` to a taxonomy lane or introducing `lane_id=daemon_paper_24h`.
+**Purpose:** Represent combined daemon paper+shadow OUTROOTs as **composition/index metadata** in Generic Evidence Run Registry v1 without promoting `runs&#47;daemon_paper_24h&#47;` to a taxonomy lane or introducing `lane_id=daemon_paper_24h`.
 
-**Normative rule:** `paper`, `shadow`, and `testnet` remain the only bounded primary-evidence **lanes** (§3). A combined OUTROOT under `runs/daemon_paper_24h/{run_id}/` is a **composition wrapper** that references child lane rows; it is **not** a runtime lane, approval lane, evidence standard, or closeout standard.
+**Normative rule:** `paper`, `shadow`, and `testnet` remain the only bounded primary-evidence **lanes** (§3). A combined OUTROOT under `runs&#47;daemon_paper_24h&#47;{run_id}&#47;` is a **composition wrapper** that references child lane rows; it is **not** a runtime lane, approval lane, evidence standard, or closeout standard.
 
 Implementation index:
 
 - Registry builder: [build_generic_evidence_run_registry_v1.py](../../../scripts/ops/build_generic_evidence_run_registry_v1.py) — `compositions[]` records with `record_kind=composition_index`; lane rows remain in `runs[]`.
-- Per-lane primary evidence owner unchanged: [primary_evidence_retention_v0.py](../../../scripts/ops/primary_evidence_retention_v0.py) — `MANIFEST.sha256` at `runs/{paper,shadow,testnet}/{run_id}/`.
+- Per-lane primary evidence owner unchanged: [primary_evidence_retention_v0.py](../../../scripts/ops/primary_evidence_retention_v0.py) — `MANIFEST.sha256` at `runs&#47;{paper,shadow,testnet}&#47;{run_id}&#47;`.
 - Preflight §2a anchor: [PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md](../runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md) — per-lane manifest verify remains canonical.
 
 #### composition_index vs lane_id
@@ -385,14 +385,14 @@ Implementation index:
 #### paper_then_shadow composition semantics
 
 - `runtime_mode=paper_then_shadow` on a composition record documents sequencing context only.
-- Composition record **`child_lane_refs`** point at canonical lane run roots: `runs/paper/{run_id}/`, `runs/shadow/{run_id}/`.
+- Composition record **`child_lane_refs`** point at canonical lane run roots: `runs&#47;paper&#47;{run_id}&#47;`, `runs&#47;shadow&#47;{run_id}&#47;`.
 - Child lane rows in `runs[]` remain authoritative for lane primary evidence, review verdicts, and closeout artifacts.
 - Composition record may carry governance/context pointers; it does **not** substitute for per-lane evidence or clear gates.
 
 #### Manifest resolution
 
-- **Per-lane primary:** `runs/{lane}/{run_id}/MANIFEST.sha256` — sole canonical primary evidence manifest for that lane (Preflight §2a; unchanged).
-- **Composition rollup (optional):** `runs/daemon_paper_24h/{run_id}/manifests/MANIFEST.sha256` — composition rollup only; paths relative to the composition root.
+- **Per-lane primary:** `runs&#47;{lane}&#47;{run_id}&#47;MANIFEST.sha256` — sole canonical primary evidence manifest for that lane (Preflight §2a; unchanged).
+- **Composition rollup (optional):** `runs&#47;daemon_paper_24h&#47;{run_id}&#47;manifests&#47;MANIFEST.sha256` — composition rollup only; paths relative to the composition root.
 - Composition rollup manifest **does not replace** per-lane `MANIFEST.sha256`.
 - Root-level `MANIFEST.sha256` on a composition OUTROOT is **not** primary evidence; registry emits `COMPOSITION_ROOT_MANIFEST_NOT_PRIMARY` when present.
 
@@ -407,8 +407,8 @@ Implementation index:
 #### Illustrative anchor (non-authorizing)
 
 - `RUN_ID=daemon_paper_24h_20260524T205447Z`
-- Combined OUTROOT: `runs/daemon_paper_24h/{run_id}/` with optional `manifests/MANIFEST.sha256`
-- Child lanes: `runs/paper/{run_id}/`, `runs/shadow/{run_id}/` — canonical per-lane evidence
+- Combined OUTROOT: `runs&#47;daemon_paper_24h&#47;{run_id}&#47;` with optional `manifests&#47;MANIFEST.sha256`
+- Child lanes: `runs&#47;paper&#47;{run_id}&#47;`, `runs&#47;shadow&#47;{run_id}&#47;` — canonical per-lane evidence
 
 ## 7. Scheduler lane — launcher and CLI hard-block (partial verification)
 

--- a/scripts/ops/build_generic_evidence_run_registry_v1.py
+++ b/scripts/ops/build_generic_evidence_run_registry_v1.py
@@ -5,6 +5,7 @@ Non-authorizing: indexes run metadata only. Does not start runtime, read secrets
 grant Live/Testnet/Go, or imply scheduler/canary/live authority.
 
 Lane semantics: docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+(§6a remote runtime host metadata; §6b combined OUTROOT composition-index).
 """
 
 from __future__ import annotations
@@ -67,6 +68,14 @@ BLOCKER_BROKER = "BROKER_EXCHANGE_NOT_AUTHORIZED"
 
 PRIMARY_EVIDENCE_LANES = ("paper", "shadow", "testnet")
 NON_RUN_LANES = frozenset({"dashboard", "ai_orchestrator", "notion", "docs"})
+
+# Combined OUTROOT composition-index v0 (taxonomy §6b): directory names under runs/ that are
+# composition wrappers, not lane_id catalog entries. Does not introduce lane_id=daemon_paper_24h.
+COMBINED_OUTROOT_COMPOSITION_INDEX_V0 = True
+COMPOSITION_INDEX_DIRECTORIES = frozenset({"daemon_paper_24h"})
+COMPOSITION_INDEX_FORBIDDEN_LANE_IDS = frozenset({"daemon_paper_24h", "remote_runtime"})
+COMPOSITION_INDEX_DEFAULT_RUNTIME_MODE = "paper_then_shadow"
+COMPOSITION_ROLLUP_MANIFEST_REL = Path("manifests") / "MANIFEST.sha256"
 
 UNSAFE_TRUE_KEYS: frozenset[str] = frozenset(
     {
@@ -279,6 +288,34 @@ def scan_unsafe_text(text: str, ctx: BuildContext, path: Path) -> None:
 
 def verify_manifest_directory(root: Path, ctx: BuildContext, label: str) -> bool:
     manifest_path = root / "MANIFEST.sha256"
+    return _verify_manifest_at_path(root, manifest_path, ctx, label)
+
+
+def verify_composition_rollup_manifest(
+    composition_root: Path, ctx: BuildContext, label: str
+) -> bool:
+    """Verify manifests/MANIFEST.sha256 rollup on a combined OUTROOT (taxonomy §6b).
+
+    Rollup manifest paths are relative to the composition root. This does not replace
+    per-lane MANIFEST.sha256 at runs/{paper,shadow,testnet}/{run_id}/.
+    """
+    manifest_path = composition_root / COMPOSITION_ROLLUP_MANIFEST_REL
+    if not composition_root.is_dir():
+        ctx.add_issue("MISSING_RUN_DIR", f"{label} composition directory missing", composition_root)
+        return False
+    if not manifest_path.is_file():
+        ctx.add_issue(
+            "MISSING_COMPOSITION_ROLLUP_MANIFEST",
+            f"{label} composition rollup manifest missing at manifests/MANIFEST.sha256",
+            manifest_path,
+        )
+        return False
+    return _verify_manifest_at_path(composition_root, manifest_path, ctx, label)
+
+
+def _verify_manifest_at_path(
+    root: Path, manifest_path: Path, ctx: BuildContext, label: str
+) -> bool:
     if not root.is_dir():
         ctx.add_issue("MISSING_RUN_DIR", f"{label} run directory missing", root)
         return False
@@ -333,7 +370,7 @@ def _load_review_verdict(review_path: Path) -> tuple[str | None, str | None]:
     return verdict, None
 
 
-def _discover_all_runs(archive_root: Path) -> list[tuple[str, Path]]:
+def _discover_lane_runs(archive_root: Path) -> list[tuple[str, Path]]:
     runs_root = archive_root / "runs"
     if not runs_root.is_dir():
         return []
@@ -342,10 +379,158 @@ def _discover_all_runs(archive_root: Path) -> list[tuple[str, Path]]:
         if not lane_dir.is_dir():
             continue
         lane_id = lane_dir.name
+        if lane_id in COMPOSITION_INDEX_DIRECTORIES:
+            continue
         for run_dir in sorted(lane_dir.iterdir()):
             if run_dir.is_dir():
                 out.append((lane_id, run_dir))
     return out
+
+
+def _discover_composition_runs(archive_root: Path) -> list[tuple[str, Path]]:
+    runs_root = archive_root / "runs"
+    if not runs_root.is_dir():
+        return []
+    out: list[tuple[str, Path]] = []
+    for composition_id in sorted(COMPOSITION_INDEX_DIRECTORIES):
+        composition_lane = runs_root / composition_id
+        if not composition_lane.is_dir():
+            continue
+        for run_dir in sorted(composition_lane.iterdir()):
+            if run_dir.is_dir():
+                out.append((composition_id, run_dir))
+    return out
+
+
+def _discover_all_runs(archive_root: Path) -> list[tuple[str, Path]]:
+    """Backward-compatible alias: lane runs only (excludes composition-index directories)."""
+    return _discover_lane_runs(archive_root)
+
+
+def _infer_child_lane_refs(
+    archive_root: Path, run_id: str, *, expected_lanes: tuple[str, ...] = ("paper", "shadow")
+) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for lane_id in expected_lanes:
+        child_dir = archive_root / "runs" / lane_id / run_id
+        present = child_dir.is_dir()
+        ref: dict[str, Any] = {
+            "lane_id": lane_id,
+            "present": present,
+        }
+        if present:
+            ref["archive_path"] = str(child_dir.relative_to(archive_root).as_posix())
+            ref["manifest_present"] = (child_dir / "MANIFEST.sha256").is_file()
+        else:
+            ref["archive_path"] = None
+            ref["manifest_present"] = False
+        refs.append(ref)
+    return refs
+
+
+def _build_composition_record(
+    composition_root: Path,
+    composition_id: str,
+    ctx: BuildContext,
+    lane_run_index: dict[tuple[str, str], dict[str, Any]],
+) -> dict[str, Any]:
+    run_id = composition_root.name
+    scan_unsafe_text(_scan_texts(composition_root), ctx, composition_root)
+
+    child_lane_refs = _infer_child_lane_refs(ctx.archive_root, run_id)
+    child_present_count = sum(1 for ref in child_lane_refs if ref["present"])
+    child_manifest_count = sum(1 for ref in child_lane_refs if ref.get("manifest_present"))
+
+    rollup_path = composition_root / COMPOSITION_ROLLUP_MANIFEST_REL
+    rollup_present = rollup_path.is_file()
+    if rollup_present:
+        rollup_verified = verify_composition_rollup_manifest(composition_root, ctx, composition_id)
+    else:
+        ctx.add_issue(
+            "MISSING_COMPOSITION_ROLLUP_MANIFEST",
+            (
+                f"composition {composition_id!r} rollup manifest missing at "
+                "manifests/MANIFEST.sha256"
+            ),
+            rollup_path,
+        )
+        rollup_verified = False
+
+    root_manifest_present = (composition_root / "MANIFEST.sha256").is_file()
+    if root_manifest_present:
+        ctx.add_issue(
+            "COMPOSITION_ROOT_MANIFEST_NOT_PRIMARY",
+            (
+                f"composition {composition_id!r} must not use root MANIFEST.sha256; "
+                "per-lane primary evidence remains at runs/{lane}/{run_id}/MANIFEST.sha256; "
+                "composition rollup belongs at manifests/MANIFEST.sha256 only"
+            ),
+            composition_root / "MANIFEST.sha256",
+        )
+
+    child_lane_status: list[dict[str, Any]] = []
+    for ref in child_lane_refs:
+        lane_id = ref["lane_id"]
+        lane_row = lane_run_index.get((lane_id, run_id))
+        status = {
+            "lane_id": lane_id,
+            "present": ref["present"],
+            "manifest_present": ref.get("manifest_present", False),
+        }
+        if lane_row is not None:
+            status["evidence_status"] = lane_row.get("evidence_status")
+            status["manifest_verified"] = lane_row.get("manifest_verified")
+        elif ref["present"]:
+            status["evidence_status"] = "unknown"
+            status["manifest_verified"] = ref.get("manifest_present", False)
+        else:
+            status["evidence_status"] = "missing"
+            status["manifest_verified"] = False
+        child_lane_status.append(status)
+
+    if not rollup_present:
+        composition_evidence_status = "incomplete"
+    elif not rollup_verified:
+        composition_evidence_status = "incomplete"
+    elif child_present_count < len(child_lane_refs):
+        composition_evidence_status = "partial"
+    else:
+        child_statuses = [s.get("evidence_status") for s in child_lane_status if s["present"]]
+        if any(s not in ("verified", None) for s in child_statuses):
+            composition_evidence_status = "partial"
+        else:
+            composition_evidence_status = "indexed"
+
+    rel_archive = str(composition_root.relative_to(ctx.archive_root).as_posix())
+
+    return {
+        "record_kind": "composition_index",
+        "composition_id": composition_id,
+        "run_id": run_id,
+        "runtime_mode": COMPOSITION_INDEX_DEFAULT_RUNTIME_MODE,
+        "archive_path": rel_archive,
+        "rollup_manifest_present": rollup_present,
+        "rollup_manifest_path": COMPOSITION_ROLLUP_MANIFEST_REL.as_posix(),
+        "rollup_manifest_verified": rollup_verified,
+        "root_manifest_present": root_manifest_present,
+        "child_lane_refs": child_lane_refs,
+        "child_lane_status": child_lane_status,
+        "child_lanes_present": child_present_count,
+        "child_lanes_with_manifest": child_manifest_count,
+        "composition_index_authority": False,
+        "live_authority": False,
+        "testnet_authority": False,
+        "s3_authority": False,
+        "notion_authority": False,
+        "market_dashboard_authority": False,
+        "can_clear_hold": False,
+        "can_clear_glb": False,
+        "can_authorize_live": False,
+        "can_touch_broker_exchange": False,
+        "protected_master_v2_boundary": True,
+        "evidence_status": composition_evidence_status,
+        "issues": [],
+    }
 
 
 def _build_run_record(
@@ -546,6 +731,8 @@ def derive_verdict(ctx: BuildContext) -> str:
         "MANIFEST_ENTRY_MISSING",
         "MISSING_REVIEW_JSON",
         "MISSING_EXTERNAL_LIVE_RECORD",
+        "MISSING_COMPOSITION_ROLLUP_MANIFEST",
+        "COMPOSITION_ROOT_MANIFEST_NOT_PRIMARY",
     }
     if codes & review_codes:
         return VERDICT_REVIEW_REQUIRED
@@ -565,11 +752,19 @@ def build_registry(ctx: BuildContext) -> dict[str, Any]:
     scan_unsafe_text(_scan_texts(planning_root), ctx, planning_root)
 
     runs: list[dict[str, Any]] = []
+    compositions: list[dict[str, Any]] = []
     runs_by_lane: dict[str, int] = {lid: 0 for lid in LANE_DEFAULTS}
 
-    for lane_id, run_dir in _discover_all_runs(archive_root):
+    for lane_id, run_dir in _discover_lane_runs(archive_root):
         runs_by_lane[lane_id] = runs_by_lane.get(lane_id, 0) + 1
         runs.append(_build_run_record(run_dir, lane_id, ctx))
+
+    lane_run_index = {(r["lane_id"], r["run_id"]): r for r in runs}
+
+    for composition_id, composition_root in _discover_composition_runs(archive_root):
+        compositions.append(
+            _build_composition_record(composition_root, composition_id, ctx, lane_run_index)
+        )
 
     # Testnet PASS must not imply live — check planning/run text for promotion markers
     blob = _scan_texts(archive_root)
@@ -625,6 +820,7 @@ def build_registry(ctx: BuildContext) -> dict[str, Any]:
 
     summaries = {
         "total_runs": len(runs),
+        "total_compositions": len(compositions),
         "runs_by_lane": {k: runs_by_lane.get(k, 0) for k in PRIMARY_EVIDENCE_LANES},
         "verified_runs": verified,
         "review_required_runs": review_required_runs,
@@ -649,6 +845,7 @@ def build_registry(ctx: BuildContext) -> dict[str, Any]:
         "archive_root": str(archive_root.resolve()),
         "lanes": lanes,
         "runs": runs,
+        "compositions": compositions,
         "summaries": summaries,
         "authority": authority,
         "blockers": blockers,

--- a/tests/ops/test_combined_outroot_composition_index_v0.py
+++ b/tests/ops/test_combined_outroot_composition_index_v0.py
@@ -1,0 +1,266 @@
+"""Contract tests for combined OUTROOT composition-index v0 (Registry v1 + taxonomy §6b)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_SCRIPT = ROOT / "scripts" / "ops" / "build_generic_evidence_run_registry_v1.py"
+TAXONOMY_SPEC = (
+    ROOT / "docs" / "ops" / "specs" / "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md"
+)
+PREFLIGHT = ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+RUN_ID = "daemon_paper_24h_20260524T205447Z"
+
+COMPOSITION_MARKERS = (
+    "COMBINED_OUTROOT_COMPOSITION_INDEX_V0=true",
+    "COMPOSITION_INDEX_IS_NOT_LANE=true",
+    "LANE_ID_DAEMON_PAPER_24H_FORBIDDEN=true",
+    "LANE_ID_REMOTE_RUNTIME_FORBIDDEN=true",
+    "COMPOSITION_INDEX_AUTHORITY=false",
+    "composition_index_authority=false",
+    "PER_LANE_MANIFEST_SHA256_REMAINS_CANONICAL=true",
+)
+
+
+def _load_registry():
+    spec = importlib.util.spec_from_file_location(
+        "build_generic_evidence_run_registry_v1_composition",
+        REGISTRY_SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _sha256_file(path: Path) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_lane_manifest(run_dir: Path) -> None:
+    entries: list[str] = []
+    for path in sorted(run_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name in {"MANIFEST.sha256", "MANIFEST_VERIFY.log"}:
+            continue
+        rel = path.relative_to(run_dir).as_posix()
+        entries.append(f"{_sha256_file(path)}  {rel}")
+    (run_dir / "MANIFEST.sha256").write_text("\n".join(entries) + "\n", encoding="utf-8")
+
+
+def _write_lane_run(
+    archive: Path,
+    lane: str,
+    run_id: str,
+    *,
+    review_verdict: str | None = None,
+    write_manifest: bool = True,
+) -> Path:
+    run_dir = archive / "runs" / lane / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "evidence.txt").write_text(f"{lane}:{run_id}\n", encoding="utf-8")
+    if review_verdict is not None:
+        review_dir = run_dir / "review"
+        review_dir.mkdir(parents=True, exist_ok=True)
+        (review_dir / "REVIEW_RESULT.json").write_text(
+            json.dumps({"verdict": review_verdict, "issues": []}) + "\n",
+            encoding="utf-8",
+        )
+    if write_manifest:
+        _write_lane_manifest(run_dir)
+    return run_dir
+
+
+def _write_composition_rollup(comp_dir: Path, *, include_file: bool = True) -> None:
+    if include_file:
+        (comp_dir / "COMPOSITION_INDEX.md").write_text(
+            "composition_index_authority=false\nlive_authority=false\n",
+            encoding="utf-8",
+        )
+    manifests = comp_dir / "manifests"
+    manifests.mkdir(parents=True, exist_ok=True)
+    entries: list[str] = []
+    for path in sorted(comp_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name == "MANIFEST.sha256" and path.parent.name == "manifests":
+            continue
+        rel = path.relative_to(comp_dir).as_posix()
+        entries.append(f"{_sha256_file(path)}  {rel}")
+    (manifests / "MANIFEST.sha256").write_text("\n".join(entries) + "\n", encoding="utf-8")
+
+
+def _write_combined_archive(
+    archive: Path,
+    run_id: str = RUN_ID,
+    *,
+    rollup: bool = True,
+    paper_manifest: bool = True,
+    shadow_manifest: bool = True,
+    shadow_review: str = "PASS",
+) -> Path:
+    _write_lane_run(archive, "paper", run_id, write_manifest=paper_manifest)
+    _write_lane_run(
+        archive, "shadow", run_id, review_verdict=shadow_review, write_manifest=shadow_manifest
+    )
+    comp_dir = archive / "runs" / "daemon_paper_24h" / run_id
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    if rollup:
+        _write_composition_rollup(comp_dir)
+    return comp_dir
+
+
+def _build(mod, archive: Path) -> dict:
+    return mod.build_registry(mod.BuildContext(archive_root=archive, repo_root=ROOT))
+
+
+@pytest.fixture
+def mod():
+    return _load_registry()
+
+
+def test_taxonomy_section_6b_markers_present() -> None:
+    text = TAXONOMY_SPEC.read_text(encoding="utf-8")
+    assert "## 6b. Combined OUTROOT composition-index v0" in text
+    for marker in COMPOSITION_MARKERS:
+        assert marker in text
+    assert "lane_id=daemon_paper_24h" in text
+    assert "lane_id=remote_runtime" in text
+    assert "manifests/MANIFEST.sha256" in text
+
+
+def test_preflight_cross_references_composition_index() -> None:
+    section = PREFLIGHT.read_text(encoding="utf-8").split("## 2a.", 1)[1].split("## 2b.", 1)[0]
+    assert "composition/index" in section.lower() or "compositions[]" in section
+    assert "taxonomy §6b" in section or "§6b" in section
+
+
+def test_registry_script_exposes_composition_constants() -> None:
+    mod = _load_registry()
+    assert mod.COMBINED_OUTROOT_COMPOSITION_INDEX_V0 is True
+    assert "daemon_paper_24h" in mod.COMPOSITION_INDEX_DIRECTORIES
+    assert "daemon_paper_24h" in mod.COMPOSITION_INDEX_FORBIDDEN_LANE_IDS
+    assert mod.SCHEMA == "peak_trade.generic_evidence_run_registry.v1"
+
+
+def test_combined_outroot_no_unknown_lane(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_combined_archive(archive)
+    payload = _build(mod, archive)
+    codes = {i["code"] for i in payload["issues"]}
+    assert "UNKNOWN_LANE" not in codes
+    lane_ids = {r["lane_id"] for r in payload["runs"]}
+    assert "daemon_paper_24h" not in lane_ids
+    assert lane_ids <= {"paper", "shadow"}
+
+
+def test_composition_record_emitted(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_combined_archive(archive)
+    payload = _build(mod, archive)
+    assert payload["schema"] == "peak_trade.generic_evidence_run_registry.v1"
+    assert payload["summaries"]["total_compositions"] == 1
+    assert len(payload["compositions"]) == 1
+    comp = payload["compositions"][0]
+    assert comp["record_kind"] == "composition_index"
+    assert comp["composition_id"] == "daemon_paper_24h"
+    assert comp["run_id"] == RUN_ID
+    assert comp["runtime_mode"] == "paper_then_shadow"
+    assert comp["rollup_manifest_present"] is True
+    assert comp["rollup_manifest_path"] == "manifests/MANIFEST.sha256"
+    assert comp["rollup_manifest_verified"] is True
+
+
+def test_composition_record_non_authorizing(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_combined_archive(archive)
+    comp = _build(mod, archive)["compositions"][0]
+    assert comp["composition_index_authority"] is False
+    assert comp["live_authority"] is False
+    assert comp["testnet_authority"] is False
+    assert comp["s3_authority"] is False
+    assert comp["notion_authority"] is False
+    assert comp["market_dashboard_authority"] is False
+    assert comp["can_authorize_live"] is False
+
+
+def test_rollup_manifest_at_manifests_path_only(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    comp_dir = _write_combined_archive(archive, rollup=True)
+    payload = _build(mod, archive)
+    codes = {i["code"] for i in payload["issues"]}
+    assert "MISSING_MANIFEST" not in codes or all(
+        "daemon_paper_24h" not in i.get("path", "") or "manifests" in i.get("path", "")
+        for i in payload["issues"]
+        if i["code"] == "MISSING_MANIFEST"
+    )
+    comp = payload["compositions"][0]
+    assert comp["rollup_manifest_verified"] is True
+    assert not (comp_dir / "MANIFEST.sha256").exists()
+
+
+def test_root_manifest_on_composition_review_required(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    comp_dir = _write_combined_archive(archive)
+    (comp_dir / "MANIFEST.sha256").write_text("deadbeef  COMPOSITION_INDEX.md\n", encoding="utf-8")
+    payload = _build(mod, archive)
+    codes = {i["code"] for i in payload["issues"]}
+    assert "COMPOSITION_ROOT_MANIFEST_NOT_PRIMARY" in codes
+
+
+def test_missing_child_lane_manifest_not_masked(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_combined_archive(archive, paper_manifest=False, shadow_manifest=True)
+    payload = _build(mod, archive)
+    codes = {i["code"] for i in payload["issues"]}
+    assert "MISSING_MANIFEST" in codes
+    paper = next(r for r in payload["runs"] if r["lane_id"] == "paper")
+    assert paper["manifest_present"] is False
+    assert paper["evidence_status"] == "incomplete"
+    comp = payload["compositions"][0]
+    assert comp["evidence_status"] in ("partial", "incomplete", "indexed")
+    paper_child = next(c for c in comp["child_lane_status"] if c["lane_id"] == "paper")
+    assert paper_child["evidence_status"] == "incomplete"
+
+
+def test_missing_rollup_manifest_review_required_not_unknown_lane(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_combined_archive(archive, rollup=False)
+    payload = _build(mod, archive)
+    codes = {i["code"] for i in payload["issues"]}
+    assert "UNKNOWN_LANE" not in codes
+    assert "MISSING_COMPOSITION_ROLLUP_MANIFEST" in codes
+    assert payload["compositions"][0]["rollup_manifest_present"] is False
+
+
+def test_lane_catalog_unchanged_no_daemon_paper_lane(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_combined_archive(archive)
+    payload = _build(mod, archive)
+    catalog_lane_ids = {entry["lane_id"] for entry in payload["lanes"]}
+    assert "daemon_paper_24h" not in catalog_lane_ids
+    assert "remote_runtime" not in catalog_lane_ids
+
+
+def test_backward_compatible_runs_array(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_combined_archive(archive)
+    payload = _build(mod, archive)
+    assert payload["summaries"]["total_runs"] == 2
+    for run in payload["runs"]:
+        assert run["lane_id"] in {"paper", "shadow"}
+        assert "record_kind" not in run

--- a/tests/ops/test_combined_outroot_composition_index_v0.py
+++ b/tests/ops/test_combined_outroot_composition_index_v0.py
@@ -140,7 +140,7 @@ def test_taxonomy_section_6b_markers_present() -> None:
         assert marker in text
     assert "lane_id=daemon_paper_24h" in text
     assert "lane_id=remote_runtime" in text
-    assert "manifests/MANIFEST.sha256" in text
+    assert "manifests&#47;MANIFEST.sha256" in text
 
 
 def test_preflight_cross_references_composition_index() -> None:


### PR DESCRIPTION
## Summary

Adds Combined OUTROOT Composition Index v0 for Generic Evidence Run Registry v1.

Combined daemon paper+shadow OUTROOTs are now represented as non-authorizing composition/index records, not as runtime lanes. This resolves the prior `UNKNOWN_LANE` issue for `runs/daemon_paper_24h/{run_id}/` without introducing `lane_id=daemon_paper_24h`, `lane_id=remote_runtime`, Registry v2, or a new evidence standard.

## Scope

- Extends `RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md` with §6b composition-index semantics.
- Adds a §2a cross-reference in `PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`.
- Extends `build_generic_evidence_run_registry_v1.py` with `compositions[]` discovery.
- Supports combined rollup manifest resolution at:
  - `runs/daemon_paper_24h/{run_id}/manifests/MANIFEST.sha256`
- Keeps per-lane `MANIFEST.sha256` canonical for paper/shadow/testnet primary evidence.
- Adds focused offline contract tests.

## Safety Boundaries

- No new lane.
- No `lane_id=daemon_paper_24h`.
- No `lane_id=remote_runtime`.
- No Registry v2.
- No new evidence standard.
- No new closeout standard.
- No competing `SHA256SUMS.stable.txt` truth layer.
- No runtime start.
- No scheduler/daemon/paper/shadow/testnet/live execution.
- No AWS/rclone calls.
- No Notion writes.
- No Market Dashboard changes.
- No Master V2 / Double Play authority changes.
- Live authority remains false.
- Testnet authority remains false.

## Registry Behavior

- `runs/daemon_paper_24h/{run_id}/` is classified as `record_kind=composition_index`.
- `compositions[]` is added backward-compatibly; existing `runs[]` lane rows remain unchanged.
- Missing child-lane evidence is not masked by the composition record.
- A root `MANIFEST.sha256` at the combined OUTROOT is flagged as non-primary composition misuse.
- `manifests/MANIFEST.sha256` is accepted only as a composition rollup manifest and does not replace per-lane manifests.

## Validation

- `pytest` targeted registry/composition/remote-host tests:
  - 44 passed, 1 skipped
- `ruff format`
  - clean
- `ruff check`
  - clean

## Context

This follows:

- PR #3670: Remote Runtime Host Metadata Contract v0.
- PR #3671: Paper Lane Closeout Parity v0.
- Durable 24h daemon closeout:
  - `RUN_ID=daemon_paper_24h_20260524T205447Z`
  - `DURABLE_ARCHIVE_ROOT=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260525T210741Z`
  - `MANIFEST_VERIFY_RC=0`

This PR makes the shared Registry v1 feed structurally safe before §6a field population, Notion projection, Market Dashboard projection, S3 finalized evidence export, or AWS remote runtime work proceeds.

## Machine Lines

COMBINED_OUTROOT_COMPOSITION_INDEX_MODE=docs_tests_only
COMBINED_OUTROOT_IS_COMPOSITION_INDEX=true
NEW_LANE_CREATED=false
LANE_ID_DAEMON_PAPER_24H_CREATED=false
LANE_ID_REMOTE_RUNTIME_CREATED=false
NEW_EVIDENCE_STANDARD_CREATED=false
NEW_CLOSEOUT_STANDARD_CREATED=false
REGISTRY_V2_CREATED=false
COMBINED_MANIFESTS_MANIFEST_SHA256_SUPPORTED=true
PER_LANE_MANIFEST_SHA256_REMAINS_CANONICAL=true
UNKNOWN_LANE_FOR_COMBINED_OUTROOT_RESOLVED=true
RUNTIME_COMMANDS_CALLED=false
AWS_CLI_CALLED=false
RCLONE_CALLED=false
NOTION_WRITE_CALLED=false
MARKET_DASHBOARD_CHANGED=false
LIVE_AUTHORITY=false
TESTNET_AUTHORITY=false

Made with [Cursor](https://cursor.com)