### PR TITLE
docs: propagate Gap 6 dry-run proof accepted line

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -673,6 +673,51 @@ This governed repo-reflection block records scoped acceptance of external bounde
 
 Evidence acceptance is not runtime authorization. The Gap 6 Dry-Run Proof Criteria Contract v0 block above remains criteria-only and unchanged.
 
+## Gap 6 Governed Dry-Run Proof Accepted Final-Line Reflection v0
+
+GAP6_DRY_RUN_PROOF_ACCEPTED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP6_DRY_RUN_PROOF_ACCEPTED=true
+ACCEPTED_MODE=BOUNDED_DRY_RUN_PROOF_FINAL_LINE_ACCEPTED
+GOVERNED_ACCEPTANCE_BASIS=GAP6_DRY_RUN_PROOF_ACCEPTED=true
+EXTERNAL_ACCEPTANCE_RECORD_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/proof/gap6_dry_run_proof_accepted_external_v0_20260531T195813Z/
+GOVERNED_REPO_REFLECTION_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/external_gap6_dry_run_proof_governed_repo_reflection_charter_v0_20260531T195943Z/
+INPUT_RANKING_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/repo_wide_next_safe_slice_ranking_after_gap2_gap3_accepted_scoped_closeout_v0_20260604T191607Z/
+OPERATOR_GO=GO_PREPARE_SECTION5_GAP6_DRY_RUN_PROOF_ACCEPTED_FINAL_LINE_REPO_REFLECTION_DOCS_TESTS_V0
+NO_RUNTIME_AUTHORITY=true
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_ACCEPTANCE=true
+GAP6_DRY_RUN_PROOF_VERIFIED=false
+GAP6_DRY_RUN_RC0_OBSERVED=false
+ACCEPTED_NOT_VERIFIED_NOT_OBSERVED_SEMANTIC_PRESERVED=true
+PREFLIGHT_REMAINS_BLOCKED=true
+ALL_GAPS_CLOSED=false
+READY_FOR_OPERATOR_ARMING=false
+PATH_B_LIFT_DISCUSSION_READY=false
+
+This governed repo-reflection block records operator-authorized Gap-6 dry-run proof **accepted final-line propagation** only. It propagates `GAP6_DRY_RUN_PROOF_ACCEPTED=true` to Final Machine Lines based on existing scoped external bounded dry-run proof acceptance. External acceptance records remain pointer-based and subordinate to repo governance.
+
+### Accepted final-line scope (allowed only)
+
+- external bounded dry-run proof bundle referenced by governed acceptance reflection
+- `GAP6_DRY_RUN_PROOF_ACCEPTED=true` in **Final Machine Lines only**
+- Gap 6 Dry-Run Proof Criteria Contract v0 block remains criteria-only with `GAP6_DRY_RUN_PROOF_ACCEPTED=false`, `GAP6_DRY_RUN_RC0_OBSERVED=false`, and `GAP6_DRY_RUN_PROOF_VERIFIED=false`
+- accepted proof ≠ proof verified; accepted ≠ RC0 observed in criteria; observation remains separate via `GAP6_DRY_RUN_RC0_OBSERVED=true` in Final Machine Lines only
+
+### Non-authority boundary (accepted final-line reflection does not imply)
+
+- does not set `GAP6_DRY_RUN_PROOF_VERIFIED=true` in criteria or Final Machine Lines
+- does not modify Gap-6 criteria block RC0 posture (`GAP6_DRY_RUN_RC0_OBSERVED=false` in criteria unchanged)
+- does not conflate accepted proof with `GAP6_DRY_RUN_RC0_OBSERVED=true` in criteria blocks
+- does not verify Gap-4 output evidence paths or Gap-7 risk boundaries beyond existing finals
+- does not enforce Gap-2a.1 primary evidence
+- does not authorize scheduler execution
+- does not enable operator arming
+- does not open Path-B lift discussion
+- does not set `ALL_GAPS_CLOSED=true`
+- does not lift preflight
+- does not start or authorize Runtime, Paper, Shadow, Testnet, or Live
+
+Evidence acceptance is not runtime authorization. The Gap 6 Governed Dry-Run Proof Acceptance Reflection v0 block above remains scoped acceptance only and unchanged.
+
 ## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0
 
 GAP6_BOUNDED_DRY_RUN_RC0_OBSERVED_GOVERNED_REFLECTION_V0=true
@@ -1681,7 +1726,7 @@ GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false
 GAP1_ENTRYPOINT_DRY_RUN_ONLY=true
 GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true
 GAP6_CRITERIA_ONLY=true
