### PR TITLE
docs(tests): Gap-1 verified-bar contract (T1+T2 entrypoint boundary)

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -1799,6 +1799,68 @@ This governed repo-reflection block records operator-authorized Gap-1 execute en
 
 Evidence observation is not runtime authorization. The Gap 1 Governed Execute Entrypoint Observed Evidence Reflection v0 block above remains scoped observation only and unchanged.
 
+## Gap 1 Governed Execute Entrypoint Verified Final-Line Reflection v0
+
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true
+ACCEPTED_MODE=GAP1_ENTRYPOINT_BOUNDARY_VERIFIED_SCOPED_EVIDENCE_FINAL_LINE
+GOVERNED_VERIFICATION_BASIS=GAP1_T1_STATIC_ENTRYPOINT_CONTRACT_PLUS_T2_DRY_RUN_RC0_OBSERVED
+GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY
+T1_STATIC_READONLY_SUFFICIENT_FOR_GAP1_VERIFIED=false
+T2_ENTRYPOINT_DRY_RUN_RC0_SUFFICIENT_FOR_GAP1_VERIFIED=true
+T3_BOUNDED_EXECUTE_REQUIRED_FOR_GAP1_VERIFIED=false
+GAP1_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false
+GAP1_VERIFIED_REQUIRES_CONTRACT_LIFT=true
+ENTRYPOINT=scripts/run_scheduler.py
+EXTERNAL_DRY_RUN_EVIDENCE_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/evidence/gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z/
+EXTERNAL_CROSSREF_EVIDENCE_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/runtime/gap2_bounded_scheduler_dry_run_once_no_network_no_credentials_v0_20260604T193701Z/
+EXTERNAL_PRECHECK_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/gap1_verified_bar_precheck_no_execute_v0_20260604T213021Z/
+OPERATOR_GO=GO_PREPARE_SECTION5_GAP1_VERIFIED_BAR_CONTRACT_DOCS_TESTS_V0
+NO_RUNTIME_AUTHORITY=true
+NO_REPO_FLAG_LIFT_FROM_EXTERNAL_EVIDENCE=true
+VERIFIED_NOT_OBSERVED_SEMANTIC_PRESERVED=true
+GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true
+GAP1_RUNTIME_APPROVED=false
+GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false
+GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=false
+GAP1_ENTRYPOINT_DRY_RUN_ONLY=true
+GAP6_DRY_RUN_PROOF_VERIFIED=true
+GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF
+GAP2_CANONICAL_JOB_SET_VERIFIED=true
+GAP3_EXECUTE_COMMAND_VERIFIED=true
+PREFLIGHT_REMAINS_BLOCKED=true
+ALL_GAPS_CLOSED=false
+READY_FOR_OPERATOR_ARMING=false
+NEXT_EXECUTE_ALLOWED=false
+
+This governed repo-reflection block records operator-authorized Gap-1 execute entrypoint **verified final-line propagation** only. Verified means **entrypoint-boundary verification** (T1 static entrypoint contract + T2 Tier-2 bounded dry-run RC=0 observed on canonical entrypoint `scripts/run_scheduler.py`), not scheduler execution authorization or non-dry-run dispatch. External evidence bundles remain pointer-based and subordinate to repo governance.
+
+Command (Tier-2 primary observed RC=0 on entrypoint):
+
+`uv run python scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose --include-tags paper_shadow_247,preflight,readonly`
+
+### Verified final-line scope (allowed only)
+
+- T1 static entrypoint contract via existing drift-guard tests; T2 Tier-2 bounded dry-run RC=0 observed on primary bundle `20260603T153911Z` via `scripts/run_scheduler.py`
+- `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true` in **Final Machine Lines only**
+- `GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY` in **this block and Final Machine Lines**
+- Gap 1 Execute Entrypoint Contract v0 criteria block remains criteria-only with `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false`
+- `GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true` in Final Machine Lines unchanged
+- verified entrypoint boundary ≠ RC0 observed alone; verified ≠ scheduler execution authorization
+
+### Non-authority boundary (verified final-line reflection does not imply)
+
+- does not modify Gap-1 criteria block verification posture (`GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false` in criteria unchanged)
+- does not modify Gap-1 observed posture in criteria (`GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED` not in criteria block)
+- does not set `GAP1_SCHEDULER_EXECUTION_AUTHORIZED=true` or `GAP1_RUNTIME_APPROVED=true`
+- does not modify Gap-2, Gap-3, Gap-6, Tier-1, or Gap-2a.1 enforcement posture beyond existing finals
+- does not lift preflight (`PREFLIGHT_REMAINS_BLOCKED=true` unchanged)
+- does not set `READY_FOR_OPERATOR_ARMING=true` or `NEXT_EXECUTE_ALLOWED=true`
+- does not set `ALL_GAPS_CLOSED=true`
+- does not authorize Live, Testnet, orders, validate-only, private API, or unscoped scheduler loops
+
+Evidence verification is not runtime authorization. The Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0 block above remains scoped observation only and unchanged.
+
 ## Tier-1 Governed Zero-Dispatch Manifest Observed Final-Line Reflection v0
 
 TIER1_ZERO_DISPATCH_MANIFEST_OBSERVED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
