### PR TITLE
docs(tests): Gap-6 verified-bar contract (T1+T2 dry-run proof)

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -1697,6 +1697,65 @@ This governed repo-reflection block records operator-authorized Gap-6 dry-run RC
 
 Evidence observation is not runtime authorization. The Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0 block above remains scoped observation only and unchanged.
 
+## Gap 6 Governed Dry-Run Proof Verified Final-Line Reflection v0
+
+GAP6_DRY_RUN_PROOF_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP6_DRY_RUN_PROOF_VERIFIED=true
+ACCEPTED_MODE=GAP6_DRY_RUN_PROOF_VERIFIED_SCOPED_EVIDENCE_FINAL_LINE
+GOVERNED_VERIFICATION_BASIS=GAP6_T1_STATIC_PROOF_CRITERIA_PLUS_T2_DRY_RUN_RC0_OBSERVED
+GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF
+T1_STATIC_READONLY_SUFFICIENT_FOR_GAP6_VERIFIED=false
+T2_DRY_RUN_PROOF_RC0_SUFFICIENT_FOR_GAP6_VERIFIED=true
+T3_BOUNDED_EXECUTE_REQUIRED_FOR_GAP6_VERIFIED=false
+GAP6_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false
+GAP6_VERIFIED_REQUIRES_CONTRACT_LIFT=true
+EXTERNAL_DRY_RUN_EVIDENCE_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/evidence/gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z/
+EXTERNAL_CROSSREF_EVIDENCE_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/runtime/gap2_bounded_scheduler_dry_run_once_no_network_no_credentials_v0_20260604T193701Z/
+EXTERNAL_PRECHECK_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap6_verified_bar_precheck_no_execute_v0_20260604T211309Z/
+OPERATOR_GO=GO_PREPARE_SECTION5_GAP6_VERIFIED_BAR_CONTRACT_DOCS_TESTS_V0
+NO_RUNTIME_AUTHORITY=true
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_EVIDENCE=true
+VERIFIED_NOT_OBSERVED_NOT_ACCEPTED_SEMANTIC_PRESERVED=true
+GAP6_DRY_RUN_RC0_OBSERVED=true
+GAP6_DRY_RUN_PROOF_ACCEPTED=true
+GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP2_CANONICAL_JOB_SET_VERIFIED=true
+GAP3_EXECUTE_COMMAND_VERIFIED=true
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false
+PREFLIGHT_REMAINS_BLOCKED=true
+ALL_GAPS_CLOSED=false
+READY_FOR_OPERATOR_ARMING=false
+NEXT_EXECUTE_ALLOWED=false
+
+This governed repo-reflection block records operator-authorized Gap-6 dry-run proof **verified final-line propagation** only. Verified means **dry-run proof verification** (T1 static proof criteria + T2 Tier-2 bounded dry-run RC=0 observed on primary capture), not scheduler execution authorization or non-dry-run dispatch. External evidence bundles remain pointer-based and subordinate to repo governance.
+
+Command (Tier-2 primary observed RC=0):
+
+`uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose --include-tags paper_shadow_247,preflight,readonly`
+
+### Verified final-line scope (allowed only)
+
+- T1 static dry-run proof criteria via existing drift-guard tests; T2 Tier-2 bounded dry-run RC=0 observed on primary bundle `20260603T153911Z`
+- `GAP6_DRY_RUN_PROOF_VERIFIED=true` in **Final Machine Lines only**
+- `GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF` in **this block and Final Machine Lines**
+- Gap 6 Dry-Run Proof Criteria Contract v0 criteria block remains criteria-only with `GAP6_DRY_RUN_PROOF_VERIFIED=false`
+- `GAP6_DRY_RUN_RC0_OBSERVED=true` and `GAP6_DRY_RUN_PROOF_ACCEPTED=true` in Final Machine Lines unchanged
+- verified dry-run proof ≠ RC0 observed alone; verified ≠ proof accepted alone; verified ≠ scheduler execution authorization
+
+### Non-authority boundary (verified final-line reflection does not imply)
+
+- does not modify Gap-6 criteria block verification posture (`GAP6_DRY_RUN_PROOF_VERIFIED=false` in criteria unchanged)
+- does not modify Gap-6 criteria RC0/accepted posture (`GAP6_DRY_RUN_RC0_OBSERVED=false`, `GAP6_DRY_RUN_PROOF_ACCEPTED=false` in criteria unchanged)
+- does not set `GAP6_SCHEDULER_EXECUTION_AUTHORIZED=true`
+- does not set `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true` in criteria or Final Machine Lines
+- does not modify Gap-2, Gap-3, Tier-1, or Gap-2a.1 enforcement posture beyond existing finals
+- does not lift preflight (`PREFLIGHT_REMAINS_BLOCKED=true` unchanged)
+- does not set `READY_FOR_OPERATOR_ARMING=true` or `NEXT_EXECUTE_ALLOWED=true`
+- does not set `ALL_GAPS_CLOSED=true`
+- does not authorize Live, Testnet, orders, validate-only, private API, or unscoped scheduler loops
+
+Evidence verification is not runtime authorization. The Gap 6 Governed Dry-Run RC0 Observed Final-Line Reflection v0 block above remains scoped observation only and unchanged.
+
 ## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0
 
 GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
