### PR TITLE
ops: add gap6 dry-run proof criteria contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -172,6 +172,49 @@ Future runs are not considered complete unless primary evidence artifacts are du
 
 This contract does not authorize runtime, scheduler, Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
 
+## Gap 6 Dry-Run Proof Criteria Contract v0
+
+GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true
+GAP6_CRITERIA_ONLY=true
+GAP6_DRY_RUN_PROOF_ACCEPTED=false
+GAP6_DRY_RUN_PROOF_VERIFIED=false
+GAP6_DRY_RUN_RC0_OBSERVED=false
+GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP6_DRY_RUN_PROOF_DEFAULT_ON=false
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+
+This is a docs/tests-only criteria contract. It defines future dry-run proof acceptance criteria only. It does not claim that a dry-run proof exists, does not claim RC=0 was observed, and does not accept or verify any proof. Current status remains criteria-only, not proof-accepted, not verified, and not scheduler-authorized.
+
+Gap 1 remains the entrypoint boundary. Gap 3 remains the canonical command-text contract. Gap 4 remains the durable output/evidence path contract.
+
+### Reuse-first owner surfaces
+
+- `scripts/run_scheduler.py`
+- `config/scheduler/jobs.toml`
+- `scripts/ops/primary_evidence_retention_v0.py`
+- `scripts/ops/durable_closeout_copy_verify_v0.py`
+- `tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py`
+- existing preflight contract §5.6 and `docs/SCHEDULER_DAEMON.md` dry-run discipline
+- existing docs truth map / reference / token-policy checks
+
+### Future dry-run proof criteria (planning only; not executed or accepted in this contract)
+
+Any future dry-run proof considered for preflight dimension 6 must satisfy all of the following criteria through existing reuse-first surfaces:
+
+1. **Entrypoint boundary** — bounded execute path named by Gap 1 (`scripts/run_scheduler.py` only; no parallel entrypoints).
+2. **Command contract** — canonical bounded dry-run command text from Gap 3 (`--dry-run --once`; no implicit long-running poll).
+3. **Durable evidence** — primary evidence durable, archived outside `/tmp`, checksummed, manifest-verified, and linked through Gap 4 and existing closeout surfaces (`primary_evidence_retention_v0.py`, `durable_closeout_copy_verify_v0.py`).
+4. **No unexpected job execution** — process gate and scheduler dry-run discipline documented; no claim that unexpected jobs ran.
+
+This contract records criteria only. It does not execute `scripts/run_scheduler.py`, does not observe or record RC=0, and does not treat any archive or prior bounded dry-run as proof accepted here.
+
+### Non-authorization
+
+This contract does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not enable or modify `config/scheduler/jobs.toml`, and does not authorize runtime, Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
+
 ## Final Machine Lines
 
 SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true
@@ -214,3 +257,10 @@ GAP1_RUNTIME_APPROVED=false
 GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false
 GAP1_ENTRYPOINT_DRY_RUN_ONLY=true
+GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true
+GAP6_CRITERIA_ONLY=true
+GAP6_DRY_RUN_PROOF_ACCEPTED=false
+GAP6_DRY_RUN_PROOF_VERIFIED=false
+GAP6_DRY_RUN_RC0_OBSERVED=false
+GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP6_DRY_RUN_PROOF_DEFAULT_ON=false

