### PR TITLE
ops: add private-readonly futures harness contract

### DIFF
--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -37,9 +37,16 @@ from src.ops.bounded_futures_private_readonly_contract_v0 import (
     CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
     DEMO_FUTURES_REST_BASE_URL,
     FUTURES_PRIVATE_READONLY_GET_ENDPOINTS,
+    PRIVATE_READONLY_HTTP_WIRING_PRESENT,
     PRIVATE_READONLY_MODE,
+    PrivateReadonlyHttpRequest,
+    PrivateReadonlyRestFetcher,
     assert_private_readonly_authority_unchanged,
+    build_private_readonly_evidence_from_network,
     build_private_readonly_plan_evidence_skeleton,
+    resolve_private_readonly_credentials_from_environ,
+    run_private_readonly_reachability,
+    validate_private_readonly_url,
 )
 from src.ops.bounded_futures_testnet_contract_v0 import (
     DEFAULT_INSTRUMENT,
@@ -65,6 +72,7 @@ from src.ops.bounded_futures_testnet_runtime_harness_contract_v0 import (
 
 PACKAGE_MARKER = "ARCHIVE_FUTURES_TESTNET_HARNESS_V0=true"
 SAFE_PUBLIC_URLLIB_FETCHER_PRESENT = True
+SAFE_PRIVATE_READONLY_URLLIB_FETCHER_PRESENT = PRIVATE_READONLY_HTTP_WIRING_PRESENT
 HARNESS_VERSION = "archive_futures_testnet_harness_v0"
 
 DEFAULT_MODE = "zero_order_reachability_only"
@@ -272,8 +280,14 @@ def _validate_private_readonly_harness_namespace(
         reasons.append("scheduler/background must be disabled")
     if args.allow_unbounded:
         reasons.append("unbounded loops forbidden")
-    if args.execute_network:
-        reasons.append("execute-network forbidden for private_readonly mode in v0")
+    if (
+        args.execute_network
+        and (getattr(args, "confirm_futures_private_readonly_reachability", "") or "")
+        != CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY
+    ):
+        reasons.append(
+            "confirm-futures-private-readonly-reachability token required when execute-network set"
+        )
 
     for key in (
         "FUTURES_EXECUTE_AUTHORIZED",
@@ -467,11 +481,46 @@ def build_private_readonly_evidence_payload(
             "bounded_futures_testnet_pass": pe8_pass,
             "network_target_allowlist": sorted(FUTURES_PRIVATE_READONLY_GET_ENDPOINTS),
             "rest_base_url": DEMO_FUTURES_REST_BASE_URL,
-            "private_readonly_execute_wired": False,
+            "private_readonly_http_wiring_present": PRIVATE_READONLY_HTTP_WIRING_PRESENT,
+            "private_readonly_execute_wired": True,
             "confirm_token_reserved": CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
         }
     )
     return evidence
+
+
+class SafePrivateReadonlyUrllibRestFetcher:
+    """Bounded stdlib urllib private GET client (demo allowlist + auth headers)."""
+
+    def fetch(
+        self,
+        http_request: PrivateReadonlyHttpRequest,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[int, bytes]:
+        url_reasons = validate_private_readonly_url(
+            http_request.url,
+            rest_base_url=DEMO_FUTURES_REST_BASE_URL,
+        )
+        if url_reasons:
+            _die(f"ERR: private-readonly url blocked: {url_reasons[0]}")
+        if http_request.method != "GET":
+            _die(f"ERR: private-readonly method must be GET (got {http_request.method})")
+        bounded_timeout = min(
+            float(timeout_seconds),
+            float(DEFAULT_DURATION_CAP_SECONDS),
+        )
+        req = request.Request(http_request.url, method="GET", headers=dict(http_request.headers))
+        try:
+            with request.urlopen(req, timeout=bounded_timeout) as resp:
+                status = int(getattr(resp, "status", resp.getcode()))
+                return status, resp.read()
+        except error.HTTPError as exc:
+            return int(exc.code), exc.read() or b""
+
+
+def default_safe_private_readonly_rest_fetcher() -> SafePrivateReadonlyUrllibRestFetcher:
+    return SafePrivateReadonlyUrllibRestFetcher()
 
 
 def _assert_network_url_allowed(url: str, rest_base: str) -> None:
@@ -569,6 +618,7 @@ def write_durable_evidence_bundle(
         "\n".join(
             [
                 "FUTURES_EXECUTE_AUTHORIZED=false",
+                "FUTURES_PRIVATE_API_AUTHORIZED=false",
                 "FUTURES_SESSION_AUTHORIZED_NOW=false",
                 "NEXT_EXECUTE_ALLOWED=false",
                 "LIVE_NOT_AUTHORIZED=true",
@@ -620,7 +670,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--execute-network",
         action="store_true",
-        help="Allow allowlisted public GET after confirm token (default: plan-only, no network).",
+        help="Allow allowlisted GET after mode-specific confirm token (default: plan-only).",
     )
     parser.add_argument(
         "--confirm-futures-zero-order-reachability",
@@ -630,7 +680,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--confirm-futures-private-readonly-reachability",
         default="",
-        help="Reserved for future private-readonly execute (not wired in v0).",
+        help="Required exact token when --execute-network is set in private_readonly mode.",
     )
     parser.add_argument("--scheduler-enabled", action="store_true")
     parser.add_argument("--background-enabled", action="store_true")
@@ -644,7 +694,13 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+    *,
+    fetcher: PublicRestFetcher | None = None,
+    private_fetcher: PrivateReadonlyRestFetcher | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> int:
     if FUTURES_SESSION_AUTHORIZED_NOW:
         _die("ERR: FUTURES_SESSION_AUTHORIZED_NOW must be false")
     if RUNTIME_HARNESS_EXECUTE_ALLOWED or RUNTIME_HARNESS_NETWORK_ALLOWED:
@@ -656,7 +712,8 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
     args = parser.parse_args(argv)
     _require_safe_run_id(args.run_id)
 
-    fail_reasons = validate_harness_namespace(args)
+    env = environ if environ is not None else {}
+    fail_reasons = validate_harness_namespace(args, environ=env)
     if fail_reasons:
         for r in fail_reasons:
             print(f"ERR: {r}", file=sys.stderr)
@@ -691,7 +748,31 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
     request_count = 0
 
     network_result: NetworkReachabilityResult | None = None
-    if args.execute_network:
+    private_result = None
+    if args.execute_network and args.mode == PRIVATE_READONLY_MODE:
+        credentials = resolve_private_readonly_credentials_from_environ(env)
+        if credentials is None:
+            _die(
+                "ERR: KRAKEN_FUTURES_DEMO_API_KEY and KRAKEN_FUTURES_DEMO_API_SECRET required "
+                "for private-readonly execute-network"
+            )
+        api_key, api_secret = credentials
+        active_private_fetcher: PrivateReadonlyRestFetcher = (
+            private_fetcher
+            if private_fetcher is not None
+            else default_safe_private_readonly_rest_fetcher()
+        )
+        private_result = run_private_readonly_reachability(
+            rest_base_url=args.rest_base_url,
+            api_key=api_key,
+            api_secret_b64=api_secret,
+            fetcher=active_private_fetcher,
+            duration_cap_seconds=args.duration_cap_seconds,
+        )
+        endpoints_called = private_result.endpoints_called
+        request_count = private_result.request_count
+        plan = HarnessPlan(**{**asdict(plan), "network_enabled": True})
+    elif args.execute_network:
         if args.confirm_futures_zero_order_reachability != CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY:
             _die("ERR: missing or invalid --confirm-futures-zero-order-reachability token")
         active_fetcher: PublicRestFetcher = (
@@ -717,11 +798,20 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
 
     if args.mode == PRIVATE_READONLY_MODE:
         spec = default_bounded_futures_private_readonly_reachability_v0_spec()
-        evidence = build_private_readonly_evidence_payload(
-            timing=timing,
-            run_id=args.run_id,
-            pe8_pass=False,
-        )
+        if private_result is not None:
+            evidence = build_private_readonly_evidence_from_network(
+                timing=timing,
+                run_id=args.run_id,
+                result=private_result,
+                pe8_pass=False,
+                harness_version=HARNESS_VERSION,
+            )
+        else:
+            evidence = build_private_readonly_evidence_payload(
+                timing=timing,
+                run_id=args.run_id,
+                pe8_pass=False,
+            )
     else:
         spec = default_bounded_futures_zero_order_reachability_v0_spec()
         evidence = build_zero_order_evidence_payload(
@@ -753,7 +843,7 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
         evidence=evidence,
         evaluation=evaluation,
     )
-    plan_only = not args.execute_network or args.mode == PRIVATE_READONLY_MODE
+    plan_only = not args.execute_network
     print(
         json.dumps(
             {"evidence_dir": str(out), "plan_only": plan_only, "mode": args.mode},

--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -33,6 +33,14 @@ from scripts.ops.primary_evidence_retention_v0 import (
 from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
     DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
 )
+from src.ops.bounded_futures_private_readonly_contract_v0 import (
+    CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
+    DEMO_FUTURES_REST_BASE_URL,
+    FUTURES_PRIVATE_READONLY_GET_ENDPOINTS,
+    PRIVATE_READONLY_MODE,
+    assert_private_readonly_authority_unchanged,
+    build_private_readonly_plan_evidence_skeleton,
+)
 from src.ops.bounded_futures_testnet_contract_v0 import (
     DEFAULT_INSTRUMENT,
     DEFAULT_MARGIN_MODE,
@@ -43,6 +51,7 @@ from src.ops.bounded_futures_testnet_contract_v0 import (
     EVIDENCE_SOURCE_FUTURES_HARNESS,
     FUTURES_SESSION_AUTHORIZED_NOW,
     REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS,
+    default_bounded_futures_private_readonly_reachability_v0_spec,
     default_bounded_futures_zero_order_reachability_v0_spec,
     evaluate_bounded_futures_testnet_evidence,
 )
@@ -234,12 +243,61 @@ def _reject_spot_lane_flags(args: argparse.Namespace) -> None:
             _die(f"ERR: forbidden spot entrypoint reference: {frag}")
 
 
+def _validate_private_readonly_harness_namespace(
+    args: argparse.Namespace,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Fail-closed validation for private_readonly_reachability_only (plan-only v0)."""
+    reasons: list[str] = []
+    env = environ if environ is not None else {}
+    assert_private_readonly_authority_unchanged()
+
+    if args.mode != PRIVATE_READONLY_MODE:
+        reasons.append(f"mode must be {PRIVATE_READONLY_MODE!r}")
+    if args.instrument in REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS:
+        reasons.append(f"instrument {args.instrument!r} is rejected placeholder")
+    if args.instrument != DEFAULT_FUTURES_SYMBOL:
+        reasons.append(f"instrument must default to {DEFAULT_FUTURES_SYMBOL!r}")
+    if args.order_cap != DEFAULT_ORDER_CAP or args.order_cap < 0:
+        reasons.append("order_cap must be 0")
+    if args.validate_only_order_cap != DEFAULT_VALIDATE_ONLY_ORDER_CAP:
+        reasons.append("validate_only_order_cap must be 0")
+    if args.duration_cap_seconds > DEFAULT_DURATION_CAP_SECONDS or args.duration_cap_seconds <= 0:
+        reasons.append("duration_cap_seconds must be in (0, 300]")
+    url_reason = _rest_base_url_fail_reason(args.rest_base_url)
+    if url_reason:
+        reasons.append(url_reason)
+    if args.scheduler_enabled or args.background_enabled:
+        reasons.append("scheduler/background must be disabled")
+    if args.allow_unbounded:
+        reasons.append("unbounded loops forbidden")
+    if args.execute_network:
+        reasons.append("execute-network forbidden for private_readonly mode in v0")
+
+    for key in (
+        "FUTURES_EXECUTE_AUTHORIZED",
+        "FUTURES_PRIVATE_API_AUTHORIZED",
+        "FUTURES_SESSION_AUTHORIZED_NOW",
+        "NEXT_EXECUTE_ALLOWED",
+        "READY_FOR_OPERATOR_ARMING",
+    ):
+        if env.get(key, "").lower() in ("1", "true", "yes"):
+            reasons.append(f"{key} must not be true in environment")
+
+    _reject_spot_lane_flags(args)
+    return reasons
+
+
 def validate_harness_namespace(
     args: argparse.Namespace,
     *,
     environ: Mapping[str, str] | None = None,
 ) -> list[str]:
     """Fail-closed validation; returns fail reasons (empty = pass)."""
+    if args.mode == PRIVATE_READONLY_MODE:
+        return _validate_private_readonly_harness_namespace(args, environ=environ)
+
     reasons: list[str] = []
     env = environ if environ is not None else {}
 
@@ -391,6 +449,31 @@ def build_zero_order_evidence_payload(
     }
 
 
+def build_private_readonly_evidence_payload(
+    *,
+    timing: HarnessTiming,
+    run_id: str,
+    pe8_pass: bool,
+) -> dict[str, Any]:
+    """Plan-only private-readonly evidence (no network, no credential values)."""
+    evidence = build_private_readonly_plan_evidence_skeleton(run_id=run_id)
+    evidence.update(
+        {
+            "harness_version": HARNESS_VERSION,
+            "monotonic_elapsed_seconds": timing.monotonic_elapsed_seconds,
+            "wall_clock_elapsed_seconds": timing.wall_clock_elapsed_seconds,
+            "wall_clock_start_utc": timing.wall_clock_start_utc,
+            "wall_clock_end_utc": timing.wall_clock_end_utc,
+            "bounded_futures_testnet_pass": pe8_pass,
+            "network_target_allowlist": sorted(FUTURES_PRIVATE_READONLY_GET_ENDPOINTS),
+            "rest_base_url": DEMO_FUTURES_REST_BASE_URL,
+            "private_readonly_execute_wired": False,
+            "confirm_token_reserved": CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
+        }
+    )
+    return evidence
+
+
 def _assert_network_url_allowed(url: str, rest_base: str) -> None:
     parsed = urlparse(url)
     if parsed.scheme != "https" or parsed.netloc != "demo-futures.kraken.com":
@@ -461,7 +544,12 @@ def write_durable_evidence_bundle(
     evaluation: dict[str, Any],
 ) -> Path:
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    out = archive_root / "runtime" / f"bounded_futures_zero_order_{run_id}_{ts}"
+    runtime_prefix = (
+        "bounded_futures_private_readonly"
+        if plan.mode == PRIVATE_READONLY_MODE
+        else "bounded_futures_zero_order"
+    )
+    out = archive_root / "runtime" / f"{runtime_prefix}_{run_id}_{ts}"
     if is_under_tmp(out):
         _die("ERR: evidence root must not be under /tmp")
     out.mkdir(parents=True, exist_ok=True)
@@ -504,8 +592,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--mode",
         default=DEFAULT_MODE,
-        choices=[DEFAULT_MODE],
-        help="Run mode (zero-order reachability only).",
+        choices=[DEFAULT_MODE, PRIVATE_READONLY_MODE],
+        help="Run mode: zero-order public or private-readonly plan-only (v0).",
     )
     parser.add_argument("--instrument", default=DEFAULT_FUTURES_SYMBOL)
     parser.add_argument("--rest-base-url", default=DEFAULT_REST_BASE_URL)
@@ -538,6 +626,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--confirm-futures-zero-order-reachability",
         default="",
         help="Required exact token when --execute-network is set.",
+    )
+    parser.add_argument(
+        "--confirm-futures-private-readonly-reachability",
+        default="",
+        help="Reserved for future private-readonly execute (not wired in v0).",
     )
     parser.add_argument("--scheduler-enabled", action="store_true")
     parser.add_argument("--background-enabled", action="store_true")
@@ -622,22 +715,30 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
         wall_clock_end_utc=wall_end,
     )
 
-    spec = default_bounded_futures_zero_order_reachability_v0_spec()
-    evidence = build_zero_order_evidence_payload(
-        timing=timing,
-        endpoints_called=endpoints_called,
-        request_count=request_count,
-        network_host=DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
-        run_id=args.run_id,
-        pe8_pass=False,
-        network_reachability_proven=(
-            network_result.network_reachability_proven if network_result else False
-        ),
-        network_calls=network_result.network_calls if network_result else None,
-        pf_xbtusd_symbol_visibility=(
-            network_result.pf_xbtusd_symbol_visibility if network_result else "not_checked"
-        ),
-    )
+    if args.mode == PRIVATE_READONLY_MODE:
+        spec = default_bounded_futures_private_readonly_reachability_v0_spec()
+        evidence = build_private_readonly_evidence_payload(
+            timing=timing,
+            run_id=args.run_id,
+            pe8_pass=False,
+        )
+    else:
+        spec = default_bounded_futures_zero_order_reachability_v0_spec()
+        evidence = build_zero_order_evidence_payload(
+            timing=timing,
+            endpoints_called=endpoints_called,
+            request_count=request_count,
+            network_host=DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
+            run_id=args.run_id,
+            pe8_pass=False,
+            network_reachability_proven=(
+                network_result.network_reachability_proven if network_result else False
+            ),
+            network_calls=network_result.network_calls if network_result else None,
+            pf_xbtusd_symbol_visibility=(
+                network_result.pf_xbtusd_symbol_visibility if network_result else "not_checked"
+            ),
+        )
     evaluation = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
     evidence["bounded_futures_testnet_pass"] = evaluation["bounded_futures_testnet_pass"]
     if not evaluation["bounded_futures_testnet_pass"]:
@@ -652,9 +753,10 @@ def main(argv: list[str] | None = None, *, fetcher: PublicRestFetcher | None = N
         evidence=evidence,
         evaluation=evaluation,
     )
+    plan_only = not args.execute_network or args.mode == PRIVATE_READONLY_MODE
     print(
         json.dumps(
-            {"evidence_dir": str(out), "plan_only": not args.execute_network},
+            {"evidence_dir": str(out), "plan_only": plan_only, "mode": args.mode},
             indent=2,
         )
     )

--- a/src/ops/bounded_futures_private_readonly_contract_v0.py
+++ b/src/ops/bounded_futures_private_readonly_contract_v0.py
@@ -1,0 +1,354 @@
+"""Kraken Futures Demo private-readonly reachability contract (v0).
+
+Offline policy for private_readonly_reachability_only harness mode: GET allowlist,
+order/host blocklist, response redaction rules. Does not authorize network, private
+API execute, credentials read, or orders.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
+    DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
+    FUTURES_TESTNET_ENDPOINT_ALLOWLIST,
+    LIVE_FUTURES_HOST_PREFIXES,
+    SPOT_KRAKEN_ENDPOINT_PREFIXES,
+)
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    DEFAULT_INSTRUMENT,
+    DEFAULT_MARGIN_MODE,
+    DEFAULT_MARKET_TYPE,
+    DEFAULT_ORDER_POLICY,
+    DEFAULT_POSITION_MODE,
+    EVIDENCE_SOURCE_FUTURES_HARNESS,
+    FUTURES_SESSION_AUTHORIZED_NOW,
+)
+from src.ops.kraken_futures_demo_credential_presence_contract_v0 import (
+    build_checker_boundary_v0,
+)
+
+PACKAGE_MARKER = "BOUNDED_FUTURES_PRIVATE_READONLY_CONTRACT_V0=true"
+PRIVATE_READONLY_MODE = "private_readonly_reachability_only"
+PRIVATE_READONLY_SESSION_CLASS = "bounded-futures-private-readonly-reachability-v0"
+PRIVATE_READONLY_MAX_REQUEST_COUNT = 3
+
+DEMO_FUTURES_HOST = "demo-futures.kraken.com"
+DEMO_FUTURES_REST_BASE_URL = f"{DEFAULT_FUTURES_TESTNET_NETWORK_HOST}/derivatives/api/v3"
+
+FUTURES_PRIVATE_READONLY_GET_ENDPOINTS: frozenset[str] = frozenset(
+    {
+        "/derivatives/api/v3/accounts",
+        "/derivatives/api/v3/openpositions",
+        "/derivatives/api/v3/openorders",
+    }
+)
+
+PRIVATE_READONLY_ENDPOINT_ORDER: tuple[str, ...] = (
+    "/derivatives/api/v3/accounts",
+    "/derivatives/api/v3/openpositions",
+    "/derivatives/api/v3/openorders",
+)
+
+FUTURES_PRIVATE_READONLY_FORBIDDEN_PATH_SUBSTRINGS: tuple[str, ...] = (
+    "sendorder",
+    "cancelorder",
+    "cancelallorders",
+    "cancelall",
+    "validate-order",
+    "validateorder",
+    "batchorder",
+    "withdraw",
+    "transfer",
+)
+
+FUTURES_ORDER_MUTATION_ENDPOINTS: frozenset[str] = frozenset(
+    {
+        "/derivatives/api/v3/sendorder",
+        "/derivatives/api/v3/cancelorder",
+        "/derivatives/api/v3/cancelallorders",
+    }
+)
+
+ALLOWED_HTTP_METHODS_PRIVATE_READONLY: frozenset[str] = frozenset({"GET"})
+
+CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY = (
+    "I_ACCEPT_ARCHIVE_FUTURES_PRIVATE_READONLY_REACHABILITY_MANUAL_EXECUTE"
+)
+
+FUTURES_PRIVATE_API_AUTHORIZED = False
+PRIVATE_READONLY_EXECUTE_AUTHORIZED_NOW = False
+PRIVATE_READONLY_NETWORK_AUTHORIZED_NOW = False
+
+_REDACTED_NETWORK_CALL_KEYS = frozenset(
+    {
+        "endpoint",
+        "http_status",
+        "http_status_class",
+        "response_size_bytes",
+        "response_sha256",
+        "response_redacted",
+        "parsed_summary",
+    }
+)
+
+
+def assert_private_readonly_authority_unchanged() -> None:
+    """Defense-in-depth: module must not flip authorization flags."""
+    if FUTURES_SESSION_AUTHORIZED_NOW:
+        raise RuntimeError("FUTURES_SESSION_AUTHORIZED_NOW must remain false")
+    if FUTURES_PRIVATE_API_AUTHORIZED:
+        raise RuntimeError("FUTURES_PRIVATE_API_AUTHORIZED must remain false")
+    if PRIVATE_READONLY_EXECUTE_AUTHORIZED_NOW:
+        raise RuntimeError("PRIVATE_READONLY_EXECUTE_AUTHORIZED_NOW must remain false")
+    if PRIVATE_READONLY_NETWORK_AUTHORIZED_NOW:
+        raise RuntimeError("PRIVATE_READONLY_NETWORK_AUTHORIZED_NOW must remain false")
+
+
+def path_contains_forbidden_substring(path: str) -> str | None:
+    lowered = path.lower()
+    for frag in FUTURES_PRIVATE_READONLY_FORBIDDEN_PATH_SUBSTRINGS:
+        if frag in lowered:
+            return frag
+    return None
+
+
+def validate_private_readonly_endpoint_path(path: str) -> list[str]:
+    """Fail-closed path validation for private-readonly stage."""
+    reasons: list[str] = []
+    if not path.startswith("/derivatives/api/v3/"):
+        reasons.append(f"path must be under /derivatives/api/v3/: {path!r}")
+    forbidden = path_contains_forbidden_substring(path)
+    if forbidden:
+        reasons.append(f"forbidden path substring: {forbidden}")
+    if path in FUTURES_ORDER_MUTATION_ENDPOINTS:
+        reasons.append(f"order/mutation endpoint forbidden: {path}")
+    if path in SPOT_KRAKEN_ENDPOINT_PREFIXES:
+        reasons.append(f"spot endpoint forbidden: {path}")
+    if path not in FUTURES_TESTNET_ENDPOINT_ALLOWLIST:
+        reasons.append(f"path not on futures adapter allowlist: {path}")
+    if path not in FUTURES_PRIVATE_READONLY_GET_ENDPOINTS:
+        reasons.append(f"path not on private-readonly GET allowlist: {path}")
+    return reasons
+
+
+def validate_private_readonly_http_method(method: str) -> list[str]:
+    normalized = method.strip().upper()
+    if normalized not in ALLOWED_HTTP_METHODS_PRIVATE_READONLY:
+        return [f"http method {method!r} forbidden; only GET allowed"]
+    return []
+
+
+def validate_private_readonly_rest_base_url(rest_base: str) -> list[str]:
+    reasons: list[str] = []
+    parsed = urlparse(rest_base)
+    if parsed.scheme != "https":
+        reasons.append("rest_base_url must use https")
+    if parsed.netloc != DEMO_FUTURES_HOST:
+        reasons.append(f"rest_base_url host must be {DEMO_FUTURES_HOST!r}")
+    path = (parsed.path or "").rstrip("/")
+    if path != "/derivatives/api/v3":
+        reasons.append("rest_base_url path must be /derivatives/api/v3")
+    for prefix in LIVE_FUTURES_HOST_PREFIXES:
+        if rest_base.startswith(prefix):
+            reasons.append(f"live host forbidden: {prefix}")
+    if rest_base.startswith("https://api.kraken.com"):
+        reasons.append("spot kraken.com host forbidden")
+    return reasons
+
+
+def validate_private_readonly_url(url: str, *, rest_base_url: str) -> list[str]:
+    reasons: list[str] = []
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != DEMO_FUTURES_HOST:
+        reasons.append(f"network host not allowlisted: {url}")
+    for prefix in LIVE_FUTURES_HOST_PREFIXES:
+        if url.startswith(prefix):
+            reasons.append(f"forbidden host prefix: {prefix}")
+    if not url.startswith(rest_base_url.rstrip("/")):
+        reasons.append("url must be under rest-base-url")
+    path = parsed.path or ""
+    reasons.extend(validate_private_readonly_endpoint_path(path))
+    return reasons
+
+
+def summarize_private_response_for_evidence(
+    *,
+    endpoint: str,
+    http_status: int,
+    body: bytes,
+) -> dict[str, Any]:
+    """Redacted network call metadata — no raw body, balances, or order ids."""
+    parsed_summary: dict[str, Any] = {
+        "top_level_type": "unknown",
+        "record_count": None,
+        "order_id_fields_present": False,
+    }
+    if body:
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            parsed_summary["top_level_type"] = "unparseable"
+        else:
+            if isinstance(payload, dict):
+                parsed_summary["top_level_type"] = "object"
+                parsed_summary["top_level_keys"] = sorted(str(k) for k in payload.keys())
+                for key in ("accounts", "openPositions", "openOrders", "positions", "orders"):
+                    if key in payload and isinstance(payload[key], list):
+                        parsed_summary["record_count"] = len(payload[key])
+                dump = json.dumps(payload)
+                if re.search(r'"order[_-]?id"', dump, re.IGNORECASE):
+                    parsed_summary["order_id_fields_present"] = True
+            elif isinstance(payload, list):
+                parsed_summary["top_level_type"] = "array"
+                parsed_summary["record_count"] = len(payload)
+    return {
+        "endpoint": endpoint,
+        "http_status": http_status,
+        "http_status_class": _http_status_class(http_status),
+        "response_size_bytes": len(body),
+        "response_sha256": hashlib.sha256(body).hexdigest(),
+        "response_redacted": True,
+        "parsed_summary": parsed_summary,
+    }
+
+
+def _http_status_class(status: int) -> str:
+    if 200 <= status < 300:
+        return "2xx"
+    if 400 <= status < 500:
+        return "4xx"
+    if 500 <= status < 600:
+        return "5xx"
+    return "other"
+
+
+def validate_redacted_network_call_record(record: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    extra = set(record.keys()) - _REDACTED_NETWORK_CALL_KEYS
+    if extra:
+        reasons.append(f"unexpected network call keys: {sorted(extra)}")
+    if not record.get("response_redacted"):
+        reasons.append("response_redacted must be true")
+    if "response_body" in record or "raw_response" in record:
+        reasons.append("raw response body forbidden in evidence")
+    summary = record.get("parsed_summary")
+    if isinstance(summary, dict) and summary.get("order_id_fields_present"):
+        reasons.append("order id fields must not be copied into evidence summary")
+    return reasons
+
+
+def build_private_readonly_checker_boundary() -> dict[str, Any]:
+    boundary = build_checker_boundary_v0()
+    boundary["private_readonly_harness_mode"] = PRIVATE_READONLY_MODE
+    boundary["credential_presence_implies_execute"] = False
+    return boundary
+
+
+def build_private_readonly_plan_evidence_skeleton(
+    *,
+    run_id: str,
+    rest_base_url: str = DEMO_FUTURES_REST_BASE_URL,
+) -> dict[str, Any]:
+    """Plan-only evidence template (no network, no credentials)."""
+    assert_private_readonly_authority_unchanged()
+    return {
+        "session_class": PRIVATE_READONLY_SESSION_CLASS,
+        "order_policy": DEFAULT_ORDER_POLICY,
+        "instrument": DEFAULT_INSTRUMENT,
+        "market_type": DEFAULT_MARKET_TYPE,
+        "margin_mode": DEFAULT_MARGIN_MODE,
+        "max_leverage": 5.0,
+        "leverage_within_cap": True,
+        "position_mode": DEFAULT_POSITION_MODE,
+        "order_side_semantics": "long",
+        "reduce_only_supported": True,
+        "order_attempt_count": 0,
+        "real_orders_created_count": 0,
+        "cancel_or_close_attempt_count": 0,
+        "order_notional_eur": 0.0,
+        "order_notional_within_cap": True,
+        "position_flattened_by_end": True,
+        "cancel_or_close_evidence_valid": True,
+        "futures_endpoint_isolation_pass": True,
+        "spot_endpoint_isolation_pass": True,
+        "funding_risk_acknowledged": True,
+        "liquidation_risk_acknowledged": True,
+        "risk_killswitch_scope_active": True,
+        "risk_killswitch_scope_pass": True,
+        "master_v2_double_play_authority_used": False,
+        "endpoints_called": [],
+        "network_host": DEFAULT_FUTURES_TESTNET_NETWORK_HOST,
+        "scheduler_started": False,
+        "runtime_started": False,
+        "live_env_present": False,
+        "futures_session_authorized_now": False,
+        "futures_private_api_authorized": False,
+        "order_attempted": False,
+        "order_created": False,
+        "fills": 0,
+        "positions_changed": False,
+        "credential_values_logged": False,
+        "credential_values_read": False,
+        "evidence_source": EVIDENCE_SOURCE_FUTURES_HARNESS,
+        "harness_mode": PRIVATE_READONLY_MODE,
+        "run_id": run_id,
+        "request_count": 0,
+        "private_readonly_reachability_proven": False,
+        "network_private_readonly_proven": False,
+        "network_target_allowlist": sorted(FUTURES_PRIVATE_READONLY_GET_ENDPOINTS),
+        "network_calls": [],
+        "manifest_verification_expected": True,
+        "checker_boundary_v0": build_private_readonly_checker_boundary(),
+    }
+
+
+def evaluate_private_readonly_policy(
+    *,
+    endpoints_called: list[str] | None = None,
+    http_methods: list[str] | None = None,
+    rest_base_url: str = DEMO_FUTURES_REST_BASE_URL,
+) -> dict[str, Any]:
+    """Offline policy evaluation for allowlist/blocklist."""
+    result: dict[str, Any] = {
+        "private_readonly_policy_pass": False,
+        "allowlist_exact_match": False,
+        "post_blocked": True,
+        "order_endpoints_blocked": True,
+        "live_host_blocked": True,
+        "demo_host_only": True,
+        "fail_reasons": [],
+    }
+    result["fail_reasons"].extend(validate_private_readonly_rest_base_url(rest_base_url))
+
+    methods = http_methods or ["GET"]
+    for method in methods:
+        result["fail_reasons"].extend(validate_private_readonly_http_method(method))
+    result["post_blocked"] = all(m.strip().upper() == "GET" for m in methods)
+
+    eps = endpoints_called or []
+    if eps:
+        if set(eps) - FUTURES_PRIVATE_READONLY_GET_ENDPOINTS:
+            result["fail_reasons"].append("endpoints_called outside private-readonly allowlist")
+        for ep in eps:
+            result["fail_reasons"].extend(validate_private_readonly_endpoint_path(ep))
+    else:
+        result["allowlist_exact_match"] = True
+
+    for order_ep in FUTURES_ORDER_MUTATION_ENDPOINTS:
+        if order_ep in eps:
+            result["fail_reasons"].append(f"order endpoint must remain blocked: {order_ep}")
+            result["order_endpoints_blocked"] = False
+
+    result["allowlist_exact_match"] = (
+        bool(eps) and set(eps) <= FUTURES_PRIVATE_READONLY_GET_ENDPOINTS
+    ) or not eps
+    result["demo_host_only"] = not any(
+        r for r in result["fail_reasons"] if "host" in r and "demo-futures" not in r
+    )
+    result["private_readonly_policy_pass"] = not result["fail_reasons"]
+    return result

--- a/src/ops/bounded_futures_private_readonly_contract_v0.py
+++ b/src/ops/bounded_futures_private_readonly_contract_v0.py
@@ -7,10 +7,13 @@ API execute, credentials read, or orders.
 
 from __future__ import annotations
 
+import base64
 import hashlib
+import hmac
 import json
-import re
-from typing import Any
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol, Sequence
 from urllib.parse import urlparse
 
 from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
@@ -33,7 +36,11 @@ from src.ops.kraken_futures_demo_credential_presence_contract_v0 import (
 )
 
 PACKAGE_MARKER = "BOUNDED_FUTURES_PRIVATE_READONLY_CONTRACT_V0=true"
+PRIVATE_READONLY_HTTP_WIRING_PRESENT = True
+KRAKEN_FUTURES_DEMO_API_KEY_ENV_NAME = "KRAKEN_FUTURES_DEMO_API_KEY"
+KRAKEN_FUTURES_DEMO_API_SECRET_ENV_NAME = "KRAKEN_FUTURES_DEMO_API_SECRET"
 PRIVATE_READONLY_MODE = "private_readonly_reachability_only"
+DEFAULT_PRIVATE_READONLY_GET_TIMEOUT_SECONDS = 10.0
 PRIVATE_READONLY_SESSION_CLASS = "bounded-futures-private-readonly-reachability-v0"
 PRIVATE_READONLY_MAX_REQUEST_COUNT = 3
 
@@ -87,14 +94,60 @@ PRIVATE_READONLY_NETWORK_AUTHORIZED_NOW = False
 _REDACTED_NETWORK_CALL_KEYS = frozenset(
     {
         "endpoint",
+        "http_method",
         "http_status",
         "http_status_class",
         "response_size_bytes",
         "response_sha256",
         "response_redacted",
         "parsed_summary",
+        "auth_header_names",
+        "credential_values_logged",
     }
 )
+
+_SENSITIVE_JSON_KEY_FRAGMENTS: tuple[str, ...] = (
+    "balance",
+    "available",
+    "margin",
+    "pnl",
+    "position",
+    "order",
+    "account",
+    "wallet",
+    "key",
+    "secret",
+    "authent",
+)
+
+
+@dataclass(frozen=True)
+class PrivateReadonlyHttpRequest:
+    """Transport-ready GET request; header values must never appear in evidence."""
+
+    method: str
+    url: str
+    endpoint_path: str
+    headers: dict[str, str]
+    auth_header_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PrivateReadonlyReachabilityResult:
+    endpoints_called: list[str]
+    request_count: int
+    network_calls: list[dict[str, Any]]
+    private_readonly_reachability_proven: bool
+
+
+class PrivateReadonlyRestFetcher(Protocol):
+    def fetch(
+        self,
+        http_request: PrivateReadonlyHttpRequest,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[int, bytes]:
+        """Return HTTP status and body bytes (caller redacts before evidence)."""
 
 
 def assert_private_readonly_authority_unchanged() -> None:
@@ -161,6 +214,120 @@ def validate_private_readonly_rest_base_url(rest_base: str) -> list[str]:
     return reasons
 
 
+def compute_futures_private_authent(
+    *,
+    api_secret_b64: str,
+    endpoint_path: str,
+    post_data: str = "",
+    nonce: str = "",
+) -> str:
+    """Kraken Futures v3 Authent (offline helper; secret must not be logged)."""
+    sha = hashlib.sha256()
+    sha.update(post_data.encode())
+    sha.update(nonce.encode())
+    sha.update(endpoint_path.encode())
+    digest = sha.digest()
+    secret = base64.b64decode(api_secret_b64)
+    sig = hmac.new(secret, digest, hashlib.sha512).digest()
+    return base64.b64encode(sig).decode().strip()
+
+
+def _endpoint_path_suffix(full_path: str) -> str:
+    if full_path.startswith("/derivatives/api/v3"):
+        return full_path.split("/derivatives/api/v3", 1)[-1] or ""
+    return full_path
+
+
+def build_private_readonly_get_url(rest_base_url: str, endpoint_path: str) -> str:
+    reasons = validate_private_readonly_endpoint_path(endpoint_path)
+    if reasons:
+        raise ValueError(f"private-readonly endpoint not allowed: {'; '.join(reasons)}")
+    suffix = _endpoint_path_suffix(endpoint_path)
+    return f"{rest_base_url.rstrip('/')}{suffix}"
+
+
+def build_private_readonly_http_request(
+    *,
+    rest_base_url: str,
+    endpoint_path: str,
+    api_key: str,
+    api_secret_b64: str,
+    nonce: str | None = None,
+) -> PrivateReadonlyHttpRequest:
+    """Build a single authenticated GET request (fail-closed on blocklisted paths)."""
+    method_reasons = validate_private_readonly_http_method("GET")
+    if method_reasons:
+        raise ValueError(method_reasons[0])
+    url = build_private_readonly_get_url(rest_base_url, endpoint_path)
+    url_reasons = validate_private_readonly_url(url, rest_base_url=rest_base_url)
+    if url_reasons:
+        raise ValueError(url_reasons[0])
+    nonce_value = nonce if nonce is not None else str(int(time.time() * 1000))
+    authent = compute_futures_private_authent(
+        api_secret_b64=api_secret_b64,
+        endpoint_path=endpoint_path,
+        post_data="",
+        nonce=nonce_value,
+    )
+    headers = {
+        "APIKey": api_key,
+        "Authent": authent,
+        "Nonce": nonce_value,
+    }
+    return PrivateReadonlyHttpRequest(
+        method="GET",
+        url=url,
+        endpoint_path=endpoint_path,
+        headers=headers,
+        auth_header_names=("APIKey", "Authent", "Nonce"),
+    )
+
+
+def build_private_readonly_get_request_plan(
+    *,
+    rest_base_url: str = DEMO_FUTURES_REST_BASE_URL,
+) -> list[dict[str, str]]:
+    """Unauthenticated plan rows (method/url/endpoint only) for offline tests."""
+    plan: list[dict[str, str]] = []
+    for endpoint_path in PRIVATE_READONLY_ENDPOINT_ORDER:
+        plan.append(
+            {
+                "method": "GET",
+                "endpoint_path": endpoint_path,
+                "url": build_private_readonly_get_url(rest_base_url, endpoint_path),
+            }
+        )
+    return plan
+
+
+def _parsed_summary_without_sensitive_values(payload: Any) -> dict[str, Any]:
+    """Schema/count metadata only — never copy balances, positions, orders, or secrets."""
+    summary: dict[str, Any] = {
+        "top_level_type": "unknown",
+        "record_count": None,
+        "sensitive_field_names_detected": [],
+        "raw_values_emitted": False,
+    }
+    if isinstance(payload, dict):
+        summary["top_level_type"] = "object"
+        summary["top_level_keys"] = sorted(str(k) for k in payload.keys())
+        for key, value in payload.items():
+            key_l = str(key).lower()
+            if any(frag in key_l for frag in _SENSITIVE_JSON_KEY_FRAGMENTS):
+                summary["sensitive_field_names_detected"].append(str(key))
+            if isinstance(value, list):
+                summary["record_count"] = len(value)
+    elif isinstance(payload, list):
+        summary["top_level_type"] = "array"
+        summary["record_count"] = len(payload)
+    else:
+        summary["top_level_type"] = type(payload).__name__
+    summary["sensitive_field_names_detected"] = sorted(
+        set(summary.get("sensitive_field_names_detected", []))
+    )
+    return summary
+
+
 def validate_private_readonly_url(url: str, *, rest_base_url: str) -> list[str]:
     reasons: list[str] = []
     parsed = urlparse(url)
@@ -181,40 +348,99 @@ def summarize_private_response_for_evidence(
     endpoint: str,
     http_status: int,
     body: bytes,
+    http_method: str = "GET",
+    auth_header_names: Sequence[str] | None = None,
 ) -> dict[str, Any]:
-    """Redacted network call metadata — no raw body, balances, or order ids."""
+    """Redacted network call metadata — no raw body, balances, positions, orders, or secrets."""
     parsed_summary: dict[str, Any] = {
-        "top_level_type": "unknown",
+        "top_level_type": "unparseable",
         "record_count": None,
-        "order_id_fields_present": False,
+        "sensitive_field_names_detected": [],
+        "raw_values_emitted": False,
     }
     if body:
         try:
             payload = json.loads(body.decode("utf-8"))
         except (json.JSONDecodeError, UnicodeDecodeError):
-            parsed_summary["top_level_type"] = "unparseable"
+            pass
         else:
-            if isinstance(payload, dict):
-                parsed_summary["top_level_type"] = "object"
-                parsed_summary["top_level_keys"] = sorted(str(k) for k in payload.keys())
-                for key in ("accounts", "openPositions", "openOrders", "positions", "orders"):
-                    if key in payload and isinstance(payload[key], list):
-                        parsed_summary["record_count"] = len(payload[key])
-                dump = json.dumps(payload)
-                if re.search(r'"order[_-]?id"', dump, re.IGNORECASE):
-                    parsed_summary["order_id_fields_present"] = True
-            elif isinstance(payload, list):
-                parsed_summary["top_level_type"] = "array"
-                parsed_summary["record_count"] = len(payload)
-    return {
+            parsed_summary = _parsed_summary_without_sensitive_values(payload)
+    record = {
         "endpoint": endpoint,
+        "http_method": http_method,
         "http_status": http_status,
         "http_status_class": _http_status_class(http_status),
         "response_size_bytes": len(body),
         "response_sha256": hashlib.sha256(body).hexdigest(),
         "response_redacted": True,
         "parsed_summary": parsed_summary,
+        "auth_header_names": list(auth_header_names or ()),
+        "credential_values_logged": False,
     }
+    return record
+
+
+def run_private_readonly_reachability(
+    *,
+    rest_base_url: str,
+    api_key: str,
+    api_secret_b64: str,
+    fetcher: PrivateReadonlyRestFetcher,
+    duration_cap_seconds: int,
+) -> PrivateReadonlyReachabilityResult:
+    """Execute bounded private-readonly GET sequence via injectable fetcher."""
+    assert_private_readonly_authority_unchanged()
+    endpoints_called: list[str] = []
+    network_calls: list[dict[str, Any]] = []
+    deadline = time.monotonic() + float(duration_cap_seconds)
+    timeout = min(
+        DEFAULT_PRIVATE_READONLY_GET_TIMEOUT_SECONDS,
+        float(duration_cap_seconds),
+    )
+    for endpoint_path in PRIVATE_READONLY_ENDPOINT_ORDER:
+        if time.monotonic() > deadline:
+            break
+        http_request = build_private_readonly_http_request(
+            rest_base_url=rest_base_url,
+            endpoint_path=endpoint_path,
+            api_key=api_key,
+            api_secret_b64=api_secret_b64,
+        )
+        status, body = fetcher.fetch(http_request, timeout_seconds=timeout)
+        record = summarize_private_response_for_evidence(
+            endpoint=endpoint_path,
+            http_status=status,
+            body=body,
+            http_method=http_request.method,
+            auth_header_names=http_request.auth_header_names,
+        )
+        redact_reasons = validate_redacted_network_call_record(record)
+        if redact_reasons:
+            raise RuntimeError(
+                f"private-readonly evidence redaction failed: {'; '.join(redact_reasons)}"
+            )
+        network_calls.append(record)
+        endpoints_called.append(endpoint_path)
+    proven = bool(endpoints_called) and all(
+        200 <= int(call["http_status"]) < 300 for call in network_calls
+    )
+    return PrivateReadonlyReachabilityResult(
+        endpoints_called=endpoints_called,
+        request_count=len(endpoints_called),
+        network_calls=network_calls,
+        private_readonly_reachability_proven=proven,
+    )
+
+
+def resolve_private_readonly_credentials_from_environ(
+    environ: Mapping[str, str],
+) -> tuple[str, str] | None:
+    """Read demo key names from environ only (never log values; no env-file I/O)."""
+    api_key = (environ.get(KRAKEN_FUTURES_DEMO_API_KEY_ENV_NAME) or "").strip()
+    api_secret = (environ.get(KRAKEN_FUTURES_DEMO_API_SECRET_ENV_NAME) or "").strip()
+    if api_key and api_secret:
+        return api_key, api_secret
+    return None
 
 
 def _http_status_class(status: int) -> str:
@@ -237,6 +463,8 @@ def validate_redacted_network_call_record(record: dict[str, Any]) -> list[str]:
     if "response_body" in record or "raw_response" in record:
         reasons.append("raw response body forbidden in evidence")
     summary = record.get("parsed_summary")
+    if isinstance(summary, dict) and summary.get("raw_values_emitted"):
+        reasons.append("raw_values_emitted must be false")
     if isinstance(summary, dict) and summary.get("order_id_fields_present"):
         reasons.append("order id fields must not be copied into evidence summary")
     return reasons
@@ -304,7 +532,36 @@ def build_private_readonly_plan_evidence_skeleton(
         "network_calls": [],
         "manifest_verification_expected": True,
         "checker_boundary_v0": build_private_readonly_checker_boundary(),
+        "private_readonly_http_wiring_present": PRIVATE_READONLY_HTTP_WIRING_PRESENT,
+        "private_readonly_execute_wired": True,
     }
+
+
+def build_private_readonly_evidence_from_network(
+    *,
+    timing: Any,
+    run_id: str,
+    result: PrivateReadonlyReachabilityResult,
+    pe8_pass: bool,
+    harness_version: str,
+) -> dict[str, Any]:
+    evidence = build_private_readonly_plan_evidence_skeleton(run_id=run_id)
+    evidence.update(
+        {
+            "harness_version": harness_version,
+            "monotonic_elapsed_seconds": timing.monotonic_elapsed_seconds,
+            "wall_clock_elapsed_seconds": timing.wall_clock_elapsed_seconds,
+            "wall_clock_start_utc": timing.wall_clock_start_utc,
+            "wall_clock_end_utc": timing.wall_clock_end_utc,
+            "bounded_futures_testnet_pass": pe8_pass,
+            "endpoints_called": list(result.endpoints_called),
+            "request_count": result.request_count,
+            "network_calls": list(result.network_calls),
+            "private_readonly_reachability_proven": result.private_readonly_reachability_proven,
+            "network_private_readonly_proven": result.private_readonly_reachability_proven,
+        }
+    )
+    return evidence
 
 
 def evaluate_private_readonly_policy(

--- a/src/ops/bounded_futures_testnet_adapter_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_adapter_contract_v0.py
@@ -29,6 +29,8 @@ FUTURES_TESTNET_INSTRUMENT_EXCHANGE_PROVEN = False
 DEFAULT_FUTURES_TESTNET_NETWORK_HOST = "https://demo-futures.kraken.com"
 
 # Futures REST paths — separate from spot SPOT_KRAKEN_ENDPOINT_PREFIXES.
+# Private-readonly GET subset (policy): bounded_futures_private_readonly_contract_v0.py
+# accounts, openpositions, openorders — not sendorder/cancel*.
 FUTURES_TESTNET_ENDPOINT_ALLOWLIST: frozenset[str] = frozenset(
     {
         "/derivatives/api/v3/tickers",

--- a/src/ops/bounded_futures_testnet_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_contract_v0.py
@@ -109,6 +109,26 @@ def default_bounded_futures_normal_v0_spec() -> BoundedFuturesTestnetSpec:
     )
 
 
+def default_bounded_futures_private_readonly_reachability_v0_spec() -> BoundedFuturesTestnetSpec:
+    """Private-readonly reachability profile: no order attempts, no notional."""
+    return BoundedFuturesTestnetSpec(
+        session_class="bounded-futures-private-readonly-reachability-v0",
+        order_policy=DEFAULT_ORDER_POLICY,
+        instrument=DEFAULT_INSTRUMENT,
+        market_type=DEFAULT_MARKET_TYPE,
+        margin_mode=DEFAULT_MARGIN_MODE,
+        position_mode=DEFAULT_POSITION_MODE,
+        max_leverage=DEFAULT_MAX_LEVERAGE,
+        max_real_orders=0,
+        max_order_attempts=0,
+        max_cancel_attempts=0,
+        max_notional_eur=0.0,
+        max_position_hold_seconds=300,
+        position_must_be_flattened=True,
+        require_reduce_only_support=True,
+    )
+
+
 def default_bounded_futures_zero_order_reachability_v0_spec() -> BoundedFuturesTestnetSpec:
     """Zero-order reachability profile: no order attempts, no notional."""
     return BoundedFuturesTestnetSpec(

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -10,10 +10,12 @@ from pathlib import Path
 import pytest
 
 from scripts.ops import archive_futures_testnet_harness_v0 as harness
+from src.ops.bounded_futures_private_readonly_contract_v0 import PRIVATE_READONLY_MODE
 from src.ops.bounded_futures_testnet_contract_v0 import (
     DEFAULT_INSTRUMENT,
     FUTURES_SESSION_AUTHORIZED_NOW,
     REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS,
+    default_bounded_futures_private_readonly_reachability_v0_spec,
     default_bounded_futures_zero_order_reachability_v0_spec,
     evaluate_bounded_futures_testnet_evidence,
 )
@@ -328,3 +330,45 @@ def test_pe8_zero_order_spec_accepts_harness_evidence() -> None:
 def test_rejected_placeholder_set_unchanged() -> None:
     assert "BTCUSDT" in REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS
     assert DEFAULT_INSTRUMENT == "PF_XBTUSD"
+
+
+def test_private_readonly_mode_plan_only_writes_evidence(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "privro",
+            "--mode",
+            PRIVATE_READONLY_MODE,
+        ],
+    )
+    assert rc == 0
+    bundle = list((archive / "runtime").iterdir())[0]
+    assert bundle.name.startswith("bounded_futures_private_readonly_")
+    evidence = json.loads((bundle / "FUTURES_EVIDENCE.json").read_text(encoding="utf-8"))
+    assert evidence["harness_mode"] == PRIVATE_READONLY_MODE
+    assert evidence["request_count"] == 0
+    assert evidence["private_readonly_reachability_proven"] is False
+    assert evidence["futures_private_api_authorized"] is False
+    assert evidence["credential_values_logged"] is False
+    spec = default_bounded_futures_private_readonly_reachability_v0_spec()
+    assert evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)[
+        "bounded_futures_testnet_pass"
+    ]
+
+
+def test_private_readonly_execute_network_forbidden(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    argv = [
+        "--archive-root",
+        str(archive),
+        "--run-id",
+        "privroexec",
+        "--mode",
+        PRIVATE_READONLY_MODE,
+        "--execute-network",
+    ]
+    rc = harness.main(argv)
+    assert rc == harness.USAGE_EXIT

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -359,7 +359,7 @@ def test_private_readonly_mode_plan_only_writes_evidence(tmp_path: Path) -> None
     ]
 
 
-def test_private_readonly_execute_network_forbidden(tmp_path: Path) -> None:
+def test_private_readonly_execute_network_requires_confirm_token(tmp_path: Path) -> None:
     archive = _durable_test_archive_root(tmp_path)
     argv = [
         "--archive-root",
@@ -370,5 +370,11 @@ def test_private_readonly_execute_network_forbidden(tmp_path: Path) -> None:
         PRIVATE_READONLY_MODE,
         "--execute-network",
     ]
-    rc = harness.main(argv)
+    rc = harness.main(
+        argv,
+        environ={
+            "KRAKEN_FUTURES_DEMO_API_KEY": "k",
+            "KRAKEN_FUTURES_DEMO_API_SECRET": "c2VjcmV0LXNlY3JldC1zZWNyZXQtc2VjcmV0LXNlY3JldCE=",
+        },
+    )
     assert rc == harness.USAGE_EXIT

--- a/tests/ops/test_bounded_futures_private_readonly_contract_v0.py
+++ b/tests/ops/test_bounded_futures_private_readonly_contract_v0.py
@@ -15,9 +15,12 @@ from src.ops.bounded_futures_private_readonly_contract_v0 import (
     FUTURES_PRIVATE_API_AUTHORIZED,
     PACKAGE_MARKER,
     PRIVATE_READONLY_EXECUTE_AUTHORIZED_NOW,
+    PRIVATE_READONLY_HTTP_WIRING_PRESENT,
     PRIVATE_READONLY_MODE,
     PRIVATE_READONLY_NETWORK_AUTHORIZED_NOW,
     build_private_readonly_checker_boundary,
+    build_private_readonly_get_request_plan,
+    build_private_readonly_http_request,
     build_private_readonly_plan_evidence_skeleton,
     evaluate_private_readonly_policy,
     summarize_private_response_for_evidence,
@@ -46,9 +49,17 @@ TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_PRIVATE_READONLY_CONTRACT_GUARD_V0=true"
 def test_package_marker_and_harness_wires_mode() -> None:
     assert TEST_PACKAGE_MARKER
     assert PACKAGE_MARKER in CONTRACT_MODULE.read_text(encoding="utf-8")
+    assert PRIVATE_READONLY_HTTP_WIRING_PRESENT is True
     harness_text = HARNESS_SCRIPT.read_text(encoding="utf-8")
     assert PRIVATE_READONLY_MODE in harness_text
     assert "build_private_readonly_evidence_payload" in harness_text
+    assert "SafePrivateReadonlyUrllibRestFetcher" in harness_text
+    assert "run_private_readonly_reachability" in harness_text
+
+
+def test_get_request_plan_has_three_endpoints() -> None:
+    plan = build_private_readonly_get_request_plan()
+    assert len(plan) == 3
 
 
 def test_authority_flags_blocked() -> None:
@@ -119,15 +130,18 @@ def test_redaction_contract_no_raw_body() -> None:
     assert validate_redacted_network_call_record(record) == []
 
 
-def test_redaction_fails_if_order_id_fields_copied() -> None:
+def test_redaction_fails_if_raw_values_emitted_flag_set() -> None:
     bad = {
         "endpoint": "/derivatives/api/v3/openorders",
+        "http_method": "GET",
         "http_status": 200,
         "http_status_class": "2xx",
         "response_size_bytes": 1,
         "response_sha256": "a" * 64,
         "response_redacted": True,
-        "parsed_summary": {"order_id_fields_present": True},
+        "parsed_summary": {"raw_values_emitted": True},
+        "auth_header_names": [],
+        "credential_values_logged": False,
     }
     assert validate_redacted_network_call_record(bad)
 

--- a/tests/ops/test_bounded_futures_private_readonly_contract_v0.py
+++ b/tests/ops/test_bounded_futures_private_readonly_contract_v0.py
@@ -1,0 +1,152 @@
+"""Static + offline tests for bounded_futures_private_readonly_contract_v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.ops.bounded_futures_private_readonly_contract_v0 import (
+    CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
+    DEMO_FUTURES_REST_BASE_URL,
+    FUTURES_ORDER_MUTATION_ENDPOINTS,
+    FUTURES_PRIVATE_READONLY_GET_ENDPOINTS,
+    FUTURES_PRIVATE_API_AUTHORIZED,
+    PACKAGE_MARKER,
+    PRIVATE_READONLY_EXECUTE_AUTHORIZED_NOW,
+    PRIVATE_READONLY_MODE,
+    PRIVATE_READONLY_NETWORK_AUTHORIZED_NOW,
+    build_private_readonly_checker_boundary,
+    build_private_readonly_plan_evidence_skeleton,
+    evaluate_private_readonly_policy,
+    summarize_private_response_for_evidence,
+    validate_private_readonly_endpoint_path,
+    validate_private_readonly_http_method,
+    validate_private_readonly_rest_base_url,
+    validate_private_readonly_url,
+    validate_redacted_network_call_record,
+)
+from src.ops.bounded_futures_testnet_contract_v0 import (
+    FUTURES_SESSION_AUTHORIZED_NOW,
+    default_bounded_futures_private_readonly_reachability_v0_spec,
+    evaluate_bounded_futures_testnet_evidence,
+)
+from src.ops.kraken_futures_demo_credential_presence_contract_v0 import (
+    build_checker_boundary_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_MODULE = REPO_ROOT / "src" / "ops" / "bounded_futures_private_readonly_contract_v0.py"
+HARNESS_SCRIPT = REPO_ROOT / "scripts" / "ops" / "archive_futures_testnet_harness_v0.py"
+
+TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_PRIVATE_READONLY_CONTRACT_GUARD_V0=true"
+
+
+def test_package_marker_and_harness_wires_mode() -> None:
+    assert TEST_PACKAGE_MARKER
+    assert PACKAGE_MARKER in CONTRACT_MODULE.read_text(encoding="utf-8")
+    harness_text = HARNESS_SCRIPT.read_text(encoding="utf-8")
+    assert PRIVATE_READONLY_MODE in harness_text
+    assert "build_private_readonly_evidence_payload" in harness_text
+
+
+def test_authority_flags_blocked() -> None:
+    assert FUTURES_SESSION_AUTHORIZED_NOW is False
+    assert FUTURES_PRIVATE_API_AUTHORIZED is False
+    assert PRIVATE_READONLY_EXECUTE_AUTHORIZED_NOW is False
+    assert PRIVATE_READONLY_NETWORK_AUTHORIZED_NOW is False
+
+
+def test_allowlist_exactly_three_get_endpoints() -> None:
+    assert FUTURES_PRIVATE_READONLY_GET_ENDPOINTS == frozenset(
+        {
+            "/derivatives/api/v3/accounts",
+            "/derivatives/api/v3/openpositions",
+            "/derivatives/api/v3/openorders",
+        }
+    )
+
+
+def test_order_mutation_endpoints_blocked_by_policy() -> None:
+    policy = evaluate_private_readonly_policy(
+        endpoints_called=list(FUTURES_ORDER_MUTATION_ENDPOINTS),
+        http_methods=["POST"],
+    )
+    assert policy["private_readonly_policy_pass"] is False
+    assert policy["order_endpoints_blocked"] is False
+
+
+def test_post_http_method_blocked() -> None:
+    assert validate_private_readonly_http_method("POST") != []
+
+
+def test_live_host_blocked() -> None:
+    reasons = validate_private_readonly_rest_base_url(
+        "https://futures.kraken.com/derivatives/api/v3"
+    )
+    assert reasons
+
+
+def test_demo_host_allowed() -> None:
+    assert validate_private_readonly_rest_base_url(DEMO_FUTURES_REST_BASE_URL) == []
+
+
+def test_sendorder_url_rejected() -> None:
+    url = f"{DEMO_FUTURES_REST_BASE_URL}/sendorder"
+    assert validate_private_readonly_url(url, rest_base_url=DEMO_FUTURES_REST_BASE_URL)
+
+
+def test_accounts_openpositions_openorders_paths_allowed() -> None:
+    for ep in FUTURES_PRIVATE_READONLY_GET_ENDPOINTS:
+        assert validate_private_readonly_endpoint_path(ep) == []
+
+
+def test_redaction_contract_no_raw_body() -> None:
+    body = json.dumps(
+        {
+            "accounts": [{"type": "marginAccount"}],
+            "openPositions": [],
+        }
+    ).encode()
+    record = summarize_private_response_for_evidence(
+        endpoint="/derivatives/api/v3/accounts",
+        http_status=200,
+        body=body,
+    )
+    assert record["response_redacted"] is True
+    assert "response_body" not in record
+    assert validate_redacted_network_call_record(record) == []
+
+
+def test_redaction_fails_if_order_id_fields_copied() -> None:
+    bad = {
+        "endpoint": "/derivatives/api/v3/openorders",
+        "http_status": 200,
+        "http_status_class": "2xx",
+        "response_size_bytes": 1,
+        "response_sha256": "a" * 64,
+        "response_redacted": True,
+        "parsed_summary": {"order_id_fields_present": True},
+    }
+    assert validate_redacted_network_call_record(bad)
+
+
+def test_credential_presence_does_not_authorize_execute() -> None:
+    boundary = build_private_readonly_checker_boundary()
+    presence = build_checker_boundary_v0()
+    assert boundary["futures_private_api_authorized"] is False
+    assert boundary["next_execute_allowed"] is False
+    assert boundary["credential_presence_implies_execute"] is False
+    assert presence["futures_private_api_authorized"] is False
+
+
+def test_plan_skeleton_passes_pe8_private_readonly_spec() -> None:
+    evidence = build_private_readonly_plan_evidence_skeleton(run_id="offline")
+    spec = default_bounded_futures_private_readonly_reachability_v0_spec()
+    result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    assert result["bounded_futures_testnet_pass"] is True
+
+
+def test_confirm_token_reserved_not_empty() -> None:
+    assert "PRIVATE_READONLY" in CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY

--- a/tests/ops/test_bounded_futures_private_readonly_http_wiring_v0.py
+++ b/tests/ops/test_bounded_futures_private_readonly_http_wiring_v0.py
@@ -1,0 +1,191 @@
+"""Offline tests for private-readonly HTTP wiring (mocked fetcher only)."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from scripts.ops import archive_futures_testnet_harness_v0 as harness
+from src.ops.bounded_futures_private_readonly_contract_v0 import (
+    CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
+    DEMO_FUTURES_REST_BASE_URL,
+    FUTURES_PRIVATE_READONLY_GET_ENDPOINTS,
+    PRIVATE_READONLY_ENDPOINT_ORDER,
+    PRIVATE_READONLY_HTTP_WIRING_PRESENT,
+    PrivateReadonlyHttpRequest,
+    build_private_readonly_get_request_plan,
+    build_private_readonly_http_request,
+    build_private_readonly_plan_evidence_skeleton,
+    resolve_private_readonly_credentials_from_environ,
+    run_private_readonly_reachability,
+    summarize_private_response_for_evidence,
+    validate_redacted_network_call_record,
+)
+from src.ops.kraken_futures_demo_credential_presence_contract_v0 import (
+    build_checker_boundary_v0,
+)
+
+TEST_PACKAGE_MARKER = "BOUNDED_FUTURES_PRIVATE_READONLY_HTTP_WIRING_GUARD_V0=true"
+
+
+class _FakePrivateFetcher:
+    def __init__(self, *, body: bytes | None = None) -> None:
+        self.requests: list[PrivateReadonlyHttpRequest] = []
+        self._body = body if body is not None else b'{"accounts":[]}'
+
+    def fetch(
+        self,
+        http_request: PrivateReadonlyHttpRequest,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[int, bytes]:
+        self.requests.append(http_request)
+        assert http_request.method == "GET"
+        assert "sendorder" not in http_request.url
+        assert set(http_request.headers.keys()) == {"APIKey", "Authent", "Nonce"}
+        return 200, self._body
+
+
+def test_package_marker_and_http_wiring_flag() -> None:
+    assert TEST_PACKAGE_MARKER
+    assert PRIVATE_READONLY_HTTP_WIRING_PRESENT is True
+    assert harness.SAFE_PRIVATE_READONLY_URLLIB_FETCHER_PRESENT is True
+
+
+def test_request_plan_builds_exactly_three_gets() -> None:
+    plan = build_private_readonly_get_request_plan()
+    assert len(plan) == 3
+    assert [row["method"] for row in plan] == ["GET", "GET", "GET"]
+    assert {row["endpoint_path"] for row in plan} == set(FUTURES_PRIVATE_READONLY_GET_ENDPOINTS)
+    assert list(PRIVATE_READONLY_ENDPOINT_ORDER) == [
+        "/derivatives/api/v3/accounts",
+        "/derivatives/api/v3/openpositions",
+        "/derivatives/api/v3/openorders",
+    ]
+
+
+def test_blocklisted_endpoint_cannot_be_built() -> None:
+    secret = base64.b64encode(b"test-secret-bytes-32chars-long!!").decode()
+    with pytest.raises(ValueError, match="forbidden|not allowed|allowlist"):
+        build_private_readonly_http_request(
+            rest_base_url=DEMO_FUTURES_REST_BASE_URL,
+            endpoint_path="/derivatives/api/v3/sendorder",
+            api_key="demo-key",
+            api_secret_b64=secret,
+        )
+
+
+def test_auth_header_names_present_values_not_in_evidence() -> None:
+    secret = base64.b64encode(b"test-secret-bytes-32chars-long!!").decode()
+    http_request = build_private_readonly_http_request(
+        rest_base_url=DEMO_FUTURES_REST_BASE_URL,
+        endpoint_path="/derivatives/api/v3/accounts",
+        api_key="demo-key-not-logged",
+        api_secret_b64=secret,
+        nonce="12345",
+    )
+    assert http_request.auth_header_names == ("APIKey", "Authent", "Nonce")
+    record = summarize_private_response_for_evidence(
+        endpoint=http_request.endpoint_path,
+        http_status=200,
+        body=b'{"accounts":[{"balance":"999"}],"openPositions":[]}',
+        auth_header_names=http_request.auth_header_names,
+    )
+    assert record["credential_values_logged"] is False
+    assert "999" not in json.dumps(record)
+    assert "demo-key" not in json.dumps(record)
+    assert validate_redacted_network_call_record(record) == []
+
+
+def test_mocked_reachability_calls_three_endpoints() -> None:
+    secret = base64.b64encode(b"test-secret-bytes-32chars-long!!").decode()
+    fetcher = _FakePrivateFetcher()
+    result = run_private_readonly_reachability(
+        rest_base_url=DEMO_FUTURES_REST_BASE_URL,
+        api_key="demo-key",
+        api_secret_b64=secret,
+        fetcher=fetcher,
+        duration_cap_seconds=60,
+    )
+    assert result.request_count == 3
+    assert set(result.endpoints_called) == set(FUTURES_PRIVATE_READONLY_GET_ENDPOINTS)
+    assert result.private_readonly_reachability_proven is True
+    assert len(fetcher.requests) == 3
+
+
+def test_credentials_present_does_not_authorize_execute() -> None:
+    boundary = build_checker_boundary_v0()
+    skeleton = build_private_readonly_plan_evidence_skeleton(run_id="x")
+    assert boundary["futures_private_api_authorized"] is False
+    assert skeleton["futures_private_api_authorized"] is False
+    assert skeleton["private_readonly_execute_wired"] is True
+
+
+def test_resolve_credentials_from_environ_without_logging() -> None:
+    secret = base64.b64encode(b"s" * 32).decode()
+    creds = resolve_private_readonly_credentials_from_environ(
+        {
+            "KRAKEN_FUTURES_DEMO_API_KEY": "k",
+            "KRAKEN_FUTURES_DEMO_API_SECRET": secret,
+        }
+    )
+    assert creds == ("k", secret)
+
+
+def test_harness_private_execute_blocked_without_confirm(tmp_path) -> None:
+    from tests.ops.test_archive_futures_testnet_harness_v0 import _durable_test_archive_root
+
+    archive = _durable_test_archive_root(tmp_path)
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "no-confirm",
+            "--mode",
+            "private_readonly_reachability_only",
+            "--execute-network",
+        ],
+        environ={
+            "KRAKEN_FUTURES_DEMO_API_KEY": "k",
+            "KRAKEN_FUTURES_DEMO_API_SECRET": base64.b64encode(b"x" * 32).decode(),
+        },
+    )
+    assert rc == harness.USAGE_EXIT
+
+
+def test_harness_private_execute_mocked_fetcher(tmp_path) -> None:
+    from tests.ops.test_archive_futures_testnet_harness_v0 import _durable_test_archive_root
+
+    archive = _durable_test_archive_root(tmp_path)
+    fake = _FakePrivateFetcher()
+    secret = base64.b64encode(b"test-secret-bytes-32chars-long!!").decode()
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "privexec",
+            "--mode",
+            "private_readonly_reachability_only",
+            "--execute-network",
+            "--confirm-futures-private-readonly-reachability",
+            CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
+        ],
+        private_fetcher=fake,
+        environ={
+            "KRAKEN_FUTURES_DEMO_API_KEY": "demo-key",
+            "KRAKEN_FUTURES_DEMO_API_SECRET": secret,
+        },
+    )
+    assert rc == 0
+    assert len(fake.requests) == 3
+    evidence_path = list((archive / "runtime").iterdir())[0] / "FUTURES_EVIDENCE.json"
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert evidence["request_count"] == 3
+    assert evidence["private_readonly_reachability_proven"] is True
+    dump = json.dumps(evidence)
+    assert "demo-key" not in dump
+    assert evidence["futures_private_api_authorized"] is False


### PR DESCRIPTION
## Summary

- Adds `bounded_futures_private_readonly_contract_v0` with GET allowlist (`accounts`, `openpositions`, `openorders`), order/host blocklist, response redaction, and **HTTP wiring** (request builder + Kraken `Authent` helper + `run_private_readonly_reachability`).
- Extends `archive_futures_testnet_harness_v0.py` with `private_readonly_reachability_only` mode including a **fail-closed execute path** (`--execute-network` + confirm token + demo env key names). Default remains plan-only.
- **Not just contract:** includes private-readonly HTTP wiring skeleton; **offline mocked tests only**; no real Kraken calls in CI/tests.

## NO-RUN / safety (PR scope)

- No credentials read from env files; no secret logging in evidence.
- Tests use injectable fake fetchers only (`OFFLINE_TESTS_ONLY`).
- Endpoint allowlist: GET `/derivatives/api/v3/{accounts,openpositions,openorders}` on `demo-futures.kraken.com` only.
- Blocklist: `sendorder`, `cancelorder`, `cancelallorders`, POST, spot/live hosts.
- Evidence redaction: SHA-256 + schema/count metadata; no raw balances/positions/orders/secrets.
- `NEXT_EXECUTE_ALLOWED=false`; `FUTURES_PRIVATE_API_AUTHORIZED=false`.
- Real operator execute requires **separate GO** after merge + post-merge closeout.

## Test plan

- [x] targeted pytest (`test_bounded_futures_private_readonly_*`, `test_archive_futures_testnet_harness_v0`)
- [x] ruff on touched files
- [ ] merge after required CI
- [ ] post-merge closeout before any live private-readonly execute GO