### PR TITLE
docs: propagate Gap 2 and Gap 3 accepted scoped lines

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -478,6 +478,96 @@ Without the Tier-2 tag filter, an unfiltered dry-run may plan against seven enab
 
 Evidence acceptance is not runtime authorization. The Gap 3 Execute Command Contract v0 block above remains contract-only and unchanged.
 
+## Gap 2 Governed Canonical Job Set Accepted Scoped-Criteria Final-Line Reflection v0
+
+GAP2_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP2_ACCEPTED_SCOPED_CRITERIA=true
+ACCEPTED_MODE=PAPER_PLUS_BOUNDED_SHADOW_NON_24_7_SCOPED_CRITERIA_FINAL_LINE_ACCEPTED
+GOVERNED_ACCEPTANCE_BASIS=GAP2_ACCEPTED_SCOPED_CRITERIA=true
+EXTERNAL_ACCEPTANCE_RECORD_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap2_canonical_job_set_bounded_scoping_readonly_no_run_v0_20260603T152117Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/section5_breakthrough_unlock_strategy_no_run_v0_20260603T153035Z/
+INPUT_SCOPE_REVIEW_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap2_canonical_job_set_scope_review_no_run_v0_20260604T190850Z/
+OPERATOR_GO=GO_PREPARE_SECTION5_GAP2_GAP3_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_REPO_REFLECTION_DOCS_TESTS_V0
+NO_RUNTIME_AUTHORITY=true
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+GAP2_CANONICAL_JOB_SET_VERIFIED=false
+GAP2_JOB_SET_ENABLED=false
+GAP2_JOBS_TOML_CHANGED=false
+ACCEPTED_NOT_VERIFIED_SEMANTIC_PRESERVED=true
+PREFLIGHT_REMAINS_BLOCKED=true
+ALL_GAPS_CLOSED=false
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-authorized Gap-2 canonical job-set **accepted scoped-criteria final-line propagation** only. It propagates `GAP2_ACCEPTED_SCOPED_CRITERIA=true` to Final Machine Lines based on existing bounded scoping acceptance in the Gap-2 governed reflection block. External acceptance records remain pointer-based and subordinate to repo governance.
+
+### Accepted scoped-criteria final-line scope (allowed only)
+
+- external bounded-scoping bundle referenced by governed acceptance reflection
+- `GAP2_ACCEPTED_SCOPED_CRITERIA=true` in **Final Machine Lines only**
+- Gap 2 Canonical Job Set Contract v0 block remains criteria-only with `GAP2_CANONICAL_JOB_SET_VERIFIED=false` and without `GAP2_ACCEPTED_SCOPED_CRITERIA=true`
+- accepted scoped criteria ≠ canonical job-set verified; acceptance ≠ scheduler execution authorization
+
+### Non-authority boundary (accepted final-line reflection does not imply)
+
+- does not set `GAP2_CANONICAL_JOB_SET_VERIFIED=true` in criteria or Final Machine Lines
+- does not set `GAP2_JOB_SET_ENABLED=true` or `GAP2_JOBS_TOML_CHANGED=true`
+- does not modify `config/scheduler/jobs.toml` or enable any scheduler job
+- does not verify Gap-4 output evidence paths or Gap-7 risk boundaries beyond existing finals
+- does not enforce Gap-2a.1 primary evidence
+- does not authorize scheduler execution
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not set `ALL_GAPS_CLOSED=true`
+- does not lift preflight
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+
+Evidence acceptance is not runtime authorization. The Gap 2 Governed Canonical Job Set Scoped Criteria Acceptance Reflection v0 block above remains scoped acceptance only and unchanged.
+
+## Gap 3 Governed Tier-2 Command Accepted Scoped-Criteria Final-Line Reflection v0
+
+GAP3_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP3_ACCEPTED_SCOPED_CRITERIA=true
+ACCEPTED_MODE=BOUNDED_DRY_RUN_COMMAND_TIER2_SCOPED_CRITERIA_FINAL_LINE_ACCEPTED
+GOVERNED_ACCEPTANCE_BASIS=GAP3_ACCEPTED_SCOPED_CRITERIA=true
+EXTERNAL_ACCEPTANCE_RECORD_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap3_execute_command_contract_readonly_no_run_v0_20260603T152336Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/section5_breakthrough_unlock_strategy_no_run_v0_20260603T153035Z/
+INPUT_SCOPE_REVIEW_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap2_canonical_job_set_scope_review_no_run_v0_20260604T190850Z/
+OPERATOR_GO=GO_PREPARE_SECTION5_GAP2_GAP3_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_REPO_REFLECTION_DOCS_TESTS_V0
+NO_RUNTIME_AUTHORITY=true
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+GAP3_EXECUTE_COMMAND_VERIFIED=false
+GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false
+ACCEPTED_NOT_VERIFIED_SEMANTIC_PRESERVED=true
+PREFLIGHT_REMAINS_BLOCKED=true
+ALL_GAPS_CLOSED=false
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-authorized Gap-3 Tier-2 command **accepted scoped-criteria final-line propagation** only. It propagates `GAP3_ACCEPTED_SCOPED_CRITERIA=true` to Final Machine Lines based on existing bounded command acceptance in the Gap-3 governed reflection block. External acceptance records remain pointer-based and subordinate to repo governance.
+
+### Accepted scoped-criteria final-line scope (allowed only)
+
+- external command-contract acceptance bundle referenced by governed acceptance reflection
+- `GAP3_ACCEPTED_SCOPED_CRITERIA=true` in **Final Machine Lines only**
+- Gap 3 Execute Command Contract v0 block remains criteria-only with `GAP3_EXECUTE_COMMAND_VERIFIED=false` and without `GAP3_ACCEPTED_SCOPED_CRITERIA=true`
+- accepted scoped criteria ≠ execute-command verified; acceptance ≠ scheduler execution authorization
+
+### Non-authority boundary (accepted final-line reflection does not imply)
+
+- does not set `GAP3_EXECUTE_COMMAND_VERIFIED=true` in criteria or Final Machine Lines
+- does not observe or record `GAP6_DRY_RUN_RC0_OBSERVED=true` in the Gap-3 criteria block
+- does not modify `config/scheduler/jobs.toml` or authorize scheduler execution
+- does not verify Gap-4 output evidence paths or Gap-7 risk boundaries beyond existing finals
+- does not enforce Gap-2a.1 primary evidence
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not set `ALL_GAPS_CLOSED=true`
+- does not lift preflight
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+
+Evidence acceptance is not runtime authorization. The Gap 3 Governed Tier-2 Command Scoped Criteria Acceptance Reflection v0 block above remains scoped acceptance only and unchanged.
+
 ## Gap 5 Governed Stop Proof Acceptance Reflection v0
 
 GAP5_STOP_PROOF_GOVERNED_REFLECTION_V0=true
