### PR TITLE
Gate WebUI-only PRs through fast CI path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,16 @@ jobs:
   # Change Detection (pragmatic flow)
   # ============================================================================
   # Outputs: code_changed (historical output name), run_matrix, run_fast_lane, docs_only, workflow_only,
-  # static_contract_changed, docs_or_static_contract_only.
+  # static_contract_changed, docs_or_static_contract_only, webui_surface_changed, webui_surface_only.
   # - run_fast_lane: always true (Fast-Lane always runs).
-  # - run_matrix: true when code paths changed (or workflow_dispatch force_matrix=true).
+  # - run_matrix: true when non_webui_code paths changed (or workflow_dispatch force_matrix=true).
   # - run_fast: always true. run_fast_lane: alias.
   # - docs_only: true when ONLY docs/out/*.md changed (no code, workflow, or static-contract paths).
   # - workflow_only: true when ONLY .github/workflows changed.
   # - static_contract_changed: tests/ci/**, tests/ops/**, or tests/webui/test_*_structure_contract*.py (not full-matrix code).
   # - docs_or_static_contract_only: no src/scripts/config/workflow code paths; docs and/or static-contract only.
+  # - webui_surface_changed: Market/Observability/WebUI surface paths (bounded Fast-Lane lane).
+  # - webui_surface_only: webui_surface without non_webui_code (Case D — skip full matrix, bounded WebUI pytest).
   # Code paths: src/**, templates/**, tests/** minus tests/ci/**, tests/ops/**, and whitelisted tests/webui/test_*_structure_contract*.py; plus scripts/**, config/**, schemas/levelup/**, deps, Makefile.
   # ============================================================================
   changes:
@@ -49,6 +51,8 @@ jobs:
       workflow_only: ${{ steps.set_outputs.outputs.workflow_only }}
       static_contract_changed: ${{ steps.set_outputs.outputs.static_contract_changed }}
       docs_or_static_contract_only: ${{ steps.set_outputs.outputs.docs_or_static_contract_only }}
+      webui_surface_changed: ${{ steps.set_outputs.outputs.webui_surface_changed }}
+      webui_surface_only: ${{ steps.set_outputs.outputs.webui_surface_only }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -77,6 +81,27 @@ jobs:
               - 'uv.lock'
               - 'pytest.ini'
               - 'Makefile'
+            webui_surface:
+              - 'src/webui/**'
+              - 'templates/peak_trade_dashboard/**'
+              - 'docs/webui/**'
+              - 'tests/webui/**'
+              - 'tests/fixtures/**'
+              - 'tests/ops/test_*_env_schema_boundary*.py'
+            non_webui_code:
+              - 'src/!(ops|webui)/**'
+              - 'src/ops/!(*_contract_v0.py)'
+              - 'templates/!(peak_trade_dashboard)/**'
+              - 'tests/!(ci|ops|webui|fixtures)/**'
+              - 'scripts/**'
+              - 'config/**'
+              - 'schemas/levelup/**'
+              - 'requirements.txt'
+              - 'requirements*.txt'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'pytest.ini'
+              - 'Makefile'
             static_contract:
               - 'tests/ci/**'
               - 'tests/ops/**'
@@ -94,19 +119,30 @@ jobs:
         run: |
           FORCE_MATRIX="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_matrix == 'true' }}"
           CODE="${{ steps.filter.outputs.code }}"
+          NON_WEBUI="${{ steps.filter.outputs.non_webui_code }}"
+          WEBUI="${{ steps.filter.outputs.webui_surface }}"
           STATIC="${{ steps.filter.outputs.static_contract }}"
           DOCS="${{ steps.filter.outputs.docs }}"
           WF="${{ steps.filter.outputs.workflow }}"
 
           echo "code_changed=${CODE}" >> "$GITHUB_OUTPUT"
           echo "static_contract_changed=${STATIC}" >> "$GITHUB_OUTPUT"
+          echo "webui_surface_changed=${WEBUI}" >> "$GITHUB_OUTPUT"
 
           if [ "$FORCE_MATRIX" = "true" ]; then
             echo "run_matrix=true" >> "$GITHUB_OUTPUT"
+          elif [ "$NON_WEBUI" = "true" ]; then
+            echo "run_matrix=true" >> "$GITHUB_OUTPUT"
           else
-            echo "run_matrix=${CODE}" >> "$GITHUB_OUTPUT"
+            echo "run_matrix=false" >> "$GITHUB_OUTPUT"
           fi
           echo "run_fast=true" >> "$GITHUB_OUTPUT"
+
+          if [ "$WEBUI" = "true" ] && [ "$NON_WEBUI" != "true" ] && [ "$WF" != "true" ]; then
+            echo "webui_surface_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "webui_surface_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
           if [ "$DOCS" = "true" ] && [ "$CODE" != "true" ] && [ "$WF" != "true" ] && [ "$STATIC" != "true" ]; then
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
@@ -187,7 +223,7 @@ jobs:
   fast-lane:
     name: Fast-Lane
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: changes
     steps:
       - name: Checkout
@@ -217,7 +253,7 @@ jobs:
           pytest tests/test_stability_smoke.py tests/test_data_contracts.py tests/test_error_taxonomy.py tests/test_resilience.py -m smoke -v --tb=short
 
       - name: Static contract tests (tests/ci, tests/ops, WebUI structure-contract, src/ops contract modules via tests)
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.static_contract_changed == 'true' && needs.changes.outputs.code_changed != 'true' && needs.changes.outputs.workflow_only != 'true' }}
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.static_contract_changed == 'true' && needs.changes.outputs.run_matrix != 'true' && needs.changes.outputs.workflow_only != 'true' }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -225,12 +261,32 @@ jobs:
           shopt -u nullglob
           pytest tests/ci tests/ops "${webui_structure_contract[@]}" -q --tb=short -m "not network and not external_tools"
 
