### PR TITLE
ops: add manual-only workflow recommender

### DIFF
--- a/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
+++ b/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
@@ -109,6 +109,33 @@ gh run list --workflow="ci-export-pack-download-verify.yml" --limit 5
 
 ---
 
+## Manual-only workflow recommender after PR #3896
+
+Fourteen ops/schedule workflows remain **active** on GitHub with **`workflow_dispatch` retained**; their **`schedule` / cron triggers were removed** in PR #3896 to reduce recurring Actions cost. Cron is not restored by merging or running this recommender.
+
+**Read-only CLI:** `scripts/ops/recommend_manual_only_workflows.py`
+
+| Behavior | Detail |
+|----------|--------|
+| Purpose | Map an operator **intent** (e.g. paper/shadow evidence, health suite) to relevant manual-only workflows |
+| Output | Workflow file, display name, rationale, cost/risk notes, optional `gh workflow run "…"` **text only** |
+| Does **not** | Run `gh`, mutate repo files, re-enable `schedule`, or change GitHub settings |
+| Operator-GO | Every manual run needs an explicit operator decision; runs can incur runner and provider (e.g. AI) costs |
+
+**Re-enabling cron** requires a **separate PR** that restores `schedule:` in workflow YAML plus explicit **operator-GO** — not this recommender.
+
+**Examples:**
+
+```bash
+python scripts/ops/recommend_manual_only_workflows.py --list-intents
+python scripts/ops/recommend_manual_only_workflows.py --intent paper_shadow_evidence --include-commands
+python scripts/ops/recommend_manual_only_workflows.py --intent market_info_daily --include-commands --json
+```
+
+AI-adjacent workflows (`infostream-automation`, `market_outlook_automation`) may incur model/API cost; prefer safe dispatch inputs (e.g. `skip_ai=true`) unless cost is explicitly approved.
+
+---
+
 ## Cross-References
 
 - [CI.md](CI.md) — CI pipeline overview

--- a/scripts/ops/recommend_manual_only_workflows.py
+++ b/scripts/ops/recommend_manual_only_workflows.py
@@ -373,7 +373,9 @@ def format_text(payload: dict[str, Any]) -> str:
         if rec.get("variable_gates"):
             lines.append(f"   variable gates: {rec['variable_gates']}")
         if rec.get("ai_or_paid"):
-            lines.append(f"   AI/paid: yes — {rec.get('ai_note') or 'confirm cost before dispatch'}")
+            lines.append(
+                f"   AI/paid: yes — {rec.get('ai_note') or 'confirm cost before dispatch'}"
+            )
         if rec.get("warning"):
             lines.append(f"   WARNING: {rec['warning']}")
         lines.append("   operator-GO: required before running any gh command")

