### PR TITLE
docs: propagate Gap 6 and Gap 1 RC0 observed lines

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -1248,6 +1248,92 @@ This governed repo-reflection block records operator-authorized **bounded future
 
 Evidence reflection is not runtime authorization. The PE-8/9/10 contract blocks above remain offline guards unchanged.
 
+## Gap 6 Governed Dry-Run RC0 Observed Final-Line Reflection v0
+
+GAP6_DRY_RUN_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP6_DRY_RUN_RC0_OBSERVED=true
+ACCEPTED_MODE=GAP6_DRY_RUN_RC0_OBSERVED_SCOPED_EVIDENCE_FINAL_LINE
+GOVERNED_ACCEPTANCE_BASIS=GAP6_BOUNDED_DRY_RUN_RC0_OBSERVED_GOVERNED_REFLECTION_V0=true
+EXTERNAL_EVIDENCE_BUNDLE_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/evidence/gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap6_gap1_final_line_propagation_scheduler_arc_no_run_v0_20260604T185422Z
+OPERATOR_GO=GO_PREPARE_SECTION5_GAP6_GAP1_RC0_OBSERVED_FINAL_LINE_REPO_REFLECTION_DOCS_TESTS_V0
+NO_RUNTIME_AUTHORITY=true
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+GAP6_DRY_RUN_PROOF_VERIFIED=false
+GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false
+OBSERVED_NOT_VERIFIED_SEMANTIC_PRESERVED=true
+PREFLIGHT_REMAINS_BLOCKED=true
+ALL_GAPS_CLOSED=false
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-authorized Gap-6 dry-run RC0 **observed final-line propagation** only. It propagates `GAP6_DRY_RUN_RC0_OBSERVED=true` to Final Machine Lines based on existing bounded Tier-2 dry-run RC=0 observed evidence. External evidence bundles remain pointer-based and subordinate to repo governance.
+
+### Observed final-line scope (allowed only)
+
+- external capture bundle MANIFEST_VERIFY_RC=0; bounded dry-run RC=0 observed
+- `GAP6_DRY_RUN_RC0_OBSERVED=true` in **Final Machine Lines only**
+- Gap 6 Dry-Run Proof Criteria Contract v0 block remains criteria-only with `GAP6_DRY_RUN_RC0_OBSERVED=false` and `GAP6_DRY_RUN_PROOF_VERIFIED=false`
+- observed RC0 ≠ proof verified; observation ≠ scheduler execution authorization
+
+### Non-authority boundary (observed final-line reflection does not imply)
+
+- does not modify Gap-6 criteria block verification posture (`GAP6_DRY_RUN_PROOF_VERIFIED=false` unchanged)
+- does not set `GAP6_DRY_RUN_PROOF_VERIFIED=true` in criteria or Final Machine Lines
+- does not verify Gap-4 output evidence paths or Gap-7 risk boundaries beyond existing finals
+- does not enforce Gap-2a.1 primary evidence
+- does not authorize scheduler execution
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not set `ALL_GAPS_CLOSED=true`
+- does not lift preflight
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+
+Evidence observation is not runtime authorization. The Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0 block above remains scoped observation only and unchanged.
+
+## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0
+
+GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true
+ACCEPTED_MODE=GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_SCOPED_EVIDENCE_FINAL_LINE
+GOVERNED_ACCEPTANCE_BASIS=GAP1_EXECUTE_ENTRYPOINT_OBSERVED_GOVERNED_REFLECTION_V0=true
+EXTERNAL_EVIDENCE_BUNDLE_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/evidence/gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap6_gap1_final_line_propagation_scheduler_arc_no_run_v0_20260604T185422Z
+OPERATOR_GO=GO_PREPARE_SECTION5_GAP6_GAP1_RC0_OBSERVED_FINAL_LINE_REPO_REFLECTION_DOCS_TESTS_V0
+NO_RUNTIME_AUTHORITY=true
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false
+GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false
+OBSERVED_NOT_VERIFIED_SEMANTIC_PRESERVED=true
+PREFLIGHT_REMAINS_BLOCKED=true
+ALL_GAPS_CLOSED=false
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-authorized Gap-1 execute entrypoint RC0 **observed final-line propagation** only. It propagates `GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true` to Final Machine Lines based on the same bounded dry-run RC=0 capture evidence as Gap 6. External evidence bundles remain pointer-based and subordinate to repo governance.
+
+### Observed final-line scope (allowed only)
+
+- entrypoint `scripts/run_scheduler.py` observed RC=0 on bounded dry-run capture
+- `GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true` in **Final Machine Lines only**
+- Gap 1 Execute Entrypoint Contract v0 block remains criteria-only with `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false`
+- observed RC0 ≠ entrypoint verified; observation ≠ scheduler execution authorization
+
+### Non-authority boundary (observed final-line reflection does not imply)
+
+- does not modify Gap-1 criteria block verification posture (`GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false` unchanged)
+- does not set `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true` in criteria or Final Machine Lines
+- does not verify Gap-4 output evidence paths or Gap-7 risk boundaries beyond existing finals
+- does not enforce Gap-2a.1 primary evidence
+- does not authorize scheduler execution
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not set `ALL_GAPS_CLOSED=true`
+- does not lift preflight
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+
+Evidence observation is not runtime authorization. The Gap 1 Governed Execute Entrypoint Observed Evidence Reflection v0 block above remains scoped observation only and unchanged.
+
 ## Preflight Synthesis Docs Block Reflection v0
 
 PREFLIGHT_SYNTHESIS_GOVERNED_REFLECTION_V0=true
