### PR TITLE
ops: extend primary evidence retention hard gate

### DIFF
--- a/scripts/ops/primary_evidence_retention_v0.py
+++ b/scripts/ops/primary_evidence_retention_v0.py
@@ -12,6 +12,8 @@ CLOSEOUT_REFERENCE_REQUIRED=true
 RUN_INCOMPLETE_WITHOUT_PRIMARY_EVIDENCE=true
 EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true
 VALIDATE_DURABLE_PRIMARY_EVIDENCE_ROOT_V0=true
+PRIMARY_EVIDENCE_RETENTION_HARD_GATE_EXTENSION_V0=true
+VALIDATE_DURABLE_LIFECYCLE_CLOSEOUT_ROOT_V0=true
 ```
 """
 
@@ -50,6 +52,23 @@ KNOWN_CLOSEOUT_FILENAMES = (
     "scheduler_completion_closeout_v0.json",
     "supervisor_session_closeout_v0.json",
 )
+
+# Lifecycle / planning / remote closeout slices (Preflight §2a.1 extension v0).
+MANIFEST_VERIFY_LOG_FILENAMES: tuple[str, ...] = (
+    "MANIFEST_VERIFY.log",
+    "LOCAL_MANIFEST_VERIFY.log",
+)
+
+LIFECYCLE_CLOSEOUT_MARKER_SUFFIXES: tuple[str, ...] = (
+    "_REPORT.md",
+    "_READONLY.md",
+    "_RECORD.md",
+    "_MACHINE_LINES.txt",
+    "CLOSEOUT.md",
+)
+
+LIFECYCLE_CLOSEOUT_CLASSIFICATION = "lifecycle_closeout_slice_v0"
+FINAL_STOP_IDLE_CLOSEOUT_CLASSIFICATION = "final_stop_idle_lifecycle_closeout_v0"
 
 
 def is_under_tmp(path: Path) -> bool:
@@ -167,3 +186,125 @@ def validate_durable_primary_evidence_root(
         return False, msg, {"checks": checks, "issues": issues}
 
     return True, "", {"checks": checks, "issues": []}
+
+
+def parse_manifest_verify_log_rc(root: Path) -> tuple[int | None, str, str]:
+    """Parse MANIFEST_VERIFY_RC from standard or LOCAL manifest verify logs."""
+    for name in MANIFEST_VERIFY_LOG_FILENAMES:
+        log_path = root / name
+        if not log_path.is_file():
+            continue
+        text = log_path.read_text(encoding="utf-8")
+        for raw in text.splitlines():
+            line = raw.strip()
+            if not line.startswith("MANIFEST_VERIFY_RC="):
+                continue
+            value = line.split("=", 1)[1].strip()
+            try:
+                return int(value), "", name
+            except ValueError:
+                return None, f"invalid MANIFEST_VERIFY_RC in {name}", name
+        return None, f"MANIFEST_VERIFY_RC missing in {name}", name
+    return None, "manifest verify log missing", ""
+
+
+def _has_lifecycle_closeout_marker(root: Path) -> bool:
+    for path in root.iterdir():
+        if not path.is_file():
+            continue
+        if any(path.name.endswith(suffix) for suffix in LIFECYCLE_CLOSEOUT_MARKER_SUFFIXES):
+            return True
+    return False
+
+
+def _has_final_stop_idle_marker(root: Path) -> bool:
+    for path in root.iterdir():
+        if not path.is_file():
+            continue
+        name = path.name
+        upper = name.upper()
+        if "STOP_IDLE" not in upper:
+            continue
+        if name.endswith(".md") or name.endswith("_MACHINE_LINES.txt"):
+            return True
+    return False
+
+
+def validate_durable_lifecycle_closeout_root(
+    root: Path,
+    *,
+    require_closeout_marker: bool = True,
+    require_final_stop_idle_marker: bool = False,
+) -> tuple[bool, str, dict[str, Any]]:
+    """Validate durable lifecycle/planning/remote closeout slice root (§2a.1 extension v0).
+
+    Machine marker: ``VALIDATE_DURABLE_LIFECYCLE_CLOSEOUT_ROOT_V0=true``
+
+    Accepts ``MANIFEST_VERIFY.log`` or ``LOCAL_MANIFEST_VERIFY.log`` when RC=0.
+    Nested subdirectory manifests are orthogonal; parent ``MANIFEST.sha256`` is canonical.
+    """
+    checks: dict[str, bool] = {}
+    issues: list[str] = []
+    classification = (
+        FINAL_STOP_IDLE_CLOSEOUT_CLASSIFICATION
+        if require_final_stop_idle_marker
+        else LIFECYCLE_CLOSEOUT_CLASSIFICATION
+    )
+
+    ok, msg = require_durable_archive_root(root)
+    checks["durable_root_outside_tmp"] = ok
+    if not ok:
+        issues.append(msg)
+        return False, msg, {"checks": checks, "issues": issues, "classification": classification}
+
+    ok, msg = verify_manifest_sha256(root)
+    checks["manifest_sha256_verify"] = ok
+    if not ok:
+        issues.append(msg)
+        return False, msg, {"checks": checks, "issues": issues, "classification": classification}
+
+    rc, rc_msg, log_name = parse_manifest_verify_log_rc(root)
+    checks["manifest_verify_log_present"] = bool(log_name)
+    checks["manifest_verify_rc_zero"] = rc == 0
+    if rc is None:
+        issues.append(rc_msg)
+        return False, rc_msg, {"checks": checks, "issues": issues, "classification": classification}
+    if rc != 0:
+        msg = f"manifest verify RC must be 0 (got {rc} in {log_name})"
+        issues.append(msg)
+        return False, msg, {"checks": checks, "issues": issues, "classification": classification}
+
+    if require_closeout_marker:
+        has_marker = _has_lifecycle_closeout_marker(root)
+        checks["closeout_marker_present"] = has_marker
+        if not has_marker:
+            msg = "lifecycle closeout marker artifact missing"
+            issues.append(msg)
+            return (
+                False,
+                msg,
+                {"checks": checks, "issues": issues, "classification": classification},
+            )
+
+    if require_final_stop_idle_marker:
+        has_stop_idle = _has_final_stop_idle_marker(root)
+        checks["final_stop_idle_marker_present"] = has_stop_idle
+        if not has_stop_idle:
+            msg = "final stop-idle marker missing"
+            issues.append(msg)
+            return (
+                False,
+                msg,
+                {"checks": checks, "issues": issues, "classification": classification},
+            )
+
+    return (
+        True,
+        "",
+        {
+            "checks": checks,
+            "issues": [],
+            "classification": classification,
+            "manifest_verify_log": log_name,
+        },
+    )

--- a/tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py
+++ b/tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py
@@ -438,3 +438,180 @@ def test_require_durable_archive_root_accepts_durable_path() -> None:
         assert ok is True, reason
     finally:
         durable.rmdir()
+
+
+def _durable_closeout_root(tmp_path: Path) -> Path:
+    path = REPO_ROOT / "tests" / ".pytest_archive_roots" / f"lifecycle_{tmp_path.name}"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_lifecycle_closeout_bundle(
+    root: Path,
+    *,
+    verify_log_name: str = "MANIFEST_VERIFY.log",
+    verify_rc: int = 0,
+    marker_name: str = "HOST_TEARDOWN_EXECUTION_SLICE_V0_REPORT.md",
+    nested_mirror: bool = False,
+) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+    (root / marker_name).write_text("# lifecycle closeout\n", encoding="utf-8")
+    (root / verify_log_name).write_text(f"MANIFEST_VERIFY_RC={verify_rc}\n", encoding="utf-8")
+    if nested_mirror:
+        mirror = root / "remote_archive_mirror"
+        mirror.mkdir(parents=True, exist_ok=True)
+        (mirror / "evidence.txt").write_text("nested evidence\n", encoding="utf-8")
+        (mirror / "MANIFEST.sha256").write_text("# nested-local manifest\n", encoding="utf-8")
+    write_manifest_sha256(root)
+
+
+def test_shared_helper_exposes_lifecycle_closeout_hard_gate_extension() -> None:
+    text = SHARED_HELPER.read_text(encoding="utf-8")
+    assert "PRIMARY_EVIDENCE_RETENTION_HARD_GATE_EXTENSION_V0=true" in text
+    assert "VALIDATE_DURABLE_LIFECYCLE_CLOSEOUT_ROOT_V0=true" in text
+    assert "def parse_manifest_verify_log_rc" in text
+    assert "def validate_durable_lifecycle_closeout_root" in text
+    assert "LOCAL_MANIFEST_VERIFY.log" in text
+
+
+def test_validate_durable_lifecycle_closeout_root_accepts_local_manifest_verify_log(
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import validate_durable_lifecycle_closeout_root
+
+    root = _durable_closeout_root(tmp_path)
+    _write_lifecycle_closeout_bundle(
+        root,
+        verify_log_name="LOCAL_MANIFEST_VERIFY.log",
+        marker_name="BOUNDED_RUNTIME_GRACEFUL_STOP_AND_DURABLE_CLOSEOUT_REPORT.md",
+    )
+    ok, reason, detail = validate_durable_lifecycle_closeout_root(root)
+    assert ok is True, reason
+    assert detail["manifest_verify_log"] == "LOCAL_MANIFEST_VERIFY.log"
+    assert detail["classification"] == "lifecycle_closeout_slice_v0"
+
+
+@pytest.mark.parametrize(
+    ("setup", "expected_substring"),
+    [
+        ("missing_root", "archive root missing"),
+        ("tmp_only", "outside /tmp"),
+        ("missing_manifest", "MANIFEST.sha256 missing"),
+        ("manifest_mismatch", "checksum mismatch"),
+        ("missing_verify_log", "manifest verify log missing"),
+        ("verify_rc_nonzero", "manifest verify RC must be 0"),
+        ("missing_marker", "lifecycle closeout marker artifact missing"),
+        ("missing_stop_idle", "final stop-idle marker missing"),
+    ],
+)
+def test_validate_durable_lifecycle_closeout_root_fail_closed_cases(
+    tmp_path: Path,
+    setup: str,
+    expected_substring: str,
+) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import (
+        validate_durable_lifecycle_closeout_root,
+        write_manifest_sha256,
+    )
+
+    if setup == "missing_root":
+        root = REPO_ROOT / "tests" / ".pytest_archive_roots" / f"missing_{tmp_path.name}"
+        require_final = False
+    elif setup == "tmp_only":
+        root = Path("/tmp") / f"peak_trade_lifecycle_closeout_{tmp_path.name}"
+        root.mkdir(parents=True, exist_ok=True)
+        _write_lifecycle_closeout_bundle(root)
+        require_final = False
+    else:
+        root = _durable_closeout_root(tmp_path)
+        require_final = setup == "missing_stop_idle"
+        if setup == "missing_manifest":
+            (root / "HOST_TEARDOWN_EXECUTION_SLICE_V0_REPORT.md").write_text(
+                "# x\n", encoding="utf-8"
+            )
+            (root / "MANIFEST_VERIFY.log").write_text("MANIFEST_VERIFY_RC=0\n", encoding="utf-8")
+        elif setup == "manifest_mismatch":
+            _write_lifecycle_closeout_bundle(root)
+            (root / "HOST_TEARDOWN_EXECUTION_SLICE_V0_REPORT.md").write_text(
+                "# tampered\n", encoding="utf-8"
+            )
+        elif setup == "missing_verify_log":
+            (root / "HOST_TEARDOWN_EXECUTION_SLICE_V0_REPORT.md").write_text(
+                "# x\n", encoding="utf-8"
+            )
+            write_manifest_sha256(root)
+        elif setup == "verify_rc_nonzero":
+            _write_lifecycle_closeout_bundle(root, verify_rc=1)
+        elif setup == "missing_marker":
+            (root / "MANIFEST_VERIFY.log").write_text("MANIFEST_VERIFY_RC=0\n", encoding="utf-8")
+            write_manifest_sha256(root)
+        elif setup == "missing_stop_idle":
+            _write_lifecycle_closeout_bundle(
+                root,
+                marker_name="HOST_TEARDOWN_PLANNING_SLICE_V0_READONLY.md",
+            )
+        else:
+            _write_lifecycle_closeout_bundle(root)
+
+    ok, reason, _detail = validate_durable_lifecycle_closeout_root(
+        root,
+        require_final_stop_idle_marker=require_final,
+    )
+    assert ok is False
+    assert expected_substring in reason
+
+
+def test_validate_durable_lifecycle_closeout_root_passes_with_nested_mirror_parent_manifest(
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import validate_durable_lifecycle_closeout_root
+
+    root = _durable_closeout_root(tmp_path)
+    _write_lifecycle_closeout_bundle(
+        root,
+        nested_mirror=True,
+        marker_name="SG_CLEANUP_EXECUTION_SLICE_V0_REPORT.md",
+    )
+    ok, reason, detail = validate_durable_lifecycle_closeout_root(root)
+    assert ok is True, reason
+    assert detail["checks"]["manifest_sha256_verify"] is True
+    assert (root / "remote_archive_mirror" / "MANIFEST.sha256").is_file()
+
+
+def test_validate_durable_lifecycle_closeout_root_final_stop_idle_record(tmp_path: Path) -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import validate_durable_lifecycle_closeout_root
+
+    root = _durable_closeout_root(tmp_path)
+    _write_lifecycle_closeout_bundle(
+        root,
+        marker_name="BOUNDED_REMOTE_LIFECYCLE_FINAL_STOP_IDLE_RECORD.md",
+    )
+    (root / "BOUNDED_REMOTE_LIFECYCLE_FINAL_STOP_IDLE_MACHINE_LINES.txt").write_text(
+        "NEXT_ACTION=STOP_IDLE_LIFECYCLE_COMPLETE_KEEP_IAM_FOR_REUSE\n",
+        encoding="utf-8",
+    )
+    from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+    write_manifest_sha256(root)
+    ok, reason, detail = validate_durable_lifecycle_closeout_root(
+        root,
+        require_final_stop_idle_marker=True,
+    )
+    assert ok is True, reason
+    assert detail["classification"] == "final_stop_idle_lifecycle_closeout_v0"


### PR DESCRIPTION
## Summary

Adds Primary Evidence Retention Hard Gate Extension v0 as a bounded offline helper-contract slice.

- extends `scripts/ops/primary_evidence_retention_v0.py`
- adds lifecycle/remote/planning closeout validation coverage
- accepts `MANIFEST_VERIFY.log` and `LOCAL_MANIFEST_VERIFY.log` when RC=0
- adds final Stop-Idle marker gating
- keeps nested mirror manifests orthogonal when the parent manifest verifies cleanly
- extends hard-gate pytest coverage for fail-closed lifecycle cases

## Safety / Boundaries

- Runtime started: false
- AWS/IAM/S3 mutation: false
- Notion mutation: false
- Market Dashboard changed: false
- Master V2 / Double Play changed: false
- New surface created: false
- Duplicate docs created: false
- No broker/exchange/order-flow touch
- No runbook, registry schema, dashboard, KG, or Notion surface added

Evidence/Notion/Dashboard/Docs do not authorize runtime or trading.

## Validation

- `python3 -m pytest tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py`
- `python3 -m ruff check scripts/ops/primary_evidence_retention_v0.py tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py`
- `python3 -m ruff format --check scripts/ops/primary_evidence_retention_v0.py tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py`

## Test plan

- [x] Hard-gate pytest module passes locally
- [x] Ruff check/format on touched files
- [ ] CI green on PR

## Machine Lines

PRIMARY_EVIDENCE_RETENTION_HARD_GATE_EXTENSION_DONE=true
READ_ONLY_INVENTORY_DONE=true
REPO_CHANGED=true
FILES_TOUCHED=scripts/ops/primary_evidence_retention_v0.py,tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py
RUNTIME_STARTED=false
AWS_MUTATION_USED=false
IAM_MUTATION_USED=false
S3_UPLOAD_USED=false
NOTION_MUTATION_USED=false
MARKET_DASHBOARD_CHANGED=false
MASTER_V2_DOUBLE_PLAY_CHANGED=false
NEW_SURFACE_CREATED=false
DUPLICATE_DOC_CREATED=false

Made with [Cursor](https://cursor.com)