### PR TITLE
test(webui): guard market ranking funnel region coexistence

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -160,6 +160,8 @@ Landed boundaries:
 
 The default disabled or empty state remains valid. When enabled with bundle rows, `/market` may render read-only ranking rows and explicit non-authority copy.
 
+**Landmark / region (SSR v0):** section **`#market-v0-ranking-funnel-ssr`** has **`role="region"`**, **`aria-labelledby="market-v0-landmark-ranking-funnel-h2"`**, and **`data-market-v0-ranking-funnel-landmark-heading-v0="true"`** on the visible **`h2`** — same IA pattern family as depth/orderbook landmarks. Depth SSR and ranking funnel SSR may **coexist** on **`GET`** **`/market`** when both env gates and fixtures are enabled; markers must not replace each other. **`GET`** **`/market/double-play`** remains **without** ranking-funnel SSR landmarks.
+
 Non-authority invariants remain unchanged:
 
 - `DASHBOARD_AUTHORITY_CHANGED=false`

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -158,6 +158,7 @@
   {% endif %}
 
   <section
+    id="market-v0-ranking-funnel-ssr"
     role="region"
     aria-labelledby="market-v0-landmark-ranking-funnel-h2"
     class="rounded-xl border border-violet-900/45 bg-gradient-to-br from-slate-950/92 via-violet-950/22 to-slate-950/85 px-3 py-3 sm:px-4 ring-1 ring-violet-900/25 shadow-md shadow-black/20"
@@ -169,7 +170,7 @@
   >
     <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
       <div class="min-w-0 space-y-1">
-        <h2 id="market-v0-landmark-ranking-funnel-h2" class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">
+        <h2 id="market-v0-landmark-ranking-funnel-h2" data-market-v0-ranking-funnel-landmark-heading-v0="true" class="text-xs sm:text-sm font-semibold text-slate-100 tracking-tight m-0">
           {% if ranking_funnel.has_rows %}
           Futures-Ranking-Funnel · nur Darstellung (Zeilen)
           {% else %}

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -59,6 +59,30 @@ def client_ranking_funnel_fixture_bundle_on(
         yield test_client
 
 
+@pytest.fixture()
+def client_depth_and_ranking_funnel_fixtures_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[TestClient]:
+    """Depth and ranking funnel SSR enabled with repo offline fixtures."""
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    depth_bundle = (
+        project_root / "tests" / "fixtures" / "market_depth_readmodel_v0" / "complete_minimal"
+    ).resolve()
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(depth_bundle))
+    monkeypatch.setenv("PEAK_TRADE_FIXED_GENERATED_AT_UTC", "2030-01-15T12:34:56.000000+00:00")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED", "1")
+    ranking_bundle = (
+        project_root
+        / "tests"
+        / "fixtures"
+        / "market_ranking_funnel_readmodel_v0"
+        / "complete_minimal"
+    ).resolve()
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT", str(ranking_bundle))
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
 def _html(client: TestClient, path: str) -> str:
     response = client.get(path)
     assert response.status_code == 200
@@ -520,6 +544,29 @@ def test_double_play_market_dashboard_excludes_orderbook_fixture_levels_markers_
     assert 'data-market-v0-orderbook-asks="true"' not in html
 
 
+def test_market_dashboard_ranking_funnel_region_role_contract_v0(client: TestClient) -> None:
+    """Ranking funnel section exposes role=region and aria-labelledby to landmark h2."""
+    html = _html(client, "/market")
+    assert re.search(
+        r'id="market-v0-ranking-funnel-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-ranking-funnel-h2"',
+        html,
+    )
+    assert 'id="market-v0-landmark-ranking-funnel-h2"' in html
+    assert 'data-market-v0-ranking-funnel-landmark-heading-v0="true"' in html
+
+
+def test_double_play_market_dashboard_excludes_ranking_funnel_region_role_contract_v0(
+    client: TestClient,
+) -> None:
+    html = _html(client, "/market/double-play")
+    assert not re.search(
+        r'id="market-v0-ranking-funnel-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-ranking-funnel-h2"',
+        html,
+    )
+    assert "market-v0-ranking-funnel-ssr" not in html
+    assert "data-market-v0-ranking-funnel-landmark-heading-v0" not in html
+
+
 def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClient) -> None:
     """Contract-first funnel panel: stable marker only; no ranking data wired on /market."""
     market_html = _html(client, "/market")
