### PR TITLE
ops: add offline autonomous control plane planner

### DIFF
--- a/scripts/ops/build_autonomous_ops_control_plane_plan_v0.py
+++ b/scripts/ops/build_autonomous_ops_control_plane_plan_v0.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Offline Autonomous Ops Control Plane plan generator v0 (fixture-only, non-authorizing).
+
+Reads a transition fixture JSON (PR #3755 schema) and writes local plan artifacts.
+Does not start runtime, scheduler, supervisor, daemon, paper, shadow, testnet, or live.
+Does not invoke child processes, network, AWS, S3, or SSH.
+
+Machine marker: ``OFFLINE_CONTROL_PLANE_PLAN_GENERATOR_V0=true``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "control_plane_plan_v0"
+PLAN_JSON_FILENAME = "CONTROL_PLANE_PLAN_V0.json"
+PLAN_MACHINE_LINES_FILENAME = "CONTROL_PLANE_PLAN_MACHINE_LINES.txt"
+PLAN_MD_FILENAME = "CONTROL_PLANE_PLAN_V0.md"
+
+# Frozen literals aligned with tests/ops/test_autonomous_ops_control_plane_state_model_contract_v0.py
+CONTROL_PLANE_STATES_V0: tuple[str, ...] = (
+    "STOP_IDLE",
+    "PREFLIGHT_BLOCKED",
+    "PREFLIGHT_PASS",
+    "READY_FOR_OPERATOR_TOKEN",
+    "RUNNING",
+    "CLOSEOUT_REQUIRED",
+    "EVIDENCE_VERIFIED",
+    "FAILED_CLOSED",
+)
+
+FORBIDDEN_TRANSITIONS_V0: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("STOP_IDLE", "RUNNING"),
+        ("PREFLIGHT_BLOCKED", "RUNNING"),
+        ("PREFLIGHT_PASS", "RUNNING"),
+        ("RUNNING", "EVIDENCE_VERIFIED"),
+        ("FAILED_CLOSED", "RUNNING"),
+        ("EVIDENCE_VERIFIED", "RUNNING"),
+    }
+)
+
+REQUIRED_INTERMEDIATE_FOR_TARGET: dict[tuple[str, str], tuple[str, ...]] = {
+    ("PREFLIGHT_PASS", "RUNNING"): ("READY_FOR_OPERATOR_TOKEN",),
+    ("RUNNING", "EVIDENCE_VERIFIED"): ("CLOSEOUT_REQUIRED",),
+}
+
+REQUIRED_FIXTURE_KEYS: frozenset[str] = frozenset(
+    {
+        "case_id",
+        "initial_state",
+        "target_state",
+        "steps",
+        "expected_forbidden",
+        "required_intermediate_states",
+        "expected_machine_lines",
+    }
+)
+
+CORE_MACHINE_LINE_KEYS: tuple[str, ...] = (
+    "OFFLINE_CONTROL_PLANE_PLAN_GENERATOR_V0",
+    "CONTROL_PLANE_PLAN_STATUS",
+    "CONTROL_PLANE_PLAN_NON_AUTHORIZING",
+    "START_RUNTIME_NOW",
+    "START_SCHEDULER_NOW",
+    "START_SUPERVISOR_NOW",
+    "START_DAEMON_NOW",
+    "START_PAPER_SHADOW_TESTNET_LIVE_NOW",
+    "AWS_REMOTE_REQUIRED",
+    "S3_UPLOAD_REQUIRED",
+    "SSH_REQUIRED",
+    "NETWORK_REQUIRED",
+    "LIVE_AUTHORITY_CHANGED",
+    "MASTER_V2_DOUBLE_PLAY_TOUCHED",
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _edges(steps: list[str]) -> list[tuple[str, str]]:
+    return list(zip(steps, steps[1:]))
+
+
+def _has_forbidden_direct_edge(steps: list[str]) -> bool:
+    return any(edge in FORBIDDEN_TRANSITIONS_V0 for edge in _edges(steps))
+
+
+def _missing_required_intermediate(steps: list[str]) -> bool:
+    step_set = set(steps)
+    for (src, dst), required in REQUIRED_INTERMEDIATE_FOR_TARGET.items():
+        if src in step_set and dst in step_set:
+            for mid in required:
+                if mid not in step_set:
+                    return True
+    return False
+
+
+def transition_violation(steps: list[str]) -> bool:
+    return _has_forbidden_direct_edge(steps) or _missing_required_intermediate(steps)
+
+
+def _validate_fixture(fixture: dict[str, Any], fixture_path: Path) -> None:
+    missing = REQUIRED_FIXTURE_KEYS - fixture.keys()
+    if missing:
+        raise ValueError(f"fixture missing keys {sorted(missing)}: {fixture_path}")
+    states = set(CONTROL_PLANE_STATES_V0)
+    for key in ("initial_state", "target_state"):
+        if fixture[key] not in states:
+            raise ValueError(f"unknown state {fixture[key]!r} in {fixture_path}")
+    steps = fixture["steps"]
+    if not isinstance(steps, list) or not steps:
+        raise ValueError(f"steps must be a non-empty list: {fixture_path}")
+    if steps[0] != fixture["initial_state"] or steps[-1] != fixture["target_state"]:
+        raise ValueError(f"steps must begin/end at initial/target state: {fixture_path}")
+    for step in steps:
+        if step not in states:
+            raise ValueError(f"unknown step state {step!r} in {fixture_path}")
+    if not isinstance(fixture["expected_forbidden"], bool):
+        raise ValueError(f"expected_forbidden must be bool: {fixture_path}")
+    computed = transition_violation(steps)
+    if fixture["expected_forbidden"] != computed:
+        raise ValueError(
+            f"expected_forbidden={fixture['expected_forbidden']} "
+            f"does not match computed violation={computed}: {fixture_path}"
+        )
+
+
+def _plan_status(expected_forbidden: bool) -> str:
+    return "blocked" if expected_forbidden else "plan_only"
+
+
+def _build_decision(status: str) -> dict[str, Any]:
+    return {
+        "status": status,
+        "non_authorizing": True,
+        "execute_authorized": False,
+        "runtime_start_authorized": False,
+        "scheduler_start_authorized": False,
+        "supervisor_start_authorized": False,
+        "daemon_start_authorized": False,
+        "paper_shadow_testnet_live_start_authorized": False,
+        "aws_remote_required": False,
+        "s3_upload_required": False,
+        "ssh_required": False,
+        "network_required": False,
+        "live_authority_changed": False,
+        "master_v2_double_play_touched": False,
+    }
+
+
+def _build_machine_lines_dict(status: str) -> dict[str, str]:
+    lines = {key: "false" for key in CORE_MACHINE_LINE_KEYS if key.startswith("START_")}
+    lines.update(
+        {
+            "OFFLINE_CONTROL_PLANE_PLAN_GENERATOR_V0": "true",
+            "CONTROL_PLANE_PLAN_STATUS": status,
+            "CONTROL_PLANE_PLAN_NON_AUTHORIZING": "true",
+            "START_RUNTIME_NOW": "false",
+            "START_SCHEDULER_NOW": "false",
+            "START_SUPERVISOR_NOW": "false",
+            "START_DAEMON_NOW": "false",
+            "START_PAPER_SHADOW_TESTNET_LIVE_NOW": "false",
+            "AWS_REMOTE_REQUIRED": "false",
+            "S3_UPLOAD_REQUIRED": "false",
+            "SSH_REQUIRED": "false",
+            "NETWORK_REQUIRED": "false",
+            "LIVE_AUTHORITY_CHANGED": "false",
+            "MASTER_V2_DOUBLE_PLAY_TOUCHED": "false",
+        }
+    )
+    return lines
+
+
+def build_control_plane_plan_v0(
+    fixture: dict[str, Any],
+    *,
+    source_fixture: str,
+) -> dict[str, Any]:
+    status = _plan_status(fixture["expected_forbidden"])
+    machine_lines = _build_machine_lines_dict(status)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_fixture": source_fixture,
+        "case_id": fixture["case_id"],
+        "initial_state": fixture["initial_state"],
+        "target_state": fixture["target_state"],
+        "steps": list(fixture["steps"]),
+        "expected_forbidden": fixture["expected_forbidden"],
+        "required_intermediate_states": list(fixture["required_intermediate_states"]),
+        "decision": _build_decision(status),
+        "machine_lines": machine_lines,
+    }
+
+
+def _write_machine_lines_file(path: Path, machine_lines: dict[str, str]) -> None:
+    ordered = sorted(machine_lines.items())
+    path.write_text(
+        "\n".join(f"{key}={value}" for key, value in ordered) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_plan_markdown(path: Path, plan: dict[str, Any]) -> None:
+    decision = plan["decision"]
+    lines = [
+        "# Autonomous Ops Control Plane Plan v0",
+        "",
+        f"- case_id: `{plan['case_id']}`",
+        f"- status: `{decision['status']}`",
+        f"- non_authorizing: `{decision['non_authorizing']}`",
+        f"- execute_authorized: `{decision['execute_authorized']}`",
+        "",
+        "## Steps",
+        "",
+    ]
+    lines.extend(f"- `{step}`" for step in plan["steps"])
+    lines.append("")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_plan_artifacts_v0(outdir: Path, plan: dict[str, Any]) -> None:
+    outdir.mkdir(parents=True, exist_ok=True)
+    json_path = outdir / PLAN_JSON_FILENAME
+    json_path.write_text(
+        json.dumps(plan, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_machine_lines_file(outdir / PLAN_MACHINE_LINES_FILENAME, plan["machine_lines"])
+    _write_plan_markdown(outdir / PLAN_MD_FILENAME, plan)
+
+
+def run_plan_generator(
+    *,
+    fixture_path: Path,
+    outdir: Path,
+) -> dict[str, Any]:
+    fixture = _load_json(fixture_path)
+    _validate_fixture(fixture, fixture_path)
+    plan = build_control_plane_plan_v0(
+        fixture,
+        source_fixture=str(fixture_path.resolve()),
+    )
+    write_plan_artifacts_v0(outdir, plan)
+    return plan
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Offline Autonomous Ops Control Plane plan generator (fixture-only)."
+    )
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--outdir", type=Path, required=True)
+    parser.add_argument(
+        "--format",
+        choices=("json",),
+        default="json",
+        help="Output format (json only in v0).",
+    )
+    args = parser.parse_args(argv)
+    _ = args.format
+
+    try:
+        plan = run_plan_generator(
+            fixture_path=args.fixture.resolve(),
+            outdir=args.outdir.resolve(),
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
+    for key in CORE_MACHINE_LINE_KEYS:
+        sys.stdout.write(f"{key}={plan['machine_lines'][key]}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_autonomous_ops_control_plane_plan_generator_contract_v0.py
+++ b/tests/ops/test_autonomous_ops_control_plane_plan_generator_contract_v0.py
@@ -1,0 +1,149 @@
+"""Contract tests for offline Autonomous Ops Control Plane plan generator v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops import build_autonomous_ops_control_plane_plan_v0 as plan_mod
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = REPO_ROOT / "tests/fixtures/ops/control_plane_transition_v0"
+SCRIPT = REPO_ROOT / "scripts/ops/build_autonomous_ops_control_plane_plan_v0.py"
+
+LEGAL_FIXTURE = FIXTURE_DIR / "legal_ready_for_operator_token_path_v0.json"
+FORBIDDEN_FIXTURE = FIXTURE_DIR / "forbidden_stop_idle_to_running_v0.json"
+FAIL_CLOSED_FIXTURE = FIXTURE_DIR / "fail_closed_missing_evidence_v0.json"
+
+REQUIRED_MACHINE_LINE_ASSERTIONS = (
+    "START_RUNTIME_NOW=false",
+    "START_SCHEDULER_NOW=false",
+    "START_SUPERVISOR_NOW=false",
+    "START_DAEMON_NOW=false",
+    "START_PAPER_SHADOW_TESTNET_LIVE_NOW=false",
+    "AWS_REMOTE_REQUIRED=false",
+    "S3_UPLOAD_REQUIRED=false",
+    "SSH_REQUIRED=false",
+    "NETWORK_REQUIRED=false",
+    "LIVE_AUTHORITY_CHANGED=false",
+    "MASTER_V2_DOUBLE_PLAY_TOUCHED=false",
+)
+
+FORBIDDEN_SOURCE_PATTERNS = (
+    "import subprocess",
+    "from subprocess",
+    "subprocess.run",
+    "subprocess.Popen",
+    "os.system",
+    "import boto3",
+    "import paramiko",
+    "import requests",
+    "import urllib",
+    "import socket",
+    "run_scheduler",
+    'add_argument("--execute"',
+    "add_argument('--execute'",
+)
+
+
+def _parse_machine_lines(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if "=" in line:
+            key, _, value = line.partition("=")
+            out[key.strip()] = value.strip()
+    return out
+
+
+def _run_cli(fixture: Path, outdir: Path) -> int:
+    return plan_mod.main(["--fixture", str(fixture), "--outdir", str(outdir)])
+
+
+@pytest.fixture
+def plan_out_dir(tmp_path: Path) -> Path:
+    out = tmp_path / "plan_out"
+    out.mkdir()
+    return out
+
+
+def test_legal_fixture_produces_plan_only_and_no_starts(plan_out_dir: Path) -> None:
+    rc = _run_cli(LEGAL_FIXTURE, plan_out_dir)
+    assert rc == 0
+    plan = json.loads((plan_out_dir / plan_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8"))
+    assert plan["schema_version"] == plan_mod.SCHEMA_VERSION
+    assert plan["decision"]["status"] == "plan_only"
+    assert plan["decision"]["execute_authorized"] is False
+    lines = _parse_machine_lines(
+        (plan_out_dir / plan_mod.PLAN_MACHINE_LINES_FILENAME).read_text(encoding="utf-8")
+    )
+    assert lines["CONTROL_PLANE_PLAN_STATUS"] == "plan_only"
+    for key in (
+        "START_RUNTIME_NOW",
+        "START_SCHEDULER_NOW",
+        "START_PAPER_SHADOW_TESTNET_LIVE_NOW",
+    ):
+        assert lines[key] == "false"
+
+
+def test_forbidden_fixture_produces_blocked_and_no_starts(plan_out_dir: Path) -> None:
+    rc = _run_cli(FORBIDDEN_FIXTURE, plan_out_dir)
+    assert rc == 0
+    plan = json.loads((plan_out_dir / plan_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8"))
+    assert plan["decision"]["status"] == "blocked"
+    assert plan["expected_forbidden"] is True
+    lines = _parse_machine_lines(
+        (plan_out_dir / plan_mod.PLAN_MACHINE_LINES_FILENAME).read_text(encoding="utf-8")
+    )
+    assert lines["CONTROL_PLANE_PLAN_STATUS"] == "blocked"
+    for assertion in REQUIRED_MACHINE_LINE_ASSERTIONS:
+        key = assertion.split("=", 1)[0]
+        assert lines[key] == "false"
+
+
+def test_fail_closed_fixture_does_not_authorize_runtime_or_network(plan_out_dir: Path) -> None:
+    rc = _run_cli(FAIL_CLOSED_FIXTURE, plan_out_dir)
+    assert rc == 0
+    plan = json.loads((plan_out_dir / plan_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8"))
+    assert plan["target_state"] == "FAILED_CLOSED"
+    decision = plan["decision"]
+    assert decision["runtime_start_authorized"] is False
+    assert decision["network_required"] is False
+    assert decision["live_authority_changed"] is False
+    lines = _parse_machine_lines(
+        (plan_out_dir / plan_mod.PLAN_MACHINE_LINES_FILENAME).read_text(encoding="utf-8")
+    )
+    assert lines["NETWORK_REQUIRED"] == "false"
+    assert lines["LIVE_AUTHORITY_CHANGED"] == "false"
+
+
+def test_json_output_is_deterministic_for_legal_fixture(plan_out_dir: Path) -> None:
+    rc1 = _run_cli(LEGAL_FIXTURE, plan_out_dir)
+    text1 = (plan_out_dir / plan_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8")
+    rc2 = _run_cli(LEGAL_FIXTURE, plan_out_dir)
+    text2 = (plan_out_dir / plan_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8")
+    assert rc1 == rc2 == 0
+    assert text1 == text2
+    payload = json.loads(text1)
+    assert payload["schema_version"] == "control_plane_plan_v0"
+    assert payload["machine_lines"]["OFFLINE_CONTROL_PLANE_PLAN_GENERATOR_V0"] == "true"
+
+
+def test_machine_lines_file_contains_required_flags(plan_out_dir: Path) -> None:
+    assert _run_cli(LEGAL_FIXTURE, plan_out_dir) == 0
+    text = (plan_out_dir / plan_mod.PLAN_MACHINE_LINES_FILENAME).read_text(encoding="utf-8")
+    for assertion in REQUIRED_MACHINE_LINE_ASSERTIONS:
+        assert assertion in text
+
+
+def test_script_source_has_no_dangerous_imports_or_execute_flag() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    for pattern in FORBIDDEN_SOURCE_PATTERNS:
+        assert pattern not in source, f"forbidden pattern in planner source: {pattern!r}"
+
+
+def test_planner_script_and_contract_module_exist_v0() -> None:
+    assert SCRIPT.is_file()
+    assert Path(__file__).resolve().is_file()


### PR DESCRIPTION
## Summary
- adds a stdlib-only offline Autonomous Ops Control Plane plan generator
- reads existing transition fixtures via `--fixture` and writes plan artifacts via `--outdir`
- emits `CONTROL_PLANE_PLAN_V0.json`, `CONTROL_PLANE_PLAN_MACHINE_LINES.txt`, and `CONTROL_PLANE_PLAN_V0.md`
- preserves non-authorizing semantics: legal fixture => `plan_only`, forbidden fixture => `blocked`, all start/live/network/Master-V2 flags remain false
- adds focused contract tests for legal, forbidden, fail-closed, deterministic output, machine lines, and import-safety behavior

## Files
- scripts/ops/build_autonomous_ops_control_plane_plan_v0.py
- tests/ops/test_autonomous_ops_control_plane_plan_generator_contract_v0.py

## Validation
- uv run pytest tests/ops/test_autonomous_ops_control_plane_plan_generator_contract_v0.py -q
- uv run pytest tests/ops/test_autonomous_ops_control_plane_transition_fixtures_contract_v0.py -q
- uv run pytest tests/ops/test_autonomous_ops_control_plane_state_model_contract_v0.py -q
- uv run ruff check scripts/ops/build_autonomous_ops_control_plane_plan_v0.py tests/ops/test_autonomous_ops_control_plane_plan_generator_contract_v0.py
- uv run ruff format --check scripts/ops/build_autonomous_ops_control_plane_plan_v0.py tests/ops/test_autonomous_ops_control_plane_plan_generator_contract_v0.py
- python3 scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

## Durable Evidence
- /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/offline_control_plane_plan_generator_v0_20260528T203726Z
- MANIFEST_VERIFY_RC=0

## Safety
- OFFLINE_ONLY=true
- PLAN_GENERATOR_IMPLEMENTED=true
- DOCS_CHANGED=false
- ONLY_ALLOWED_FILES_CHANGED=true
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- SUPERVISOR_STARTED=false
- DAEMON_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- AWS_REMOTE_TOUCHED=false
- S3_UPLOAD_REQUIRED=false
- SSH_REQUIRED=false
- NETWORK_REQUIRED=false
- LIVE_AUTHORITY_CHANGED=false
- MASTER_V2_DOUBLE_PLAY_TOUCHED=false
- NO_EXECUTE_FLAG=true
- BROKER_EXCHANGE_AUTHORITY=false