### PR TITLE
ops: add gap3 execute command contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -79,6 +79,39 @@ This contract records the primary-evidence enforcement posture for future run-li
 
 This contract does not enable default enforcement, does not lift preflight, does not approve runtime, does not start Paper/Shadow/Testnet/Live, and does not mutate AWS/Notion/broker/exchange surfaces.
 
+## Gap 3 Execute Command Contract v0
+
+GAP3_EXECUTE_COMMAND_CONTRACT_V0=true
+GAP3_EXECUTE_COMMAND_VERIFIED=false
+GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP3_EXECUTE_COMMAND_DEFAULT_ON=false
+GAP3_EXECUTE_COMMAND_DRY_RUN_ONLY=true
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+
+This is a docs/tests-only command contract. It records the canonical bounded dry-run execute-command posture for future planning. Current status remains contract-only, not verified, and not execution-authorized.
+
+### Canonical bounded dry-run command (text only; not executed in this PR)
+
+`uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose`
+
+The canonical command is documentation/planning text only in this contract slice. This PR does not execute the scheduler, does not authorize scheduler execution, and does not enable `config/scheduler/jobs.toml`.
+
+### Reuse-first owner surfaces
+
+- `scripts/run_scheduler.py`
+- `config/scheduler/jobs.toml`
+- `scripts/ops/primary_evidence_retention_v0.py`
+- `scripts/ops/durable_closeout_copy_verify_v0.py`
+- existing scheduler CLI tests and ops runbooks
+- existing docs truth map / reference / token-policy checks
+
+### Non-authorization
+
+This PR does not authorize runtime, Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
+
 ## Gap 4 Output/Evidence Paths Contract v0
 
 GAP4_OUTPUT_EVIDENCE_PATHS_CONTRACT_V0=true
@@ -141,3 +174,8 @@ GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false
 GAP4_OUTPUT_EVIDENCE_DEFAULT_ON=false
 GAP4_OUTPUT_EVIDENCE_OPT_IN_ONLY=true
 GAP4_DURABLE_OUTPUT_REQUIRED_FOR_FUTURE_RUNS=true
+GAP3_EXECUTE_COMMAND_CONTRACT_V0=true
+GAP3_EXECUTE_COMMAND_VERIFIED=false
+GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP3_EXECUTE_COMMAND_DEFAULT_ON=false
+GAP3_EXECUTE_COMMAND_DRY_RUN_ONLY=true

--- a/tests/ops/test_gap3_execute_command_contract_v0.py
+++ b/tests/ops/test_gap3_execute_command_contract_v0.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+GAP3_SECTION_HEADER = "## Gap 3 Execute Command Contract v0"
+CANONICAL_COMMAND = (
+    "uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml "
+    "--dry-run --once --verbose"
+)
+GAP3_PARALLEL_MARKERS = (
+    "GAP3_EXECUTE_COMMAND_CONTRACT_V0=true",
+    "Gap 3 Execute Command Contract v0",
+)
+
+
+def _gap3_section(text: str) -> str:
+    return text.split(GAP3_SECTION_HEADER, 1)[1].split("## Gap 4 Output/Evidence Paths Contract v0", 1)[0]
+
+
+def test_gap3_execute_command_contract_is_present_and_non_authorizing():
+    section = _gap3_section(DOC.read_text(encoding="utf-8"))
+
+    required = [
+        "GAP3_EXECUTE_COMMAND_CONTRACT_V0=true",
+        "GAP3_EXECUTE_COMMAND_VERIFIED=false",
+        "GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false",
+        "GAP3_EXECUTE_COMMAND_DEFAULT_ON=false",
+        "GAP3_EXECUTE_COMMAND_DRY_RUN_ONLY=true",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+    ]
+
+    for marker in required:
+        assert marker in section
+
+
+def test_gap3_execute_command_contract_contains_canonical_bounded_command():
+    section = _gap3_section(DOC.read_text(encoding="utf-8"))
+    assert CANONICAL_COMMAND in section
+
+
+def test_gap3_execute_command_contract_reuses_existing_surfaces():
+    section = _gap3_section(DOC.read_text(encoding="utf-8"))
+
+    required_surfaces = [
+        "scripts/run_scheduler.py",
+        "config/scheduler/jobs.toml",
+        "primary_evidence_retention_v0.py",
+        "durable_closeout_copy_verify_v0.py",
+    ]
+
+    for surface in required_surfaces:
+        assert surface in section
+
+
+def test_gap3_execute_command_contract_is_not_execution_authorized_or_lifted():
+    section = _gap3_section(DOC.read_text(encoding="utf-8"))
+    lines = {line.strip() for line in section.splitlines()}
+
+    forbidden = [
+        "READY_FOR_OPERATOR_ARMING=true",
+        "PATH_B_LIFT_DISCUSSION_READY=true",
+        "GAP3_EXECUTE_COMMAND_VERIFIED=true",
+        "GAP3_SCHEDULER_EXECUTION_AUTHORIZED=true",
+        "GAP3_EXECUTE_COMMAND_DEFAULT_ON=true",
+    ]
+
+    for marker in forbidden:
+        assert marker not in lines
+
+
+def test_gap3_execute_command_contract_has_no_parallel_doc_surface():
+    owner_map = DOC.resolve()
+    parallel_docs: list[Path] = []
+
+    for path in (ROOT / "docs").rglob("*.md"):
+        if path.resolve() == owner_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in GAP3_PARALLEL_MARKERS):
+            parallel_docs.append(path.relative_to(ROOT))
+
+    assert parallel_docs == []

