### PR TITLE
ops: add gap7 risk boundary criteria contract

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -307,6 +307,59 @@ This contract records criteria only. It does not execute `scripts/run_scheduler.
 
 This contract does not modify `config/scheduler/jobs.toml`, does not enable any scheduler job, does not verify or activate a canonical job set, does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not approve runtime execution, and does not authorize Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
 
+## Gap 7 Risk Boundary Criteria Contract v0
+
+GAP7_RISK_BOUNDARY_CRITERIA_CONTRACT_V0=true
+GAP7_CRITERIA_ONLY=true
+GAP7_RISK_BOUNDARY_VERIFIED=false
+GAP7_RISK_KILLSWITCH_AUTHORITY_CHANGED=false
+GAP7_RISK_KILLSWITCH_RUNTIME_CHANGED=false
+GAP7_MASTER_V2_DOUBLE_PLAY_CHANGED=false
+GAP7_BULL_BEAR_SCOPE_CAPITAL_CHANGED=false
+GAP7_EXECUTION_LIVE_GATES_CHANGED=false
+GAP7_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP7_RUNTIME_APPROVED=false
+GAP7_RISK_BOUNDARY_DEFAULT_ON=false
+PATH_B_LIFT_DISCUSSION_READY=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+RUNTIME_APPROVED=false
+
+This is a docs/tests-only criteria contract. It prepares future Risk Boundary / Risk-KillSwitch criteria only. Existing Risk/KillSwitch surfaces are referenced as read-only boundary surfaces only. It does not verify or activate Risk Boundaries, does not change Risk/KillSwitch authority, does not change Risk/KillSwitch runtime behavior, does not change Master V2 / Double Play logic, does not change Bull/Bear side-switching or Scope/Capital behavior, and does not change execution/live gates. It does not modify `config/scheduler/jobs.toml`, does not enable any scheduler job, does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not approve runtime execution, and does not authorize Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, and does not lift Path B. Current status remains criteria-only, not verified, no authority change, no runtime change, not scheduler-authorized, and not runtime-approved.
+
+Gap 1 remains the entrypoint boundary. Gap 2 remains the canonical job-set criteria contract. Gap 3 remains the canonical command-text contract. Gap 4 remains the durable output/evidence path contract. Gap 5 remains the stop criteria contract. Gap 6 remains the dry-run proof criteria contract.
+
+### Reuse-first owner surfaces
+
+- `docs/risk/KILL_SWITCH_RUNBOOK.md`
+- `docs/ops/specs/SCHEDULER_BOUNDARY_HARD_BLOCK_CONTRACT_V0.md`
+- `docs/ops/specs/MASTER_V2_DECISION_AUTHORITY_MAP_V1.md`
+- `scripts/ops/snapshot_operator_stop_signals.py`
+- `tests/ops/test_scheduler_boundary_hard_block_contract_v0.py`
+- `scripts/run_scheduler.py`
+- `config/scheduler/jobs.toml`
+- `scripts/ops/primary_evidence_retention_v0.py`
+- `scripts/ops/durable_closeout_copy_verify_v0.py`
+- existing docs truth map / reference / token-policy checks
+
+### Future Risk Boundary criteria (planning only; not verified or authority-changed in this contract)
+
+Any future Risk Boundary / Risk-KillSwitch planning considered for preflight risk-boundary dimensions must satisfy criteria through existing reuse-first surfaces:
+
+1. **Boundary visibility (read-only)** — operator can identify canonical Risk/KillSwitch and execution/live gate surfaces via existing docs and read-only snapshot tools without claiming boundaries were verified or authority changed.
+2. **No authority change** — criteria do not modify Risk/KillSwitch authority, runtime wiring, or execution/live gate behavior.
+3. **Protected domains preserved** — Master V2 / Double Play, Bull/Bear side-switching, and Scope/Capital behavior remain untouched; criteria reference authority maps only.
+4. **Orthogonality to Gap 5** — stop/Type-2/rehearsal criteria remain Gap 5; this contract does not grant waivers or accept stop proof.
+5. **Orthogonality to Gap 6** — dry-run proof acceptance remains Gap 6 criteria-only.
+6. **Dependency chain** — Gap 1 entrypoint, Gap 2 job-set boundary, Gap 3 command text, Gap 4 durable evidence, Gap 5 stop criteria, and Gap 6 dry-run proof criteria remain authoritative for their domains.
+7. **Durable evidence** — any future Risk Boundary evidence must be durable, archived outside `/tmp`, checksummed, manifest-verified, and linked through existing reuse-first evidence/closeout surfaces (`primary_evidence_retention_v0.py`, `durable_closeout_copy_verify_v0.py`).
+
+This contract records criteria only. It does not execute `scripts/run_scheduler.py`, does not execute kill-switch tools, and does not treat any archive or prior risk review as Risk Boundary verified here.
+
+### Non-authorization
+
+This contract does not verify or activate Risk Boundaries, does not change Risk/KillSwitch authority, does not change Risk/KillSwitch runtime behavior, does not change Master V2 / Double Play logic, does not change Bull/Bear side-switching or Scope/Capital behavior, and does not change execution/live gates. It does not modify `config/scheduler/jobs.toml`, does not enable any scheduler job, does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not approve runtime execution, and does not authorize Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
+
 ## Final Machine Lines
 
 SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true
@@ -372,3 +425,14 @@ GAP2_JOBS_TOML_CHANGED=false
 GAP2_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP2_RUNTIME_APPROVED=false
 GAP2_JOB_SET_DEFAULT_ON=false
+GAP7_RISK_BOUNDARY_CRITERIA_CONTRACT_V0=true
+GAP7_CRITERIA_ONLY=true
+GAP7_RISK_BOUNDARY_VERIFIED=false
+GAP7_RISK_KILLSWITCH_AUTHORITY_CHANGED=false
+GAP7_RISK_KILLSWITCH_RUNTIME_CHANGED=false
+GAP7_MASTER_V2_DOUBLE_PLAY_CHANGED=false
+GAP7_BULL_BEAR_SCOPE_CAPITAL_CHANGED=false
+GAP7_EXECUTION_LIVE_GATES_CHANGED=false
+GAP7_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP7_RUNTIME_APPROVED=false
+GAP7_RISK_BOUNDARY_DEFAULT_ON=false

--- a/tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py
+++ b/tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+GAP7_SECTION_HEADER = "## Gap 7 Risk Boundary Criteria Contract v0"
+GAP7_PARALLEL_MARKERS = (
+    "GAP7_RISK_BOUNDARY_CRITERIA_CONTRACT_V0=true",
+    "Gap 7 Risk Boundary Criteria Contract v0",
+)
+
+
+def _gap7_section(text: str) -> str:
+    return text.split(GAP7_SECTION_HEADER, 1)[1].split("## Final Machine Lines", 1)[0]
+
+
+def test_gap7_risk_boundary_criteria_contract_is_present_and_non_authorizing():
+    section = _gap7_section(DOC.read_text(encoding="utf-8"))
+
+    required = [
+        "GAP7_RISK_BOUNDARY_CRITERIA_CONTRACT_V0=true",
+        "GAP7_CRITERIA_ONLY=true",
+        "GAP7_RISK_BOUNDARY_VERIFIED=false",
+        "GAP7_RISK_KILLSWITCH_AUTHORITY_CHANGED=false",
+        "GAP7_RISK_KILLSWITCH_RUNTIME_CHANGED=false",
+        "GAP7_MASTER_V2_DOUBLE_PLAY_CHANGED=false",
+        "GAP7_BULL_BEAR_SCOPE_CAPITAL_CHANGED=false",
+        "GAP7_EXECUTION_LIVE_GATES_CHANGED=false",
+        "GAP7_SCHEDULER_EXECUTION_AUTHORIZED=false",
+        "GAP7_RUNTIME_APPROVED=false",
+        "GAP7_RISK_BOUNDARY_DEFAULT_ON=false",
+        "PATH_B_LIFT_DISCUSSION_READY=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+    ]
+
+    for marker in required:
+        assert marker in section
+
+
+def test_gap7_risk_boundary_criteria_contract_is_criteria_only_not_verified_or_changed():
+    section = _gap7_section(DOC.read_text(encoding="utf-8"))
+
+    required_language = [
+        "docs/tests-only criteria contract",
+        "prepares future Risk Boundary / Risk-KillSwitch criteria only",
+        "Existing Risk/KillSwitch surfaces are referenced as read-only boundary surfaces only",
+        "does not verify or activate Risk Boundaries",
+        "does not change Risk/KillSwitch authority",
+        "does not change Risk/KillSwitch runtime behavior",
+        "does not change Master V2 / Double Play logic",
+        "does not change Bull/Bear side-switching or Scope/Capital behavior",
+        "does not change execution/live gates",
+        "criteria-only",
+        "not verified",
+        "no authority change",
+        "no runtime change",
+        "not scheduler-authorized",
+        "not runtime-approved",
+    ]
+
+    for phrase in required_language:
+        assert phrase in section
+
+
+def test_gap7_risk_boundary_criteria_contract_reuses_existing_surfaces():
+    section = _gap7_section(DOC.read_text(encoding="utf-8"))
+
+    required_surfaces = [
+        "docs/risk/KILL_SWITCH_RUNBOOK.md",
+        "SCHEDULER_BOUNDARY_HARD_BLOCK_CONTRACT_V0.md",
+        "MASTER_V2_DECISION_AUTHORITY_MAP_V1.md",
+        "snapshot_operator_stop_signals.py",
+        "test_scheduler_boundary_hard_block_contract_v0.py",
+        "scripts/run_scheduler.py",
+        "config/scheduler/jobs.toml",
+        "primary_evidence_retention_v0.py",
+        "durable_closeout_copy_verify_v0.py",
+    ]
+
+    for surface in required_surfaces:
+        assert surface in section
+
+
+def test_gap7_risk_boundary_criteria_contract_references_dependency_chain():
+    section = _gap7_section(DOC.read_text(encoding="utf-8"))
+
+    required_chain = [
+        "Gap 1 remains the entrypoint boundary",
+        "Gap 2 remains the canonical job-set criteria contract",
+        "Gap 3 remains the canonical command-text contract",
+        "Gap 4 remains the durable output/evidence path contract",
+        "Gap 5 remains the stop criteria contract",
+        "Gap 6 remains the dry-run proof criteria contract",
+    ]
+
+    for link in required_chain:
+        assert link in section
+
+
+def test_gap7_risk_boundary_criteria_contract_is_not_verified_or_lifted():
+    section = _gap7_section(DOC.read_text(encoding="utf-8"))
+    lines = {line.strip() for line in section.splitlines()}
+
+    forbidden = [
+        "READY_FOR_OPERATOR_ARMING=true",
+        "PATH_B_LIFT_DISCUSSION_READY=true",
+        "GAP7_RISK_BOUNDARY_VERIFIED=true",
+        "GAP7_RISK_KILLSWITCH_AUTHORITY_CHANGED=true",
+        "GAP7_RISK_KILLSWITCH_RUNTIME_CHANGED=true",
+        "GAP7_MASTER_V2_DOUBLE_PLAY_CHANGED=true",
+        "GAP7_BULL_BEAR_SCOPE_CAPITAL_CHANGED=true",
+        "GAP7_EXECUTION_LIVE_GATES_CHANGED=true",
+        "GAP7_SCHEDULER_EXECUTION_AUTHORIZED=true",
+        "GAP7_RUNTIME_APPROVED=true",
+        "GAP7_RISK_BOUNDARY_DEFAULT_ON=true",
+    ]
+
+    for marker in forbidden:
+        assert marker not in lines
+
+
+def test_gap7_risk_boundary_criteria_contract_has_no_parallel_doc_surface():
+    owner_map = DOC.resolve()
+    parallel_docs: list[Path] = []
+
+    for path in (ROOT / "docs").rglob("*.md"):
+        if path.resolve() == owner_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(marker in text for marker in GAP7_PARALLEL_MARKERS):
+            parallel_docs.append(path.relative_to(ROOT))
+
+    assert parallel_docs == []


### PR DESCRIPTION
## Summary

- docs/tests-only criteria contract slice for **Gap 7 Risk Boundary Criteria Contract v0**
- Extends the single canonical §5 owner-map with criteria-only Risk/KillSwitch boundary markers
- Adds static contract test `tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py` (mirrors Gap 5/6 pattern)
- Completes the §5 criteria contract arc on paper — **preflight remains blocked**

**Source charter:** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/section5_gap7_risk_boundary_criteria_charter_20260530T230000Z/SECTION5_GAP7_RISK_BOUNDARY_CRITERIA_CHARTER_V0.md`

