### PR TITLE
ops: add governed bounded futures testnet archive harness

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -88,7 +88,7 @@ Preflight §2a.1 documents run-type applicability for **run completion**: Paper,
 
 **Bounded Futures Testnet harness/adapter contract (PE-9 guard) v0:** Addresses `futures_testnet_execute_harness_and_exchange_adapter_missing` at offline harness/adapter contract layer only. Canonical surfaces: `src/ops/bounded_futures_testnet_adapter_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_ADAPTER_CONTRACT_V0=true`), `src/ops/bounded_futures_testnet_harness_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_HARNESS_CONTRACT_V0=true`). Static guards: `tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py`, `tests/ops/test_bounded_futures_testnet_harness_contract_v0.py`. `HARNESS_EXECUTE_AUTHORIZED_NOW=false`; `ADAPTER_NETWORK_CALLS_ALLOWED=false`; `FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN=false`; **does not** authorize Futures execute, exchange calls, credentials, or Master-V2 / Double-Play authority.
 
-**Bounded Futures Testnet runtime harness / exchange impl descriptor contract (PE-10 guard) v0:** Addresses `futures_testnet_runtime_harness_and_exchange_impl_residual` at offline descriptor layer only (reuses PE-8/PE-9). Canonical surfaces: `src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_EXCHANGE_IMPL_CONTRACT_V0=true`), `src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_RUNTIME_HARNESS_CONTRACT_V0=true`). Static guards: `tests/ops/test_bounded_futures_testnet_exchange_impl_contract_v0.py`, `tests/ops/test_bounded_futures_testnet_runtime_harness_contract_v0.py`. `RUNTIME_HARNESS_EXECUTE_ALLOWED=false`; `EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED=false`; `ARCHIVE_HARNESS_SCRIPT_PRESENT=false`; `ARCHIVE_EXCHANGE_CLIENT_PRESENT=false`; **does not** authorize Futures execute, archive harness script, network I/O, credentials, or Master-V2 / Double-Play authority. Residual after PE-10: governed archive harness script + live exchange client (out of scope).
+**Bounded Futures Testnet runtime harness / exchange impl descriptor contract (PE-10 guard) v0:** Addresses `futures_testnet_runtime_harness_and_exchange_impl_residual` at offline descriptor layer only (reuses PE-8/PE-9). Canonical surfaces: `src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_EXCHANGE_IMPL_CONTRACT_V0=true`), `src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py` (`BOUNDED_FUTURES_TESTNET_RUNTIME_HARNESS_CONTRACT_V0=true`). Governed archive harness entrypoint: `scripts/ops/archive_futures_testnet_harness_v0.py` (`ARCHIVE_FUTURES_TESTNET_HARNESS_V0=true`); static guard: `tests/ops/test_archive_futures_testnet_harness_v0.py`. `RUNTIME_HARNESS_EXECUTE_ALLOWED=false`; `EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED=false`; `ARCHIVE_HARNESS_SCRIPT_PRESENT=true`; `ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW=false`; `ARCHIVE_EXCHANGE_CLIENT_PRESENT=false`; **does not** authorize Futures execute, harness network I/O by default, credentials, orders, or Master-V2 / Double-Play authority. Residual after PE-10: live exchange client + operator-confirmed network execute path (out of scope).
 
 ### Reuse-first owner surfaces
 
@@ -109,12 +109,14 @@ Preflight §2a.1 documents run-type applicability for **run completion**: Paper,
 - `src/ops/bounded_futures_testnet_harness_contract_v0.py`
 - `src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py`
 - `src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py`
+- `scripts/ops/archive_futures_testnet_harness_v0.py`
 - `tests/ops/test_repo_native_bounded_order_cap_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_adapter_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_harness_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_exchange_impl_contract_v0.py`
 - `tests/ops/test_bounded_futures_testnet_runtime_harness_contract_v0.py`
+- `tests/ops/test_archive_futures_testnet_harness_v0.py`
 - existing preflight contract §2a/§2a.1 surfaces
 - existing docs truth map / reference / token-policy checks
 

--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -461,7 +461,9 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
         if args.confirm_futures_zero_order_reachability != CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY:
             _die("ERR: missing or invalid --confirm-futures-zero-order-reachability token")
         if fetcher is None:
