### PR TITLE
ops: guard gap5 stop criteria drift

### DIFF
--- a/tests/ops/test_gap5_stop_criteria_contract_v0.py
+++ b/tests/ops/test_gap5_stop_criteria_contract_v0.py
@@ -9,6 +9,7 @@ GAP5_PARALLEL_MARKERS = (
     "Gap 5 Stop Criteria Contract v0",
 )
 HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_source_contract_v0.py"
+DRIFT_GUARD_OWNER = ROOT / "tests" / "ops" / "test_gap5_stop_criteria_drift_guard_contract_v0.py"
 HARDENING_MARKER = "SCHEDULER_DRY_RUN_HARDENING_SOURCE_CONTRACT_V0=true"
 SNAPSHOT_OWNER = ROOT / "tests" / "ops" / "test_snapshot_operator_stop_signals.py"
 _MARKER_TRUE = "=true"
@@ -139,3 +140,11 @@ def test_gap5_owner_crosslinks_snapshot_operator_stop_signals_v0():
     assert "snapshot_operator_stop_signals.py" in section
     hardening_text = HARDENING_OWNER.read_text(encoding="utf-8")
     assert "test_snapshot_operator_stop_signals.py" in hardening_text
+
+
+def test_gap5_owner_crosslinks_stop_criteria_drift_guard_contract_v0():
+    assert DRIFT_GUARD_OWNER.is_file()
+    text = DRIFT_GUARD_OWNER.read_text(encoding="utf-8")
+    assert "test_gap5_stop_criteria_contract_v0.py" in text
+    assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in text
+    assert "DRIFT_GUARD_FORBIDDEN_GAP5_REPO_TOKENS" in text

