### PR TITLE
Read universe selection in dashboard

### DIFF
--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -8,7 +8,9 @@ This document defines the **normative persistence contract** for **`universe_sel
 
 **Slice 2 status:** Closeout-only **producer helper** (`universe_selection_producer_v1.py`) with Mode-B missing-truth write, atomic persistence, and manifest verify. **No adapter hooks** in Slice 2 (env-gated adapter wiring deferred to Slice 2b). **No dashboard population** until Slice 3. **No runtime start**.
 
-**Slice 2b status:** Env-gated **closeout-only adapter hooks** in Paper/Shadow/Testnet bounded observation adapters. Default off. Non-blocking write failure. **No dashboard population** until Slice 3. **No runtime start**. **Live forbidden**.
+**Slice 2b status:** Env-gated **closeout-only adapter hooks** in Paper/Shadow/Testnet bounded observation adapters. Default off. Non-blocking write failure. **No runtime start**. **Live forbidden**.
+
+**Slice 3 status:** Read-only **dashboard reader** in `workflow_dashboard_readmodel.v1` builder + `GET &#47;observability` template. Verify-before-trust. Missing Truth fallback. **No producer write**. **No runtime start**. **Live forbidden**.
 
 **Contract prep reference:** `planning&#47;universe_top20_selected_future_persistence_contract_prep_no_run_v1_20260608T133943Z` (durable archive).
 
@@ -217,12 +219,36 @@ No BTC/USD dummy truth, no synthetic ranking, no dashboard faking.
 
 **Tests:** `tests/webui/test_universe_selection_producer_closeout_hook_v1.py`
 
