### PR TITLE
ops: forward environ for private-readonly harness CLI

### DIFF
--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import sys
 import time
@@ -854,4 +855,4 @@ def main(
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(environ=os.environ))

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -378,3 +381,83 @@ def test_private_readonly_execute_network_requires_confirm_token(tmp_path: Path)
         },
     )
     assert rc == harness.USAGE_EXIT
+
+
+def test_cli_entrypoint_forwards_process_environ(tmp_path: Path) -> None:
+    """CLI must pass os.environ so authority/credential namespace validation applies."""
+    archive = _durable_test_archive_root(tmp_path)
+    env = os.environ.copy()
+    env["FUTURES_EXECUTE_AUTHORIZED"] = "true"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(HARNESS_SCRIPT),
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "clienv",
+            "--mode",
+            PRIVATE_READONLY_MODE,
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == harness.USAGE_EXIT
+    assert "FUTURES_EXECUTE_AUTHORIZED" in result.stderr
+
+
+def test_cli_execute_network_does_not_log_credential_values(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    secret_marker = "peak-trade-test-secret-marker-v0-not-a-real-secret"
+    env = os.environ.copy()
+    env["KRAKEN_FUTURES_DEMO_API_KEY"] = "test-key-marker"
+    env["KRAKEN_FUTURES_DEMO_API_SECRET"] = secret_marker
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(HARNESS_SCRIPT),
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "clinosec",
+            "--mode",
+            PRIVATE_READONLY_MODE,
+            "--execute-network",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == harness.USAGE_EXIT
+    combined = result.stdout + result.stderr
+    assert secret_marker not in combined
+    assert "test-key-marker" not in combined
+
+
+def test_credentials_in_environ_alone_do_not_authorize_execute(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "credonly",
+            "--mode",
+            PRIVATE_READONLY_MODE,
+        ],
+        environ={
+            "KRAKEN_FUTURES_DEMO_API_KEY": "k",
+            "KRAKEN_FUTURES_DEMO_API_SECRET": "c2VjcmV0LXNlY3JldC1zZWNyZXQtc2VjcmV0LXNlY3JldCE=",
+        },
+    )
+    assert rc == 0
+    bundle = list((archive / "runtime").iterdir())[0]
+    evidence = json.loads((bundle / "FUTURES_EVIDENCE.json").read_text(encoding="utf-8"))
+    assert evidence["request_count"] == 0
+    assert evidence["private_readonly_reachability_proven"] is False
+    assert evidence["futures_private_api_authorized"] is False


### PR DESCRIPTION
## Summary

- Fixes CLI `environ` forwarding gap: `__main__` now calls `main(environ=os.environ)` so private-readonly harness validation and credential resolution see the operator process environment without a Python wrapper workaround.
- Adds offline subprocess tests for CLI forwarding, confirm-token gate, and no secret logging.

## Safety / scope

- **NO-RUN** — no execute, no network, no credentials read from disk
- No private API calls in tests (mocked/offline only)
- No orders, no authority lift (`NEXT_EXECUTE_ALLOWED` remains false)
- Retry/execute still blocked without separate Operator-GO

## Test plan

- [x] Targeted pytest: archive harness + private-readonly contract/http wiring (49 tests)
- [x] `ruff check` on touched files

Made with [Cursor](https://cursor.com)