### PR TITLE
test: guard ops cockpit status index

### DIFF
--- a/tests/ops/test_ops_cockpit_payload_top_level_contract.py
+++ b/tests/ops/test_ops_cockpit_payload_top_level_contract.py
@@ -149,7 +149,10 @@ def test_ops_cockpit_operator_summary_surface_oc1_reflection_tokens_v0() -> None
 
     assert "read-only" in section.lower()
     assert "reflection" in section.lower()
-    assert "ops_cockpit_display_reflection_only" in section.lower() or "display or reflect" in section.lower()
+    assert (
+        "ops_cockpit_display_reflection_only" in section.lower()
+        or "display or reflect" in section.lower()
+    )
     assert "durable Evidence Archive" in section or "durable evidence archive" in section.lower()
     assert "mirror/status" in section.lower() or "mirror" in section.lower()
     assert "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md" in section

--- a/tests/ops/test_ops_cockpit_payload_top_level_contract.py
+++ b/tests/ops/test_ops_cockpit_payload_top_level_contract.py
@@ -3,13 +3,46 @@ Regression: minimal top-level key presence for ``build_ops_cockpit_payload``.
 
 Values are intentionally not asserted — only key names, per
 ``docs/ops/specs/OPS_COCKPIT_PAYLOAD_READ_MODEL_CONTRACT.md``.
