### PR TITLE
Add universe selection closeout hooks

### DIFF
--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -6,7 +6,9 @@ This document defines the **normative persistence contract** for **`universe_sel
 
 **Slice 1 status:** Schema, validation helpers, fixtures, and static tests only.
 
-**Slice 2 status:** Closeout-only **producer helper** (`universe_selection_producer_v1.py`) with Mode-B missing-truth write, atomic persistence, and manifest verify. **No adapter hooks** in Slice 2 (env-gated adapter wiring deferred). **No dashboard population** until Slice 3. **No runtime start**.
+**Slice 2 status:** Closeout-only **producer helper** (`universe_selection_producer_v1.py`) with Mode-B missing-truth write, atomic persistence, and manifest verify. **No adapter hooks** in Slice 2 (env-gated adapter wiring deferred to Slice 2b). **No dashboard population** until Slice 3. **No runtime start**.
+
+**Slice 2b status:** Env-gated **closeout-only adapter hooks** in Paper/Shadow/Testnet bounded observation adapters. Default off. Non-blocking write failure. **No dashboard population** until Slice 3. **No runtime start**. **Live forbidden**.
 
 **Contract prep reference:** `planning&#47;universe_top20_selected_future_persistence_contract_prep_no_run_v1_20260608T133943Z` (durable archive).
 
@@ -185,18 +187,42 @@ No BTC/USD dummy truth, no synthetic ranking, no dashboard faking.
 3. Manifest: reuse `scripts/ops/primary_evidence_retention_v0.py` (`write_manifest_sha256`, `verify_manifest_sha256`) on `readmodels&#47;` subtree
 4. Fail closed: invalid payload or manifest verify failure → no partial final file
 
-### Adapter hooks (deferred)
+### Adapter hooks (Slice 2b)
 
-Slice 2 does **not** wire `run_*_bounded_observation_adapter_v0.py` closeout paths. Future slice: env-gated hook (`PEAK_TRADE_UNIVERSE_SELECTION_PRODUCER_V1_ENABLED=1`, default off) after separate operator GO.
+**Env gate:** `PEAK_TRADE_UNIVERSE_SELECTION_PRODUCER_V1_ENABLED=1` — only literal `1` enables; default **off** (unset, `0`, `false`, or any other value → no-op, no file).
 
-**Live remains forbidden.** `source_stage=live` is rejected by schema validation.
+**Hook placement:** After per-run `verify_manifest_sha256(archive_dest)` succeeds, before optional durable closeout (Paper/Shadow) or adapter `return 0` (Testnet). Closeout-only — not at run start, not in hot path.
+
+**Hook function:** `maybe_write_missing_truth_after_bounded_closeout(...)` in `universe_selection_producer_v1.py`.
+
+| Adapter | `source_stage` | `run_bundle_path` |
+|---------|----------------|-------------------|
+| `run_paper_only_bounded_observation_adapter_v0.py` | `paper` | `{archive_root}&#47;runs&#47;paper&#47;{run_id}` |
+| `run_shadow_bounded_observation_adapter_v0.py` | `shadow` | `{archive_root}&#47;runs&#47;shadow&#47;{run_id}` |
+| `run_testnet_bounded_observation_adapter_v0.py` | `testnet` | `{archive_root}&#47;runs&#47;testnet&#47;{run_id}` |
+
+**Machine lines (emitted on every successful per-run closeout):**
+
+- `UNIVERSE_SELECTION_PRODUCER_V1_ENABLED=true|false`
+- `UNIVERSE_SELECTION_READMODEL_WRITTEN=true|false`
+- `UNIVERSE_SELECTION_READMODEL_PATH=<path>|NOT_WRITTEN`
+- `UNIVERSE_SELECTION_READMODEL_MANIFEST_VERIFY_RC=<rc>|NOT_RUN`
+- `UNIVERSE_SELECTION_READMODEL_ERROR=<message>|` (empty when no error)
+
+**Failure semantics (non-blocking):** Primary per-run closeout success is unchanged. When gate is on and write/verify fails, adapter exit remains `0` but machine lines record `UNIVERSE_SELECTION_READMODEL_WRITTEN=false` and `UNIVERSE_SELECTION_READMODEL_ERROR=...`.
+
+**Futures-first:** Mode-B missing truth only — no BTC/USD, no spot dummy, no synthetic ranking. Repair/operator bundles out of initial 2b scope.
+
+**Live remains forbidden.** `source_stage=live` is rejected (no write).
+
+**Tests:** `tests/webui/test_universe_selection_producer_closeout_hook_v1.py`
 
 ## 11. Implementation slices
 
 | Slice | Scope |
 |-------|-------|
 | **1** | Contract docs + schema + fixtures + static tests |
