### PR TITLE
ops: control plane hook dry-run input hardening v0

### DIFF
--- a/scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py
+++ b/scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py
@@ -60,7 +60,13 @@ READINESS_MACHINE_LINE_KEYS: tuple[str, ...] = (
 
 
 def _load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be object: {path}")
+    return payload
 
 
 def _validate_plan(plan: dict[str, Any], plan_path: Path) -> str:

--- a/scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py
+++ b/scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py
@@ -102,6 +102,25 @@ def missing_chain_rel_paths(
     return missing
 
 
+def _validate_chain_json_artifacts(
+    chain_root: Path,
+    required_chain_rel_paths: tuple[str, ...] = REQUIRED_CHAIN_REL_PATHS_V0,
+) -> None:
+    """Fail closed when required chain JSON artifacts exist but are malformed."""
+    for rel in required_chain_rel_paths:
+        if not rel.endswith(".json"):
+            continue
+        path = chain_root / rel
+        if not path.is_file():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"malformed JSON in chain artifact {rel}: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"chain artifact JSON root must be object: {rel}")
+
+
 def evaluate_attachment_plan_v0(
     *,
     source_chain_root: Path,
@@ -116,6 +135,7 @@ def evaluate_attachment_plan_v0(
     elif is_under_tmp(target_archive_root):
         status = STATUS_BLOCKED_TARGET_ARCHIVE_ROOT_UNDER_TMP
     else:
+        _validate_chain_json_artifacts(source_chain_root, required_chain_rel_paths)
         status = STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING
 
     machine_lines = {
@@ -238,11 +258,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--outdir", type=Path, required=True)
     args = parser.parse_args(argv)
 
-    plan = run_attachment_planner(
-        chain_root=args.chain_root,
-        target_archive_root=args.target_archive_root,
-        outdir=args.outdir,
-    )
+    try:
+        plan = run_attachment_planner(
+            chain_root=args.chain_root,
+            target_archive_root=args.target_archive_root,
+            outdir=args.outdir,
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
     for key in PLAN_MACHINE_LINE_KEYS:
         sys.stdout.write(f"{key}={plan['machine_lines'][key]}\n")
     return 0

--- a/scripts/ops/run_autonomous_ops_control_plane_offline_chain_v0.py
+++ b/scripts/ops/run_autonomous_ops_control_plane_offline_chain_v0.py
@@ -206,7 +206,7 @@ def main(argv: list[str] | None = None) -> int:
             fixture_path=args.fixture.resolve(),
             outdir=args.outdir.resolve(),
         )
-    except ValueError as exc:
+    except (ValueError, json.JSONDecodeError) as exc:
         sys.stderr.write(f"{exc}\n")
         return 2
 

--- a/scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py
+++ b/scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from scripts.ops.plan_control_plane_offline_chain_durable_attachment_v0 import (
     DURABLE_ATTACHMENT_CONTRACT_MODE,
+    SCHEMA_VERSION as ATTACHMENT_PLAN_SCHEMA_VERSION,
     STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
     missing_chain_rel_paths,
 )
@@ -59,6 +60,17 @@ FORBIDDEN_CLI_FLAGS: tuple[str, ...] = (
     "--s3",
     "--ssh",
     "--start",
+)
+
+REQUIRED_ATTACHMENT_PLAN_KEYS: frozenset[str] = frozenset(
+    {
+        "schema_version",
+        "status",
+        "pointer_only",
+        "target_archive_root",
+        "hook_implemented",
+        "full_post_closeout_automation_implemented",
+    }
 )
 
 SUMMARY_MACHINE_LINE_KEYS: tuple[str, ...] = (
@@ -246,6 +258,34 @@ def build_summary_machine_lines(status: str) -> dict[str, str]:
     }
 
 
+def _load_attachment_plan_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed JSON attachment plan: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"attachment plan JSON root must be object: {path}")
+    return payload
+
+
+def _validate_attachment_plan_json(plan: dict[str, Any], path: Path) -> None:
+    missing = REQUIRED_ATTACHMENT_PLAN_KEYS - plan.keys()
+    if missing:
+        raise ValueError(f"attachment plan missing keys {sorted(missing)}: {path}")
+    if plan["schema_version"] != ATTACHMENT_PLAN_SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported attachment plan schema {plan['schema_version']!r} "
+            f"(expected {ATTACHMENT_PLAN_SCHEMA_VERSION!r}): {path}"
+        )
+    if plan["hook_implemented"] is True:
+        raise ValueError(f"hostile attachment plan hook_implemented must remain false: {path}")
+    if plan["full_post_closeout_automation_implemented"] is True:
+        raise ValueError(
+            "hostile attachment plan full_post_closeout_automation_implemented "
+            f"must remain false: {path}"
+        )
+
+
 def evaluate_hook_dry_run_summary_v0(
     *,
     chain_root: Path,
@@ -253,7 +293,8 @@ def evaluate_hook_dry_run_summary_v0(
     attachment_e2e_complete: bool = True,
 ) -> dict[str, Any]:
     """Evaluate hook dry-run summary from chain root + attachment plan JSON path."""
-    plan = json.loads(attachment_plan_path.read_text(encoding="utf-8"))
+    plan = _load_attachment_plan_json(attachment_plan_path)
+    _validate_attachment_plan_json(plan, attachment_plan_path)
     chain_root_resolved = chain_root.resolve()
     attachment_plan_resolved = attachment_plan_path.resolve()
 
@@ -340,11 +381,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--outdir", type=Path, required=True)
     args = parser.parse_args(argv)
 
-    summary = run_hook_dry_run_summary(
-        chain_root=args.chain_root,
-        attachment_plan=args.attachment_plan,
-        outdir=args.outdir,
-    )
+    try:
+        summary = run_hook_dry_run_summary(
+            chain_root=args.chain_root,
+            attachment_plan=args.attachment_plan,
+            outdir=args.outdir,
+        )
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
     for key in SUMMARY_MACHINE_LINE_KEYS:
         sys.stdout.write(f"{key}={summary['machine_lines'][key]}\n")
     return 0

--- a/tests/ops/test_control_plane_planner_and_hook_summary_cli_e2e_contract_v0.py
+++ b/tests/ops/test_control_plane_planner_and_hook_summary_cli_e2e_contract_v0.py
@@ -16,6 +16,7 @@ import pytest
 from scripts.ops import plan_control_plane_offline_chain_durable_attachment_v0 as planner_mod
 from scripts.ops import run_autonomous_ops_control_plane_offline_chain_v0 as chain_mod
 from scripts.ops import summarize_control_plane_automation_hook_dry_run_v0 as summary_mod
+from scripts.ops import bridge_control_plane_plan_to_post_closeout_readiness_v0 as bridge_mod
 from tests.ops.test_control_plane_first_automation_hook_dry_run_contract_v0 import (
     build_control_plane_automation_hook_dry_run_summary as contract_build_summary,
 )
@@ -356,3 +357,47 @@ def test_module_has_no_runtime_invocation_or_cost_rearm_patterns_v0() -> None:
 
 def test_summary_cli_forbidden_flags_match_planner_posture_v0() -> None:
     assert summary_mod.FORBIDDEN_CLI_FLAGS == planner_mod.FORBIDDEN_CLI_FLAGS
+
+
+def test_bridge_exits_2_on_malformed_plan_json(tmp_path: Path) -> None:
+    plan_path = tmp_path / "malformed_plan.json"
+    plan_path.write_text("{not-json\n", encoding="utf-8")
+    readiness_dir = tmp_path / "readiness"
+    rc = bridge_mod.main(["--plan", str(plan_path), "--outdir", str(readiness_dir)])
+    assert rc == 2
+    assert not (readiness_dir / bridge_mod.READINESS_JSON_FILENAME).exists()
+
+
+def test_chain_orchestrator_exits_2_on_malformed_fixture_json(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "malformed_fixture.json"
+    fixture_path.write_text("{not-json\n", encoding="utf-8")
+    chain_dir = tmp_path / "chain_malformed"
+    rc = chain_mod.main(["--fixture", str(fixture_path), "--outdir", str(chain_dir)])
+    assert rc == 2
+    assert not (chain_dir / chain_mod.CHAIN_JSON_FILENAME).exists()
+
+
+def test_e2e_summary_exits_2_on_tampered_attachment_plan_without_side_effects(
+    tmp_path: Path,
+) -> None:
+    chain_dir = tmp_path / "chain"
+    planner_dir = tmp_path / "planner"
+    summary_dir = tmp_path / "summary_tampered"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    plan = _run_planner(chain_dir, SYNTHETIC_DURABLE_ARCHIVE_ROOT, planner_dir)
+    plan_path = planner_dir / planner_mod.PLAN_JSON_FILENAME
+    tampered = {**plan, "hook_implemented": True}
+    plan_path.write_text(json.dumps(tampered, indent=2) + "\n", encoding="utf-8")
+    rc = summary_mod.main(
+        [
+            "--chain-root",
+            str(chain_dir),
+            "--attachment-plan",
+            str(plan_path),
+            "--outdir",
+            str(summary_dir),
+        ]
+    )
+    assert rc == 2
+    assert not (summary_dir / summary_mod.SUMMARY_JSON_FILENAME).exists()
+    _assert_no_side_effect_artifacts(tmp_path)

--- a/tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
+++ b/tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
@@ -279,3 +279,23 @@ def test_contract_module_imports_are_stdlib_scripts_ops_tests_ops_only_v0() -> N
             for alias in node.names:
                 root = alias.name.split(".")[0]
                 assert root in allowed_roots, f"unexpected import: {alias.name!r}"
+
+
+def test_planner_exits_2_on_malformed_chain_json_artifact(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    plan_dir = tmp_path / "plan_malformed"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    malformed_rel = "CONTROL_PLANE_OFFLINE_CHAIN_V0.json"
+    (chain_dir / malformed_rel).write_text("{not-json\n", encoding="utf-8")
+    rc = planner_mod.main(
+        [
+            "--chain-root",
+            str(chain_dir),
+            "--target-archive-root",
+            str(SYNTHETIC_DURABLE_ARCHIVE_ROOT),
+            "--outdir",
+            str(plan_dir),
+        ]
+    )
+    assert rc == 2
+    assert not (plan_dir / planner_mod.PLAN_JSON_FILENAME).exists()

--- a/tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
+++ b/tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
@@ -313,3 +313,152 @@ def test_summary_machine_lines_include_required_keys_v0(tmp_path: Path) -> None:
 
 def test_summary_script_forbidden_flags_match_planner_posture_v0() -> None:
     assert summary_mod.FORBIDDEN_CLI_FLAGS == planner_mod.FORBIDDEN_CLI_FLAGS
+
+
+def _write_minimal_valid_attachment_plan(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": planner_mod.SCHEMA_VERSION,
+                "status": STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+                "pointer_only": True,
+                "target_archive_root": str(SYNTHETIC_DURABLE_ARCHIVE_ROOT),
+                "hook_implemented": False,
+                "full_post_closeout_automation_implemented": False,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_summary_exits_2_on_malformed_attachment_plan_json(tmp_path: Path) -> None:
+    chain_dir = tmp_path / "chain"
+    summary_dir = tmp_path / "summary_malformed"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    plan_path = tmp_path / "malformed_plan.json"
+    plan_path.write_text("{not-json\n", encoding="utf-8")
+    rc = summary_mod.main(
+        [
+            "--chain-root",
+            str(chain_dir),
+            "--attachment-plan",
+            str(plan_path),
+            "--outdir",
+            str(summary_dir),
+        ]
+    )
+    assert rc == 2
+    assert not (summary_dir / summary_mod.SUMMARY_JSON_FILENAME).exists()
+
+
+@pytest.mark.parametrize(
+    ("plan_body", "expected_substring"),
+    [
+        (
+            {
+                "status": STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+                "pointer_only": True,
+                "target_archive_root": str(SYNTHETIC_DURABLE_ARCHIVE_ROOT),
+                "hook_implemented": False,
+                "full_post_closeout_automation_implemented": False,
+            },
+            "missing keys",
+        ),
+        (
+            {
+                "schema_version": "wrong_schema_v0",
+                "status": STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+                "pointer_only": True,
+                "target_archive_root": str(SYNTHETIC_DURABLE_ARCHIVE_ROOT),
+                "hook_implemented": False,
+                "full_post_closeout_automation_implemented": False,
+            },
+            "unsupported attachment plan schema",
+        ),
+        (
+            {
+                "schema_version": planner_mod.SCHEMA_VERSION,
+                "status": STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+                "pointer_only": True,
+                "target_archive_root": str(SYNTHETIC_DURABLE_ARCHIVE_ROOT),
+                "hook_implemented": True,
+                "full_post_closeout_automation_implemented": False,
+            },
+            "hook_implemented must remain false",
+        ),
+        (
+            {
+                "schema_version": planner_mod.SCHEMA_VERSION,
+                "status": STATUS_READY_FOR_DURABLE_ATTACHMENT_PLANNING,
+                "pointer_only": True,
+                "target_archive_root": str(SYNTHETIC_DURABLE_ARCHIVE_ROOT),
+                "hook_implemented": False,
+                "full_post_closeout_automation_implemented": True,
+            },
+            "full_post_closeout_automation_implemented must remain false",
+        ),
+    ],
+)
+def test_summary_exits_2_on_hostile_attachment_plan(
+    tmp_path: Path,
+    plan_body: dict,
+    expected_substring: str,
+) -> None:
+    chain_dir = tmp_path / "chain"
+    summary_dir = tmp_path / "summary_hostile"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    plan_path = tmp_path / "hostile_plan.json"
+    plan_path.write_text(json.dumps(plan_body, indent=2) + "\n", encoding="utf-8")
+    rc = summary_mod.main(
+        [
+            "--chain-root",
+            str(chain_dir),
+            "--attachment-plan",
+            str(plan_path),
+            "--outdir",
+            str(summary_dir),
+        ]
+    )
+    assert rc == 2
+    assert not (summary_dir / summary_mod.SUMMARY_JSON_FILENAME).exists()
+
+
+def test_summary_blocked_operational_path_still_exits_zero_and_non_authorizing(
+    tmp_path: Path,
+) -> None:
+    chain_dir = tmp_path / "chain_partial"
+    summary_dir = tmp_path / "summary_operational_blocked"
+    assert _run_offline_chain(LEGAL_FIXTURE, chain_dir) == 0
+    (chain_dir / REQUIRED_CHAIN_REL_PATHS_V0[0]).unlink()
+    plan_path = tmp_path / "valid_blocked_plan.json"
+    _write_minimal_valid_attachment_plan(plan_path)
+    plan_path.write_text(
+        json.dumps(
+            {
+                **json.loads(plan_path.read_text(encoding="utf-8")),
+                "status": STATUS_BLOCKED_MISSING_REQUIRED_CHAIN_ARTIFACT,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rc = summary_mod.main(
+        [
+            "--chain-root",
+            str(chain_dir),
+            "--attachment-plan",
+            str(plan_path),
+            "--outdir",
+            str(summary_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(
+        (summary_dir / summary_mod.SUMMARY_JSON_FILENAME).read_text(encoding="utf-8"),
+    )
+    assert summary["status"] != STATUS_READY_FOR_CP_HOOK_DRY_RUN
+    assert summary["hook_implemented"] is False
+    assert summary["machine_lines"]["HOOK_IMPLEMENTED"] == "false"


### PR DESCRIPTION
## Summary

Adds CONTROL_PLANE_HOOK_DRY_RUN_INPUT_HARDENING_V0 as a bounded input-hardening slice for existing Control-Plane dry-run CLIs.

- malformed JSON now fails closed with deterministic exit code 2
- hostile attachment plans fail closed
- wrong or missing schema versions fail closed
- missing required keys fail closed
- `hook_implemented: true` / `full_automation: true` do not authorize execution
- operative blocked states remain non-authorizing
- `HOOK_IMPLEMENTED=false` remains unchanged
- no `--execute` path added

## Scope

Touched existing Control-Plane owners only:

- `scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py`
- `scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py`
- `scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py`
- `scripts/ops/run_autonomous_ops_control_plane_offline_chain_v0.py`
- `tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py`
- `tests/ops/test_control_plane_planner_and_hook_summary_cli_e2e_contract_v0.py`
- `tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py`

## Safety / Boundaries

- Runtime started: false
- AWS/IAM/S3 mutation: false
- Notion mutation: false
- Market Dashboard changed: false
- Master V2 / Double Play changed: false
- Closed remote lifecycle reopened: false
- Hook implemented: false
- Execute path added: false
- New surface created: false
- New chain script created: false
- Duplicate docs created: false
- No broker/exchange/order-flow touch
- No live Notion write
- No runtime launcher or adapter execution wiring

Evidence/Notion/Dashboard/Docs do not authorize runtime or trading.

## Validation

- `python3 -m pytest tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py`
- `python3 -m pytest tests/ops/test_control_plane_planner_and_hook_summary_cli_e2e_contract_v0.py`
- `python3 -m pytest tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py`
- `python3 -m ruff check scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py scripts/ops/run_autonomous_ops_control_plane_offline_chain_v0.py tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py tests/ops/test_control_plane_planner_and_hook_summary_cli_e2e_contract_v0.py tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py`
- `python3 -m ruff format --check scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py scripts/ops/run_autonomous_ops_control_plane_offline_chain_v0.py tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py tests/ops/test_control_plane_planner_and_hook_summary_cli_e2e_contract_v0.py tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py`

## Machine Lines

CONTROL_PLANE_HOOK_DRY_RUN_INPUT_HARDENING_DONE=true
FILES_TOUCHED=scripts/ops/plan_control_plane_offline_chain_durable_attachment_v0.py,scripts/ops/summarize_control_plane_automation_hook_dry_run_v0.py,scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py,scripts/ops/run_autonomous_ops_control_plane_offline_chain_v0.py,tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py,tests/ops/test_control_plane_planner_and_hook_summary_cli_e2e_contract_v0.py,tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
TESTS_PASSED=51/51
RUFF_PASSED=true
RUNTIME_STARTED=false
AWS_MUTATION_USED=false
IAM_MUTATION_USED=false
S3_UPLOAD_USED=false
NOTION_MUTATION_USED=false
MARKET_DASHBOARD_CHANGED=false
MASTER_V2_DOUBLE_PLAY_CHANGED=false
CLOSED_REMOTE_LIFECYCLE_REOPENED=false
HOOK_IMPLEMENTED=false
EXECUTE_PATH_ADDED=false
NEW_SURFACE_CREATED=false
NEW_CHAIN_SCRIPT_CREATED=false
DUPLICATE_DOC_CREATED=false

Made with [Cursor](https://cursor.com)