### PR TITLE
ops: add safe public futures network fetcher

### DIFF
--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -10,6 +10,7 @@ Does not authorize futures execute, orders, scheduler, live, preflight lift, or 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sys
@@ -17,7 +18,8 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Mapping, Protocol, Sequence
+from typing import Any, Literal, Mapping, Protocol, Sequence
+from urllib import error, request
 from urllib.parse import urlparse
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -30,7 +32,6 @@ from scripts.ops.primary_evidence_retention_v0 import (
 )
 from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
     DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
-    FUTURES_TESTNET_ENDPOINT_ALLOWLIST,
 )
 from src.ops.bounded_futures_testnet_contract_v0 import (
     DEFAULT_INSTRUMENT,
@@ -54,6 +55,7 @@ from src.ops.bounded_futures_testnet_runtime_harness_contract_v0 import (
 )
 
 PACKAGE_MARKER = "ARCHIVE_FUTURES_TESTNET_HARNESS_V0=true"
+SAFE_PUBLIC_URLLIB_FETCHER_PRESENT = True
 HARNESS_VERSION = "archive_futures_testnet_harness_v0"
 
 DEFAULT_MODE = "zero_order_reachability_only"
@@ -76,6 +78,19 @@ ZERO_ORDER_PUBLIC_ENDPOINTS: frozenset[str] = frozenset(
         "/derivatives/api/v3/instruments",
     }
 )
