### PR TITLE
docs/tests: reflect T3 run attempt execute policy gate

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -2732,6 +2732,88 @@ This governed repo-reflection block records operator-authorized **T3_BOUNDED_EXE
 
 Policy T3 bounded execute run attempt lift is not runtime authorization, scheduler authorization, order authorization, live authorization, futures authority, or concrete run authorization. Prior governed reflection blocks above remain scoped acceptance/verification only and unchanged except Final Machine Lines propagation recorded here.
 
+## T3_RUN_ATTEMPT_EXECUTE Explicit Authorization CLASS_4 Reflection v0
+
+T3_RUN_ATTEMPT_EXECUTE_CLASS4_GOVERNED_REFLECTION_V0=true
+T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true
+ACCEPTED_MODE=T3_RUN_ATTEMPT_EXECUTE_EXPLICIT_AUTHORIZATION_CLASS4_DOCS_TESTS_ONLY
+OPERATOR_GO=GO_T3_RUN_ATTEMPT_EXECUTE_DOCS_TESTS_POLICY_REFLECTION_V0
+CLASS4_OPERATOR_GO_ACCEPTED=true
+DOCS_TESTS_ONLY=true
+GOVERNED_ACCEPTANCE_BASIS=SECTION5_WEDGE_COMPLETE+ALL_GAPS_CLOSED+PREFLIGHT_LIFT_CLASS4+OPERATOR_ARMING+NEXT_EXECUTE+BOUNDED_EXECUTE_RUN+T3_BOUNDED_EXECUTE_RUN_ATTEMPT+T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD
+INPUT_T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/t3_run_attempt_execute_operator_decision_record_no_run_v0_20260605T003415Z/
+INPUT_T3_RUN_ATTEMPT_EXECUTE_DECISION_PACKET_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/t3_run_attempt_execute_decision_packet_no_run_v0_20260605T003255Z/
+INPUT_T3_RUN_ATTEMPT_EXECUTE_CHARTER_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/t3_run_attempt_execute_charter_no_run_v0_20260605T003151Z/
+INPUT_PR4017_CLOSEOUT_POINTER=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/pr4017_t3_bounded_execute_run_attempt_policy_reflection_post_merge_closeout_no_run_v0_20260605T002829Z/
+ALL_GAPS_CLOSED=true
+PREFLIGHT_REMAINS_BLOCKED=false
+PREFLIGHT_LIFTED_BY_CLASS4_POLICY=true
+T3_BOUNDED_EXECUTE_RUN_ATTEMPT_AUTHORIZED=true
+T3_BOUNDED_EXECUTE_RUN_ATTEMPT_IS_NOT_RUNTIME_START=true
+T3_BOUNDED_EXECUTE_RUN_ATTEMPT_IS_NOT_LIVE=true
+T3_BOUNDED_EXECUTE_RUN_ATTEMPT_OPERATOR_DECISION_RECORD_REFLECTED=true
+T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_REFLECTED=true
+OPERATOR_NAME=Frank Rauter
+OPERATOR_DECISION_SCOPE=T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD
+OP_T3_EXEC_01=CONFIRMED
+OP_T3_EXEC_02=CONFIRMED
+OP_T3_EXEC_03=CONFIRMED
+OP_T3_EXEC_04=CONFIRMED
+OP_T3_EXEC_05=CONFIRMED
+OP_T3_EXEC_06=CONFIRMED
+OPERATOR_CONFIRMATIONS_ALL_CONFIRMED=true
+GUARD_T3_EXECUTE_NOT_AUTHORITY_LIFT=true
+T3_RUN_ATTEMPT_EXECUTE_IS_NOT_RUNTIME_START=true
+T3_RUN_ATTEMPT_EXECUTE_NOT_RUNTIME=true
+T3_RUN_ATTEMPT_EXECUTE_IS_NOT_LIVE=true
+T3_RUN_ATTEMPT_EXECUTE_NOT_FUTURES_AUTHORITY=true
+T3_RUN_ATTEMPT_EXECUTE_NOT_ORDERS=true
+POLICY_T3_EXECUTE_NOT_OPERATIONAL_AUTHORIZATION=true
+CONCRETE_RUN_AUTHORIZED=false
+T3_CONCRETE_RUN_GO_REQUIRED=true
+T3_RUN_ATTEMPT_READINESS_PREFLIGHT_REQUIRED=true
+T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false
+MINIMAL_REMAINING_BLOCKER_CLASS=T3_READINESS_PREFLIGHT_ONLY
+RUNTIME_APPROVED=false
+RUNTIME_STARTED=false
+SCHEDULER_STARTED=false
+ORDERS_ATTEMPTED=false
+PRIVATE_API_USED=false
+CREDENTIALS_READ=false
+ENV_FILE_OPENED=false
+PREFLIGHT_LIFT_EXECUTED=false
+ACTUAL_PREFLIGHT_LIFT_EXECUTED=false
+FUTURES_EXECUTE_AUTHORIZED=false
+FUTURES_PRIVATE_API_AUTHORIZED=false
+FUTURES_VALIDATE_ONLY_AUTHORIZED=false
+FUTURES_SESSION_AUTHORIZED_NOW=false
+
+This governed repo-reflection block records operator-authorized **T3_RUN_ATTEMPT_EXECUTE policy lift** to Final Machine Lines only, under explicit CLASS_4 Operator-GO `GO_T3_RUN_ATTEMPT_EXECUTE_DOCS_TESTS_POLICY_REFLECTION_V0`, after T3 Run Attempt Execute Operator Decision Record fulfilment (Frank Rauter, 2026-06-05T00:34:15Z). **T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true ≠ Runtime start ≠ Scheduler start ≠ Orders ≠ Live ≠ futures authority ≠ concrete run authorization.** Docs/tests policy reflection only — not runtime authorization, scheduler authorization, order authorization, live authorization, futures authority, or concrete T3 bounded execute run attempt.
+
+### T3_RUN_ATTEMPT_EXECUTE-policy scope (Final Machine Lines only)
+
+- `T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true` in **Final Machine Lines only** — documents that a later separate T3 run-attempt readiness preflight and scoped run GO may be prepared; not automatic activation or concrete run authorization
+- Prior NEXT_EXECUTE, Operator Arming, BOUNDED_EXECUTE_RUN, T3_BOUNDED_EXECUTE_RUN_ATTEMPT, and ALL_GAPS_CLOSED reflection blocks remain unchanged — historical `T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=false` posture preserved in those blocks
+- Gap criteria blocks, Status block, Tier-C crosslink, synthesis block, and individual governed reflection blocks above remain unchanged where they record `T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=false` as historical scoped non-run posture
+
+### Why runtime and concrete run gates remain false (T3_RUN_ATTEMPT_EXECUTE-policy record only)
+
+- `RUNTIME_APPROVED=false`, `CONCRETE_RUN_AUTHORIZED=false`, `T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false` — concrete T3 bounded execute run attempt requires separate readiness preflight and explicit scoped GO
+- `PREFLIGHT_LIFT_EXECUTED=false`, `ACTUAL_PREFLIGHT_LIFT_EXECUTED=false` — no runtime preflight lift
+- T3 run attempt execute policy at FML ≠ runtime start ≠ scheduler dispatch ≠ order authorization ≠ live authorization ≠ concrete run execution
+
+### Non-authority boundary (T3_RUN_ATTEMPT_EXECUTE-policy reflection does not imply)
+
+- does not set `RUNTIME_APPROVED=true` or `CONCRETE_RUN_AUTHORIZED=true`
+- does not set `T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=true`
+- does not set `PREFLIGHT_LIFT_EXECUTED=true` or `ACTUAL_PREFLIGHT_LIFT_EXECUTED=true`
+- does not authorize scheduler execution, Paper, Shadow, Testnet, Live, orders, validate-only, tiny-order, private API, credentials, env-open, or unscoped runtime loops
+- does not grant futures authority (`FUTURES_EXECUTE_AUTHORIZED`, `FUTURES_PRIVATE_API_AUTHORIZED`, `FUTURES_VALIDATE_ONLY_AUTHORIZED`, `FUTURES_SESSION_AUTHORIZED_NOW` remain false)
+- does not modify `scripts/run_scheduler.py`, `config/scheduler/jobs.toml`, or production code in this slice
+- does not start or authorize Runtime, Paper 24/7, Shadow 24/7, or Live
+
+Policy T3 run attempt execute lift is not runtime authorization, scheduler authorization, order authorization, live authorization, futures authority, or concrete run authorization. Prior governed reflection blocks above remain scoped acceptance/verification only and unchanged except Final Machine Lines propagation recorded here.
+
 ## Tier-C + Shadow durable evidence archive crosslink v0
 
 TIER_C_SHADOW_DURABLE_EVIDENCE_REPO_STATIC_CROSSLINK_V0=true