@@ -1578,6 +1668,7 @@ GAP4_OUTPUT_EVIDENCE_OPT_IN_ONLY=true
 GAP4_DURABLE_OUTPUT_REQUIRED_FOR_FUTURE_RUNS=true
 GAP3_EXECUTE_COMMAND_CONTRACT_V0=true
 GAP3_EXECUTE_COMMAND_VERIFIED=false
+GAP3_ACCEPTED_SCOPED_CRITERIA=true
 GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP3_EXECUTE_COMMAND_DEFAULT_ON=false
 GAP3_EXECUTE_COMMAND_DRY_RUN_ONLY=true
@@ -1606,6 +1697,7 @@ GAP5_STOP_CRITERIA_DEFAULT_ON=false
 GAP2_CANONICAL_JOB_SET_CONTRACT_V0=true
 GAP2_CRITERIA_ONLY=true
 GAP2_CANONICAL_JOB_SET_VERIFIED=false
+GAP2_ACCEPTED_SCOPED_CRITERIA=true
 GAP2_JOB_SET_ENABLED=false
 GAP2_JOBS_TOML_CHANGED=false
 GAP2_SCHEDULER_EXECUTION_AUTHORIZED=false

--- a/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
+++ b/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
@@ -29,6 +29,12 @@ GAP2_GOVERNED_REFLECTION_HEADER = (
 GAP3_GOVERNED_REFLECTION_HEADER = (
     "## Gap 3 Governed Tier-2 Command Scoped Criteria Acceptance Reflection v0"
 )
+GAP2_ACCEPTED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 2 Governed Canonical Job Set Accepted Scoped-Criteria Final-Line Reflection v0"
+)
+GAP3_ACCEPTED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 3 Governed Tier-2 Command Accepted Scoped-Criteria Final-Line Reflection v0"
+)
 GAP5_GOVERNED_REFLECTION_HEADER = "## Gap 5 Governed Stop Proof Acceptance Reflection v0"
 _MARKER_TRUE = "=true"
 
