### PR TITLE
chore(gh): make audit workflow manual-only

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,8 +2,6 @@ name: Audit
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: "0 6 * * 1"   # Mo 06:00 UTC (Berlin i.d.R. 07:00/08:00)
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:

--- a/scripts/ops/recommend_manual_only_workflows.py
+++ b/scripts/ops/recommend_manual_only_workflows.py
@@ -55,7 +55,7 @@ MANUAL_ONLY_WORKFLOW_FILES: frozenset[str] = frozenset(
 # Related downstream workflow (dispatch-only; schedule commented in YAML).
 PAPER_TEST_EVIDENCE_FILE = "paper_tests_audit_evidence.yml"
 
-# Residual schedule inventory (13 files): 11 active schedule + 2 manual-only (GH-001, GH-002).
+# Residual schedule inventory (13 files): 10 active schedule + 3 manual-only (GH-001, GH-002, GH-003).
 RESIDUAL_SCHEDULE_WORKFLOW_FILES: frozenset[str] = frozenset(
     {
         "audit.yml",
@@ -78,7 +78,7 @@ RESIDUAL_INTENT_LABELS: dict[str, str] = {
     "residual_ci_ops": "Residual scheduled CI core / audit / PR-U drift (do not batch-remove)",
     "residual_scorecard_chain": "Residual PR-B / PR-K nightly scorecard and evidence chain",
     "residual_data_smoke": "Residual high-frequency market forward evidence smoke",
-    "residual_all": "13 inventory workflows (11 active schedule + 2 manual-only; read-only)",
+    "residual_all": "13 inventory workflows (10 active schedule + 3 manual-only; read-only)",
 }
 
 RESIDUAL_INTENT_TO_FILES: dict[str, tuple[str, ...]] = {

--- a/tests/ops/test_recommend_manual_only_workflows.py
+++ b/tests/ops/test_recommend_manual_only_workflows.py
@@ -56,11 +56,12 @@ RESIDUAL_SCHEDULE_FILES = frozenset(
     }
 )
 
-# SLICE-GH-001/002: schedule removed; workflow_dispatch retained (recommender inventory unchanged).
+# SLICE-GH-001/002/003: schedule removed; other triggers retained (inventory unchanged).
 GH001_MANUAL_ONLY_FORMER_RESIDUAL = frozenset(
     {
         "pro-prk-nightly-selfcheck.yml",
         "real-market-forward-evidence-smoke.yml",
+        "audit.yml",
     }
 )
 PRO_PRK_NIGHTLY_SELFCHECK_WORKFLOW = (
@@ -69,10 +70,11 @@ PRO_PRK_NIGHTLY_SELFCHECK_WORKFLOW = (
 REAL_MARKET_FORWARD_EVIDENCE_SMOKE_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "real-market-forward-evidence-smoke.yml"
 )
+AUDIT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "audit.yml"
 
 RESIDUAL_INVENTORY_COUNT = 13
-RESIDUAL_ACTIVE_SCHEDULE_COUNT = 11
-RESIDUAL_MANUAL_ONLY_COUNT = 2
+RESIDUAL_ACTIVE_SCHEDULE_COUNT = 10
+RESIDUAL_MANUAL_ONLY_COUNT = 3
 RESIDUAL_ALL_INTENT_MISLEADING_PHRASE = "13 workflows with active schedule"
 
 RESIDUAL_CI_OPS_FILES = frozenset({"ci.yml", "audit.yml", "pru-required-checks-drift-detector.yml"})
@@ -172,7 +174,7 @@ def test_residual_all_intent_label_inventory_split_v0() -> None:
     lowered = proc.stdout.lower()
     assert RESIDUAL_ALL_INTENT_MISLEADING_PHRASE not in lowered
     assert "13 inventory" in lowered
-    assert "11 active schedule" in lowered
+    assert "10 active schedule" in lowered
     assert "manual-only" in lowered
 
     proc_json = _run_cli("--list-intents", "--json")
@@ -182,7 +184,7 @@ def test_residual_all_intent_label_inventory_split_v0() -> None:
     label = row["label"].lower()
     assert RESIDUAL_ALL_INTENT_MISLEADING_PHRASE not in label
     assert "13 inventory" in label
-    assert "11 active schedule" in label
+    assert "10 active schedule" in label
     assert "manual-only" in label
     assert payload["residual_schedule_count"] == RESIDUAL_INVENTORY_COUNT
 
@@ -226,6 +228,16 @@ def test_real_market_forward_evidence_smoke_manual_only_yaml_shape() -> None:
     text = REAL_MARKET_FORWARD_EVIDENCE_SMOKE_WORKFLOW.read_text(encoding="utf-8")
     assert "workflow_dispatch" in text
     assert "schedule:" not in text
+
+
+def test_audit_manual_only_yaml_shape() -> None:
+    """GH-003: cron removed; dispatch and PR/push/merge_group retained."""
+    text = AUDIT_WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch" in text
+    assert "schedule:" not in text
+    assert "pull_request:" in text
+    assert "push:" in text
+    assert "merge_group:" in text
 
 
 def test_residual_ci_ops_intent_count() -> None:
@@ -341,7 +353,7 @@ def test_github_workflows_active_schedule_allowlist_drift_guard_v0() -> None:
 
 
 def test_residual_active_schedule_allowlist_each_has_schedule_v0() -> None:
-    """Each of the 11 residual cron workflows must still expose schedule in on block."""
+    """Each of the 10 residual cron workflows must still expose schedule in on block."""
     pytest.importorskip("yaml")
     for fname in sorted(RESIDUAL_ACTIVE_SCHEDULE_ALLOWLIST):
         rec = _parse_workflow_file(fname)


### PR DESCRIPTION
## Summary
- Removes schedule from `.github/workflows/audit.yml`.
- Preserves `workflow_dispatch` and existing PR/push/merge_group paths.
- No jobs or steps changed.
- No runtime/scheduler/testnet/live/source changes.
- No workflow dispatch executed.

## Safety
- READY_FOR_OPERATOR_ARMING=false
- PREFLIGHT_REMAINS_BLOCKED=true
- RUN_TESTNET_SESSION_ALLOWED=false
- SCHEDULER_ALLOWED=false
- RUNTIME_ALLOWED=false
- No secrets/env access, no workflow run, no Notion write.
- No batch YAML; only selected workflow plus minimal SSOT/test update if required.

## Validation
- `python3 -m pytest tests/ops/test_recommend_manual_only_workflows.py -q`

Made with [Cursor](https://cursor.com)