### PR TITLE
docs: reflect operator experience release start

### DIFF
--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -1278,3 +1278,46 @@ LOCAL_DRY_HOST_NO_RUN_PREFLIGHT_DOCS_TESTS_ONLY=true
 **Guard module (reuse — no parallel local-dry-host runtime anchor):** `tests/ops/test_remote_runtime_contract_docs_guard_v0.py`.
 
 **Non-authorizing:** No runtime/scheduler/daemon execution, no paper/shadow/testnet/live, no AWS/network/rclone/S3 upload, no Notion write, no Market Dashboard authority, no Preflight lift, no Path-B lift, and no Global-Preflight lift. `/tmp`-only evidence remains invalid.
+
+## Operator Experience Release RC v0 — index v0
+
+**Release:** `OPERATOR_EXPERIENCE_RELEASE_RC_V0` · **Slice:** `SLICE-OE-1` (docs-only start) · **UTC:** 2026-06-02 · **Canonical repo owners (reuse — no parallel index):**
+
+| Concern | Owner |
+|---------|-------|
+| Market Surface routes, visual polish status, non-authority boundaries | `docs/webui/MARKET_SURFACE_V0.md` (**§ Operator Experience Release RC v0 — SLICE-OE-1 Status-Reflexion**) |
+| CI audit posture, ops pointers, schedule/Notion handoff | `docs/ops/CI_AUDIT_KNOWN_ISSUES.md` (this section) |
+
+**Durable operator pointers (archive only — not repo-ingested):**
+
+| Token | Durable path |
+|-------|--------------|
+| Final consolidated handoff after PR3901 | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/final_consolidated_handoff_after_pr3901_notion_and_generator_stop_idle_v0_20260602T170236Z/` |
+| Notion update after PR3901 | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/notion_update_after_pr3901_operator_go_v0_20260602T165522Z/` |
+| Notion Auto-Sync Charter | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/notion_auto_sync_charter_and_design_readonly_v0_20260602T165746Z/` |
+| Notion Sync Package Generator v0 | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/notion_sync_package_generator_v0_20260602T165958Z/` |
+| GH residual schedule cost review | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gh_residual_schedule_cost_review_readonly_v0_20260602T171045Z/` |
+| Larger release candidate planning | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/larger_release_candidate_planning_after_pr3901_v0_20260602T170937Z/` |
+| SLICE-OE-1 docs-only start (this slice) | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/operator_experience_release_rc_v0_slice_oe1_docs_only_start_20260602T171519Z/` |
+
+**Operational rules:**
+
+- **Notion** remains a **mirror/status surface only** — **not** an authority source for runtime, trading, gates, or approvals.
+- **Notion Auto-Sync** is **operator_gated** or **draft-only**; **no** auto-write for Runtime/Live, PII, raw logs, or secrets.
+- **`workflow_dispatch` must not be executed** from agent/CI automation in this release line; optional **SLICE-GH-001** remains a **separate sub-GO** (GH schedule residual cost review pointer above).
+
+```text
+OPERATOR_EXPERIENCE_RELEASE_RC_V0=true
+SLICE_OE1_DOCS_ONLY=true
+NOTION_AS_MIRROR_ONLY=true
+NOTION_AUTO_SYNC_OPERATOR_GATED=true
+NOTION_AUTO_WRITE_FORBIDDEN=true
+WORKFLOW_DISPATCH_EXECUTED=false
+GH_SCHEDULE_REVIEW_POINTER_ONLY=true
+SLICE_GH_001_SEPARATE_SUB_GO=true
+DASHBOARD_AUTHORITY_CHANGED=false
+RUNTIME_TOUCHED=false
+TRADING_AUTHORITY_CHANGED=false
+NOTION_WRITES=false
+PARALLEL_DOCS_CREATED=false
+```

--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -531,6 +531,33 @@ RUNTIME_AUTHORITY_CHANGED=false
 MARKET_AIRPORT_TOUCHED=false
 ```
 
