### PR TITLE
ops: add bounded paper adapter return-code instrumentation

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -75,6 +75,7 @@ REQUIRED_APPROVAL = {
 USAGE_EXIT = 2
 VALIDATION_EXIT = 1
 TIMEOUT_EXIT = 124
+START_RETURN_CODE_ARTIFACT = "start_return_code.txt"
 
 
 @dataclass(frozen=True)
@@ -509,6 +510,23 @@ def _write_closeout_artifacts(
     )
 
 
+def _write_start_return_code_artifact(
+    staging_root: Path,
+    rc: int,
+    *,
+    blocker_hint: str = "",
+) -> None:
+    """Persist execute return code for external orchestrators."""
+    staging_root.mkdir(parents=True, exist_ok=True)
+    lines = [f"START_RC={int(rc)}"]
+    if blocker_hint:
+        lines.append(f"BLOCKER_HINT={blocker_hint}")
+    (staging_root / START_RETURN_CODE_ARTIFACT).write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
 def execute_plan(
     ctx: ExecuteContext,
     plan: AdapterPlan,
@@ -744,11 +762,23 @@ def main(
             environ=environ,
         )
         if issues:
+            blocker_hint = ";".join(issues)
+            _write_start_return_code_artifact(
+                staging_root,
+                VALIDATION_EXIT,
+                blocker_hint=blocker_hint,
+            )
             for issue in issues:
                 print(issue, file=sys.stderr)
             return VALIDATION_EXIT
         runner = subprocess_runner or _default_subprocess_runner
-        return execute_plan(ctx, plan, subprocess_runner=runner)
+        rc = execute_plan(ctx, plan, subprocess_runner=runner)
+        _write_start_return_code_artifact(
+            staging_root,
+            rc,
+            blocker_hint="" if rc == 0 else "execute_plan_nonzero",
+        )
+        return rc
 
     print(render_plan(plan, args.json))
     return 0

--- a/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
@@ -145,6 +145,11 @@ def test_execute_without_approval_record_fails(tmp_path: Path) -> None:
         repo_clean_checker=lambda _root: (True, ""),
     )
     assert rc != 0
+    start_rc = staging / mod.START_RETURN_CODE_ARTIFACT
+    assert start_rc.is_file()
+    content = start_rc.read_text(encoding="utf-8")
+    assert f"START_RC={mod.VALIDATION_EXIT}" in content
+    assert "execute requires --approval-record" in content
 
 
 def test_execute_without_archive_root_fails(tmp_path: Path) -> None:
@@ -298,6 +303,9 @@ def test_execute_accepts_sample_approval_with_mocked_runner(tmp_path: Path) -> N
     assert rc == 0
     assert calls
     assert scheduler_extra_env is None
+    start_rc = staging / mod.START_RETURN_CODE_ARTIFACT
+    assert start_rc.is_file()
+    assert f"START_RC=0" in start_rc.read_text(encoding="utf-8")
 
 
 def test_command_plan_includes_make_scheduler_temp_config(tmp_path: Path) -> None:
@@ -636,3 +644,6 @@ def test_24h_profile_execute_accepts_sample_fixture_mocked(tmp_path: Path) -> No
     assert scheduler_extra_env is not None
     assert scheduler_extra_env.get(SCHEDULER_HOLD_RUNTIME_OUTROOT_ENV) == expected_outroot
     assert scheduler_extra_env.get(SCHEDULER_HOLD_RUNTIME_RUN_ID_ENV) == RUN_ID_24H
+    start_rc = staging / mod.START_RETURN_CODE_ARTIFACT
+    assert start_rc.is_file()
+    assert "START_RC=0" in start_rc.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds minimal return-code instrumentation to `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` so bounded paper adapter execute paths produce a durable `start_return_code.txt` artifact.

This closes the remote-run blocker where a bounded adapter attempt could exit synchronously with empty stdout/stderr and no reliable return-code artifact for closeout/diagnostics.

## Scope

- Adds `START_RETURN_CODE_ARTIFACT = "start_return_code.txt"`
- Adds helper instrumentation for execute/block paths
- Preserves existing runtime/scheduler semantics
- Extends existing offline adapter tests only

## Safety

- No Remote SSH
- No AWS changes
- No runtime start
- No scheduler start
- No paper/shadow/testnet/live run
- No broker/exchange credentials
- No Master V2 / Double Play / Risk / KillSwitch / Scope / Capital / Execution / Live-Gate changes

## Checks

- `uv run pytest tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py -q`
- `uv run ruff check scripts/ops/run_paper_only_bounded_observation_adapter_v0.py tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py`

## Evidence

- `/tmp/peak_trade_adapter_return_code_instrumentation_fix_20260528T034826Z`
