### PR TITLE
ops: add control plane hook dry-run summary

### DIFF
--- a/scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py
+++ b/scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Offline Control Plane automation hook dry-run summary stub v0 (summary-only).
+
+Reads offline chain root + durable attachment plan JSON and writes a local hook dry-run
+summary. Does not execute hooks, copy, verify, write MANIFEST.sha256, retain evidence,
+invoke closeout, projection, Notion, runtime, or network.
+
+Machine marker: ``CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_CLI_STUB_V0=true``
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.ops.plan_control_plane_offline_chain_durable_attachment_v0 import (
+    DURABLE_ATTACHMENT_CONTRACT_MODE,
+    STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+    missing_chain_rel_paths,
+)
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp
+
+SCHEMA_VERSION = "control_plane_hook_dry_run_summary_v0"
+
+SUMMARY_JSON_FILENAME = "CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_V0.json"
+SUMMARY_MACHINE_LINES_FILENAME = "CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_MACHINE_LINES.txt"
+SUMMARY_MD_FILENAME = "CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_V0.md"
+
+STATUS_READY_FOR_CP_HOOK_DRY_RUN = "ready_for_control_plane_hook_dry_run"
+STATUS_BLOCKED_OFFLINE_CHAIN_INCOMPLETE = "blocked_offline_chain_incomplete"
+STATUS_BLOCKED_ATTACHMENT_NOT_READY = "blocked_attachment_not_ready"
+STATUS_BLOCKED_POINTER_ONLY_REQUIRED = "blocked_pointer_only_required"
+STATUS_BLOCKED_TARGET_ARCHIVE_UNDER_TMP = "blocked_target_archive_under_tmp"
+STATUS_BLOCKED_HOOK_IMPLEMENTED = "blocked_hook_implemented"
+STATUS_BLOCKED_FULL_AUTOMATION_CLAIMED = "blocked_full_automation_claimed"
+STATUS_BLOCKED_INVOKE_OR_START_FLAG = "blocked_invoke_or_start_flag"
+
+OWNER_REFERENCES_V0: tuple[str, ...] = (
+    "tests/ops/test_control_plane_first_automation_hook_dry_run_contract_v0.py",
+    "scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py",
+    "tests/ops/test_control_plane_planner_and_hook_e2e_cli_contract_v0.py",
+    "tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py",
+    "tests/ops/test_post_closeout_hook_attach_readiness_bridge_v0.py",
+)
+
+FORBIDDEN_CLI_FLAGS: tuple[str, ...] = (
+    "--execute",
+    "--copy",
+    "--verify",
+    "--retention",
+    "--closeout",
+    "--projection",
+    "--notion-sync",
+    "--upload",
+    "--s3",
+    "--ssh",
+    "--start",
+)
+
+SUMMARY_MACHINE_LINE_KEYS: tuple[str, ...] = (
+    "CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_CLI_STUB_V0",
+    "CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_STATUS",
+    "HOOK_IMPLEMENTED",
+    "HOOK_DRY_RUN_ONLY",
+    "FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED",
+    "DURABLE_ATTACHMENT_CONTRACT_MODE",
+    "DURABLE_COPY_INVOKED",
+    "PRIMARY_EVIDENCE_RETENTION_INVOKED",
+    "MANIFEST_WRITE_INVOKED",
+    "COPY_VERIFY_INVOKED",
+    "CLOSEOUT_INVOKED",
+    "PROJECTION_INVOKED",
+    "NOTION_SYNC_INVOKED",
+    "RUNTIME_STARTED",
+    "SCHEDULER_STARTED",
+    "SUPERVISOR_STARTED",
+    "DAEMON_STARTED",
+    "PAPER_SHADOW_TESTNET_LIVE_STARTED",
+    "AWS_REMOTE_TOUCHED",
+    "S3_UPLOAD_REQUIRED",
+    "SSH_REQUIRED",
+    "NETWORK_REQUIRED",
+    "LIVE_AUTHORITY_CHANGED",
+    "MASTER_V2_DOUBLE_PLAY_TOUCHED",
+    "KRAKEN_TESTNET_CRON_REARMED",
+    "AI_PAID_VARS_REARMED",
+)
+
+
+@dataclass(frozen=True)
+class ControlPlaneAutomationHookDryRunInputs:
+    """Hook dry-run readiness inputs (offline summary only; not production API)."""
+
+    offline_chain_complete: bool = False
+    attachment_e2e_complete: bool = False
+    attachment_status: str = "blocked_missing_required_chain_artifact"
+    pointer_only: bool = False
+    target_archive_root: Path | None = None
+    hook_implemented: bool = False
+    full_post_closeout_automation_implemented: bool = False
+    closeout_invoked: bool = False
+    projection_invoked: bool = False
+    notion_sync_invoked: bool = False
+    durable_copy_invoked: bool = False
+    primary_evidence_retention_invoked: bool = False
+    manifest_write_invoked: bool = False
+    copy_verify_invoked: bool = False
+    runtime_started: bool = False
+    scheduler_started: bool = False
+    supervisor_started: bool = False
+    daemon_started: bool = False
+    paper_shadow_testnet_live_started: bool = False
+    aws_remote_touched: bool = False
+    network_required: bool = False
+    live_authority_changed: bool = False
+    master_v2_double_play_touched: bool = False
+    replaces_generic_hook_owners: bool = False
+
+
+def build_control_plane_automation_hook_dry_run_summary(
+    inp: ControlPlaneAutomationHookDryRunInputs,
+) -> tuple[str, list[str]]:
+    """Return (status, blockers) matching #3763 contract semantics."""
+    blockers: list[str] = []
+
+    if not inp.offline_chain_complete:
+        blockers.append("offline_chain_complete_required")
+    if not inp.attachment_e2e_complete:
+        blockers.append("attachment_e2e_complete_required")
+    if inp.attachment_status != STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING:
+        blockers.append("attachment_status_not_ready_for_durable_attachment_planning")
+    if not inp.pointer_only:
+        blockers.append("pointer_only_durable_attachment_required")
+    if inp.target_archive_root is None:
+        blockers.append("target_archive_root_missing")
+    elif is_under_tmp(inp.target_archive_root):
+        blockers.append("target_archive_root_under_tmp")
+    if inp.hook_implemented:
+        blockers.append("hook_implemented_must_remain_false")
+    if inp.full_post_closeout_automation_implemented:
+        blockers.append("full_post_closeout_automation_must_remain_false")
+    if inp.replaces_generic_hook_owners:
+        blockers.append("must_not_replace_generic_post_closeout_hook_owners")
+
+    invoke_flags = (
+        ("closeout_invoked", inp.closeout_invoked),
+        ("projection_invoked", inp.projection_invoked),
+        ("notion_sync_invoked", inp.notion_sync_invoked),
+        ("durable_copy_invoked", inp.durable_copy_invoked),
+        ("primary_evidence_retention_invoked", inp.primary_evidence_retention_invoked),
+        ("manifest_write_invoked", inp.manifest_write_invoked),
+        ("copy_verify_invoked", inp.copy_verify_invoked),
+        ("runtime_started", inp.runtime_started),
+        ("scheduler_started", inp.scheduler_started),
+        ("supervisor_started", inp.supervisor_started),
+        ("daemon_started", inp.daemon_started),
+        ("paper_shadow_testnet_live_started", inp.paper_shadow_testnet_live_started),
+        ("aws_remote_touched", inp.aws_remote_touched),
+        ("network_required", inp.network_required),
+        ("live_authority_changed", inp.live_authority_changed),
+        ("master_v2_double_play_touched", inp.master_v2_double_play_touched),
+    )
+    for name, value in invoke_flags:
+        if value:
+            blockers.append(f"forbidden_invoke_or_start:{name}")
+
+    if blockers:
+        if "offline_chain_complete_required" in blockers:
+            status = STATUS_BLOCKED_OFFLINE_CHAIN_INCOMPLETE
+        elif "attachment_e2e_complete_required" in blockers or (
+            "attachment_status_not_ready_for_durable_attachment_planning" in blockers
+        ):
+            status = STATUS_BLOCKED_ATTACHMENT_NOT_READY
+        elif "pointer_only_durable_attachment_required" in blockers:
+            status = STATUS_BLOCKED_POINTER_ONLY_REQUIRED
+        elif "target_archive_root_under_tmp" in blockers:
+            status = STATUS_BLOCKED_TARGET_ARCHIVE_UNDER_TMP
+        elif "hook_implemented_must_remain_false" in blockers:
+            status = STATUS_BLOCKED_HOOK_IMPLEMENTED
+        elif "full_post_closeout_automation_must_remain_false" in blockers:
+            status = STATUS_BLOCKED_FULL_AUTOMATION_CLAIMED
+        elif any(b.startswith("forbidden_invoke_or_start:") for b in blockers):
+            status = STATUS_BLOCKED_INVOKE_OR_START_FLAG
+        else:
+            status = STATUS_BLOCKED_ATTACHMENT_NOT_READY
+        return status, blockers
+
+    return STATUS_READY_FOR_CP_HOOK_DRY_RUN, []
+
+
+def hook_inputs_from_attachment_plan(
+    *,
+    chain_root: Path,
+    plan: dict[str, Any],
+    attachment_e2e_complete: bool = True,
+) -> ControlPlaneAutomationHookDryRunInputs:
+    """Map planner attachment plan JSON to hook dry-run inputs."""
+    missing = missing_chain_rel_paths(chain_root)
+    offline_chain_complete = len(missing) == 0
+    target_raw = plan.get("target_archive_root")
+    return ControlPlaneAutomationHookDryRunInputs(
+        offline_chain_complete=offline_chain_complete,
+        attachment_e2e_complete=attachment_e2e_complete,
+        attachment_status=str(plan["status"]),
+        pointer_only=bool(plan.get("pointer_only")),
+        target_archive_root=Path(target_raw) if target_raw else None,
+        hook_implemented=bool(plan.get("hook_implemented")),
+        full_post_closeout_automation_implemented=bool(
+            plan.get("full_post_closeout_automation_implemented")
+        ),
+    )
+
+
+def build_summary_machine_lines(status: str) -> dict[str, str]:
+    return {
+        "CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_CLI_STUB_V0": "true",
+        "CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_STATUS": status,
+        "HOOK_IMPLEMENTED": "false",
+        "HOOK_DRY_RUN_ONLY": "true",
+        "FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED": "false",
+        "DURABLE_ATTACHMENT_CONTRACT_MODE": DURABLE_ATTACHMENT_CONTRACT_MODE,
+        "DURABLE_COPY_INVOKED": "false",
+        "PRIMARY_EVIDENCE_RETENTION_INVOKED": "false",
+        "MANIFEST_WRITE_INVOKED": "false",
+        "COPY_VERIFY_INVOKED": "false",
+        "CLOSEOUT_INVOKED": "false",
+        "PROJECTION_INVOKED": "false",
+        "NOTION_SYNC_INVOKED": "false",
+        "RUNTIME_STARTED": "false",
+        "SCHEDULER_STARTED": "false",
+        "SUPERVISOR_STARTED": "false",
+        "DAEMON_STARTED": "false",
+        "PAPER_SHADOW_TESTNET_LIVE_STARTED": "false",
+        "AWS_REMOTE_TOUCHED": "false",
+        "S3_UPLOAD_REQUIRED": "false",
+        "SSH_REQUIRED": "false",
+        "NETWORK_REQUIRED": "false",
+        "LIVE_AUTHORITY_CHANGED": "false",
+        "MASTER_V2_DOUBLE_PLAY_TOUCHED": "false",
+        "KRAKEN_TESTNET_CRON_REARMED": "false",
+        "AI_PAID_VARS_REARMED": "false",
+    }
+
+
+def evaluate_hook_dry_run_summary_v0(
+    *,
+    chain_root: Path,
+    attachment_plan_path: Path,
+    attachment_e2e_complete: bool = True,
+) -> dict[str, Any]:
+    """Evaluate hook dry-run summary from chain root + attachment plan JSON path."""
+    plan = json.loads(attachment_plan_path.read_text(encoding="utf-8"))
+    chain_root_resolved = chain_root.resolve()
+    attachment_plan_resolved = attachment_plan_path.resolve()
+
+    inp = hook_inputs_from_attachment_plan(
+        chain_root=chain_root_resolved,
+        plan=plan,
+        attachment_e2e_complete=attachment_e2e_complete,
+    )
+    status, blockers = build_control_plane_automation_hook_dry_run_summary(inp)
+    machine_lines = build_summary_machine_lines(status)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_chain_root": str(chain_root_resolved),
+        "attachment_plan_path": str(attachment_plan_resolved),
+        "attachment_plan_status": str(plan["status"]),
+        "status": status,
+        "blockers": blockers,
+        "hook_implemented": False,
+        "hook_dry_run_only": True,
+        "full_post_closeout_automation_implemented": False,
+        "durable_attachment_contract_mode": DURABLE_ATTACHMENT_CONTRACT_MODE,
+        "owner_references": list(OWNER_REFERENCES_V0),
+        "machine_lines": machine_lines,
+    }
+
+
+def _write_machine_lines_file(path: Path, machine_lines: dict[str, str]) -> None:
+    ordered = sorted(machine_lines.items())
+    path.write_text(
+        "\n".join(f"{key}={value}" for key, value in ordered) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_summary_markdown(path: Path, summary: dict[str, Any]) -> None:
+    lines = [
+        "# Control Plane Hook Dry-Run Summary v0",
+        "",
+        f"- status: `{summary['status']}`",
+        f"- attachment_plan_status: `{summary['attachment_plan_status']}`",
+        f"- source_chain_root: `{summary['source_chain_root']}`",
+        f"- attachment_plan_path: `{summary['attachment_plan_path']}`",
+        f"- hook_implemented: `{summary['hook_implemented']}`",
+        f"- hook_dry_run_only: `{summary['hook_dry_run_only']}`",
+        f"- blockers: `{summary['blockers']}`",
+        "",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_hook_dry_run_summary_artifacts_v0(outdir: Path, summary: dict[str, Any]) -> None:
+    outdir.mkdir(parents=True, exist_ok=True)
+    (outdir / SUMMARY_JSON_FILENAME).write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_machine_lines_file(outdir / SUMMARY_MACHINE_LINES_FILENAME, summary["machine_lines"])
+    _write_summary_markdown(outdir / SUMMARY_MD_FILENAME, summary)
+
+
+def run_hook_dry_run_summary(
+    *,
+    chain_root: Path,
+    attachment_plan: Path,
+    outdir: Path,
+) -> dict[str, Any]:
+    summary = evaluate_hook_dry_run_summary_v0(
+        chain_root=chain_root,
+        attachment_plan_path=attachment_plan,
+    )
+    write_hook_dry_run_summary_artifacts_v0(outdir.resolve(), summary)
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Control Plane hook dry-run summary (summary-only; no hook execution)."
+        )
+    )
+    parser.add_argument("--chain-root", type=Path, required=True)
+    parser.add_argument("--attachment-plan", type=Path, required=True)
+    parser.add_argument("--outdir", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    summary = run_hook_dry_run_summary(
+        chain_root=args.chain_root,
+        attachment_plan=args.attachment_plan,
+        outdir=args.outdir,
+    )
+    for key in SUMMARY_MACHINE_LINE_KEYS:
+        sys.stdout.write(f"{key}={summary['machine_lines'][key]}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
+++ b/tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
@@ -1,0 +1,315 @@
+"""Contract tests for Control Plane hook dry-run summary CLI stub v0."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops import plan_control_plane_offline_chain_durable_attachment_v0 as planner_mod
+from scripts.ops import run_autonomous_ops_control_plane_offline_chain_v0 as chain_mod
+from scripts.ops import summarize_control_plane_automation_hook_dry_run_v0 as summary_mod
+from tests.ops.test_control_plane_first_automation_hook_dry_run_contract_v0 import (
+    STATUS_READY_FOR_CP_HOOK_DRY_RUN,
+    ControlPlaneAutomationHookDryRunInputs,
+    build_control_plane_automation_hook_dry_run_summary as contract_build_summary,
+)
+from tests.ops.test_control_plane_offline_chain_durable_evidence_attachment_contracts_v0 import (
+    LEGAL_FIXTURE,
+    REQUIRED_CHAIN_REL_PATHS_V0,
+    STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT,
+    STATUS_BLOCKED_TARGET_ARCHIVE_ROOT_UNDER_TMP,
+    STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+    SYNTHETIC_DURABLE_ARCHIVE_ROOT,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SUMMARY_SCRIPT = REPO_ROOT / "scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py"
+THIS_MODULE = Path(__file__)
+
+HOOK_MACHINE_LINE_ASSERTIONS: tuple[str, ...] = (
+    "HOOK_IMPLEMENTED=false",
+    "HOOK_DRY_RUN_ONLY=true",
+    "FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED=false",
+    "DURABLE_COPY_INVOKED=false",
+    "PRIMARY_EVIDENCE_RETENTION_INVOKED=false",
+    "MANIFEST_WRITE_INVOKED=false",
+    "COPY_VERIFY_INVOKED=false",
+    "CLOSEOUT_INVOKED=false",
+    "PROJECTION_INVOKED=false",
+    "NOTION_SYNC_INVOKED=false",
+    "RUNTIME_STARTED=false",
+    "SCHEDULER_STARTED=false",
+    "SUPERVISOR_STARTED=false",
+    "DAEMON_STARTED=false",
+    "PAPER_SHADOW_TESTNET_LIVE_STARTED=false",
+    "AWS_REMOTE_TOUCHED=false",
+    "S3_UPLOAD_REQUIRED=false",
+    "SSH_REQUIRED=false",
+    "NETWORK_REQUIRED=false",
+    "LIVE_AUTHORITY_CHANGED=false",
+    "MASTER_V2_DOUBLE_PLAY_TOUCHED=false",
+    "KRAKEN_TESTNET_CRON_REARMED=false",
+    "AI_PAID_VARS_REARMED=false",
+)
+
+_FORBIDDEN_SOURCE_PATTERNS: tuple[str, ...] = (
+    "import subprocess",
+    "from subprocess",
+    "subprocess.run",
+    "subprocess.Popen",
+    "os.system",
+    "import boto3",
+    "import paramiko",
+    "import requests",
+    "import urllib",
+    "import socket",
+    "run_scheduler",
+    "launchctl",
+    'add_argument("--execute"',
+    "add_argument('--execute'",
+    'add_argument("--copy"',
+    'add_argument("--verify"',
+    'add_argument("--retention"',
+    'add_argument("--closeout"',
+    'add_argument("--projection"',
+    'add_argument("--notion-sync"',
+    'add_argument("--upload"',
+    'add_argument("--s3"',
+    'add_argument("--ssh"',
+    'add_argument("--start"',
+    "durable_closeout_copy_verify_v0.main(",
+    "build_post_closeout_projection_payload_v0.main(",
+    "notion_post_closeout_sync_dry_run_v0.main(",
+    "primary_evidence_retention_v0.main(",
+    "write_manifest_sha256(",
+)
+
+
+def _this_module_source() -> str:
+    return THIS_MODULE.read_text(encoding="utf-8")
+
+
+def _summary_script_source() -> str:
+    return SUMMARY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _run_offline_chain(fixture: Path, outdir: Path) -> int:
+    return chain_mod.main(["--fixture", str(fixture), "--outdir", str(outdir)])
+
+
+def _run_planner(chain_root: Path, target_archive_root: Path, outdir: Path) -> dict:
+    assert (
+        planner_mod.main(
+            [
+                "--chain-root",
+                str(chain_root),
+                "--target-archive-root",
+                str(target_archive_root),
+                "--outdir",
+                str(outdir),
+            ]
+        )
+        == 0
+    )
+    return json.loads(
+        (outdir / planner_mod.PLAN_JSON_FILENAME).read_text(encoding="utf-8"),
+    )
+
+
+def _run_summary(chain_root: Path, attachment_plan: Path, outdir: Path) -> dict:
+    assert (
+        summary_mod.main(
+            [
+                "--chain-root",
+                str(chain_root),
+                "--attachment-plan",
+                str(attachment_plan),
+                "--outdir",
+                str(outdir),
+            ]
+        )
+        == 0
+    )
+    return json.loads(
+        (outdir / summary_mod.SUMMARY_JSON_FILENAME).read_text(encoding="utf-8"),
+    )
+
+
+def _assert_summary_artifacts_exist(outdir: Path) -> None:
+    assert (outdir / summary_mod.SUMMARY_JSON_FILENAME).is_file()
+    assert (outdir / summary_mod.SUMMARY_MACHINE_LINES_FILENAME).is_file()
+    assert (outdir / summary_mod.SUMMARY_MD_FILENAME).is_file()
+
+
+def _assert_machine_lines_safety(machine_lines: dict[str, str]) -> None:
+    for assertion in HOOK_MACHINE_LINE_ASSERTIONS:
+        key, _, value = assertion.partition("=")
+        assert machine_lines[key] == value, f"expected {assertion}"
+
+
+def _contract_inputs_from_planner_plan(
+    *,
+    chain_root: Path,
+    plan: dict,
+) -> ControlPlaneAutomationHookDryRunInputs:
+    offline_chain_complete = len(plan.get("missing_chain_rel_paths") or []) == 0
+    return ControlPlaneAutomationHookDryRunInputs(
+        offline_chain_complete=offline_chain_complete,
+        attachment_e2e_complete=True,
+        attachment_status=str(plan["status"]),
+        pointer_only=bool(plan["pointer_only"]),
+        target_archive_root=Path(plan["target_archive_root"]),
+    )
+
+
+def _assert_parity_with_contract_helper(
+    summary: dict,
+    *,
+    chain_root: Path,
+    plan: dict,
+) -> None:
+    inp = _contract_inputs_from_planner_plan(chain_root=chain_root, plan=plan)
+    expected_status, _, expected_blockers = contract_build_summary(inp)
+    assert summary["status"] == expected_status
+    assert summary["blockers"] == expected_blockers
+
+
+def test_summary_ready_case_writes_artifacts_and_matches_contract_v0(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    planner_dir = tmp_path / "planner"
+    summary_dir = tmp_path / "summary_ready"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    plan = _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, planner_dir)
+    plan_path = planner_dir / planner_mod.PLAN_JSON_FILENAME
+
+    summary = _run_summary(chain_dir, plan_path, summary_dir)
+    _assert_summary_artifacts_exist(summary_dir)
+    assert summary["status"] == STATUS_READY_FOR_CP_HOOK_DRY_RUN
+    assert summary["attachment_plan_status"] == STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING
+    assert summary["hook_implemented"] is False
+    assert summary["hook_dry_run_only"] is True
+    assert summary["full_post_closeout_automation_implemented"] is False
+    assert summary["schema_version"] == summary_mod.SCHEMA_VERSION
+    _assert_machine_lines_safety(summary["machine_lines"])
+    _assert_parity_with_contract_helper(summary, chain_root=chain_dir, plan=plan)
+
+    text1 = (summary_dir / summary_mod.SUMMARY_JSON_FILENAME).read_text(encoding="utf-8")
+    assert _run_summary(chain_dir, plan_path, summary_dir) is not None
+    text2 = (summary_dir / summary_mod.SUMMARY_JSON_FILENAME).read_text(encoding="utf-8")
+    assert text1 == text2
+
+
+def test_summary_blocked_missing_chain_artifact_not_ready_v0(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain_partial"
+    planner_dir = tmp_path / "planner_blocked"
+    summary_dir = tmp_path / "summary_blocked"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    removed_rel = REQUIRED_CHAIN_REL_PATHS_V0[0]
+    (chain_dir / removed_rel).unlink()
+
+    plan = _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, planner_dir)
+    assert plan["status"] == STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT
+    plan_path = planner_dir / planner_mod.PLAN_JSON_FILENAME
+
+    summary = _run_summary(chain_dir, plan_path, summary_dir)
+    _assert_summary_artifacts_exist(summary_dir)
+    assert summary["status"] != STATUS_READY_FOR_CP_HOOK_DRY_RUN
+    _assert_machine_lines_safety(summary["machine_lines"])
+    _assert_parity_with_contract_helper(summary, chain_root=chain_dir, plan=plan)
+
+
+def test_summary_blocked_tmp_target_archive_not_ready_v0(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    planner_dir = tmp_path / "planner_tmp"
+    summary_dir = tmp_path / "summary_tmp"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    tmp_archive = Path("/tmp/control_plane_hook_dry_run_summary_cli_contract_v0")
+
+    plan = _run_planner(chain_dir, tmp_archive, planner_dir)
+    assert plan["status"] == STATUS_BLOCKED_TARGET_ARCHIVE_ROOT_UNDER_TMP
+    plan_path = planner_dir / planner_mod.PLAN_JSON_FILENAME
+
+    summary = _run_summary(chain_dir, plan_path, summary_dir)
+    _assert_summary_artifacts_exist(summary_dir)
+    assert summary["status"] != STATUS_READY_FOR_CP_HOOK_DRY_RUN
+    _assert_machine_lines_safety(summary["machine_lines"])
+    _assert_parity_with_contract_helper(summary, chain_root=chain_dir, plan=plan)
+
+
+@pytest.mark.parametrize("owner_rel", summary_mod.OWNER_REFERENCES_V0)
+def test_summary_owner_references_exist_v0(owner_rel: str) -> None:
+    assert (REPO_ROOT / owner_rel).is_file(), f"missing owner reference: {owner_rel!r}"
+
+
+def test_summary_script_has_no_forbidden_cli_flags_v0() -> None:
+    source = _summary_script_source()
+    for flag in summary_mod.FORBIDDEN_CLI_FLAGS:
+        assert f'add_argument("{flag}"' not in source
+        assert f"add_argument('{flag}'" not in source
+
+
+def test_summary_script_has_no_runtime_or_invocation_patterns_v0() -> None:
+    for pattern in _FORBIDDEN_SOURCE_PATTERNS:
+        assert pattern not in _summary_script_source(), (
+            f"forbidden pattern in summary script: {pattern!r}"
+        )
+
+
+def test_contract_module_has_no_runtime_or_invocation_patterns_v0() -> None:
+    in_forbidden_tuple = False
+    for line in _this_module_source().splitlines():
+        if "_FORBIDDEN_SOURCE_PATTERNS" in line:
+            in_forbidden_tuple = True
+            continue
+        if in_forbidden_tuple:
+            if line.strip().startswith(")"):
+                in_forbidden_tuple = False
+            continue
+        stripped = line.strip()
+        if stripped.startswith("assert ") and " not in " in stripped:
+            continue
+        for pattern in _FORBIDDEN_SOURCE_PATTERNS:
+            assert pattern not in line, (
+                f"forbidden pattern in contract test source: {pattern!r} line={line!r}"
+            )
+
+
+def test_contract_module_imports_are_stdlib_scripts_ops_tests_ops_only_v0() -> None:
+    allowed_roots = frozenset(
+        {"__future__", "ast", "json", "pathlib", "pytest", "scripts", "tests"}
+    )
+    tree = ast.parse(_this_module_source())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.module is not None
+            root = node.module.split(".")[0]
+            assert root in allowed_roots, f"unexpected import from: {node.module!r}"
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                assert root in allowed_roots, f"unexpected import: {alias.name!r}"
+
+
+def test_summary_machine_lines_include_required_keys_v0(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    planner_dir = tmp_path / "planner"
+    summary_dir = tmp_path / "summary_ml"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    plan = _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, planner_dir)
+    plan_path = planner_dir / planner_mod.PLAN_JSON_FILENAME
+    summary = _run_summary(chain_dir, plan_path, summary_dir)
+    for key in summary_mod.SUMMARY_MACHINE_LINE_KEYS:
+        assert key in summary["machine_lines"]
+    ml_text = (summary_dir / summary_mod.SUMMARY_MACHINE_LINES_FILENAME).read_text(
+        encoding="utf-8",
+    )
+    assert "CONTROL_PLANE_HOOK_DRY_RUN_SUMMARY_CLI_STUB_V0=true" in ml_text
+    assert "HOOK_IMPLEMENTED=false" in ml_text
+    assert plan["status"] == STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING
+
+
+def test_summary_script_forbidden_flags_match_planner_posture_v0() -> None:
+    assert summary_mod.FORBIDDEN_CLI_FLAGS == planner_mod.FORBIDDEN_CLI_FLAGS


### PR DESCRIPTION
## Summary
- adds offline-only Control Plane hook dry-run summary CLI
- reads `--chain-root`, `--attachment-plan`, and `--outdir`
- emits hook dry-run summary JSON, machine-lines, and Markdown
- preserves parity with the #3763 hook dry-run summary semantics
- validates ready, missing-artifact, and `/tmp` archive-root blocked cases
- keeps `HOOK_IMPLEMENTED=false` and `FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED=false`
- does not execute hooks, runtime, scheduler, copy, verify, retention, closeout, projection, Notion, AWS, S3, SSH, network, paper, shadow, testnet, or live paths
- preserves cost posture: Kraken Testnet cron is not re-armed and AI paid vars are not re-armed

## Files
- `scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py`
- `tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py`

## Validation
- uv run pytest tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py -q
- uv run pytest tests/ops/test_control_plane_planner_and_hook_e2e_cli_contract_v0.py -q
- uv run pytest tests/ops/test_control_plane_first_automation_hook_dry_run_contract_v0.py -q
- uv run pytest tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py -q
- uv run ruff check scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
- uv run ruff format --check scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
- python3 scripts/ops/check_docs_drift_guard.py --base origin/main
- git diff --check

## Durable Evidence
- /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/control_plane_hook_dry_run_summary_cli_stub_v0_20260528T234019Z
- includes sample_hook_summary_output/ready and blocked examples
- MANIFEST_VERIFY_RC=0

## Safety
- OFFLINE_ONLY=true
- SUMMARY_ONLY=true
- DOCS_CHANGED=false
- ONLY_ALLOWED_FILES_CHANGED=true
- HOOK_IMPLEMENTED=false
- HOOK_DRY_RUN_ONLY=true
- FULL_POST_CLOSEOUT_AUTOMATION_IMPLEMENTED=false
- DURABLE_ATTACHMENT_CONTRACT_MODE=pointer_only_no_copy_no_verify
- DURABLE_COPY_INVOKED=false
- PRIMARY_EVIDENCE_RETENTION_INVOKED=false
- MANIFEST_WRITE_INVOKED=false
- COPY_VERIFY_INVOKED=false
- CLOSEOUT_INVOKED=false
- PROJECTION_INVOKED=false
- NOTION_SYNC_INVOKED=false
- RUNTIME_STARTED=false
- SCHEDULER_STARTED=false
- SUPERVISOR_STARTED=false
- DAEMON_STARTED=false
- PAPER_SHADOW_TESTNET_LIVE_STARTED=false
- AWS_REMOTE_TOUCHED=false
- S3_UPLOAD_REQUIRED=false
- SSH_REQUIRED=false
- NETWORK_REQUIRED=false
- LIVE_AUTHORITY_CHANGED=false
- MASTER_V2_DOUBLE_PLAY_TOUCHED=false
- KRAKEN_TESTNET_CRON_REARMED=false
- AI_PAID_VARS_REARMED=false