### PR TITLE
docs(ops): reflect gap6 bounded dry run rc0 evidence

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -566,6 +566,61 @@ This governed repo-reflection block records scoped acceptance of external bounde
 
 Evidence acceptance is not runtime authorization. The Gap 6 Dry-Run Proof Criteria Contract v0 block above remains criteria-only and unchanged.
 
+## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0
+
+GAP6_BOUNDED_DRY_RUN_RC0_OBSERVED_GOVERNED_REFLECTION_V0=true
+GAP6_DRY_RUN_RC0_OBSERVED=true
+ACCEPTED_MODE=BOUNDED_TIER2_TAG_FILTERED_DRY_RUN_RC0
+EXIT_CODE=0
+DRY_RUN_EXECUTED=true
+DRY_RUN_ONCE=true
+INCLUDE_TAGS=paper_shadow_247,preflight,readonly
+UNEXPECTED_EXECUTION_OBSERVED=false
+LEGACY_JOBS_EXCLUDED=true
+CANONICAL_JOB_SCOPE_RESPECTED=true
+GAP6_DRY_RUN_PROOF_VERIFIED=false
+GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false
+EXTERNAL_EVIDENCE_BUNDLE_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/evidence/gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/section5_breakthrough_unlock_strategy_no_run_v0_20260603T153035Z/
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-authorized bounded Tier-2 tag-filtered dry-run RC=0 observed evidence only. It does not adopt external-only tokens as repo SSOT. External evidence bundles remain pointer-based and subordinate to repo governance.
+
+### Observed evidence facts (2026-06-03 capture GO)
+
+Command (Tier-2, observed RC=0):
+
+`uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose --include-tags paper_shadow_247,preflight,readonly`
+
+| Fact | Value |
+|------|-------|
+| External bundle MANIFEST_VERIFY_RC | 0 |
+| Due/dispatched (dry-run simulate) | `paper_shadow_247_paper_only_preflight_status_v0` only |
+| Tag-filtered jobs in plan | 5 (all `PAPER_PLUS_BOUNDED_SHADOW_NON_24_7`) |
+| Legacy/autonomous jobs in plan | excluded |
+| Gap 2/3 bounded scope | accepted per PR #3963 |
+| Live/Testnet/Shadow/Paper/Broker/Network/AWS | not observed |
+
+### Non-authority boundary (scoped reflection does not imply)
+
+- does not modify Final Machine Lines
+- does not set `GAP6_DRY_RUN_PROOF_VERIFIED=true` in criteria or Final Machine Lines
+- does not verify Gap-4 output evidence paths
+- does not verify Gap-7 risk boundaries
+- does not enforce Gap-2a.1 primary evidence
+- does not authorize scheduler execution
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not set `ALL_GAPS_CLOSED=true`
+- does not lift preflight
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+- does not modify the existing Gap-6 criteria block or May-2026 acceptance reflection block
+
+Evidence observation is not runtime authorization. The Gap 6 Dry-Run Proof Criteria Contract v0 block above remains criteria-only and unchanged.
+
 ## Gap 4 Governed Output Evidence Acceptance Reflection v0
 
 GAP4_REQ_A_PAPER_HOLD_BINDING_PROFILE_V0=true

--- a/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
+++ b/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
@@ -5,6 +5,9 @@ ROOT = Path(__file__).resolve().parents[2]
 DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
 GAP6_SECTION_HEADER = "## Gap 6 Dry-Run Proof Criteria Contract v0"
 GAP6_GOVERNED_REFLECTION_HEADER = "## Gap 6 Governed Dry-Run Proof Acceptance Reflection v0"
