### PR TITLE
test: guard evidence retention release index

### DIFF
--- a/tests/ops/test_mandatory_durable_closeout_contract_v0.py
+++ b/tests/ops/test_mandatory_durable_closeout_contract_v0.py
@@ -13,7 +13,12 @@ PRIMARY_EVIDENCE = REPO_ROOT / "scripts" / "ops" / "primary_evidence_retention_v
 PLANNING_RETENTION_TESTS = (
     REPO_ROOT / "tests" / "ops" / "test_planning_artifact_durable_retention_contract_v0.py"
 )
+PRIMARY_EVIDENCE_INVARIANT_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_primary_evidence_retention_invariant_contract_v0.py"
+)
 DOCS_TRUTH_MAP = REPO_ROOT / "docs" / "ops" / "registry" / "DOCS_TRUTH_MAP.md"
+ER_RELEASE_RC_INDEX_HEADING = "### Evidence Durable Closeout Retention RC v0 — index v0"
+THIS_MODULE = Path(__file__).name
 
 MANDATORY_MARKERS = (
     "MANDATORY_DURABLE_CLOSEOUT_CONTRACT_V0=true",
@@ -149,3 +154,23 @@ def test_adjacent_section_ordering() -> None:
     assert text.index("## 2b.2 Closeout Enforcement Planning Contract v0") < text.index(
         "## 3. Non-authority"
     )
+
+
+def test_evidence_durable_closeout_retention_rc_v0_slice_er1_closeout_guard_crosslink_v0() -> None:
+    text = PREFLIGHT.read_text(encoding="utf-8")
+    start = text.find(ER_RELEASE_RC_INDEX_HEADING)
+    assert start != -1, "missing Evidence Durable Closeout Retention RC v0 index section"
+    section = text[start : start + 8000]
+    collapsed = text.lower()
+
+    assert "EVIDENCE_DURABLE_CLOSEOUT_RETENTION_RC_V0" in section
+    assert "SLICE-ER-1" in section
+    assert "SLICE-ER-2" in section
+    assert THIS_MODULE in section
+    assert PRIMARY_EVIDENCE_INVARIANT_TESTS.name in section
+    assert "docs/tests/tooling-only" in section
+    assert "RETENTION_ENFORCEMENT_ACTIVATED=false" in text
+    assert "PRE_FLIGHT_BLOCKED_LIFTED=false" in text
+    assert "no parallel" in collapsed
+    assert "NO_RUNTIME=true" in text
+    assert "WORKFLOW_DISPATCH_EXECUTED=false" in text

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -729,13 +729,19 @@ def test_evidence_durable_closeout_retention_rc_v0_slice_er1_release_index_v0() 
     assert "SLICE-ER-2" in section
     assert "SLICE-ER-3" in section
     assert "docs/tests/tooling-only" in section
-    assert "this document (§2a / §2a.1)" in section or "§2a primary evidence retention invariant" in section
+    assert (
+        "this document (§2a / §2a.1)" in section
+        or "§2a primary evidence retention invariant" in section
+    )
     assert THIS_MODULE in section
     assert MANDATORY_CLOSEOUT_CONTRACT_TESTS.name in section
     assert DURABLE_CLOSEOUT_VERIFY_TESTS.name in section
     assert ER_PLANNING_BUNDLE_PATH in section
     assert "no parallel" in collapsed
-    assert "does **not** authorize future runs" in section or "does not authorize future runs" in collapsed
+    assert (
+        "does **not** authorize future runs" in section
+        or "does not authorize future runs" in collapsed
+    )
     assert "does **not** claim retention is fully enforced" in section or (
         "does not claim retention is fully enforced" in collapsed
     )
@@ -753,7 +759,12 @@ def test_evidence_durable_closeout_retention_rc_v0_slice_er2_guard_owner_crossli
     section = _er_release_rc_index_section(_owner_text())
 
     assert "SLICE-ER-2" in section
-    assert "test_*retention*" in section or "test_primary_evidence_retention_invariant_contract_v0.py" in section
-    assert "test_*closeout*" in section or "test_mandatory_durable_closeout_contract_v0.py" in section
+    assert (
+        "test_*retention*" in section
+        or "test_primary_evidence_retention_invariant_contract_v0.py" in section
+    )
+    assert (
+        "test_*closeout*" in section or "test_mandatory_durable_closeout_contract_v0.py" in section
+    )
     assert THIS_MODULE in section
     assert MANDATORY_CLOSEOUT_CONTRACT_TESTS.is_file()

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -42,6 +42,37 @@ ARTIFACT_RETENTION_CROSSLINK_TESTS = (
 )
 RECIPROCAL_CROSSLINK_MARKER = "CYBERSECURITY_VISIBILITY_ARTIFACT_RETENTION_DURABLE_PRIMARY_EVIDENCE_RECIPROCAL_CROSSLINK_V0=true"
 _MARKER_TRUE = "=true"
+ER_RELEASE_RC_INDEX_HEADING = "### Evidence Durable Closeout Retention RC v0 — index v0"
+ER_RELEASE_RC_BLOCK_ANCHOR = "EVIDENCE_DURABLE_CLOSEOUT_RETENTION_RC_V0=true"
+ER_PLANNING_BUNDLE_PATH = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "planning/evidence_durable_closeout_retention_rc_v0_planning_20260602T180921Z/"
+)
+MANDATORY_CLOSEOUT_CONTRACT_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_mandatory_durable_closeout_contract_v0.py"
+)
+DURABLE_CLOSEOUT_VERIFY_TESTS = (
+    REPO_ROOT / "tests" / "ops" / "test_durable_closeout_copy_verify_v0.py"
+)
+THIS_MODULE = Path(__file__).name
+
+ER_RELEASE_RC_EXPECTED: dict[str, str] = {
+    "EVIDENCE_DURABLE_CLOSEOUT_RETENTION_RC_V0": "true",
+    "SLICE_ER1_DOCS_ONLY": "true",
+    "RETENTION_ENFORCEMENT_ACTIVATED": "false",
+    "CLOSEOUT_ENFORCEMENT_ACTIVATED": "false",
+    "PRE_FLIGHT_BLOCKED_LIFTED": "false",
+    "READY_FOR_START": "false",
+    "NO_RUNTIME": "true",
+    "NO_PAPER_SHADOW_TESTNET_LIVE": "true",
+    "NO_AWS_S3_RCLONE": "true",
+    "NOTION_WRITES": "false",
+    "WORKFLOW_DISPATCH_EXECUTED": "false",
+    "NO_TRADING_AUTHORITY_CHANGE": "true",
+    "MASTER_V2_LOGIC_CHANGED": "false",
+    "PARALLEL_EVIDENCE_INDEX_CREATED": "false",
+    "REUSE_BEFORE_NEW_PASS": "true",
+}
 
 
 def _owner_text() -> str:
@@ -50,6 +81,32 @@ def _owner_text() -> str:
 
 def _section_2a1() -> str:
     return _owner_text().split("## 2a.1", 1)[1].split("## 2b.", 1)[0]
+
+
+def _er_release_rc_index_section(text: str) -> str:
+    start = text.find(ER_RELEASE_RC_INDEX_HEADING)
+    assert start != -1, "missing Evidence Durable Closeout Retention RC v0 index section"
+    end = text.find("## 2b.2 Closeout Enforcement Planning Contract v0", start)
+    assert end != -1
+    return text[start:end]
+
+
+def _machine_line_values_from_anchor(text: str, anchor: str) -> dict[str, str]:
+    idx = text.find(anchor)
+    assert idx != -1, f"missing anchor {anchor}"
+    fence_start = text.rfind("```", 0, idx)
+    fence_end = text.find("```", idx)
+    assert fence_start != -1 and fence_end != -1
+    inner = text[fence_start + 3 : fence_end]
+    if inner.startswith("text\n"):
+        inner = inner[5:]
+    values: dict[str, str] = {}
+    for line in inner.splitlines():
+        stripped = line.strip()
+        if "=" in stripped:
+            key, value = stripped.split("=", 1)
+            values[key.strip()] = value.strip()
+    return values
 
 
 def _adapter_text() -> str:
@@ -659,3 +716,44 @@ def test_invariant_owner_crosslinks_cybersecurity_artifact_retention_histogram_v
     ci_lines = {line.strip() for line in ci_audit.splitlines()}
     assert ("INPUT_JSONL_PROVIDED" + _MARKER_TRUE) not in ci_lines
     assert ("R001_R002_R007_MAPPING_COMPLETED" + _MARKER_TRUE) not in ci_lines
