### PR TITLE
Add universe selection readmodel contract

### DIFF
--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -57,6 +57,18 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 - **Boundaries:** SSR only when gate on; no POST, no fetch/polling, no trading controls. `stale=true`, `stale_reason=archive_snapshot`.
 - **Tests:** `tests/webui/test_workflow_dashboard_readmodel_v1.py`, `tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py`, `tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py`.
 
+### Universe Selection Persistence Contract v1 (Slice 1 — schema/docs only)
+
+**Contract doc:** [**Universe Selection Read-model Schema v1**](UNIVERSE_SELECTION_READMODEL_V1.md) — `schema_name=universe_selection_readmodel.v1`.
+
+- **Storage target (Slice 2+):** `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` under `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT`.
+- **Validation (Slice 1):** `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py` — offline schema only; **no archive writes**, **no runtime I/O**.
+- **Dashboard today:** Panels B–E remain **Missing Truth** (`UNIVERSE_SOURCE_NOT_PERSISTED`, `TOP20_RANKING_NOT_PERSISTED`, `SELECTED_FUTURE_NOT_PERSISTED`, `FUTURE_DETAIL_NOT_AVAILABLE`). Slice 1 does **not** populate rows.
+- **Slice 3 (future):** `workflow_dashboard_readmodel.v1` builder will read the persisted file when present and manifest-verified; until then Missing Truth stays valid.
+- **Producer eligibility (Slice 2+):** Paper / Shadow / Testnet bounded observation closeout adapters only — **Live not authorized**.
+- **BTC/USD rule:** `GET /market` dummy and Market Surface defaults must **never** substitute Observability universe/selection truth.
+- **Tests:** `tests/webui/test_universe_selection_contract_v1.py`, fixtures under `tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/`.
+
 ## Last Paper Run panel (view-only SSR v0)
 
 **Route:** **`GET &#47;observability`** only (not primary on **`GET &#47;market`**).

--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -61,12 +61,12 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 
 **Contract doc:** [**Universe Selection Read-model Schema v1**](UNIVERSE_SELECTION_READMODEL_V1.md) — `schema_name=universe_selection_readmodel.v1`.
 
-- **Storage target (Slice 2+):** `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` under `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT`.
+- **Storage target (Slice 2+):** `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json` under `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT`.
 - **Validation (Slice 1):** `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py` — offline schema only; **no archive writes**, **no runtime I/O**.
 - **Dashboard today:** Panels B–E remain **Missing Truth** (`UNIVERSE_SOURCE_NOT_PERSISTED`, `TOP20_RANKING_NOT_PERSISTED`, `SELECTED_FUTURE_NOT_PERSISTED`, `FUTURE_DETAIL_NOT_AVAILABLE`). Slice 1 does **not** populate rows.
 - **Slice 3 (future):** `workflow_dashboard_readmodel.v1` builder will read the persisted file when present and manifest-verified; until then Missing Truth stays valid.
 - **Producer eligibility (Slice 2+):** Paper / Shadow / Testnet bounded observation closeout adapters only — **Live not authorized**.
-- **BTC/USD rule:** `GET /market` dummy and Market Surface defaults must **never** substitute Observability universe/selection truth.
+- **BTC&#47;USD rule:** `GET &#47;market` dummy and Market Surface defaults must **never** substitute Observability universe/selection truth.
 - **Tests:** `tests/webui/test_universe_selection_contract_v1.py`, fixtures under `tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/`.
 
 ## Last Paper Run panel (view-only SSR v0)

