### PR TITLE
webui: add read-only market registry projection overlay v0

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -43,14 +43,16 @@ This document is the **canonical Market Surface v0** owner for **`GET &#47;marke
 
 Dashboard ≠ Freigabe. Market Surface v0 is **review input only** for operators; it must not be read as trading authorization.
 
-### Post-Closeout Registry run projection (future, contract-only)
+### Post-Closeout Registry run projection (env-gated SSR v0)
 
-Future **registry-derived run/evidence status** on **`GET &#47;market`** only (not **`GET &#47;market&#47;double-play`**) is governed by [Runtime Lane Taxonomy + Authority Levels Contract v0](../ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) **§6a.0.8** (Post-Closeout Projection Automation Charter), **§6a.2** (Market Dashboard read-only run projection), and Generic Evidence Run Registry v1 — **not** by a parallel Market Surface or readmodel SSOT.
+**`GET &#47;market`** only (not **`GET &#47;market&#47;double-play`**) may render an env-gated **read-only** registry/run projection panel from operator-supplied Post-Closeout Projection Payload JSON plus Registry v1 JSON (via payload `registry_pointer`). Governed by [Runtime Lane Taxonomy + Authority Levels Contract v0](../ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) **§6a.0.8**, **§6a.2**, and Generic Evidence Run Registry v1 — **not** a new route, **not** a new `readmodel_id`, **not** a parallel Market Surface SSOT.
 
-- **Source:** finalized/verified durable evidence → Registry v1 JSON (`build_generic_evidence_run_registry_v1.py`) → read-only projection payload fields only; **no** ad-hoc archive walks; **no** `/tmp`-only closeouts as canonical input.
-- **Default:** `MARKET_DASHBOARD_RUN_PROJECTION_ENABLED=false` / `market_dashboard_projection=disabled` until an explicit future operator-chartered slice opts in.
-- **Boundaries:** read-only display (readmodel/projection semantics only); **no** runtime control from projection paths (`RUNTIME_CONTROL_FROM_PROJECTION=false`, `DASHBOARD_RUNTIME_CONTROL=false`); **no** start/stop buttons, polling of active runtime, or scheduler clearance; **no** Testnet/Live/broker/exchange authority; **no** Double Play / Master V2 authority or route changes (`MARKET_DASHBOARD_DOUBLE_PLAY_TOUCHED=false` in §6a.2).
-- **Orthogonal:** existing OHLCV/depth/ranking SSR on this page remains unchanged; F5 futures display owner stays [Futures Read-only Market Dashboard Contract v0](../ops/specs/FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md).
+- **Gate (default off):** `PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED=1` and `PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON=<path>` — implemented in `src/webui/market_surface.py` (`build_market_run_projection_display_context()`).
+- **Payload schema:** `peak_trade.post_closeout_projection_payload.v0` (offline builder: `scripts/ops/build_post_closeout_projection_payload_v0.py` — **not** invoked by this SSR path).
+- **Registry load:** read-only JSON at `registry_pointer` when `projection_ready=true` and `consumers.market_dashboard_projection_allowed=true` (Registry v1 from `scripts/ops/build_generic_evidence_run_registry_v1.py`); **no** archive walks; UI shows basename labels only (no full durable paths).
+- **Markers:** `data-market-v0-run-projection="true"`, `data-market-v0-run-projection-readonly="true"`, `data-market-v0-run-projection-authority="false"`, `data-market-v0-run-projection-enabled`, `data-market-v0-run-projection-ready`.
+- **Boundaries:** read-only SSR; **no** runtime control (`RUNTIME_CONTROL_FROM_PROJECTION=false`, `DASHBOARD_RUNTIME_CONTROL=false`); **no** Testnet/Live/broker/exchange authority; **no** Double Play template/route changes (`MARKET_DASHBOARD_DOUBLE_PLAY_TOUCHED=false`).
+- **Orthogonal:** OHLCV/depth/ranking SSR unchanged; F5 owner remains [Futures Read-only Market Dashboard Contract v0](../ops/specs/FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md).
 
 `MARKET_DASHBOARD_IS_PROJECTION_ONLY=true` — this surface must not be promoted to approval, gate clearance, or execution authority.
 
