### PR TITLE
ops: let bounded adapters invoke durable closeout

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -28,6 +28,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from scripts.ops import bounded_daemon_paper_shadow_24h_approval_v0 as contract_24h
 from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
     verify_manifest_sha256,
     write_manifest_sha256 as _write_manifest_sha256,
 )
@@ -78,6 +79,9 @@ TIMEOUT_EXIT = 124
 START_RETURN_CODE_ARTIFACT = "start_return_code.txt"
 FINAL_MACHINE_LINES_FILENAME = "FINAL_MACHINE_LINES.txt"
 BOUNDED_ADAPTER_LANE_PAPER = "paper_only_bounded_observation_v0"
+DURABLE_CLOSEOUT_SCRIPT = _REPO_ROOT / "scripts" / "ops" / "durable_closeout_copy_verify_v0.py"
+
+DurableCloseoutInvoker = Callable[[Sequence[str]], int]
 
 
 @dataclass(frozen=True)
@@ -416,7 +420,117 @@ def validate_execute_preconditions(
         clean, reason = repo_clean_checker(ctx.repo_root)
         if not clean:
             issues.append(reason or "repository is not clean")
+    issues.extend(validate_durable_closeout_invoke_cli_args(ctx.args))
     return issues
+
+
+def validate_durable_closeout_invoke_cli_args(args: argparse.Namespace) -> list[str]:
+    """Validate durable closeout invocation flags (default-off; fail-closed when enabled)."""
+    if not getattr(args, "invoke_durable_closeout_v0", False):
+        return []
+    dest = getattr(args, "durable_closeout_dest_dir", None)
+    if dest is None:
+        return ["--durable-closeout-dest-dir is required with --invoke-durable-closeout-v0"]
+    dest_path = Path(dest).expanduser().resolve()
+    if is_under_tmp(dest_path):
+        return ["durable closeout destination must be outside /tmp"]
+    return []
+
+
+def _default_durable_closeout_invoker(argv: Sequence[str]) -> int:
+    proc = subprocess.run(
+        list(argv),
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if proc.stderr:
+        print(proc.stderr, file=sys.stderr)
+    return int(proc.returncode)
+
+
+def build_durable_closeout_invoke_argv(
+    *,
+    source_dir: Path,
+    dest_dir: Path,
+) -> list[str]:
+    argv = [
+        sys.executable,
+        str(DURABLE_CLOSEOUT_SCRIPT),
+        "--source-dir",
+        str(source_dir.resolve()),
+        "--dest-dir",
+        str(dest_dir.resolve()),
+    ]
+    if is_under_tmp(source_dir):
+        argv.append("--allow-tmp-source")
+    return argv
+
+
+def invoke_durable_closeout_after_archive(
+    *,
+    source_dir: Path,
+    dest_dir: Path,
+    durable_closeout_invoker: DurableCloseoutInvoker | None = None,
+) -> int:
+    """Invoke canonical durable closeout helper after adapter archive success."""
+    invoker = durable_closeout_invoker or _default_durable_closeout_invoker
+    return invoker(build_durable_closeout_invoke_argv(source_dir=source_dir, dest_dir=dest_dir))
+
+
+def emit_bounded_adapter_durable_closeout_machine_lines(
+    *,
+    invoked: bool,
+    rc: int,
+    source_dir: Path,
+    dest_dir: Path | None,
+) -> None:
+    print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_INVOKED={'true' if invoked else 'false'}")
+    if not invoked:
+        return
+    status = "pass" if rc == 0 else "failed"
+    print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_STATUS={status}")
+    print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_SOURCE_DIR={source_dir.resolve()}")
+    if dest_dir is not None:
+        print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_DEST_DIR={dest_dir.resolve()}")
+    print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_HELPER_RC={rc}")
+    print("BOUNDED_ADAPTER_DURABLE_CLOSEOUT_NON_AUTHORIZING=true")
+    print("REMOTE_AWS_TOUCHED=false")
+    print("RUNTIME_STARTED=false")
+    print("SCHEDULER_STARTED=false")
+    print("PAPER_SHADOW_TESTNET_LIVE_STARTED=false")
+    print("LIVE_AUTHORITY_CHANGED=false")
+    print("DUPLICATE_SURFACE_CREATED=false")
+
+
+def maybe_invoke_durable_closeout_after_archive(
+    ctx: ExecuteContext,
+    archive_dest: Path,
+    *,
+    durable_closeout_invoker: DurableCloseoutInvoker | None = None,
+) -> int:
+    """Return adapter exit code after optional durable closeout invocation."""
+    if not getattr(ctx.args, "invoke_durable_closeout_v0", False):
+        emit_bounded_adapter_durable_closeout_machine_lines(
+            invoked=False,
+            rc=0,
+            source_dir=archive_dest,
+            dest_dir=None,
+        )
+        return 0
+    dest_dir = Path(ctx.args.durable_closeout_dest_dir).expanduser().resolve()
+    rc = invoke_durable_closeout_after_archive(
+        source_dir=archive_dest,
+        dest_dir=dest_dir,
+        durable_closeout_invoker=durable_closeout_invoker,
+    )
+    emit_bounded_adapter_durable_closeout_machine_lines(
+        invoked=True,
+        rc=rc,
+        source_dir=archive_dest,
+        dest_dir=dest_dir,
+    )
+    return 0 if rc == 0 else VALIDATION_EXIT
 
 
 def _default_subprocess_runner(
@@ -611,6 +725,7 @@ def execute_plan(
     plan: AdapterPlan,
     *,
     subprocess_runner: SubprocessRunner,
+    durable_closeout_invoker: DurableCloseoutInvoker | None = None,
 ) -> int:
     ctx.staging_root.mkdir(parents=True, exist_ok=True)
     ctx.runtime_out.mkdir(parents=True, exist_ok=True)
@@ -698,7 +813,11 @@ def execute_plan(
         + "\n",
         encoding="utf-8",
     )
-    return 0
+    return maybe_invoke_durable_closeout_after_archive(
+        ctx,
+        archive_dest,
+        durable_closeout_invoker=durable_closeout_invoker,
+    )
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -757,6 +876,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Do not require clean git working tree before execute.",
     )
     parser.add_argument("--json", action="store_true", help="Emit plan as JSON.")
+    parser.add_argument(
+        "--invoke-durable-closeout-v0",
+        action="store_true",
+        help=(
+            "After successful archive copy, invoke durable_closeout_copy_verify_v0.py "
+            "(requires --durable-closeout-dest-dir outside /tmp)."
+        ),
+    )
+    parser.add_argument(
+        "--durable-closeout-dest-dir",
+        type=Path,
+        default=None,
+        help="Durable material closeout destination (required with --invoke-durable-closeout-v0).",
+    )
     return parser
 
 
@@ -764,6 +897,7 @@ def main(
     argv: list[str] | None = None,
     *,
     subprocess_runner: SubprocessRunner | None = None,
+    durable_closeout_invoker: DurableCloseoutInvoker | None = None,
     repo_clean_checker: RepoCleanChecker | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> int:
@@ -851,7 +985,12 @@ def main(
                 print(issue, file=sys.stderr)
             return VALIDATION_EXIT
         runner = subprocess_runner or _default_subprocess_runner
-        rc = execute_plan(ctx, plan, subprocess_runner=runner)
+        rc = execute_plan(
+            ctx,
+            plan,
+            subprocess_runner=runner,
+            durable_closeout_invoker=durable_closeout_invoker,
+        )
         _write_start_return_code_artifact(
             staging_root,
             rc,

--- a/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
@@ -32,8 +32,11 @@ from scripts.ops.primary_evidence_retention_v0 import (
     write_manifest_sha256 as _write_manifest_sha256,
 )
 from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
+    DurableCloseoutInvoker,
     FINAL_MACHINE_LINES_FILENAME,
     _write_final_machine_lines_artifact,
+    maybe_invoke_durable_closeout_after_archive,
+    validate_durable_closeout_invoke_cli_args,
 )
 
 BOUNDED_ADAPTER_LANE_SHADOW = "shadow_bounded_observation_v0"
@@ -416,6 +419,7 @@ def validate_execute_preconditions(
         clean, reason = repo_clean_checker(ctx.repo_root)
         if not clean:
             issues.append(reason or "repository is not clean")
+    issues.extend(validate_durable_closeout_invoke_cli_args(ctx.args))
     return issues
 
 
@@ -526,6 +530,7 @@ def execute_plan(
     plan: AdapterPlan,
     *,
     subprocess_runner: SubprocessRunner,
+    durable_closeout_invoker: DurableCloseoutInvoker | None = None,
 ) -> int:
     if ctx.staging_root.exists():
         shutil.rmtree(ctx.staging_root)
@@ -581,7 +586,11 @@ def execute_plan(
     if not ok:
         print(reason, file=sys.stderr)
         return VALIDATION_EXIT
-    return 0
+    return maybe_invoke_durable_closeout_after_archive(
+        ctx,
+        archive_dest,
+        durable_closeout_invoker=durable_closeout_invoker,
+    )
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -636,6 +645,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Do not require clean git working tree before execute.",
     )
     parser.add_argument("--json", action="store_true", help="Emit plan as JSON.")
+    parser.add_argument(
+        "--invoke-durable-closeout-v0",
+        action="store_true",
+        help=(
+            "After successful archive copy, invoke durable_closeout_copy_verify_v0.py "
+            "(requires --durable-closeout-dest-dir outside /tmp)."
+        ),
+    )
+    parser.add_argument(
+        "--durable-closeout-dest-dir",
+        type=Path,
+        default=None,
+        help="Durable material closeout destination (required with --invoke-durable-closeout-v0).",
+    )
     return parser
 
 
@@ -643,6 +666,7 @@ def main(
     argv: list[str] | None = None,
     *,
     subprocess_runner: SubprocessRunner | None = None,
+    durable_closeout_invoker: DurableCloseoutInvoker | None = None,
     repo_clean_checker: RepoCleanChecker | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> int:
@@ -742,7 +766,12 @@ def main(
                 print(issue, file=sys.stderr)
             return VALIDATION_EXIT
         runner = subprocess_runner or _default_subprocess_runner
-        return execute_plan(ctx, plan, subprocess_runner=runner)
+        return execute_plan(
+            ctx,
+            plan,
+            subprocess_runner=runner,
+            durable_closeout_invoker=durable_closeout_invoker,
+        )
 
     print(render_plan(plan, args.json))
     return 0

--- a/tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py
+++ b/tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py
@@ -1,0 +1,230 @@
+"""Tests for bounded adapter optional durable closeout invocation (non-authorizing)."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PAPER_ADAPTER = REPO_ROOT / "scripts/ops/run_paper_only_bounded_observation_adapter_v0.py"
+SHADOW_ADAPTER = REPO_ROOT / "scripts/ops/run_shadow_bounded_observation_adapter_v0.py"
+DURABLE_HELPER = REPO_ROOT / "scripts/ops/durable_closeout_copy_verify_v0.py"
+FORBIDDEN_CHAIN_SCRIPT = REPO_ROOT / "scripts/ops/post_closeout_chain_execute_v0.py"
+PYTEST_DURABLE_DEST_ROOT = REPO_ROOT / "out" / "ops" / "_pytest_bounded_adapter_durable_closeout"
+
+
+def _load_paper():
+    spec = importlib.util.spec_from_file_location("paper_adapter_invoke_durable", PAPER_ADAPTER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_shadow():
+    spec = importlib.util.spec_from_file_location("shadow_adapter_invoke_durable", SHADOW_ADAPTER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _durable_dest(tmp_path: Path, name: str = "dest") -> Path:
+    safe = tmp_path.name.replace("/", "_")
+    dest = PYTEST_DURABLE_DEST_ROOT / safe / name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+@pytest.fixture(scope="module")
+def paper():
+    return _load_paper()
+
+
+@pytest.fixture(scope="module")
+def shadow():
+    return _load_shadow()
+
+
+def test_default_off_validate_returns_no_issues(paper):
+    args = argparse.Namespace(invoke_durable_closeout_v0=False, durable_closeout_dest_dir=None)
+    assert paper.validate_durable_closeout_invoke_cli_args(args) == []
+
+
+def test_missing_dest_when_flag_enabled(paper):
+    args = argparse.Namespace(invoke_durable_closeout_v0=True, durable_closeout_dest_dir=None)
+    issues = paper.validate_durable_closeout_invoke_cli_args(args)
+    assert any("durable-closeout-dest-dir" in issue for issue in issues)
+
+
+def test_tmp_dest_blocked_when_flag_enabled(paper):
+    args = argparse.Namespace(
+        invoke_durable_closeout_v0=True,
+        durable_closeout_dest_dir=Path("/tmp/peak_trade_bounded_adapter_durable_dest_fixture"),
+    )
+    issues = paper.validate_durable_closeout_invoke_cli_args(args)
+    assert any("outside /tmp" in issue for issue in issues)
+
+
+def test_build_argv_uses_archive_source_and_durable_helper_only(paper, tmp_path):
+    archive_source = tmp_path / "archive" / "runs" / "paper" / "run_id"
+    archive_source.mkdir(parents=True)
+    (archive_source / "CLOSEOUT.md").write_text("# closeout\n", encoding="utf-8")
+    (archive_source / "evidence.txt").write_text("fixture\n", encoding="utf-8")
+    durable_dest = _durable_dest(tmp_path)
+
+    argv = paper.build_durable_closeout_invoke_argv(
+        source_dir=archive_source,
+        dest_dir=durable_dest,
+    )
+    assert argv[1].endswith("durable_closeout_copy_verify_v0.py")
+    assert str(archive_source.resolve()) in argv
+    assert str(durable_dest.resolve()) in argv
+    joined = " ".join(argv)
+    assert "build_generic_evidence_run_registry_v1.py" not in joined
+    assert "build_post_closeout_projection_payload_v0.py" not in joined
+    assert "post_closeout_sync_dry_run_v0.py" not in joined
+    assert "run-local-post-closeout-chain-v0" not in joined
+
+
+def test_invoke_fail_closed_on_nonzero_rc(paper, tmp_path):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    (archive_source / "note.txt").write_text("x\n", encoding="utf-8")
+    durable_dest = _durable_dest(tmp_path, "fail_closed")
+
+    def _failing_invoker(_argv: list[str]) -> int:
+        return 1
+
+    rc = paper.invoke_durable_closeout_after_archive(
+        source_dir=archive_source,
+        dest_dir=durable_dest,
+        durable_closeout_invoker=_failing_invoker,
+    )
+    assert rc == 1
+
+
+def test_invoke_records_helper_call(paper, tmp_path):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    (archive_source / "note.txt").write_text("x\n", encoding="utf-8")
+    durable_dest = _durable_dest(tmp_path, "recorded")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = paper.invoke_durable_closeout_after_archive(
+        source_dir=archive_source,
+        dest_dir=durable_dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    assert calls[0][1].endswith("durable_closeout_copy_verify_v0.py")
+
+
+def test_maybe_invoke_without_flag_does_not_call_helper(paper, tmp_path, capsys):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    args = argparse.Namespace(
+        invoke_durable_closeout_v0=False,
+        durable_closeout_dest_dir=None,
+    )
+    ctx = paper.ExecuteContext(
+        args=args,
+        repo_root=REPO_ROOT,
+        staging_root=tmp_path / "staging",
+        archive_root=tmp_path / "archive",
+        runtime_out=tmp_path / "staging" / "runtime_out",
+        logs_dir=tmp_path / "staging" / "logs",
+        plan_dir=tmp_path / "staging" / "plan",
+        review_dir=tmp_path / "staging" / "review",
+        temp_jobs=tmp_path / "staging" / "plan" / "temp_jobs.toml",
+        run_id="paper_run",
+    )
+    rc = paper.maybe_invoke_durable_closeout_after_archive(
+        ctx,
+        archive_source,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert calls == []
+    out = capsys.readouterr().out
+    assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_INVOKED=false" in out
+
+
+def test_maybe_invoke_with_flag_calls_helper(paper, tmp_path, capsys):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    (archive_source / "note.txt").write_text("x\n", encoding="utf-8")
+    durable_dest = _durable_dest(tmp_path, "invoked")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    args = argparse.Namespace(
+        invoke_durable_closeout_v0=True,
+        durable_closeout_dest_dir=durable_dest,
+    )
+    ctx = paper.ExecuteContext(
+        args=args,
+        repo_root=REPO_ROOT,
+        staging_root=tmp_path / "staging",
+        archive_root=tmp_path / "archive",
+        runtime_out=tmp_path / "staging" / "runtime_out",
+        logs_dir=tmp_path / "staging" / "logs",
+        plan_dir=tmp_path / "staging" / "plan",
+        review_dir=tmp_path / "staging" / "review",
+        temp_jobs=tmp_path / "staging" / "plan" / "temp_jobs.toml",
+        run_id="paper_run",
+    )
+    rc = paper.maybe_invoke_durable_closeout_after_archive(
+        ctx,
+        archive_source,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    out = capsys.readouterr().out
+    assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_INVOKED=true" in out
+    assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_STATUS=pass" in out
+
+
+def test_paper_and_shadow_expose_cli_flags(paper, shadow):
+    paper_flags = {
+        a.option_strings[0] for a in paper.build_arg_parser()._actions if a.option_strings
+    }
+    shadow_flags = {
+        a.option_strings[0] for a in shadow.build_arg_parser()._actions if a.option_strings
+    }
+    assert "--invoke-durable-closeout-v0" in paper_flags
+    assert "--durable-closeout-dest-dir" in paper_flags
+    assert "--invoke-durable-closeout-v0" in shadow_flags
+    assert "--durable-closeout-dest-dir" in shadow_flags
+
+
+def test_forbidden_parallel_execute_script_absent():
+    assert not FORBIDDEN_CHAIN_SCRIPT.exists()
+    assert DURABLE_HELPER.is_file()
+
+
+def test_shadow_validate_delegates_same_rules(shadow):
+    args = argparse.Namespace(invoke_durable_closeout_v0=True, durable_closeout_dest_dir=None)
+    issues = shadow.validate_durable_closeout_invoke_cli_args(args)
+    assert any("durable-closeout-dest-dir" in issue for issue in issues)


### PR DESCRIPTION
## Summary

- Adds default-off `--invoke-durable-closeout-v0` and `--durable-closeout-dest-dir` to bounded Paper and Shadow adapters
- After successful archive/closeout copy, adapters optionally invoke the canonical `durable_closeout_copy_verify_v0.py` helper (fail-closed on non-zero)
- Does not call Registry, projection payload builder, or Notion dry-run from adapters in this slice

## Reuse Drift Guard

- **Extended owners:** `run_paper_only_bounded_observation_adapter_v0.py`, `run_shadow_bounded_observation_adapter_v0.py`
- **Reused helper:** `durable_closeout_copy_verify_v0.py` via subprocess only
- **Forbidden surface absent:** `post_closeout_chain_execute_v0.py` not created
- **Duplicate surface risk:** low — no parallel orchestrator; shared validation/invoke helpers in paper module

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/bounded_adapter_invoke_durable_closeout_v0_*` (see PR_METADATA in archive)

## Safety flags

- REMOTE_AWS_TOUCHED=false
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- LIVE_AUTHORITY_CHANGED=false
- DUPLICATE_SURFACE_CREATED=false

## Tests run

- `uv run pytest tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py -q`
- `uv run pytest tests/ops -k "bounded_observation or durable_closeout or final_machine_lines" -q`
- ruff check/format on touched files

## Explicit statements

- No AWS, runtime, scheduler, paper, shadow, testnet, or live processes were started during this implementation.
- No Live authority was changed.


Made with [Cursor](https://cursor.com)