### PR TITLE
ops: add offline post-closeout projection payload builder v0

### DIFF
--- a/scripts/ops/build_post_closeout_projection_payload_v0.py
+++ b/scripts/ops/build_post_closeout_projection_payload_v0.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Build a local post-closeout projection payload JSON (taxonomy §6a.0.9).
+
+Offline, non-authorizing: reads operator-supplied closeout and Registry v1 JSON paths only;
+writes exactly one output JSON path. Does not call Notion, Dashboard, S3/AWS/rclone, runtime,
+scheduler, daemon, adapter, workflow dispatch, or broker/exchange.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    MANIFEST_FILENAME,
+    verify_manifest_sha256,
+)
+
+SCHEMA_VERSION = "peak_trade.post_closeout_projection_payload.v0"
+REGISTRY_SCHEMA = "peak_trade.generic_evidence_run_registry.v1"
+
+MANIFEST_VERIFY_LOG = "MANIFEST_VERIFY.log"
+FINAL_MACHINE_LINES = "FINAL_MACHINE_LINES.txt"
+DURABLE_README = "DURABLE_COPY_README.md"
+
+# Keys expected on operator closeout bundles (missing any => missing_boundary_flags).
+REQUIRED_MACHINE_LINE_KEYS: tuple[str, ...] = (
+    "RUNTIME_COMMANDS_CALLED",
+    "NOTION_WRITE_CALLED",
+    "S3_AWS_RCLONE_CALLED",
+    "WORKFLOW_DISPATCH_CALLED",
+    "BROKER_EXCHANGE_CALLED",
+    "LIVE_AUTHORITY",
+    "TESTNET_AUTHORITY",
+)
+
+AUTHORITY_VIOLATION_KEYS: tuple[str, ...] = (
+    "LIVE_AUTHORITY",
+    "TESTNET_AUTHORITY",
+    "BROKER_EXCHANGE_CALLED",
+    "BROKER_EXCHANGE_AUTHORITY",
+)
+
+_TRUTHY = frozenset({"true", "1", "yes"})
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_machine_lines(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.lower() in _TRUTHY
+
+
+def _authority_object() -> dict[str, bool]:
+    return {
+        "notion_authority": False,
+        "market_dashboard_authority": False,
+        "runtime_authority": False,
+        "scheduler_authority": False,
+        "daemon_authority": False,
+        "adapter_authority": False,
+        "s3_authority": False,
+        "workflow_dispatch_authority": False,
+        "broker_exchange_authority": False,
+        "testnet_authority": False,
+        "live_authority": False,
+        "master_v2_double_play_authority": False,
+    }
+
+
+def _consumers(*, projection_ready: bool) -> dict[str, bool]:
+    allowed = projection_ready
+    return {
+        "notion_projection_allowed": allowed,
+        "market_dashboard_projection_allowed": allowed,
+        "notion_write_allowed": False,
+        "dashboard_write_allowed": False,
+    }
+
+
+def _s3_export_status_from_registry(registry: dict[str, Any], run: dict[str, Any] | None) -> str:
+    transport = None
+    if run is not None:
+        transport = run.get("evidence_transport")
+    if transport == "s3_export_after_finalize":
+        return "planned"
+    if transport == "local_only":
+        return "disabled"
+    return "unknown"
+
+
+def _load_registry(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, "malformed_registry_v1"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None, "malformed_registry_v1"
+    if not isinstance(payload, dict):
+        return None, "malformed_registry_v1"
+    if payload.get("schema") != REGISTRY_SCHEMA:
+        return None, "malformed_registry_v1"
+    return payload, None
+
+
+def _select_run(registry: dict[str, Any], run_id: str | None) -> dict[str, Any] | None:
+    runs = registry.get("runs")
+    if not isinstance(runs, list) or not runs:
+        return None
+    if run_id:
+        for row in runs:
+            if isinstance(row, dict) and row.get("run_id") == run_id:
+                return row
+        return None
+    first = runs[0]
+    return first if isinstance(first, dict) else None
+
+
+def _manifest_verify_rc(closeout_root: Path) -> tuple[int | None, str | None]:
+    manifest = closeout_root / MANIFEST_FILENAME
+    if not manifest.is_file():
+        return None, "missing_manifest"
+    ok, _msg = verify_manifest_sha256(closeout_root)
+    if ok:
+        return 0, None
+    verify_log = closeout_root / MANIFEST_VERIFY_LOG
+    if verify_log.is_file():
+        text = verify_log.read_text(encoding="utf-8")
+        if re.search(r"\bOK\b", text):
+            return 0, None
+        return 1, "manifest_verify_missing_or_failed"
+    return 1, "manifest_verify_failed"
+
+
+def build_projection_payload(
+    *,
+    closeout_root: Path,
+    registry_path: Path,
+    run_id: str | None = None,
+    repo_commit: str | None = None,
+) -> tuple[dict[str, Any], int]:
+    """Return (payload, exit_code). exit_code 0 for valid CLI run; blocked payloads still exit 0."""
+    closeout_root = closeout_root.expanduser().resolve()
+    registry_path = registry_path.expanduser().resolve()
+
+    source_files = {
+        "manifest_sha256": str(closeout_root / MANIFEST_FILENAME),
+        "manifest_verify_log": str(closeout_root / MANIFEST_VERIFY_LOG),
+        "final_machine_lines": str(closeout_root / FINAL_MACHINE_LINES),
+        "registry_json": str(registry_path),
+    }
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": _utc_now_iso(),
+        "run_id": run_id,
+        "projection_ready": False,
+        "projection_blocked_reason": None,
+        "manifest_verify_rc": None,
+        "closeout_accepted": False,
+        "primary_evidence_finalized": False,
+        "registry_pointer": str(registry_path),
+        "closeout_pointer": str(closeout_root),
+        "repo_commit": repo_commit,
+        "s3_export_status": "unknown",
+        "download_verify_rc": None,
+        "authority": _authority_object(),
+        "consumers": _consumers(projection_ready=False),
+        "source_files": source_files,
+    }
+
+    if not closeout_root.is_dir():
+        payload["projection_blocked_reason"] = "CLOSEOUT_INCOMPLETE"
+        return payload, 0
+
+    closeout_accepted = (closeout_root / DURABLE_README).is_file() or any(closeout_root.iterdir())
+    payload["closeout_accepted"] = closeout_accepted
+    if not closeout_accepted:
+        payload["projection_blocked_reason"] = "CLOSEOUT_INCOMPLETE"
+        return payload, 0
+
+    manifest_rc, manifest_block = _manifest_verify_rc(closeout_root)
+    payload["manifest_verify_rc"] = manifest_rc
+    if manifest_block:
+        payload["projection_blocked_reason"] = manifest_block
+        return payload, 0
+
+    payload["primary_evidence_finalized"] = True
+
+    machine_lines_path = closeout_root / FINAL_MACHINE_LINES
+    if not machine_lines_path.is_file():
+        payload["projection_blocked_reason"] = "missing_final_machine_lines"
+        return payload, 0
+
+    machine_lines = _parse_machine_lines(machine_lines_path)
+    missing_keys = [key for key in REQUIRED_MACHINE_LINE_KEYS if key not in machine_lines]
+    if missing_keys:
+        payload["projection_blocked_reason"] = "missing_boundary_flags"
+        return payload, 0
+
+    for key in AUTHORITY_VIOLATION_KEYS:
+        if _is_truthy(machine_lines.get(key)):
+            payload["projection_blocked_reason"] = "authority_boundary_violation"
+            return payload, 0
+
+    registry, registry_block = _load_registry(registry_path)
+    if registry_block:
+        payload["projection_blocked_reason"] = registry_block
+        return payload, 0
+
+    run = _select_run(registry, run_id)
+    if run is None:
+        payload["projection_blocked_reason"] = "malformed_registry_v1"
+        return payload, 0
+
+    payload["run_id"] = run.get("run_id", run_id)
+    if run.get("live_authority") is True or run.get("testnet_authority") is True:
+        payload["projection_blocked_reason"] = "authority_boundary_violation"
+        return payload, 0
+
+    if registry.get("verdict") == "GENERIC_EVIDENCE_RUN_REGISTRY_FAIL_CLOSED":
+        payload["projection_blocked_reason"] = "REGISTRY_FAIL_CLOSED"
+        return payload, 0
+
+    payload["s3_export_status"] = _s3_export_status_from_registry(registry, run)
+    payload["projection_ready"] = True
+    payload["projection_blocked_reason"] = None
+    payload["consumers"] = _consumers(projection_ready=True)
+    return payload, 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--closeout-root", type=Path, required=True)
+    parser.add_argument("--registry-json", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument("--repo-commit", default=None)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 when projection_ready=false (default: always exit 0 for blocked payloads).",
+    )
+    parser.add_argument("--stdout", action="store_true", help="Also print payload JSON to stdout.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = build_arg_parser().parse_args(argv)
+    except SystemExit as exc:
+        return 2 if exc.code != 0 else 0
+
+    output_path = args.output_json.expanduser().resolve()
+    repo_root = _REPO_ROOT.resolve()
+    if repo_root in output_path.parents or output_path == repo_root:
+        print("ERROR: --output-json must not be inside the repository", file=sys.stderr)
+        return 2
+
+    try:
+        payload, _ = build_projection_payload(
+            closeout_root=args.closeout_root,
+            registry_path=args.registry_json,
+            run_id=args.run_id,
+            repo_commit=args.repo_commit,
+        )
+    except OSError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 — CLI boundary
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.stdout:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+
+    if args.strict and not payload.get("projection_ready"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_build_post_closeout_projection_payload_v0.py
+++ b/tests/ops/test_build_post_closeout_projection_payload_v0.py
@@ -1,0 +1,303 @@
+"""Tests for build_post_closeout_projection_payload_v0 (offline projection payload builder)."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILDER = REPO_ROOT / "scripts/ops/build_post_closeout_projection_payload_v0.py"
+
+REQUIRED_MACHINE_LINES: dict[str, str] = {
+    "RUNTIME_COMMANDS_CALLED": "false",
+    "NOTION_WRITE_CALLED": "false",
+    "S3_AWS_RCLONE_CALLED": "false",
+    "WORKFLOW_DISPATCH_CALLED": "false",
+    "BROKER_EXCHANGE_CALLED": "false",
+    "LIVE_AUTHORITY": "false",
+    "TESTNET_AUTHORITY": "false",
+}
+
+FORBIDDEN_BUILDER_SUBSTRINGS = (
+    "aws ",
+    "rclone",
+    "boto3",
+    "subprocess.run",
+    "os.system",
+    "Popen(",
+    "gh workflow",
+    "requests.",
+)
+
+FORBIDDEN_BUILDER_IMPORT_MARKERS = (
+    "preflight_remote_runtime_runner",
+    "remote_paper_validator",
+    "scheduler",
+    "daemon",
+)
+
+
+def _load_builder():
+    spec = importlib.util.spec_from_file_location(
+        "build_post_closeout_projection_payload_v0", BUILDER
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_machine_lines(path: Path, overrides: dict[str, str] | None = None) -> None:
+    lines = dict(REQUIRED_MACHINE_LINES)
+    if overrides:
+        lines.update(overrides)
+    path.write_text("\n".join(f"{k}={v}" for k, v in lines.items()) + "\n", encoding="utf-8")
+
+
+def _write_closeout_bundle(
+    closeout_root: Path,
+    *,
+    with_manifest: bool = True,
+    manifest_valid: bool = True,
+    with_verify_log: bool = True,
+    verify_log_ok: bool = True,
+    with_machine_lines: bool = True,
+    machine_line_overrides: dict[str, str] | None = None,
+) -> None:
+    closeout_root.mkdir(parents=True, exist_ok=True)
+    (closeout_root / "evidence.txt").write_text("fixture\n", encoding="utf-8")
+    (closeout_root / "DURABLE_COPY_README.md").write_text("# durable copy\n", encoding="utf-8")
+    if with_machine_lines:
+        _write_machine_lines(closeout_root / "FINAL_MACHINE_LINES.txt", machine_line_overrides)
+    if with_manifest:
+        from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+        write_manifest_sha256(closeout_root)
+        if not manifest_valid:
+            manifest = closeout_root / "MANIFEST.sha256"
+            manifest.write_text("deadbeef  evidence.txt\n", encoding="utf-8")
+    if with_verify_log:
+        log = closeout_root / "MANIFEST_VERIFY.log"
+        log.write_text(
+            "evidence.txt: OK\n" if verify_log_ok else "evidence.txt: FAILED\n", encoding="utf-8"
+        )
+
+
+def _write_registry(
+    path: Path, tmp_path: Path, *, run_id: str = "paper_run", live: bool = False
+) -> None:
+    archive = tmp_path / "archive"
+    pc.write_minimal_paper_run(archive, run_id)
+    registry = pc.build_registry(archive)
+    if live:
+        registry["runs"][0]["live_authority"] = True
+    path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+
+
+def _run_cli(builder, closeout: Path, registry: Path, out: Path, **extra: str) -> int:
+    argv = [
+        "--closeout-root",
+        str(closeout),
+        "--registry-json",
+        str(registry),
+        "--output-json",
+        str(out),
+    ]
+    for key, value in extra.items():
+        argv.extend([f"--{key.replace('_', '-')}", value])
+    return builder.main(argv)
+
+
+@pytest.fixture(scope="module")
+def builder():
+    return _load_builder()
+
+
+def test_happy_path_projection_ready(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "out" / "payload.json"
+    _write_closeout_bundle(closeout)
+    _write_registry(registry_path, tmp_path)
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "peak_trade.post_closeout_projection_payload.v0"
+    assert payload["projection_ready"] is True
+    assert payload["projection_blocked_reason"] is None
+    assert payload["manifest_verify_rc"] == 0
+    assert payload["closeout_accepted"] is True
+    assert payload["primary_evidence_finalized"] is True
+    assert all(v is False for v in payload["authority"].values())
+    assert payload["consumers"]["notion_write_allowed"] is False
+    assert payload["consumers"]["dashboard_write_allowed"] is False
+    assert payload["consumers"]["notion_projection_allowed"] is True
+    assert payload["consumers"]["market_dashboard_projection_allowed"] is True
+
+
+def test_missing_manifest_blocked(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "payload.json"
+    _write_closeout_bundle(closeout, with_manifest=False)
+    _write_registry(registry_path, tmp_path)
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["projection_ready"] is False
+    assert payload["projection_blocked_reason"] == "missing_manifest"
+
+
+def test_manifest_verify_failed_blocked(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "payload.json"
+    _write_closeout_bundle(
+        closeout,
+        manifest_valid=False,
+        verify_log_ok=False,
+    )
+    _write_registry(registry_path, tmp_path)
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["projection_ready"] is False
+    assert payload["projection_blocked_reason"] in (
+        "manifest_verify_failed",
+        "manifest_verify_missing_or_failed",
+    )
+
+
+def test_missing_final_machine_lines_blocked(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "payload.json"
+    _write_closeout_bundle(closeout, with_machine_lines=False)
+    _write_registry(registry_path, tmp_path)
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["projection_ready"] is False
+    assert payload["projection_blocked_reason"] == "missing_final_machine_lines"
+
+
+def test_boundary_violation_live_authority(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "payload.json"
+    _write_closeout_bundle(closeout, machine_line_overrides={"LIVE_AUTHORITY": "true"})
+    _write_registry(registry_path, tmp_path)
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["projection_ready"] is False
+    assert payload["projection_blocked_reason"] == "authority_boundary_violation"
+
+
+def test_boundary_violation_registry_live_authority(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "payload.json"
+    _write_closeout_bundle(closeout)
+    _write_registry(registry_path, tmp_path, live=True)
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["projection_ready"] is False
+    assert payload["projection_blocked_reason"] == "authority_boundary_violation"
+
+
+def test_malformed_registry_blocked(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "payload.json"
+    _write_closeout_bundle(closeout)
+    registry_path.write_text("{not-json", encoding="utf-8")
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["projection_ready"] is False
+    assert payload["projection_blocked_reason"] == "malformed_registry_v1"
+
+
+def test_output_write_only_inputs_unchanged(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "payload.json"
+    _write_closeout_bundle(closeout)
+    _write_registry(registry_path, tmp_path)
+
+    def digest(path: Path) -> str:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    before = {p: digest(p) for p in closeout.rglob("*") if p.is_file()}
+    before[registry_path] = digest(registry_path)
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    assert out.is_file()
+
+    after = {p: digest(p) for p in closeout.rglob("*") if p.is_file()}
+    after[registry_path] = digest(registry_path)
+    assert before == after
+
+
+def test_builder_has_no_runtime_or_external_side_effect_markers():
+    text = BUILDER.read_text(encoding="utf-8")
+    import_lines = [
+        line.strip().lower()
+        for line in text.splitlines()
+        if line.strip().startswith(("import ", "from "))
+    ]
+    joined_imports = "\n".join(import_lines)
+    for marker in FORBIDDEN_BUILDER_IMPORT_MARKERS:
+        assert marker not in joined_imports, f"forbidden import marker {marker!r}"
+    for marker in FORBIDDEN_BUILDER_SUBSTRINGS:
+        assert marker not in joined_imports, f"forbidden import substring {marker!r}"
+    assert "subprocess" not in joined_imports
+    assert "import requests" not in joined_imports
+    assert "import boto3" not in joined_imports
+
+
+def test_missing_boundary_flags_blocked(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "payload.json"
+    _write_closeout_bundle(closeout)
+    (closeout / "FINAL_MACHINE_LINES.txt").write_text(
+        "RUNTIME_COMMANDS_CALLED=false\n", encoding="utf-8"
+    )
+    _write_registry(registry_path, tmp_path)
+
+    rc = _run_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["projection_blocked_reason"] == "missing_boundary_flags"
+
+
+def test_cli_rejects_output_inside_repo(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    _write_closeout_bundle(closeout)
+    _write_registry(registry_path, tmp_path)
+    out = REPO_ROOT / "out" / "_pytest_payload.json"
+    try:
+        rc = _run_cli(builder, closeout, registry_path, out)
+        assert rc == 2
+    finally:
+        out.unlink(missing_ok=True)

--- a/tests/ops/test_registry_v1_projection_consumer_smoke_fixtures_v0.py
+++ b/tests/ops/test_registry_v1_projection_consumer_smoke_fixtures_v0.py
@@ -65,7 +65,7 @@ def test_payload_builder_planning_contract_present() -> None:
     assert "projection_ready=false" in section.lower()
     assert "build_post_closeout_projection_payload_v0" in section
     builder_script = REPO_ROOT / "scripts" / "ops" / "build_post_closeout_projection_payload_v0.py"
-    assert not builder_script.is_file()
+    assert builder_script.is_file()
     assert pc.REGISTRY_V1_PROJECTION_CONSUMER_SMOKE_FIXTURES_V0 is True
 
 


### PR DESCRIPTION
## Summary

Adds the offline Post-Closeout Projection Payload Builder v0.

The new CLI reads finalized/verifiable closeout and registry inputs, then writes a local operator-specified projection payload JSON. It is offline-only and non-authorizing.

## Changes

- Adds `scripts/ops/build_post_closeout_projection_payload_v0.py`
- Adds `tests/ops/test_build_post_closeout_projection_payload_v0.py`
- Updates the registry projection smoke expectation now that the builder script exists
- Reuses:
  - `verify_manifest_sha256` from `primary_evidence_retention_v0.py`
  - Registry v1 schema contract
  - `projection_consumer_v0.py` synthetic fixtures

## CLI

```bash
python3 scripts/ops/build_post_closeout_projection_payload_v0.py \
  --closeout-root <path> \
  --registry-json <path> \
  --output-json /tmp/projection_payload.json
```

## Exit behavior

- Valid inputs but blocked conditions: writes payload with `projection_ready=false`, exit 0
- Malformed CLI args or output path inside repo: exit 2
- Unexpected internal error: exit 1
- Optional `--strict`: exit 1 when projection is not ready

## Boundaries (unchanged)

- No Notion write, Dashboard change, S3/AWS/rclone, runtime/scheduler/daemon/adapter, workflow dispatch, or broker/exchange
- Reads closeout and registry only; writes exactly `--output-json`

## Test plan

- [x] `pytest tests/ops/test_build_post_closeout_projection_payload_v0.py`
- [x] `pytest tests/ops/test_notion_post_closeout_sync_projection_spec_v0.py`
- [x] `pytest tests/ops/test_market_dashboard_readonly_run_projection_spec_v0.py`
- [x] `pytest tests/ops/test_registry_v1_projection_consumer_smoke_fixtures_v0.py`
- [x] `ruff format` / `ruff check` on new Python files

Made with [Cursor](https://cursor.com)