+      - name: WebUI bounded pytest (market/observability surface)
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.webui_surface_changed == 'true' && needs.changes.outputs.run_matrix != 'true' }}
+        env:
+          PEAK_TRADE_LAST_PAPER_RUN_PANEL_ENABLED: ""
+          PEAK_TRADE_LAST_PAPER_RUN_BUNDLE_ROOT: ""
+          PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED: ""
+          PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT: ""
+        run: |
+          set -euo pipefail
+          pytest \
+            tests/webui/test_workflow_dashboard_readmodel_v1.py \
+            tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py \
+            tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py \
+            tests/webui/test_observability_hub.py \
+            tests/webui/test_last_paper_run_panel_readmodel_v0.py \
+            tests/webui/test_observability_last_paper_run_panel_structure_contract_v0.py \
+            tests/ops/test_last_paper_run_panel_env_schema_boundary_v0.py \
+            tests/webui/test_market_dashboard_readonly_structure_contract_v0.py \
+            -q --tb=short -m "not network and not external_tools"
+
   # ============================================================================
   # Tests (all Python versions)
   # ============================================================================
   # Always creates test jobs for all required Python versions (3.9, 3.10, 3.11).
-  # On docs-only / static-contract-only PRs, jobs short-circuit SUCCESS (not missing/skipped).
-  # On code changes (or workflow-only), runs full test suite.
+  # On docs-only / webui_surface-only / static-contract-only PRs, jobs short-circuit SUCCESS (not missing/skipped).
+  # On non_webui_code changes (or workflow-only), runs full test suite.
   # ============================================================================
   tests:
     name: tests (${{ matrix.python-version }})
@@ -247,22 +303,22 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
-      - name: Docs/static-contract PR — skip full matrix tests
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.code_changed != 'true' && needs.changes.outputs.workflow_only != 'true' }}
-        run: echo "Docs/static-contract PR - skipping full matrix for Python ${{ matrix.python-version }} (contract tests run in Fast-Lane when applicable)"
+      - name: WebUI/docs/static-contract PR — skip full matrix tests
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.run_matrix != 'true' && needs.changes.outputs.workflow_only != 'true' }}
+        run: echo "WebUI/docs/static-contract PR - skipping full matrix for Python ${{ matrix.python-version }} (bounded WebUI/contract tests run in Fast-Lane when applicable)"
 
       - name: Checkout
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
@@ -271,14 +327,14 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install dependencies
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest pytest-cov
 
       - name: "Stability Smoke Tests (Fast Gate)"
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         id: stability_smoke
         shell: bash
         run: |
