### PR TITLE
Add universe selection producer helper

### DIFF
--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -4,7 +4,9 @@
 
 This document defines the **normative persistence contract** for **`universe_selection_readmodel.v1`**: governed Universe (~50 futures), Top-20 ranking, Selected Future, Future detail metadata, and related evidence links for the **view-only Workflow Dashboard** on **`GET &#47;observability`**.
 
-**Slice 1 status:** Schema, validation helpers, fixtures, and static tests only. **No producer write**, **no dashboard population**, **no runtime start**. The dashboard continues to show **Missing Truth** until Slice 3 integrates archive reads.
+**Slice 1 status:** Schema, validation helpers, fixtures, and static tests only.
+
+**Slice 2 status:** Closeout-only **producer helper** (`universe_selection_producer_v1.py`) with Mode-B missing-truth write, atomic persistence, and manifest verify. **No adapter hooks** in Slice 2 (env-gated adapter wiring deferred). **No dashboard population** until Slice 3. **No runtime start**.
 
 **Contract prep reference:** `planning&#47;universe_top20_selected_future_persistence_contract_prep_no_run_v1_20260608T133943Z` (durable archive).
 
@@ -151,11 +153,50 @@ Missing Truth is a **valid** operator-visible state — not a dashboard defect.
 | `tests/webui/test_workflow_dashboard_readmodel_v1.py` | Dashboard still Missing Truth |
 | `tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py` | HTML unchanged |
 
-## 10. Implementation slices
+## 10. Slice 2 producer helper contract (helper-only)
+
+**Module:** `src/webui/workflow_dashboard_readmodel_v1/universe_selection_producer_v1.py`  
+**Tests:** `tests/webui/test_universe_selection_producer_v1.py`
+
+### Functions
+
+| Function | Purpose |
+|----------|---------|
+| `build_missing_truth_universe_selection_readmodel(...)` | Build Mode-B payload (empty rows + canonical reason codes) |
+| `write_universe_selection_readmodel(archive_root, payload)` | Validate, atomic write, manifest update |
+| `write_missing_truth_universe_selection_readmodel(...)` | Build + write Mode-B in one call |
+
+### Mode B — missing inputs at closeout
+
+When a bounded Paper/Shadow/Testnet closeout completes but **no governed universe/scan inputs** exist, the producer **must not stay silent**. It writes explicit Missing Truth:
+
+- `universe[]` and `ranking[]` empty
+- `selected_future.truth_status` = `NOT_PERSISTED`
+- `missing_truth` reason codes: `UNIVERSE_SOURCE_NOT_PERSISTED`, `TOP20_RANKING_NOT_PERSISTED`, `SELECTED_FUTURE_NOT_PERSISTED`, `FUTURE_DETAIL_NOT_AVAILABLE`
+- `evidence.links` includes at least the triggering `run_bundle_path` (or `run_bundle_uri`)
+- `non_authorizing: true` required
+
+No BTC/USD dummy truth, no synthetic ranking, no dashboard faking.
+
+### Persistence mechanics
+
+1. Target: `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json`
+2. Atomic write: temp file in `readmodels/`, then `os.replace`
+3. Manifest: reuse `scripts/ops/primary_evidence_retention_v0.py` (`write_manifest_sha256`, `verify_manifest_sha256`) on `readmodels/` subtree
+4. Fail closed: invalid payload or manifest verify failure → no partial final file
+
+### Adapter hooks (deferred)
+
+Slice 2 does **not** wire `run_*_bounded_observation_adapter_v0.py` closeout paths. Future slice: env-gated hook (`PEAK_TRADE_UNIVERSE_SELECTION_PRODUCER_V1_ENABLED=1`, default off) after separate operator GO.
+
+**Live remains forbidden.** `source_stage=live` is rejected by schema validation.
+
+## 11. Implementation slices
 
 | Slice | Scope |
 |-------|-------|
-| **1 (this doc)** | Contract docs + schema + fixtures + static tests |
-| **2** | Producer write adapter (Paper/Shadow/Testnet) |
+| **1** | Contract docs + schema + fixtures + static tests |
+| **2 (this slice)** | Producer helper + Mode-B write + unit tests (no adapter hooks) |
+| **2b (future)** | Env-gated adapter closeout hooks (Paper/Shadow/Testnet) |
 | **3** | Dashboard readmodel integration |
 | **4** | Bounded run verification (explicit operator GO) |

