### PR TITLE
ops: add supervisor pack durable closeout hook

### DIFF
--- a/scripts/ops/pack_online_readiness_supervisor_evidence_v0.py
+++ b/scripts/ops/pack_online_readiness_supervisor_evidence_v0.py
@@ -13,7 +13,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Callable, Optional, Sequence
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
@@ -51,6 +51,112 @@ def _utc_ts() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def validate_supervisor_pack_durable_closeout_hook_cli(
+    *,
+    invoke_durable_closeout_after_pack_v0: bool,
+    durable_closeout_dest_dir: Optional[Path],
+) -> Optional[int]:
+    """Return exit code when durable closeout hook CLI options are invalid; else None."""
+    if not invoke_durable_closeout_after_pack_v0:
+        return None
+    if durable_closeout_dest_dir is None:
+        print(
+            "ERR: --durable-closeout-dest-dir is required with "
+            "--invoke-durable-closeout-after-pack-v0",
+            file=sys.stderr,
+        )
+        return 1
+    if is_under_tmp(durable_closeout_dest_dir):
+        print("ERR: --durable-closeout-dest-dir must be outside /tmp", file=sys.stderr)
+        return 1
+    return None
+
+
+def emit_supervisor_pack_durable_closeout_machine_lines(
+    *,
+    requested: bool,
+    invoked: bool,
+    exit_code: int,
+    dest_dir: Optional[Path],
+) -> None:
+    print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_REQUESTED={'true' if requested else 'false'}")
+    print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_INVOKED={'true' if invoked else 'false'}")
+    print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_EXIT_CODE={exit_code}")
+    if dest_dir is not None:
+        print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_DEST_DIR={dest_dir.resolve()}")
+    else:
+        print("SUPERVISOR_PACK_DURABLE_CLOSEOUT_DEST_DIR=")
+
+
+def invoke_supervisor_pack_durable_closeout_after_pack(
+    *,
+    source_dir: Path,
+    dest_dir: Path,
+    durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
+) -> int:
+    """Invoke canonical durable closeout helper after supervisor evidence pack."""
+    from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
+        _default_durable_closeout_invoker,
+        build_durable_closeout_invoke_argv,
+    )
+
+    invoker = durable_closeout_invoker or _default_durable_closeout_invoker
+    return invoker(build_durable_closeout_invoke_argv(source_dir=source_dir, dest_dir=dest_dir))
+
+
+def maybe_invoke_supervisor_pack_durable_closeout_after_pack(
+    *,
+    archive_root: Path,
+    invoke_durable_closeout_after_pack_v0: bool,
+    durable_closeout_dest_dir: Optional[Path],
+    pack_evidence_finalized: bool,
+    durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
+) -> int:
+    """Return exit code after optional durable closeout hook (default-off; fail-closed)."""
+    if not invoke_durable_closeout_after_pack_v0:
+        emit_supervisor_pack_durable_closeout_machine_lines(
+            requested=False,
+            invoked=False,
+            exit_code=0,
+            dest_dir=None,
+        )
+        return 0
+    dest_dir = durable_closeout_dest_dir.resolve() if durable_closeout_dest_dir else None
+    if not pack_evidence_finalized:
+        emit_supervisor_pack_durable_closeout_machine_lines(
+            requested=True,
+            invoked=False,
+            exit_code=1,
+            dest_dir=dest_dir,
+        )
+        print(
+            "ERR: durable closeout hook skipped; supervisor pack evidence not finalized",
+            file=sys.stderr,
+        )
+        return 1
+    assert dest_dir is not None
+    hook_rc = invoke_supervisor_pack_durable_closeout_after_pack(
+        source_dir=archive_root,
+        dest_dir=dest_dir,
+        durable_closeout_invoker=durable_closeout_invoker,
+    )
+    emit_supervisor_pack_durable_closeout_machine_lines(
+        requested=True,
+        invoked=True,
+        exit_code=hook_rc,
+        dest_dir=dest_dir,
+    )
+    return hook_rc
+
+
+def _pack_evidence_finalized(result: PackResult) -> bool:
+    if result.exit_code != 0:
+        return False
+    if result.primary_evidence_enforce:
+        return result.manifest_verified
+    return True
+
+
 def _copy_file_or_tree(source: Path, dest: Path) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     if source.is_dir():