+GAP6_RC0_OBSERVED_REFLECTION_HEADER = (
+    "## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0"
+)
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP6_PARALLEL_MARKERS = (
     "GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true",
@@ -21,7 +24,9 @@ def _gap6_criteria_section(text: str) -> str:
 
 
 def _gap6_governed_reflection_section(text: str) -> str:
-    return text.split(GAP6_GOVERNED_REFLECTION_HEADER, 1)[1].split(FINAL_MACHINE_LINES_HEADER, 1)[0]
+    return text.split(GAP6_GOVERNED_REFLECTION_HEADER, 1)[1].split(
+        GAP6_RC0_OBSERVED_REFLECTION_HEADER, 1
+    )[0]
 
 
 def _final_machine_lines(text: str) -> str:

--- a/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
@@ -206,7 +206,10 @@ def test_gap6_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     assert "CANONICAL_JOB_SCOPE_RESPECTED=true" in reflection
     assert "paper_shadow_247_paper_only_preflight_status_v0" in reflection
     assert "EXTERNAL_EVIDENCE_BUNDLE_POINTER=" in reflection
-    assert "gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z" in reflection
+    assert (
+        "gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z"
+        in reflection
+    )
     assert "NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true" in reflection
     assert "does not modify Final Machine Lines" in reflection
     assert "does not lift preflight" in reflection

--- a/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
@@ -21,7 +21,16 @@ HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_sou
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP6_SECTION_HEADER = "## Gap 6 Dry-Run Proof Criteria Contract v0"
 GAP6_GOVERNED_REFLECTION_HEADER = "## Gap 6 Governed Dry-Run Proof Acceptance Reflection v0"
+GAP6_RC0_OBSERVED_REFLECTION_HEADER = (
+    "## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0"
+)
+GAP4_GOVERNED_REFLECTION_HEADER = "## Gap 4 Governed Output Evidence Acceptance Reflection v0"
 _MARKER_TRUE = "=true"
+
+CANONICAL_BOUNDED_DRY_RUN_COMMAND_TIER2 = (
+    "uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml "
+    "--dry-run --once --verbose --include-tags paper_shadow_247,preflight,readonly"
+)
 
 DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "PREFLIGHT_REMAINS_BLOCKED=true",
@@ -61,7 +70,15 @@ def _gap6_criteria_section(text: str) -> str:
 
 
 def _gap6_governed_reflection_section(text: str) -> str:
-    return text.split(GAP6_GOVERNED_REFLECTION_HEADER, 1)[1].split(FINAL_MACHINE_LINES_HEADER, 1)[0]
+    return text.split(GAP6_GOVERNED_REFLECTION_HEADER, 1)[1].split(
+        GAP6_RC0_OBSERVED_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap6_rc0_observed_reflection_section(text: str) -> str:
+    return text.split(GAP6_RC0_OBSERVED_REFLECTION_HEADER, 1)[1].split(
+        GAP4_GOVERNED_REFLECTION_HEADER, 1
+    )[0]
 
 
 def _section5_text() -> str:
@@ -168,3 +185,41 @@ def test_gap6_external_repo_drift_guard_governed_reflection_scoped_acceptance_v0
     assert "READY_FOR_OPERATOR_ARMING=false" in block
     assert "PATH_B_LIFT_DISCUSSION_READY=false" in block
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
+
+
+def test_gap6_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
+    text = _section5_text()
+    reflection = _gap6_rc0_observed_reflection_section(text)
+    criteria = _gap6_criteria_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP6_BOUNDED_DRY_RUN_RC0_OBSERVED_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in reflection
+    assert "ACCEPTED_MODE=BOUNDED_TIER2_TAG_FILTERED_DRY_RUN_RC0" in reflection
+    assert "EXIT_CODE=0" in reflection
+    assert "DRY_RUN_EXECUTED=true" in reflection
+    assert "DRY_RUN_ONCE=true" in reflection
+    assert "INCLUDE_TAGS=paper_shadow_247,preflight,readonly" in reflection
+    assert CANONICAL_BOUNDED_DRY_RUN_COMMAND_TIER2 in reflection
+    assert "UNEXPECTED_EXECUTION_OBSERVED=false" in reflection
+    assert "LEGACY_JOBS_EXCLUDED=true" in reflection
+    assert "CANONICAL_JOB_SCOPE_RESPECTED=true" in reflection
+    assert "paper_shadow_247_paper_only_preflight_status_v0" in reflection
+    assert "EXTERNAL_EVIDENCE_BUNDLE_POINTER=" in reflection
+    assert "gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z" in reflection
+    assert "NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true" in reflection
+    assert "does not modify Final Machine Lines" in reflection
+    assert "does not lift preflight" in reflection
+    assert "Evidence observation is not runtime authorization" in reflection
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in criteria
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "ALL_GAPS_CLOSED=false" in block
+    assert "READY_FOR_OPERATOR_ARMING=false" in block
+    assert "GAP7_RISK_BOUNDARY_VERIFIED=false" in block
+    reflection_lines = {line.strip() for line in reflection.splitlines()}
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in reflection_lines
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" not in criteria_lines
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" not in block_lines
+    assert "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true" not in text


### PR DESCRIPTION
## Summary

- Adds **Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0** to SECTION5, pointing to fresh evidence bundle `…153911Z` (EXIT_CODE=0, Tier-2 tags, canonical scope).
- Extends `test_gap6_external_repo_drift_guard_contract_v0.py` with RC0 reflection guards; narrows legacy reflection section parser in both gap6 test modules.

## Safety summary

- **No execute** — no re-run of dry-run/scheduler/runtime.
- **Final Machine Lines unchanged** — `GAP6_DRY_RUN_RC0_OBSERVED=false` in criteria + finals; RC=0 observed only in governed reflection block.
- **No preflight lift** — `PREFLIGHT_REMAINS_BLOCKED=true`, `ALL_GAPS_CLOSED=false`, `READY_FOR_OPERATOR_ARMING=false`, `GAP7_RISK_BOUNDARY_VERIFIED=false`.
- **No config/src/workflow changes** — docs + tests only (3 files).

## Changed files

- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py`
- `tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py`

## Validation

```bash
python3 -m pytest tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py tests/ops/test_gap2_gap3_command_dependency_contract_v0.py -q
python3 -m pytest tests/ops -k "section5 or gap6 or preflight" -q
```

Result: **348 passed** (40 targeted + 308 broader), 1 skipped.

## Forbidden scope (confirmed absent)

- No jobs.toml, run_scheduler.py, src/**, workflows, risk/killswitch
- No preflight/arming/Path-B/ALL_GAPS_CLOSED lift
- No claim that preflight is cleared


Made with [Cursor](https://cursor.com)