### PR TITLE
feat(webui): add market ranking funnel readmodel v0

### DIFF
--- a/src/webui/market_ranking_funnel_readmodel_v0/__init__.py
+++ b/src/webui/market_ranking_funnel_readmodel_v0/__init__.py
@@ -1,0 +1,11 @@
+"""Read-only Market Ranking Funnel readmodel v0."""
+
+from .builder import (
+    MarketRankingFunnelReadmodelError,
+    build_market_ranking_funnel_readmodel,
+)
+
+__all__ = [
+    "MarketRankingFunnelReadmodelError",
+    "build_market_ranking_funnel_readmodel",
+]

--- a/src/webui/market_ranking_funnel_readmodel_v0/builder.py
+++ b/src/webui/market_ranking_funnel_readmodel_v0/builder.py
@@ -1,0 +1,148 @@
+"""Offline read-only Market Ranking Funnel readmodel v0 builder."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+READMODEL_ID = "market_ranking_funnel_readmodel.v0"
+STAGES = ("universe", "shortlist", "selected")
+FORBIDDEN_ROW_FIELDS = {
+    "order_id",
+    "side",
+    "quantity",
+    "leverage",
+    "approval",
+    "approved",
+    "live_authorized",
+    "strategy_activation",
+}
+
+
+class MarketRankingFunnelReadmodelError(ValueError):
+    """Raised when the ranking funnel readmodel payload is invalid."""
+
+
+def _as_mapping(value: Any, *, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MarketRankingFunnelReadmodelError(f"{field} must be an object")
+    return value
+
+
+def _as_bool(value: Any, *, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise MarketRankingFunnelReadmodelError(f"{field} must be a boolean")
+    return value
+
+
+def _as_optional_string(value: Any, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise MarketRankingFunnelReadmodelError(f"{field} must be a string or null")
+    return value
+
+
+def _as_string(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise MarketRankingFunnelReadmodelError(f"{field} must be a non-empty string")
+    return value
+
+
+def _as_int(value: Any, *, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise MarketRankingFunnelReadmodelError(f"{field} must be an integer")
+    return value
+
+
+def _normalize_row(row: Any, *, stage: str, index: int) -> dict[str, Any]:
+    row_map = _as_mapping(row, field=f"stages.{stage}[{index}]")
+    forbidden = sorted(FORBIDDEN_ROW_FIELDS.intersection(row_map))
+    if forbidden:
+        raise MarketRankingFunnelReadmodelError(
+            f"stages.{stage}[{index}] contains forbidden fields: {', '.join(forbidden)}"
+        )
+
+    normalized: dict[str, Any] = {
+        "row_id": _as_string(row_map.get("row_id"), field=f"stages.{stage}[{index}].row_id"),
+        "symbol": _as_string(row_map.get("symbol"), field=f"stages.{stage}[{index}].symbol"),
+        "rank": _as_int(row_map.get("rank"), field=f"stages.{stage}[{index}].rank"),
+    }
+
+    if "display_score" in row_map:
+        score = row_map["display_score"]
+        if not isinstance(score, (int, float)) or isinstance(score, bool):
+            raise MarketRankingFunnelReadmodelError(
+                f"stages.{stage}[{index}].display_score must be numeric"
+            )
+        normalized["display_score"] = float(score)
+
+    if "notes" in row_map:
+        normalized["notes"] = _as_optional_string(
+            row_map["notes"],
+            field=f"stages.{stage}[{index}].notes",
+        )
+
+    return normalized
+
+
+def _normalize_stage_rows(value: Any, *, stage: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise MarketRankingFunnelReadmodelError(f"stages.{stage} must be a list")
+    return [_normalize_row(row, stage=stage, index=index) for index, row in enumerate(value)]
+
+
+def build_market_ranking_funnel_readmodel(bundle_root: str | Path) -> dict[str, Any]:
+    """Build a deterministic, read-only ranking funnel readmodel from an offline bundle."""
+    root = Path(bundle_root)
+    payload_path = root / "ranking_funnel.json"
+    if not payload_path.is_file():
+        raise MarketRankingFunnelReadmodelError(
+            f"missing ranking funnel payload: {payload_path}"
+        )
+
+    try:
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise MarketRankingFunnelReadmodelError(f"invalid JSON: {exc}") from exc
+
+    payload_map = _as_mapping(payload, field="payload")
+    readmodel_id = _as_string(payload_map.get("readmodel_id"), field="readmodel_id")
+    if readmodel_id != READMODEL_ID:
+        raise MarketRankingFunnelReadmodelError(
+            f"readmodel_id must be {READMODEL_ID!r}"
+        )
+
+    non_authorizing = _as_bool(
+        payload_map.get("non_authorizing"),
+        field="non_authorizing",
+    )
+    if not non_authorizing:
+        raise MarketRankingFunnelReadmodelError("non_authorizing must be true")
+
+    stages = _as_mapping(payload_map.get("stages"), field="stages")
+    normalized_stages = {
+        stage: _normalize_stage_rows(stages.get(stage), stage=stage)
+        for stage in STAGES
+    }
+
+    return {
+        "readmodel_id": readmodel_id,
+        "generated_at_iso": _as_string(
+            payload_map.get("generated_at_iso"),
+            field="generated_at_iso",
+        ),
+        "source": _as_string(payload_map.get("source"), field="source"),
+        "stale": _as_bool(payload_map.get("stale"), field="stale"),
+        "stale_reason": _as_optional_string(
+            payload_map.get("stale_reason"),
+            field="stale_reason",
+        ),
+        "non_authorizing": non_authorizing,
+        "stages": normalized_stages,
+        "stage_counts": {
+            stage: len(rows)
+            for stage, rows in normalized_stages.items()
+        },
+    }

--- a/src/webui/market_ranking_funnel_readmodel_v0/builder.py
+++ b/src/webui/market_ranking_funnel_readmodel_v0/builder.py
@@ -98,9 +98,7 @@ def build_market_ranking_funnel_readmodel(bundle_root: str | Path) -> dict[str, 
     root = Path(bundle_root)
     payload_path = root / "ranking_funnel.json"
     if not payload_path.is_file():
-        raise MarketRankingFunnelReadmodelError(
-            f"missing ranking funnel payload: {payload_path}"
-        )
+        raise MarketRankingFunnelReadmodelError(f"missing ranking funnel payload: {payload_path}")
 
     try:
         payload = json.loads(payload_path.read_text(encoding="utf-8"))
@@ -110,9 +108,7 @@ def build_market_ranking_funnel_readmodel(bundle_root: str | Path) -> dict[str, 
     payload_map = _as_mapping(payload, field="payload")
     readmodel_id = _as_string(payload_map.get("readmodel_id"), field="readmodel_id")
     if readmodel_id != READMODEL_ID:
-        raise MarketRankingFunnelReadmodelError(
-            f"readmodel_id must be {READMODEL_ID!r}"
-        )
+        raise MarketRankingFunnelReadmodelError(f"readmodel_id must be {READMODEL_ID!r}")
 
     non_authorizing = _as_bool(
         payload_map.get("non_authorizing"),
@@ -123,8 +119,7 @@ def build_market_ranking_funnel_readmodel(bundle_root: str | Path) -> dict[str, 
 
     stages = _as_mapping(payload_map.get("stages"), field="stages")
     normalized_stages = {
-        stage: _normalize_stage_rows(stages.get(stage), stage=stage)
-        for stage in STAGES
+        stage: _normalize_stage_rows(stages.get(stage), stage=stage) for stage in STAGES
     }
 
     return {
@@ -141,8 +136,5 @@ def build_market_ranking_funnel_readmodel(bundle_root: str | Path) -> dict[str, 
         ),
         "non_authorizing": non_authorizing,
         "stages": normalized_stages,
-        "stage_counts": {
-            stage: len(rows)
-            for stage, rows in normalized_stages.items()
-        },
+        "stage_counts": {stage: len(rows) for stage, rows in normalized_stages.items()},
     }

--- a/tests/fixtures/market_ranking_funnel_readmodel_v0/complete_minimal/ranking_funnel.json
+++ b/tests/fixtures/market_ranking_funnel_readmodel_v0/complete_minimal/ranking_funnel.json
@@ -1,0 +1,37 @@
+{
+  "readmodel_id": "market_ranking_funnel_readmodel.v0",
+  "generated_at_iso": "2026-05-27T00:00:00Z",
+  "source": "fixture:complete_minimal",
+  "stale": false,
+  "stale_reason": null,
+  "non_authorizing": true,
+  "stages": {
+    "universe": [
+      {
+        "row_id": "universe-1",
+        "symbol": "BTCUSDT",
+        "rank": 1,
+        "display_score": 0.91,
+        "notes": "fixture row"
+      }
+    ],
+    "shortlist": [
+      {
+        "row_id": "shortlist-1",
+        "symbol": "BTCUSDT",
+        "rank": 1,
+        "display_score": 0.88,
+        "notes": "fixture row"
+      }
+    ],
+    "selected": [
+      {
+        "row_id": "selected-1",
+        "symbol": "BTCUSDT",
+        "rank": 1,
+        "display_score": 0.84,
+        "notes": "fixture row"
+      }
+    ]
+  }
+}

--- a/tests/webui/test_market_ranking_funnel_readmodel_v0.py
+++ b/tests/webui/test_market_ranking_funnel_readmodel_v0.py
@@ -1,0 +1,106 @@
+"""Tests for the read-only Market Ranking Funnel readmodel v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.webui.market_ranking_funnel_readmodel_v0 import (
+    MarketRankingFunnelReadmodelError,
+    build_market_ranking_funnel_readmodel,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_ROOT = (
+    PROJECT_ROOT
+    / "tests"
+    / "fixtures"
+    / "market_ranking_funnel_readmodel_v0"
+    / "complete_minimal"
+)
+
+
+def test_market_ranking_funnel_readmodel_builds_complete_minimal_fixture_v0() -> None:
+    model = build_market_ranking_funnel_readmodel(FIXTURE_ROOT)
+
+    assert model["readmodel_id"] == "market_ranking_funnel_readmodel.v0"
+    assert model["generated_at_iso"] == "2026-05-27T00:00:00Z"
+    assert model["source"] == "fixture:complete_minimal"
+    assert model["stale"] is False
+    assert model["stale_reason"] is None
+    assert model["non_authorizing"] is True
+    assert model["stage_counts"] == {
+        "universe": 1,
+        "shortlist": 1,
+        "selected": 1,
+    }
+    assert model["stages"]["universe"][0] == {
+        "row_id": "universe-1",
+        "symbol": "BTCUSDT",
+        "rank": 1,
+        "display_score": 0.91,
+        "notes": "fixture row",
+    }
+
+
+def test_market_ranking_funnel_readmodel_rejects_missing_payload_v0(tmp_path: Path) -> None:
+    with pytest.raises(MarketRankingFunnelReadmodelError, match="missing ranking funnel payload"):
+        build_market_ranking_funnel_readmodel(tmp_path)
+
+
+def test_market_ranking_funnel_readmodel_rejects_wrong_readmodel_id_v0(tmp_path: Path) -> None:
+    payload = json.loads((FIXTURE_ROOT / "ranking_funnel.json").read_text(encoding="utf-8"))
+    payload["readmodel_id"] = "wrong.v0"
+    (tmp_path / "ranking_funnel.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(MarketRankingFunnelReadmodelError, match="readmodel_id"):
+        build_market_ranking_funnel_readmodel(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "order_id",
+        "side",
+        "quantity",
+        "leverage",
+        "approval",
+        "approved",
+        "live_authorized",
+        "strategy_activation",
+    ],
+)
+def test_market_ranking_funnel_readmodel_rejects_authority_fields_v0(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    payload = json.loads((FIXTURE_ROOT / "ranking_funnel.json").read_text(encoding="utf-8"))
+    payload["stages"]["selected"][0][field] = "forbidden"
+    (tmp_path / "ranking_funnel.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(MarketRankingFunnelReadmodelError, match="forbidden fields"):
+        build_market_ranking_funnel_readmodel(tmp_path)
+
+
+def test_market_ranking_funnel_readmodel_rejects_missing_required_stage_v0(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads((FIXTURE_ROOT / "ranking_funnel.json").read_text(encoding="utf-8"))
+    del payload["stages"]["shortlist"]
+    (tmp_path / "ranking_funnel.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(MarketRankingFunnelReadmodelError, match="stages.shortlist"):
+        build_market_ranking_funnel_readmodel(tmp_path)
+
+
+def test_market_ranking_funnel_readmodel_rejects_authorizing_payload_v0(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads((FIXTURE_ROOT / "ranking_funnel.json").read_text(encoding="utf-8"))
+    payload["non_authorizing"] = False
+    (tmp_path / "ranking_funnel.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(MarketRankingFunnelReadmodelError, match="non_authorizing"):
+        build_market_ranking_funnel_readmodel(tmp_path)

--- a/tests/webui/test_market_ranking_funnel_readmodel_v0.py
+++ b/tests/webui/test_market_ranking_funnel_readmodel_v0.py
@@ -14,11 +14,7 @@ from src.webui.market_ranking_funnel_readmodel_v0 import (
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_ROOT = (
-    PROJECT_ROOT
-    / "tests"
-    / "fixtures"
-    / "market_ranking_funnel_readmodel_v0"
-    / "complete_minimal"
+    PROJECT_ROOT / "tests" / "fixtures" / "market_ranking_funnel_readmodel_v0" / "complete_minimal"
 )
 
 


### PR DESCRIPTION
## Summary

Adds the offline, read-only Market Ranking Funnel readmodel v0.

This is Slice C PR1 / Readmodel B only:

- adds a deterministic offline bundle builder
- adds a complete minimal fixture
- adds unit tests for valid payloads and forbidden authority fields

## Scope

Changed files:

- `src/webui/market_ranking_funnel_readmodel_v0/`
- `tests/fixtures/market_ranking_funnel_readmodel_v0/`
- `tests/webui/test_market_ranking_funnel_readmodel_v0.py`

## Guardrails

- No template integration.
- No `market_surface.py` integration.
- No new route.
- No API endpoint.
- No polling.
- No broker/exchange/runtime authority.
- No Scheduler/Paper/Shadow/Testnet/Live behavior.
- Dashboard remains read-only and non-authorizing.
- Ranking producer does not authorize trades.
- Does not use `FuturesRankingSnapshot` or Master V2 ranking as input.

## Local validation

- `python3 -m pytest tests/webui/test_market_ranking_funnel_readmodel_v0.py -q`
- `python3 -m ruff check src/webui/market_ranking_funnel_readmodel_v0 tests/webui/test_market_ranking_funnel_readmodel_v0.py`

## CI expectation

Touches `src/**`, `tests/webui/**`, and `tests/fixtures/**`; full matrix is expected.

Made with [Cursor](https://cursor.com)