### PR TITLE
ops: post-closeout chain lifecycle validator hook v0

### DIFF
--- a/scripts/ops/durable_closeout_copy_verify_v0.py
+++ b/scripts/ops/durable_closeout_copy_verify_v0.py
@@ -22,10 +22,18 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.ops.primary_evidence_retention_v0 import (
+    LIFECYCLE_CLOSEOUT_MARKER_SUFFIXES,
     MANIFEST_FILENAME,
     is_under_tmp,
+    validate_durable_lifecycle_closeout_root,
     verify_manifest_sha256,
     write_manifest_sha256,
+)
+
+# Chain hook markers: lifecycle/planning/remote/final-stop-idle slices only.
+# ``FINAL_MACHINE_LINES.txt`` alone does not activate the hook (paper bounded observation).
+_CHAIN_LIFECYCLE_HOOK_MARKER_SUFFIXES: tuple[str, ...] = tuple(
+    suffix for suffix in LIFECYCLE_CLOSEOUT_MARKER_SUFFIXES if suffix != "_MACHINE_LINES.txt"
 )
 
 README_FILENAME = "DURABLE_COPY_README.md"
@@ -355,6 +363,32 @@ def _default_cli_invoker(argv: Sequence[str], cwd: Path) -> tuple[int, str]:
     return int(proc.returncode), combined
 
 