@@ -287,7 +343,7 @@ jobs:
           pytest tests/test_stability_smoke.py tests/test_data_contracts.py tests/test_error_taxonomy.py tests/test_resilience.py -m smoke -v --tb=short
 
       - name: "Smoke: RL v0.1 Contract Test"
-        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true') && runner.os == 'Linux' }}
+        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true') && runner.os == 'Linux' }}
         id: rl_v0_1_smoke
         shell: bash
         run: |
@@ -295,7 +351,7 @@ jobs:
           pytest -q tests/test_rl_v0_1_smoke.py
 
       - name: Validate RL v0.1 Contract
-        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true') && runner.os == 'Linux' }}
+        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true') && runner.os == 'Linux' }}
         id: rl_v0_1_contract
         shell: bash
         run: |
@@ -314,12 +370,12 @@ jobs:
           retention-days: 7
 
       - name: Run tests
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         run: |
           pytest tests/ -v --tb=short -m "not network and not external_tools"
 
       - name: Run tests with coverage
-        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true') && matrix.python-version == '3.11' }}
+        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true') && matrix.python-version == '3.11' }}
         run: |
           pytest tests/ --cov=src --cov-report=xml --cov-report=term-missing -m "not network and not external_tools"
 
@@ -348,22 +404,22 @@ jobs:
     # to satisfy branch protection rules (e.g., "strategy-smoke" check)
 
     steps:
-      - name: Docs/static-contract PR — skip strategy smoke tests
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.code_changed != 'true' && needs.changes.outputs.workflow_only != 'true' }}
-        run: echo "Docs/static-contract PR - skipping strategy smoke tests"
+      - name: WebUI/docs/static-contract PR — skip strategy smoke tests
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.run_matrix != 'true' && needs.changes.outputs.workflow_only != 'true' }}
+        run: echo "WebUI/docs/static-contract PR - skipping strategy smoke tests"
 
       - name: Checkout
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         uses: actions/checkout@v5
 
       - name: Set up Python 3.11
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Cache pip
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
@@ -372,31 +428,31 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install dependencies
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest
 
       - name: Run strategy smoke pytest
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         run: |
           pytest tests/test_strategy_smoke_cli.py -v --tb=short
 
       - name: Create smoke results directory
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         run: |
           mkdir -p test_results/strategy_smoke
 
       - name: Run strategy smoke CLI
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true' }}
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true' }}
         run: |
           python scripts/strategy_smoke_check.py \
             --output-json test_results/strategy_smoke/ci_smoke_latest.json \
             --output-md test_results/strategy_smoke/ci_smoke_latest.md
 
       - name: Upload smoke test artifacts
-        if: ${{ always() && (github.event_name != 'pull_request' || needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.workflow_only == 'true') }}
+        if: ${{ always() && (github.event_name != 'pull_request' || needs.changes.outputs.run_matrix == 'true' || needs.changes.outputs.workflow_only == 'true') }}
         uses: actions/upload-artifact@v4
         with:
           name: strategy-smoke-results
@@ -423,4 +479,4 @@ jobs:
           [[ "${{ needs.fast-lane.result }}" == "success" ]] || { echo "Fast-Lane failed"; exit 1; }
           [[ "${{ needs.tests.result }}" == "success" ]] || { echo "tests failed"; exit 1; }
           [[ "${{ needs.strategy-smoke.result }}" == "success" ]] || { echo "strategy-smoke failed"; exit 1; }
