### PR TITLE
ops: notion post-closeout sync dry-run cli v0

### DIFF
--- a/scripts/ops/notion_post_closeout_sync_dry_run_v0.py
+++ b/scripts/ops/notion_post_closeout_sync_dry_run_v0.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Offline Notion post-closeout sync dry-run report (taxonomy §6a.1.1).
+
+Reads operator-supplied projection payload JSON only; emits a local dry-run report.
+Does not call Notion MCP/API, does not write to Notion, and does not enable write mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PAYLOAD_SCHEMA_VERSION = "peak_trade.post_closeout_projection_payload.v0"
+REPORT_SCHEMA_VERSION = "peak_trade.notion_post_closeout_sync_dry_run_report.v0"
+
+DEFAULT_TARGET_NAME = "Evidence & Closeouts"
+
+AUTHORITY_KEYS: tuple[str, ...] = (
+    "notion_authority",
+    "market_dashboard_authority",
+    "runtime_authority",
+    "scheduler_authority",
+    "daemon_authority",
+    "adapter_authority",
+    "s3_authority",
+    "workflow_dispatch_authority",
+    "broker_exchange_authority",
+    "testnet_authority",
+    "live_authority",
+    "master_v2_double_play_authority",
+)
+
+FORBIDDEN_REPORT_SUBSTRINGS: tuple[str, ...] = (
+    "source_files",
+    "/Users/",
+    "AKIA",
+    "sk-",
+    "Bearer ",
+)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _authority_object() -> dict[str, bool]:
+    return {key: False for key in AUTHORITY_KEYS}
+
+
+def _safe_basename(path_value: str | None) -> str:
+    if not path_value:
+        return "missing"
+    name = Path(path_value).name
+    return name if name else "configured"
+
+
+def _redact_target_id(file_path: Path) -> str | None:
+    if not file_path.is_file():
+        return None
+    digest = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    return digest[:8]
+
+
+def _load_payload(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, "PAYLOAD_MISSING"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None, "PAYLOAD_MALFORMED"
+    if not isinstance(data, dict):
+        return None, "PAYLOAD_MALFORMED"
+    if data.get("schema_version") != PAYLOAD_SCHEMA_VERSION:
+        return None, "PAYLOAD_SCHEMA_UNSUPPORTED"
+    return data, None
+
+
+def _authority_violation(payload: dict[str, Any]) -> bool:
+    authority = payload.get("authority")
+    if isinstance(authority, dict):
+        for key in AUTHORITY_KEYS:
+            if authority.get(key) is True:
+                return True
+    return False
+
+
+def _build_would_write_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    registry_pointer = payload.get("registry_pointer")
+    closeout_pointer = payload.get("closeout_pointer")
+    return {
+        "run_id": payload.get("run_id"),
+        "projection_ready": payload.get("projection_ready"),
+        "manifest_verify_rc": payload.get("manifest_verify_rc"),
+        "closeout_accepted": payload.get("closeout_accepted"),
+        "primary_evidence_finalized": payload.get("primary_evidence_finalized"),
+        "repo_commit": payload.get("repo_commit"),
+        "s3_export_status": payload.get("s3_export_status"),
+        "download_verify_rc": payload.get("download_verify_rc"),
+        "registry_configured": bool(registry_pointer),
+        "closeout_configured": bool(closeout_pointer),
+        "authority": _authority_object(),
+    }
+
+
+def build_dry_run_report(
+    *,
+    payload_path: Path,
+    target_name: str,
+    boundary_text_verified: bool,
+    target_id_file: Path | None = None,
+    payload_basename: str | None = None,
+) -> dict[str, Any]:
+    """Build dry-run report dict (does not write files)."""
+    payload, load_block = _load_payload(payload_path)
+    basename = payload_basename or payload_path.name
+
+    report: dict[str, Any] = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "generated_at_utc": _utc_now_iso(),
+        "dry_run": True,
+        "write_requested": False,
+        "write_allowed": False,
+        "notion_mcp_write_ready": False,
+        "notion_target_name_safe": target_name.strip() if target_name else "",
+        "notion_target_id_redacted": None,
+        "boundary_text_verified": boundary_text_verified,
+        "projection_ready": False,
+        "blocked_reason": load_block,
+        "would_create": False,
+        "would_update": False,
+        "would_write_fields": _build_would_write_fields(payload or {}),
+        "source": {
+            "projection_payload_basename": basename,
+            "registry_pointer_safe": "missing",
+            "closeout_pointer_safe": "missing",
+        },
+    }
+
+    if target_id_file is not None:
+        report["notion_target_id_redacted"] = _redact_target_id(target_id_file)
+
+    if payload is None:
+        return report
+
+    report["projection_ready"] = bool(payload.get("projection_ready"))
+    report["would_write_fields"] = _build_would_write_fields(payload)
+    report["source"]["registry_pointer_safe"] = _safe_basename(
+        str(payload.get("registry_pointer") or "")
+    )
+    report["source"]["closeout_pointer_safe"] = _safe_basename(
+        str(payload.get("closeout_pointer") or "")
+    )
+
+    blocked: str | None = load_block
+
+    if not target_name.strip():
+        blocked = blocked or "TARGET_DB_NOT_APPROVED"
+    elif target_id_file is not None and not target_id_file.is_file():
+        blocked = blocked or "TARGET_DB_NOT_APPROVED"
+
+    if not boundary_text_verified:
+        blocked = blocked or "BOUNDARY_TEXT_NOT_VERIFIED"
+
+    if blocked is None and not payload.get("projection_ready"):
+        reason = payload.get("projection_blocked_reason")
+        blocked = str(reason) if reason else "PROJECTION_NOT_READY"
+
+    consumers = payload.get("consumers")
+    if blocked is None and isinstance(consumers, dict):
+        if not consumers.get("notion_projection_allowed"):
+            blocked = "NOTION_PROJECTION_NOT_ALLOWED"
+
+    if blocked is None and payload.get("manifest_verify_rc") != 0:
+        blocked = "MANIFEST_VERIFY_FAILED"
+
+    if blocked is None and not payload.get("closeout_accepted"):
+        blocked = "CLOSEOUT_NOT_ACCEPTED"
+
+    if blocked is None and not payload.get("primary_evidence_finalized"):
+        blocked = "PRIMARY_EVIDENCE_NOT_FINALIZED"
+
+    if blocked is None and _authority_violation(payload):
+        blocked = "UNSAFE_AUTHORITY_TRUE"
+
+    report["blocked_reason"] = blocked
+    report["projection_ready"] = bool(payload.get("projection_ready"))
+
+    if blocked is None:
+        report["would_update"] = True
+        report["would_create"] = False
+    else:
+        report["would_update"] = False
+        report["would_create"] = False
+
+    return report
+
+
+def _validate_report_redaction(report: dict[str, Any]) -> None:
+    text = json.dumps(report)
+    for forbidden in FORBIDDEN_REPORT_SUBSTRINGS:
+        if forbidden in text:
+            raise ValueError(f"report contains forbidden substring: {forbidden!r}")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--projection-payload-json", type=Path, required=True)
+    parser.add_argument(
+        "--target-name",
+        default=DEFAULT_TARGET_NAME,
+        help=f"Safe Notion database label (default: {DEFAULT_TARGET_NAME!r}).",
+    )
+    parser.add_argument(
+        "--target-id-file",
+        type=Path,
+        default=None,
+        help="Optional operator-local file with Notion target id; never echoed in full.",
+    )
+    parser.add_argument(
+        "--boundary-text-verified",
+        action="store_true",
+        help="Operator attestation that §6a.1 boundary copy is present on target DB.",
+    )
+    parser.add_argument("--output-report-json", type=Path, required=True)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 when report is blocked (default: exit 0 after writing report).",
+    )
+    parser.add_argument("--stdout", action="store_true", help="Also print report JSON to stdout.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = build_arg_parser().parse_args(argv)
+    except SystemExit as exc:
+        return 2 if exc.code not in (0, None) else 0
+
+    output_path = args.output_report_json.expanduser().resolve()
+    repo_root = _REPO_ROOT.resolve()
+    if repo_root in output_path.parents or output_path == repo_root:
+        print("ERROR: --output-report-json must not be inside the repository", file=sys.stderr)
+        return 2
+
+    payload_path = args.projection_payload_json.expanduser().resolve()
+    target_id_file = (
+        args.target_id_file.expanduser().resolve() if args.target_id_file is not None else None
+    )
+
+    try:
+        report = build_dry_run_report(
+            payload_path=payload_path,
+            target_name=args.target_name,
+            boundary_text_verified=args.boundary_text_verified,
+            target_id_file=target_id_file,
+            payload_basename=payload_path.name,
+        )
+        _validate_report_redaction(report)
+    except OSError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 — CLI boundary
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.stdout:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    blocked = report.get("blocked_reason")
+    if args.strict and blocked:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_notion_post_closeout_sync_dry_run_v0.py
+++ b/tests/ops/test_notion_post_closeout_sync_dry_run_v0.py
@@ -1,0 +1,340 @@
+"""Tests for notion_post_closeout_sync_dry_run_v0 (offline Notion dry-run report CLI)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DRY_RUN_CLI = REPO_ROOT / "scripts/ops/notion_post_closeout_sync_dry_run_v0.py"
+BUILDER = REPO_ROOT / "scripts/ops/build_post_closeout_projection_payload_v0.py"
+
+PAYLOAD_SCHEMA = "peak_trade.post_closeout_projection_payload.v0"
+REPORT_SCHEMA = "peak_trade.notion_post_closeout_sync_dry_run_report.v0"
+
+FORBIDDEN_CLI_SUBSTRINGS = (
+    "notion-",
+    "notion.",
+    "create_database",
+    "create_pages",
+    "update_page",
+    "move_pages",
+    "archive",
+    "httpx",
+    "requests.",
+    "--write",
+    "confirm-token",
+    "confirm_token",
+    "boto3",
+    "rclone",
+    "subprocess.run",
+    "Popen(",
+)
+
+FORBIDDEN_IMPORT_MARKERS = (
+    "import requests",
+    "from requests",
+    "import httpx",
+    "from httpx",
+)
+
+
+def _load_dry_run():
+    spec = importlib.util.spec_from_file_location(
+        "notion_post_closeout_sync_dry_run_v0", DRY_RUN_CLI
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _authority_false() -> dict[str, bool]:
+    return {
+        key: False
+        for key in (
+            "notion_authority",
+            "market_dashboard_authority",
+            "runtime_authority",
+            "scheduler_authority",
+            "daemon_authority",
+            "adapter_authority",
+            "s3_authority",
+            "workflow_dispatch_authority",
+            "broker_exchange_authority",
+            "testnet_authority",
+            "live_authority",
+            "master_v2_double_play_authority",
+        )
+    }
+
+
+def _valid_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": PAYLOAD_SCHEMA,
+        "generated_at_utc": "2026-05-26T00:00:00Z",
+        "run_id": "paper_run",
+        "projection_ready": True,
+        "projection_blocked_reason": None,
+        "manifest_verify_rc": 0,
+        "closeout_accepted": True,
+        "primary_evidence_finalized": True,
+        "registry_pointer": "registry.json",
+        "closeout_pointer": "closeout_bundle",
+        "repo_commit": "fd61ca07",
+        "s3_export_status": "disabled",
+        "download_verify_rc": None,
+        "authority": _authority_false(),
+        "consumers": {
+            "notion_projection_allowed": True,
+            "market_dashboard_projection_allowed": True,
+            "notion_write_allowed": False,
+            "dashboard_write_allowed": False,
+        },
+        "source_files": {
+            "registry_json": "/secret/path/registry.json",
+            "final_machine_lines": "/secret/path/FINAL_MACHINE_LINES.txt",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_payload(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _run_cli(
+    dry_run,
+    payload: Path,
+    out: Path,
+    *,
+    boundary: bool = True,
+    target_name: str = "Evidence & Closeouts",
+    target_id_file: Path | None = None,
+    strict: bool = False,
+) -> int:
+    argv = [
+        "--projection-payload-json",
+        str(payload),
+        "--target-name",
+        target_name,
+        "--output-report-json",
+        str(out),
+    ]
+    if boundary:
+        argv.append("--boundary-text-verified")
+    if target_id_file is not None:
+        argv.extend(["--target-id-file", str(target_id_file)])
+    if strict:
+        argv.append("--strict")
+    return dry_run.main(argv)
+
+
+@pytest.fixture(scope="module")
+def dry_run():
+    return _load_dry_run()
+
+
+def test_happy_dry_run(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(payload_path, _valid_payload())
+
+    rc = _run_cli(dry_run, payload_path, out)
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["schema_version"] == REPORT_SCHEMA
+    assert report["dry_run"] is True
+    assert report["write_requested"] is False
+    assert report["write_allowed"] is False
+    assert report["would_update"] is True
+    assert report["would_create"] is False
+    assert report["blocked_reason"] is None
+    assert report["boundary_text_verified"] is True
+    assert report["notion_target_name_safe"] == "Evidence & Closeouts"
+    assert all(v is False for v in report["would_write_fields"]["authority"].values())
+    assert report["source"]["projection_payload_basename"] == "payload.json"
+    assert "/secret" not in json.dumps(report)
+    assert "source_files" not in json.dumps(report)
+
+
+def test_projection_ready_false_blocked(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(
+        payload_path,
+        _valid_payload(projection_ready=False, projection_blocked_reason="REGISTRY_FAIL_CLOSED"),
+    )
+
+    rc = _run_cli(dry_run, payload_path, out)
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["would_update"] is False
+    assert report["blocked_reason"] == "REGISTRY_FAIL_CLOSED"
+
+
+def test_notion_projection_not_allowed(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    consumers = {
+        "notion_projection_allowed": False,
+        "market_dashboard_projection_allowed": True,
+        "notion_write_allowed": False,
+        "dashboard_write_allowed": False,
+    }
+    _write_payload(payload_path, _valid_payload(consumers=consumers))
+
+    rc = _run_cli(dry_run, payload_path, out)
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["blocked_reason"] == "NOTION_PROJECTION_NOT_ALLOWED"
+
+
+def test_boundary_not_verified_blocked(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(payload_path, _valid_payload())
+
+    rc = _run_cli(dry_run, payload_path, out, boundary=False)
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["blocked_reason"] == "BOUNDARY_TEXT_NOT_VERIFIED"
+
+
+def test_boundary_not_verified_strict_exit_one(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(payload_path, _valid_payload())
+
+    rc = _run_cli(dry_run, payload_path, out, boundary=False, strict=True)
+    assert rc == 1
+
+
+def test_authority_violation_blocked(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    authority = _authority_false()
+    authority["live_authority"] = True
+    _write_payload(payload_path, _valid_payload(authority=authority))
+
+    rc = _run_cli(dry_run, payload_path, out)
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["blocked_reason"] == "UNSAFE_AUTHORITY_TRUE"
+
+
+def test_wrong_schema_blocked(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(payload_path, _valid_payload(schema_version="peak_trade.other.v0"))
+
+    rc = _run_cli(dry_run, payload_path, out)
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["blocked_reason"] == "PAYLOAD_SCHEMA_UNSUPPORTED"
+
+
+def test_malformed_payload_blocked(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    payload_path.write_text("{not json", encoding="utf-8")
+
+    rc = _run_cli(dry_run, payload_path, out)
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["blocked_reason"] == "PAYLOAD_MALFORMED"
+
+
+def test_output_path_inside_repo_exit_two(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    _write_payload(payload_path, _valid_payload())
+    out = REPO_ROOT / "tmp_forbidden_report.json"
+    try:
+        rc = _run_cli(dry_run, payload_path, out)
+        assert rc == 2
+    finally:
+        if out.exists():
+            out.unlink()
+
+
+def test_target_id_redaction(dry_run, tmp_path):
+    raw_id = "85f00bc3-a934-476a-9b16-9ec295dc00b3"
+    id_file = tmp_path / "notion_target_id.txt"
+    id_file.write_text(raw_id + "\n", encoding="utf-8")
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(payload_path, _valid_payload())
+
+    rc = _run_cli(dry_run, payload_path, out, target_id_file=id_file)
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert raw_id not in text
+    report = json.loads(text)
+    assert report["notion_target_id_redacted"]
+    assert len(report["notion_target_id_redacted"]) == 8
+
+
+def test_input_payload_unchanged(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(payload_path, _valid_payload())
+    before = payload_path.read_bytes()
+
+    rc = _run_cli(dry_run, payload_path, out)
+    assert rc == 0
+    assert payload_path.read_bytes() == before
+
+
+def test_no_mcp_or_write_in_cli_source():
+    text = DRY_RUN_CLI.read_text(encoding="utf-8")
+    help_text = _load_dry_run().build_arg_parser().format_help()
+    for marker in FORBIDDEN_IMPORT_MARKERS:
+        assert marker not in text
+    for sub in FORBIDDEN_CLI_SUBSTRINGS:
+        assert sub not in help_text
+    assert "notion_post_closeout_sync_dry_run" in text
+
+
+def test_manifest_verify_failed_blocked(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(payload_path, _valid_payload(manifest_verify_rc=1))
+
+    rc = _run_cli(dry_run, payload_path, out)
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["blocked_reason"] == "MANIFEST_VERIFY_FAILED"
+
+
+def test_empty_target_name_blocked(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    out = tmp_path / "report.json"
+    _write_payload(payload_path, _valid_payload())
+
+    rc = _run_cli(dry_run, payload_path, out, target_name="  ")
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["blocked_reason"] == "TARGET_DB_NOT_APPROVED"
+
+
+def test_build_dry_run_report_unit(dry_run, tmp_path):
+    payload_path = tmp_path / "payload.json"
+    _write_payload(payload_path, _valid_payload())
+    report = dry_run.build_dry_run_report(
+        payload_path=payload_path,
+        target_name="Evidence & Closeouts",
+        boundary_text_verified=True,
+    )
+    assert report["schema_version"] == REPORT_SCHEMA
+    assert (
+        "NOTION_DRY_RUN_WRITER_DEFAULT_DRY_RUN=true"
+        in pc.POST_CLOSEOUT_NOTION_DRY_RUN_WRITER_PLANNING_MARKERS
+    )


### PR DESCRIPTION
## Summary

Adds an offline Notion Post-Closeout Sync Dry-run CLI v0.

The CLI reads a `peak_trade.post_closeout_projection_payload.v0` payload and writes a local `peak_trade.notion_post_closeout_sync_dry_run_report.v0` report to an operator-provided path outside the repo.

This PR implements dry-run reporting only. It does not use MCP, does not call the Notion API, and does not implement write mode.

## Changes

- Adds `scripts/ops/notion_post_closeout_sync_dry_run_v0.py`
- Adds `tests/ops/test_notion_post_closeout_sync_dry_run_v0.py`
- Implements fail-closed gates from Taxonomy §6a.1.1
- Adds redaction for target IDs and source pointers
- Rejects repo-local output paths
- Preserves all source input files unchanged

## CLI

```bash
python3 scripts/ops/notion_post_closeout_sync_dry_run_v0.py \
  --projection-payload-json <path> \
  --target-name "Evidence & Closeouts" \
  --boundary-text-verified \
  --output-report-json /tmp/notion_dry_run_report.json
```

Optional: `--target-id-file <operator-local-path>`, `--strict` (exit 1 when blocked).

## Safety Boundaries

- No Notion MCP / API
- No `--write` flag
- No confirm-token write mode
- No Notion DB/page creation or destructive operations
- No payload builder execution in CI slice
- No projection/report JSON committed to repo
- No Market overlay, Dashboard, hook, runtime, S3, workflow dispatch, broker/exchange, testnet/live changes

## Checks

- `tests/ops/test_notion_post_closeout_sync_dry_run_v0.py` (15 tests)
- Related ops projection tests green locally
- ruff check/format on new files

Made with [Cursor](https://cursor.com)