### PR TITLE
ops: PE-10 offline futures runtime harness and exchange impl contracts

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -88,6 +88,8 @@ Preflight §2a.1 documents run-type applicability for **run completion**: Paper,
 
 **Bounded Futures Testnet harness/adapter contract (PE-9 guard) v0:** Addresses `futures_testnet_execute_harness_and_exchange_adapter_missing` at offline harness/adapter contract layer only. Canonical surfaces: `src/ops/bounded_futures_testnet_adapter_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_ADAPTER_CONTRACT_V0=true`), `src/ops/bounded_futures_testnet_harness_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_HARNESS_CONTRACT_V0=true`). Static guards: `tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py`, `tests/ops/test_bounded_futures_testnet_harness_contract_v0.py`. `HARNESS_EXECUTE_AUTHORIZED_NOW=false`; `ADAPTER_NETWORK_CALLS_ALLOWED=false`; `FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN=false`; **does not** authorize Futures execute, exchange calls, credentials, or Master-V2 / Double-Play authority.
 
+**Bounded Futures Testnet runtime harness / exchange impl descriptor contract (PE-10 guard) v0:** Addresses `futures_testnet_runtime_harness_and_exchange_impl_residual` at offline descriptor layer only (reuses PE-8/PE-9). Canonical surfaces: `src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_EXCHANGE_IMPL_CONTRACT_V0=true`), `src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_RUNTIME_HARNESS_CONTRACT_V0=true`). Static guards: `tests/ops/test_bounded_futures_testnet_exchange_impl_contract_v0.py`, `tests/ops/test_bounded_futures_testnet_runtime_harness_contract_v0.py`. `RUNTIME_HARNESS_EXECUTE_ALLOWED=false`; `EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED=false`; `ARCHIVE_HARNESS_SCRIPT_PRESENT=false`; `ARCHIVE_EXCHANGE_CLIENT_PRESENT=false`; **does not** authorize Futures execute, archive harness script, network I/O, credentials, or Master-V2 / Double-Play authority. Residual after PE-10: governed archive harness script + live exchange client (out of scope).
+
 ### Reuse-first owner surfaces
 
 - `scripts/ops/primary_evidence_retention_v0.py`
@@ -105,10 +107,14 @@ Preflight §2a.1 documents run-type applicability for **run completion**: Paper,
 - `src/ops/bounded_futures_testnet_contract_v0.py`
 - `src/ops/bounded_futures_testnet_adapter_contract_v0.py`
 - `src/ops/bounded_futures_testnet_harness_contract_v0.py`
+- `src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py`
+- `src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py`
 - `tests/ops/test_repo_native_bounded_order_cap_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_harness_contract_v0.py`
+- `tests/ops/test_bounded_futures_testnet_exchange_impl_contract_v0.py`
+- `tests/ops/test_bounded_futures_testnet_runtime_harness_contract_v0.py`
 - existing preflight contract §2a/§2a.1 surfaces
 - existing docs truth map / reference / token-policy checks
 

