### PR TITLE
ops: add registry v1 projection consumer smoke fixtures

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures package (non-runtime, test-only helpers)."""

--- a/tests/fixtures/ops/__init__.py
+++ b/tests/fixtures/ops/__init__.py
@@ -1,0 +1,1 @@
+"""Ops test fixtures."""

--- a/tests/fixtures/ops/generic_evidence_run_registry_v1/README.md
+++ b/tests/fixtures/ops/generic_evidence_run_registry_v1/README.md
@@ -7,6 +7,51 @@ Layout per archive:
 - `runs&#47;paper&#47;{run_id}&#47;` — manifest required; review optional
 - `runs&#47;shadow&#47;{run_id}&#47;` — manifest + review PASS required
 - `runs&#47;testnet&#47;{run_id}&#47;` — manifest + review PASS required
+- `runs&#47;daemon_paper_24h&#47;{run_id}&#47;` — composition-index directory (not a lane)
 - `planning&#47;` — optional governance machine lines
 
-Fixtures are created programmatically in tests; this directory documents conventions only.
+## Projection consumer smoke fixtures v0
+
+**Module:** `projection_consumer_v0.py` (test-only; **non-authorizing**)
+
+Shared helpers and canonical field constants for Registry v1 projection consumers:
+
+- Notion post-closeout sync projection (taxonomy §6a.1)
+- Market Dashboard read-only run projection (taxonomy §6a.2)
+- Future S3 finalized-evidence export gate contract tests (metadata only; no S3 implementation)
+
+### Canonical field contract
+
+- `ALLOWED_PROJECTION_FIELDS` — pointer/status fields for `runs[]` and `compositions[]`
+- `RUN_PROJECTION_FIELDS` — minimum `runs[]` row fields for consumer smoke tests
+- `S3_RELEVANT_PROJECTION_FIELDS` — `evidence_transport`, `manifest_verified`, `archive_path`, `evidence_status` for future export gate tests
+- `TOP_LEVEL_PROJECTION_SUMMARY_FIELDS` — `verdict`, `issues`, `blockers`, `archive_root`
+
+### Authority posture (fixtures only)
+
+```
+REGISTRY_V1_PROJECTION_CONSUMER_SMOKE_FIXTURES_V0=true
+NOTION_AUTHORITY=false
+MARKET_DASHBOARD_AUTHORITY=false
+S3_AUTHORITY=false
+RUNTIME_AUTHORITY=false
+SCHEDULER_CLEARANCE_AUTHORITY=false
+LIVE_AUTHORITY=false
+TESTNET_AUTHORITY=false
+BROKER_AUTHORITY=false
+DOUBLE_PLAY_AUTHORITY=false
+```
+
+Fixtures build offline archives and validate Registry v1 JSON only. They do **not** grant runtime, scheduler, testnet, live, broker, Notion, Dashboard, or S3 export authority.
+
+### Usage
+
+Import from tests:
+
+```python
+from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as registry_fixtures
+```
+
+Helpers: `write_lane`, `write_composition`, `write_minimal_paper_run`, `build_registry`, `assert_non_authorizing_run_projection_defaults`.
+
+Fixtures are created programmatically in tests; this directory documents conventions and hosts shared test-only helpers.

--- a/tests/fixtures/ops/generic_evidence_run_registry_v1/__init__.py
+++ b/tests/fixtures/ops/generic_evidence_run_registry_v1/__init__.py
@@ -1,0 +1,1 @@
+"""Generic Evidence Run Registry v1 test fixtures."""

--- a/tests/fixtures/ops/generic_evidence_run_registry_v1/projection_consumer_v0.py
+++ b/tests/fixtures/ops/generic_evidence_run_registry_v1/projection_consumer_v0.py
@@ -1,0 +1,170 @@
+"""Shared Registry v1 projection consumer smoke fixtures (test-only, non-authorizing).
+
+Consumers: Notion §6a.1, Market Dashboard §6a.2, future S3 finalized-evidence export gate tests.
+Does not define runtime authority, Registry v2, or new lanes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REGISTRY_V1_PROJECTION_CONSUMER_SMOKE_FIXTURES_V0 = True
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+REGISTRY_SCRIPT = REPO_ROOT / "scripts" / "ops" / "build_generic_evidence_run_registry_v1.py"
+
+# Canonical pointer/status fields for Registry v1 projection consumers (§6a.1 + §6a.2 aligned).
+ALLOWED_PROJECTION_FIELDS: tuple[str, ...] = (
+    "run_id",
+    "lane_id",
+    "composition_id",
+    "record_kind",
+    "runtime_host",
+    "runtime_backend",
+    "runtime_mode",
+    "evidence_root_type",
+    "evidence_transport",
+    "evidence_status",
+    "review_verdict",
+    "manifest_verified",
+    "archive_path",
+)
+
+RUN_PROJECTION_FIELDS: tuple[str, ...] = (
+    "run_id",
+    "lane_id",
+    "runtime_host",
+    "runtime_backend",
+    "runtime_mode",
+    "evidence_root_type",
+    "evidence_transport",
+    "evidence_status",
+    "review_verdict",
+    "manifest_verified",
+    "archive_path",
+)
+
+# Subset referenced by future S3 finalized-evidence export gate contract tests (no S3 impl here).
+S3_RELEVANT_PROJECTION_FIELDS: tuple[str, ...] = (
+    "evidence_transport",
+    "manifest_verified",
+    "archive_path",
+    "evidence_status",
+)
+
+TOP_LEVEL_PROJECTION_SUMMARY_FIELDS: tuple[str, ...] = (
+    "verdict",
+    "issues",
+    "blockers",
+    "archive_root",
+)
+
+SECTION_6A_METADATA_FIELDS: tuple[str, ...] = (
+    "runtime_host",
+    "runtime_backend",
+    "runtime_mode",
+    "evidence_root_type",
+    "evidence_transport",
+    "notion_projection",
+    "market_dashboard_projection",
+    "live_authority",
+    "testnet_authority",
+)
+
+DEFAULT_COMPOSITION_RUN_ID = "daemon_paper_24h_fixture_projection_v0"
+
+
+def load_registry_module(
+    *, module_name: str = "build_generic_evidence_run_registry_v1_projection_consumer"
+):
+    spec = importlib.util.spec_from_file_location(module_name, REGISTRY_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_lane_manifest(run_dir: Path) -> None:
+    entries: list[str] = []
+    for path in sorted(run_dir.rglob("*")):
+        if not path.is_file() or path.name == "MANIFEST.sha256":
+            continue
+        rel = path.relative_to(run_dir).as_posix()
+        entries.append(f"{sha256_file(path)}  {rel}")
+    (run_dir / "MANIFEST.sha256").write_text("\n".join(entries) + "\n", encoding="utf-8")
+
+
+def write_lane(
+    archive: Path,
+    lane: str,
+    run_id: str,
+    *,
+    review: str | None = None,
+) -> Path:
+    run_dir = archive / "runs" / lane / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "evidence.txt").write_text(f"{lane}:{run_id}\n", encoding="utf-8")
+    if review is not None:
+        review_dir = run_dir / "review"
+        review_dir.mkdir(parents=True, exist_ok=True)
+        (review_dir / "REVIEW_RESULT.json").write_text(
+            json.dumps({"verdict": review, "issues": []}) + "\n",
+            encoding="utf-8",
+        )
+    write_lane_manifest(run_dir)
+    return run_dir
+
+
+def write_composition(archive: Path, run_id: str) -> Path:
+    comp_dir = archive / "runs" / "daemon_paper_24h" / run_id
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "COMPOSITION_INDEX.md").write_text(
+        "composition_index_authority=false\n",
+        encoding="utf-8",
+    )
+    manifests = comp_dir / "manifests"
+    manifests.mkdir(parents=True, exist_ok=True)
+    rel = "COMPOSITION_INDEX.md"
+    digest = sha256_file(comp_dir / rel)
+    (manifests / "MANIFEST.sha256").write_text(f"{digest}  {rel}\n", encoding="utf-8")
+    return comp_dir
+
+
+def write_minimal_paper_run(archive: Path, run_id: str = "paper_run") -> Path:
+    """Minimal verified paper lane archive for projection consumer smoke tests."""
+    return write_lane(archive, "paper", run_id)
+
+
+def build_registry(archive: Path, *, repo_root: Path | None = None) -> dict[str, Any]:
+    mod = load_registry_module()
+    return mod.build_registry(
+        mod.BuildContext(archive_root=archive, repo_root=repo_root or REPO_ROOT)
+    )
+
+
+def assert_non_authorizing_run_projection_defaults(run: dict[str, Any]) -> None:
+    for field in RUN_PROJECTION_FIELDS:
+        if field not in run:
+            raise AssertionError(f"missing projection field {field!r} on runs[] row")
+    if run.get("live_authority") is not False:
+        raise AssertionError("live_authority must be false on projection consumer fixture runs")
+    if run.get("testnet_authority") is not False:
+        raise AssertionError("testnet_authority must be false on projection consumer fixture runs")
+    if run.get("notion_projection") != "disabled":
+        raise AssertionError("notion_projection must be disabled by default")
+    if run.get("market_dashboard_projection") != "disabled":
+        raise AssertionError("market_dashboard_projection must be disabled by default")

