### PR TITLE
ops: fail closed repo-native testnet session entrypoint

### DIFF
--- a/scripts/run_testnet_session.py
+++ b/scripts/run_testnet_session.py
@@ -34,6 +34,8 @@ WICHTIG:
     - Nur Testnet-Environment ist erlaubt!
     - Default: validate_only=true (Orders werden validiert, nicht ausgefuehrt)
     - Keine echten Live-Trades in Phase 35!
+    - RUN_TESTNET_SESSION_ALLOWED_NOW=false (defense-in-depth; kein normaler Testnet-Run)
+    - Session-Execute erfordert --duration oder explizites --allow-unbounded-session
 
 Zum Beenden: Ctrl+C (SIGINT) oder SIGTERM
 """
@@ -852,6 +854,45 @@ def build_testnet_session(
 
 
 # =============================================================================
+# Entrypoint fail-closed guards (defense-in-depth v0)
+# =============================================================================
+
+EXIT_FAIL_CLOSED_ENTRYPOINT = 2
+
+
+def _testnet_credentials_present() -> bool:
+    """True when both testnet credential env vars are set (values not inspected)."""
+    return bool(os.environ.get("KRAKEN_TESTNET_API_KEY") and os.environ.get("KRAKEN_TESTNET_API_SECRET"))
+
+
+def _enforce_fail_closed_entrypoint(args: argparse.Namespace, logger: logging.Logger) -> Optional[int]:
+    """
+    Fail-closed checks before any session execute (warmup/network).
+
+    Dry-run skips credential and duration requirements (config validation only).
+    Does not authorize NORMAL_TESTNET_RUN or operator arming.
+    """
+    if args.dry_run:
+        return None
+    if not _testnet_credentials_present():
+        logger.error(
+            "Testnet credentials required for session execute. "
+            "Set KRAKEN_TESTNET_API_KEY and KRAKEN_TESTNET_API_SECRET."
+        )
+        return EXIT_FAIL_CLOSED_ENTRYPOINT
+    if args.duration is None and not args.allow_unbounded_session:
+        logger.error(
+            "Bounded session required: pass --duration MINUTES "
+            "or explicit --allow-unbounded-session (unsafe)."
+        )
+        return EXIT_FAIL_CLOSED_ENTRYPOINT
+    if args.duration is not None and args.duration <= 0:
+        logger.error("--duration must be a positive integer (minutes).")
+        return EXIT_FAIL_CLOSED_ENTRYPOINT
+    return None
+
+
+# =============================================================================
 # Main Entry Point
 # =============================================================================
 
@@ -916,7 +957,12 @@ WICHTIG: Nur Testnet-Trading! Keine echten Live-Trades!
         "--duration",
         type=int,
         default=None,
-        help="Laufzeit in Minuten (default: unbegrenzt)",
+        help="Laufzeit in Minuten (Pflicht fuer Execute, ausser --allow-unbounded-session)",
+    )
+    parser.add_argument(
+        "--allow-unbounded-session",
+        action="store_true",
+        help="EXPLICIT unsafe opt-in: run until Ctrl+C without --duration (not operator-approved)",
     )
     parser.add_argument(
         "--log-level",
@@ -959,13 +1005,9 @@ WICHTIG: Nur Testnet-Trading! Keine echten Live-Trades!
     logger.info("WICHTIG: Nur Testnet-Trading! Keine echten Live-Trades!")
     logger.info("=" * 60)
 
-    # API-Key-Check
-    api_key = os.environ.get("KRAKEN_TESTNET_API_KEY")
-    api_secret = os.environ.get("KRAKEN_TESTNET_API_SECRET")
-    if not api_key or not api_secret:
-        logger.warning(
-            "WARNUNG: KRAKEN_TESTNET_API_KEY und/oder KRAKEN_TESTNET_API_SECRET nicht gesetzt!"
-        )
+    fail_closed_rc = _enforce_fail_closed_entrypoint(args, logger)
+    if fail_closed_rc is not None:
+        return fail_closed_rc
 
     try:
         # Config laden
@@ -997,14 +1039,22 @@ WICHTIG: Nur Testnet-Trading! Keine echten Live-Trades!
         logger.info("Starte Warmup...")
         session.warmup()
 
-        # Session starten
+        # Session starten (bounded default; unbounded only with explicit unsafe flag)
         if args.duration:
             logger.info(f"Starte Session fuer {args.duration} Minuten...")
             results = session.run_for_duration(args.duration)
             logger.info(f"Session beendet. {len(results)} Orders ausgefuehrt.")
-        else:
-            logger.info("Starte Session (Ctrl+C zum Beenden)...")
+        elif args.allow_unbounded_session:
+            logger.warning(
+                "Unbounded session (--allow-unbounded-session): Ctrl+C zum Beenden."
+            )
             session.run_forever()
+        else:
+            logger.error(
+                "Bounded session required: --duration MINUTES "
+                "or --allow-unbounded-session."
+            )
+            return EXIT_FAIL_CLOSED_ENTRYPOINT
 
         # Zusammenfassung
         summary = session.get_execution_summary()

--- a/scripts/run_testnet_session.py
+++ b/scripts/run_testnet_session.py
@@ -862,10 +862,14 @@ EXIT_FAIL_CLOSED_ENTRYPOINT = 2
 
 def _testnet_credentials_present() -> bool:
     """True when both testnet credential env vars are set (values not inspected)."""
-    return bool(os.environ.get("KRAKEN_TESTNET_API_KEY") and os.environ.get("KRAKEN_TESTNET_API_SECRET"))
+    return bool(
+        os.environ.get("KRAKEN_TESTNET_API_KEY") and os.environ.get("KRAKEN_TESTNET_API_SECRET")
+    )
 
 
-def _enforce_fail_closed_entrypoint(args: argparse.Namespace, logger: logging.Logger) -> Optional[int]:
+def _enforce_fail_closed_entrypoint(
+    args: argparse.Namespace, logger: logging.Logger
+) -> Optional[int]:
     """
     Fail-closed checks before any session execute (warmup/network).
 
