### PR TITLE
ops: add control plane post-closeout readiness bridge

### DIFF
--- a/scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py
+++ b/scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Bridge Autonomous Ops Control Plane plan output to post-closeout readiness (offline only).
+
+Reads ``CONTROL_PLANE_PLAN_V0.json`` from the offline plan generator and emits a local
+readiness summary for future post-closeout/projection planning. Does not invoke closeout,
+projection, Notion, durable copy, primary evidence retention, runtime, or network.
+
+Machine marker: ``CONTROL_PLANE_POST_CLOSEOUT_READINESS_V0=true``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "control_plane_post_closeout_readiness_v0"
+SOURCE_PLAN_SCHEMA_VERSION = "control_plane_plan_v0"
+READINESS_JSON_FILENAME = "CONTROL_PLANE_POST_CLOSEOUT_READINESS_V0.json"
+READINESS_MACHINE_LINES_FILENAME = "CONTROL_PLANE_POST_CLOSEOUT_READINESS_MACHINE_LINES.txt"
+READINESS_MD_FILENAME = "CONTROL_PLANE_POST_CLOSEOUT_READINESS_V0.md"
+
+OWNER_CLOSEOUT_CHAIN_TEST = "tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py"
+OWNER_PROJECTION_BUILDER = "scripts/ops/build_post_closeout_projection_payload_v0.py"
+OWNER_NOTION_DRY_RUN = "scripts/ops/notion_post_closeout_sync_dry_run_v0.py"
+OWNER_DURABLE_COPY_VERIFY = "scripts/ops/durable_closeout_copy_verify_v0.py"
+
+REQUIRED_PLAN_KEYS: frozenset[str] = frozenset(
+    {
+        "schema_version",
+        "case_id",
+        "decision",
+        "machine_lines",
+    }
+)
+
+READINESS_MACHINE_LINE_KEYS: tuple[str, ...] = (
+    "CONTROL_PLANE_POST_CLOSEOUT_READINESS_V0",
+    "CONTROL_PLANE_POST_CLOSEOUT_READINESS_STATUS",
+    "PLANNING_ONLY",
+    "CLOSEOUT_INVOKE_AUTHORIZED",
+    "PROJECTION_INVOKE_AUTHORIZED",
+    "NOTION_SYNC_AUTHORIZED",
+    "DURABLE_COPY_AUTHORIZED",
+    "PRIMARY_EVIDENCE_RETENTION_INVOKE_AUTHORIZED",
+    "RUNTIME_START_REQUIRED",
+    "SCHEDULER_START_REQUIRED",
+    "SUPERVISOR_START_REQUIRED",
+    "DAEMON_START_REQUIRED",
+    "PAPER_SHADOW_TESTNET_LIVE_START_REQUIRED",
+    "AWS_REMOTE_REQUIRED",
+    "S3_UPLOAD_REQUIRED",
+    "SSH_REQUIRED",
+    "NETWORK_REQUIRED",
+    "LIVE_AUTHORITY_CHANGED",
+    "MASTER_V2_DOUBLE_PLAY_TOUCHED",
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_plan(plan: dict[str, Any], plan_path: Path) -> str:
+    missing = REQUIRED_PLAN_KEYS - plan.keys()
+    if missing:
+        raise ValueError(f"plan missing keys {sorted(missing)}: {plan_path}")
+    if plan["schema_version"] != SOURCE_PLAN_SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported plan schema {plan['schema_version']!r} "
+            f"(expected {SOURCE_PLAN_SCHEMA_VERSION!r}): {plan_path}"
+        )
+    machine_lines = plan["machine_lines"]
+    if not isinstance(machine_lines, dict):
+        raise ValueError(f"plan machine_lines must be object: {plan_path}")
+    status = machine_lines.get("CONTROL_PLANE_PLAN_STATUS")
+    if status not in {"plan_only", "blocked"}:
+        decision_status = plan.get("decision", {}).get("status")
+        if decision_status in {"plan_only", "blocked"}:
+            status = decision_status
+        else:
+            raise ValueError(f"unknown control plane plan status: {plan_path}")
+    return str(status)
+
+
+def _readiness_status(plan_status: str) -> str:
+    if plan_status == "plan_only":
+        return "ready_for_projection_planning"
+    return "blocked"
+
+
+def _readiness_reason(plan_status: str, case_id: str) -> str:
+    if plan_status == "plan_only":
+        return (
+            f"case_id={case_id}: control plane plan is plan_only; "
+            "projection payload planning may be prepared offline only"
+        )
+    return (
+        f"case_id={case_id}: control plane plan is blocked; "
+        "post-closeout projection planning remains blocked"
+    )
+
+
+def build_post_closeout_readiness_v0(
+    plan: dict[str, Any],
+    *,
+    source_plan: str,
+) -> dict[str, Any]:
+    plan_status = _validate_plan(plan, Path(source_plan))
+    readiness_status = _readiness_status(plan_status)
+    can_prepare = plan_status == "plan_only"
+    machine_lines = _build_readiness_machine_lines(readiness_status)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_plan": source_plan,
+        "source_plan_schema_version": SOURCE_PLAN_SCHEMA_VERSION,
+        "case_id": plan["case_id"],
+        "control_plane_plan_status": plan_status,
+        "planning_only": True,
+        "non_authorizing": True,
+        "closeout_invoke_authorized": False,
+        "projection_invoke_authorized": False,
+        "notion_sync_authorized": False,
+        "durable_copy_authorized": False,
+        "primary_evidence_retention_invoke_authorized": False,
+        "readiness": {
+            "can_prepare_post_closeout_projection_payload": can_prepare,
+            "reason": _readiness_reason(plan_status, plan["case_id"]),
+        },
+        "owners": {
+            "closeout_projection_chain_test": OWNER_CLOSEOUT_CHAIN_TEST,
+            "projection_builder": OWNER_PROJECTION_BUILDER,
+            "notion_dry_run": OWNER_NOTION_DRY_RUN,
+            "durable_copy_verify": OWNER_DURABLE_COPY_VERIFY,
+        },
+        "machine_lines": machine_lines,
+    }
+
+
+def _build_readiness_machine_lines(readiness_status: str) -> dict[str, str]:
+    return {
+        "CONTROL_PLANE_POST_CLOSEOUT_READINESS_V0": "true",
+        "CONTROL_PLANE_POST_CLOSEOUT_READINESS_STATUS": readiness_status,
+        "PLANNING_ONLY": "true",
+        "CLOSEOUT_INVOKE_AUTHORIZED": "false",
+        "PROJECTION_INVOKE_AUTHORIZED": "false",
+        "NOTION_SYNC_AUTHORIZED": "false",
+        "DURABLE_COPY_AUTHORIZED": "false",
+        "PRIMARY_EVIDENCE_RETENTION_INVOKE_AUTHORIZED": "false",
+        "RUNTIME_START_REQUIRED": "false",
+        "SCHEDULER_START_REQUIRED": "false",
+        "SUPERVISOR_START_REQUIRED": "false",
+        "DAEMON_START_REQUIRED": "false",
+        "PAPER_SHADOW_TESTNET_LIVE_START_REQUIRED": "false",
+        "AWS_REMOTE_REQUIRED": "false",
+        "S3_UPLOAD_REQUIRED": "false",
+        "SSH_REQUIRED": "false",
+        "NETWORK_REQUIRED": "false",
+        "LIVE_AUTHORITY_CHANGED": "false",
+        "MASTER_V2_DOUBLE_PLAY_TOUCHED": "false",
+    }
+
+
+def _write_machine_lines_file(path: Path, machine_lines: dict[str, str]) -> None:
+    ordered = sorted(machine_lines.items())
+    path.write_text(
+        "\n".join(f"{key}={value}" for key, value in ordered) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_readiness_markdown(path: Path, readiness: dict[str, Any]) -> None:
+    lines = [
+        "# Control Plane Post-Closeout Readiness v0",
+        "",
+        f"- case_id: `{readiness['case_id']}`",
+        f"- control_plane_plan_status: `{readiness['control_plane_plan_status']}`",
+        f"- readiness_status: `{readiness['machine_lines']['CONTROL_PLANE_POST_CLOSEOUT_READINESS_STATUS']}`",
+        f"- planning_only: `{readiness['planning_only']}`",
+        f"- closeout_invoke_authorized: `{readiness['closeout_invoke_authorized']}`",
+        "",
+        f"Reason: {readiness['readiness']['reason']}",
+        "",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_readiness_artifacts_v0(outdir: Path, readiness: dict[str, Any]) -> None:
+    outdir.mkdir(parents=True, exist_ok=True)
+    (outdir / READINESS_JSON_FILENAME).write_text(
+        json.dumps(readiness, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_machine_lines_file(
+        outdir / READINESS_MACHINE_LINES_FILENAME,
+        readiness["machine_lines"],
+    )
+    _write_readiness_markdown(outdir / READINESS_MD_FILENAME, readiness)
+
+
+def run_bridge(*, plan_path: Path, outdir: Path) -> dict[str, Any]:
+    plan = _load_json(plan_path)
+    readiness = build_post_closeout_readiness_v0(
+        plan,
+        source_plan=str(plan_path.resolve()),
+    )
+    write_readiness_artifacts_v0(outdir, readiness)
+    return readiness
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bridge control plane plan output to post-closeout readiness (offline only)."
+    )
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--outdir", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        readiness = run_bridge(
+            plan_path=args.plan.resolve(),
+            outdir=args.outdir.resolve(),
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
+    for key in READINESS_MACHINE_LINE_KEYS:
+        sys.stdout.write(f"{key}={readiness['machine_lines'][key]}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_control_plane_plan_output_closeout_projection_bridge_contract_v0.py
+++ b/tests/ops/test_control_plane_plan_output_closeout_projection_bridge_contract_v0.py
@@ -1,0 +1,169 @@
+"""Contract tests for control plane plan → post-closeout readiness bridge v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops import bridge_control_plane_plan_to_post_closeout_readiness_v0 as bridge_mod
+from scripts.ops import build_autonomous_ops_control_plane_plan_v0 as plan_mod
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = REPO_ROOT / "tests/fixtures/ops/control_plane_transition_v0"
+BRIDGE_SCRIPT = REPO_ROOT / "scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py"
+
+LEGAL_FIXTURE = FIXTURE_DIR / "legal_ready_for_operator_token_path_v0.json"
+FORBIDDEN_FIXTURE = FIXTURE_DIR / "forbidden_stop_idle_to_running_v0.json"
+
+OWNER_PATHS = (
+    REPO_ROOT / "tests/ops/test_closeout_to_projection_chain_automation_contract_v0.py",
+    REPO_ROOT / "scripts/ops/build_post_closeout_projection_payload_v0.py",
+    REPO_ROOT / "scripts/ops/notion_post_closeout_sync_dry_run_v0.py",
+    REPO_ROOT / "scripts/ops/durable_closeout_copy_verify_v0.py",
+)
+
+REQUIRED_MACHINE_LINE_ASSERTIONS = (
+    "PLANNING_ONLY=true",
+    "CLOSEOUT_INVOKE_AUTHORIZED=false",
+    "PROJECTION_INVOKE_AUTHORIZED=false",
+    "NOTION_SYNC_AUTHORIZED=false",
+    "DURABLE_COPY_AUTHORIZED=false",
+    "PRIMARY_EVIDENCE_RETENTION_INVOKE_AUTHORIZED=false",
+    "RUNTIME_START_REQUIRED=false",
+    "SCHEDULER_START_REQUIRED=false",
+    "SUPERVISOR_START_REQUIRED=false",
+    "DAEMON_START_REQUIRED=false",
+    "PAPER_SHADOW_TESTNET_LIVE_START_REQUIRED=false",
+    "AWS_REMOTE_REQUIRED=false",
+    "S3_UPLOAD_REQUIRED=false",
+    "SSH_REQUIRED=false",
+    "NETWORK_REQUIRED=false",
+    "LIVE_AUTHORITY_CHANGED=false",
+    "MASTER_V2_DOUBLE_PLAY_TOUCHED=false",
+)
+
+FORBIDDEN_SOURCE_PATTERNS = (
+    "import subprocess",
+    "from subprocess",
+    "subprocess.run",
+    "subprocess.Popen",
+    "os.system",
+    "import boto3",
+    "import paramiko",
+    "import requests",
+    "import urllib",
+    "import socket",
+    "run_scheduler",
+    'add_argument("--execute"',
+    "add_argument('--execute'",
+    "durable_closeout_copy_verify_v0.main(",
+    "build_post_closeout_projection_payload_v0.main(",
+    "notion_post_closeout_sync_dry_run_v0.main(",
+)
+
+
+def _parse_machine_lines(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if "=" in line:
+            key, _, value = line.partition("=")
+            out[key.strip()] = value.strip()
+    return out
+
+
+def _make_plan(tmp_path: Path, fixture: Path) -> Path:
+    plan_dir = tmp_path / "plan"
+    plan_dir.mkdir()
+    rc = plan_mod.main(["--fixture", str(fixture), "--outdir", str(plan_dir)])
+    assert rc == 0
+    return plan_dir / plan_mod.PLAN_JSON_FILENAME
+
+
+def _run_bridge(plan_json: Path, outdir: Path) -> int:
+    return bridge_mod.main(["--plan", str(plan_json), "--outdir", str(outdir)])
+
+
+@pytest.fixture
+def bridge_out_dir(tmp_path: Path) -> Path:
+    out = tmp_path / "readiness"
+    out.mkdir()
+    return out
+
+
+def test_plan_only_source_produces_ready_for_projection_planning(
+    tmp_path: Path, bridge_out_dir: Path
+) -> None:
+    plan_json = _make_plan(tmp_path, LEGAL_FIXTURE)
+    assert _run_bridge(plan_json, bridge_out_dir) == 0
+    readiness = json.loads(
+        (bridge_out_dir / bridge_mod.READINESS_JSON_FILENAME).read_text(encoding="utf-8")
+    )
+    assert readiness["schema_version"] == bridge_mod.SCHEMA_VERSION
+    assert readiness["control_plane_plan_status"] == "plan_only"
+    assert (
+        readiness["machine_lines"]["CONTROL_PLANE_POST_CLOSEOUT_READINESS_STATUS"]
+        == "ready_for_projection_planning"
+    )
+    assert readiness["readiness"]["can_prepare_post_closeout_projection_payload"] is True
+    assert readiness["closeout_invoke_authorized"] is False
+    assert readiness["projection_invoke_authorized"] is False
+    assert readiness["notion_sync_authorized"] is False
+    assert readiness["durable_copy_authorized"] is False
+
+
+def test_blocked_source_remains_blocked(tmp_path: Path, bridge_out_dir: Path) -> None:
+    plan_json = _make_plan(tmp_path, FORBIDDEN_FIXTURE)
+    assert _run_bridge(plan_json, bridge_out_dir) == 0
+    readiness = json.loads(
+        (bridge_out_dir / bridge_mod.READINESS_JSON_FILENAME).read_text(encoding="utf-8")
+    )
+    assert readiness["control_plane_plan_status"] == "blocked"
+    assert readiness["machine_lines"]["CONTROL_PLANE_POST_CLOSEOUT_READINESS_STATUS"] == "blocked"
+    assert readiness["readiness"]["can_prepare_post_closeout_projection_payload"] is False
+    assert readiness["closeout_invoke_authorized"] is False
+    assert readiness["projection_invoke_authorized"] is False
+
+
+def test_machine_lines_file_contains_required_flags(tmp_path: Path, bridge_out_dir: Path) -> None:
+    plan_json = _make_plan(tmp_path, LEGAL_FIXTURE)
+    assert _run_bridge(plan_json, bridge_out_dir) == 0
+    text = (bridge_out_dir / bridge_mod.READINESS_MACHINE_LINES_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    for assertion in REQUIRED_MACHINE_LINE_ASSERTIONS:
+        assert assertion in text
+    lines = _parse_machine_lines(text)
+    assert lines["PLANNING_ONLY"] == "true"
+    assert lines["CLOSEOUT_INVOKE_AUTHORIZED"] == "false"
+
+
+def test_owner_pointers_reference_existing_canonical_files(
+    tmp_path: Path, bridge_out_dir: Path
+) -> None:
+    plan_json = _make_plan(tmp_path, LEGAL_FIXTURE)
+    assert _run_bridge(plan_json, bridge_out_dir) == 0
+    readiness = json.loads(
+        (bridge_out_dir / bridge_mod.READINESS_JSON_FILENAME).read_text(encoding="utf-8")
+    )
+    owners = readiness["owners"]
+    for path in OWNER_PATHS:
+        assert path.is_file()
+        assert path.name in owners.values() or str(path.relative_to(REPO_ROOT)) in owners.values()
+
+
+def test_bridge_script_source_has_no_dangerous_imports_or_invocations() -> None:
+    source = BRIDGE_SCRIPT.read_text(encoding="utf-8")
+    for pattern in FORBIDDEN_SOURCE_PATTERNS:
+        assert pattern not in source, f"forbidden pattern in bridge source: {pattern!r}"
+
+
+def test_readiness_json_is_deterministic(tmp_path: Path, bridge_out_dir: Path) -> None:
+    plan_json = _make_plan(tmp_path, LEGAL_FIXTURE)
+    assert _run_bridge(plan_json, bridge_out_dir) == 0
+    text1 = (bridge_out_dir / bridge_mod.READINESS_JSON_FILENAME).read_text(encoding="utf-8")
+    assert _run_bridge(plan_json, bridge_out_dir) == 0
+    text2 = (bridge_out_dir / bridge_mod.READINESS_JSON_FILENAME).read_text(encoding="utf-8")
+    assert text1 == text2


### PR DESCRIPTION
## Summary
- adds an offline-only bridge from `CONTROL_PLANE_PLAN_V0.json` to post-closeout readiness artifacts
- writes `CONTROL_PLANE_POST_CLOSEOUT_READINESS_V0.json`, machine lines, and markdown summary
- preserves planning-only semantics: no closeout/projection/Notion/durable-copy/primary-evidence invocation
- maps `plan_only` to `ready_for_projection_planning` and keeps `blocked` blocked
- adds contract tests for ready/blocked behavior, machine lines, owner pointers, and import-safety boundaries

## Files
- scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py
- tests/ops/test_control_plane_plan_output_closeout_projection_bridge_contract_v0.py

## Validation
- uv run pytest tests/ops/test_control_plane_plan_output_closeout_projection_bridge_contract_v0.py -q
- uv run pytest tests/ops/test_autonomous_ops_control_plane_plan_generator_contract_v0.py -q
- uv run pytest tests/ops/test_autonomous_ops_control_plane_transition_fixtures_contract_v0.py -q
- uv run pytest tests/ops/test_autonomous_ops_control_plane_state_model_contract_v0.py -q
- uv run ruff check scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py tests/ops/test_control_plane_plan_output_closeout_projection_bridge_contract_v0.py
- uv run ruff format --check scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py tests/ops/test_control_plane_plan_output_closeout_projection_bridge_contract_v0.py
- python3 scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

## Durable Evidence
- /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/control_plane_plan_closeout_projection_bridge_v0_20260528T210517Z
- MANIFEST_VERIFY_RC=0

## Safety
- OFFLINE_ONLY=true
- DOCS_CHANGED=false
- ONLY_ALLOWED_FILES_CHANGED=true
- CLOSEOUT_INVOKED=false
- PROJECTION_INVOKED=false
- NOTION_SYNC_INVOKED=false
- DURABLE_COPY_INVOKED=false
- PRIMARY_EVIDENCE_RETENTION_INVOKED=false
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- SUPERVISOR_STARTED=false
- DAEMON_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- AWS_REMOTE_TOUCHED=false
- S3_UPLOAD_REQUIRED=false
- SSH_REQUIRED=false
- NETWORK_REQUIRED=false
- LIVE_AUTHORITY_CHANGED=false
- MASTER_V2_DOUBLE_PLAY_TOUCHED=false