### PR TITLE
ops: offline bounded futures testnet harness/adapter contracts (v0)

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -86,6 +86,8 @@ Preflight §2a.1 documents run-type applicability for **run completion**: Paper,
 
 **Bounded Futures Testnet contract (PE-8 guard) v0:** Addresses `futures_bounded_testnet_contract_adapter_and_evidence_path_missing` at offline contract layer only. Canonical evaluator: `src/ops/bounded_futures_testnet_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_CONTRACT_V0=true`). Static guard: `tests/ops/test_bounded_futures_testnet_contract_v0.py`. Spot BTC/EUR bounded evidence **must not** satisfy this contract; `FUTURES_SESSION_AUTHORIZED_NOW=false`; **does not** authorize Futures execute, adapter binding, or Master-V2 / Double-Play authority.
 
+**Bounded Futures Testnet harness/adapter contract (PE-9 guard) v0:** Addresses `futures_testnet_execute_harness_and_exchange_adapter_missing` at offline harness/adapter contract layer only. Canonical surfaces: `src/ops/bounded_futures_testnet_adapter_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_ADAPTER_CONTRACT_V0=true`), `src/ops/bounded_futures_testnet_harness_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_HARNESS_CONTRACT_V0=true`). Static guards: `tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py`, `tests/ops/test_bounded_futures_testnet_harness_contract_v0.py`. `HARNESS_EXECUTE_AUTHORIZED_NOW=false`; `ADAPTER_NETWORK_CALLS_ALLOWED=false`; `FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN=false`; **does not** authorize Futures execute, exchange calls, credentials, or Master-V2 / Double-Play authority.
+
 ### Reuse-first owner surfaces
 
 - `scripts/ops/primary_evidence_retention_v0.py`
@@ -101,8 +103,12 @@ Preflight §2a.1 documents run-type applicability for **run completion**: Paper,
 - `tests/ci/test_cybersecurity_visibility_repo_static_histogram_artifact_retention_or_evidence_gap_crosslink_v0.py`
 - `src/ops/bounded_testnet_order_cap_contract_v0.py`
 - `src/ops/bounded_futures_testnet_contract_v0.py`
+- `src/ops/bounded_futures_testnet_adapter_contract_v0.py`
+- `src/ops/bounded_futures_testnet_harness_contract_v0.py`
 - `tests/ops/test_repo_native_bounded_order_cap_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_contract_v0.py`
+- `tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py`
+- `tests/ops/test_bounded_futures_testnet_harness_contract_v0.py`
 - existing preflight contract §2a/§2a.1 surfaces
 - existing docs truth map / reference / token-policy checks
 