@@ -2924,8 +3006,17 @@ T3_BOUNDED_EXECUTE_RUN_ATTEMPT_NOT_RUNTIME=true
 T3_BOUNDED_EXECUTE_RUN_ATTEMPT_IS_NOT_LIVE=true
 T3_BOUNDED_EXECUTE_RUN_ATTEMPT_NOT_FUTURES_AUTHORITY=true
 T3_BOUNDED_EXECUTE_RUN_ATTEMPT_NOT_ORDERS=true
+T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true
+T3_RUN_ATTEMPT_EXECUTE_CLASS4_GOVERNED_REFLECTION_V0=true
+T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_REFLECTED=true
+T3_RUN_ATTEMPT_EXECUTE_IS_NOT_RUNTIME_START=true
+T3_RUN_ATTEMPT_EXECUTE_NOT_RUNTIME=true
+T3_RUN_ATTEMPT_EXECUTE_IS_NOT_LIVE=true
+T3_RUN_ATTEMPT_EXECUTE_NOT_FUTURES_AUTHORITY=true
+T3_RUN_ATTEMPT_EXECUTE_NOT_ORDERS=true
 CONCRETE_RUN_AUTHORIZED=false
 T3_CONCRETE_RUN_GO_REQUIRED=true
+T3_RUN_ATTEMPT_READINESS_PREFLIGHT_REQUIRED=true
 T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false
 RUNTIME_APPROVED=false
 RUNTIME_STARTED=false

