### PR TITLE
ops: populate registry v1 section 6a metadata fields

### DIFF
--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -250,15 +250,16 @@ MARKET_DASHBOARD_PROJECTION_READONLY=true
 REMOTE_RUNTIME_V0_LIVE_AUTHORITY=false
 REMOTE_RUNTIME_V0_TESTNET_AUTHORITY=false
 REGISTRY_V1_REMOTE_RUNTIME_HOST_METADATA_FIELDS_DEFINED=true
+REGISTRY_V1_SECTION_6A_FIELDS_POPULATED=true
 ```
 
 **Purpose:** Describe where a bounded `paper` / `shadow` run executes (local laptop vs remote host) and how finalized evidence may be transported or projected — **without** creating a new lane, scheduler authority, evidence standard, or closeout standard.
 
 **Normative rule:** Remote Runtime is **backend metadata** for existing bounded lanes (`paper`, `shadow`, `testnet`). It is **not** a new `lane_id`. Remote hosts run the **same** canonical adapters, scheduler boundary guards, approval records, and `primary_evidence_retention_v0` manifest rules as local hosts.
 
-Implementation index (optional run-row metadata; default off until populated):
+Implementation index (Registry v1 emits §6a fields as non-authorizing metadata defaults):
 
-- Constants owner: [build_generic_evidence_run_registry_v1.py](../../../scripts/ops/build_generic_evidence_run_registry_v1.py) — `REMOTE_RUNTIME_HOST_METADATA_V0_DEFAULTS` (non-authorizing defaults; does not alter registry build output until a future slice opts in).
+- Constants owner: [build_generic_evidence_run_registry_v1.py](../../../scripts/ops/build_generic_evidence_run_registry_v1.py) — `REMOTE_RUNTIME_HOST_METADATA_V0_DEFAULTS` merged into every `runs[]` and `compositions[]` record (`REGISTRY_V1_SECTION_6A_FIELDS_POPULATED=true`). Defaults remain `runtime_host=local`, `runtime_backend=laptop`, `evidence_transport=local_only`, `notion_projection=disabled`, `market_dashboard_projection=disabled`, `live_authority=false`, `testnet_authority=false` unless explicit future operator metadata opts in. Archive presence alone does **not** infer remote runtime, S3 export, Notion sync, or dashboard projection.
 - Manifest owner unchanged: [primary_evidence_retention_v0.py](../../../scripts/ops/primary_evidence_retention_v0.py) — `MANIFEST.sha256` remains the sole primary evidence manifest format.
 - Preflight / bounded gate owner unchanged: [PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md](../runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md) §2a/§2a.1.
 

--- a/scripts/ops/build_generic_evidence_run_registry_v1.py
+++ b/scripts/ops/build_generic_evidence_run_registry_v1.py
@@ -23,8 +23,9 @@ from typing import Any
 
 SCHEMA = "peak_trade.generic_evidence_run_registry.v1"
 
-# Remote Runtime Host Metadata v0 (taxonomy §6a): optional run-row fields; non-authorizing.
-# Does not alter registry build output until a future slice opts in to populate these fields.
+# Remote Runtime Host Metadata v0 (taxonomy §6a): run-row metadata; non-authorizing defaults.
+# Machine marker: REGISTRY_V1_SECTION_6A_FIELDS_POPULATED=true
+REGISTRY_V1_SECTION_6A_FIELDS_POPULATED = True
 REMOTE_RUNTIME_HOST_METADATA_CONTRACT_V0 = True
 
 REMOTE_RUNTIME_HOST_METADATA_V0_FIELD_ALLOWED: dict[str, tuple[str, ...]] = {
@@ -52,6 +53,10 @@ REMOTE_RUNTIME_HOST_METADATA_V0_DEFAULTS: dict[str, str | bool] = {
     "live_authority": False,
     "testnet_authority": False,
 }
+
+SECTION_6A_METADATA_FIELD_NAMES: tuple[str, ...] = tuple(
+    REMOTE_RUNTIME_HOST_METADATA_V0_DEFAULTS.keys()
+)
 
 TAXONOMY_SPEC_REL = Path("docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md")
 
@@ -269,6 +274,29 @@ def _parse_machine_line(text: str, key: str) -> bool | None:
     if not values:
         return None
     return values[-1]
+
+
+def _section_6a_runtime_mode_for_lane(lane_id: str) -> str:
+    """Return safe §6a runtime_mode default for a lane row (non-authorizing)."""
+    if lane_id == "paper":
+        return "paper_only"
+    return str(REMOTE_RUNTIME_HOST_METADATA_V0_DEFAULTS["runtime_mode"])
+
+
+def _section_6a_metadata(*, runtime_mode: str | None = None) -> dict[str, str | bool]:
+    """Build taxonomy §6a metadata defaults without inferring remote/S3/Notion/Dashboard."""
+    out = dict(REMOTE_RUNTIME_HOST_METADATA_V0_DEFAULTS)
+    if runtime_mode is not None:
+        allowed = REMOTE_RUNTIME_HOST_METADATA_V0_FIELD_ALLOWED["runtime_mode"]
+        if runtime_mode not in allowed:
+            raise ValueError(f"runtime_mode {runtime_mode!r} not in allowed values {allowed!r}")
+        out["runtime_mode"] = runtime_mode
+    return out
+
+
+def _apply_section_6a_metadata(record: dict[str, Any], *, runtime_mode: str | None = None) -> None:
+    """Merge §6a fields into an existing runs[] or compositions[] record (additive only)."""
+    record.update(_section_6a_metadata(runtime_mode=runtime_mode))
 
 
 def scan_unsafe_text(text: str, ctx: BuildContext, path: Path) -> None:
@@ -503,7 +531,7 @@ def _build_composition_record(
 
     rel_archive = str(composition_root.relative_to(ctx.archive_root).as_posix())
 
-    return {
+    record: dict[str, Any] = {
         "record_kind": "composition_index",
         "composition_id": composition_id,
         "run_id": run_id,
@@ -531,6 +559,8 @@ def _build_composition_record(
         "evidence_status": composition_evidence_status,
         "issues": [],
     }
+    _apply_section_6a_metadata(record, runtime_mode=COMPOSITION_INDEX_DEFAULT_RUNTIME_MODE)
+    return record
 
 
 def _build_run_record(
@@ -625,7 +655,7 @@ def _build_run_record(
 
     rel_archive = str(run_dir.relative_to(ctx.archive_root).as_posix())
 
-    return {
+    record: dict[str, Any] = {
         "run_id": run_dir.name,
         "lane_id": lane_id,
         "lane_kind": defaults["lane_kind"],
@@ -650,6 +680,8 @@ def _build_run_record(
         "evidence_status": evidence_status,
         "issues": run_issues,
     }
+    _apply_section_6a_metadata(record, runtime_mode=_section_6a_runtime_mode_for_lane(lane_id))
+    return record
 
 
 def _lane_catalog_entry(lane_id: str, discovered: int) -> dict[str, Any]:

--- a/tests/ops/test_registry_v1_section_6a_field_population_v0.py
+++ b/tests/ops/test_registry_v1_section_6a_field_population_v0.py
@@ -1,0 +1,186 @@
+"""Contract tests for Registry v1 taxonomy §6a field population v0."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_SCRIPT = ROOT / "scripts" / "ops" / "build_generic_evidence_run_registry_v1.py"
+TAXONOMY_SPEC = (
+    ROOT / "docs" / "ops" / "specs" / "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md"
+)
+
+SECTION_6A_FIELDS = (
+    "runtime_host",
+    "runtime_backend",
+    "runtime_mode",
+    "evidence_root_type",
+    "evidence_transport",
+    "notion_projection",
+    "market_dashboard_projection",
+    "live_authority",
+    "testnet_authority",
+)
+
+RUN_ID = "daemon_paper_24h_fixture_6a_v0"
+
+
+def _load_registry():
+    spec = importlib.util.spec_from_file_location(
+        "build_generic_evidence_run_registry_v1_section_6a",
+        REGISTRY_SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _sha256_file(path: Path) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_lane_manifest(run_dir: Path) -> None:
+    entries: list[str] = []
+    for path in sorted(run_dir.rglob("*")):
+        if not path.is_file() or path.name == "MANIFEST.sha256":
+            continue
+        rel = path.relative_to(run_dir).as_posix()
+        entries.append(f"{_sha256_file(path)}  {rel}")
+    (run_dir / "MANIFEST.sha256").write_text("\n".join(entries) + "\n", encoding="utf-8")
+
+
+def _write_lane(archive: Path, lane: str, run_id: str, *, review: str | None = None) -> Path:
+    run_dir = archive / "runs" / lane / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "evidence.txt").write_text(f"{lane}:{run_id}\n", encoding="utf-8")
+    if review is not None:
+        review_dir = run_dir / "review"
+        review_dir.mkdir(parents=True, exist_ok=True)
+        (review_dir / "REVIEW_RESULT.json").write_text(
+            json.dumps({"verdict": review, "issues": []}) + "\n",
+            encoding="utf-8",
+        )
+    _write_lane_manifest(run_dir)
+    return run_dir
+
+
+def _write_composition(archive: Path, run_id: str) -> Path:
+    comp_dir = archive / "runs" / "daemon_paper_24h" / run_id
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "COMPOSITION_INDEX.md").write_text(
+        "composition_index_authority=false\n", encoding="utf-8"
+    )
+    manifests = comp_dir / "manifests"
+    manifests.mkdir(parents=True, exist_ok=True)
+    rel = "COMPOSITION_INDEX.md"
+    digest = _sha256_file(comp_dir / rel)
+    (manifests / "MANIFEST.sha256").write_text(f"{digest}  {rel}\n", encoding="utf-8")
+    return comp_dir
+
+
+def _build(mod, archive: Path) -> dict:
+    return mod.build_registry(mod.BuildContext(archive_root=archive, repo_root=ROOT))
+
+
+@pytest.fixture
+def mod():
+    return _load_registry()
+
+
+def test_registry_module_exposes_section_6a_population_marker() -> None:
+    mod = _load_registry()
+    assert mod.REGISTRY_V1_SECTION_6A_FIELDS_POPULATED is True
+    assert mod.SCHEMA == "peak_trade.generic_evidence_run_registry.v1"
+
+
+def test_taxonomy_documents_section_6a_population() -> None:
+    text = TAXONOMY_SPEC.read_text(encoding="utf-8")
+    assert "REGISTRY_V1_SECTION_6A_FIELDS_POPULATED=true" in text
+    assert "non-authorizing metadata defaults" in text
+
+
+def test_runs_include_all_section_6a_fields(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_lane(archive, "paper", "paper_run")
+    _write_lane(archive, "shadow", "shadow_run", review="PASS")
+    payload = _build(mod, archive)
+    for run in payload["runs"]:
+        for field in SECTION_6A_FIELDS:
+            assert field in run
+        assert run["live_authority"] is False
+        assert run["testnet_authority"] is False
+        assert run["notion_projection"] == "disabled"
+        assert run["market_dashboard_projection"] == "disabled"
+        assert run["evidence_transport"] == "local_only"
+
+
+def test_paper_lane_runtime_mode_paper_only(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_lane(archive, "paper", "paper_run")
+    paper = _build(mod, archive)["runs"][0]
+    assert paper["lane_id"] == "paper"
+    assert paper["runtime_mode"] == "paper_only"
+    assert paper["runtime_host"] == "local"
+    assert paper["runtime_backend"] == "laptop"
+
+
+def test_shadow_lane_uses_safe_section_6a_default(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_lane(archive, "shadow", "shadow_run", review="PASS")
+    shadow = _build(mod, archive)["runs"][0]
+    assert shadow["lane_id"] == "shadow"
+    assert shadow["runtime_mode"] == "paper_only"
+    assert shadow["live_authority"] is False
+
+
+def test_composition_includes_section_6a_fields(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_lane(archive, "paper", RUN_ID)
+    _write_lane(archive, "shadow", RUN_ID, review="PASS")
+    _write_composition(archive, RUN_ID)
+    payload = _build(mod, archive)
+    assert len(payload["compositions"]) == 1
+    comp = payload["compositions"][0]
+    for field in SECTION_6A_FIELDS:
+        assert field in comp
+    assert comp["runtime_mode"] == "paper_then_shadow"
+    assert comp["composition_index_authority"] is False
+    assert comp["notion_projection"] == "disabled"
+    assert comp["market_dashboard_projection"] == "disabled"
+
+
+def test_no_registry_v2_or_new_lane_ids(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    _write_lane(archive, "paper", RUN_ID)
+    _write_composition(archive, RUN_ID)
+    payload = _build(mod, archive)
+    assert payload["schema"] == "peak_trade.generic_evidence_run_registry.v1"
+    assert "generic_evidence_run_registry.v2" not in json.dumps(payload)
+    lane_ids = {r["lane_id"] for r in payload["runs"]}
+    assert "daemon_paper_24h" not in lane_ids
+    assert "remote_runtime" not in lane_ids
+
+
+def test_manifest_hash_mismatch_still_fail_closed(mod, tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    run_dir = _write_lane(archive, "paper", "paper_run")
+    (run_dir / "MANIFEST.sha256").write_text("deadbeef  evidence.txt\n", encoding="utf-8")
+    payload = _build(mod, archive)
+    assert payload["verdict"] == mod.VERDICT_FAIL_CLOSED
+    paper = payload["runs"][0]
+    for field in SECTION_6A_FIELDS:
+        assert field in paper
+    assert any(i["code"] == "MANIFEST_HASH_MISMATCH" for i in payload["issues"])


### PR DESCRIPTION
## Summary

Populates Taxonomy §6a Remote Runtime Host Metadata fields in Generic Evidence Run Registry v1 JSON output.

This enriches existing `runs[]` and `compositions[]` records with non-authorizing metadata defaults for future Notion, Market Dashboard, S3 finalized evidence export, and remote-runtime planning.

## Scope

- Adds Registry v1 §6a field population helpers.
- Populates §6a fields on `runs[]`.
- Populates §6a fields on `compositions[]`.
- Documents that Registry v1 emits §6a defaults.
- Adds focused offline contract tests.

## §6a Defaults

- `runtime_host=local`
- `runtime_backend=laptop`
- `runtime_mode=paper_only` for lane rows unless explicitly inferred otherwise
- `runtime_mode=paper_then_shadow` for composition records
- `evidence_root_type=local_durable`
- `evidence_transport=local_only`
- `notion_projection=disabled`
- `market_dashboard_projection=disabled`
- `live_authority=false`
- `testnet_authority=false`

## Safety Boundaries

- No Registry v2.
- No new schema outside Registry v1.
- No new lane.
- No `lane_id=daemon_paper_24h`.
- No `lane_id=remote_runtime`.
- No new evidence standard.
- No new closeout standard.
- No runtime start.
- No scheduler/daemon/paper/shadow/testnet/live execution.
- No AWS/rclone calls.
- No Notion writes.
- No Market Dashboard changes.
- No Master V2 / Double Play authority changes.
- Live authority remains false.
- Testnet authority remains false.
- S3 remains finalized evidence transport only.
- Notion remains projection/index only.
- Market Dashboard remains read-only projection only.

## Validation

- `pytest` targeted registry/composition/remote-host tests:
  - 52 passed, 1 skipped
- `ruff format`
  - clean
- `ruff check`
  - clean

## Context

This follows:

- PR #3670: Remote Runtime Host Metadata §6a.
- PR #3671: Paper Lane Closeout Parity v0.
- PR #3672: Combined OUTROOT Composition Index v0.

The shared Registry v1 feed is now structurally ready for downstream projection specs without creating a parallel Notion/Dashboard/S3 schema.

## Machine Lines

REGISTRY_V1_SECTION_6A_FIELD_POPULATION_MODE=docs_tests_only
REGISTRY_V2_CREATED=false
NEW_SCHEMA_CREATED=false
NEW_LANE_CREATED=false
LANE_ID_DAEMON_PAPER_24H_CREATED=false
LANE_ID_REMOTE_RUNTIME_CREATED=false
SECTION_6A_FIELDS_POPULATED_IN_RUNS=true
SECTION_6A_FIELDS_POPULATED_IN_COMPOSITIONS=true
PAPER_RUNTIME_MODE_DEFAULT=paper_only
COMPOSITION_RUNTIME_MODE_DEFAULT=paper_then_shadow
LIVE_AUTHORITY=false
TESTNET_AUTHORITY=false
NOTION_PROJECTION_DEFAULT=disabled
MARKET_DASHBOARD_PROJECTION_DEFAULT=disabled
EVIDENCE_TRANSPORT_DEFAULT=local_only
RUNTIME_COMMANDS_CALLED=false
AWS_CLI_CALLED=false
RCLONE_CALLED=false
NOTION_WRITE_CALLED=false
MARKET_DASHBOARD_CHANGED=false

Made with [Cursor](https://cursor.com)