-GAP6_DRY_RUN_PROOF_ACCEPTED=false
+GAP6_DRY_RUN_PROOF_ACCEPTED=true
 GAP6_DRY_RUN_PROOF_VERIFIED=false
 GAP6_DRY_RUN_RC0_OBSERVED=true
 GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false

--- a/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
@@ -59,7 +59,7 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
     "GAP5_STOP_REHEARSAL_EXECUTED=false",
     "GAP5_STOP_PROOF_ACCEPTED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_RC0_OBSERVED=true",
 )
 
@@ -74,7 +74,6 @@ DRIFT_GUARD_FORBIDDEN_GAP1_REPO_TOKENS = (
     "DRY_RUN_BOUNDARY_IMPLIES_EXECUTION_AUTHORIZED=true",
     "CONTRACT_PRESENT_IMPLIES_VERIFIED=true",
     "PREFLIGHT_MARKER_IMPLIES_RUNTIME_APPROVED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true",
     "WORKSHEET_COMPLETE=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
@@ -208,7 +207,7 @@ def test_gap1_drift_guard_sample_conflation_lines_not_final_line_lifts_v0() -> N
 
 def test_gap1_drift_guard_gap6_gap7_gap2a1_orthogonal_v0() -> None:
     block = _final_machine_lines(_section5_text())
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP7_RISK_BOUNDARY_VERIFIED=true" in block
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in block

--- a/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
+++ b/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
@@ -64,7 +64,7 @@ DEPENDENCY_REQUIRED_FINAL_LINES = (
     "GAP2_JOB_SET_ENABLED=false",
     "GAP3_EXECUTE_COMMAND_VERIFIED=false",
     "GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_RC0_OBSERVED=true",
 )
 
@@ -79,7 +79,6 @@ DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
     "ALL_GAPS_CLOSED=true",
     "READY_FOR_OPERATOR_ARMING=true",
     "PREFLIGHT_REMAINS_BLOCKED=false",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 GAP2_BEFORE_GAP3_DEPENDENCY = "Gap 2 job-set boundary, Gap 3 command text"
@@ -212,7 +211,7 @@ def test_gap2_gap3_dependency_shadow_24_7_not_authorized_in_repo_ssot_v0() -> No
 
 def test_gap2_gap3_dependency_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 

--- a/tests/ops/test_gap2_job_set_boundary_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap2_job_set_boundary_drift_guard_contract_v0.py
@@ -52,7 +52,7 @@ BOUNDARY_REQUIRED_FINAL_LINES = (
     "GAP2_CANONICAL_JOB_SET_VERIFIED=false",
     "GAP2_JOB_SET_ENABLED=false",
     "GAP2_JOBS_TOML_CHANGED=false",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 BOUNDARY_FORBIDDEN_REPO_TOKENS = (
@@ -65,7 +65,6 @@ BOUNDARY_FORBIDDEN_REPO_TOKENS = (
     "ALL_GAPS_CLOSED=true",
     "READY_FOR_OPERATOR_ARMING=true",
     "PREFLIGHT_REMAINS_BLOCKED=false",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 
@@ -180,7 +179,7 @@ def test_gap2_job_set_boundary_shadow_24_7_not_authorized_in_repo_ssot_v0() -> N
 
 def test_gap2_job_set_boundary_gap6_tokens_untouched_by_gap2_slice_v0() -> None:
     block = _final_machine_lines(_section5_text())
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 

--- a/tests/ops/test_gap2a1_primary_evidence_enforcement_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap2a1_primary_evidence_enforcement_drift_guard_contract_v0.py
@@ -52,7 +52,7 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
     "GAP5_STOP_REHEARSAL_EXECUTED=false",
     "GAP5_STOP_PROOF_ACCEPTED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 TIER1_CONTRACT_SLICE_FILE_ALLOWLIST = (
@@ -80,7 +80,6 @@ DRIFT_GUARD_FORBIDDEN_GAP2A1_REPO_TOKENS = (
     "EXTERNAL_MANIFEST_VERIFY_RC0_IMPLIES_ENFORCED=true",
     "DURABLE_ARCHIVE_EXISTS_IMPLIES_ENFORCED=true",
     "EVIDENCE_PRESENCE_IMPLIES_ENFORCED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "WORKSHEET_COMPLETE=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
     "ALL_GAPS_CLOSED=true",
@@ -208,7 +207,7 @@ def test_gap2a1_drift_guard_gap5_gap6_orthogonal_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in block
     assert "GAP5_STOP_PROOF_ACCEPTED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 

--- a/tests/ops/test_gap4_gap2a1_primary_evidence_dependency_contract_v0.py
+++ b/tests/ops/test_gap4_gap2a1_primary_evidence_dependency_contract_v0.py
@@ -69,7 +69,7 @@ DEPENDENCY_REQUIRED_FINAL_LINES = (
     "GAP2A1_ENFORCEMENT_DEFAULT_ON=false",
     "GAP5_STOP_REHEARSAL_EXECUTED=false",
     "GAP5_STOP_PROOF_ACCEPTED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
@@ -84,7 +84,6 @@ DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
     "GAP2A1_TIER_COMPLETE=true",
     "GAP2A1_TIER_5_SATISFIED=true",
     "EXTERNAL_TIER_PLAN_COMPLETE=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "WORKSHEET_COMPLETE=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
     "ALL_GAPS_CLOSED=true",
@@ -288,7 +287,7 @@ def test_gap4_gap2a1_dependency_gap5_gap6_orthogonal_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP5_STOP_REHEARSAL_EXECUTED=false" in block
     assert "GAP5_STOP_PROOF_ACCEPTED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
 
 

--- a/tests/ops/test_gap4_output_evidence_paths_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap4_output_evidence_paths_drift_guard_contract_v0.py
@@ -63,14 +63,13 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "GAP4_OUTPUT_EVIDENCE_OPT_IN_ONLY=true",
     "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false",
     "GAP5_STOP_PROOF_ACCEPTED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 DRIFT_GUARD_FORBIDDEN_GAP4_REPO_TOKENS = (
     "GAP4_OUTPUT_EVIDENCE_DEFAULT_ON=true",
     "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true",
     "GAP2A1_ENFORCEMENT_DEFAULT_ON=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "WORKSHEET_COMPLETE=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
     "ALL_GAPS_CLOSED=true",
@@ -246,7 +245,7 @@ def test_gap4_output_evidence_paths_drift_guard_hardening_tmp_boundary_anchors_v
 def test_gap4_output_evidence_paths_drift_guard_gap5_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP5_STOP_PROOF_ACCEPTED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 

--- a/tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py
+++ b/tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py
@@ -49,7 +49,7 @@ DEPENDENCY_REQUIRED_FINAL_LINES = (
     "GAP5_STOP_REHEARSAL_EXECUTED=false",
     "GAP5_STOP_PROOF_ACCEPTED=true",
     "GAP5_TYPE2_WAIVER_GRANTED=false",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
@@ -57,7 +57,6 @@ DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
     "GAP5_STOP_REHEARSAL_EXECUTED=true",
     "GAP5_TYPE2_WAIVER_GRANTED=true",
     "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "WORKSHEET_COMPLETE=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
     "ALL_GAPS_CLOSED=true",
@@ -197,7 +196,7 @@ def test_gap5_gap4_durable_evidence_dependency_drift_guards_are_not_proof_or_cha
 
 def test_gap5_gap4_durable_evidence_dependency_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 

--- a/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
@@ -49,7 +49,7 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "GAP5_STOP_PROOF_ACCEPTED=true",
     "GAP5_TYPE2_WAIVER_GRANTED=false",
     "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 DRIFT_GUARD_FORBIDDEN_GAP5_REPO_TOKENS = (
@@ -65,7 +65,6 @@ DRIFT_GUARD_FORBIDDEN_GAP5_REPO_TOKENS = (
     "ALL_GAPS_CLOSED=true",
     "READY_FOR_OPERATOR_ARMING=true",
     "PREFLIGHT_REMAINS_BLOCKED=false",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 PREFLIGHT_AUTHORIZATION_KEYS = (
@@ -238,7 +237,7 @@ def test_gap5_stop_criteria_drift_guard_preflight_toml_stop_commands_inventory_o
 def test_gap5_stop_criteria_drift_guard_gap4_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 

--- a/tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py
+++ b/tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py
@@ -43,7 +43,7 @@ CLASSIFICATION_REQUIRED_FINAL_LINES = (
     "GAP5_TYPE2_WAIVER_GRANTED=false",
     "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
     "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
 )
 
 CLASSIFICATION_FORBIDDEN_REPO_TOKENS = (
@@ -60,7 +60,6 @@ CLASSIFICATION_FORBIDDEN_REPO_TOKENS = (
     "ALL_GAPS_CLOSED=true",
     "READY_FOR_OPERATOR_ARMING=true",
     "PREFLIGHT_REMAINS_BLOCKED=false",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "SHADOW_24_7_AUTHORIZED=true",
 )
 
@@ -164,7 +163,7 @@ def test_gap5_rehearsal_classification_dependency_is_not_proof_acceptance_v0() -
 def test_gap5_rehearsal_classification_gap4_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
 

--- a/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
+++ b/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
@@ -5,6 +5,9 @@ ROOT = Path(__file__).resolve().parents[2]
 DOC = ROOT / "docs" / "ops" / "planning" / "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md"
 GAP6_SECTION_HEADER = "## Gap 6 Dry-Run Proof Criteria Contract v0"
 GAP6_GOVERNED_REFLECTION_HEADER = "## Gap 6 Governed Dry-Run Proof Acceptance Reflection v0"
+GAP6_ACCEPTED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 6 Governed Dry-Run Proof Accepted Final-Line Reflection v0"
+)
 GAP6_RC0_OBSERVED_REFLECTION_HEADER = (
     "## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0"
 )
@@ -28,6 +31,12 @@ def _gap6_criteria_section(text: str) -> str:
 
 def _gap6_governed_reflection_section(text: str) -> str:
     return text.split(GAP6_GOVERNED_REFLECTION_HEADER, 1)[1].split(
+        GAP6_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap6_accepted_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP6_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
         GAP6_RC0_OBSERVED_REFLECTION_HEADER, 1
     )[0]
 
@@ -171,8 +180,9 @@ def test_gap6_dry_run_proof_criteria_contract_governed_reflection_non_authorizin
     assert "does not modify Final Machine Lines" in reflection
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in criteria
     assert "does not accept or verify any proof" in criteria
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED_EXTERNAL=true" not in text
     assert "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true" not in text
     reflection_lines = {line.strip() for line in reflection.splitlines()}
@@ -180,4 +190,34 @@ def test_gap6_dry_run_proof_criteria_contract_governed_reflection_non_authorizin
     block_lines = {line.strip() for line in block.splitlines()}
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in reflection_lines
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" not in criteria_lines
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" not in block_lines
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block_lines
+
+
+def test_gap6_dry_run_proof_accepted_final_line_governed_reflection_v0() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    reflection = _gap6_accepted_final_line_reflection_section(text)
+    acceptance = _gap6_governed_reflection_section(text)
+    criteria = _gap6_criteria_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in reflection
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in reflection
+    assert "ACCEPTED_NOT_VERIFIED_NOT_OBSERVED_SEMANTIC_PRESERVED=true" in reflection
+    assert "GOVERNED_ACCEPTANCE_BASIS=GAP6_DRY_RUN_PROOF_ACCEPTED=true" in reflection
+    assert (
+        "OPERATOR_GO=GO_PREPARE_SECTION5_GAP6_DRY_RUN_PROOF_ACCEPTED_FINAL_LINE_REPO_REFLECTION_DOCS_TESTS_V0"
+        in reflection
+    )
+    assert "does not set `GAP6_DRY_RUN_PROOF_VERIFIED=true`" in reflection
+    assert "does not modify Gap-6 criteria block RC0 posture" in reflection
+    assert "NO_RUNTIME_AUTHORITY=true" in reflection
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in acceptance
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in criteria
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in criteria
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" not in criteria_lines
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block_lines

--- a/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
@@ -21,6 +21,9 @@ HARDENING_OWNER = ROOT / "tests" / "ops" / "test_scheduler_dry_run_hardening_sou
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP6_SECTION_HEADER = "## Gap 6 Dry-Run Proof Criteria Contract v0"
 GAP6_GOVERNED_REFLECTION_HEADER = "## Gap 6 Governed Dry-Run Proof Acceptance Reflection v0"
+GAP6_ACCEPTED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 6 Governed Dry-Run Proof Accepted Final-Line Reflection v0"
+)
 GAP6_RC0_OBSERVED_REFLECTION_HEADER = (
     "## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0"
 )
@@ -42,7 +45,7 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "PATH_B_LIFT_DISCUSSION_READY=false",
     "ALL_GAPS_CLOSED=false",
     "GAP6_DRY_RUN_RC0_OBSERVED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_PROOF_VERIFIED=false",
     "GAP2_CANONICAL_JOB_SET_VERIFIED=false",
     "GAP2_JOB_SET_ENABLED=false",
@@ -51,7 +54,6 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
 
 DRIFT_GUARD_FORBIDDEN_REPO_TOKENS = (
     "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_PROOF_VERIFIED=true",
     "WORKSHEET_COMPLETE=true",
     "SHADOW_24_7_AUTHORIZED=true",
@@ -76,7 +78,7 @@ def _gap6_criteria_section(text: str) -> str:
 
 def _gap6_governed_reflection_section(text: str) -> str:
     return text.split(GAP6_GOVERNED_REFLECTION_HEADER, 1)[1].split(
-        GAP6_RC0_OBSERVED_REFLECTION_HEADER, 1
+        GAP6_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1
     )[0]
 
 
@@ -180,7 +182,7 @@ def test_gap6_external_repo_drift_guard_governed_reflection_scoped_acceptance_v0
     assert "does not modify Final Machine Lines" in reflection
     assert "Evidence acceptance is not runtime authorization" in reflection
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in criteria
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block

--- a/tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py
@@ -66,7 +66,7 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "GAP7_RISK_BOUNDARY_DEFAULT_ON=false",
     "GAP5_STOP_REHEARSAL_EXECUTED=false",
     "GAP5_STOP_PROOF_ACCEPTED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=false",
+    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false",
     "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true",
 )
@@ -85,7 +85,6 @@ DRIFT_GUARD_FORBIDDEN_GAP7_REPO_TOKENS = (
     "ALL_GAPS_CLOSED=true",
     "PREFLIGHT_REMAINS_BLOCKED=false",
     "SHADOW_24_7_AUTHORIZED=true",
-    "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true",
     "WORKSHEET_COMPLETE=true",
 )
@@ -254,7 +253,7 @@ def test_gap7_drift_guard_sample_conflation_lines_not_final_line_lifts_v0() -> N
 
 def test_gap7_drift_guard_gap6_gap2a1_orthogonal_v0() -> None:
     block = _final_machine_lines(_section5_text())
-    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in block

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -292,9 +292,7 @@ def _gap6_accepted_final_line_reflection_section(text: str) -> str:
     )[0]
 
 
-def test_section5_gap6_dry_run_proof_accepted_final_line_reflection_non_authorizing_v0() -> (
-    None
-):
+def test_section5_gap6_dry_run_proof_accepted_final_line_reflection_non_authorizing_v0() -> None:
     text = DOC.read_text(encoding="utf-8")
     section = _gap6_accepted_final_line_reflection_section(text)
     block = _final_machine_lines(text)

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -281,6 +281,41 @@ def test_section5_pe11_bounded_futures_reachability_reflection_non_authorizing_v
     assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
 
 
+GAP6_ACCEPTED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 6 Governed Dry-Run Proof Accepted Final-Line Reflection v0"
+)
+
+
+def _gap6_accepted_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP6_ACCEPTED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0", 1
+    )[0]
+
+
+def test_section5_gap6_dry_run_proof_accepted_final_line_reflection_non_authorizing_v0() -> (
+    None
+):
+    text = DOC.read_text(encoding="utf-8")
+    section = _gap6_accepted_final_line_reflection_section(text)
+    block = _final_machine_lines(text)
+
+    for token in (
+        "GAP6_DRY_RUN_PROOF_ACCEPTED_FINAL_LINE_GOVERNED_REFLECTION_V0=true",
+        "ACCEPTED_NOT_VERIFIED_NOT_OBSERVED_SEMANTIC_PRESERVED=true",
+        "GAP6_DRY_RUN_PROOF_VERIFIED=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "ALL_GAPS_CLOSED=false",
+    ):
+        assert token in section
+
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" not in block_lines
+    assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
+
+
 GAP6_GAP1_FINAL_LINE_REFLECTION_HEADER = (
     "## Gap 6 Governed Dry-Run RC0 Observed Final-Line Reflection v0"
 )


### PR DESCRIPTION
## Summary
- docs/tests-only repo reflection for Section 5 Gap 6
- `GAP6_DRY_RUN_PROOF_ACCEPTED=true` in Final Machine Lines only
- `GAP6_DRY_RUN_PROOF_VERIFIED=false` unchanged; RC0 observed criteria remain separate

## Boundaries
- no jobs.toml
- no scheduler/runtime
- no network
- no credentials
- no orders
- no preflight/live/arming lift
- `ALL_GAPS_CLOSED` remains false

## Test plan
- [x] targeted pytest: section5 + gap6 drift guards + related dependency tests (231 passed)
- [x] ruff check on touched test files

Made with [Cursor](https://cursor.com)