@@ -84,7 +90,7 @@ def _final_machine_lines(text: str) -> str:
 
 
 def _gap2_section(text: str) -> str:
-    return text.split(GAP2_SECTION_HEADER, 1)[1].split(GAP7_SECTION_HEADER, 1)[0]
+    return text.split(GAP2_SECTION_HEADER, 1)[1].split(FINAL_MACHINE_LINES_HEADER, 1)[0]
 
 
 def _gap2_criteria_section(text: str) -> str:
@@ -109,6 +115,18 @@ def _gap2_governed_reflection_section(text: str) -> str:
 
 def _gap3_governed_reflection_section(text: str) -> str:
     return text.split(GAP3_GOVERNED_REFLECTION_HEADER, 1)[1].split(
+        GAP2_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap2_accepted_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP2_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        GAP3_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap3_accepted_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP3_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
         GAP5_GOVERNED_REFLECTION_HEADER, 1
     )[0]
 
@@ -270,6 +288,35 @@ def test_gap2_governed_reflection_scoped_acceptance_v0() -> None:
     assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" not in criteria
 
 
+def test_gap2_accepted_scoped_criteria_final_line_governed_reflection_v0() -> None:
+    text = _section5_text()
+    reflection = _gap2_accepted_final_line_reflection_section(text)
+    acceptance = _gap2_governed_reflection_section(text)
+    criteria = _gap2_criteria_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" in reflection
+    assert "ACCEPTED_NOT_VERIFIED_SEMANTIC_PRESERVED=true" in reflection
+    assert "GOVERNED_ACCEPTANCE_BASIS=GAP2_ACCEPTED_SCOPED_CRITERIA=true" in reflection
+    assert (
+        "OPERATOR_GO=GO_PREPARE_SECTION5_GAP2_GAP3_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_REPO_REFLECTION_DOCS_TESTS_V0"
+        in reflection
+    )
+    assert "does not set `GAP2_CANONICAL_JOB_SET_VERIFIED=true`" in reflection
+    assert "does not modify `config/scheduler/jobs.toml`" in reflection
+    assert "NO_RUNTIME_AUTHORITY=true" in reflection
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" in acceptance
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in criteria
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" not in criteria
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" in block
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in block
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" not in criteria_lines
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" in block_lines
+
+
 def test_gap3_governed_reflection_tier2_command_v0() -> None:
     text = _section5_text()
     reflection = _gap3_governed_reflection_section(text)
@@ -293,11 +340,44 @@ def test_gap3_governed_reflection_tier2_command_v0() -> None:
     assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" not in criteria
 
 
