### PR TITLE
chore(gh): make PRBJ testnet exec events manual-only

### DIFF
--- a/.github/workflows/prbj-testnet-exec-events.yml
+++ b/.github/workflows/prbj-testnet-exec-events.yml
@@ -1,8 +1,6 @@
 name: PR-BJ / Testnet Exec Events Artifact
 
 on:
-  schedule:
-    - cron: "9 2 * * *"
   workflow_dispatch:
     inputs:
       profile:

--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -2976,7 +2976,7 @@ PARALLEL_OPERATOR_STATUS_INDEX_CREATED=false
 | **SLICE-GH-2** (optional) | Static test guard after GH-001 if needed | none | **deferred** (GH-001 yaml-shape guard merged #3911) |
 | **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` (`schedule:` removed; `workflow_dispatch`, `pull_request`, `push`, `merge_group` retained) | **one file** | **pending PR** (GH-CI slice) |
 
-**Residual schedules on `main` (post GH-001..004 + GH-CI + PRCC + PRK/PRBD Option2):** **6** workflows retain active `schedule:` — `prbc-stability-gate.yml`, `prbd-live-readiness-scorecard.yml`, `prbe-shadow-testnet-scorecard.yml`, `prbg-execution-evidence.yml`, `prbi-live-pilot-scorecard.yml`, `prbj-testnet-exec-events.yml`. **7** are **manual-only** (no active `schedule:`; other triggers retained): `ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`. Recommender inventory set remains **13** files (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **6** have active schedules. **No batch YAML wave.** **No schedule reactivation** for PR #3896 manual-only set.
+**Residual schedules on `main` (post GH-001..004 + GH-CI + PRCC + PRK/PRBD Option2 + PRBJ Option B):** **5** workflows retain active `schedule:` — `prbc-stability-gate.yml`, `prbd-live-readiness-scorecard.yml`, `prbe-shadow-testnet-scorecard.yml`, `prbg-execution-evidence.yml`, `prbi-live-pilot-scorecard.yml`. **8** are **manual-only** (no active `schedule:`; other triggers retained): `ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`, `prbj-testnet-exec-events.yml`. Recommender inventory set remains **13** files (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **5** have active schedules. **No batch YAML wave.** **No schedule reactivation** for PR #3896 manual-only set.
 
 **Durable operator pointers (archive only — not repo-ingested):**
 
@@ -2989,9 +2989,9 @@ PARALLEL_OPERATOR_STATUS_INDEX_CREATED=false
 
 **Operational rules:**
 
-- **SLICE-GH-0 / SLICE-GH-001 complete** — **no** further YAML in this release line without **per-workflow Sub-GO**; **no** `workflow_dispatch` execution from agent/CI automation; **no** batch cron removal on residual active schedules (**6** after GH-CI + PRCC + PRK/PRBD Option2).
+- **SLICE-GH-0 / SLICE-GH-001 complete** — **no** further YAML in this release line without **per-workflow Sub-GO**; **no** `workflow_dispatch` execution from agent/CI automation; **no** batch cron removal on residual active schedules (**5** after GH-CI + PRCC + PRK/PRBD Option2 + PRBJ Option B).
 - **Manual-only recommender output** is **read-only** and **not** equivalent to schedule deactivation.
-- **`residual_all` intent** — **13** inventory entries (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **6** active `schedule:` + **7** manual-only; CLI label must not imply “13 active schedules”.
+- **`residual_all` intent** — **13** inventory entries (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **5** active `schedule:` + **8** manual-only; CLI label must not imply “13 active schedules”.
 - **STOP_IDLE preserved** — `PREFLIGHT_REMAINS_BLOCKED=true`; no paper/shadow/testnet/live, no scheduler/daemon execution, no runtime.
 - **Notion** remains mirror/status only — **no** Notion writes.
 - **No trading / execution / risk / governance / live-gate authority** — no Master V2 / Double Play logic changes.

--- a/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
+++ b/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
@@ -124,7 +124,7 @@ Fourteen ops/schedule workflows remain **active** on GitHub with **`workflow_dis
 
 **Re-enabling cron** requires a **separate PR** that restores `schedule:` in workflow YAML plus explicit **operator-GO** — not this recommender.
 
-**`residual_all` intent:** lists all **13** entries in `RESIDUAL_SCHEDULE_WORKFLOW_FILES` — **8** with active `schedule:` plus **5** manual-only (GH-001..004 + GH-CI); not “13 active schedules”.
+**`residual_all` intent:** lists all **13** entries in `RESIDUAL_SCHEDULE_WORKFLOW_FILES` — **5** with active `schedule:` plus **8** manual-only (GH-001..004 + GH-CI + PRCC + PRK + PRBJ); not “13 active schedules”.
 
 **Examples:**
 
@@ -150,7 +150,7 @@ AI-adjacent workflows (`infostream-automation`, `market_outlook_automation`) may
 | **SLICE-GH-001** | Single-workflow manual-only: `.github&#47;workflows&#47;pro-prk-nightly-selfcheck.yml` | **complete** (#3911) |
 | **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` | **pending PR** (GH-CI slice) |
 
-**Post GH-001..004 + GH-CI schedule posture:** **5** residual inventory workflows are manual-only (`ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`); **`workflow_dispatch`** and other non-schedule triggers retained per workflow. Among `RESIDUAL_SCHEDULE_WORKFLOW_FILES`, **8** retain active `schedule:`. **No batch YAML wave.**
+**Post GH-001..004 + GH-CI + PRCC + PRK/PRBD + PRBJ Option B schedule posture:** **8** residual inventory workflows are manual-only (`ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`, `prbj-testnet-exec-events.yml`); **`workflow_dispatch`** and other non-schedule triggers retained per workflow. Among `RESIDUAL_SCHEDULE_WORKFLOW_FILES`, **5** retain active `schedule:`. **No batch YAML wave.**
 
 **Governance boundaries:**
 

--- a/scripts/ops/recommend_manual_only_workflows.py
+++ b/scripts/ops/recommend_manual_only_workflows.py
@@ -55,7 +55,7 @@ MANUAL_ONLY_WORKFLOW_FILES: frozenset[str] = frozenset(
 # Related downstream workflow (dispatch-only; schedule commented in YAML).
 PAPER_TEST_EVIDENCE_FILE = "paper_tests_audit_evidence.yml"
 
-# Residual schedule inventory (13 files): 6 active schedule + 7 manual-only (GH-001..004 + GH-CI + PRCC + PRK).
+# Residual schedule inventory (13 files): 5 active schedule + 8 manual-only (GH-001..004 + GH-CI + PRCC + PRK + PRBJ).
 RESIDUAL_SCHEDULE_WORKFLOW_FILES: frozenset[str] = frozenset(
     {
         "audit.yml",
@@ -78,7 +78,7 @@ RESIDUAL_INTENT_LABELS: dict[str, str] = {
     "residual_ci_ops": "Residual scheduled CI core / audit / PR-U drift (do not batch-remove)",
     "residual_scorecard_chain": "Residual PR-B / PR-K nightly scorecard and evidence chain",
     "residual_data_smoke": "Residual high-frequency market forward evidence smoke",
-    "residual_all": "13 inventory workflows (6 active schedule + 7 manual-only; read-only)",
+    "residual_all": "13 inventory workflows (5 active schedule + 8 manual-only; read-only)",
 }
 
 RESIDUAL_INTENT_TO_FILES: dict[str, tuple[str, ...]] = {
@@ -298,11 +298,11 @@ RESIDUAL_STATIC_META: dict[str, dict[str, Any]] = {
         "residual_schedule": True,
     },
     "prbj-testnet-exec-events.yml": {
-        "why": "Daily testnet exec events producer (orchestrator).",
-        "risk": "BLOCKED when KRAKEN_TESTNET_CRON_ENABLED — testnet/runtime boundary.",
-        "variable_gates": "vars.KRAKEN_TESTNET_CRON_ENABLED",
+        "why": "Testnet exec events producer (dispatch-only; schedule removed per signed PRBJ Option B).",
+        "risk": "BLOCKED — testnet/runtime boundary; workflow_dispatch requires named Operator-GO.",
+        "variable_gates": "vars.KRAKEN_TESTNET_CRON_ENABLED (job if: legacy schedule branch)",
         "ai": False,
-        "residual_schedule": True,
+        "residual_schedule": False,
     },
     "prbg-execution-evidence.yml": {
         "why": "Daily execution evidence bundle (testnet-adjacent).",

--- a/tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py
+++ b/tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py
@@ -1,4 +1,4 @@
-"""Static contract for PR-BJ Kraken testnet exec-events workflow cron gate.
+"""Static contract for PR-BJ Kraken testnet exec-events workflow (manual-only dispatch).
 
 Parses workflow YAML as UTF-8 text only. Never dispatches workflows, never
 reads secret values, and never touches runtime/testnet execution paths.
@@ -43,15 +43,13 @@ def _run_testnet_job() -> dict[str, Any]:
     return job
 
 
-def test_workflow_has_schedule_and_workflow_dispatch_triggers() -> None:
+def test_workflow_has_workflow_dispatch_only_no_schedule() -> None:
+    """PRBJ Option B: schedule removed; workflow_dispatch retained."""
     triggers = _trigger_section(_workflow())
 
     assert "workflow_dispatch" in triggers
-
-    schedule = triggers.get("schedule")
-    assert isinstance(schedule, list)
-    assert len(schedule) >= 1
-    assert any(isinstance(entry, dict) and "cron" in entry for entry in schedule)
+    assert "schedule" not in triggers
+    assert "schedule:" not in _workflow_text()
 
 
 def test_workflow_schedule_requires_kraken_testnet_cron_enabled_var() -> None:

--- a/tests/ops/test_recommend_manual_only_workflows.py
+++ b/tests/ops/test_recommend_manual_only_workflows.py
@@ -56,7 +56,7 @@ RESIDUAL_SCHEDULE_FILES = frozenset(
     }
 )
 
-# SLICE-GH-001..004 + GH-CI + PRCC + PRK/PRBD Option2: schedule removed; other triggers retained.
+# SLICE-GH-001..004 + GH-CI + PRCC + PRK/PRBD Option2 + PRBJ Option B: schedule removed; other triggers retained.
 GH001_MANUAL_ONLY_FORMER_RESIDUAL = frozenset(
     {
         "ci.yml",
@@ -66,6 +66,7 @@ GH001_MANUAL_ONLY_FORMER_RESIDUAL = frozenset(
         "pru-required-checks-drift-detector.yml",
         "prcc-aws-export-smoke.yml",
         "prk-prj-status-report.yml",
+        "prbj-testnet-exec-events.yml",
     }
 )
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
@@ -81,8 +82,8 @@ PRU_REQUIRED_CHECKS_DRIFT_DETECTOR_WORKFLOW = (
 )
 
 RESIDUAL_INVENTORY_COUNT = 13
-RESIDUAL_ACTIVE_SCHEDULE_COUNT = 6
-RESIDUAL_MANUAL_ONLY_COUNT = 7
+RESIDUAL_ACTIVE_SCHEDULE_COUNT = 5
+RESIDUAL_MANUAL_ONLY_COUNT = 8
 RESIDUAL_ALL_INTENT_MISLEADING_PHRASE = "13 workflows with active schedule"
 
 RESIDUAL_CI_OPS_FILES = frozenset({"ci.yml", "audit.yml", "pru-required-checks-drift-detector.yml"})
@@ -182,7 +183,7 @@ def test_residual_all_intent_label_inventory_split_v0() -> None:
     lowered = proc.stdout.lower()
     assert RESIDUAL_ALL_INTENT_MISLEADING_PHRASE not in lowered
     assert "13 inventory" in lowered
-    assert "6 active schedule" in lowered
+    assert "5 active schedule" in lowered
     assert "manual-only" in lowered
 
     proc_json = _run_cli("--list-intents", "--json")
@@ -192,7 +193,7 @@ def test_residual_all_intent_label_inventory_split_v0() -> None:
     label = row["label"].lower()
     assert RESIDUAL_ALL_INTENT_MISLEADING_PHRASE not in label
     assert "13 inventory" in label
-    assert "6 active schedule" in label
+    assert "5 active schedule" in label
     assert "manual-only" in label
     assert payload["residual_schedule_count"] == RESIDUAL_INVENTORY_COUNT
 
@@ -279,6 +280,16 @@ def test_prcc_aws_export_smoke_manual_only_yaml_shape() -> None:
 
 
 PRK_PRJ_STATUS_REPORT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "prk-prj-status-report.yml"
+PRBJ_TESTNET_EXEC_EVENTS_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "prbj-testnet-exec-events.yml"
+)
+
+
+def test_prbj_testnet_exec_events_manual_only_yaml_shape() -> None:
+    """PRBJ Option B: cron removed; dispatch retained (signed testnet policy)."""
+    text = PRBJ_TESTNET_EXEC_EVENTS_WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch" in text
+    assert "schedule:" not in text
 
 
 def test_prk_prj_status_report_manual_only_yaml_shape() -> None:


### PR DESCRIPTION
## Summary
- Removes schedule from `.github/workflows/prbj-testnet-exec-events.yml`.
- Preserves `workflow_dispatch`.
- No jobs or steps changed.
- No if/gate/repo-var/secret/script changes.
- No workflow dispatch or testnet execution.

## Safety
- Signed PRBJ policy Option B.
- PRBJ_CRON_DECISION=DENY.
- PRBJ_WORKFLOW_DISPATCH_DECISION=ALLOW_UNDER_NAMED_GO_ONLY.
- PRBJ_EXECUTE_DECISION=DENY_NOW.
- PRBJ_SECRET_ACCESS_DECISION=DENY_NOW.
- READY_FOR_OPERATOR_ARMING=false.
- PREFLIGHT_REMAINS_BLOCKED=true.
- RUN_TESTNET_SESSION_ALLOWED=false.
- SCHEDULER_ALLOWED=false.
- RUNTIME_ALLOWED=false.
- No secrets/env access, no Notion write.
- No batch YAML.

## Validation
- `python3 -m pytest tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py tests/ops/test_recommend_manual_only_workflows.py -q` (38 passed)

## SSOT
- Residual counts: 5 active schedules, 8 manual-only (PRBJ added to manual-only set).


Made with [Cursor](https://cursor.com)