--- a/tests/ops/test_bounded_network_testnet_preflight_contract_v0.py
+++ b/tests/ops/test_bounded_network_testnet_preflight_contract_v0.py
@@ -274,6 +274,10 @@ def test_section5_next_execute_policy_lift_does_not_authorize_runtime() -> None:
     assert "BOUNDED_EXECUTE_RUN_IS_NOT_RUNTIME_START=true" in final_lines
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_AUTHORIZED=true" in final_lines
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_IS_NOT_RUNTIME_START=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_REFLECTED=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_IS_NOT_RUNTIME_START=true" in final_lines
+    assert "T3_RUN_ATTEMPT_READINESS_PREFLIGHT_REQUIRED=true" in final_lines
     assert "CONCRETE_RUN_AUTHORIZED=false" in final_lines
     assert "T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false" in final_lines
     assert "RUNTIME_STARTED=false" in final_lines

--- a/tests/ops/test_repo_native_bounded_order_cap_contract_v0.py
+++ b/tests/ops/test_repo_native_bounded_order_cap_contract_v0.py
@@ -104,6 +104,10 @@ def test_section5_next_execute_policy_lift_does_not_authorize_runtime() -> None:
     assert "BOUNDED_EXECUTE_RUN_NOT_ORDERS=true" in final_lines
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_AUTHORIZED=true" in final_lines
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_IS_NOT_RUNTIME_START=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_REFLECTED=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_IS_NOT_RUNTIME_START=true" in final_lines
+    assert "T3_RUN_ATTEMPT_READINESS_PREFLIGHT_REQUIRED=true" in final_lines
     assert "CONCRETE_RUN_AUTHORIZED=false" in final_lines
     assert "T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false" in final_lines
     assert "RUNTIME_STARTED=false" in final_lines

