### PR TITLE
ops: align bounded futures default instrument with PF_XBTUSD

### DIFF
--- a/src/ops/bounded_futures_testnet_adapter_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_adapter_contract_v0.py
@@ -17,6 +17,7 @@ from src.ops.bounded_futures_testnet_contract_v0 import (
     DEFAULT_MAX_LEVERAGE,
     DEFAULT_POSITION_MODE,
     FUTURES_SESSION_AUTHORIZED_NOW,
+    REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS,
     SPOT_KRAKEN_ENDPOINT_PREFIXES,
 )
 
@@ -102,6 +103,10 @@ def validate_futures_testnet_adapter_binding(
         result["fail_reasons"].append(f"market_type must be {DEFAULT_MARKET_TYPE!r}")
     if not binding.instrument:
         result["fail_reasons"].append("instrument required")
+    if binding.instrument in REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS:
+        result["fail_reasons"].append(
+            f"instrument {binding.instrument!r} is a rejected futures placeholder"
+        )
     if binding.margin_mode != DEFAULT_MARGIN_MODE:
         result["fail_reasons"].append(f"margin_mode must be {DEFAULT_MARGIN_MODE!r}")
     if binding.margin_mode == "cross":

--- a/src/ops/bounded_futures_testnet_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_contract_v0.py
@@ -14,8 +14,10 @@ PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_CONTRACT_V0=true"
 FUTURES_SESSION_AUTHORIZED_NOW = False
 DEFAULT_SESSION_CLASS = "bounded-futures-normal-testnet-v0"
 DEFAULT_ORDER_POLICY = "normal-testnet-futures-bounded"
-DEFAULT_INSTRUMENT = "BTCUSDT"
+DEFAULT_INSTRUMENT = "PF_XBTUSD"
 DEFAULT_MARKET_TYPE = "futures"
+# Binance-style placeholder — must not be used as bounded futures testnet default.
+REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS: frozenset[str] = frozenset({"BTCUSDT"})
 DEFAULT_MARGIN_MODE = "isolated"
 DEFAULT_POSITION_MODE = "one_way"
 DEFAULT_MAX_LEVERAGE = 5.0
@@ -114,6 +116,10 @@ def spot_evidence_misclassified_as_futures(evidence: dict[str, Any]) -> list[str
     if session_class in SPOT_SESSION_CLASSES:
         reasons.append(f"session_class {session_class!r} is spot-tier, not futures")
     instrument = evidence.get("instrument")
+    if instrument in REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS:
+        reasons.append(
+            f"instrument {instrument!r} is a rejected futures placeholder (use Kraken-native symbol)"
+        )
     if instrument in SPOT_INSTRUMENTS:
         reasons.append(f"instrument {instrument!r} is spot, not futures perpetual")
     market_type = evidence.get("market_type")

--- a/tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py
@@ -21,7 +21,11 @@ from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
     default_offline_adapter_binding,
     validate_futures_testnet_adapter_binding,
 )
-from src.ops.bounded_futures_testnet_contract_v0 import FUTURES_SESSION_AUTHORIZED_NOW
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    DEFAULT_INSTRUMENT,
+    FUTURES_SESSION_AUTHORIZED_NOW,
+    REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ADAPTER_MODULE = REPO_ROOT / "src" / "ops" / "bounded_futures_testnet_adapter_contract_v0.py"
@@ -54,9 +58,31 @@ def test_futures_session_and_network_not_authorized() -> None:
 
 def test_default_binding_passes_offline_validation() -> None:
     binding = default_offline_adapter_binding()
+    assert binding.instrument == "PF_XBTUSD"
+    assert binding.instrument == DEFAULT_INSTRUMENT
     result = validate_futures_testnet_adapter_binding(binding)
     assert result["adapter_binding_pass"] is True
     assert result["fail_reasons"] == []
+
+
+def test_btcusdt_placeholder_instrument_fails_adapter_binding() -> None:
+    binding = default_offline_adapter_binding()
+    bad = BoundedFuturesTestnetAdapterBinding(
+        adapter_id=binding.adapter_id,
+        instrument="BTCUSDT",
+        market_type=binding.market_type,
+        margin_mode=binding.margin_mode,
+        max_leverage=binding.max_leverage,
+        position_mode=binding.position_mode,
+        network_host=binding.network_host,
+        endpoint_allowlist=binding.endpoint_allowlist,
+        reduce_only_supported=binding.reduce_only_supported,
+        testnet_scoped=binding.testnet_scoped,
+        order_side_semantics=binding.order_side_semantics,
+    )
+    assert "BTCUSDT" in REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS
+    result = validate_futures_testnet_adapter_binding(bad)
+    assert result["adapter_binding_pass"] is False
 
 
 def test_spot_endpoint_in_endpoints_called_fails() -> None:

--- a/tests/ops/test_bounded_futures_testnet_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_contract_v0.py
@@ -15,6 +15,7 @@ from src.ops.bounded_futures_testnet_contract_v0 import (
     DEFAULT_SESSION_CLASS,
     FUTURES_SESSION_AUTHORIZED_NOW,
     PACKAGE_MARKER,
+    REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS,
     REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES,
     SPOT_KRAKEN_ENDPOINT_PREFIXES,
     default_bounded_futures_normal_v0_spec,
@@ -150,11 +151,21 @@ def test_required_evidence_field_names_documented() -> None:
     assert "futures_endpoint_isolation_pass" in REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES
 
 
-def test_default_spec_matches_review_instrument() -> None:
+def test_default_spec_uses_kraken_futures_operator_instrument() -> None:
     spec = default_bounded_futures_normal_v0_spec()
-    assert spec.instrument == "BTCUSDT"
+    assert spec.instrument == "PF_XBTUSD"
+    assert spec.instrument == DEFAULT_INSTRUMENT
+    assert spec.instrument not in REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS
     assert spec.max_leverage == 5.0
     assert spec.margin_mode == "isolated"
+
+
+def test_btcusdt_placeholder_rejected_in_futures_evidence() -> None:
+    evidence = _valid_futures_evidence()
+    evidence["instrument"] = "BTCUSDT"
+    assert spot_evidence_misclassified_as_futures(evidence)
+    result = evaluate_bounded_futures_testnet_evidence(evidence)
+    assert result["bounded_futures_testnet_pass"] is False
 
 
 def test_closeout_review_bundle_suffix_documented_in_test() -> None:


### PR DESCRIPTION
## Summary
- Set `DEFAULT_INSTRUMENT` to `PF_XBTUSD` (operator/Kraken futures decision).
- Add `REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS` (`BTCUSDT`) fail-closed in PE-8 evidence and PE-9 adapter binding.
- Extend static guards so defaults and placeholder rejection are tested.

## Input bundles (archive)
- `planning/bounded_futures_testnet_execute_readiness_review_no_run_v0_20260604T140734Z`
- `planning/bounded_futures_testnet_charter_prepare_no_run_v0_20260604T140544Z`
- `planning/futures_testnet_operator_symbol_decision_packet_no_run_v0_20260604T140343Z`
- `planning/futures_market_dashboard_notion_readiness_review_no_run_v0_20260604T141002Z`
- `closeout/pr3985_futures_runtime_harness_exchange_impl_post_merge_closeout_v0_20260604T135222Z`

## Safety boundaries
- No execute, session, scheduler, network I/O, credentials, orders, preflight lift, arming, or Master-V2/Double-Play authority.
- `FUTURES_SESSION_AUTHORIZED_NOW` / execute flags unchanged (false).
- Dashboard and Notion intentionally untouched.

## Validations
- 52 targeted pytest (PE-8..PE-10 + SECTION5 drift): pass
- ruff on changed files: pass

## Next
- Post-merge closeout bundle after merge.
- Then zero-order/validate-only GO-template NO-RUN review (not execute).


Made with [Cursor](https://cursor.com)