### PR TITLE
test: align control-plane offline stub contracts

### DIFF
--- a/tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
+++ b/tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py
@@ -49,6 +49,12 @@ NON_AUTHORITY_JSON_KEYS: tuple[str, ...] = (
     "master_v2_double_play_touched",
 )
 
+CHARTER_NON_EXECUTING_EXTRA_FLAGS_V0: tuple[str, ...] = (
+    "--run",
+    "--live",
+    "--dispatch",
+)
+
 _FORBIDDEN_SOURCE_PATTERNS: tuple[str, ...] = (
     "import subprocess",
     "from subprocess",
@@ -238,6 +244,12 @@ def test_cli_parser_has_no_forbidden_flags_v0() -> None:
     for flag in planner_mod.FORBIDDEN_CLI_FLAGS:
         assert f'add_argument("{flag}"' not in source
         assert f"add_argument('{flag}'" not in source
+
+    for flag in CHARTER_NON_EXECUTING_EXTRA_FLAGS_V0:
+        assert f'add_argument("{flag}"' not in source
+        assert f"add_argument('{flag}'" not in source
+
+    assert "workflow_dispatch" not in source
 
 
 def test_planner_script_has_no_runtime_or_invocation_patterns_v0() -> None:

--- a/tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
+++ b/tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py
@@ -55,6 +55,8 @@ HOOK_MACHINE_LINE_ASSERTIONS: tuple[str, ...] = (
     "AI_PAID_VARS_REARMED=false",
 )
 
+DOCS_TRUTH_MAP = REPO_ROOT / "docs" / "ops" / "registry" / "DOCS_TRUTH_MAP.md"
+
 CHARTER_NON_EXECUTING_EXTRA_FLAGS_V0: tuple[str, ...] = (
     "--run",
     "--live",
@@ -261,6 +263,19 @@ def test_summary_script_has_no_forbidden_cli_flags_v0() -> None:
         assert f"add_argument('{flag}'" not in source
 
     assert "workflow_dispatch" not in source
+
+
+def test_docs_truth_map_records_summary_forbidden_cli_flags_chronicle_v0() -> None:
+    docs_truth_map = DOCS_TRUTH_MAP.read_text(encoding="utf-8")
+
+    assert "test_summarize_control_plane_automation_hook_dry_run_contract_v0.py" in docs_truth_map
+    assert "#3808" in docs_truth_map
+    assert "Control-Plane summary forbidden CLI flags lock" in docs_truth_map
+    assert "--run" in docs_truth_map
+    assert "--live" in docs_truth_map
+    assert "--dispatch" in docs_truth_map
+    assert "workflow_dispatch" in docs_truth_map
+    assert "STOP_IDLE" in docs_truth_map
 
 
 def test_summary_script_has_no_runtime_or_invocation_patterns_v0() -> None:


### PR DESCRIPTION
## Summary
- align Control-Plane offline stub static contracts across planner and summary tests
- add planner-side charter-explicit non-executing flag checks for `--run`, `--live`, `--dispatch`, and `workflow_dispatch`
- add a summary-side static DOCS_TRUTH_MAP pointer check for the existing PR #3808 chronicle
- keep the package additive, two-file, tests-only, and non-authorizing

## Validation
- `uv run pytest tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py -q`
- `uv run ruff check tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py`
- `uv run ruff format --check tests/ops/test_plan_control_plane_offline_chain_durable_attachment_contract_v0.py tests/ops/test_summarize_control_plane_automation_hook_dry_run_contract_v0.py`
- `python3 scripts/ops/check_docs_drift_guard.py --base origin/main`
- `git diff --check`

## Boundaries
- STOP_IDLE preserved
- PREFLIGHT_REMAINS_BLOCKED=true
- no runtime/scheduler/paper/shadow/testnet/live
- no AWS/broker/exchange
- no production code
- no docs or new SSOT
- no Control-Plane CLI execution
- no scripts/run_scheduler.py
- no jobs.toml
- no workflow_dispatch
- no Master V2 / Double Play changes
- no Dashboard authority changes

Made with [Cursor](https://cursor.com)