--- a/tests/ops/test_market_dashboard_readonly_run_projection_spec_v0.py
+++ b/tests/ops/test_market_dashboard_readonly_run_projection_spec_v0.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TAXONOMY_SPEC = (
     REPO_ROOT / "docs" / "ops" / "specs" / "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md"
@@ -27,6 +29,9 @@ SECTION_6A_POPULATION_TESTS = (
 )
 NOTION_SPEC_TESTS = (
     REPO_ROOT / "tests" / "ops" / "test_notion_post_closeout_sync_projection_spec_v0.py"
+)
+PROJECTION_FIXTURE_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_registry_v1_projection_consumer_smoke_fixtures_v0.py"
 )
 MARKET_DASHBOARD_READONLY_TESTS = (
     REPO_ROOT / "tests" / "webui" / "test_market_dashboard_readonly_structure_contract_v0.py"
@@ -62,35 +67,8 @@ FORBIDDEN_TRUTH_LAYER_PHRASES = (
     "dashboard truth layer is canonical",
 )
 
-ALLOWED_PROJECTION_FIELDS = (
-    "run_id",
-    "lane_id",
-    "composition_id",
-    "record_kind",
-    "runtime_host",
-    "runtime_backend",
-    "runtime_mode",
-    "evidence_root_type",
-    "evidence_transport",
-    "evidence_status",
-    "review_verdict",
-    "manifest_verified",
-    "archive_path",
-)
-
-RUN_PROJECTION_FIELDS = (
-    "run_id",
-    "lane_id",
-    "runtime_host",
-    "runtime_backend",
-    "runtime_mode",
-    "evidence_root_type",
-    "evidence_transport",
-    "evidence_status",
-    "review_verdict",
-    "manifest_verified",
-    "archive_path",
-)
+ALLOWED_PROJECTION_FIELDS = pc.ALLOWED_PROJECTION_FIELDS
+RUN_PROJECTION_FIELDS = pc.RUN_PROJECTION_FIELDS
 
 
 def _section_6a2() -> str:
@@ -202,17 +180,10 @@ def test_surface_cross_references() -> None:
 
 def test_registry_fixture_supports_projection_field_extraction(mod, tmp_path: Path) -> None:
     archive = tmp_path / "archive"
-    run_dir = archive / "runs" / "paper" / "paper_run"
-    run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "evidence.txt").write_text("paper:paper_run\n", encoding="utf-8")
-    digest = __import__("hashlib").sha256(b"paper:paper_run\n").hexdigest()
-    (run_dir / "MANIFEST.sha256").write_text(f"{digest}  evidence.txt\n", encoding="utf-8")
+    pc.write_minimal_paper_run(archive)
     payload = mod.build_registry(mod.BuildContext(archive_root=archive, repo_root=REPO_ROOT))
     run = payload["runs"][0]
