### PR TITLE
ops: add bounded paper runtime heartbeat freshness

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -272,6 +272,8 @@ def build_plan(
         INCLUDE_TAGS,
         "--no-registry",
         "--no-alerts",
+        "--heartbeat-file",
+        str((runtime_out / "scheduler_heartbeat_freshness_v0.json").resolve()),
     ]
     run_with_timeout = _python_cmd(repo_root, "scripts/ops/run_with_timeout.py") + [
         "--timeout-seconds",

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -168,7 +168,9 @@ def write_scheduler_heartbeat_freshness(
         "jobs_dispatched_total": jobs_dispatched_total,
         "reason": reason,
     }
-    heartbeat_file.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    heartbeat_file.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def finalize_scheduler_completion_evidence(

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -74,6 +74,7 @@ from scripts.ops.scheduler_start_boundary_guard_v0 import (
 )
 
 SCHEDULER_COMPLETION_CLOSEOUT_FILENAME = "scheduler_completion_closeout_v0.json"
+SCHEDULER_HEARTBEAT_FRESHNESS_FILENAME = "scheduler_heartbeat_freshness_v0.json"
 
 # Globaler Flag für graceful shutdown
 _shutdown_requested = False
@@ -130,6 +131,44 @@ def write_scheduler_completion_closeout(
     }
     closeout_path = evidence_dir / SCHEDULER_COMPLETION_CLOSEOUT_FILENAME
     closeout_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_scheduler_heartbeat_freshness(
+    heartbeat_file: Path,
+    *,
+    config_path: Path,
+    poll_interval: int,
+    include_tags: Optional[Set[str]],
+    exclude_tags: Optional[Set[str]],
+    dry_run: bool,
+    once: bool,
+    iteration: int,
+    due_jobs_count: int,
+    jobs_dispatched_total: int,
+    reason: str,
+) -> None:
+    """Write non-authorizing freshness marker for scheduler loop visibility."""
+    heartbeat_file.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": SCHEDULER_HEARTBEAT_FRESHNESS_FILENAME.replace(".json", ""),
+        "heartbeat_only": True,
+        "does_not_authorize_trading": True,
+        "live_authority_changed": False,
+        "testnet_started": False,
+        "real_orders_started": False,
+        "ts_utc": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "config_path": str(config_path),
+        "poll_interval_seconds": poll_interval,
+        "include_tags": sorted(include_tags) if include_tags else [],
+        "exclude_tags": sorted(exclude_tags) if exclude_tags else [],
+        "dry_run": dry_run,
+        "once": once,
+        "iteration": iteration,
+        "due_jobs_count": due_jobs_count,
+        "jobs_dispatched_total": jobs_dispatched_total,
+        "reason": reason,
+    }
+    heartbeat_file.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def finalize_scheduler_completion_evidence(
@@ -253,6 +292,12 @@ Examples:
         "--primary-evidence-enforce",
         action="store_true",
         help="Require MANIFEST.sha256 finalize at completion (requires --evidence-dir; non-dry-run only)",
+    )
+    parser.add_argument(
+        "--heartbeat-file",
+        type=str,
+        default=None,
+        help="Optional non-authorizing scheduler heartbeat/freshness file path",
     )
 
     return parser.parse_args(argv)
@@ -503,6 +548,7 @@ def run_scheduler_loop(
     notifier,
     evidence_dir: Optional[Path] = None,
     primary_evidence_enforce: bool = False,
+    heartbeat_file: Optional[Path] = None,
 ) -> int:
     """Hauptschleife des Schedulers."""
     global _shutdown_requested
@@ -579,6 +625,21 @@ def run_scheduler_loop(
 
         # Fällige Jobs finden
         due_jobs = get_due_jobs(jobs, now=now)
+
+        if heartbeat_file is not None:
+            write_scheduler_heartbeat_freshness(
+                heartbeat_file,
+                config_path=config_path,
+                poll_interval=poll_interval,
+                include_tags=include_tags,
+                exclude_tags=exclude_tags,
+                dry_run=dry_run,
+                once=once,
+                iteration=iteration,
+                due_jobs_count=len(due_jobs),
+                jobs_dispatched_total=total_jobs_run,
+                reason="jobs_due" if due_jobs else "idle_no_due_jobs",
+            )
 
         if due_jobs:
             print(f"\n[SCHEDULER] {len(due_jobs)} fällige Jobs:")
@@ -700,6 +761,9 @@ def main(argv=None) -> int:
         notifier=notifier,
         evidence_dir=evidence_dir,
         primary_evidence_enforce=primary_evidence_enforce,
+        heartbeat_file=Path(args.heartbeat_file).expanduser().resolve()
+        if args.heartbeat_file
+        else None,
     )
 
 

--- a/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
@@ -324,6 +324,8 @@ def test_command_plan_includes_run_scheduler(tmp_path: Path) -> None:
     plan = _plan_dict(_staging(tmp_path))
     joined = " ".join(plan["commands"]["scheduler_bounded"])
     assert "run_scheduler.py" in joined
+    assert "--heartbeat-file" in joined
+    assert "scheduler_heartbeat_freshness_v0.json" in joined
 
 
 def test_command_plan_includes_review_helper(tmp_path: Path) -> None:

--- a/tests/ops/test_scheduler_heartbeat_freshness_v0.py
+++ b/tests/ops/test_scheduler_heartbeat_freshness_v0.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import run_scheduler
+
+
+def test_write_scheduler_heartbeat_freshness_is_non_authorizing(tmp_path: Path) -> None:
+    heartbeat = tmp_path / "runtime_out" / "scheduler_heartbeat_freshness_v0.json"
+
+    run_scheduler.write_scheduler_heartbeat_freshness(
+        heartbeat,
+        config_path=Path("config/scheduler/jobs.toml"),
+        poll_interval=30,
+        include_tags={"paper_runtime"},
+        exclude_tags=None,
+        dry_run=False,
+        once=False,
+        iteration=7,
+        due_jobs_count=0,
+        jobs_dispatched_total=1,
+        reason="idle_no_due_jobs",
+    )
+
+    payload = json.loads(heartbeat.read_text(encoding="utf-8"))
+    assert payload["version"] == "scheduler_heartbeat_freshness_v0"
+    assert payload["heartbeat_only"] is True
+    assert payload["does_not_authorize_trading"] is True
+    assert payload["live_authority_changed"] is False
+    assert payload["testnet_started"] is False
+    assert payload["real_orders_started"] is False
+    assert payload["include_tags"] == ["paper_runtime"]
+    assert payload["reason"] == "idle_no_due_jobs"


### PR DESCRIPTION
## Summary

Adds non-authorizing heartbeat/freshness evidence for bounded paper runtime observation flows.

This addresses the stale-run observability gap found during the instrumented remote paper retry: the scheduler could remain running after an initial `schedule_type=once` bootstrap without producing fresh runtime evidence or logs, making the run look stale even when no safety boundary was breached.

## Scope

- Adds optional scheduler heartbeat/freshness artifact:
  - `scheduler_heartbeat_freshness_v0.json`
- Adapter passes a heartbeat path through the existing bounded paper runtime context:
  - `staging/runtime_out/scheduler_heartbeat_freshness_v0.json`
- Heartbeat markers are explicitly non-authorizing:
  - `heartbeat_only=true`
  - `does_not_authorize_trading=true`
  - `live_authority_changed=false`
  - `testnet_started=false`
  - `real_orders_started=false`
- Extends existing offline tests and adds focused heartbeat/freshness coverage.

## Safety

- No remote SSH
- No AWS changes
- No runtime start
- No scheduler start
- No paper/shadow/testnet/live run
- No broker/exchange credentials
- No Master V2 / Double Play / Risk / KillSwitch / Scope / Capital / Execution / Live-Gate changes
- No trading/execution semantics changed
- No jobs are forced by the heartbeat

## Checks

- `uv run pytest tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py tests/ops/test_scheduler_hold_runtime_binding_v0.py tests/ops/test_scheduler_heartbeat_freshness_v0.py -q`
- `uv run pytest tests/ops -k "heartbeat or freshness or paper_runtime or bounded_observation or scheduler_hold_runtime_binding" -q`
- `uv run ruff check scripts/run_scheduler.py scripts/ops/run_paper_only_bounded_observation_adapter_v0.py tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py tests/ops/test_scheduler_heartbeat_freshness_v0.py`

## Evidence

- `/tmp/peak_trade_paper_runtime_heartbeat_freshness_fix_20260528T104157Z`