+def _lifecycle_closeout_hook_applies(dest_dir: Path) -> bool:
+    """Return True when dest classifies as lifecycle/planning/remote/final-stop-idle closeout."""
+    for path in dest_dir.iterdir():
+        if not path.is_file():
+            continue
+        name = path.name
+        if any(name.endswith(suffix) for suffix in _CHAIN_LIFECYCLE_HOOK_MARKER_SUFFIXES):
+            return True
+        upper = name.upper()
+        if "STOP_IDLE" in upper and (name.endswith(".md") or name.endswith("_MACHINE_LINES.txt")):
+            return True
+    return False
+
+
+def _requires_final_stop_idle_lifecycle_gate(dest_dir: Path) -> bool:
+    for path in dest_dir.iterdir():
+        if not path.is_file():
+            continue
+        name = path.name
+        if "STOP_IDLE" not in name.upper():
+            continue
+        if name.endswith(".md") or name.endswith("_MACHINE_LINES.txt"):
+            return True
+    return False
+
+
 def _chain_artifact_paths(dest_dir: Path) -> dict[str, Path]:
     chain_dir = _safe_dest_child(dest_dir, Path(POST_CLOSEOUT_CHAIN_SUBDIR))
     return {
@@ -408,6 +442,25 @@ def run_local_post_closeout_chain_v0(
     if not archive_root.is_dir():
         chain.error = f"chain archive root is not a directory: {archive_root}"
         return chain
+
+    if _lifecycle_closeout_hook_applies(dest_dir):
+        require_final_stop_idle = _requires_final_stop_idle_lifecycle_gate(dest_dir)
+        ok_lifecycle, lifecycle_msg, lifecycle_detail = validate_durable_lifecycle_closeout_root(
+            dest_dir,
+            require_final_stop_idle_marker=require_final_stop_idle,
+        )
+        chain.steps.append(
+            ChainStepResult(
+                step="validate_durable_lifecycle_closeout_root_v0",
+                rc=0 if ok_lifecycle else 1,
+                status="ok" if ok_lifecycle else "failed",
+                detail=str(lifecycle_detail.get("classification", "")),
+            )
+        )
+        if not ok_lifecycle:
+            chain.error = f"lifecycle closeout validation failed: {lifecycle_msg}"
+            chain.status = "invalid"
+            return chain
 
     paths["chain_dir"].mkdir(parents=True, exist_ok=True)
 

--- a/tests/ops/test_durable_closeout_local_post_closeout_chain_v0.py
+++ b/tests/ops/test_durable_closeout_local_post_closeout_chain_v0.py
@@ -47,6 +47,56 @@ def _write_source_with_chain_inputs(tmp_path: Path) -> tuple[Path, Path]:
     return src, archive
 
 
+def _write_source_without_lifecycle_closeout_marker(tmp_path: Path) -> tuple[Path, Path]:
+    """Paper bounded observation fixture: FINAL_MACHINE_LINES only (no lifecycle slice marker)."""
+    archive = tmp_path / "archive"
+    run_dir = pc.write_minimal_paper_run(archive, "paper_no_lifecycle_marker")
+    payload_tests._write_machine_lines(run_dir / "FINAL_MACHINE_LINES.txt", CHAIN_MACHINE_LINES)
+    src = tmp_path / "source"
+    shutil.copytree(run_dir, src)
+    return src, archive
+
+
+def _durable_lifecycle_closeout_dest(tmp_path: Path, name: str) -> Path:
+    return closeout_tests._archive_like_dest(tmp_path, name)
+
+
+def _write_lifecycle_closeout_chain_dest(
+    tmp_path: Path,
+    *,
+    name: str = "lifecycle_chain",
+    verify_log_name: str = "MANIFEST_VERIFY.log",
+    verify_rc: int = 0,
+    marker_name: str = "HOST_TEARDOWN_EXECUTION_SLICE_V0_REPORT.md",
+    nested_mirror: bool = False,
+    with_final_stop_idle: bool = False,
+) -> Path:
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+    dest = _durable_lifecycle_closeout_dest(tmp_path, name)
+    dest.mkdir(parents=True, exist_ok=True)
+    if with_final_stop_idle:
+        marker_name = "BOUNDED_REMOTE_LIFECYCLE_FINAL_STOP_IDLE_RECORD.md"
+    (dest / marker_name).write_text("# lifecycle closeout\n", encoding="utf-8")
+    (dest / verify_log_name).write_text(f"MANIFEST_VERIFY_RC={verify_rc}\n", encoding="utf-8")
+    if with_final_stop_idle:
+        (dest / "BOUNDED_REMOTE_LIFECYCLE_FINAL_STOP_IDLE_MACHINE_LINES.txt").write_text(
+            "NEXT_ACTION=STOP_IDLE_LIFECYCLE_COMPLETE_KEEP_IAM_FOR_REUSE\n",
+            encoding="utf-8",
+        )
+    if nested_mirror:
+        mirror = dest / "remote_archive_mirror"
+        mirror.mkdir(parents=True, exist_ok=True)
+        (mirror / "evidence.txt").write_text("nested evidence\n", encoding="utf-8")
+        (mirror / "MANIFEST.sha256").write_text("# nested-local manifest\n", encoding="utf-8")
+    payload_tests._write_machine_lines(dest / "FINAL_MACHINE_LINES.txt", CHAIN_MACHINE_LINES)
+    write_manifest_sha256(dest)
+    return dest
+
+
 def _mock_invoker_factory(
     tmp_path: Path,
     *,
@@ -248,3 +298,133 @@ def test_chain_blocked_without_archive_root(helper, tmp_path):
 
 def test_forbidden_parallel_execute_script_absent():
     assert not FORBIDDEN_PARALLEL_SCRIPT.exists()
+
+
+def test_lifecycle_closeout_hook_happy_path_runs_chain_steps(helper, tmp_path, monkeypatch):
+    archive = tmp_path / "lifecycle_archive"
+    pc.write_minimal_paper_run(archive, "lifecycle_chain_v0")
+    dest = _write_lifecycle_closeout_chain_dest(
+        tmp_path,
+        nested_mirror=True,
+        marker_name="SG_CLEANUP_EXECUTION_SLICE_V0_REPORT.md",
+    )
+    invoker, calls = _mock_invoker_factory(tmp_path)
+    monkeypatch.setattr(helper, "_default_cli_invoker", invoker)
+    try:
+        chain = helper.run_local_post_closeout_chain_v0(
+            dest_dir=dest,
+            archive_root=archive,
+            run_id="lifecycle_chain_v0",
+            fixed_generated_at_utc=None,
+        )
+        assert chain.status == "pass"
+        assert chain.steps[0].step == "validate_durable_lifecycle_closeout_root_v0"
+        assert chain.steps[0].status == "ok"
+        assert chain.steps[0].detail == "lifecycle_closeout_slice_v0"
+        assert len(calls) == 3
+    finally:
+        closeout_tests._cleanup_archive_like_dest(dest)
+
+
+def test_lifecycle_closeout_hook_fail_closed_skips_registry_projection_notion(
+    helper, tmp_path, monkeypatch
+):
+    archive = tmp_path / "lifecycle_archive_fail"
+    pc.write_minimal_paper_run(archive, "lifecycle_chain_fail")
+    dest = _write_lifecycle_closeout_chain_dest(
+        tmp_path,
+        name="lifecycle_chain_fail",
+        verify_rc=1,
+        marker_name="HOST_TEARDOWN_PLANNING_SLICE_V0_READONLY.md",
+    )
+    invoker, calls = _mock_invoker_factory(tmp_path)
+    monkeypatch.setattr(helper, "_default_cli_invoker", invoker)
+    try:
+        chain = helper.run_local_post_closeout_chain_v0(
+            dest_dir=dest,
+            archive_root=archive,
+            run_id=None,
+            fixed_generated_at_utc=None,
+        )
+        assert chain.status == "invalid"
+        assert chain.steps[0].step == "validate_durable_lifecycle_closeout_root_v0"
+        assert chain.steps[0].status == "failed"
+        assert "manifest verify RC must be 0" in chain.error
+        assert calls == []
+    finally:
+        closeout_tests._cleanup_archive_like_dest(dest)
+
+
+def test_paper_chain_without_lifecycle_marker_skips_lifecycle_hook(helper, tmp_path, monkeypatch):
+    src, archive = _write_source_without_lifecycle_closeout_marker(tmp_path)
+    dest = closeout_tests._archive_like_dest(tmp_path, "paper_no_lifecycle_hook")
+    invoker, calls = _mock_invoker_factory(tmp_path)
+    monkeypatch.setattr(helper, "_default_cli_invoker", invoker)
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *closeout_tests._tmp_source_args(),
+                "--no-require-closeout-report",
+                "--force",
+                "--run-local-post-closeout-chain-v0",
+                "--chain-archive-root",
+                str(archive),
+                "--chain-run-id",
+                "paper_no_lifecycle_marker",
+            ]
+        )
+        assert rc == 0
+        status = json.loads(
+            (dest / helper.LOCAL_POST_CLOSEOUT_CHAIN_STATUS_FILENAME).read_text(encoding="utf-8")
+        )
+        assert status["status"] == "pass"
+        step_names = [step["step"] for step in status["steps"]]
+        assert "validate_durable_lifecycle_closeout_root_v0" not in step_names
+        assert len(calls) == 3
+    finally:
+        closeout_tests._cleanup_archive_like_dest(dest)
+
+
+def test_lifecycle_closeout_hook_via_main_after_durable_copy(helper, tmp_path, monkeypatch):
+    archive = tmp_path / "lifecycle_main_archive"
+    run_dir = archive / "lifecycle_main_v0"
+    run_dir.mkdir(parents=True)
+    (run_dir / "BOUNDED_RUNTIME_GRACEFUL_STOP_AND_DURABLE_CLOSEOUT_REPORT.md").write_text(
+        "# lifecycle\n",
+        encoding="utf-8",
+    )
+    payload_tests._write_machine_lines(run_dir / "FINAL_MACHINE_LINES.txt", CHAIN_MACHINE_LINES)
+    src = tmp_path / "lifecycle_source"
+    shutil.copytree(run_dir, src)
+    dest = closeout_tests._archive_like_dest(tmp_path, "lifecycle_main_chain")
+    invoker, calls = _mock_invoker_factory(tmp_path)
+    monkeypatch.setattr(helper, "_default_cli_invoker", invoker)
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *closeout_tests._tmp_source_args(),
+                "--no-require-closeout-report",
+                "--force",
+                "--run-local-post-closeout-chain-v0",
+                "--chain-archive-root",
+                str(archive),
+            ]
+        )
+        assert rc == 0
+        status = json.loads(
+            (dest / helper.LOCAL_POST_CLOSEOUT_CHAIN_STATUS_FILENAME).read_text(encoding="utf-8")
+        )
+        assert status["status"] == "pass"
+        assert status["steps"][0]["step"] == "validate_durable_lifecycle_closeout_root_v0"
+        assert status["steps"][0]["status"] == "ok"
+        assert len(calls) == 3
+    finally:
+        closeout_tests._cleanup_archive_like_dest(dest)


