### PR TITLE
ops: reflect gap7 risk boundary acceptance

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -451,6 +451,36 @@ This governed repo-reflection block records scoped acceptance of external Tier-A
 
 Evidence acceptance is not runtime authorization. The Gap 4 Output/Evidence Paths Contract v0 block above remains contract-only and unchanged.
 
+## Gap 7 Governed Risk Boundary Acceptance Reflection v0
+
+GAP7_RISK_BOUNDARY_GOVERNED_REFLECTION_V0=true
+GAP7_RISK_BOUNDARY_ACCEPTED=true
+ACCEPTED_MODE=GAP7_RISK_BOUNDARY_SCOPED_EXTERNAL_CHECKLIST_WALKTHROUGH_ACCEPTANCE
+EXTERNAL_ACCEPTANCE_RECORD_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap7_risk_boundary_operator_walkthrough_external_acceptance_record_v0_20260531T202750Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap7_risk_boundary_governed_repo_reflection_charter_v0_after_external_acceptance_20260531T202930Z/
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records scoped acceptance of external Gap-7 risk-boundary checklist walkthrough evidence only. It does not adopt external-only acceptance tokens as repo SSOT. External acceptance records remain pointer-based and subordinate to repo governance.
+
+### Non-authority boundary (scoped reflection does not imply)
+
+- does not verify Gap-7 risk boundaries in criteria or Final Machine Lines
+- does not change Risk/KillSwitch authority or runtime behavior
+- does not change execution/live gates
+- does not verify Gap-4 output evidence paths in criteria or Final Machine Lines
+- does not enforce Gap-2a.1 primary evidence
+- does not authorize scheduler execution
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+- does not modify existing Gap-7 criteria/final machine-line verification status
+- does not lift preflight
+
+Evidence acceptance is not runtime authorization. The Gap 7 Risk Boundary Criteria Contract v0 block above remains criteria-only and unchanged.
+
 ## Final Machine Lines
 
 SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true

--- a/tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py
+++ b/tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py
@@ -4,6 +4,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
 GAP7_SECTION_HEADER = "## Gap 7 Risk Boundary Criteria Contract v0"