--- a/tests/ops/test_run_testnet_session_entrypoint_fail_closed_contract_v0.py
+++ b/tests/ops/test_run_testnet_session_entrypoint_fail_closed_contract_v0.py
@@ -124,6 +124,10 @@ def test_section5_next_execute_policy_lift_does_not_authorize_runtime_while_entr
     assert "BOUNDED_EXECUTE_RUN_IS_NOT_RUNTIME_START=true" in final_lines
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_AUTHORIZED=true" in final_lines
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_IS_NOT_RUNTIME_START=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_REFLECTED=true" in final_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_IS_NOT_RUNTIME_START=true" in final_lines
+    assert "T3_RUN_ATTEMPT_READINESS_PREFLIGHT_REQUIRED=true" in final_lines
     assert "CONCRETE_RUN_AUTHORIZED=false" in final_lines
     assert "T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false" in final_lines
     assert "RUNTIME_STARTED=false" in final_lines

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -161,6 +161,9 @@ BOUNDED_EXECUTE_RUN_CLASS4_REFLECTION_HEADER = (
 T3_BOUNDED_EXECUTE_RUN_ATTEMPT_CLASS4_REFLECTION_HEADER = (
     "## T3_BOUNDED_EXECUTE_RUN_ATTEMPT Explicit Authorization CLASS_4 Reflection v0"
 )
+T3_RUN_ATTEMPT_EXECUTE_CLASS4_REFLECTION_HEADER = (
+    "## T3_RUN_ATTEMPT_EXECUTE Explicit Authorization CLASS_4 Reflection v0"
+)
 TIER_C_SHADOW_CROSSLINK_HEADER = "## Tier-C + Shadow durable evidence archive crosslink v0"
 FINAL_MACHINE_LINES_HEADER = "## Final Machine Lines"
 
@@ -203,6 +206,12 @@ def _bounded_execute_run_class4_reflection_section(text: str) -> str:
 
 def _t3_bounded_execute_run_attempt_class4_reflection_section(text: str) -> str:
     return text.split(T3_BOUNDED_EXECUTE_RUN_ATTEMPT_CLASS4_REFLECTION_HEADER, 1)[1].split(
+        T3_RUN_ATTEMPT_EXECUTE_CLASS4_REFLECTION_HEADER, 1
+    )[0]
+
+
+def _t3_run_attempt_execute_class4_reflection_section(text: str) -> str:
+    return text.split(T3_RUN_ATTEMPT_EXECUTE_CLASS4_REFLECTION_HEADER, 1)[1].split(
         TIER_C_SHADOW_CROSSLINK_HEADER, 1
     )[0]
 
@@ -632,6 +641,64 @@ def test_section5_t3_bounded_execute_run_attempt_explicit_authorization_class4_n
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_CLASS4_GOVERNED_REFLECTION_V0=true" in block_lines
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_IS_NOT_RUNTIME_START=true" in block_lines
     assert "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_IS_NOT_LIVE=true" in block_lines
+    assert "CONCRETE_RUN_AUTHORIZED=false" in block_lines
+    assert "T3_CONCRETE_RUN_GO_REQUIRED=true" in block_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false" in block_lines
+    assert "FUTURES_EXECUTE_AUTHORIZED=true" not in block_lines
+
+
+def test_section5_t3_run_attempt_execute_explicit_authorization_class4_non_authorizing_v0() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    reflection = _t3_run_attempt_execute_class4_reflection_section(text)
+    t3_policy = _t3_bounded_execute_run_attempt_class4_reflection_section(text)
+    block = _final_machine_lines(text)
+
+    for token in (
+        "T3_RUN_ATTEMPT_EXECUTE_CLASS4_GOVERNED_REFLECTION_V0=true",
+        "T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true",
+        "ACCEPTED_MODE=T3_RUN_ATTEMPT_EXECUTE_EXPLICIT_AUTHORIZATION_CLASS4_DOCS_TESTS_ONLY",
+        "OPERATOR_GO=GO_T3_RUN_ATTEMPT_EXECUTE_DOCS_TESTS_POLICY_REFLECTION_V0",
+        "CLASS4_OPERATOR_GO_ACCEPTED=true",
+        "T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_REFLECTED=true",
+        "GUARD_T3_EXECUTE_NOT_AUTHORITY_LIFT=true",
+        "T3_RUN_ATTEMPT_EXECUTE_IS_NOT_RUNTIME_START=true",
+        "T3_RUN_ATTEMPT_EXECUTE_NOT_RUNTIME=true",
+        "T3_RUN_ATTEMPT_EXECUTE_IS_NOT_LIVE=true",
+        "T3_RUN_ATTEMPT_EXECUTE_NOT_FUTURES_AUTHORITY=true",
+        "T3_RUN_ATTEMPT_EXECUTE_NOT_ORDERS=true",
+        "CONCRETE_RUN_AUTHORIZED=false",
+        "T3_CONCRETE_RUN_GO_REQUIRED=true",
+        "T3_RUN_ATTEMPT_READINESS_PREFLIGHT_REQUIRED=true",
+        "T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false",
+        "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_AUTHORIZED=true",
+        "T3_BOUNDED_EXECUTE_RUN_ATTEMPT_OPERATOR_DECISION_RECORD_REFLECTED=true",
+        "ALL_GAPS_CLOSED=true",
+        "PREFLIGHT_REMAINS_BLOCKED=false",
+        "PREFLIGHT_LIFTED_BY_CLASS4_POLICY=true",
+        "RUNTIME_APPROVED=false",
+        "RUNTIME_STARTED=false",
+        "SCHEDULER_STARTED=false",
+        "ORDERS_ATTEMPTED=false",
+        "PRIVATE_API_USED=false",
+        "CREDENTIALS_READ=false",
+        "ENV_FILE_OPENED=false",
+        "FUTURES_EXECUTE_AUTHORIZED=false",
+        "FUTURES_PRIVATE_API_AUTHORIZED=false",
+        "FUTURES_VALIDATE_ONLY_AUTHORIZED=false",
+        "FUTURES_SESSION_AUTHORIZED_NOW=false",
+    ):
+        assert token in reflection
+
+    assert "T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true ≠ Runtime start" in reflection
+    assert "does not set `RUNTIME_APPROVED=true`" in reflection
+    assert "T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=false" not in t3_policy
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true" in block_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_CLASS4_GOVERNED_REFLECTION_V0=true" in block_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_REFLECTED=true" in block_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_IS_NOT_RUNTIME_START=true" in block_lines
+    assert "T3_RUN_ATTEMPT_EXECUTE_IS_NOT_LIVE=true" in block_lines
+    assert "T3_RUN_ATTEMPT_READINESS_PREFLIGHT_REQUIRED=true" in block_lines
     assert "CONCRETE_RUN_AUTHORIZED=false" in block_lines
     assert "T3_CONCRETE_RUN_GO_REQUIRED=true" in block_lines
     assert "T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false" in block_lines


### PR DESCRIPTION
## Summary
- Reflects T3 Run Attempt Execute Operator Decision Record into existing SECTION5 Final Machine Lines and drift-guard tests (reuse PR #4017 pattern).
- Sets policy-gate tokens only: `T3_RUN_ATTEMPT_EXECUTE_OPERATOR_DECISION_RECORD_REFLECTED=true`, `T3_RUN_ATTEMPT_EXECUTE_AUTHORIZED=true`, `T3_RUN_ATTEMPT_READINESS_PREFLIGHT_REQUIRED=true`; all runtime/order/live/futures gates remain false.

## Safety boundaries (no-run)
- No runtime, scheduler, orders, validate-only, private API, credentials, env-open, live, or futures authority.
- `CONCRETE_RUN_AUTHORIZED=false`, `T3_RUN_ATTEMPT_EXECUTE_ALLOWED_NOW=false`, `RUNTIME_STARTED=false`, `SCHEDULER_STARTED=false`.
- Docs/tests-only; no production code changes.

## Input bundles (MANIFEST_VERIFY_RC=0)
- T3 Execute Operator Decision Record: `planning/t3_run_attempt_execute_operator_decision_record_no_run_v0_20260605T003415Z/`
- T3 Execute Decision Packet: `planning/t3_run_attempt_execute_decision_packet_no_run_v0_20260605T003255Z/`
- T3 Execute Charter: `planning/t3_run_attempt_execute_charter_no_run_v0_20260605T003151Z/`
- Ranking after PR #4017: `planning/repo_wide_next_safe_slice_ranking_after_t3_policy_reflection_closeout_no_run_v0_20260605T003038Z/`
- PR #4017 closeout: `closeout/pr4017_t3_bounded_execute_run_attempt_policy_reflection_post_merge_closeout_no_run_v0_20260605T002829Z/`

## Test plan
- [x] Targeted pytest: section5 T3 execute + drift-guard tests (54 passed)
- [x] ruff format/check on changed test files
- [x] validate_docs_token_policy.py


Made with [Cursor](https://cursor.com)