@@ -2131,7 +2190,14 @@ GAP1_ENTRYPOINT_DRY_RUN_ONLY=true
 GAP6_DRY_RUN_PROOF_CRITERIA_CONTRACT_V0=true
 GAP6_CRITERIA_ONLY=true
 GAP6_DRY_RUN_PROOF_ACCEPTED=true
-GAP6_DRY_RUN_PROOF_VERIFIED=false
+GAP6_DRY_RUN_PROOF_VERIFIED=true
+GAP6_DRY_RUN_PROOF_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF
+T1_STATIC_READONLY_SUFFICIENT_FOR_GAP6_VERIFIED=false
+T2_DRY_RUN_PROOF_RC0_SUFFICIENT_FOR_GAP6_VERIFIED=true
+T3_BOUNDED_EXECUTE_REQUIRED_FOR_GAP6_VERIFIED=false
+GAP6_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false
+GAP6_VERIFIED_REQUIRES_CONTRACT_LIFT=true
 GAP6_DRY_RUN_RC0_OBSERVED=true
 GAP6_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP6_DRY_RUN_PROOF_DEFAULT_ON=false

--- a/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
+++ b/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
@@ -68,12 +68,13 @@ DEPENDENCY_REQUIRED_FINAL_LINES = (
     "GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false",
     "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_RC0_OBSERVED=true",
+    "GAP6_DRY_RUN_PROOF_VERIFIED=true",
+    "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF",
 )
 
 DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
     "GAP2_JOB_SET_ENABLED=true",
     "GAP3_SCHEDULER_EXECUTION_AUTHORIZED=true",
-    "GAP6_DRY_RUN_PROOF_VERIFIED=true",
     "SHADOW_24_7_AUTHORIZED=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
     "ALL_GAPS_CLOSED=true",
@@ -239,7 +240,7 @@ def test_gap2_gap3_dependency_gap6_tokens_untouched_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
 
 
 def test_gap2_gap3_dependency_criteria_complete_does_not_close_gaps_v0() -> None:
@@ -473,6 +474,6 @@ def test_gap2_gap3_reflection_final_lines_gap3_verified_without_authority_lift_v
     assert "GAP3_EXECUTE_COMMAND_VERIFIED=true" in block
     assert "GAP3_EXECUTE_COMMAND_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
     assert "ALL_GAPS_CLOSED=false" in block

--- a/tests/ops/test_gap2_job_set_boundary_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap2_job_set_boundary_drift_guard_contract_v0.py
@@ -184,7 +184,7 @@ def test_gap2_job_set_boundary_gap6_tokens_untouched_by_gap2_slice_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
 
 
 def test_gap2_job_set_boundary_criteria_complete_does_not_close_gaps_v0() -> None:

--- a/tests/ops/test_gap2a1_primary_evidence_enforcement_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap2a1_primary_evidence_enforcement_drift_guard_contract_v0.py
@@ -279,7 +279,7 @@ def test_gap2a1_drift_guard_gap5_gap6_orthogonal_v0() -> None:
     assert "GAP5_STOP_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
 
 
 def _module_preamble() -> str:

--- a/tests/ops/test_gap4_output_evidence_paths_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap4_output_evidence_paths_drift_guard_contract_v0.py
@@ -247,7 +247,7 @@ def test_gap4_output_evidence_paths_drift_guard_gap5_gap6_tokens_untouched_v0() 
     assert "GAP5_STOP_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
 
 
 def test_gap4_output_evidence_paths_drift_guard_stop_proof_not_from_inventory_only_v0() -> None:

