### PR TITLE
ops: add control plane plan bridge readiness e2e

### DIFF
--- a/tests/ops/test_control_plane_plan_bridge_readiness_cli_e2e_contract_v0.py
+++ b/tests/ops/test_control_plane_plan_bridge_readiness_cli_e2e_contract_v0.py
@@ -1,0 +1,206 @@
+"""Control Plane plan generator CLI → bridge CLI → post-closeout readiness E2E v0.
+
+Proves: transition fixture → plan generator CLI → bridge CLI → readiness artifacts,
+with fail-closed blocked and malformed-plan paths. Visibility-only; does not invoke
+runtime, network, closeout, copy, verify, retention, projection, Notion, or hooks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops import bridge_control_plane_plan_to_post_closeout_readiness_v0 as bridge_mod
+from scripts.ops import build_autonomous_ops_control_plane_plan_v0 as plan_mod
+from tests.ops.test_control_plane_plan_output_closeout_projection_bridge_contract_v0 import (
+    FORBIDDEN_FIXTURE,
+    LEGAL_FIXTURE,
+    REQUIRED_MACHINE_LINE_ASSERTIONS,
+    _make_plan,
+    _run_bridge,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THIS_MODULE = Path(__file__)
+
+E2E_OWNER_REFERENCES_V0: tuple[str, ...] = (
+    "scripts/ops/build_autonomous_ops_control_plane_plan_v0.py",
+    "scripts/ops/bridge_control_plane_plan_to_post_closeout_readiness_v0.py",
+    "tests/ops/test_control_plane_plan_output_closeout_projection_bridge_contract_v0.py",
+    "tests/ops/test_control_plane_post_closeout_automation_readiness_contracts_v0.py",
+    "tests/ops/test_control_plane_plan_bridge_readiness_cli_e2e_contract_v0.py",
+)
+
+_FORBIDDEN_SIDE_EFFECT_NAMES: tuple[str, ...] = (
+    "MANIFEST.sha256",
+    "MANIFEST_VERIFY.log",
+    "FINAL_MACHINE_LINES.txt",
+)
+
+_FORBIDDEN_SOURCE_PATTERNS: tuple[str, ...] = (
+    "import subprocess",
+    "from subprocess",
+    "subprocess.run",
+    "subprocess.Popen",
+    "os.system",
+    "import boto3",
+    "import paramiko",
+    "import requests",
+    "import urllib",
+    "import socket",
+    "run_scheduler",
+    "launchctl",
+    'add_argument("--execute"',
+    "add_argument('--execute'",
+    'add_argument("--copy"',
+    'add_argument("--verify"',
+    'add_argument("--retention"',
+    'add_argument("--closeout"',
+    'add_argument("--projection"',
+    'add_argument("--notion-sync"',
+    'add_argument("--upload"',
+    'add_argument("--s3"',
+    'add_argument("--ssh"',
+    'add_argument("--start"',
+    "durable_closeout_copy_verify_v0.main(",
+    "build_post_closeout_projection_payload_v0.main(",
+    "notion_post_closeout_sync_dry_run_v0.main(",
+    "primary_evidence_retention_v0.main(",
+    "write_manifest_sha256(",
+)
+
+
+def _this_module_source() -> str:
+    return THIS_MODULE.read_text(encoding="utf-8")
+
+
+def _assert_readiness_artifacts_exist(readiness_dir: Path) -> None:
+    assert (readiness_dir / bridge_mod.READINESS_JSON_FILENAME).is_file()
+    assert (readiness_dir / bridge_mod.READINESS_MACHINE_LINES_FILENAME).is_file()
+    assert (readiness_dir / bridge_mod.READINESS_MD_FILENAME).is_file()
+
+
+def _assert_no_side_effect_artifacts(root: Path) -> None:
+    for name in _FORBIDDEN_SIDE_EFFECT_NAMES:
+        assert not list(root.rglob(name)), f"unexpected side-effect artifact: {name}"
+
+
+def _assert_non_authorizing_readiness(readiness: dict) -> None:
+    assert readiness["planning_only"] is True
+    assert readiness["closeout_invoke_authorized"] is False
+    assert readiness["projection_invoke_authorized"] is False
+    assert readiness["notion_sync_authorized"] is False
+    assert readiness["durable_copy_authorized"] is False
+    assert readiness["primary_evidence_retention_invoke_authorized"] is False
+
+
+def test_ready_e2e_plan_generator_cli_to_bridge_readiness_cli_v0(tmp_path: Path) -> None:
+    plan_dir = tmp_path / "plan"
+    readiness_dir = tmp_path / "readiness"
+    plan_dir.mkdir()
+    readiness_dir.mkdir()
+
+    assert plan_mod.main(["--fixture", str(LEGAL_FIXTURE), "--outdir", str(plan_dir)]) == 0
+    plan_json = plan_dir / plan_mod.PLAN_JSON_FILENAME
+    assert plan_json.is_file()
+
+    assert _run_bridge(plan_json, readiness_dir) == 0
+    _assert_readiness_artifacts_exist(readiness_dir)
+
+    readiness = json.loads(
+        (readiness_dir / bridge_mod.READINESS_JSON_FILENAME).read_text(encoding="utf-8"),
+    )
+    assert readiness["schema_version"] == bridge_mod.SCHEMA_VERSION
+    assert readiness["control_plane_plan_status"] == "plan_only"
+    assert (
+        readiness["machine_lines"]["CONTROL_PLANE_POST_CLOSEOUT_READINESS_STATUS"]
+        == "ready_for_projection_planning"
+    )
+    assert readiness["readiness"]["can_prepare_post_closeout_projection_payload"] is True
+    _assert_non_authorizing_readiness(readiness)
+
+    machine_lines_text = (readiness_dir / bridge_mod.READINESS_MACHINE_LINES_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    for assertion in REQUIRED_MACHINE_LINE_ASSERTIONS:
+        assert assertion in machine_lines_text
+
+    md_text = (readiness_dir / bridge_mod.READINESS_MD_FILENAME).read_text(encoding="utf-8")
+    assert "planning" in md_text.lower() or "readiness" in md_text.lower()
+
+    _assert_no_side_effect_artifacts(tmp_path)
+
+
+def test_blocked_forbidden_fixture_bridge_readiness_remains_non_authorizing_v0(
+    tmp_path: Path,
+) -> None:
+    readiness_dir = tmp_path / "readiness_blocked"
+    readiness_dir.mkdir()
+    plan_json = _make_plan(tmp_path, FORBIDDEN_FIXTURE)
+
+    assert _run_bridge(plan_json, readiness_dir) == 0
+    _assert_readiness_artifacts_exist(readiness_dir)
+
+    readiness = json.loads(
+        (readiness_dir / bridge_mod.READINESS_JSON_FILENAME).read_text(encoding="utf-8"),
+    )
+    assert readiness["control_plane_plan_status"] == "blocked"
+    assert readiness["machine_lines"]["CONTROL_PLANE_POST_CLOSEOUT_READINESS_STATUS"] == "blocked"
+    assert readiness["readiness"]["can_prepare_post_closeout_projection_payload"] is False
+    _assert_non_authorizing_readiness(readiness)
+
+    machine_lines_text = (readiness_dir / bridge_mod.READINESS_MACHINE_LINES_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    assert "CLOSEOUT_INVOKE_AUTHORIZED=false" in machine_lines_text
+    assert "PROJECTION_INVOKE_AUTHORIZED=false" in machine_lines_text
+
+    _assert_no_side_effect_artifacts(tmp_path)
+
+
+def test_bridge_exits_2_on_malformed_plan_json_without_readiness_v0(tmp_path: Path) -> None:
+    plan_path = tmp_path / "malformed_plan.json"
+    plan_path.write_text("{not-json\n", encoding="utf-8")
+    readiness_dir = tmp_path / "readiness_malformed"
+    readiness_dir.mkdir()
+
+    rc = bridge_mod.main(["--plan", str(plan_path), "--outdir", str(readiness_dir)])
+    assert rc == 2
+    assert not (readiness_dir / bridge_mod.READINESS_JSON_FILENAME).exists()
+    assert not (readiness_dir / bridge_mod.READINESS_MACHINE_LINES_FILENAME).exists()
+    assert not (readiness_dir / bridge_mod.READINESS_MD_FILENAME).exists()
+    _assert_no_side_effect_artifacts(tmp_path)
+
+
+@pytest.mark.parametrize("owner_rel", E2E_OWNER_REFERENCES_V0)
+def test_e2e_owner_references_exist_v0(owner_rel: str) -> None:
+    assert (REPO_ROOT / owner_rel).is_file(), f"missing E2E owner reference: {owner_rel}"
+
+
+def test_e2e_module_documents_plan_bridge_readiness_path_v0() -> None:
+    text = _this_module_source()
+    assert "plan generator CLI" in text
+    assert "bridge CLI" in text
+    assert "post-closeout readiness" in text
+    assert "plan→bridge→readiness" in text or "plan generator CLI → bridge CLI" in text
+
+
+def test_e2e_module_has_no_forbidden_runtime_or_invoke_patterns_v0() -> None:
+    in_forbidden_tuple = False
+    for line in _this_module_source().splitlines():
+        if "_FORBIDDEN_SOURCE_PATTERNS" in line:
+            in_forbidden_tuple = True
+            continue
+        if in_forbidden_tuple:
+            if line.strip().startswith(")"):
+                in_forbidden_tuple = False
+            continue
+        stripped = line.strip()
+        if stripped.startswith("assert ") and " not in " in stripped:
+            continue
+        for pattern in _FORBIDDEN_SOURCE_PATTERNS:
+            assert pattern not in line, (
+                f"forbidden pattern in E2E contract test source: {pattern!r} line={line!r}"
+            )


### PR DESCRIPTION
## Summary

Adds CONTROL_PLANE_PLAN_BRIDGE_READINESS_CLI_E2E_VISIBILITY_V0 as a tests-only Control-Plane visibility slice.

- adds a dedicated plan → bridge → post-closeout readiness CLI E2E contract
- verifies legal fixture plan generation flows into bridge readiness output
- verifies all three readiness artifacts are produced for the legal path
- verifies blocked forbidden fixture remains non-authorizing
- verifies malformed plan JSON exits fail-closed and produces no readiness artifacts
- verifies owner references exist
- verifies no runtime / invoke / closeout side-effect patterns
- adds no execute path and changes no script behavior

## Scope

Touched exactly one new test file:

- `tests/ops/test_control_plane_plan_bridge_readiness_cli_e2e_contract_v0.py`

No docs, scripts, source, runtime, dashboard, or evidence files were changed.

## Safety / Boundaries

- Runtime started: false
- AWS/IAM/S3 mutation: false
- Notion mutation: false
- Market Dashboard changed: false
- Master V2 / Double Play changed: false
- Trading logic changed: false
- Strategy runtime changed: false
- Futures runtime changed: false
- Paper test data changed: false
- Closed remote lifecycle reopened: false
- Control-Plane execute path added: false
- Hook implementation added: false
- R-001/R-002/R-007 mapping changed: false
- INPUT_JSONL_PROVIDED remains false
- New parallel surface created: false

## Validation

- `uv run pytest tests/ops/test_control_plane_plan_output_closeout_projection_bridge_contract_v0.py tests/ops/test_control_plane_plan_bridge_readiness_cli_e2e_contract_v0.py -q`
- `uv run pytest tests/ops/test_control_plane_post_closeout_automation_readiness_contracts_v0.py -q`
- `uv run pytest tests/ops/test_control_plane_planner_and_hook_summary_cli_e2e_contract_v0.py -q`
- `uv run ruff check tests/ops/test_control_plane_plan_bridge_readiness_cli_e2e_contract_v0.py`
- `uv run ruff format --check tests/ops/test_control_plane_plan_bridge_readiness_cli_e2e_contract_v0.py`

## Machine Lines

CONTROL_PLANE_PLAN_BRIDGE_READINESS_CLI_E2E_VISIBILITY_V0_DONE=true
FILES_TOUCHED=tests/ops/test_control_plane_plan_bridge_readiness_cli_e2e_contract_v0.py
DOCS_CHANGED=false
TESTS_PASSED=true
RUFF_PASSED=true
INPUT_JSONL_PROVIDED=false
R001_R002_R007_MAPPING_CHANGED=false
RUNTIME_STARTED=false
AWS_MUTATION_USED=false
IAM_MUTATION_USED=false
S3_UPLOAD_USED=false
NOTION_MUTATION_USED=false
MARKET_DASHBOARD_CHANGED=false
MASTER_V2_DOUBLE_PLAY_CHANGED=false
TRADING_LOGIC_CHANGED=false
STRATEGY_RUNTIME_CHANGED=false
FUTURES_RUNTIME_CHANGED=false
PAPER_TEST_DATA_CHANGED=false
CLOSED_REMOTE_LIFECYCLE_REOPENED=false
CONTROL_PLANE_EXECUTE_PATH_ADDED=false
NEW_PARALLEL_SURFACE_CREATED=false

Made with [Cursor](https://cursor.com)