### PR TITLE
webui: add market ranking funnel dynamic labels contract

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -89,7 +89,9 @@ Auf **`GET`** **`/market`** zeigt das Template einen **Futures-Ranking-Funnel** 
 
 - **Sichtbare Stufen-Bezeichner:** **Top Universe** → **Shortlist** → **Top Ranking / Selected Candidates** (sprachlicher Zielpfad auf **einer** Seite; **keine** separate Ranking-Route).
 - **Keine festen Endgrößen:** frühere illustrative Größen wie `Top 50&#47;20&#47;5` sind **kein** vertragliches Versprechen — **Umfang** jeder Stufe bleibt **producer-definiert** / datengetrieben.
-- **Stabile Marker:** `data-market-v0-ranking-funnel-empty-state-v0="true"`, `data-market-v0-ranking-funnel-dynamic-labels-v0="true"` (Tests/Strukturvertrag — **keine** operationalen Freigaben).
+- **Stabile Marker:** `data-market-v0-ranking-funnel-v0="true"`, `data-market-v0-ranking-funnel-empty-state-v0="true"`, `data-market-v0-ranking-funnel-dynamic-labels-v0="true"`, `data-market-v0-ranking-funnel-display-only-v0="true"` (Tests/Strukturvertrag — **keine** operationalen Freigaben).
+- **Per-stage dynamic-label markers (`GET` `/market` only):** `data-market-v0-ranking-funnel-label-stage-v0` (stage key: `universe`, `shortlist`, `selected`), `data-market-v0-ranking-funnel-label-text-v0="true"` on the human-readable producer label (`Top Universe`, `Shortlist`, `Top Ranking &#47; Selected Candidates`). Labels are **display-only** — **no** execution authority, **no** live-entry approval, **no** broker/exchange action, **no** polling/runtime dependency.
+- **Route separation:** **`GET` `/market/double-play`** must **not** carry `/market`-only ranking-funnel dynamic-label SSR markers.
 - **Operator-Hinweis (Empty-State):** Fehlende Kandidatenzeilen bedeuten **nicht** Freigabe, Sperre, „Ready“, Handelserlaubnis oder Signal — nur, dass diese **read-only** Oberfläche (noch) **keine** Producer-/Ranking-Zeilen für die Stufen ausgibt.
 - **Implementierung** des Ranking Producers folgt dem Charter in § Market Ranking Funnel Producer v0 (read-only charter) unten; bis zur Implementierung **keine** Umsetzungsannahme durch dieses Dokument.
 

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -162,8 +162,10 @@
     role="region"
     aria-labelledby="market-v0-landmark-ranking-funnel-h2"
     class="rounded-xl border border-violet-900/45 bg-gradient-to-br from-slate-950/92 via-violet-950/22 to-slate-950/85 px-3 py-3 sm:px-4 ring-1 ring-violet-900/25 shadow-md shadow-black/20"
+    data-market-v0-ranking-funnel-v0="true"
     data-market-v0-ranking-funnel-dynamic-labels-v0="true"
     data-market-v0-ranking-funnel-stages-v0="true"
+    data-market-v0-ranking-funnel-display-only-v0="true"
     {% if ranking_funnel.gate_enabled %}data-market-v0-ranking-funnel-enabled-v0="true"{% endif %}
     {% if ranking_funnel.has_rows %}data-market-v0-ranking-funnel-has-rows-v0="true"{% else %}data-market-v0-ranking-funnel-empty-state-v0="true"{% endif %}
     {% if ranking_funnel.non_authorizing %}data-market-v0-ranking-funnel-non-authorizing-v0="true"{% endif %}
@@ -204,9 +206,16 @@
       <div
         class="rounded-lg border border-slate-700/75 bg-slate-950/65 px-2.5 py-2"
         data-market-v0-ranking-funnel-stage-v0="{{ stage_key|e }}"
+        data-market-v0-ranking-funnel-label-stage-v0="{{ stage_key|e }}"
       >
-        <p class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0">{{ stage_key|e }}</p>
-        <p class="text-sm font-semibold text-slate-100 m-0 mt-1">{{ stage_label|e }}</p>
+        <p
+          class="text-[9px] font-bold uppercase tracking-[0.1em] text-violet-300/88 m-0"
+          data-market-v0-ranking-funnel-label-stage-v0="{{ stage_key|e }}"
+        >{{ stage_key|e }}</p>
+        <p
+          class="text-sm font-semibold text-slate-100 m-0 mt-1"
+          data-market-v0-ranking-funnel-label-text-v0="true"
+        >{{ stage_label|e }}</p>
         <p class="text-[9px] text-slate-500 m-0 mt-1 leading-snug tabular-nums">
           {{ ranking_funnel.stage_counts[stage_key] }} row(s) · producer-defined count
         </p>

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -721,7 +721,27 @@ def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClien
 def test_market_dashboard_ranking_funnel_dynamic_labels_v0_marker(client: TestClient) -> None:
     """Funnel stages use dynamic labels (no fixed final-count wording in UI contract)."""
     market_html = _html(client, "/market")