-    for field in RUN_PROJECTION_FIELDS:
-        assert field in run, f"missing projection field {field!r} on runs[] row"
-    assert run["market_dashboard_projection"] == "disabled"
-    assert run["live_authority"] is False
+    pc.assert_non_authorizing_run_projection_defaults(run)
     assert payload["schema"] == "peak_trade.generic_evidence_run_registry.v1"
     assert "generic_evidence_run_registry.v2" not in json.dumps(payload)
 
@@ -222,6 +193,7 @@ def test_owner_crosslinks() -> None:
     assert REMOTE_RUNTIME_TESTS.name in owner_text
     assert SECTION_6A_POPULATION_TESTS.name in owner_text
     assert NOTION_SPEC_TESTS.name in owner_text
+    assert PROJECTION_FIXTURE_TESTS.name in owner_text
     remote_text = REMOTE_RUNTIME_TESTS.read_text(encoding="utf-8")
     assert "MARKET_DASHBOARD_PROJECTION_READONLY=true" in remote_text
     assert MARKET_DASHBOARD_READONLY_TESTS.is_file()

--- a/tests/ops/test_notion_post_closeout_sync_projection_spec_v0.py
+++ b/tests/ops/test_notion_post_closeout_sync_projection_spec_v0.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TAXONOMY_SPEC = (
     REPO_ROOT / "docs" / "ops" / "specs" / "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md"
@@ -20,6 +22,9 @@ REMOTE_RUNTIME_TESTS = (
 )
 SECTION_6A_POPULATION_TESTS = (
     REPO_ROOT / "tests" / "ops" / "test_registry_v1_section_6a_field_population_v0.py"
+)
+PROJECTION_FIXTURE_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_registry_v1_projection_consumer_smoke_fixtures_v0.py"
 )
 
 NOTION_SPEC_MARKERS = (
@@ -49,35 +54,8 @@ FORBIDDEN_TRUTH_LAYER_PHRASES = (
     "notion truth layer is canonical",
 )
 
-ALLOWED_PROJECTION_FIELDS = (
-    "run_id",
-    "lane_id",
-    "composition_id",
-    "record_kind",
-    "runtime_host",
-    "runtime_backend",
-    "runtime_mode",
-    "evidence_root_type",
-    "evidence_transport",
-    "evidence_status",
-    "review_verdict",
-    "manifest_verified",
-    "archive_path",
-)
-
-RUN_PROJECTION_FIELDS = (
-    "run_id",
-    "lane_id",
-    "runtime_host",
-    "runtime_backend",
-    "runtime_mode",
-    "evidence_root_type",
-    "evidence_transport",
-    "evidence_status",
-    "review_verdict",
-    "manifest_verified",
-    "archive_path",
-)
+ALLOWED_PROJECTION_FIELDS = pc.ALLOWED_PROJECTION_FIELDS
+RUN_PROJECTION_FIELDS = pc.RUN_PROJECTION_FIELDS
 
 
 def _section_6a1() -> str:
@@ -178,17 +156,10 @@ def test_no_registry_v2_or_new_lane_ids() -> None:
 
 def test_registry_fixture_supports_projection_field_extraction(mod, tmp_path: Path) -> None:
     archive = tmp_path / "archive"
-    run_dir = archive / "runs" / "paper" / "paper_run"
-    run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "evidence.txt").write_text("paper:paper_run\n", encoding="utf-8")
-    digest = __import__("hashlib").sha256(b"paper:paper_run\n").hexdigest()
-    (run_dir / "MANIFEST.sha256").write_text(f"{digest}  evidence.txt\n", encoding="utf-8")
+    pc.write_minimal_paper_run(archive)
     payload = mod.build_registry(mod.BuildContext(archive_root=archive, repo_root=REPO_ROOT))
     run = payload["runs"][0]
