### PR TITLE
feat(webui): render market ranking funnel SSR rows

### DIFF
--- a/src/webui/market_ranking_funnel_runtime_v0.py
+++ b/src/webui/market_ranking_funnel_runtime_v0.py
@@ -1,0 +1,128 @@
+"""Market Ranking Funnel runtime resolution (env + offline bundle), SSR-only."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from .market_ranking_funnel_readmodel_v0 import (
+    MarketRankingFunnelReadmodelError,
+    build_market_ranking_funnel_readmodel,
+)
+from .market_ranking_funnel_readmodel_v0.builder import READMODEL_ID
+
+ENV_ENABLED = "PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED"
+ENV_BUNDLE_ROOT = "PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT"
+
+STAGE_DISPLAY_LABELS: dict[str, str] = {
+    "universe": "Top Universe",
+    "shortlist": "Shortlist",
+    "selected": "Top Ranking / Selected Candidates",
+}
+
+
+def enabled_explicitly_on() -> bool:
+    raw = os.environ.get(ENV_ENABLED)
+    return raw is not None and raw.strip() == "1"
+
+
+def resolved_bundle_root_or_none() -> Path | None:
+    raw = os.environ.get(ENV_BUNDLE_ROOT)
+    if raw is None or not str(raw).strip():
+        return None
+    path = Path(raw).expanduser()
+    try:
+        path = path.resolve(strict=True)
+    except OSError:
+        return None
+    if not path.is_dir():
+        return None
+    return path
+
+
+def _base_context(*, gate_enabled: bool, display_status: str) -> dict[str, Any]:
+    return {
+        "gate_enabled": gate_enabled,
+        "display_status": display_status,
+        "readmodel_id": READMODEL_ID,
+        "has_rows": False,
+        "non_authorizing": True,
+        "stale": True,
+        "stale_reason": "",
+        "source": "",
+        "generated_at_iso": "",
+        "summary_line": "",
+        "stage_counts": {"universe": 0, "shortlist": 0, "selected": 0},
+        "stages": {"universe": [], "shortlist": [], "selected": []},
+        "stage_labels": dict(STAGE_DISPLAY_LABELS),
+    }
+
+
+def build_market_ranking_funnel_display_context() -> dict[str, Any]:
+    """SSR-only ranking funnel panel context for GET /market (fail closed by default)."""
+    if not enabled_explicitly_on():
+        ctx = _base_context(gate_enabled=False, display_status="disabled")
+        ctx["summary_line"] = "Ranking funnel producer disabled (env gate off)."
+        ctx["stale_reason"] = "source_disabled"
+        return ctx
+
+    bundle_root = resolved_bundle_root_or_none()
+    if bundle_root is None:
+        ctx = _base_context(gate_enabled=True, display_status="unconfigured")
+        ctx["summary_line"] = "Ranking funnel bundle root unconfigured."
+        ctx["stale_reason"] = "bundle_root_unconfigured"
+        return ctx
+
+    try:
+        readmodel = build_market_ranking_funnel_readmodel(bundle_root)
+    except MarketRankingFunnelReadmodelError:
+        ctx = _base_context(gate_enabled=True, display_status="builder_error")
+        ctx["summary_line"] = "Ranking funnel bundle could not be loaded (read-only empty display)."
+        ctx["stale_reason"] = "bundle_build_failed"
+        return ctx
+
+    stages = readmodel.get("stages") or {}
+    stage_counts = readmodel.get("stage_counts") or {
+        stage: len(stages.get(stage) or []) for stage in STAGE_DISPLAY_LABELS
+    }
+    has_rows = any(int(stage_counts.get(stage, 0)) > 0 for stage in STAGE_DISPLAY_LABELS)
+
+    if has_rows:
+        display_status = "ready"
+        summary_line = (
+            f"{readmodel.get('source', '')} — "
+            f"universe {stage_counts.get('universe', 0)}, "
+            f"shortlist {stage_counts.get('shortlist', 0)}, "
+            f"selected {stage_counts.get('selected', 0)} "
+            "(offline bundle, read-only display)"
+        )
+    else:
+        display_status = "empty"
+        summary_line = "Ranking funnel enabled but no stage rows in bundle (display-only empty)."
+
+    return {
+        "gate_enabled": True,
+        "display_status": display_status,
+        "readmodel_id": str(readmodel.get("readmodel_id", READMODEL_ID)),
+        "has_rows": has_rows,
+        "non_authorizing": bool(readmodel.get("non_authorizing") is True),
+        "stale": bool(readmodel.get("stale") is True),
+        "stale_reason": str(readmodel.get("stale_reason") or ""),
+        "source": str(readmodel.get("source", "")),
+        "generated_at_iso": str(readmodel.get("generated_at_iso", "")),
+        "summary_line": summary_line.strip(),
+        "stage_counts": stage_counts,
+        "stages": {stage: list(stages.get(stage) or []) for stage in STAGE_DISPLAY_LABELS},
+        "stage_labels": dict(STAGE_DISPLAY_LABELS),
+    }
+
+
+__all__ = [
+    "ENV_BUNDLE_ROOT",
+    "ENV_ENABLED",
+    "STAGE_DISPLAY_LABELS",
+    "build_market_ranking_funnel_display_context",
+    "enabled_explicitly_on",
+    "resolved_bundle_root_or_none",
+]

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -27,10 +27,11 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from .market_depth_runtime_v0 import market_depth_json_payload_v0
+from .market_ranking_funnel_runtime_v0 import build_market_ranking_funnel_display_context
 
 logger = logging.getLogger(__name__)
 
-# Aligniert mit scripts/_shared_forward_args.OHLCV_TIMEFRAME_CHOICES / Kraken-ccxt-Übliches
+# Aligniert mit scripts/_shared_forward_args.OHLCV_TIMEFRAME_CHOICES (übliche Timeframes)
 MARKET_TIMEFRAMES: tuple[str, ...] = ("1m", "5m", "15m", "1h", "4h", "1d")
 MAX_OHLCV_LIMIT = 720
 MARKET_DEPTH_SSR_TOP_LEVELS = 8
@@ -562,6 +563,7 @@ def create_market_router(
         proj_status = get_project_status()
         market_depth = build_market_depth_display_context()
         run_projection = build_market_run_projection_display_context()
+        ranking_funnel = build_market_ranking_funnel_display_context()
         return templates.TemplateResponse(
             request,
             "market_v0.html",
@@ -570,6 +572,7 @@ def create_market_router(
                 "payload": payload,
                 "market_depth": market_depth,
                 "run_projection": run_projection,
+                "ranking_funnel": ranking_funnel,
                 "query": {
                     "symbol": symbol,
                     "timeframe": timeframe,

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -161,44 +161,82 @@
     role="region"
     aria-labelledby="market-v0-landmark-ranking-funnel-h2"
     class="rounded-xl border border-violet-900/45 bg-gradient-to-br from-slate-950/92 via-violet-950/22 to-slate-950/85 px-3 py-3 sm:px-4 ring-1 ring-violet-900/25 shadow-md shadow-black/20"
-    data-market-v0-ranking-funnel-empty-state-v0="true"
     data-market-v0-ranking-funnel-dynamic-labels-v0="true"
+    data-market-v0-ranking-funnel-stages-v0="true"
+    {% if ranking_funnel.gate_enabled %}data-market-v0-ranking-funnel-enabled-v0="true"{% endif %}
+    {% if ranking_funnel.has_rows %}data-market-v0-ranking-funnel-has-rows-v0="true"{% else %}data-market-v0-ranking-funnel-empty-state-v0="true"{% endif %}
+    {% if ranking_funnel.non_authorizing %}data-market-v0-ranking-funnel-non-authorizing-v0="true"{% endif %}
   >
     <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
       <div class="min-w-0 space-y-1">
         <h2 id="market-v0-landmark-ranking-funnel-h2" class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">
+          {% if ranking_funnel.has_rows %}
+          Futures-Ranking-Funnel · nur Darstellung (Zeilen)
+          {% else %}
           Futures-Ranking-Funnel · nur Darstellung (leer)
+          {% endif %}
         </h2>
         <p class="text-[10px] text-slate-500 m-0 max-w-2xl leading-snug">
+          {% if ranking_funnel.has_rows %}
+          <strong class="text-slate-400 font-semibold">Read-only SSR</strong> aus offline Bundle —
+          <strong class="text-amber-200/90 font-semibold">keine Orders, keine Freigabe, kein Signal</strong>.
+          {{ ranking_funnel.summary_line|e }}
+          {% else %}
           Auf <strong class="text-slate-400 font-semibold">dieser read-only Oberfläche</strong> werden hier
-          <strong class="text-amber-200/90 font-semibold">keine Kandidatenzeilen</strong> aus einem Ranking-/Producer-Kontext angezeigt — bewusst, bis ein kanonischer Producer angebunden ist.
-          <strong class="text-slate-400">Das ist weder Empfehlung noch Signal, weder Freigabe noch Sperre noch „Ready“-Status</strong>; es fehlen schlicht Anzeigedaten für diese Stufen.
-          Zielpfad bleibt auf <strong class="text-slate-400 font-semibold">einer Seite</strong>, ohne separate Ranking-Route.
+          <strong class="text-amber-200/90 font-semibold">keine Kandidatenzeilen</strong> aus einem Ranking-/Producer-Kontext angezeigt.
+          <strong class="text-slate-400">Das ist weder Empfehlung noch Signal, weder Freigabe noch Sperre noch „Ready“-Status</strong>.
+          {% if ranking_funnel.summary_line %}{{ ranking_funnel.summary_line|e }}{% endif %}
+          {% endif %}
         </p>
       </div>
+      {% if ranking_funnel.has_rows %}
+      <span class="shrink-0 inline-flex items-center rounded-md border border-violet-800/55 bg-violet-950/45 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide text-violet-200/90">Zeilen · display-only</span>
+      {% else %}
       <span class="shrink-0 inline-flex items-center rounded-md border border-amber-800/55 bg-amber-950/45 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide text-amber-200/90">Leer · display-only</span>
+      {% endif %}
     </div>
     <div
       class="grid grid-cols-1 sm:grid-cols-3 gap-2"
-      data-market-v0-ranking-funnel-stages-v0="true"
-      aria-label="Funnel-Stufen: nur Beschriftung; leer — keine Kandidatenzeilen von dieser read-only Oberfläche"
+      aria-label="Funnel-Stufen: read-only ranking producer display"
     >
-      <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
-        <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 1</p>
-        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top Universe</p>
-        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Breites Feld — hier keine Zeilen; spätere Größe nur vom Producer, nicht von dieser Oberfläche festgelegt.</p>
+      {% for stage_key, stage_label in ranking_funnel.stage_labels.items() %}
+      <div
+        class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2"
+        data-market-v0-ranking-funnel-stage-v0="{{ stage_key|e }}"
+      >
+        <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">{{ stage_key|e }}</p>
+        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">{{ stage_label|e }}</p>
+        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug tabular-nums">
+          {{ ranking_funnel.stage_counts[stage_key] }} row(s) · producer-defined count
+        </p>
+        {% if ranking_funnel.has_rows and ranking_funnel.stages[stage_key] %}
+        <ul class="m-0 mt-2 p-0 list-none space-y-1" data-market-v0-ranking-funnel-stage-rows-v0="true">
+          {% for row in ranking_funnel.stages[stage_key] %}
+          <li
+            class="rounded border border-slate-800/80 bg-slate-950/50 px-2 py-1 text-[10px] font-mono text-slate-200"
+            data-market-v0-ranking-funnel-row-v0="true"
+          >
+            <span class="text-violet-300/90">#{{ row.rank|e }}</span>
+            <span class="text-slate-400 px-1">·</span>
+            <span>{{ row.symbol|e }}</span>
+            {% if "display_score" in row %}
+            <span class="text-slate-500 px-1">·</span>
+            <span class="text-slate-400">score {{ row.display_score|e }}</span>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+        {% elif not ranking_funnel.has_rows %}
+        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Keine Zeilen in dieser Stufe (display-only leer).</p>
+        {% endif %}
       </div>
-      <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
-        <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 2</p>
-        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Shortlist</p>
-        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Vorgefiltertes Feld — hier keine Shortlist-Zeilen; Umfang später producer-definiert.</p>
-      </div>
-      <div class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2">
-        <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">Stage 3</p>
-        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">Top Ranking / Selected Candidates</p>
-        <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug">Auswahl-Feld — hier keine Zeilen; spätere Anzahl nur vom Producer, keine Darstellung als Entscheidung.</p>
-      </div>
+      {% endfor %}
     </div>
+    {% if ranking_funnel.has_rows %}
+    <p class="text-[9px] text-slate-500 m-0 mt-2 leading-snug" data-market-v0-ranking-funnel-readonly-copy-v0="true">
+      Ranking producer output is display-only. It does not authorize trades, signals, approvals, or live operation.
+    </p>
+    {% else %}
     <div class="mt-2.5 rounded-lg border border-slate-800/85 bg-slate-950/55 px-2.5 py-2">
       <p class="text-[9px] font-semibold text-slate-400 uppercase tracking-wide m-0 mb-1.5">
         Vorgesehene Kriterien-Kategorien (nur Bezeichner, keine Werte)
@@ -211,6 +249,7 @@
         <li class="rounded border border-slate-800/80 bg-slate-950/40 px-1.5 py-0.5">Score-Aufschlüsselung (später)</li>
       </ul>
     </div>
+    {% endif %}
   </section>
 
   <!-- Pro cockpit grid: chart/main column + read-only side panels (IA inspiration only; no order UI) -->

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -34,6 +34,27 @@ FORM_ACTION_RE = re.compile(
 @pytest.fixture()
 def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT", raising=False)
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def client_ranking_funnel_fixture_bundle_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[TestClient]:
+    """Offline ranking funnel SSR enabled with repo complete_minimal fixture."""
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED", "1")
+    bundle = (
+        project_root
+        / "tests"
+        / "fixtures"
+        / "market_ranking_funnel_readmodel_v0"
+        / "complete_minimal"
+    ).resolve()
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT", str(bundle))
     with TestClient(create_app()) as test_client:
         yield test_client
 
@@ -586,9 +607,53 @@ def test_double_play_market_dashboard_excludes_ranking_funnel_markers_v0(
     assert "data-market-v0-ranking-funnel-empty-state-v0" not in html
     assert "data-market-v0-ranking-funnel-dynamic-labels-v0" not in html
     assert "data-market-v0-ranking-funnel-stages-v0" not in html
+    assert "data-market-v0-ranking-funnel-has-rows-v0" not in html
+    assert "data-market-v0-ranking-funnel-enabled-v0" not in html
+    assert "data-market-v0-ranking-funnel-row-v0" not in html
+    assert "data-market-v0-ranking-funnel-stage-rows-v0" not in html
     assert "market-v0-landmark-ranking-funnel-h2" not in html
     assert "data-market-v0-" not in html
     assert 'data-market-readonly="true"' in html
+
+
+def test_market_dashboard_ranking_funnel_rows_when_bundle_enabled_v0(
+    client_ranking_funnel_fixture_bundle_on: TestClient,
+) -> None:
+    """Enabled ranking funnel with fixture bundle renders SSR rows on /market only."""
+    html = _html(client_ranking_funnel_fixture_bundle_on, "/market")
+    assert 'data-market-v0-ranking-funnel-enabled-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-has-rows-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-non-authorizing-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-row-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-stage-rows-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-stage-v0="universe"' in html
+    assert "BTCUSDT" in html
+    assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' not in html
+
+
+def test_market_dashboard_ranking_funnel_non_authorizing_copy_when_rows_v0(
+    client_ranking_funnel_fixture_bundle_on: TestClient,
+) -> None:
+    """Row rendering includes explicit non-authority copy."""
+    html = _html(client_ranking_funnel_fixture_bundle_on, "/market")
+    assert 'data-market-v0-ranking-funnel-readonly-copy-v0="true"' in html
+    assert "does not authorize trades" in html
+
+
+def test_market_dashboard_ranking_funnel_fail_closed_missing_bundle_v0(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enabled gate with missing bundle stays read-only empty display (no 500)."""
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED", "1")
+    monkeypatch.setenv(
+        "PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT", "/tmp/nonexistent-ranking-bundle"
+    )
+    with TestClient(create_app()) as test_client:
+        html = _html(test_client, "/market")
+    assert 'data-market-v0-ranking-funnel-enabled-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-has-rows-v0="true"' not in html
+    assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' in html
 
 
 def test_double_play_market_dashboard_excludes_pro_shell_markers_v0(


### PR DESCRIPTION
## Summary

Adds env-gated SSR integration for the Market Ranking Funnel Producer v0.

This is Slice C PR2:

- adds fail-closed ranking funnel runtime/env helper
- wires `/market` SSR context only
- renders ranking funnel rows when enabled and fixture rows exist
- preserves empty-state behavior when disabled or empty
- keeps `/market/double-play` excluded
- adds structure-contract coverage for enabled, disabled, non-authority, and Double-Play exclusion behavior

## Scope

Changed files:

- `src/webui/market_ranking_funnel_runtime_v0.py`
- `src/webui/market_surface.py`
- `templates/peak_trade_dashboard/market_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Guardrails

- No new route.
- No API endpoint.
- No polling.
- No broker/exchange/runtime authority.
- No Scheduler/Paper/Shadow/Testnet/Live behavior.
- No Master V2 / FuturesRankingSnapshot feed.
- `/market/double-play` remains excluded.
- Dashboard remains read-only and non-authorizing.
- Ranking producer does not authorize trades.

## Local validation

- `python3 -m pytest tests/webui/test_market_ranking_funnel_readmodel_v0.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -k "ranking_funnel or ranking" -q`
- `python3 -m ruff check src/webui/market_ranking_funnel_readmodel_v0 src/webui/market_ranking_funnel_runtime_v0.py src/webui/market_surface.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- `python3 -m ruff format --check src/webui/market_ranking_funnel_runtime_v0.py src/webui/market_surface.py tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## CI expectation

Touches `src/**`, template, and `tests/webui/**`; full matrix is expected.

Made with [Cursor](https://cursor.com)