### PR TITLE
ops: add gap4 output evidence paths contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -79,6 +79,37 @@ This contract records the primary-evidence enforcement posture for future run-li
 
 This contract does not enable default enforcement, does not lift preflight, does not approve runtime, does not start Paper/Shadow/Testnet/Live, and does not mutate AWS/Notion/broker/exchange surfaces.
 
+## Gap 4 Output/Evidence Paths Contract v0
+
+GAP4_OUTPUT_EVIDENCE_PATHS_CONTRACT_V0=true
+GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false
+GAP4_OUTPUT_EVIDENCE_DEFAULT_ON=false
+GAP4_OUTPUT_EVIDENCE_OPT_IN_ONLY=true
+GAP4_DURABLE_OUTPUT_REQUIRED_FOR_FUTURE_RUNS=true
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+
+This is a docs/tests-only contract. It records the durable output/evidence path posture for future run-like actions. Current status remains contract-only, not verified, and not enforcement-on.
+
+### Reuse-first owner surfaces
+
+- `scripts/ops/primary_evidence_retention_v0.py`
+- `scripts/ops/durable_closeout_copy_verify_v0.py`
+- `scripts/run_scheduler.py`
+- `tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py`
+- existing preflight contract §2a/§2a.1 surfaces
+- existing docs truth map / reference / token-policy checks
+
+### Durable output contract
+
+Future runs are not considered complete unless primary evidence artifacts are durable, archived outside `/tmp`, checksummed, verified, and available for later use. This contract reuses existing durable evidence and closeout surfaces instead of creating parallel docs.
+
+### Non-authorization
+
+This contract does not authorize runtime, scheduler, Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
+
 ## Final Machine Lines
 
 SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true
@@ -105,3 +136,8 @@ GAP2A1_PRIMARY_EVIDENCE_ENFORCEMENT_CONTRACT_V0=true
 GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false
 GAP2A1_ENFORCEMENT_DEFAULT_ON=false
 GAP2A1_ENFORCEMENT_OPT_IN_ONLY=true
+GAP4_OUTPUT_EVIDENCE_PATHS_CONTRACT_V0=true
+GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false
+GAP4_OUTPUT_EVIDENCE_DEFAULT_ON=false
+GAP4_OUTPUT_EVIDENCE_OPT_IN_ONLY=true
+GAP4_DURABLE_OUTPUT_REQUIRED_FOR_FUTURE_RUNS=true

--- a/tests/ops/test_gap4_output_evidence_paths_contract_v0.py
+++ b/tests/ops/test_gap4_output_evidence_paths_contract_v0.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+GAP4_SECTION_HEADER = "## Gap 4 Output/Evidence Paths Contract v0"
+GAP4_PARALLEL_MARKERS = (
+    "GAP4_OUTPUT_EVIDENCE_PATHS_CONTRACT_V0=true",
+    "Gap 4 Output/Evidence Paths Contract v0",
+)
+
+
+def _gap4_section(text: str) -> str:
+    return text.split(GAP4_SECTION_HEADER, 1)[1].split("## Final Machine Lines", 1)[0]
+
+
+def test_gap4_output_evidence_paths_contract_is_present_and_non_authorizing():
+    section = _gap4_section(DOC.read_text(encoding="utf-8"))
+
+    required = [
+        "GAP4_OUTPUT_EVIDENCE_PATHS_CONTRACT_V0=true",
+        "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false",
+        "GAP4_OUTPUT_EVIDENCE_DEFAULT_ON=false",
+        "GAP4_OUTPUT_EVIDENCE_OPT_IN_ONLY=true",
+        "GAP4_DURABLE_OUTPUT_REQUIRED_FOR_FUTURE_RUNS=true",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+    ]
+
+    for marker in required:
+        assert marker in section
+
+
+def test_gap4_output_evidence_paths_contract_reuses_existing_surfaces():
+    section = _gap4_section(DOC.read_text(encoding="utf-8"))
+
+    required_surfaces = [
+        "primary_evidence_retention_v0.py",
+        "durable_closeout_copy_verify_v0.py",
+        "run_scheduler.py",
+    ]
+
+    for surface in required_surfaces:
+        assert surface in section
+
+
+def test_gap4_output_evidence_paths_contract_is_not_default_on_or_lifted():
+    section = _gap4_section(DOC.read_text(encoding="utf-8"))
+    lines = {line.strip() for line in section.splitlines()}
+
+    forbidden = [
+        "READY_FOR_OPERATOR_ARMING=true",
+        "PATH_B_LIFT_DISCUSSION_READY=true",
+        "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
+        "GAP4_OUTPUT_EVIDENCE_DEFAULT_ON=true",
+    ]
+
+    for marker in forbidden:
+        assert marker not in lines
+
+
+def test_gap4_output_evidence_paths_contract_has_no_parallel_doc_surface():
+    owner_map = DOC.resolve()
+    parallel_docs: list[Path] = []
+
+    for path in (ROOT / "docs").rglob("*.md"):
+        if path.resolve() == owner_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in GAP4_PARALLEL_MARKERS):
+            parallel_docs.append(path.relative_to(ROOT))
+
+    assert parallel_docs == []


### PR DESCRIPTION
## Summary

Docs/tests-only contract slice for §5 Gap 4 Output/Evidence Paths on the existing canonical owner-map surface. Reuse-first update only — no parallel docs.

## Intended files only

- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap4_output_evidence_paths_contract_v0.py`

## Boundaries

- **No runtime / scheduler / paper / shadow / testnet / live started**
- **No AWS / broker / exchange touched**
- **No default-on enforcement** (`GAP4_OUTPUT_EVIDENCE_DEFAULT_ON=false`, opt-in only)
- **No Path-B lift** (`PATH_B_LIFT_DISCUSSION_READY=false`)
- **`READY_FOR_OPERATOR_ARMING` remains false / not granted**
- **Preflight remains blocked** (`PREFLIGHT_REMAINS_BLOCKED=true`)
- Reuse-before-new applied; no parallel documentation

## Validation commands and results

| Command | Result |
|---|---|
| `uv run pytest tests/ops/test_gap4_output_evidence_paths_contract_v0.py tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py` | 10 passed |
| `uv run ruff check tests/ops/test_gap4_output_evidence_paths_contract_v0.py` | All checks passed |
| `DocsTokenPolicyValidator.scan_file(owner_map)` | 0 violations |
| `bash scripts/ops/verify_docs_reference_targets.sh` | All referenced targets exist |
| `python3 scripts/ops/check_docs_drift_guard.py --base origin/main` | OK (2 changed files) |

## Test plan

- [ ] CI green on contract + owner-map tests
- [ ] Review Gap 4 truth markers remain non-authorizing

Made with [Cursor](https://cursor.com)