--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -1,0 +1,161 @@
+# Universe Selection Read-model Schema v1
+
+## 1. Purpose
+
+This document defines the **normative persistence contract** for **`universe_selection_readmodel.v1`**: governed Universe (~50 futures), Top-20 ranking, Selected Future, Future detail metadata, and related evidence links for the **view-only Workflow Dashboard** on **`GET /observability`**.
+
+**Slice 1 status:** Schema, validation helpers, fixtures, and static tests only. **No producer write**, **no dashboard population**, **no runtime start**. The dashboard continues to show **Missing Truth** until Slice 3 integrates archive reads.
+
+**Contract prep reference:** `planning/universe_top20_selected_future_persistence_contract_prep_no_run_v1_20260608T133943Z` (durable archive).
+
+## 2. Non-authority note
+
+- **`non_authorizing: true`** is required on every persisted payload.
+- This readmodel is **display-only** — no order placement, no live arming, no strategy activation, no scheduler trigger.
+- **`GET /market`** dummy OHLCV and **`market_ranking_funnel_readmodel.v0`** remain a **separate** Market Surface SSOT — they must **not** backfill Observability Missing Truth.
+- **BTC/USD** (and `market_surface_dummy` source kinds) are **forbidden** as Selected Future paper/future/runtime truth.
+
+## 3. Schema identity
+
+| Field | Value |
+|-------|-------|
+| `schema_name` | `universe_selection_readmodel.v1` |
+| `schema_version` | `1` |
+| Storage target | `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` |
+| Validation module | `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py` |
+| Dashboard consumer (Slice 3+) | `src/webui/workflow_dashboard_readmodel_v1/builder.py` |
+| Workflow SSR gate | `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` + `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` |
+
+## 4. Required top-level fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `schema_name` | string | yes | Must equal `universe_selection_readmodel.v1` |
+| `schema_version` | integer | yes | Must equal `1` |
+| `generated_at` | string (ISO-8601) | yes | Snapshot timestamp |
+| `source_run_id` | string | yes | Producer run bundle id or fixture id |
+| `source_stage` | string | yes | `paper`, `shadow`, or `testnet` — **`live` forbidden** |
+| `non_authorizing` | boolean | yes | Must be `true` |
+| `universe` | array | yes | ~50 futures target; max 60 rows; may be empty |
+| `ranking` | array | yes | Top-20 target; max 20 rows; may be empty |
+| `selected_future` | object \| null | yes | Explicit `NOT_PERSISTED` allowed |
+| `market_snapshot` | object | yes | Metadata only — not full OHLCV series |
+| `evidence` | object | yes | Producer contract ref + durable links |
+| `missing_truth` | object | yes | Per-panel truth status |
+
+Optional: `fixture_marked: true` for test fixtures only.
+
+## 5. Row shapes
+
+### `universe[]` and `ranking[]`
+
+| Field | Type | Required |
+|-------|------|----------|
+| `row_id` | string | yes |
+| `symbol` | string | yes |
+| `rank` | integer | yes |
+| `exchange` | string | no |
+| `display_score` | number | no |
+| `notes` | string | no |
+
+**Forbidden row fields:** `order_id`, `side`, `quantity`, `leverage`, `approval`, `approved`, `live_authorized`, `strategy_activation`.
+
+### `selected_future`
+
+When not persisted:
+
+```json
+{"truth_status": "NOT_PERSISTED"}
+```
+
+When persisted:
+
+| Field | Type | Required |
+|-------|------|----------|
+| `row_id` | string | yes |
+| `symbol` | string | yes |
+| `rank` | integer | yes |
+| `truth_status` | string | yes | Must be `PERSISTED` |
+| `selection_reason` | string | no |
+| `notes` | string | no |
+
+**Forbidden symbols as selected truth:** `BTC/USD`, `BTCUSD`, `BTC-USD`.  
+**Forbidden `source_kind` values:** `market_surface_dummy`, `get_market_dummy`, `btc_usd_dummy_default`.
+
+### `market_snapshot`
+
+Non-authorizing metadata block. Allowed keys include `truth_status`, `source_kind`, `snapshot_id`, `exchange`, `captured_at`. Must not embed tradable authority or full OHLCV history.
+
+### `evidence`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `producer_contract` | string | e.g. `universe_selection_producer.v1` |
+| `storage_target` | string | `readmodels/universe_selection_readmodel.v1.json` |
+| `manifest_verify_rc_expected` | integer | `0` after atomic write |
+| `links` | array | Durable paths to run bundles / primary evidence |
+
+### `missing_truth`
+
+| Key | Allowed statuses |
+|-----|------------------|
+| `universe` | `UNIVERSE_SOURCE_NOT_PERSISTED`, `PERSISTED`, `NOT_PERSISTED`, `UNKNOWN` |
+| `ranking` | `TOP20_RANKING_NOT_PERSISTED`, `PERSISTED`, `NOT_PERSISTED`, `UNKNOWN` |
+| `selected_future` | `SELECTED_FUTURE_NOT_PERSISTED`, `PERSISTED`, `NOT_PERSISTED`, `UNKNOWN` |
+| `future_detail` | `FUTURE_DETAIL_NOT_AVAILABLE`, `AVAILABLE`, `NOT_AVAILABLE`, `UNKNOWN` |
+| `orders_fills_pnl` | `NOT_PERSISTED`, `PERSISTED`, `UNKNOWN` (optional aggregate — may stay `NOT_PERSISTED`) |
+
+**Consistency rule:** `missing_truth` must agree with row presence (e.g. empty `universe` cannot pair with `PERSISTED`).
+
+## 6. Producer eligibility (Slice 2+)
+
+| Lane | Authorized | Notes |
+|------|:----------:|-------|
+| Paper bounded observation closeout | yes | Primary target for first governed write |
+| Shadow bounded observation closeout | yes | No orders; universe optional |
+| Testnet bounded observation closeout | yes | Staging/dry-run/observation only |
+| Live | **no** | `source_stage=live` rejected by schema |
+
+Producers extend existing bounded observation adapters — **not** `src/execution/`.
+
+## 7. Durable storage and MANIFEST
+
+1. Write to `{ARCHIVE_ROOT}/readmodels/.staging/` then atomic rename.
+2. Update `{ARCHIVE_ROOT}/readmodels/MANIFEST.sha256`.
+3. Require `MANIFEST_VERIFY_RC=0` before dashboard treats panels as `PERSISTED` (Slice 3).
+4. No `/tmp`-only final storage.
+
+## 8. Missing Truth semantics (current Slice 1 behavior)
+
+Until Slice 3 reads the archive file, `workflow_dashboard_readmodel.v1` builder keeps hardcoded Missing Truth cards:
+
+- `UNIVERSE_SOURCE_NOT_PERSISTED`
+- `TOP20_RANKING_NOT_PERSISTED`
+- `SELECTED_FUTURE_NOT_PERSISTED`
+- `FUTURE_DETAIL_NOT_AVAILABLE`
+
+Missing Truth is a **valid** operator-visible state — not a dashboard defect.
+
+## 9. Tests and fixtures (Slice 1)
+
+| Fixture | Path |
+|---------|------|
+| Missing truth | `tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/missing_truth/` |
+| Complete minimal (fixture-marked) | `tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/complete_minimal/` |
+| Invalid BTC/USD selected | `tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/invalid_btc_usd_selected/` |
+
+| Test module | Purpose |
+|-------------|---------|
+| `tests/webui/test_universe_selection_contract_v1.py` | Schema validation contract |
+| `tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py` | Hub doc references |
+| `tests/webui/test_workflow_dashboard_readmodel_v1.py` | Dashboard still Missing Truth |
+| `tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py` | HTML unchanged |
+
+## 10. Implementation slices
+
+| Slice | Scope |
+|-------|-------|
+| **1 (this doc)** | Contract docs + schema + fixtures + static tests |
+| **2** | Producer write adapter (Paper/Shadow/Testnet) |
+| **3** | Dashboard readmodel integration |
+| **4** | Bounded run verification (explicit operator GO) |

--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -2,17 +2,17 @@
 
 ## 1. Purpose
 
-This document defines the **normative persistence contract** for **`universe_selection_readmodel.v1`**: governed Universe (~50 futures), Top-20 ranking, Selected Future, Future detail metadata, and related evidence links for the **view-only Workflow Dashboard** on **`GET /observability`**.
+This document defines the **normative persistence contract** for **`universe_selection_readmodel.v1`**: governed Universe (~50 futures), Top-20 ranking, Selected Future, Future detail metadata, and related evidence links for the **view-only Workflow Dashboard** on **`GET &#47;observability`**.
 
 **Slice 1 status:** Schema, validation helpers, fixtures, and static tests only. **No producer write**, **no dashboard population**, **no runtime start**. The dashboard continues to show **Missing Truth** until Slice 3 integrates archive reads.
 
-**Contract prep reference:** `planning/universe_top20_selected_future_persistence_contract_prep_no_run_v1_20260608T133943Z` (durable archive).
+**Contract prep reference:** `planning&#47;universe_top20_selected_future_persistence_contract_prep_no_run_v1_20260608T133943Z` (durable archive).
 
 ## 2. Non-authority note
 
 - **`non_authorizing: true`** is required on every persisted payload.
 - This readmodel is **display-only** — no order placement, no live arming, no strategy activation, no scheduler trigger.
-- **`GET /market`** dummy OHLCV and **`market_ranking_funnel_readmodel.v0`** remain a **separate** Market Surface SSOT — they must **not** backfill Observability Missing Truth.
+- **`GET &#47;market`** dummy OHLCV and **`market_ranking_funnel_readmodel.v0`** remain a **separate** Market Surface SSOT — they must **not** backfill Observability Missing Truth.
 - **BTC/USD** (and `market_surface_dummy` source kinds) are **forbidden** as Selected Future paper/future/runtime truth.
 
 ## 3. Schema identity
@@ -21,7 +21,7 @@ This document defines the **normative persistence contract** for **`universe_sel
 |-------|-------|
 | `schema_name` | `universe_selection_readmodel.v1` |
 | `schema_version` | `1` |
-| Storage target | `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` |
+| Storage target | `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json` |
 | Validation module | `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py` |
 | Dashboard consumer (Slice 3+) | `src/webui/workflow_dashboard_readmodel_v1/builder.py` |
 | Workflow SSR gate | `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` + `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` |
@@ -79,7 +79,7 @@ When persisted:
 | `selection_reason` | string | no |
 | `notes` | string | no |
 
-**Forbidden symbols as selected truth:** `BTC/USD`, `BTCUSD`, `BTC-USD`.  
+**Forbidden symbols as selected truth:** `BTC&#47;USD`, `BTCUSD`, `BTC-USD`.  
 **Forbidden `source_kind` values:** `market_surface_dummy`, `get_market_dummy`, `btc_usd_dummy_default`.
 
 ### `market_snapshot`
