### PR TITLE
ops: add scheduler durable closeout hook

### DIFF
--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -106,6 +106,111 @@ def validate_scheduler_evidence_cli(
     return None
 
 
+def validate_scheduler_durable_closeout_hook_cli(
+    *,
+    invoke_durable_closeout_after_completion_v0: bool,
+    durable_closeout_dest_dir: Optional[Path],
+    evidence_dir: Optional[Path],
+) -> Optional[int]:
+    """Return exit code when durable closeout hook CLI options are invalid; else None."""
+    if not invoke_durable_closeout_after_completion_v0:
+        return None
+    if durable_closeout_dest_dir is None:
+        print(
+            "ERR: --durable-closeout-dest-dir is required with "
+            "--invoke-durable-closeout-after-completion-v0",
+            file=sys.stderr,
+        )
+        return 1
+    if is_under_tmp(durable_closeout_dest_dir):
+        print("ERR: --durable-closeout-dest-dir must be outside /tmp", file=sys.stderr)
+        return 1
+    if evidence_dir is None:
+        print(
+            "ERR: --invoke-durable-closeout-after-completion-v0 requires --evidence-dir",
+            file=sys.stderr,
+        )
+        return 1
+    return None
+
+
+def emit_scheduler_durable_closeout_machine_lines(
+    *,
+    requested: bool,
+    invoked: bool,
+    exit_code: int,
+    dest_dir: Optional[Path],
+) -> None:
+    print(f"SCHEDULER_DURABLE_CLOSEOUT_REQUESTED={'true' if requested else 'false'}")
+    print(f"SCHEDULER_DURABLE_CLOSEOUT_INVOKED={'true' if invoked else 'false'}")
+    print(f"SCHEDULER_DURABLE_CLOSEOUT_EXIT_CODE={exit_code}")
+    if dest_dir is not None:
+        print(f"SCHEDULER_DURABLE_CLOSEOUT_DEST_DIR={dest_dir.resolve()}")
+    else:
+        print("SCHEDULER_DURABLE_CLOSEOUT_DEST_DIR=")
+
+
+def invoke_scheduler_durable_closeout_after_completion(
+    *,
+    source_dir: Path,
+    dest_dir: Path,
+    durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
+) -> int:
+    """Invoke canonical durable closeout helper after scheduler completion evidence."""
+    from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
+        _default_durable_closeout_invoker,
+        build_durable_closeout_invoke_argv,
+    )
+
+    invoker = durable_closeout_invoker or _default_durable_closeout_invoker
+    return invoker(build_durable_closeout_invoke_argv(source_dir=source_dir, dest_dir=dest_dir))
+
+
+def maybe_invoke_scheduler_durable_closeout_after_completion(
+    *,
+    evidence_dir: Path,
+    invoke_durable_closeout_after_completion_v0: bool,
+    durable_closeout_dest_dir: Optional[Path],
+    completion_evidence_finalized: bool,
+    durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
+) -> int:
+    """Return exit code after optional durable closeout hook (default-off; fail-closed)."""
+    if not invoke_durable_closeout_after_completion_v0:
+        emit_scheduler_durable_closeout_machine_lines(
+            requested=False,
+            invoked=False,
+            exit_code=0,
+            dest_dir=None,
+        )
+        return 0
+    dest_dir = durable_closeout_dest_dir.resolve() if durable_closeout_dest_dir else None
+    if not completion_evidence_finalized:
+        emit_scheduler_durable_closeout_machine_lines(
+            requested=True,
+            invoked=False,
+            exit_code=1,
+            dest_dir=dest_dir,
+        )
+        print(
+            "ERR: durable closeout hook skipped; scheduler completion evidence not finalized",
+            file=sys.stderr,
+        )
+        return 1
+    assert dest_dir is not None
+    hook_rc = invoke_scheduler_durable_closeout_after_completion(
+        source_dir=evidence_dir,
+        dest_dir=dest_dir,
+        durable_closeout_invoker=durable_closeout_invoker,
+    )
+    emit_scheduler_durable_closeout_machine_lines(
+        requested=True,
+        invoked=True,
+        exit_code=hook_rc,
+        dest_dir=dest_dir,
+    )
+    return hook_rc
+
+
 def write_scheduler_completion_closeout(
     evidence_dir: Path,
     *,
@@ -183,6 +288,9 @@ def finalize_scheduler_completion_evidence(
     iterations: int,
     jobs_dispatched: int,
     exit_status: int,
+    invoke_durable_closeout_after_completion_v0: bool = False,
+    durable_closeout_dest_dir: Optional[Path] = None,
+    durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
 ) -> int:
     """Write closeout when evidence dir is set; finalize MANIFEST when enforce is on."""
     if evidence_dir is None and not primary_evidence_enforce:
@@ -203,6 +311,15 @@ def finalize_scheduler_completion_evidence(
     )
 
     if not primary_evidence_enforce:
+        hook_rc = maybe_invoke_scheduler_durable_closeout_after_completion(
+            evidence_dir=evidence_dir,
+            invoke_durable_closeout_after_completion_v0=invoke_durable_closeout_after_completion_v0,
+            durable_closeout_dest_dir=durable_closeout_dest_dir,
+            completion_evidence_finalized=True,
+            durable_closeout_invoker=durable_closeout_invoker,
+        )
+        if hook_rc != 0:
+            return hook_rc
         return exit_status
 
     if dry_run:
@@ -215,6 +332,15 @@ def finalize_scheduler_completion_evidence(
     if not ok:
         print(f"ERR: primary evidence finalize failed: {msg}")
         return 1
+    hook_rc = maybe_invoke_scheduler_durable_closeout_after_completion(
+        evidence_dir=evidence_dir,
+        invoke_durable_closeout_after_completion_v0=invoke_durable_closeout_after_completion_v0,
+        durable_closeout_dest_dir=durable_closeout_dest_dir,
+        completion_evidence_finalized=True,
+        durable_closeout_invoker=durable_closeout_invoker,
+    )
+    if hook_rc != 0:
+        return hook_rc
     return exit_status
 
 
@@ -300,6 +426,24 @@ Examples:
         type=str,
         default=None,
         help="Optional non-authorizing scheduler heartbeat/freshness file path",
+    )
+    parser.add_argument(
+        "--invoke-durable-closeout-after-completion-v0",
+        action="store_true",
+        help=(
+            "After successful scheduler completion evidence finalization, invoke "
+            "durable_closeout_copy_verify_v0.py (requires --evidence-dir and "
+            "--durable-closeout-dest-dir outside /tmp)."
+        ),
+    )
+    parser.add_argument(
+        "--durable-closeout-dest-dir",
+        type=str,
+        default=None,
+        help=(
+            "Durable material closeout destination for post-completion hook "
+            "(required with --invoke-durable-closeout-after-completion-v0)."
+        ),
     )
 
     return parser.parse_args(argv)
@@ -551,6 +695,9 @@ def run_scheduler_loop(
     evidence_dir: Optional[Path] = None,
     primary_evidence_enforce: bool = False,
     heartbeat_file: Optional[Path] = None,
+    invoke_durable_closeout_after_completion_v0: bool = False,
+    durable_closeout_dest_dir: Optional[Path] = None,
+    durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
 ) -> int:
     """Hauptschleife des Schedulers."""
     global _shutdown_requested
@@ -584,6 +731,9 @@ def run_scheduler_loop(
             iterations=iteration,
             jobs_dispatched=total_jobs_run,
             exit_status=exit_code,
+            invoke_durable_closeout_after_completion_v0=invoke_durable_closeout_after_completion_v0,
+            durable_closeout_dest_dir=durable_closeout_dest_dir,
+            durable_closeout_invoker=durable_closeout_invoker,
         )
 
     # Jobs filtern
@@ -600,6 +750,9 @@ def run_scheduler_loop(
             iterations=iteration,
             jobs_dispatched=total_jobs_run,
             exit_status=exit_code,
+            invoke_durable_closeout_after_completion_v0=invoke_durable_closeout_after_completion_v0,
+            durable_closeout_dest_dir=durable_closeout_dest_dir,
+            durable_closeout_invoker=durable_closeout_invoker,
         )
 
     # Validierung
@@ -708,6 +861,9 @@ def run_scheduler_loop(
         iterations=iteration,
         jobs_dispatched=total_jobs_run,
         exit_status=exit_code,
+        invoke_durable_closeout_after_completion_v0=invoke_durable_closeout_after_completion_v0,
+        durable_closeout_dest_dir=durable_closeout_dest_dir,
+        durable_closeout_invoker=durable_closeout_invoker,
     )
 
 
@@ -717,6 +873,14 @@ def main(argv=None) -> int:
 
     evidence_dir = Path(args.evidence_dir) if args.evidence_dir else None
     primary_evidence_enforce = bool(args.primary_evidence_enforce)
+    invoke_durable_closeout_after_completion_v0 = bool(
+        args.invoke_durable_closeout_after_completion_v0
+    )
+    durable_closeout_dest_dir = (
+        Path(args.durable_closeout_dest_dir).expanduser().resolve()
+        if args.durable_closeout_dest_dir
+        else None
+    )
 
     cli_rc = validate_scheduler_evidence_cli(
         evidence_dir=evidence_dir,
@@ -725,6 +889,14 @@ def main(argv=None) -> int:
     )
     if cli_rc is not None:
         return cli_rc
+
+    hook_cli_rc = validate_scheduler_durable_closeout_hook_cli(
+        invoke_durable_closeout_after_completion_v0=invoke_durable_closeout_after_completion_v0,
+        durable_closeout_dest_dir=durable_closeout_dest_dir,
+        evidence_dir=evidence_dir,
+    )
+    if hook_cli_rc is not None:
+        return hook_cli_rc
 
     # Signal-Handler registrieren
     signal.signal(signal.SIGINT, signal_handler)
@@ -766,6 +938,8 @@ def main(argv=None) -> int:
         heartbeat_file=Path(args.heartbeat_file).expanduser().resolve()
         if args.heartbeat_file
         else None,
+        invoke_durable_closeout_after_completion_v0=invoke_durable_closeout_after_completion_v0,
+        durable_closeout_dest_dir=durable_closeout_dest_dir,
     )
 
 

