### PR TITLE
docs: add section5 preflight gap owner map contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -1,0 +1,67 @@
+# Section 5 Preflight Gap Owner Map Contract v0
+
+## Status
+
+SECTION5_OWNER_MAP_CONTRACT_V0=true
+SECTION5_GAP_CLOSURE_EXECUTED=false
+ALL_GAPS_CLOSED=false
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+
+This document is a reuse-first owner-map contract for the §5 preflight gap-closure arc. It does not close any gap by itself and does not authorize preflight lift, operator arming, runtime approval, Paper, Shadow, Testnet, Live, AWS mutation, Notion write, broker/exchange interaction, or scheduler/supervisor/daemon/background processes.
+
+## Upstream Evidence
+
+- RUN_ID: `level3_bounded_dry_run_go_charter_20260530T190916Z`
+- Execution charter dir: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/level3_bounded_dry_run_go_charter_20260530T190916Z_section5_gap_closure_execution_charter_only_20260530T193112Z`
+- Execution charter SHA256: `28d524d0ff1f997860cd736ccff2c181ceceea4101ecb30e6acfff75d1045834`
+
+## Reuse-First Canonical Owner Table
+
+| Gap | Status | Canonical owner to reuse first | Follow-up shape |
+|---|---:|---|---|
+| Execute entrypoint | OPEN | `scripts/run_scheduler.py` plus scheduler/runbook contracts | Add/verify explicit bounded dry-run and non-runtime-start contracts before any lift discussion |
+| Canonical job set | OPEN | `config/scheduler/jobs.toml` plus scheduler tests | Define which jobs are in-scope for bounded non-authorizing checks |
+| Execute command contracts | OPEN | scheduler CLI tests and existing ops runbooks | Lock exact `--dry-run --once` command contract and forbid implicit long-running commands |
+| Output/evidence paths | OPEN | durable evidence archive/run-root docs and closeout helpers | Require durable outside-`/tmp` primary evidence, manifest, and manifest verification |
+| Risk boundaries | OPEN | existing Risk/KillSwitch, Execution/Live Gate, and operator boundary docs | Preserve no-live/no-broker/no-exchange/no-AWS-mutation defaults |
+| Primary-evidence enforcement | OPEN | durable primary evidence review gate and closeout conventions | Convert evidence retention from convention to checked invariant where appropriate |
+| §2a.1 prerequisites | OPEN/PARTIAL | existing readiness/preflight/runbook surfaces | Map prerequisite fields to existing owner docs before implementation |
+| Stop/rehearsal and dry-run proof | PARTIAL | bounded dry-run evidence chain and stop/incident owner docs | Determine whether Type-1 rehearsal + bounded dry-run RC=0 is sufficient or what remains |
+
+## Required Reuse/Drift Guard
+
+Any follow-up that edits docs must consider the existing docs truth map / drift guard / token policy / reference checks before adding new surfaces. Prefer extending existing canonical owners over adding parallel documents.
+
+## Protected Boundaries
+
+- Do not lift preflight.
+- Do not mark `READY_FOR_OPERATOR_ARMING=true`.
+- Do not approve runtime.
+- Do not start Paper, Shadow, Testnet, Live, Scheduler, Supervisor, daemon, broker, exchange, AWS, or background processes.
+- Do not mutate AWS, Notion, broker, exchange, paper test data, dashboard authority, Master V2 / Double Play, Risk/KillSwitch, Scope/Capital, or Execution/Live Gates.
+
+## Final Machine Lines
+
+SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true
+SECTION5_GAP_CLOSURE_EXECUTED=false
+ALL_GAPS_CLOSED=false
+PATH_B_LIFT_DISCUSSION_READY=false
+ACTUAL_PREFLIGHT_LIFT_EXECUTED=false
+PREFLIGHT_LIFT_EXECUTED=false
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+RUNTIME_STARTED=false
+PAPER_STARTED=false
+SHADOW_STARTED=false
+TESTNET_STARTED=false
+LIVE_STARTED=false
+AWS_MUTATION_USED=false
+NOTION_WRITE_USED=false
+PARALLEL_DOCS_CREATED=false
+REUSE_BEFORE_NEW_CHECKED=true
+REUSE_DRIFT_GUARD_CHECKED=true
+PREFLIGHT_REMAINS_BLOCKED=true
+STOP_IDLE_PRESERVED=true

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+
+
+def test_section5_owner_map_contract_exists_and_is_non_authorizing():
+    text = DOC.read_text(encoding="utf-8")
+
+    required = [
+        "SECTION5_OWNER_MAP_CONTRACT_V0=true",
+        "SECTION5_GAP_CLOSURE_EXECUTED=false",
+        "ALL_GAPS_CLOSED=false",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "READY_FOR_OPERATOR_ARMING=false",
+        "RUNTIME_APPROVED=false",
+        "PREFLIGHT_LIFT_EXECUTED=false",
+    ]
+
+    for marker in required:
+        assert marker in text
+
+
+def test_section5_owner_map_contract_covers_all_gap_targets():
+    text = DOC.read_text(encoding="utf-8")
+
+    required_gaps = [
+        "Execute entrypoint",
+        "Canonical job set",
+        "Execute command contracts",
+        "Output/evidence paths",
+        "Risk boundaries",
+        "Primary-evidence enforcement",
+        "§2a.1 prerequisites",
+        "Stop/rehearsal and dry-run proof",
+    ]
+
+    for gap in required_gaps:
+        assert gap in text
+
+
+def test_section5_owner_map_contract_reuse_first_and_no_parallel_docs():
+    text = DOC.read_text(encoding="utf-8")
+
+    required = [
+        "reuse-first",
+        "Canonical owner to reuse first",
+        "Prefer extending existing canonical owners over adding parallel documents",
+        "Do not lift preflight",
+        "Do not mark `READY_FOR_OPERATOR_ARMING=true`",
+        "Do not approve runtime",
+    ]
+
+    for marker in required:
+        assert marker in text


### PR DESCRIPTION
## Summary

Adds a reuse-first §5 preflight gap owner-map contract and a focused static contract test.

## Scope

- Adds canonical owner mapping for the 8 §5 preflight gap targets.
- Adds non-authorizing contract tests for the owner-map document.
- Keeps all governance blocked.

## Validation

- `uv run pytest tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py`
- `uv run ruff check tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py`
- `bash scripts/ops/verify_docs_reference_targets.sh`

## Governance

- No preflight lift.
- No READY_FOR_OPERATOR_ARMING.
- No runtime approval.
- No Paper/Shadow/Testnet/Live start.
- No AWS/Notion/broker/exchange mutation.
- No Master V2 / Double Play change.
- No Risk/KillSwitch, Scope/Capital, or Execution/Live Gate change.
- Reuse-before-new preserved.
- No parallel docs intended.

Made with [Cursor](https://cursor.com)