@@ -1497,6 +1583,7 @@ GAP3_EXECUTE_COMMAND_DEFAULT_ON=false
 GAP3_EXECUTE_COMMAND_DRY_RUN_ONLY=true
 GAP1_EXECUTE_ENTRYPOINT_CONTRACT_V0=true
 GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false
+GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true
 GAP1_RUNTIME_APPROVED=false
 GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false
@@ -1505,7 +1592,7 @@ GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true
 GAP6_CRITERIA_ONLY=true
 GAP6_DRY_RUN_PROOF_ACCEPTED=false
 GAP6_DRY_RUN_PROOF_VERIFIED=false
-GAP6_DRY_RUN_RC0_OBSERVED=false
+GAP6_DRY_RUN_RC0_OBSERVED=true
 GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP6_DRY_RUN_PROOF_DEFAULT_ON=false
 GAP5_STOP_CRITERIA_CONTRACT_V0=true

--- a/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
@@ -135,6 +135,6 @@ def test_gap1_rc0_observed_governed_reflection_present_and_non_authorizing_v0() 
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in reflection
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in reflection
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
-    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" not in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block_lines
     assert "ALL_GAPS_CLOSED=false" in block
     assert "READY_FOR_OPERATOR_ARMING=false" in block

--- a/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
@@ -51,6 +51,7 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "PATH_B_LIFT_DISCUSSION_READY=false",
     "ALL_GAPS_CLOSED=false",
     "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false",
+    "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true",
     "GAP1_RUNTIME_APPROVED=false",
     "GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false",
     "GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false",
@@ -59,10 +60,10 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "GAP5_STOP_REHEARSAL_EXECUTED=false",
     "GAP5_STOP_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_RC0_OBSERVED=true",
 )
 
 DRIFT_GUARD_FORBIDDEN_GAP1_REPO_TOKENS = (
-    "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true",
     "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_EXTERNAL=true",
     "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true",
     "GAP1_RUNTIME_APPROVED=true",
@@ -208,7 +209,7 @@ def test_gap1_drift_guard_sample_conflation_lines_not_final_line_lifts_v0() -> N
 def test_gap1_drift_guard_gap6_gap7_gap2a1_orthogonal_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP7_RISK_BOUNDARY_VERIFIED=true" in block
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in block
 
@@ -280,6 +281,7 @@ def test_gap1_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     assert "Evidence observation is not runtime authorization" in reflection
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in criteria
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
     assert "ALL_GAPS_CLOSED=false" in block
     assert "READY_FOR_OPERATOR_ARMING=false" in block
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
@@ -289,6 +291,36 @@ def test_gap1_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     block_lines = {line.strip() for line in block.splitlines()}
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in reflection_lines
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" not in criteria_lines
-    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" not in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_EXTERNAL=true" not in text
     assert "Live/Testnet/Shadow/Paper/Broker/Network/AWS" in reflection
+
+
+GAP1_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0"
+)
+
+
+def _gap1_rc0_observed_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP1_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Preflight Synthesis Docs Block Reflection v0", 1
+    )[0]
+
+
+def test_gap1_rc0_observed_final_line_reflection_non_authorizing_v0() -> None:
+    text = _section5_text()
+    final_line = _gap1_rc0_observed_final_line_reflection_section(text)
+    criteria = _gap1_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in final_line
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in final_line
+    assert "OBSERVED_NOT_VERIFIED_SEMANTIC_PRESERVED=true" in final_line
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in final_line
+    assert "does not set `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true`" in final_line
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in criteria
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    assert "ALL_GAPS_CLOSED=false" in block
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in block

--- a/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
@@ -314,7 +314,9 @@ def test_gap1_rc0_observed_final_line_reflection_non_authorizing_v0() -> None:
     criteria = _gap1_section(text)
     block = _final_machine_lines(text)
 
-    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in final_line
+    assert (
+        "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in final_line
+    )
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in final_line
     assert "OBSERVED_NOT_VERIFIED_SEMANTIC_PRESERVED=true" in final_line
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in final_line