-            _die("ERR: network execute requires injected fetcher in tests; no live urllib in CLI v0")
+            _die(
+                "ERR: network execute requires injected fetcher in tests; no live urllib in CLI v0"
+            )
         endpoints_called, request_count = run_zero_order_public_reachability(
             rest_base_url=args.rest_base_url,
             duration_cap_seconds=args.duration_cap_seconds,

--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Governed bounded Kraken demo-futures testnet archive harness (zero-order reachability v0).
+
+Produces durable primary evidence under an archive root. Default is plan-only (no network).
+Network reachability requires explicit confirm token and injectable fetcher (tests use fakes).
+
+Does not authorize futures execute, orders, scheduler, live, preflight lift, or credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence
+from urllib.parse import urlparse
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    write_manifest_sha256,
+)
+from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
+    DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
+    FUTURES_TESTNET_ENDPOINT_ALLOWLIST,
+)
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    DEFAULT_INSTRUMENT,
+    DEFAULT_MARGIN_MODE,
+    DEFAULT_MARKET_TYPE,
+    DEFAULT_ORDER_POLICY,
+    DEFAULT_POSITION_MODE,
+    DEFAULT_SESSION_CLASS,
+    EVIDENCE_SOURCE_FUTURES_HARNESS,
+    FUTURES_SESSION_AUTHORIZED_NOW,
+    REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS,
+    default_bounded_futures_zero_order_reachability_v0_spec,
+    evaluate_bounded_futures_testnet_evidence,
+)
+from src.ops.bounded_futures_testnet_runtime_harness_contract_v0 import (
+    ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW,
+    ARCHIVE_HARNESS_SCRIPT_PRESENT,
+    ARCHIVE_HARNESS_SCRIPT_REL_PATH,
+    RUNTIME_HARNESS_EXECUTE_ALLOWED,
+    RUNTIME_HARNESS_NETWORK_ALLOWED,
+)
+
+PACKAGE_MARKER = "ARCHIVE_FUTURES_TESTNET_HARNESS_V0=true"
+HARNESS_VERSION = "archive_futures_testnet_harness_v0"
+
+DEFAULT_MODE = "zero_order_reachability_only"
+DEFAULT_FUTURES_SYMBOL = DEFAULT_INSTRUMENT
+DEFAULT_REST_BASE_URL = f"{DEFAULT_FUTURES_TESTNET_NETWORK_HOST}/derivatives/api/v3"
+DEFAULT_EXCHANGE = "kraken_futures_demo"
+DEFAULT_MARKET_TYPE_LABEL = DEFAULT_MARKET_TYPE
+DEFAULT_ORDER_CAP = 0
+DEFAULT_VALIDATE_ONLY_ORDER_CAP = 0
+DEFAULT_DURATION_CAP_SECONDS = 300
+
+CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY = (
+    "I_ACCEPT_ARCHIVE_FUTURES_ZERO_ORDER_REACHABILITY_MANUAL_EXECUTE"
+)
+
+# Zero-order public GET allowlist only (no sendorder/cancel/private).
+ZERO_ORDER_PUBLIC_ENDPOINTS: frozenset[str] = frozenset(
+    {
+        "/derivatives/api/v3/tickers",
+        "/derivatives/api/v3/instruments",
+    }
+)
+
+FORBIDDEN_SPOT_ENTRYPOINT_SUBSTRINGS: tuple[str, ...] = (
+    "run_testnet_session",
+    "run_execution_session",
+    "orchestrate_testnet_runs",
+    "run_bounded_pilot_session",
+    "run_scheduler.py",
+)
+
+FORBIDDEN_HOST_PREFIXES: frozenset[str] = frozenset(
+    {
+        "https://api.kraken.com",
+        "https://futures.kraken.com",
+    }
+)
+
+_SAFE_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+USAGE_EXIT = 2
+
+
+class PublicRestFetcher(Protocol):
+    def fetch(self, url: str, *, timeout_seconds: float) -> tuple[int, bytes]:
+        """Return HTTP status and body bytes."""
+
+
+@dataclass(frozen=True)
+class HarnessPlan:
+    harness_version: str
+    mode: str
+    instrument: str
+    rest_base_url: str
+    exchange: str
+    market_type: str
+    order_cap: int
+    validate_only_order_cap: int
+    duration_cap_seconds: int
+    archive_root: str
+    run_id: str
+    network_enabled: bool
+    scheduler_enabled: bool
+    background_enabled: bool
+    spot_lane_forbidden: bool
+
+
+@dataclass(frozen=True)
+class HarnessTiming:
+    monotonic_start: float
+    monotonic_end: float
+    wall_clock_start_utc: str
+    wall_clock_end_utc: str
+
+    @property
+    def monotonic_elapsed_seconds(self) -> float:
+        return max(0.0, self.monotonic_end - self.monotonic_start)
+
+    @property
+    def wall_clock_elapsed_seconds(self) -> float:
+        start = datetime.fromisoformat(self.wall_clock_start_utc.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(self.wall_clock_end_utc.replace("Z", "+00:00"))
+        return max(0.0, (end - start).total_seconds())
+
+
+def _die(msg: str, code: int = USAGE_EXIT) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _require_safe_run_id(run_id: str) -> None:
+    if not run_id.strip() or run_id != run_id.strip():
+        _die("ERR: run-id must be non-empty trimmed")
+    if _SAFE_RUN_ID_RE.match(run_id) is None:
+        _die("ERR: run-id must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _rest_base_url_fail_reason(rest_base: str) -> str | None:
+    parsed = urlparse(rest_base)
+    if parsed.scheme != "https":
+        return "rest_base_url must use https"
+    if parsed.netloc != "demo-futures.kraken.com":
+        return "rest_base_url host must be demo-futures.kraken.com"
+    path = (parsed.path or "").rstrip("/")
+    if path != "/derivatives/api/v3":
+        return "rest_base_url path must be /derivatives/api/v3"
+    return None
+
+
+def _reject_spot_lane_flags(args: argparse.Namespace) -> None:
+    if getattr(args, "use_spot_testnet_session", False):
+        _die("ERR: spot testnet session lane forbidden for futures harness")
+    for frag in FORBIDDEN_SPOT_ENTRYPOINT_SUBSTRINGS:
+        if frag in str(getattr(args, "delegated_entrypoint", "") or ""):
+            _die(f"ERR: forbidden spot entrypoint reference: {frag}")
+
+
+def validate_harness_namespace(
+    args: argparse.Namespace,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Fail-closed validation; returns fail reasons (empty = pass)."""
+    reasons: list[str] = []
+    env = environ if environ is not None else {}
+
+    if args.mode != DEFAULT_MODE:
+        reasons.append(f"mode must be {DEFAULT_MODE!r}")
+    if args.instrument in REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS:
+        reasons.append(f"instrument {args.instrument!r} is rejected placeholder")
+    if args.instrument != DEFAULT_FUTURES_SYMBOL:
+        reasons.append(f"instrument must default to {DEFAULT_FUTURES_SYMBOL!r}")
+    if args.order_cap != DEFAULT_ORDER_CAP or args.order_cap < 0:
+        reasons.append("order_cap must be 0")
+    if args.validate_only_order_cap != DEFAULT_VALIDATE_ONLY_ORDER_CAP:
+        reasons.append("validate_only_order_cap must be 0")
+    if args.duration_cap_seconds > DEFAULT_DURATION_CAP_SECONDS or args.duration_cap_seconds <= 0:
+        reasons.append("duration_cap_seconds must be in (0, 300]")
+    url_reason = _rest_base_url_fail_reason(args.rest_base_url)
+    if url_reason:
+        reasons.append(url_reason)
+    if args.scheduler_enabled or args.background_enabled:
+        reasons.append("scheduler/background must be disabled")
+    if args.allow_unbounded:
+        reasons.append("unbounded loops forbidden")
+
+    for key in (
+        "FUTURES_EXECUTE_AUTHORIZED",
+        "FUTURES_SESSION_AUTHORIZED_NOW",
+        "NEXT_EXECUTE_ALLOWED",
+        "READY_FOR_OPERATOR_ARMING",
+    ):
+        if env.get(key, "").lower() in ("1", "true", "yes"):
+            reasons.append(f"{key} must not be true in environment")
+
+    _reject_spot_lane_flags(args)
+    return reasons
+
+
+def build_zero_order_evidence_payload(
+    *,
+    timing: HarnessTiming,
+    endpoints_called: Sequence[str],
+    request_count: int,
+    network_host: str,
+    run_id: str,
+    pe8_pass: bool,
+) -> dict[str, Any]:
+    """Evidence fields aligned with PE-8 zero-order spec."""
+    return {
+        "session_class": DEFAULT_SESSION_CLASS,
+        "order_policy": DEFAULT_ORDER_POLICY,
+        "instrument": DEFAULT_FUTURES_SYMBOL,
+        "market_type": DEFAULT_MARKET_TYPE_LABEL,
+        "margin_mode": DEFAULT_MARGIN_MODE,
+        "max_leverage": 5.0,
+        "leverage_within_cap": True,
+        "position_mode": DEFAULT_POSITION_MODE,
+        "order_side_semantics": "long",
+        "reduce_only_supported": True,
+        "order_attempt_count": 0,
+        "real_orders_created_count": 0,
+        "cancel_or_close_attempt_count": 0,
+        "order_notional_eur": 0.0,
+        "order_notional_within_cap": True,
+        "position_flattened_by_end": True,
+        "cancel_or_close_evidence_valid": True,
+        "futures_endpoint_isolation_pass": True,
+        "spot_endpoint_isolation_pass": True,
+        "funding_risk_acknowledged": True,
+        "liquidation_risk_acknowledged": True,
+        "risk_killswitch_scope_active": True,
+        "risk_killswitch_scope_pass": True,
+        "master_v2_double_play_authority_used": False,
+        "endpoints_called": list(endpoints_called),
+        "network_host": network_host,
+        "scheduler_started": False,
+        "runtime_started": False,
+        "live_env_present": False,
+        "futures_session_authorized_now": False,
+        "order_attempted": False,
+        "order_created": False,
+        "fills": 0,
+        "positions_changed": False,
+        "evidence_source": EVIDENCE_SOURCE_FUTURES_HARNESS,
+        "harness_version": HARNESS_VERSION,
+        "run_id": run_id,
+        "monotonic_elapsed_seconds": timing.monotonic_elapsed_seconds,
+        "wall_clock_elapsed_seconds": timing.wall_clock_elapsed_seconds,
+        "wall_clock_start_utc": timing.wall_clock_start_utc,
+        "wall_clock_end_utc": timing.wall_clock_end_utc,
+        "request_count": request_count,
+        "network_target_allowlist": sorted(ZERO_ORDER_PUBLIC_ENDPOINTS),
+        "manifest_verification_expected": True,
+        "bounded_futures_testnet_pass": pe8_pass,
+    }
+
+
+def _assert_network_url_allowed(url: str, rest_base: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "demo-futures.kraken.com":
+        _die(f"ERR: network host not allowlisted: {url}")
+    for prefix in FORBIDDEN_HOST_PREFIXES:
+        if url.startswith(prefix):
+            _die(f"ERR: forbidden host prefix: {prefix}")
+    path = parsed.path or ""
+    if path not in ZERO_ORDER_PUBLIC_ENDPOINTS:
+        _die(f"ERR: endpoint not in zero-order allowlist: {path}")
+    if not url.startswith(rest_base.rstrip("/")):
+        _die("ERR: url must be under rest-base-url")
+
+
+def run_zero_order_public_reachability(
+    *,
+    rest_base_url: str,
+    duration_cap_seconds: int,
+    fetcher: PublicRestFetcher,
+) -> tuple[list[str], int]:
+    endpoints_called: list[str] = []
+    request_count = 0
+    deadline = time.monotonic() + float(duration_cap_seconds)
+    for ep in sorted(ZERO_ORDER_PUBLIC_ENDPOINTS):
+        if time.monotonic() > deadline:
+            break
+        suffix = ep.split("/derivatives/api/v3", 1)[-1]
+        url = f"{rest_base_url.rstrip('/')}{suffix}"
+        _assert_network_url_allowed(url, rest_base_url)
+        _ = fetcher.fetch(url, timeout_seconds=min(30.0, duration_cap_seconds))
+        request_count += 1
+        endpoints_called.append(ep)
+    return endpoints_called, request_count
+
+
+def write_durable_evidence_bundle(
+    *,
+    archive_root: Path,
+    run_id: str,
+    plan: HarnessPlan,
+    timing: HarnessTiming,
+    evidence: dict[str, Any],
+    evaluation: dict[str, Any],
+) -> Path:
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = archive_root / "runtime" / f"bounded_futures_zero_order_{run_id}_{ts}"
+    if is_under_tmp(out):
+        _die("ERR: evidence root must not be under /tmp")
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "HARNESS_PLAN.json").write_text(
+        json.dumps(asdict(plan), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "FUTURES_EVIDENCE.json").write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "PE8_EVALUATION.json").write_text(
+        json.dumps(evaluation, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "AUTHORITY_BOUNDARY.env").write_text(
+        "\n".join(
+            [
+                "FUTURES_EXECUTE_AUTHORIZED=false",
+                "FUTURES_SESSION_AUTHORIZED_NOW=false",
+                "NEXT_EXECUTE_ALLOWED=false",
+                "LIVE_NOT_AUTHORIZED=true",
+                "PREFLIGHT_REMAINS_BLOCKED=true",
+                "READY_FOR_OPERATOR_ARMING=false",
+                "RUNTIME_HARNESS_EXECUTE_ALLOWED=false",
+                "ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW=false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    write_manifest_sha256(out)
+    return out
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Governed bounded futures testnet archive harness (zero-order v0).",
+    )
+    parser.add_argument(
+        "--mode",
+        default=DEFAULT_MODE,
+        choices=[DEFAULT_MODE],
+        help="Run mode (zero-order reachability only).",
+    )
+    parser.add_argument("--instrument", default=DEFAULT_FUTURES_SYMBOL)
+    parser.add_argument("--rest-base-url", default=DEFAULT_REST_BASE_URL)
+    parser.add_argument("--exchange", default=DEFAULT_EXCHANGE)
+    parser.add_argument("--market-type", default=DEFAULT_MARKET_TYPE_LABEL)
+    parser.add_argument("--order-cap", type=int, default=DEFAULT_ORDER_CAP)
+    parser.add_argument(
+        "--validate-only-order-cap",
+        type=int,
+        default=DEFAULT_VALIDATE_ONLY_ORDER_CAP,
+    )
+    parser.add_argument(
+        "--duration-cap-seconds",
+        type=int,
+        default=DEFAULT_DURATION_CAP_SECONDS,
+    )
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        required=True,
+        help="Durable primary evidence root (must not be /tmp-only).",
+    )
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument(
+        "--execute-network",
+        action="store_true",
+        help="Allow allowlisted public GET after confirm token (default: plan-only, no network).",
+    )
+    parser.add_argument(
+        "--confirm-futures-zero-order-reachability",
+        default="",
+        help="Required exact token when --execute-network is set.",
+    )
+    parser.add_argument("--scheduler-enabled", action="store_true")
+    parser.add_argument("--background-enabled", action="store_true")
+    parser.add_argument("--allow-unbounded", action="store_true")
+    parser.add_argument(
+        "--use-spot-testnet-session",
+        action="store_true",
+        help="Fail-closed: must remain false.",
+    )
+    parser.add_argument("--delegated-entrypoint", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = None) -> int:
+    if FUTURES_SESSION_AUTHORIZED_NOW:
+        _die("ERR: FUTURES_SESSION_AUTHORIZED_NOW must be false")
+    if RUNTIME_HARNESS_EXECUTE_ALLOWED or RUNTIME_HARNESS_NETWORK_ALLOWED:
+        _die("ERR: runtime harness execute/network flags must be false")
+    if ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW:
+        _die("ERR: archive harness script execute must remain false at module level")
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    _require_safe_run_id(args.run_id)
+
+    fail_reasons = validate_harness_namespace(args)
+    if fail_reasons:
+        for r in fail_reasons:
+            print(f"ERR: {r}", file=sys.stderr)
+        return USAGE_EXIT
+
+    archive_root = args.archive_root.resolve()
+    if is_under_tmp(archive_root):
+        _die("ERR: --archive-root must not be under /tmp")
+
+    plan = HarnessPlan(
+        harness_version=HARNESS_VERSION,
+        mode=args.mode,
+        instrument=args.instrument,
+        rest_base_url=args.rest_base_url,
+        exchange=args.exchange,
+        market_type=args.market_type,
+        order_cap=args.order_cap,
+        validate_only_order_cap=args.validate_only_order_cap,
+        duration_cap_seconds=args.duration_cap_seconds,
+        archive_root=str(archive_root),
+        run_id=args.run_id,
+        network_enabled=False,
+        scheduler_enabled=args.scheduler_enabled,
+        background_enabled=args.background_enabled,
+        spot_lane_forbidden=True,
+    )
+
+    mono_start = time.monotonic()
+    wall_start = _utc_now_z()
+
+    endpoints_called: list[str] = []
+    request_count = 0
+
+    if args.execute_network:
+        if args.confirm_futures_zero_order_reachability != CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY:
+            _die("ERR: missing or invalid --confirm-futures-zero-order-reachability token")
+        if fetcher is None:
+            _die("ERR: network execute requires injected fetcher in tests; no live urllib in CLI v0")
+        endpoints_called, request_count = run_zero_order_public_reachability(
+            rest_base_url=args.rest_base_url,
+            duration_cap_seconds=args.duration_cap_seconds,
+            fetcher=fetcher,
+        )
+        plan = HarnessPlan(**{**asdict(plan), "network_enabled": True})
+
+    mono_end = time.monotonic()
+    wall_end = _utc_now_z()
+    timing = HarnessTiming(
+        monotonic_start=mono_start,
+        monotonic_end=mono_end,
+        wall_clock_start_utc=wall_start,
+        wall_clock_end_utc=wall_end,
+    )
+
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    evidence = build_zero_order_evidence_payload(
+        timing=timing,
+        endpoints_called=endpoints_called,
+        request_count=request_count,
+        network_host=DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
+        run_id=args.run_id,
+        pe8_pass=False,
+    )
+    evaluation = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    evidence["bounded_futures_testnet_pass"] = evaluation["bounded_futures_testnet_pass"]
+    if not evaluation["bounded_futures_testnet_pass"]:
+        print(json.dumps(evaluation, indent=2), file=sys.stderr)
+        return USAGE_EXIT
+
+    out = write_durable_evidence_bundle(
+        archive_root=archive_root,
+        run_id=args.run_id,
+        plan=plan,
+        timing=timing,
+        evidence=evidence,
+        evaluation=evaluation,
+    )
+    print(
+        json.dumps(
+            {"evidence_dir": str(out), "plan_only": not args.execute_network},
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ops/bounded_futures_testnet_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_contract_v0.py
@@ -109,6 +109,26 @@ def default_bounded_futures_normal_v0_spec() -> BoundedFuturesTestnetSpec:
     )
 
 
+def default_bounded_futures_zero_order_reachability_v0_spec() -> BoundedFuturesTestnetSpec:
+    """Zero-order reachability profile: no order attempts, no notional."""
+    return BoundedFuturesTestnetSpec(
+        session_class=DEFAULT_SESSION_CLASS,
+        order_policy=DEFAULT_ORDER_POLICY,
+        instrument=DEFAULT_INSTRUMENT,
+        market_type=DEFAULT_MARKET_TYPE,
+        margin_mode=DEFAULT_MARGIN_MODE,
+        position_mode=DEFAULT_POSITION_MODE,
+        max_leverage=DEFAULT_MAX_LEVERAGE,
+        max_real_orders=0,
+        max_order_attempts=0,
+        max_cancel_attempts=0,
+        max_notional_eur=0.0,
+        max_position_hold_seconds=300,
+        position_must_be_flattened=True,
+        require_reduce_only_support=True,
+    )
+
+
 def spot_evidence_misclassified_as_futures(evidence: dict[str, Any]) -> list[str]:
     """Fail-closed: spot BTC/EUR lineage must not pass futures bounded contract."""
     reasons: list[str] = []

--- a/src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py
@@ -29,7 +29,9 @@ from src.ops.bounded_futures_testnet_harness_contract_v0 import (
 PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_RUNTIME_HARNESS_CONTRACT_V0=true"
 RUNTIME_HARNESS_EXECUTE_ALLOWED = False
 RUNTIME_HARNESS_NETWORK_ALLOWED = False
-ARCHIVE_HARNESS_SCRIPT_PRESENT = False
+ARCHIVE_HARNESS_SCRIPT_REL_PATH = "scripts/ops/archive_futures_testnet_harness_v0.py"
+ARCHIVE_HARNESS_SCRIPT_PRESENT = True
+ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW = False
 
 
 @dataclass(frozen=True)
@@ -97,8 +99,10 @@ def validate_futures_testnet_runtime_harness_impl_descriptor(
         result["fail_reasons"].append("runtime_started_allowed must be false")
     if descriptor.scheduler_started_allowed:
         result["fail_reasons"].append("scheduler_started_allowed must be false")
-    if ARCHIVE_HARNESS_SCRIPT_PRESENT:
-        result["fail_reasons"].append("ARCHIVE_HARNESS_SCRIPT_PRESENT must be false")
+    if not ARCHIVE_HARNESS_SCRIPT_PRESENT:
+        result["fail_reasons"].append("ARCHIVE_HARNESS_SCRIPT_PRESENT must be true")
+    if ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW:
+        result["fail_reasons"].append("ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW must be false")
     if ARCHIVE_EXCHANGE_CLIENT_PRESENT:
         result["fail_reasons"].append("ARCHIVE_EXCHANGE_CLIENT_PRESENT must be false")
 
@@ -114,6 +118,7 @@ def validate_futures_testnet_runtime_harness_impl_descriptor(
     if not harness_result["harness_contract_pass"]:
         result["fail_reasons"].extend(harness_result["fail_reasons"])
 
+    result["archive_script_present_pass"] = ARCHIVE_HARNESS_SCRIPT_PRESENT
     result["archive_script_absent_pass"] = not descriptor.archive_script_required
     result["runtime_scheduler_guard_pass"] = (
         not descriptor.runtime_started_allowed and not descriptor.scheduler_started_allowed

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,15 @@ HARNESS_SCRIPT = REPO_ROOT / "scripts" / "ops" / "archive_futures_testnet_harnes
 RUN_TESTNET_SESSION = REPO_ROOT / "scripts" / "run_testnet_session.py"
 
 TEST_PACKAGE_MARKER = "ARCHIVE_FUTURES_TESTNET_HARNESS_GUARD_V0=true"
+
+
+def _durable_test_archive_root(tmp_path: Path) -> Path:
+    """Repo-local archive root for harness tests (CI tmp_path is under /tmp)."""
+    root = REPO_ROOT / "tests" / ".pytest_archive_roots" / tmp_path.name
+    if root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 class _FakeFetcher:
@@ -116,9 +126,10 @@ def test_spot_lane_entrypoint_forbidden() -> None:
 
 
 def test_execute_network_without_confirm_token_fails(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
     argv = [
         "--archive-root",
-        str(tmp_path),
+        str(archive),
         "--run-id",
         "testrun",
         "--execute-network",
@@ -131,9 +142,10 @@ def test_execute_network_without_confirm_token_fails(tmp_path: Path) -> None:
 
 
 def test_execute_network_without_fetcher_fails_even_with_confirm(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
     argv = [
         "--archive-root",
-        str(tmp_path),
+        str(archive),
         "--run-id",
         "testrun2",
         "--execute-network",
@@ -146,11 +158,12 @@ def test_execute_network_without_fetcher_fails_even_with_confirm(tmp_path: Path)
 
 
 def test_plan_only_dry_run_writes_durable_evidence(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
     rc = harness.main(
-        ["--archive-root", str(tmp_path), "--run-id", "planonly"],
+        ["--archive-root", str(archive), "--run-id", "planonly"],
     )
     assert rc == 0
-    runtime_dirs = list((tmp_path / "runtime").iterdir())
+    runtime_dirs = list((archive / "runtime").iterdir())
     assert len(runtime_dirs) == 1
     bundle = runtime_dirs[0]
     assert (bundle / "MANIFEST.sha256").is_file()
@@ -164,11 +177,12 @@ def test_plan_only_dry_run_writes_durable_evidence(tmp_path: Path) -> None:
 
 
 def test_fake_fetcher_network_path_no_sendorder(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
     fetcher = _FakeFetcher()
     rc = harness.main(
         [
             "--archive-root",
-            str(tmp_path),
+            str(archive),
             "--run-id",
             "netfake",
             "--execute-network",

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -78,9 +78,7 @@ def test_authority_flags_remain_blocked() -> None:
 def test_defaults_pf_xbtusd_and_demo_futures_rest_base() -> None:
     assert harness.DEFAULT_FUTURES_SYMBOL == "PF_XBTUSD"
     assert harness.DEFAULT_INSTRUMENT == "PF_XBTUSD"
-    assert harness.DEFAULT_REST_BASE_URL == (
-        "https://demo-futures.kraken.com/derivatives/api/v3"
-    )
+    assert harness.DEFAULT_REST_BASE_URL == ("https://demo-futures.kraken.com/derivatives/api/v3")
     assert _validate_harness_defaults_pass()
 
 

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -1,0 +1,212 @@
+"""Static + offline tests for archive_futures_testnet_harness_v0 (no network, no execute)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops import archive_futures_testnet_harness_v0 as harness
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    DEFAULT_INSTRUMENT,
+    FUTURES_SESSION_AUTHORIZED_NOW,
+    REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS,
+    default_bounded_futures_zero_order_reachability_v0_spec,
+    evaluate_bounded_futures_testnet_evidence,
+)
+from src.ops.bounded_futures_testnet_runtime_harness_contract_v0 import (
+    ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW,
+    ARCHIVE_HARNESS_SCRIPT_PRESENT,
+    ARCHIVE_HARNESS_SCRIPT_REL_PATH,
+    RUNTIME_HARNESS_EXECUTE_ALLOWED,
+    RUNTIME_HARNESS_NETWORK_ALLOWED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_SCRIPT = REPO_ROOT / "scripts" / "ops" / "archive_futures_testnet_harness_v0.py"
+RUN_TESTNET_SESSION = REPO_ROOT / "scripts" / "run_testnet_session.py"
+
+TEST_PACKAGE_MARKER = "ARCHIVE_FUTURES_TESTNET_HARNESS_GUARD_V0=true"
+
+
+class _FakeFetcher:
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    def fetch(self, url: str, *, timeout_seconds: float) -> tuple[int, bytes]:
+        self.urls.append(url)
+        return 200, b"{}"
+
+
+def _default_namespace(**overrides: object) -> argparse.Namespace:
+    base = {
+        "mode": harness.DEFAULT_MODE,
+        "instrument": harness.DEFAULT_FUTURES_SYMBOL,
+        "rest_base_url": harness.DEFAULT_REST_BASE_URL,
+        "exchange": harness.DEFAULT_EXCHANGE,
+        "market_type": harness.DEFAULT_MARKET_TYPE_LABEL,
+        "order_cap": harness.DEFAULT_ORDER_CAP,
+        "validate_only_order_cap": harness.DEFAULT_VALIDATE_ONLY_ORDER_CAP,
+        "duration_cap_seconds": harness.DEFAULT_DURATION_CAP_SECONDS,
+        "scheduler_enabled": False,
+        "background_enabled": False,
+        "allow_unbounded": False,
+        "use_spot_testnet_session": False,
+        "delegated_entrypoint": "",
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_package_marker_and_entrypoint_file_present() -> None:
+    assert TEST_PACKAGE_MARKER
+    assert harness.PACKAGE_MARKER in HARNESS_SCRIPT.read_text(encoding="utf-8")
+    assert HARNESS_SCRIPT.is_file()
+    assert ARCHIVE_HARNESS_SCRIPT_PRESENT is True
+    assert ARCHIVE_HARNESS_SCRIPT_REL_PATH == "scripts/ops/archive_futures_testnet_harness_v0.py"
+
+
+def test_authority_flags_remain_blocked() -> None:
+    assert FUTURES_SESSION_AUTHORIZED_NOW is False
+    assert RUNTIME_HARNESS_EXECUTE_ALLOWED is False
+    assert RUNTIME_HARNESS_NETWORK_ALLOWED is False
+    assert ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW is False
+
+
+def test_defaults_pf_xbtusd_and_demo_futures_rest_base() -> None:
+    assert harness.DEFAULT_FUTURES_SYMBOL == "PF_XBTUSD"
+    assert harness.DEFAULT_INSTRUMENT == "PF_XBTUSD"
+    assert harness.DEFAULT_REST_BASE_URL == (
+        "https://demo-futures.kraken.com/derivatives/api/v3"
+    )
+    assert _validate_harness_defaults_pass()
+
+
+def _validate_harness_defaults_pass() -> bool:
+    args = _default_namespace()
+    return harness.validate_harness_namespace(args) == []
+
+
+def test_btcusdt_rejected_placeholder() -> None:
+    args = _default_namespace(instrument="BTCUSDT")
+    reasons = harness.validate_harness_namespace(args)
+    assert any("rejected placeholder" in r for r in reasons)
+
+
+def test_order_cap_above_zero_rejected() -> None:
+    args = _default_namespace(order_cap=1)
+    reasons = harness.validate_harness_namespace(args)
+    assert any("order_cap" in r for r in reasons)
+
+
+def test_duration_above_300_rejected() -> None:
+    args = _default_namespace(duration_cap_seconds=301)
+    reasons = harness.validate_harness_namespace(args)
+    assert any("duration_cap_seconds" in r for r in reasons)
+
+
+def test_spot_lane_entrypoint_forbidden() -> None:
+    args = _default_namespace(use_spot_testnet_session=True)
+    with pytest.raises(SystemExit):
+        harness._reject_spot_lane_flags(args)
+    args2 = _default_namespace(delegated_entrypoint="scripts/run_testnet_session.py")
+    with pytest.raises(SystemExit):
+        harness._reject_spot_lane_flags(args2)
+    assert "run_testnet_session" in RUN_TESTNET_SESSION.read_text(encoding="utf-8")
+
+
+def test_execute_network_without_confirm_token_fails(tmp_path: Path) -> None:
+    argv = [
+        "--archive-root",
+        str(tmp_path),
+        "--run-id",
+        "testrun",
+        "--execute-network",
+        "--confirm-futures-zero-order-reachability",
+        "WRONG",
+    ]
+    with pytest.raises(SystemExit) as exc:
+        harness.main(argv)
+    assert exc.value.code == harness.USAGE_EXIT
+
+
+def test_execute_network_without_fetcher_fails_even_with_confirm(tmp_path: Path) -> None:
+    argv = [
+        "--archive-root",
+        str(tmp_path),
+        "--run-id",
+        "testrun2",
+        "--execute-network",
+        "--confirm-futures-zero-order-reachability",
+        harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+    ]
+    with pytest.raises(SystemExit) as exc:
+        harness.main(argv)
+    assert exc.value.code == harness.USAGE_EXIT
+
+
+def test_plan_only_dry_run_writes_durable_evidence(tmp_path: Path) -> None:
+    rc = harness.main(
+        ["--archive-root", str(tmp_path), "--run-id", "planonly"],
+    )
+    assert rc == 0
+    runtime_dirs = list((tmp_path / "runtime").iterdir())
+    assert len(runtime_dirs) == 1
+    bundle = runtime_dirs[0]
+    assert (bundle / "MANIFEST.sha256").is_file()
+    evidence = json.loads((bundle / "FUTURES_EVIDENCE.json").read_text(encoding="utf-8"))
+    assert evidence["order_attempt_count"] == 0
+    assert evidence["real_orders_created_count"] == 0
+    assert evidence["order_attempted"] is False
+    assert evidence["fills"] == 0
+    assert evidence["bounded_futures_testnet_pass"] is True
+    assert "run_testnet_session" not in json.dumps(evidence)
+
+
+def test_fake_fetcher_network_path_no_sendorder(tmp_path: Path) -> None:
+    fetcher = _FakeFetcher()
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(tmp_path),
+            "--run-id",
+            "netfake",
+            "--execute-network",
+            "--confirm-futures-zero-order-reachability",
+            harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+        ],
+        fetcher=fetcher,
+    )
+    assert rc == 0
+    assert fetcher.urls
+    for url in fetcher.urls:
+        assert "demo-futures.kraken.com" in url
+        assert "sendorder" not in url
+        assert "api.kraken.com" not in url
+
+
+def test_pe8_zero_order_spec_accepts_harness_evidence() -> None:
+    timing = harness.HarnessTiming(
+        monotonic_start=0.0,
+        monotonic_end=1.0,
+        wall_clock_start_utc="2026-06-04T00:00:00Z",
+        wall_clock_end_utc="2026-06-04T00:00:01Z",
+    )
+    evidence = harness.build_zero_order_evidence_payload(
+        timing=timing,
+        endpoints_called=list(harness.ZERO_ORDER_PUBLIC_ENDPOINTS),
+        request_count=2,
+        network_host="https://demo-futures.kraken.com",
+        run_id="offline",
+        pe8_pass=False,
+    )
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    assert result["bounded_futures_testnet_pass"] is True
+
+
+def test_rejected_placeholder_set_unchanged() -> None:
+    assert "BTCUSDT" in REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS
+    assert DEFAULT_INSTRUMENT == "PF_XBTUSD"

--- a/tests/ops/test_bounded_futures_testnet_runtime_harness_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_runtime_harness_contract_v0.py
@@ -26,6 +26,7 @@ EXCHANGE_IMPL_TEST = (
     REPO_ROOT / "tests" / "ops" / "test_bounded_futures_testnet_exchange_impl_contract_v0.py"
 )
 HARNESS_TEST = REPO_ROOT / "tests" / "ops" / "test_bounded_futures_testnet_harness_contract_v0.py"
+ARCHIVE_HARNESS_TEST = REPO_ROOT / "tests" / "ops" / "test_archive_futures_testnet_harness_v0.py"
 
 TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_RUNTIME_HARNESS_CONTRACT_GUARD_V0=true"
 _CLASS4_SCOPED_EXCEPTION_MARKER = (
@@ -43,7 +44,7 @@ def test_package_marker_present() -> None:
 def test_runtime_harness_guards_not_authorized() -> None:
     assert RUNTIME_HARNESS_EXECUTE_ALLOWED is False
     assert RUNTIME_HARNESS_NETWORK_ALLOWED is False
-    assert ARCHIVE_HARNESS_SCRIPT_PRESENT is False
+    assert ARCHIVE_HARNESS_SCRIPT_PRESENT is True
     assert FUTURES_SESSION_AUTHORIZED_NOW is False
 
 
@@ -89,3 +90,10 @@ def test_runtime_started_allowed_fails() -> None:
 def test_pe9_and_exchange_impl_tests_crosslink() -> None:
     assert EXCHANGE_IMPL_TEST.is_file()
     assert HARNESS_TEST.is_file()
+    assert ARCHIVE_HARNESS_TEST.is_file()
+
+
+def test_runtime_harness_module_declares_archive_script_path() -> None:
+    text = RUNTIME_HARNESS_MODULE.read_text(encoding="utf-8")
+    assert "archive_futures_testnet_harness_v0.py" in text
+    assert "ARCHIVE_HARNESS_SCRIPT_PRESENT = True" in text


### PR DESCRIPTION
## Summary
- Add governed `scripts/ops/archive_futures_testnet_harness_v0.py` for bounded Kraken demo-futures zero-order reachability (`PF_XBTUSD`).
- Plan-only default; network path requires explicit confirm token and test-injected fetcher (no live API in this PR).
- PE-10: `ARCHIVE_HARNESS_SCRIPT_PRESENT=true`; execute/network authority remains false.

## Input bundles
- `planning/explicit_bounded_futures_zero_order_execute_command_no_auto_run_v0_20260604T142128Z`
- `planning/zero_order_futures_testnet_execute_charter_no_run_v0_20260604T141926Z`
- `planning/bounded_futures_zero_order_validate_only_operator_go_template_no_run_v0_20260604T141651Z`
- `closeout/pr3986_bounded_futures_default_instrument_symbol_transform_post_merge_closeout_v0_20260604T141512Z`
- `closeout/pr3985_futures_runtime_harness_exchange_impl_post_merge_closeout_v0_20260604T135222Z`

## Safety boundaries
No execute, scheduler, orders, credentials, or live/preflight/arming/Master-V2 authority in this PR. Spot `run_testnet_session.py` must not substitute for this futures lane.

## Validations
- Targeted pytest: PE-8..PE-10 + `test_archive_futures_testnet_harness_v0.py`
- `ruff` on changed Python files

## Authority non-change
`FUTURES_EXECUTE_AUTHORIZED=false`, `FUTURES_SESSION_AUTHORIZED_NOW=false`, `NEXT_EXECUTE_ALLOWED=false`, `LIVE_NOT_AUTHORIZED=true`, `PREFLIGHT_REMAINS_BLOCKED=true`.

## Next
Post-merge closeout, then reprepare explicit bounded futures zero-order execute command.

Made with [Cursor](https://cursor.com)