--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -180,9 +180,9 @@ No BTC/USD dummy truth, no synthetic ranking, no dashboard faking.
 
 ### Persistence mechanics
 
-1. Target: `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json`
-2. Atomic write: temp file in `readmodels/`, then `os.replace`
-3. Manifest: reuse `scripts/ops/primary_evidence_retention_v0.py` (`write_manifest_sha256`, `verify_manifest_sha256`) on `readmodels/` subtree
+1. Target: `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json`
+2. Atomic write: temp file in `readmodels&#47;`, then `os.replace`
+3. Manifest: reuse `scripts/ops/primary_evidence_retention_v0.py` (`write_manifest_sha256`, `verify_manifest_sha256`) on `readmodels&#47;` subtree
 4. Fail closed: invalid payload or manifest verify failure → no partial final file
 
 ### Adapter hooks (deferred)

--- a/src/webui/workflow_dashboard_readmodel_v1/__init__.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/__init__.py
@@ -19,6 +19,13 @@ from .universe_selection_contract_v1 import (
     load_universe_selection_contract,
     validate_universe_selection_payload,
 )
+from .universe_selection_producer_v1 import (
+    ProducerWriteError,
+    ProducerWriteResult,
+    build_missing_truth_universe_selection_readmodel,
+    write_missing_truth_universe_selection_readmodel,
+    write_universe_selection_readmodel,
+)
 
 __all__ = [
     "PIPELINE_READMODEL_ID",
@@ -26,9 +33,14 @@ __all__ = [
     "SCHEMA_VERSION",
     "UNIVERSE_SELECTION_SCHEMA_NAME",
     "UNIVERSE_SELECTION_STORAGE_PATH",
+    "ProducerWriteError",
+    "ProducerWriteResult",
     "UniverseSelectionContractError",
     "UniverseSelectionContractV1",
     "WorkflowDashboardReadModelV1",
+    "build_missing_truth_universe_selection_readmodel",
+    "write_missing_truth_universe_selection_readmodel",
+    "write_universe_selection_readmodel",
     "build_workflow_dashboard_readmodel_v1",
     "build_workflow_pipeline_aggregate_v1",
     "load_universe_selection_contract",

--- a/src/webui/workflow_dashboard_readmodel_v1/universe_selection_producer_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/universe_selection_producer_v1.py
@@ -1,0 +1,241 @@
+"""Closeout-only producer helper for universe_selection_readmodel.v1 (Slice 2 — no runtime I/O)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .universe_selection_contract_v1 import (
+    MISSING_TRUTH_FUTURE_DETAIL,
+    MISSING_TRUTH_PNL,
+    MISSING_TRUTH_RANKING,
+    MISSING_TRUTH_SELECTED,
+    MISSING_TRUTH_UNIVERSE,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    STORAGE_RELATIVE_PATH,
+    UniverseSelectionContractError,
+    contract_to_json_dict,
+    validate_universe_selection_payload,
+)
+
+PRODUCER_CONTRACT = "universe_selection_producer.v1"
+READMODELS_DIRNAME = "readmodels"
+READMODEL_FILENAME = "universe_selection_readmodel.v1.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+
+
+class ProducerWriteError(ValueError):
+    """Raised when a universe selection readmodel write cannot complete safely."""
+
+
+@dataclass(frozen=True)
+class ProducerWriteResult:
+    archive_root: str
+    readmodels_dir: str
+    readmodel_path: str
+    manifest_path: str
+    manifest_verify_ok: bool
+    manifest_verify_message: str
+    manifest_verify_rc: int
+    dry_run: bool
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _import_manifest_helpers() -> tuple[Any, Any, Any]:
+    repo_root = _repo_root()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from scripts.ops.primary_evidence_retention_v0 import (
+        require_durable_archive_root,
+        verify_manifest_sha256,
+        write_manifest_sha256,
+    )
+
+    return require_durable_archive_root, write_manifest_sha256, verify_manifest_sha256
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _readmodels_dir(archive_root: Path) -> Path:
+    return archive_root.expanduser().resolve() / READMODELS_DIRNAME
+
+
+def _readmodel_path(archive_root: Path) -> Path:
+    return _readmodels_dir(archive_root) / READMODEL_FILENAME
+
+
+def _build_evidence_links(
+    *,
+    run_bundle_path: str | None,
+    run_bundle_uri: str | None,
+    extra_links: tuple[str, ...] | None,
+) -> list[str]:
+    links: list[str] = []
+    if run_bundle_path and run_bundle_path.strip():
+        links.append(run_bundle_path.strip())
+    if run_bundle_uri and run_bundle_uri.strip():
+        uri = run_bundle_uri.strip()
+        if uri not in links:
+            links.append(uri)
+    if extra_links:
+        for item in extra_links:
+            text = str(item).strip()
+            if text and text not in links:
+                links.append(text)
+    return links
+
+
+def build_missing_truth_universe_selection_readmodel(
+    *,
+    source_run_id: str,
+    source_stage: str,
+    generated_at: str | None = None,
+    run_bundle_path: str | None = None,
+    run_bundle_uri: str | None = None,
+    evidence_links: tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    """Build a Mode-B missing-truth payload that validates against Slice 1 schema."""
+    links = _build_evidence_links(
+        run_bundle_path=run_bundle_path,
+        run_bundle_uri=run_bundle_uri,
+        extra_links=evidence_links,
+    )
+    payload: dict[str, Any] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at or _now_iso(),
+        "source_run_id": source_run_id.strip(),
+        "source_stage": source_stage.strip().lower(),
+        "non_authorizing": True,
+        "universe": [],
+        "ranking": [],
+        "selected_future": {"truth_status": "NOT_PERSISTED"},
+        "market_snapshot": {
+            "truth_status": "NOT_PERSISTED",
+            "source_kind": "NOT_PERSISTED",
+            "snapshot_id": None,
+            "exchange": None,
+            "captured_at": None,
+        },
+        "evidence": {
+            "producer_contract": PRODUCER_CONTRACT,
+            "storage_target": STORAGE_RELATIVE_PATH,
+            "manifest_verify_rc_expected": 0,
+            "links": links,
+        },
+        "missing_truth": {
+            "universe": MISSING_TRUTH_UNIVERSE,
+            "ranking": MISSING_TRUTH_RANKING,
+            "selected_future": MISSING_TRUTH_SELECTED,
+            "future_detail": MISSING_TRUTH_FUTURE_DETAIL,
+            "orders_fills_pnl": MISSING_TRUTH_PNL,
+        },
+    }
+    contract = validate_universe_selection_payload(payload)
+    return contract_to_json_dict(contract)
+
+
+def write_universe_selection_readmodel(
+    archive_root: str | Path,
+    payload: dict[str, Any],
+    *,
+    dry_run: bool = False,
+) -> ProducerWriteResult:
+    """Validate and atomically persist universe_selection_readmodel.v1 under archive readmodels/."""
+    require_durable_archive_root, write_manifest_sha256, verify_manifest_sha256 = (
+        _import_manifest_helpers()
+    )
+
+    root = Path(archive_root).expanduser().resolve()
+    ok, msg = require_durable_archive_root(root)
+    if not ok:
+        raise ProducerWriteError(msg)
+
+    try:
+        contract = validate_universe_selection_payload(payload)
+    except UniverseSelectionContractError as exc:
+        raise ProducerWriteError(str(exc)) from exc
+
+    serialized = contract_to_json_dict(contract)
+    readmodels_dir = _readmodels_dir(root)
+    final_path = readmodels_dir / READMODEL_FILENAME
+    manifest_path = readmodels_dir / MANIFEST_FILENAME
+
+    if dry_run:
+        return ProducerWriteResult(
+            archive_root=str(root),
+            readmodels_dir=str(readmodels_dir),
+            readmodel_path=str(final_path),
+            manifest_path=str(manifest_path),
+            manifest_verify_ok=True,
+            manifest_verify_message="dry_run",
+            manifest_verify_rc=0,
+            dry_run=True,
+        )
+
+    readmodels_dir.mkdir(parents=True, exist_ok=True)
+    body = json.dumps(serialized, indent=2, sort_keys=True) + "\n"
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{READMODEL_FILENAME}.",
+        suffix=".tmp",
+        dir=readmodels_dir,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, final_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+    write_manifest_sha256(readmodels_dir)
+    verify_ok, verify_msg = verify_manifest_sha256(readmodels_dir)
+    return ProducerWriteResult(
+        archive_root=str(root),
+        readmodels_dir=str(readmodels_dir),
+        readmodel_path=str(final_path),
+        manifest_path=str(manifest_path),
+        manifest_verify_ok=verify_ok,
+        manifest_verify_message=verify_msg,
+        manifest_verify_rc=0 if verify_ok else 1,
+        dry_run=False,
+    )
+
+
+def write_missing_truth_universe_selection_readmodel(
+    archive_root: str | Path,
+    *,
+    source_run_id: str,
+    source_stage: str,
+    generated_at: str | None = None,
+    run_bundle_path: str | None = None,
+    run_bundle_uri: str | None = None,
+    evidence_links: tuple[str, ...] | None = None,
+    dry_run: bool = False,
+) -> ProducerWriteResult:
+    """Build and write explicit Mode-B missing-truth readmodel for a closeout bundle."""
+    payload = build_missing_truth_universe_selection_readmodel(
+        source_run_id=source_run_id,
+        source_stage=source_stage,
+        generated_at=generated_at,
+        run_bundle_path=run_bundle_path,
+        run_bundle_uri=run_bundle_uri,
+        evidence_links=evidence_links,
+    )
+    return write_universe_selection_readmodel(archive_root, payload, dry_run=dry_run)

--- a/tests/webui/test_universe_selection_producer_v1.py
+++ b/tests/webui/test_universe_selection_producer_v1.py
@@ -1,0 +1,211 @@
+"""Unit tests for universe_selection_producer_v1 (Slice 2 — helper-only, no runtime)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp, verify_manifest_sha256
+from src.webui.workflow_dashboard_readmodel_v1 import (
+    ProducerWriteError,
+    UniverseSelectionContractError,
+    build_missing_truth_universe_selection_readmodel,
+    load_universe_selection_contract,
+    validate_universe_selection_payload,
+    write_missing_truth_universe_selection_readmodel,
+    write_universe_selection_readmodel,
+)
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
+    MISSING_TRUTH_SELECTED,
+    MISSING_TRUTH_UNIVERSE,
+)
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
+    READMODEL_FILENAME,
+    READMODELS_DIRNAME,
+)
+
+SCRATCH_ROOT = project_root / "tests" / "_durable_archive_scratch"
+
+
+@pytest.fixture
+def archive_root(tmp_path: Path) -> Path:
+    candidate = tmp_path / "archive_root"
+    candidate.mkdir(parents=True, exist_ok=True)
+    if not is_under_tmp(candidate):
+        return candidate
+    SCRATCH_ROOT.mkdir(parents=True, exist_ok=True)
+    durable = SCRATCH_ROOT / str(uuid.uuid4())
+    durable.mkdir(parents=True, exist_ok=True)
+    return durable
+
+
+def test_build_missing_truth_payload_validates() -> None:
+    payload = build_missing_truth_universe_selection_readmodel(
+        source_run_id="p1_short_bounded_paper_test",
+        source_stage="paper",
+        generated_at="2026-06-08T14:00:00Z",
+        run_bundle_path="/archive/runs/p1_short_bounded_paper_test",
+    )
+    contract = validate_universe_selection_payload(payload)
+    assert contract.universe == ()
+    assert contract.ranking == ()
+    assert contract.selected_future is None
+    assert contract.missing_truth.universe == MISSING_TRUTH_UNIVERSE
+    assert contract.missing_truth.selected_future == MISSING_TRUTH_SELECTED
+    assert payload["evidence"]["links"] == ["/archive/runs/p1_short_bounded_paper_test"]
+
+
+def test_write_missing_truth_creates_readmodel_and_manifest(archive_root: Path) -> None:
+    run_bundle = str(archive_root / "runs" / "p1_short_bounded_paper_test")
+    result = write_missing_truth_universe_selection_readmodel(
+        archive_root,
+        source_run_id="p1_short_bounded_paper_test",
+        source_stage="paper",
+        generated_at="2026-06-08T14:00:00Z",
+        run_bundle_path=run_bundle,
+    )
+
+    readmodels_dir = archive_root / READMODELS_DIRNAME
+    readmodel_path = readmodels_dir / READMODEL_FILENAME
+    manifest_path = readmodels_dir / "MANIFEST.sha256"
+
+    assert readmodel_path.is_file()
+    assert manifest_path.is_file()
+    assert result.manifest_verify_ok is True
+    assert result.manifest_verify_rc == 0
+    assert result.readmodel_path == str(readmodel_path)
+
+    contract = load_universe_selection_contract(readmodel_path)
+    assert contract.source_run_id == "p1_short_bounded_paper_test"
+    assert contract.source_stage == "paper"
+    assert run_bundle in contract.evidence["links"]
+
+    ok, msg = verify_manifest_sha256(readmodels_dir)
+    assert ok, msg
+
+
+def test_atomic_write_leaves_no_tmp_files(archive_root: Path) -> None:
+    write_missing_truth_universe_selection_readmodel(
+        archive_root,
+        source_run_id="s1_shadow_test",
+        source_stage="shadow",
+        run_bundle_path=str(archive_root / "runs" / "s1_shadow_test"),
+    )
+    readmodels_dir = archive_root / READMODELS_DIRNAME
+    leftovers = [
+        p.name
+        for p in readmodels_dir.iterdir()
+        if p.name.startswith(f".{READMODEL_FILENAME}.") and p.name.endswith(".tmp")
+    ]
+    assert leftovers == []
+
+
+def test_evidence_links_include_run_bundle_and_stage_metadata(archive_root: Path) -> None:
+    run_bundle = str(archive_root / "runs" / "t2_medium_testnet_test")
+    payload = build_missing_truth_universe_selection_readmodel(
+        source_run_id="t2_medium_testnet_test",
+        source_stage="testnet",
+        run_bundle_path=run_bundle,
+        run_bundle_uri="file:///archive/runs/t2_medium_testnet_test",
+    )
+    assert run_bundle in payload["evidence"]["links"]
+    assert "file:///archive/runs/t2_medium_testnet_test" in payload["evidence"]["links"]
+    assert payload["source_run_id"] == "t2_medium_testnet_test"
+    assert payload["source_stage"] == "testnet"
+
+
+def test_btc_usd_selected_truth_rejected_on_write(archive_root: Path) -> None:
+    payload = build_missing_truth_universe_selection_readmodel(
+        source_run_id="reject_btc",
+        source_stage="paper",
+        run_bundle_path="/archive/runs/reject_btc",
+    )
+    payload["selected_future"] = {
+        "row_id": "row-1",
+        "symbol": "BTC/USD",
+        "rank": 1,
+        "truth_status": "PERSISTED",
+    }
+    payload["missing_truth"]["selected_future"] = "PERSISTED"
+    with pytest.raises(ProducerWriteError, match="forbidden"):
+        write_universe_selection_readmodel(archive_root, payload)
+
+
+def test_live_source_stage_rejected_on_write(archive_root: Path) -> None:
+    payload = build_missing_truth_universe_selection_readmodel(
+        source_run_id="reject_live",
+        source_stage="paper",
+        run_bundle_path="/archive/runs/reject_live",
+    )
+    payload["source_stage"] = "live"
+    with pytest.raises(ProducerWriteError, match="forbidden"):
+        write_universe_selection_readmodel(archive_root, payload)
+
+
+def test_dry_run_does_not_mutate_archive(archive_root: Path) -> None:
+    result = write_missing_truth_universe_selection_readmodel(
+        archive_root,
+        source_run_id="dry_run_only",
+        source_stage="paper",
+        run_bundle_path=str(archive_root / "runs" / "dry_run_only"),
+        dry_run=True,
+    )
+    assert result.dry_run is True
+    assert not (archive_root / READMODELS_DIRNAME).exists()
+
+
+def test_tmp_archive_root_rejected() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as tmp_dir:
+        tmp_archive = Path(tmp_dir) / "archive_root"
+        tmp_archive.mkdir()
+        with pytest.raises(ProducerWriteError, match="outside /tmp"):
+            write_missing_truth_universe_selection_readmodel(
+                tmp_archive,
+                source_run_id="tmp_reject",
+                source_stage="paper",
+                run_bundle_path=str(tmp_archive / "runs" / "tmp_reject"),
+            )
+
+
+def test_written_payload_is_valid_json(archive_root: Path) -> None:
+    write_missing_truth_universe_selection_readmodel(
+        archive_root,
+        source_run_id="json_ok",
+        source_stage="testnet",
+        run_bundle_path=str(archive_root / "runs" / "json_ok"),
+    )
+    raw = (archive_root / READMODELS_DIRNAME / READMODEL_FILENAME).read_text(encoding="utf-8")
+    loaded = json.loads(raw)
+    validate_universe_selection_payload(loaded)
+
+
+def test_missing_inputs_write_explicit_missing_truth_not_rows(archive_root: Path) -> None:
+    write_missing_truth_universe_selection_readmodel(
+        archive_root,
+        source_run_id="explicit_missing",
+        source_stage="paper",
+        run_bundle_path=str(archive_root / "runs" / "explicit_missing"),
+    )
+    contract = load_universe_selection_contract(
+        archive_root / READMODELS_DIRNAME / READMODEL_FILENAME
+    )
+    assert contract.universe == ()
+    assert contract.ranking == ()
+    assert contract.missing_truth.universe == MISSING_TRUTH_UNIVERSE
+    with pytest.raises(UniverseSelectionContractError):
+        payload = json.loads(
+            (archive_root / READMODELS_DIRNAME / READMODEL_FILENAME).read_text(encoding="utf-8")
+        )
+        payload["universe"] = [
+            {"row_id": "u1", "symbol": "BTC/USD", "rank": 1},
+        ]
+        validate_universe_selection_payload(payload)


