### PR TITLE
ops: add gap2 canonical job set contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -261,6 +261,52 @@ This contract records criteria only. It does not execute `scripts/run_scheduler.
 
 This contract does not grant a Type-2 waiver, does not execute or claim a stop-tool rehearsal, does not accept or verify stop proof, and does not change Risk/KillSwitch or runtime stop authority. It does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not enable or modify `config/scheduler/jobs.toml`, and does not authorize runtime, Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
 
+## Gap 2 Canonical Job Set Contract v0
+
+GAP2_CANONICAL_JOB_SET_CONTRACT_V0=true
+GAP2_CRITERIA_ONLY=true
+GAP2_CANONICAL_JOB_SET_VERIFIED=false
+GAP2_JOB_SET_ENABLED=false
+GAP2_JOBS_TOML_CHANGED=false
+GAP2_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP2_RUNTIME_APPROVED=false
+GAP2_JOB_SET_DEFAULT_ON=false
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+
+This is a docs/tests-only criteria contract. It prepares future canonical job-set boundary criteria only. `config/scheduler/jobs.toml` is referenced as a boundary surface only. It does not modify `config/scheduler/jobs.toml`, does not enable any scheduler job, does not verify or activate a canonical job set, does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not approve runtime execution, and does not authorize Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, and does not lift Path B. Current status remains criteria-only, not verified, not job-enabled, not scheduler-authorized, and not runtime-approved.
+
+Gap 1 remains the entrypoint boundary. Gap 3 remains the canonical command-text contract. Gap 4 remains the durable output/evidence path contract. Gap 5 remains the stop criteria-only contract. Gap 6 remains the dry-run proof criteria-only contract.
+
+### Reuse-first owner surfaces
+
+- `scripts/run_scheduler.py`
+- `config/scheduler/jobs.toml`
+- `scripts/ops/primary_evidence_retention_v0.py`
+- `scripts/ops/durable_closeout_copy_verify_v0.py`
+- `tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py`
+- `tests/ops/test_paper_shadow_247_preflight_contract_v0.py`
+- `tests/ops/test_scheduler_boundary_hard_block_contract_v0.py`
+- existing docs truth map / reference / token-policy checks
+
+### Future canonical job-set boundary criteria (planning only; not verified or enabled in this contract)
+
+Any future canonical job-set boundary considered for preflight job-set dimensions must satisfy criteria through existing reuse-first surfaces:
+
+1. **Job-definition boundary (read-only)** — `config/scheduler/jobs.toml` is the canonical job-definition surface; criteria name job classes/tags in-scope for bounded dry-run planning vs explicitly out-of-scope without enabling jobs or mutating `enabled` fields.
+2. **No enablement** — criteria do not authorize changing `enabled` fields, starting scheduler loops, or claiming the job set is active.
+3. **Orthogonality to Gap 6** — dry-run proof acceptance remains Gap 6 criteria-only; this contract does not accept dry-run proof or RC=0 for job-set paths.
+4. **Dependency chain** — Gap 1 entrypoint, Gap 3 command text, Gap 4 durable evidence, Gap 5 stop criteria, and Gap 6 dry-run proof criteria remain authoritative for their domains.
+5. **Durable evidence** — any future job-set evidence must be durable, archived outside `/tmp`, checksummed, manifest-verified, and linked through existing reuse-first evidence/closeout surfaces (`primary_evidence_retention_v0.py`, `durable_closeout_copy_verify_v0.py`).
+
+This contract records criteria only. It does not execute `scripts/run_scheduler.py` and does not treat any archive or prior job inventory as canonical job set verified here.
+
+### Non-authorization
+
+This contract does not modify `config/scheduler/jobs.toml`, does not enable any scheduler job, does not verify or activate a canonical job set, does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not approve runtime execution, and does not authorize Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
+
 ## Final Machine Lines
 
 SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true
@@ -318,3 +364,11 @@ GAP5_STOP_PROOF_ACCEPTED=false
 GAP5_RUNTIME_STOP_AUTHORITY_CHANGED=false
 GAP5_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP5_STOP_CRITERIA_DEFAULT_ON=false
+GAP2_CANONICAL_JOB_SET_CONTRACT_V0=true
+GAP2_CRITERIA_ONLY=true
+GAP2_CANONICAL_JOB_SET_VERIFIED=false
+GAP2_JOB_SET_ENABLED=false
+GAP2_JOBS_TOML_CHANGED=false
+GAP2_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP2_RUNTIME_APPROVED=false
+GAP2_JOB_SET_DEFAULT_ON=false

--- a/tests/ops/test_gap2_canonical_job_set_contract_v0.py
+++ b/tests/ops/test_gap2_canonical_job_set_contract_v0.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+GAP2_SECTION_HEADER = "## Gap 2 Canonical Job Set Contract v0"
+GAP2A1_SECTION_HEADER = "## §2a.1 Primary Evidence Enforcement Contract v0"
+GAP2_PARALLEL_MARKERS = (
+    "GAP2_CANONICAL_JOB_SET_CONTRACT_V0=true",
+    "Gap 2 Canonical Job Set Contract v0",
+)
+
+
+def _gap2_section(text: str) -> str:
+    return text.split(GAP2_SECTION_HEADER, 1)[1].split("## Final Machine Lines", 1)[0]
+
+
+def test_gap2_canonical_job_set_contract_is_present_and_non_authorizing():
+    section = _gap2_section(DOC.read_text(encoding="utf-8"))
+
+    required = [
+        "GAP2_CANONICAL_JOB_SET_CONTRACT_V0=true",
+        "GAP2_CRITERIA_ONLY=true",
+        "GAP2_CANONICAL_JOB_SET_VERIFIED=false",
+        "GAP2_JOB_SET_ENABLED=false",
+        "GAP2_JOBS_TOML_CHANGED=false",
+        "GAP2_SCHEDULER_EXECUTION_AUTHORIZED=false",
+        "GAP2_RUNTIME_APPROVED=false",
+        "GAP2_JOB_SET_DEFAULT_ON=false",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+    ]
+
+    for marker in required:
+        assert marker in section
+
+
+def test_gap2_canonical_job_set_contract_is_criteria_only_not_verified_or_enabled():
+    section = _gap2_section(DOC.read_text(encoding="utf-8"))
+
+    required_language = [
+        "docs/tests-only criteria contract",
+        "prepares future canonical job-set boundary criteria only",
+        "`config/scheduler/jobs.toml` is referenced as a boundary surface only",
+        "does not modify `config/scheduler/jobs.toml`",
+        "does not enable any scheduler job",
+        "does not verify or activate a canonical job set",
+        "does not execute `scripts/run_scheduler.py`",
+        "does not authorize scheduler execution",
+        "does not approve runtime execution",
+        "criteria-only",
+        "not verified",
+        "not job-enabled",
+        "not scheduler-authorized",
+        "not runtime-approved",
+    ]
+
+    for phrase in required_language:
+        assert phrase in section
+
+
+def test_gap2_canonical_job_set_contract_reuses_existing_surfaces():
+    section = _gap2_section(DOC.read_text(encoding="utf-8"))
+
+    required_surfaces = [
+        "scripts/run_scheduler.py",
+        "config/scheduler/jobs.toml",
+        "test_paper_shadow_247_runtime_scheduler_job_config_v0.py",
+        "test_paper_shadow_247_preflight_contract_v0.py",
+        "test_scheduler_boundary_hard_block_contract_v0.py",
+        "primary_evidence_retention_v0.py",
+        "durable_closeout_copy_verify_v0.py",
+    ]
+
+    for surface in required_surfaces:
+        assert surface in section
+
+
+def test_gap2_canonical_job_set_contract_references_dependency_chain():
+    section = _gap2_section(DOC.read_text(encoding="utf-8"))
+
+    required_chain = [
+        "Gap 1 remains the entrypoint boundary",
+        "Gap 3 remains the canonical command-text contract",
+        "Gap 4 remains the durable output/evidence path contract",
+        "Gap 5 remains the stop criteria-only contract",
+        "Gap 6 remains the dry-run proof criteria-only contract",
+    ]
+
+    for link in required_chain:
+        assert link in section
+
+
+def test_gap2_canonical_job_set_contract_is_not_verified_or_lifted():
+    section = _gap2_section(DOC.read_text(encoding="utf-8"))
+    lines = {line.strip() for line in section.splitlines()}
+
+    forbidden = [
+        "READY_FOR_OPERATOR_ARMING=true",
+        "PATH_B_LIFT_DISCUSSION_READY=true",
+        "GAP2_CANONICAL_JOB_SET_VERIFIED=true",
+        "GAP2_JOB_SET_ENABLED=true",
+        "GAP2_JOBS_TOML_CHANGED=true",
+        "GAP2_SCHEDULER_EXECUTION_AUTHORIZED=true",
+        "GAP2_RUNTIME_APPROVED=true",
+        "GAP2_JOB_SET_DEFAULT_ON=true",
+    ]
+
+    for marker in forbidden:
+        assert marker not in lines
+
+
+def test_gap2_canonical_job_set_contract_has_no_parallel_doc_surface():
+    owner_map = DOC.resolve()
+    parallel_docs: list[Path] = []
+
+    for path in (ROOT / "docs").rglob("*.md"):
+        if path.resolve() == owner_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in GAP2_PARALLEL_MARKERS):
+            parallel_docs.append(path.relative_to(ROOT))
+
+    assert parallel_docs == []
+
+
+def test_gap2a1_markers_remain_in_section2a1_not_gap2_canonical_job_set():
+    text = DOC.read_text(encoding="utf-8")
+    gap2_section = _gap2_section(text)
+    gap2a1_section = text.split(GAP2A1_SECTION_HEADER, 1)[1].split(
+        "## Gap 1 Execute Entrypoint Contract v0", 1
+    )[0]
+
+    gap2a1_markers = [
+        "GAP2A1_PRIMARY_EVIDENCE_ENFORCEMENT_CONTRACT_V0=true",
+        "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false",
+        "GAP2A1_ENFORCEMENT_DEFAULT_ON=false",
+        "GAP2A1_ENFORCEMENT_OPT_IN_ONLY=true",
+    ]
+
+    for marker in gap2a1_markers:
+        assert marker in gap2a1_section
+        assert marker not in gap2_section


### PR DESCRIPTION
## Summary

- docs/tests-only criteria contract slice for **Gap 2 Canonical Job Set Contract v0**
- Extends the single canonical §5 owner-map with criteria-only job-set boundary markers
- Adds static contract test `tests/ops/test_gap2_canonical_job_set_contract_v0.py` (mirrors Gap 5/6 pattern)

**Source charter:** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/section5_gap2_canonical_job_set_criteria_charter_20260530T220000Z/SECTION5_GAP2_CANONICAL_JOB_SET_CRITERIA_CHARTER_V0.md`

