### PR TITLE
ops: guard gap6 external evidence drift

### DIFF
--- a/tests/ops/test_gap2_canonical_job_set_contract_v0.py
+++ b/tests/ops/test_gap2_canonical_job_set_contract_v0.py
@@ -165,3 +165,11 @@ def test_gap2_owner_crosslinks_paper_shadow_runtime_scheduler_job_config_v0():
     assert "test_paper_shadow_247_runtime_scheduler_job_config_v0.py" in section
     hardening_text = HARDENING_OWNER.read_text(encoding="utf-8")
     assert "test_paper_shadow_247_runtime_scheduler_job_config_v0.py" in hardening_text
+
+
+def test_gap2_owner_crosslinks_gap6_external_repo_drift_guard_contract_v0():
+    drift_guard = ROOT / "tests" / "ops" / "test_gap6_external_repo_drift_guard_contract_v0.py"
+    assert drift_guard.is_file()
+    text = drift_guard.read_text(encoding="utf-8")
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in text
+    assert "GAP2_JOB_SET_ENABLED=false" in text

--- a/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
+++ b/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
@@ -9,6 +9,7 @@ GAP6_PARALLEL_MARKERS = (
     "Gap 6 Dry-Run Proof Criteria Contract v0",
 )
 HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_source_contract_v0.py"
+DRIFT_GUARD_OWNER = ROOT / "tests" / "ops" / "test_gap6_external_repo_drift_guard_contract_v0.py"
 HARDENING_MARKER = "SCHEDULER_DRY_RUN_HARDENING_SOURCE_CONTRACT_V0=true"
 _MARKER_TRUE = "=true"
 
@@ -122,3 +123,11 @@ def test_gap6_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0():
     assert HARDENING_MARKER in text
     lines = {line.strip() for line in text.splitlines()}
     assert ("GAP6_DRY_RUN_RC0_OBSERVED" + _MARKER_TRUE) not in lines
+
+
+def test_gap6_owner_crosslinks_external_repo_drift_guard_contract_v0():
+    assert DRIFT_GUARD_OWNER.is_file()
+    text = DRIFT_GUARD_OWNER.read_text(encoding="utf-8")
+    assert "test_gap6_dry_run_proof_criteria_contract_v0.py" in text
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in text
+    assert "DRIFT_GUARD_FORBIDDEN_REPO_TOKENS" in text