+### Dashboard reader (Slice 3)
+
+**Module:** `src/webui/workflow_dashboard_readmodel_v1/universe_selection_reader_v1.py`  
+**Consumer:** `src/webui/workflow_dashboard_readmodel_v1/builder.py`  
+**SSR gate:** `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` + `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` (unchanged)  
+**Tests:** `tests/webui/test_universe_selection_reader_v1.py`
+
+**Storage path:** `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json`
+
+**Verify-before-trust:**
+
+1. If readmodel file missing → Missing Truth fallback (no diagnostic; unchanged Slice 1 behavior).
+2. If `readmodels&#47;MANIFEST.sha256` missing → Missing Truth + `load_error=MANIFEST_NOT_FOUND`.
+3. If `verify_manifest_sha256(readmodels_dir)` RC ≠ 0 → Missing Truth + `load_error=MANIFEST_VERIFY_FAILED`.
+4. If JSON invalid → Missing Truth + `load_error=INVALID_JSON`.
+5. If contract validation fails (including BTC&#47;USD selected) → Missing Truth + `load_error=CONTRACT_INVALID`.
+6. On success → Universe/Top20/Selected Future/Future Detail panels show persisted futures-only values.
+
+**Read-only constraints:** No archive writes, no producer/adapter calls, no runtime/exchange/API calls, no forms/buttons/fetch/post in workflow dashboard section.
+
+**Futures-first:** Contract validator rejects spot/BTC dummy selected truth; UI never displays rejected payloads.
+
+**GET &#47;market** remains separate SSOT — must not backfill Observability Missing Truth.
+
 ## 11. Implementation slices
 
 | Slice | Scope |
 |-------|-------|
 | **1** | Contract docs + schema + fixtures + static tests |
 | **2** | Producer helper + Mode-B write + unit tests (no adapter hooks) |
-| **2b (this slice)** | Env-gated adapter closeout hooks (Paper/Shadow/Testnet) |
-| **3** | Dashboard readmodel integration |
+| **2b** | Env-gated adapter closeout hooks (Paper/Shadow/Testnet) |
+| **3 (this slice)** | Dashboard readmodel integration (read-only reader) |
 | **4** | Bounded run verification (explicit operator GO) |

--- a/src/webui/workflow_dashboard_readmodel_v1/__init__.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/__init__.py
@@ -26,6 +26,13 @@ from .universe_selection_producer_v1 import (
     write_missing_truth_universe_selection_readmodel,
     write_universe_selection_readmodel,
 )
+from .universe_selection_reader_v1 import (
+    LOAD_ERROR_CONTRACT_INVALID,
+    LOAD_ERROR_INVALID_JSON,
+    LOAD_ERROR_MANIFEST_NOT_FOUND,
+    LOAD_ERROR_MANIFEST_VERIFY_FAILED,
+    try_load_universe_selection_for_dashboard,
+)
 
 __all__ = [
     "PIPELINE_READMODEL_ID",
@@ -33,6 +40,10 @@ __all__ = [
     "SCHEMA_VERSION",
     "UNIVERSE_SELECTION_SCHEMA_NAME",
     "UNIVERSE_SELECTION_STORAGE_PATH",
+    "LOAD_ERROR_CONTRACT_INVALID",
+    "LOAD_ERROR_INVALID_JSON",
+    "LOAD_ERROR_MANIFEST_NOT_FOUND",
+    "LOAD_ERROR_MANIFEST_VERIFY_FAILED",
     "ProducerWriteError",
     "ProducerWriteResult",
     "UniverseSelectionContractError",
@@ -45,5 +56,6 @@ __all__ = [
     "build_workflow_pipeline_aggregate_v1",
     "load_universe_selection_contract",
     "to_json_dict",
+    "try_load_universe_selection_for_dashboard",
     "validate_universe_selection_payload",
 ]

--- a/src/webui/workflow_dashboard_readmodel_v1/builder.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/builder.py
@@ -17,13 +17,22 @@ from .types import (
     NextGoCardV1,
     OrdersFillsPnlCardV1,
     SafetyCardV1,
+    UniverseSelectionDashboardSliceV1,
     WorkflowDashboardReadModelV1,
 )
+from .universe_selection_contract_v1 import (
+    MISSING_TRUTH_FUTURE_DETAIL,
+    MISSING_TRUTH_RANKING,
+    MISSING_TRUTH_SELECTED,
+    MISSING_TRUTH_UNIVERSE,
+)
+from .universe_selection_reader_v1 import try_load_universe_selection_for_dashboard
 
 _FIXED_GEN_ENV = "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
 T2_NEXT_GO_FALLBACK = "GO_T3_LONGER_TESTNET_STAGE_READY_PACKAGE_NO_RUN_V1"
 
 _PRODUCER_FOLLOWUP = "Producer persistence contract (Slice 2) — no dashboard substitution."
+_READER_FOLLOWUP = "Loaded from universe_selection_readmodel.v1 (Slice 3 reader)."
 
 
 def _now_iso() -> str:
@@ -33,13 +42,88 @@ def _now_iso() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
-def _missing_truth(panel_key: str, truth_status: str, message: str) -> MissingTruthCardV1:
+def _missing_truth(
+    panel_key: str,
+    truth_status: str,
+    message: str,
+    *,
+    producer_followup: str = _PRODUCER_FOLLOWUP,
+) -> MissingTruthCardV1:
     return MissingTruthCardV1(
         panel_key=panel_key,
         truth_status=truth_status,
         message=message,
-        producer_followup=_PRODUCER_FOLLOWUP,
+        producer_followup=producer_followup,
     )
+
+
+def _universe_selection_missing_cards(
+    selection: UniverseSelectionDashboardSliceV1,
+) -> tuple[MissingTruthCardV1, MissingTruthCardV1, MissingTruthCardV1, MissingTruthCardV1]:
+    followup = _READER_FOLLOWUP if selection.loaded else _PRODUCER_FOLLOWUP
+
+    if selection.loaded and selection.universe:
+        universe = _missing_truth(
+            "universe",
+            "PERSISTED",
+            f"Governed universe snapshot ({len(selection.universe)} futures rows).",
+            producer_followup=followup,
+        )
+    else:
+        universe = _missing_truth(
+            "universe",
+            MISSING_TRUTH_UNIVERSE,
+            "No governed universe snapshot (~50 futures) is persisted for this workflow view.",
+            producer_followup=followup,
+        )
+
+    if selection.loaded and selection.ranking:
+        top20 = _missing_truth(
+            "top20",
+            "PERSISTED",
+            f"Top-20 ranking snapshot ({len(selection.ranking)} rows).",
+            producer_followup=followup,
+        )
+    else:
+        top20 = _missing_truth(
+            "top20",
+            MISSING_TRUTH_RANKING,
+            "No Top-20 ranking snapshot is persisted for this workflow view.",
+            producer_followup=followup,
+        )
+
+    if selection.loaded and selection.selected_future is not None:
+        selected = _missing_truth(
+            "selected_future",
+            "PERSISTED",
+            f"Selected future: {selection.selected_future.symbol} (rank {selection.selected_future.rank}).",
+            producer_followup=followup,
+        )
+    else:
+        selected = _missing_truth(
+            "selected_future",
+            MISSING_TRUTH_SELECTED,
+            "No selected-future decision artifact is linked to pipeline runs.",
+            producer_followup=followup,
+        )
+
+    snapshot = selection.market_snapshot
+    if selection.loaded and snapshot is not None and snapshot.truth_status == "PERSISTED":
+        future_detail = _missing_truth(
+            "future_detail",
+            "AVAILABLE",
+            "Future detail metadata loaded from persisted market snapshot.",
+            producer_followup=followup,
+        )
+    else:
+        future_detail = _missing_truth(
+            "future_detail",
+            MISSING_TRUTH_FUTURE_DETAIL,
+            "Future detail requires a persisted selection and market snapshot — not available.",
+            producer_followup=followup,
+        )
+
+    return universe, top20, selected, future_detail
 
 
 def build_workflow_dashboard_readmodel_v1(archive_root: Path) -> WorkflowDashboardReadModelV1:
@@ -64,25 +148,12 @@ def build_workflow_dashboard_readmodel_v1(archive_root: Path) -> WorkflowDashboa
         current_mode_label="Research / Paper / Shadow / Testnet — Live blocked",
     )
 
-    universe_missing = _missing_truth(
-        "universe",
-        "UNIVERSE_SOURCE_NOT_PERSISTED",
-        "No governed universe snapshot (~50 futures) is persisted for this workflow view.",
-    )
-    top20_missing = _missing_truth(
-        "top20",
-        "TOP20_RANKING_NOT_PERSISTED",
-        "No Top-20 ranking snapshot is persisted for this workflow view.",
-    )
-    selected_future_missing = _missing_truth(
-        "selected_future",
-        "SELECTED_FUTURE_NOT_PERSISTED",
-        "No selected-future decision artifact is linked to pipeline runs.",
-    )
-    future_detail_missing = _missing_truth(
-        "future_detail",
-        "FUTURE_DETAIL_NOT_AVAILABLE",
-        "Future detail requires a persisted selection and market snapshot — not available.",
+    universe_selection = try_load_universe_selection_for_dashboard(root)
+    if universe_selection.load_errors:
+        errors.extend(universe_selection.load_errors)
+
+    universe_missing, top20_missing, selected_future_missing, future_detail_missing = (
+        _universe_selection_missing_cards(universe_selection)
     )
 
     max_real = 0
@@ -190,6 +261,7 @@ def build_workflow_dashboard_readmodel_v1(archive_root: Path) -> WorkflowDashboa
         top20_missing=top20_missing,
         selected_future_missing=selected_future_missing,
         future_detail_missing=future_detail_missing,
+        universe_selection=universe_selection,
         pipeline=pipeline,
         orders_fills_pnl=orders_fills,
         evidence_explorer=evidence_card,

--- a/src/webui/workflow_dashboard_readmodel_v1/types.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/types.py
@@ -103,6 +103,49 @@ class NextGoCardV1:
 
 
 @dataclass(frozen=True)
+class UniverseSelectionRowDisplayV1:
+    row_id: str
+    symbol: str
+    rank: int
+    exchange: str | None = None
+    display_score: float | None = None
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class SelectedFutureDisplayV1:
+    row_id: str
+    symbol: str
+    rank: int
+    truth_status: str
+    selection_reason: str | None = None
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class MarketSnapshotDisplayV1:
+    truth_status: str
+    source_kind: str | None = None
+    snapshot_id: str | None = None
+    exchange: str | None = None
+    captured_at: str | None = None
+
+
+@dataclass(frozen=True)
+class UniverseSelectionDashboardSliceV1:
+    loaded: bool
+    load_errors: tuple[str, ...]
+    source_run_id: str | None = None
+    source_stage: str | None = None
+    generated_at: str | None = None
+    universe: tuple[UniverseSelectionRowDisplayV1, ...] = ()
+    ranking: tuple[UniverseSelectionRowDisplayV1, ...] = ()
+    selected_future: SelectedFutureDisplayV1 | None = None
+    market_snapshot: MarketSnapshotDisplayV1 | None = None
+    evidence_links: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class WorkflowDashboardReadModelV1:
     schema_version: str
     readmodel_id: str
@@ -119,6 +162,7 @@ class WorkflowDashboardReadModelV1:
     top20_missing: MissingTruthCardV1
     selected_future_missing: MissingTruthCardV1
     future_detail_missing: MissingTruthCardV1
+    universe_selection: UniverseSelectionDashboardSliceV1
     pipeline: WorkflowPipelineAggregateV1
     orders_fills_pnl: OrdersFillsPnlCardV1
     evidence_explorer: EvidenceCardV1
@@ -169,6 +213,59 @@ def to_json_dict(model: WorkflowDashboardReadModelV1) -> dict[str, Any]:
             "truth_status": model.future_detail_missing.truth_status,
             "message": model.future_detail_missing.message,
             "producer_followup": model.future_detail_missing.producer_followup,
+        },
+        "universe_selection": {
+            "loaded": model.universe_selection.loaded,
+            "load_errors": list(model.universe_selection.load_errors),
+            "source_run_id": model.universe_selection.source_run_id,
+            "source_stage": model.universe_selection.source_stage,
+            "generated_at": model.universe_selection.generated_at,
+            "universe": [
+                {
+                    "row_id": row.row_id,
+                    "symbol": row.symbol,
+                    "rank": row.rank,
+                    "exchange": row.exchange,
+                    "display_score": row.display_score,
+                    "notes": row.notes,
+                }
+                for row in model.universe_selection.universe
+            ],
+            "ranking": [
+                {
+                    "row_id": row.row_id,
+                    "symbol": row.symbol,
+                    "rank": row.rank,
+                    "exchange": row.exchange,
+                    "display_score": row.display_score,
+                    "notes": row.notes,
+                }
+                for row in model.universe_selection.ranking
+            ],
+            "selected_future": (
+                None
+                if model.universe_selection.selected_future is None
+                else {
+                    "row_id": model.universe_selection.selected_future.row_id,
+                    "symbol": model.universe_selection.selected_future.symbol,
+                    "rank": model.universe_selection.selected_future.rank,
+                    "truth_status": model.universe_selection.selected_future.truth_status,
+                    "selection_reason": model.universe_selection.selected_future.selection_reason,
+                    "notes": model.universe_selection.selected_future.notes,
+                }
+            ),
+            "market_snapshot": (
+                None
+                if model.universe_selection.market_snapshot is None
+                else {
+                    "truth_status": model.universe_selection.market_snapshot.truth_status,
+                    "source_kind": model.universe_selection.market_snapshot.source_kind,
+                    "snapshot_id": model.universe_selection.market_snapshot.snapshot_id,
+                    "exchange": model.universe_selection.market_snapshot.exchange,
+                    "captured_at": model.universe_selection.market_snapshot.captured_at,
+                }
+            ),
+            "evidence_links": list(model.universe_selection.evidence_links),
         },
         "pipeline": {
             "readmodel_id": model.pipeline.readmodel_id,

--- a/src/webui/workflow_dashboard_readmodel_v1/universe_selection_reader_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/universe_selection_reader_v1.py
@@ -1,0 +1,173 @@
+"""Read-only dashboard loader for universe_selection_readmodel.v1 (Slice 3 — no writes)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .types import (
+    MarketSnapshotDisplayV1,
+    SelectedFutureDisplayV1,
+    UniverseSelectionDashboardSliceV1,
+    UniverseSelectionRowDisplayV1,
+)
+from .universe_selection_contract_v1 import (
+    MISSING_TRUTH_FUTURE_DETAIL,
+    MISSING_TRUTH_RANKING,
+    MISSING_TRUTH_SELECTED,
+    MISSING_TRUTH_UNIVERSE,
+    STORAGE_RELATIVE_PATH,
+    UniverseSelectionContractError,
+    UniverseSelectionContractV1,
+    UniverseSelectionRowV1,
+    validate_universe_selection_payload,
+)
+from .universe_selection_producer_v1 import (
+    MANIFEST_FILENAME,
+    READMODEL_FILENAME,
+    READMODELS_DIRNAME,
+)
+
+LOAD_ERROR_MANIFEST_NOT_FOUND = "MANIFEST_NOT_FOUND"
+LOAD_ERROR_MANIFEST_VERIFY_FAILED = "MANIFEST_VERIFY_FAILED"
+LOAD_ERROR_INVALID_JSON = "INVALID_JSON"
+LOAD_ERROR_CONTRACT_INVALID = "CONTRACT_INVALID"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _import_verify_manifest() -> Any:
+    repo_root = _repo_root()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+
+    return verify_manifest_sha256
+
+
+def _empty_slice(*, load_errors: tuple[str, ...]) -> UniverseSelectionDashboardSliceV1:
+    return UniverseSelectionDashboardSliceV1(loaded=False, load_errors=load_errors)
+
+
+def _normalize_evidence_links(evidence: dict[str, Any]) -> tuple[str, ...]:
+    raw_links = evidence.get("links")
+    if not isinstance(raw_links, list):
+        return ()
+    out: list[str] = []
+    for item in raw_links:
+        if isinstance(item, str) and item.strip():
+            out.append(item.strip())
+        elif isinstance(item, dict):
+            path = item.get("path")
+            label = item.get("label")
+            if isinstance(path, str) and path.strip():
+                text = path.strip()
+                if isinstance(label, str) and label.strip():
+                    text = f"{label.strip()}: {text}"
+                out.append(text)
+    return tuple(out)
+
+
+def _row_display(row: UniverseSelectionRowV1) -> UniverseSelectionRowDisplayV1:
+    return UniverseSelectionRowDisplayV1(
+        row_id=row.row_id,
+        symbol=row.symbol,
+        rank=row.rank,
+        exchange=row.exchange,
+        display_score=row.display_score,
+        notes=row.notes,
+    )
+
+
+def _contract_to_slice(contract: UniverseSelectionContractV1) -> UniverseSelectionDashboardSliceV1:
+    selected = None
+    if contract.selected_future is not None:
+        sf = contract.selected_future
+        selected = SelectedFutureDisplayV1(
+            row_id=sf.row_id,
+            symbol=sf.symbol,
+            rank=sf.rank,
+            truth_status=sf.truth_status,
+            selection_reason=sf.selection_reason,
+            notes=sf.notes,
+        )
+    snapshot_raw = contract.market_snapshot
+    market_snapshot = MarketSnapshotDisplayV1(
+        truth_status=str(snapshot_raw.get("truth_status", "NOT_PERSISTED")),
+        source_kind=(
+            str(snapshot_raw["source_kind"])
+            if isinstance(snapshot_raw.get("source_kind"), str)
+            else None
+        ),
+        snapshot_id=(
+            str(snapshot_raw["snapshot_id"])
+            if isinstance(snapshot_raw.get("snapshot_id"), str)
+            else None
+        ),
+        exchange=(
+            str(snapshot_raw["exchange"]) if isinstance(snapshot_raw.get("exchange"), str) else None
+        ),
+        captured_at=(
+            str(snapshot_raw["captured_at"])
+            if isinstance(snapshot_raw.get("captured_at"), str)
+            else None
+        ),
+    )
+    return UniverseSelectionDashboardSliceV1(
+        loaded=True,
+        load_errors=(),
+        source_run_id=contract.source_run_id,
+        source_stage=contract.source_stage,
+        generated_at=contract.generated_at,
+        universe=tuple(_row_display(row) for row in contract.universe),
+        ranking=tuple(_row_display(row) for row in contract.ranking),
+        selected_future=selected,
+        market_snapshot=market_snapshot,
+        evidence_links=_normalize_evidence_links(contract.evidence),
+    )
+
+
+def try_load_universe_selection_for_dashboard(
+    archive_root: str | Path,
+) -> UniverseSelectionDashboardSliceV1:
+    """Verify-before-trust read of universe_selection_readmodel.v1 (read-only, no writes)."""
+    root = Path(archive_root).expanduser().resolve()
+    readmodels_dir = root / READMODELS_DIRNAME
+    readmodel_path = readmodels_dir / READMODEL_FILENAME
+
+    if not readmodel_path.is_file():
+        return _empty_slice(load_errors=())
+
+    manifest_path = readmodels_dir / MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return _empty_slice(load_errors=(LOAD_ERROR_MANIFEST_NOT_FOUND,))
+
+    verify_manifest_sha256 = _import_verify_manifest()
+    verify_ok, _ = verify_manifest_sha256(readmodels_dir)
+    if not verify_ok:
+        return _empty_slice(load_errors=(LOAD_ERROR_MANIFEST_VERIFY_FAILED,))
+
+    try:
+        raw = readmodel_path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty_slice(load_errors=(LOAD_ERROR_CONTRACT_INVALID,))
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _empty_slice(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    if not isinstance(payload, dict):
+        return _empty_slice(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    try:
+        contract = validate_universe_selection_payload(payload)
+    except UniverseSelectionContractError:
+        return _empty_slice(load_errors=(LOAD_ERROR_CONTRACT_INVALID,))
+
+    _ = STORAGE_RELATIVE_PATH
+    return _contract_to_slice(contract)

--- a/templates/peak_trade_dashboard/observability_hub.html
+++ b/templates/peak_trade_dashboard/observability_hub.html
@@ -93,35 +93,74 @@
       <p class="text-[11px] text-slate-400 m-0 font-mono">{{ saf.current_mode_label }}</p>
     </section>
 
+    {% set usel = wd.universe_selection %}
     <section class="rounded-xl border border-amber-900/40 bg-amber-950/20 px-5 py-4 space-y-3" data-workflow-panel-universe-v1="true" data-workflow-universe-truth-status="{{ wd.universe_missing.truth_status }}">
       <h2 class="text-sm font-semibold text-amber-200/95 uppercase text-[11px] m-0">Universe ~50 Futures</h2>
       <p class="text-xs font-mono text-amber-200/95 m-0">{{ wd.universe_missing.truth_status }}</p>
       <p class="text-xs text-slate-400 m-0">{{ wd.universe_missing.message }}</p>
+      {% if usel.loaded and wd.universe_missing.truth_status == 'PERSISTED' and usel.universe %}
+      <p class="text-[10px] text-slate-500 m-0 font-mono">rows={{ usel.universe | length }} · source={{ usel.source_stage }}/{{ usel.source_run_id }}</p>
+      <table class="w-full text-[10px] text-slate-400 border border-slate-800/60 rounded">
+        <thead><tr class="text-left"><th class="px-2 py-1">rank</th><th class="px-2 py-1">symbol</th><th class="px-2 py-1">exchange</th><th class="px-2 py-1">notes</th></tr></thead>
+        <tbody>
+          {% for row in usel.universe %}
+          <tr><td class="px-2 py-1 font-mono">{{ row.rank }}</td><td class="px-2 py-1 font-mono">{{ row.symbol }}</td><td class="px-2 py-1">{{ row.exchange or '—' }}</td><td class="px-2 py-1 text-slate-500">{{ row.notes or '' }}</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
       <table class="w-full text-[10px] text-slate-500 border border-slate-800/60 rounded">
         <thead><tr class="text-left"><th class="px-2 py-1">symbol</th><th class="px-2 py-1">exchange</th><th class="px-2 py-1">available</th><th class="px-2 py-1">exclusion_reason</th></tr></thead>
         <tbody><tr><td class="px-2 py-2 text-slate-600" colspan="4">No persisted universe rows — producer follow-up required.</td></tr></tbody>
       </table>
+      {% endif %}
     </section>
 
     <section class="rounded-xl border border-amber-900/40 bg-amber-950/20 px-5 py-4 space-y-3" data-workflow-panel-top20-v1="true" data-workflow-top20-truth-status="{{ wd.top20_missing.truth_status }}">
       <h2 class="text-sm font-semibold text-amber-200/95 uppercase text-[11px] m-0">Top 20 Ranking</h2>
       <p class="text-xs font-mono text-amber-200/95 m-0">{{ wd.top20_missing.truth_status }}</p>
       <p class="text-xs text-slate-400 m-0">{{ wd.top20_missing.message }}</p>
+      {% if usel.loaded and wd.top20_missing.truth_status == 'PERSISTED' and usel.ranking %}
+      <ol class="list-decimal pl-5 text-[10px] text-slate-400 space-y-0.5 m-0" start="1">
+        {% for row in usel.ranking %}
+        <li><span class="font-mono">{{ row.symbol }}</span>{% if row.display_score is not none %} · score {{ row.display_score }}{% endif %}</li>
+        {% endfor %}
+      </ol>
+      {% else %}
       <ol class="list-decimal pl-5 text-[10px] text-slate-600 space-y-0.5 m-0" start="1">
         {% for r in range(1, 21) %}<li>rank {{ r }} — not persisted</li>{% endfor %}
       </ol>
+      {% endif %}
     </section>
 
     <section class="rounded-xl border border-amber-900/40 bg-amber-950/20 px-5 py-4 space-y-3" data-workflow-panel-selected-future-v1="true" data-workflow-selected-future-truth-status="{{ wd.selected_future_missing.truth_status }}">
       <h2 class="text-sm font-semibold text-amber-200/95 uppercase text-[11px] m-0">Selected Future</h2>
       <p class="text-xs font-mono text-amber-200/95 m-0">{{ wd.selected_future_missing.truth_status }}</p>
       <p class="text-xs text-slate-400 m-0">{{ wd.selected_future_missing.message }}</p>
+      {% if usel.loaded and wd.selected_future_missing.truth_status == 'PERSISTED' and usel.selected_future %}
+      <dl class="grid grid-cols-2 gap-x-4 gap-y-1 text-[10px] m-0">
+        <div><dt class="text-slate-500">symbol</dt><dd class="font-mono text-slate-200">{{ usel.selected_future.symbol }}</dd></div>
+        <div><dt class="text-slate-500">rank</dt><dd class="font-mono text-slate-200">{{ usel.selected_future.rank }}</dd></div>
+        {% if usel.selected_future.selection_reason %}<div class="col-span-2"><dt class="text-slate-500">selection_reason</dt><dd class="text-slate-300">{{ usel.selected_future.selection_reason }}</dd></div>{% endif %}
+      </dl>
+      {% endif %}
     </section>
 
     <section class="rounded-xl border border-amber-900/40 bg-amber-950/20 px-5 py-4 space-y-3" data-workflow-panel-future-detail-v1="true" data-workflow-future-detail-status="{{ wd.future_detail_missing.truth_status }}">
       <h2 class="text-sm font-semibold text-amber-200/95 uppercase text-[11px] m-0">Future Detail</h2>
       <p class="text-xs font-mono text-amber-200/95 m-0">{{ wd.future_detail_missing.truth_status }}</p>
       <p class="text-xs text-slate-400 m-0">{{ wd.future_detail_missing.message }}</p>
+      {% if usel.loaded and wd.future_detail_missing.truth_status == 'AVAILABLE' and usel.market_snapshot %}
+      <dl class="grid grid-cols-2 gap-x-4 gap-y-1 text-[10px] m-0">
+        <div><dt class="text-slate-500">exchange</dt><dd class="font-mono text-slate-200">{{ usel.market_snapshot.exchange or '—' }}</dd></div>
+        <div><dt class="text-slate-500">snapshot_id</dt><dd class="font-mono text-slate-200">{{ usel.market_snapshot.snapshot_id or '—' }}</dd></div>
+        <div><dt class="text-slate-500">source_kind</dt><dd class="font-mono text-slate-200">{{ usel.market_snapshot.source_kind or '—' }}</dd></div>
+        <div><dt class="text-slate-500">captured_at</dt><dd class="font-mono text-slate-200">{{ usel.market_snapshot.captured_at or '—' }}</dd></div>
+      </dl>
+      {% endif %}
+      {% if usel.loaded and usel.evidence_links %}
+      <p class="text-[10px] text-slate-500 m-0 font-mono">evidence: {{ usel.evidence_links | join(' · ') }}</p>
+      {% endif %}
       <p class="text-[10px] text-slate-500 m-0">GET /market BTC/USD dummy is <strong>not</strong> Future or Paper runtime truth.</p>
     </section>
 

--- a/tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py
+++ b/tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
 
@@ -33,6 +34,13 @@ LPR_FIXTURE = (
     / "last_paper_run_panel_readmodel_v0"
     / "p1_complete_minimal"
 ).resolve()
+UNIVERSE_FIXTURES = (
+    project_root
+    / "tests"
+    / "fixtures"
+    / "workflow_dashboard_readmodel_v1"
+    / "universe_selection_readmodel_v1"
+)
 
 
 @pytest.fixture()
@@ -127,6 +135,44 @@ def test_market_separation(client_off: TestClient) -> None:
     html = client_off.get("/market").text
     assert 'data-workflow-dashboard-v1="true"' not in html
     assert 'data-market-v0-paper-run-truth-separation-v0="true"' in html
+
+
+def test_persisted_readmodel_renders_futures_only_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+    archive = tmp_path / "archive_with_universe"
+    shutil.copytree(FIXTURE_ARCHIVE, archive)
+    readmodels_dir = archive / "readmodels"
+    readmodels_dir.mkdir(parents=True, exist_ok=True)
+    src = UNIVERSE_FIXTURES / "complete_minimal" / "universe_selection_readmodel.v1.json"
+    shutil.copy2(src, readmodels_dir / "universe_selection_readmodel.v1.json")
+    write_manifest_sha256(readmodels_dir)
+
+    monkeypatch.setenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT", str(archive))
+    monkeypatch.setenv("PEAK_TRADE_FIXED_GENERATED_AT_UTC", "2026-06-08T12:00:00+00:00")
+    client = TestClient(create_app())
+    html = client.get("/observability").text
+    start = html.index('data-workflow-dashboard-v1="true"')
+    end = html.index('data-observability-status-summary="true"')
+    section = html[start:end]
+    assert "SOLUSDT" in section
+    assert "ETHUSDT" in section
+    assert "PERSISTED" in section
+    assert (
+        "GET /market BTC/USD dummy is <strong>not</strong> Future or Paper runtime truth."
+        in section
+    )
+    assert "selected_symbol" not in section
+    for marker in (
+        'data-workflow-panel-universe-v1="true"',
+        'data-workflow-panel-top20-v1="true"',
+        'data-workflow-panel-selected-future-v1="true"',
+        'data-workflow-panel-future-detail-v1="true"',
+    ):
+        assert marker in section
 
 
 def test_last_paper_run_still_works_with_both_gates(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/webui/test_universe_selection_reader_v1.py
+++ b/tests/webui/test_universe_selection_reader_v1.py
@@ -1,0 +1,146 @@
+"""Tests for universe_selection_reader_v1 (Slice 3 — read-only, no runtime)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp, verify_manifest_sha256
+from scripts.ops.primary_evidence_retention_v0 import (
+    write_manifest_sha256 as _write_manifest_sha256,
+)
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_reader_v1 import (
+    LOAD_ERROR_CONTRACT_INVALID,
+    LOAD_ERROR_INVALID_JSON,
+    LOAD_ERROR_MANIFEST_NOT_FOUND,
+    LOAD_ERROR_MANIFEST_VERIFY_FAILED,
+    try_load_universe_selection_for_dashboard,
+)
+
+SCRATCH_ROOT = project_root / "tests" / "_durable_archive_scratch"
+FIXTURES_ROOT = (
+    project_root
+    / "tests"
+    / "fixtures"
+    / "workflow_dashboard_readmodel_v1"
+    / "universe_selection_readmodel_v1"
+)
+
+
+@pytest.fixture
+def archive_root(tmp_path: Path) -> Path:
+    candidate = tmp_path / "archive_root"
+    candidate.mkdir(parents=True, exist_ok=True)
+    if not is_under_tmp(candidate):
+        return candidate
+    SCRATCH_ROOT.mkdir(parents=True, exist_ok=True)
+    durable = SCRATCH_ROOT / str(uuid.uuid4())
+    durable.mkdir(parents=True, exist_ok=True)
+    return durable
+
+
+def _install_fixture(archive_root: Path, fixture_dir: str, *, write_manifest: bool = True) -> Path:
+    src = FIXTURES_ROOT / fixture_dir / "universe_selection_readmodel.v1.json"
+    readmodels_dir = archive_root / "readmodels"
+    readmodels_dir.mkdir(parents=True, exist_ok=True)
+    dest = readmodels_dir / "universe_selection_readmodel.v1.json"
+    shutil.copy2(src, dest)
+    if write_manifest:
+        _write_manifest_sha256(readmodels_dir)
+    return dest
+
+
+def test_no_file_missing_truth_fallback(archive_root: Path) -> None:
+    result = try_load_universe_selection_for_dashboard(archive_root)
+    assert result.loaded is False
+    assert result.load_errors == ()
+    assert result.universe == ()
+
+
+def test_missing_manifest_fallback(archive_root: Path) -> None:
+    _install_fixture(archive_root, "complete_minimal", write_manifest=False)
+    result = try_load_universe_selection_for_dashboard(archive_root)
+    assert result.loaded is False
+    assert result.load_errors == (LOAD_ERROR_MANIFEST_NOT_FOUND,)
+
+
+def test_manifest_verify_fail_fallback(archive_root: Path) -> None:
+    path = _install_fixture(archive_root, "complete_minimal")
+    path.write_text(path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    result = try_load_universe_selection_for_dashboard(archive_root)
+    assert result.loaded is False
+    assert result.load_errors == (LOAD_ERROR_MANIFEST_VERIFY_FAILED,)
+
+
+def test_invalid_json_fallback(archive_root: Path) -> None:
+    readmodels_dir = archive_root / "readmodels"
+    readmodels_dir.mkdir(parents=True)
+    bad = readmodels_dir / "universe_selection_readmodel.v1.json"
+    bad.write_text("{not-json", encoding="utf-8")
+    _write_manifest_sha256(readmodels_dir)
+    result = try_load_universe_selection_for_dashboard(archive_root)
+    assert result.loaded is False
+    assert result.load_errors == (LOAD_ERROR_INVALID_JSON,)
+
+
+def test_invalid_btc_selected_fallback(archive_root: Path) -> None:
+    _install_fixture(archive_root, "invalid_btc_usd_selected")
+    result = try_load_universe_selection_for_dashboard(archive_root)
+    assert result.loaded is False
+    assert result.load_errors == (LOAD_ERROR_CONTRACT_INVALID,)
+    assert "BTC/USD" not in str(result)
+
+
+def test_valid_complete_minimal_loaded(archive_root: Path) -> None:
+    _install_fixture(archive_root, "complete_minimal")
+    result = try_load_universe_selection_for_dashboard(archive_root)
+    assert result.loaded is True
+    assert result.load_errors == ()
+    assert len(result.universe) == 3
+    assert result.selected_future is not None
+    assert result.selected_future.symbol == "SOLUSDT"
+    assert "ETHUSDT" in {row.symbol for row in result.universe}
+    ok, _ = verify_manifest_sha256(archive_root / "readmodels")
+    assert ok
+
+
+def test_reader_performs_no_writes(archive_root: Path) -> None:
+    _install_fixture(archive_root, "complete_minimal")
+    readmodels_dir = archive_root / "readmodels"
+    before = {p.name: p.stat().st_mtime_ns for p in readmodels_dir.iterdir()}
+    try_load_universe_selection_for_dashboard(archive_root)
+    after = {p.name: p.stat().st_mtime_ns for p in readmodels_dir.iterdir()}
+    assert before == after
+
+
+def test_invalid_json_without_manifest_tamper(archive_root: Path) -> None:
+    readmodels_dir = archive_root / "readmodels"
+    readmodels_dir.mkdir(parents=True)
+    bad = readmodels_dir / "universe_selection_readmodel.v1.json"
+    bad.write_text("{not-json", encoding="utf-8")
+    (readmodels_dir / "MANIFEST.sha256").write_text(
+        f"{bad.name}  deadbeef\n",
+        encoding="utf-8",
+    )
+    result = try_load_universe_selection_for_dashboard(archive_root)
+    assert result.loaded is False
+    assert result.load_errors == (LOAD_ERROR_MANIFEST_VERIFY_FAILED,)
+
+
+def test_contract_invalid_after_valid_manifest(archive_root: Path) -> None:
+    path = _install_fixture(archive_root, "complete_minimal")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["schema_version"] = 999
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    _write_manifest_sha256(path.parent)
+    result = try_load_universe_selection_for_dashboard(archive_root)
+    assert result.loaded is False
+    assert result.load_errors == (LOAD_ERROR_CONTRACT_INVALID,)

--- a/tests/webui/test_workflow_dashboard_readmodel_v1.py
+++ b/tests/webui/test_workflow_dashboard_readmodel_v1.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
 
@@ -24,6 +25,13 @@ FIXTURE_ARCHIVE = (
     / "pipeline_minimal"
     / "archive_root"
 ).resolve()
+UNIVERSE_FIXTURES = (
+    project_root
+    / "tests"
+    / "fixtures"
+    / "workflow_dashboard_readmodel_v1"
+    / "universe_selection_readmodel_v1"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -91,3 +99,38 @@ def test_next_go_from_t2() -> None:
 def test_archive_root_not_directory_raises() -> None:
     with pytest.raises(ValueError, match="archive_root_not_directory"):
         build_workflow_dashboard_readmodel_v1(FIXTURE_ARCHIVE / "nonexistent_dir_xyz")
+
+
+def _copy_pipeline_archive_with_readmodel(tmp_path: Path, fixture_dir: str) -> Path:
+    from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+    archive = tmp_path / "archive_with_universe"
+    shutil.copytree(FIXTURE_ARCHIVE, archive)
+    readmodels_dir = archive / "readmodels"
+    readmodels_dir.mkdir(parents=True, exist_ok=True)
+    src = UNIVERSE_FIXTURES / fixture_dir / "universe_selection_readmodel.v1.json"
+    shutil.copy2(src, readmodels_dir / "universe_selection_readmodel.v1.json")
+    write_manifest_sha256(readmodels_dir)
+    return archive
+
+
+def test_valid_readmodel_populates_model_fields(tmp_path: Path) -> None:
+    archive = _copy_pipeline_archive_with_readmodel(tmp_path, "complete_minimal")
+    m = build_workflow_dashboard_readmodel_v1(archive)
+    assert m.universe_selection.loaded is True
+    assert m.universe_missing.truth_status == "PERSISTED"
+    assert m.top20_missing.truth_status == "PERSISTED"
+    assert m.selected_future_missing.truth_status == "PERSISTED"
+    assert m.future_detail_missing.truth_status == "AVAILABLE"
+    assert len(m.universe_selection.universe) == 3
+    assert m.universe_selection.selected_future is not None
+    assert m.universe_selection.selected_future.symbol == "SOLUSDT"
+    assert "BTC/USD" not in str(to_json_dict(m))
+
+
+def test_invalid_btc_readmodel_preserves_missing_truth(tmp_path: Path) -> None:
+    archive = _copy_pipeline_archive_with_readmodel(tmp_path, "invalid_btc_usd_selected")
+    m = build_workflow_dashboard_readmodel_v1(archive)
+    assert m.universe_selection.loaded is False
+    assert m.universe_missing.truth_status == "UNIVERSE_SOURCE_NOT_PERSISTED"
+    assert "CONTRACT_INVALID" in m.load_errors or "MANIFEST" in str(m.load_errors)


### PR DESCRIPTION
## Summary

- Add read-only Slice 3 dashboard reader for `universe_selection_readmodel.v1` on GET /observability.
- When `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` is manifest-verified and contract-valid, Universe/Top20/Selected Future/Future Detail panels show persisted futures-only values.
- Otherwise existing Missing Truth fallback is preserved with diagnostic `load_errors`.

## Scope

- `src/webui/workflow_dashboard_readmodel_v1/universe_selection_reader_v1.py` (new)
- `src/webui/workflow_dashboard_readmodel_v1/builder.py`
- `src/webui/workflow_dashboard_readmodel_v1/types.py`
- `src/webui/workflow_dashboard_readmodel_v1/__init__.py`
- `templates/peak_trade_dashboard/observability_hub.html`
- `docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md`
- `tests/webui/test_universe_selection_reader_v1.py` (new)
- `tests/webui/test_workflow_dashboard_readmodel_v1.py`
- `tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py`

## Futures-first semantics

Universe/Top20/Selected-Future refer exclusively to futures/derivative instruments. Contract validation rejects BTC/USD and spot dummy symbols; UI never displays rejected payloads. No synthetic ranking or fake market data.

## Verify-before-trust behavior

1. Readmodel file must exist under `readmodels/`.
2. `readmodels/MANIFEST.sha256` must exist.
3. `verify_manifest_sha256(readmodels_dir)` must return RC=0.
4. JSON must parse and pass `validate_universe_selection_payload`.
5. On any failure: Missing Truth fallback + diagnostic load error (except missing file → silent fallback).

## Missing Truth fallback behavior

Without a trusted readmodel, panels retain `UNIVERSE_SOURCE_NOT_PERSISTED`, `TOP20_RANKING_NOT_PERSISTED`, `SELECTED_FUTURE_NOT_PERSISTED`, and `FUTURE_DETAIL_NOT_AVAILABLE` — unchanged from pre-Slice-3 behavior.

## No producer/adapter writes

Reader is read-only. No changes to producer helper, adapter hooks, or archive write paths.

## No forms/buttons/fetch/post

Workflow dashboard section remains view-only. Structure contract tests confirm no forms, buttons, fetch, or POST in the workflow panel region.

## Safety boundaries

- No changes to `src/execution`, `src/governance`, `src/risk`.
- No workflow YAML, scheduler, runtime, or Live start logic.
- No GET /market changes or dashboard fake-data injection.
- No new parallel SSOT surface.

## Tests

- `tests/webui/test_universe_selection_reader_v1.py` (9 tests)
- Extended workflow dashboard and observability structure contract tests
- Regression: universe selection contract, producer, closeout hook tests
- 63 tests passed locally; ruff check/format passed; docs token preflight passed (1 file).

## Evidence bundles

- Implementation: `implementation/universe_top20_selected_future_dashboard_reader_slice3_bounded_write_tests_v1_20260608T152847Z`
- Post-implementation review: `review/universe_top20_selected_future_dashboard_reader_slice3_post_implementation_review_no_run_v1_20260608T153003Z`

## No-Live statement

This PR is display-only SSR wiring. It does not authorize Live trading, broker/exchange access, scheduler dispatch, runtime start, or producer/adapter execution.


Made with [Cursor](https://cursor.com)