### PR TITLE
ops: pass through bounded adapter durable chain

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -426,15 +426,49 @@ def validate_execute_preconditions(
 
 def validate_durable_closeout_invoke_cli_args(args: argparse.Namespace) -> list[str]:
     """Validate durable closeout invocation flags (default-off; fail-closed when enabled)."""
+    issues: list[str] = []
+    chain_requested = bool(getattr(args, "run_local_post_closeout_chain_v0", False))
+    if chain_requested and not getattr(args, "invoke_durable_closeout_v0", False):
+        issues.append("--run-local-post-closeout-chain-v0 requires --invoke-durable-closeout-v0")
+    if chain_requested:
+        chain_archive = getattr(args, "chain_archive_root", None)
+        if chain_archive is None:
+            issues.append(
+                "--chain-archive-root is required with --run-local-post-closeout-chain-v0"
+            )
+        else:
+            chain_archive_path = Path(chain_archive).expanduser().resolve()
+            if is_under_tmp(chain_archive_path):
+                issues.append(
+                    "chain archive root must be outside /tmp when "
+                    "--run-local-post-closeout-chain-v0 is set"
+                )
     if not getattr(args, "invoke_durable_closeout_v0", False):
-        return []
+        return issues
     dest = getattr(args, "durable_closeout_dest_dir", None)
     if dest is None:
-        return ["--durable-closeout-dest-dir is required with --invoke-durable-closeout-v0"]
-    dest_path = Path(dest).expanduser().resolve()
-    if is_under_tmp(dest_path):
-        return ["durable closeout destination must be outside /tmp"]
-    return []
+        issues.append("--durable-closeout-dest-dir is required with --invoke-durable-closeout-v0")
+    else:
+        dest_path = Path(dest).expanduser().resolve()
+        if is_under_tmp(dest_path):
+            issues.append("durable closeout destination must be outside /tmp")
+    return issues
+
+
+def resolve_bounded_adapter_chain_run_id(
+    args: argparse.Namespace,
+    *,
+    adapter_run_id: str,
+) -> str | None:
+    """Resolve chain run_id: explicit CLI wins; else adapter run_id when chain is requested."""
+    explicit = (getattr(args, "chain_run_id", None) or "").strip()
+    if explicit:
+        return explicit
+    if getattr(args, "run_local_post_closeout_chain_v0", False):
+        run_id = adapter_run_id.strip()
+        if run_id:
+            return run_id
+    return None
 
 
 def _default_durable_closeout_invoker(argv: Sequence[str]) -> int:
@@ -453,6 +487,9 @@ def build_durable_closeout_invoke_argv(
     *,
     source_dir: Path,
     dest_dir: Path,
+    run_local_post_closeout_chain_v0: bool = False,
+    chain_archive_root: Path | None = None,
+    chain_run_id: str | None = None,
 ) -> list[str]:
     argv = [
         sys.executable,
@@ -464,6 +501,13 @@ def build_durable_closeout_invoke_argv(
     ]
     if is_under_tmp(source_dir):
         argv.append("--allow-tmp-source")
+    if run_local_post_closeout_chain_v0:
+        if chain_archive_root is None:
+            raise ValueError("chain_archive_root is required when run_local_post_closeout_chain_v0")
+        argv.append("--run-local-post-closeout-chain-v0")
+        argv.extend(["--chain-archive-root", str(chain_archive_root.resolve())])
+        if chain_run_id:
+            argv.extend(["--chain-run-id", chain_run_id])
     return argv
 
 
@@ -471,11 +515,30 @@ def invoke_durable_closeout_after_archive(
     *,
     source_dir: Path,
     dest_dir: Path,
+    args: argparse.Namespace | None = None,
+    adapter_run_id: str = "",
     durable_closeout_invoker: DurableCloseoutInvoker | None = None,
 ) -> int:
     """Invoke canonical durable closeout helper after adapter archive success."""
+    chain_requested = bool(args and getattr(args, "run_local_post_closeout_chain_v0", False))
+    chain_archive_root: Path | None = None
+    if chain_requested and args is not None:
+        chain_archive_root = Path(args.chain_archive_root).expanduser().resolve()
+    chain_run_id = (
+        resolve_bounded_adapter_chain_run_id(args, adapter_run_id=adapter_run_id)
+        if args is not None
+        else None
+    )
     invoker = durable_closeout_invoker or _default_durable_closeout_invoker
-    return invoker(build_durable_closeout_invoke_argv(source_dir=source_dir, dest_dir=dest_dir))
+    return invoker(
+        build_durable_closeout_invoke_argv(
+            source_dir=source_dir,
+            dest_dir=dest_dir,
+            run_local_post_closeout_chain_v0=chain_requested,
+            chain_archive_root=chain_archive_root,
+            chain_run_id=chain_run_id,
+        )
+    )
 
 
 def emit_bounded_adapter_durable_closeout_machine_lines(
@@ -503,6 +566,28 @@ def emit_bounded_adapter_durable_closeout_machine_lines(
     print("DUPLICATE_SURFACE_CREATED=false")
 
 
+def emit_bounded_adapter_local_post_closeout_chain_machine_lines(
+    *,
+    requested: bool,
+    passthrough: bool,
+    chain_archive_root: Path | None = None,
+    chain_run_id: str | None = None,
+) -> None:
+    print(f"BOUNDED_ADAPTER_LOCAL_POST_CLOSEOUT_CHAIN_REQUESTED={'true' if requested else 'false'}")
+    print(
+        "BOUNDED_ADAPTER_LOCAL_POST_CLOSEOUT_CHAIN_PASSTHROUGH="
+        f"{'true' if passthrough else 'false'}"
+    )
+    if chain_archive_root is not None:
+        print(f"BOUNDED_ADAPTER_CHAIN_ARCHIVE_ROOT={chain_archive_root.resolve()}")
+    else:
+        print("BOUNDED_ADAPTER_CHAIN_ARCHIVE_ROOT=")
+    if chain_run_id:
+        print(f"BOUNDED_ADAPTER_CHAIN_RUN_ID={chain_run_id}")
+    else:
+        print("BOUNDED_ADAPTER_CHAIN_RUN_ID=")
+
+
 def maybe_invoke_durable_closeout_after_archive(
     ctx: ExecuteContext,
     archive_dest: Path,
@@ -510,18 +595,34 @@ def maybe_invoke_durable_closeout_after_archive(
     durable_closeout_invoker: DurableCloseoutInvoker | None = None,
 ) -> int:
     """Return adapter exit code after optional durable closeout invocation."""
-    if not getattr(ctx.args, "invoke_durable_closeout_v0", False):
+    chain_requested = bool(getattr(ctx.args, "run_local_post_closeout_chain_v0", False))
+    chain_archive_root: Path | None = None
+    if chain_requested:
+        chain_archive_root = Path(ctx.args.chain_archive_root).expanduser().resolve()
+    chain_run_id = resolve_bounded_adapter_chain_run_id(ctx.args, adapter_run_id=ctx.run_id)
+    invoke_requested = bool(getattr(ctx.args, "invoke_durable_closeout_v0", False))
+    chain_passthrough = chain_requested and invoke_requested
+
+    if not invoke_requested:
         emit_bounded_adapter_durable_closeout_machine_lines(
             invoked=False,
             rc=0,
             source_dir=archive_dest,
             dest_dir=None,
         )
+        emit_bounded_adapter_local_post_closeout_chain_machine_lines(
+            requested=chain_requested,
+            passthrough=False,
+            chain_archive_root=chain_archive_root,
+            chain_run_id=chain_run_id,
+        )
         return 0
     dest_dir = Path(ctx.args.durable_closeout_dest_dir).expanduser().resolve()
     rc = invoke_durable_closeout_after_archive(
         source_dir=archive_dest,
         dest_dir=dest_dir,
+        args=ctx.args,
+        adapter_run_id=ctx.run_id,
         durable_closeout_invoker=durable_closeout_invoker,
     )
     emit_bounded_adapter_durable_closeout_machine_lines(
@@ -529,6 +630,12 @@ def maybe_invoke_durable_closeout_after_archive(
         rc=rc,
         source_dir=archive_dest,
         dest_dir=dest_dir,
+    )
+    emit_bounded_adapter_local_post_closeout_chain_machine_lines(
+        requested=chain_requested,
+        passthrough=chain_passthrough,
+        chain_archive_root=chain_archive_root,
+        chain_run_id=chain_run_id,
     )
     return 0 if rc == 0 else VALIDATION_EXIT
 
@@ -876,6 +983,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Do not require clean git working tree before execute.",
     )
     parser.add_argument("--json", action="store_true", help="Emit plan as JSON.")
+    add_bounded_adapter_durable_closeout_cli_args(parser)
+    return parser
+
+
+def add_bounded_adapter_durable_closeout_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Register default-off durable closeout + local post-closeout chain CLI flags."""
     parser.add_argument(
         "--invoke-durable-closeout-v0",
         action="store_true",
@@ -890,7 +1003,29 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="Durable material closeout destination (required with --invoke-durable-closeout-v0).",
     )
-    return parser
+    parser.add_argument(
+        "--run-local-post-closeout-chain-v0",
+        action="store_true",
+        help=(
+            "Pass through to durable_closeout_copy_verify_v0.py local post-closeout chain "
+            "(requires --invoke-durable-closeout-v0 and --chain-archive-root outside /tmp)."
+        ),
+    )
+    parser.add_argument(
+        "--chain-archive-root",
+        type=Path,
+        default=None,
+        help="Evidence archive root for Registry v1 (required with --run-local-post-closeout-chain-v0).",
+    )
+    parser.add_argument(
+        "--chain-run-id",
+        type=str,
+        default="",
+        help=(
+            "Optional run_id for projection payload builder; defaults to adapter --run-id "
+            "when --run-local-post-closeout-chain-v0 is set."
+        ),
+    )
 
 
 def main(

--- a/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
@@ -35,6 +35,7 @@ from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
     DurableCloseoutInvoker,
     FINAL_MACHINE_LINES_FILENAME,
     _write_final_machine_lines_artifact,
+    add_bounded_adapter_durable_closeout_cli_args,
     maybe_invoke_durable_closeout_after_archive,
     validate_durable_closeout_invoke_cli_args,
 )
@@ -645,20 +646,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Do not require clean git working tree before execute.",
     )
     parser.add_argument("--json", action="store_true", help="Emit plan as JSON.")
-    parser.add_argument(
-        "--invoke-durable-closeout-v0",
-        action="store_true",
-        help=(
-            "After successful archive copy, invoke durable_closeout_copy_verify_v0.py "
-            "(requires --durable-closeout-dest-dir outside /tmp)."
-        ),
-    )
-    parser.add_argument(
-        "--durable-closeout-dest-dir",
-        type=Path,
-        default=None,
-        help="Durable material closeout destination (required with --invoke-durable-closeout-v0).",
-    )
+    add_bounded_adapter_durable_closeout_cli_args(parser)
     return parser
 
 

--- a/tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py
+++ b/tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py
@@ -42,6 +42,24 @@ def _durable_dest(tmp_path: Path, name: str = "dest") -> Path:
     return dest
 
 
+def _chain_archive_root(tmp_path: Path) -> Path:
+    root = PYTEST_DURABLE_DEST_ROOT / f"chain_archive_{tmp_path.name.replace('/', '_')}"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _durable_args(**overrides: object) -> argparse.Namespace:
+    base = {
+        "invoke_durable_closeout_v0": False,
+        "durable_closeout_dest_dir": None,
+        "run_local_post_closeout_chain_v0": False,
+        "chain_archive_root": None,
+        "chain_run_id": "",
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
 @pytest.fixture(scope="module")
 def paper():
     return _load_paper()
@@ -53,23 +71,76 @@ def shadow():
 
 
 def test_default_off_validate_returns_no_issues(paper):
-    args = argparse.Namespace(invoke_durable_closeout_v0=False, durable_closeout_dest_dir=None)
-    assert paper.validate_durable_closeout_invoke_cli_args(args) == []
+    assert paper.validate_durable_closeout_invoke_cli_args(_durable_args()) == []
 
 
 def test_missing_dest_when_flag_enabled(paper):
-    args = argparse.Namespace(invoke_durable_closeout_v0=True, durable_closeout_dest_dir=None)
-    issues = paper.validate_durable_closeout_invoke_cli_args(args)
+    issues = paper.validate_durable_closeout_invoke_cli_args(
+        _durable_args(invoke_durable_closeout_v0=True)
+    )
     assert any("durable-closeout-dest-dir" in issue for issue in issues)
 
 
 def test_tmp_dest_blocked_when_flag_enabled(paper):
-    args = argparse.Namespace(
-        invoke_durable_closeout_v0=True,
-        durable_closeout_dest_dir=Path("/tmp/peak_trade_bounded_adapter_durable_dest_fixture"),
+    issues = paper.validate_durable_closeout_invoke_cli_args(
+        _durable_args(
+            invoke_durable_closeout_v0=True,
+            durable_closeout_dest_dir=Path("/tmp/peak_trade_bounded_adapter_durable_dest_fixture"),
+        )
     )
-    issues = paper.validate_durable_closeout_invoke_cli_args(args)
     assert any("outside /tmp" in issue for issue in issues)
+
+
+def test_chain_without_invoke_blocked(paper, tmp_path):
+    issues = paper.validate_durable_closeout_invoke_cli_args(
+        _durable_args(
+            run_local_post_closeout_chain_v0=True,
+            chain_archive_root=_chain_archive_root(tmp_path),
+        )
+    )
+    assert any("requires --invoke-durable-closeout-v0" in issue for issue in issues)
+
+
+def test_chain_without_archive_root_blocked(paper, tmp_path):
+    issues = paper.validate_durable_closeout_invoke_cli_args(
+        _durable_args(
+            invoke_durable_closeout_v0=True,
+            durable_closeout_dest_dir=_durable_dest(tmp_path, "dest"),
+            run_local_post_closeout_chain_v0=True,
+        )
+    )
+    assert any("chain-archive-root" in issue for issue in issues)
+
+
+def test_tmp_chain_archive_root_blocked(paper, tmp_path):
+    issues = paper.validate_durable_closeout_invoke_cli_args(
+        _durable_args(
+            invoke_durable_closeout_v0=True,
+            durable_closeout_dest_dir=_durable_dest(tmp_path, "dest"),
+            run_local_post_closeout_chain_v0=True,
+            chain_archive_root=Path("/tmp/peak_trade_chain_archive_fixture"),
+        )
+    )
+    assert any("chain archive root must be outside /tmp" in issue for issue in issues)
+
+
+def test_chain_run_id_defaults_to_adapter_run_id(paper):
+    run_id = paper.resolve_bounded_adapter_chain_run_id(
+        _durable_args(run_local_post_closeout_chain_v0=True),
+        adapter_run_id="paper_run_abc",
+    )
+    assert run_id == "paper_run_abc"
+
+
+def test_explicit_chain_run_id_forwarded(paper):
+    run_id = paper.resolve_bounded_adapter_chain_run_id(
+        _durable_args(
+            run_local_post_closeout_chain_v0=True,
+            chain_run_id="explicit_run",
+        ),
+        adapter_run_id="paper_run_abc",
+    )
+    assert run_id == "explicit_run"
 
 
 def test_build_argv_uses_archive_source_and_durable_helper_only(paper, tmp_path):
@@ -91,6 +162,30 @@ def test_build_argv_uses_archive_source_and_durable_helper_only(paper, tmp_path)
     assert "build_post_closeout_projection_payload_v0.py" not in joined
     assert "post_closeout_sync_dry_run_v0.py" not in joined
     assert "run-local-post-closeout-chain-v0" not in joined
+
+
+def test_build_argv_includes_chain_flags_when_requested(paper, tmp_path):
+    archive_source = tmp_path / "archive" / "runs" / "paper" / "run_id"
+    archive_source.mkdir(parents=True)
+    durable_dest = _durable_dest(tmp_path)
+    chain_archive = _chain_archive_root(tmp_path)
+
+    argv = paper.build_durable_closeout_invoke_argv(
+        source_dir=archive_source,
+        dest_dir=durable_dest,
+        run_local_post_closeout_chain_v0=True,
+        chain_archive_root=chain_archive,
+        chain_run_id="paper_run_chain",
+    )
+    joined = " ".join(argv)
+    assert "--run-local-post-closeout-chain-v0" in joined
+    assert "--chain-archive-root" in joined
+    assert str(chain_archive.resolve()) in joined
+    assert "--chain-run-id" in joined
+    assert "paper_run_chain" in joined
+    assert "build_generic_evidence_run_registry_v1.py" not in joined
+    assert "build_post_closeout_projection_payload_v0.py" not in joined
+    assert "post_closeout_sync_dry_run_v0.py" not in joined
 
 
 def test_invoke_fail_closed_on_nonzero_rc(paper, tmp_path):
@@ -140,10 +235,7 @@ def test_maybe_invoke_without_flag_does_not_call_helper(paper, tmp_path, capsys)
         calls.append(list(argv))
         return 0
 
-    args = argparse.Namespace(
-        invoke_durable_closeout_v0=False,
-        durable_closeout_dest_dir=None,
-    )
+    args = _durable_args()
     ctx = paper.ExecuteContext(
         args=args,
         repo_root=REPO_ROOT,
@@ -165,6 +257,8 @@ def test_maybe_invoke_without_flag_does_not_call_helper(paper, tmp_path, capsys)
     assert calls == []
     out = capsys.readouterr().out
     assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_INVOKED=false" in out
+    assert "BOUNDED_ADAPTER_LOCAL_POST_CLOSEOUT_CHAIN_REQUESTED=false" in out
+    assert "BOUNDED_ADAPTER_LOCAL_POST_CLOSEOUT_CHAIN_PASSTHROUGH=false" in out
 
 
 def test_maybe_invoke_with_flag_calls_helper(paper, tmp_path, capsys):
@@ -178,7 +272,7 @@ def test_maybe_invoke_with_flag_calls_helper(paper, tmp_path, capsys):
         calls.append(list(argv))
         return 0
 
-    args = argparse.Namespace(
+    args = _durable_args(
         invoke_durable_closeout_v0=True,
         durable_closeout_dest_dir=durable_dest,
     )
@@ -204,6 +298,57 @@ def test_maybe_invoke_with_flag_calls_helper(paper, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_INVOKED=true" in out
     assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_STATUS=pass" in out
+    assert "BOUNDED_ADAPTER_LOCAL_POST_CLOSEOUT_CHAIN_PASSTHROUGH=false" in out
+
+
+def test_maybe_invoke_with_chain_passes_helper_flags(paper, tmp_path, capsys):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    (archive_source / "note.txt").write_text("x\n", encoding="utf-8")
+    durable_dest = _durable_dest(tmp_path, "chain_invoked")
+    chain_archive = _chain_archive_root(tmp_path)
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    args = _durable_args(
+        invoke_durable_closeout_v0=True,
+        durable_closeout_dest_dir=durable_dest,
+        run_local_post_closeout_chain_v0=True,
+        chain_archive_root=chain_archive,
+    )
+    ctx = paper.ExecuteContext(
+        args=args,
+        repo_root=REPO_ROOT,
+        staging_root=tmp_path / "staging",
+        archive_root=tmp_path / "archive",
+        runtime_out=tmp_path / "staging" / "runtime_out",
+        logs_dir=tmp_path / "staging" / "logs",
+        plan_dir=tmp_path / "staging" / "plan",
+        review_dir=tmp_path / "staging" / "review",
+        temp_jobs=tmp_path / "staging" / "plan" / "temp_jobs.toml",
+        run_id="paper_run_default_chain",
+    )
+    rc = paper.maybe_invoke_durable_closeout_after_archive(
+        ctx,
+        archive_source,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    joined = " ".join(calls[0])
+    assert calls[0][1].endswith("durable_closeout_copy_verify_v0.py")
+    assert "--run-local-post-closeout-chain-v0" in joined
+    assert str(chain_archive.resolve()) in joined
+    assert "--chain-run-id" in joined
+    assert "paper_run_default_chain" in joined
+    assert "build_generic_evidence_run_registry_v1.py" not in joined
+    out = capsys.readouterr().out
+    assert "BOUNDED_ADAPTER_LOCAL_POST_CLOSEOUT_CHAIN_REQUESTED=true" in out
+    assert "BOUNDED_ADAPTER_LOCAL_POST_CLOSEOUT_CHAIN_PASSTHROUGH=true" in out
+    assert "BOUNDED_ADAPTER_CHAIN_RUN_ID=paper_run_default_chain" in out
 
 
 def test_paper_and_shadow_expose_cli_flags(paper, shadow):
@@ -213,10 +358,12 @@ def test_paper_and_shadow_expose_cli_flags(paper, shadow):
     shadow_flags = {
         a.option_strings[0] for a in shadow.build_arg_parser()._actions if a.option_strings
     }
-    assert "--invoke-durable-closeout-v0" in paper_flags
-    assert "--durable-closeout-dest-dir" in paper_flags
-    assert "--invoke-durable-closeout-v0" in shadow_flags
-    assert "--durable-closeout-dest-dir" in shadow_flags
+    for flags in (paper_flags, shadow_flags):
+        assert "--invoke-durable-closeout-v0" in flags
+        assert "--durable-closeout-dest-dir" in flags
+        assert "--run-local-post-closeout-chain-v0" in flags
+        assert "--chain-archive-root" in flags
+        assert "--chain-run-id" in flags
 
 
 def test_forbidden_parallel_execute_script_absent():
@@ -225,6 +372,17 @@ def test_forbidden_parallel_execute_script_absent():
 
 
 def test_shadow_validate_delegates_same_rules(shadow):
-    args = argparse.Namespace(invoke_durable_closeout_v0=True, durable_closeout_dest_dir=None)
-    issues = shadow.validate_durable_closeout_invoke_cli_args(args)
+    issues = shadow.validate_durable_closeout_invoke_cli_args(
+        _durable_args(invoke_durable_closeout_v0=True)
+    )
     assert any("durable-closeout-dest-dir" in issue for issue in issues)
+
+
+def test_shadow_chain_validation_delegates_same_rules(shadow, tmp_path):
+    issues = shadow.validate_durable_closeout_invoke_cli_args(
+        _durable_args(
+            run_local_post_closeout_chain_v0=True,
+            chain_archive_root=_chain_archive_root(tmp_path),
+        )
+    )
+    assert any("requires --invoke-durable-closeout-v0" in issue for issue in issues)


### PR DESCRIPTION
## Summary
- Adds default-off bounded adapter CLI pass-through for `--run-local-post-closeout-chain-v0`, `--chain-archive-root`, and `--chain-run-id` into the existing `durable_closeout_copy_verify_v0.py` invoke argv (paper + shadow adapters).
- Fail-closed validation: chain requires invoke + non-/tmp archive root; `--chain-run-id` defaults to adapter `--run-id` when omitted.
- Emits non-authorizing machine lines for chain request/passthrough state.

## Reuse Drift Guard
- **Canonical owners reused:** `run_paper_only_bounded_observation_adapter_v0.py` (validation/argv/machine lines), `durable_closeout_copy_verify_v0.py` (subprocess only), shadow adapter imports shared CLI helper.
- **Forbidden surface:** `post_closeout_chain_execute_v0.py` not created; adapters do not call Registry / projection / Notion scripts directly.
- **Duplicate surface risk:** low

## Durable evidence
Written under `Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/bounded_adapter_durable_chain_pass_through_v0_*` with `RUN_REPORT.md`, test/ruff logs, `MANIFEST.sha256`, `MANIFEST_VERIFY.log`.

## Safety flags
- `REMOTE_AWS_TOUCHED=false`
- `RUNTIME_STARTED=false`
- `SCHEDULER_STARTED=false`
- `PAPER_SHADOW_TESTNET_LIVE_STARTED=false`
- `LIVE_AUTHORITY_CHANGED=false`
- `DUPLICATE_SURFACE_CREATED=false`

No AWS/runtime/scheduler/paper/shadow/testnet/live was started during this slice.

## Test plan
- [x] `uv run pytest tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py -q`
- [x] `uv run pytest tests/ops/test_durable_closeout_local_post_closeout_chain_v0.py -q`
- [x] `uv run pytest tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py -q`
- [x] `uv run pytest tests/ops -k "bounded_observation or durable_closeout or post_closeout or final_machine_lines" -q`
- [x] `uv run ruff check` / `ruff format --check` on touched files

Made with [Cursor](https://cursor.com)