--- a/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
+++ b/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+GAP6_SECTION_HEADER = "## Gap 6 Dry-Run Proof Criteria Contract v0"
+GAP6_PARALLEL_MARKERS = (
+    "GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true",
+    "Gap 6 Dry-Run Proof Criteria Contract v0",
+)
+
+
+def _gap6_section(text: str) -> str:
+    return text.split(GAP6_SECTION_HEADER, 1)[1].split("## Final Machine Lines", 1)[0]
+
+
+def test_gap6_dry_run_proof_criteria_contract_is_present_and_non_authorizing():
+    section = _gap6_section(DOC.read_text(encoding="utf-8"))
+
+    required = [
+        "GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true",
+        "GAP6_CRITERIA_ONLY=true",
+        "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+        "GAP6_DRY_RUN_PROOF_VERIFIED=false",
+        "GAP6_DRY_RUN_RC0_OBSERVED=false",
+        "GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false",
+        "GAP6_DRY_RUN_PROOF_DEFAULT_ON=false",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+    ]
+
+    for marker in required:
+        assert marker in section
+
+
+def test_gap6_dry_run_proof_criteria_contract_is_criteria_only_not_proof_claimed():
+    section = _gap6_section(DOC.read_text(encoding="utf-8"))
+
+    required_language = [
+        "docs/tests-only criteria contract",
+        "defines future dry-run proof acceptance criteria only",
+        "does not claim that a dry-run proof exists",
+        "does not claim RC=0 was observed",
+        "does not accept or verify any proof",
+        "criteria-only",
+        "not proof-accepted",
+        "not verified",
+        "not scheduler-authorized",
+    ]
+
+    for phrase in required_language:
+        assert phrase in section
+
+
+def test_gap6_dry_run_proof_criteria_contract_reuses_existing_surfaces():
+    section = _gap6_section(DOC.read_text(encoding="utf-8"))
+
+    required_surfaces = [
+        "scripts/run_scheduler.py",
+        "config/scheduler/jobs.toml",
+        "primary_evidence_retention_v0.py",
+        "durable_closeout_copy_verify_v0.py",
+    ]
+
+    for surface in required_surfaces:
+        assert surface in section
+
+
+def test_gap6_dry_run_proof_criteria_contract_references_dependency_chain():
+    section = _gap6_section(DOC.read_text(encoding="utf-8"))
+
+    required_chain = [
+        "Gap 1 remains the entrypoint boundary",
+        "Gap 3 remains the canonical command-text contract",
+        "Gap 4 remains the durable output/evidence path contract",
+    ]
+
+    for link in required_chain:
+        assert link in section
+
+
+def test_gap6_dry_run_proof_criteria_contract_is_not_proof_accepted_or_lifted():
+    section = _gap6_section(DOC.read_text(encoding="utf-8"))
+    lines = {line.strip() for line in section.splitlines()}
+
+    forbidden = [
+        "READY_FOR_OPERATOR_ARMING=true",
+        "PATH_B_LIFT_DISCUSSION_READY=true",
+        "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
+        "GAP6_DRY_RUN_PROOF_VERIFIED=true",
+        "GAP6_DRY_RUN_RC0_OBSERVED=true",
+        "GAP6_SCHEDULER_EXECUTION_AUTHORIZED=true",
+        "GAP6_DRY_RUN_PROOF_DEFAULT_ON=true",
+    ]
+
+    for marker in forbidden:
+        assert marker not in lines
+
+
+def test_gap6_dry_run_proof_criteria_contract_has_no_parallel_doc_surface():
+    owner_map = DOC.resolve()
+    parallel_docs: list[Path] = []
+
+    for path in (ROOT / "docs").rglob("*.md"):
+        if path.resolve() == owner_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in GAP6_PARALLEL_MARKERS):
+            parallel_docs.append(path.relative_to(ROOT))
+
+    assert parallel_docs == []


### PR DESCRIPTION
## Summary

- Adds **Gap 6 Dry-Run Proof Criteria Contract v0** to the existing canonical §5 owner-map (`SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`).
- Adds static contract tests in `tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py`.

## Scope

- **docs/tests-only criteria contract slice**
- **Intended files only:** owner-map + gap6 static test
- **criteria-only** — defines future acceptance criteria; **no proof accepted**
- **no RC=0 observed claim**
- **no scheduler execution** — `scripts/run_scheduler.py` not executed
- **no runtime/paper/shadow/testnet/live**
- **no AWS/broker/exchange**
- **no jobs.toml enablement or modification**
- **no default-on enforcement**
- **no Path-B lift**
- `READY_FOR_OPERATOR_ARMING` remains false / not granted
- **preflight remains blocked**
- **no parallel docs**
- **reuse-before-new applied**

## Validation

```bash
uv run pytest tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py \
  tests/ops/test_gap1_execute_entrypoint_contract_v0.py \
  tests/ops/test_gap3_execute_command_contract_v0.py \
  tests/ops/test_gap4_output_evidence_paths_contract_v0.py \
  tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py \
  tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py
# 26 passed

uv run ruff check tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
uv run ruff format --check tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
# All checks passed

python3 -c "from pathlib import Path; import sys; sys.path.insert(0,'scripts/ops'); from validate_docs_token_policy import DocsTokenPolicyValidator; v=DocsTokenPolicyValidator(Path('.'), Path('scripts/ops/docs_token_policy_allowlist.txt')); r=v.scan_file(Path('docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md')); assert not r.violations"

bash scripts/ops/verify_docs_reference_targets.sh
# All referenced targets exist

python3 scripts/ops/check_docs_drift_guard.py --base origin/main
# docs_drift_guard: OK (changed_files=2)
```


Made with [Cursor](https://cursor.com)