### PR TITLE
ops: add gap1 execute entrypoint contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -79,6 +79,35 @@ This contract records the primary-evidence enforcement posture for future run-li
 
 This contract does not enable default enforcement, does not lift preflight, does not approve runtime, does not start Paper/Shadow/Testnet/Live, and does not mutate AWS/Notion/broker/exchange surfaces.
 
+## Gap 1 Execute Entrypoint Contract v0
+
+GAP1_EXECUTE_ENTRYPOINT_CONTRACT_V0=true
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false
+GAP1_RUNTIME_APPROVED=false
+GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false
+GAP1_ENTRYPOINT_DRY_RUN_ONLY=true
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+
+This is a docs/tests-only entrypoint contract. It identifies `scripts/run_scheduler.py` as the bounded scheduler entrypoint under contract. Current status remains contract-only, not verified, not runtime-approved, and not scheduler-authorized.
+
+Gap 3 remains the canonical command-text contract; Gap 1 only identifies the entrypoint boundary.
+
+### Reuse-first owner surfaces
+
+- `scripts/run_scheduler.py`
+- `config/scheduler/jobs.toml`
+- `scripts/ops/primary_evidence_retention_v0.py`
+- `scripts/ops/durable_closeout_copy_verify_v0.py`
+- existing scheduler CLI tests and ops runbooks
+- existing docs truth map / reference / token-policy checks
+
+### Non-authorization
+
+This contract does not execute `scripts/run_scheduler.py`, does not authorize runtime or scheduler execution, does not enable or modify `config/scheduler/jobs.toml`, and does not authorize Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, and does not lift Path B.
+
 ## Gap 3 Execute Command Contract v0
 
 GAP3_EXECUTE_COMMAND_CONTRACT_V0=true
@@ -179,3 +208,9 @@ GAP3_EXECUTE_COMMAND_VERIFIED=false
 GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP3_EXECUTE_COMMAND_DEFAULT_ON=false
 GAP3_EXECUTE_COMMAND_DRY_RUN_ONLY=true
+GAP1_EXECUTE_ENTRYPOINT_CONTRACT_V0=true
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false
+GAP1_RUNTIME_APPROVED=false
+GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false
+GAP1_ENTRYPOINT_DRY_RUN_ONLY=true

--- a/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+GAP1_SECTION_HEADER = "## Gap 1 Execute Entrypoint Contract v0"
+GAP1_PARALLEL_MARKERS = (
+    "GAP1_EXECUTE_ENTRYPOINT_CONTRACT_V0=true",
+    "Gap 1 Execute Entrypoint Contract v0",
+)
+
+
+def _gap1_section(text: str) -> str:
+    return text.split(GAP1_SECTION_HEADER, 1)[1].split("## Gap 3 Execute Command Contract v0", 1)[0]
+
+
+def test_gap1_execute_entrypoint_contract_is_present_and_non_authorizing():
+    section = _gap1_section(DOC.read_text(encoding="utf-8"))
+
+    required = [
+        "GAP1_EXECUTE_ENTRYPOINT_CONTRACT_V0=true",
+        "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false",
+        "GAP1_RUNTIME_APPROVED=false",
+        "GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false",
+        "GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false",
+        "GAP1_ENTRYPOINT_DRY_RUN_ONLY=true",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+    ]
+
+    for marker in required:
+        assert marker in section
+
+
+def test_gap1_execute_entrypoint_contract_identifies_bounded_entrypoint():
+    section = _gap1_section(DOC.read_text(encoding="utf-8"))
+    assert "scripts/run_scheduler.py" in section
+    assert "Gap 3 remains the canonical command-text contract" in section
+
+
+def test_gap1_execute_entrypoint_contract_reuses_existing_surfaces():
+    section = _gap1_section(DOC.read_text(encoding="utf-8"))
+
+    required_surfaces = [
+        "scripts/run_scheduler.py",
+        "config/scheduler/jobs.toml",
+        "primary_evidence_retention_v0.py",
+        "durable_closeout_copy_verify_v0.py",
+    ]
+
+    for surface in required_surfaces:
+        assert surface in section
+
+
+def test_gap1_execute_entrypoint_contract_is_not_runtime_approved_or_lifted():
+    section = _gap1_section(DOC.read_text(encoding="utf-8"))
+    lines = {line.strip() for line in section.splitlines()}
+
+    forbidden = [
+        "READY_FOR_OPERATOR_ARMING=true",
+        "PATH_B_LIFT_DISCUSSION_READY=true",
+        "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true",
+        "GAP1_RUNTIME_APPROVED=true",
+        "GAP1_SCHEDULER_EXECUTION_AUTHORIZED=true",
+        "GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=true",
+    ]
+
+    for marker in forbidden:
+        assert marker not in lines
+
+
+def test_gap1_execute_entrypoint_contract_has_no_parallel_doc_surface():
+    owner_map = DOC.resolve()
+    parallel_docs: list[Path] = []
+
+    for path in (ROOT / "docs").rglob("*.md"):
+        if path.resolve() == owner_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in GAP1_PARALLEL_MARKERS):
+            parallel_docs.append(path.relative_to(ROOT))
+
+    assert parallel_docs == []


### PR DESCRIPTION
## Summary

Docs/tests-only contract slice for §5 Gap 1 Execute Entrypoint on the existing canonical owner-map surface. Reuse-first update only — no parallel docs.

## Intended files only

- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap1_execute_entrypoint_contract_v0.py`

## Boundaries

- **Entrypoint is text/contract only; `scripts/run_scheduler.py` was not executed**
- **No scheduler execution**
- **No runtime / paper / shadow / testnet / live started**
- **No AWS / broker / exchange touched**
- **No jobs.toml enablement or modification**
- **No default-on enforcement** (`GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false`)
- **No Path-B lift** (`PATH_B_LIFT_DISCUSSION_READY=false`)
- **`READY_FOR_OPERATOR_ARMING` remains false / not granted**
- **Preflight remains blocked** (`PREFLIGHT_REMAINS_BLOCKED=true`)
- Gap 3 remains canonical command-text contract; Gap 1 identifies entrypoint boundary only
- Reuse-before-new applied; no parallel documentation

## Validation commands and results

| Command | Result |
|---|---|
| `uv run pytest tests/ops/test_gap1_execute_entrypoint_contract_v0.py tests/ops/test_gap3_execute_command_contract_v0.py tests/ops/test_gap4_output_evidence_paths_contract_v0.py tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py` | 20 passed |
| `uv run ruff check tests/ops/test_gap1_execute_entrypoint_contract_v0.py` | All checks passed |
| `uv run ruff format --check tests/ops/test_gap1_execute_entrypoint_contract_v0.py` | 1 file already formatted |
| `DocsTokenPolicyValidator.scan_file(owner_map)` | 0 violations |
| `bash scripts/ops/verify_docs_reference_targets.sh` | All referenced targets exist |
| `python3 scripts/ops/check_docs_drift_guard.py --base origin/main` | OK (2 changed files) |

## Test plan

- [ ] CI green on contract + owner-map tests
- [ ] Lint Gate (ruff format) passes
- [ ] Review Gap 1 truth markers remain non-authorizing

Made with [Cursor](https://cursor.com)