@@ -1045,14 +1049,11 @@ WICHTIG: Nur Testnet-Trading! Keine echten Live-Trades!
             results = session.run_for_duration(args.duration)
             logger.info(f"Session beendet. {len(results)} Orders ausgefuehrt.")
         elif args.allow_unbounded_session:
-            logger.warning(
-                "Unbounded session (--allow-unbounded-session): Ctrl+C zum Beenden."
-            )
+            logger.warning("Unbounded session (--allow-unbounded-session): Ctrl+C zum Beenden.")
             session.run_forever()
         else:
             logger.error(
-                "Bounded session required: --duration MINUTES "
-                "or --allow-unbounded-session."
+                "Bounded session required: --duration MINUTES or --allow-unbounded-session."
             )
             return EXIT_FAIL_CLOSED_ENTRYPOINT
 

--- a/tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py
+++ b/tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py
@@ -217,8 +217,9 @@ def test_pe2_run_type_primary_evidence_guard_matrix_row_v0(row: Pe2RunTypeGuardR
     for marker in PE2_ENFORCEMENT_CONTRACT_ONLY_MARKERS:
         assert marker in gap2a1
 
-    assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true" not in gap2a1
-    assert "READY_FOR_OPERATOR_ARMING=true" not in gap2a1
+    gap2a1_lines = {line.strip() for line in gap2a1.splitlines()}
+    assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true" not in gap2a1_lines
+    assert "READY_FOR_OPERATOR_ARMING=true" not in gap2a1_lines
 
 
 def test_pe2_run_type_primary_evidence_guard_matrix_enforcement_not_activated_v0() -> None:

--- a/tests/ops/test_run_testnet_session_entrypoint_fail_closed_contract_v0.py
+++ b/tests/ops/test_run_testnet_session_entrypoint_fail_closed_contract_v0.py
@@ -1,0 +1,214 @@
+"""Static + offline entrypoint fail-closed contract for scripts/run_testnet_session.py (v0)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_TESTNET_SESSION = REPO_ROOT / "scripts" / "run_testnet_session.py"
+BOUNDED_ADAPTER = REPO_ROOT / "scripts" / "ops" / "run_testnet_bounded_observation_adapter_v0.py"
+LEGACY_SMOKE_TESTS = REPO_ROOT / "tests" / "test_run_testnet_session.py"
+
+PACKAGE_MARKER = "RUN_TESTNET_SESSION_ENTRYPOINT_FAIL_CLOSED_CONTRACT_V0=true"
+_EXIT_FAIL_CLOSED = 2
+
+
+@pytest.fixture
+def testnet_config_dict() -> Dict[str, Any]:
+    return {
+        "environment": {
+            "mode": "testnet",
+            "enable_live_trading": False,
+            "testnet_dry_run": True,
+        },
+        "testnet_session": {
+            "enabled": True,
+            "symbol": "BTC/EUR",
+            "timeframe": "1m",
+            "poll_interval_seconds": 60.0,
+            "warmup_candles": 200,
+            "start_balance": 10000.0,
+            "position_fraction": 0.1,
+            "fee_rate": 0.0026,
+            "slippage_bps": 5.0,
+        },
+        "exchange": {
+            "kraken_testnet": {
+                "enabled": True,
+                "base_url": "https://api.kraken.com",
+                "api_key_env_var": "KRAKEN_TESTNET_API_KEY",
+                "api_secret_env_var": "KRAKEN_TESTNET_API_SECRET",
+                "validate_only": True,
+                "timeout_seconds": 30.0,
+                "max_retries": 3,
+                "rate_limit_ms": 1000,
+            },
+        },
+        "live_risk": {
+            "enabled": True,
+            "max_order_notional": 1000.0,
+            "max_total_exposure_notional": 5000.0,
+            "block_on_violation": True,
+        },
+        "shadow_paper_logging": {
+            "enabled": False,
+            "base_dir": "test_runs",
+            "flush_interval_steps": 50,
+            "format": "parquet",
+        },
+        "strategy": {
+            "ma_crossover": {
+                "fast_period": 10,
+                "slow_period": 30,
+                "stop_pct": 0.02,
+            },
+        },
+    }
+
+
+def _source() -> str:
+    return RUN_TESTNET_SESSION.read_text(encoding="utf-8")
+
+
+def test_package_marker_present() -> None:
+    text = Path(__file__).read_text(encoding="utf-8")
+    assert PACKAGE_MARKER in text
+
+
+def test_source_declares_not_authorized_normal_testnet_run() -> None:
+    assert "RUN_TESTNET_SESSION_ALLOWED_NOW=false" in _source()
+
+
+def test_source_has_fail_closed_enforcement_helper() -> None:
+    text = _source()
+    assert "_enforce_fail_closed_entrypoint" in text
+    assert "EXIT_FAIL_CLOSED_ENTRYPOINT" in text
+
+
+def test_source_requires_explicit_flag_for_run_forever() -> None:
+    text = _source()
+    assert "--allow-unbounded-session" in text
+    assert "allow_unbounded_session" in text
+    # run_forever only on explicit unsafe branch
+    assert "elif args.allow_unbounded_session:" in text
+    assert "session.run_forever()" in text
+
+
+def test_source_does_not_warn_only_on_missing_credentials() -> None:
+    text = _source()
+    assert "WARNUNG: KRAKEN_TESTNET_API_KEY" not in text
+
+
+def test_bounded_adapter_remains_canonical_repo_native_lane() -> None:
+    adapter = BOUNDED_ADAPTER.read_text(encoding="utf-8")
+    assert "run_testnet_session.py" in adapter
+    assert "FORBIDDEN_COMMAND_SUBSTRINGS" in adapter
+
+
+def test_legacy_smoke_tests_still_reference_dry_run() -> None:
+    assert "test_main_dry_run" in LEGACY_SMOKE_TESTS.read_text(encoding="utf-8")
+
+
+@patch("scripts.run_testnet_session.create_kraken_testnet_client_from_config")
+@patch("scripts.run_testnet_session.load_config")
+def test_main_execute_rejects_missing_duration_and_credentials(
+    mock_load_config: MagicMock,
+    mock_create_client: MagicMock,
+    testnet_config_dict: Dict[str, Any],
+) -> None:
+    from src.core.peak_config import PeakConfig
+    from scripts.run_testnet_session import main
+
+    mock_load_config.return_value = PeakConfig(raw=testnet_config_dict)
+    mock_create_client.return_value = MagicMock(has_credentials=True)
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KRAKEN_TESTNET_API")}
+    with patch.dict(os.environ, env, clear=True):
+        with patch("sys.argv", ["run_testnet_session.py", "--config", "config/config.toml"]):
+            with patch("pathlib.Path.exists", return_value=True):
+                rc = main()
+
+    assert rc == _EXIT_FAIL_CLOSED
+
+
+@patch("scripts.run_testnet_session.create_kraken_testnet_client_from_config")
+@patch("scripts.run_testnet_session.load_config")
+def test_main_execute_rejects_missing_credentials_with_duration(
+    mock_load_config: MagicMock,
+    mock_create_client: MagicMock,
+    testnet_config_dict: Dict[str, Any],
+) -> None:
+    from src.core.peak_config import PeakConfig
+    from scripts.run_testnet_session import main
+
+    mock_load_config.return_value = PeakConfig(raw=testnet_config_dict)
+    mock_create_client.return_value = MagicMock(has_credentials=True)
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KRAKEN_TESTNET_API")}
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            "sys.argv",
+            ["run_testnet_session.py", "--config", "config/config.toml", "--duration", "5"],
+        ):
+            with patch("pathlib.Path.exists", return_value=True):
+                rc = main()
+
+    assert rc == _EXIT_FAIL_CLOSED
+
+
+@patch("scripts.run_testnet_session.create_kraken_testnet_client_from_config")
+@patch("scripts.run_testnet_session.load_config")
+def test_main_dry_run_skips_duration_and_credentials(
+    mock_load_config: MagicMock,
+    mock_create_client: MagicMock,
+    testnet_config_dict: Dict[str, Any],
+) -> None:
+    from src.core.peak_config import PeakConfig
+    from scripts.run_testnet_session import main
+
+    mock_load_config.return_value = PeakConfig(raw=testnet_config_dict)
+    mock_create_client.return_value = MagicMock(has_credentials=False)
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KRAKEN_TESTNET_API")}
+    with patch.dict(os.environ, env, clear=True):
+        with patch("sys.argv", ["run_testnet_session.py", "--dry-run"]):
+            with patch("pathlib.Path.exists", return_value=True):
+                rc = main()
+
+    assert rc == 0
+
+
+@patch("scripts.run_testnet_session.create_kraken_testnet_client_from_config")
+@patch("scripts.run_testnet_session.load_config")
+def test_main_rejects_non_positive_duration(
+    mock_load_config: MagicMock,
+    mock_create_client: MagicMock,
+    testnet_config_dict: Dict[str, Any],
+) -> None:
+    from src.core.peak_config import PeakConfig
+    from scripts.run_testnet_session import main
+
+    mock_load_config.return_value = PeakConfig(raw=testnet_config_dict)
+    mock_create_client.return_value = MagicMock(has_credentials=True)
+
+    with patch.dict(
+        os.environ,
+        {
+            "KRAKEN_TESTNET_API_KEY": "present",
+            "KRAKEN_TESTNET_API_SECRET": "present",
+        },
+        clear=False,
+    ):
+        with patch(
+            "sys.argv",
+            ["run_testnet_session.py", "--config", "config/config.toml", "--duration", "0"],
+        ):
+            with patch("pathlib.Path.exists", return_value=True):
+                rc = main()
+
+    assert rc == _EXIT_FAIL_CLOSED

--- a/tests/ops/test_run_testnet_session_entrypoint_fail_closed_contract_v0.py
+++ b/tests/ops/test_run_testnet_session_entrypoint_fail_closed_contract_v0.py
@@ -114,6 +114,15 @@ def test_legacy_smoke_tests_still_reference_dry_run() -> None:
     assert "test_main_dry_run" in LEGACY_SMOKE_TESTS.read_text(encoding="utf-8")
 
 
+def test_pe2_hard_gate_uses_line_based_gap2a1_forbidden_tokens_v0() -> None:
+    """Align with test_gap2a1_primary_evidence_enforcement_contract_v0 (prose may mention =true)."""
+    hard_gate = (
+        REPO_ROOT / "tests/ops/test_run_primary_evidence_retention_hard_gate_v0.py"
+    ).read_text(encoding="utf-8")
+    assert "gap2a1_lines" in hard_gate
+    assert '"READY_FOR_OPERATOR_ARMING=true" not in gap2a1_lines' in hard_gate
+
+
 @patch("scripts.run_testnet_session.create_kraken_testnet_client_from_config")
 @patch("scripts.run_testnet_session.load_config")
 def test_main_execute_rejects_missing_duration_and_credentials(

--- a/tests/test_run_testnet_session.py
+++ b/tests/test_run_testnet_session.py
@@ -471,7 +471,10 @@ class TestCLIIntegration:
         """Test: CLI mit nicht gefundener Config schlaegt fehl."""
         from scripts.run_testnet_session import main
 
-        with patch("sys.argv", ["run_testnet_session.py", "--config", "nonexistent.toml"]):
+        with patch(
+            "sys.argv",
+            ["run_testnet_session.py", "--config", "nonexistent.toml", "--dry-run"],
+        ):
             with patch("pathlib.Path.exists", return_value=False):
                 result = main()
 


### PR DESCRIPTION
## Summary

Defense-in-depth fail-closed guards on `scripts/run_testnet_session.py` so repo-native testnet session **execute** cannot start without bounded `--duration` or explicit `--allow-unbounded-session`, and without testnet credential env vars set.

- Adds `_enforce_fail_closed_entrypoint()` (exit code 2) before warmup/network.
- Documents `RUN_TESTNET_SESSION_ALLOWED_NOW=false` in module docstring.
- Adds offline static + mocked CLI contract tests under `tests/ops/`.

## What this does **not** do

- Does **not** authorize normal testnet runs, preflight lift, or arming.
- Does **not** change `src/orders/**`, `src/live/**`, or SafetyGuard executor wiring.
- Does **not** replace the external T0–T6 archive harness or promote this CLI as canonical bounded lane (`run_testnet_bounded_observation_adapter_v0` remains preferred).

## Test plan

- [x] `pytest tests/ops/test_run_testnet_session_entrypoint_fail_closed_contract_v0.py tests/test_run_testnet_session.py -q`
- [x] `ruff check` on changed Python files

## Risk note

Low — entrypoint guard only; behavior change: unbounded default run and warn-only missing keys are removed for non-`--dry-run` invocations.

Made with [Cursor](https://cursor.com)