### PR TITLE
ops: add gap5 stop rehearsal evidence classification tests

### DIFF
--- a/tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py
+++ b/tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py
@@ -254,3 +254,15 @@ def test_gap5_gap4_durable_evidence_dependency_owner_crosslinks_hardening_source
     lines = {line.strip() for line in text.splitlines()}
     assert ("GAP5_STOP_PROOF_ACCEPTED" + _MARKER_TRUE) not in lines
     assert ("GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED" + _MARKER_TRUE) not in lines
+
+
+def test_gap5_gap4_durable_evidence_dependency_owner_crosslinks_rehearsal_classification_v0() -> (
+    None
+):
+    classification = (
+        ROOT / "tests" / "ops" / "test_gap5_stop_rehearsal_evidence_classification_contract_v0.py"
+    )
+    assert classification.is_file()
+    text = classification.read_text(encoding="utf-8")
+    assert "test_gap5_gap4_durable_evidence_dependency_contract_v0.py" in text
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in text

--- a/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
@@ -225,3 +225,13 @@ def test_gap5_stop_criteria_drift_guard_owner_crosslinks_gap5_gap4_dependency_v0
     text = dependency.read_text(encoding="utf-8")
     assert "test_gap5_stop_criteria_drift_guard_contract_v0.py" in text
     assert "GAP5_STOP_PROOF_ACCEPTED=false" in text
+
+
+def test_gap5_stop_criteria_drift_guard_owner_crosslinks_rehearsal_classification_v0() -> None:
+    classification = (
+        ROOT / "tests" / "ops" / "test_gap5_stop_rehearsal_evidence_classification_contract_v0.py"
+    )
+    assert classification.is_file()
+    text = classification.read_text(encoding="utf-8")
+    assert "test_gap5_stop_criteria_drift_guard_contract_v0.py" in text
+    assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in text

