### PR TITLE
docs(ops): reflect gap2 gap3 bounded scope acceptance

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -413,6 +413,99 @@ This contract records criteria only. It does not execute `scripts/run_scheduler.
 
 This contract does not verify or activate Risk Boundaries, does not change Risk/KillSwitch authority, does not change Risk/KillSwitch runtime behavior, does not change Master V2 / Double Play logic, does not change Bull/Bear side-switching or Scope/Capital behavior, and does not change execution/live gates. It does not modify `config/scheduler/jobs.toml`, does not enable any scheduler job, does not execute `scripts/run_scheduler.py`, does not authorize scheduler execution, does not approve runtime execution, and does not authorize Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity. It does not change default-on enforcement, does not mark `READY_FOR_OPERATOR_ARMING=true`, does not lift Path B, does not lift preflight, and does not approve runtime.
 
+## Gap 2 Governed Canonical Job Set Scoped Criteria Acceptance Reflection v0
+
+GAP2_CANONICAL_JOB_SET_GOVERNED_REFLECTION_V0=true
+GAP2_ACCEPTED_SCOPED_CRITERIA=true
+ACCEPTED_MODE=PAPER_PLUS_BOUNDED_SHADOW_NON_24_7
+GAP2_CANONICAL_JOB_SET_VERIFIED=false
+GAP2_JOB_SET_ENABLED=false
+GAP2_JOBS_TOML_CHANGED=false
+GAP2_SCHEDULER_EXECUTION_AUTHORIZED=false
+EXECUTED=false
+EXTERNAL_ACCEPTANCE_RECORD_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap2_canonical_job_set_bounded_scoping_readonly_no_run_v0_20260603T152117Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/section5_breakthrough_unlock_strategy_no_run_v0_20260603T153035Z/
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-accepted scoped criteria for the bounded canonical job set only. It does not adopt external-only acceptance tokens as repo SSOT. External acceptance records remain pointer-based and subordinate to repo governance.
+
+### Operator-accepted bounded canonical job set (scoped criteria only; not verified or enabled)
+
+| Class | Job names |
+|-------|-----------|
+| Paper | `paper_shadow_247_paper_only_preflight_status_v0`, `paper_shadow_247_paper_only_runtime_min_v0`, `paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0` |
+| Shadow | `p7_shadow_high_vol_no_trade_runner_manual_v0` |
+| Excluded placeholder | `shadow_247_futures_prestart_evidence_drycheck_placeholder_v0` |
+
+Twelve legacy/research/autonomous jobs in `config/scheduler/jobs.toml` remain **out-of-scope** for this bounded candidate set. Without tag filtering at dry-run time, seven jobs may appear enabled in the file; only one canonical job is enabled among the bounded set.
+
+### Non-authority boundary (scoped reflection does not imply)
+
+- does not set `GAP2_CANONICAL_JOB_SET_VERIFIED=true` in criteria or Final Machine Lines
+- does not enable any scheduler job or mutate `config/scheduler/jobs.toml`
+- does not verify Gap-4 output evidence paths
+- does not accept Gap-6 dry-run RC=0 proof in repo SSOT
+- does not verify Gap-7 risk boundaries
+- does not enforce Gap-2a.1 primary evidence
+- does not authorize scheduler execution
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+- does not modify the existing Gap-2 criteria block
+- does not modify Final Machine Lines
+- does not lift preflight
+
+Evidence acceptance is not runtime authorization. The Gap 2 Canonical Job Set Contract v0 block above remains criteria-only and unchanged.
+
+## Gap 3 Governed Tier-2 Command Scoped Criteria Acceptance Reflection v0
+
+GAP3_EXECUTE_COMMAND_GOVERNED_REFLECTION_V0=true
+GAP3_ACCEPTED_SCOPED_CRITERIA=true
+ACCEPTED_MODE=BOUNDED_DRY_RUN_COMMAND_TIER2
+GAP3_EXECUTE_COMMAND_VERIFIED=false
+GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false
+EXECUTED=false
+EXTERNAL_ACCEPTANCE_RECORD_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap3_execute_command_contract_readonly_no_run_v0_20260603T152336Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/section5_breakthrough_unlock_strategy_no_run_v0_20260603T153035Z/
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-accepted scoped criteria for Gap-3 Tier-1 and Tier-2 bounded dry-run command text only. It does not adopt external-only acceptance tokens as repo SSOT. External acceptance records remain pointer-based and subordinate to repo governance.
+
+### Operator-accepted command contracts (planning text only; not executed)
+
+Tier-1 canonical (repo SSOT — unchanged):
+
+`uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose`
+
+Tier-2 bounded (operator-accepted scoped criteria for future Gap-6 dry-run evidence capture):
+
+`uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose --include-tags paper_shadow_247,preflight,readonly`
+
+Without the Tier-2 tag filter, an unfiltered dry-run may plan against seven enabled jobs in `jobs.toml`, of which only one is canonical. Gap-6 RC=0 proof requires a **separate operator-authorized bounded execute GO**; this reflection does not claim RC=0 was observed or that any dry-run was executed.
+
+### Non-authority boundary (scoped reflection does not imply)
+
+- does not set `GAP3_EXECUTE_COMMAND_VERIFIED=true` in criteria or Final Machine Lines
+- does not authorize scheduler execution
+- does not observe or record `GAP6_DRY_RUN_RC0_OBSERVED=true`
+- does not verify Gap-4 output evidence paths
+- does not verify Gap-7 risk boundaries
+- does not enforce Gap-2a.1 primary evidence
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+- does not modify the existing Gap-3 criteria block
+- does not modify Final Machine Lines
+- does not lift preflight
+
+Evidence acceptance is not runtime authorization. The Gap 3 Execute Command Contract v0 block above remains contract-only and unchanged.
+
 ## Gap 5 Governed Stop Proof Acceptance Reflection v0
 
 GAP5_STOP_PROOF_GOVERNED_REFLECTION_V0=true

--- a/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
+++ b/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
@@ -23,13 +23,31 @@ FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP2_SECTION_HEADER = "## Gap 2 Canonical Job Set Contract v0"
 GAP3_SECTION_HEADER = "## Gap 3 Execute Command Contract v0"
 GAP7_SECTION_HEADER = "## Gap 7 Risk Boundary Criteria Contract v0"
+GAP2_GOVERNED_REFLECTION_HEADER = (
+    "## Gap 2 Governed Canonical Job Set Scoped Criteria Acceptance Reflection v0"
+)
+GAP3_GOVERNED_REFLECTION_HEADER = (
+    "## Gap 3 Governed Tier-2 Command Scoped Criteria Acceptance Reflection v0"
+)
+GAP5_GOVERNED_REFLECTION_HEADER = "## Gap 5 Governed Stop Proof Acceptance Reflection v0"
 _MARKER_TRUE = "=true"
 
 CANONICAL_BOUNDED_DRY_RUN_COMMAND = (
     "uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml "
     "--dry-run --once --verbose"
 )
+CANONICAL_BOUNDED_DRY_RUN_COMMAND_TIER2 = (
+    "uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml "
+    "--dry-run --once --verbose --include-tags paper_shadow_247,preflight,readonly"
+)
 BOUNDED_PATH_B_CANDIDATE_SCOPE = "PAPER_PLUS_BOUNDED_SHADOW_NON_24_7"
+BOUNDED_PAPER_JOBS = (
+    "paper_shadow_247_paper_only_preflight_status_v0",
+    "paper_shadow_247_paper_only_runtime_min_v0",
+    "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0",
+)
+BOUNDED_SHADOW_JOB = "p7_shadow_high_vol_no_trade_runner_manual_v0"
+EXCLUDED_PLACEHOLDER = "shadow_247_futures_prestart_evidence_drycheck_placeholder_v0"
 
 DEPENDENCY_REQUIRED_FINAL_LINES = (
     "PREFLIGHT_REMAINS_BLOCKED=true",
@@ -48,6 +66,7 @@ DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
     "GAP2_JOB_SET_ENABLED=true",
     "GAP3_EXECUTE_COMMAND_VERIFIED=true",
     "GAP3_SCHEDULER_EXECUTION_AUTHORIZED=true",
+    "GAP6_DRY_RUN_RC0_OBSERVED=true",
     "SHADOW_24_7_AUTHORIZED=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
     "ALL_GAPS_CLOSED=true",
@@ -64,7 +83,11 @@ def _final_machine_lines(text: str) -> str:
 
 
 def _gap2_section(text: str) -> str:
-    return text.split(GAP2_SECTION_HEADER, 1)[1].split(GAP3_SECTION_HEADER, 1)[0]
+    return text.split(GAP2_SECTION_HEADER, 1)[1].split(GAP7_SECTION_HEADER, 1)[0]
+
+
+def _gap2_criteria_section(text: str) -> str:
+    return _gap2_section(text)
 
 
 def _gap3_section(text: str) -> str:
@@ -74,7 +97,19 @@ def _gap3_section(text: str) -> str:
 
 
 def _gap7_section(text: str) -> str:
-    return text.split(GAP7_SECTION_HEADER, 1)[1].split(FINAL_MACHINE_LINES_HEADER, 1)[0]
+    return text.split(GAP7_SECTION_HEADER, 1)[1].split(GAP2_GOVERNED_REFLECTION_HEADER, 1)[0]
+
+
+def _gap2_governed_reflection_section(text: str) -> str:
+    return text.split(GAP2_GOVERNED_REFLECTION_HEADER, 1)[1].split(
+        GAP3_GOVERNED_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap3_governed_reflection_section(text: str) -> str:
+    return text.split(GAP3_GOVERNED_REFLECTION_HEADER, 1)[1].split(
+        GAP5_GOVERNED_REFLECTION_HEADER, 1
+    )[0]
 
 
 def _section5_text() -> str:
@@ -124,11 +159,9 @@ def test_gap2_gap3_dependency_gap3_cannot_verify_while_gap2_unverified_v0() -> N
     assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in gap2
     assert "GAP2_JOB_SET_ENABLED=false" in gap2
     assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in gap3
-    for scope in (gap2, gap3, block):
-        assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in scope
-    for scope in (gap2, block):
-        assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in scope
-        assert "GAP2_JOB_SET_ENABLED=false" in scope
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in block
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in block
+    assert "GAP2_JOB_SET_ENABLED=false" in block
 
 
 def test_gap2_gap3_dependency_gap3_command_is_dry_run_planning_only_v0() -> None:
@@ -208,3 +241,63 @@ def test_gap2_gap3_dependency_owner_crosslinks_hardening_source_contract_v0() ->
     assert HARDENING_OWNER.is_file()
     text = HARDENING_OWNER.read_text(encoding="utf-8")
     assert "test_gap2_gap3_command_dependency_contract_v0.py" in text
+
+
+def test_gap2_governed_reflection_scoped_acceptance_v0() -> None:
+    text = _section5_text()
+    reflection = _gap2_governed_reflection_section(text)
+    criteria = _gap2_criteria_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP2_CANONICAL_JOB_SET_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" in reflection
+    assert f"ACCEPTED_MODE={BOUNDED_PATH_B_CANDIDATE_SCOPE}" in reflection
+    assert "NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true" in reflection
+    assert "EXTERNAL_ACCEPTANCE_RECORD_POINTER=" in reflection
+    assert "GOVERNED_REPO_REFLECTION_CHARTER_POINTER=" in reflection
+    assert "EXECUTED=false" in reflection
+    for job in BOUNDED_PAPER_JOBS:
+        assert job in reflection
+    assert BOUNDED_SHADOW_JOB in reflection
+    assert EXCLUDED_PLACEHOLDER in reflection
+    assert "Evidence acceptance is not runtime authorization" in reflection
+    assert "does not modify Final Machine Lines" in reflection
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in criteria
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in block
+    reflection_lines = {line.strip() for line in reflection.splitlines()}
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=true" not in reflection_lines
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" not in criteria
+
+
+def test_gap3_governed_reflection_tier2_command_v0() -> None:
+    text = _section5_text()
+    reflection = _gap3_governed_reflection_section(text)
+    criteria = _gap3_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP3_EXECUTE_COMMAND_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" in reflection
+    assert "ACCEPTED_MODE=BOUNDED_DRY_RUN_COMMAND_TIER2" in reflection
+    assert CANONICAL_BOUNDED_DRY_RUN_COMMAND in reflection
+    assert CANONICAL_BOUNDED_DRY_RUN_COMMAND_TIER2 in reflection
+    assert "--include-tags paper_shadow_247,preflight,readonly" in reflection
+    assert "does not observe or record `GAP6_DRY_RUN_RC0_OBSERVED=true`" in reflection
+    assert "separate operator-authorized bounded execute GO" in reflection
+    assert "NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true" in reflection
+    assert "EXECUTED=false" in reflection
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in criteria
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in block
+    reflection_lines = {line.strip() for line in reflection.splitlines()}
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=true" not in reflection_lines
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" not in criteria
+
+
+def test_gap2_gap3_reflection_final_lines_no_verified_or_rc0_flip_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    lines = {line.strip() for line in block.splitlines()}
+    for token in DEPENDENCY_FORBIDDEN_REPO_TOKENS:
+        assert token not in lines
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
+    assert "ALL_GAPS_CLOSED=false" in block


### PR DESCRIPTION
## Summary

- Adds **Gap 2** and **Gap 3** governed repo-reflection blocks to `SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md` recording operator-accepted bounded scoped criteria from external archive bundles (`…152117Z`, `…152336Z`).
- Extends `test_gap2_gap3_command_dependency_contract_v0.py` to guard reflection presence, canonical set tokens, Tier-2 `--include-tags` command, and forbid verified/RC=0/preflight-lift flips in Final Machine Lines.

## Safety summary

- **No execute** — no scheduler, dry-run, runtime, shadow, testnet, or live.
- **No verified flips** — `GAP2_CANONICAL_JOB_SET_VERIFIED`, `GAP3_EXECUTE_COMMAND_VERIFIED`, `GAP6_DRY_RUN_RC0_OBSERVED` remain `false` in Final Machine Lines.
- **No preflight lift** — `PREFLIGHT_REMAINS_BLOCKED=true`, `READY_FOR_OPERATOR_ARMING=false`, `BL002_PATH_B_BLOCKED` unchanged.
- **No config/src/workflow changes** — docs + tests only (2 files).

## Changed files

- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap2_gap3_command_dependency_contract_v0.py`

## Validation

```bash
python3 -m pytest tests/ops/test_gap2_gap3_command_dependency_contract_v0.py tests/ops/test_gap2_job_set_boundary_drift_guard_contract_v0.py tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py -q
python3 -m pytest tests/ops -k "section5 or gap2 or gap3 or preflight" -q
```

Result: **442 passed** (47 targeted + 395 broader), 1 skipped.

## Forbidden scope (confirmed absent)

- No `jobs.toml`, `run_scheduler.py`, `src/**`, workflows, risk/killswitch, paper data
- No `*_VERIFIED=true`, no preflight/arming/Path-B lift
- Gap-6 RC=0 proof deferred to separate bounded execute GO

## Next step

After merge: operator may authorize `GO_GAP6_BOUNDED_DRY_RUN_EVIDENCE_CAPTURE_OPERATOR_AUTHORIZED_V0`.


Made with [Cursor](https://cursor.com)