--- a/src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py
@@ -1,0 +1,132 @@
+"""Repo-native bounded Futures Testnet exchange impl descriptor contract (v0).
+
+Offline contract for a futures testnet exchange *implementation stub* layered on PE-9
+adapter binding. No network I/O, no credentials, no orders. Does not authorize execute.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
+    ADAPTER_NETWORK_CALLS_ALLOWED,
+    BoundedFuturesTestnetAdapterBinding,
+    FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN,
+    default_offline_adapter_binding,
+    validate_futures_testnet_adapter_binding,
+)
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    FUTURES_SESSION_AUTHORIZED_NOW,
+    REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES,
+)
+
+PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_EXCHANGE_IMPL_CONTRACT_V0=true"
+EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED = False
+ARCHIVE_EXCHANGE_CLIENT_PRESENT = False
+FUTURES_EXECUTE_AUTHORITY_ADDED = False
+
+ALLOWED_IMPL_KINDS: frozenset[str] = frozenset({"offline_contract_stub"})
+
+
+@dataclass(frozen=True)
+class BoundedFuturesTestnetExchangeImplDescriptor:
+    impl_id: str
+    adapter_binding: BoundedFuturesTestnetAdapterBinding
+    impl_kind: str
+    network_calls_allowed: bool
+    reduce_only_command_model: str
+    close_only_command_model: str
+    flatten_evidence_required: bool
+    funding_evidence_required: bool
+    liquidation_evidence_required: bool
+
+
+def default_offline_exchange_impl_descriptor() -> BoundedFuturesTestnetExchangeImplDescriptor:
+    return BoundedFuturesTestnetExchangeImplDescriptor(
+        impl_id="offline_bounded_futures_testnet_exchange_impl_v0",
+        adapter_binding=default_offline_adapter_binding(),
+        impl_kind="offline_contract_stub",
+        network_calls_allowed=False,
+        reduce_only_command_model="reduce_only_flag_required",
+        close_only_command_model="cancel_or_close_bounded",
+        flatten_evidence_required=True,
+        funding_evidence_required=True,
+        liquidation_evidence_required=True,
+    )
+
+
+def validate_futures_testnet_exchange_impl_descriptor(
+    descriptor: BoundedFuturesTestnetExchangeImplDescriptor,
+    *,
+    endpoints_called: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fail-closed exchange impl descriptor validation (offline)."""
+    result: dict[str, Any] = {
+        "exchange_impl_pass": False,
+        "adapter_binding_pass": False,
+        "instrument_endpoint_pass": False,
+        "margin_leverage_command_model_pass": False,
+        "evidence_field_contract_pass": False,
+        "fail_reasons": [],
+    }
+
+    if EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED:
+        result["fail_reasons"].append("EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED must be false")
+    if FUTURES_EXECUTE_AUTHORITY_ADDED:
+        result["fail_reasons"].append("FUTURES_EXECUTE_AUTHORITY_ADDED must be false")
+    if FUTURES_SESSION_AUTHORIZED_NOW:
+        result["fail_reasons"].append("FUTURES_SESSION_AUTHORIZED_NOW must be false")
+    if descriptor.network_calls_allowed:
+        result["fail_reasons"].append("descriptor.network_calls_allowed must be false")
+    if not descriptor.impl_id:
+        result["fail_reasons"].append("impl_id required")
+    if descriptor.impl_kind not in ALLOWED_IMPL_KINDS:
+        result["fail_reasons"].append(f"impl_kind must be one of {sorted(ALLOWED_IMPL_KINDS)}")
+    if descriptor.reduce_only_command_model != "reduce_only_flag_required":
+        result["fail_reasons"].append("reduce_only_command_model must be reduce_only_flag_required")
+    if descriptor.close_only_command_model != "cancel_or_close_bounded":
+        result["fail_reasons"].append("close_only_command_model must be cancel_or_close_bounded")
+    if not descriptor.flatten_evidence_required:
+        result["fail_reasons"].append("flatten_evidence_required must be true")
+    if not descriptor.funding_evidence_required:
+        result["fail_reasons"].append("funding_evidence_required must be true")
+    if not descriptor.liquidation_evidence_required:
+        result["fail_reasons"].append("liquidation_evidence_required must be true")
+
+    binding = descriptor.adapter_binding
+    if not binding.instrument or binding.instrument.strip() == "":
+        result["fail_reasons"].append("unknown or empty futures instrument")
+    if not binding.network_host:
+        result["fail_reasons"].append("unknown or empty futures endpoint host")
+    if not binding.testnet_scoped:
+        result["fail_reasons"].append("adapter must be testnet_scoped")
+
+    adapter_result = validate_futures_testnet_adapter_binding(
+        binding, endpoints_called=endpoints_called
+    )
+    result["adapter_binding_pass"] = adapter_result["adapter_binding_pass"]
+    result["fail_reasons"].extend(adapter_result["fail_reasons"])
+
+    required_runtime_fields = (
+        "position_flattened_by_end",
+        "cancel_or_close_evidence_valid",
+        "funding_risk_acknowledged",
+        "liquidation_risk_acknowledged",
+        "reduce_only_supported",
+        "order_side_semantics",
+    )
+    missing = [f for f in required_runtime_fields if f not in REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES]
+    result["evidence_field_contract_pass"] = not missing
+    if missing:
+        result["fail_reasons"].append(f"missing futures evidence fields: {missing}")
+
+    result["instrument_endpoint_pass"] = (
+        bool(binding.instrument)
+        and bool(binding.network_host)
+        and adapter_result.get("futures_endpoint_allowlist_pass", False)
+    )
+    result["margin_leverage_command_model_pass"] = adapter_result.get("margin_leverage_pass", False)
+    result["exchange_impl_pass"] = not result["fail_reasons"]
+    result["futures_testnet_instrument_exchange_proven"] = FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN
+    return result

