### PR TITLE
ops: align Section5 Gap4 token contract tests

### DIFF
--- a/tests/ops/test_gap4_gap2a1_primary_evidence_dependency_contract_v0.py
+++ b/tests/ops/test_gap4_gap2a1_primary_evidence_dependency_contract_v0.py
@@ -26,6 +26,8 @@ GAP2A1_DRIFT_GUARD = (
 HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_source_contract_v0.py"
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP4_SECTION_HEADER = "## Gap 4 Output/Evidence Paths Contract v0"
+GAP4_COMPLETENESS_REFLECTION_HEADER = "## Gap 4 Full-Scope Evidence Completeness Reflection v0"
+GAP4_VERIFIED_REFLECTION_HEADER = "## Gap 4 Full-Scope Gap4 Verified Reflection v0"
 GAP2A1_SECTION_HEADER = "## §2a.1 Primary Evidence Enforcement Contract v0"
 _MARKER_TRUE = "=true"
 
@@ -96,6 +98,10 @@ CONFLATION_SAMPLE_LINES_MUST_NOT_LIFT_ENFORCEMENT = (
     "EXTERNAL_TIER_PLAN_TIER_5_SATISFIED=true",
 )
 
+CONFLATION_SAMPLE_ALLOWED_IN_COMPLETENESS_REFLECTION_ONLY = (
+    "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
+)
+
 
 def _final_machine_lines(text: str) -> str:
     return text.split(FINAL_MACHINE_LINES_HEADER, 1)[1]
@@ -110,6 +116,18 @@ def _gap4_section(text: str) -> str:
 def _gap2a1_section(text: str) -> str:
     return text.split(GAP2A1_SECTION_HEADER, 1)[1].split(
         "## Gap 1 Execute Entrypoint Contract v0", 1
+    )[0]
+
+
+def _gap4_completeness_reflection_section(text: str) -> str:
+    return text.split(GAP4_COMPLETENESS_REFLECTION_HEADER, 1)[1].split(
+        GAP4_VERIFIED_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap4_verified_reflection_section(text: str) -> str:
+    return text.split(GAP4_VERIFIED_REFLECTION_HEADER, 1)[1].split(
+        "## Gap 7 Governed Risk Boundary Acceptance Reflection v0", 1
     )[0]
 
 
@@ -192,12 +210,21 @@ def test_gap4_gap2a1_dependency_durable_evidence_not_enforcement_v0() -> None:
 
 def test_gap4_gap2a1_dependency_sample_conflation_lines_not_repo_ssot_lifts_v0() -> None:
     text = _section5_text()
-    block = _final_machine_lines(text)
-    block_lines = {line.strip() for line in block.splitlines()}
-    doc_lines = {line.strip() for line in text.splitlines()}
+    block_lines = {line.strip() for line in _final_machine_lines(text).splitlines()}
+    criteria_lines = {line.strip() for line in _gap4_section(text).splitlines()}
+    gap2a1_lines = {line.strip() for line in _gap2a1_section(text).splitlines()}
+    completeness_lines = {
+        line.strip() for line in _gap4_completeness_reflection_section(text).splitlines()
+    }
+    verified_lines = {line.strip() for line in _gap4_verified_reflection_section(text).splitlines()}
+    repo_ssot_lines = block_lines | criteria_lines | gap2a1_lines
     for sample in CONFLATION_SAMPLE_LINES_MUST_NOT_LIFT_ENFORCEMENT:
         assert sample not in block_lines
-        assert sample not in doc_lines
+        if sample in CONFLATION_SAMPLE_ALLOWED_IN_COMPLETENESS_REFLECTION_ONLY:
+            assert sample in completeness_lines or sample in verified_lines
+            assert sample not in repo_ssot_lines
+            continue
+        assert sample not in repo_ssot_lines
 
 
 def test_gap4_gap2a1_dependency_tmp_not_canonical_durable_chain_v0() -> None:

--- a/tests/ops/test_gap4_req_b_shadow_b07_b08_adapter_parity_contract_v0.py
+++ b/tests/ops/test_gap4_req_b_shadow_b07_b08_adapter_parity_contract_v0.py
@@ -16,6 +16,19 @@ REVIEW_SCRIPT = ROOT / "scripts" / "ops" / "review_shadow_bounded_observation_ev
 SECTION5_DOC = (
     ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
 )
+FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
+GAP4_CRITERIA_HEADER = "## Gap 4 Output/Evidence Paths Contract v0"
+GAP4_ADAPTER_PARITY_HEADER = "## Gap 4 REQ-B Shadow B07/B08 Adapter Parity v0"
+GAP4_COMPLETENESS_REFLECTION_HEADER = "## Gap 4 Full-Scope Evidence Completeness Reflection v0"
+GAP4_VERIFIED_REFLECTION_HEADER = "## Gap 4 Full-Scope Gap4 Verified Reflection v0"
+
+ADAPTER_PARITY_FORBIDDEN_TRUE_OUTSIDE_SCOPED_REFLECTION = (
+    "REQ_B_TIER_D_POPULATED_PATHS_FOUND=true",
+    "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
+    "FULL_SCOPE_GAP4_VERIFIED=true",
+    "GAP4_FULL_SCOPE_EVIDENCE_COMPLETE=true",
+)
+
 APPROVAL_FIXTURE = ROOT / "tests" / "fixtures" / "ops" / "shadow_adapter_stage3_approval_sample.md"
 ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
 
@@ -46,6 +59,38 @@ def _load_review():
 
 def _staging(tmp_path: Path) -> Path:
     return Path("/tmp") / f"peak_trade_shadow_parity_test_{tmp_path.name}"
+
+
+def _section5_text() -> str:
+    return SECTION5_DOC.read_text(encoding="utf-8")
+
+
+def _final_machine_lines(text: str) -> str:
+    return text.split(FINAL_MACHINE_LINES_HEADER, 1)[1]
+
+
+def _gap4_criteria_section(text: str) -> str:
+    return text.split(GAP4_CRITERIA_HEADER, 1)[1].split(
+        "## Gap 6 Dry-Run Proof Criteria Contract v0", 1
+    )[0]
+
+
+def _gap4_adapter_parity_section(text: str) -> str:
+    return text.split(GAP4_ADAPTER_PARITY_HEADER, 1)[1].split(
+        GAP4_COMPLETENESS_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap4_completeness_reflection_section(text: str) -> str:
+    return text.split(GAP4_COMPLETENESS_REFLECTION_HEADER, 1)[1].split(
+        GAP4_VERIFIED_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap4_verified_reflection_section(text: str) -> str:
+    return text.split(GAP4_VERIFIED_REFLECTION_HEADER, 1)[1].split(
+        "## Gap 7 Governed Risk Boundary Acceptance Reflection v0", 1
+    )[0]
 
 
 def _base_argv(staging: Path, archive: Path) -> list[str]:
@@ -290,15 +335,31 @@ def test_plan_only_does_not_execute_runtime_v0(tmp_path: Path) -> None:
 
 
 def test_adapter_parity_does_not_flip_section5_evidence_tokens_v0() -> None:
-    text = SECTION5_DOC.read_text(encoding="utf-8")
-    lines = {line.strip() for line in text.splitlines()}
-    assert "SHADOW_B07_B08_MISSING=true" in lines
-    assert "REQ_B_TIER_D_POPULATED_PATHS_FOUND=false" in lines
-    assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false" in lines
-    assert "FULL_SCOPE_GAP4_VERIFIED=false" in lines
-    assert "PREFLIGHT_REMAINS_BLOCKED=true" in lines
-    assert "SHADOW_B07_B08_MISSING=false" not in lines
-    assert "REQ_B_TIER_D_POPULATED_PATHS_FOUND=true" not in lines
+    text = _section5_text()
+    parity = _gap4_adapter_parity_section(text)
+    parity_lines = {line.strip() for line in parity.splitlines()}
+    criteria_lines = {line.strip() for line in _gap4_criteria_section(text).splitlines()}
+    block_lines = {line.strip() for line in _final_machine_lines(text).splitlines()}
+    completeness_lines = {
+        line.strip() for line in _gap4_completeness_reflection_section(text).splitlines()
+    }
+    verified_lines = {line.strip() for line in _gap4_verified_reflection_section(text).splitlines()}
+    repo_ssot_lines = criteria_lines | block_lines | parity_lines
+
+    assert "SHADOW_B07_B08_MISSING=true" in parity_lines
+    assert "REQ_B_TIER_D_POPULATED_PATHS_FOUND=false" in parity_lines
+    assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=false" in parity_lines
+    assert "FULL_SCOPE_GAP4_VERIFIED=false" in parity_lines
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in parity_lines
+    assert "SHADOW_B07_B08_MISSING=false" not in parity_lines
+
+    for token in ADAPTER_PARITY_FORBIDDEN_TRUE_OUTSIDE_SCOPED_REFLECTION:
+        assert token not in repo_ssot_lines
+
+    assert "REQ_B_TIER_D_POPULATED_PATHS_FOUND=true" in completeness_lines
+    assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in completeness_lines
+    assert "FULL_SCOPE_GAP4_VERIFIED=true" in verified_lines
+    assert "FULL_SCOPE_GAP4_VERIFIED=true" not in completeness_lines
 
 
 def test_pr_scope_excludes_trading_and_double_play_paths() -> None:


### PR DESCRIPTION
## Summary

- Separate fix **unrelated to PR #3853**
- Section-scoped SECTION5 token contract tests (2 files only)
- No SECTION5 document change

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/section5_gap4_contract_token_alignment_separate_pr_v0_20260601T063236Z`

## Test plan

- [x] pytest + ruff on changed tests
