### PR TITLE
ops: persist private-readonly timeout evidence

### DIFF
--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -832,18 +832,35 @@ def main(
         )
     evaluation = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
     evidence["bounded_futures_testnet_pass"] = evaluation["bounded_futures_testnet_pass"]
+    persist_runtime_bundle = evaluation["bounded_futures_testnet_pass"] or (
+        args.execute_network and args.mode == PRIVATE_READONLY_MODE
+    )
+    out: Path | None = None
+    if persist_runtime_bundle:
+        out = write_durable_evidence_bundle(
+            archive_root=archive_root,
+            run_id=args.run_id,
+            plan=plan,
+            timing=timing,
+            evidence=evidence,
+            evaluation=evaluation,
+        )
     if not evaluation["bounded_futures_testnet_pass"]:
         print(json.dumps(evaluation, indent=2), file=sys.stderr)
+        if out is not None:
+            print(
+                json.dumps(
+                    {
+                        "evidence_dir": str(out),
+                        "plan_only": False,
+                        "mode": args.mode,
+                        "bounded_futures_testnet_pass": False,
+                    },
+                    indent=2,
+                )
+            )
         return USAGE_EXIT
 
-    out = write_durable_evidence_bundle(
-        archive_root=archive_root,
-        run_id=args.run_id,
-        plan=plan,
-        timing=timing,
-        evidence=evidence,
-        evaluation=evaluation,
-    )
     plan_only = not args.execute_network
     print(
         json.dumps(

--- a/src/ops/bounded_futures_private_readonly_contract_v0.py
+++ b/src/ops/bounded_futures_private_readonly_contract_v0.py
@@ -621,9 +621,7 @@ def build_private_readonly_evidence_from_network(
     harness_version: str,
 ) -> dict[str, Any]:
     evidence = build_private_readonly_plan_evidence_skeleton(run_id=run_id)
-    policy_accepted = (
-        result.private_readonly_reachability_proven and not result.fetch_failure
-    )
+    policy_accepted = result.private_readonly_reachability_proven and not result.fetch_failure
     updates: dict[str, Any] = {
         "harness_version": harness_version,
         "monotonic_elapsed_seconds": timing.monotonic_elapsed_seconds,

--- a/src/ops/bounded_futures_private_readonly_contract_v0.py
+++ b/src/ops/bounded_futures_private_readonly_contract_v0.py
@@ -11,9 +11,11 @@ import base64
 import hashlib
 import hmac
 import json
+import socket
 import time
 from dataclasses import dataclass
 from typing import Any, Mapping, Protocol, Sequence
+from urllib import error
 from urllib.parse import urlparse
 
 from src.ops.bounded_futures_testnet_adapter_contract_v0 import (
@@ -43,6 +45,7 @@ PRIVATE_READONLY_MODE = "private_readonly_reachability_only"
 DEFAULT_PRIVATE_READONLY_GET_TIMEOUT_SECONDS = 10.0
 PRIVATE_READONLY_SESSION_CLASS = "bounded-futures-private-readonly-reachability-v0"
 PRIVATE_READONLY_MAX_REQUEST_COUNT = 3
+FETCH_FAILURE_CLASS_NETWORK = "network_timeout_or_fetch_exception"
 
 DEMO_FUTURES_HOST = "demo-futures.kraken.com"
 DEMO_FUTURES_REST_BASE_URL = f"{DEFAULT_FUTURES_TESTNET_NETWORK_HOST}/derivatives/api/v3"
@@ -138,6 +141,15 @@ class PrivateReadonlyReachabilityResult:
     request_count: int
     network_calls: list[dict[str, Any]]
     private_readonly_reachability_proven: bool
+    fetch_failure: bool = False
+    failure_class: str | None = None
+    failed_endpoint: str | None = None
+    failed_method: str = "GET"
+    failed_host: str = DEMO_FUTURES_HOST
+    request_count_attempted: int = 0
+    completed_request_count: int = 0
+    exception_type: str | None = None
+    partial_policy_accepted: bool = False
 
 
 class PrivateReadonlyRestFetcher(Protocol):
@@ -381,6 +393,41 @@ def summarize_private_response_for_evidence(
     return record
 
 
+def _is_private_readonly_fetch_exception(exc: BaseException) -> bool:
+    return isinstance(exc, (TimeoutError, error.URLError, socket.timeout))
+
+
+def build_private_readonly_fetch_failure_network_record(
+    *,
+    endpoint: str,
+    auth_header_names: Sequence[str],
+) -> dict[str, Any]:
+    """Redacted failure row when fetch raises before HTTP response (no secrets)."""
+    record = {
+        "endpoint": endpoint,
+        "http_method": "GET",
+        "http_status": 0,
+        "http_status_class": "unknown",
+        "response_size_bytes": 0,
+        "response_sha256": hashlib.sha256(b"").hexdigest(),
+        "response_redacted": True,
+        "parsed_summary": {
+            "top_level_type": "fetch_exception",
+            "record_count": None,
+            "sensitive_field_names_detected": [],
+            "raw_values_emitted": False,
+        },
+        "auth_header_names": list(auth_header_names),
+        "credential_values_logged": False,
+    }
+    redact_reasons = validate_redacted_network_call_record(record)
+    if redact_reasons:
+        raise RuntimeError(
+            f"private-readonly failure evidence redaction failed: {'; '.join(redact_reasons)}"
+        )
+    return record
+
+
 def run_private_readonly_reachability(
     *,
     rest_base_url: str,
@@ -407,7 +454,31 @@ def run_private_readonly_reachability(
             api_key=api_key,
             api_secret_b64=api_secret_b64,
         )
-        status, body = fetcher.fetch(http_request, timeout_seconds=timeout)
+        try:
+            status, body = fetcher.fetch(http_request, timeout_seconds=timeout)
+        except BaseException as exc:
+            if not _is_private_readonly_fetch_exception(exc):
+                raise
+            attempted = len(endpoints_called) + 1
+            failure_record = build_private_readonly_fetch_failure_network_record(
+                endpoint=endpoint_path,
+                auth_header_names=http_request.auth_header_names,
+            )
+            return PrivateReadonlyReachabilityResult(
+                endpoints_called=list(endpoints_called),
+                request_count=len(endpoints_called),
+                network_calls=network_calls + [failure_record],
+                private_readonly_reachability_proven=False,
+                fetch_failure=True,
+                failure_class=FETCH_FAILURE_CLASS_NETWORK,
+                failed_endpoint=endpoint_path,
+                failed_method=http_request.method,
+                failed_host=DEMO_FUTURES_HOST,
+                request_count_attempted=attempted,
+                completed_request_count=len(endpoints_called),
+                exception_type=type(exc).__name__,
+                partial_policy_accepted=True,
+            )
         record = summarize_private_response_for_evidence(
             endpoint=endpoint_path,
             http_status=status,
@@ -425,11 +496,14 @@ def run_private_readonly_reachability(
     proven = bool(endpoints_called) and all(
         200 <= int(call["http_status"]) < 300 for call in network_calls
     )
+    completed = len(endpoints_called)
     return PrivateReadonlyReachabilityResult(
         endpoints_called=endpoints_called,
-        request_count=len(endpoints_called),
+        request_count=completed,
         network_calls=network_calls,
         private_readonly_reachability_proven=proven,
+        request_count_attempted=completed,
+        completed_request_count=completed,
     )
 
 
@@ -547,21 +621,44 @@ def build_private_readonly_evidence_from_network(
     harness_version: str,
 ) -> dict[str, Any]:
     evidence = build_private_readonly_plan_evidence_skeleton(run_id=run_id)
-    evidence.update(
-        {
-            "harness_version": harness_version,
-            "monotonic_elapsed_seconds": timing.monotonic_elapsed_seconds,
-            "wall_clock_elapsed_seconds": timing.wall_clock_elapsed_seconds,
-            "wall_clock_start_utc": timing.wall_clock_start_utc,
-            "wall_clock_end_utc": timing.wall_clock_end_utc,
-            "bounded_futures_testnet_pass": pe8_pass,
-            "endpoints_called": list(result.endpoints_called),
-            "request_count": result.request_count,
-            "network_calls": list(result.network_calls),
-            "private_readonly_reachability_proven": result.private_readonly_reachability_proven,
-            "network_private_readonly_proven": result.private_readonly_reachability_proven,
-        }
+    policy_accepted = (
+        result.private_readonly_reachability_proven and not result.fetch_failure
     )
+    updates: dict[str, Any] = {
+        "harness_version": harness_version,
+        "monotonic_elapsed_seconds": timing.monotonic_elapsed_seconds,
+        "wall_clock_elapsed_seconds": timing.wall_clock_elapsed_seconds,
+        "wall_clock_start_utc": timing.wall_clock_start_utc,
+        "wall_clock_end_utc": timing.wall_clock_end_utc,
+        "bounded_futures_testnet_pass": pe8_pass,
+        "endpoints_called": list(result.endpoints_called),
+        "request_count": result.request_count,
+        "network_calls": list(result.network_calls),
+        "private_readonly_reachability_proven": result.private_readonly_reachability_proven,
+        "network_private_readonly_proven": result.private_readonly_reachability_proven,
+        "private_readonly_policy_accepted": policy_accepted,
+        "request_count_attempted": result.request_count_attempted,
+        "completed_request_count": result.completed_request_count,
+        "order_attempted": False,
+        "order_created": False,
+        "position_mutation_attempted": False,
+        "balance_mutation_attempted": False,
+    }
+    if result.fetch_failure:
+        updates.update(
+            {
+                "fetch_failure": True,
+                "failure_class": result.failure_class,
+                "failed_endpoint": result.failed_endpoint,
+                "failed_method": result.failed_method,
+                "failed_host": result.failed_host,
+                "exception_type": result.exception_type,
+                "partial_policy_accepted": result.partial_policy_accepted,
+                "private_readonly_policy_accepted": False,
+                "http_status_unknown": True,
+            }
+        )
+    evidence.update(updates)
     return evidence
 
 

--- a/src/ops/bounded_futures_testnet_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_contract_v0.py
@@ -290,6 +290,9 @@ def evaluate_bounded_futures_testnet_evidence(
     if evidence.get("futures_session_authorized_now"):
         result["fail_reasons"].append("futures_session_authorized_now must be false")
 
+    if evidence.get("fetch_failure"):
+        result["fail_reasons"].append("private_readonly_fetch_failure")
+
     result["futures_instrument_pass"] = evidence.get("instrument") == spec.instrument
     result["futures_endpoint_isolation_pass"] = (
         evidence.get("futures_endpoint_isolation_pass") is True

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import shutil
@@ -13,7 +14,10 @@ from pathlib import Path
 import pytest
 
 from scripts.ops import archive_futures_testnet_harness_v0 as harness
-from src.ops.bounded_futures_private_readonly_contract_v0 import PRIVATE_READONLY_MODE
+from src.ops.bounded_futures_private_readonly_contract_v0 import (
+    CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
+    PRIVATE_READONLY_MODE,
+)
 from src.ops.bounded_futures_testnet_contract_v0 import (
     DEFAULT_INSTRUMENT,
     FUTURES_SESSION_AUTHORIZED_NOW,
@@ -54,6 +58,11 @@ class _FakeFetcher:
     def fetch(self, url: str, *, timeout_seconds: float) -> tuple[int, bytes]:
         self.urls.append(url)
         return 200, self._body
+
+
+class _PrivateTimeoutFetcher:
+    def fetch(self, http_request, *, timeout_seconds: float) -> tuple[int, bytes]:
+        raise TimeoutError("timed out")
 
 
 def _default_namespace(**overrides: object) -> argparse.Namespace:
@@ -360,6 +369,50 @@ def test_private_readonly_mode_plan_only_writes_evidence(tmp_path: Path) -> None
     assert evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)[
         "bounded_futures_testnet_pass"
     ]
+
+
+def test_private_readonly_timeout_writes_durable_failure_evidence(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    secret = base64.b64encode(b"test-secret-bytes-32chars-long!!").decode()
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "privrotimeout",
+            "--mode",
+            PRIVATE_READONLY_MODE,
+            "--execute-network",
+            "--confirm-futures-private-readonly-reachability",
+            CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
+        ],
+        private_fetcher=_PrivateTimeoutFetcher(),
+        environ={
+            "KRAKEN_FUTURES_DEMO_API_KEY": "k",
+            "KRAKEN_FUTURES_DEMO_API_SECRET": secret,
+        },
+    )
+    assert rc == harness.USAGE_EXIT
+    bundle = list((archive / "runtime").iterdir())[0]
+    assert bundle.name.startswith("bounded_futures_private_readonly_privrotimeout_")
+    evidence = json.loads((bundle / "FUTURES_EVIDENCE.json").read_text(encoding="utf-8"))
+    assert evidence["fetch_failure"] is True
+    assert evidence["failure_class"] == "network_timeout_or_fetch_exception"
+    assert evidence["failed_endpoint"] == "/derivatives/api/v3/accounts"
+    assert evidence["request_count_attempted"] == 1
+    assert evidence["completed_request_count"] == 0
+    assert evidence["private_readonly_reachability_proven"] is False
+    assert evidence["partial_policy_accepted"] is True
+    assert evidence["credential_values_logged"] is False
+    dumped = json.dumps(evidence)
+    assert "test-secret" not in dumped
+    assert "Authent" not in dumped or evidence["network_calls"][0].get("auth_header_names") == [
+        "APIKey",
+        "Authent",
+        "Nonce",
+    ]
+    assert "response_body" not in dumped
+    assert (bundle / "MANIFEST.sha256").exists()
 
 
 def test_private_readonly_execute_network_requires_confirm_token(tmp_path: Path) -> None:

--- a/tests/ops/test_bounded_futures_private_readonly_http_wiring_v0.py
+++ b/tests/ops/test_bounded_futures_private_readonly_http_wiring_v0.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+from urllib import error
 
 import pytest
 
@@ -11,10 +12,12 @@ from scripts.ops import archive_futures_testnet_harness_v0 as harness
 from src.ops.bounded_futures_private_readonly_contract_v0 import (
     CONFIRM_TOKEN_PRIVATE_READONLY_REACHABILITY,
     DEMO_FUTURES_REST_BASE_URL,
+    FETCH_FAILURE_CLASS_NETWORK,
     FUTURES_PRIVATE_READONLY_GET_ENDPOINTS,
     PRIVATE_READONLY_ENDPOINT_ORDER,
     PRIVATE_READONLY_HTTP_WIRING_PRESENT,
     PrivateReadonlyHttpRequest,
+    build_private_readonly_evidence_from_network,
     build_private_readonly_get_request_plan,
     build_private_readonly_http_request,
     build_private_readonly_plan_evidence_skeleton,
@@ -47,6 +50,26 @@ class _FakePrivateFetcher:
         assert "sendorder" not in http_request.url
         assert set(http_request.headers.keys()) == {"APIKey", "Authent", "Nonce"}
         return 200, self._body
+
+
+class _TimeoutOnFirstGetFetcher:
+    def fetch(
+        self,
+        http_request: PrivateReadonlyHttpRequest,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[int, bytes]:
+        raise TimeoutError("timed out")
+
+
+class _UrlErrorOnFirstGetFetcher:
+    def fetch(
+        self,
+        http_request: PrivateReadonlyHttpRequest,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[int, bytes]:
+        raise error.URLError("connection reset")
 
 
 def test_package_marker_and_http_wiring_flag() -> None:
@@ -142,6 +165,39 @@ def test_auth_header_names_present_values_not_in_evidence() -> None:
     assert "999" not in json.dumps(record)
     assert "demo-key" not in json.dumps(record)
     assert validate_redacted_network_call_record(record) == []
+
+
+def test_fetch_timeout_returns_failure_result() -> None:
+    secret = base64.b64encode(b"test-secret-bytes-32chars-long!!").decode()
+    result = run_private_readonly_reachability(
+        rest_base_url=DEMO_FUTURES_REST_BASE_URL,
+        api_key="demo-key",
+        api_secret_b64=secret,
+        fetcher=_TimeoutOnFirstGetFetcher(),
+        duration_cap_seconds=60,
+    )
+    assert result.fetch_failure is True
+    assert result.failure_class == FETCH_FAILURE_CLASS_NETWORK
+    assert result.failed_endpoint == "/derivatives/api/v3/accounts"
+    assert result.request_count_attempted == 1
+    assert result.completed_request_count == 0
+    assert result.exception_type == "TimeoutError"
+    assert len(result.network_calls) == 1
+    assert "demo-key" not in json.dumps(result.network_calls)
+    assert result.network_calls[0]["http_status_class"] == "unknown"
+
+
+def test_fetch_urlerror_returns_failure_result() -> None:
+    secret = base64.b64encode(b"test-secret-bytes-32chars-long!!").decode()
+    result = run_private_readonly_reachability(
+        rest_base_url=DEMO_FUTURES_REST_BASE_URL,
+        api_key="demo-key",
+        api_secret_b64=secret,
+        fetcher=_UrlErrorOnFirstGetFetcher(),
+        duration_cap_seconds=60,
+    )
+    assert result.fetch_failure is True
+    assert result.exception_type == "URLError"
 
 
 def test_mocked_reachability_calls_three_endpoints() -> None:


### PR DESCRIPTION
## Summary

- Catches `TimeoutError`, `socket.timeout`, and `urllib.error.URLError` during private-readonly GETs
- Writes durable runtime evidence with `fetch_failure` / `failure_class=network_timeout_or_fetch_exception` (no secrets, no raw bodies)
- Persists runtime bundle for private-readonly execute-network even when PE8 fails (e.g. timeout)
- Exit remains fail-closed (`USAGE_EXIT`)

## Safety / scope

- NO-RUN; no credentials read; no network in tests
- No authority lift; auth/URL/allowlist/confirm gates unchanged
- Retry still requires separate Operator-GO

## Test plan

- [x] Offline timeout/URLError tests (contract + harness bundle write)
- [x] Targeted pytest (55 tests)
- [x] ruff check

Made with [Cursor](https://cursor.com)