+GAP7_GOVERNED_REFLECTION_HEADER = "## Gap 7 Governed Risk Boundary Acceptance Reflection v0"
+GAP5_GOVERNED_REFLECTION_HEADER = "## Gap 5 Governed Stop Proof Acceptance Reflection v0"
+FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP7_PARALLEL_MARKERS = (
     "GAP7_RISK_BOUNDARY_CRITERIA_CONTRACT_V0=true",
     "Gap 7 Risk Boundary Criteria Contract v0",
@@ -15,8 +18,16 @@ DRIFT_GUARD_OWNER = ROOT / "tests" / "ops" / "test_gap7_risk_boundary_drift_guar
 _MARKER_TRUE = "=true"
 
 
+def _gap7_criteria_section(text: str) -> str:
+    return text.split(GAP7_SECTION_HEADER, 1)[1].split(GAP5_GOVERNED_REFLECTION_HEADER, 1)[0]
+
+
+def _gap7_governed_reflection_section(text: str) -> str:
+    return text.split(GAP7_GOVERNED_REFLECTION_HEADER, 1)[1].split(FINAL_MACHINE_LINES_HEADER, 1)[0]
+
+
 def _gap7_section(text: str) -> str:
-    return text.split(GAP7_SECTION_HEADER, 1)[1].split("## Final Machine Lines", 1)[0]
+    return _gap7_criteria_section(text)
 
 
 def test_gap7_risk_boundary_criteria_contract_is_present_and_non_authorizing():
@@ -165,3 +176,39 @@ def test_gap7_owner_crosslinks_risk_boundary_drift_guard_contract_v0():
     assert "GAP7_RISK_BOUNDARY_VERIFIED=false" in text
     assert "GAP7_RISK_KILLSWITCH_AUTHORITY_CHANGED=false" in text
     assert "DRIFT_GUARD_FORBIDDEN_GAP7_REPO_TOKENS" in text
+
+
+def test_gap7_risk_boundary_criteria_contract_governed_reflection_non_authorizing_v0():
+    text = DOC.read_text(encoding="utf-8")
+    reflection = _gap7_governed_reflection_section(text)
+    criteria = _gap7_criteria_section(text)
+    block = text.split(FINAL_MACHINE_LINES_HEADER, 1)[1]
+
+    assert "GAP7_RISK_BOUNDARY_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED=true" in reflection
+    assert (
+        "ACCEPTED_MODE=GAP7_RISK_BOUNDARY_SCOPED_EXTERNAL_CHECKLIST_WALKTHROUGH_ACCEPTANCE"
+        in reflection
+    )
+    assert "EXTERNAL_ACCEPTANCE_RECORD_POINTER=" in reflection
+    assert "Evidence acceptance is not runtime authorization" in reflection
+    assert "does not verify Gap-7 risk boundaries in criteria or Final Machine Lines" in reflection
+    assert "does not change Risk/KillSwitch authority or runtime behavior" in reflection
+    assert "does not authorize scheduler execution" in reflection
+    assert "does not enable operator arming" in reflection
+    assert "does not start or authorize Runtime, Paper, Shadow, Testnet, or Live" in reflection
+    assert (
+        "does not modify existing Gap-7 criteria/final machine-line verification status"
+        in reflection
+    )
+    assert "GAP7_RISK_BOUNDARY_VERIFIED=false" in criteria
+    assert "criteria-only" in criteria
+    assert "not verified" in criteria
+    assert "GAP7_RISK_BOUNDARY_VERIFIED=false" in block
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED_EXTERNAL=true" not in text
+    reflection_lines = {line.strip() for line in reflection.splitlines()}
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED=true" in reflection_lines
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED=true" not in criteria_lines
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED=true" not in block_lines

--- a/tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py
@@ -23,6 +23,8 @@ HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_sou
 BOUNDARY_OWNER = ROOT / "tests" / "ops" / "test_scheduler_boundary_hard_block_contract_v0.py"
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP7_SECTION_HEADER = "## Gap 7 Risk Boundary Criteria Contract v0"
+GAP7_GOVERNED_REFLECTION_HEADER = "## Gap 7 Governed Risk Boundary Acceptance Reflection v0"
+GAP5_GOVERNED_REFLECTION_HEADER = "## Gap 5 Governed Stop Proof Acceptance Reflection v0"
 _MARKER_TRUE = "=true"
 
 GAP7_RISK_BOUNDARY_PLANNED = True
@@ -118,8 +120,16 @@ def _final_machine_lines(text: str) -> str:
     return text.split(FINAL_MACHINE_LINES_HEADER, 1)[1]
 
 
+def _gap7_criteria_section(text: str) -> str:
+    return text.split(GAP7_SECTION_HEADER, 1)[1].split(GAP5_GOVERNED_REFLECTION_HEADER, 1)[0]
+
+
+def _gap7_governed_reflection_section(text: str) -> str:
+    return text.split(GAP7_GOVERNED_REFLECTION_HEADER, 1)[1].split(FINAL_MACHINE_LINES_HEADER, 1)[0]
+
+
 def _gap7_section(text: str) -> str:
-    return text.split(GAP7_SECTION_HEADER, 1)[1].split(FINAL_MACHINE_LINES_HEADER, 1)[0]
+    return _gap7_criteria_section(text)
 
 
 def _section5_text() -> str:
@@ -296,3 +306,55 @@ def test_gap7_drift_guard_owner_crosslinks_boundary_contract_v0() -> None:
     assert BOUNDARY_OWNER.is_file()
     section = _gap7_section(_section5_text())
     assert "test_scheduler_boundary_hard_block_contract_v0.py" in section
+
+
+def test_gap7_drift_guard_repo_ssot_forbids_external_gap7_acceptance_token_v0() -> None:
+    text = _section5_text()
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED_EXTERNAL=true" not in text
+    assert "GAP7_RISK_BOUNDARY_VERIFIED=false" in text
+
+
+def test_gap7_drift_guard_governed_reflection_scoped_acceptance_v0() -> None:
+    text = _section5_text()
+    reflection = _gap7_governed_reflection_section(text)
+    criteria = _gap7_criteria_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP7_RISK_BOUNDARY_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED=true" in reflection
+    assert (
+        "ACCEPTED_MODE=GAP7_RISK_BOUNDARY_SCOPED_EXTERNAL_CHECKLIST_WALKTHROUGH_ACCEPTANCE"
+        in reflection
+    )
+    assert "NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true" in reflection
+    assert "EXTERNAL_ACCEPTANCE_RECORD_POINTER=" in reflection
+    assert "GOVERNED_REPO_REFLECTION_CHARTER_POINTER=" in reflection
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED_EXTERNAL=true" not in text
+    assert "does not verify Gap-7 risk boundaries in criteria or Final Machine Lines" in reflection
+    assert "does not change Risk/KillSwitch authority or runtime behavior" in reflection
+    assert "does not change execution/live gates" in reflection
+    assert "does not authorize scheduler execution" in reflection
+    assert "does not enable operator arming" in reflection
+    assert "does not open Path-B lift discussion" in reflection
+    assert "does not start or authorize Runtime, Paper, Shadow, Testnet, or Live" in reflection
+    assert (
+        "does not modify existing Gap-7 criteria/final machine-line verification status"
+        in reflection
+    )
+    assert "Evidence acceptance is not runtime authorization" in reflection
+    assert "GAP7_RISK_BOUNDARY_VERIFIED=false" in criteria
+    assert "criteria-only" in criteria
+    assert "not verified" in criteria
+    assert "GAP7_RISK_BOUNDARY_VERIFIED=false" in block
+    assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false" in block
+    assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in block
+    assert "READY_FOR_OPERATOR_ARMING=false" in block
+    assert "PATH_B_LIFT_DISCUSSION_READY=false" in block
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
+    reflection_lines = {line.strip() for line in reflection.splitlines()}
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED=true" in reflection_lines
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED=true" not in criteria_lines
+    assert "GAP7_RISK_BOUNDARY_ACCEPTED=true" not in block_lines
+    assert "GAP7_RISK_BOUNDARY_VERIFIED=true" not in block_lines


### PR DESCRIPTION
## Summary

Governed, minimal repo reflection of external scoped Gap-7 risk-boundary checklist walkthrough acceptance. Adds a scoped reflection block to Section5 and extends existing Gap-7 criteria/drift-guard test contracts. Criteria block and Final Machine Lines remain `GAP7_RISK_BOUNDARY_VERIFIED=false`. No Risk/KillSwitch implementation, runtime, scheduler, preflight lift, Path-B, or arming lift.

## External inputs

**Governed reflection charter:**
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap7_risk_boundary_governed_repo_reflection_charter_v0_after_external_acceptance_20260531T202930Z/`

**External acceptance record:**
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap7_risk_boundary_operator_walkthrough_external_acceptance_record_v0_20260531T202750Z/`

## Scope

- **docs-tests-only** (3 files max, mirror #3838)
- `GAP7_RISK_BOUNDARY_ACCEPTED=true` — scoped governed reflection block only
- `GAP7_RISK_BOUNDARY_ACCEPTED_EXTERNAL=true` — **not** in repo text
- `GAP7_RISK_BOUNDARY_VERIFIED=false` — unchanged in criteria + Final Machine Lines

## Boundaries preserved

- `PREFLIGHT_REMAINS_BLOCKED=true`
- `PATH_B_LIFT_DISCUSSION_READY=false`
- No runtime / config / Risk-KillSwitch / scheduler / paper / shadow / testnet / live changes

## Touched files (3)

- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py`
- `tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py`

## Validation

| Check | RC |
|-------|-----|
| `pytest tests/ops/test_gap7_risk_boundary_criteria_contract_v0.py tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py -q` | 0 (30 passed) |
| `pytest tests/ops/test_gap7_* tests/ops/test_gap4_* tests/ops/test_gap5_* tests/ops/test_gap6_* -q` | 0 (157 passed) |
| `ruff check` (touched Python) | 0 |
| `ruff format --check` (touched Python) | 0 |
| `GAP7_RISK_BOUNDARY_ACCEPTED_EXTERNAL=true` in repo | absent |
| `GAP7_RISK_BOUNDARY_VERIFIED=true` introduced | no |


Made with [Cursor](https://cursor.com)