--- a/src/ops/bounded_futures_testnet_adapter_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_adapter_contract_v0.py
@@ -119,7 +119,9 @@ def validate_futures_testnet_adapter_binding(
 
     host = binding.network_host.strip().rstrip("/")
     if any(host.startswith(prefix) for prefix in LIVE_FUTURES_HOST_PREFIXES):
-        result["fail_reasons"].append("live or spot Kraken host not allowed for bounded futures testnet")
+        result["fail_reasons"].append(
+            "live or spot Kraken host not allowed for bounded futures testnet"
+        )
     if host == "https://api.kraken.com":
         result["fail_reasons"].append("spot kraken.com host forbidden for futures bounded adapter")
 
@@ -136,7 +138,9 @@ def validate_futures_testnet_adapter_binding(
             result["fail_reasons"].append(f"endpoint not on futures testnet allowlist: {ep}")
 
     result["instrument_binding_pass"] = bool(binding.instrument)
-    result["spot_endpoint_isolation_pass"] = not any("spot endpoint" in r for r in result["fail_reasons"])
+    result["spot_endpoint_isolation_pass"] = not any(
+        "spot endpoint" in r for r in result["fail_reasons"]
+    )
     result["futures_endpoint_allowlist_pass"] = (
         binding.endpoint_allowlist.issubset(FUTURES_TESTNET_ENDPOINT_ALLOWLIST)
         and result["spot_endpoint_isolation_pass"]

--- a/src/ops/bounded_futures_testnet_adapter_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_adapter_contract_v0.py
@@ -1,0 +1,156 @@
+"""Repo-native bounded Futures Testnet adapter binding contract (v0).
+
+Offline contract for futures testnet adapter surface: instrument, endpoint allowlist,
+margin/leverage, and spot isolation. No network I/O, no credentials, no orders.
+Does not authorize Futures Testnet execute; FUTURES_SESSION_AUTHORIZED_NOW remains false.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    DEFAULT_INSTRUMENT,
+    DEFAULT_MARGIN_MODE,
+    DEFAULT_MARKET_TYPE,
+    DEFAULT_MAX_LEVERAGE,
+    DEFAULT_POSITION_MODE,
+    FUTURES_SESSION_AUTHORIZED_NOW,
+    SPOT_KRAKEN_ENDPOINT_PREFIXES,
+)
+
+PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_ADAPTER_CONTRACT_V0=true"
+ADAPTER_NETWORK_CALLS_ALLOWED = False
+FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN = False
+
+# Contract-default testnet futures host (planning placeholder; not live spot Kraken).
+DEFAULT_FUTURES_TESTNET_NETWORK_HOST = "https://demo-futures.kraken.com"
+
+# Futures REST paths — separate from spot SPOT_KRAKEN_ENDPOINT_PREFIXES.
+FUTURES_TESTNET_ENDPOINT_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "/derivatives/api/v3/tickers",
+        "/derivatives/api/v3/instruments",
+        "/derivatives/api/v3/accounts",
+        "/derivatives/api/v3/openpositions",
+        "/derivatives/api/v3/openorders",
+        "/derivatives/api/v3/sendorder",
+        "/derivatives/api/v3/cancelorder",
+        "/derivatives/api/v3/cancelallorders",
+    }
+)
+
+LIVE_FUTURES_HOST_PREFIXES: frozenset[str] = frozenset(
+    {
+        "https://futures.kraken.com",
+        "https://api.kraken.com",
+    }
+)
+
+
+@dataclass(frozen=True)
+class BoundedFuturesTestnetAdapterBinding:
+    adapter_id: str
+    instrument: str
+    market_type: str
+    margin_mode: str
+    max_leverage: float
+    position_mode: str
+    network_host: str
+    endpoint_allowlist: frozenset[str]
+    reduce_only_supported: bool
+    testnet_scoped: bool
+    order_side_semantics: str
+
+
+def default_offline_adapter_binding() -> BoundedFuturesTestnetAdapterBinding:
+    """Contract-default binding for offline planning; exchange proof remains false."""
+    return BoundedFuturesTestnetAdapterBinding(
+        adapter_id="offline_bounded_futures_testnet_adapter_v0",
+        instrument=DEFAULT_INSTRUMENT,
+        market_type=DEFAULT_MARKET_TYPE,
+        margin_mode=DEFAULT_MARGIN_MODE,
+        max_leverage=DEFAULT_MAX_LEVERAGE,
+        position_mode=DEFAULT_POSITION_MODE,
+        network_host=DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
+        endpoint_allowlist=FUTURES_TESTNET_ENDPOINT_ALLOWLIST,
+        reduce_only_supported=True,
+        testnet_scoped=True,
+        order_side_semantics="long",
+    )
+
+
+def validate_futures_testnet_adapter_binding(
+    binding: BoundedFuturesTestnetAdapterBinding,
+    *,
+    endpoints_called: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fail-closed adapter binding validation (offline, no I/O)."""
+    result: dict[str, Any] = {
+        "adapter_binding_pass": False,
+        "futures_endpoint_allowlist_pass": False,
+        "spot_endpoint_isolation_pass": False,
+        "margin_leverage_pass": False,
+        "instrument_binding_pass": False,
+        "fail_reasons": [],
+    }
+
+    if not binding.adapter_id:
+        result["fail_reasons"].append("adapter_id required")
+    if binding.market_type != DEFAULT_MARKET_TYPE:
+        result["fail_reasons"].append(f"market_type must be {DEFAULT_MARKET_TYPE!r}")
+    if not binding.instrument:
+        result["fail_reasons"].append("instrument required")
+    if binding.margin_mode != DEFAULT_MARGIN_MODE:
+        result["fail_reasons"].append(f"margin_mode must be {DEFAULT_MARGIN_MODE!r}")
+    if binding.margin_mode == "cross":
+        result["fail_reasons"].append("cross margin not allowed unless explicitly governed")
+    if binding.max_leverage > DEFAULT_MAX_LEVERAGE:
+        result["fail_reasons"].append("max_leverage exceeds contract cap")
+    if binding.position_mode != DEFAULT_POSITION_MODE:
+        result["fail_reasons"].append(f"position_mode must be {DEFAULT_POSITION_MODE!r}")
+    if binding.order_side_semantics not in ("long", "short", "long_or_short_bounded"):
+        result["fail_reasons"].append("order_side_semantics must be long/short bounded")
+    if not binding.reduce_only_supported:
+        result["fail_reasons"].append("reduce_only_supported must be true")
+    if not binding.testnet_scoped:
+        result["fail_reasons"].append("testnet_scoped must be true")
+
+    host = binding.network_host.strip().rstrip("/")
+    if any(host.startswith(prefix) for prefix in LIVE_FUTURES_HOST_PREFIXES):
+        result["fail_reasons"].append("live or spot Kraken host not allowed for bounded futures testnet")
+    if host == "https://api.kraken.com":
+        result["fail_reasons"].append("spot kraken.com host forbidden for futures bounded adapter")
+
+    if not binding.endpoint_allowlist:
+        result["fail_reasons"].append("endpoint_allowlist must be non-empty")
+    elif not binding.endpoint_allowlist.issubset(FUTURES_TESTNET_ENDPOINT_ALLOWLIST):
+        result["fail_reasons"].append("endpoint_allowlist contains paths outside futures allowlist")
+
+    endpoints = endpoints_called or []
+    for ep in endpoints:
+        if ep in SPOT_KRAKEN_ENDPOINT_PREFIXES:
+            result["fail_reasons"].append(f"spot endpoint not allowed: {ep}")
+        if ep not in FUTURES_TESTNET_ENDPOINT_ALLOWLIST:
+            result["fail_reasons"].append(f"endpoint not on futures testnet allowlist: {ep}")
+
+    result["instrument_binding_pass"] = bool(binding.instrument)
+    result["spot_endpoint_isolation_pass"] = not any("spot endpoint" in r for r in result["fail_reasons"])
+    result["futures_endpoint_allowlist_pass"] = (
+        binding.endpoint_allowlist.issubset(FUTURES_TESTNET_ENDPOINT_ALLOWLIST)
+        and result["spot_endpoint_isolation_pass"]
+        and not any("endpoint not on" in r for r in result["fail_reasons"])
+        and not any("endpoint_allowlist contains" in r for r in result["fail_reasons"])
+    )
+    result["margin_leverage_pass"] = (
+        binding.margin_mode == DEFAULT_MARGIN_MODE and binding.max_leverage <= DEFAULT_MAX_LEVERAGE
+    )
+    result["adapter_binding_pass"] = not result["fail_reasons"]
+    return result
+
+
+def assert_futures_session_not_authorized() -> None:
+    """Defense-in-depth: module must not flip session authorization."""
+    if FUTURES_SESSION_AUTHORIZED_NOW:
+        raise RuntimeError("FUTURES_SESSION_AUTHORIZED_NOW must remain false")

--- a/src/ops/bounded_futures_testnet_harness_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_harness_contract_v0.py
@@ -1,0 +1,161 @@
+"""Repo-native bounded Futures Testnet harness contract (v0).
+
+Offline contract for futures-specific bounded testnet execute harness readiness.
+Validates adapter binding + evidence template against bounded_futures_testnet_contract_v0.
+Does not authorize harness execute, network, credentials, or orders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
+    ADAPTER_NETWORK_CALLS_ALLOWED,
+    BoundedFuturesTestnetAdapterBinding,
+    FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN,
+    PACKAGE_MARKER as ADAPTER_PACKAGE_MARKER,
+    default_offline_adapter_binding,
+    validate_futures_testnet_adapter_binding,
+)
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    DEFAULT_ORDER_POLICY,
+    DEFAULT_SESSION_CLASS,
+    EVIDENCE_SOURCE_FUTURES_HARNESS,
+    FUTURES_SESSION_AUTHORIZED_NOW,
+    default_bounded_futures_normal_v0_spec,
+    evaluate_bounded_futures_testnet_evidence,
+)
+
+HARNESS_PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_HARNESS_CONTRACT_V0=true"
+HARNESS_EXECUTE_AUTHORIZED_NOW = False
+FUTURES_EXECUTE_AUTHORITY_ADDED = False
+
+
+@dataclass(frozen=True)
+class BoundedFuturesTestnetHarnessConfig:
+    session_class: str
+    order_policy: str
+    evidence_source: str
+    evidence_dir: str
+    planned_duration_seconds: int
+    max_order_attempts: int
+    max_real_orders: int
+    max_cancel_attempts: int
+    max_notional_eur: float
+    max_position_hold_seconds: int
+    operator_go_token: str | None
+
+
+def default_offline_harness_config(*, evidence_dir: str = "") -> BoundedFuturesTestnetHarnessConfig:
+    spec = default_bounded_futures_normal_v0_spec()
+    return BoundedFuturesTestnetHarnessConfig(
+        session_class=DEFAULT_SESSION_CLASS,
+        order_policy=DEFAULT_ORDER_POLICY,
+        evidence_source=EVIDENCE_SOURCE_FUTURES_HARNESS,
+        evidence_dir=evidence_dir,
+        planned_duration_seconds=300,
+        max_order_attempts=spec.max_order_attempts,
+        max_real_orders=spec.max_real_orders,
+        max_cancel_attempts=spec.max_cancel_attempts,
+        max_notional_eur=spec.max_notional_eur,
+        max_position_hold_seconds=spec.max_position_hold_seconds,
+        operator_go_token=None,
+    )
+
+
+def build_offline_harness_evidence_template(
+    binding: BoundedFuturesTestnetAdapterBinding,
+    config: BoundedFuturesTestnetHarnessConfig,
+) -> dict[str, Any]:
+    """Skeleton evidence dict for contract evaluation (zero-order planning template)."""
+    return {
+        "session_class": config.session_class,
+        "order_policy": config.order_policy,
+        "instrument": binding.instrument,
+        "market_type": binding.market_type,
+        "margin_mode": binding.margin_mode,
+        "max_leverage": binding.max_leverage,
+        "leverage_within_cap": binding.max_leverage <= default_bounded_futures_normal_v0_spec().max_leverage,
+        "position_mode": binding.position_mode,
+        "order_side_semantics": binding.order_side_semantics,
+        "reduce_only_supported": binding.reduce_only_supported,
+        "order_attempt_count": 0,
+        "real_orders_created_count": 0,
+        "cancel_or_close_attempt_count": 0,
+        "order_notional_eur": 0.0,
+        "order_notional_within_cap": True,
+        "position_flattened_by_end": True,
+        "cancel_or_close_evidence_valid": True,
+        "futures_endpoint_isolation_pass": True,
+        "spot_endpoint_isolation_pass": True,
+        "funding_risk_acknowledged": True,
+        "liquidation_risk_acknowledged": True,
+        "risk_killswitch_scope_active": True,
+        "risk_killswitch_scope_pass": True,
+        "master_v2_double_play_authority_used": False,
+        "endpoints_called": [],
+        "network_host": binding.network_host,
+        "evidence_source": config.evidence_source,
+        "scheduler_started": False,
+        "runtime_started": False,
+        "live_env_present": False,
+        "futures_session_authorized_now": False,
+        "harness_execute_authorized_now": False,
+        "futures_testnet_instrument_exchange_proven": FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN,
+    }
+
+
+def evaluate_bounded_futures_testnet_harness_readiness(
+    config: BoundedFuturesTestnetHarnessConfig,
+    binding: BoundedFuturesTestnetAdapterBinding | None = None,
+) -> dict[str, Any]:
+    """Fail-closed harness readiness (offline). Execute remains unauthorized."""
+    binding = binding or default_offline_adapter_binding()
+    result: dict[str, Any] = {
+        "harness_contract_pass": False,
+        "adapter_binding_pass": False,
+        "evidence_template_pass": False,
+        "harness_execute_authorized_now": HARNESS_EXECUTE_AUTHORIZED_NOW,
+        "futures_session_authorized_now": FUTURES_SESSION_AUTHORIZED_NOW,
+        "futures_testnet_instrument_exchange_proven": FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN,
+        "fail_reasons": [],
+    }
+
+    if HARNESS_EXECUTE_AUTHORIZED_NOW:
+        result["fail_reasons"].append("HARNESS_EXECUTE_AUTHORIZED_NOW must be false")
+    if FUTURES_EXECUTE_AUTHORITY_ADDED:
+        result["fail_reasons"].append("FUTURES_EXECUTE_AUTHORITY_ADDED must be false")
+    if ADAPTER_NETWORK_CALLS_ALLOWED:
+        result["fail_reasons"].append("ADAPTER_NETWORK_CALLS_ALLOWED must be false")
+    if config.operator_go_token:
+        result["fail_reasons"].append("operator_go_token must not be set without separate execute GO")
+
+    spec = default_bounded_futures_normal_v0_spec()
+    if config.session_class != spec.session_class:
+        result["fail_reasons"].append(f"session_class must be {spec.session_class!r}")
+    if config.order_policy != spec.order_policy:
+        result["fail_reasons"].append(f"order_policy must be {spec.order_policy!r}")
+    if config.evidence_source != EVIDENCE_SOURCE_FUTURES_HARNESS:
+        result["fail_reasons"].append(f"evidence_source must be {EVIDENCE_SOURCE_FUTURES_HARNESS!r}")
+    if config.max_real_orders > spec.max_real_orders:
+        result["fail_reasons"].append("max_real_orders exceeds spec cap")
+    if config.max_order_attempts > spec.max_order_attempts:
+        result["fail_reasons"].append("max_order_attempts exceeds spec cap")
+    if config.max_cancel_attempts > spec.max_cancel_attempts:
+        result["fail_reasons"].append("max_cancel_attempts exceeds spec cap")
+    if config.max_notional_eur > spec.max_notional_eur:
+        result["fail_reasons"].append("max_notional_eur exceeds spec cap")
+
+    adapter_result = validate_futures_testnet_adapter_binding(binding)
+    result["adapter_binding_pass"] = adapter_result["adapter_binding_pass"]
+    result["fail_reasons"].extend(adapter_result["fail_reasons"])
+
+    template = build_offline_harness_evidence_template(binding, config)
+    evidence_result = evaluate_bounded_futures_testnet_evidence(template)
+    result["evidence_template_pass"] = evidence_result["bounded_futures_testnet_pass"]
+    if not evidence_result["bounded_futures_testnet_pass"]:
+        result["fail_reasons"].extend(evidence_result["fail_reasons"])
+
+    result["harness_contract_pass"] = not result["fail_reasons"]
+    return result

--- a/src/ops/bounded_futures_testnet_harness_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_harness_contract_v0.py
@@ -76,7 +76,8 @@ def build_offline_harness_evidence_template(
         "market_type": binding.market_type,
         "margin_mode": binding.margin_mode,
         "max_leverage": binding.max_leverage,
-        "leverage_within_cap": binding.max_leverage <= default_bounded_futures_normal_v0_spec().max_leverage,
+        "leverage_within_cap": binding.max_leverage
+        <= default_bounded_futures_normal_v0_spec().max_leverage,
         "position_mode": binding.position_mode,
         "order_side_semantics": binding.order_side_semantics,
         "reduce_only_supported": binding.reduce_only_supported,
@@ -129,7 +130,9 @@ def evaluate_bounded_futures_testnet_harness_readiness(
     if ADAPTER_NETWORK_CALLS_ALLOWED:
         result["fail_reasons"].append("ADAPTER_NETWORK_CALLS_ALLOWED must be false")
     if config.operator_go_token:
-        result["fail_reasons"].append("operator_go_token must not be set without separate execute GO")
+        result["fail_reasons"].append(
+            "operator_go_token must not be set without separate execute GO"
+        )
 
     spec = default_bounded_futures_normal_v0_spec()
     if config.session_class != spec.session_class:
@@ -137,7 +140,9 @@ def evaluate_bounded_futures_testnet_harness_readiness(
     if config.order_policy != spec.order_policy:
         result["fail_reasons"].append(f"order_policy must be {spec.order_policy!r}")
     if config.evidence_source != EVIDENCE_SOURCE_FUTURES_HARNESS:
-        result["fail_reasons"].append(f"evidence_source must be {EVIDENCE_SOURCE_FUTURES_HARNESS!r}")
+        result["fail_reasons"].append(
+            f"evidence_source must be {EVIDENCE_SOURCE_FUTURES_HARNESS!r}"
+        )
     if config.max_real_orders > spec.max_real_orders:
         result["fail_reasons"].append("max_real_orders exceeds spec cap")
     if config.max_order_attempts > spec.max_order_attempts:

--- a/tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py
@@ -1,0 +1,126 @@
+"""Static + offline bounded Futures Testnet adapter binding contract (v0).
+
+Docs/tests-only Class-4 scoped exception. No runtime, network, credentials, or Testnet start.
+Planning: futures_testnet_execute_harness_adapter_follow_up_pr_planning_v0
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
+    ADAPTER_NETWORK_CALLS_ALLOWED,
+    BoundedFuturesTestnetAdapterBinding,
+    DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
+    FUTURES_TESTNET_ENDPOINT_ALLOWLIST,
+    FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN,
+    PACKAGE_MARKER,
+    SPOT_KRAKEN_ENDPOINT_PREFIXES,
+    default_offline_adapter_binding,
+    validate_futures_testnet_adapter_binding,
+)
+from src.ops.bounded_futures_testnet_contract_v0 import FUTURES_SESSION_AUTHORIZED_NOW
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ADAPTER_MODULE = REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_adapter_contract_v0.py"
+FUTURES_CONTRACT_MODULE = REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_contract_v0.py"
+SECTION5_GAP_OWNER_MAP = (
+    REPO_ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+)
+
+TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_ADAPTER_CONTRACT_GUARD_V0=true"
+_CLASS4_SCOPED_EXCEPTION_MARKER = (
+    "BOUNDED_FUTURES_TESTNET_ADAPTER_GUARD_CLASS4_SCOPED_EXCEPTION_V0=true"
+)
+CHARTER_BUNDLE_SUFFIX = (
+    "futures_specific_bounded_testnet_readiness_charter_no_run_v0_20260604T125147Z"
+)
+
+
+def test_package_marker_present() -> None:
+    text = Path(__file__).read_text(encoding="utf-8")
+    assert TEST_PACKAGE_MARKER in text
+    assert _CLASS4_SCOPED_EXCEPTION_MARKER in text
+    assert PACKAGE_MARKER in ADAPTER_MODULE.read_text(encoding="utf-8")
+
+
+def test_futures_session_and_network_not_authorized() -> None:
+    assert FUTURES_SESSION_AUTHORIZED_NOW is False
+    assert ADAPTER_NETWORK_CALLS_ALLOWED is False
+    assert FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN is False
+
+
+def test_default_binding_passes_offline_validation() -> None:
+    binding = default_offline_adapter_binding()
+    result = validate_futures_testnet_adapter_binding(binding)
+    assert result["adapter_binding_pass"] is True
+    assert result["fail_reasons"] == []
+
+
+def test_spot_endpoint_in_endpoints_called_fails() -> None:
+    binding = default_offline_adapter_binding()
+    spot_ep = next(iter(SPOT_KRAKEN_ENDPOINT_PREFIXES))
+    result = validate_futures_testnet_adapter_binding(binding, endpoints_called=[spot_ep])
+    assert result["adapter_binding_pass"] is False
+    assert result["spot_endpoint_isolation_pass"] is False
+
+
+def test_live_kraken_host_fails() -> None:
+    binding = default_offline_adapter_binding()
+    bad = BoundedFuturesTestnetAdapterBinding(
+        adapter_id=binding.adapter_id,
+        instrument=binding.instrument,
+        market_type=binding.market_type,
+        margin_mode=binding.margin_mode,
+        max_leverage=binding.max_leverage,
+        position_mode=binding.position_mode,
+        network_host="https://api.kraken.com",
+        endpoint_allowlist=binding.endpoint_allowlist,
+        reduce_only_supported=binding.reduce_only_supported,
+        testnet_scoped=binding.testnet_scoped,
+        order_side_semantics=binding.order_side_semantics,
+    )
+    result = validate_futures_testnet_adapter_binding(bad)
+    assert result["adapter_binding_pass"] is False
+
+
+def test_cross_margin_fails() -> None:
+    binding = default_offline_adapter_binding()
+    bad = BoundedFuturesTestnetAdapterBinding(
+        adapter_id=binding.adapter_id,
+        instrument=binding.instrument,
+        market_type=binding.market_type,
+        margin_mode="cross",
+        max_leverage=binding.max_leverage,
+        position_mode=binding.position_mode,
+        network_host=binding.network_host,
+        endpoint_allowlist=binding.endpoint_allowlist,
+        reduce_only_supported=binding.reduce_only_supported,
+        testnet_scoped=binding.testnet_scoped,
+        order_side_semantics=binding.order_side_semantics,
+    )
+    result = validate_futures_testnet_adapter_binding(bad)
+    assert result["adapter_binding_pass"] is False
+
+
+def test_futures_contract_module_crosslink() -> None:
+    assert FUTURES_CONTRACT_MODULE.is_file()
+    assert "SPOT_KRAKEN_ENDPOINT_PREFIXES" in ADAPTER_MODULE.read_text(encoding="utf-8")
+
+
+def test_section5_pe9_crosslink_present() -> None:
+    section5 = SECTION5_GAP_OWNER_MAP.read_text(encoding="utf-8")
+    assert "bounded_futures_testnet_adapter_contract_v0" in section5
+    assert "bounded_futures_testnet_harness_contract_v0" in section5
+
+
+def test_endpoint_allowlist_non_empty_and_testnet_host() -> None:
+    assert len(FUTURES_TESTNET_ENDPOINT_ALLOWLIST) >= 5
+    assert DEFAULT_FUTURES_TESTNET_NETWORK_HOST.startswith("https://")
+    assert "demo-futures" in DEFAULT_FUTURES_TESTNET_NETWORK_HOST
+
+
+def test_charter_bundle_suffix_documented_in_test() -> None:
+    assert CHARTER_BUNDLE_SUFFIX in Path(__file__).read_text(encoding="utf-8")

--- a/tests/ops/test_bounded_futures_testnet_harness_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_harness_contract_v0.py
@@ -1,0 +1,124 @@
+"""Static + offline bounded Futures Testnet harness contract (v0).
+
+Docs/tests-only Class-4 scoped exception. No runtime, network, credentials, or Testnet start.
+Planning: futures_testnet_execute_harness_adapter_follow_up_pr_planning_v0
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.ops.bounded_futures_testnet_harness_contract_v0 import (
+    FUTURES_EXECUTE_AUTHORITY_ADDED,
+    HARNESS_EXECUTE_AUTHORIZED_NOW,
+    HARNESS_PACKAGE_MARKER,
+    default_offline_harness_config,
+    evaluate_bounded_futures_testnet_harness_readiness,
+)
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    EVIDENCE_SOURCE_FUTURES_HARNESS,
+    FUTURES_SESSION_AUTHORIZED_NOW,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_MODULE = REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_harness_contract_v0.py"
+ADAPTER_TEST = REPO_ROOT / "tests" / "ops" / "test_bounded_futures_testnet_adapter_contract_v0.py"
+FUTURES_CONTRACT_TEST = REPO_ROOT / "tests" / "ops" / "test_bounded_futures_testnet_contract_v0.py"
+
+TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_HARNESS_CONTRACT_GUARD_V0=true"
+_CLASS4_SCOPED_EXCEPTION_MARKER = (
+    "BOUNDED_FUTURES_TESTNET_HARNESS_GUARD_CLASS4_SCOPED_EXCEPTION_V0=true"
+)
+
+
+def test_package_marker_present() -> None:
+    text = Path(__file__).read_text(encoding="utf-8")
+    assert TEST_PACKAGE_MARKER in text
+    assert _CLASS4_SCOPED_EXCEPTION_MARKER in text
+    assert HARNESS_PACKAGE_MARKER in HARNESS_MODULE.read_text(encoding="utf-8")
+
+
+def test_harness_and_futures_session_not_authorized() -> None:
+    assert HARNESS_EXECUTE_AUTHORIZED_NOW is False
+    assert FUTURES_SESSION_AUTHORIZED_NOW is False
+    assert FUTURES_EXECUTE_AUTHORITY_ADDED is False
+
+
+def test_default_harness_readiness_passes_offline() -> None:
+    config = default_offline_harness_config()
+    result = evaluate_bounded_futures_testnet_harness_readiness(config)
+    assert result["harness_contract_pass"] is True
+    assert result["adapter_binding_pass"] is True
+    assert result["evidence_template_pass"] is True
+    assert result["fail_reasons"] == []
+    assert result["harness_execute_authorized_now"] is False
+    assert result["futures_testnet_instrument_exchange_proven"] is False
+
+
+def test_operator_go_token_without_execute_go_fails() -> None:
+    config = default_offline_harness_config()
+    bad = type(config)(
+        session_class=config.session_class,
+        order_policy=config.order_policy,
+        evidence_source=config.evidence_source,
+        evidence_dir=config.evidence_dir,
+        planned_duration_seconds=config.planned_duration_seconds,
+        max_order_attempts=config.max_order_attempts,
+        max_real_orders=config.max_real_orders,
+        max_cancel_attempts=config.max_cancel_attempts,
+        max_notional_eur=config.max_notional_eur,
+        max_position_hold_seconds=config.max_position_hold_seconds,
+        operator_go_token="GO_EXECUTE_FUTURES",
+    )
+    result = evaluate_bounded_futures_testnet_harness_readiness(bad)
+    assert result["harness_contract_pass"] is False
+
+
+def test_excessive_order_cap_fails() -> None:
+    config = default_offline_harness_config()
+    bad = type(config)(
+        session_class=config.session_class,
+        order_policy=config.order_policy,
+        evidence_source=config.evidence_source,
+        evidence_dir=config.evidence_dir,
+        planned_duration_seconds=config.planned_duration_seconds,
+        max_order_attempts=99,
+        max_real_orders=config.max_real_orders,
+        max_cancel_attempts=config.max_cancel_attempts,
+        max_notional_eur=config.max_notional_eur,
+        max_position_hold_seconds=config.max_position_hold_seconds,
+        operator_go_token=None,
+    )
+    result = evaluate_bounded_futures_testnet_harness_readiness(bad)
+    assert result["harness_contract_pass"] is False
+
+
+def test_evidence_source_must_be_futures_harness() -> None:
+    config = default_offline_harness_config()
+    bad = type(config)(
+        session_class=config.session_class,
+        order_policy=config.order_policy,
+        evidence_source="repo_native_session",
+        evidence_dir=config.evidence_dir,
+        planned_duration_seconds=config.planned_duration_seconds,
+        max_order_attempts=config.max_order_attempts,
+        max_real_orders=config.max_real_orders,
+        max_cancel_attempts=config.max_cancel_attempts,
+        max_notional_eur=config.max_notional_eur,
+        max_position_hold_seconds=config.max_position_hold_seconds,
+        operator_go_token=None,
+    )
+    result = evaluate_bounded_futures_testnet_harness_readiness(bad)
+    assert result["harness_contract_pass"] is False
+
+
+def test_adapter_and_futures_contract_tests_crosslink() -> None:
+    assert ADAPTER_TEST.is_file()
+    assert FUTURES_CONTRACT_TEST.is_file()
+
+
+def test_harness_evidence_source_constant() -> None:
+    config = default_offline_harness_config()
+    assert config.evidence_source == EVIDENCE_SOURCE_FUTURES_HARNESS


### PR DESCRIPTION
## Summary
- Add offline `bounded_futures_testnet_adapter_contract_v0` (futures endpoint allowlist, spot isolation, margin/leverage binding; no network).
- Add offline `bounded_futures_testnet_harness_contract_v0` (harness readiness + evidence template vs PE-8 evaluator).
- Static guard tests + SECTION5 PE-9 note.

## Safety
- `FUTURES_SESSION_AUTHORIZED_NOW=false`, `HARNESS_EXECUTE_AUTHORIZED_NOW=false`, `NEXT_EXECUTE_ALLOWED=false` unchanged.
- No execute, orders, credentials, runtime/scheduler, or Master-V2 authority.

## Test plan
- [x] pytest adapter + harness + futures bounded + spot cap + CLI wiring + entrypoint fail-closed (66 passed)
- [x] ruff check on changed Python files

Made with [Cursor](https://cursor.com)