-          echo "PR Gate: all gates passed (run_matrix=${{ needs.changes.outputs.run_matrix }}, docs_only=${{ needs.changes.outputs.docs_only }}, workflow_only=${{ needs.changes.outputs.workflow_only }}, static_contract_changed=${{ needs.changes.outputs.static_contract_changed }}, docs_or_static_contract_only=${{ needs.changes.outputs.docs_or_static_contract_only }})"
+          echo "PR Gate: all gates passed (run_matrix=${{ needs.changes.outputs.run_matrix }}, docs_only=${{ needs.changes.outputs.docs_only }}, workflow_only=${{ needs.changes.outputs.workflow_only }}, static_contract_changed=${{ needs.changes.outputs.static_contract_changed }}, docs_or_static_contract_only=${{ needs.changes.outputs.docs_or_static_contract_only }}, webui_surface_changed=${{ needs.changes.outputs.webui_surface_changed }}, webui_surface_only=${{ needs.changes.outputs.webui_surface_only }})"

--- a/docs/ops/ci_pragmatic_flow_inventory.md
+++ b/docs/ops/ci_pragmatic_flow_inventory.md
@@ -7,7 +7,7 @@
 
 **Canonical reference:** [GATES_OVERVIEW.md](GATES_OVERVIEW.md) ist SSoT für Gates. Dieses Doc beschreibt pragmatische Flow-Details.
 
-**Stand:** 2026-02-07 (historischer Pragmatic-Flow-Kontext). Aktuelle Required-Checks-Semantik ist JSON-SSOT (`config/ci/required_status_checks.json`).
+**Stand:** 2026-06-08 (webui_surface path gating v1). Aktuelle Required-Checks-Semantik ist JSON-SSOT (`config/ci/required_status_checks.json`).
 
 ## Relevante Workflows und Jobs
 
@@ -29,14 +29,20 @@
 
 | Output | Bedeutung |
 |--------|-----------|
-| `run_matrix` | true → volle Py-Matrix (tests 3.9/3.10/3.11, strategy-smoke) laufen |
+| `run_matrix` | true → volle Py-Matrix (tests 3.9/3.10/3.11, strategy-smoke Inhalt) laufen |
 | `run_fast` / `run_fast_lane` | immer true → Fast-Lane läuft immer |
 | `docs_only` | true → nur docs/grafana/out/md geändert |
 | `workflow_only` | true → nur .github/workflows geändert |
+| `webui_surface_changed` | true → Market/Observability/WebUI-Oberflächenpfade geändert |
+| `webui_surface_only` | true → nur webui_surface (+ docs/static-contract), kein non_webui_code |
 
-- **Code-Änderungen** (run_matrix): `src&#47;**`, `tests&#47;**`, `scripts&#47;**`, `config&#47;**`, `pyproject.toml`, `uv.lock`, `requirements*.txt`, `pytest.ini`, `Makefile`.
+- **non_webui_code** (run_matrix): `src&#47;**` außer `src&#47;webui&#47;**`, `templates&#47;**` außer `peak_trade_dashboard`, `tests&#47;**` außer `webui`/`fixtures`/env-boundary-ops, plus `scripts&#47;**`, `config&#47;**`, deps, `Makefile`.
+- **webui_surface** (bounded Fast-Lane): `src&#47;webui&#47;**`, `templates&#47;peak_trade_dashboard&#47;**`, `docs&#47;webui&#47;**`, `tests&#47;webui&#47;**`, `tests&#47;fixtures&#47;**`, `tests&#47;ops&#47;test_*_env_schema_boundary*.py`.
+- **Code-Änderungen** (`code_changed`, historisch): wie bisher breiter `code`-Bucket (inkl. webui); **nicht** identisch mit `run_matrix`.
 - **Docs/Grafana-only:** `docs&#47;**`, `**&#47;grafana&#47;dashboards&#47;**`, `out&#47;**`, `**&#47;*.md`.
 - **Workflow-only:** `.github&#47;workflows&#47;**`.
+
+**Hinweis:** Globale required checks werden **nicht** entfernt. `tests (3.11)` und `strategy-smoke` bleiben als Check-Namen materialisiert; bei `webui_surface_only` short-circuit skip-success.
 
 ## Beispiel-Pfade → welche Jobs
 