-| **2 (this slice)** | Producer helper + Mode-B write + unit tests (no adapter hooks) |
-| **2b (future)** | Env-gated adapter closeout hooks (Paper/Shadow/Testnet) |
+| **2** | Producer helper + Mode-B write + unit tests (no adapter hooks) |
+| **2b (this slice)** | Env-gated adapter closeout hooks (Paper/Shadow/Testnet) |
 | **3** | Dashboard readmodel integration |
 | **4** | Bounded run verification (explicit operator GO) |

--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -33,6 +33,10 @@ from scripts.ops.primary_evidence_retention_v0 import (
     verify_manifest_sha256,
     write_manifest_sha256 as _write_manifest_sha256,
 )
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
+    emit_universe_selection_closeout_machine_lines,
+    maybe_write_missing_truth_after_bounded_closeout,
+)
 
 ADAPTER_VERSION = "cli_adapter_scheduler_composition_v0"
 ALLOWED_JOB = "paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0"
@@ -1080,6 +1084,13 @@ def execute_plan(
         + "\n",
         encoding="utf-8",
     )
+    hook_result = maybe_write_missing_truth_after_bounded_closeout(
+        archive_root=ctx.archive_root,
+        run_bundle_path=archive_dest,
+        source_run_id=ctx.run_id,
+        source_stage="paper",
+    )
+    emit_universe_selection_closeout_machine_lines(hook_result)
     return maybe_invoke_durable_closeout_after_archive(
         ctx,
         archive_dest,

--- a/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
@@ -39,6 +39,10 @@ from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
     maybe_invoke_durable_closeout_after_archive,
     validate_durable_closeout_invoke_cli_args,
 )
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
+    emit_universe_selection_closeout_machine_lines,
+    maybe_write_missing_truth_after_bounded_closeout,
+)
 
 BOUNDED_ADAPTER_LANE_SHADOW = "shadow_bounded_observation_v0"
 