+
+
+def test_evidence_durable_closeout_retention_rc_v0_slice_er1_release_index_v0() -> None:
+    text = _owner_text()
+    collapsed = text.lower()
+    section = _er_release_rc_index_section(text)
+    release_values = _machine_line_values_from_anchor(text, ER_RELEASE_RC_BLOCK_ANCHOR)
+
+    assert "EVIDENCE_DURABLE_CLOSEOUT_RETENTION_RC_V0" in section
+    assert "SLICE-ER-1" in section
+    assert "SLICE-ER-2" in section
+    assert "SLICE-ER-3" in section
+    assert "docs/tests/tooling-only" in section
+    assert "this document (§2a / §2a.1)" in section or "§2a primary evidence retention invariant" in section
+    assert THIS_MODULE in section
+    assert MANDATORY_CLOSEOUT_CONTRACT_TESTS.name in section
+    assert DURABLE_CLOSEOUT_VERIFY_TESTS.name in section
+    assert ER_PLANNING_BUNDLE_PATH in section
+    assert "no parallel" in collapsed
+    assert "does **not** authorize future runs" in section or "does not authorize future runs" in collapsed
+    assert "does **not** claim retention is fully enforced" in section or (
+        "does not claim retention is fully enforced" in collapsed
+    )
+    assert "Canonical remains repo + durable Evidence Archive" in section
+
+    for key, expected in ER_RELEASE_RC_EXPECTED.items():
+        assert release_values.get(key) == expected, (
+            f"release RC index {key}={release_values.get(key)!r} expected {expected!r}"
+        )
+
+    assert "non-authorizing" in collapsed or "BLOCKED" in section
+
+
+def test_evidence_durable_closeout_retention_rc_v0_slice_er2_guard_owner_crosslink_v0() -> None:
+    section = _er_release_rc_index_section(_owner_text())
+
+    assert "SLICE-ER-2" in section
+    assert "test_*retention*" in section or "test_primary_evidence_retention_invariant_contract_v0.py" in section
+    assert "test_*closeout*" in section or "test_mandatory_durable_closeout_contract_v0.py" in section
+    assert THIS_MODULE in section
+    assert MANDATORY_CLOSEOUT_CONTRACT_TESTS.is_file()


### PR DESCRIPTION
## Summary

Anchor **EVIDENCE_DURABLE_CLOSEOUT_RETENTION_RC_V0** ER-1 release index tokens in existing retention/closeout contract test guards (**SLICE-ER-2** tests-only).

## Scope

- **SLICE-ER-2** tests-only
- Extends 2 existing test modules; no new files

## Changed files

- `tests/ops/test_primary_evidence_retention_invariant_contract_v0.py` (+98)
- `tests/ops/test_mandatory_durable_closeout_contract_v0.py` (+25)

## Source planning bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/evidence_durable_closeout_retention_rc_v0_planning_20260602T180921Z/`

## ER-1 merge/closeout reference

- Merge: PR #3906 @ `5152a863`
- Post-merge closeout: `…/closeout/evidence_durable_closeout_retention_rc_v0_slice_er1_post_merge_closeout_20260602T181524Z/`

## Reuse-before-new

- Extended existing guards only — `REUSE_BEFORE_NEW_PASS=true`

## Duplicate-surface check

- `DUPLICATE_SURFACE_RISK=low`

## Validation

- 78/78 contract tests passed

## Durable Evidence Bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/evidence_durable_closeout_retention_rc_v0_slice_er2_tests_only_20260602T181736Z/`

## Explicit non-goals

- no docs changes
- no runtime / paper / shadow / testnet / live
- no retention enforcement activation
- no archive/S3/rclone/AWS mutation
- no trading authority / Master V2 logic change
- no src/templates/scripts/workflows/YAML changes
- no Notion write / workflow_dispatch

## Test plan

- [x] `pytest tests/ops/test_primary_evidence_retention_invariant_contract_v0.py tests/ops/test_mandatory_durable_closeout_contract_v0.py tests/ops/test_paper_shadow_247_preflight_contract_v0.py`

Made with [Cursor](https://cursor.com)