### PR TITLE
chore(gh): make CI schedule manual-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    - cron: "0 3 * * 1"  # Monday 03:00 UTC
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -2974,8 +2974,9 @@ PARALLEL_OPERATOR_STATUS_INDEX_CREATED=false
 | **SLICE-GH-0** | Docs-only governance start | **none** | **complete** (#3910) |
 | **SLICE-GH-001** | Single-workflow manual-only: `.github&#47;workflows&#47;pro-prk-nightly-selfcheck.yml` (`schedule:` removed; `workflow_dispatch` retained) | **one file** | **complete** (#3911) |
 | **SLICE-GH-2** (optional) | Static test guard after GH-001 if needed | none | **deferred** (GH-001 yaml-shape guard merged #3911) |
+| **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` (`schedule:` removed; `workflow_dispatch`, `pull_request`, `push`, `merge_group` retained) | **one file** | **pending PR** (GH-CI slice) |
 
-**Residual schedules on `main` (post #3911):** **12** workflows retain active `schedule:` — `audit.yml`, `ci.yml`, `prbc-stability-gate.yml`, `prbd-live-readiness-scorecard.yml`, `prbe-shadow-testnet-scorecard.yml`, `prbg-execution-evidence.yml`, `prbi-live-pilot-scorecard.yml`, `prbj-testnet-exec-events.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`, `pru-required-checks-drift-detector.yml`, `real-market-forward-evidence-smoke.yml`. **`pro-prk-nightly-selfcheck.yml`** is **manual-only** (no active `schedule:`; `workflow_dispatch` retained). Recommender inventory set remains **13** files (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **12** have active schedules. **No batch YAML wave.** **No schedule reactivation** for PR #3896 manual-only set.
+**Residual schedules on `main` (post GH-001..004 + GH-CI):** **8** workflows retain active `schedule:` — `prbc-stability-gate.yml`, `prbd-live-readiness-scorecard.yml`, `prbe-shadow-testnet-scorecard.yml`, `prbg-execution-evidence.yml`, `prbi-live-pilot-scorecard.yml`, `prbj-testnet-exec-events.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`. **5** are **manual-only** (no active `schedule:`; other triggers retained): `ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`. Recommender inventory set remains **13** files (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **8** have active schedules. **No batch YAML wave.** **No schedule reactivation** for PR #3896 manual-only set.
 
 **Durable operator pointers (archive only — not repo-ingested):**
 
@@ -2988,9 +2989,9 @@ PARALLEL_OPERATOR_STATUS_INDEX_CREATED=false
 
 **Operational rules:**
 
-- **SLICE-GH-0 / SLICE-GH-001 complete** — **no** further YAML in this release line without **per-workflow Sub-GO**; **no** `workflow_dispatch` execution from agent/CI automation; **no** batch cron removal on the **12** remaining active residual workflows.
+- **SLICE-GH-0 / SLICE-GH-001 complete** — **no** further YAML in this release line without **per-workflow Sub-GO**; **no** `workflow_dispatch` execution from agent/CI automation; **no** batch cron removal on residual active schedules (**8** after GH-CI).
 - **Manual-only recommender output** is **read-only** and **not** equivalent to schedule deactivation.
-- **`residual_all` intent** — **13** inventory entries (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **12** active `schedule:` + **1** manual-only (`pro-prk-nightly-selfcheck.yml`); CLI label must not imply “13 active schedules”.
+- **`residual_all` intent** — **13** inventory entries (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **8** active `schedule:` + **5** manual-only; CLI label must not imply “13 active schedules”.
 - **STOP_IDLE preserved** — `PREFLIGHT_REMAINS_BLOCKED=true`; no paper/shadow/testnet/live, no scheduler/daemon execution, no runtime.
 - **Notion** remains mirror/status only — **no** Notion writes.
 - **No trading / execution / risk / governance / live-gate authority** — no Master V2 / Double Play logic changes.
@@ -3007,9 +3008,12 @@ GH001_SCHEDULE_REMOVED=true
 SLICE_GH_001_SEPARATE_SUB_GO=true
 BATCH_SCHEDULE_CHANGES=false
 SCHEDULE_REACTIVATION=false
-RESIDUAL_ACTIVE_SCHEDULE_COUNT=12
+RESIDUAL_ACTIVE_SCHEDULE_COUNT=8
+RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=5
 RESIDUAL_SCHEDULE_INVENTORY_COUNT=13
 GH001_CANDIDATE_WORKFLOW=pro-prk-nightly-selfcheck.yml
+GH_CI_SCHEDULE_MANUAL_ONLY=true
+GH_CI_CANDIDATE_WORKFLOW=ci.yml
 WORKFLOW_DISPATCH_EXECUTED=false
 RECOMMENDER_READ_ONLY=true
 PREFLIGHT_REMAINS_BLOCKED=true

--- a/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
+++ b/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
@@ -124,7 +124,7 @@ Fourteen ops/schedule workflows remain **active** on GitHub with **`workflow_dis
 
 **Re-enabling cron** requires a **separate PR** that restores `schedule:` in workflow YAML plus explicit **operator-GO** — not this recommender.
 
-**`residual_all` intent:** lists all **13** entries in `RESIDUAL_SCHEDULE_WORKFLOW_FILES` — **12** with active `schedule:` plus **1** manual-only (`pro-prk-nightly-selfcheck.yml`, GH-001); not “13 active schedules”.
+**`residual_all` intent:** lists all **13** entries in `RESIDUAL_SCHEDULE_WORKFLOW_FILES` — **8** with active `schedule:` plus **5** manual-only (GH-001..004 + GH-CI); not “13 active schedules”.
 
 **Examples:**
 
@@ -148,8 +148,9 @@ AI-adjacent workflows (`infostream-automation`, `market_outlook_automation`) may
 |-------|-------|--------|
 | **SLICE-GH-0** | Docs-only governance start | **complete** (#3910) |
 | **SLICE-GH-001** | Single-workflow manual-only: `.github&#47;workflows&#47;pro-prk-nightly-selfcheck.yml` | **complete** (#3911) |
+| **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` | **pending PR** (GH-CI slice) |
 
-**Post #3911 schedule posture:** `.github&#47;workflows&#47;pro-prk-nightly-selfcheck.yml` has **no** active `schedule:`; **`workflow_dispatch`** retained. Among workflows listed in `scripts&#47;ops&#47;recommend_manual_only_workflows.py` (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`), **12** retain active `schedule:` and **1** (`pro-prk-nightly-selfcheck.yml`) is manual-only. **All other 11 active residuals remain unchanged** beyond GH-001; **no batch YAML wave.**
+**Post GH-001..004 + GH-CI schedule posture:** **5** residual inventory workflows are manual-only (`ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`); **`workflow_dispatch`** and other non-schedule triggers retained per workflow. Among `RESIDUAL_SCHEDULE_WORKFLOW_FILES`, **8** retain active `schedule:`. **No batch YAML wave.**
 
 **Governance boundaries:**
 
@@ -174,7 +175,8 @@ GH_SCHEDULE_GOVERNANCE_MINIMAL_RC_V0_CORE_DONE=true
 SLICE_GH0_DOCS_ONLY=true
 SLICE_GH001_COMPLETE=true
 GH001_MANUAL_ONLY=true
-RESIDUAL_ACTIVE_SCHEDULE_COUNT=12
+RESIDUAL_ACTIVE_SCHEDULE_COUNT=8
+RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=5
 RESIDUAL_SCHEDULE_INVENTORY_COUNT=13
 GH001_CANDIDATE_WORKFLOW=pro-prk-nightly-selfcheck.yml
 WORKFLOW_DISPATCH_EXECUTED=false

--- a/scripts/ops/recommend_manual_only_workflows.py
+++ b/scripts/ops/recommend_manual_only_workflows.py
@@ -55,7 +55,7 @@ MANUAL_ONLY_WORKFLOW_FILES: frozenset[str] = frozenset(
 # Related downstream workflow (dispatch-only; schedule commented in YAML).
 PAPER_TEST_EVIDENCE_FILE = "paper_tests_audit_evidence.yml"
 
-# Residual schedule inventory (13 files): 9 active schedule + 4 manual-only (GH-001..004).
+# Residual schedule inventory (13 files): 8 active schedule + 5 manual-only (GH-001..004 + GH-CI).
 RESIDUAL_SCHEDULE_WORKFLOW_FILES: frozenset[str] = frozenset(
     {
         "audit.yml",
@@ -78,7 +78,7 @@ RESIDUAL_INTENT_LABELS: dict[str, str] = {
     "residual_ci_ops": "Residual scheduled CI core / audit / PR-U drift (do not batch-remove)",
     "residual_scorecard_chain": "Residual PR-B / PR-K nightly scorecard and evidence chain",
     "residual_data_smoke": "Residual high-frequency market forward evidence smoke",
-    "residual_all": "13 inventory workflows (9 active schedule + 4 manual-only; read-only)",
+    "residual_all": "13 inventory workflows (8 active schedule + 5 manual-only; read-only)",
 }
 
 RESIDUAL_INTENT_TO_FILES: dict[str, tuple[str, ...]] = {
@@ -256,11 +256,11 @@ STATIC_META: dict[str, dict[str, Any]] = {
 
 RESIDUAL_STATIC_META: dict[str, dict[str, Any]] = {
     "ci.yml": {
-        "why": "Weekly full Python matrix (supplements PR/push/merge_group).",
-        "risk": "HIGH — redundant weekly full matrix; required-gate hybrid — do not remove schedule without explicit GO.",
+        "why": "Full Python matrix on PR/push/merge_group/workflow_dispatch (schedule removed GH-CI).",
+        "risk": "HIGH — required-gate hybrid; schedule manual-only; dispatch/PR paths unchanged.",
         "variable_gates": "",
         "ai": False,
-        "residual_schedule": True,
+        "residual_schedule": False,
     },
     "audit.yml": {
         "why": "Weekly pip-audit + PR report validation (supplements PR runs).",

--- a/tests/ops/test_recommend_manual_only_workflows.py
+++ b/tests/ops/test_recommend_manual_only_workflows.py
@@ -56,15 +56,17 @@ RESIDUAL_SCHEDULE_FILES = frozenset(
     }
 )
 
-# SLICE-GH-001..004: schedule removed; other triggers retained (inventory unchanged).
+# SLICE-GH-001..004 + GH-CI: schedule removed; other triggers retained (inventory unchanged).
 GH001_MANUAL_ONLY_FORMER_RESIDUAL = frozenset(
     {
+        "ci.yml",
         "pro-prk-nightly-selfcheck.yml",
         "real-market-forward-evidence-smoke.yml",
         "audit.yml",
         "pru-required-checks-drift-detector.yml",
     }
 )
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 PRO_PRK_NIGHTLY_SELFCHECK_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "pro-prk-nightly-selfcheck.yml"
 )
@@ -77,8 +79,8 @@ PRU_REQUIRED_CHECKS_DRIFT_DETECTOR_WORKFLOW = (
 )
 
 RESIDUAL_INVENTORY_COUNT = 13
-RESIDUAL_ACTIVE_SCHEDULE_COUNT = 9
-RESIDUAL_MANUAL_ONLY_COUNT = 4
+RESIDUAL_ACTIVE_SCHEDULE_COUNT = 8
+RESIDUAL_MANUAL_ONLY_COUNT = 5
 RESIDUAL_ALL_INTENT_MISLEADING_PHRASE = "13 workflows with active schedule"
 
 RESIDUAL_CI_OPS_FILES = frozenset({"ci.yml", "audit.yml", "pru-required-checks-drift-detector.yml"})
@@ -178,7 +180,7 @@ def test_residual_all_intent_label_inventory_split_v0() -> None:
     lowered = proc.stdout.lower()
     assert RESIDUAL_ALL_INTENT_MISLEADING_PHRASE not in lowered
     assert "13 inventory" in lowered
-    assert "9 active schedule" in lowered
+    assert "8 active schedule" in lowered
     assert "manual-only" in lowered
 
     proc_json = _run_cli("--list-intents", "--json")
@@ -188,7 +190,7 @@ def test_residual_all_intent_label_inventory_split_v0() -> None:
     label = row["label"].lower()
     assert RESIDUAL_ALL_INTENT_MISLEADING_PHRASE not in label
     assert "13 inventory" in label
-    assert "9 active schedule" in label
+    assert "8 active schedule" in label
     assert "manual-only" in label
     assert payload["residual_schedule_count"] == RESIDUAL_INVENTORY_COUNT
 
@@ -218,6 +220,16 @@ def test_residual_all_json_covers_thirteen_without_duplicates() -> None:
     assert len(files) == RESIDUAL_INVENTORY_COUNT
     assert active_count == RESIDUAL_ACTIVE_SCHEDULE_COUNT
     assert manual_only_count == RESIDUAL_MANUAL_ONLY_COUNT
+
+
+def test_ci_manual_only_yaml_shape() -> None:
+    """GH-CI: cron removed; dispatch and PR/push/merge_group retained."""
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch" in text
+    assert "schedule:" not in text
+    assert "pull_request:" in text
+    assert "push:" in text
+    assert "merge_group:" in text
 
 
 def test_pro_prk_nightly_selfcheck_manual_only_yaml_shape() -> None:


### PR DESCRIPTION
## Summary
- Removes schedule from `.github/workflows/ci.yml`.
- Preserves `workflow_dispatch`, `pull_request`, `push`, and `merge_group`.
- No jobs, steps, matrix, runtime, scheduler, testnet, live, source, or risk behavior changed.
- Synchronizes existing schedule-governance SSOT/guards/docs only as needed.

## Safety
- READY_FOR_OPERATOR_ARMING=false
- PREFLIGHT_REMAINS_BLOCKED=true
- RUN_TESTNET_SESSION_ALLOWED=false
- SCHEDULER_ALLOWED=false
- RUNTIME_ALLOWED=false
- No workflow dispatch, no secrets/env access, no Notion write.
- No batch YAML; only selected `ci.yml` plus existing SSOT/guard/doc sync if required.

## Validation
- `python3 -m pytest tests/ops/test_recommend_manual_only_workflows.py -q`

Made with [Cursor](https://cursor.com)