@@ -91,7 +91,7 @@ Non-authorizing metadata block. Allowed keys include `truth_status`, `source_kin
 | Field | Type | Notes |
 |-------|------|-------|
 | `producer_contract` | string | e.g. `universe_selection_producer.v1` |
-| `storage_target` | string | `readmodels/universe_selection_readmodel.v1.json` |
+| `storage_target` | string | `readmodels&#47;universe_selection_readmodel.v1.json` |
 | `manifest_verify_rc_expected` | integer | `0` after atomic write |
 | `links` | array | Durable paths to run bundles / primary evidence |
 
@@ -120,8 +120,8 @@ Producers extend existing bounded observation adapters — **not** `src/executio
 
 ## 7. Durable storage and MANIFEST
 
-1. Write to `{ARCHIVE_ROOT}/readmodels/.staging/` then atomic rename.
-2. Update `{ARCHIVE_ROOT}/readmodels/MANIFEST.sha256`.
+1. Write to `{ARCHIVE_ROOT}&#47;readmodels&#47;.staging&#47;` then atomic rename.
+2. Update `{ARCHIVE_ROOT}&#47;readmodels&#47;MANIFEST.sha256`.
 3. Require `MANIFEST_VERIFY_RC=0` before dashboard treats panels as `PERSISTED` (Slice 3).
 4. No `/tmp`-only final storage.
 

--- a/src/webui/workflow_dashboard_readmodel_v1/__init__.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/__init__.py
@@ -11,13 +11,27 @@ from .types import (
     WorkflowDashboardReadModelV1,
     to_json_dict,
 )
+from .universe_selection_contract_v1 import (
+    SCHEMA_NAME as UNIVERSE_SELECTION_SCHEMA_NAME,
+    STORAGE_RELATIVE_PATH as UNIVERSE_SELECTION_STORAGE_PATH,
+    UniverseSelectionContractError,
+    UniverseSelectionContractV1,
+    load_universe_selection_contract,
+    validate_universe_selection_payload,
+)
 
 __all__ = [
     "PIPELINE_READMODEL_ID",
     "READMODEL_ID",
     "SCHEMA_VERSION",
+    "UNIVERSE_SELECTION_SCHEMA_NAME",
+    "UNIVERSE_SELECTION_STORAGE_PATH",
+    "UniverseSelectionContractError",
+    "UniverseSelectionContractV1",
     "WorkflowDashboardReadModelV1",
     "build_workflow_dashboard_readmodel_v1",
     "build_workflow_pipeline_aggregate_v1",
+    "load_universe_selection_contract",
     "to_json_dict",
+    "validate_universe_selection_payload",
 ]