@@ -64,6 +66,7 @@ Stabile `data-*`‑Marker (Anker für Anzeige und automatisierte Tests — **kei
 - `data-market-non-authorizing="true"`
 - `data-market-safety-banner="true"`
 - `data-market-surface-v0="true"`
+- **Registry run projection SSR v0 (**`GET`** **`&#47;market`**, env-gated):** `data-market-v0-run-projection="true"`, `data-market-v0-run-projection-readonly="true"`, `data-market-v0-run-projection-authority="false"`, `data-market-v0-run-projection-enabled`, `data-market-v0-run-projection-ready` — **absent** when gate disabled; **never** on **`GET &#47;market&#47;double-play`**.
 - **Market Depth SSR v0 (**`GET`** **`&#47;market`**):** `data-market-depth-panel="true"`, `data-market-depth-status="<status>"` — bei Hilfs‑**HTTP 200** zeigt das Template **`display_status` `ok`**; sonst **`runtime_source_status`** aus Diagnose‑JSON (z. B. **`disabled`**, **`unconfigured`**, **`builder_error`**); optional `data-market-depth-readmodel-id`, `data-market-depth-summary`; **Darstellung/Test‑Anker**, **keine** operationalen Freigaben.
 - **`GET`** **`/market` · SSR Tiefen-Bundle-Provenienz (gleiche Region):** wenn das eingebettete Depth-Hilfstupel bereits **`generated_at_iso`**, **`stale`** / **`stale_reason`** (Fixture-/Diagnose‑Semantik) und ggf. Bundle-**`source`** liefert, rendert `/market` darunter einen **getrennten** Kurzblock **„Tiefen-Bundle-Provenienz“** (**nicht** der OHLC-**„Snapshot bei Seitenladen“** / **`generated_at_utc`**); Marker **`data-market-v0-depth-bundle-provenance-v0="true"`** plus **`data-market-v0-depth-bundle-stale`** — **display-only**.
 - **Embedded OHLCV payload snapshot time (`GET` `/market`):** sichtbarer Hinweis **„Snapshot bei Seitenladen“** mit dem gleichen Feld **`generated_at_utc`** wie im eingebetteten Market-Payload (und wie der JSON-Vertrag **`GET`** **`&#47;api&#47;market&#47;ohlcv`**); Marker **`data-market-v0-embedded-snapshot-generated-at-v0="true"`** — bezeichnet **SSR‑Zeitpunkt beim Seitenauftrag**, keine Live‑ oder Exchange‑**Freshness**‑Autorität.

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -14,7 +14,9 @@ Keine Orders, kein OPS-Cockpit-Bezug. Dummy-Quelle für Offline/CI; Kraken über
 from __future__ import annotations
 
 import importlib.util
+import json
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal
@@ -35,6 +37,26 @@ MARKET_DEPTH_SSR_TOP_LEVELS = 8
 DEFAULT_SYMBOL = "BTC/USD"
 DEFAULT_TIMEFRAME = "1h"
 DEFAULT_LIMIT = 120
+
+MARKET_RUN_PROJECTION_ENABLED_ENV = "PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED"
+MARKET_RUN_PROJECTION_PAYLOAD_JSON_ENV = "PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON"
+PROJECTION_PAYLOAD_SCHEMA_V0 = "peak_trade.post_closeout_projection_payload.v0"
+REGISTRY_V1_SCHEMA = "peak_trade.generic_evidence_run_registry.v1"
+
+RUN_PROJECTION_REGISTRY_FIELDS: tuple[str, ...] = (
+    "run_id",
+    "lane_id",
+    "runtime_host",
+    "runtime_backend",
+    "runtime_mode",
+    "evidence_root_type",
+    "evidence_transport",
+    "evidence_status",
+    "review_verdict",
+    "manifest_verified",
+    "archive_path",
+    "market_dashboard_projection",
+)
 
 _dummy_loader_mod: Any = None
 
@@ -223,6 +245,201 @@ def dataframe_to_bars(df: pd.DataFrame) -> List[Dict[str, Any]]:
     return bars
 
 
+def _market_run_projection_env_enabled() -> bool:
+    return (os.getenv(MARKET_RUN_PROJECTION_ENABLED_ENV) or "").strip() == "1"
+
+
+def _pointer_basename(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    try:
+        return Path(text).name
+    except (TypeError, ValueError):
+        return "configured"
+
+
+def _truncate_display(value: object, *, max_len: int = 120) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if len(text) > max_len:
+        return f"{text[: max_len - 3]}..."
+    return text
+
+
+def _load_projection_payload_json(path: Path) -> tuple[Dict[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, "payload_missing"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None, "payload_malformed"
+    if not isinstance(payload, dict):
+        return None, "payload_invalid_shape"
+    return payload, None
+
+
+def _load_registry_v1_json(path: Path) -> tuple[Dict[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, "registry_missing"
+    try:
+        registry = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None, "registry_malformed"
+    if not isinstance(registry, dict):
+        return None, "registry_invalid_shape"
+    if registry.get("schema") != REGISTRY_V1_SCHEMA:
+        return None, "registry_schema_unsupported"
+    return registry, None
+
+
+def _select_registry_run(registry: Dict[str, Any], run_id: str | None) -> Dict[str, Any] | None:
+    runs = registry.get("runs")
+    if not isinstance(runs, list) or not runs:
+        return None
+    if run_id:
+        for row in runs:
+            if isinstance(row, dict) and row.get("run_id") == run_id:
+                return row
+        return None
+    first = runs[0]
+    return first if isinstance(first, dict) else None
+
+
+def _registry_run_projection_subset(run: Dict[str, Any]) -> Dict[str, Any]:
+    subset: Dict[str, Any] = {}
+    for key in RUN_PROJECTION_REGISTRY_FIELDS:
+        if key not in run:
+            continue
+        value = run.get(key)
+        if key == "archive_path" and value is not None:
+            subset[key] = _pointer_basename(value)
+        else:
+            subset[key] = value
+    return subset
+
+
+def build_market_run_projection_display_context() -> Dict[str, Any]:
+    """SSR-only post-closeout registry projection panel for GET /market (env-gated, read-only)."""
+
+    base: Dict[str, Any] = {
+        "section_visible": False,
+        "gate_enabled": False,
+        "projection_ready": False,
+        "projection_blocked_reason": "",
+        "manifest_verify_rc": "",
+        "closeout_accepted": False,
+        "primary_evidence_finalized": False,
+        "repo_commit": "",
+        "s3_export_status": "",
+        "download_verify_rc": "",
+        "run_id": "",
+        "payload_generated_at_utc": "",
+        "dashboard_projection_allowed": False,
+        "registry_configured_label": "",
+        "closeout_configured_label": "",
+        "registry_generated_at_utc": "",
+        "registry_verdict": "",
+        "registry_run_count": 0,
+        "registry_run": {},
+        "status": "disabled",
+    }
+
+    if not _market_run_projection_env_enabled():
+        return base
+
+    base["gate_enabled"] = True
+    payload_path_raw = (os.getenv(MARKET_RUN_PROJECTION_PAYLOAD_JSON_ENV) or "").strip()
+    if not payload_path_raw:
+        base["status"] = "unconfigured"
+        return base
+
+    payload_path = Path(payload_path_raw).expanduser()
+    payload, load_err = _load_projection_payload_json(payload_path)
+    if load_err or payload is None:
+        base["section_visible"] = True
+        base["status"] = load_err or "payload_malformed"
+        base["projection_blocked_reason"] = load_err or "payload_malformed"
+        return base
+
+    if payload.get("schema_version") != PROJECTION_PAYLOAD_SCHEMA_V0:
+        base["section_visible"] = True
+        base["status"] = "payload_schema_unsupported"
+        base["projection_blocked_reason"] = "payload_schema_unsupported"
+        return base
+
+    base["section_visible"] = True
+    base["status"] = "loaded"
+    base["run_id"] = _truncate_display(payload.get("run_id"))
+    base["payload_generated_at_utc"] = _truncate_display(payload.get("generated_at_utc"))
+    base["projection_ready"] = payload.get("projection_ready") is True
+    blocked = payload.get("projection_blocked_reason")
+    base["projection_blocked_reason"] = _truncate_display(blocked) if blocked else ""
+    manifest_rc = payload.get("manifest_verify_rc")
+    base["manifest_verify_rc"] = "" if manifest_rc is None else _truncate_display(manifest_rc)
+    base["closeout_accepted"] = payload.get("closeout_accepted") is True
+    base["primary_evidence_finalized"] = payload.get("primary_evidence_finalized") is True
+    base["repo_commit"] = _truncate_display(payload.get("repo_commit"), max_len=40)
+    base["s3_export_status"] = _truncate_display(payload.get("s3_export_status"), max_len=40)
+    download_rc = payload.get("download_verify_rc")
+    base["download_verify_rc"] = "" if download_rc is None else _truncate_display(download_rc)
+
+    base["registry_configured_label"] = _pointer_basename(payload.get("registry_pointer"))
+    base["closeout_configured_label"] = _pointer_basename(payload.get("closeout_pointer"))
+
+    consumers = payload.get("consumers")
+    if isinstance(consumers, dict):
+        base["dashboard_projection_allowed"] = (
+            consumers.get("market_dashboard_projection_allowed") is True
+        )
+
+    if not base["projection_ready"]:
+        base["status"] = "blocked"
+        return base
+
+    if not base["dashboard_projection_allowed"]:
+        base["projection_ready"] = False
+        base["status"] = "consumer_not_allowed"
+        base["projection_blocked_reason"] = base["projection_blocked_reason"] or (
+            "market_dashboard_projection_not_allowed"
+        )
+        return base
+
+    registry_pointer = payload.get("registry_pointer")
+    if not registry_pointer:
+        base["status"] = "registry_pointer_missing"
+        base["projection_blocked_reason"] = "registry_pointer_missing"
+        base["projection_ready"] = False
+        return base
+
+    registry_path = Path(str(registry_pointer)).expanduser()
+    registry, reg_err = _load_registry_v1_json(registry_path)
+    if reg_err or registry is None:
+        base["status"] = reg_err or "registry_unavailable"
+        base["projection_blocked_reason"] = reg_err or "registry_unavailable"
+        base["projection_ready"] = False
+        return base
+
+    base["registry_generated_at_utc"] = _truncate_display(registry.get("generated_at_utc"))
+    base["registry_verdict"] = _truncate_display(registry.get("verdict"), max_len=80)
+    runs = registry.get("runs")
+    base["registry_run_count"] = len(runs) if isinstance(runs, list) else 0
+
+    run = _select_registry_run(registry, payload.get("run_id"))
+    if run is None:
+        base["status"] = "registry_run_not_found"
+        base["projection_blocked_reason"] = "registry_run_not_found"
+        base["projection_ready"] = False
+        return base
+
+    base["registry_run"] = _registry_run_projection_subset(run)
+    base["status"] = "ready"
+    return base
+
+
 def build_market_depth_display_context() -> Dict[str, Any]:
     """SSR-only snapshot for templates: tuple from helper, unchanged semantics."""
 
@@ -344,6 +561,7 @@ def create_market_router(
         payload = build_market_payload(symbol=symbol, timeframe=timeframe, limit=limit, source=src)
         proj_status = get_project_status()
         market_depth = build_market_depth_display_context()
+        run_projection = build_market_run_projection_display_context()
         return templates.TemplateResponse(
             request,
             "market_v0.html",
@@ -351,6 +569,7 @@ def create_market_router(
                 "status": proj_status,
                 "payload": payload,
                 "market_depth": market_depth,
+                "run_projection": run_projection,
                 "query": {
                     "symbol": symbol,
                     "timeframe": timeframe,

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -110,6 +110,53 @@
     </p>
   </section>
 
+  {% if run_projection.section_visible %}
+  <section
+    role="region"
+    aria-labelledby="market-v0-landmark-run-projection-h2"
+    class="rounded-xl border border-sky-900/45 bg-gradient-to-br from-sky-950/35 via-slate-950/40 to-slate-950/20 px-3 py-2.5 sm:px-4 text-xs text-sky-100/95"
+    data-market-v0-run-projection="true"
+    data-market-v0-run-projection-readonly="true"
+    data-market-v0-run-projection-authority="false"
+    data-market-v0-run-projection-enabled="{{ 'true' if run_projection.gate_enabled else 'false' }}"
+    data-market-v0-run-projection-ready="{{ 'true' if run_projection.projection_ready else 'false' }}"
+  >
+    <h2 id="market-v0-landmark-run-projection-h2" class="font-semibold text-sky-200/95 tracking-wide uppercase text-[11px] m-0 mb-2">
+      Registry run projection (read-only)
+    </h2>
+    <p class="leading-snug text-sky-100/90 m-0 text-[11px] mb-2">
+      Read-only operational projection. This dashboard does not authorize runtime, testnet, live trading, broker access, exchange access, or strategy execution. Repo contracts and durable evidence remain canonical.
+    </p>
+    <dl class="m-0 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-[11px] tabular-nums">
+      <div><dt class="inline text-slate-400">run_id</dt> <dd class="inline text-slate-100">{{ run_projection.run_id or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">projection_ready</dt> <dd class="inline text-slate-100">{{ run_projection.projection_ready }}</dd></div>
+      <div><dt class="inline text-slate-400">blocked_reason</dt> <dd class="inline text-slate-100">{{ run_projection.projection_blocked_reason or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">manifest_verify_rc</dt> <dd class="inline text-slate-100">{{ run_projection.manifest_verify_rc or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">closeout_accepted</dt> <dd class="inline text-slate-100">{{ run_projection.closeout_accepted }}</dd></div>
+      <div><dt class="inline text-slate-400">primary_evidence_finalized</dt> <dd class="inline text-slate-100">{{ run_projection.primary_evidence_finalized }}</dd></div>
+      <div><dt class="inline text-slate-400">repo_commit</dt> <dd class="inline text-slate-100">{{ run_projection.repo_commit or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">s3_export_status</dt> <dd class="inline text-slate-100">{{ run_projection.s3_export_status or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">download_verify_rc</dt> <dd class="inline text-slate-100">{{ run_projection.download_verify_rc or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">dashboard_projection_allowed</dt> <dd class="inline text-slate-100">{{ run_projection.dashboard_projection_allowed }}</dd></div>
+      <div><dt class="inline text-slate-400">registry</dt> <dd class="inline text-slate-100">{{ run_projection.registry_configured_label or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">closeout</dt> <dd class="inline text-slate-100">{{ run_projection.closeout_configured_label or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">payload_built_at</dt> <dd class="inline text-slate-100">{{ run_projection.payload_generated_at_utc or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">status</dt> <dd class="inline text-slate-100">{{ run_projection.status }}</dd></div>
+    </dl>
+    {% if run_projection.registry_run %}
+    <div class="mt-2 pt-2 border-t border-sky-800/30">
+      <p class="m-0 mb-1 text-[10px] font-semibold uppercase tracking-wide text-sky-300/90">Registry v1 row (subset)</p>
+      <dl class="m-0 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-[11px] tabular-nums">
+        {% for key, value in run_projection.registry_run.items() %}
+        <div><dt class="inline text-slate-400">{{ key }}</dt> <dd class="inline text-slate-100">{{ value }}</dd></div>
+        {% endfor %}
+      </dl>
+      <p class="m-0 mt-1 text-[10px] text-slate-400">registry_verdict: {{ run_projection.registry_verdict or "—" }} · runs: {{ run_projection.registry_run_count }} · built_at: {{ run_projection.registry_generated_at_utc or "—" }}</p>
+    </div>
+    {% endif %}
+  </section>
+  {% endif %}
+
   <section
     role="region"
     aria-labelledby="market-v0-landmark-ranking-funnel-h2"

--- a/tests/fixtures/ops/market_registry_projection_overlay_v0.py
+++ b/tests/fixtures/ops/market_registry_projection_overlay_v0.py
@@ -1,0 +1,68 @@
+"""Synthetic fixtures for market registry projection overlay tests (non-authorizing)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
+
+PAYLOAD_SCHEMA = "peak_trade.post_closeout_projection_payload.v0"
+
+
+def write_registry(archive: Path) -> Path:
+    pc.write_minimal_paper_run(archive, "paper_run")
+    registry = pc.build_registry(archive)
+    registry_path = archive.parent / "registry.json"
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+    return registry_path
+
+
+def write_payload(
+    dest: Path,
+    *,
+    registry_path: Path,
+    closeout_label: str = "closeout_fixture",
+    projection_ready: bool = True,
+    market_dashboard_allowed: bool = True,
+    blocked_reason: str | None = None,
+    schema_version: str = PAYLOAD_SCHEMA,
+) -> Path:
+    consumers = {
+        "notion_projection_allowed": projection_ready and market_dashboard_allowed,
+        "market_dashboard_projection_allowed": projection_ready and market_dashboard_allowed,
+        "notion_write_allowed": False,
+        "dashboard_write_allowed": False,
+    }
+    payload: dict[str, Any] = {
+        "schema_version": schema_version,
+        "generated_at_utc": "2026-05-26T12:00:00Z",
+        "run_id": "paper_run",
+        "projection_ready": projection_ready,
+        "projection_blocked_reason": blocked_reason,
+        "manifest_verify_rc": 0 if projection_ready else 1,
+        "closeout_accepted": True,
+        "primary_evidence_finalized": projection_ready,
+        "registry_pointer": str(registry_path.resolve()),
+        "closeout_pointer": str((registry_path.parent / closeout_label).resolve()),
+        "repo_commit": "deadbeef",
+        "s3_export_status": "disabled",
+        "download_verify_rc": None,
+        "authority": {"live_authority": False, "testnet_authority": False},
+        "consumers": consumers,
+        "source_files": {
+            "manifest_sha256": "/secret/MANIFEST.sha256",
+            "registry_json": str(registry_path.resolve()),
+        },
+    }
+    dest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return dest
+
+
+def write_ready_bundle(work_dir: Path) -> tuple[Path, Path]:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    archive = work_dir / "archive"
+    registry_path = write_registry(archive)
+    payload_path = write_payload(work_dir / "payload.json", registry_path=registry_path)
+    return payload_path, registry_path

--- a/tests/ops/test_market_dashboard_readonly_run_projection_spec_v0.py
+++ b/tests/ops/test_market_dashboard_readonly_run_projection_spec_v0.py
@@ -230,7 +230,10 @@ def test_market_surface_documents_post_closeout_registry_projection_crosslink() 
     text = MARKET_SURFACE.read_text(encoding="utf-8")
     assert "Post-Closeout Registry run projection" in text
     assert "§6a.0.8" in text
-    assert "MARKET_DASHBOARD_RUN_PROJECTION_ENABLED=false" in text
+    assert "PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED" in text
+    assert "PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON" in text
+    assert "data-market-v0-run-projection" in text
+    assert "build_market_run_projection_display_context" in text
     assert "MARKET_DASHBOARD_IS_PROJECTION_ONLY=true" in text
     assert "RUNTIME_CONTROL_FROM_PROJECTION=false" in text
     assert "DASHBOARD_RUNTIME_CONTROL=false" in text
@@ -238,3 +241,4 @@ def test_market_surface_documents_post_closeout_registry_projection_crosslink() 
     assert "build_generic_evidence_run_registry_v1.py" in text
     assert "parallel Market Surface" in text
     assert "MARKET_DASHBOARD_DOUBLE_PLAY_TOUCHED=false" in text
+    assert "no new `readmodel_id`" in text or "not** a new `readmodel_id`" in text

--- a/tests/webui/test_market_registry_projection_overlay_v0.py
+++ b/tests/webui/test_market_registry_projection_overlay_v0.py
@@ -1,0 +1,157 @@
+"""Web UI tests for env-gated market registry projection overlay v0 on GET /market."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+from src.webui.market_surface import build_market_run_projection_display_context
+from tests.fixtures.ops import market_registry_projection_overlay_v0 as overlay_fixtures
+
+BOUNDARY_COPY = (
+    "Read-only operational projection. This dashboard does not authorize runtime, "
+    "testnet, live trading, broker access, exchange access, or strategy execution. "
+    "Repo contracts and durable evidence remain canonical."
+)
+
+RUN_PROJECTION_MARKERS = (
+    "data-market-v0-run-projection=",
+    "data-market-v0-run-projection-readonly=",
+    "data-market-v0-run-projection-authority=",
+)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", raising=False)
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _html(client: TestClient, path: str = "/market") -> str:
+    response = client.get(path)
+    assert response.status_code == 200
+    return response.text
+
+
+def test_gate_disabled_no_run_projection_section(client: TestClient) -> None:
+    html = _html(client)
+    for marker in RUN_PROJECTION_MARKERS:
+        assert marker not in html
+    assert BOUNDARY_COPY not in html
+
+
+def test_gate_enabled_ready_fixture_shows_panel(
+    tmp_path: Path, client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload_path, _registry_path = overlay_fixtures.write_ready_bundle(tmp_path / "bundle")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", str(payload_path))
+    html = _html(client)
+
+    assert 'data-market-v0-run-projection="true"' in html
+    assert 'data-market-v0-run-projection-readonly="true"' in html
+    assert 'data-market-v0-run-projection-authority="false"' in html
+    assert 'data-market-v0-run-projection-ready="true"' in html
+    assert BOUNDARY_COPY in html
+    assert "paper_run" in html
+    assert "registry.json" in html or "registry" in html.lower()
+    assert str(payload_path.resolve()) not in html
+    assert str(_registry_path.resolve()) not in html
+    assert "source_files" not in html
+    assert "/secret/MANIFEST.sha256" not in html
+
+
+def test_double_play_excludes_run_projection_markers(
+    tmp_path: Path, client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload_path, _ = overlay_fixtures.write_ready_bundle(tmp_path / "bundle")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", str(payload_path))
+    html = _html(client, "/market/double-play")
+    for marker in RUN_PROJECTION_MARKERS:
+        assert marker not in html
+    assert BOUNDARY_COPY not in html
+
+
+def test_blocked_payload_renders_without_registry_row(
+    tmp_path: Path, client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry_path = overlay_fixtures.write_registry(tmp_path / "archive")
+    payload_path = overlay_fixtures.write_payload(
+        tmp_path / "payload.json",
+        registry_path=registry_path,
+        projection_ready=False,
+        blocked_reason="missing_manifest",
+    )
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", str(payload_path))
+    html = _html(client)
+    assert 'data-market-v0-run-projection-ready="false"' in html
+    assert "missing_manifest" in html
+    assert "Registry v1 row (subset)" not in html
+
+
+def test_consumer_not_allowed_no_registry_row(
+    tmp_path: Path, client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry_path = overlay_fixtures.write_registry(tmp_path / "archive")
+    payload_path = overlay_fixtures.write_payload(
+        tmp_path / "payload.json",
+        registry_path=registry_path,
+        projection_ready=True,
+        market_dashboard_allowed=False,
+    )
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", str(payload_path))
+    html = _html(client)
+    assert 'data-market-v0-run-projection-ready="false"' in html
+    assert "Registry v1 row (subset)" not in html
+
+
+def test_malformed_payload_page_still_renders(
+    tmp_path: Path, client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bad = tmp_path / "payload.json"
+    bad.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", str(bad))
+    html = _html(client)
+    assert 'data-market-readonly="true"' in html
+    assert 'data-market-v0-run-projection-authority="false"' in html
+    assert 'data-market-v0-run-projection-ready="false"' in html
+    lowered = html.lower()
+    assert "<form" not in lowered
+    assert "<button" not in lowered
+
+
+def test_build_context_unit_ready(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload_path, _ = overlay_fixtures.write_ready_bundle(tmp_path / "bundle")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", str(payload_path))
+    ctx = build_market_run_projection_display_context()
+    assert ctx["section_visible"] is True
+    assert ctx["projection_ready"] is True
+    assert ctx["status"] == "ready"
+    assert ctx["registry_run"]["run_id"] == "paper_run"
+
+
+def test_build_context_gate_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", raising=False)
+    ctx = build_market_run_projection_display_context()
+    assert ctx["section_visible"] is False


### PR DESCRIPTION
## Summary

Adds an env-gated, read-only Post-Closeout Registry/Run Projection overlay to `GET /market`.

The overlay consumes an operator-provided `peak_trade.post_closeout_projection_payload.v0` payload and, only when allowed by the payload, reads Registry v1 via `registry_pointer`. It does not create a new route, readmodel, hook, or control surface.

## Changes

- Adds `build_market_run_projection_display_context()` in `market_surface.py`
- Extends `market_v0.html` with a read-only SSR panel and boundary copy
- Updates `MARKET_SURFACE_V0.md` from future contract to env-gated SSR v0
- Adds/extends webui tests and synthetic fixtures

## Env

```bash
export PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED=1
export PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON=/path/to/payload.json
```

Default: panel hidden (fail-closed).

## Boundaries

- `GET /market` only; `GET /market/double-play` unchanged
- No new route, readmodel, hook, Notion, S3, or runtime
- UI shows basename labels only (no full durable paths or `source_files`)
- Payload builder not invoked by SSR path

## Test plan

- [x] `pytest tests/webui/test_market_registry_projection_overlay_v0.py`
- [x] `pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- [x] `pytest tests/ops/test_market_dashboard_readonly_run_projection_spec_v0.py`
- [x] `ruff format` / `ruff check` on changed Python files

Made with [Cursor](https://cursor.com)