### PR TITLE
docs(ops): reflect gap1 execute entrypoint evidence

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -621,6 +621,64 @@ Command (Tier-2, observed RC=0):
 
 Evidence observation is not runtime authorization. The Gap 6 Dry-Run Proof Criteria Contract v0 block above remains criteria-only and unchanged.
 
+## Gap 1 Governed Execute Entrypoint Observed Evidence Reflection v0
+
+GAP1_EXECUTE_ENTRYPOINT_OBSERVED_GOVERNED_REFLECTION_V0=true
+GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true
+ACCEPTED_MODE=BOUNDED_TIER2_TAG_FILTERED_ENTRYPOINT_DRY_RUN_RC0
+ENTRYPOINT=scripts/run_scheduler.py
+EXIT_CODE=0
+DRY_RUN_OBSERVED=true
+DRY_RUN_ONCE=true
+INCLUDE_TAGS=paper_shadow_247,preflight,readonly
+UNEXPECTED_EXECUTION_OBSERVED=false
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false
+GAP1_RUNTIME_APPROVED=false
+GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP6_EVIDENCE_SOURCE=true
+EXTERNAL_EVIDENCE_BUNDLE_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/evidence/gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap1_execute_entrypoint_bounded_evidence_adoption_or_capture_strategy_v0_20260603T154906Z/
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-authorized bounded execute entrypoint observed evidence for Gap 1 only. Entrypoint proof is derived from the existing Gap 6 bounded dry-run capture bundle (same command, same RC=0 run). It does not adopt external-only tokens as repo SSOT. External evidence bundles remain pointer-based and subordinate to repo governance.
+
+### Observed evidence facts (2026-06-03 Gap 6 capture; Gap 1 entrypoint proof)
+
+Command (Tier-2, observed RC=0 on canonical entrypoint `scripts/run_scheduler.py`):
+
+`uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose --include-tags paper_shadow_247,preflight,readonly`
+
+| Fact | Value |
+|------|-------|
+| Entrypoint observed | `scripts/run_scheduler.py` |
+| External bundle MANIFEST_VERIFY_RC | 0 |
+| Exit code | 0 (RC=0) |
+| Mode | dry-run only (`--dry-run --once`) |
+| Gap 6 evidence source | same bundle; Gap 1 entrypoint boundary only |
+| Unexpected execution | not observed |
+| Live/Testnet/Shadow/Paper/Broker/Network/AWS | not observed |
+| Repo post-capture | clean (no mutation) |
+
+### Non-authority boundary (scoped reflection does not imply)
+
+- does not modify Final Machine Lines
+- does not set `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true` in criteria or Final Machine Lines
+- does not verify Gap-4 output evidence paths
+- does not verify Gap-7 risk boundaries
+- does not enforce Gap-2a.1 primary evidence
+- does not authorize scheduler execution
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not set `ALL_GAPS_CLOSED=true`
+- does not lift preflight
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+- does not modify the existing Gap-1 criteria block
+
+Evidence observation is not runtime authorization. The Gap 1 Execute Entrypoint Contract v0 block above remains contract-only and unchanged.
+
 ## Gap 4 Governed Output Evidence Acceptance Reflection v0
 
 GAP4_REQ_A_PAPER_HOLD_BINDING_PROFILE_V0=true

--- a/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
@@ -4,6 +4,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
 GAP1_SECTION_HEADER = "## Gap 1 Execute Entrypoint Contract v0"
