### PR TITLE
test(ops): guard market ranking funnel env schema boundary

### DIFF
--- a/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
+++ b/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
@@ -1,0 +1,54 @@
+"""Docs contract for Market Ranking Funnel Producer v0 env/schema boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_market_surface_ranking_funnel_env_schema_boundary_v0() -> None:
+    """Ranking funnel env/schema boundary stays pinned before implementation."""
+    surface = (PROJECT_ROOT / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")
+
+    required_tokens = [
+        "PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED=1",
+        "PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT",
+        "market_ranking_funnel_readmodel.v0",
+        "tests&#47;fixtures&#47;market_ranking_funnel_readmodel_v0&#47;",
+        "readmodel_id",
+        "generated_at_iso",
+        "source",
+        "stale",
+        "stale_reason",
+        "non_authorizing=true",
+        "stages.universe[]",
+        "stages.shortlist[]",
+        "stages.selected[]",
+        "row_id",
+        "symbol",
+        "rank",
+        "display_score",
+        "notes",
+        "&#47;api&#47;market&#47;ranking",
+    ]
+
+    for token in required_tokens:
+        assert token in surface
+
+    charter_start = surface.index("### Market Ranking Funnel Producer v0")
+    marker_start = surface.index("### Marker / IA crosswalk policy v0")
+    charter = surface[charter_start:marker_start]
+
+    forbidden_payload_tokens = [
+        "order_id",
+        "side",
+        "quantity",
+        "leverage",
+        "approval=true",
+        "live_authorized=true",
+        "strategy_activation=true",
+    ]
+
+    for token in forbidden_payload_tokens:
+        assert token not in charter


### PR DESCRIPTION
## Summary

Adds an ops/static-contract guard for the Market Ranking Funnel Producer v0 env/schema boundary added in PR #3719.

The test asserts the existing Market Surface contract keeps:

- ranking funnel env gate
- canonical bundle root
- readmodel id
- future fixture target
- minimal JSON envelope fields
- stage arrays
- display row fields
- no v0 ranking API endpoint
- no execution/order/live authorization payload fields in the charter section

## Scope

Changed files:

- `tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`

## Guardrails

- Reuses existing Market Surface contract.
- No docs changes.
- No webui tests touched.
- No templates, backend, runtime, fixtures, routes, polling, broker, or exchange changes.
- Dashboard remains read-only and non-authorizing.
- Ranking producer does not authorize trades.

## Local validation

- `python3 -m pytest tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py -q`
- `python3 -m ruff check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`

## CI expectation

Touches `tests/ops/**` only; expected static-contract/short-CI path, not full webui matrix.

Made with [Cursor](https://cursor.com)