-    for field in RUN_PROJECTION_FIELDS:
-        assert field in run, f"missing projection field {field!r} on runs[] row"
-    assert run["notion_projection"] == "disabled"
-    assert run["live_authority"] is False
+    pc.assert_non_authorizing_run_projection_defaults(run)
     assert payload["schema"] == "peak_trade.generic_evidence_run_registry.v1"
     assert "generic_evidence_run_registry.v2" not in json.dumps(payload)
 
@@ -197,6 +168,7 @@ def test_owner_crosslinks_remote_runtime_and_section_6a_population_tests() -> No
     owner_text = Path(__file__).read_text(encoding="utf-8")
     assert REMOTE_RUNTIME_TESTS.name in owner_text
     assert SECTION_6A_POPULATION_TESTS.name in owner_text
+    assert PROJECTION_FIXTURE_TESTS.name in owner_text
     remote_text = REMOTE_RUNTIME_TESTS.read_text(encoding="utf-8")
     assert "NOTION_PROJECTION_NON_AUTHORIZING=true" in remote_text
 

--- a/tests/ops/test_registry_v1_projection_consumer_smoke_fixtures_v0.py
+++ b/tests/ops/test_registry_v1_projection_consumer_smoke_fixtures_v0.py
@@ -1,0 +1,127 @@
+"""Contract tests for shared Registry v1 projection consumer smoke fixtures v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
+from tests.ops import test_market_dashboard_readonly_run_projection_spec_v0 as dashboard_spec
+from tests.ops import test_notion_post_closeout_sync_projection_spec_v0 as notion_spec
+
+REPO_ROOT = pc.REPO_ROOT
+TAXONOMY_SPEC = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md"
+)
+FIXTURES_README = (
+    REPO_ROOT / "tests" / "fixtures" / "ops" / "generic_evidence_run_registry_v1" / "README.md"
+)
+
+AUTHORITY_MARKERS = (
+    "NOTION_AUTHORITY=false",
+    "MARKET_DASHBOARD_AUTHORITY=false",
+    "S3_AUTHORITY=false",
+    "RUNTIME_AUTHORITY=false",
+    "SCHEDULER_CLEARANCE_AUTHORITY=false",
+    "LIVE_AUTHORITY=false",
+    "TESTNET_AUTHORITY=false",
+    "BROKER_AUTHORITY=false",
+    "DOUBLE_PLAY_AUTHORITY=false",
+)
+
+
+def _section_6a1() -> str:
+    text = TAXONOMY_SPEC.read_text(encoding="utf-8")
+    return text.split("### 6a.1 Notion post-closeout sync projection contract v0", 1)[1].split(
+        "### 6a.2 Market Dashboard read-only run projection contract v0", 1
+    )[0]
+
+
+def _section_6a2() -> str:
+    text = TAXONOMY_SPEC.read_text(encoding="utf-8")
+    return text.split("### 6a.2 Market Dashboard read-only run projection contract v0", 1)[1].split(
+        "### v0 authority posture", 1
+    )[0]
+
+
+def test_shared_fixture_module_marker() -> None:
+    assert pc.REGISTRY_V1_PROJECTION_CONSUMER_SMOKE_FIXTURES_V0 is True
+
+
+def test_notion_and_dashboard_tests_import_shared_field_constants() -> None:
+    assert notion_spec.ALLOWED_PROJECTION_FIELDS is pc.ALLOWED_PROJECTION_FIELDS
+    assert notion_spec.RUN_PROJECTION_FIELDS is pc.RUN_PROJECTION_FIELDS
+    assert dashboard_spec.ALLOWED_PROJECTION_FIELDS is pc.ALLOWED_PROJECTION_FIELDS
+    assert dashboard_spec.RUN_PROJECTION_FIELDS is pc.RUN_PROJECTION_FIELDS
+
+
+def test_taxonomy_sections_document_shared_projection_fields() -> None:
+    for field in pc.ALLOWED_PROJECTION_FIELDS:
+        assert field in _section_6a1()
+        assert field in _section_6a2()
+
+
+def test_s3_relevant_fields_subset_of_run_projection_fields() -> None:
+    for field in pc.S3_RELEVANT_PROJECTION_FIELDS:
+        assert field in pc.RUN_PROJECTION_FIELDS
+
+
+def test_fixtures_readme_documents_projection_consumer_contract() -> None:
+    text = FIXTURES_README.read_text(encoding="utf-8")
+    assert "Projection consumer smoke fixtures v0" in text
+    assert "REGISTRY_V1_PROJECTION_CONSUMER_SMOKE_FIXTURES_V0=true" in text
+    assert "S3_RELEVANT_PROJECTION_FIELDS" in text
+    for marker in AUTHORITY_MARKERS:
+        assert marker in text
+    assert "non-authorizing" in text.lower()
+
+
+def test_minimal_paper_run_builds_registry_v1_with_projection_fields(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    pc.write_minimal_paper_run(archive)
+    payload = pc.build_registry(archive)
+    assert payload["schema"] == "peak_trade.generic_evidence_run_registry.v1"
+    for field in pc.TOP_LEVEL_PROJECTION_SUMMARY_FIELDS:
+        assert field in payload
+    run = payload["runs"][0]
+    pc.assert_non_authorizing_run_projection_defaults(run)
+    for field in pc.S3_RELEVANT_PROJECTION_FIELDS:
+        assert field in run
+
+
+def test_composition_fixture_includes_record_kind_and_section_6a_fields(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    run_id = pc.DEFAULT_COMPOSITION_RUN_ID
+    pc.write_lane(archive, "paper", run_id)
+    pc.write_lane(archive, "shadow", run_id, review="PASS")
+    pc.write_composition(archive, run_id)
+    payload = pc.build_registry(archive)
+    comp = payload["compositions"][0]
+    assert comp["record_kind"] == "composition_index"
+    for field in pc.SECTION_6A_METADATA_FIELDS:
+        assert field in comp
+    assert comp["composition_id"] == "daemon_paper_24h"
+    assert comp["rollup_manifest_verified"] is True
+    for field in pc.ALLOWED_PROJECTION_FIELDS:
+        if field in ("lane_id", "review_verdict", "manifest_verified"):
+            continue
+        assert field in comp
+
+
+def test_no_registry_v2_or_forbidden_lane_ids(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    pc.write_minimal_paper_run(archive)
+    payload = pc.build_registry(archive)
+    assert "generic_evidence_run_registry.v2" not in json.dumps(payload)
+    lane_ids = {r["lane_id"] for r in payload["runs"]}
+    assert "daemon_paper_24h" not in lane_ids
+    assert "remote_runtime" not in lane_ids
+
+
+def test_section_6a_population_tests_use_shared_archive_helpers() -> None:
+    from tests.ops import test_registry_v1_section_6a_field_population_v0 as section_6a
+
+    assert section_6a._write_lane is pc.write_lane
+    assert section_6a._write_composition is pc.write_composition

--- a/tests/ops/test_registry_v1_section_6a_field_population_v0.py
+++ b/tests/ops/test_registry_v1_section_6a_field_population_v0.py
@@ -2,93 +2,28 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
-import sys
 from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[2]
-REGISTRY_SCRIPT = ROOT / "scripts" / "ops" / "build_generic_evidence_run_registry_v1.py"
+from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
+
+ROOT = pc.REPO_ROOT
+REGISTRY_SCRIPT = pc.REGISTRY_SCRIPT
 TAXONOMY_SPEC = (
     ROOT / "docs" / "ops" / "specs" / "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md"
 )
 
-SECTION_6A_FIELDS = (
-    "runtime_host",
-    "runtime_backend",
-    "runtime_mode",
-    "evidence_root_type",
-    "evidence_transport",
-    "notion_projection",
-    "market_dashboard_projection",
-    "live_authority",
-    "testnet_authority",
-)
+SECTION_6A_FIELDS = pc.SECTION_6A_METADATA_FIELDS
+RUN_ID = pc.DEFAULT_COMPOSITION_RUN_ID
 
-RUN_ID = "daemon_paper_24h_fixture_6a_v0"
+_write_lane = pc.write_lane
+_write_composition = pc.write_composition
 
 
 def _load_registry():
-    spec = importlib.util.spec_from_file_location(
-        "build_generic_evidence_run_registry_v1_section_6a",
-        REGISTRY_SCRIPT,
-    )
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = mod
-    spec.loader.exec_module(mod)
-    return mod
-
-
-def _sha256_file(path: Path) -> str:
-    import hashlib
-
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _write_lane_manifest(run_dir: Path) -> None:
-    entries: list[str] = []
-    for path in sorted(run_dir.rglob("*")):
-        if not path.is_file() or path.name == "MANIFEST.sha256":
-            continue
-        rel = path.relative_to(run_dir).as_posix()
-        entries.append(f"{_sha256_file(path)}  {rel}")
-    (run_dir / "MANIFEST.sha256").write_text("\n".join(entries) + "\n", encoding="utf-8")
-
-
-def _write_lane(archive: Path, lane: str, run_id: str, *, review: str | None = None) -> Path:
-    run_dir = archive / "runs" / lane / run_id
-    run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "evidence.txt").write_text(f"{lane}:{run_id}\n", encoding="utf-8")
-    if review is not None:
-        review_dir = run_dir / "review"
-        review_dir.mkdir(parents=True, exist_ok=True)
-        (review_dir / "REVIEW_RESULT.json").write_text(
-            json.dumps({"verdict": review, "issues": []}) + "\n",
-            encoding="utf-8",
-        )
-    _write_lane_manifest(run_dir)
-    return run_dir
-
-
-def _write_composition(archive: Path, run_id: str) -> Path:
-    comp_dir = archive / "runs" / "daemon_paper_24h" / run_id
-    comp_dir.mkdir(parents=True, exist_ok=True)
-    (comp_dir / "COMPOSITION_INDEX.md").write_text(
-        "composition_index_authority=false\n", encoding="utf-8"
-    )
-    manifests = comp_dir / "manifests"
-    manifests.mkdir(parents=True, exist_ok=True)
-    rel = "COMPOSITION_INDEX.md"
-    digest = _sha256_file(comp_dir / rel)
-    (manifests / "MANIFEST.sha256").write_text(f"{digest}  {rel}\n", encoding="utf-8")
-    return comp_dir
+    return pc.load_registry_module(module_name="build_generic_evidence_run_registry_v1_section_6a")
 
 
 def _build(mod, archive: Path) -> dict:


### PR DESCRIPTION
## Summary

Adds shared Registry v1 projection consumer smoke fixtures for Notion, Market Dashboard, and future S3 finalized-evidence consumers.

This consolidates duplicated projection field lists and archive builders across the Notion and Market Dashboard projection spec tests, while keeping everything test-only and non-authorizing.

## Scope

- Adds shared test-only fixture helper:
  - `tests/fixtures/ops/generic_evidence_run_registry_v1/projection_consumer_v0.py`
- Adds package init files for fixture imports.
- Extends fixture README with the projection consumer contract.
- Adds focused smoke fixture contract tests.
- Refactors Notion projection spec tests to use shared constants/helpers.
- Refactors Market Dashboard projection spec tests to use shared constants/helpers.
- Reuses shared lane/composition builders in Registry §6a population tests.
- Includes S3-relevant projection fields for future S3 gate tests without implementing S3 export.

## Shared Fixture Contract

Shared constants/helpers include:

- `ALLOWED_PROJECTION_FIELDS`
- `RUN_PROJECTION_FIELDS`
- `S3_RELEVANT_PROJECTION_FIELDS`
- `TOP_LEVEL_PROJECTION_SUMMARY_FIELDS`
- `SECTION_6A_METADATA_FIELDS`
- `write_lane`
- `write_composition`
- `write_minimal_paper_run`
- `build_registry`
- `assert_non_authorizing_run_projection_defaults`

## Safety Boundaries

- Test fixtures only.
- No production Registry behavior changes.
- No Registry v2.
- No new schema.
- No new lane.
- No `lane_id=daemon_paper_24h`.
- No `lane_id=remote_runtime`.
- No runtime start.
- No scheduler/daemon/paper/shadow/testnet/live execution.
- No AWS/rclone calls.
- No Notion writes.
- No Dashboard rendering.
- No S3 export implementation.
- No Master V2 / Double Play authority changes.
- Notion remains projection/index only.
- Market Dashboard remains read-only projection only.
- S3 remains finalized evidence transport only.
- Live authority remains false.
- Testnet authority remains false.

## S3 Readiness Without Implementation

The shared fixture contract includes S3-relevant projection fields for future S3 finalized-evidence export gate tests:

- `evidence_transport`
- `manifest_verified`
- `archive_path`
- `evidence_status`

No S3 export logic is implemented in this PR.

## Validation

- `pytest` targeted projection fixture / Notion / Dashboard / Registry tests:
  - 55 passed
- `ruff format`
  - clean
- `ruff check`
  - clean
- docs token policy for touched README:
  - passed

## Context

This follows the canonical projection chain:

- PR #3670: Remote Runtime Host Metadata §6a.
- PR #3671: Paper Lane Closeout Parity v0.
- PR #3672: Combined OUTROOT Composition Index v0.
- PR #3673: Registry v1 §6a Field Population.
- PR #3674: Notion Post-Closeout Sync Projection Spec v0.
- PR #3675: Market Dashboard Read-only Run Projection Spec v0.

This PR prevents Notion, Market Dashboard, and future S3 tests from growing parallel projection field contracts.

## Machine Lines

REGISTRY_V1_PROJECTION_CONSUMER_SMOKE_FIXTURES_MODE=docs_tests_only
SHARED_REGISTRY_V1_PROJECTION_FIXTURES_CREATED=true
NOTION_DASHBOARD_FIELD_DUPLICATION_REMOVED=true
S3_RELEVANT_FIELDS_INCLUDED_FOR_FUTURE_TESTS=true
REGISTRY_V2_CREATED=false
NEW_SCHEMA_CREATED=false
NEW_LANE_CREATED=false
LANE_ID_DAEMON_PAPER_24H_CREATED=false
LANE_ID_REMOTE_RUNTIME_CREATED=false
RUNTIME_COMMANDS_CALLED=false
AWS_CLI_CALLED=false
RCLONE_CALLED=false
NOTION_WRITE_CALLED=false
MARKET_DASHBOARD_IMPLEMENTED=false
S3_EXPORT_IMPLEMENTED=false
RUNTIME_AUTHORITY=false
SCHEDULER_CLEARANCE_AUTHORITY=false
LIVE_AUTHORITY=false
TESTNET_AUTHORITY=false
BROKER_AUTHORITY=false
DOUBLE_PLAY_AUTHORITY=false

Made with [Cursor](https://cursor.com)