+    assert 'data-market-v0-ranking-funnel-v0="true"' in market_html
     assert 'data-market-v0-ranking-funnel-dynamic-labels-v0="true"' in market_html
+    assert 'data-market-v0-ranking-funnel-display-only-v0="true"' in market_html
+    assert 'data-market-v0-ranking-funnel-label-text-v0="true"' in market_html
+    for stage_key in ("universe", "shortlist", "selected"):
+        assert f'data-market-v0-ranking-funnel-label-stage-v0="{stage_key}"' in market_html
+    assert "Top Universe" in market_html
+    assert "Shortlist" in market_html
+    assert "Top Ranking / Selected Candidates" in market_html
+    assert 'data-market-v0-ranking-funnel-non-authorizing-v0="true"' in market_html
+
+
+def test_market_dashboard_ranking_funnel_dynamic_labels_excluded_on_double_play_v0(
+    client: TestClient,
+) -> None:
+    """Double-Play must not carry /market-only ranking funnel dynamic-label SSR markers."""
+    html = _html(client, "/market/double-play")
+    assert 'data-market-v0-ranking-funnel-v0="true"' not in html
+    assert "data-market-v0-ranking-funnel-label-stage-v0" not in html
+    assert "data-market-v0-ranking-funnel-label-text-v0" not in html
+    assert 'data-market-v0-ranking-funnel-display-only-v0="true"' not in html
 
 
 def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> None:
@@ -782,7 +802,9 @@ def test_market_dashboard_ranking_funnel_and_pro_shell_marker_families_v0(
     """Positive pairing: /market carries ranking funnel and pro-shell IA marker families."""
     html = _html(client, "/market")
     assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-v0="true"' in html
     assert 'data-market-v0-ranking-funnel-dynamic-labels-v0="true"' in html
+    assert 'data-market-v0-ranking-funnel-display-only-v0="true"' in html
     assert 'data-market-v0-ranking-funnel-stages-v0="true"' in html
     assert 'id="market-v0-landmark-ranking-funnel-h2"' in html
     assert 'data-market-v0-pro-shell="true"' in html
@@ -798,6 +820,9 @@ def test_double_play_market_dashboard_excludes_ranking_funnel_markers_v0(
     html = _html(client, "/market/double-play")
     assert "data-market-v0-ranking-funnel-empty-state-v0" not in html
     assert "data-market-v0-ranking-funnel-dynamic-labels-v0" not in html
+    assert "data-market-v0-ranking-funnel-label-stage-v0" not in html
+    assert "data-market-v0-ranking-funnel-label-text-v0" not in html
+    assert "data-market-v0-ranking-funnel-display-only-v0" not in html
     assert "data-market-v0-ranking-funnel-stages-v0" not in html
     assert "data-market-v0-ranking-funnel-has-rows-v0" not in html
     assert "data-market-v0-ranking-funnel-enabled-v0" not in html


### PR DESCRIPTION
## Summary

Bounded `/market` docs/tests/template-only slice locking the Ranking Funnel dynamic-label SSR contract under the canonical Market Dashboard owner.

- Reuses `docs/webui/MARKET_SURFACE_V0.md` as canonical doc owner (no parallel dashboard docs)
- Adds/tightens SSR markers on `templates/peak_trade_dashboard/market_v0.html` only (`data-market-v0-ranking-funnel-v0`, per-stage `label-stage` / `label-text`, `display-only`)
- Extends structure-contract tests in `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- `/market` and `/market/double-play` separation preserved (double-play excludes ranking-funnel dynamic-label markers)

## Guardrails (unchanged)

- No new route, readmodel, API, or template surface
- No polling, broker/exchange wiring, runtime, or scheduler activity
- No Master V2 / Double Play trading logic or behavior change
- No dashboard authority or execution meaning added
- Preflight remains blocked; no lift/arming/authorization claims

## Validation

```bash
uv run pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py  # 63 passed
uv run pytest tests/test_market_surface_api.py  # 12 passed
uv run ruff check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
uv run ruff format --check tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
python3 -c "..." # DocsTokenPolicyValidator on MARKET_SURFACE_V0.md — 0 violations
bash scripts/ops/verify_docs_reference_targets.sh
python3 scripts/ops/check_docs_drift_guard.py --base origin/main
```

## Test plan

- [x] Structure contract: `/market` ranking-funnel dynamic-label markers present
- [x] Structure contract: stage keys + display labels (Top Universe, Shortlist, Selected Candidates)
- [x] Structure contract: `/market/double-play` excludes ranking-funnel dynamic-label markers
- [x] Market surface API tests unchanged/passing


Made with [Cursor](https://cursor.com)