--- a/src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py
@@ -128,5 +128,7 @@ def validate_futures_testnet_exchange_impl_descriptor(
     )
     result["margin_leverage_command_model_pass"] = adapter_result.get("margin_leverage_pass", False)
     result["exchange_impl_pass"] = not result["fail_reasons"]
-    result["futures_testnet_instrument_exchange_proven"] = FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN
+    result["futures_testnet_instrument_exchange_proven"] = (
+        FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN
+    )
     return result

--- a/src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py
@@ -1,0 +1,122 @@
+"""Repo-native bounded Futures Testnet runtime harness impl descriptor contract (v0).
+
+Offline contract composing PE-9 harness readiness with PE-10 exchange impl descriptor.
+No archive harness script, no scheduler/runtime start, no network, no orders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.ops.bounded_futures_testnet_adapter_contract_v0 import ADAPTER_NETWORK_CALLS_ALLOWED
+from src.ops.bounded_futures_testnet_contract_v0 import FUTURES_SESSION_AUTHORIZED_NOW
+from src.ops.bounded_futures_testnet_exchange_impl_contract_v0 import (
+    ARCHIVE_EXCHANGE_CLIENT_PRESENT,
+    BoundedFuturesTestnetExchangeImplDescriptor,
+    EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED,
+    FUTURES_EXECUTE_AUTHORITY_ADDED,
+    default_offline_exchange_impl_descriptor,
+    validate_futures_testnet_exchange_impl_descriptor,
+)
+from src.ops.bounded_futures_testnet_harness_contract_v0 import (
+    HARNESS_EXECUTE_AUTHORIZED_NOW,
+    BoundedFuturesTestnetHarnessConfig,
+    default_offline_harness_config,
+    evaluate_bounded_futures_testnet_harness_readiness,
+)
+
+PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_RUNTIME_HARNESS_CONTRACT_V0=true"
+RUNTIME_HARNESS_EXECUTE_ALLOWED = False
+RUNTIME_HARNESS_NETWORK_ALLOWED = False
+ARCHIVE_HARNESS_SCRIPT_PRESENT = False
+
+
+@dataclass(frozen=True)
+class BoundedFuturesTestnetRuntimeHarnessImplDescriptor:
+    impl_id: str
+    exchange_impl_id: str
+    harness_config: BoundedFuturesTestnetHarnessConfig
+    exchange_impl: BoundedFuturesTestnetExchangeImplDescriptor
+    archive_script_required: bool
+    runtime_started_allowed: bool
+    scheduler_started_allowed: bool
+
+
+def default_offline_runtime_harness_impl_descriptor(
+    *,
+    evidence_dir: str = "",
+) -> BoundedFuturesTestnetRuntimeHarnessImplDescriptor:
+    exchange = default_offline_exchange_impl_descriptor()
+    return BoundedFuturesTestnetRuntimeHarnessImplDescriptor(
+        impl_id="offline_bounded_futures_testnet_runtime_harness_v0",
+        exchange_impl_id=exchange.impl_id,
+        harness_config=default_offline_harness_config(evidence_dir=evidence_dir),
+        exchange_impl=exchange,
+        archive_script_required=False,
+        runtime_started_allowed=False,
+        scheduler_started_allowed=False,
+    )
+
+
+def validate_futures_testnet_runtime_harness_impl_descriptor(
+    descriptor: BoundedFuturesTestnetRuntimeHarnessImplDescriptor,
+) -> dict[str, Any]:
+    """Fail-closed runtime harness impl descriptor (offline)."""
+    result: dict[str, Any] = {
+        "runtime_harness_impl_pass": False,
+        "pe9_harness_readiness_pass": False,
+        "exchange_impl_pass": False,
+        "archive_script_absent_pass": False,
+        "runtime_scheduler_guard_pass": False,
+        "fail_reasons": [],
+    }
+
+    if RUNTIME_HARNESS_EXECUTE_ALLOWED:
+        result["fail_reasons"].append("RUNTIME_HARNESS_EXECUTE_ALLOWED must be false")
+    if RUNTIME_HARNESS_NETWORK_ALLOWED:
+        result["fail_reasons"].append("RUNTIME_HARNESS_NETWORK_ALLOWED must be false")
+    if HARNESS_EXECUTE_AUTHORIZED_NOW:
+        result["fail_reasons"].append("HARNESS_EXECUTE_AUTHORIZED_NOW must be false")
+    if FUTURES_EXECUTE_AUTHORITY_ADDED:
+        result["fail_reasons"].append("FUTURES_EXECUTE_AUTHORITY_ADDED must be false")
+    if ADAPTER_NETWORK_CALLS_ALLOWED:
+        result["fail_reasons"].append("ADAPTER_NETWORK_CALLS_ALLOWED must be false")
+    if EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED:
+        result["fail_reasons"].append("EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED must be false")
+    if FUTURES_SESSION_AUTHORIZED_NOW:
+        result["fail_reasons"].append("FUTURES_SESSION_AUTHORIZED_NOW must be false")
+
+    if not descriptor.impl_id:
+        result["fail_reasons"].append("impl_id required")
+    if descriptor.exchange_impl_id != descriptor.exchange_impl.impl_id:
+        result["fail_reasons"].append("exchange_impl_id must match exchange_impl.impl_id")
+    if descriptor.archive_script_required:
+        result["fail_reasons"].append("archive_script_required must be false in v0")
+    if descriptor.runtime_started_allowed:
+        result["fail_reasons"].append("runtime_started_allowed must be false")
+    if descriptor.scheduler_started_allowed:
+        result["fail_reasons"].append("scheduler_started_allowed must be false")
+    if ARCHIVE_HARNESS_SCRIPT_PRESENT:
+        result["fail_reasons"].append("ARCHIVE_HARNESS_SCRIPT_PRESENT must be false")
+    if ARCHIVE_EXCHANGE_CLIENT_PRESENT:
+        result["fail_reasons"].append("ARCHIVE_EXCHANGE_CLIENT_PRESENT must be false")
+
+    exchange_result = validate_futures_testnet_exchange_impl_descriptor(descriptor.exchange_impl)
+    result["exchange_impl_pass"] = exchange_result["exchange_impl_pass"]
+    result["fail_reasons"].extend(exchange_result["fail_reasons"])
+
+    harness_result = evaluate_bounded_futures_testnet_harness_readiness(
+        descriptor.harness_config,
+        binding=descriptor.exchange_impl.adapter_binding,
+    )
+    result["pe9_harness_readiness_pass"] = harness_result["harness_contract_pass"]
+    if not harness_result["harness_contract_pass"]:
+        result["fail_reasons"].extend(harness_result["fail_reasons"])
+
+    result["archive_script_absent_pass"] = not descriptor.archive_script_required
+    result["runtime_scheduler_guard_pass"] = (
+        not descriptor.runtime_started_allowed and not descriptor.scheduler_started_allowed
+    )
+    result["runtime_harness_impl_pass"] = not result["fail_reasons"]
+    return result

--- a/tests/ops/test_bounded_futures_testnet_exchange_impl_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_exchange_impl_contract_v0.py
@@ -1,0 +1,121 @@
+"""Static + offline bounded Futures Testnet exchange impl descriptor contract (v0).
+
+Docs/tests-only Class-4 scoped exception. No runtime, network, credentials, or Testnet start.
+Planning: futures_runtime_harness_exchange_impl_follow_up_pr_planning_v0
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
+    BoundedFuturesTestnetAdapterBinding,
+    default_offline_adapter_binding,
+)
+from src.ops.bounded_futures_testnet_contract_v0 import FUTURES_SESSION_AUTHORIZED_NOW
+from src.ops.bounded_futures_testnet_exchange_impl_contract_v0 import (
+    ARCHIVE_EXCHANGE_CLIENT_PRESENT,
+    EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED,
+    FUTURES_EXECUTE_AUTHORITY_ADDED,
+    PACKAGE_MARKER,
+    default_offline_exchange_impl_descriptor,
+    validate_futures_testnet_exchange_impl_descriptor,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXCHANGE_IMPL_MODULE = (
+    REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_exchange_impl_contract_v0.py"
+)
+RUNTIME_HARNESS_MODULE = (
+    REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_runtime_harness_contract_v0.py"
+)
+SECTION5_GAP_OWNER_MAP = (
+    REPO_ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
+)
+
+TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_EXCHANGE_IMPL_CONTRACT_GUARD_V0=true"
+_CLASS4_SCOPED_EXCEPTION_MARKER = (
+    "BOUNDED_FUTURES_TESTNET_EXCHANGE_IMPL_GUARD_CLASS4_SCOPED_EXCEPTION_V0=true"
+)
+
+
+def test_package_marker_present() -> None:
+    text = Path(__file__).read_text(encoding="utf-8")
+    assert TEST_PACKAGE_MARKER in text
+    assert _CLASS4_SCOPED_EXCEPTION_MARKER in text
+    assert PACKAGE_MARKER in EXCHANGE_IMPL_MODULE.read_text(encoding="utf-8")
+
+
+def test_exchange_impl_not_authorized_and_no_network() -> None:
+    assert FUTURES_SESSION_AUTHORIZED_NOW is False
+    assert EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED is False
+    assert ARCHIVE_EXCHANGE_CLIENT_PRESENT is False
+    assert FUTURES_EXECUTE_AUTHORITY_ADDED is False
+
+
+def test_default_exchange_impl_descriptor_passes() -> None:
+    descriptor = default_offline_exchange_impl_descriptor()
+    result = validate_futures_testnet_exchange_impl_descriptor(descriptor)
+    assert result["exchange_impl_pass"] is True
+    assert result["fail_reasons"] == []
+
+
+def test_unknown_instrument_fails() -> None:
+    binding = default_offline_adapter_binding()
+    bad_binding = BoundedFuturesTestnetAdapterBinding(
+        adapter_id=binding.adapter_id,
+        instrument="",
+        market_type=binding.market_type,
+        margin_mode=binding.margin_mode,
+        max_leverage=binding.max_leverage,
+        position_mode=binding.position_mode,
+        network_host=binding.network_host,
+        endpoint_allowlist=binding.endpoint_allowlist,
+        reduce_only_supported=binding.reduce_only_supported,
+        testnet_scoped=binding.testnet_scoped,
+        order_side_semantics=binding.order_side_semantics,
+    )
+    descriptor = default_offline_exchange_impl_descriptor()
+    bad = type(descriptor)(
+        impl_id=descriptor.impl_id,
+        adapter_binding=bad_binding,
+        impl_kind=descriptor.impl_kind,
+        network_calls_allowed=descriptor.network_calls_allowed,
+        reduce_only_command_model=descriptor.reduce_only_command_model,
+        close_only_command_model=descriptor.close_only_command_model,
+        flatten_evidence_required=descriptor.flatten_evidence_required,
+        funding_evidence_required=descriptor.funding_evidence_required,
+        liquidation_evidence_required=descriptor.liquidation_evidence_required,
+    )
+    result = validate_futures_testnet_exchange_impl_descriptor(bad)
+    assert result["exchange_impl_pass"] is False
+
+
+def test_network_calls_allowed_on_descriptor_fails() -> None:
+    descriptor = default_offline_exchange_impl_descriptor()
+    bad = type(descriptor)(
+        impl_id=descriptor.impl_id,
+        adapter_binding=descriptor.adapter_binding,
+        impl_kind=descriptor.impl_kind,
+        network_calls_allowed=True,
+        reduce_only_command_model=descriptor.reduce_only_command_model,
+        close_only_command_model=descriptor.close_only_command_model,
+        flatten_evidence_required=descriptor.flatten_evidence_required,
+        funding_evidence_required=descriptor.funding_evidence_required,
+        liquidation_evidence_required=descriptor.liquidation_evidence_required,
+    )
+    result = validate_futures_testnet_exchange_impl_descriptor(bad)
+    assert result["exchange_impl_pass"] is False
+
+
+def test_runtime_harness_module_crosslink() -> None:
+    assert RUNTIME_HARNESS_MODULE.is_file()
+    assert "bounded_futures_testnet_exchange_impl_contract_v0" in RUNTIME_HARNESS_MODULE.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_section5_pe10_crosslink_present() -> None:
+    section5 = SECTION5_GAP_OWNER_MAP.read_text(encoding="utf-8")
+    assert "bounded_futures_testnet_exchange_impl_contract_v0" in section5
+    assert "bounded_futures_testnet_runtime_harness_contract_v0" in section5

--- a/tests/ops/test_bounded_futures_testnet_runtime_harness_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_runtime_harness_contract_v0.py
@@ -1,0 +1,91 @@
+"""Static + offline bounded Futures Testnet runtime harness impl contract (v0).
+
+Docs/tests-only Class-4 scoped exception. No runtime, network, credentials, or Testnet start.
+Planning: futures_runtime_harness_exchange_impl_follow_up_pr_planning_v0
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.ops.bounded_futures_testnet_contract_v0 import FUTURES_SESSION_AUTHORIZED_NOW
+from src.ops.bounded_futures_testnet_runtime_harness_contract_v0 import (
+    ARCHIVE_HARNESS_SCRIPT_PRESENT,
+    PACKAGE_MARKER,
+    RUNTIME_HARNESS_EXECUTE_ALLOWED,
+    RUNTIME_HARNESS_NETWORK_ALLOWED,
+    default_offline_runtime_harness_impl_descriptor,
+    validate_futures_testnet_runtime_harness_impl_descriptor,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_HARNESS_MODULE = (
+    REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_runtime_harness_contract_v0.py"
+)
+EXCHANGE_IMPL_TEST = (
+    REPO_ROOT / "tests" / "ops" / "test_bounded_futures_testnet_exchange_impl_contract_v0.py"
+)
+HARNESS_TEST = REPO_ROOT / "tests" / "ops" / "test_bounded_futures_testnet_harness_contract_v0.py"
+
+TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_RUNTIME_HARNESS_CONTRACT_GUARD_V0=true"
+_CLASS4_SCOPED_EXCEPTION_MARKER = (
+    "BOUNDED_FUTURES_TESTNET_RUNTIME_HARNESS_GUARD_CLASS4_SCOPED_EXCEPTION_V0=true"
+)
+
+
+def test_package_marker_present() -> None:
+    text = Path(__file__).read_text(encoding="utf-8")
+    assert TEST_PACKAGE_MARKER in text
+    assert _CLASS4_SCOPED_EXCEPTION_MARKER in text
+    assert PACKAGE_MARKER in RUNTIME_HARNESS_MODULE.read_text(encoding="utf-8")
+
+
+def test_runtime_harness_guards_not_authorized() -> None:
+    assert RUNTIME_HARNESS_EXECUTE_ALLOWED is False
+    assert RUNTIME_HARNESS_NETWORK_ALLOWED is False
+    assert ARCHIVE_HARNESS_SCRIPT_PRESENT is False
+    assert FUTURES_SESSION_AUTHORIZED_NOW is False
+
+
+def test_default_runtime_harness_impl_passes() -> None:
+    descriptor = default_offline_runtime_harness_impl_descriptor()
+    result = validate_futures_testnet_runtime_harness_impl_descriptor(descriptor)
+    assert result["runtime_harness_impl_pass"] is True
+    assert result["pe9_harness_readiness_pass"] is True
+    assert result["exchange_impl_pass"] is True
+    assert result["fail_reasons"] == []
+
+
+def test_archive_script_required_fails() -> None:
+    descriptor = default_offline_runtime_harness_impl_descriptor()
+    bad = type(descriptor)(
+        impl_id=descriptor.impl_id,
+        exchange_impl_id=descriptor.exchange_impl_id,
+        harness_config=descriptor.harness_config,
+        exchange_impl=descriptor.exchange_impl,
+        archive_script_required=True,
+        runtime_started_allowed=descriptor.runtime_started_allowed,
+        scheduler_started_allowed=descriptor.scheduler_started_allowed,
+    )
+    result = validate_futures_testnet_runtime_harness_impl_descriptor(bad)
+    assert result["runtime_harness_impl_pass"] is False
+
+
+def test_runtime_started_allowed_fails() -> None:
+    descriptor = default_offline_runtime_harness_impl_descriptor()
+    bad = type(descriptor)(
+        impl_id=descriptor.impl_id,
+        exchange_impl_id=descriptor.exchange_impl_id,
+        harness_config=descriptor.harness_config,
+        exchange_impl=descriptor.exchange_impl,
+        archive_script_required=descriptor.archive_script_required,
+        runtime_started_allowed=True,
+        scheduler_started_allowed=descriptor.scheduler_started_allowed,
+    )
+    result = validate_futures_testnet_runtime_harness_impl_descriptor(bad)
+    assert result["runtime_harness_impl_pass"] is False
+
+
+def test_pe9_and_exchange_impl_tests_crosslink() -> None:
+    assert EXCHANGE_IMPL_TEST.is_file()
+    assert HARNESS_TEST.is_file()


### PR DESCRIPTION
## Summary

- Add `bounded_futures_testnet_exchange_impl_contract_v0` and `bounded_futures_testnet_runtime_harness_contract_v0` (PE-10) composing existing PE-8/PE-9 futures bounded surfaces.
- Fail-closed offline descriptors only: no network, credentials, orders, execute/session authority, or archive harness script.
- Extend SECTION5 owner map with PE-10 guard crosslinks and static contract tests.

## Safety

- `FUTURES_SESSION_AUTHORIZED_NOW=false` (unchanged)
- `RUNTIME_HARNESS_EXECUTE_ALLOWED=false`, `EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED=false`
- No testnet/paper/shadow session, no CI fastlane changes

## Test plan

- [x] `pytest` futures PE-8/9/10 + repo-native cap + entrypoint fail-closed tests (79 passed locally)
- [x] `ruff check` on new/changed Python files
- [ ] CI Fast-Lane expected for contract-only `src/ops/*_contract_v0.py` paths (post #3984)


Made with [Cursor](https://cursor.com)