--- a/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
@@ -1,0 +1,217 @@
+"""Static contract for Gap-5 stop-criteria drift guard v0.
+
+Reads repo markdown/TOML/source only. Never executes stop/scheduler/runtime, never reads
+external archive paths as pass/fail SSOT, and never treats external F5 approval or planning
+charters as repo Gap-5 rehearsal execution or proof acceptance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef,import-not-found]
+
+ROOT = Path(__file__).resolve().parents[2]
+SECTION5_DOC = (
+    ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+)
+PREFLIGHT_CONTRACT = (
+    ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+)
+PREFLIGHT_TOML = ROOT / "config" / "ops" / "paper_shadow_247_preflight.toml"
+GAP5_TESTS = ROOT / "tests" / "ops" / "test_gap5_stop_criteria_contract_v0.py"
+HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_source_contract_v0.py"
+FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
+GAP5_SECTION_HEADER = "## Gap 5 Stop Criteria Contract v0"
+_MARKER_TRUE = "=true"
+
+# External planning posture only — must not appear as verified/rehearsed/proof in repo SSOT.
+GAP5_STOP_CRITERIA_PLANNED = True
+GAP5_STOP_CRITERIA_VERIFIED = False
+F5_APPROVAL_IS_PROCEDURE_TEXT_ONLY = True
+FUTURE_REHEARSAL_REQUIRES_OPERATOR_GO_AND_RUN_ID = True
+EVIDENCE_EQUALS_APPROVAL = False
+CRITERIA_COMPLETE_EQUALS_GAP_CLOSED = False
+
+DRIFT_GUARD_REQUIRED_FINAL_LINES = (
+    "PREFLIGHT_REMAINS_BLOCKED=true",
+    "READY_FOR_OPERATOR_ARMING=false",
+    "PATH_B_LIFT_DISCUSSION_READY=false",
+    "ALL_GAPS_CLOSED=false",
+    "GAP5_STOP_REHEARSAL_EXECUTED=false",
+    "GAP5_STOP_PROOF_ACCEPTED=false",
+    "GAP5_TYPE2_WAIVER_GRANTED=false",
+    "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+)
+
+DRIFT_GUARD_FORBIDDEN_GAP5_REPO_TOKENS = (
+    "GAP5_STOP_REHEARSAL_EXECUTED=true",
+    "GAP5_STOP_PROOF_ACCEPTED=true",
+    "GAP5_TYPE2_WAIVER_GRANTED=true",
+    "GAP5_RUNTIME_STOP_AUTHORITY_CHANGED=true",
+    "GAP5_SCHEDULER_EXECUTION_AUTHORIZED=true",
+    "GAP5_STOP_CRITERIA_DEFAULT_ON=true",
+    "GAP5_STOP_CRITERIA_VERIFIED=true",
+    "F5_EXACT_PROCEDURE_APPROVED=true",
+    "WORKSHEET_COMPLETE=true",
+    "PATH_B_LIFT_DISCUSSION_READY=true",
+    "ALL_GAPS_CLOSED=true",
+    "READY_FOR_OPERATOR_ARMING=true",
+    "PREFLIGHT_REMAINS_BLOCKED=false",
+    "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
+)
+
+PREFLIGHT_AUTHORIZATION_KEYS = (
+    "activation_authorized",
+    "daemon_activation_authorized",
+    "scheduler_execution_authorized",
+    "paper_runtime_authorized",
+    "shadow_runtime_authorized",
+    "testnet_authorized",
+    "live_authorized",
+    "broker_authorized",
+    "exchange_authorized",
+    "order_submission_authorized",
+)
+
+
+def _final_machine_lines(text: str) -> str:
+    return text.split(FINAL_MACHINE_LINES_HEADER, 1)[1]
+
+
+def _gap5_section(text: str) -> str:
+    return text.split(GAP5_SECTION_HEADER, 1)[1].split(FINAL_MACHINE_LINES_HEADER, 1)[0]
+
+
+def _section5_text() -> str:
+    return SECTION5_DOC.read_text(encoding="utf-8")
+
+
+def _preflight_payload() -> dict:
+    return tomllib.loads(PREFLIGHT_TOML.read_text(encoding="utf-8"))
+
+
+def test_gap5_stop_criteria_drift_guard_external_planning_constants_v0() -> None:
+    assert GAP5_STOP_CRITERIA_PLANNED is True
+    assert GAP5_STOP_CRITERIA_VERIFIED is False
+    assert F5_APPROVAL_IS_PROCEDURE_TEXT_ONLY is True
+    assert FUTURE_REHEARSAL_REQUIRES_OPERATOR_GO_AND_RUN_ID is True
+    assert EVIDENCE_EQUALS_APPROVAL is False
+    assert CRITERIA_COMPLETE_EQUALS_GAP_CLOSED is False
+
+
+def test_gap5_stop_criteria_drift_guard_final_machine_lines_remain_blocked_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    for marker in DRIFT_GUARD_REQUIRED_FINAL_LINES:
+        assert marker in block
+
+
+def test_gap5_stop_criteria_drift_guard_forbids_lift_and_verified_tokens_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    lines = {line.strip() for line in block.splitlines()}
+    for token in DRIFT_GUARD_FORBIDDEN_GAP5_REPO_TOKENS:
+        assert token not in lines
+
+
+def test_gap5_stop_criteria_drift_guard_repo_ssot_forbids_f5_and_verified_tokens_v0() -> None:
+    text = _section5_text()
+    assert "F5_EXACT_PROCEDURE_APPROVED=true" not in text
+    assert "GAP5_STOP_CRITERIA_VERIFIED=true" not in text
+    assert "WORKSHEET_COMPLETE=true" not in text
+
+
+def test_gap5_stop_criteria_drift_guard_gap5_section_preserves_criteria_only_v0() -> None:
+    section = _gap5_section(_section5_text())
+    assert "GAP5_STOP_CRITERIA_CONTRACT_V0=true" in section
+    assert "GAP5_CRITERIA_ONLY=true" in section
+    assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in section
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in section
+    assert "GAP5_TYPE2_WAIVER_GRANTED=false" in section
+    assert "does not execute or claim a stop-tool rehearsal" in section
+    assert "does not accept or verify stop proof" in section
+    assert "does not execute stop tools" in section
+    lines = {line.strip() for line in section.splitlines()}
+    for token in DRIFT_GUARD_FORBIDDEN_GAP5_REPO_TOKENS:
+        assert token not in lines
+
+
+def test_gap5_stop_criteria_drift_guard_f5_approval_not_rehearsal_or_proof_v0() -> None:
+    text = _section5_text()
+    block = _final_machine_lines(text)
+    assert "F5_EXACT_PROCEDURE_APPROVED=true" not in text
+    assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in block
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in block
+
+
+def test_gap5_stop_criteria_drift_guard_preflight_contract_remains_blocked_v0() -> None:
+    text = PREFLIGHT_CONTRACT.read_text(encoding="utf-8")
+    assert "Current status: **BLOCKED**." in text
+    assert "Evidence ≠ approval" in text
+
+
+def test_gap5_stop_criteria_drift_guard_preflight_toml_stop_commands_inventory_only_v0() -> None:
+    payload = _preflight_payload()
+    assert payload["stop_command"] == (
+        "uv run python scripts/ops/report_paper_shadow_247_preflight_status.py --json"
+    )
+    assert payload["emergency_stop_command"] == (
+        "uv run python scripts/ops/snapshot_operator_stop_signals.py --json"
+    )
+    for key in PREFLIGHT_AUTHORIZATION_KEYS:
+        assert payload[key] is False, key
+
+
+def test_gap5_stop_criteria_drift_guard_gap4_gap6_tokens_untouched_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+
+
+def test_gap5_stop_criteria_drift_guard_criteria_complete_does_not_close_gaps_v0() -> None:
+    text = _section5_text()
+    assert "SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true" in text
+    assert "ALL_GAPS_CLOSED=false" in text
+    assert "GAP5_CRITERIA_ONLY=true" in text
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in text
+
+
+def test_gap5_stop_criteria_drift_guard_evidence_not_approval_language_v0() -> None:
+    section = _gap5_section(_section5_text())
+    assert "criteria-only" in section
+    assert "not rehearsal-executed" in section
+    assert "not proof-accepted" in section
+    assert "does not treat any archive or prior stop rehearsal as proof accepted" in section
+
+
+def test_gap5_stop_criteria_drift_guard_module_is_static_parse_only_v0() -> None:
+    import ast
+
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "subprocess"
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module != "subprocess"
+
+
+def test_gap5_stop_criteria_drift_guard_owner_crosslinks_gap5_criteria_tests_v0() -> None:
+    assert GAP5_TESTS.is_file()
+    text = GAP5_TESTS.read_text(encoding="utf-8")
+    assert "test_gap5_stop_criteria_drift_guard_contract_v0.py" in text
+
+
+def test_gap5_stop_criteria_drift_guard_owner_crosslinks_hardening_source_contract_v0() -> None:
+    assert HARDENING_OWNER.is_file()
+    text = HARDENING_OWNER.read_text(encoding="utf-8")
+    assert "test_gap5_stop_criteria_drift_guard_contract_v0.py" in text
+    lines = {line.strip() for line in text.splitlines()}
+    assert ("GAP5_STOP_REHEARSAL_EXECUTED" + _MARKER_TRUE) not in lines
+    assert ("GAP5_STOP_PROOF_ACCEPTED" + _MARKER_TRUE) not in lines

--- a/tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py
+++ b/tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py
@@ -25,6 +25,9 @@ GAP2_GAP3_DEPENDENCY_TESTS = (
 )
 GAP4_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap4_output_evidence_paths_contract_v0.py"
 GAP5_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap5_stop_criteria_contract_v0.py"
+GAP5_DRIFT_GUARD_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_gap5_stop_criteria_drift_guard_contract_v0.py"
+)
 GAP7_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap7_risk_boundary_criteria_contract_v0.py"
 HARD_GATE_TESTS = (
     REPO_ROOT / "tests" / "ops" / "test_run_primary_evidence_retention_hard_gate_v0.py"
@@ -49,6 +52,7 @@ OWNER_REFERENCES_V0 = (
     "tests/ops/test_gap3_execute_command_contract_v0.py",
     "tests/ops/test_gap4_output_evidence_paths_contract_v0.py",
     "tests/ops/test_gap5_stop_criteria_contract_v0.py",
+    "tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py",
     "tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py",
     "tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py",
     "tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py",
@@ -239,6 +243,13 @@ def test_gap5_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0() 
     text = GAP5_TESTS.read_text(encoding="utf-8")
     assert "test_scheduler_dry_run_hardening_source_contract_v0.py" in text
     assert PACKAGE_MARKER in text
+
+
+def test_gap5_drift_guard_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0() -> None:
+    text = GAP5_DRIFT_GUARD_TESTS.read_text(encoding="utf-8")
+    assert "test_scheduler_dry_run_hardening_source_contract_v0.py" in text
+    assert "test_gap5_stop_criteria_contract_v0.py" in text
+    assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in text
 
 
 def test_gap7_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0() -> None:

--- a/tests/ops/test_snapshot_operator_stop_signals.py
+++ b/tests/ops/test_snapshot_operator_stop_signals.py
@@ -254,10 +254,13 @@ def test_snapshot_owner_crosslinks_gap5_and_scheduler_dry_run_hardening_v0() -> 
     assert gap5_owner.is_file()
     assert hardening_owner.is_file()
 
+    gap5_drift_guard = ROOT / "tests" / "ops" / "test_gap5_stop_criteria_drift_guard_contract_v0.py"
     gap5_text = gap5_owner.read_text(encoding="utf-8")
     assert "test_scheduler_dry_run_hardening_source_contract_v0.py" in gap5_text
     assert hardening_marker in gap5_text
     assert Path(__file__).name in gap5_text
+    assert gap5_drift_guard.is_file()
+    assert "snapshot_operator_stop_signals.py" in gap5_drift_guard.read_text(encoding="utf-8")
 
     hardening_text = hardening_owner.read_text(encoding="utf-8")
     assert "test_gap5_stop_criteria_contract_v0.py" in hardening_text


### PR DESCRIPTION
## Summary

- **tests-only** static drift guard for Gap-5 stop/emergency-stop criteria
- **no runtime** — parse §5 markdown, preflight TOML, and test sources only
- **no scheduler** start/stop or mutation
- **no stop command** execution
- **no process kill**
- **no subprocess execution** for trading/runtime/stop scripts
- **no config mutation**
- **no jobs.toml mutation**
- **no preflight TOML mutation**
- **no reporter mutation**
- **no flag lifts**
- **no Notion**
- **no parallel docs/builds**
- **F5 external approved remains procedure-text only** — forbidden in repo SSOT
- **Gap5 remains not rehearsed and not proof-accepted**
- **Gap4/Gap6 not touched/bundled**
- **Preflight remains BLOCKED**

Adds `test_gap5_stop_criteria_drift_guard_contract_v0.py` (mirror Gap-6/Gap-2 drift-guard pattern) plus minimal reciprocal crosslinks in existing Gap-5, hardening, and snapshot test owners.

## Test plan

- [x] `uv run pytest tests/ops/test_gap5_stop_criteria_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_snapshot_operator_stop_signals.py -q`
- [x] `uv run pytest tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py -q`
- [x] `uv run ruff check` / `ruff format --check` on touched test files


Made with [Cursor](https://cursor.com)