--- a/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
+++ b/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
@@ -59,6 +59,7 @@ DEPENDENCY_REQUIRED_FINAL_LINES = (
     "GAP3_EXECUTE_COMMAND_VERIFIED=false",
     "GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false",
     "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_RC0_OBSERVED=true",
 )
 
 DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
@@ -66,7 +67,7 @@ DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
     "GAP2_JOB_SET_ENABLED=true",
     "GAP3_EXECUTE_COMMAND_VERIFIED=true",
     "GAP3_SCHEDULER_EXECUTION_AUTHORIZED=true",
-    "GAP6_DRY_RUN_RC0_OBSERVED=true",
+    "GAP6_DRY_RUN_PROOF_VERIFIED=true",
     "SHADOW_24_7_AUTHORIZED=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
     "ALL_GAPS_CLOSED=true",
@@ -194,7 +195,7 @@ def test_gap2_gap3_dependency_shadow_24_7_not_authorized_in_repo_ssot_v0() -> No
 def test_gap2_gap3_dependency_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 
 
@@ -297,7 +298,7 @@ def test_gap2_gap3_reflection_final_lines_no_verified_or_rc0_flip_v0() -> None:
     lines = {line.strip() for line in block.splitlines()}
     for token in DEPENDENCY_FORBIDDEN_REPO_TOKENS:
         assert token not in lines
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
     assert "ALL_GAPS_CLOSED=false" in block

--- a/tests/ops/test_gap2_job_set_boundary_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap2_job_set_boundary_drift_guard_contract_v0.py
@@ -181,7 +181,7 @@ def test_gap2_job_set_boundary_shadow_24_7_not_authorized_in_repo_ssot_v0() -> N
 def test_gap2_job_set_boundary_gap6_tokens_untouched_by_gap2_slice_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 
 

--- a/tests/ops/test_gap2a1_primary_evidence_enforcement_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap2a1_primary_evidence_enforcement_drift_guard_contract_v0.py
@@ -209,7 +209,7 @@ def test_gap2a1_drift_guard_gap5_gap6_orthogonal_v0() -> None:
     assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in block
     assert "GAP5_STOP_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 
 

--- a/tests/ops/test_gap4_gap2a1_primary_evidence_dependency_contract_v0.py
+++ b/tests/ops/test_gap4_gap2a1_primary_evidence_dependency_contract_v0.py
@@ -289,7 +289,7 @@ def test_gap4_gap2a1_dependency_gap5_gap6_orthogonal_v0() -> None:
     assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in block
     assert "GAP5_STOP_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
 
 
 def test_gap4_gap2a1_dependency_criteria_complete_does_not_close_gaps_v0() -> None:

--- a/tests/ops/test_gap4_output_evidence_paths_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap4_output_evidence_paths_drift_guard_contract_v0.py
@@ -247,7 +247,7 @@ def test_gap4_output_evidence_paths_drift_guard_gap5_gap6_tokens_untouched_v0() 
     block = _final_machine_lines(_section5_text())
     assert "GAP5_STOP_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 
 

--- a/tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py
+++ b/tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py
@@ -198,7 +198,7 @@ def test_gap5_gap4_durable_evidence_dependency_drift_guards_are_not_proof_or_cha
 def test_gap5_gap4_durable_evidence_dependency_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 
 

--- a/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
@@ -239,7 +239,7 @@ def test_gap5_stop_criteria_drift_guard_gap4_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 
 

--- a/tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py
+++ b/tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py
@@ -165,7 +165,7 @@ def test_gap5_rehearsal_classification_gap4_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 
 

--- a/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
+++ b/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
@@ -172,7 +172,7 @@ def test_gap6_dry_run_proof_criteria_contract_governed_reflection_non_authorizin
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in criteria
     assert "does not accept or verify any proof" in criteria
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED_EXTERNAL=true" not in text
     assert "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true" not in text
     reflection_lines = {line.strip() for line in reflection.splitlines()}

--- a/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
@@ -24,6 +24,9 @@ GAP6_GOVERNED_REFLECTION_HEADER = "## Gap 6 Governed Dry-Run Proof Acceptance Re
 GAP6_RC0_OBSERVED_REFLECTION_HEADER = (
     "## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0"
 )
+GAP6_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 6 Governed Dry-Run RC0 Observed Final-Line Reflection v0"
+)
 GAP5_GOVERNED_STOP_PROOF_REFLECTION_HEADER = "## Gap 5 Governed Stop Proof Acceptance Reflection v0"
 GAP4_GOVERNED_REFLECTION_HEADER = "## Gap 4 Governed Output Evidence Acceptance Reflection v0"
 _MARKER_TRUE = "=true"
