### PR TITLE
chore(gh): make real market forward evidence smoke manual-only

### DIFF
--- a/.github/workflows/real-market-forward-evidence-smoke.yml
+++ b/.github/workflows/real-market-forward-evidence-smoke.yml
@@ -2,8 +2,6 @@ name: Real Market Forward Evidence Smoke
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "17 */6 * * *"
 
 permissions:
   contents: read

--- a/scripts/ops/recommend_manual_only_workflows.py
+++ b/scripts/ops/recommend_manual_only_workflows.py
@@ -55,7 +55,7 @@ MANUAL_ONLY_WORKFLOW_FILES: frozenset[str] = frozenset(
 # Related downstream workflow (dispatch-only; schedule commented in YAML).
 PAPER_TEST_EVIDENCE_FILE = "paper_tests_audit_evidence.yml"
 
-# Residual schedule inventory (13 files): 12 active schedule + 1 manual-only (GH-001).
+# Residual schedule inventory (13 files): 11 active schedule + 2 manual-only (GH-001, GH-002).
 RESIDUAL_SCHEDULE_WORKFLOW_FILES: frozenset[str] = frozenset(
     {
         "audit.yml",
@@ -78,7 +78,7 @@ RESIDUAL_INTENT_LABELS: dict[str, str] = {
     "residual_ci_ops": "Residual scheduled CI core / audit / PR-U drift (do not batch-remove)",
     "residual_scorecard_chain": "Residual PR-B / PR-K nightly scorecard and evidence chain",
     "residual_data_smoke": "Residual high-frequency market forward evidence smoke",
-    "residual_all": "13 inventory workflows (12 active schedule + 1 manual-only; read-only)",
+    "residual_all": "13 inventory workflows (11 active schedule + 2 manual-only; read-only)",
 }
 
 RESIDUAL_INTENT_TO_FILES: dict[str, tuple[str, ...]] = {

--- a/tests/ops/test_recommend_manual_only_workflows.py
+++ b/tests/ops/test_recommend_manual_only_workflows.py
@@ -56,15 +56,23 @@ RESIDUAL_SCHEDULE_FILES = frozenset(
     }
 )
 
-# SLICE-GH-001: schedule removed; workflow_dispatch retained (recommender inventory unchanged).
-GH001_MANUAL_ONLY_FORMER_RESIDUAL = frozenset({"pro-prk-nightly-selfcheck.yml"})
+# SLICE-GH-001/002: schedule removed; workflow_dispatch retained (recommender inventory unchanged).
+GH001_MANUAL_ONLY_FORMER_RESIDUAL = frozenset(
+    {
+        "pro-prk-nightly-selfcheck.yml",
+        "real-market-forward-evidence-smoke.yml",
+    }
+)
 PRO_PRK_NIGHTLY_SELFCHECK_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "pro-prk-nightly-selfcheck.yml"
 )
+REAL_MARKET_FORWARD_EVIDENCE_SMOKE_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "real-market-forward-evidence-smoke.yml"
+)
 
 RESIDUAL_INVENTORY_COUNT = 13
-RESIDUAL_ACTIVE_SCHEDULE_COUNT = 12
-RESIDUAL_MANUAL_ONLY_COUNT = 1
+RESIDUAL_ACTIVE_SCHEDULE_COUNT = 11
+RESIDUAL_MANUAL_ONLY_COUNT = 2
 RESIDUAL_ALL_INTENT_MISLEADING_PHRASE = "13 workflows with active schedule"
 
 RESIDUAL_CI_OPS_FILES = frozenset({"ci.yml", "audit.yml", "pru-required-checks-drift-detector.yml"})
@@ -164,7 +172,7 @@ def test_residual_all_intent_label_inventory_split_v0() -> None:
     lowered = proc.stdout.lower()
     assert RESIDUAL_ALL_INTENT_MISLEADING_PHRASE not in lowered
     assert "13 inventory" in lowered
-    assert "12 active schedule" in lowered
+    assert "11 active schedule" in lowered
     assert "manual-only" in lowered
 
     proc_json = _run_cli("--list-intents", "--json")
@@ -174,7 +182,7 @@ def test_residual_all_intent_label_inventory_split_v0() -> None:
     label = row["label"].lower()
     assert RESIDUAL_ALL_INTENT_MISLEADING_PHRASE not in label
     assert "13 inventory" in label
-    assert "12 active schedule" in label
+    assert "11 active schedule" in label
     assert "manual-only" in label
     assert payload["residual_schedule_count"] == RESIDUAL_INVENTORY_COUNT
 
@@ -209,6 +217,13 @@ def test_residual_all_json_covers_thirteen_without_duplicates() -> None:
 def test_pro_prk_nightly_selfcheck_manual_only_yaml_shape() -> None:
     """GH-001: cron removed; dispatch retained."""
     text = PRO_PRK_NIGHTLY_SELFCHECK_WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch" in text
+    assert "schedule:" not in text
+
+
+def test_real_market_forward_evidence_smoke_manual_only_yaml_shape() -> None:
+    """GH-002: cron removed; dispatch retained."""
+    text = REAL_MARKET_FORWARD_EVIDENCE_SMOKE_WORKFLOW.read_text(encoding="utf-8")
     assert "workflow_dispatch" in text
     assert "schedule:" not in text
 
@@ -326,7 +341,7 @@ def test_github_workflows_active_schedule_allowlist_drift_guard_v0() -> None:
 
 
 def test_residual_active_schedule_allowlist_each_has_schedule_v0() -> None:
-    """Each of the 12 residual cron workflows must still expose schedule in on block."""
+    """Each of the 11 residual cron workflows must still expose schedule in on block."""
     pytest.importorskip("yaml")
     for fname in sorted(RESIDUAL_ACTIVE_SCHEDULE_ALLOWLIST):
         rec = _parse_workflow_file(fname)


### PR DESCRIPTION
## Summary
- Removes schedule from `.github/workflows/real-market-forward-evidence-smoke.yml`.
- Preserves `workflow_dispatch` for explicit manual invocation.
- No runtime/scheduler/testnet/live/source changes.
- No workflow dispatch executed.

## Safety
- READY_FOR_OPERATOR_ARMING=false
- PREFLIGHT_REMAINS_BLOCKED=true
- RUN_TESTNET_SESSION_ALLOWED=false
- SCHEDULER_ALLOWED=false
- RUNTIME_ALLOWED=false
- YAML-only unless existing guard SSOT requires minimal update.
- No secrets/env access, no market-data run, no Notion write.

## Validation
- `python3 -m pytest tests/ops/test_recommend_manual_only_workflows.py -q`

Made with [Cursor](https://cursor.com)