@@ -2181,7 +2243,14 @@ GAP3_SCHEDULER_EXECUTION_AUTHORIZED=false
 GAP3_EXECUTE_COMMAND_DEFAULT_ON=false
 GAP3_EXECUTE_COMMAND_DRY_RUN_ONLY=true
 GAP1_EXECUTE_ENTRYPOINT_CONTRACT_V0=true
-GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true
+GAP1_EXECUTE_ENTRYPOINT_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true
+GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY
+T1_STATIC_READONLY_SUFFICIENT_FOR_GAP1_VERIFIED=false
+T2_ENTRYPOINT_DRY_RUN_RC0_SUFFICIENT_FOR_GAP1_VERIFIED=true
+T3_BOUNDED_EXECUTE_REQUIRED_FOR_GAP1_VERIFIED=false
+GAP1_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false
+GAP1_VERIFIED_REQUIRES_CONTRACT_LIFT=true
 GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true
 GAP1_RUNTIME_APPROVED=false
 GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false

--- a/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_contract_v0.py
@@ -7,6 +7,12 @@ GAP1_SECTION_HEADER = "## Gap 1 Execute Entrypoint Contract v0"
 GAP1_RC0_OBSERVED_REFLECTION_HEADER = (
     "## Gap 1 Governed Execute Entrypoint Observed Evidence Reflection v0"
 )
+GAP1_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0"
+)
+GAP1_VERIFIED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 1 Governed Execute Entrypoint Verified Final-Line Reflection v0"
+)
 GAP4_GOVERNED_REFLECTION_HEADER = "## Gap 4 Governed Output Evidence Acceptance Reflection v0"
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 GAP1_PARALLEL_MARKERS = (
@@ -134,7 +140,46 @@ def test_gap1_rc0_observed_governed_reflection_present_and_non_authorizing_v0() 
     )
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in reflection
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in reflection
-    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block_lines
     assert "ALL_GAPS_CLOSED=false" in block
     assert "READY_FOR_OPERATOR_ARMING=false" in block