@@ -38,7 +41,7 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "READY_FOR_OPERATOR_ARMING=false",
     "PATH_B_LIFT_DISCUSSION_READY=false",
     "ALL_GAPS_CLOSED=false",
-    "GAP6_DRY_RUN_RC0_OBSERVED=false",
+    "GAP6_DRY_RUN_RC0_OBSERVED=true",
     "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
     "GAP6_DRY_RUN_PROOF_VERIFIED=false",
     "GAP2_CANONICAL_JOB_SET_VERIFIED=false",
@@ -48,7 +51,6 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
 
 DRIFT_GUARD_FORBIDDEN_REPO_TOKENS = (
     "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true",
-    "GAP6_DRY_RUN_RC0_OBSERVED=true",
     "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_PROOF_VERIFIED=true",
     "WORKSHEET_COMPLETE=true",
@@ -179,7 +181,8 @@ def test_gap6_external_repo_drift_guard_governed_reflection_scoped_acceptance_v0
     assert "Evidence acceptance is not runtime authorization" in reflection
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in criteria
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block
     assert "GAP7_RISK_BOUNDARY_VERIFIED=true" in block
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in block
@@ -218,7 +221,8 @@ def test_gap6_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     assert "does not lift preflight" in reflection
     assert "Evidence observation is not runtime authorization" in reflection
     assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in criteria
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
     assert "ALL_GAPS_CLOSED=false" in block
     assert "READY_FOR_OPERATOR_ARMING=false" in block
     assert "GAP7_RISK_BOUNDARY_VERIFIED=true" in block
@@ -227,5 +231,30 @@ def test_gap6_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     block_lines = {line.strip() for line in block.splitlines()}
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in reflection_lines
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" not in criteria_lines
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" not in block_lines
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block_lines
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" not in block_lines
     assert "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true" not in text
+
+
+def _gap6_rc0_observed_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP6_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0", 1
+    )[0]
+
+
+def test_gap6_rc0_observed_final_line_reflection_non_authorizing_v0() -> None:
+    text = _section5_text()
+    final_line = _gap6_rc0_observed_final_line_reflection_section(text)
+    criteria = _gap6_criteria_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP6_DRY_RUN_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in final_line
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in final_line
+    assert "OBSERVED_NOT_VERIFIED_SEMANTIC_PRESERVED=true" in final_line
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in final_line
+    assert "does not set `GAP6_DRY_RUN_PROOF_VERIFIED=true`" in final_line
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in criteria
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "ALL_GAPS_CLOSED=false" in block
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in block

--- a/tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py
@@ -255,7 +255,7 @@ def test_gap7_drift_guard_sample_conflation_lines_not_final_line_lifts_v0() -> N
 def test_gap7_drift_guard_gap6_gap2a1_orthogonal_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
-    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in block
     assert "GAP2A1_ENFORCEMENT_DEFAULT_ON=false" in block

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -279,3 +279,38 @@ def test_section5_pe11_bounded_futures_reachability_reflection_non_authorizing_v
     assert "ARCHIVE_HARNESS_SCRIPT_EXECUTE_AUTHORIZED_NOW=true" not in block_lines
     assert "ALL_GAPS_CLOSED=true" not in block_lines
     assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
+
+
+GAP6_GAP1_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 6 Governed Dry-Run RC0 Observed Final-Line Reflection v0"
+)
+
+
+def _gap6_gap1_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP6_GAP1_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Preflight Synthesis Docs Block Reflection v0", 1
+    )[0]
+
+
+def test_section5_gap6_gap1_rc0_observed_final_line_reflection_non_authorizing_v0() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    section = _gap6_gap1_final_line_reflection_section(text)
+    block = _final_machine_lines(text)
+
+    for token in (
+        "GAP6_DRY_RUN_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true",
+        "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true",
+        "OBSERVED_NOT_VERIFIED_SEMANTIC_PRESERVED=true",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "ALL_GAPS_CLOSED=false",
+    ):
+        assert token in section
+
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" not in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
+    assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines


### PR DESCRIPTION
## Summary
- docs/tests-only repo reflection for Gap 6 and Gap 1 RC0 observed final machine lines
- Sets `GAP6_DRY_RUN_RC0_OBSERVED=true` and `GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true` in Section 5 Final Machine Lines
- Verified/proof criteria remain false; observed ≠ verified semantic preserved

## Scope boundaries
- No scheduler execute
- No runtime
- No network
- No credentials
- No orders
- No preflight/live/arming lift
- `ALL_GAPS_CLOSED` remains false

## Test plan
- [x] `tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py`
- [x] `tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py`
- [x] `tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py`
- [x] Related drift-guard dependency tests (173 passed)
- [x] ruff check on changed test files


Made with [Cursor](https://cursor.com)