### PR DESCRIPTION
## Summary

- Add closeout-only producer helper for `universe_selection_readmodel.v1` (Slice 2).
- Mode B writes explicit Missing Truth when no governed futures inputs exist — empty arrays, canonical reason codes, and `evidence.links` to the run bundle.
- Reuses existing contract validation and `primary_evidence_retention_v0` manifest helpers with atomic write (`tempfile` + `os.replace`).

## Scope

- `src/webui/workflow_dashboard_readmodel_v1/universe_selection_producer_v1.py` (new)
- `src/webui/workflow_dashboard_readmodel_v1/__init__.py` (exports)
- `docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md` (Slice 2 contract)
- `tests/webui/test_universe_selection_producer_v1.py` (new)

**Not in this PR:** adapter closeout hooks, dashboard reader integration, runtime/scheduler changes.

## Futures-first semantics

Universe / Top20 / Selected Future target **futures/derivative instruments only**. Spot symbols (e.g. BTC/USD, BTC/EUR) and market-surface dummy data are forbidden as selected-future or dashboard truth. Without a governed futures source, the helper persists explicit `NOT_PERSISTED` / Missing Truth — never synthetic rows.

## Missing Truth Mode B behavior

On successful closeout without upstream scan inputs:
- `universe[]` and `ranking[]` remain empty
- `selected_future.truth_status = NOT_PERSISTED`
- Reason codes: `UNIVERSE_SOURCE_NOT_PERSISTED`, `TOP20_RANKING_NOT_PERSISTED`, `SELECTED_FUTURE_NOT_PERSISTED`, `FUTURE_DETAIL_NOT_AVAILABLE`
- `evidence.links` includes `run_bundle_path` / optional URI plus `source_run_id` / `source_stage`

