### PR TITLE
fix(ci): exclude tests/ci and tests/ops from code paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   # - workflow_only: true when ONLY .github/workflows changed.
   # - static_contract_changed: tests/ci/** or tests/ops/** (CI/ops contract tests; not full-matrix code).
   # - docs_or_static_contract_only: no src/scripts/config/workflow code paths; docs and/or static-contract only.
-  # Code paths: src/**, tests/** (except tests/ci/**, tests/ops/**), scripts/**, config/**, schemas/levelup/**, deps, Makefile.
+  # Code paths: src/**, tests/!(ci|ops)/** (excludes tests/ci/**, tests/ops/**), scripts/**, config/**, schemas/levelup/**, deps, Makefile.
   # ============================================================================
   changes:
     runs-on: ubuntu-latest
@@ -62,9 +62,7 @@ jobs:
           filters: |
             code:
               - 'src/**'
-              - 'tests/**'
-              - '!tests/ci/**'
-              - '!tests/ops/**'
+              - 'tests/!(ci|ops)/**'
               - 'scripts/**'
               - 'config/**'
               - 'schemas/levelup/**'

--- a/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
+++ b/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
@@ -27,8 +27,11 @@ def test_code_filter_excludes_tests_ci_and_ops_buckets() -> None:
     assert "static_contract:" in text
     assert "'tests/ci/**'" in text
     assert "'tests/ops/**'" in text
-    assert "'!tests/ci/**'" in text
-    assert "'!tests/ops/**'" in text
+    assert "'tests/!(ci|ops)/**'" in text
+    code_block_start = text.index("            code:")
+    code_block_end = text.index("            static_contract:")
+    code_block = text[code_block_start:code_block_end]
+    assert "'tests/**'" not in code_block
 
 
 def test_matrix_jobs_keep_no_job_level_if_and_short_circuit_skip() -> None:


### PR DESCRIPTION
## Summary

Fixes the CI paths-filter behavior observed after PR #3712.

PR #3712 changed only docs/static-contract surfaces, but the full Python matrix still ran because `tests/ci/**` matched the broad `tests/**` code filter under `dorny/paths-filter@v3` with the default `predicate-quantifier: some`.

This PR replaces the broad `tests/**` + ineffective negation pattern with a picomatch extended glob:

- `tests/!(ci|ops)/**`

and updates the existing static contract test accordingly.

## Scope

Changed files only:

- `.github/workflows/ci.yml`
- `tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py`

## Guardrails

- Reuses existing CI workflow owner.
- Reuses existing contract-test owner.
- No parallel workflow.
- No parallel documentation.
- No runtime/trading/scheduler/paper/shadow/testnet/live changes.
- Keeps real code and non-static test changes on the full matrix path.

## Local validation

- `python3 -m pytest -q tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py`

## Expected behavior

A PR touching only `docs/**` plus `tests/ci/**` or `tests/ops/**` should remain Fast-Lane/static-contract eligible and should not force `code_changed=true`.

Real changes under `src/**`, `scripts/**`, or non-static test paths should still trigger the full matrix.

Made with [Cursor](https://cursor.com)