### PR TITLE
test(webui): guard market ranking funnel producer charter

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -743,3 +743,47 @@ def test_double_play_market_dashboard_excludes_run_projection_landmark_v0(
 
     assert "market-v0-landmark-run-projection-h2" not in html
     assert 'data-market-v0-run-projection="true"' not in html
+
+
+def test_market_surface_ranking_funnel_producer_charter_v0() -> None:
+    """Market Ranking Funnel Producer v0 charter stays read-only and non-authorizing."""
+    market_surface_doc = "docs/webui/MARKET_SURFACE_V0.md"
+    surface = (project_root / market_surface_doc).read_text(encoding="utf-8")
+
+    required_tokens = [
+        "### Market Ranking Funnel Producer v0 (read-only charter)",
+        "market_ranking_funnel_readmodel.v0",
+        "PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED=1",
+        "GET &#47;market",
+        "&#47;market&#47;double-play",
+        "&#47;api&#47;market&#47;ranking",
+        "endpoint in v0",
+        "tests/webui/test_market_dashboard_readonly_structure_contract_v0.py",
+        "DASHBOARD_AUTHORITY_CHANGED=false",
+        "RANKING_PRODUCER_AUTHORIZES_TRADES=false",
+        "FuturesRankingSnapshot",
+        "must not be directly wired",
+        "non_authorizing=true",
+        "universe",
+        "shortlist",
+        "selected",
+    ]
+
+    for token in required_tokens:
+        assert token in surface
+
+    forbidden_promotions = [
+        "trade signal",
+        "approval",
+        "readiness",
+        "live authorization",
+        "strategy activation",
+        "Master V2",
+        "Double Play trading input",
+    ]
+
+    forbidden_section_start = surface.index("Forbidden promotions:")
+    forbidden_section = surface[forbidden_section_start:]
+
+    for token in forbidden_promotions:
+        assert token in forbidden_section


### PR DESCRIPTION
## Summary

Adds a structure-contract guard for the Market Ranking Funnel Producer v0 charter in `MARKET_SURFACE_V0.md`.

The test asserts the charter preserves:

- readmodel id
- env gate
- route scope
- Double-Play exclusion
- no v0 ranking API endpoint
- structure-contract owner
- non-authority markers
- forbidden direct Master V2 / FuturesRankingSnapshot wiring
- stage names

## Scope

Changed files:

- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Guardrails

- Reuses existing Market Dashboard structure-contract owner.
- No new test surface.
- No docs changes.
- No template/backend/runtime changes.
- No new route.
- No polling.
- No broker/exchange/runtime authority.
- Dashboard remains read-only and non-authorizing.
- Ranking producer does not authorize trades.

## Local validation

- `python3 -m pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -k "ranking_funnel_producer_charter or ranking_funnel" -q`
- `python3 -m ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## CI expectation

Touches `tests/webui/**`; full matrix is expected.

Made with [Cursor](https://cursor.com)