## Manifest / atomic write reuse

- Storage: `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json`
- Atomic write in `readmodels/` then manifest via `write_manifest_sha256` / `verify_manifest_sha256`
- No parallel manifest policy

## Safety boundaries

- No adapter hooks (`run_*_bounded_observation_adapter_v0.py` untouched)
- No `src/execution/**`, `src/governance/**`, `src/risk/**`
- No scheduler/runtime/paper/shadow/testnet/live start logic
- No workflow YAML changes
- No dashboard fake data (`builder.py` unchanged)
- No Live secrets or orders

## Tests

```bash
uv run pytest \
  tests/webui/test_universe_selection_producer_v1.py \
  tests/webui/test_universe_selection_contract_v1.py \
  tests/webui/test_workflow_dashboard_readmodel_v1.py -q
```

31 passed. Ruff check + format passed.

## Evidence bundles

- Implementation: `implementation/universe_top20_selected_future_producer_persistence_slice2_bounded_write_tests_v1_20260608T143854Z`
- Post-implementation review: `review/universe_top20_selected_future_producer_persistence_slice2_post_implementation_review_no_run_v1_20260608T144215Z`

## No-Live statement

This PR is **non-authorizing**. `non_authorizing: true` is required; `source_stage=live` is rejected. No Live arming, execution, or trading authority is conveyed.

**Auto-merge: disabled.** Operator review required before merge.

Made with [Cursor](https://cursor.com)