### PR TITLE
ops: enforce durable closeout completion

### DIFF
--- a/scripts/ops/durable_closeout_copy_verify_v0.py
+++ b/scripts/ops/durable_closeout_copy_verify_v0.py
@@ -27,6 +27,15 @@ from scripts.ops.primary_evidence_retention_v0 import (
 
 README_FILENAME = "DURABLE_COPY_README.md"
 CLOSEOUT_GLOB = "*CLOSEOUT*.md"
+MANIFEST_VERIFY_LOG_FILENAME = "MANIFEST_VERIFY.log"
+DEFAULT_POINTER_EVIDENCE_PATTERNS: tuple[str, ...] = (
+    "PR_URL.txt",
+    "PR_METADATA.json",
+    "ARCHIVE_POINTER.md",
+    "*.pointer",
+    "*INDEX*.md",
+    "*index*.md",
+)
 
 
 @dataclass
@@ -36,6 +45,9 @@ class CopyVerifyResult:
     source_dir: str
     dest_dir: str
     dest_manifest_verify_rc: str
+    manifest_verify_log_status: str
+    pointer_evidence_required: bool
+    pointer_evidence_found: bool
     source_tmp_not_canonical: bool
     force_overwrite: bool
     error: str = ""
@@ -100,6 +112,33 @@ def _copy_tree(source: Path, dest: Path) -> None:
         shutil.copy2(src_path, dst_path)
 
 
+def _verify_manifest_with_log(dest: Path) -> tuple[bool, str, str]:
+    """Verify MANIFEST and write MANIFEST_VERIFY.log with deterministic summary."""
+    ok, msg = verify_manifest_sha256(dest)
+    verify_log = _safe_dest_child(dest, Path(MANIFEST_VERIFY_LOG_FILENAME))
+    if ok:
+        verify_log.write_text("MANIFEST_VERIFY_RC=0\nSTATUS=OK\n", encoding="utf-8")
+        return True, "", "ok"
+    verify_log.write_text(f"MANIFEST_VERIFY_RC=1\nSTATUS=FAILED\nERROR={msg}\n", encoding="utf-8")
+    return False, msg, "failed"
+
+
+def _manifest_verify_log_is_success(dest: Path) -> bool:
+    path = _safe_dest_child(dest, Path(MANIFEST_VERIFY_LOG_FILENAME))
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    return "MANIFEST_VERIFY_RC=0" in text and "STATUS=OK" in text
+
+
+def _pointer_evidence_exists(dest: Path, patterns: tuple[str, ...]) -> bool:
+    for pattern in patterns:
+        for matched in dest.glob(pattern):
+            if matched.is_file():
+                return True
+    return False
+
+
 def _write_durable_readme(dest: Path, source: Path, *, pr_number: int | None) -> None:
     lines = [
         "# Durable Copy README",
@@ -124,6 +163,8 @@ def plan_and_execute(
     pr_number: int | None,
     pr_json: Path | None,
     require_closeout_report: bool,
+    require_durable_pointer_evidence: bool,
+    durable_pointer_patterns: tuple[str, ...],
     allow_tmp_source: bool,
     force: bool,
 ) -> CopyVerifyResult:
@@ -133,6 +174,9 @@ def plan_and_execute(
         source_dir=str(source_dir),
         dest_dir=str(dest_dir),
         dest_manifest_verify_rc="not_run",
+        manifest_verify_log_status="not_run",
+        pointer_evidence_required=require_durable_pointer_evidence,
+        pointer_evidence_found=False,
         source_tmp_not_canonical=is_under_tmp(source_dir),
         force_overwrite=force,
     )
@@ -165,6 +209,7 @@ def plan_and_execute(
     if dry_run:
         result.status = "pass"
         result.dest_manifest_verify_rc = "not_run"
+        result.manifest_verify_log_status = "not_run"
         return result
 
     if force and _dest_has_content(dest_dir):
@@ -174,10 +219,21 @@ def plan_and_execute(
         _copy_tree(source_dir, dest_dir)
         _write_durable_readme(dest_dir, source_dir, pr_number=pr_number)
         write_manifest_sha256(dest_dir)
-        ok_manifest, manifest_msg = verify_manifest_sha256(dest_dir)
+        ok_manifest, manifest_msg, log_status = _verify_manifest_with_log(dest_dir)
+        result.manifest_verify_log_status = log_status
         if not ok_manifest:
             result.dest_manifest_verify_rc = "nonzero"
             return _fail(result, f"manifest verify failed: {manifest_msg}")
+        if not _manifest_verify_log_is_success(dest_dir):
+            result.dest_manifest_verify_rc = "nonzero"
+            return _fail(result, "manifest verify log missing or failed")
+        result.pointer_evidence_found = _pointer_evidence_exists(dest_dir, durable_pointer_patterns)
+        if require_durable_pointer_evidence and not result.pointer_evidence_found:
+            result.dest_manifest_verify_rc = "nonzero"
+            return _fail(
+                result,
+                "durable pointer/index evidence missing while enforcement enabled",
+            )
         result.dest_manifest_verify_rc = "0"
         result.status = "pass"
         return result
@@ -193,6 +249,13 @@ def emit_machine_lines(result: CopyVerifyResult) -> None:
     print(f"DURABLE_CLOSEOUT_SOURCE_DIR={result.source_dir}")
     print(f"DURABLE_CLOSEOUT_DEST_DIR={result.dest_dir}")
     print(f"DURABLE_CLOSEOUT_DEST_MANIFEST_VERIFY_RC={result.dest_manifest_verify_rc}")
+    print(f"DURABLE_CLOSEOUT_MANIFEST_VERIFY_LOG_STATUS={result.manifest_verify_log_status}")
+    print(
+        f"DURABLE_CLOSEOUT_POINTER_EVIDENCE_REQUIRED={'true' if result.pointer_evidence_required else 'false'}"
+    )
+    print(
+        f"DURABLE_CLOSEOUT_POINTER_EVIDENCE_FOUND={'true' if result.pointer_evidence_found else 'false'}"
+    )
     print(f"SOURCE_TMP_NOT_CANONICAL={'true' if result.source_tmp_not_canonical else 'false'}")
     print("CLOSEOUT_DOES_NOT_AUTHORIZE_RUNTIME=true")
     print("RUNTIME_COMMANDS_CALLED=false")
@@ -232,6 +295,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
         action=argparse.BooleanOptionalAction,
         default=True,
     )
+    parser.add_argument(
+        "--require-durable-pointer-evidence",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Fail closed when no pointer/index evidence file exists in durable destination.",
+    )
+    parser.add_argument(
+        "--durable-pointer-pattern",
+        action="append",
+        default=None,
+        help="Glob pattern for acceptable durable pointer/index evidence files (repeatable).",
+    )
     parser.add_argument("--allow-tmp-source", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--json", action="store_true", dest="json_output")
@@ -240,6 +315,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_arg_parser().parse_args(argv)
+    pointer_patterns = tuple(
+        p for p in (args.durable_pointer_pattern or DEFAULT_POINTER_EVIDENCE_PATTERNS) if p
+    )
     result = plan_and_execute(
         source_dir=args.source_dir,
         dest_dir=args.dest_dir,
@@ -247,6 +325,8 @@ def main(argv: list[str] | None = None) -> int:
         pr_number=args.pr_number,
         pr_json=args.pr_json,
         require_closeout_report=args.require_closeout_report,
+        require_durable_pointer_evidence=args.require_durable_pointer_evidence,
+        durable_pointer_patterns=pointer_patterns,
         allow_tmp_source=args.allow_tmp_source,
         force=args.force,
     )

--- a/tests/ops/test_durable_closeout_copy_verify_v0.py
+++ b/tests/ops/test_durable_closeout_copy_verify_v0.py
@@ -70,7 +70,13 @@ def _cleanup_archive_like_dest(path: Path) -> None:
     shutil.rmtree(path.parents[2], ignore_errors=True)
 
 
-def _minimal_source(tmp_path: Path, *, with_closeout: bool = True, with_pr: bool = False) -> Path:
+def _minimal_source(
+    tmp_path: Path,
+    *,
+    with_closeout: bool = True,
+    with_pr: bool = False,
+    with_pointer: bool = False,
+) -> Path:
     src = tmp_path / "source"
     src.mkdir()
     (src / "note.txt").write_text("fixture\n", encoding="utf-8")
@@ -78,6 +84,8 @@ def _minimal_source(tmp_path: Path, *, with_closeout: bool = True, with_pr: bool
         (src / "AFTER_FIXTURE_CLOSEOUT.md").write_text("# closeout\n", encoding="utf-8")
     if with_pr:
         (src / "PR42.json").write_text('{"number": 42}\n', encoding="utf-8")
+    if with_pointer:
+        (src / "PR_URL.txt").write_text("https://example.invalid/pr/42\n", encoding="utf-8")
     return src
 
 
@@ -294,6 +302,7 @@ def test_non_dry_copy_creates_readme_and_manifest(helper, tmp_path):
         assert rc == 0
         assert (dest / "DURABLE_COPY_README.md").is_file()
         assert (dest / "MANIFEST.sha256").is_file()
+        assert (dest / "MANIFEST_VERIFY.log").is_file()
     finally:
         _cleanup_archive_like_dest(dest)
 
@@ -342,6 +351,82 @@ def test_duplicate_dest_with_force_succeeds(helper, tmp_path, capsys):
         rc = helper.main([*base_args, "--force"])
         assert rc == 0
         assert "FORCE_OVERWRITE=true" in capsys.readouterr().err
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
+def test_pointer_enforcement_enabled_blocks_without_pointer(helper, tmp_path):
+    src = _minimal_source(tmp_path, with_pointer=False)
+    dest = _archive_like_dest(tmp_path, "pointer_missing")
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
+                "--require-durable-pointer-evidence",
+            ]
+        )
+        assert rc == 1
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
+def test_pointer_enforcement_enabled_passes_with_pointer(helper, tmp_path):
+    src = _minimal_source(tmp_path, with_pointer=True)
+    dest = _archive_like_dest(tmp_path, "pointer_present")
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
+                "--require-durable-pointer-evidence",
+            ]
+        )
+        assert rc == 0
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
+def test_pointer_enforcement_disabled_is_backward_compatible(helper, tmp_path):
+    src = _minimal_source(tmp_path, with_pointer=False)
+    dest = _archive_like_dest(tmp_path, "pointer_optional")
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
+            ]
+        )
+        assert rc == 0
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
+def test_missing_manifest_verify_log_blocks(helper, tmp_path, monkeypatch):
+    src = _minimal_source(tmp_path, with_pointer=True)
+    dest = _archive_like_dest(tmp_path, "missing_manifest_log")
+    try:
+        monkeypatch.setattr(helper, "_manifest_verify_log_is_success", lambda _dest: False)
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
+                "--require-durable-pointer-evidence",
+            ]
+        )
+        assert rc == 1
     finally:
         _cleanup_archive_like_dest(dest)
 