### PR DESCRIPTION
## Summary

Adds POST_CLOSEOUT_CHAIN_LIFECYCLE_VALIDATOR_HOOK_V0 as a bounded offline post-closeout chain hardening slice.

- reuses `validate_durable_lifecycle_closeout_root()` from PR #3771
- hooks lifecycle validation into existing `run_local_post_closeout_chain_v0()`
- activates the hook only for lifecycle/planning/remote/final-stop-idle classifications
- fail-closes before Registry → Projection Payload → Notion dry-run when lifecycle validation fails
- preserves existing paper/bounded observation chain behavior where lifecycle markers are absent
- adds synthetic lifecycle fixtures and fail-closed tests
- does not add any new chain script, runbook, registry schema, dashboard, Notion live write, AWS/S3 behavior, or runtime path

## Safety / Boundaries

- Runtime started: false
- AWS/IAM/S3 mutation: false
- Notion mutation: false
- Market Dashboard changed: false
- Master V2 / Double Play changed: false
- Closed remote lifecycle reopened: false
- New surface created: false
- New chain script created: false
- Duplicate docs created: false
- No broker/exchange/order-flow touch
- No live Notion write
- No S3 upload/backfill
- No runtime launcher or adapter `--execute` wiring

Evidence/Notion/Dashboard/Docs do not authorize runtime or trading.