+GAP1_RC0_OBSERVED_REFLECTION_HEADER = (
+    "## Gap 1 Governed Execute Entrypoint Observed Evidence Reflection v0"
+)
+GAP4_GOVERNED_REFLECTION_HEADER = "## Gap 4 Governed Output Evidence Acceptance Reflection v0"
+FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP1_PARALLEL_MARKERS = (
     "GAP1_EXECUTE_ENTRYPOINT_CONTRACT_V0=true",
     "Gap 1 Execute Entrypoint Contract v0",
@@ -15,6 +20,16 @@ _MARKER_TRUE = "=true"
 
 def _gap1_section(text: str) -> str:
     return text.split(GAP1_SECTION_HEADER, 1)[1].split("## Gap 3 Execute Command Contract v0", 1)[0]
+
+
+def _gap1_rc0_observed_reflection_section(text: str) -> str:
+    return text.split(GAP1_RC0_OBSERVED_REFLECTION_HEADER, 1)[1].split(
+        GAP4_GOVERNED_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _final_machine_lines(text: str) -> str:
+    return text.split(FINAL_MACHINE_LINES_HEADER, 1)[1]
 
 
 def test_gap1_execute_entrypoint_contract_is_present_and_non_authorizing():
@@ -102,3 +117,21 @@ def test_gap1_execute_entrypoint_contract_owner_crosslinks_drift_guard_v0() -> N
     text = drift_guard.read_text(encoding="utf-8")
     assert "test_gap1_execute_entrypoint_contract_v0.py" in text
     assert "GAP1_RUNTIME_APPROVED=false" in text
+
+
+def test_gap1_rc0_observed_governed_reflection_present_and_non_authorizing_v0() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    reflection = _gap1_rc0_observed_reflection_section(text)
+    block = _final_machine_lines(text)
+    block_lines = {line.strip() for line in block.splitlines()}
+
+    assert "GAP1_EXECUTE_ENTRYPOINT_OBSERVED_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in reflection
+    assert "scripts/run_scheduler.py" in reflection
+    assert "gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z" in reflection
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in reflection
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in reflection
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" not in block_lines
+    assert "ALL_GAPS_CLOSED=false" in block
+    assert "READY_FOR_OPERATOR_ARMING=false" in block

--- a/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
@@ -128,7 +128,10 @@ def test_gap1_rc0_observed_governed_reflection_present_and_non_authorizing_v0() 
     assert "GAP1_EXECUTE_ENTRYPOINT_OBSERVED_GOVERNED_REFLECTION_V0=true" in reflection
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in reflection
     assert "scripts/run_scheduler.py" in reflection
-    assert "gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z" in reflection
+    assert (
+        "gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z"
+        in reflection
+    )
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in reflection
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in reflection
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block

--- a/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
@@ -22,6 +22,14 @@ GAP1_CONTRACT = ROOT / "tests" / "ops" / "test_gap1_execute_entrypoint_contract_
 HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_source_contract_v0.py"
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP1_SECTION_HEADER = "## Gap 1 Execute Entrypoint Contract v0"
+GAP1_RC0_OBSERVED_REFLECTION_HEADER = (
+    "## Gap 1 Governed Execute Entrypoint Observed Evidence Reflection v0"
+)
+GAP4_GOVERNED_REFLECTION_HEADER = "## Gap 4 Governed Output Evidence Acceptance Reflection v0"
+CANONICAL_BOUNDED_DRY_RUN_COMMAND_TIER2 = (
+    "uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml "
+    "--dry-run --once --verbose --include-tags paper_shadow_247,preflight,readonly"
+)
 _MARKER_TRUE = "=true"
 
 GAP1_EXECUTE_ENTRYPOINT_PLANNED = True
@@ -54,6 +62,8 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
 )
 
 DRIFT_GUARD_FORBIDDEN_GAP1_REPO_TOKENS = (
+    "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true",
+    "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_EXTERNAL=true",
     "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true",
     "GAP1_RUNTIME_APPROVED=true",
     "GAP1_SCHEDULER_EXECUTION_AUTHORIZED=true",
@@ -97,6 +107,12 @@ def _final_machine_lines(text: str) -> str:
 
 def _gap1_section(text: str) -> str:
     return text.split(GAP1_SECTION_HEADER, 1)[1].split("## Gap 3 Execute Command Contract v0", 1)[0]
+
+
+def _gap1_rc0_observed_reflection_section(text: str) -> str:
+    return text.split(GAP1_RC0_OBSERVED_REFLECTION_HEADER, 1)[1].split(
+        GAP4_GOVERNED_REFLECTION_HEADER, 1
+    )[0]
 
 
 def _section5_text() -> str:
@@ -234,3 +250,46 @@ def test_gap1_drift_guard_owner_crosslinks_hardening_source_contract_v0() -> Non
     assert ("GAP1_EXECUTE_ENTRYPOINT_VERIFIED" + _MARKER_TRUE) not in lines
     assert ("GAP1_RUNTIME_APPROVED" + _MARKER_TRUE) not in lines
     assert ("GAP1_SCHEDULER_EXECUTION_AUTHORIZED" + _MARKER_TRUE) not in lines
+
+
+def test_gap1_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
+    text = _section5_text()
+    reflection = _gap1_rc0_observed_reflection_section(text)
+    criteria = _gap1_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP1_EXECUTE_ENTRYPOINT_OBSERVED_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in reflection
+    assert "ACCEPTED_MODE=BOUNDED_TIER2_TAG_FILTERED_ENTRYPOINT_DRY_RUN_RC0" in reflection
+    assert "ENTRYPOINT=scripts/run_scheduler.py" in reflection
+    assert "EXIT_CODE=0" in reflection
+    assert "DRY_RUN_OBSERVED=true" in reflection
+    assert "DRY_RUN_ONCE=true" in reflection
+    assert "INCLUDE_TAGS=paper_shadow_247,preflight,readonly" in reflection
+    assert CANONICAL_BOUNDED_DRY_RUN_COMMAND_TIER2 in reflection
+    assert "scripts/run_scheduler.py" in reflection
+    assert "UNEXPECTED_EXECUTION_OBSERVED=false" in reflection
+    assert "GAP6_EVIDENCE_SOURCE=true" in reflection
+    assert "EXTERNAL_EVIDENCE_BUNDLE_POINTER=" in reflection
+    assert (
+        "gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z"
+        in reflection
+    )
+    assert "NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true" in reflection
+    assert "does not modify Final Machine Lines" in reflection
+    assert "does not lift preflight" in reflection
+    assert "Evidence observation is not runtime authorization" in reflection
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in criteria
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    assert "ALL_GAPS_CLOSED=false" in block
+    assert "READY_FOR_OPERATOR_ARMING=false" in block
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
+    assert "GAP7_RISK_BOUNDARY_VERIFIED=false" in block
+    reflection_lines = {line.strip() for line in reflection.splitlines()}
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in reflection_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" not in criteria_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" not in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_EXTERNAL=true" not in text
+    assert "Live/Testnet/Shadow/Paper/Broker/Network/AWS" in reflection


### PR DESCRIPTION
## Summary

- Adds **Gap 1 Governed Execute Entrypoint Observed Evidence Reflection v0** to the Section-5 owner map, adopting existing Gap 6 bounded dry-run evidence (`…153911Z`) as entrypoint proof for `scripts/run_scheduler.py`.
- Reflection-only token `GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true` lives in the reflection block only; criteria and Final Machine Lines remain blocked.
- Extends Gap 1 drift-guard and contract tests to protect against preflight lift, verified flip, and runtime authorization conflation.

## Safety summary

| Guard | Status |
|-------|--------|
| `GAP1_EXECUTE_ENTRYPOINT_VERIFIED` | **false** (unchanged in finals) |
| `PREFLIGHT_REMAINS_BLOCKED` | **true** |
| `ALL_GAPS_CLOSED` | **false** |
| `READY_FOR_OPERATOR_ARMING` | **false** |
| Execute / dry-run in this PR | **none** |
| Scheduler / runtime started | **none** |

## Changed files (3)

- `docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- `tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py`
- `tests/ops/test_gap1_execute_entrypoint_contract_v0.py`

## Validation

```bash
python3 -m pytest tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py tests/ops/test_gap1_execute_entrypoint_contract_v0.py -q
python3 -m pytest tests/ops -k "section5 or gap1 or preflight" -q
```

Result: **23 + 300 passed**

## Forbidden scope (not touched)

- No `config/scheduler/jobs.toml`, `scripts/run_scheduler.py`, or `src/**` changes
- No workflow dispatch, scheduler execute, dry-run, or runtime
- No preflight / Path-B / arming / BL002 lift
- No parallel doc surfaces

## Test plan

- [x] Gap 1 contract + drift-guard tests pass
- [x] Section-5 / preflight related ops tests pass
- [ ] CI green on merge


Made with [Cursor](https://cursor.com)