--- a/src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py
@@ -1,0 +1,402 @@
+"""Schema contract and validation for universe_selection_readmodel.v1 (Slice 1 — no runtime I/O)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_NAME = "universe_selection_readmodel.v1"
+SCHEMA_VERSION = 1
+STORAGE_RELATIVE_PATH = "readmodels/universe_selection_readmodel.v1.json"
+
+ALLOWED_SOURCE_STAGES = frozenset({"paper", "shadow", "testnet"})
+FORBIDDEN_SOURCE_STAGES = frozenset({"live"})
+
+MISSING_TRUTH_UNIVERSE = "UNIVERSE_SOURCE_NOT_PERSISTED"
+MISSING_TRUTH_RANKING = "TOP20_RANKING_NOT_PERSISTED"
+MISSING_TRUTH_SELECTED = "SELECTED_FUTURE_NOT_PERSISTED"
+MISSING_TRUTH_FUTURE_DETAIL = "FUTURE_DETAIL_NOT_AVAILABLE"
+MISSING_TRUTH_PNL = "NOT_PERSISTED"
+
+ALLOWED_MISSING_TRUTH_STATUSES = frozenset(
+    {
+        "PERSISTED",
+        "NOT_PERSISTED",
+        "UNKNOWN",
+        MISSING_TRUTH_UNIVERSE,
+        MISSING_TRUTH_RANKING,
+        MISSING_TRUTH_SELECTED,
+        MISSING_TRUTH_FUTURE_DETAIL,
+        MISSING_TRUTH_PNL,
+        "AVAILABLE",
+        "NOT_AVAILABLE",
+    }
+)
+
+FORBIDDEN_ROW_FIELDS = frozenset(
+    {
+        "order_id",
+        "side",
+        "quantity",
+        "leverage",
+        "approval",
+        "approved",
+        "live_authorized",
+        "strategy_activation",
+    }
+)
+
+FORBIDDEN_SELECTED_SYMBOLS = frozenset(
+    {
+        "BTC/USD",
+        "BTCUSD",
+        "BTC-USD",
+    }
+)
+
+FORBIDDEN_TRUTH_SOURCE_KINDS = frozenset(
+    {
+        "market_surface_dummy",
+        "get_market_dummy",
+        "btc_usd_dummy_default",
+    }
+)
+
+MAX_UNIVERSE_ROWS = 60
+MAX_RANKING_ROWS = 20
+
+
+class UniverseSelectionContractError(ValueError):
+    """Raised when a universe selection contract payload is invalid."""
+
+
+@dataclass(frozen=True)
+class UniverseSelectionRowV1:
+    row_id: str
+    symbol: str
+    rank: int
+    exchange: str | None = None
+    display_score: float | None = None
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class SelectedFutureV1:
+    row_id: str
+    symbol: str
+    rank: int
+    truth_status: str
+    selection_reason: str | None = None
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class MissingTruthBlockV1:
+    universe: str
+    ranking: str
+    selected_future: str
+    future_detail: str
+    orders_fills_pnl: str
+
+
+@dataclass(frozen=True)
+class UniverseSelectionContractV1:
+    schema_name: str
+    schema_version: int
+    generated_at: str
+    source_run_id: str
+    source_stage: str
+    universe: tuple[UniverseSelectionRowV1, ...]
+    ranking: tuple[UniverseSelectionRowV1, ...]
+    selected_future: SelectedFutureV1 | None
+    market_snapshot: dict[str, Any]
+    evidence: dict[str, Any]
+    missing_truth: MissingTruthBlockV1
+    non_authorizing: bool
+    fixture_marked: bool
+
+
+def _as_mapping(value: Any, *, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise UniverseSelectionContractError(f"{field} must be an object")
+    return value
+
+
+def _as_string(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise UniverseSelectionContractError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _as_int(value: Any, *, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise UniverseSelectionContractError(f"{field} must be an integer")
+    return value
+
+
+def _as_bool(value: Any, *, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise UniverseSelectionContractError(f"{field} must be a boolean")
+    return value
+
+
+def _normalize_row(row: Any, *, field: str) -> UniverseSelectionRowV1:
+    row_map = _as_mapping(row, field=field)
+    forbidden = sorted(FORBIDDEN_ROW_FIELDS.intersection(row_map))
+    if forbidden:
+        raise UniverseSelectionContractError(
+            f"{field} contains forbidden fields: {', '.join(forbidden)}"
+        )
+    symbol = _as_string(row_map.get("symbol"), field=f"{field}.symbol")
+    normalized = UniverseSelectionRowV1(
+        row_id=_as_string(row_map.get("row_id"), field=f"{field}.row_id"),
+        symbol=symbol,
+        rank=_as_int(row_map.get("rank"), field=f"{field}.rank"),
+        exchange=row_map.get("exchange") if row_map.get("exchange") is None else _as_string(
+            row_map.get("exchange"), field=f"{field}.exchange"
+        ),
+        display_score=(
+            float(row_map["display_score"])
+            if "display_score" in row_map and row_map["display_score"] is not None
+            else None
+        ),
+        notes=row_map.get("notes") if row_map.get("notes") is None else _as_string(
+            row_map.get("notes"), field=f"{field}.notes"
+        ),
+    )
+    return normalized
+
+
+def _normalize_rows(value: Any, *, field: str, max_rows: int) -> tuple[UniverseSelectionRowV1, ...]:
+    if not isinstance(value, list):
+        raise UniverseSelectionContractError(f"{field} must be a list")
+    if len(value) > max_rows:
+        raise UniverseSelectionContractError(f"{field} exceeds max rows ({max_rows})")
+    return tuple(_normalize_row(row, field=f"{field}[{index}]") for index, row in enumerate(value))
+
+
+def _normalize_missing_truth(value: Any) -> MissingTruthBlockV1:
+    block = _as_mapping(value, field="missing_truth")
+    fields = {
+        "universe": _as_string(block.get("universe"), field="missing_truth.universe"),
+        "ranking": _as_string(block.get("ranking"), field="missing_truth.ranking"),
+        "selected_future": _as_string(
+            block.get("selected_future"), field="missing_truth.selected_future"
+        ),
+        "future_detail": _as_string(block.get("future_detail"), field="missing_truth.future_detail"),
+        "orders_fills_pnl": _as_string(
+            block.get("orders_fills_pnl"), field="missing_truth.orders_fills_pnl"
+        ),
+    }
+    for name, status in fields.items():
+        if status not in ALLOWED_MISSING_TRUTH_STATUSES:
+            raise UniverseSelectionContractError(
+                f"missing_truth.{name} has unsupported status: {status}"
+            )
+    return MissingTruthBlockV1(**fields)
+
+
+def _normalize_selected_future(value: Any) -> SelectedFutureV1 | None:
+    if value is None:
+        return None
+    block = _as_mapping(value, field="selected_future")
+    truth_status = _as_string(block.get("truth_status"), field="selected_future.truth_status")
+    if truth_status == "NOT_PERSISTED":
+        return None
+    symbol = _as_string(block.get("symbol"), field="selected_future.symbol")
+    _reject_btc_dummy_selected_truth(
+        symbol=symbol,
+        source_kind=block.get("source_kind"),
+        field="selected_future",
+    )
+    forbidden = sorted(FORBIDDEN_ROW_FIELDS.intersection(block))
+    if forbidden:
+        raise UniverseSelectionContractError(
+            f"selected_future contains forbidden fields: {', '.join(forbidden)}"
+        )
+    return SelectedFutureV1(
+        row_id=_as_string(block.get("row_id"), field="selected_future.row_id"),
+        symbol=symbol,
+        rank=_as_int(block.get("rank"), field="selected_future.rank"),
+        truth_status=truth_status,
+        selection_reason=(
+            None
+            if block.get("selection_reason") is None
+            else _as_string(block.get("selection_reason"), field="selected_future.selection_reason")
+        ),
+        notes=(
+            None
+            if block.get("notes") is None
+            else _as_string(block.get("notes"), field="selected_future.notes")
+        ),
+    )
+
+
+def _reject_btc_dummy_selected_truth(
+    *,
+    symbol: str,
+    source_kind: Any,
+    field: str,
+) -> None:
+    normalized = symbol.upper().replace("-", "").replace("/", "")
+    if symbol in FORBIDDEN_SELECTED_SYMBOLS or normalized == "BTCUSD":
+        raise UniverseSelectionContractError(
+            f"{field}.symbol forbidden as paper/future/runtime truth: {symbol}"
+        )
+    if isinstance(source_kind, str) and source_kind in FORBIDDEN_TRUTH_SOURCE_KINDS:
+        raise UniverseSelectionContractError(
+            f"{field}.source_kind forbidden: {source_kind}"
+        )
+
+
+def _validate_missing_truth_consistency(
+    contract: UniverseSelectionContractV1,
+) -> None:
+    mt = contract.missing_truth
+    if contract.universe and mt.universe in (MISSING_TRUTH_UNIVERSE, "NOT_PERSISTED"):
+        raise UniverseSelectionContractError(
+            "universe rows present but missing_truth.universe is NOT_PERSISTED"
+        )
+    if not contract.universe and mt.universe == "PERSISTED":
+        raise UniverseSelectionContractError(
+            "missing_truth.universe is PERSISTED but universe is empty"
+        )
+    if contract.ranking and mt.ranking in (MISSING_TRUTH_RANKING, "NOT_PERSISTED"):
+        raise UniverseSelectionContractError(
+            "ranking rows present but missing_truth.ranking is NOT_PERSISTED"
+        )
+    if not contract.ranking and mt.ranking == "PERSISTED":
+        raise UniverseSelectionContractError(
+            "missing_truth.ranking is PERSISTED but ranking is empty"
+        )
+    if contract.selected_future and mt.selected_future in (MISSING_TRUTH_SELECTED, "NOT_PERSISTED"):
+        raise UniverseSelectionContractError(
+            "selected_future present but missing_truth.selected_future is NOT_PERSISTED"
+        )
+    if contract.selected_future is None and mt.selected_future == "PERSISTED":
+        raise UniverseSelectionContractError(
+            "missing_truth.selected_future is PERSISTED but selected_future is absent"
+        )
+
+
+def validate_universe_selection_payload(payload: dict[str, Any]) -> UniverseSelectionContractV1:
+    """Validate a universe_selection_readmodel.v1 JSON object (no filesystem access)."""
+    schema_name = _as_string(payload.get("schema_name"), field="schema_name")
+    if schema_name != SCHEMA_NAME:
+        raise UniverseSelectionContractError(f"schema_name must be {SCHEMA_NAME}")
+
+    schema_version = payload.get("schema_version")
+    if schema_version != SCHEMA_VERSION:
+        raise UniverseSelectionContractError(f"schema_version must be {SCHEMA_VERSION}")
+
+    source_stage = _as_string(payload.get("source_stage"), field="source_stage").lower()
+    if source_stage in FORBIDDEN_SOURCE_STAGES:
+        raise UniverseSelectionContractError(f"source_stage forbidden: {source_stage}")
+    if source_stage not in ALLOWED_SOURCE_STAGES:
+        raise UniverseSelectionContractError(f"source_stage unsupported: {source_stage}")
+
+    non_authorizing = _as_bool(payload.get("non_authorizing"), field="non_authorizing")
+    if not non_authorizing:
+        raise UniverseSelectionContractError("non_authorizing must be true")
+
+    universe = _normalize_rows(payload.get("universe"), field="universe", max_rows=MAX_UNIVERSE_ROWS)
+    ranking = _normalize_rows(payload.get("ranking"), field="ranking", max_rows=MAX_RANKING_ROWS)
+    selected_future = _normalize_selected_future(payload.get("selected_future"))
+    market_snapshot = _as_mapping(payload.get("market_snapshot"), field="market_snapshot")
+    evidence = _as_mapping(payload.get("evidence"), field="evidence")
+    missing_truth = _normalize_missing_truth(payload.get("missing_truth"))
+
+    contract = UniverseSelectionContractV1(
+        schema_name=schema_name,
+        schema_version=schema_version,
+        generated_at=_as_string(payload.get("generated_at"), field="generated_at"),
+        source_run_id=_as_string(payload.get("source_run_id"), field="source_run_id"),
+        source_stage=source_stage,
+        universe=universe,
+        ranking=ranking,
+        selected_future=selected_future,
+        market_snapshot=market_snapshot,
+        evidence=evidence,
+        missing_truth=missing_truth,
+        non_authorizing=non_authorizing,
+        fixture_marked=bool(payload.get("fixture_marked", False)),
+    )
+    _validate_missing_truth_consistency(contract)
+    return contract
+
+
+def load_universe_selection_contract(path: str | Path) -> UniverseSelectionContractV1:
+    """Load and validate universe_selection_readmodel.v1.json from a fixture or archive path."""
+    payload_path = Path(path)
+    if payload_path.is_dir():
+        payload_path = payload_path / "universe_selection_readmodel.v1.json"
+    try:
+        raw = payload_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise UniverseSelectionContractError(f"cannot read contract file: {payload_path}") from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise UniverseSelectionContractError("contract json_decode_error") from exc
+    if not isinstance(payload, dict):
+        raise UniverseSelectionContractError("contract root must be an object")
+    return validate_universe_selection_payload(payload)
+
+
+def contract_to_json_dict(contract: UniverseSelectionContractV1) -> dict[str, Any]:
+    """Serialize a validated contract back to JSON-compatible dict."""
+    selected: dict[str, Any] | None
+    if contract.selected_future is None:
+        selected = {"truth_status": "NOT_PERSISTED"}
+    else:
+        sf = contract.selected_future
+        selected = {
+            "row_id": sf.row_id,
+            "symbol": sf.symbol,
+            "rank": sf.rank,
+            "truth_status": sf.truth_status,
+            "selection_reason": sf.selection_reason,
+            "notes": sf.notes,
+        }
+
+    def _rows(rows: tuple[UniverseSelectionRowV1, ...]) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            item: dict[str, Any] = {
+                "row_id": row.row_id,
+                "symbol": row.symbol,
+                "rank": row.rank,
+            }
+            if row.exchange is not None:
+                item["exchange"] = row.exchange
+            if row.display_score is not None:
+                item["display_score"] = row.display_score
+            if row.notes is not None:
+                item["notes"] = row.notes
+            out.append(item)
+        return out
+
+    mt = contract.missing_truth
+    return {
+        "schema_name": contract.schema_name,
+        "schema_version": contract.schema_version,
+        "generated_at": contract.generated_at,
+        "source_run_id": contract.source_run_id,
+        "source_stage": contract.source_stage,
+        "non_authorizing": contract.non_authorizing,
+        "fixture_marked": contract.fixture_marked,
+        "universe": _rows(contract.universe),
+        "ranking": _rows(contract.ranking),
+        "selected_future": selected,
+        "market_snapshot": contract.market_snapshot,
+        "evidence": contract.evidence,
+        "missing_truth": {
+            "universe": mt.universe,
+            "ranking": mt.ranking,
+            "selected_future": mt.selected_future,
+            "future_detail": mt.future_detail,
+            "orders_fills_pnl": mt.orders_fills_pnl,
+        },
+    }

--- a/src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py
@@ -154,17 +154,17 @@ def _normalize_row(row: Any, *, field: str) -> UniverseSelectionRowV1:
         row_id=_as_string(row_map.get("row_id"), field=f"{field}.row_id"),
         symbol=symbol,
         rank=_as_int(row_map.get("rank"), field=f"{field}.rank"),
-        exchange=row_map.get("exchange") if row_map.get("exchange") is None else _as_string(
-            row_map.get("exchange"), field=f"{field}.exchange"
-        ),
+        exchange=row_map.get("exchange")
+        if row_map.get("exchange") is None
+        else _as_string(row_map.get("exchange"), field=f"{field}.exchange"),
         display_score=(
             float(row_map["display_score"])
             if "display_score" in row_map and row_map["display_score"] is not None
             else None
         ),
-        notes=row_map.get("notes") if row_map.get("notes") is None else _as_string(
-            row_map.get("notes"), field=f"{field}.notes"
-        ),
+        notes=row_map.get("notes")
+        if row_map.get("notes") is None
+        else _as_string(row_map.get("notes"), field=f"{field}.notes"),
     )
     return normalized
 
@@ -185,7 +185,9 @@ def _normalize_missing_truth(value: Any) -> MissingTruthBlockV1:
         "selected_future": _as_string(
             block.get("selected_future"), field="missing_truth.selected_future"
         ),
-        "future_detail": _as_string(block.get("future_detail"), field="missing_truth.future_detail"),
+        "future_detail": _as_string(
+            block.get("future_detail"), field="missing_truth.future_detail"
+        ),
         "orders_fills_pnl": _as_string(
             block.get("orders_fills_pnl"), field="missing_truth.orders_fills_pnl"
         ),
@@ -246,9 +248,7 @@ def _reject_btc_dummy_selected_truth(
             f"{field}.symbol forbidden as paper/future/runtime truth: {symbol}"
         )
     if isinstance(source_kind, str) and source_kind in FORBIDDEN_TRUTH_SOURCE_KINDS:
-        raise UniverseSelectionContractError(
-            f"{field}.source_kind forbidden: {source_kind}"
-        )
+        raise UniverseSelectionContractError(f"{field}.source_kind forbidden: {source_kind}")
 
 
 def _validate_missing_truth_consistency(
@@ -301,7 +301,9 @@ def validate_universe_selection_payload(payload: dict[str, Any]) -> UniverseSele
     if not non_authorizing:
         raise UniverseSelectionContractError("non_authorizing must be true")
 
-    universe = _normalize_rows(payload.get("universe"), field="universe", max_rows=MAX_UNIVERSE_ROWS)
+    universe = _normalize_rows(
+        payload.get("universe"), field="universe", max_rows=MAX_UNIVERSE_ROWS
+    )
     ranking = _normalize_rows(payload.get("ranking"), field="ranking", max_rows=MAX_RANKING_ROWS)
     selected_future = _normalize_selected_future(payload.get("selected_future"))
     market_snapshot = _as_mapping(payload.get("market_snapshot"), field="market_snapshot")

--- a/tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/complete_minimal/universe_selection_readmodel.v1.json
+++ b/tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/complete_minimal/universe_selection_readmodel.v1.json
@@ -1,0 +1,48 @@
+{
+  "schema_name": "universe_selection_readmodel.v1",
+  "schema_version": 1,
+  "generated_at": "2026-06-08T12:00:00Z",
+  "source_run_id": "fixture_complete_minimal_v1",
+  "source_stage": "paper",
+  "non_authorizing": true,
+  "fixture_marked": true,
+  "universe": [
+    {"row_id": "u-eth", "symbol": "ETHUSDT", "rank": 1, "exchange": "binance_futures", "notes": "fixture testdata"},
+    {"row_id": "u-sol", "symbol": "SOLUSDT", "rank": 2, "exchange": "binance_futures", "notes": "fixture testdata"},
+    {"row_id": "u-avax", "symbol": "AVAXUSDT", "rank": 3, "exchange": "binance_futures", "notes": "fixture testdata"}
+  ],
+  "ranking": [
+    {"row_id": "r-eth", "symbol": "ETHUSDT", "rank": 1, "display_score": 0.91, "notes": "fixture testdata"},
+    {"row_id": "r-sol", "symbol": "SOLUSDT", "rank": 2, "display_score": 0.87, "notes": "fixture testdata"}
+  ],
+  "selected_future": {
+    "row_id": "s-sol",
+    "symbol": "SOLUSDT",
+    "rank": 1,
+    "truth_status": "PERSISTED",
+    "selection_reason": "fixture_top_ranked_candidate",
+    "notes": "fixture testdata — not production truth"
+  },
+  "market_snapshot": {
+    "truth_status": "PERSISTED",
+    "source_kind": "governed_producer_fixture",
+    "snapshot_id": "fixture-snapshot-001",
+    "exchange": "binance_futures",
+    "captured_at": "2026-06-08T11:59:00Z"
+  },
+  "evidence": {
+    "producer_contract": "universe_selection_producer.v1",
+    "storage_target": "readmodels/universe_selection_readmodel.v1.json",
+    "manifest_verify_rc_expected": 0,
+    "links": [
+      {"label": "source_run_bundle", "path": "runs/p2_longer_bounded_paper_20260607T233758Z"}
+    ]
+  },
+  "missing_truth": {
+    "universe": "PERSISTED",
+    "ranking": "PERSISTED",
+    "selected_future": "PERSISTED",
+    "future_detail": "AVAILABLE",
+    "orders_fills_pnl": "NOT_PERSISTED"
+  }
+}

--- a/tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/invalid_btc_usd_selected/universe_selection_readmodel.v1.json
+++ b/tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/invalid_btc_usd_selected/universe_selection_readmodel.v1.json
@@ -1,0 +1,34 @@
+{
+  "schema_name": "universe_selection_readmodel.v1",
+  "schema_version": 1,
+  "generated_at": "2026-06-08T12:00:00Z",
+  "source_run_id": "fixture_invalid_btc_usd_v1",
+  "source_stage": "paper",
+  "non_authorizing": true,
+  "fixture_marked": true,
+  "universe": [],
+  "ranking": [],
+  "selected_future": {
+    "row_id": "s-btc",
+    "symbol": "BTC/USD",
+    "rank": 1,
+    "truth_status": "PERSISTED",
+    "source_kind": "market_surface_dummy",
+    "notes": "invalid — must be rejected by schema"
+  },
+  "market_snapshot": {
+    "truth_status": "NOT_PERSISTED",
+    "source_kind": "NOT_PERSISTED"
+  },
+  "evidence": {
+    "producer_contract": "universe_selection_producer.v1",
+    "links": []
+  },
+  "missing_truth": {
+    "universe": "UNIVERSE_SOURCE_NOT_PERSISTED",
+    "ranking": "TOP20_RANKING_NOT_PERSISTED",
+    "selected_future": "PERSISTED",
+    "future_detail": "NOT_AVAILABLE",
+    "orders_fills_pnl": "NOT_PERSISTED"
+  }
+}

--- a/tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/missing_truth/universe_selection_readmodel.v1.json
+++ b/tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/missing_truth/universe_selection_readmodel.v1.json
@@ -1,0 +1,33 @@
+{
+  "schema_name": "universe_selection_readmodel.v1",
+  "schema_version": 1,
+  "generated_at": "2026-06-08T12:00:00Z",
+  "source_run_id": "fixture_missing_truth_v1",
+  "source_stage": "paper",
+  "non_authorizing": true,
+  "fixture_marked": true,
+  "universe": [],
+  "ranking": [],
+  "selected_future": {
+    "truth_status": "NOT_PERSISTED"
+  },
+  "market_snapshot": {
+    "truth_status": "NOT_PERSISTED",
+    "source_kind": "NOT_PERSISTED",
+    "snapshot_id": null,
+    "exchange": null,
+    "captured_at": null
+  },
+  "evidence": {
+    "producer_contract": "universe_selection_producer.v1",
+    "storage_target": "readmodels/universe_selection_readmodel.v1.json",
+    "links": []
+  },
+  "missing_truth": {
+    "universe": "UNIVERSE_SOURCE_NOT_PERSISTED",
+    "ranking": "TOP20_RANKING_NOT_PERSISTED",
+    "selected_future": "SELECTED_FUTURE_NOT_PERSISTED",
+    "future_detail": "FUTURE_DETAIL_NOT_AVAILABLE",
+    "orders_fills_pnl": "NOT_PERSISTED"
+  }
+}

--- a/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
+++ b/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
@@ -29,7 +29,7 @@ def test_universe_selection_contract_doc_exists() -> None:
     doc = doc_path.read_text(encoding="utf-8")
     assert "schema_name" in doc
     assert "universe_selection_readmodel.v1" in doc
-    assert "readmodels/universe_selection_readmodel.v1.json" in doc
+    assert "readmodels&#47;universe_selection_readmodel.v1.json" in doc
     assert "BTC/USD" in doc
     assert "UNIVERSE_SOURCE_NOT_PERSISTED" in doc
 

--- a/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
+++ b/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
@@ -21,3 +21,22 @@ def test_observability_hub_doc_documents_workflow_dashboard() -> None:
     assert "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED" in doc
     assert "workflow_dashboard_readmodel.v1" in doc
     assert "UNIVERSE_SOURCE_NOT_PERSISTED" in doc
+
+
+def test_universe_selection_contract_doc_exists() -> None:
+    doc_path = PROJECT_ROOT / "docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md"
+    assert doc_path.is_file()
+    doc = doc_path.read_text(encoding="utf-8")
+    assert "schema_name" in doc
+    assert "universe_selection_readmodel.v1" in doc
+    assert "readmodels/universe_selection_readmodel.v1.json" in doc
+    assert "BTC/USD" in doc
+    assert "UNIVERSE_SOURCE_NOT_PERSISTED" in doc
+
+
+def test_observability_hub_links_universe_selection_contract() -> None:
+    doc = (PROJECT_ROOT / "docs/webui/observability/OBSERVABILITY_HUB_V0.md").read_text(
+        encoding="utf-8"
+    )
+    assert "UNIVERSE_SELECTION_READMODEL_V1.md" in doc
+    assert "universe_selection_readmodel.v1" in doc

--- a/tests/webui/test_universe_selection_contract_v1.py
+++ b/tests/webui/test_universe_selection_contract_v1.py
@@ -24,7 +24,11 @@ from src.webui.workflow_dashboard_readmodel_v1 import (
 )
 
 FIXTURE_ROOT = (
-    project_root / "tests" / "fixtures" / "workflow_dashboard_readmodel_v1" / "universe_selection_readmodel_v1"
+    project_root
+    / "tests"
+    / "fixtures"
+    / "workflow_dashboard_readmodel_v1"
+    / "universe_selection_readmodel_v1"
 ).resolve()
 FIXTURE_MISSING = FIXTURE_ROOT / "missing_truth"
 FIXTURE_COMPLETE = FIXTURE_ROOT / "complete_minimal"
@@ -37,14 +41,16 @@ FIXTURE_ARCHIVE = (
     / "pipeline_minimal"
     / "archive_root"
 ).resolve()
-CONTRACT_DOC = project_root / "docs" / "webui" / "observability" / "UNIVERSE_SELECTION_READMODEL_V1.md"
+CONTRACT_DOC = (
+    project_root / "docs" / "webui" / "observability" / "UNIVERSE_SELECTION_READMODEL_V1.md"
+)
 HUB_DOC = project_root / "docs" / "webui" / "observability" / "OBSERVABILITY_HUB_V0.md"
 
 
 def test_contract_doc_exists_and_names_schema() -> None:
     text = CONTRACT_DOC.read_text(encoding="utf-8")
     assert "universe_selection_readmodel.v1" in text
-    assert "readmodels/universe_selection_readmodel.v1.json" in text
+    assert "readmodels&#47;universe_selection_readmodel.v1.json" in text
     assert "BTC/USD" in text
     assert "UNIVERSE_SOURCE_NOT_PERSISTED" in text
     assert "live" in text.lower()
@@ -56,7 +62,7 @@ def test_observability_hub_references_universe_selection_contract() -> None:
     assert "UNIVERSE_SELECTION_READMODEL_V1.md" in text
     assert "universe_selection_readmodel.v1" in text
     assert "UNIVERSE_SOURCE_NOT_PERSISTED" in text
-    assert "readmodels/universe_selection_readmodel.v1.json" in text
+    assert "readmodels&#47;universe_selection_readmodel.v1.json" in text
 
 
 def test_schema_constants() -> None:
@@ -152,7 +158,9 @@ def contract_to_safe_dict(contract: object) -> dict:
 
 def test_market_surface_dummy_source_kind_rejected() -> None:
     payload = copy.deepcopy(
-        json.loads((FIXTURE_COMPLETE / "universe_selection_readmodel.v1.json").read_text(encoding="utf-8"))
+        json.loads(
+            (FIXTURE_COMPLETE / "universe_selection_readmodel.v1.json").read_text(encoding="utf-8")
+        )
     )
     payload["selected_future"]["source_kind"] = "market_surface_dummy"
     with pytest.raises(UniverseSelectionContractError, match="source_kind forbidden"):

--- a/tests/webui/test_universe_selection_contract_v1.py
+++ b/tests/webui/test_universe_selection_contract_v1.py
@@ -1,0 +1,159 @@
+"""Static contract tests for universe_selection_readmodel.v1 (Slice 1)."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+from src.webui.workflow_dashboard_readmodel_v1 import (
+    SCHEMA_VERSION,
+    UNIVERSE_SELECTION_SCHEMA_NAME,
+    UNIVERSE_SELECTION_STORAGE_PATH,
+    UniverseSelectionContractError,
+    build_workflow_dashboard_readmodel_v1,
+    load_universe_selection_contract,
+    to_json_dict,
+    validate_universe_selection_payload,
+)
+
+FIXTURE_ROOT = (
+    project_root / "tests" / "fixtures" / "workflow_dashboard_readmodel_v1" / "universe_selection_readmodel_v1"
+).resolve()
+FIXTURE_MISSING = FIXTURE_ROOT / "missing_truth"
+FIXTURE_COMPLETE = FIXTURE_ROOT / "complete_minimal"
+FIXTURE_INVALID_BTC = FIXTURE_ROOT / "invalid_btc_usd_selected"
+FIXTURE_ARCHIVE = (
+    project_root
+    / "tests"
+    / "fixtures"
+    / "workflow_dashboard_readmodel_v1"
+    / "pipeline_minimal"
+    / "archive_root"
+).resolve()
+CONTRACT_DOC = project_root / "docs" / "webui" / "observability" / "UNIVERSE_SELECTION_READMODEL_V1.md"
+HUB_DOC = project_root / "docs" / "webui" / "observability" / "OBSERVABILITY_HUB_V0.md"
+
+
+def test_contract_doc_exists_and_names_schema() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    assert "universe_selection_readmodel.v1" in text
+    assert "readmodels/universe_selection_readmodel.v1.json" in text
+    assert "BTC/USD" in text
+    assert "UNIVERSE_SOURCE_NOT_PERSISTED" in text
+    assert "live" in text.lower()
+    assert "non_authorizing" in text
+
+
+def test_observability_hub_references_universe_selection_contract() -> None:
+    text = HUB_DOC.read_text(encoding="utf-8")
+    assert "UNIVERSE_SELECTION_READMODEL_V1.md" in text
+    assert "universe_selection_readmodel.v1" in text
+    assert "UNIVERSE_SOURCE_NOT_PERSISTED" in text
+    assert "readmodels/universe_selection_readmodel.v1.json" in text
+
+
+def test_schema_constants() -> None:
+    assert UNIVERSE_SELECTION_SCHEMA_NAME == "universe_selection_readmodel.v1"
+    assert UNIVERSE_SELECTION_STORAGE_PATH == "readmodels/universe_selection_readmodel.v1.json"
+    assert SCHEMA_VERSION == "workflow_dashboard_readmodel.v1"
+
+
+def test_missing_truth_fixture_accepted() -> None:
+    contract = load_universe_selection_contract(FIXTURE_MISSING)
+    assert contract.schema_name == UNIVERSE_SELECTION_SCHEMA_NAME
+    assert contract.universe == ()
+    assert contract.ranking == ()
+    assert contract.selected_future is None
+    assert contract.missing_truth.universe == "UNIVERSE_SOURCE_NOT_PERSISTED"
+    assert contract.missing_truth.selected_future == "SELECTED_FUTURE_NOT_PERSISTED"
+    assert contract.fixture_marked is True
+
+
+def test_complete_minimal_fixture_accepted() -> None:
+    contract = load_universe_selection_contract(FIXTURE_COMPLETE)
+    assert contract.fixture_marked is True
+    assert len(contract.universe) == 3
+    assert len(contract.ranking) == 2
+    assert contract.selected_future is not None
+    assert contract.selected_future.symbol == "SOLUSDT"
+    assert contract.missing_truth.universe == "PERSISTED"
+    assert contract.missing_truth.orders_fills_pnl == "NOT_PERSISTED"
+    assert "BTC/USD" not in json.dumps(contract_to_safe_dict(contract))
+
+
+def test_btc_usd_selected_truth_rejected() -> None:
+    with pytest.raises(UniverseSelectionContractError, match="forbidden"):
+        load_universe_selection_contract(FIXTURE_INVALID_BTC)
+
+
+def test_live_source_stage_rejected() -> None:
+    payload = json.loads(
+        (FIXTURE_MISSING / "universe_selection_readmodel.v1.json").read_text(encoding="utf-8")
+    )
+    payload["source_stage"] = "live"
+    with pytest.raises(UniverseSelectionContractError, match="forbidden"):
+        validate_universe_selection_payload(payload)
+
+
+def test_non_authorizing_required() -> None:
+    payload = json.loads(
+        (FIXTURE_MISSING / "universe_selection_readmodel.v1.json").read_text(encoding="utf-8")
+    )
+    payload["non_authorizing"] = False
+    with pytest.raises(UniverseSelectionContractError, match="non_authorizing"):
+        validate_universe_selection_payload(payload)
+
+
+def test_forbidden_authority_field_in_row_rejected() -> None:
+    payload = json.loads(
+        (FIXTURE_COMPLETE / "universe_selection_readmodel.v1.json").read_text(encoding="utf-8")
+    )
+    payload["universe"][0]["live_authorized"] = True
+    with pytest.raises(UniverseSelectionContractError, match="forbidden fields"):
+        validate_universe_selection_payload(payload)
+
+
+def test_missing_truth_inconsistent_with_rows_rejected() -> None:
+    payload = json.loads(
+        (FIXTURE_COMPLETE / "universe_selection_readmodel.v1.json").read_text(encoding="utf-8")
+    )
+    payload["missing_truth"]["universe"] = "UNIVERSE_SOURCE_NOT_PERSISTED"
+    with pytest.raises(UniverseSelectionContractError, match="NOT_PERSISTED"):
+        validate_universe_selection_payload(payload)
+
+
+def test_dashboard_builder_unchanged_missing_truth() -> None:
+    model = build_workflow_dashboard_readmodel_v1(FIXTURE_ARCHIVE)
+    assert model.universe_missing.truth_status == "UNIVERSE_SOURCE_NOT_PERSISTED"
+    assert model.top20_missing.truth_status == "TOP20_RANKING_NOT_PERSISTED"
+    assert model.selected_future_missing.truth_status == "SELECTED_FUTURE_NOT_PERSISTED"
+    assert model.future_detail_missing.truth_status == "FUTURE_DETAIL_NOT_AVAILABLE"
+    dumped = to_json_dict(model)
+    assert "SOLUSDT" not in str(dumped)
+    assert "ETHUSDT" not in str(dumped)
+
+
+def contract_to_safe_dict(contract: object) -> dict:
+    from src.webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
+        UniverseSelectionContractV1,
+        contract_to_json_dict,
+    )
+
+    assert isinstance(contract, UniverseSelectionContractV1)
+    return contract_to_json_dict(contract)
+
+
+def test_market_surface_dummy_source_kind_rejected() -> None:
+    payload = copy.deepcopy(
+        json.loads((FIXTURE_COMPLETE / "universe_selection_readmodel.v1.json").read_text(encoding="utf-8"))
+    )
+    payload["selected_future"]["source_kind"] = "market_surface_dummy"
+    with pytest.raises(UniverseSelectionContractError, match="source_kind forbidden"):
+        validate_universe_selection_payload(payload)