--- a/scripts/ops/recommend_manual_only_workflows.py
+++ b/scripts/ops/recommend_manual_only_workflows.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""
+Read-only recommender for manual-only GitHub Actions workflows (post PR #3896).
+
+Lists workflows that match an operator intent and prints suggested `gh workflow run`
+commands as text only. Does not invoke gh, mutate files, or re-enable cron schedules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None  # type: ignore[assignment]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+GUARD_BANNER = (
+    "READ-ONLY RECOMMENDER — does not run workflows. "
+    "Operator-GO required before any manual `gh workflow run`. "
+    "Cron/schedule is not reactivated by this tool."
+)
+
+# Workflows that lost schedule in PR #3896 (manual dispatch retained).
+MANUAL_ONLY_WORKFLOW_FILES: frozenset[str] = frozenset(
+    {
+        "ci-scheduled-paper-and-export-smoke.yml",
+        "class-a-shadow-paper-scheduled-probe-v1.yml",
+        "docs_reference_targets_fullscan_schedule.yml",
+        "full_audit_weekly.yml",
+        "infostream-automation.yml",
+        "knowledge_extras_chromadb.yml",
+        "market_outlook_automation.yml",
+        "offline_suites.yml",
+        "ops_doctor_dashboard.yml",
+        "ops_doctor_pages.yml",
+        "prj-scheduled-shadow-paper-features-smoke.yml",
+        "test-health-automation.yml",
+        "test_health.yml",
+        "weekly_core_audit.yml",
+    }
+)
+
+# Related downstream workflow (dispatch-only; schedule commented in YAML).
+PAPER_TEST_EVIDENCE_FILE = "paper_tests_audit_evidence.yml"
+
+INTENT_LABELS: dict[str, str] = {
+    "paper_shadow_evidence": "Paper / shadow / scheduled-smoke orchestration",
+    "paper_test_evidence": "Direct paper-tests-audit-evidence run",
+    "health_suite": "Test health profiles and weekly core audit",
+    "market_info_daily": "Market outlook and InfoStream (AI-capable)",
+    "ops_hygiene": "Ops doctor, offline suites, knowledge extras",
+    "docs_hygiene": "Docs reference full scan",
+    "security_audit": "Weekly security and quality audit",
+    "all": "All manual-only workflows in the PR #3896 set",
+}
+
+INTENT_TO_FILES: dict[str, tuple[str, ...]] = {
+    "paper_shadow_evidence": (
+        "ci-scheduled-paper-and-export-smoke.yml",
+        "class-a-shadow-paper-scheduled-probe-v1.yml",
+        "prj-scheduled-shadow-paper-features-smoke.yml",
+    ),
+    "paper_test_evidence": (PAPER_TEST_EVIDENCE_FILE,),
+    "health_suite": (
+        "test-health-automation.yml",
+        "test_health.yml",
+        "weekly_core_audit.yml",
+    ),
+    "market_info_daily": (
+        "infostream-automation.yml",
+        "market_outlook_automation.yml",
+    ),
+    "ops_hygiene": (
+        "offline_suites.yml",
+        "ops_doctor_dashboard.yml",
+        "ops_doctor_pages.yml",
+        "knowledge_extras_chromadb.yml",
+    ),
+    "docs_hygiene": ("docs_reference_targets_fullscan_schedule.yml",),
+    "security_audit": ("full_audit_weekly.yml",),
+}
+
+STATIC_META: dict[str, dict[str, Any]] = {
+    "ci-scheduled-paper-and-export-smoke.yml": {
+        "why": "Orchestrates paper-tests-audit-evidence and export-pack verify (former hourly schedule).",
+        "risk": "medium — may dispatch child workflows; check PT_SCHEDULED_* vars and export secrets.",
+        "variable_gates": "PT_SCHEDULED_PAPER_TESTS_ENABLED, PT_SCHEDULED_EXPORT_VERIFY_ENABLED",
+        "ai": False,
+    },
+    "class-a-shadow-paper-scheduled-probe-v1.yml": {
+        "why": "Class-A shadow/paper probe (former ~4x/day schedule).",
+        "risk": "medium — shadow probe job; CLASS_A_SHADOW_PAPER_SCHEDULE_ENABLED var for gated jobs.",
+        "variable_gates": "CLASS_A_SHADOW_PAPER_SCHEDULE_ENABLED (job if:)",
+        "ai": False,
+    },
+    "prj-scheduled-shadow-paper-features-smoke.yml": {
+        "why": "PR-J shadow/paper features smoke (former hourly schedule).",
+        "risk": "medium — uses dispatch inputs for PT_ENABLED/ARMED; keep defaults safe.",
+        "variable_gates": "PT_PRJ_FEATURES_SMOKE_ENABLED",
+        "ai": False,
+        "default_flags": {
+            "enabled": "false",
+            "armed": "false",
+            "confirm_present": "false",
+            "allow_double_play": "false",
+            "allow_dynamic_leverage": "false",
+            "strength": "1.0",
+            "switch_score": "0.0",
+        },
+    },
+    "test-health-automation.yml": {
+        "why": "Full test-health automation suite (former nightly schedule).",
+        "risk": "high — long-running matrix; use profile wisely.",
+        "variable_gates": "",
+        "ai": False,
+        "default_flags": {
+            "profile": "weekly_core",
+            "skip_coverage_checks": "true",
+            "fail_on_violations": "false",
+        },
+    },
+    "test_health.yml": {
+        "why": "Test health profiles; also runs on PR/push — manual dispatch for ad-hoc profile.",
+        "risk": "medium-high depending on profile.",
+        "variable_gates": "",
+        "ai": False,
+        "default_flags": {"profile": "daily_quick"},
+    },
+    "weekly_core_audit.yml": {
+        "why": "Weekly core audit orchestration (former Monday schedule).",
+        "risk": "low — dispatches other workflows.",
+        "variable_gates": "",
+        "ai": False,
+        "default_flags": {"note": "weekly core audit"},
+    },
+    "infostream-automation.yml": {
+        "why": "InfoStream cycle after TestHealth (former 03:15 UTC schedule).",
+        "risk": "AI cost if skip_ai=false; requires PT_AI_MODELS_ENABLED / PT_PAPERTRAIL_READY for cycle.",
+        "variable_gates": "PT_AI_MODELS_ENABLED, PT_PAPERTRAIL_READY",
+        "ai": True,
+        "default_flags": {"skip_ai": "true", "dry_run": "true"},
+        "ai_note": "Prefer -f skip_ai=true unless explicit AI cost approval.",
+    },
+    "market_outlook_automation.yml": {
+        "why": "MarketSentinel daily outlook (former 05:00 UTC schedule).",
+        "risk": "AI cost — uses OPENAI_API_KEY; scheduled runs used --skip-llm in CI cron.",
+        "variable_gates": "",
+        "ai": True,
+        "ai_note": "Confirm OPENAI usage / use repo skip-llm patterns before paid run.",
+    },
+    "offline_suites.yml": {
+        "why": "Offline daily/weekly test suites (former schedule).",
+        "risk": "medium-long runner time.",
+        "variable_gates": "",
+        "ai": False,
+        "default_flags": {"suite_type": "daily"},
+    },
+    "ops_doctor_dashboard.yml": {
+        "why": "Ops Doctor dashboard artifact (former Monday schedule).",
+        "risk": "low",
+        "variable_gates": "",
+        "ai": False,
+    },
+    "ops_doctor_pages.yml": {
+        "why": "Ops Doctor Pages publish (former Monday schedule).",
+        "risk": "low — Pages deploy permissions.",
+        "variable_gates": "",
+        "ai": False,
+    },
+    "full_audit_weekly.yml": {
+        "why": "Full security and quality audit (former weekly schedule).",
+        "risk": "medium",
+        "variable_gates": "",
+        "ai": False,
+    },
+    "docs_reference_targets_fullscan_schedule.yml": {
+        "why": "Repo-wide docs reference target scan (former Monday schedule).",
+        "risk": "low-medium",
+        "variable_gates": "",
+        "ai": False,
+    },
+    "knowledge_extras_chromadb.yml": {
+        "why": "Optional ChromaDB knowledge tests (former Monday schedule).",
+        "risk": "medium — optional deps.",
+        "variable_gates": "",
+        "ai": False,
+        "default_flags": {"reason": "manual trigger"},
+    },
+    PAPER_TEST_EVIDENCE_FILE: {
+        "why": "Direct paper test audit evidence (downstream of scheduled orchestrator).",
+        "risk": "medium — execution scope tests.",
+        "variable_gates": "",
+        "ai": False,
+        "default_flags": {"scope": "execution", "note": "manual via recommender"},
+    },
+}
+
+
+@dataclass
+class WorkflowRecord:
+    file: str
+    name: str
+    has_workflow_dispatch: bool
+    has_active_schedule: bool
+    input_keys: list[str]
+    input_defaults: dict[str, str] = field(default_factory=dict)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if yaml is None:
+        raise RuntimeError("PyYAML is required; install requirements.txt dependencies.")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return data
+
+
+def _trigger_section(data: dict[str, Any]) -> dict[str, Any]:
+    triggers = data.get("on")
+    if triggers is None:
+        triggers = data.get(True)
+    if not isinstance(triggers, dict):
+        return {}
+    return triggers
+
+
+def _parse_workflow_file(filename: str) -> WorkflowRecord:
+    path = WORKFLOWS_DIR / filename
+    if not path.exists():
+        raise FileNotFoundError(f"Missing workflow file: {path}")
+
+    data = _load_yaml(path)
+    triggers = _trigger_section(data)
+    has_dispatch = "workflow_dispatch" in triggers
+    has_schedule = "schedule" in triggers
+
+    input_keys: list[str] = []
+    input_defaults: dict[str, str] = {}
+    wd = triggers.get("workflow_dispatch")
+    if isinstance(wd, dict):
+        inputs = wd.get("inputs")
+        if isinstance(inputs, dict):
+            for key, spec in inputs.items():
+                input_keys.append(str(key))
+                if isinstance(spec, dict) and "default" in spec:
+                    input_defaults[str(key)] = str(spec["default"])
+
+    meta = STATIC_META.get(filename, {})
+    for key, val in (meta.get("default_flags") or {}).items():
+        input_defaults[str(key)] = str(val)
+
+    for key, val in list(input_defaults.items()):
+        if val in ("True", "False"):
+            input_defaults[key] = val.lower()
+
+    wf_name = data.get("name")
+    if not isinstance(wf_name, str) or not wf_name.strip():
+        wf_name = filename
+
+    return WorkflowRecord(
+        file=filename,
+        name=wf_name.strip(),
+        has_workflow_dispatch=has_dispatch,
+        has_active_schedule=has_schedule,
+        input_keys=input_keys,
+        input_defaults=input_defaults,
+    )
+
+
+def _files_for_intent(intent: str) -> list[str]:
+    if intent == "all":
+        files = sorted(MANUAL_ONLY_WORKFLOW_FILES)
+        if (WORKFLOWS_DIR / PAPER_TEST_EVIDENCE_FILE).exists():
+            files.append(PAPER_TEST_EVIDENCE_FILE)
+        return files
+    return list(INTENT_TO_FILES[intent])
+
+
+def _build_gh_command(rec: WorkflowRecord, ref: str = "main") -> str:
+    parts = [f'gh workflow run "{rec.name}"', f"--ref {ref}"]
+    for key in rec.input_keys:
+        if key in rec.input_defaults:
+            parts.append(f"-f {key}={rec.input_defaults[key]}")
+    return " ".join(parts)
+
+
+def _recommendation_dict(rec: WorkflowRecord, include_commands: bool, ref: str) -> dict[str, Any]:
+    meta = STATIC_META.get(rec.file, {})
+    item: dict[str, Any] = {
+        "workflow_file": f".github/workflows/{rec.file}",
+        "workflow_name": rec.name,
+        "why_recommended": meta.get("why", "Listed for selected intent."),
+        "cost_risk_note": meta.get("risk", "review runner time before dispatch."),
+        "variable_gates": meta.get("variable_gates") or None,
+        "ai_or_paid": bool(meta.get("ai")),
+        "ai_note": meta.get("ai_note"),
+        "has_active_schedule": rec.has_active_schedule,
+        "operator_go_required": True,
+    }
+    if include_commands:
+        item["suggested_command"] = _build_gh_command(rec, ref=ref)
+    if rec.has_active_schedule:
+        item["warning"] = "YAML still contains schedule: — review before dispatch."
+    return item
+
+
+def recommend(
+    intent: str,
+    *,
+    include_commands: bool = False,
+    ref: str = "main",
+) -> dict[str, Any]:
+    files = _files_for_intent(intent)
+    recommendations: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for filename in files:
+        try:
+            rec = _parse_workflow_file(filename)
+        except (OSError, ValueError, yaml.YAMLError) as exc:  # type: ignore[union-attr]
+            errors.append(f"{filename}: {exc}")
+            continue
+
+        if not rec.has_workflow_dispatch:
+            errors.append(f"{filename}: missing workflow_dispatch")
+            continue
+
+        recommendations.append(_recommendation_dict(rec, include_commands, ref))
+
+    return {
+        "intent": intent,
+        "intent_label": INTENT_LABELS.get(intent, intent),
+        "guard": GUARD_BANNER,
+        "schedule_reactivation": False,
+        "executes_workflows": False,
+        "recommendations": recommendations,
+        "errors": errors,
+    }
+
+
+def format_text(payload: dict[str, Any]) -> str:
+    lines = [
+        payload["guard"],
+        "",
+        f"Intent: {payload['intent']} — {payload['intent_label']}",
+        "Cron/schedule is NOT reactivated by this CLI. Manual runs may incur Actions runner and provider costs.",
+        "",
+    ]
+    if payload["errors"]:
+        lines.append("Errors:")
+        for err in payload["errors"]:
+            lines.append(f"  - {err}")
+        lines.append("")
+
+    if not payload["recommendations"]:
+        lines.append("No workflows matched.")
+        return "\n".join(lines)
+
+    for idx, rec in enumerate(payload["recommendations"], start=1):
+        lines.append(f"{idx}. {rec['workflow_name']}")
+        lines.append(f"   file: {rec['workflow_file']}")
+        lines.append(f"   why: {rec['why_recommended']}")
+        lines.append(f"   cost/risk: {rec['cost_risk_note']}")
+        if rec.get("variable_gates"):
+            lines.append(f"   variable gates: {rec['variable_gates']}")
+        if rec.get("ai_or_paid"):
+            lines.append(f"   AI/paid: yes — {rec.get('ai_note') or 'confirm cost before dispatch'}")
+        if rec.get("warning"):
+            lines.append(f"   WARNING: {rec['warning']}")
+        lines.append("   operator-GO: required before running any gh command")
+        if "suggested_command" in rec:
+            lines.append(f"   command (text only): {rec['suggested_command']}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Recommend manual-only GitHub Actions workflows for an operator intent (read-only)."
+    )
+    parser.add_argument(
+        "--intent",
+        choices=sorted(INTENT_TO_FILES.keys()) + ["all"],
+        help="Operator planning intent",
+    )
+    parser.add_argument(
+        "--list-intents",
+        action="store_true",
+        help="Print supported intents and exit",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument(
+        "--include-commands",
+        action="store_true",
+        help="Include suggested gh workflow run command lines (text only)",
+    )
+    parser.add_argument(
+        "--ref",
+        default="main",
+        help="Git ref for suggested gh workflow run commands (default: main)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list_intents:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "intents": [
+                            {"id": k, "label": INTENT_LABELS[k], "files": list(v)}
+                            for k, v in INTENT_TO_FILES.items()
+                        ]
+                        + [
+                            {
+                                "id": "all",
+                                "label": INTENT_LABELS["all"],
+                                "files": _files_for_intent("all"),
+                            }
+                        ],
+                        "guard": GUARD_BANNER,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(GUARD_BANNER)
+            print()
+            print("Supported intents:")
+            for intent_id in sorted(INTENT_TO_FILES.keys()):
+                print(f"  - {intent_id}: {INTENT_LABELS[intent_id]}")
+            print(f"  - all: {INTENT_LABELS['all']}")
+        return 0
+
+    if not args.intent:
+        parser.error("--intent is required unless --list-intents is set")
+
+    payload = recommend(
+        args.intent,
+        include_commands=args.include_commands,
+        ref=args.ref,
+    )
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(format_text(payload))
+
+    return 1 if payload["errors"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ops/test_recommend_manual_only_workflows.py
+++ b/tests/ops/test_recommend_manual_only_workflows.py
@@ -1,0 +1,104 @@
+"""Tests for read-only manual-only workflow recommender CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ops" / "recommend_manual_only_workflows.py"
+DOC = REPO_ROOT / "docs" / "ops" / "CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md"
+
+EXPECTED_INTENTS = frozenset(
+    {
+        "paper_shadow_evidence",
+        "health_suite",
+        "market_info_daily",
+        "ops_hygiene",
+        "security_audit",
+        "docs_hygiene",
+        "paper_test_evidence",
+        "all",
+    }
+)
+
+PAPER_SHADOW_FILES = frozenset(
+    {
+        "ci-scheduled-paper-and-export-smoke.yml",
+        "class-a-shadow-paper-scheduled-probe-v1.yml",
+        "prj-scheduled-shadow-paper-features-smoke.yml",
+    }
+)
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+def test_list_intents_includes_all_expected() -> None:
+    proc = _run_cli("--list-intents")
+    assert proc.returncode == 0, proc.stderr
+    for intent in EXPECTED_INTENTS:
+        assert intent in proc.stdout
+
+
+def test_paper_shadow_evidence_recommends_paper_shadow_workflows() -> None:
+    proc = _run_cli("--intent", "paper_shadow_evidence", "--include-commands")
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout
+    for filename in PAPER_SHADOW_FILES:
+        assert filename in out
+    assert "gh workflow run" in out
+    assert "Operator-GO" in out or "operator-GO" in out
+    assert "does not run workflows" in out or "READ-ONLY" in out
+
+
+def test_market_info_daily_includes_ai_cost_hint() -> None:
+    proc = _run_cli("--intent", "market_info_daily", "--include-commands")
+    assert proc.returncode == 0, proc.stderr
+    lowered = proc.stdout.lower()
+    assert "infostream" in lowered or "market" in lowered
+    assert "ai" in lowered or "openai" in lowered or "skip_ai" in lowered
+
+
+def test_json_mode_valid_and_contains_guard() -> None:
+    proc = _run_cli("--intent", "market_info_daily", "--json", "--include-commands")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schedule_reactivation"] is False
+    assert payload["executes_workflows"] is False
+    assert payload["guard"]
+    assert payload["recommendations"]
+
+
+def test_doc_manual_only_section_no_auto_cron_reactivation() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    assert "Manual-only workflow recommender after PR #3896" in text
+    assert "does not" in text.lower() or "Does **not**" in text
+    assert "separate PR" in text
+    assert "operator-GO" in text or "Operator-GO" in text
+    assert "separate PR" in text
+    assert "Re-enabling cron" in text or "re-enabling cron" in text
+    section_start = text.index("Manual-only workflow recommender after PR #3896")
+    section = text[section_start : section_start + 2500].lower()
+    assert "does **not**" in section or "does not" in section
+    assert "re-enable" in section or "re-enabling" in section
+
+
+@pytest.mark.parametrize("intent", ["paper_shadow_evidence", "health_suite"])
+def test_recommender_does_not_invoke_gh(intent: str) -> None:
+    """CLI must only print gh commands; subprocess list should be stdlib-only."""
+    proc = _run_cli("--intent", intent, "--include-commands")
+    assert proc.returncode == 0
+    assert "gh workflow run" in proc.stdout


### PR DESCRIPTION
## Summary
- Adds read-only CLI `scripts/ops/recommend_manual_only_workflows.py` to map operator intents to manual-only workflows (post PR #3896) and print suggested `gh workflow run` commands as text only.
- Extends `docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md` with Manual-only recommender section.
- Adds `tests/ops/test_recommend_manual_only_workflows.py`.

## Scope / safety
- No `.github/workflows/*` changes
- No cron/schedule reactivation
- No GitHub settings mutation (`gh workflow enable/disable`, etc.)
- Recommender only — does not execute workflows or invoke `gh`

## Test plan
- [x] `python scripts/ops/recommend_manual_only_workflows.py --list-intents`
- [x] `python scripts/ops/recommend_manual_only_workflows.py --intent paper_shadow_evidence --include-commands`
- [x] `python scripts/ops/recommend_manual_only_workflows.py --intent market_info_daily --include-commands --json`
- [x] `pytest tests/ops/test_recommend_manual_only_workflows.py`


Made with [Cursor](https://cursor.com)