### PR TITLE
test: extend control-plane summary forbidden cli flags

### DIFF
--- a/tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
+++ b/tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
@@ -55,6 +55,12 @@ HOOK_MACHINE_LINE_ASSERTIONS: tuple[str, ...] = (
     "AI_PAID_VARS_REARMED=false",
 )
 
+CHARTER_NON_EXECUTING_EXTRA_FLAGS_V0: tuple[str, ...] = (
+    "--run",
+    "--live",
+    "--dispatch",
+)
+
 _FORBIDDEN_SOURCE_PATTERNS: tuple[str, ...] = (
     "import subprocess",
     "from subprocess",
@@ -249,6 +255,12 @@ def test_summary_script_has_no_forbidden_cli_flags_v0() -> None:
     for flag in summary_mod.FORBIDDEN_CLI_FLAGS:
         assert f'add_argument("{flag}"' not in source
         assert f"add_argument('{flag}'" not in source
+
+    for flag in CHARTER_NON_EXECUTING_EXTRA_FLAGS_V0:
+        assert f'add_argument("{flag}"' not in source
+        assert f"add_argument('{flag}'" not in source
+
+    assert "workflow_dispatch" not in source
 
 
 def test_summary_script_has_no_runtime_or_invocation_patterns_v0() -> None:


### PR DESCRIPTION
## Summary
- extend the Control-Plane hook dry-run summary CLI static contract with charter-explicit non-executing flags
- assert the summary CLI source does not add `--run`, `--live`, or `--dispatch`
- assert the source does not reference `workflow_dispatch`
- keep the slice additive, one-file, tests-only, and non-authorizing

## Validation
- `uv run pytest tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py -q`
- `uv run ruff check tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py`
- `uv run ruff format --check tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`
- `git diff --check`

## Boundaries
- STOP_IDLE preserved
- PREFLIGHT_REMAINS_BLOCKED=true
- no runtime/scheduler/paper/shadow/testnet/live
- no AWS/broker/exchange
- no production code
- no docs or new SSOT
- no Control-Plane CLI execution
- no scripts/run_scheduler.py
- no jobs.toml
- no workflow_dispatch
- no Master V2 / Double Play changes
- no Dashboard authority changes

Made with [Cursor](https://cursor.com)