--- a/tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py
+++ b/tests/ops/test_gap5_gap4_durable_evidence_dependency_contract_v0.py
@@ -198,7 +198,7 @@ def test_gap5_gap4_durable_evidence_dependency_gap6_tokens_untouched_v0() -> Non
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
 
 
 def test_gap5_gap4_durable_evidence_dependency_criteria_complete_does_not_close_gaps_v0() -> None:

--- a/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap5_stop_criteria_drift_guard_contract_v0.py
@@ -239,7 +239,7 @@ def test_gap5_stop_criteria_drift_guard_gap4_gap6_tokens_untouched_v0() -> None:
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
 
 
 def test_gap5_stop_criteria_drift_guard_criteria_complete_does_not_close_gaps_v0() -> None:

--- a/tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py
+++ b/tests/ops/test_gap5_stop_rehearsal_evidence_classification_contract_v0.py
@@ -165,7 +165,7 @@ def test_gap5_rehearsal_classification_gap4_gap6_tokens_untouched_v0() -> None:
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
 
 
 def test_gap5_rehearsal_classification_criteria_complete_does_not_close_gaps_v0() -> None:

--- a/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
+++ b/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
@@ -11,6 +11,9 @@ GAP6_ACCEPTED_FINAL_LINE_REFLECTION_HEADER = (
 GAP6_RC0_OBSERVED_REFLECTION_HEADER = (
     "## Gap 6 Governed Bounded Dry-Run RC0 Observed Evidence Reflection v0"
 )
+GAP6_VERIFIED_FINAL_LINE_HEADER = (
+    "## Gap 6 Governed Dry-Run Proof Verified Final-Line Reflection v0"
+)
 GAP5_GOVERNED_STOP_PROOF_REFLECTION_HEADER = "## Gap 5 Governed Stop Proof Acceptance Reflection v0"
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP6_PARALLEL_MARKERS = (
@@ -182,7 +185,7 @@ def test_gap6_dry_run_proof_criteria_contract_governed_reflection_non_authorizin
     assert "does not accept or verify any proof" in criteria
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED_EXTERNAL=true" not in text
     assert "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true" not in text
     reflection_lines = {line.strip() for line in reflection.splitlines()}
@@ -191,6 +194,48 @@ def test_gap6_dry_run_proof_criteria_contract_governed_reflection_non_authorizin
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in reflection_lines
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" not in criteria_lines
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block_lines
+
+
+def _gap6_rc0_observed_final_line_reflection_section(text: str) -> str:
+    return text.split("## Gap 6 Governed Dry-Run RC0 Observed Final-Line Reflection v0", 1)[
+        1
+    ].split(GAP6_VERIFIED_FINAL_LINE_HEADER, 1)[0]
+
+
+def _gap6_verified_final_line_section(text: str) -> str:
+    return text.split(GAP6_VERIFIED_FINAL_LINE_HEADER, 1)[1].split(
+        "## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0", 1
+    )[0]
+
+
+def test_gap6_verified_final_line_governed_reflection_v0() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    section = _gap6_verified_final_line_section(text)
+    observed_final = _gap6_rc0_observed_final_line_reflection_section(text)
+    criteria = _gap6_criteria_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in section
+    assert "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF" in section
+    assert "T1_STATIC_READONLY_SUFFICIENT_FOR_GAP6_VERIFIED=false" in section
+    assert "T2_DRY_RUN_PROOF_RC0_SUFFICIENT_FOR_GAP6_VERIFIED=true" in section
+    assert "T3_BOUNDED_EXECUTE_REQUIRED_FOR_GAP6_VERIFIED=false" in section
+    assert "GAP6_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false" in section
+    assert "VERIFIED_NOT_OBSERVED_NOT_ACCEPTED_SEMANTIC_PRESERVED=true" in section
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in observed_final
+    assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
+    assert "does not modify Gap-6 criteria block verification posture" in section
+    assert "does not set `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true`" in section
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in criteria
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
+    assert "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF" in block
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in criteria_lines
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block_lines
+    assert "GAP6_SCHEDULER_EXECUTION_AUTHORIZED=true" not in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
 
 
 def test_gap6_dry_run_proof_accepted_final_line_governed_reflection_v0() -> None:
@@ -216,7 +261,7 @@ def test_gap6_dry_run_proof_accepted_final_line_governed_reflection_v0() -> None
     assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in criteria
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
     criteria_lines = {line.strip() for line in criteria.splitlines()}
     block_lines = {line.strip() for line in block.splitlines()}
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" not in criteria_lines

--- a/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py
@@ -30,6 +30,9 @@ GAP6_RC0_OBSERVED_REFLECTION_HEADER = (
 GAP6_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER = (
     "## Gap 6 Governed Dry-Run RC0 Observed Final-Line Reflection v0"
 )
+GAP6_VERIFIED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 6 Governed Dry-Run Proof Verified Final-Line Reflection v0"
+)
 GAP5_GOVERNED_STOP_PROOF_REFLECTION_HEADER = "## Gap 5 Governed Stop Proof Acceptance Reflection v0"
 GAP4_GOVERNED_REFLECTION_HEADER = "## Gap 4 Governed Output Evidence Acceptance Reflection v0"
 _MARKER_TRUE = "=true"
@@ -46,7 +49,8 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "ALL_GAPS_CLOSED=false",
     "GAP6_DRY_RUN_RC0_OBSERVED=true",
     "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
-    "GAP6_DRY_RUN_PROOF_VERIFIED=false",
+    "GAP6_DRY_RUN_PROOF_VERIFIED=true",
+    "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF",
     "GAP2_CANONICAL_JOB_SET_VERIFIED=true",
     "GAP2_ACCEPTED_SCOPED_CRITERIA=true",
     "GAP2_CANONICAL_JOB_SET_DRY_RUN_OBSERVED=true",
@@ -56,7 +60,6 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
 
 DRIFT_GUARD_FORBIDDEN_REPO_TOKENS = (
     "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true",
-    "GAP6_DRY_RUN_PROOF_VERIFIED=true",
     "WORKSHEET_COMPLETE=true",
     "SHADOW_24_7_AUTHORIZED=true",
     "PATH_B_LIFT_DISCUSSION_READY=true",
@@ -185,7 +188,7 @@ def test_gap6_external_repo_drift_guard_governed_reflection_scoped_acceptance_v0
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=false" in criteria
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
     assert "GAP4_OUTPUT_EVIDENCE_PATHS_VERIFIED=true" in block
     assert "GAP7_RISK_BOUNDARY_VERIFIED=true" in block
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in block
@@ -225,7 +228,7 @@ def test_gap6_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     assert "Evidence observation is not runtime authorization" in reflection
     assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in criteria
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
     assert "ALL_GAPS_CLOSED=false" in block
     assert "READY_FOR_OPERATOR_ARMING=false" in block
     assert "GAP7_RISK_BOUNDARY_VERIFIED=true" in block
@@ -235,12 +238,18 @@ def test_gap6_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in reflection_lines
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" not in criteria_lines
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block_lines
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" not in block_lines
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block_lines
     assert "GAP6_DRY_RUN_RC0_OBSERVED_EXTERNAL=true" not in text
 
 
 def _gap6_rc0_observed_final_line_reflection_section(text: str) -> str:
     return text.split(GAP6_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        GAP6_VERIFIED_FINAL_LINE_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap6_verified_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP6_VERIFIED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
         "## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0", 1
     )[0]
 
@@ -258,6 +267,27 @@ def test_gap6_rc0_observed_final_line_reflection_non_authorizing_v0() -> None:
     assert "does not set `GAP6_DRY_RUN_PROOF_VERIFIED=true`" in final_line
     assert "GAP6_DRY_RUN_RC0_OBSERVED=false" in criteria
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
+    assert "ALL_GAPS_CLOSED=false" in block
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
+
+
+def test_gap6_verified_final_line_reflection_scoped_verification_v0() -> None:
+    text = _section5_text()
+    final_line = _gap6_verified_final_line_reflection_section(text)
+    observed_final = _gap6_rc0_observed_final_line_reflection_section(text)
+    criteria = _gap6_criteria_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in final_line
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in final_line
+    assert "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF" in final_line
+    assert "GAP6_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false" in final_line
+    assert "VERIFIED_NOT_OBSERVED_NOT_ACCEPTED_SEMANTIC_PRESERVED=true" in final_line
+    assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in observed_final
+    assert "does not set `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true`" in final_line
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in criteria
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
+    assert "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF" in block
     assert "ALL_GAPS_CLOSED=false" in block
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in block

--- a/tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap7_risk_boundary_drift_guard_contract_v0.py
@@ -255,7 +255,7 @@ def test_gap7_drift_guard_gap6_gap2a1_orthogonal_v0() -> None:
     block = _final_machine_lines(_section5_text())
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in block
     assert "GAP2A1_ENFORCEMENT_DEFAULT_ON=false" in block
     assert "GAP7_RISK_BOUNDARY_VERIFIED=true" in block

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -307,10 +307,10 @@ def test_section5_gap6_dry_run_proof_accepted_final_line_reflection_non_authoriz
         assert token in section
 
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     block_lines = {line.strip() for line in block.splitlines()}
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" not in block_lines
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block_lines
     assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
 
 
@@ -341,10 +341,10 @@ def test_section5_gap6_gap1_rc0_observed_final_line_reflection_non_authorizing_v
 
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
     block_lines = {line.strip() for line in block.splitlines()}
-    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" not in block_lines
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block_lines
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
     assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
 
@@ -539,6 +539,50 @@ def test_section5_gap3_verified_final_line_reflection_non_authorizing_v0() -> No
     assert "GAP3_EXECUTE_COMMAND_VERIFIED=false" in gap3
     block_lines = {line.strip() for line in block.splitlines()}
     assert "GAP3_EXECUTE_COMMAND_VERIFIED=true" in block_lines
+    assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
+
+
+GAP6_VERIFIED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 6 Governed Dry-Run Proof Verified Final-Line Reflection v0"
+)
+
+
+def _gap6_verified_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP6_VERIFIED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0", 1
+    )[0]
+
+
+def test_section5_gap6_verified_final_line_reflection_non_authorizing_v0() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    section = _gap6_verified_final_line_reflection_section(text)
+    block = _final_machine_lines(text)
+    gap6 = text.split("## Gap 6 Dry-Run Proof Criteria Contract v0", 1)[1].split(
+        "## Final Machine Lines", 1
+    )[0]
+
+    for token in (
+        "GAP6_DRY_RUN_PROOF_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true",
+        "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF",
+        "T1_STATIC_READONLY_SUFFICIENT_FOR_GAP6_VERIFIED=false",
+        "T2_DRY_RUN_PROOF_RC0_SUFFICIENT_FOR_GAP6_VERIFIED=true",
+        "T3_BOUNDED_EXECUTE_REQUIRED_FOR_GAP6_VERIFIED=false",
+        "GAP6_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false",
+        "VERIFIED_NOT_OBSERVED_NOT_ACCEPTED_SEMANTIC_PRESERVED=true",
+        "GAP6_DRY_RUN_RC0_OBSERVED=true",
+        "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
+        "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "ALL_GAPS_CLOSED=false",
+    ):
+        assert token in section
+
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
+    assert "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF" in block
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in gap6
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
     assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
 
 


### PR DESCRIPTION
## Summary

- Adds governed **Gap-6 Dry-Run Proof Verified Final-Line Reflection v0** to `SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- Sets `GAP6_DRY_RUN_PROOF_VERIFIED=true` and `GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF` in **Final Machine Lines only**; Gap-6 criteria block remains `VERIFIED=false`
- Verified bar based on **T1 static contract/tests** + **T2 RC=0 dry-run proof evidence** from primary capture `20260603T153911Z` (no new execute)
- Extends existing Gap-6 / Section-5 drift-guard tests; updates cross-gap finals assertions

## Safety / non-authorization

- **No new execute**, scheduler start, preflight lift, arming, live/order/futures authority
- `GAP6_DRY_RUN_RC0_OBSERVED=true` and `GAP6_DRY_RUN_PROOF_ACCEPTED=true` unchanged in finals
- **Gap-1 remains observed-only** (`GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false`)
- Gap-2/Gap-3 verified tokens unchanged; Tier-1 / Gap-2a.1 repo-lift remains blocked
- `ALL_GAPS_CLOSED=false`, `PREFLIGHT_REMAINS_BLOCKED=true`, `NEXT_EXECUTE_ALLOWED=false`

## Test plan

- [x] `uv run pytest tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_gap2_canonical_job_set_contract_v0.py tests/ops/test_gap3_execute_command_contract_v0.py tests/ops/test_gap2_gap3_command_dependency_contract_v0.py -q`
- [x] Cross-gap drift guards (gap4/5/7/2a1/2 boundary) — 139 passed
- [x] `uv run ruff check` + `ruff format --check` on changed tests


Made with [Cursor](https://cursor.com)