--- a/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
@@ -1,0 +1,125 @@
+"""Static contract for Gap-6 external↔repo drift guard v0.
+
+Reads repo markdown/TOML/source only. Never executes scheduler/runtime, never reads
+external archive paths as pass/fail SSOT, and never treats external F6 evidence as
+repo Gap-6 acceptance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SECTION5_DOC = (
+    ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+)
+PREFLIGHT_CONTRACT = (
+    ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+)
+GAP6_TESTS = ROOT / "tests" / "ops" / "test_gap6_dry_run_proof_criteria_contract_v0.py"
+HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_source_contract_v0.py"
+FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
+_MARKER_TRUE = "=true"
+
+DRIFT_GUARD_REQUIRED_FINAL_LINES = (
+    "PREFLIGHT_REMAINS_BLOCKED=true",
+    "READY_FOR_OPERATOR_ARMING=false",
+    "PATH_B_LIFT_DISCUSSION_READY=false",
+    "ALL_GAPS_CLOSED=false",
+    "GAP6_DRY_RUN_RC0_OBSERVED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_VERIFIED=false",
+    "GAP2_CANONICAL_JOB_SET_VERIFIED=false",
+    "GAP2_JOB_SET_ENABLED=false",
+    "SECTION5_GAP_CLOSURE_EXECUTED=false",
+)
+
+DRIFT_GUARD_FORBIDDEN_REPO_TOKENS = (
+    "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true",
+    "GAP6_DRY_RUN_RC0_OBSERVED=true",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
+    "GAP6_DRY_RUN_PROOF_VERIFIED=true",
+    "WORKSHEET_COMPLETE=true",
+    "SHADOW_24_7_AUTHORIZED=true",
+    "PATH_B_LIFT_DISCUSSION_READY=true",
+    "ALL_GAPS_CLOSED=true",
+    "READY_FOR_OPERATOR_ARMING=true",
+    "PREFLIGHT_REMAINS_BLOCKED=false",
+    "GAP2_CANONICAL_JOB_SET_VERIFIED=true",
+    "GAP2_JOB_SET_ENABLED=true",
+)
+
+
+def _final_machine_lines(text: str) -> str:
+    return text.split(FINAL_MACHINE_LINES_HEADER, 1)[1]
+
+
+def _section5_text() -> str:
+    return SECTION5_DOC.read_text(encoding="utf-8")
+
+
+def test_gap6_external_repo_drift_guard_final_machine_lines_remain_blocked_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    for marker in DRIFT_GUARD_REQUIRED_FINAL_LINES:
+        assert marker in block
+
+
+def test_gap6_external_repo_drift_guard_repo_ssot_forbids_external_gap6_observed_token_v0() -> None:
+    text = _section5_text()
+    assert "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true" not in text
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in text
+
+
+def test_gap6_external_repo_drift_guard_repo_ssot_forbids_lift_and_verified_tokens_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    lines = {line.strip() for line in block.splitlines()}
+    for token in DRIFT_GUARD_FORBIDDEN_REPO_TOKENS:
+        assert token not in lines
+
+
+def test_gap6_external_repo_drift_guard_criteria_complete_does_not_close_gaps_v0() -> None:
+    text = _section5_text()
+    assert "SECTION5_OWNER_MAP_CONTRACT_V0=true" in text
+    assert "SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true" in text
+    assert "ALL_GAPS_CLOSED=false" in text
+    assert "GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true" in text
+    assert "GAP6_CRITERIA_ONLY=true" in text
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in text
+
+
+def test_gap6_external_repo_drift_guard_preflight_contract_remains_blocked_v0() -> None:
+    text = PREFLIGHT_CONTRACT.read_text(encoding="utf-8")
+    assert "Current status: **BLOCKED**." in text
+    assert "Evidence ≠ approval" in text
+
+
+def test_gap6_external_repo_drift_guard_gap6_section_preserves_evidence_not_approval_v0() -> None:
+    gap6_section = (
+        _section5_text()
+        .split("## Gap 6 Dry-Run Proof Criteria Contract v0", 1)[1]
+        .split("## Gap 5 Stop Criteria Contract v0", 1)[0]
+    )
+    assert "does not claim RC=0 was observed" in gap6_section
+    assert "does not accept or verify any proof" in gap6_section
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in gap6_section
+
+
+def test_gap6_external_repo_drift_guard_shadow_24_7_not_authorized_in_repo_ssot_v0() -> None:
+    text = _section5_text()
+    assert "SHADOW_24_7_AUTHORIZED=true" not in text
+    block = _final_machine_lines(text)
+    assert "SHADOW_24_7_AUTHORIZED=true" not in block
+
+
+def test_gap6_external_repo_drift_guard_owner_crosslinks_gap6_criteria_tests_v0() -> None:
+    assert GAP6_TESTS.is_file()
+    text = GAP6_TESTS.read_text(encoding="utf-8")
+    assert "test_gap6_external_repo_drift_guard_contract_v0.py" in text
+
+
+def test_gap6_external_repo_drift_guard_owner_crosslinks_hardening_source_contract_v0() -> None:
+    assert HARDENING_OWNER.is_file()
+    text = HARDENING_OWNER.read_text(encoding="utf-8")
+    assert "test_gap6_external_repo_drift_guard_contract_v0.py" in text
+    lines = {line.strip() for line in text.splitlines()}
+    assert ("GAP6_DRY_RUN_RC0_OBSERVED" + _MARKER_TRUE) not in lines

--- a/tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py
+++ b/tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py
@@ -12,6 +12,9 @@ SECTION5_DOC = (
 DOCS_TRUTH_MAP = REPO_ROOT / "docs" / "ops" / "registry" / "DOCS_TRUTH_MAP.md"
 GAP3_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap3_execute_command_contract_v0.py"
 GAP6_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap6_dry_run_proof_criteria_contract_v0.py"
+GAP6_DRIFT_GUARD_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_gap6_external_repo_drift_guard_contract_v0.py"
+)
 GAP1_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap1_execute_entrypoint_contract_v0.py"
 GAP2_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap2_canonical_job_set_contract_v0.py"
 GAP4_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap4_output_evidence_paths_contract_v0.py"
@@ -40,6 +43,7 @@ OWNER_REFERENCES_V0 = (
     "tests/ops/test_gap5_stop_criteria_contract_v0.py",
     "tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py",
     "tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py",
+    "tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py",
     "tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py",
     "tests/ops/test_snapshot_operator_stop_signals.py",
     "tests/ops/test_scheduler_boundary_hard_block_contract_v0.py",
@@ -215,6 +219,13 @@ def test_gap6_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0() 
     text = GAP6_TESTS.read_text(encoding="utf-8")
     assert "test_scheduler_dry_run_hardening_source_contract_v0.py" in text
     assert PACKAGE_MARKER in text
+
+
+def test_gap6_drift_guard_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0() -> None:
+    text = GAP6_DRIFT_GUARD_TESTS.read_text(encoding="utf-8")
+    assert "test_scheduler_dry_run_hardening_source_contract_v0.py" in text
+    assert "test_gap6_dry_run_proof_criteria_contract_v0.py" in text
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in text
 
 
 def test_boundary_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0() -> None:


### PR DESCRIPTION
## Summary

- Add static tests-only Gap-6 external↔repo drift guard module (`test_gap6_external_repo_drift_guard_contract_v0.py`).
- Extend existing Gap-6, Gap-2, and scheduler dry-run hardening test owners with reciprocal crosslinks.
- Lock repo SSOT: Preflight remains **BLOCKED**; Gap-6 RC0 observed / proof accepted / verified remain **false**; Path-B lift discussion remains **not ready**.

## Scope

- **tests-only** — no production code, no config mutation, no flag lifts
- **no runtime** — no scheduler/Paper/Shadow/Testnet/Live execution
- **no Notion** — no parallel docs/builds/SSOT
- External F6 remains **subordinate evidence only**; repo must not ingest `GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true`

## Test plan

- [x] `uv run pytest tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_gap2_canonical_job_set_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py -q`
- [x] `uv run ruff check` / `ruff format --check` on touched files

## Machine lines

```
FUTURE_PR_TESTS_ONLY=true
FUTURE_PR_FLAG_LIFT_ALLOWED=false
GAP6_DRY_RUN_RC0_OBSERVED_REPO=false
GAP6_DRY_RUN_PROOF_ACCEPTED_REPO=false
GAP6_DRY_RUN_PROOF_VERIFIED=false
PREFLIGHT_REMAINS_BLOCKED=true
READY_FOR_OPERATOR_ARMING=false
PATH_B_LIFT_DISCUSSION_READY=false
ALL_GAPS_CLOSED=false
EVIDENCE_EQUALS_APPROVAL=false
CRITERIA_COMPLETE_EQUALS_GAP_CLOSED=false
SHADOW_24_7_OUT_OF_SCOPE=true
F2_IS_NOT_24_7_APPROVAL=true
GAP2_CANONICAL_JOB_SET_VERIFIED=false
GAP2_JOB_SET_ENABLED=false
NO_PARALLEL_BUILDS_OR_DOCS=true
```


Made with [Cursor](https://cursor.com)