@@ -46,6 +52,7 @@
 | `docs&#47;foo.md` | false | wie oben | <!-- pt:ref-target-ignore -->
 | `.github&#47;workflows&#47;lint.yml` | false | wie oben (+ Lint Gate, Docs Gates in eigenen Workflows) |
 | `src&#47;foo.py` | true | changes, Fast-Lane, **tests (3.9/3.10/3.11)**, **strategy-smoke**, **PR Gate** | <!-- pt:ref-target-ignore -->
+| `src&#47;webui&#47;app.py`, `templates&#47;peak_trade_dashboard&#47;*.html`, `tests&#47;webui&#47;*.py` | false | changes, Fast-Lane (+ bounded WebUI pytest), tests/strategy-smoke **skip SUCCESS**, Lint/docs-token/audit | <!-- pt:ref-target-ignore -->
 | `tests&#47;test_x.py`, `scripts&#47;bar.py`, `pyproject.toml`, `uv.lock`, `requirements.txt` | true | wie oben | <!-- pt:ref-target-ignore -->
 
 ## workflow_dispatch: Matrix erzwingen
@@ -65,3 +72,10 @@
 **Case C (workflow-only):** e.g. only `.github&#47;workflows&#47;lint.yml` changed.  
 - Expected jobs: changes + Fast-Lane + PR Gate; tests/strategy-smoke **SKIP** (same as Case A).  
 - Lint Gate / workflow-related checks run in their own workflows. PR Gate: SUCCESS after Fast-Lane + skip pass.
