### PR TITLE
tests: sync csc rchain 002 infra paid ai guard count

### DIFF
--- a/tests/ci/test_cybersecurity_visibility_repo_static_histogram_paid_ai_eval_gate_crosslink_v0.py
+++ b/tests/ci/test_cybersecurity_visibility_repo_static_histogram_paid_ai_eval_gate_crosslink_v0.py
@@ -134,8 +134,8 @@ def test_cybersecurity_visibility_repo_static_histogram_paid_ai_eval_gate_crossl
     assert ACCEPTED_SUBGROUP_009A in guard_block
     assert ACCEPTED_SUBGROUP_009B in guard_block
     assert GROUPING_REFLECTION_GUARD_MODULE in guard_block
-    assert "CSC_RCHAIN_V1_ACCEPTED_GROUP_COUNT=5" in guard_block
-    assert "CSC_RCHAIN_V1_ACCEPTED_CANDIDATE_COUNT=124" in guard_block
+    assert "CSC_RCHAIN_V1_ACCEPTED_GROUP_COUNT=6" in guard_block
+    assert "CSC_RCHAIN_V1_ACCEPTED_CANDIDATE_COUNT=125" in guard_block
     assert "CSC-RCHAIN-v1-009" in guard_block
     assert "parent **CSC-RCHAIN-v1-009**" in guard_block
 


### PR DESCRIPTION
## Summary
- **Tests-only count-sync** for existing `paid_ai_eval_gate` CSC-RCHAIN drift guard.
- Syncs assertions **5/124 → 6/125** to match main after PR #3856 (`CSC-RCHAIN-v1-002-infra` reflection).
- **No new ACCEPT unit**, no new lossless candidate, no docs change.

## Guardrails
- Strict **one-file** allowlist: `tests/ci/test_cybersecurity_visibility_repo_static_histogram_paid_ai_eval_gate_crosslink_v0.py`
- Parent **002**, groups **001–005**, parent **009** remain **PARK**
- **002-infra** remains subgroup-ACCEPT only (not parent-002-ACCEPT)
- No paid_ai_eval semantic change; Reuse Drift Guard only
- Master V2 / Double Play / Handelslogik **no-touch**
- No runtime/scheduler/AWS/trading/src/workflow touch

## Durable bundle
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/pr3856_paid_ai_eval_count_sync_after_002_infra_v0_20260601T093637Z`

## Validation
```bash
python3 -m pytest \
  tests/ci/test_csc_rchain_v1_grouping_reflection_contract_v0.py \
  tests/ci/test_cybersecurity_visibility_repo_static_histogram_scheduler_boundary_crosslink_v0.py \
  tests/ci/test_cybersecurity_visibility_repo_static_histogram_paid_ai_eval_gate_crosslink_v0.py \
  -q
```
RC=0 (see bundle `VALIDATION.log`)

## Test plan
- [ ] CI green
- [ ] Diff is exactly one allowlisted test file