@@ -86,6 +192,9 @@ def pack_supervisor_evidence(
     optional_artifacts: Sequence[Path] = (),
     primary_evidence_enforce: bool = False,
     require_optional_artifacts: bool = False,
+    invoke_durable_closeout_after_pack_v0: bool = False,
+    durable_closeout_dest_dir: Optional[Path] = None,
+    durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
 ) -> PackResult:
     """Copy supervisor OUT_DIR and optional artifacts into archive_root; optional MANIFEST finalize."""
     result = PackResult(
@@ -133,6 +242,19 @@ def pack_supervisor_evidence(
             result.error = f"primary evidence finalize failed: {msg}"
             _write_closeout(archive_root, result)
             return result
+
+    if result.exit_code == 0:
+        hook_rc = maybe_invoke_supervisor_pack_durable_closeout_after_pack(
+            archive_root=archive_root,
+            invoke_durable_closeout_after_pack_v0=invoke_durable_closeout_after_pack_v0,
+            durable_closeout_dest_dir=durable_closeout_dest_dir,
+            pack_evidence_finalized=_pack_evidence_finalized(result),
+            durable_closeout_invoker=durable_closeout_invoker,
+        )
+        if hook_rc != 0:
+            result.exit_code = hook_rc
+            result.error = result.error or f"durable closeout hook failed: exit {hook_rc}"
+            _write_closeout(archive_root, result)
 
     return result
 
@@ -200,17 +322,41 @@ def build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Fail closed when any --optional-artifact path is missing",
     )
+    parser.add_argument(
+        "--invoke-durable-closeout-after-pack-v0",
+        action="store_true",
+        help=(
+            "After successful pack (and manifest verify when --primary-evidence-enforce), "
+            "invoke durable_closeout_copy_verify_v0 (default off)."
+        ),
+    )
+    parser.add_argument(
+        "--durable-closeout-dest-dir",
+        type=Path,
+        default=None,
+        help="Durable material closeout destination (required with --invoke-durable-closeout-after-pack-v0).",
+    )
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_arg_parser().parse_args(list(argv) if argv is not None else None)
+    invoke_durable_closeout_after_pack_v0 = bool(args.invoke_durable_closeout_after_pack_v0)
+    durable_closeout_dest_dir = args.durable_closeout_dest_dir
+    hook_cli_rc = validate_supervisor_pack_durable_closeout_hook_cli(
+        invoke_durable_closeout_after_pack_v0=invoke_durable_closeout_after_pack_v0,
+        durable_closeout_dest_dir=durable_closeout_dest_dir,
+    )
+    if hook_cli_rc is not None:
+        return hook_cli_rc
     result = pack_supervisor_evidence(
         out_dir=args.out_dir,
         archive_root=args.archive_root,
         optional_artifacts=tuple(args.optional_artifact or []),
         primary_evidence_enforce=bool(args.primary_evidence_enforce),
         require_optional_artifacts=bool(args.require_optional_artifacts),
+        invoke_durable_closeout_after_pack_v0=invoke_durable_closeout_after_pack_v0,
+        durable_closeout_dest_dir=durable_closeout_dest_dir,
     )
     if result.error:
         print(f"ERR: {result.error}", file=sys.stderr)

--- a/tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py
+++ b/tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py
@@ -1,0 +1,314 @@
+"""Tests for supervisor pack durable closeout hook pass-through (non-authorizing)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACK_SCRIPT = REPO_ROOT / "scripts" / "ops" / "pack_online_readiness_supervisor_evidence_v0.py"
+DURABLE_HELPER = REPO_ROOT / "scripts" / "ops" / "durable_closeout_copy_verify_v0.py"
+FORBIDDEN_CHAIN_SCRIPT = REPO_ROOT / "scripts/ops/post_closeout_chain_execute_v0.py"
+PYTEST_DURABLE_DEST_ROOT = (
+    REPO_ROOT / "out" / "ops" / "_pytest_supervisor_pack_durable_closeout_hook"
+)
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.ops.pack_online_readiness_supervisor_evidence_v0 as pack_mod
+from scripts.ops.pack_online_readiness_supervisor_evidence_v0 import (
+    CLOSEOUT_FILENAME,
+    pack_supervisor_evidence,
+)
+
+
+def _durable_dest(tmp_path: Path, name: str = "dest") -> Path:
+    safe = tmp_path.name.replace("/", "_")
+    dest = PYTEST_DURABLE_DEST_ROOT / safe / name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def _durable_archive(tmp_path: Path) -> Path:
+    path = REPO_ROOT / "tests" / ".pytest_archive_roots" / tmp_path.name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture(scope="module")
+def pm():
+    return pack_mod
+
+
+def test_forbidden_parallel_execute_script_absent():
+    assert not FORBIDDEN_CHAIN_SCRIPT.exists()
+    assert DURABLE_HELPER.is_file()
+
+
+def test_cli_flags_present_in_source():
+    text = PACK_SCRIPT.read_text(encoding="utf-8")
+    assert "--invoke-durable-closeout-after-pack-v0" in text
+    assert "--durable-closeout-dest-dir" in text
+    assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_REQUESTED=" in text
+    assert "--run-local-post-closeout-chain-v0" not in text
+    assert "--require-durable-pointer-evidence" not in text
+
+
+def test_hook_validate_requires_dest_dir(pm):
+    assert (
+        pm.validate_supervisor_pack_durable_closeout_hook_cli(
+            invoke_durable_closeout_after_pack_v0=True,
+            durable_closeout_dest_dir=None,
+        )
+        == 1
+    )
+
+
+def test_hook_validate_blocks_tmp_dest(pm):
+    assert (
+        pm.validate_supervisor_pack_durable_closeout_hook_cli(
+            invoke_durable_closeout_after_pack_v0=True,
+            durable_closeout_dest_dir=Path("/tmp/supervisor_durable_dest"),
+        )
+        == 1
+    )
+
+
+def test_main_hook_without_dest_fails_before_pack(pm, monkeypatch, tmp_path: Path):
+    pack_calls: list[object] = []
+    monkeypatch.setattr(
+        pm,
+        "pack_supervisor_evidence",
+        lambda **kwargs: pack_calls.append(kwargs)
+        or pm.PackResult(
+            out_dir="",
+            archive_root="",
+            closeout_path="",
+            supervisor_session_dest="",
+        ),
+    )
+    rc = pm.main(
+        [
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--archive-root",
+            str(tmp_path / "archive"),
+            "--invoke-durable-closeout-after-pack-v0",
+        ]
+    )
+    assert rc == 1
+    assert pack_calls == []
+
+
+def test_invoke_calls_only_durable_helper(pm, tmp_path: Path):
+    source = tmp_path / "archive"
+    source.mkdir()
+    (source / CLOSEOUT_FILENAME).write_text("{}\n", encoding="utf-8")
+    dest = _durable_dest(tmp_path, "helper_only")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = pm.invoke_supervisor_pack_durable_closeout_after_pack(
+        source_dir=source,
+        dest_dir=dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    joined = " ".join(calls[0])
+    assert calls[0][1].endswith("durable_closeout_copy_verify_v0.py")
+    assert str(source.resolve()) in joined
+    assert str(dest.resolve()) in joined
+    assert "build_generic_evidence_run_registry_v1.py" not in joined
+    assert "build_post_closeout_projection_payload_v0.py" not in joined
+    assert "notion_post_closeout_sync_dry_run_v0.py" not in joined
+
+
+def test_pack_invokes_hook_after_success_without_enforce(pm, tmp_path: Path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text("{}\n", encoding="utf-8")
+    archive = tmp_path / "archive"
+    dest = _durable_dest(tmp_path, "after_pack")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=archive,
+        invoke_durable_closeout_after_pack_v0=True,
+        durable_closeout_dest_dir=dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert str(archive.resolve()) in " ".join(calls[0])
+
+
+def test_pack_invokes_hook_after_primary_evidence_success(pm, monkeypatch, tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text("{}\n", encoding="utf-8")
+    archive = _durable_archive(tmp_path)
+    dest = _durable_dest(tmp_path, "after_finalize")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(
+        pack_mod,
+        "finalize_primary_evidence_root",
+        lambda _root: (True, ""),
+    )
+
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=archive,
+        primary_evidence_enforce=True,
+        invoke_durable_closeout_after_pack_v0=True,
+        durable_closeout_dest_dir=dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert result.exit_code == 0
+    assert result.manifest_verified is True
+    assert len(calls) == 1
+    assert (archive / CLOSEOUT_FILENAME).is_file()
+
+
+def test_pack_hook_fail_closed_on_helper_nonzero(pm, monkeypatch, tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text("{}\n", encoding="utf-8")
+    archive = _durable_archive(tmp_path)
+    dest = _durable_dest(tmp_path, "fail_closed")
+
+    monkeypatch.setattr(
+        pack_mod,
+        "finalize_primary_evidence_root",
+        lambda _root: (True, ""),
+    )
+
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=archive,
+        primary_evidence_enforce=True,
+        invoke_durable_closeout_after_pack_v0=True,
+        durable_closeout_dest_dir=dest,
+        durable_closeout_invoker=lambda _argv: 2,
+    )
+    assert result.exit_code == 2
+
+
+def test_pack_skips_hook_when_primary_evidence_finalize_fails(
+    pm, monkeypatch, tmp_path: Path
+) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "meta.json").write_text("{}\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(
+        pack_mod,
+        "finalize_primary_evidence_root",
+        lambda _root: (False, "checksum mismatch"),
+    )
+    dest = _durable_dest(tmp_path, "no_hook")
+
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=_durable_archive(tmp_path),
+        primary_evidence_enforce=True,
+        invoke_durable_closeout_after_pack_v0=True,
+        durable_closeout_dest_dir=dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert result.exit_code == 1
+    assert calls == []
+
+
+def test_pack_skips_hook_when_pack_fails(pm, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    result = pack_supervisor_evidence(
+        out_dir=tmp_path / "missing",
+        archive_root=tmp_path / "archive",
+        invoke_durable_closeout_after_pack_v0=True,
+        durable_closeout_dest_dir=_durable_dest(tmp_path),
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert result.exit_code == 1
+    assert calls == []
+
+
+def test_pack_default_off_no_hook(pm, monkeypatch, tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "supervisor_meta.json").write_text("{}\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(
+        pack_mod,
+        "finalize_primary_evidence_root",
+        lambda _root: (True, ""),
+    )
+
+    result = pack_supervisor_evidence(
+        out_dir=out_dir,
+        archive_root=_durable_archive(tmp_path),
+        primary_evidence_enforce=True,
+        invoke_durable_closeout_after_pack_v0=False,
+        durable_closeout_dest_dir=None,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert result.exit_code == 0
+    assert calls == []
+
+
+def test_maybe_invoke_emits_machine_lines(pm, tmp_path: Path, capsys):
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    dest = _durable_dest(tmp_path, "lines")
+
+    rc = pm.maybe_invoke_supervisor_pack_durable_closeout_after_pack(
+        archive_root=archive,
+        invoke_durable_closeout_after_pack_v0=False,
+        durable_closeout_dest_dir=dest,
+        pack_evidence_finalized=True,
+        durable_closeout_invoker=lambda _argv: 0,
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_REQUESTED=false" in out
+    assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_INVOKED=false" in out
+
+
+def test_pack_script_no_direct_chain_owners(pm):
+    text = PACK_SCRIPT.read_text(encoding="utf-8")
+    assert "build_generic_evidence_run_registry_v1" not in text
+    assert "build_post_closeout_projection_payload_v0" not in text
+    assert "notion_post_closeout_sync_dry_run_v0" not in text
+    assert "launchctl " not in text

--- a/tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py
+++ b/tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py
@@ -83,12 +83,14 @@ def test_main_hook_without_dest_fails_before_pack(pm, monkeypatch, tmp_path: Pat
     monkeypatch.setattr(
         pm,
         "pack_supervisor_evidence",
-        lambda **kwargs: pack_calls.append(kwargs)
-        or pm.PackResult(
-            out_dir="",
-            archive_root="",
-            closeout_path="",
-            supervisor_session_dest="",
+        lambda **kwargs: (
+            pack_calls.append(kwargs)
+            or pm.PackResult(
+                out_dir="",
+                archive_root="",
+                closeout_path="",
+                supervisor_session_dest="",
+            )
         ),
     )
     rc = pm.main(


### PR DESCRIPTION
## Summary
- **Package C2:** default-off supervisor evidence pack hook that invokes canonical `scripts/ops/durable_closeout_copy_verify_v0.py` only after successful pack completion (and after manifest verification when `--primary-evidence-enforce` is set). Fail-closed on helper non-zero exit.
- **Reuse Drift Guard:** reuses adapter `build_durable_closeout_invoke_argv` / `_default_durable_closeout_invoker`; no duplicate orchestration script; no Registry/Projection/Notion calls from pack script.
- **CLI:** `--invoke-durable-closeout-after-pack-v0` + `--durable-closeout-dest-dir` (required when enabled; outside `/tmp`). Default pack behavior unchanged when flags absent.

## Canonical owners reused
- `scripts/ops/pack_online_readiness_supervisor_evidence_v0.py`
- `scripts/ops/durable_closeout_copy_verify_v0.py`
- `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py` (argv/invoker reuse only)

## Duplicate surface risk
- **DUPLICATE_SURFACE_CREATED=false** — no `post_closeout_chain_execute_v0.py`, no Supervisor/Scheduler/Remote/S3/Market changes beyond pack hook.

## Durable evidence (implementation closeout)
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/supervisor_pack_durable_closeout_hook_pass_through_v0_20260528T161523Z/`

## Safety flags
- REMOTE_AWS_TOUCHED=false
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- SUPERVISOR_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- LIVE_AUTHORITY_CHANGED=false

## Tests run (local)
- `uv run pytest tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py -q`
- `uv run pytest tests/ops/test_pack_online_readiness_supervisor_evidence_v0.py -q`
- `uv run pytest tests/ops/test_p79_supervisor_primary_evidence_manifest_gate_v0.py -q`
- `uv run pytest tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py -q`
- `uv run pytest tests/ops -k "supervisor and (pack or closeout or durable or primary_evidence or manifest)" -q`
- `uv run ruff check` / `ruff format --check` on touched files

## Explicit statements
- **No docs touched.**
- **No AWS / runtime / scheduler / supervisor / launchctl / paper / shadow / testnet / live started** (mocks/fixtures only).
- **No Live authority changed.**


Made with [Cursor](https://cursor.com)