### PR TITLE
test(webui): depth+ranking funnel coexistence depth markers

### DIFF
--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -784,6 +784,8 @@ def test_market_dashboard_depth_and_ranking_funnel_coexistence_contract_v0(
         html,
     )
     assert 'data-market-depth-panel="true"' in html
+    assert 'data-market-depth-status="ok"' in html
+    assert 'data-market-depth-readmodel-id="market_depth_readmodel.v0"' in html
     assert 'id="market-v0-orderbook-topn"' in html
     assert 'data-market-v0-orderbook-topn="true"' in html
 


### PR DESCRIPTION
## Summary

Tiny structure-contract hardening for **`test_market_dashboard_depth_and_ranking_funnel_coexistence_contract_v0`**: when depth and ranking funnel offline fixtures are both enabled on `GET /market`, assert:

- `data-market-depth-status="ok"`
- `data-market-depth-readmodel-id="market_depth_readmodel.v0"`

Marker-only; no `src/**`, `templates/**`, `docs/**`, fixtures, or workflow changes.

## Expected CI (#3730 fastpath)

| Output | Expected |
|--------|----------|
| `static_contract_changed` | `true` |
| `code_changed` | `false` |
| `docs_or_static_contract_only` | `true` |
| `run_matrix` | `false` |
| Fast-Lane | static-contract pytest incl. this file |
| `tests (3.x)` | matrix short-circuit |

## Test plan

- [x] `pytest … -k "coexistence or ranking_funnel or depth"` (35 passed)
- [x] ruff check / format --check


Made with [Cursor](https://cursor.com)