@@ -612,6 +659,8 @@ def test_double_play_market_dashboard_excludes_ranking_funnel_markers_v0(
     assert "data-market-v0-ranking-funnel-row-v0" not in html
     assert "data-market-v0-ranking-funnel-stage-rows-v0" not in html
     assert "market-v0-landmark-ranking-funnel-h2" not in html
+    assert "market-v0-ranking-funnel-ssr" not in html
+    assert "data-market-v0-ranking-funnel-landmark-heading-v0" not in html
     assert "data-market-v0-" not in html
     assert 'data-market-readonly="true"' in html
 
@@ -638,6 +687,31 @@ def test_market_dashboard_ranking_funnel_non_authorizing_copy_when_rows_v0(
     html = _html(client_ranking_funnel_fixture_bundle_on, "/market")
     assert 'data-market-v0-ranking-funnel-readonly-copy-v0="true"' in html
     assert "does not authorize trades" in html
+
+
+def test_market_dashboard_depth_and_ranking_funnel_coexistence_contract_v0(
+    client_depth_and_ranking_funnel_fixtures_on: TestClient,
+) -> None:
+    """Depth/orderbook SSR and ranking funnel rows may coexist on /market without marker loss."""
+    html = _html(client_depth_and_ranking_funnel_fixtures_on, "/market")
+
+    assert re.search(
+        r'id="market-v0-depth-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-depth-ssr-h2"',
+        html,
+    )
+    assert 'data-market-depth-panel="true"' in html
+    assert 'id="market-v0-orderbook-topn"' in html
+    assert 'data-market-v0-orderbook-topn="true"' in html
+
+    assert re.search(
+        r'id="market-v0-ranking-funnel-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-ranking-funnel-h2"',
+        html,
+    )
+    assert 'data-market-v0-ranking-funnel-has-rows-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-row-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-stage-v0="universe"' in html
+    assert 'data-market-v0-ranking-funnel-readonly-copy-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-non-authorizing-v0="true"' in html
 
 
 def test_market_dashboard_ranking_funnel_fail_closed_missing_bundle_v0(
@@ -682,7 +756,9 @@ def test_market_dashboard_landmarks_and_labelled_regions_v0(client: TestClient) 
     assert 'id="market-v0-landmark-safety-banner-h2"' in html
     assert 'aria-labelledby="market-v0-landmark-safety-banner-h2"' in html
     assert 'id="market-v0-landmark-ranking-funnel-h2"' in html
+    assert 'data-market-v0-ranking-funnel-landmark-heading-v0="true"' in html
     assert 'aria-labelledby="market-v0-landmark-ranking-funnel-h2"' in html
+    assert 'id="market-v0-ranking-funnel-ssr"' in html
     assert 'id="market-v0-landmark-visual-cockpit-h2"' in html
     assert 'aria-labelledby="market-v0-landmark-visual-cockpit-h2"' in html
     assert 'id="market-v0-landmark-surface-links-h2"' in html


### PR DESCRIPTION
## Summary

Adds Market Dashboard contract coverage for Ranking Funnel region/marker coexistence after SSR v0.

## Scope

Changed files:

- `docs/webui/MARKET_SURFACE_V0.md`
- `templates/peak_trade_dashboard/market_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`

## Guardrails

- Reuses existing Market Dashboard owners.
- No new route.
- No API endpoint.
- No polling.
- No broker/exchange/runtime authority.
- No Scheduler/Paper/Shadow/Testnet/Live behavior.
- Dashboard remains read-only and non-authorizing.
- Ranking producer does not authorize trades.

## CI expectation

Touches template and `tests/webui/**`; full matrix is expected.

Made with [Cursor](https://cursor.com)