### PR TITLE
ops: add control plane durable attachment planner

### DIFF
--- a/scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py
+++ b/scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Offline Control Plane durable attachment planner stub v0 (pointer-only, non-authorizing).
+
+Reads offline chain output root + target durable archive root and writes a local attachment
+plan. Does not copy, verify, write MANIFEST.sha256, retain evidence, invoke closeout,
+projection, Notion, hooks, runtime, or network.
+
+Machine marker: ``CONTROL_PLANE_DURABLE_ATTACHMENT_PLANNER_CLI_STUB_V0=true``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp
+
+SCHEMA_VERSION = "control_plane_offline_chain_durable_attachment_v0"
+DURABLE_ATTACHMENT_CONTRACT_MODE = "pointer_only_no_copy_no_verify"
+TARGET_ARCHIVE_ROOT_POLICY = "must_be_outside_tmp"
+
+PLAN_JSON_FILENAME = "CONTROL_PLANE_DURABLE_ATTACHMENT_PLAN_V0.json"
+PLAN_MACHINE_LINES_FILENAME = "CONTROL_PLANE_DURABLE_ATTACHMENT_PLAN_MACHINE_LINES.txt"
+PLAN_MD_FILENAME = "CONTROL_PLANE_DURABLE_ATTACHMENT_PLAN_V0.md"
+
+REQUIRED_CHAIN_REL_PATHS_V0: tuple[str, ...] = (
+    "plan/CONTROL_PLANE_PLAN_V0.json",
+    "plan/CONTROL_PLANE_PLAN_MACHINE_LINES.txt",
+    "plan/CONTROL_PLANE_PLAN_V0.md",
+    "readiness/CONTROL_PLANE_POST_CLOSEOUT_READINESS_V0.json",
+    "readiness/CONTROL_PLANE_POST_CLOSEOUT_READINESS_MACHINE_LINES.txt",
+    "readiness/CONTROL_PLANE_POST_CLOSEOUT_READINESS_V0.md",
+    "CONTROL_PLANE_OFFLINE_CHAIN_V0.json",
+    "CONTROL_PLANE_OFFLINE_CHAIN_MACHINE_LINES.txt",
+    "CONTROL_PLANE_OFFLINE_CHAIN_V0.md",
+)
+
+OWNER_REFERENCES_V0: tuple[str, ...] = (
+    "scripts/ops/primary_evidence_retention_v0.py",
+    "scripts/ops/durable_closeout_copy_verify_v0.py",
+    "scripts/ops/run_autonomous_ops_control_plane_offline_chain_v0.py",
+    "tests/ops/test_control_plane_offline_chain_durable_evidence_attachment_contracts_v0.py",
+)
+
+STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING = "ready_for_durable_attachment_planning"
+STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT = "blocked_missing_required_chain_artifact"
+STATUS_BLOCKED_TARGET_ARCHIVE_ROOT_UNDER_TMP = "blocked_target_archive_root_under_tmp"
+
+FORBIDDEN_CLI_FLAGS: tuple[str, ...] = (
+    "--execute",
+    "--copy",
+    "--verify",
+    "--retention",
+    "--closeout",
+    "--projection",
+    "--notion-sync",
+    "--upload",
+    "--s3",
+    "--ssh",
+    "--start",
+)
+
+PLAN_MACHINE_LINE_KEYS: tuple[str, ...] = (
+    "CONTROL_PLANE_DURABLE_ATTACHMENT_PLANNER_CLI_STUB_V0",
+    "CONTROL_PLANE_DURABLE_ATTACHMENT_PLAN_STATUS",
+    "DURABLE_ATTACHMENT_CONTRACT_MODE",
+    "POINTER_ONLY",
+    "DURABLE_COPY_INVOKED",
+    "PRIMARY_EVIDENCE_RETENTION_INVOKED",
+    "MANIFEST_WRITE_INVOKED",
+    "COPY_VERIFY_INVOKED",
+    "CLOSEOUT_INVOKED",
+    "PROJECTION_INVOKED",
+    "NOTION_SYNC_INVOKED",
+    "HOOK_IMPLEMENTED",
+    "FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED",
+    "RUNTIME_STARTED",
+    "SCHEDULER_STARTED",
+    "SUPERVISOR_STARTED",
+    "DAEMON_STARTED",
+    "PAPER_SHADOW_TESTNET_LIVE_STARTED",
+    "AWS_REMOTE_TOUCHED",
+    "S3_UPLOAD_REQUIRED",
+    "SSH_REQUIRED",
+    "NETWORK_REQUIRED",
+    "LIVE_AUTHORITY_CHANGED",
+    "MASTER_V2_DOUBLE_PLAY_TOUCHED",
+)
+
+
+def missing_chain_rel_paths(
+    chain_root: Path,
+    required_chain_rel_paths: tuple[str, ...] = REQUIRED_CHAIN_REL_PATHS_V0,
+) -> list[str]:
+    missing: list[str] = []
+    for rel in required_chain_rel_paths:
+        if not (chain_root / rel).is_file():
+            missing.append(rel)
+    return missing
+
+
+def evaluate_attachment_plan_v0(
+    *,
+    source_chain_root: Path,
+    target_archive_root: Path,
+    required_chain_rel_paths: tuple[str, ...] = REQUIRED_CHAIN_REL_PATHS_V0,
+) -> dict[str, Any]:
+    """Evaluate pointer-only durable attachment plan (planner-only; no side effects)."""
+    missing = missing_chain_rel_paths(source_chain_root, required_chain_rel_paths)
+
+    if missing:
+        status = STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT
+    elif is_under_tmp(target_archive_root):
+        status = STATUS_BLOCKED_TARGET_ARCHIVE_ROOT_UNDER_TMP
+    else:
+        status = STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING
+
+    machine_lines = {
+        "CONTROL_PLANE_DURABLE_ATTACHMENT_PLANNER_CLI_STUB_V0": "true",
+        "CONTROL_PLANE_DURABLE_ATTACHMENT_PLAN_STATUS": status,
+        "DURABLE_ATTACHMENT_CONTRACT_MODE": DURABLE_ATTACHMENT_CONTRACT_MODE,
+        "POINTER_ONLY": "true",
+        "DURABLE_COPY_INVOKED": "false",
+        "PRIMARY_EVIDENCE_RETENTION_INVOKED": "false",
+        "MANIFEST_WRITE_INVOKED": "false",
+        "COPY_VERIFY_INVOKED": "false",
+        "CLOSEOUT_INVOKED": "false",
+        "PROJECTION_INVOKED": "false",
+        "NOTION_SYNC_INVOKED": "false",
+        "HOOK_IMPLEMENTED": "false",
+        "FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED": "false",
+        "RUNTIME_STARTED": "false",
+        "SCHEDULER_STARTED": "false",
+        "SUPERVISOR_STARTED": "false",
+        "DAEMON_STARTED": "false",
+        "PAPER_SHADOW_TESTNET_LIVE_STARTED": "false",
+        "AWS_REMOTE_TOUCHED": "false",
+        "S3_UPLOAD_REQUIRED": "false",
+        "SSH_REQUIRED": "false",
+        "NETWORK_REQUIRED": "false",
+        "LIVE_AUTHORITY_CHANGED": "false",
+        "MASTER_V2_DOUBLE_PLAY_TOUCHED": "false",
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_chain_root": str(source_chain_root.resolve()),
+        "target_archive_root": str(target_archive_root.resolve()),
+        "required_chain_rel_paths": list(required_chain_rel_paths),
+        "missing_chain_rel_paths": missing,
+        "target_archive_root_policy": TARGET_ARCHIVE_ROOT_POLICY,
+        "pointer_only": True,
+        "status": status,
+        "durable_attachment_contract_mode": DURABLE_ATTACHMENT_CONTRACT_MODE,
+        "owner_references": list(OWNER_REFERENCES_V0),
+        "durable_copy_invoked": False,
+        "primary_evidence_retention_invoked": False,
+        "manifest_write_invoked": False,
+        "copy_verify_invoked": False,
+        "closeout_invoked": False,
+        "projection_invoked": False,
+        "notion_sync_invoked": False,
+        "hook_implemented": False,
+        "full_post_closeout_automation_implemented": False,
+        "runtime_started": False,
+        "scheduler_started": False,
+        "supervisor_started": False,
+        "daemon_started": False,
+        "paper_shadow_testnet_live_started": False,
+        "aws_remote_touched": False,
+        "s3_upload_required": False,
+        "ssh_required": False,
+        "network_required": False,
+        "live_authority_changed": False,
+        "master_v2_double_play_touched": False,
+        "machine_lines": machine_lines,
+    }
+
+
+def _write_machine_lines_file(path: Path, machine_lines: dict[str, str]) -> None:
+    ordered = sorted(machine_lines.items())
+    path.write_text(
+        "\n".join(f"{key}={value}" for key, value in ordered) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_plan_markdown(path: Path, plan: dict[str, Any]) -> None:
+    lines = [
+        "# Control Plane Durable Attachment Plan v0",
+        "",
+        f"- status: `{plan['status']}`",
+        f"- source_chain_root: `{plan['source_chain_root']}`",
+        f"- target_archive_root: `{plan['target_archive_root']}`",
+        f"- pointer_only: `{plan['pointer_only']}`",
+        f"- durable_attachment_contract_mode: `{plan['durable_attachment_contract_mode']}`",
+        f"- missing_chain_rel_paths: `{plan['missing_chain_rel_paths']}`",
+        "",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_attachment_plan_artifacts_v0(outdir: Path, plan: dict[str, Any]) -> None:
+    outdir.mkdir(parents=True, exist_ok=True)
+    (outdir / PLAN_JSON_FILENAME).write_text(
+        json.dumps(plan, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_machine_lines_file(outdir / PLAN_MACHINE_LINES_FILENAME, plan["machine_lines"])
+    _write_plan_markdown(outdir / PLAN_MD_FILENAME, plan)
+
+
+def run_attachment_planner(
+    *,
+    chain_root: Path,
+    target_archive_root: Path,
+    outdir: Path,
+) -> dict[str, Any]:
+    plan = evaluate_attachment_plan_v0(
+        source_chain_root=chain_root.resolve(),
+        target_archive_root=target_archive_root.resolve(),
+    )
+    write_attachment_plan_artifacts_v0(outdir.resolve(), plan)
+    return plan
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Control Plane durable attachment planner (pointer-only; no copy/verify)."
+        )
+    )
+    parser.add_argument("--chain-root", type=Path, required=True)
+    parser.add_argument("--target-archive-root", type=Path, required=True)
+    parser.add_argument("--outdir", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    plan = run_attachment_planner(
+        chain_root=args.chain_root,
+        target_archive_root=args.target_archive_root,
+        outdir=args.outdir,
+    )
+    for key in PLAN_MACHINE_LINE_KEYS:
+        sys.stdout.write(f"{key}={plan['machine_lines'][key]}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
+++ b/tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
@@ -1,0 +1,281 @@
+"""Contract tests for Control Plane durable attachment planner CLI stub v0."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops import plan_control_plane_offline_chain_durable_attachment_v0 as planner_mod
+from scripts.ops import run_autonomous_ops_control_plane_offline_chain_v0 as chain_mod
+from tests.ops.test_control_plane_offline_chain_durable_evidence_attachment_contracts_v0 import (
+    CONTROL_PLANE_OFFLINE_CHAIN_DURABLE_ATTACHMENT_SCHEMA_VERSION_V0,
+    LEGAL_FIXTURE,
+    REQUIRED_CHAIN_REL_PATHS_V0,
+    STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT,
+    STATUS_BLOCKED_TARGET_ARCHIVE_ROOT_UNDER_TMP,
+    STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+    SYNTHETIC_DURABLE_ARCHIVE_ROOT,
+    _evaluate_attachment_plan,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLANNER_SCRIPT = REPO_ROOT / "scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py"
+THIS_MODULE = Path(__file__)
+
+NON_AUTHORITY_JSON_KEYS: tuple[str, ...] = (
+    "pointer_only",
+    "durable_copy_invoked",
+    "primary_evidence_retention_invoked",
+    "manifest_write_invoked",
+    "copy_verify_invoked",
+    "closeout_invoked",
+    "projection_invoked",
+    "notion_sync_invoked",
+    "hook_implemented",
+    "full_post_closeout_automation_implemented",
+    "runtime_started",
+    "scheduler_started",
+    "supervisor_started",
+    "daemon_started",
+    "paper_shadow_testnet_live_started",
+    "aws_remote_touched",
+    "s3_upload_required",
+    "ssh_required",
+    "network_required",
+    "live_authority_changed",
+    "master_v2_double_play_touched",
+)
+
+_FORBIDDEN_SOURCE_PATTERNS: tuple[str, ...] = (
+    "import subprocess",
+    "from subprocess",
+    "subprocess.run",
+    "subprocess.Popen",
+    "os.system",
+    "import boto3",
+    "import paramiko",
+    "import requests",
+    "import urllib",
+    "import socket",
+    "run_scheduler",
+    "launchctl",
+    'add_argument("--execute"',
+    "add_argument('--execute'",
+    "durable_closeout_copy_verify_v0.main(",
+    "build_post_closeout_projection_payload_v0.main(",
+    "notion_post_closeout_sync_dry_run_v0.main(",
+    "primary_evidence_retention_v0.main(",
+    "write_manifest_sha256(",
+)
+
+
+def _this_module_source() -> str:
+    return THIS_MODULE.read_text(encoding="utf-8")
+
+
+def _planner_script_source() -> str:
+    return PLANNER_SCRIPT.read_text(encoding="utf-8")
+
+
+def _run_offline_chain(fixture: Path, outdir: Path) -> int:
+    return chain_mod.main(["--fixture", str(fixture), "--outdir", str(outdir)])
+
+
+def _run_planner(chain_root: Path, target_archive_root: Path, outdir: Path) -> dict:
+    assert (
+        planner_mod.main(
+            [
+                "--chain-root",
+                str(chain_root),
+                "--target-archive-root",
+                str(target_archive_root),
+                "--outdir",
+                str(outdir),
+            ]
+        )
+        == 0
+    )
+    return json.loads(
+        (outdir / planner_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8"),
+    )
+
+
+def _assert_plan_artifacts_exist(outdir: Path) -> None:
+    assert (outdir / planner_mod.PLAN_JSON_FILENAME).is_file()
+    assert (outdir / planner_mod.PLAN_MACHINE_LINES_FILENAME).is_file()
+    assert (outdir / planner_mod.PLAN_MD_FILENAME).is_file()
+
+
+def _assert_non_authority_flags_false(plan: dict) -> None:
+    assert plan["pointer_only"] is True
+    for key in NON_AUTHORITY_JSON_KEYS:
+        if key == "pointer_only":
+            continue
+        assert plan[key] is False, f"expected {key}=false, got {plan[key]!r}"
+
+
+def _assert_parity_with_test_helper(
+    plan: dict,
+    *,
+    expected_status: str,
+    source_chain_root: Path,
+    target_archive_root: Path,
+) -> None:
+    helper_status, helper_plan = _evaluate_attachment_plan(
+        source_chain_root=source_chain_root,
+        target_archive_root=target_archive_root,
+    )
+    assert plan["status"] == helper_status == expected_status
+    assert helper_status == expected_status
+    assert plan["schema_version"] == helper_plan.schema_version
+    assert (
+        plan["schema_version"] == CONTROL_PLANE_OFFLINE_CHAIN_DURABLE_ATTACHMENT_SCHEMA_VERSION_V0
+    )
+    assert plan["pointer_only"] == helper_plan.pointer_only is True
+    assert plan["target_archive_root_policy"] == helper_plan.target_archive_root_policy
+    assert tuple(plan["required_chain_rel_paths"]) == helper_plan.required_chain_rel_paths
+    assert plan["durable_copy_invoked"] == helper_plan.durable_copy_invoked is False
+    assert plan["copy_verify_invoked"] == helper_plan.copy_verify_invoked is False
+
+
+def test_planner_ready_case_matches_helper_and_writes_artifacts(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    plan_dir = tmp_path / "plan_ready"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    plan = _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, plan_dir)
+    _assert_plan_artifacts_exist(plan_dir)
+    assert plan["status"] == STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING
+    assert plan["missing_chain_rel_paths"] == []
+    _assert_non_authority_flags_false(plan)
+    _assert_parity_with_test_helper(
+        plan,
+        expected_status=STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+        source_chain_root=chain_dir,
+        target_archive_root=SYNTHETIC_DURABLE_ARCHIVE_ROOT,
+    )
+    text1 = (plan_dir / planner_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8")
+    assert _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, plan_dir) is not None
+    text2 = (plan_dir / planner_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8")
+    assert text1 == text2
+
+
+def test_planner_blocked_missing_chain_artifact_matches_helper(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain_empty"
+    chain_dir.mkdir()
+    plan_dir = tmp_path / "plan_missing"
+    plan = _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, plan_dir)
+    _assert_plan_artifacts_exist(plan_dir)
+    assert plan["status"] == STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT
+    assert len(plan["missing_chain_rel_paths"]) > 0
+    assert plan["missing_chain_rel_paths"][0] == REQUIRED_CHAIN_REL_PATHS_V0[0]
+    _assert_non_authority_flags_false(plan)
+    _assert_parity_with_test_helper(
+        plan,
+        expected_status=STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT,
+        source_chain_root=chain_dir,
+        target_archive_root=SYNTHETIC_DURABLE_ARCHIVE_ROOT,
+    )
+
+
+def test_planner_blocked_target_archive_under_tmp_matches_helper(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    plan_dir = tmp_path / "plan_tmp"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    tmp_archive = Path("/tmp/control_plane_durable_attachment_planner_contract_v0")
+    plan = _run_planner(chain_dir, tmp_archive, plan_dir)
+    _assert_plan_artifacts_exist(plan_dir)
+    assert plan["status"] == STATUS_BLOCKED_TARGET_ARCHIVE_ROOT_UNDER_TMP
+    assert plan["missing_chain_rel_paths"] == []
+    _assert_non_authority_flags_false(plan)
+    _assert_parity_with_test_helper(
+        plan,
+        expected_status=STATUS_BLOCKED_TARGET_ARCHIVE_ROOT_UNDER_TMP,
+        source_chain_root=chain_dir,
+        target_archive_root=tmp_archive,
+    )
+
+
+def test_planner_blocked_after_removing_chain_artifact(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    plan_dir = tmp_path / "plan_partial"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    removed_rel = REQUIRED_CHAIN_REL_PATHS_V0[0]
+    (chain_dir / removed_rel).unlink()
+    plan = _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, plan_dir)
+    assert plan["status"] == STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT
+    assert removed_rel in plan["missing_chain_rel_paths"]
+    _assert_parity_with_test_helper(
+        plan,
+        expected_status=STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT,
+        source_chain_root=chain_dir,
+        target_archive_root=SYNTHETIC_DURABLE_ARCHIVE_ROOT,
+    )
+
+
+@pytest.mark.parametrize("owner_rel", planner_mod.OWNER_REFERENCES_V0)
+def test_owner_references_exist_v0(owner_rel: str) -> None:
+    assert (REPO_ROOT / owner_rel).is_file(), f"missing owner reference: {owner_rel!r}"
+
+
+def test_machine_lines_include_required_keys_v0(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    plan_dir = tmp_path / "plan_ml"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    plan = _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, plan_dir)
+    for key in planner_mod.PLAN_MACHINE_LINE_KEYS:
+        assert key in plan["machine_lines"]
+    ml_text = (plan_dir / planner_mod.PLAN_MACHINE_LINES_FILENAME).read_text(encoding="utf-8")
+    assert "CONTROL_PLANE_DURABLE_ATTACHMENT_PLANNER_CLI_STUB_V0=true" in ml_text
+    assert "HOOK_IMPLEMENTED=false" in ml_text
+    assert "FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED=false" in ml_text
+
+
+def test_cli_parser_has_no_forbidden_flags_v0() -> None:
+    source = _planner_script_source()
+    for flag in planner_mod.FORBIDDEN_CLI_FLAGS:
+        assert f'add_argument("{flag}"' not in source
+        assert f"add_argument('{flag}'" not in source
+
+
+def test_planner_script_has_no_runtime_or_invocation_patterns_v0() -> None:
+    source = _planner_script_source()
+    for pattern in _FORBIDDEN_SOURCE_PATTERNS:
+        assert pattern not in source, f"forbidden pattern in planner script: {pattern!r}"
+
+
+def test_contract_module_has_no_runtime_or_invocation_patterns_v0() -> None:
+    in_forbidden_tuple = False
+    for line in _this_module_source().splitlines():
+        if "_FORBIDDEN_SOURCE_PATTERNS" in line:
+            in_forbidden_tuple = True
+            continue
+        if in_forbidden_tuple:
+            if line.strip().startswith(")"):
+                in_forbidden_tuple = False
+            continue
+        stripped = line.strip()
+        if stripped.startswith("assert ") and " not in " in stripped:
+            continue
+        for pattern in _FORBIDDEN_SOURCE_PATTERNS:
+            assert pattern not in line, (
+                f"forbidden pattern in contract test source: {pattern!r} line={line!r}"
+            )
+
+
+def test_contract_module_imports_are_stdlib_scripts_ops_tests_ops_only_v0() -> None:
+    allowed_roots = frozenset(
+        {"__future__", "ast", "json", "pathlib", "pytest", "scripts", "tests"}
+    )
+    tree = ast.parse(_this_module_source())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.module is not None
+            root = node.module.split(".")[0]
+            assert root in allowed_roots, f"unexpected import from: {node.module!r}"
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                assert root in allowed_roots, f"unexpected import: {alias.name!r}"


### PR DESCRIPTION
## Summary
- adds offline-only Control Plane durable attachment planner CLI
- reads `--chain-root`, `--target-archive-root`, and `--outdir`
- emits pointer-only attachment plan JSON, machine-lines, and Markdown
- preserves parity with existing #3761 durable attachment test-helper semantics
- supports ready, missing-chain-artifact, and `/tmp` target-root blocked states
- does not copy, verify, write manifests, invoke retention, invoke closeout/projection/Notion, implement hooks, start runtime, or use network

## Files
- scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py
- tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py

## Validation
- uv run pytest tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py -q
- uv run pytest tests/ops/test_control_plane_offline_chain_durable_evidence_attachment_contracts_v0.py -q
- uv run pytest tests/ops/test_control_plane_offline_chain_attachment_e2e_contract_v0.py -q
- uv run pytest tests/ops/test_control_plane_first_automation_hook_dry_run_contract_v0.py -q
- uv run ruff check scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
- uv run ruff format --check scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
- python3 scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

## Durable Evidence
- /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/control_plane_durable_attachment_planner_cli_stub_v0_20260528T224748Z
- includes sample_planner_output/ready and blocked_missing
- MANIFEST_VERIFY_RC=0

## Safety
- OFFLINE_ONLY=true
- PLANNER_ONLY=true
- DOCS_CHANGED=false
- ONLY_ALLOWED_FILES_CHANGED=true
- HOOK_IMPLEMENTED=false
- FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED=false
- DURABLE_ATTACHMENT_CONTRACT_MODE=pointer_only_no_copy_no_verify
- DURABLE_COPY_INVOKED=false
- PRIMARY_EVIDENCE_RETENTION_INVOKED=false
- MANIFEST_WRITE_INVOKED=false
- COPY_VERIFY_INVOKED=false
- CLOSEOUT_INVOKED=false
- PROJECTION_INVOKED=false
- NOTION_SYNC_INVOKED=false
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- SUPERVISOR_STARTED=false
- DAEMON_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- AWS_REMOTE_TOUCHED=false
- S3_UPLOAD_REQUIRED=false
- SSH_REQUIRED=false
- NETWORK_REQUIRED=false
- LIVE_AUTHORITY_CHANGED=false
- MASTER_V2_DOUBLE_PLAY_TOUCHED=false

Made with [Cursor](https://cursor.com)