+## Operator Experience Release RC v0 — SLICE-OE-1 Status-Reflexion (docs-only)
+
+**Release:** `OPERATOR_EXPERIENCE_RELEASE_RC_V0` · **Slice:** `SLICE-OE-1` · **UTC:** 2026-06-02 · **Repo-SSOT:** dieses Dokument — **kein** paralleler Market-/Dashboard-Index.
+
+**Visual Polish abgeschlossen (templates-only, merged):**
+
+| Route | PR | Scope |
+|-------|-----|--------|
+| **`GET`** **`/market`** | **#3900** | Visual polish — `templates/peak_trade_dashboard/market_v0.html` only |
+| **`GET`** **`/market/double-play`** | **#3901** | Visual polish — `templates/peak_trade_dashboard/double_play_market_dashboard_v0.html` only |
+
+- **Charakter:** rein **Template-/Darstellungs**-Polish auf bestehenden SSR-/Payload-/JSON-Pfaden — **keine** `src/`-, API-, Route-, Provider-, Runtime-, Scheduler-, Paper-/Testnet-/Live-, Trading-, Execution-, Risk-, Governance-, Scope/Capital-, KillSwitch- oder Master-V2-/Double-Play-**Entscheidlogik**-Änderung.
+- **Dashboard zeigt/reflektiert nur:** alle Status-, „ready“-, Label- und Rail-Felder bleiben **display-only** / **non-authorizing** (siehe Safety banner, Double-Play v1.2/v1.3, Lane taxonomy §7h).
+- **Ops-/Status-Pointer:** kompakter Operator-Experience-Index in [CI Audit — Known Issues](../ops/CI_AUDIT_KNOWN_ISSUES.md) (**§ Operator Experience Release RC v0 — index v0**).
+
+```text
+OPERATOR_EXPERIENCE_RELEASE_RC_V0=true
+SLICE_OE1_DOCS_ONLY_REFLECTION=true
+MARKET_VISUAL_POLISH_PR3900_COMPLETE=true
+DOUBLE_PLAY_VISUAL_POLISH_PR3901_COMPLETE=true
+TEMPLATES_ONLY_POLISH=true
+DASHBOARD_AUTHORITY_CHANGED=false
+RUNTIME_AUTHORITY_CHANGED=false
+TRADING_AUTHORITY_CHANGED=false
+MARKET_SURFACE_AUTHORITY_SOURCE=false
+```
+
 ## Operator‑Downloads — Ingest‑Ledger (nicht kanonisch, v0)
 
 **Authority / Lesereihenfolge:** Markdown- oder PDF‑Exporte, die außerhalb des Repos unter einem **„Downloads“‑Ordner** des Operators liegen, sind **Hilfs-/Entwurfsspuren**. Sie ersetzen **keine** `docs/ops/specs/`‑Verträge, **keine** Runbooks und **keinen** dieser Market‑Surface‑Abschnitte. **`GET`** **`&#47;market&#47;double-play`** und **`GET`** **`&#47;api&#47;master‑v2&#47;double‑play&#47;dashboard-display.json`** bleiben an die **bereits eingecheckten** Read‑only‑Kontrakte gekoppelt ([**MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0**](../ops/specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md); reine Dokumentation, **ohne** Steuerbefugnis).


### PR DESCRIPTION
## Summary
- **Scope:** SLICE-OE-1 docs-only — Operator Experience Release RC v0 start
- Reflect Visual Polish completion: PR **#3900** (`GET /market`), PR **#3901** (`GET /market/double-play`) — templates-only, non-authorizing

## Changed files
- `docs/webui/MARKET_SURFACE_V0.md`
- `docs/ops/CI_AUDIT_KNOWN_ISSUES.md`

## Reuse-before-new
- Extended existing Market Surface and CI Audit SSOT owners only; **no** new repo documentation files.

## Duplicate-surface
- **PASS** — no parallel Evidence/Readiness/Map/Handoff/Index surfaces; archive paths are external pointers only.

## Validation
- `git diff --name-only` — exactly two allowed docs files
- Forbidden path grep: no `templates/`, `src/`, `tests/`, `.github/` changes
- Contract tests: `SKIPPED_MISSING_TEST` (files not present)
- Manifest: `MANIFEST_VERIFY_RC=0`

## Durable Evidence Bundle
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/operator_experience_release_rc_v0_slice_oe1_docs_only_start_20260602T171519Z/`

## Explicit non-goals
- No runtime, scheduler, paper/shadow/testnet/live
- No trading/execution/risk/governance/live authority changes
- No `templates/`, `src/`, `tests/`, `workflows/` changes
- No Notion write; no `workflow_dispatch` execution
