### PR TITLE
ops: add gap5 stop criteria contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -215,6 +215,52 @@ This contract records criteria only. It does not execute `scripts/run_scheduler.
 
 This contract does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not enable or modify `config/scheduler/jobs.toml`, and does not authorize runtime, Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
 
+## Gap 5 Stop Criteria Contract v0
+
+GAP5_STOP_CRITERIA_CONTRACT_V0=true
+GAP5_CRITERIA_ONLY=true
+GAP5_TYPE2_WAIVER_GRANTED=false
+GAP5_STOP_REHEARSAL_EXECUTED=false
+GAP5_STOP_PROOF_ACCEPTED=false
+GAP5_RUNTIME_STOP_AUTHORITY_CHANGED=false
+GAP5_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP5_STOP_CRITERIA_DEFAULT_ON=false
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+
+This is a docs/tests-only criteria contract. It prepares future stop / Type-2 / rehearsal readiness criteria only. It does not grant a Type-2 waiver, does not execute or claim a stop-tool rehearsal, does not accept or verify stop proof, and does not change Risk/KillSwitch or runtime stop authority. Current status remains criteria-only, not waiver-granted, not rehearsal-executed, not proof-accepted, and not runtime-stop-authority-changed.
+
+Gap 1 remains the entrypoint boundary. Gap 3 remains the canonical command-text contract. Gap 4 remains the durable output/evidence path contract. Gap 6 remains the dry-run proof criteria-only contract.
+
+### Reuse-first owner surfaces
+
+- `scripts/ops/snapshot_operator_stop_signals.py`
+- `scripts/run_scheduler.py`
+- `config/scheduler/jobs.toml`
+- `scripts/ops/primary_evidence_retention_v0.py`
+- `scripts/ops/durable_closeout_copy_verify_v0.py`
+- `docs/ops/runbooks/incident_stop_freeze_rollback.md`
+- existing preflight contract stop/emergency-stop surfaces
+- existing docs truth map / reference / token-policy checks
+
+### Future stop / Type-2 / rehearsal criteria (planning only; not executed or accepted in this contract)
+
+Any future stop, Type-2 scoped-exception discussion, or stop-tool rehearsal readiness considered for preflight stop/rehearsal dimensions must satisfy criteria through existing reuse-first surfaces:
+
+1. **Stop visibility (read-only)** — operator can identify canonical stop surfaces via `snapshot_operator_stop_signals.py` and incident-stop runbooks without claiming stop was invoked or rehearsed.
+2. **Type-2 eligibility (planning text only)** — criteria for when a **future separate** operator charter might discuss Type-2 scoped exceptions; **no waiver granted** in this contract.
+3. **Rehearsal readiness (planning only)** — criteria for evidence that would be required before any future stop-tool rehearsal charter; **no rehearsal executed** here.
+4. **Orthogonality to Gap 6** — dry-run proof acceptance remains Gap 6 criteria-only; this contract does not accept dry-run proof or RC=0 for stop paths.
+5. **Durable evidence** — any future stop/rehearsal evidence must be durable, archived outside `/tmp`, checksummed, manifest-verified, and linked through Gap 4 and existing closeout surfaces (`primary_evidence_retention_v0.py`, `durable_closeout_copy_verify_v0.py`).
+
+This contract records criteria only. It does not execute `scripts/run_scheduler.py`, does not execute stop tools, and does not treat any archive or prior stop rehearsal as proof accepted here.
+
+### Non-authorization
+
+This contract does not grant a Type-2 waiver, does not execute or claim a stop-tool rehearsal, does not accept or verify stop proof, and does not change Risk/KillSwitch or runtime stop authority. It does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not enable or modify `config/scheduler/jobs.toml`, and does not authorize runtime, Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
+
 ## Final Machine Lines
 
 SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true
@@ -264,3 +310,11 @@ GAP6_DRY_RUN_PROOF_VERIFIED=false
 GAP6_DRY_RUN_RC0_OBSERVED=false
 GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP6_DRY_RUN_PROOF_DEFAULT_ON=false
+GAP5_STOP_CRITERIA_CONTRACT_V0=true
+GAP5_CRITERIA_ONLY=true
+GAP5_TYPE2_WAIVER_GRANTED=false
+GAP5_STOP_REHEARSAL_EXECUTED=false
+GAP5_STOP_PROOF_ACCEPTED=false
+GAP5_RUNTIME_STOP_AUTHORITY_CHANGED=false
+GAP5_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP5_STOP_CRITERIA_DEFAULT_ON=false

--- a/tests/ops/test_gap5_stop_criteria_contract_v0.py
+++ b/tests/ops/test_gap5_stop_criteria_contract_v0.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+GAP5_SECTION_HEADER = "## Gap 5 Stop Criteria Contract v0"
+GAP5_PARALLEL_MARKERS = (
+    "GAP5_STOP_CRITERIA_CONTRACT_V0=true",
+    "Gap 5 Stop Criteria Contract v0",
+)
+
+
+def _gap5_section(text: str) -> str:
+    return text.split(GAP5_SECTION_HEADER, 1)[1].split("## Final Machine Lines", 1)[0]
+
+
+def test_gap5_stop_criteria_contract_is_present_and_non_authorizing():
+    section = _gap5_section(DOC.read_text(encoding="utf-8"))
+
+    required = [
+        "GAP5_STOP_CRITERIA_CONTRACT_V0=true",
+        "GAP5_CRITERIA_ONLY=true",
+        "GAP5_TYPE2_WAIVER_GRANTED=false",
+        "GAP5_STOP_REHEARSAL_EXECUTED=false",
+        "GAP5_STOP_PROOF_ACCEPTED=false",
+        "GAP5_RUNTIME_STOP_AUTHORITY_CHANGED=false",
+        "GAP5_SCHEDULER_EXECUTION_AUTHORIZED=false",
+        "GAP5_STOP_CRITERIA_DEFAULT_ON=false",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+    ]
+
+    for marker in required:
+        assert marker in section
+
+
+def test_gap5_stop_criteria_contract_is_criteria_only_not_waiver_or_proof_claimed():
+    section = _gap5_section(DOC.read_text(encoding="utf-8"))
+
+    required_language = [
+        "docs/tests-only criteria contract",
+        "prepares future stop / Type-2 / rehearsal readiness criteria only",
+        "does not grant a Type-2 waiver",
+        "does not execute or claim a stop-tool rehearsal",
+        "does not accept or verify stop proof",
+        "does not change Risk/KillSwitch or runtime stop authority",
+        "criteria-only",
+        "not waiver-granted",
+        "not rehearsal-executed",
+        "not proof-accepted",
+        "not runtime-stop-authority-changed",
+    ]
+
+    for phrase in required_language:
+        assert phrase in section
+
+
+def test_gap5_stop_criteria_contract_reuses_existing_surfaces():
+    section = _gap5_section(DOC.read_text(encoding="utf-8"))
+
+    required_surfaces = [
+        "scripts/ops/snapshot_operator_stop_signals.py",
+        "scripts/run_scheduler.py",
+        "config/scheduler/jobs.toml",
+        "primary_evidence_retention_v0.py",
+        "durable_closeout_copy_verify_v0.py",
+    ]
+
+    for surface in required_surfaces:
+        assert surface in section
+
+
+def test_gap5_stop_criteria_contract_references_dependency_chain():
+    section = _gap5_section(DOC.read_text(encoding="utf-8"))
+
+    required_chain = [
+        "Gap 1 remains the entrypoint boundary",
+        "Gap 3 remains the canonical command-text contract",
+        "Gap 4 remains the durable output/evidence path contract",
+        "Gap 6 remains the dry-run proof criteria-only contract",
+    ]
+
+    for link in required_chain:
+        assert link in section
+
+
+def test_gap5_stop_criteria_contract_is_not_waiver_or_lifted():
+    section = _gap5_section(DOC.read_text(encoding="utf-8"))
+    lines = {line.strip() for line in section.splitlines()}
+
+    forbidden = [
+        "READY_FOR_OPERATOR_ARMING=true",
+        "PATH_B_LIFT_DISCUSSION_READY=true",
+        "GAP5_TYPE2_WAIVER_GRANTED=true",
+        "GAP5_STOP_REHEARSAL_EXECUTED=true",
+        "GAP5_STOP_PROOF_ACCEPTED=true",
+        "GAP5_RUNTIME_STOP_AUTHORITY_CHANGED=true",
+        "GAP5_SCHEDULER_EXECUTION_AUTHORIZED=true",
+        "GAP5_STOP_CRITERIA_DEFAULT_ON=true",
+    ]
+
+    for marker in forbidden:
+        assert marker not in lines
+
+
+def test_gap5_stop_criteria_contract_has_no_parallel_doc_surface():
+    owner_map = DOC.resolve()
+    parallel_docs: list[Path] = []
+
+    for path in (ROOT / "docs").rglob("*.md"):
+        if path.resolve() == owner_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in GAP5_PARALLEL_MARKERS):
+            parallel_docs.append(path.relative_to(ROOT))
+
+    assert parallel_docs == []


### PR DESCRIPTION
## Summary
- docs/tests-only §5 Gap 5 Stop / Type-2 / Rehearsal Criteria Contract v0
- Source charter: `section5_gap5_stop_criteria_charter_20260530T213000Z/SECTION5_GAP5_STOP_CRITERIA_CHARTER_V0.md`
- Intended files only: `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md` + `tests/ops/test_gap5_stop_criteria_contract_v0.py`

## Guardrails preserved
- Criteria-only; no Type-2 waiver granted
- No stop-tool rehearsal executed or claimed
- No stop proof accepted
- No Risk/KillSwitch authority/runtime change
- No scheduler execution; no `run_scheduler.py` execution
- No runtime/paper/shadow/testnet/live/AWS/broker/exchange
- No jobs.toml enablement or modification
- No default-on enforcement; no Path-B lift
- `READY_FOR_OPERATOR_ARMING` remains false/not granted
- Preflight remains blocked
- No parallel docs; reuse-before-new applied

## Validation
- pytest Gap 5 + Gap 1/3/4/6 + §2a.1 + owner-map tests — 32 passed
- ruff check / format --check on new test — pass
- DocsTokenPolicyValidator on owner-map — 0 violations
- verify_docs_reference_targets.sh — pass
- check_docs_drift_guard.py --base origin/main — OK (changed_files=2)

## Test plan
- [x] Gap 5 section contains required truth markers
- [x] Criteria-only language; forbidden waiver/lift/proof markers absent
- [x] Reuse surfaces and Gap 1/3/4/6 dependency chain referenced
- [x] No parallel Gap 5 markdown doc surface

Made with [Cursor](https://cursor.com)