### PR TITLE
ci: gate kraken testnet cron behind opt-in variable

### DIFF
--- a/.github/workflows/prbj-testnet-exec-events.yml
+++ b/.github/workflows/prbj-testnet-exec-events.yml
@@ -29,6 +29,7 @@ jobs:
   run-testnet:
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    if: ${{ github.event_name != 'schedule' || vars.KRAKEN_TESTNET_CRON_ENABLED == 'true' }}
     steps:
       - uses: actions/checkout@v5
 

--- a/tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py
+++ b/tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py
@@ -1,0 +1,106 @@
+"""Static contract for PR-BJ Kraken testnet exec-events workflow cron gate.
+
+Parses workflow YAML as UTF-8 text only. Never dispatches workflows, never
+reads secret values, and never touches runtime/testnet execution paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+WORKFLOW = Path(".github/workflows/prbj-testnet-exec-events.yml")
+
+
+def _workflow() -> dict[str, Any]:
+    assert WORKFLOW.exists()
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _trigger_section(data: dict[str, Any]) -> dict[str, Any]:
+    triggers = data.get("on")
+    if triggers is None:
+        triggers = data.get(True)
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def _run_testnet_job() -> dict[str, Any]:
+    jobs = _workflow().get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get("run-testnet")
+    assert isinstance(job, dict)
+    return job
+
+
+def test_workflow_has_schedule_and_workflow_dispatch_triggers() -> None:
+    triggers = _trigger_section(_workflow())
+
+    assert "workflow_dispatch" in triggers
+
+    schedule = triggers.get("schedule")
+    assert isinstance(schedule, list)
+    assert len(schedule) >= 1
+    assert any(isinstance(entry, dict) and "cron" in entry for entry in schedule)
+
+
+def test_workflow_schedule_requires_kraken_testnet_cron_enabled_var() -> None:
+    text = _workflow_text()
+
+    assert "KRAKEN_TESTNET_CRON_ENABLED" in text
+    assert "vars.KRAKEN_TESTNET_CRON_ENABLED == 'true'" in text
+    assert "github.event_name != 'schedule'" in text
+
+
+def test_workflow_job_gate_preserves_manual_dispatch() -> None:
+    job_if = _run_testnet_job().get("if")
+    assert isinstance(job_if, str)
+
+    assert "github.event_name != 'schedule'" in job_if
+    assert "workflow_dispatch" not in job_if.lower()
+    assert "KRAKEN_TESTNET_CRON_ENABLED" in job_if
+
+
+def test_workflow_references_kraken_testnet_secrets_without_exposing_values() -> None:
+    text = _workflow_text()
+
+    assert "${{ secrets.KRAKEN_TESTNET_API_KEY }}" in text
+    assert "${{ secrets.KRAKEN_TESTNET_API_SECRET }}" in text
+    assert "sk-" not in text
+    assert "AKIA" not in text
+
+
+def test_workflow_does_not_introduce_live_authority_or_aws_paths() -> None:
+    lowered = _workflow_text().lower()
+
+    forbidden = (
+        "live_authority",
+        "live_enabled=true",
+        "armed=true",
+        "s3://",
+        "ssh ",
+        "openai_api_key",
+        "anthropic",
+        "promptfoo",
+        "master_v2",
+        "double_play",
+    )
+
+    for term in forbidden:
+        assert term not in lowered
+
+
+def test_workflow_permissions_remain_read_only_contents() -> None:
+    permissions = _workflow().get("permissions")
+    assert isinstance(permissions, dict)
+    assert permissions.get("contents") == "read"


### PR DESCRIPTION
## Summary
- gates the scheduled Kraken testnet workflow behind `vars.KRAKEN_TESTNET_CRON_ENABLED == true`
- keeps `workflow_dispatch` available for explicit operator-triggered runs
- keeps existing `KRAKEN_TESTNET_*` secrets untouched
- adds static CI contract coverage for the workflow gate
- makes scheduled Kraken testnet execution default-off during the current offline Control-Plane phase

## Files
- `.github/workflows/prbj-testnet-exec-events.yml`
- `tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py`

## Validation
- uv run pytest tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py -q
- uv run pytest tests/ci -q
- uv run pytest tests/ops -q -k "testnet or workflow or secret or schedule or cost or promptfoo or manual_dispatch"
- uv run ruff check .
- uv run ruff format --check .
- python3 scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

## Durable Evidence
- /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/kraken_testnet_cron_gate_v0_20260528T230640Z
- MANIFEST_VERIFY_RC=0

## Safety
- KRAKEN_TESTNET_CRON_DEFAULT_OFF=true
- REQUIRED_ENABLE_VAR=KRAKEN_TESTNET_CRON_ENABLED
- SECRETS_DELETED=false
- SECRET_VALUES_READ=false
- AI_LLM_PATHS_TOUCHED=false
- AWS_TOUCHED=false
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- SUPERVISOR_STARTED=false
- DAEMON_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- TESTNET_EXECUTED=false
- LIVE_AUTHORITY_CHANGED=false
- MASTER_V2_DOUBLE_PLAY_TOUCHED=false
- DOCS_CHANGED=false
- ONLY_ALLOWED_FILES_CHANGED=true

Made with [Cursor](https://cursor.com)