--- a/tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py
+++ b/tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py
@@ -1,0 +1,266 @@
+"""Tests for scheduler durable closeout hook pass-through (non-authorizing)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_SCHEDULER = REPO_ROOT / "scripts" / "run_scheduler.py"
+DURABLE_HELPER = REPO_ROOT / "scripts" / "ops" / "durable_closeout_copy_verify_v0.py"
+FORBIDDEN_CHAIN_SCRIPT = REPO_ROOT / "scripts/ops/post_closeout_chain_execute_v0.py"
+PYTEST_DURABLE_DEST_ROOT = REPO_ROOT / "out" / "ops" / "_pytest_scheduler_durable_closeout_hook"
+
+
+def _load_run_scheduler():
+    spec = importlib.util.spec_from_file_location("run_scheduler_hook", RUN_SCHEDULER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _durable_dest(tmp_path: Path, name: str = "dest") -> Path:
+    safe = tmp_path.name.replace("/", "_")
+    dest = PYTEST_DURABLE_DEST_ROOT / safe / name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+@pytest.fixture(scope="module")
+def rs():
+    return _load_run_scheduler()
+
+
+def test_forbidden_parallel_execute_script_absent():
+    assert not FORBIDDEN_CHAIN_SCRIPT.exists()
+    assert DURABLE_HELPER.is_file()
+
+
+def test_cli_flags_present_in_source():
+    text = RUN_SCHEDULER.read_text(encoding="utf-8")
+    assert "--invoke-durable-closeout-after-completion-v0" in text
+    assert "--durable-closeout-dest-dir" in text
+    assert "SCHEDULER_DURABLE_CLOSEOUT_REQUESTED=" in text
+
+
+def test_hook_validate_requires_dest_dir(rs):
+    assert (
+        rs.validate_scheduler_durable_closeout_hook_cli(
+            invoke_durable_closeout_after_completion_v0=True,
+            durable_closeout_dest_dir=None,
+            evidence_dir=Path("/var/tmp/evidence"),
+        )
+        == 1
+    )
+
+
+def test_hook_validate_requires_evidence_dir(rs, tmp_path):
+    dest = _durable_dest(tmp_path)
+    assert (
+        rs.validate_scheduler_durable_closeout_hook_cli(
+            invoke_durable_closeout_after_completion_v0=True,
+            durable_closeout_dest_dir=dest,
+            evidence_dir=None,
+        )
+        == 1
+    )
+
+
+def test_hook_validate_blocks_tmp_dest(rs, tmp_path):
+    assert (
+        rs.validate_scheduler_durable_closeout_hook_cli(
+            invoke_durable_closeout_after_completion_v0=True,
+            durable_closeout_dest_dir=Path("/tmp/scheduler_durable_dest"),
+            evidence_dir=tmp_path,
+        )
+        == 1
+    )
+
+
+def test_main_hook_without_dest_fails_before_loop(rs, monkeypatch):
+    loop_calls: list[object] = []
+    monkeypatch.setattr(rs, "run_scheduler_loop", lambda **kwargs: loop_calls.append(kwargs) or 0)
+
+    rc = rs.main(
+        [
+            "--once",
+            "--config",
+            "config/scheduler/jobs.toml",
+            "--evidence-dir",
+            str(_durable_dest(Path("no_loop"))),
+            "--invoke-durable-closeout-after-completion-v0",
+        ]
+    )
+    assert rc == 1
+    assert loop_calls == []
+
+
+def test_invoke_calls_only_durable_helper(rs, tmp_path):
+    source = tmp_path / "evidence"
+    source.mkdir()
+    (source / "scheduler_completion_closeout_v0.json").write_text("{}\n", encoding="utf-8")
+    dest = _durable_dest(tmp_path, "helper_only")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = rs.invoke_scheduler_durable_closeout_after_completion(
+        source_dir=source,
+        dest_dir=dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    joined = " ".join(calls[0])
+    assert calls[0][1].endswith("durable_closeout_copy_verify_v0.py")
+    assert str(source.resolve()) in joined
+    assert str(dest.resolve()) in joined
+    assert "build_generic_evidence_run_registry_v1.py" not in joined
+    assert "build_post_closeout_projection_payload_v0.py" not in joined
+    assert "post_closeout_sync_dry_run_v0.py" not in joined
+
+
+def test_finalize_invokes_hook_after_primary_evidence_success(
+    rs, monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(
+        "scripts.ops.primary_evidence_retention_v0.finalize_primary_evidence_root",
+        lambda _root: (True, ""),
+    )
+    dest = _durable_dest(tmp_path, "after_finalize")
+
+    rc = rs.finalize_scheduler_completion_evidence(
+        tmp_path,
+        primary_evidence_enforce=True,
+        dry_run=False,
+        once=True,
+        config_path=Path("config/scheduler/jobs.toml"),
+        iterations=1,
+        jobs_dispatched=0,
+        exit_status=0,
+        invoke_durable_closeout_after_completion_v0=True,
+        durable_closeout_dest_dir=dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    assert (tmp_path / "scheduler_completion_closeout_v0.json").is_file()
+
+
+def test_finalize_hook_fail_closed_on_helper_nonzero(rs, monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "scripts.ops.primary_evidence_retention_v0.finalize_primary_evidence_root",
+        lambda _root: (True, ""),
+    )
+    dest = _durable_dest(tmp_path, "fail_closed")
+
+    def _failing_invoker(_argv: list[str]) -> int:
+        return 2
+
+    rc = rs.finalize_scheduler_completion_evidence(
+        tmp_path,
+        primary_evidence_enforce=True,
+        dry_run=False,
+        once=True,
+        config_path=Path("config/scheduler/jobs.toml"),
+        iterations=1,
+        jobs_dispatched=0,
+        exit_status=0,
+        invoke_durable_closeout_after_completion_v0=True,
+        durable_closeout_dest_dir=dest,
+        durable_closeout_invoker=_failing_invoker,
+    )
+    assert rc == 2
+
+
+def test_finalize_skips_hook_when_primary_evidence_finalize_fails(
+    rs, monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(
+        "scripts.ops.primary_evidence_retention_v0.finalize_primary_evidence_root",
+        lambda _root: (False, "checksum mismatch"),
+    )
+    dest = _durable_dest(tmp_path, "no_hook")
+
+    rc = rs.finalize_scheduler_completion_evidence(
+        tmp_path,
+        primary_evidence_enforce=True,
+        dry_run=False,
+        once=True,
+        config_path=Path("config/scheduler/jobs.toml"),
+        iterations=1,
+        jobs_dispatched=0,
+        exit_status=0,
+        invoke_durable_closeout_after_completion_v0=True,
+        durable_closeout_dest_dir=dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 1
+    assert calls == []
+
+
+def test_finalize_default_off_no_hook(rs, monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(
+        "scripts.ops.primary_evidence_retention_v0.finalize_primary_evidence_root",
+        lambda _root: (True, ""),
+    )
+
+    rc = rs.finalize_scheduler_completion_evidence(
+        tmp_path,
+        primary_evidence_enforce=True,
+        dry_run=False,
+        once=True,
+        config_path=Path("config/scheduler/jobs.toml"),
+        iterations=1,
+        jobs_dispatched=0,
+        exit_status=0,
+        invoke_durable_closeout_after_completion_v0=False,
+        durable_closeout_dest_dir=None,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert calls == []
+
+
+def test_maybe_invoke_emits_machine_lines(rs, tmp_path, capsys):
+    source = tmp_path / "evidence"
+    source.mkdir()
+    dest = _durable_dest(tmp_path, "lines")
+
+    rc = rs.maybe_invoke_scheduler_durable_closeout_after_completion(
+        evidence_dir=source,
+        invoke_durable_closeout_after_completion_v0=False,
+        durable_closeout_dest_dir=dest,
+        completion_evidence_finalized=True,
+        durable_closeout_invoker=lambda _argv: 0,
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "SCHEDULER_DURABLE_CLOSEOUT_REQUESTED=false" in out
+    assert "SCHEDULER_DURABLE_CLOSEOUT_INVOKED=false" in out


### PR DESCRIPTION
## Summary
- **Package C1:** default-off scheduler completion hook that invokes canonical `scripts/ops/durable_closeout_copy_verify_v0.py` only after successful completion evidence finalization (fail-closed on helper non-zero exit).
- **Reuse Drift Guard:** reuses adapter `build_durable_closeout_invoke_argv` / `_default_durable_closeout_invoker`; no duplicate orchestration script; no Registry/Projection/Notion calls from `run_scheduler.py`.
- **CLI:** `--invoke-durable-closeout-after-completion-v0` + `--durable-closeout-dest-dir` (required when enabled; destination must be outside `/tmp`). Existing scheduler behavior unchanged when flags absent.

## Canonical owners reused
- `scripts/run_scheduler.py`
- `scripts/ops/durable_closeout_copy_verify_v0.py`
- `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` (argv/invoker reuse only)

## Duplicate surface risk
- **DUPLICATE_SURFACE_CREATED=false** — no `post_closeout_chain_execute_v0.py`, no parallel execute script, no Supervisor/Remote/S3/Market changes in this PR.

## Durable evidence (implementation closeout)
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/scheduler_durable_closeout_hook_pass_through_v0_20260528T154836Z/`
(`RUN_REPORT.md`, pytest/ruff logs, `MANIFEST.sha256`, `MANIFEST_VERIFY.log` — verify RC 0)

## Safety flags
- REMOTE_AWS_TOUCHED=false
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- LIVE_AUTHORITY_CHANGED=false

## Tests run (local)
- `uv run pytest tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py -q`
- `uv run pytest tests/ops/test_scheduler_completion_primary_evidence_closeout_v0.py -q`
- `uv run pytest tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py -q`
- `uv run pytest tests/ops -k "scheduler and (closeout or durable or completion or primary_evidence)" -q`
- `uv run ruff check` / `ruff format --check` on touched files

## Explicit statements
- **No docs touched.**
- **No AWS / runtime / scheduler loop / paper / shadow / testnet / live started** during implementation or tests (mocks/fixtures only).
- **No Live authority changed.**


Made with [Cursor](https://cursor.com)