### PR TITLE
ops: bounded futures testnet offline contract and guards v0

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -84,6 +84,8 @@ Preflight §2a.1 documents run-type applicability for **run completion**: Paper,
 
 **Repo-native bounded Testnet order-cap contract (PE-7 guard) v0:** Closes the documented `repo_native_bounded_order_cap_contract_residual` gap at contract/evaluator layer. Canonical offline evaluator: `src/ops/bounded_testnet_order_cap_contract_v0.py` (`BOUNDED_TESTNET_ORDER_CAP_CONTRACT_V0=true`). Static guards: `tests/ops/test_repo_native_bounded_order_cap_contract_v0.py`, `tests/ops/test_repo_native_entrypoint_cli_cap_wiring_contract_v0.py`. `scripts/run_testnet_session.py` exposes bounded cap CLI via `add_bounded_order_cap_cli_arguments` (`REPO_NATIVE_BOUNDED_ORDER_CAP_CLI_WIRING_COMPLETE=true`); **does not** authorize Testnet execute, **does not** lift preflight.
 
+**Bounded Futures Testnet contract (PE-8 guard) v0:** Addresses `futures_bounded_testnet_contract_adapter_and_evidence_path_missing` at offline contract layer only. Canonical evaluator: `src/ops/bounded_futures_testnet_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_CONTRACT_V0=true`). Static guard: `tests/ops/test_bounded_futures_testnet_contract_v0.py`. Spot BTC/EUR bounded evidence **must not** satisfy this contract; `FUTURES_SESSION_AUTHORIZED_NOW=false`; **does not** authorize Futures execute, adapter binding, or Master-V2 / Double-Play authority.
+
 ### Reuse-first owner surfaces
 
 - `scripts/ops/primary_evidence_retention_v0.py`
@@ -98,7 +100,9 @@ Preflight §2a.1 documents run-type applicability for **run completion**: Paper,
 - `tests/ops/test_gap4_output_evidence_paths_contract_v0.py`
 - `tests/ci/test_cybersecurity_visibility_repo_static_histogram_artifact_retention_or_evidence_gap_crosslink_v0.py`
 - `src/ops/bounded_testnet_order_cap_contract_v0.py`
+- `src/ops/bounded_futures_testnet_contract_v0.py`
 - `tests/ops/test_repo_native_bounded_order_cap_contract_v0.py`
+- `tests/ops/test_bounded_futures_testnet_contract_v0.py`
 - existing preflight contract §2a/§2a.1 surfaces
 - existing docs truth map / reference / token-policy checks
 

