### PR TITLE
test(ci): revalidate webui structure-contract fastpath post-#3729

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -184,6 +184,8 @@ def test_double_play_market_dashboard_depth_ssr_post_merge_contract_v0(
     assert 'data-double-play-market-depth-readonly-copy-v0="true"' in html
     assert 'data-double-play-market-depth-landmark-heading-v0="true"' in html
     assert 'data-double-play-market-depth-readmodel-id="market_depth_readmodel.v0"' in html
+    assert 'id="double-play-market-v0-landmark-depth-ssr-h2"' in html
+    assert 'data-double-play-market-depth-operator-hint="true"' not in html
     assert "does not authorize trades" in html
 
     assert 'id="double-play-market-v0-shell"' in html


### PR DESCRIPTION
## Summary

**Fastpath revalidation PR** after merge of #3729 (picomatch extglob `code` filter fix).

Touches **only** `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`:

- Fixture depth `ok`: `id="double-play-market-v0-landmark-depth-ssr-h2"` present; `data-double-play-market-depth-operator-hint` absent
- Disabled path unchanged (operator-hint already asserted)

No `src/**`, `templates/**`, `docs/**`, workflows, fixtures, or config.

## Expected CI classifier outcome (#3729)

| Output | Expected |
|--------|----------|
| `static_contract_changed` | `true` |
| `code_changed` | `false` |
| `docs_or_static_contract_only` | `true` |
| `run_matrix` | `false` |
| Fast-Lane | Static contract tests incl. this file |
| `tests (3.9/3.10/3.11)` | Jobs created, **matrix short-circuit** (no full `pytest tests/`) |

Contrasts with validation PR #3728 (pre-#3729): `code=true`, Full Matrix ran.

## Test plan

- [x] `pytest … -k "double_play and depth"`
- [x] ruff check / format --check
- [ ] Observe `changes` job + Fast-Lane + `tests (3.x)` logs on this PR


Made with [Cursor](https://cursor.com)