### PR TITLE
ops: add primary evidence enforcement contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -43,6 +43,42 @@ Any follow-up that edits docs must consider the existing docs truth map / drift 
 - Do not start Paper, Shadow, Testnet, Live, Scheduler, Supervisor, daemon, broker, exchange, AWS, or background processes.
 - Do not mutate AWS, Notion, broker, exchange, paper test data, dashboard authority, Master V2 / Double Play, Risk/KillSwitch, Scope/Capital, or Execution/Live Gates.
 
+
+
+## §2a.1 Primary Evidence Enforcement Contract v0
+
+GAP2A1_PRIMARY_EVIDENCE_ENFORCEMENT_CONTRACT_V0=true
+GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false
+GAP2A1_ENFORCEMENT_DEFAULT_ON=false
+GAP2A1_ENFORCEMENT_OPT_IN_ONLY=true
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+
+This contract records the primary-evidence enforcement posture for future run-like actions. It is intentionally non-authorizing and opt-in only.
+
+### Reuse-first owner surfaces
+
+- `scripts/ops/primary_evidence_retention_v0.py`
+- `scripts/ops/durable_closeout_copy_verify_v0.py`
+- `scripts/run_scheduler.py`
+- `tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py`
+- existing preflight contract §2a/§2a.1 surfaces
+- existing docs truth map / reference / token-policy checks
+
+### Enforcement tiers
+
+| Tier | Contract |
+|---|---|
+| Archive planning | durable manifest + verification already expected |
+| Bounded dry-run | manifest + closeout required; enforcement remains optional |
+| Non-dry-run execute | explicit operator GO + durable root + opt-in enforce flag required |
+
+### Non-authorization
+
+This contract does not enable default enforcement, does not lift preflight, does not approve runtime, does not start Paper/Shadow/Testnet/Live, and does not mutate AWS/Notion/broker/exchange surfaces.
+
 ## Final Machine Lines
 
 SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true
@@ -65,3 +101,7 @@ REUSE_BEFORE_NEW_CHECKED=true
 REUSE_DRIFT_GUARD_CHECKED=true
 PREFLIGHT_REMAINS_BLOCKED=true
 STOP_IDLE_PRESERVED=true
+GAP2A1_PRIMARY_EVIDENCE_ENFORCEMENT_CONTRACT_V0=true
+GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false
+GAP2A1_ENFORCEMENT_DEFAULT_ON=false
+GAP2A1_ENFORCEMENT_OPT_IN_ONLY=true

--- a/tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py
+++ b/tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+
+
+def test_gap2a1_primary_evidence_enforcement_contract_is_present_and_non_authorizing():
+    text = DOC.read_text(encoding="utf-8")
+
+    required = [
+        "GAP2A1_PRIMARY_EVIDENCE_ENFORCEMENT_CONTRACT_V0=true",
+        "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false",
+        "GAP2A1_ENFORCEMENT_DEFAULT_ON=false",
+        "GAP2A1_ENFORCEMENT_OPT_IN_ONLY=true",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "READY_FOR_OPERATOR_ARMING=false",
+        "RUNTIME_APPROVED=false",
+    ]
+
+    for marker in required:
+        assert marker in text
+
+
+def test_gap2a1_primary_evidence_enforcement_contract_reuses_existing_surfaces():
+    text = DOC.read_text(encoding="utf-8")
+
+    required_surfaces = [
+        "scripts/ops/primary_evidence_retention_v0.py",
+        "scripts/ops/durable_closeout_copy_verify_v0.py",
+        "scripts/run_scheduler.py",
+        "tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py",
+    ]
+
+    for surface in required_surfaces:
+        assert surface in text
+
+
+def test_gap2a1_primary_evidence_enforcement_contract_is_not_default_on():
+    text = DOC.read_text(encoding="utf-8")
+    section = text.split("## §2a.1 Primary Evidence Enforcement Contract v0", 1)[1].split(
+        "## Final Machine Lines", 1
+    )[0]
+
+    forbidden = [
+        "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true",
+        "GAP2A1_ENFORCEMENT_DEFAULT_ON=true",
+    ]
+
+    for marker in forbidden:
+        assert marker not in section


### PR DESCRIPTION
## Summary

Docs/tests-only contract slice for §2a.1 Primary Evidence Enforcement on the existing canonical owner-map surface (`SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`). Reuse-first update only — no parallel docs or duplicate owner surfaces.

## Boundaries

- **No runtime started**
- **No scheduler started**
- **No AWS / broker / exchange touched**
- **No default-on enforcement** (`GAP2A1_ENFORCEMENT_DEFAULT_ON=false`, opt-in only)
- **Preflight remains blocked** (`PREFLIGHT_REMAINS_BLOCKED=true`)
- Reuse-first owner-map update only; no parallel documentation

## Changed files

- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md` — §2a.1 enforcement contract section
- `tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py` — static contract tests

## Validation commands and results

| Command | Result |
|---|---|
| `uv run pytest tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py` | 6 passed |
| `uv run pytest tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py::test_section_2a1_reuses_shared_helper_not_parallel_doc` | 1 passed |
| `uv run ruff check tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py` | All checks passed |
| `DocsTokenPolicyValidator.scan_file(owner_map)` | 0 violations |
| `bash scripts/ops/verify_docs_reference_targets.sh` | All referenced targets exist |
| `python3 scripts/ops/check_docs_drift_guard.py --base origin/main` | OK (2 changed files) |

## Test plan

- [ ] CI green on contract + owner-map tests
- [ ] Review §2a.1 truth markers remain non-authorizing

Made with [Cursor](https://cursor.com)