+def test_gap3_accepted_scoped_criteria_final_line_governed_reflection_v0() -> None:
+    text = _section5_text()
+    reflection = _gap3_accepted_final_line_reflection_section(text)
+    acceptance = _gap3_governed_reflection_section(text)
+    criteria = _gap3_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" in reflection
+    assert "ACCEPTED_NOT_VERIFIED_SEMANTIC_PRESERVED=true" in reflection
+    assert "GOVERNED_ACCEPTANCE_BASIS=GAP3_ACCEPTED_SCOPED_CRITERIA=true" in reflection
+    assert (
+        "OPERATOR_GO=GO_PREPARE_SECTION5_GAP2_GAP3_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_REPO_REFLECTION_DOCS_TESTS_V0"
+        in reflection
+    )
+    assert "does not set `GAP3_EXECUTE_COMMAND_VERIFIED=true`" in reflection
+    assert "does not observe or record `GAP6_DRY_RUN_RC0_OBSERVED=true`" in reflection
+    assert "NO_RUNTIME_AUTHORITY=true" in reflection
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" in acceptance
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in criteria
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" not in criteria
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" in block
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in block
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" not in criteria_lines
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" in block_lines
+
+
 def test_gap2_gap3_reflection_final_lines_no_verified_or_rc0_flip_v0() -> None:
     block = _final_machine_lines(_section5_text())
     lines = {line.strip() for line in block.splitlines()}
     for token in DEPENDENCY_FORBIDDEN_REPO_TOKENS:
         assert token not in lines
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" in block
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" in block
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in block
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in block

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -314,3 +314,40 @@ def test_section5_gap6_gap1_rc0_observed_final_line_reflection_non_authorizing_v
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" not in block_lines
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
     assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
+
+
+GAP2_GAP3_ACCEPTED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 2 Governed Canonical Job Set Accepted Scoped-Criteria Final-Line Reflection v0"
+)
+
+
+def _gap2_gap3_accepted_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP2_GAP3_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Gap 5 Governed Stop Proof Acceptance Reflection v0", 1
+    )[0]
+
+
+def test_section5_gap2_gap3_accepted_scoped_criteria_final_line_reflection_non_authorizing_v0() -> (
+    None
+):
+    text = DOC.read_text(encoding="utf-8")
+    section = _gap2_gap3_accepted_final_line_reflection_section(text)
+    block = _final_machine_lines(text)
+
+    for token in (
+        "GAP2_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_GOVERNED_REFLECTION_V0=true",
+        "GAP3_ACCEPTED_SCOPED_CRITERIA_FINAL_LINE_GOVERNED_REFLECTION_V0=true",
+        "ACCEPTED_NOT_VERIFIED_SEMANTIC_PRESERVED=true",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "ALL_GAPS_CLOSED=false",
+    ):
+        assert token in section
+
+    assert "GAP2_ACCEPTED_SCOPED_CRITERIA=true" in block
+    assert "GAP3_ACCEPTED_SCOPED_CRITERIA=true" in block
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=false" in block
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in block
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP2_CANONICAL_JOB_SET_VERIFIED=true" not in block_lines
+    assert "GAP3_EXECUTE_COMMAND_VERIFIED=true" not in block_lines
+    assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines


### PR DESCRIPTION
## Summary
- docs/tests-only: propagate `GAP2_ACCEPTED_SCOPED_CRITERIA=true` and `GAP3_ACCEPTED_SCOPED_CRITERIA=true` to Final Machine Lines only (Gap 5 accepted final-line pattern).
- Add governed final-line reflection blocks for Gap 2 and Gap 3; scoped acceptance reflection blocks unchanged.
- `GAP2_CANONICAL_JOB_SET_VERIFIED=false`, `GAP3_EXECUTE_COMMAND_VERIFIED=false`, and authority gates unchanged.

## Safety boundaries
- No `jobs.toml` changes
- No scheduler/runtime execution
- No network, credentials, or orders
- No preflight/live/arming lift
- `ALL_GAPS_CLOSED` remains false

## Test plan
- [x] Targeted pytest: section5, gap2/gap3 dependency, gap2 boundary, gap2/3/5 contracts (86 passed)
- [x] `ruff check` on touched test files


Made with [Cursor](https://cursor.com)