**Intended files only (2):**
- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py`

## Guardrails (unchanged)

- criteria-only; **no Risk/KillSwitch boundary verified**
- **no** Risk/KillSwitch authority/runtime change
- **no** Master V2 / Double Play change
- **no** Bull/Bear / Scope/Capital change
- **no** execution/live gate change
- **no** `config/scheduler/jobs.toml` mutation
- **no** scheduler execution or authorization
- **no** runtime approval
- **no** runtime/paper/shadow/testnet/live
- **no** AWS/broker/exchange
- **no** default-on enforcement
- **no** Path-B lift
- `READY_FOR_OPERATOR_ARMING` remains false/not granted
- preflight remains blocked
- **no** parallel docs
- reuse-before-new applied

## Test plan

- [x] `uv run pytest tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py tests/ops/test_gap2_canonical_job_set_contract_v0.py tests/ops/test_gap5_stop_criteria_contract_v0.py tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py tests/ops/test_gap1_execute_entrypoint_contract_v0.py tests/ops/test_gap3_execute_command_contract_v0.py tests/ops/test_gap4_output_evidence_paths_contract_v0.py tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py` — **45 passed**
- [x] `uv run pytest tests/ops/test_scheduler_boundary_hard_block_contract_v0.py` — **21 passed**
- [x] `uv run ruff check` + `ruff format --check` on new test — **pass**
- [x] `DocsTokenPolicyValidator.scan_file(owner-map)` — **0 violations**
- [x] `bash scripts/ops/verify_docs_reference_targets.sh` — **pass**
- [x] `python3 scripts/ops/check_docs_drift_guard.py --base origin/main` — **OK**


Made with [Cursor](https://cursor.com)