### PR TITLE
PRBD scorecard artifact upload on NO_GO

### DIFF
--- a/.github/workflows/prbd-live-readiness-scorecard.yml
+++ b/.github/workflows/prbd-live-readiness-scorecard.yml
@@ -49,6 +49,7 @@ jobs:
             --health reports/status/prj_health_summary.json
 
       - name: Upload artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: live_readiness_scorecard

--- a/tests/ci/test_prbd_live_readiness_scorecard_contract.py
+++ b/tests/ci/test_prbd_live_readiness_scorecard_contract.py
@@ -78,3 +78,45 @@ def test_no_go_on_stability_fail(tmp_path: Path):
         cwd=Path(__file__).resolve().parent.parent.parent,
     )
     assert r.returncode == 2
+
+
+def test_no_go_on_soft_penalties_only(tmp_path: Path):
+    stab = {
+        "overall_ok": True,
+        "results": [
+            {"name": "PR-K", "age_hours": 1.0},
+            {"name": "PR-J", "age_hours": 13.0},
+        ],
+    }
+    st = {"dummy": True}
+    hs = {"status": "STALE"}
+    (tmp_path / "s.json").write_text(json.dumps(stab), encoding="utf-8")
+    (tmp_path / "st.json").write_text(json.dumps(st), encoding="utf-8")
+    (tmp_path / "h.json").write_text(json.dumps(hs), encoding="utf-8")
+    out = tmp_path / "out"
+    out.mkdir()
+    r = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci/live_readiness_scorecard.py",
+            "--out-dir",
+            str(out),
+            "--stability",
+            str(tmp_path / "s.json"),
+            "--status",
+            str(tmp_path / "st.json"),
+            "--health",
+            str(tmp_path / "h.json"),
+            "--go-threshold",
+            "85",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parent.parent.parent,
+    )
+    assert r.returncode == 2
+    obj = json.loads((out / "live_readiness_scorecard.json").read_text(encoding="utf-8"))
+    assert obj["score"] == 75
+    assert obj["decision"] == "NO_GO"
+    assert obj["hard_blocks"] == []
+    assert set(obj["warnings"]) == {"PRJ_AGE_GT_12H", "HEALTH_STALE"}


### PR DESCRIPTION
## Summary
- 2-file CI/test fix for PRBD scorecard observability on NO_GO.
- Workflow: upload artifact step gets `if: always()` so scorecard JSON is available on NO_GO/exit 2.
- Test: soft-penalty-only NO_GO contract coverage.

## Scope
- `.github/workflows/prbd-live-readiness-scorecard.yml`
- `tests/ci/test_prbd_live_readiness_scorecard_contract.py`

## No change
- No scoring/threshold/penalty/exit-code changes.
- Script, docs, and protected local M excluded.

## Validation
- `python3 -m pytest tests/ci/test_prbd_live_readiness_scorecard_contract.py -q` → 4 passed, RC=0

## Boundaries
- No Runtime/Testnet/Shadow/Paper/Live authorization.
- Protected local M excluded.

## Evidence
- Commit closeout: closeout/prbd_scorecard_policy_fix_commit_result_closeout_no_run_v0_20260605T112728Z/
- Implementation closeout: closeout/prbd_scorecard_policy_fix_implementation_result_closeout_no_run_v0_20260605T111945Z/
- Policy review: review/prbd_scorecard_policy_review_execute_no_run_v0_20260605T110011Z/
