### PR TITLE
ops: emit bounded adapter final machine lines

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -76,6 +76,8 @@ USAGE_EXIT = 2
 VALIDATION_EXIT = 1
 TIMEOUT_EXIT = 124
 START_RETURN_CODE_ARTIFACT = "start_return_code.txt"
+FINAL_MACHINE_LINES_FILENAME = "FINAL_MACHINE_LINES.txt"
+BOUNDED_ADAPTER_LANE_PAPER = "paper_only_bounded_observation_v0"
 
 
 @dataclass(frozen=True)
@@ -309,6 +311,7 @@ def build_plan(
         "MANIFEST.sha256",
         "CLOSEOUT.md",
         "POSTRUN_ANALYSIS.md",
+        FINAL_MACHINE_LINES_FILENAME,
     ]
 
     commands = {
@@ -451,6 +454,72 @@ def _default_subprocess_runner(
     return int(proc.returncode or 0)
 
 
+def build_bounded_adapter_final_machine_lines_v0(
+    *,
+    run_id: str,
+    adapter_lane: str,
+    execution_performed: bool,
+    review_verdict: str | None = None,
+    closeout_succeeded: bool = True,
+) -> dict[str, str]:
+    """Deterministic non-authorizing FINAL_MACHINE_LINES payload for bounded adapters."""
+    from scripts.ops.build_post_closeout_projection_payload_v0 import (
+        REQUIRED_MACHINE_LINE_KEYS,
+    )
+
+    lines = {key: "false" for key in REQUIRED_MACHINE_LINE_KEYS}
+    if execution_performed:
+        lines["RUNTIME_COMMANDS_CALLED"] = "true"
+    lines.update(
+        {
+            "ADAPTER_EXECUTED": "true" if execution_performed else "false",
+            "ADAPTER_LANE": adapter_lane,
+            "RUN_ID": run_id,
+            "REMOTE_AWS_TOUCHED": "false",
+            "RUNTIME_STARTED": "false",
+            "SCHEDULER_STARTED": "false",
+            "PAPER_SHADOW_TESTNET_LIVE_STARTED": "false",
+            "LIVE_AUTHORITY_CHANGED": "false",
+            "PREFLIGHT_BLOCKED": "true",
+            "CLOSEOUT_ARTIFACT_EMIT_V0": "true",
+            "CLOSEOUT_SUCCEEDED": "true" if closeout_succeeded else "false",
+            "REVIEW_VERDICT": str(review_verdict or "UNKNOWN"),
+            "BOUNDED_OBSERVATION_ONLY": "true",
+            "NOTION_WRITE_CALLED": "false",
+            "S3_AWS_RCLONE_CALLED": "false",
+            "WORKFLOW_DISPATCH_CALLED": "false",
+            "BROKER_EXCHANGE_CALLED": "false",
+            "LIVE_AUTHORITY": "false",
+            "TESTNET_AUTHORITY": "false",
+        }
+    )
+    return lines
+
+
+def _write_final_machine_lines_artifact(
+    staging_root: Path,
+    *,
+    run_id: str,
+    adapter_lane: str,
+    execution_performed: bool,
+    review_verdict: str | None,
+    closeout_succeeded: bool = True,
+) -> None:
+    lines = build_bounded_adapter_final_machine_lines_v0(
+        run_id=run_id,
+        adapter_lane=adapter_lane,
+        execution_performed=execution_performed,
+        review_verdict=review_verdict,
+        closeout_succeeded=closeout_succeeded,
+    )
+    staging_root.mkdir(parents=True, exist_ok=True)
+    ordered = sorted(lines.items())
+    (staging_root / FINAL_MACHINE_LINES_FILENAME).write_text(
+        "\n".join(f"{key}={value}" for key, value in ordered) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _write_closeout_artifacts(
     ctx: ExecuteContext,
     plan: AdapterPlan,
@@ -509,6 +578,14 @@ def _write_closeout_artifacts(
     (ctx.staging_root / "POSTRUN_ANALYSIS.md").write_text(
         "\n".join(postrun_lines) + "\n",
         encoding="utf-8",
+    )
+    _write_final_machine_lines_artifact(
+        ctx.staging_root,
+        run_id=ctx.run_id,
+        adapter_lane=BOUNDED_ADAPTER_LANE_PAPER,
+        execution_performed=True,
+        review_verdict=str(review_payload.get("verdict") or "UNKNOWN"),
+        closeout_succeeded=True,
     )
 
 

--- a/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
@@ -31,6 +31,12 @@ from scripts.ops.primary_evidence_retention_v0 import (
     verify_manifest_sha256,
     write_manifest_sha256 as _write_manifest_sha256,
 )
+from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
+    FINAL_MACHINE_LINES_FILENAME,
+    _write_final_machine_lines_artifact,
+)
+
+BOUNDED_ADAPTER_LANE_SHADOW = "shadow_bounded_observation_v0"
 
 ADAPTER_VERSION = "cli_adapter_wrapper_composition_v0"
 WRAPPER_SCRIPT = "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py"
@@ -304,6 +310,7 @@ def build_plan(
         "CLOSEOUT.md",
         "POSTRUN_ANALYSIS.md",
         "RUN_METADATA.json",
+        FINAL_MACHINE_LINES_FILENAME,
     ]
 
     commands = {
@@ -491,6 +498,14 @@ def _write_closeout_artifacts(
     (ctx.staging_root / "POSTRUN_ANALYSIS.md").write_text(
         "\n".join(postrun_lines) + "\n",
         encoding="utf-8",
+    )
+    _write_final_machine_lines_artifact(
+        ctx.staging_root,
+        run_id=ctx.run_id,
+        adapter_lane=BOUNDED_ADAPTER_LANE_SHADOW,
+        execution_performed=True,
+        review_verdict=str(review_payload.get("verdict") or "UNKNOWN"),
+        closeout_succeeded=True,
     )
 
 

--- a/tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py
+++ b/tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py
@@ -1,0 +1,224 @@
+"""Tests for bounded adapter FINAL_MACHINE_LINES.txt emission (non-authorizing)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.ops import test_build_post_closeout_projection_payload_v0 as payload_tests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PAPER_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_paper_only_bounded_observation_adapter_v0.py"
+SHADOW_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_shadow_bounded_observation_adapter_v0.py"
+FORBIDDEN_CHAIN_SCRIPT = REPO_ROOT / "scripts" / "ops" / "post_closeout_chain_execute_v0.py"
+
+SAFETY_FLAGS: tuple[str, ...] = (
+    "REMOTE_AWS_TOUCHED",
+    "RUNTIME_STARTED",
+    "SCHEDULER_STARTED",
+    "PAPER_SHADOW_TESTNET_LIVE_STARTED",
+    "LIVE_AUTHORITY_CHANGED",
+)
+
+
+def _load_paper():
+    import importlib.util
+    import sys
+
+    spec = importlib.util.spec_from_file_location(
+        "run_paper_only_bounded_observation_adapter_v0", PAPER_ADAPTER
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_shadow():
+    import importlib.util
+    import sys
+
+    spec = importlib.util.spec_from_file_location(
+        "run_shadow_bounded_observation_adapter_v0", SHADOW_ADAPTER
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def builder():
+    return payload_tests._load_builder()
+
+
+@pytest.fixture(scope="module")
+def paper():
+    return _load_paper()
+
+
+@pytest.fixture(scope="module")
+def shadow():
+    return _load_shadow()
+
+
+def _parse_machine_lines(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def test_forbidden_post_closeout_chain_execute_script_absent() -> None:
+    assert not FORBIDDEN_CHAIN_SCRIPT.exists()
+
+
+@pytest.mark.parametrize(
+    "lane",
+    [
+        "paper_only_bounded_observation_v0",
+        "shadow_bounded_observation_v0",
+    ],
+)
+def test_build_bounded_adapter_final_machine_lines_has_required_keys(
+    paper, builder, lane: str
+) -> None:
+    lines = paper.build_bounded_adapter_final_machine_lines_v0(
+        run_id="fixture_run",
+        adapter_lane=lane,
+        execution_performed=True,
+        review_verdict="PASS",
+    )
+    for key in builder.REQUIRED_MACHINE_LINE_KEYS:
+        assert key in lines
+    for flag in SAFETY_FLAGS:
+        assert lines[flag] == "false"
+
+
+def test_paper_write_closeout_artifacts_emits_final_machine_lines(paper, tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir(parents=True, exist_ok=True)
+    archive_dest = tmp_path / "archive" / "runs" / "paper" / "fixture_run"
+    ctx = paper.ExecuteContext(
+        args=type("Args", (), {})(),
+        repo_root=REPO_ROOT,
+        staging_root=staging,
+        archive_root=tmp_path / "archive",
+        runtime_out=staging / "runtime_out",
+        logs_dir=staging / "logs",
+        plan_dir=staging / "plan",
+        review_dir=staging / "review",
+        temp_jobs=staging / "jobs.toml",
+        run_id="fixture_run",
+    )
+    plan = paper.AdapterPlan(
+        adapter_version="test",
+        mode="execute",
+        staging_root=str(staging),
+        archive_root=str(tmp_path / "archive"),
+        duration_seconds=60,
+        poll_interval_seconds=30,
+        job_name="paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0",
+        include_tags="paper_runtime",
+        run_id="fixture_run",
+        repo_root=str(REPO_ROOT),
+        source_jobs_toml=str(REPO_ROOT / "config/scheduler/jobs.toml"),
+        commands={},
+        retention_steps=[],
+        expected_artifacts=[],
+    )
+    paper._write_closeout_artifacts(
+        ctx,
+        plan,
+        archive_dest,
+        {"verdict": "PASS", "issues": []},
+    )
+    path = staging / paper.FINAL_MACHINE_LINES_FILENAME
+    assert path.is_file()
+    lines = _parse_machine_lines(path)
+    assert lines["ADAPTER_LANE"] == paper.BOUNDED_ADAPTER_LANE_PAPER
+    assert lines["REVIEW_VERDICT"] == "PASS"
+
+
+def test_shadow_write_closeout_artifacts_emits_final_machine_lines(shadow, tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir(parents=True, exist_ok=True)
+    archive_dest = tmp_path / "archive" / "runs" / "shadow" / "fixture_run"
+    ctx = shadow.ExecuteContext(
+        args=type("Args", (), {})(),
+        repo_root=REPO_ROOT,
+        staging_root=staging,
+        archive_root=tmp_path / "archive",
+        wrapper_evidence=staging / "wrapper_evidence",
+        logs_dir=staging / "logs",
+        plan_dir=staging / "plan",
+        review_dir=staging / "review",
+        run_id="fixture_run",
+    )
+    plan = shadow.AdapterPlan(
+        adapter_version="test",
+        mode="execute",
+        staging_root=str(staging),
+        archive_root=str(tmp_path / "archive"),
+        duration_minutes=10,
+        max_steps=120,
+        step_interval_seconds=0.0,
+        run_id="fixture_run",
+        repo_root=str(REPO_ROOT),
+        wrapper_script="scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py",
+        wrapper_mode="bounded-shadow-dry-run",
+        commands={},
+        retention_steps=[],
+        expected_artifacts=[],
+    )
+    shadow._write_closeout_artifacts(
+        ctx,
+        plan,
+        archive_dest,
+        {"verdict": "PASS", "issues": []},
+    )
+    path = staging / shadow.FINAL_MACHINE_LINES_FILENAME
+    assert path.is_file()
+    lines = _parse_machine_lines(path)
+    assert lines["ADAPTER_LANE"] == shadow.BOUNDED_ADAPTER_LANE_SHADOW
+
+
+def test_emitted_lines_accepted_by_projection_builder(builder, paper, tmp_path: Path) -> None:
+    staging = tmp_path / "closeout"
+    staging.mkdir()
+    lines = paper.build_bounded_adapter_final_machine_lines_v0(
+        run_id="fixture_run",
+        adapter_lane=paper.BOUNDED_ADAPTER_LANE_PAPER,
+        execution_performed=True,
+        review_verdict="PASS",
+    )
+    (staging / "FINAL_MACHINE_LINES.txt").write_text(
+        "\n".join(f"{k}={v}" for k, v in sorted(lines.items())) + "\n",
+        encoding="utf-8",
+    )
+    payload_tests._write_closeout_bundle(staging, with_machine_lines=False, closeout_artifact="md")
+    registry_path = tmp_path / "registry.json"
+    payload_tests._write_registry(registry_path, tmp_path)
+    out = tmp_path / "payload.json"
+    rc = builder.main(
+        [
+            "--closeout-root",
+            str(staging),
+            "--registry-json",
+            str(registry_path),
+            "--output-json",
+            str(out),
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["projection_ready"] is True

--- a/tests/ops/test_closeout_final_machine_lines_contract_v0.py
+++ b/tests/ops/test_closeout_final_machine_lines_contract_v0.py
@@ -158,14 +158,19 @@ def test_projection_ready_is_not_wall_clock_duration_evidence(builder, tmp_path)
 
 
 def test_no_repo_production_script_writes_final_machine_lines_file():
-    """Inventory: only tests + payload builder reference FINAL_MACHINE_LINES.txt in-repo."""
+    """Inventory: bounded adapters + payload builder may write FINAL_MACHINE_LINES.txt."""
     scripts_ops = REPO_ROOT / "scripts" / "ops"
+    allowed_writers = {
+        "scripts/ops/build_post_closeout_projection_payload_v0.py",
+        "scripts/ops/run_paper_only_bounded_observation_adapter_v0.py",
+        "scripts/ops/run_shadow_bounded_observation_adapter_v0.py",
+    }
     writers: list[str] = []
     for path in scripts_ops.rglob("*.py"):
         text = path.read_text(encoding="utf-8")
         if 'FINAL_MACHINE_LINES.txt"' in text or "FINAL_MACHINE_LINES.txt'" in text:
             rel = path.relative_to(REPO_ROOT).as_posix()
-            if rel != "scripts/ops/build_post_closeout_projection_payload_v0.py":
+            if rel not in allowed_writers:
                 writers.append(rel)
     assert writers == [], (
         "unexpected production writers of FINAL_MACHINE_LINES.txt; "

--- a/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
@@ -306,6 +306,10 @@ def test_execute_accepts_sample_approval_with_mocked_runner(tmp_path: Path) -> N
     start_rc = staging / mod.START_RETURN_CODE_ARTIFACT
     assert start_rc.is_file()
     assert f"START_RC=0" in start_rc.read_text(encoding="utf-8")
+    assert (staging / mod.FINAL_MACHINE_LINES_FILENAME).is_file()
+    run_dirs = list((archive / "runs" / "paper").iterdir())
+    assert run_dirs
+    assert (run_dirs[0] / mod.FINAL_MACHINE_LINES_FILENAME).is_file()
 
 
 def test_command_plan_includes_make_scheduler_temp_config(tmp_path: Path) -> None:

--- a/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
@@ -362,6 +362,8 @@ def test_execute_accepts_sample_approval_with_mocked_runner(tmp_path: Path) -> N
     ok, reason = mod.verify_manifest_sha256(copied)
     assert ok, reason
     assert (copied / "review" / "REVIEW_RESULT.json").is_file()
+    assert (staging / mod.FINAL_MACHINE_LINES_FILENAME).is_file()
+    assert (copied / mod.FINAL_MACHINE_LINES_FILENAME).is_file()
 
 
 def test_command_plan_never_uses_scheduler_or_shadow_loop(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Extend canonical bounded Paper/Shadow observation adapters to emit deterministic `FINAL_MACHINE_LINES.txt` after closeout artifact generation, reusing `REQUIRED_MACHINE_LINE_KEYS` from the existing projection payload builder.
- Add regression tests proving required boundary/safety keys, projection acceptance, and that forbidden `post_closeout_chain_execute_v0.py` remains absent.

## Reuse Drift Guard
- **Reused owners:** `run_paper_only_bounded_observation_adapter_v0.py` (emitter helper), `run_shadow_bounded_observation_adapter_v0.py` (calls shared helper), `build_post_closeout_projection_payload_v0.py` (key contract), existing closeout/projection contract tests.
- **Duplicate surface risk:** low — no new chain script, index, readiness package, or dashboard/Notion integration.
- **Durable evidence:** written under Documents archive for this Cursor run (see PR checks / merge closeout).

## Safety
- No AWS/runtime/scheduler/paper/shadow/testnet/live started during implementation.
- No Live authority changed.
- Emitter is non-authorizing evidence only; does not perform durable copy, projection, Notion, or Market writes.

## Tests run
- `uv run pytest` on bounded adapter, final machine lines contract, post-closeout projection/chain/hook tests, and paper/shadow adapter suites (172 passed).
- `uv run ruff check` and `uv run ruff format --check` on touched files.

Made with [Cursor](https://cursor.com)