### PR TITLE
docs: add workflow secrets cybersecurity visibility crosslink

### DIFF
--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -208,11 +208,13 @@ CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_PAID_AI_EVAL_GATE_CROSSLINK_V0=tr
 CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_PAID_AI_EVAL_GATE_CROSSLINK_DOCS_TESTS_ONLY=true
 CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_MANUAL_DISPATCH_SENSITIVE_SURFACE_CROSSLINK_V0=true
 CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_MANUAL_DISPATCH_SENSITIVE_SURFACE_CROSSLINK_DOCS_TESTS_ONLY=true
+CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_WORKFLOW_SECRETS_VISIBILITY_CROSSLINK_V0=true
+CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_WORKFLOW_SECRETS_VISIBILITY_CROSSLINK_DOCS_TESTS_ONLY=true
 INPUT_JSONL_PROVIDED=false
 DEFINITIVE_R001_R002_R007_MAPPING_BLOCKED=true
 ```
 
-**Non-authorizing:** Explicit histogram reuse-owner crosslinks for `manual_dispatch_sensitive_surface`, `scheduler_or_runtime_boundary`, `branch_or_environment_authority`, and `paid_ai_eval_gate` are **visibility-only**; they do **not** authorize workflow manual-dispatch execution, scheduler/daemon/runtime start, workflow write-permission approval, paid Promptfoo/OpenAI eval execution, secret-injection approval, PR/push paid-eval paths, Testnet/Live, broker/exchange, or definitive R-001/R-002/R-007 mapping while `INPUT_JSONL_PROVIDED=false`.
+**Non-authorizing:** Explicit histogram reuse-owner crosslinks for `workflow_secrets_visibility`, `manual_dispatch_sensitive_surface`, `scheduler_or_runtime_boundary`, `branch_or_environment_authority`, and `paid_ai_eval_gate` are **visibility-only**; they do **not** authorize secrets availability or access, workflow manual-dispatch execution, scheduler/daemon/runtime start, workflow write-permission approval, paid Promptfoo/OpenAI eval execution, secret-injection approval, PR/push paid-eval paths, Testnet/Live, broker/exchange, or definitive R-001/R-002/R-007 mapping while `INPUT_JSONL_PROVIDED=false`.
 
 Operators may use this histogram for **CI/Ops visibility triage** until a lossless row exists for each pending retained risk. **Do not** treat any `CSC-STATIC-v0-*` `candidate_id` as a substitute mapping for R-001/R-002/R-007 without restored lossless inventory or operator-approved triage.
 

--- a/tests/ci/test_cybersecurity_visibility_repo_static_histogram_workflow_secrets_visibility_crosslink_v0.py
+++ b/tests/ci/test_cybersecurity_visibility_repo_static_histogram_workflow_secrets_visibility_crosslink_v0.py
@@ -1,0 +1,153 @@
+"""Static contract for Cybersecurity Visibility workflow-secrets histogram crosslink v0.
+
+Reads docs/ops/CI_AUDIT_KNOWN_ISSUES.md only. Never dispatches workflows, never
+accesses secrets, never touches runtime, scheduler, daemon, adapter, hooks,
+launchctl, Notion, Market, broker/exchange, or order paths.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_AUDIT_KNOWN_ISSUES = REPO_ROOT / "docs" / "ops" / "CI_AUDIT_KNOWN_ISSUES.md"
+
+HISTOGRAM_CLASSIFICATION = "workflow_secrets_visibility"
+HISTOGRAM_ROW_RX = re.compile(
+    rf"^\| `{re.escape(HISTOGRAM_CLASSIFICATION)}` \| (\d+) \| (.+) \|$",
+    re.MULTILINE,
+)
+HISTOGRAM_REUSE_PATH_RX = re.compile(r"Reuse `(tests/(?:ci|ops|webui)/[A-Za-z0-9_./-]+\.py)`")
+RISK_TABLE_ROW_RX = re.compile(
+    r"^\| (R-\d{3}) \| ([^|]*) \| ([^|]*) \|$",
+    re.MULTILINE,
+)
+STATIC_OWNERS_SECTION_RX = re.compile(
+    r"### Static visibility contract owners \(reuse — do not duplicate\)(.*?)(?:\n### |\Z)",
+    re.DOTALL,
+)
+
+REQUIRED_WORKFLOW_SECRETS_REUSE_OWNER = (
+    "tests/ci/test_workflow_secrets_reference_visibility_contract_v0.py"
+)
+
+WORKFLOW_SECRETS_PARALLEL_MARKERS = (
+    "CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_WORKFLOW_SECRETS_VISIBILITY_CROSSLINK_V0=true",
+    "Cybersecurity Visibility repo-static histogram workflow secrets visibility",
+)
+
+FORBIDDEN_AUTHORIZATION_PHRASES: tuple[str, ...] = (
+    "secrets available",
+    "secrets accessed",
+    "secret access approved",
+    "runtime start authorized",
+    "testnet approved",
+    "live approved",
+    "operator bypass",
+    "ready_for_start=true",
+    "preflight_blocked_lifted=true",
+    "r-001 mapped",
+    "r-002 mapped",
+    "r-007 mapped",
+)
+
+FORBIDDEN_MACHINE_LINES: tuple[str, ...] = (
+    "INPUT_JSONL_PROVIDED=true",
+    "R001_R002_R007_MAPPING_COMPLETED=true",
+    "WORKFLOW_SECRETS_VISIBILITY_MAPPING_COMPLETED=true",
+)
+
+
+def _ci_audit_text() -> str:
+    assert CI_AUDIT_KNOWN_ISSUES.is_file()
+    return CI_AUDIT_KNOWN_ISSUES.read_text(encoding="utf-8")
+
+
+def _histogram_section(text: str) -> str:
+    start = text.find("**Interim classification histogram")
+    assert start != -1, "histogram section missing"
+    end = text.find("**Lossless recovery still required")
+    assert end != -1, "histogram section end missing"
+    return text[start:end]
+
+
+def _risk_table_rows(text: str) -> dict[str, tuple[str, str]]:
+    rows: dict[str, tuple[str, str]] = {}
+    for risk_id, owner_cell, status_cell in RISK_TABLE_ROW_RX.findall(text):
+        rows[risk_id] = (owner_cell.strip(), status_cell.strip())
+    return rows
+
+
+def test_cybersecurity_visibility_repo_static_histogram_workflow_secrets_crosslink_v0() -> None:
+    text = _ci_audit_text()
+    collapsed = text.lower()
+    histogram = _histogram_section(text)
+
+    assert (
+        "CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_WORKFLOW_SECRETS_VISIBILITY_CROSSLINK_V0=true"
+        in text
+    )
+    assert (
+        "CYBERSECURITY_VISIBILITY_REPO_STATIC_HISTOGRAM_WORKFLOW_SECRETS_VISIBILITY_CROSSLINK_DOCS_TESTS_ONLY=true"
+        in text
+    )
+    assert "INPUT_JSONL_PROVIDED=false" in text
+    assert "DEFINITIVE_R001_R002_R007_MAPPING_BLOCKED=true" in text
+    assert "non-authorizing" in collapsed
+    assert HISTOGRAM_CLASSIFICATION in histogram
+
+    match = HISTOGRAM_ROW_RX.search(histogram)
+    assert match is not None, f"missing histogram row for {HISTOGRAM_CLASSIFICATION!r}"
+    assert match.group(1) == "44"
+    notes_cell = match.group(2)
+    assert f"Reuse `{REQUIRED_WORKFLOW_SECRETS_REUSE_OWNER}`" in notes_cell
+    assert (REPO_ROOT / REQUIRED_WORKFLOW_SECRETS_REUSE_OWNER).is_file(), (
+        f"missing reuse owner module: {REQUIRED_WORKFLOW_SECRETS_REUSE_OWNER}"
+    )
+
+    reuse_paths = HISTOGRAM_REUSE_PATH_RX.findall(histogram)
+    assert REQUIRED_WORKFLOW_SECRETS_REUSE_OWNER in reuse_paths
+
+    owners_match = STATIC_OWNERS_SECTION_RX.search(text)
+    assert owners_match is not None, "static visibility contract owners section missing"
+    owners_section = owners_match.group(1)
+    assert "Workflow secrets/vars/braced contexts (hub)" in owners_section
+    assert REQUIRED_WORKFLOW_SECRETS_REUSE_OWNER in owners_section
+
+    rows = _risk_table_rows(text)
+    for pending_id in ("R-001", "R-002", "R-007"):
+        assert pending_id in rows
+        owner_cell, status_cell = rows[pending_id]
+        assert owner_cell == "—"
+        assert "pending" in status_cell.lower()
+        assert "mapped" not in status_cell.lower()
+
+    assert REQUIRED_WORKFLOW_SECRETS_REUSE_OWNER in text
+
+    lines = {line.strip() for line in text.splitlines()}
+    for marker in FORBIDDEN_MACHINE_LINES:
+        assert marker not in lines
+
+    for phrase in FORBIDDEN_AUTHORIZATION_PHRASES:
+        assert phrase not in collapsed
+
+    assert "workflow_dispatch executed" not in collapsed
+    assert "mapping completed" not in collapsed
+    assert "workflow_secrets_visibility mapping completed" not in collapsed
+
+    assert "CYBERSECURITY_VISIBILITY_CHAIN_PARALLEL_ANCHOR" not in text
+
+
+def test_cybersecurity_visibility_workflow_secrets_crosslink_has_no_parallel_doc_surface() -> None:
+    canonical = CI_AUDIT_KNOWN_ISSUES.resolve()
+    parallel_docs: list[Path] = []
+
+    for path in (REPO_ROOT / "docs").rglob("*.md"):
+        if path.resolve() == canonical:
+            continue
+        body = path.read_text(encoding="utf-8")
+        if any(marker in body for marker in WORKFLOW_SECRETS_PARALLEL_MARKERS):
+            parallel_docs.append(path.relative_to(REPO_ROOT))
+
+    assert parallel_docs == []


### PR DESCRIPTION
## Summary
- docs/tests-ci-only cybersecurity visibility slice for `workflow_secrets_visibility` histogram crosslink
- Intended files only: `docs/ops/CI_AUDIT_KNOWN_ISSUES.md` and `tests/ci/test_cybersecurity_visibility_repo_static_histogram_workflow_secrets_visibility_crosslink_v0.py`
- Canonical owner reused: `docs/ops/CI_AUDIT_KNOWN_ISSUES.md` — no parallel cybersecurity docs

## Guardrails preserved
- `INPUT_JSONL_PROVIDED` remains false
- No R-001/R-002/R-007 mapping completion claim
- No secrets availability/access claim
- No `workflow_dispatch` execution
- No §5 state changes
- No runtime/scheduler/paper/shadow/testnet/live
- No AWS/broker/exchange
- No `jobs.toml` change
- reuse-before-new applied

## Validation
- `uv run pytest tests/ci/test_cybersecurity_visibility_repo_static_histogram_workflow_secrets_visibility_crosslink_v0.py` — pass
- `uv run pytest tests/ci/test_cybersecurity_visibility_*.py` — 21 passed
- `uv run ruff check` / `ruff format --check` on new test — pass
- `DocsTokenPolicyValidator.scan_file(CI_AUDIT_KNOWN_ISSUES.md)` — 0 violations
- `bash scripts/ops/verify_docs_reference_targets.sh` — pass
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main` — OK

## Test plan
- [x] New crosslink test asserts histogram row `workflow_secrets_visibility` count 44
- [x] Pending mapping posture and forbidden claims enforced
- [x] No parallel cybersecurity markdown doc created

Made with [Cursor](https://cursor.com)