**Intended files only (2):**
- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap2_canonical_job_set_contract_v0.py`

## Guardrails (unchanged)

- criteria-only; **no canonical job set verified**
- **no** `config/scheduler/jobs.toml` mutation
- **no** job-set enablement
- **no** scheduler execution or authorization
- **no** runtime approval
- **no** runtime/paper/shadow/testnet/live
- **no** AWS/broker/exchange
- **no** default-on enforcement
- **no** Path-B lift
- `READY_FOR_OPERATOR_ARMING` remains false/not granted
- preflight remains blocked
- **no** parallel docs
- reuse-before-new applied
- `GAP2A1_*` (§2a.1) remains separate from `GAP2_CANONICAL_JOB_SET_*`

## Test plan

- [x] `uv run pytest tests/ops/test_gap2_canonical_job_set_contract_v0.py tests/ops/test_gap5_stop_criteria_contract_v0.py tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py tests/ops/test_gap1_execute_entrypoint_contract_v0.py tests/ops/test_gap3_execute_command_contract_v0.py tests/ops/test_gap4_output_evidence_paths_contract_v0.py tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py` — **39 passed**
- [x] `uv run pytest tests/ops/test_paper_shadow_247_runtime_scheduler_job_config_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/ops/test_scheduler_boundary_hard_block_contract_v0.py` — **33 passed**
- [x] `uv run ruff check` + `ruff format --check` on new test — **pass**
- [x] `DocsTokenPolicyValidator.scan_file(owner-map)` — **0 violations**
- [x] `bash scripts/ops/verify_docs_reference_targets.sh` — **pass**
- [x] `python3 scripts/ops/check_docs_drift_guard.py --base origin/main` — **OK**


Made with [Cursor](https://cursor.com)