@@ -711,6 +715,13 @@ def execute_plan(
     if not ok:
         print(reason, file=sys.stderr)
         return VALIDATION_EXIT
+    hook_result = maybe_write_missing_truth_after_bounded_closeout(
+        archive_root=ctx.archive_root,
+        run_bundle_path=archive_dest,
+        source_run_id=ctx.run_id,
+        source_stage="shadow",
+    )
+    emit_universe_selection_closeout_machine_lines(hook_result)
     return maybe_invoke_durable_closeout_after_archive(
         ctx,
         archive_dest,

--- a/scripts/ops/run_testnet_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_testnet_bounded_observation_adapter_v0.py
@@ -30,6 +30,10 @@ from scripts.ops.primary_evidence_retention_v0 import (
     verify_manifest_sha256,
     write_manifest_sha256 as _write_manifest_sha256,
 )
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
+    emit_universe_selection_closeout_machine_lines,
+    maybe_write_missing_truth_after_bounded_closeout,
+)
 
 ADAPTER_VERSION = "cli_testnet_evidence_flow_composition_v0"
 STAGING_SCRIPT = "scripts/ops/run_testnet_bounded_evidence_staging_v0.sh"
@@ -520,6 +524,13 @@ def execute_plan(
     if not ok:
         print(reason, file=sys.stderr)
         return VALIDATION_EXIT
+    hook_result = maybe_write_missing_truth_after_bounded_closeout(
+        archive_root=ctx.archive_root,
+        run_bundle_path=archive_dest,
+        source_run_id=ctx.run_id,
+        source_stage="testnet",
+    )
+    emit_universe_selection_closeout_machine_lines(hook_result)
     return 0
 
 

--- a/src/webui/workflow_dashboard_readmodel_v1/universe_selection_producer_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/universe_selection_producer_v1.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any
 
 from .universe_selection_contract_v1 import (
+    ALLOWED_SOURCE_STAGES,
+    FORBIDDEN_SOURCE_STAGES,
     MISSING_TRUTH_FUTURE_DETAIL,
     MISSING_TRUTH_PNL,
     MISSING_TRUTH_RANKING,
@@ -24,6 +26,8 @@ from .universe_selection_contract_v1 import (
     contract_to_json_dict,
     validate_universe_selection_payload,
 )
+
+ENV_PRODUCER_V1_ENABLED = "PEAK_TRADE_UNIVERSE_SELECTION_PRODUCER_V1_ENABLED"
 
 PRODUCER_CONTRACT = "universe_selection_producer.v1"
 READMODELS_DIRNAME = "readmodels"
@@ -45,6 +49,20 @@ class ProducerWriteResult:
     manifest_verify_message: str
     manifest_verify_rc: int
     dry_run: bool
+
+
+@dataclass(frozen=True)
+class CloseoutHookResult:
+    """Non-throwing result for env-gated closeout adapter hooks (Slice 2b)."""
+
+    enabled: bool
+    skipped: bool
+    written: bool
+    reason: str
+    archive_root: str
+    readmodel_path: str | None
+    manifest_verify_rc: int | None
+    error: str | None
 
 
 def _repo_root() -> Path:
@@ -215,6 +233,105 @@ def write_universe_selection_readmodel(
         manifest_verify_message=verify_msg,
         manifest_verify_rc=0 if verify_ok else 1,
         dry_run=False,
+    )
+
+
+def _producer_v1_enabled() -> bool:
+    return (os.environ.get(ENV_PRODUCER_V1_ENABLED) or "").strip() == "1"
+
+
+def emit_universe_selection_closeout_machine_lines(result: CloseoutHookResult) -> None:
+    """Emit deterministic machine lines for bounded adapter closeout hooks."""
+    print(f"UNIVERSE_SELECTION_PRODUCER_V1_ENABLED={'true' if result.enabled else 'false'}")
+    print(f"UNIVERSE_SELECTION_READMODEL_WRITTEN={'true' if result.written else 'false'}")
+    if result.readmodel_path:
+        print(f"UNIVERSE_SELECTION_READMODEL_PATH={result.readmodel_path}")
+    else:
+        print("UNIVERSE_SELECTION_READMODEL_PATH=NOT_WRITTEN")
+    if result.manifest_verify_rc is not None:
+        print(f"UNIVERSE_SELECTION_READMODEL_MANIFEST_VERIFY_RC={result.manifest_verify_rc}")
+    else:
+        print("UNIVERSE_SELECTION_READMODEL_MANIFEST_VERIFY_RC=NOT_RUN")
+    if result.error:
+        print(f"UNIVERSE_SELECTION_READMODEL_ERROR={result.error}")
+    else:
+        print("UNIVERSE_SELECTION_READMODEL_ERROR=")
+
+
+def maybe_write_missing_truth_after_bounded_closeout(
+    *,
+    archive_root: str | Path,
+    run_bundle_path: str | Path,
+    source_run_id: str,
+    source_stage: str,
+) -> CloseoutHookResult:
+    """Env-gated closeout hook: write Mode-B missing truth when enabled (default off)."""
+    root = Path(archive_root).expanduser().resolve()
+    if not _producer_v1_enabled():
+        return CloseoutHookResult(
+            enabled=False,
+            skipped=True,
+            written=False,
+            reason="DISABLED",
+            archive_root=str(root),
+            readmodel_path=None,
+            manifest_verify_rc=None,
+            error=None,
+        )
+
+    stage = source_stage.strip().lower()
+    if stage in FORBIDDEN_SOURCE_STAGES or stage not in ALLOWED_SOURCE_STAGES:
+        return CloseoutHookResult(
+            enabled=True,
+            skipped=True,
+            written=False,
+            reason="INVALID_STAGE",
+            archive_root=str(root),
+            readmodel_path=None,
+            manifest_verify_rc=None,
+            error=f"source_stage unsupported: {stage}",
+        )
+
+    try:
+        write_result = write_missing_truth_universe_selection_readmodel(
+            root,
+            source_run_id=source_run_id,
+            source_stage=stage,
+            run_bundle_path=str(run_bundle_path),
+        )
+    except (ProducerWriteError, UniverseSelectionContractError, OSError, ValueError) as exc:
+        return CloseoutHookResult(
+            enabled=True,
+            skipped=False,
+            written=False,
+            reason="ERROR",
+            archive_root=str(root),
+            readmodel_path=None,
+            manifest_verify_rc=None,
+            error=str(exc),
+        )
+
+    if not write_result.manifest_verify_ok:
+        return CloseoutHookResult(
+            enabled=True,
+            skipped=False,
+            written=False,
+            reason="VERIFY_FAILED",
+            archive_root=write_result.archive_root,
+            readmodel_path=write_result.readmodel_path,
+            manifest_verify_rc=write_result.manifest_verify_rc,
+            error=write_result.manifest_verify_message,
+        )
+
+    return CloseoutHookResult(
+        enabled=True,
+        skipped=False,
+        written=True,
+        reason="OK",
+        archive_root=write_result.archive_root,
+        readmodel_path=write_result.readmodel_path,
+        manifest_verify_rc=write_result.manifest_verify_rc,
+        error=None,
     )
 
 

--- a/tests/webui/test_universe_selection_producer_closeout_hook_v1.py
+++ b/tests/webui/test_universe_selection_producer_closeout_hook_v1.py
@@ -1,0 +1,220 @@
+"""Tests for env-gated closeout adapter hooks (Slice 2b — no runtime runs)."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import uuid
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp, verify_manifest_sha256
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
+    ENV_PRODUCER_V1_ENABLED,
+    READMODEL_FILENAME,
+    READMODELS_DIRNAME,
+    CloseoutHookResult,
+    emit_universe_selection_closeout_machine_lines,
+    maybe_write_missing_truth_after_bounded_closeout,
+)
+
+SCRATCH_ROOT = project_root / "tests" / "_durable_archive_scratch"
+
+ADAPTER_SCRIPTS = (
+    project_root / "scripts" / "ops" / "run_paper_only_bounded_observation_adapter_v0.py",
+    project_root / "scripts" / "ops" / "run_shadow_bounded_observation_adapter_v0.py",
+    project_root / "scripts" / "ops" / "run_testnet_bounded_observation_adapter_v0.py",
+)
+
+
+@pytest.fixture
+def archive_root(tmp_path: Path) -> Path:
+    candidate = tmp_path / "archive_root"
+    candidate.mkdir(parents=True, exist_ok=True)
+    if not is_under_tmp(candidate):
+        return candidate
+    SCRATCH_ROOT.mkdir(parents=True, exist_ok=True)
+    durable = SCRATCH_ROOT / str(uuid.uuid4())
+    durable.mkdir(parents=True, exist_ok=True)
+    return durable
+
+
+@pytest.fixture(autouse=True)
+def _clear_producer_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_PRODUCER_V1_ENABLED, raising=False)
+
+
+def test_gate_off_skips_write_no_file(archive_root: Path) -> None:
+    run_bundle = archive_root / "runs" / "paper" / "p1_test"
+    run_bundle.mkdir(parents=True)
+
+    result = maybe_write_missing_truth_after_bounded_closeout(
+        archive_root=archive_root,
+        run_bundle_path=run_bundle,
+        source_run_id="p1_test",
+        source_stage="paper",
+    )
+
+    readmodel_path = archive_root / READMODELS_DIRNAME / READMODEL_FILENAME
+    assert result.enabled is False
+    assert result.skipped is True
+    assert result.written is False
+    assert result.reason == "DISABLED"
+    assert not readmodel_path.exists()
+
+
+def test_gate_on_writes_missing_truth_readmodel(
+    archive_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ENV_PRODUCER_V1_ENABLED, "1")
+    run_bundle = archive_root / "runs" / "paper" / "p1_test"
+    run_bundle.mkdir(parents=True)
+
+    result = maybe_write_missing_truth_after_bounded_closeout(
+        archive_root=archive_root,
+        run_bundle_path=run_bundle,
+        source_run_id="p1_test",
+        source_stage="paper",
+    )
+
+    readmodels_dir = archive_root / READMODELS_DIRNAME
+    readmodel_path = readmodels_dir / READMODEL_FILENAME
+    manifest_path = readmodels_dir / "MANIFEST.sha256"
+
+    assert result.enabled is True
+    assert result.skipped is False
+    assert result.written is True
+    assert result.manifest_verify_rc == 0
+    assert readmodel_path.is_file()
+    assert manifest_path.is_file()
+    ok, _ = verify_manifest_sha256(readmodels_dir)
+    assert ok
+
+    payload = json.loads(readmodel_path.read_text(encoding="utf-8"))
+    assert payload["source_run_id"] == "p1_test"
+    assert payload["source_stage"] == "paper"
+    assert payload["selected_future"] == {"truth_status": "NOT_PERSISTED"}
+    assert str(run_bundle) in payload["evidence"]["links"]
+    assert "BTC/USD" not in readmodel_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("stage", ["paper", "shadow", "testnet"])
+def test_gate_on_accepts_bounded_stages(
+    archive_root: Path, monkeypatch: pytest.MonkeyPatch, stage: str
+) -> None:
+    monkeypatch.setenv(ENV_PRODUCER_V1_ENABLED, "1")
+    run_id = f"{stage}_run_test"
+    run_bundle = archive_root / "runs" / stage / run_id
+    run_bundle.mkdir(parents=True)
+
+    result = maybe_write_missing_truth_after_bounded_closeout(
+        archive_root=archive_root,
+        run_bundle_path=run_bundle,
+        source_run_id=run_id,
+        source_stage=stage,
+    )
+
+    assert result.written is True
+    payload = json.loads(
+        (archive_root / READMODELS_DIRNAME / READMODEL_FILENAME).read_text(encoding="utf-8")
+    )
+    assert payload["source_stage"] == stage
+
+
+def test_live_stage_rejected_no_write(archive_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_PRODUCER_V1_ENABLED, "1")
+    run_bundle = archive_root / "runs" / "live" / "l1_test"
+    run_bundle.mkdir(parents=True)
+
+    result = maybe_write_missing_truth_after_bounded_closeout(
+        archive_root=archive_root,
+        run_bundle_path=run_bundle,
+        source_run_id="l1_test",
+        source_stage="live",
+    )
+
+    assert result.enabled is True
+    assert result.skipped is True
+    assert result.written is False
+    assert result.reason == "INVALID_STAGE"
+    assert not (archive_root / READMODELS_DIRNAME / READMODEL_FILENAME).exists()
+
+
+def test_write_failure_non_blocking_no_exception(
+    archive_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ENV_PRODUCER_V1_ENABLED, "1")
+    run_bundle = archive_root / "runs" / "paper" / "p1_fail"
+    run_bundle.mkdir(parents=True)
+
+    with patch(
+        "src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1.write_missing_truth_universe_selection_readmodel",
+        side_effect=OSError("simulated write failure"),
+    ):
+        result = maybe_write_missing_truth_after_bounded_closeout(
+            archive_root=archive_root,
+            run_bundle_path=run_bundle,
+            source_run_id="p1_fail",
+            source_stage="paper",
+        )
+
+    assert result.written is False
+    assert result.reason == "ERROR"
+    assert result.error == "simulated write failure"
+
+
+def test_emit_machine_lines_gate_off() -> None:
+    result = CloseoutHookResult(
+        enabled=False,
+        skipped=True,
+        written=False,
+        reason="DISABLED",
+        archive_root="/tmp/archive",
+        readmodel_path=None,
+        manifest_verify_rc=None,
+        error=None,
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        emit_universe_selection_closeout_machine_lines(result)
+    out = buf.getvalue()
+    assert "UNIVERSE_SELECTION_PRODUCER_V1_ENABLED=false" in out
+    assert "UNIVERSE_SELECTION_READMODEL_WRITTEN=false" in out
+    assert "UNIVERSE_SELECTION_READMODEL_PATH=NOT_WRITTEN" in out
+    assert "UNIVERSE_SELECTION_READMODEL_MANIFEST_VERIFY_RC=NOT_RUN" in out
+    assert "UNIVERSE_SELECTION_READMODEL_ERROR=" in out
+
+
+def test_emit_machine_lines_gate_on_success() -> None:
+    result = CloseoutHookResult(
+        enabled=True,
+        skipped=False,
+        written=True,
+        reason="OK",
+        archive_root="/tmp/archive",
+        readmodel_path="/tmp/archive/readmodels/universe_selection_readmodel.v1.json",
+        manifest_verify_rc=0,
+        error=None,
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        emit_universe_selection_closeout_machine_lines(result)
+    out = buf.getvalue()
+    assert "UNIVERSE_SELECTION_PRODUCER_V1_ENABLED=true" in out
+    assert "UNIVERSE_SELECTION_READMODEL_WRITTEN=true" in out
+    assert "UNIVERSE_SELECTION_READMODEL_MANIFEST_VERIFY_RC=0" in out
+
+
+def test_adapters_reference_closeout_hook_helpers() -> None:
+    for script in ADAPTER_SCRIPTS:
+        text = script.read_text(encoding="utf-8")
+        assert "maybe_write_missing_truth_after_bounded_closeout" in text
+        assert "emit_universe_selection_closeout_machine_lines" in text


### PR DESCRIPTION
## Summary

- Add env-gated closeout-only universe selection producer hooks to Paper, Shadow, and Testnet bounded observation adapters (Slice 2b).
- Extend `universe_selection_producer_v1.py` with `maybe_write_missing_truth_after_bounded_closeout` and deterministic machine-line emission.
- Persist Mode-B missing-truth readmodels under `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` only when explicitly enabled.

## Scope

- `src/webui/workflow_dashboard_readmodel_v1/universe_selection_producer_v1.py`
- `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py`
- `scripts/ops/run_shadow_bounded_observation_adapter_v0.py`
- `scripts/ops/run_testnet_bounded_observation_adapter_v0.py`
- `docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md`
- `tests/webui/test_universe_selection_producer_closeout_hook_v1.py`

## Futures-first semantics

Universe/Top20/Selected-Future refer exclusively to futures/derivative instruments. No BTC/USD, spot symbols, or dummy markets as selected Future or tradable dashboard truth. Without a real futures source, the producer writes explicit `NOT_PERSISTED` / Missing Truth (Mode B), not synthetic data.

## Env-gated default-off behavior

- Gate: `PEAK_TRADE_UNIVERSE_SELECTION_PRODUCER_V1_ENABLED=1` (only literal `1` enables).
- Default off: unset, `0`, `false`, or any other value → no-op, no file write.
- Hook placement: after successful per-run `verify_manifest_sha256(archive_dest)`, before optional durable closeout (Paper/Shadow) or `return 0` (Testnet).

## Missing Truth Mode B behavior

When gate is on, `write_missing_truth_universe_selection_readmodel` writes empty `universe[]`/`ranking[]`, `selected_future.truth_status=NOT_PERSISTED`, canonical `missing_truth` reason codes, and evidence links including `run_bundle_path`.

## Non-blocking failure semantics

Primary per-run closeout success is unchanged. Write/verify failures are caught and surfaced via machine lines; adapter exit remains `0` when primary closeout already succeeded.

## Machine-lines

Emitted on every successful per-run closeout:
- `UNIVERSE_SELECTION_PRODUCER_V1_ENABLED`
- `UNIVERSE_SELECTION_READMODEL_WRITTEN`
- `UNIVERSE_SELECTION_READMODEL_PATH`
- `UNIVERSE_SELECTION_READMODEL_MANIFEST_VERIFY_RC`
- `UNIVERSE_SELECTION_READMODEL_ERROR`

## Safety boundaries

- No changes to `src/execution`, `src/governance`, `src/risk`.
- No workflow YAML, scheduler, runtime, or Live start logic.
- No dashboard reader/template fake-data integration (Slice 3 deferred).
- No new parallel SSOT surface.
- No runs, orders, secrets, or Live authorization in this PR.

## Tests

- `tests/webui/test_universe_selection_producer_closeout_hook_v1.py` (new)
- `tests/webui/test_universe_selection_producer_v1.py`
- `tests/webui/test_universe_selection_contract_v1.py`
- 32 tests passed locally; ruff check/format passed; docs token preflight passed.

## Evidence bundles

- Implementation: `implementation/universe_top20_selected_future_producer_adapter_hooks_slice2b_bounded_write_tests_v1_20260608T145645Z`
- Post-implementation review: `review/universe_top20_selected_future_producer_adapter_hooks_slice2b_post_implementation_review_no_run_v1_20260608T145815Z`

## No-Live statement

This PR is display-only persistence wiring. It does not authorize Live trading, broker/exchange access, scheduler dispatch, or runtime start. `source_stage=live` is rejected.


Made with [Cursor](https://cursor.com)