--- a/tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py
+++ b/tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py
@@ -1,0 +1,207 @@
+"""Static contract for Gap-5 stop-rehearsal evidence classification v0.
+
+Reads repo markdown/source only. Never executes stop/scheduler/runtime, never copies/moves/archives
+evidence, never reads external archive paths as pass/fail SSOT, and never treats external rehearsal
+records as repo ``GAP5_STOP_REHEARSAL_EXECUTED`` or ``GAP5_STOP_PROOF_ACCEPTED``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SECTION5_DOC = (
+    ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+)
+PREFLIGHT_CONTRACT = (
+    ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
+)
+GAP5_DRIFT_GUARD = ROOT / "tests" / "ops" / "test_gap5_stop_criteria_drift_guard_contract_v0.py"
+GAP5_GAP4_DEPENDENCY = (
+    ROOT / "tests" / "ops" / "test_gap5_gap4_durable_evidence_dependency_contract_v0.py"
+)
+HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_source_contract_v0.py"
+FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
+GAP5_SECTION_HEADER = "## Gap 5 Stop Criteria Contract v0"
+_MARKER_TRUE = "=true"
+
+EXTERNAL_REHEARSAL_RECORD_NOT_REPO_SSOT = True
+REHEARSAL_EXECUTED_EXTERNAL_NOT_GAP5_STOP_REHEARSAL_EXECUTED = True
+STOP_PROOF_OBSERVED_EXTERNAL_NOT_GAP5_STOP_PROOF_ACCEPTED = True
+EVIDENCE_EQUALS_APPROVAL = False
+CRITERIA_COMPLETE_EQUALS_GAP_CLOSED = False
+FUTURE_REHEARSAL_ACCEPTANCE_REQUIRES_GOVERNED_REPO_PROCESS = True
+
+CLASSIFICATION_REQUIRED_FINAL_LINES = (
+    "PREFLIGHT_REMAINS_BLOCKED=true",
+    "READY_FOR_OPERATOR_ARMING=false",
+    "PATH_B_LIFT_DISCUSSION_READY=false",
+    "ALL_GAPS_CLOSED=false",
+    "GAP5_STOP_REHEARSAL_EXECUTED=false",
+    "GAP5_STOP_PROOF_ACCEPTED=false",
+    "GAP5_TYPE2_WAIVER_GRANTED=false",
+    "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false",
+    "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+)
+
+CLASSIFICATION_FORBIDDEN_REPO_TOKENS = (
+    "GAP5_STOP_REHEARSAL_EXECUTED=true",
+    "GAP5_STOP_PROOF_ACCEPTED=true",
+    "GAP5_STOP_CRITERIA_VERIFIED=true",
+    "REHEARSAL_EXECUTED=true",
+    "REHEARSAL_OBSERVED=true",
+    "STOP_PROOF_OBSERVED=true",
+    "GAP5_STOP_REHEARSAL_EXECUTED_EXTERNAL=true",
+    "GAP5_STOP_PROOF_ACCEPTED_EXTERNAL=true",
+    "EXTERNAL_REHEARSAL_EVIDENCE_ACCEPTED=true",
+    "WORKSHEET_COMPLETE=true",
+    "PATH_B_LIFT_DISCUSSION_READY=true",
+    "ALL_GAPS_CLOSED=true",
+    "READY_FOR_OPERATOR_ARMING=true",
+    "PREFLIGHT_REMAINS_BLOCKED=false",
+    "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
+    "SHADOW_24_7_AUTHORIZED=true",
+)
+
+
+def _final_machine_lines(text: str) -> str:
+    return text.split(FINAL_MACHINE_LINES_HEADER, 1)[1]
+
+
+def _gap5_section(text: str) -> str:
+    return text.split(GAP5_SECTION_HEADER, 1)[1].split("## Gap 2 Canonical Job Set Contract v0", 1)[
+        0
+    ]
+
+
+def _section5_text() -> str:
+    return SECTION5_DOC.read_text(encoding="utf-8")
+
+
+def test_gap5_rehearsal_classification_module_constants_v0() -> None:
+    assert EXTERNAL_REHEARSAL_RECORD_NOT_REPO_SSOT is True
+    assert REHEARSAL_EXECUTED_EXTERNAL_NOT_GAP5_STOP_REHEARSAL_EXECUTED is True
+    assert STOP_PROOF_OBSERVED_EXTERNAL_NOT_GAP5_STOP_PROOF_ACCEPTED is True
+    assert EVIDENCE_EQUALS_APPROVAL is False
+    assert CRITERIA_COMPLETE_EQUALS_GAP_CLOSED is False
+    assert FUTURE_REHEARSAL_ACCEPTANCE_REQUIRES_GOVERNED_REPO_PROCESS is True
+
+
+def test_gap5_rehearsal_classification_final_machine_lines_remain_blocked_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    for marker in CLASSIFICATION_REQUIRED_FINAL_LINES:
+        assert marker in block
+
+
+def test_gap5_rehearsal_classification_forbids_lift_and_external_tokens_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    lines = {line.strip() for line in block.splitlines()}
+    for token in CLASSIFICATION_FORBIDDEN_REPO_TOKENS:
+        assert token not in lines
+
+
+def test_gap5_rehearsal_classification_repo_ssot_forbids_external_rehearsal_tokens_v0() -> None:
+    text = _section5_text()
+    external_tokens = (
+        "REHEARSAL_EXECUTED=true",
+        "REHEARSAL_OBSERVED=true",
+        "STOP_PROOF_OBSERVED=true",
+        "GAP5_STOP_REHEARSAL_EXECUTED_EXTERNAL=true",
+        "GAP5_STOP_PROOF_ACCEPTED_EXTERNAL=true",
+        "EXTERNAL_REHEARSAL_EVIDENCE_ACCEPTED=true",
+    )
+    for token in external_tokens:
+        assert token not in text
+
+
+def test_gap5_rehearsal_classification_gap5_section_preserves_not_rehearsed_not_proof_v0() -> None:
+    section = _gap5_section(_section5_text())
+    assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in section
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in section
+    assert "does not execute or claim a stop-tool rehearsal" in section
+    assert "does not accept or verify stop proof" in section
+    assert "criteria-only" in section
+    assert "not rehearsal-executed" in section
+    assert "not proof-accepted" in section
+    lines = {line.strip() for line in section.splitlines()}
+    for token in CLASSIFICATION_FORBIDDEN_REPO_TOKENS:
+        assert token not in lines
+
+
+def test_gap5_rehearsal_classification_preflight_evidence_not_approval_v0() -> None:
+    text = PREFLIGHT_CONTRACT.read_text(encoding="utf-8")
+    assert "Current status: **BLOCKED**." in text
+    assert "Evidence ≠ approval" in text
+
+
+def test_gap5_rehearsal_classification_drift_guard_is_not_rehearsal_executed_v0() -> None:
+    assert GAP5_DRIFT_GUARD.is_file()
+    text = GAP5_DRIFT_GUARD.read_text(encoding="utf-8")
+    assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in text
+    assert "DRIFT_GUARD_FORBIDDEN_GAP5_REPO_TOKENS" in text
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in text
+    assert "never treats external F5 approval or planning" in text
+    assert "charters as repo Gap-5 rehearsal execution or proof acceptance" in text
+
+
+def test_gap5_rehearsal_classification_dependency_is_not_proof_acceptance_v0() -> None:
+    assert GAP5_GAP4_DEPENDENCY.is_file()
+    text = GAP5_GAP4_DEPENDENCY.read_text(encoding="utf-8")
+    assert "GAP5_STOP_PROOF_REQUIRES_DURABLE_GAP4_CHAIN" in text
+    assert "GAP4_DURABLE_CHAIN_IS_FUTURE_REQUIREMENT" in text
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in text
+    assert (
+        "never treats planning/drift guards as verified durable chains or stop proof acceptance"
+        in text
+    )
+
+
+def test_gap5_rehearsal_classification_gap4_gap6_tokens_untouched_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+
+
+def test_gap5_rehearsal_classification_criteria_complete_does_not_close_gaps_v0() -> None:
+    text = _section5_text()
+    assert "SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true" in text
+    assert "ALL_GAPS_CLOSED=false" in text
+    assert "GAP5_STOP_CRITERIA_CONTRACT_V0=true" in text
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in text
+
+
+def test_gap5_rehearsal_classification_module_is_static_no_subprocess_v0() -> None:
+    import ast
+
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "subprocess"
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module != "subprocess"
+
+
+def test_gap5_rehearsal_classification_owner_crosslinks_drift_guard_v0() -> None:
+    assert GAP5_DRIFT_GUARD.is_file()
+    text = GAP5_DRIFT_GUARD.read_text(encoding="utf-8")
+    assert "test_gap5_stop_rehearsal_evidence_classification_contract_v0.py" in text
+
+
+def test_gap5_rehearsal_classification_owner_crosslinks_dependency_v0() -> None:
+    assert GAP5_GAP4_DEPENDENCY.is_file()
+    text = GAP5_GAP4_DEPENDENCY.read_text(encoding="utf-8")
+    assert "test_gap5_stop_rehearsal_evidence_classification_contract_v0.py" in text
+
+
+def test_gap5_rehearsal_classification_owner_crosslinks_hardening_source_contract_v0() -> None:
+    assert HARDENING_OWNER.is_file()
+    text = HARDENING_OWNER.read_text(encoding="utf-8")
+    assert "test_gap5_stop_rehearsal_evidence_classification_contract_v0.py" in text
+    lines = {line.strip() for line in text.splitlines()}
+    assert ("GAP5_STOP_REHEARSAL_EXECUTED" + _MARKER_TRUE) not in lines
+    assert ("GAP5_STOP_PROOF_ACCEPTED" + _MARKER_TRUE) not in lines

--- a/tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py
+++ b/tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py
@@ -34,6 +34,9 @@ GAP5_DRIFT_GUARD_TESTS = (
 GAP5_GAP4_DEPENDENCY_TESTS = (
     REPO_ROOT / "tests" / "ops" / "test_gap5_gap4_durable_evidence_dependency_contract_v0.py"
 )
+GAP5_REHEARSAL_CLASSIFICATION_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_gap5_stop_rehearsal_evidence_classification_contract_v0.py"
+)
 GAP7_TESTS = REPO_ROOT / "tests" / "ops" / "test_gap7_risk_boundary_criteria_contract_v0.py"
 HARD_GATE_TESTS = (
     REPO_ROOT / "tests" / "ops" / "test_run_primary_evidence_retention_hard_gate_v0.py"
@@ -61,6 +64,7 @@ OWNER_REFERENCES_V0 = (
     "tests/ops/test_gap5_stop_criteria_contract_v0.py",
     "tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py",
     "tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py",
+    "tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py",
     "tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py",
     "tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py",
     "tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py",
@@ -275,6 +279,20 @@ def test_gap5_gap4_dependency_owner_crosslinks_scheduler_dry_run_hardening_sourc
     assert "test_gap4_output_evidence_paths_drift_guard_contract_v0.py" in text
     assert "test_gap5_stop_criteria_drift_guard_contract_v0.py" in text
     assert "GAP5_STOP_PROOF_ACCEPTED=false" in text
+
+
+def test_gap5_rehearsal_classification_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0() -> (
+    None
+):
+    text = GAP5_REHEARSAL_CLASSIFICATION_TESTS.read_text(encoding="utf-8")
+    assert "test_scheduler_dry_run_hardening_source_contract_v0.py" in text
+    assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in text
+    assert "GAP5_STOP_PROOF_ACCEPTED=false" in text
+    hardening_text = _this_module_source()
+    assert "test_gap5_stop_rehearsal_evidence_classification_contract_v0.py" in hardening_text
+    lines = {line.strip() for line in hardening_text.splitlines()}
+    assert ("GAP5_STOP_REHEARSAL_EXECUTED" + _MARKER_TRUE) not in lines
+    assert ("GAP5_STOP_PROOF_ACCEPTED" + _MARKER_TRUE) not in lines
 
 
 def test_gap7_owner_crosslinks_scheduler_dry_run_hardening_source_contract_v0() -> None:


### PR DESCRIPTION
## Summary

- Adds static Gap-5 stop-rehearsal evidence classification tests-only guardrails per external charter.
- Closes the Gap-5 static chain after criteria drift guard (#3828) and Gap5↔Gap4 durable evidence dependency (#3830).
- External/observed rehearsal tokens (`REHEARSAL_EXECUTED`, `REHEARSAL_OBSERVED`, `STOP_PROOF_OBSERVED`, etc.) must not be read as repo SSOT lifts.

## Charter

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/repo_gap5_stop_rehearsal_evidence_classification_tests_only_charter_v0_20260531T183211Z/`

(`MANIFEST_VERIFY_RC=0`)

## Scope

- **tests-only** — `tests/ops/` only
- 4 touched files (within charter max ~4)

## Touched files

- `tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py` (new)
- `tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py` (minimal reciprocal crosslink)
- `tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py` (minimal reciprocal crosslink)
- `tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py` (OWNER_REFERENCES + reciprocal crosslink)

## Validation RCs

- `pytest tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py -q` → **14 passed, RC=0**
- `pytest tests/ops/test_gap5_stop_criteria_contract_v0.py tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py -q` → **44 passed, RC=0**
- `pytest tests/ops/test_gap5_* -q` → **58 passed, RC=0**
- `pytest tests/ops/test_scheduler_dry_run_hardening_source_contract_v0.py -q` → **30 passed, RC=0**
- `ruff check` + `ruff format --check` on touched files → **RC=0**

## Reuse-before-new

- Inventoried existing Gap-5 contract, drift guard, Gap5↔Gap4 dependency, and hardening hub owners.
- New dedicated module justified (Gap-6 external↔repo pattern); no existing owner covered external rehearsal classification.
- Reciprocal crosslinks limited to 3 existing owners; no parallel docs/SSOT.

## Reuse Drift Guard

- Extended hardening `OWNER_REFERENCES_V0` hub; reciprocal owner-reference tests added.
- No duplication of full drift-guard assertion sets in classification module.

## Confirmations

- **No parallel builds/docs** — no new markdown SSOT, Notion, or handoff surfaces.
- **Runtime/Config/Impl untouched** — no `scripts/**`, `config/**`, `src/**`, stop scripts, or Gap-6 edits.
- **Flag lifts remain false** — `GAP5_STOP_REHEARSAL_EXECUTED=false`, `GAP5_STOP_PROOF_ACCEPTED=false`, `GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false`, `GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false`, `GAP6_DRY_RUN_PROOF_ACCEPTED=false`, `SHADOW_24_7_AUTHORIZED=false`, `PREFLIGHT_REMAINS_BLOCKED=true`, `READY_FOR_OPERATOR_ARMING=false`.

## Test plan

- [x] pytest gap5 classification module
- [x] pytest gap5 family
- [x] pytest hardening hub reciprocal
- [x] ruff check/format on touched files


Made with [Cursor](https://cursor.com)