### PR TITLE
test(ci): validate webui structure-contract fastpath (#3727)

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -162,6 +162,7 @@ def test_double_play_market_dashboard_depth_ssr_default_disabled_post_merge_v0(
     assert 'data-double-play-market-depth-panel="true"' in html
     assert 'data-double-play-market-depth-status="disabled"' in html
     assert 'data-double-play-market-depth-non-authorizing="true"' in html
+    assert 'data-double-play-market-depth-operator-hint="true"' in html
     assert 'id="market-v0-depth-ssr"' not in html
     assert "data-market-v0-ranking-funnel" not in html
 
@@ -182,6 +183,7 @@ def test_double_play_market_dashboard_depth_ssr_post_merge_contract_v0(
     assert 'data-double-play-market-depth-non-authorizing="true"' in html
     assert 'data-double-play-market-depth-readonly-copy-v0="true"' in html
     assert 'data-double-play-market-depth-landmark-heading-v0="true"' in html
+    assert 'data-double-play-market-depth-readmodel-id="market_depth_readmodel.v0"' in html
     assert "does not authorize trades" in html
 
     assert 'id="double-play-market-v0-shell"' in html


### PR DESCRIPTION
## Summary

**CI fastpath validation PR** (no product/runtime changes).

Minimal structure-contract-only assertions in `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`:

- Post-merge fixture depth: `data-double-play-market-depth-readmodel-id="market_depth_readmodel.v0"`
- Default-disabled depth SSR: `data-double-play-market-depth-operator-hint="true"`

Touches **only** the existing WebUI structure contract test file (no `src/**`, `templates/**`, workflows, fixtures, or config).

## Expected CI classifier outcome (PR #3727 policy)

| Flag | Expected |
|------|----------|
| `static_contract_changed` | `true` |
| `code_changed` | `false` |
| `docs_or_static_contract_only` | `true` |
| Matrix | **short-circuit** (fast lane) |
| Full matrix | **not** expected |

## Test plan

- [x] `pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q -k "double_play and depth"`
- [x] `ruff check` / `ruff format --check` on touched file
- [ ] Observe PR checks: `tests (3.9/3.10/3.11)` should run narrow `tests/ci` + `tests/ops` + webui structure contract only, not full `pytest tests/`

## Reuse / drift guard

- Reused existing structure contract file; no new classifier, workflow, or parallel test surface.


Made with [Cursor](https://cursor.com)