+
+SLICE-OC-2: static reflection-token guard for
+``docs/ops/specs/OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md`` (read-only; non-authorizing).
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from src.webui.ops_cockpit import build_ops_cockpit_payload
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPS_COCKPIT_OPERATOR_SUMMARY_SPEC = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md"
+)
+REMOTE_RUNTIME_DOCS_GUARD = (
+    REPO_ROOT / "tests" / "ops" / "test_remote_runtime_contract_docs_guard_v0.py"
+)
+THIS_MODULE = Path(__file__).name
+
+OC_REFLECTION_HEADING = "## Ops Cockpit — post-trilogy operator status reflection v0"
+OC_REFLECTION_BLOCK_ANCHOR = "OPS_COCKPIT_OR_OPERATOR_STATUS_INDEX_RC_V0=true"
+OC_REFLECTION_EXPECTED: dict[str, str] = {
+    "OPS_COCKPIT_OR_OPERATOR_STATUS_INDEX_RC_V0": "true",
+    "SLICE_OC1_DOCS_ONLY_REFLECTION": "true",
+    "OPS_COCKPIT_DISPLAY_REFLECTION_ONLY": "true",
+    "OPS_COCKPIT_AUTHORITY_CHANGED": "false",
+    "OPERATOR_EXPERIENCE_RELEASE_RC_V0_CORE_DONE": "true",
+    "CYBERSECURITY_VISIBILITY_RELEASE_RC_V0_CORE_DONE": "true",
+    "EVIDENCE_DURABLE_CLOSEOUT_RETENTION_RC_V0_CORE_DONE": "true",
+    "ER_DETAILS_PREFLIGHT_OWNER_ONLY": "true",
+    "NOTION_AS_MIRROR_ONLY": "true",
+    "NOTION_WRITES": "false",
+    "PREFLIGHT_REMAINS_BLOCKED": "true",
+    "RUNTIME_AUTHORITY_CHANGED": "false",
+    "TRADING_AUTHORITY_CHANGED": "false",
+    "MASTER_V2_LOGIC_CHANGED": "false",
+}
+FENCED_BLOCK_RX = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
 
 # Keep in sync with docs/ops/specs/OPS_COCKPIT_PAYLOAD_READ_MODEL_CONTRACT.md (stable set).
 EXPECTED_OPS_COCKPIT_PAYLOAD_TOP_LEVEL_KEYS = frozenset(
@@ -69,3 +102,70 @@ def test_build_ops_cockpit_payload_top_level_keys_contract(tmp_path: Path) -> No
     payload = build_ops_cockpit_payload(repo_root=tmp_path)
     missing = EXPECTED_OPS_COCKPIT_PAYLOAD_TOP_LEVEL_KEYS - payload.keys()
     assert not missing, f"Missing top-level keys: {sorted(missing)}"
+
+
+def _operator_summary_text() -> str:
+    assert OPS_COCKPIT_OPERATOR_SUMMARY_SPEC.is_file()
+    return OPS_COCKPIT_OPERATOR_SUMMARY_SPEC.read_text(encoding="utf-8")
+
+
+def _fenced_blocks(text: str) -> list[str]:
+    return [block.strip() for block in FENCED_BLOCK_RX.findall(text)]
+
+
+def _block_containing(text: str, anchor: str) -> str:
+    for block in _fenced_blocks(text):
+        if anchor in block:
+            return block
+    raise AssertionError(f"missing fenced machine-line block containing {anchor!r}")
+
+
+def _machine_line_values(block: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in block.splitlines():
+        stripped = line.strip()
+        if "=" not in stripped or stripped.startswith("#"):
+            continue
+        key, _, value = stripped.partition("=")
+        if key and value:
+            values[key.strip()] = value.strip()
+    return values
+
+
+def _oc_reflection_section(text: str) -> str:
+    start = text.find(OC_REFLECTION_HEADING)
+    assert start != -1, "missing post-trilogy operator status reflection section"
+    end = text.find("## Related", start)
+    if end == -1:
+        end = len(text)
+    return text[start:end]
+
+
+def test_ops_cockpit_operator_summary_surface_oc1_reflection_tokens_v0() -> None:
+    text = _operator_summary_text()
+    section = _oc_reflection_section(text)
+    block = _block_containing(text, OC_REFLECTION_BLOCK_ANCHOR)
+    values = _machine_line_values(block)
+
+    assert "read-only" in section.lower()
+    assert "reflection" in section.lower()
+    assert "ops_cockpit_display_reflection_only" in section.lower() or "display or reflect" in section.lower()
+    assert "durable Evidence Archive" in section or "durable evidence archive" in section.lower()
+    assert "mirror/status" in section.lower() or "mirror" in section.lower()
+    assert "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md" in section
+    assert "SLICE-OC-2" in section
+    assert "new payload keys" in section.lower()
+    assert "PII" in section or "raw logs" in section.lower()
+
+    missing = set(OC_REFLECTION_EXPECTED) - values.keys()
+    assert not missing, f"missing OC reflection keys: {sorted(missing)}"
+    for key, expected in OC_REFLECTION_EXPECTED.items():
+        assert values[key] == expected, f"{key}={values[key]!r} expected {expected!r}"
+
+
+def test_ops_cockpit_payload_contract_reciprocal_remote_runtime_docs_guard_v0() -> None:
+    guard_text = REMOTE_RUNTIME_DOCS_GUARD.read_text(encoding="utf-8")
+    assert THIS_MODULE in guard_text
+    assert "test_ops_cockpit_payload_top_level_contract.py" in guard_text
+    owner_text = Path(__file__).read_text(encoding="utf-8")
+    assert "test_remote_runtime_contract_docs_guard_v0.py" in owner_text

--- a/tests/ops/test_remote_runtime_contract_docs_guard_v0.py
+++ b/tests/ops/test_remote_runtime_contract_docs_guard_v0.py
@@ -109,7 +109,40 @@ RECIPROCAL_OWNER_TESTS = (
     "test_scheduler_boundary_hard_block_contract_v0.py",
     "test_notion_post_closeout_sync_projection_spec_v0.py",
     "test_market_dashboard_readonly_run_projection_spec_v0.py",
+    "test_ops_cockpit_payload_top_level_contract.py",
 )
+
+OPS_COCKPIT_OPERATOR_SUMMARY_SPEC = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md"
+)
+OC1_PLANNING_BUNDLE_PATH = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "planning/ops_cockpit_operator_status_index_rc_v0_slice_oc1_docs_only_20260602T182955Z/"
+)
+OC_RELEASE_RC_INDEX_HEADING = "## Ops Cockpit / Operator Status Index RC v0 — meta-index v0"
+OC_RELEASE_RC_BLOCK_ANCHOR = "OPS_COCKPIT_OR_OPERATOR_STATUS_INDEX_RC_V0=true"
+OC_RELEASE_RC_EXPECTED: dict[str, str] = {
+    "OPS_COCKPIT_OR_OPERATOR_STATUS_INDEX_RC_V0": "true",
+    "SLICE_OC1_DOCS_ONLY": "true",
+    "OPERATOR_EXPERIENCE_RELEASE_RC_V0_CORE_DONE": "true",
+    "CYBERSECURITY_VISIBILITY_RELEASE_RC_V0_CORE_DONE": "true",
+    "EVIDENCE_DURABLE_CLOSEOUT_RETENTION_RC_V0_CORE_DONE": "true",
+    "ER_SSOT_PREFLIGHT_POINTER_ONLY": "true",
+    "ER3_REPO_FOLLOWUP_DEFERRED": "true",
+    "OPS_COCKPIT_REFLECTION_ONLY": "true",
+    "OPS_COCKPIT_AUTHORITY_CHANGED": "false",
+    "PREFLIGHT_REMAINS_BLOCKED": "true",
+    "STOP_IDLE_PRESERVED": "true",
+    "RETENTION_ENFORCEMENT_ACTIVATED": "false",
+    "NOTION_AS_MIRROR_ONLY": "true",
+    "NOTION_WRITES": "false",
+    "WORKFLOW_DISPATCH_EXECUTED": "false",
+    "NO_RUNTIME": "true",
+    "NO_TRADING_AUTHORITY_CHANGE": "true",
+    "MASTER_V2_LOGIC_CHANGED": "false",
+    "DOUBLE_PLAY_LOGIC_CHANGED": "false",
+    "PARALLEL_OPERATOR_STATUS_INDEX_CREATED": "false",
+}
 
 FORBIDDEN_PARALLEL_DOC_FRAGMENTS = (
     "REMOTE_RUNTIME_HOST_CONTRACT_V0.md",
@@ -236,3 +269,51 @@ def test_guard_module_declares_non_authorization() -> None:
     text = Path(__file__).read_text(encoding="utf-8")
     assert "Never starts runtime" in text or "Never starts" in text
     assert "grants GO" in text or "grants go" in text.lower()
+
+
+def _oc_release_rc_index_section(text: str) -> str:
+    start = text.find(OC_RELEASE_RC_INDEX_HEADING)
+    assert start != -1, "missing Ops Cockpit / Operator Status Index RC v0 meta-index section"
+    return text[start:]
+
+
+def test_ci_audit_ops_cockpit_operator_status_index_rc_v0_section_present() -> None:
+    text = _ci_audit_text()
+    section = _oc_release_rc_index_section(text)
+    assert "SLICE-OC-1" in section
+    assert "SLICE-OC-2" in section
+    assert "docs/tests-only" in section
+    assert "OPS_COCKPIT_OPERATOR_SUMMARY_SURFACE.md" in section
+    assert "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md" in section
+    assert "does **not** duplicate ER body" in section or "does not duplicate ER body" in section
+    assert OPS_COCKPIT_OPERATOR_SUMMARY_SPEC.name in section
+    assert OC1_PLANNING_BUNDLE_PATH in section
+    assert "parallel operator-status hub" in section.lower()
+    assert THIS_MODULE not in section
+
+
+def test_ci_audit_ops_cockpit_operator_status_index_machine_lines() -> None:
+    text = _ci_audit_text()
+    block = _block_containing(text, OC_RELEASE_RC_BLOCK_ANCHOR)
+    values = _machine_line_values(block)
+    missing = set(OC_RELEASE_RC_EXPECTED) - values.keys()
+    assert not missing, f"missing OC release RC keys: {sorted(missing)}"
+    for key, expected in OC_RELEASE_RC_EXPECTED.items():
+        assert values[key] == expected, f"{key}={values[key]!r} expected {expected!r}"
+
+
+def test_ci_audit_ops_cockpit_operator_status_index_er_preflight_pointer_only() -> None:
+    section = _oc_release_rc_index_section(_ci_audit_text())
+    assert "ER SSOT — pointer only" in section or "ER SSOT" in section
+    assert "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md" in section
+    assert "Operator Experience Release RC v0" in section
+    assert "Cybersecurity Visibility Release RC v0" in section
+    assert "Evidence Durable Closeout Retention RC v0" in section
+
+
+def test_ci_audit_ops_cockpit_operator_status_index_slice_oc2_guard_owner_v0() -> None:
+    section = _oc_release_rc_index_section(_ci_audit_text())
+    assert "SLICE-OC-2" in section
+    assert "test_ops_cockpit_" in section
+    assert "test_ops_cockpit_" in section
+    assert "extend existing" in section.lower() or "Tests-ops" in section


### PR DESCRIPTION
## Summary

- **Scope:** SLICE-OC-2 tests-only for `OPS_COCKPIT_OR_OPERATOR_STATUS_INDEX_RC_V0`
- Static guards for OC-1 CI audit meta-index and Ops Cockpit operator-summary reflection tokens

## Changed files

- `tests/ops/test_ops_cockpit_payload_top_level_contract.py`
- `tests/ops/test_remote_runtime_contract_docs_guard_v0.py`

## Source OC-1 closeout

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/ops_cockpit_operator_status_index_rc_v0_slice_oc1_post_merge_closeout_20260602T183545Z/`

## Reuse-before-new

PASS — extended existing guards only; no new test modules.

## Duplicate-surface

PASS — no new status surface.

## Validation

- ruff check + format --check: pass
- pytest (both modules): 17 passed

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/ops_cockpit_operator_status_index_rc_v0_slice_oc2_tests_only_20260602T183748Z/`

## Explicit non-goals

- no docs changes
- no new status surface
- no runtime / paper / shadow / testnet / live
- no Notion write
- no workflow_dispatch
- no trading authority
- no Master-V2 logic change
- no src/templates/scripts/workflows/YAML changes