## Validation

- `python3 -m pytest tests/ops/test_durable_closeout_local_post_closeout_chain_v0.py`
- `python3 -m pytest tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py`
- `python3 -m pytest tests/ops/test_build_post_closeout_projection_payload_v0.py tests/ops/test_notion_post_closeout_sync_dry_run_v0.py`
- `python3 -m ruff check scripts/ops/durable_closeout_copy_verify_v0.py tests/ops/test_durable_closeout_local_post_closeout_chain_v0.py`
- `python3 -m ruff format --check scripts/ops/durable_closeout_copy_verify_v0.py tests/ops/test_durable_closeout_local_post_closeout_chain_v0.py`

## Machine Lines

POST_CLOSEOUT_CHAIN_LIFECYCLE_VALIDATOR_HOOK_DONE=true
FILES_TOUCHED=scripts/ops/durable_closeout_copy_verify_v0.py,tests/ops/test_durable_closeout_local_post_closeout_chain_v0.py
TESTS_PASSED=93/93
RUFF_PASSED=true
RUNTIME_STARTED=false
AWS_MUTATION_USED=false
IAM_MUTATION_USED=false
S3_UPLOAD_USED=false
NOTION_MUTATION_USED=false
MARKET_DASHBOARD_CHANGED=false
MASTER_V2_DOUBLE_PLAY_CHANGED=false
CLOSED_REMOTE_LIFECYCLE_REOPENED=false
NEW_SURFACE_CREATED=false
NEW_CHAIN_SCRIPT_CREATED=false
DUPLICATE_DOC_CREATED=false

Made with [Cursor](https://cursor.com)