+
+**Case D (webui_surface-only):** e.g. `src&#47;webui&#47;**`, `templates&#47;peak_trade_dashboard&#47;**`, `tests&#47;webui&#47;**` (PR #4044-shaped).  
+- Expected: `run_matrix=false`, `webui_surface_only=true`.  
+- Fast-Lane: stability smoke + static-contract (wenn applicable) + **bounded WebUI pytest** (8 Module, env gates unset).  
+- tests (3.9/3.10/3.11) + strategy-smoke: Check-Namen materialisiert, **skip SUCCESS** (~Sekunden).  
+- Externe Gates unverändert: Lint Gate, docs-token-policy-gate, audit, dispatch-guard, etc.  
+- Keine globalen required checks entfernt.

--- a/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
+++ b/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
@@ -1,7 +1,8 @@
-"""Contract tests for CI static-contract narrow code path filter (ci.yml v0).
+"""Contract tests for CI static-contract narrow code path filter (ci.yml v0/v1).
 
 YAML structure assertions plus path semantics aligned with dorny/paths-filter
-(picomatch extglob). Semantics helper mirrors the three `tests/` code globs.
+(picomatch extglob). Semantics helper mirrors the three `tests/` code globs and
+webui_surface / non_webui_code buckets (Market/Observability path gating).
 """
 
 from __future__ import annotations
@@ -22,6 +23,39 @@ STATIC_CONTRACT_WEBUI_GLOB = "tests/webui/test_*_structure_contract*.py"
 STATIC_OPS_CONTRACT_GLOB = "src/ops/*_contract_v0.py"
 SRC_OPS_NON_CONTRACT_GLOB = "src/ops/!(*_contract_v0.py)"
 SRC_NON_OPS_GLOB = "src/!(ops)/**"
+WEBUI_SURFACE_GLOBS = (
+    "src/webui/**",
+    "templates/peak_trade_dashboard/**",
+    "docs/webui/**",
+    "tests/webui/**",
+    "tests/fixtures/**",
+    "tests/ops/test_*_env_schema_boundary*.py",
+)
+NON_WEBUI_CODE_GLOBS = (
+    "src/!(ops|webui)/**",
+    "src/ops/!(*_contract_v0.py)",
+    "templates/!(peak_trade_dashboard)/**",
+    "tests/!(ci|ops|webui|fixtures)/**",
+    "scripts/**",
+    "config/**",
+    "schemas/levelup/**",
+    "requirements.txt",
+    "requirements*.txt",
+    "pyproject.toml",
+    "uv.lock",
+    "pytest.ini",
+    "Makefile",
+)
+WEBUI_BOUNDED_PYTEST_MODULES = (
+    "tests/webui/test_workflow_dashboard_readmodel_v1.py",
+    "tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py",
+    "tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py",
+    "tests/webui/test_observability_hub.py",
+    "tests/webui/test_last_paper_run_panel_readmodel_v0.py",
+    "tests/webui/test_observability_last_paper_run_panel_structure_contract_v0.py",
+    "tests/ops/test_last_paper_run_panel_env_schema_boundary_v0.py",
+    "tests/webui/test_market_dashboard_readonly_structure_contract_v0.py",
+)
 
 
 def _ci_text() -> str:
@@ -31,6 +65,20 @@ def _ci_text() -> str:
 def _code_block() -> str:
     text = _ci_text()
     start = text.index("            code:")
+    end = text.index("            static_contract:")
+    return text[start:end]
+
+
+def _webui_surface_block() -> str:
+    text = _ci_text()
+    start = text.index("            webui_surface:")
+    end = text.index("            non_webui_code:")
+    return text[start:end]
+
+
+def _non_webui_code_block() -> str:
+    text = _ci_text()
+    start = text.index("            non_webui_code:")
     end = text.index("            static_contract:")
     return text[start:end]
 
@@ -89,6 +137,55 @@ def _matches_code_filter(path: str) -> bool:
     if path.startswith("src/"):
         return True
     return _matches_code_tests_bucket(path)
+
+
+def _matches_webui_surface(path: str) -> bool:
+    if path.startswith("src/webui/"):
+        return True
+    if path.startswith("templates/peak_trade_dashboard/"):
+        return True
+    if path.startswith("docs/webui/"):
+        return True
+    if path.startswith("tests/webui/"):
+        return True
+    if path.startswith("tests/fixtures/"):
+        return True
+    return fnmatch.fnmatch(path, "tests/ops/test_*_env_schema_boundary*.py")
+
+
+def _matches_non_webui_code(path: str) -> bool:
+    if path in {"requirements.txt", "pyproject.toml", "uv.lock", "pytest.ini", "Makefile"}:
+        return True
+    if path.startswith("requirements") and path.endswith(".txt"):
+        return True
+    if path.startswith(("scripts/", "config/", "schemas/levelup/")):
+        return True
+    if path.startswith("src/webui/"):
+        return False
+    if _matches_static_contract_ops_src(path):
+        return False
+    if path.startswith("src/ops/"):
+        return True
+    if path.startswith("src/"):
+        return True
+    if path.startswith("templates/peak_trade_dashboard/"):
+        return False
+    if path.startswith("templates/"):
+        return True
+    if path.startswith("tests/fixtures/") or path.startswith("tests/webui/"):
+        return False
+    if path.startswith("tests/"):
+        top = path.split("/")[1]
+        if top in {"ci", "ops", "webui", "fixtures"}:
+            return False
+        return True
+    return False
+
+
+def _run_matrix_for_paths(paths: list[str], *, force_matrix: bool = False) -> bool:
+    if force_matrix:
+        return True
+    return any(_matches_non_webui_code(p) for p in paths)
 
 
 def test_changes_job_exports_static_contract_outputs() -> None:
@@ -160,24 +257,122 @@ def test_code_and_static_contract_path_semantics_v0(
     assert static_match is expect_static
 
 
+def test_webui_surface_and_non_webui_code_filters_present() -> None:
+    webui_block = _webui_surface_block()
+    non_webui_block = _non_webui_code_block()
+    for glob in WEBUI_SURFACE_GLOBS:
+        assert f"'{glob}'" in webui_block
+    for glob in NON_WEBUI_CODE_GLOBS:
+        assert f"'{glob}'" in non_webui_block
+
+
+def test_changes_job_exports_webui_surface_outputs() -> None:
+    text = _ci_text()
+    assert "webui_surface_changed:" in text
+    assert "webui_surface_only:" in text
+    assert "webui_surface_changed=${WEBUI}" in text
+    assert "webui_surface_only=true" in text
+
+
+def test_run_matrix_derived_from_non_webui_code_not_raw_code_bucket() -> None:
+    text = _ci_text()
+    assert 'NON_WEBUI="${{ steps.filter.outputs.non_webui_code }}"' in text
+    assert 'echo "run_matrix=${CODE}"' not in text
+    assert "elif [ \"$NON_WEBUI\" = \"true\" ]; then" in text
+    assert "echo \"run_matrix=false\"" in text
+
+
 def test_matrix_jobs_keep_no_job_level_if_and_short_circuit_skip() -> None:
     text = _ci_text()
     assert "name: tests (${{ matrix.python-version }})" in text
-    assert "Docs/static-contract PR — skip full matrix tests" in text
+    assert "WebUI/docs/static-contract PR — skip full matrix tests" in text
     assert "IMPORTANT: No job-level if condition - matrix jobs must always be created" in text
-    assert "Docs/static-contract PR — skip strategy smoke tests" in text
+    assert "WebUI/docs/static-contract PR — skip strategy smoke tests" in text
+    assert "needs.changes.outputs.run_matrix != 'true'" in text
+    assert "needs.changes.outputs.run_matrix == 'true'" in text
+
+
+def test_strategy_smoke_gated_on_run_matrix_not_code_changed() -> None:
+    text = _ci_text()
+    assert "name: strategy-smoke" in text
+    assert "needs.changes.outputs.run_matrix == 'true'" in text
+    assert "needs.changes.outputs.code_changed == 'true'" not in text
 
 
 def test_fast_lane_runs_static_contract_tests_when_applicable() -> None:
     text = _ci_text()
     assert "Static contract tests (tests/ci, tests/ops, WebUI structure-contract" in text
     assert "needs.changes.outputs.static_contract_changed == 'true'" in text
+    assert "needs.changes.outputs.run_matrix != 'true'" in text
     assert "pytest tests/ci tests/ops" in text
     assert "webui_structure_contract=(tests/webui/test_*structure_contract*.py)" in text
     assert '"${webui_structure_contract[@]}"' in text
+
+
+def test_fast_lane_webui_bounded_pytest_modules() -> None:
+    text = _ci_text()
+    assert "WebUI bounded pytest (market/observability surface)" in text
+    assert "needs.changes.outputs.webui_surface_changed == 'true'" in text
+    assert "PEAK_TRADE_LAST_PAPER_RUN_PANEL_ENABLED" in text
+    assert "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED" in text
+    for module in WEBUI_BOUNDED_PYTEST_MODULES:
+        assert module in text
+
+
+def test_required_check_names_unchanged() -> None:
+    text = _ci_text()
+    assert "name: tests (${{ matrix.python-version }})" in text
+    assert "name: strategy-smoke" in text
+    assert "name: Fast-Lane" in text
+    assert "python-version: ['3.9', '3.10', '3.11']" in text
 
 
 def test_code_changed_output_uses_narrowed_code_bucket_not_raw_filter_alias() -> None:
     text = _ci_text()
     assert "code_changed: ${{ steps.set_outputs.outputs.code_changed }}" in text
     assert "code_changed: ${{ steps.filter.outputs.code }}" not in text
+
+
+@pytest.mark.parametrize(
+    ("path", "expect_webui", "expect_non_webui"),
+    [
+        ("src/webui/app.py", True, False),
+        ("templates/peak_trade_dashboard/market_v0.html", True, False),
+        ("docs/webui/observability/OBSERVABILITY_HUB_V0.md", True, False),
+        ("tests/webui/test_observability_hub.py", True, False),
+        ("tests/fixtures/workflow_dashboard_readmodel_v1/foo.json", True, False),
+        ("tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py", True, False),
+        ("tests/ops/test_other_ops.py", False, False),
+        ("src/execution/foo.py", False, True),
+        ("pyproject.toml", False, True),
+        ("templates/other/template.html", False, True),
+    ],
+)
+def test_webui_surface_and_non_webui_path_semantics_v1(
+    path: str,
+    expect_webui: bool,
+    expect_non_webui: bool,
+) -> None:
+    assert _matches_webui_surface(path) is expect_webui
+    assert _matches_non_webui_code(path) is expect_non_webui
+
+
+@pytest.mark.parametrize(
+    ("paths", "expect_run_matrix"),
+    [
+        (["src/webui/app.py", "templates/peak_trade_dashboard/market_v0.html"], False),
+        (["src/webui/app.py", "pyproject.toml"], True),
+        (["docs/foo.md"], False),
+        (["src/execution/module.py"], True),
+        (
+            [
+                "src/webui/workflow_dashboard_readmodel_v1/builder.py",
+                "tests/webui/test_workflow_dashboard_readmodel_v1.py",
+                "tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py",
+            ],
+            False,
+        ),
+    ],
+)
+def test_run_matrix_semantics_for_path_sets_v1(paths: list[str], expect_run_matrix: bool) -> None:
+    assert _run_matrix_for_paths(paths) is expect_run_matrix

--- a/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
+++ b/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
@@ -278,8 +278,8 @@ def test_run_matrix_derived_from_non_webui_code_not_raw_code_bucket() -> None:
     text = _ci_text()
     assert 'NON_WEBUI="${{ steps.filter.outputs.non_webui_code }}"' in text
     assert 'echo "run_matrix=${CODE}"' not in text
-    assert "elif [ \"$NON_WEBUI\" = \"true\" ]; then" in text
-    assert "echo \"run_matrix=false\"" in text
+    assert 'elif [ "$NON_WEBUI" = "true" ]; then' in text
+    assert 'echo "run_matrix=false"' in text
 
 
 def test_matrix_jobs_keep_no_job_level_if_and_short_circuit_skip() -> None:


### PR DESCRIPTION
## Summary

Extends the existing `ci.yml` pragmatic flow with `webui_surface` and `non_webui_code` path buckets so Market/Observability/WebUI-only PRs skip the full Python test matrix (~10min × 3.9/3.10/3.11) while still running a bounded WebUI pytest lane in Fast-Lane.

## Scope

- `.github/workflows/ci.yml` — path gating, `run_matrix` logic, Fast-Lane bounded WebUI pytest
- `tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py` — contract tests (39 cases)
- `docs/ops/ci_pragmatic_flow_inventory.md` — Case D documentation

## Safety boundaries

- **No global required checks removed** — all branch-protection check names still materialize on every PR
- **skip-success pattern** — `tests (3.9/3.10/3.11)` and `strategy-smoke` jobs always created; step-level skip when `run_matrix=false`
- **Full matrix preserved** for `non_webui_code` changes (execution, scripts, deps, non-dashboard templates, etc.)
- **No trading/runtime/live/scheduler changes**
- **No branch-protection or policy gate weakening**
- `force_matrix` workflow_dispatch escape hatch unchanged

## Required check name stability

- `tests (${{ matrix.python-version }})` — unchanged
- `strategy-smoke` — unchanged (skip-success for webui_surface-only)
- `Fast-Lane` — unchanged (adds bounded WebUI step when applicable)
- Verified via `scripts/ops/check_required_ci_contexts_present.sh`

## Tests

```bash
uv run pytest tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py -q --tb=short
bash scripts/ops/check_required_ci_contexts_present.sh
```

Result: **39 passed / 0 failed**

## Evidence bundles

- Implementation: `.../implementation/market_observability_ci_path_gating_minimal_bounded_write_tests_v1_20260608T131048Z/`
- Post-implementation review: `.../review/market_observability_ci_path_gating_post_implementation_review_no_run_v1_20260608T131413Z/`

## No-Live statement

CI workflow path-gating only. No runtime/paper/shadow/testnet/live host started. No workflow dispatches. No auto-merge.


Made with [Cursor](https://cursor.com)