--- a/tests/ops/test_gap3_execute_command_contract_v0.py
+++ b/tests/ops/test_gap3_execute_command_contract_v0.py
@@ -15,7 +15,9 @@ GAP3_PARALLEL_MARKERS = (
 
 
 def _gap3_section(text: str) -> str:
-    return text.split(GAP3_SECTION_HEADER, 1)[1].split("## Gap 4 Output/Evidence Paths Contract v0", 1)[0]
+    return text.split(GAP3_SECTION_HEADER, 1)[1].split(
+        "## Gap 4 Output/Evidence Paths Contract v0", 1
+    )[0]
 
 
 def test_gap3_execute_command_contract_is_present_and_non_authorizing():


### PR DESCRIPTION
## Summary

Docs/tests-only contract slice for §5 Gap 3 Execute Command on the existing canonical owner-map surface. Reuse-first update only — no parallel docs.

## Intended files only

- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap3_execute_command_contract_v0.py`

## Boundaries

- **Canonical command is text-only and was not executed**
- **No scheduler execution**
- **No runtime / paper / shadow / testnet / live started**
- **No AWS / broker / exchange touched**
- **No jobs.toml enablement or modification**
- **No default-on enforcement** (`GAP3_EXECUTE_COMMAND_DEFAULT_ON=false`)
- **No Path-B lift** (`PATH_B_LIFT_DISCUSSION_READY=false`)
- **`READY_FOR_OPERATOR_ARMING` remains false / not granted**
- **Preflight remains blocked** (`PREFLIGHT_REMAINS_BLOCKED=true`)
- Reuse-before-new applied; no parallel documentation

## Canonical command (declared only)

`uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose`

## Validation commands and results

| Command | Result |
|---|---|
| `uv run pytest tests/ops/test_gap3_execute_command_contract_v0.py tests/ops/test_gap4_output_evidence_paths_contract_v0.py tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py` | 15 passed |
| `uv run ruff check tests/ops/test_gap3_execute_command_contract_v0.py` | All checks passed |
| `DocsTokenPolicyValidator.scan_file(owner_map)` | 0 violations |
| `bash scripts/ops/verify_docs_reference_targets.sh` | All referenced targets exist |
| `python3 scripts/ops/check_docs_drift_guard.py --base origin/main` | OK (2 changed files) |

## Test plan

- [ ] CI green on contract + owner-map tests
- [ ] Review Gap 3 truth markers remain non-authorizing

Made with [Cursor](https://cursor.com)