+ZERO_ORDER_PUBLIC_ENDPOINT_ORDER: tuple[str, ...] = (
+    "/derivatives/api/v3/tickers",
+    "/derivatives/api/v3/instruments",
+)
+
+DEFAULT_PUBLIC_GET_TIMEOUT_SECONDS = 10.0
+
+SymbolVisibility = Literal[
+    "visible",
+    "not_visible",
+    "not_checked",
+    "response_unparseable",
+]
 
 FORBIDDEN_SPOT_ENTRYPOINT_SUBSTRINGS: tuple[str, ...] = (
     "run_testnet_session",
@@ -100,6 +115,50 @@ USAGE_EXIT = 2
 class PublicRestFetcher(Protocol):
     def fetch(self, url: str, *, timeout_seconds: float) -> tuple[int, bytes]:
         """Return HTTP status and body bytes."""
+
+
+@dataclass(frozen=True)
+class NetworkCallRecord:
+    endpoint: str
+    http_status: int
+    http_status_class: str
+    response_size_bytes: int
+    response_sha256: str
+
+
+@dataclass(frozen=True)
+class NetworkReachabilityResult:
+    endpoints_called: list[str]
+    request_count: int
+    network_calls: list[NetworkCallRecord]
+    pf_xbtusd_symbol_visibility: SymbolVisibility
+    network_reachability_proven: bool
+
+
+class SafePublicUrllibRestFetcher:
+    """Bounded stdlib urllib public GET client (demo futures allowlist only)."""
+
+    def __init__(self, rest_base_url: str) -> None:
+        self._rest_base_url = rest_base_url
+
+    def fetch(self, url: str, *, timeout_seconds: float) -> tuple[int, bytes]:
+        _assert_network_url_allowed(url, self._rest_base_url)
+        bounded_timeout = min(
+            float(timeout_seconds),
+            DEFAULT_PUBLIC_GET_TIMEOUT_SECONDS,
+            float(DEFAULT_DURATION_CAP_SECONDS),
+        )
+        req = request.Request(url, method="GET")
+        try:
+            with request.urlopen(req, timeout=bounded_timeout) as resp:
+                status = int(getattr(resp, "status", resp.getcode()))
+                return status, resp.read()
+        except error.HTTPError as exc:
+            return int(exc.code), exc.read() or b""
+
+
+def default_safe_public_rest_fetcher(rest_base_url: str) -> SafePublicUrllibRestFetcher:
+    return SafePublicUrllibRestFetcher(rest_base_url)
 
 
 @dataclass(frozen=True)
@@ -217,6 +276,46 @@ def validate_harness_namespace(
     return reasons
 
 
+def _http_status_class(status: int) -> str:
+    if 200 <= status < 300:
+        return "2xx"
+    if 300 <= status < 400:
+        return "3xx"
+    if 400 <= status < 500:
+        return "4xx"
+    if 500 <= status < 600:
+        return "5xx"
+    return "other"
+
+
+def _sha256_hex(body: bytes) -> str:
+    return hashlib.sha256(body).hexdigest()
+
+
+def classify_pf_xbtusd_symbol_visibility(
+    body: bytes,
+    *,
+    endpoint: str,
+) -> SymbolVisibility:
+    if endpoint != "/derivatives/api/v3/tickers":
+        return "not_checked"
+    if not body:
+        return "response_unparseable"
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return "response_unparseable"
+    tickers: Any = payload.get("tickers") if isinstance(payload, dict) else None
+    if tickers is None and isinstance(payload, list):
+        tickers = payload
+    if not isinstance(tickers, list):
+        return "response_unparseable"
+    for entry in tickers:
+        if isinstance(entry, dict) and entry.get("symbol") == DEFAULT_FUTURES_SYMBOL:
+            return "visible"
+    return "not_visible"
+
+
 def build_zero_order_evidence_payload(
     *,
     timing: HarnessTiming,
@@ -225,8 +324,21 @@ def build_zero_order_evidence_payload(
     network_host: str,
     run_id: str,
     pe8_pass: bool,
+    network_reachability_proven: bool = False,
+    network_calls: Sequence[NetworkCallRecord] | None = None,
+    pf_xbtusd_symbol_visibility: SymbolVisibility = "not_checked",
 ) -> dict[str, Any]:
     """Evidence fields aligned with PE-8 zero-order spec."""
+    calls_payload = [
+        {
+            "endpoint": rec.endpoint,
+            "http_status": rec.http_status,
+            "http_status_class": rec.http_status_class,
+            "response_size_bytes": rec.response_size_bytes,
+            "response_sha256": rec.response_sha256,
+        }
+        for rec in (network_calls or [])
+    ]
     return {
         "session_class": DEFAULT_SESSION_CLASS,
         "order_policy": DEFAULT_ORDER_POLICY,
@@ -270,6 +382,9 @@ def build_zero_order_evidence_payload(
         "wall_clock_start_utc": timing.wall_clock_start_utc,
         "wall_clock_end_utc": timing.wall_clock_end_utc,
         "request_count": request_count,
+        "network_reachability_proven": network_reachability_proven,
+        "network_calls": calls_payload,
+        "pf_xbtusd_symbol_visibility": pf_xbtusd_symbol_visibility,
         "network_target_allowlist": sorted(ZERO_ORDER_PUBLIC_ENDPOINTS),
         "manifest_verification_expected": True,
         "bounded_futures_testnet_pass": pe8_pass,
@@ -295,20 +410,45 @@ def run_zero_order_public_reachability(
     rest_base_url: str,
     duration_cap_seconds: int,
     fetcher: PublicRestFetcher,
-) -> tuple[list[str], int]:
+) -> NetworkReachabilityResult:
     endpoints_called: list[str] = []
-    request_count = 0
+    network_calls: list[NetworkCallRecord] = []
+    symbol_visibility: SymbolVisibility = "not_checked"
     deadline = time.monotonic() + float(duration_cap_seconds)
-    for ep in sorted(ZERO_ORDER_PUBLIC_ENDPOINTS):
+    for ep in ZERO_ORDER_PUBLIC_ENDPOINT_ORDER:
+        if ep not in ZERO_ORDER_PUBLIC_ENDPOINTS:
+            continue
         if time.monotonic() > deadline:
             break
         suffix = ep.split("/derivatives/api/v3", 1)[-1]
         url = f"{rest_base_url.rstrip('/')}{suffix}"
         _assert_network_url_allowed(url, rest_base_url)
-        _ = fetcher.fetch(url, timeout_seconds=min(30.0, duration_cap_seconds))
-        request_count += 1
+        status, body = fetcher.fetch(
+            url,
+            timeout_seconds=min(DEFAULT_PUBLIC_GET_TIMEOUT_SECONDS, duration_cap_seconds),
+        )
+        visibility = classify_pf_xbtusd_symbol_visibility(body, endpoint=ep)
+        if visibility != "not_checked":
+            symbol_visibility = visibility
+        network_calls.append(
+            NetworkCallRecord(
+                endpoint=ep,
+                http_status=status,
+                http_status_class=_http_status_class(status),
+                response_size_bytes=len(body),
+                response_sha256=_sha256_hex(body),
+            )
+        )
         endpoints_called.append(ep)
-    return endpoints_called, request_count
+    request_count = len(endpoints_called)
+    proven = request_count > 0 and all(200 <= rec.http_status < 300 for rec in network_calls)
+    return NetworkReachabilityResult(
+        endpoints_called=endpoints_called,
+        request_count=request_count,
+        network_calls=network_calls,
+        pf_xbtusd_symbol_visibility=symbol_visibility,
+        network_reachability_proven=proven,
+    )
 
 
 def write_durable_evidence_bundle(
@@ -457,18 +597,22 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
     endpoints_called: list[str] = []
     request_count = 0
 
+    network_result: NetworkReachabilityResult | None = None
     if args.execute_network:
         if args.confirm_futures_zero_order_reachability != CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY:
             _die("ERR: missing or invalid --confirm-futures-zero-order-reachability token")
-        if fetcher is None:
-            _die(
-                "ERR: network execute requires injected fetcher in tests; no live urllib in CLI v0"
-            )
-        endpoints_called, request_count = run_zero_order_public_reachability(
+        active_fetcher: PublicRestFetcher = (
+            fetcher
+            if fetcher is not None
+            else default_safe_public_rest_fetcher(args.rest_base_url)
+        )
+        network_result = run_zero_order_public_reachability(
             rest_base_url=args.rest_base_url,
             duration_cap_seconds=args.duration_cap_seconds,
-            fetcher=fetcher,
+            fetcher=active_fetcher,
         )
+        endpoints_called = network_result.endpoints_called
+        request_count = network_result.request_count
         plan = HarnessPlan(**{**asdict(plan), "network_enabled": True})
 
     mono_end = time.monotonic()
@@ -488,6 +632,13 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
         network_host=DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
         run_id=args.run_id,
         pe8_pass=False,
+        network_reachability_proven=(
+            network_result.network_reachability_proven if network_result else False
+        ),
+        network_calls=network_result.network_calls if network_result else None,
+        pf_xbtusd_symbol_visibility=(
+            network_result.pf_xbtusd_symbol_visibility if network_result else "not_checked"
+        ),
     )
     evaluation = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
     evidence["bounded_futures_testnet_pass"] = evaluation["bounded_futures_testnet_pass"]

--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -602,9 +602,7 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
         if args.confirm_futures_zero_order_reachability != CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY:
             _die("ERR: missing or invalid --confirm-futures-zero-order-reachability token")
         active_fetcher: PublicRestFetcher = (
-            fetcher
-            if fetcher is not None
-            else default_safe_public_rest_fetcher(args.rest_base_url)
+            fetcher if fetcher is not None else default_safe_public_rest_fetcher(args.rest_base_url)
         )
         network_result = run_zero_order_public_reachability(
             rest_base_url=args.rest_base_url,

--- a/src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_exchange_impl_contract_v0.py
@@ -23,7 +23,7 @@ from src.ops.bounded_futures_testnet_contract_v0 import (
 
 PACKAGE_MARKER = "BOUNDED_FUTURES_TESTNET_EXCHANGE_IMPL_CONTRACT_V0=true"
 EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED = False
-ARCHIVE_EXCHANGE_CLIENT_PRESENT = False
+ARCHIVE_EXCHANGE_CLIENT_PRESENT = True
 FUTURES_EXECUTE_AUTHORITY_ADDED = False
 
 ALLOWED_IMPL_KINDS: frozenset[str] = frozenset({"offline_contract_stub"})

--- a/src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_runtime_harness_contract_v0.py
@@ -103,8 +103,10 @@ def validate_futures_testnet_runtime_harness_impl_descriptor(
         result["fail_reasons"].append("ARCHIVE_HARNESS_SCRIPT_PRESENT must be true")
     if ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW:
         result["fail_reasons"].append("ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW must be false")
-    if ARCHIVE_EXCHANGE_CLIENT_PRESENT:
-        result["fail_reasons"].append("ARCHIVE_EXCHANGE_CLIENT_PRESENT must be false")
+    if ARCHIVE_EXCHANGE_CLIENT_PRESENT and EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED:
+        result["fail_reasons"].append(
+            "ARCHIVE_EXCHANGE_CLIENT_PRESENT requires EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED false"
+        )
 
     exchange_result = validate_futures_testnet_exchange_impl_descriptor(descriptor.exchange_impl)
     result["exchange_impl_pass"] = exchange_result["exchange_impl_pass"]

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -42,12 +42,13 @@ def _durable_test_archive_root(tmp_path: Path) -> Path:
 
 
 class _FakeFetcher:
-    def __init__(self) -> None:
+    def __init__(self, *, body: bytes | None = None) -> None:
         self.urls: list[str] = []
+        self._body = body if body is not None else b'{"tickers":[{"symbol":"PF_XBTUSD"}]}'
 
     def fetch(self, url: str, *, timeout_seconds: float) -> tuple[int, bytes]:
         self.urls.append(url)
-        return 200, b"{}"
+        return 200, self._body
 
 
 def _default_namespace(**overrides: object) -> argparse.Namespace:
@@ -141,20 +142,42 @@ def test_execute_network_without_confirm_token_fails(tmp_path: Path) -> None:
     assert exc.value.code == harness.USAGE_EXIT
 
 
-def test_execute_network_without_fetcher_fails_even_with_confirm(tmp_path: Path) -> None:
+def test_safe_public_urllib_fetcher_marker_present() -> None:
+    assert harness.SAFE_PUBLIC_URLLIB_FETCHER_PRESENT is True
+    text = HARNESS_SCRIPT.read_text(encoding="utf-8")
+    assert "SafePublicUrllibRestFetcher" in text
+    assert "SAFE_PUBLIC_URLLIB_FETCHER_PRESENT" in text
+
+
+def test_execute_network_default_fetcher_without_live_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     archive = _durable_test_archive_root(tmp_path)
-    argv = [
-        "--archive-root",
-        str(archive),
-        "--run-id",
-        "testrun2",
-        "--execute-network",
-        "--confirm-futures-zero-order-reachability",
-        harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
-    ]
-    with pytest.raises(SystemExit) as exc:
-        harness.main(argv)
-    assert exc.value.code == harness.USAGE_EXIT
+    fake = _FakeFetcher()
+
+    def _factory(rest_base_url: str) -> _FakeFetcher:
+        assert rest_base_url == harness.DEFAULT_REST_BASE_URL
+        return fake
+
+    monkeypatch.setattr(harness, "default_safe_public_rest_fetcher", _factory)
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "defaultfetcher",
+            "--execute-network",
+            "--confirm-futures-zero-order-reachability",
+            harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+        ],
+    )
+    assert rc == 0
+    assert fake.urls
+    bundle = list((archive / "runtime").iterdir())[0]
+    evidence = json.loads((bundle / "FUTURES_EVIDENCE.json").read_text(encoding="utf-8"))
+    assert evidence["request_count"] == 2
+    assert evidence["network_reachability_proven"] is True
+    assert evidence["pf_xbtusd_symbol_visibility"] == "visible"
 
 
 def test_plan_only_dry_run_writes_durable_evidence(tmp_path: Path) -> None:
@@ -197,6 +220,87 @@ def test_fake_fetcher_network_path_no_sendorder(tmp_path: Path) -> None:
         assert "demo-futures.kraken.com" in url
         assert "sendorder" not in url
         assert "api.kraken.com" not in url
+    bundle = list((archive / "runtime").iterdir())[0]
+    evidence = json.loads((bundle / "FUTURES_EVIDENCE.json").read_text(encoding="utf-8"))
+    assert evidence["request_count"] == 2
+    assert "/derivatives/api/v3/tickers" in evidence["endpoints_called"]
+    assert evidence["order_attempted"] is False
+    assert evidence["fills"] == 0
+    assert evidence["pf_xbtusd_symbol_visibility"] == "visible"
+    evidence_dump = json.dumps(evidence)
+    assert '{"tickers"' not in evidence_dump
+    for call in evidence["network_calls"]:
+        assert "response_sha256" in call
+        assert call["response_size_bytes"] >= 0
+        assert set(call.keys()) == {
+            "endpoint",
+            "http_status",
+            "http_status_class",
+            "response_size_bytes",
+            "response_sha256",
+        }
+
+
+def test_assert_network_url_rejects_forbidden_host() -> None:
+    with pytest.raises(SystemExit):
+        harness._assert_network_url_allowed(
+            "https://api.kraken.com/derivatives/api/v3/tickers",
+            harness.DEFAULT_REST_BASE_URL,
+        )
+
+
+def test_assert_network_url_rejects_non_allowlisted_path() -> None:
+    with pytest.raises(SystemExit):
+        harness._assert_network_url_allowed(
+            "https://demo-futures.kraken.com/derivatives/api/v3/sendorder",
+            harness.DEFAULT_REST_BASE_URL,
+        )
+
+
+def test_tickers_path_increments_request_count_and_endpoints() -> None:
+    fetcher = _FakeFetcher(body=b'{"tickers":[{"symbol":"PF_XBTUSD"}]}')
+    result = harness.run_zero_order_public_reachability(
+        rest_base_url=harness.DEFAULT_REST_BASE_URL,
+        duration_cap_seconds=60,
+        fetcher=fetcher,
+    )
+    assert result.request_count == 2
+    assert "/derivatives/api/v3/tickers" in result.endpoints_called
+    assert result.pf_xbtusd_symbol_visibility == "visible"
+    assert result.network_reachability_proven is True
+
+
+def test_pf_xbtusd_not_visible_classification() -> None:
+    fetcher = _FakeFetcher(body=b'{"tickers":[{"symbol":"PF_ETHUSD"}]}')
+    result = harness.run_zero_order_public_reachability(
+        rest_base_url=harness.DEFAULT_REST_BASE_URL,
+        duration_cap_seconds=60,
+        fetcher=fetcher,
+    )
+    assert result.pf_xbtusd_symbol_visibility == "not_visible"
+
+
+def test_pf_xbtusd_unparseable_classification() -> None:
+    fetcher = _FakeFetcher(body=b"not-json")
+    result = harness.run_zero_order_public_reachability(
+        rest_base_url=harness.DEFAULT_REST_BASE_URL,
+        duration_cap_seconds=60,
+        fetcher=fetcher,
+    )
+    assert result.pf_xbtusd_symbol_visibility == "response_unparseable"
+
+
+def test_plan_only_network_reachability_not_proven(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    harness.main(["--archive-root", str(archive), "--run-id", "planonly2"])
+    evidence = json.loads(
+        list((archive / "runtime").iterdir())[0].joinpath("FUTURES_EVIDENCE.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert evidence["request_count"] == 0
+    assert evidence["network_reachability_proven"] is False
+    assert evidence["pf_xbtusd_symbol_visibility"] == "not_checked"
 
 
 def test_pe8_zero_order_spec_accepts_harness_evidence() -> None:
@@ -208,11 +312,13 @@ def test_pe8_zero_order_spec_accepts_harness_evidence() -> None:
     )
     evidence = harness.build_zero_order_evidence_payload(
         timing=timing,
-        endpoints_called=list(harness.ZERO_ORDER_PUBLIC_ENDPOINTS),
+        endpoints_called=list(harness.ZERO_ORDER_PUBLIC_ENDPOINT_ORDER),
         request_count=2,
         network_host="https://demo-futures.kraken.com",
         run_id="offline",
         pe8_pass=False,
+        network_reachability_proven=True,
+        pf_xbtusd_symbol_visibility="visible",
     )
     spec = default_bounded_futures_zero_order_reachability_v0_spec()
     result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -294,9 +294,9 @@ def test_plan_only_network_reachability_not_proven(tmp_path: Path) -> None:
     archive = _durable_test_archive_root(tmp_path)
     harness.main(["--archive-root", str(archive), "--run-id", "planonly2"])
     evidence = json.loads(
-        list((archive / "runtime").iterdir())[0].joinpath("FUTURES_EVIDENCE.json").read_text(
-            encoding="utf-8"
-        )
+        list((archive / "runtime").iterdir())[0]
+        .joinpath("FUTURES_EVIDENCE.json")
+        .read_text(encoding="utf-8")
     )
     assert evidence["request_count"] == 0
     assert evidence["network_reachability_proven"] is False

--- a/tests/ops/test_bounded_futures_testnet_exchange_impl_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_exchange_impl_contract_v0.py
@@ -49,7 +49,7 @@ def test_package_marker_present() -> None:
 def test_exchange_impl_not_authorized_and_no_network() -> None:
     assert FUTURES_SESSION_AUTHORIZED_NOW is False
     assert EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED is False
-    assert ARCHIVE_EXCHANGE_CLIENT_PRESENT is False
+    assert ARCHIVE_EXCHANGE_CLIENT_PRESENT is True
     assert FUTURES_EXECUTE_AUTHORITY_ADDED is False
 
 


### PR DESCRIPTION
## Summary

- Adds bounded `SafePublicUrllibRestFetcher` (stdlib GET only) to `archive_futures_testnet_harness_v0.py` for allowlisted demo-futures public endpoints (`/tickers`, `/instruments`).
- Extends zero-order evidence with `network_reachability_proven`, `network_calls` (status class, size, sha256), and `pf_xbtusd_symbol_visibility`.
- Sets `ARCHIVE_EXCHANGE_CLIENT_PRESENT=true` with PE-10 guard unchanged (`EXCHANGE_IMPL_NETWORK_CALLS_ALLOWED=false`).
- Default remains plan-only; `--execute-network` still requires explicit confirm token.

## Input bundles (manifest-verified)

1. `planning/futures_network_reachability_stage_charter_no_run_v0_20260604T151104Z`
2. `closeout/bounded_futures_zero_order_harness_plan_only_post_run_evidence_review_v0_20260604T150850Z`
3. `closeout/bounded_futures_zero_order_harness_plan_only_run_closeout_v0_20260604T150718Z`
4. `closeout/pr3987_governed_archive_futures_testnet_harness_post_merge_closeout_v0_20260604T150233Z`
5. `planning/reprepared_explicit_bounded_futures_zero_order_execute_command_no_auto_run_v0_20260604T150430Z`

## Safety boundaries

- No orders, credentials, live, preflight lift, arming, Master-V2, or strategy authority.
- No POST/private/trading endpoints; host/path allowlist enforced fail-closed.
- No real network in tests (fake fetcher / monkeypatched default fetcher only).

## Validations

- Targeted pytest: 66 passed (archive harness + bounded futures contracts)
- `ruff check` on changed Python files: pass

## Next

After merge: post-merge closeout bundle, then reprepare explicit network reachability command (NO-AUTO-RUN). No execute in this PR.

Made with [Cursor](https://cursor.com)