+
+
+def _gap1_rc0_observed_final_line_section(text: str) -> str:
+    return text.split(GAP1_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        GAP1_VERIFIED_FINAL_LINE_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap1_verified_final_line_section(text: str) -> str:
+    return text.split(GAP1_VERIFIED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Tier-1 Governed Zero-Dispatch Manifest Observed Final-Line Reflection v0", 1
+    )[0]
+
+
+def test_gap1_verified_final_line_governed_reflection_v0() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    section = _gap1_verified_final_line_section(text)
+    observed = _gap1_rc0_observed_final_line_section(text)
+    criteria = _gap1_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in section
+    assert "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY" in section
+    assert "T1_STATIC_READONLY_SUFFICIENT_FOR_GAP1_VERIFIED=false" in section
+    assert "T2_ENTRYPOINT_DRY_RUN_RC0_SUFFICIENT_FOR_GAP1_VERIFIED=true" in section
+    assert "T3_BOUNDED_EXECUTE_REQUIRED_FOR_GAP1_VERIFIED=false" in section
+    assert "GAP1_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false" in section
+    assert "VERIFIED_NOT_OBSERVED_SEMANTIC_PRESERVED=true" in section
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in observed
+    assert "does not modify Gap-1 criteria block verification posture" in section
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in criteria
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block
+    assert "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
+    criteria_lines = {line.strip() for line in criteria.splitlines()}
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in criteria_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block_lines
+    assert "GAP1_SCHEDULER_EXECUTION_AUTHORIZED=true" not in block_lines

--- a/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
+++ b/tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py
@@ -50,7 +50,8 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "READY_FOR_OPERATOR_ARMING=false",
     "PATH_B_LIFT_DISCUSSION_READY=false",
     "ALL_GAPS_CLOSED=false",
-    "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false",
+    "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true",
+    "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY",
     "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true",
     "GAP1_RUNTIME_APPROVED=false",
     "GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false",
@@ -61,11 +62,11 @@ DRIFT_GUARD_REQUIRED_FINAL_LINES = (
     "GAP5_STOP_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_PROOF_ACCEPTED=true",
     "GAP6_DRY_RUN_RC0_OBSERVED=true",
+    "GAP6_DRY_RUN_PROOF_VERIFIED=true",
 )
 
 DRIFT_GUARD_FORBIDDEN_GAP1_REPO_TOKENS = (
     "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_EXTERNAL=true",
-    "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true",
     "GAP1_RUNTIME_APPROVED=true",
     "GAP1_SCHEDULER_EXECUTION_AUTHORIZED=true",
     "GAP1_EXECUTE_ENTRYPOINT_DEFAULT_ON=true",
@@ -279,7 +280,7 @@ def test_gap1_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     assert "does not lift preflight" in reflection
     assert "Evidence observation is not runtime authorization" in reflection
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in criteria
-    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
     assert "ALL_GAPS_CLOSED=false" in block
     assert "READY_FOR_OPERATOR_ARMING=false" in block
@@ -291,7 +292,7 @@ def test_gap1_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in reflection_lines
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" not in criteria_lines
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block_lines
-    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block_lines
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED_EXTERNAL=true" not in text
     assert "Live/Testnet/Shadow/Paper/Broker/Network/AWS" in reflection
 
@@ -299,11 +300,20 @@ def test_gap1_rc0_observed_governed_reflection_scoped_evidence_v0() -> None:
 GAP1_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER = (
     "## Gap 1 Governed Execute Entrypoint RC0 Observed Final-Line Reflection v0"
 )
+GAP1_VERIFIED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 1 Governed Execute Entrypoint Verified Final-Line Reflection v0"
+)
 
 
 def _gap1_rc0_observed_final_line_reflection_section(text: str) -> str:
     return text.split(GAP1_RC0_OBSERVED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
-        "## Preflight Synthesis Docs Block Reflection v0", 1
+        GAP1_VERIFIED_FINAL_LINE_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _gap1_verified_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP1_VERIFIED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Tier-1 Governed Zero-Dispatch Manifest Observed Final-Line Reflection v0", 1
     )[0]
 
 
@@ -322,6 +332,27 @@ def test_gap1_rc0_observed_final_line_reflection_non_authorizing_v0() -> None:
     assert "does not set `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true`" in final_line
     assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in criteria
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
-    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block
+    assert "ALL_GAPS_CLOSED=false" in block
+    assert "PREFLIGHT_REMAINS_BLOCKED=true" in block
+
+
+def test_gap1_verified_final_line_reflection_non_authorizing_v0() -> None:
+    text = _section5_text()
+    final_line = _gap1_verified_final_line_reflection_section(text)
+    observed_final = _gap1_rc0_observed_final_line_reflection_section(text)
+    criteria = _gap1_section(text)
+    block = _final_machine_lines(text)
+
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true" in final_line
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in final_line
+    assert "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY" in final_line
+    assert "GAP1_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false" in final_line
+    assert "VERIFIED_NOT_OBSERVED_SEMANTIC_PRESERVED=true" in final_line
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in observed_final
+    assert "does not modify Gap-1 criteria block verification posture" in final_line
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in criteria
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block
+    assert "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY" in block
     assert "ALL_GAPS_CLOSED=false" in block
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in block

--- a/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
+++ b/tests/ops/test_gap2_gap3_command_dependency_contract_v0.py
@@ -70,6 +70,10 @@ DEPENDENCY_REQUIRED_FINAL_LINES = (
     "GAP6_DRY_RUN_RC0_OBSERVED=true",
     "GAP6_DRY_RUN_PROOF_VERIFIED=true",
     "GAP6_VERIFIED_BAR_TIER=T1_PLUS_T2_DRY_RUN_PROOF",
+    "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true",
+    "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true",
+    "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY",
+    "GAP1_SCHEDULER_EXECUTION_AUTHORIZED=false",
 )
 
 DEPENDENCY_FORBIDDEN_REPO_TOKENS = (
@@ -241,6 +245,13 @@ def test_gap2_gap3_dependency_gap6_tokens_untouched_v0() -> None:
     assert "GAP6_DRY_RUN_PROOF_ACCEPTED=true" in block
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
+
+
+def test_gap2_gap3_dependency_gap1_verified_tokens_present_v0() -> None:
+    block = _final_machine_lines(_section5_text())
+    assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block
+    assert "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY" in block
 
 
 def test_gap2_gap3_dependency_criteria_complete_does_not_close_gaps_v0() -> None:

--- a/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
+++ b/tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py
@@ -235,7 +235,6 @@ def test_gap6_verified_final_line_governed_reflection_v0() -> None:
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in criteria_lines
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block_lines
     assert "GAP6_SCHEDULER_EXECUTION_AUTHORIZED=true" not in block_lines
-    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
 
 
 def test_gap6_dry_run_proof_accepted_final_line_governed_reflection_v0() -> None:

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -342,10 +342,10 @@ def test_section5_gap6_gap1_rc0_observed_final_line_reflection_non_authorizing_v
     assert "GAP6_DRY_RUN_RC0_OBSERVED=true" in block
     assert "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true" in block
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block
-    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block
     block_lines = {line.strip() for line in block.splitlines()}
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block_lines
-    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block_lines
     assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
 
 
@@ -582,7 +582,48 @@ def test_section5_gap6_verified_final_line_reflection_non_authorizing_v0() -> No
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=false" in gap6
     block_lines = {line.strip() for line in block.splitlines()}
     assert "GAP6_DRY_RUN_PROOF_VERIFIED=true" in block_lines
-    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" not in block_lines
+    assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
+
+
+GAP1_VERIFIED_FINAL_LINE_REFLECTION_HEADER = (
+    "## Gap 1 Governed Execute Entrypoint Verified Final-Line Reflection v0"
+)
+
+
+def _gap1_verified_final_line_reflection_section(text: str) -> str:
+    return text.split(GAP1_VERIFIED_FINAL_LINE_REFLECTION_HEADER, 1)[1].split(
+        "## Tier-1 Governed Zero-Dispatch Manifest Observed Final-Line Reflection v0", 1
+    )[0]
+
+
+def test_section5_gap1_verified_final_line_reflection_non_authorizing_v0() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    section = _gap1_verified_final_line_reflection_section(text)
+    block = _final_machine_lines(text)
+    gap1 = text.split("## Gap 1 Execute Entrypoint Contract v0", 1)[1].split(
+        "## Gap 3 Execute Command Contract v0", 1
+    )[0]
+
+    for token in (
+        "GAP1_EXECUTE_ENTRYPOINT_VERIFIED_FINAL_LINE_GOVERNED_REFLECTION_V0=true",
+        "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY",
+        "T1_STATIC_READONLY_SUFFICIENT_FOR_GAP1_VERIFIED=false",
+        "T2_ENTRYPOINT_DRY_RUN_RC0_SUFFICIENT_FOR_GAP1_VERIFIED=true",
+        "T3_BOUNDED_EXECUTE_REQUIRED_FOR_GAP1_VERIFIED=false",
+        "GAP1_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false",
+        "VERIFIED_NOT_OBSERVED_SEMANTIC_PRESERVED=true",
+        "GAP1_EXECUTE_ENTRYPOINT_RC0_OBSERVED=true",
+        "GAP6_DRY_RUN_PROOF_VERIFIED=true",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "ALL_GAPS_CLOSED=false",
+    ):
+        assert token in section
+
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block
+    assert "GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY" in block
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in gap1
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block_lines
     assert "READY_FOR_OPERATOR_ARMING=true" not in block_lines
 
 


### PR DESCRIPTION
## Summary

- Adds governed **Gap-1 Execute Entrypoint Verified Final-Line Reflection v0** block to `SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md`
- Sets `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true` and `GAP1_VERIFIED_BAR_TIER=T1_PLUS_T2_ENTRYPOINT_BOUNDARY` in **Final Machine Lines only**
- Gap-1 criteria block remains `GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false` (observed/verified semantic separation preserved)
- Extends existing Gap-1/Gap-6/Section-5 drift guards; 119 targeted pytest passed

## Evidence basis

- **T1:** static entrypoint contract + drift guards on main
- **T2:** RC=0 dry-run entrypoint evidence from `evidence/gap6_bounded_dry_run_evidence_capture_operator_authorized_v0_20260603T153911Z/` (same bounded capture used for Gap-6 verified bar)
- **Upstream:** `GAP6_DRY_RUN_PROOF_VERIFIED=true` (PR #4004) unchanged

## Non-authorization (explicit)

- **No new execute** — reuses existing T2 evidence; `GAP1_VERIFIED_REQUIRES_RUNTIME_EXECUTE=false`
- **No preflight lift** — `PREFLIGHT_REMAINS_BLOCKED=true`
- **No arming** — `READY_FOR_OPERATOR_ARMING=false`
- **No live/order/futures authority** — all futures/execute tokens remain false
- **No jobs.toml / src / scheduler code changes** — docs/tests-only diff
- Gap-6 remains verified upstream; no duplicate evidence charter

## Test plan

- [x] `uv run pytest tests/ops/test_gap1_execute_entrypoint_contract_v0.py tests/ops/test_gap1_execute_entrypoint_drift_guard_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_gap6_dry_run_proof_criteria_contract_v0.py tests/ops/test_gap6_external_repo_drift_guard_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py -q`
- [x] `uv run pytest tests/ops/test_gap2_canonical_job_set_contract_v0.py tests/ops/test_gap3_execute_command_contract_v0.py tests/ops/test_gap2_gap3_command_dependency_contract_v0.py -q`
- [x] ruff check/format on changed tests


Made with [Cursor](https://cursor.com)