### PR TITLE
test: post-closeout automation hook contract v0

### DIFF
--- a/tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py
+++ b/tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py
@@ -291,7 +291,7 @@ def _synthetic_future_hook_plan_inputs(
     paths: dict[str, Path],
 ) -> PostCloseoutHookContractInputs:
     """Offline synthetic future-hook plan after finalized evidence + full chain (tests only)."""
-    closeout = paths["closeout"]
+    durable_root = paths["durable_closeout_root"]
     return PostCloseoutHookContractInputs(
         readiness=replace(
             _synthetic_chain_readiness_inputs(paths),
@@ -299,7 +299,7 @@ def _synthetic_future_hook_plan_inputs(
             claimed_full_post_closeout_automation_implemented=True,
         ),
         run_completed=True,
-        finalized_evidence_root=closeout,
+        finalized_evidence_root=durable_root,
         hook_attaches_after_run_completion=True,
         reuses_chain_owners=True,
     )
@@ -448,127 +448,118 @@ def _run_chain_phases_2_through_9(
     run_dir = _write_archive_shadow_run(archive, run_id)
 
     closeout_dest = closeout_tests._archive_like_dest(tmp_path, "closeout_dest")
-    try:
-        closeout_helper = closeout_tests._load_helper()
-        rc = closeout_helper.main(
+    closeout_tests._cleanup_archive_like_dest(closeout_dest)
+    closeout_helper = closeout_tests._load_helper()
+    rc = closeout_helper.main(
+        [
+            "--source-dir",
+            str(run_dir),
+            "--dest-dir",
+            str(closeout_dest),
+            *closeout_tests._tmp_source_args(),
+            "--force",
+        ]
+    )
+    assert rc == 0, "phase 2 durable closeout copy failed"
+    assert (closeout_dest / "DURABLE_COPY_README.md").is_file()
+    assert (closeout_dest / "MANIFEST.sha256").is_file()
+
+    _write_final_machine_lines(closeout_dest, complete=complete_machine_lines)
+    write_manifest_sha256(closeout_dest)
+    ok, msg = verify_manifest_sha256(closeout_dest)
+    assert ok, f"phase 3 manifest verify: {msg}"
+
+    projection_dir = work / "projection"
+    projection_dir.mkdir()
+    registry_json = projection_dir / "registry.json"
+    assert _run_registry_build(archive, registry_json) == 0
+
+    payload_json = projection_dir / "projection_payload.json"
+    builder = payload_tests._load_builder()
+    payload_rc, _, payload_err = _run_payload_strict(
+        builder, closeout_dest, registry_json, payload_json, run_id
+    )
+
+    notion_report = projection_dir / "notion_dry_run_report.json"
+    dry_run = chain_smoke._load_module(chain_smoke.DRY_RUN_SCRIPT, "notion_dry_run_chain_contract")
+
+    if not complete_machine_lines:
+        assert payload_rc == 1
+        assert "projection_blocked_reason=missing_boundary_flags" in payload_err
+        return {"closeout": closeout_dest, "projection_dir": projection_dir}
+
+    assert payload_rc == 0, payload_err
+    payload = json.loads(payload_json.read_text(encoding="utf-8"))
+    assert payload["projection_ready"] is True
+
+    notion_argv = [
+        "--projection-payload-json",
+        str(payload_json),
+        "--target-name",
+        "Evidence & Closeouts",
+        "--boundary-text-verified",
+        "--output-report-json",
+        str(notion_report),
+        "--strict",
+    ]
+    assert dry_run.main(notion_argv) == 0
+    report = json.loads(notion_report.read_text(encoding="utf-8"))
+    assert report["write_allowed"] is False
+    assert report["dry_run"] is True
+
+    hints = projection_dir / "MARKET_OVERLAY_HINTS.txt"
+    hints.write_text(
+        "\n".join(
             [
-                "--source-dir",
-                str(run_dir),
-                "--dest-dir",
-                str(closeout_dest),
-                *closeout_tests._tmp_source_args(),
-                "--force",
+                "MARKET_OVERLAY_GLOBAL_ENABLED=false",
+                f"PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON={payload_json}",
+                "HANDOFF_HINT_ONLY=true",
             ]
         )
-        assert rc == 0, "phase 2 durable closeout copy failed"
-        assert (closeout_dest / "DURABLE_COPY_README.md").is_file()
-        assert (closeout_dest / "MANIFEST.sha256").is_file()
+        + "\n",
+        encoding="utf-8",
+    )
+    assert "PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED" not in hints.read_text()
 
-        _write_final_machine_lines(closeout_dest, complete=complete_machine_lines)
-        write_manifest_sha256(closeout_dest)
-        ok, msg = verify_manifest_sha256(closeout_dest)
-        assert ok, f"phase 3 manifest verify: {msg}"
-
-        projection_dir = work / "projection"
-        projection_dir.mkdir()
-        registry_json = projection_dir / "registry.json"
-        assert _run_registry_build(archive, registry_json) == 0
-
-        payload_json = projection_dir / "projection_payload.json"
-        builder = payload_tests._load_builder()
-        payload_rc, _, payload_err = _run_payload_strict(
-            builder, closeout_dest, registry_json, payload_json, run_id
+    duration_path = projection_dir / "DURATION_CONTRACT_VALIDATION.txt"
+    manifest_path = closeout_dest / "wrapper_evidence" / "manifest.json"
+    meta = json.loads(manifest_path.read_text(encoding="utf-8"))
+    duration_path.write_text(
+        "\n".join(
+            [
+                "WALL_CLOCK_VALIDATION_REQUIRED=true",
+                "OBSERVED_DURATION_SECONDS=596",
+                "EXPECTED_DURATION_SECONDS=600",
+                f"steps_emitted={meta.get('steps_emitted', 0)}",
+                f"step_interval_seconds={meta.get('step_interval_seconds', 0)}",
+                "PAYLOAD_PROJECTION_READY_NOT_WALL_CLOCK_EVIDENCE=true",
+            ]
         )
+        + "\n",
+        encoding="utf-8",
+    )
+    duration_text = duration_path.read_text(encoding="utf-8")
+    assert "OBSERVED_DURATION_SECONDS=" in duration_text
+    assert "PAYLOAD_PROJECTION_READY_NOT_WALL_CLOCK_EVIDENCE=true" in duration_text
 
-        notion_report = projection_dir / "notion_dry_run_report.json"
-        dry_run = chain_smoke._load_module(
-            chain_smoke.DRY_RUN_SCRIPT, "notion_dry_run_chain_contract"
-        )
+    serialized_payload = json.dumps(payload)
+    for forbidden in (
+        "OBSERVED_DURATION_SECONDS",
+        "WALL_CLOCK_VALIDATION",
+        "step_interval_seconds",
+    ):
+        assert forbidden not in serialized_payload
 
-        if not complete_machine_lines:
-            assert payload_rc == 1
-            assert "projection_blocked_reason=missing_boundary_flags" in payload_err
-            return {"closeout": closeout_dest, "projection_dir": projection_dir}
+    _projection_manifest_verify(projection_dir)
 
-        assert payload_rc == 0, payload_err
-        payload = json.loads(payload_json.read_text(encoding="utf-8"))
-        assert payload["projection_ready"] is True
-
-        notion_argv = [
-            "--projection-payload-json",
-            str(payload_json),
-            "--target-name",
-            "Evidence & Closeouts",
-            "--boundary-text-verified",
-            "--output-report-json",
-            str(notion_report),
-            "--strict",
-        ]
-        assert dry_run.main(notion_argv) == 0
-        report = json.loads(notion_report.read_text(encoding="utf-8"))
-        assert report["write_allowed"] is False
-        assert report["dry_run"] is True
-
-        hints = projection_dir / "MARKET_OVERLAY_HINTS.txt"
-        hints.write_text(
-            "\n".join(
-                [
-                    "MARKET_OVERLAY_GLOBAL_ENABLED=false",
-                    f"PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON={payload_json}",
-                    "HANDOFF_HINT_ONLY=true",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-        assert "PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED" not in hints.read_text()
-
-        duration_path = projection_dir / "DURATION_CONTRACT_VALIDATION.txt"
-        manifest_path = closeout_dest / "wrapper_evidence" / "manifest.json"
-        meta = json.loads(manifest_path.read_text(encoding="utf-8"))
-        duration_path.write_text(
-            "\n".join(
-                [
-                    "WALL_CLOCK_VALIDATION_REQUIRED=true",
-                    "OBSERVED_DURATION_SECONDS=596",
-                    "EXPECTED_DURATION_SECONDS=600",
-                    f"steps_emitted={meta.get('steps_emitted', 0)}",
-                    f"step_interval_seconds={meta.get('step_interval_seconds', 0)}",
-                    "PAYLOAD_PROJECTION_READY_NOT_WALL_CLOCK_EVIDENCE=true",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-        duration_text = duration_path.read_text(encoding="utf-8")
-        assert "OBSERVED_DURATION_SECONDS=" in duration_text
-        assert "PAYLOAD_PROJECTION_READY_NOT_WALL_CLOCK_EVIDENCE=true" in duration_text
-
-        serialized_payload = json.dumps(payload)
-        for forbidden in (
-            "OBSERVED_DURATION_SECONDS",
-            "WALL_CLOCK_VALIDATION",
-            "step_interval_seconds",
-        ):
-            assert forbidden not in serialized_payload
-
-        _projection_manifest_verify(projection_dir)
-
-        # ``closeout_dest`` lives under repo ``out/`` and is removed in ``finally``; keep a tmp_path
-        # snapshot so readiness checks can still inspect durable closeout layout after return.
-        closeout_snapshot = work / "closeout_readiness_snapshot"
-        if closeout_snapshot.exists():
-            shutil.rmtree(closeout_snapshot)
-        shutil.copytree(closeout_dest, closeout_snapshot)
-
-        return {
-            "closeout": closeout_snapshot,
-            "projection_dir": projection_dir,
-            "payload_json": payload_json,
-            "notion_report": notion_report,
-        }
-    finally:
-        closeout_tests._cleanup_archive_like_dest(closeout_dest)
+    # ``closeout_dest`` lives under repo ``out/`` (outside ``/tmp``) for readiness/hook checks.
+    return {
+        "closeout": closeout_dest,
+        "durable_closeout_root": closeout_dest,
+        "projection_dir": projection_dir,
+        "payload_json": payload_json,
+        "notion_report": notion_report,
+    }
 
 
 @pytest.fixture(scope="module")
@@ -934,8 +925,12 @@ def test_hook_contract_false_when_projection_manifest_verify_not_ok(tmp_path: Pa
 
 def test_hook_contract_true_offline_synthetic_future_hook_plan(tmp_path: Path) -> None:
     paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
-    ok, blockers = build_post_closeout_hook_contract_summary(
-        _synthetic_future_hook_plan_inputs(paths)
-    )
-    assert ok is True
-    assert blockers == []
+    try:
+        assert not is_under_tmp(paths["durable_closeout_root"])
+        ok, blockers = build_post_closeout_hook_contract_summary(
+            _synthetic_future_hook_plan_inputs(paths)
+        )
+        assert ok is True
+        assert blockers == []
+    finally:
+        closeout_tests._cleanup_archive_like_dest(paths["durable_closeout_root"])

--- a/tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py
+++ b/tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py
@@ -26,7 +26,11 @@ from pathlib import Path
 
 import pytest
 
-from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256, write_manifest_sha256
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
 from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
 from tests.ops import test_build_post_closeout_projection_payload_v0 as payload_tests
 from tests.ops import test_closeout_final_machine_lines_contract_v0 as ml_contract
@@ -74,6 +78,39 @@ class PostCloseoutAutomationReadinessInputs:
     hook_automation_owner_status: str = "not_implemented"
     claimed_full_post_closeout_automation_implemented: bool = False
     notion_write_occurred: bool = False
+
+
+@dataclass(frozen=True)
+class PostCloseoutHookContractInputs:
+    """Synthetic future post-closeout hook adapter contract (tests only; not production API)."""
+
+    readiness: PostCloseoutAutomationReadinessInputs
+    run_completed: bool = False
+    finalized_evidence_root: Path | None = None
+    hook_attaches_after_run_completion: bool = False
+    reuses_chain_owners: bool = False
+    bypasses_chain_owners: bool = False
+    attempts_notion_write: bool = False
+    attempts_notion_mcp: bool = False
+    attempts_notion_api: bool = False
+    attempts_market_global_enablement: bool = False
+    attempts_launchctl: bool = False
+    attempts_plist_install: bool = False
+    attempts_daemon_install: bool = False
+    attempts_testnet: bool = False
+    attempts_live: bool = False
+    attempts_broker_exchange: bool = False
+    attempts_s3_aws_rclone: bool = False
+    attempts_workflow_dispatch: bool = False
+    uses_dashboard_route_as_authority: bool = False
+
+
+CANONICAL_HOOK_CHAIN_OWNER_SCRIPTS: tuple[str, ...] = (
+    "durable_closeout_copy_verify_v0.py",
+    "build_generic_evidence_run_registry_v1.py",
+    "build_post_closeout_projection_payload_v0.py",
+    "notion_post_closeout_sync_dry_run_v0.py",
+)
 
 
 def _parse_machine_lines_file(path: Path) -> dict[str, str]:
@@ -188,6 +225,84 @@ def build_post_closeout_automation_readiness_summary(
                 blockers.append(f"authority_boundary:{key}")
 
     return (len(blockers) == 0, blockers)
+
+
+def build_post_closeout_hook_contract_summary(
+    inp: PostCloseoutHookContractInputs,
+) -> tuple[bool, list[str]]:
+    """Return (hook_contract_ok, blockers) for a future offline hook adapter plan (tests only)."""
+    blockers: list[str] = []
+
+    if not inp.run_completed:
+        blockers.append("hook_attach_before_run_completion")
+    if not inp.hook_attaches_after_run_completion:
+        blockers.append("hook_must_attach_after_run_completion")
+
+    if inp.finalized_evidence_root is None:
+        blockers.append("finalized_evidence_root_missing")
+    elif is_under_tmp(inp.finalized_evidence_root):
+        blockers.append("finalized_evidence_root_under_tmp")
+
+    if inp.bypasses_chain_owners:
+        blockers.append("hook_must_not_bypass_chain_owners")
+    if inp.run_completed and inp.hook_attaches_after_run_completion and not inp.reuses_chain_owners:
+        blockers.append("hook_must_reuse_chain_owners")
+
+    if inp.attempts_notion_write:
+        blockers.append("hook_notion_write_forbidden")
+    if inp.attempts_notion_mcp:
+        blockers.append("hook_notion_mcp_forbidden")
+    if inp.attempts_notion_api:
+        blockers.append("hook_notion_api_forbidden")
+    if inp.attempts_market_global_enablement:
+        blockers.append("hook_market_global_enablement_forbidden")
+    if inp.attempts_launchctl:
+        blockers.append("hook_launchctl_forbidden")
+    if inp.attempts_plist_install:
+        blockers.append("hook_plist_install_forbidden")
+    if inp.attempts_daemon_install:
+        blockers.append("hook_daemon_install_forbidden")
+    if inp.attempts_testnet:
+        blockers.append("hook_testnet_forbidden")
+    if inp.attempts_live:
+        blockers.append("hook_live_forbidden")
+    if inp.attempts_broker_exchange:
+        blockers.append("hook_broker_exchange_forbidden")
+    if inp.attempts_s3_aws_rclone:
+        blockers.append("hook_s3_aws_rclone_forbidden")
+    if inp.attempts_workflow_dispatch:
+        blockers.append("hook_workflow_dispatch_forbidden")
+    if inp.uses_dashboard_route_as_authority:
+        blockers.append("hook_dashboard_route_authority_forbidden")
+
+    readiness_ok, readiness_blockers = build_post_closeout_automation_readiness_summary(
+        inp.readiness
+    )
+    if not readiness_ok:
+        for item in readiness_blockers:
+            prefixed = f"readiness:{item}"
+            if prefixed not in blockers:
+                blockers.append(prefixed)
+
+    return (len(blockers) == 0, blockers)
+
+
+def _synthetic_future_hook_plan_inputs(
+    paths: dict[str, Path],
+) -> PostCloseoutHookContractInputs:
+    """Offline synthetic future-hook plan after finalized evidence + full chain (tests only)."""
+    closeout = paths["closeout"]
+    return PostCloseoutHookContractInputs(
+        readiness=replace(
+            _synthetic_chain_readiness_inputs(paths),
+            hook_automation_owner_status="identified",
+            claimed_full_post_closeout_automation_implemented=True,
+        ),
+        run_completed=True,
+        finalized_evidence_root=closeout,
+        hook_attaches_after_run_completion=True,
+        reuses_chain_owners=True,
+    )
 
 
 def _synthetic_chain_readiness_inputs(
@@ -654,3 +769,173 @@ def test_readiness_false_when_payload_authority_boundary_violation(tmp_path: Pat
     ok, blockers = build_post_closeout_automation_readiness_summary(inp)
     assert ok is False
     assert "authority_boundary:live_authority" in blockers
+
+
+def test_hook_contract_reuse_drift_guard_exports_and_no_hook_script() -> None:
+    text = Path(__file__).read_text(encoding="utf-8")
+    assert "PostCloseoutHookContractInputs" in text
+    assert "build_post_closeout_hook_contract_summary" in text
+    for script in CANONICAL_HOOK_CHAIN_OWNER_SCRIPTS:
+        assert (REPO_ROOT / "scripts" / "ops" / script).is_file(), script
+    assert not (REPO_ROOT / "scripts/ops/post_closeout_chain_execute_v0.py").exists()
+
+
+def test_hook_contract_false_before_finalized_evidence_root(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    inp = replace(_synthetic_future_hook_plan_inputs(paths), finalized_evidence_root=None)
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "finalized_evidence_root_missing" in blockers
+
+
+def test_hook_contract_false_before_closeout_manifest_verify(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    readiness = replace(
+        _synthetic_chain_readiness_inputs(paths),
+        closeout_manifest_verify_ok=False,
+        hook_automation_owner_status="identified",
+        claimed_full_post_closeout_automation_implemented=True,
+    )
+    inp = replace(
+        _synthetic_future_hook_plan_inputs(paths),
+        readiness=readiness,
+    )
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "readiness:closeout_manifest_verify_not_ok" in blockers
+
+
+def test_hook_contract_false_when_hook_owner_not_identified_while_claiming_full_automation(
+    tmp_path: Path,
+) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    readiness = replace(
+        _synthetic_chain_readiness_inputs(paths),
+        hook_automation_owner_status="not_implemented",
+        claimed_full_post_closeout_automation_implemented=True,
+    )
+    inp = replace(
+        _synthetic_future_hook_plan_inputs(paths),
+        readiness=readiness,
+    )
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "readiness:full_automation_claim_requires_hook_owner_identified" in blockers
+
+
+def test_hook_contract_false_when_hook_attempts_notion_write(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    inp = replace(_synthetic_future_hook_plan_inputs(paths), attempts_notion_write=True)
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "hook_notion_write_forbidden" in blockers
+
+
+def test_hook_contract_false_when_hook_attempts_notion_mcp_or_api(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    for field, token in (
+        ("attempts_notion_mcp", "hook_notion_mcp_forbidden"),
+        ("attempts_notion_api", "hook_notion_api_forbidden"),
+    ):
+        inp = replace(_synthetic_future_hook_plan_inputs(paths), **{field: True})
+        ok, blockers = build_post_closeout_hook_contract_summary(inp)
+        assert ok is False
+        assert token in blockers
+
+
+def test_hook_contract_false_when_hook_attempts_market_global_enablement(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    inp = replace(_synthetic_future_hook_plan_inputs(paths), attempts_market_global_enablement=True)
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "hook_market_global_enablement_forbidden" in blockers
+
+
+def test_hook_contract_false_when_hook_attempts_launchctl_or_daemon_install(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    for field, token in (
+        ("attempts_launchctl", "hook_launchctl_forbidden"),
+        ("attempts_plist_install", "hook_plist_install_forbidden"),
+        ("attempts_daemon_install", "hook_daemon_install_forbidden"),
+    ):
+        inp = replace(_synthetic_future_hook_plan_inputs(paths), **{field: True})
+        ok, blockers = build_post_closeout_hook_contract_summary(inp)
+        assert ok is False
+        assert token in blockers
+
+
+def test_hook_contract_false_when_hook_attempts_runtime_promotion_paths(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    cases = (
+        ("attempts_testnet", "hook_testnet_forbidden"),
+        ("attempts_live", "hook_live_forbidden"),
+        ("attempts_broker_exchange", "hook_broker_exchange_forbidden"),
+        ("attempts_s3_aws_rclone", "hook_s3_aws_rclone_forbidden"),
+        ("attempts_workflow_dispatch", "hook_workflow_dispatch_forbidden"),
+    )
+    for field, token in cases:
+        inp = replace(_synthetic_future_hook_plan_inputs(paths), **{field: True})
+        ok, blockers = build_post_closeout_hook_contract_summary(inp)
+        assert ok is False
+        assert token in blockers
+
+
+def test_hook_contract_false_when_hook_bypasses_chain_owners(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    inp = replace(
+        _synthetic_future_hook_plan_inputs(paths),
+        reuses_chain_owners=False,
+        bypasses_chain_owners=True,
+    )
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "hook_must_not_bypass_chain_owners" in blockers
+    assert "hook_must_reuse_chain_owners" in blockers
+
+
+def test_hook_contract_false_when_hook_uses_dashboard_route_as_authority(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    inp = replace(
+        _synthetic_future_hook_plan_inputs(paths),
+        uses_dashboard_route_as_authority=True,
+    )
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "hook_dashboard_route_authority_forbidden" in blockers
+
+
+def test_hook_contract_false_when_manual_recovery_required(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    readiness = replace(
+        _synthetic_chain_readiness_inputs(paths),
+        manual_recovery_required=True,
+        hook_automation_owner_status="identified",
+        claimed_full_post_closeout_automation_implemented=True,
+    )
+    inp = replace(_synthetic_future_hook_plan_inputs(paths), readiness=readiness)
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "readiness:manual_recovery_required" in blockers
+
+
+def test_hook_contract_false_when_projection_manifest_verify_not_ok(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    readiness = replace(
+        _synthetic_chain_readiness_inputs(paths),
+        projection_manifest_verify_ok=False,
+        hook_automation_owner_status="identified",
+        claimed_full_post_closeout_automation_implemented=True,
+    )
+    inp = replace(_synthetic_future_hook_plan_inputs(paths), readiness=readiness)
+    ok, blockers = build_post_closeout_hook_contract_summary(inp)
+    assert ok is False
+    assert "readiness:projection_manifest_verify_not_ok" in blockers
+
+
+def test_hook_contract_true_offline_synthetic_future_hook_plan(tmp_path: Path) -> None:
+    paths = _run_chain_phases_2_through_9(tmp_path, complete_machine_lines=True)
+    ok, blockers = build_post_closeout_hook_contract_summary(
+        _synthetic_future_hook_plan_inputs(paths)
+    )
+    assert ok is True
+    assert blockers == []

--- a/tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py
+++ b/tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py
@@ -7,10 +7,9 @@ from pathlib import Path
 from tests.fixtures.ops.generic_evidence_run_registry_v1 import projection_consumer_v0 as pc
 from tests.ops.test_closeout_to_projection_chain_automation_contract_v0 import (
     CANONICAL_OWNERS,
-    build_post_closeout_automation_readiness_summary,
-)
-from tests.ops.test_closeout_to_projection_chain_automation_contract_v0 import (
     PostCloseoutAutomationReadinessInputs,
+    build_post_closeout_automation_readiness_summary,
+    build_post_closeout_hook_contract_summary,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -130,3 +129,10 @@ def test_chain_contract_readiness_gate_hook_owner_semantics() -> None:
     )
     assert ok is False
     assert "durable_closeout_missing" in blockers
+
+
+def test_chain_contract_exports_hook_contract_summary() -> None:
+    text = CHAIN_CONTRACT_TESTS.read_text(encoding="utf-8")
+    assert "PostCloseoutHookContractInputs" in text
+    assert "build_post_closeout_hook_contract_summary" in text
+    assert callable(build_post_closeout_hook_contract_summary)


### PR DESCRIPTION
## Summary

Adds a tests-only contract for a future Post-Closeout Automation Hook Adapter.

This builds on PR #3705, PR #3706, and PR #3707. It defines offline fail-closed expectations for a future hook path without implementing or installing any hook.

## Changes

- Extends `tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py`
- Adds `PostCloseoutHookContractInputs`
- Adds `build_post_closeout_hook_contract_summary()`
- Adds synthetic future-hook plan inputs
- Adds 13 fail-closed hook contract tests
- Adds 1 hook-owner crosslink test
- No new files
- No docs changes
- No production logic changes

## Hook Contract Boundaries

The future hook contract blocks readiness when a hook plan:

- starts before finalized evidence root
- lacks durable primary evidence
- lacks manifest verification
- bypasses existing chain owners
- requires manual recovery
- attempts Notion write/MCP/API
- attempts Market global enablement
- attempts launchctl/plist/daemon install
- attempts Testnet/Live/Broker/Exchange/S3/workflow_dispatch
- uses Dashboard route/view as authority

## Positive Offline Scenario

Readiness is true only for a synthetic future hook plan that:

- starts after finalized evidence root
- reuses existing chain owners
- keeps Notion dry-run/write_allowed=false
- keeps Market default-off
- has manual_recovery_required=false
- has all manifests verified
- creates no authority side effects

## Reuse / Drift Guard

- REUSE_BEFORE_NEW_CHECK=true
- REUSE_DRIFT_GUARD_APPLIED=true
- NO_PARALLEL_BUILDS=true
- NO_PARALLEL_DOCS=true
- CANONICAL_OWNERS_IDENTIFIED=true
- NEW_TEST_FILE_CREATED=false
- NEW_SURFACE_CREATED=false
- Extends existing chain/readiness tests instead of creating a second hook surface

## Safety Boundaries

- Tests-only
- No production code changes
- No docs changes
- No runtime/scheduler/daemon/adapter execution
- No payload builder on real data
- No Notion dry-run on real data
- No Notion write/MCP/API
- No Market overlay enablement
- No hook install
- No launchctl/plist changes
- No S3/AWS/rclone
- No workflow dispatch
- No broker/exchange
- No Testnet/Live
- No Master V2 / Double Play authority change
- No paper/test data mutation
- No durable source evidence mutation

## Checks

- Hook precheck + chain: 41 passed
- Related chain tests: 39 passed
- Ruff: passed
- LONG_CIT_ATTESTS_TRIGGERED=false

## Durable report

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260525T210741Z/projection/post_closeout_automation_hook_contract_pr_ready_20260527T143807Z`

MANIFEST_VERIFY_RC=0

Made with [Cursor](https://cursor.com)