--- a/src/ops/bounded_futures_testnet_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_contract_v0.py
@@ -126,7 +126,10 @@ def spot_evidence_misclassified_as_futures(evidence: dict[str, Any]) -> list[str
         for ep in endpoints:
             if ep in SPOT_KRAKEN_ENDPOINT_PREFIXES:
                 reasons.append(f"spot endpoint not allowed in futures evidence: {ep}")
-    if evidence.get("network_host") == "https://api.kraken.com" and market_type == DEFAULT_MARKET_TYPE:
+    if (
+        evidence.get("network_host") == "https://api.kraken.com"
+        and market_type == DEFAULT_MARKET_TYPE
+    ):
         reasons.append("spot kraken.com host must not be used for futures bounded evidence")
     return reasons
 

--- a/src/ops/bounded_futures_testnet_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_contract_v0.py
@@ -1,0 +1,271 @@
+"""Repo-native bounded Futures Testnet contract (v0).
+
+Offline contract evaluator for bounded-futures-normal-testnet-v0 session evidence.
+Does not authorize Futures Testnet execute; FUTURES_SESSION_AUTHORIZED_NOW remains false.
+Does not grant Master-V2 / Double-Play authority. Spot BTC/EUR evidence must not satisfy this contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_CONTRACT_V0=true"
+FUTURES_SESSION_AUTHORIZED_NOW = False
+DEFAULT_SESSION_CLASS = "bounded-futures-normal-testnet-v0"
+DEFAULT_ORDER_POLICY = "normal-testnet-futures-bounded"
+DEFAULT_INSTRUMENT = "BTCUSDT"
+DEFAULT_MARKET_TYPE = "futures"
+DEFAULT_MARGIN_MODE = "isolated"
+DEFAULT_POSITION_MODE = "one_way"
+DEFAULT_MAX_LEVERAGE = 5.0
+EVIDENCE_SOURCE_FUTURES_HARNESS = "archive_futures_testnet_harness"
+EVIDENCE_SOURCE_REPO_NATIVE = "repo_native_futures_session"
+
+# Spot paths from accepted BTC/EUR harness — must not appear in futures bounded evidence.
+SPOT_KRAKEN_ENDPOINT_PREFIXES: frozenset[str] = frozenset(
+    {
+        "/0/public/Ticker",
+        "/0/public/Time",
+        "/0/public/AssetPairs",
+        "/0/private/AddOrder",
+        "/0/private/CancelOrder",
+        "/0/private/Balance",
+        "/0/private/OpenOrders",
+    }
+)
+SPOT_SESSION_CLASSES: frozenset[str] = frozenset(
+    {
+        "bounded-normal-testnet-v0",
+        "longer-bounded-normal-testnet-v0",
+    }
+)
+SPOT_INSTRUMENTS: frozenset[str] = frozenset({"BTC/EUR", "ETH/EUR"})
+
+REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES: tuple[str, ...] = (
+    "session_class",
+    "order_policy",
+    "instrument",
+    "market_type",
+    "margin_mode",
+    "max_leverage",
+    "leverage_within_cap",
+    "position_mode",
+    "order_side_semantics",
+    "reduce_only_supported",
+    "order_attempt_count",
+    "real_orders_created_count",
+    "cancel_or_close_attempt_count",
+    "order_notional_eur",
+    "order_notional_within_cap",
+    "position_flattened_by_end",
+    "cancel_or_close_evidence_valid",
+    "futures_endpoint_isolation_pass",
+    "spot_endpoint_isolation_pass",
+    "funding_risk_acknowledged",
+    "liquidation_risk_acknowledged",
+    "risk_killswitch_scope_active",
+    "risk_killswitch_scope_pass",
+    "master_v2_double_play_authority_used",
+)
+
+
+@dataclass(frozen=True)
+class BoundedFuturesTestnetSpec:
+    session_class: str
+    order_policy: str
+    instrument: str
+    market_type: str
+    margin_mode: str
+    position_mode: str
+    max_leverage: float
+    max_real_orders: int
+    max_order_attempts: int
+    max_cancel_attempts: int
+    max_notional_eur: float
+    max_position_hold_seconds: int
+    position_must_be_flattened: bool
+    require_reduce_only_support: bool
+
+
+def default_bounded_futures_normal_v0_spec() -> BoundedFuturesTestnetSpec:
+    return BoundedFuturesTestnetSpec(
+        session_class=DEFAULT_SESSION_CLASS,
+        order_policy=DEFAULT_ORDER_POLICY,
+        instrument=DEFAULT_INSTRUMENT,
+        market_type=DEFAULT_MARKET_TYPE,
+        margin_mode=DEFAULT_MARGIN_MODE,
+        position_mode=DEFAULT_POSITION_MODE,
+        max_leverage=DEFAULT_MAX_LEVERAGE,
+        max_real_orders=1,
+        max_order_attempts=1,
+        max_cancel_attempts=1,
+        max_notional_eur=10.0,
+        max_position_hold_seconds=60,
+        position_must_be_flattened=True,
+        require_reduce_only_support=True,
+    )
+
+
+def spot_evidence_misclassified_as_futures(evidence: dict[str, Any]) -> list[str]:
+    """Fail-closed: spot BTC/EUR lineage must not pass futures bounded contract."""
+    reasons: list[str] = []
+    session_class = evidence.get("session_class")
+    if session_class in SPOT_SESSION_CLASSES:
+        reasons.append(f"session_class {session_class!r} is spot-tier, not futures")
+    instrument = evidence.get("instrument")
+    if instrument in SPOT_INSTRUMENTS:
+        reasons.append(f"instrument {instrument!r} is spot, not futures perpetual")
+    market_type = evidence.get("market_type")
+    if market_type and market_type != DEFAULT_MARKET_TYPE:
+        reasons.append(f"market_type must be {DEFAULT_MARKET_TYPE!r}")
+    elif market_type is None and instrument in SPOT_INSTRUMENTS:
+        reasons.append("market_type required for futures evidence")
+    endpoints = evidence.get("endpoints_called") or []
+    if isinstance(endpoints, list):
+        for ep in endpoints:
+            if ep in SPOT_KRAKEN_ENDPOINT_PREFIXES:
+                reasons.append(f"spot endpoint not allowed in futures evidence: {ep}")
+    if evidence.get("network_host") == "https://api.kraken.com" and market_type == DEFAULT_MARKET_TYPE:
+        reasons.append("spot kraken.com host must not be used for futures bounded evidence")
+    return reasons
+
+
+def evaluate_bounded_futures_testnet_evidence(
+    evidence: dict[str, Any],
+    spec: BoundedFuturesTestnetSpec | None = None,
+) -> dict[str, Any]:
+    """Fail-closed bounded futures testnet evaluation (offline, no I/O)."""
+    spec = spec or default_bounded_futures_normal_v0_spec()
+    result: dict[str, Any] = {
+        "bounded_futures_testnet_pass": False,
+        "futures_instrument_pass": False,
+        "futures_endpoint_isolation_pass": False,
+        "margin_leverage_pass": False,
+        "position_mode_pass": False,
+        "order_cap_pass": False,
+        "cancel_flatten_pass": False,
+        "risk_killswitch_scope_pass": False,
+        "master_v2_boundary_pass": False,
+        "fail_reasons": [],
+    }
+
+    for field in REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES:
+        if field not in evidence:
+            result["fail_reasons"].append(f"missing required field: {field}")
+
+    result["fail_reasons"].extend(spot_evidence_misclassified_as_futures(evidence))
+
+    if evidence.get("session_class") != spec.session_class:
+        result["fail_reasons"].append(
+            f"session_class must be {spec.session_class!r} (got {evidence.get('session_class')!r})"
+        )
+    if evidence.get("order_policy") != spec.order_policy:
+        result["fail_reasons"].append(
+            f"order_policy must be {spec.order_policy!r} (got {evidence.get('order_policy')!r})"
+        )
+    if evidence.get("instrument") != spec.instrument:
+        result["fail_reasons"].append(
+            f"instrument must be {spec.instrument!r} (got {evidence.get('instrument')!r})"
+        )
+    if evidence.get("market_type") != spec.market_type:
+        result["fail_reasons"].append(
+            f"market_type must be {spec.market_type!r} (got {evidence.get('market_type')!r})"
+        )
+
+    margin_mode = evidence.get("margin_mode")
+    if margin_mode != spec.margin_mode:
+        result["fail_reasons"].append(
+            f"margin_mode must be {spec.margin_mode!r} (got {margin_mode!r})"
+        )
+    if margin_mode == "cross":
+        result["fail_reasons"].append("cross margin not allowed unless explicitly governed")
+
+    max_lev = evidence.get("max_leverage")
+    if max_lev is not None and float(max_lev) > spec.max_leverage:
+        result["fail_reasons"].append("max_leverage exceeds cap")
+    if not evidence.get("leverage_within_cap"):
+        result["fail_reasons"].append("leverage_within_cap must be true")
+
+    if evidence.get("position_mode") != spec.position_mode:
+        result["fail_reasons"].append(
+            f"position_mode must be {spec.position_mode!r} (got {evidence.get('position_mode')!r})"
+        )
+
+    side_sem = evidence.get("order_side_semantics")
+    if side_sem not in ("long", "short", "long_or_short_bounded"):
+        result["fail_reasons"].append("order_side_semantics must be long/short bounded")
+
+    if spec.require_reduce_only_support and not evidence.get("reduce_only_supported"):
+        result["fail_reasons"].append("reduce_only_supported must be true")
+
+    if not evidence.get("futures_endpoint_isolation_pass"):
+        result["fail_reasons"].append("futures_endpoint_isolation_pass must be true")
+    if not evidence.get("spot_endpoint_isolation_pass"):
+        result["fail_reasons"].append("spot_endpoint_isolation_pass must be true")
+
+    if not evidence.get("funding_risk_acknowledged"):
+        result["fail_reasons"].append("funding_risk_acknowledged must be true")
+    if not evidence.get("liquidation_risk_acknowledged"):
+        result["fail_reasons"].append("liquidation_risk_acknowledged must be true")
+
+    order_attempts = evidence.get("order_attempt_count")
+    if order_attempts is not None and order_attempts > spec.max_order_attempts:
+        result["fail_reasons"].append("order_attempt_count exceeds cap")
+    real_orders = evidence.get("real_orders_created_count")
+    if real_orders is not None and real_orders > spec.max_real_orders:
+        result["fail_reasons"].append("real_orders_created_count exceeds cap")
+    cancel_attempts = evidence.get("cancel_or_close_attempt_count")
+    if cancel_attempts is not None and cancel_attempts > spec.max_cancel_attempts:
+        result["fail_reasons"].append("cancel_or_close_attempt_count exceeds cap")
+
+    notional = evidence.get("order_notional_eur")
+    if notional is not None and float(notional) > spec.max_notional_eur:
+        result["fail_reasons"].append("order_notional_eur exceeds cap")
+
+    if real_orders and int(real_orders) > 0:
+        if not evidence.get("cancel_or_close_evidence_valid"):
+            result["fail_reasons"].append("cancel_or_close_evidence_valid required")
+    if spec.position_must_be_flattened and not evidence.get("position_flattened_by_end"):
+        result["fail_reasons"].append("position_flattened_by_end required")
+
+    if evidence.get("master_v2_double_play_authority_used"):
+        result["fail_reasons"].append("master_v2_double_play_authority_used must be false")
+
+    if evidence.get("scheduler_started"):
+        result["fail_reasons"].append("scheduler_started must be false")
+    if evidence.get("runtime_started"):
+        result["fail_reasons"].append("runtime_started must be false")
+    if evidence.get("live_env_present"):
+        result["fail_reasons"].append("live_env_present must be false")
+    if evidence.get("futures_session_authorized_now"):
+        result["fail_reasons"].append("futures_session_authorized_now must be false")
+
+    result["futures_instrument_pass"] = evidence.get("instrument") == spec.instrument
+    result["futures_endpoint_isolation_pass"] = (
+        evidence.get("futures_endpoint_isolation_pass") is True
+        and evidence.get("spot_endpoint_isolation_pass") is True
+        and not any(
+            ep in SPOT_KRAKEN_ENDPOINT_PREFIXES
+            for ep in (evidence.get("endpoints_called") or [])
+            if isinstance(evidence.get("endpoints_called"), list)
+        )
+    )
+    result["margin_leverage_pass"] = (
+        margin_mode == spec.margin_mode
+        and evidence.get("leverage_within_cap") is True
+        and (max_lev is None or float(max_lev) <= spec.max_leverage)
+    )
+    result["position_mode_pass"] = evidence.get("position_mode") == spec.position_mode
+    result["order_cap_pass"] = (
+        order_attempts is not None
+        and order_attempts <= spec.max_order_attempts
+        and real_orders is not None
+        and real_orders <= spec.max_real_orders
+    )
+    result["cancel_flatten_pass"] = evidence.get("position_flattened_by_end") is True
+    result["risk_killswitch_scope_pass"] = evidence.get("risk_killswitch_scope_pass") is True
+    result["master_v2_boundary_pass"] = not evidence.get("master_v2_double_play_authority_used")
+
+    result["bounded_futures_testnet_pass"] = not result["fail_reasons"]
+    return result

--- a/tests/ops/test_bounded_futures_testnet_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_contract_v0.py
@@ -21,7 +21,9 @@ from src.ops.bounded_futures_testnet_contract_v0 import (
     evaluate_bounded_futures_testnet_evidence,
     spot_evidence_misclassified_as_futures,
 )
-from src.ops.bounded_testnet_order_cap_contract_v0 import DEFAULT_SESSION_CLASS as SPOT_SESSION_CLASS
+from src.ops.bounded_testnet_order_cap_contract_v0 import (
+    DEFAULT_SESSION_CLASS as SPOT_SESSION_CLASS,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_MODULE = REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_contract_v0.py"
@@ -34,9 +36,7 @@ FUTURES_TESTNET_PROOF_SPEC = (
 )
 
 TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_CONTRACT_GUARD_V0=true"
-_CLASS4_SCOPED_EXCEPTION_MARKER = (
-    "BOUNDED_FUTURES_TESTNET_GUARD_CLASS4_SCOPED_EXCEPTION_V0=true"
-)
+_CLASS4_SCOPED_EXCEPTION_MARKER = "BOUNDED_FUTURES_TESTNET_GUARD_CLASS4_SCOPED_EXCEPTION_V0=true"
 REVIEW_BUNDLE_SUFFIX = (
     "futures_readiness_gap_review_after_spot_btc_eur_testnet_evidence_no_run_v0_20260604T122058Z"
 )

--- a/tests/ops/test_bounded_futures_testnet_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_contract_v0.py
@@ -1,0 +1,161 @@
+"""Static + offline bounded Futures Testnet contract (v0).
+
+Docs/tests-only Class-4 scoped exception. No runtime, network, credentials, or Testnet start.
+Review: futures_readiness_gap_review_after_spot_btc_eur_testnet_evidence_no_run_v0_20260604T122058Z
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    DEFAULT_INSTRUMENT,
+    DEFAULT_SESSION_CLASS,
+    FUTURES_SESSION_AUTHORIZED_NOW,
+    PACKAGE_MARKER,
+    REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES,
+    SPOT_KRAKEN_ENDPOINT_PREFIXES,
+    default_bounded_futures_normal_v0_spec,
+    evaluate_bounded_futures_testnet_evidence,
+    spot_evidence_misclassified_as_futures,
+)
+from src.ops.bounded_testnet_order_cap_contract_v0 import DEFAULT_SESSION_CLASS as SPOT_SESSION_CLASS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_MODULE = REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_contract_v0.py"
+SPOT_CONTRACT_MODULE = REPO_ROOT / "src" / "ops" / "bounded_testnet_order_cap_contract_v0.py"
+SECTION5_GAP_OWNER_MAP = (
+    REPO_ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+)
+FUTURES_TESTNET_PROOF_SPEC = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "FUTURES_TESTNET_DRY_RUN_PROOF_CONTRACT_V0.md"
+)
+
+TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_CONTRACT_GUARD_V0=true"
+_CLASS4_SCOPED_EXCEPTION_MARKER = (
+    "BOUNDED_FUTURES_TESTNET_GUARD_CLASS4_SCOPED_EXCEPTION_V0=true"
+)
+REVIEW_BUNDLE_SUFFIX = (
+    "futures_readiness_gap_review_after_spot_btc_eur_testnet_evidence_no_run_v0_20260604T122058Z"
+)
+
+
+def _valid_futures_evidence() -> dict:
+    return {
+        "session_class": DEFAULT_SESSION_CLASS,
+        "order_policy": "normal-testnet-futures-bounded",
+        "instrument": DEFAULT_INSTRUMENT,
+        "market_type": "futures",
+        "margin_mode": "isolated",
+        "max_leverage": 5.0,
+        "leverage_within_cap": True,
+        "position_mode": "one_way",
+        "order_side_semantics": "long",
+        "reduce_only_supported": True,
+        "order_attempt_count": 0,
+        "real_orders_created_count": 0,
+        "cancel_or_close_attempt_count": 0,
+        "order_notional_eur": 0.0,
+        "order_notional_within_cap": True,
+        "position_flattened_by_end": True,
+        "cancel_or_close_evidence_valid": True,
+        "futures_endpoint_isolation_pass": True,
+        "spot_endpoint_isolation_pass": True,
+        "funding_risk_acknowledged": True,
+        "liquidation_risk_acknowledged": True,
+        "risk_killswitch_scope_active": True,
+        "risk_killswitch_scope_pass": True,
+        "master_v2_double_play_authority_used": False,
+        "endpoints_called": ["/futures/v3/openOrders"],
+        "network_host": "https://futures.testnet.example",
+        "scheduler_started": False,
+        "runtime_started": False,
+        "live_env_present": False,
+        "futures_session_authorized_now": False,
+    }
+
+
+def test_package_marker_present() -> None:
+    text = Path(__file__).read_text(encoding="utf-8")
+    assert TEST_PACKAGE_MARKER in text
+    assert _CLASS4_SCOPED_EXCEPTION_MARKER in text
+    assert PACKAGE_MARKER in CONTRACT_MODULE.read_text(encoding="utf-8")
+
+
+def test_futures_session_not_authorized_in_contract_module() -> None:
+    assert FUTURES_SESSION_AUTHORIZED_NOW is False
+
+
+def test_spot_and_futures_contract_modules_are_separate() -> None:
+    assert SPOT_CONTRACT_MODULE.is_file()
+    assert CONTRACT_MODULE.is_file()
+    assert "bounded_futures_testnet_contract_v0" in CONTRACT_MODULE.name
+    assert SPOT_SESSION_CLASS == "bounded-normal-testnet-v0"
+    assert DEFAULT_SESSION_CLASS == "bounded-futures-normal-testnet-v0"
+    assert DEFAULT_SESSION_CLASS != SPOT_SESSION_CLASS
+
+
+def test_section5_and_futures_testnet_proof_spec_crosslinks_present() -> None:
+    section5 = SECTION5_GAP_OWNER_MAP.read_text(encoding="utf-8")
+    assert "bounded_futures_testnet_contract_v0" in section5
+    assert FUTURES_TESTNET_PROOF_SPEC.is_file()
+
+
+def test_spot_btc_eur_evidence_rejected_by_futures_evaluator() -> None:
+    spot = {
+        "session_class": "bounded-normal-testnet-v0",
+        "instrument": "BTC/EUR",
+        "market_type": "spot",
+        "endpoints_called": ["/0/private/AddOrder"],
+        "network_host": "https://api.kraken.com",
+    }
+    assert spot_evidence_misclassified_as_futures(spot)
+    result = evaluate_bounded_futures_testnet_evidence(spot)
+    assert result["bounded_futures_testnet_pass"] is False
+
+
+def test_valid_futures_evidence_passes_evaluator() -> None:
+    result = evaluate_bounded_futures_testnet_evidence(_valid_futures_evidence())
+    assert result["bounded_futures_testnet_pass"] is True
+    assert result["fail_reasons"] == []
+
+
+def test_missing_margin_mode_fails() -> None:
+    evidence = _valid_futures_evidence()
+    del evidence["margin_mode"]
+    result = evaluate_bounded_futures_testnet_evidence(evidence)
+    assert result["bounded_futures_testnet_pass"] is False
+    assert any("margin_mode" in r for r in result["fail_reasons"])
+
+
+def test_spot_endpoint_in_endpoints_called_fails() -> None:
+    evidence = _valid_futures_evidence()
+    evidence["endpoints_called"] = list(SPOT_KRAKEN_ENDPOINT_PREFIXES)[:1]
+    result = evaluate_bounded_futures_testnet_evidence(evidence)
+    assert result["bounded_futures_testnet_pass"] is False
+
+
+def test_master_v2_authority_used_fails() -> None:
+    evidence = _valid_futures_evidence()
+    evidence["master_v2_double_play_authority_used"] = True
+    result = evaluate_bounded_futures_testnet_evidence(evidence)
+    assert result["master_v2_boundary_pass"] is False
+    assert result["bounded_futures_testnet_pass"] is False
+
+
+def test_required_evidence_field_names_documented() -> None:
+    assert len(REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES) >= 20
+    assert "futures_endpoint_isolation_pass" in REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES
+
+
+def test_default_spec_matches_review_instrument() -> None:
+    spec = default_bounded_futures_normal_v0_spec()
+    assert spec.instrument == "BTCUSDT"
+    assert spec.max_leverage == 5.0
+    assert spec.margin_mode == "isolated"
+
+
+def test_closeout_review_bundle_suffix_documented_in_test() -> None:
+    assert REVIEW_BUNDLE_SUFFIX in Path(__file__).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add `src/ops/bounded_futures_testnet_contract_v0.py` offline evaluator for `bounded-futures-normal-testnet-v0` evidence (instrument, margin/leverage, endpoint isolation, futures vs spot misclassification guards).
- Add `tests/ops/test_bounded_futures_testnet_contract_v0.py` static Class-4 guard.
- Document PE-8 guard in SECTION5 gap owner map.

## Safety
- `FUTURES_SESSION_AUTHORIZED_NOW=false`; no futures execute authorization.
- Spot BTC/EUR bounded evidence explicitly rejected by futures contract.
- No Master-V2 / Double-Play authority changes; no exchange adapter or runtime in this slice.

## Test plan
- [x] `pytest tests/ops/test_bounded_futures_testnet_contract_v0.py`
- [x] `pytest tests/ops/test_repo_native_bounded_order_cap_contract_v0.py`
- [x] `pytest tests/ops/test_repo_native_entrypoint_cli_cap_wiring_contract_v0.py`
- [x] `pytest tests/ops/test_run_testnet_session_entrypoint_fail_closed_contract_v0.py`
- [x] `ruff check` on changed Python files


Made with [Cursor](https://cursor.com)