### PR DESCRIPTION
## Summary

- Add `universe_selection_readmodel.v1` persistence contract documentation for Observability Workflow Dashboard universe/Top20/selected-future panels.
- Add schema validation module, fixtures, and static tests (Slice 1 only).
- Extend `OBSERVABILITY_HUB_V0.md` with contract link and Slice 1 semantics.

## Scope

- Docs: `UNIVERSE_SELECTION_READMODEL_V1.md`, `OBSERVABILITY_HUB_V0.md` extension
- Schema: `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py`
- Fixtures + tests under `tests/fixtures/workflow_dashboard_readmodel_v1/universe_selection_readmodel_v1/` and `tests/webui/test_universe_selection_contract_v1.py`
- **No** producer write, **no** dashboard population, **no** runtime/scheduler changes

## Contract semantics

- `schema_name`: `universe_selection_readmodel.v1`
- Storage target (Slice 2+): `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json`
- Covers: universe (~50), Top20 ranking, selected future, future detail metadata, market snapshot metadata, evidence links
- Producer eligibility: Paper/Shadow/Testnet bounded observation closeout adapters only

## Missing Truth / BTC dummy prohibition

- Dashboard remains **Missing Truth** in Slice 1 (`UNIVERSE_SOURCE_NOT_PERSISTED`, etc.)
- Missing Truth is valid until governed producer writes evidence (Slice 2+)
- BTC/USD and `market_surface_dummy` forbidden as selected paper/future/runtime truth
- No inference from `GET /market` dummy OHLCV

## Safety boundaries

- No changes to `src/execution/`, `src/governance/`, `src/risk/`
- No scheduler/runtime/paper/shadow/testnet/live start logic
- No workflow YAML changes
- No Live secrets or orders

## Tests

```bash
uv run pytest \
  tests/webui/test_universe_selection_contract_v1.py \
  tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py \
  tests/webui/test_workflow_dashboard_readmodel_v1.py \
  tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py -q
```

35/35 passed; ruff clean on changed Python files.

## Evidence bundles

- Implementation: `implementation/universe_top20_selected_future_contract_docs_schema_tests_bounded_write_v1_20260608T134254Z`
- Review: `review/universe_top20_selected_future_contract_slice1_post_implementation_review_no_run_v1_20260608T134541Z`

## No-Live statement

Live producer lane is explicitly **not authorized**. This PR adds contract docs and validation only — no trading, execution, or Live capability changes.

**Auto-merge: disabled. Manual review required.**

Made with [Cursor](https://cursor.com)