### PR DESCRIPTION
## Summary
- Extend `scripts/ops/durable_closeout_copy_verify_v0.py` with optional fail-closed durable pointer/index enforcement (`--require-durable-pointer-evidence`) while preserving backward-compatible default behavior.
- Add deterministic manifest verify log handling (`MANIFEST_VERIFY.log`) and explicit machine lines for enforcement-required/found status.
- Reuse existing helper + tests only; no new owner surfaces or parallel docs/index/pointer layers.

## Reuse Drift Guard
- Canonical owners reused: `scripts/ops/durable_closeout_copy_verify_v0.py`, `scripts/ops/primary_evidence_retention_v0.py`, `scripts/ops/build_generic_evidence_run_registry_v1.py`, `scripts/ops/build_post_closeout_projection_payload_v0.py`, `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md`, `docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md`, `docs/ops/registry/DOCS_TRUTH_MAP.md`.
- Test owner reused: `tests/ops/test_durable_closeout_copy_verify_v0.py`.
- Duplicate surface risk managed by extending existing helper only.

## Durable Evidence
- Durable run report and logs archived outside `/tmp` under:
  `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/durable_closeout_completion_enforcement_v0_<STAMP>/`

## Safety Flags
- REMOTE_AWS_TOUCHED=false
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- LIVE_AUTHORITY_CHANGED=false
- DUPLICATE_SURFACE_CREATED=false

## Tests Run
- [x] `uv run pytest tests/ops/test_durable_closeout_copy_verify_v0.py -q`
- [x] `uv run pytest tests/ops -k "durable_closeout or closeout_completion or post_closeout or projection" -q`
- [x] `uv run ruff check scripts/ops/durable_closeout_copy_verify_v0.py tests/ops/test_durable_closeout_copy_verify_v0.py`
- [x] `uv run ruff format --check scripts/ops/durable_closeout_copy_verify_v0.py tests/ops/test_durable_closeout_copy_verify_v0.py`

No AWS/runtime/scheduler/paper/shadow/testnet/live process was started.
No Live authority changed.

Made with [Cursor](https://cursor.com)