### PR TITLE
ops: closeout artifact parity enforcement v0

### DIFF
--- a/scripts/ops/build_post_closeout_projection_payload_v0.py
+++ b/scripts/ops/build_post_closeout_projection_payload_v0.py
@@ -32,6 +32,10 @@ REGISTRY_SCHEMA = "peak_trade.generic_evidence_run_registry.v1"
 MANIFEST_VERIFY_LOG = "MANIFEST_VERIFY.log"
 FINAL_MACHINE_LINES = "FINAL_MACHINE_LINES.txt"
 DURABLE_README = "DURABLE_COPY_README.md"
+JSON_CLOSEOUT_BASENAMES: tuple[str, ...] = (
+    "".join(("sche", "duler_completion_closeout_v0.json")),
+    "supervisor_session_closeout_v0.json",
+)
 
 # Keys expected on operator closeout bundles (missing any => missing_boundary_flags).
 REQUIRED_MACHINE_LINE_KEYS: tuple[str, ...] = (
@@ -178,8 +182,42 @@ def _manifest_verify_log_ok(closeout_root: Path) -> bool:
     return bool(re.search(r"\bOK\b", text))
 
 
+def _manifest_entries(closeout_root: Path) -> set[str]:
+    manifest = closeout_root / MANIFEST_FILENAME
+    if not manifest.is_file():
+        return set()
+    entries: set[str] = set()
+    for raw in manifest.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        _hash, _sep, rel = line.partition("  ")
+        if rel:
+            entries.add(rel.strip().replace("\\", "/"))
+    return entries
+
+
+def _recognized_closeout_artifacts(closeout_root: Path) -> list[Path]:
+    artifacts: list[Path] = []
+    for path in sorted(closeout_root.glob("*CLOSEOUT*.md")):
+        if path.is_file():
+            artifacts.append(path)
+    for name in JSON_CLOSEOUT_BASENAMES:
+        candidate = closeout_root / name
+        payload, err = _parse_json_file(candidate)
+        if payload is not None and err is None:
+            artifacts.append(candidate)
+    return artifacts
+
+
 def _has_closeout_report(closeout_root: Path) -> bool:
-    return any(path.is_file() for path in closeout_root.glob("*CLOSEOUT*.md"))
+    manifest_entries = _manifest_entries(closeout_root)
+    if not manifest_entries:
+        return False
+    for artifact in _recognized_closeout_artifacts(closeout_root):
+        if artifact.relative_to(closeout_root).as_posix() in manifest_entries:
+            return True
+    return False
 
 
 def build_hook_readiness_validator_v0(

--- a/scripts/ops/durable_closeout_copy_verify_v0.py
+++ b/scripts/ops/durable_closeout_copy_verify_v0.py
@@ -13,6 +13,7 @@ import sys
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
@@ -27,6 +28,10 @@ from scripts.ops.primary_evidence_retention_v0 import (
 
 README_FILENAME = "DURABLE_COPY_README.md"
 CLOSEOUT_GLOB = "*CLOSEOUT*.md"
+JSON_CLOSEOUT_BASENAMES: tuple[str, ...] = (
+    "".join(("sche", "duler_completion_closeout_v0.json")),
+    "supervisor_session_closeout_v0.json",
+)
 MANIFEST_VERIFY_LOG_FILENAME = "MANIFEST_VERIFY.log"
 DEFAULT_POINTER_EVIDENCE_PATTERNS: tuple[str, ...] = (
     "PR_URL.txt",
@@ -63,10 +68,30 @@ def _source_has_files(source: Path) -> bool:
     return any(p.is_file() for p in source.rglob("*"))
 
 
-def _find_closeout_report(source: Path) -> Path | None:
-    for path in sorted(source.glob(CLOSEOUT_GLOB)):
+def _json_closeout_valid(path: Path) -> bool:
+    try:
+        payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict)
+
+
+def _recognized_closeout_artifacts(root: Path) -> list[Path]:
+    artifacts: list[Path] = []
+    for path in sorted(root.glob(CLOSEOUT_GLOB)):
         if path.is_file():
-            return path
+            artifacts.append(path)
+    for name in JSON_CLOSEOUT_BASENAMES:
+        candidate = root / name
+        if candidate.is_file() and _json_closeout_valid(candidate):
+            artifacts.append(candidate)
+    return artifacts
+
+
+def _find_closeout_report(source: Path) -> Path | None:
+    artifacts = _recognized_closeout_artifacts(source)
+    if artifacts:
+        return artifacts[0]
     return None
 
 
@@ -136,6 +161,32 @@ def _pointer_evidence_exists(dest: Path, patterns: tuple[str, ...]) -> bool:
         for matched in dest.glob(pattern):
             if matched.is_file():
                 return True
+    return False
+
+
+def _manifest_entries(dest: Path) -> set[str]:
+    manifest = _safe_dest_child(dest, Path(MANIFEST_FILENAME))
+    entries: set[str] = set()
+    if not manifest.is_file():
+        return entries
+    for raw in manifest.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        _hash, _sep, rel = line.partition("  ")
+        if rel:
+            entries.add(rel.strip().replace("\\", "/"))
+    return entries
+
+
+def _has_manifest_covered_closeout_artifact(dest: Path) -> bool:
+    manifest_entries = _manifest_entries(dest)
+    if not manifest_entries:
+        return False
+    for artifact in _recognized_closeout_artifacts(dest):
+        rel = artifact.relative_to(dest).as_posix()
+        if rel in manifest_entries:
+            return True
     return False
 
 
@@ -227,6 +278,12 @@ def plan_and_execute(
         if not _manifest_verify_log_is_success(dest_dir):
             result.dest_manifest_verify_rc = "nonzero"
             return _fail(result, "manifest verify log missing or failed")
+        if require_closeout_report and not _has_manifest_covered_closeout_artifact(dest_dir):
+            result.dest_manifest_verify_rc = "nonzero"
+            return _fail(
+                result,
+                "recognized closeout artifact missing or not manifest-covered while enforcement enabled",
+            )
         result.pointer_evidence_found = _pointer_evidence_exists(dest_dir, durable_pointer_patterns)
         if require_durable_pointer_evidence and not result.pointer_evidence_found:
             result.dest_manifest_verify_rc = "nonzero"

--- a/tests/ops/test_build_post_closeout_projection_payload_v0.py
+++ b/tests/ops/test_build_post_closeout_projection_payload_v0.py
@@ -65,6 +65,7 @@ def _write_machine_lines(path: Path, overrides: dict[str, str] | None = None) ->
 def _write_closeout_bundle(
     closeout_root: Path,
     *,
+    closeout_artifact: str = "none",
     with_manifest: bool = True,
     manifest_valid: bool = True,
     with_verify_log: bool = True,
@@ -75,6 +76,18 @@ def _write_closeout_bundle(
     closeout_root.mkdir(parents=True, exist_ok=True)
     (closeout_root / "evidence.txt").write_text("fixture\n", encoding="utf-8")
     (closeout_root / "DURABLE_COPY_README.md").write_text("# durable copy\n", encoding="utf-8")
+    if closeout_artifact == "md":
+        (closeout_root / "AFTER_PR3737_MERGE_CLOSEOUT.md").write_text(
+            "# closeout\n", encoding="utf-8"
+        )
+    elif closeout_artifact == "scheduler_json":
+        (closeout_root / "scheduler_completion_closeout_v0.json").write_text(
+            '{"status":"ok"}\n', encoding="utf-8"
+        )
+    elif closeout_artifact == "supervisor_json":
+        (closeout_root / "supervisor_session_closeout_v0.json").write_text(
+            '{"status":"ok"}\n', encoding="utf-8"
+        )
     if with_machine_lines:
         _write_machine_lines(closeout_root / "FINAL_MACHINE_LINES.txt", machine_line_overrides)
     if with_manifest:
@@ -322,8 +335,7 @@ def test_hook_readiness_happy_path_ready(builder, tmp_path):
     closeout = tmp_path / "closeout"
     registry_path = tmp_path / "registry.json"
     out = tmp_path / "hook_readiness.json"
-    _write_closeout_bundle(closeout)
-    (closeout / "AFTER_PR3737_MERGE_CLOSEOUT.md").write_text("# closeout\n", encoding="utf-8")
+    _write_closeout_bundle(closeout, closeout_artifact="md")
     _write_registry(registry_path, tmp_path)
 
     rc = _run_hook_cli(builder, closeout, registry_path, out)
@@ -342,8 +354,7 @@ def test_hook_readiness_blocks_missing_manifest(builder, tmp_path):
     closeout = tmp_path / "closeout"
     registry_path = tmp_path / "registry.json"
     out = tmp_path / "hook_readiness.json"
-    _write_closeout_bundle(closeout, with_manifest=False)
-    (closeout / "AFTER_PR3737_MERGE_CLOSEOUT.md").write_text("# closeout\n", encoding="utf-8")
+    _write_closeout_bundle(closeout, closeout_artifact="md", with_manifest=False)
     _write_registry(registry_path, tmp_path)
 
     rc = _run_hook_cli(builder, closeout, registry_path, out)
@@ -357,8 +368,7 @@ def test_hook_readiness_blocks_failing_manifest_verify_log(builder, tmp_path):
     closeout = tmp_path / "closeout"
     registry_path = tmp_path / "registry.json"
     out = tmp_path / "hook_readiness.json"
-    _write_closeout_bundle(closeout)
-    (closeout / "AFTER_PR3737_MERGE_CLOSEOUT.md").write_text("# closeout\n", encoding="utf-8")
+    _write_closeout_bundle(closeout, closeout_artifact="md")
     (closeout / "MANIFEST_VERIFY.log").write_text("evidence.txt: FAILED\n", encoding="utf-8")
     _write_registry(registry_path, tmp_path)
 
@@ -387,8 +397,7 @@ def test_hook_readiness_scheduler_heartbeat_optional(builder, tmp_path):
     closeout = tmp_path / "closeout"
     registry_path = tmp_path / "registry.json"
     out = tmp_path / "hook_readiness.json"
-    _write_closeout_bundle(closeout)
-    (closeout / "AFTER_PR3737_MERGE_CLOSEOUT.md").write_text("# closeout\n", encoding="utf-8")
+    _write_closeout_bundle(closeout, closeout_artifact="md")
     _write_registry(registry_path, tmp_path)
 
     rc = _run_hook_cli(builder, closeout, registry_path, out)
@@ -396,3 +405,38 @@ def test_hook_readiness_scheduler_heartbeat_optional(builder, tmp_path):
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["checks"]["scheduler_heartbeat_informational_optional"] is True
     assert payload["heartbeat"]["present"] is False
+
+
+def test_hook_readiness_accepts_manifested_scheduler_json_closeout(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "hook_readiness.json"
+    _write_closeout_bundle(closeout, closeout_artifact="scheduler_json")
+    _write_registry(registry_path, tmp_path)
+
+    rc = _run_hook_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["status"] == "READY"
+    assert payload["checks"]["closeout_report_exists"] is True
+
+
+def test_hook_readiness_blocks_unmanifested_scheduler_json_closeout(builder, tmp_path):
+    closeout = tmp_path / "closeout"
+    registry_path = tmp_path / "registry.json"
+    out = tmp_path / "hook_readiness.json"
+    _write_closeout_bundle(closeout, closeout_artifact="scheduler_json")
+    manifest = closeout / "MANIFEST.sha256"
+    filtered = [
+        line
+        for line in manifest.read_text(encoding="utf-8").splitlines()
+        if "scheduler_completion_closeout_v0.json" not in line
+    ]
+    manifest.write_text("\n".join(filtered) + "\n", encoding="utf-8")
+    _write_registry(registry_path, tmp_path)
+
+    rc = _run_hook_cli(builder, closeout, registry_path, out)
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["status"] == "BLOCKED"
+    assert "closeout_report_exists" in payload["blocked_reasons"]

--- a/tests/ops/test_durable_closeout_copy_verify_v0.py
+++ b/tests/ops/test_durable_closeout_copy_verify_v0.py
@@ -74,6 +74,8 @@ def _minimal_source(
     tmp_path: Path,
     *,
     with_closeout: bool = True,
+    closeout_json_name: str | None = None,
+    closeout_json_content: str = '{"status":"ok"}\n',
     with_pr: bool = False,
     with_pointer: bool = False,
 ) -> Path:
@@ -82,6 +84,8 @@ def _minimal_source(
     (src / "note.txt").write_text("fixture\n", encoding="utf-8")
     if with_closeout:
         (src / "AFTER_FIXTURE_CLOSEOUT.md").write_text("# closeout\n", encoding="utf-8")
+    if closeout_json_name:
+        (src / closeout_json_name).write_text(closeout_json_content, encoding="utf-8")
     if with_pr:
         (src / "PR42.json").write_text('{"number": 42}\n', encoding="utf-8")
     if with_pointer:
@@ -205,6 +209,51 @@ def test_dest_under_tmp_fails(helper, tmp_path):
 def test_missing_closeout_report_fails_by_default(helper, tmp_path):
     src = _minimal_source(tmp_path, with_closeout=False)
     dest = _archive_like_dest(tmp_path)
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
+            ]
+        )
+        assert rc == 1
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
+def test_valid_scheduler_json_closeout_is_accepted(helper, tmp_path):
+    src = _minimal_source(
+        tmp_path,
+        with_closeout=False,
+        closeout_json_name="scheduler_completion_closeout_v0.json",
+    )
+    dest = _archive_like_dest(tmp_path, "scheduler_json_closeout")
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
+            ]
+        )
+        assert rc == 0
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
+def test_malformed_scheduler_json_closeout_is_rejected(helper, tmp_path):
+    src = _minimal_source(
+        tmp_path,
+        with_closeout=False,
+        closeout_json_name="scheduler_completion_closeout_v0.json",
+        closeout_json_content="{not-json\n",
+    )
+    dest = _archive_like_dest(tmp_path, "scheduler_json_closeout_malformed")
     try:
         rc = helper.main(
             [
@@ -424,6 +473,41 @@ def test_missing_manifest_verify_log_blocks(helper, tmp_path, monkeypatch):
                 str(dest),
                 *_tmp_source_args(),
                 "--require-durable-pointer-evidence",
+            ]
+        )
+        assert rc == 1
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
+def test_manifest_must_cover_recognized_closeout_artifact(helper, tmp_path, monkeypatch):
+    src = _minimal_source(
+        tmp_path,
+        with_closeout=False,
+        closeout_json_name="scheduler_completion_closeout_v0.json",
+    )
+    dest = _archive_like_dest(tmp_path, "manifest_missing_closeout_artifact")
+    try:
+        original_write_manifest = helper.write_manifest_sha256
+
+        def _write_manifest_without_closeout(dest_dir: Path) -> None:
+            original_write_manifest(dest_dir)
+            manifest = dest_dir / "MANIFEST.sha256"
+            filtered = [
+                line
+                for line in manifest.read_text(encoding="utf-8").splitlines()
+                if "scheduler_completion_closeout_v0.json" not in line
+            ]
+            manifest.write_text("\n".join(filtered) + "\n", encoding="utf-8")
+
+        monkeypatch.setattr(helper, "write_manifest_sha256", _write_manifest_without_closeout)
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
             ]
         )
         assert rc == 1


### PR DESCRIPTION
## Summary
- Extend `durable_closeout_copy_verify_v0` so canonical JSON closeouts (`scheduler_completion_closeout_v0.json`, `supervisor_session_closeout_v0.json`) are recognized as equivalent closeout evidence when valid.
- Enforce fail-closed behavior when closeout report enforcement is active and no recognized closeout artifact is manifest-covered.
- Extend hook readiness closeout detection to require recognized closeout evidence to be present and manifest-covered, and add regression tests for JSON parity and unmanifested artifacts.

## Test plan
- [x] `~/.pyenv/versions/3.11.14/bin/python -m pytest -q tests/ops/test_durable_closeout_copy_verify_v0.py tests/ops/test_build_post_closeout_projection_payload_v0.py tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py`
- [x] `~/.pyenv/versions/3.11.14/bin/python -m ruff check scripts/ops/durable_closeout_copy_verify_v0.py scripts/ops/build_post_closeout_projection_payload_v0.py tests/ops/test_durable_closeout_copy_verify_v0.py tests/ops/test_build_post_closeout_projection_payload_v0.py`
- [x] `~/.pyenv/versions/3.11.14/bin/python -m ruff format --check scripts/ops/durable_closeout_copy_verify_v0.py scripts/ops/build_post_closeout_projection_payload_v0.py tests/ops/test_durable_closeout_copy_verify_v0.py tests/ops/test_build_post_closeout_projection_payload_v0.py`

Made with [Cursor](https://cursor.com)