### PR TITLE
Add futures universe upstream adapter

### DIFF
--- a/src/webui/workflow_dashboard_readmodel_v1/futures_universe_upstream_adapter_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/futures_universe_upstream_adapter_v1.py
@@ -1,0 +1,455 @@
+"""Upstream futures universe → universe_selection_readmodel.v1 mapping (U1 — pure, no I/O)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from trading.master_v2.double_play_futures_input import FuturesMarketType
+from trading.master_v2.double_play_futures_input_producer import FuturesProducerPacket
+
+from .universe_selection_contract_v1 import (
+    FORBIDDEN_SELECTED_SYMBOLS,
+    FORBIDDEN_TRUTH_SOURCE_KINDS,
+    MAX_RANKING_ROWS,
+    MAX_UNIVERSE_ROWS,
+    MISSING_TRUTH_FUTURE_DETAIL,
+    MISSING_TRUTH_PNL,
+    MISSING_TRUTH_RANKING,
+    MISSING_TRUTH_SELECTED,
+    MISSING_TRUTH_UNIVERSE,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    STORAGE_RELATIVE_PATH,
+    validate_universe_selection_payload,
+)
+from .universe_selection_producer_v1 import PRODUCER_CONTRACT
+
+FUTURES_UNIVERSE_UPSTREAM_ADAPTER_VERSION = "v1"
+UPSTREAM_ADAPTER_CONTRACT = "futures_universe_upstream_adapter.v1"
+
+ELIGIBLE_MARKET_TYPES = frozenset(
+    {
+        FuturesMarketType.FUTURES,
+        FuturesMarketType.PERPETUAL,
+        FuturesMarketType.SWAP,
+    }
+)
+
+FORBIDDEN_UPSTREAM_SOURCE_MARKERS = frozenset(
+    {
+        "market_ranking_funnel_readmodel.v0",
+        "market_surface",
+        "market_surface_dummy",
+        "get_market_dummy",
+        "btc_usd_dummy_default",
+    }
+)
+
+INELIGIBLE_SPOT_SYMBOLS = frozenset(
+    {
+        "BTC/USD",
+        "BTC/EUR",
+        "ETH/USD",
+        "BTCUSD",
+        "BTC-USD",
+        "BTCEUR",
+        "ETHUSD",
+    }
+)
+
+REASON_UPSTREAM_SOURCE_EMPTY = "UPSTREAM_SOURCE_EMPTY"
+REASON_MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH = "MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH"
+REASON_SPOT_OR_NON_DERIVATIVE_SELECTED_FUTURE_REJECTED = (
+    "SPOT_OR_NON_DERIVATIVE_SELECTED_FUTURE_REJECTED"
+)
+REASON_SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE = "SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE"
+REASON_INELIGIBLE_MARKET_TYPE = "INELIGIBLE_MARKET_TYPE"
+REASON_INELIGIBLE_INSTRUMENT_METADATA_INCOMPLETE = "INELIGIBLE_INSTRUMENT_METADATA_INCOMPLETE"
+REASON_INELIGIBLE_SPOT_SYMBOL = "INELIGIBLE_SPOT_SYMBOL"
+
+
+@dataclass(frozen=True)
+class FuturesUniverseUpstreamInputV1:
+    """Governed upstream input for futures-only universe/ranking/selection mapping."""
+
+    source_run_id: str
+    source_stage: str
+    generated_at: str
+    packets: tuple[FuturesProducerPacket, ...]
+    upstream_source_kind: str | None = None
+    upstream_producer_id: str | None = None
+    selected_candidate_id: str | None = None
+    evidence_links: tuple[str, ...] = ()
+    fixture_marked: bool = False
+
+
+@dataclass(frozen=True)
+class EligibilityExclusionV1:
+    candidate_id: str
+    symbol: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class FuturesUniverseUpstreamAdapterResultV1:
+    """Pure adapter outcome — payload always contract-valid; status signals mapping mode."""
+
+    status: str
+    payload: dict[str, Any]
+    rejection_reasons: tuple[str, ...]
+    eligibility_exclusions: tuple[EligibilityExclusionV1, ...]
+
+
+def _normalize_symbol(symbol: str) -> str:
+    return symbol.upper().replace("-", "").replace("/", "")
+
+
+def _is_spot_symbol(symbol: str) -> bool:
+    if symbol in INELIGIBLE_SPOT_SYMBOLS or symbol in FORBIDDEN_SELECTED_SYMBOLS:
+        return True
+    normalized = _normalize_symbol(symbol)
+    if normalized in INELIGIBLE_SPOT_SYMBOLS:
+        return True
+    if "/" in symbol:
+        return True
+    return False
+
+
+def is_forbidden_upstream_source(
+    *,
+    upstream_source_kind: str | None,
+    upstream_producer_id: str | None,
+) -> bool:
+    markers = (
+        upstream_source_kind,
+        upstream_producer_id,
+    )
+    for marker in markers:
+        if not marker:
+            continue
+        text = marker.strip()
+        if text in FORBIDDEN_UPSTREAM_SOURCE_MARKERS:
+            return True
+        if text in FORBIDDEN_TRUTH_SOURCE_KINDS:
+            return True
+    return False
+
+
+def evaluate_packet_eligibility(packet: FuturesProducerPacket) -> tuple[bool, str | None]:
+    """Return (eligible, exclusion_reason). Futures/derivative-only; no symbol heuristics alone."""
+    symbol = packet.candidate.symbol
+    if _is_spot_symbol(symbol):
+        return False, REASON_INELIGIBLE_SPOT_SYMBOL
+    if packet.candidate.market_type not in ELIGIBLE_MARKET_TYPES:
+        return False, REASON_INELIGIBLE_MARKET_TYPE
+    if not packet.instrument.complete:
+        return False, REASON_INELIGIBLE_INSTRUMENT_METADATA_INCOMPLETE
+    return True, None
+
+
+def _missing_truth_payload(
+    *,
+    source_run_id: str,
+    source_stage: str,
+    generated_at: str,
+    evidence_links: tuple[str, ...],
+    fixture_marked: bool,
+    rejection_reasons: tuple[str, ...],
+) -> dict[str, Any]:
+    links = [item.strip() for item in evidence_links if item and item.strip()]
+    payload: dict[str, Any] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "source_run_id": source_run_id.strip(),
+        "source_stage": source_stage.strip().lower(),
+        "non_authorizing": True,
+        "fixture_marked": fixture_marked,
+        "universe": [],
+        "ranking": [],
+        "selected_future": {"truth_status": "NOT_PERSISTED"},
+        "market_snapshot": {
+            "truth_status": "NOT_PERSISTED",
+            "source_kind": "NOT_PERSISTED",
+            "snapshot_id": None,
+            "exchange": None,
+            "captured_at": None,
+        },
+        "evidence": {
+            "producer_contract": PRODUCER_CONTRACT,
+            "upstream_adapter": UPSTREAM_ADAPTER_CONTRACT,
+            "storage_target": STORAGE_RELATIVE_PATH,
+            "manifest_verify_rc_expected": 0,
+            "links": links,
+            "rejection_reasons": list(rejection_reasons),
+        },
+        "missing_truth": {
+            "universe": MISSING_TRUTH_UNIVERSE,
+            "ranking": MISSING_TRUTH_RANKING,
+            "selected_future": MISSING_TRUTH_SELECTED,
+            "future_detail": MISSING_TRUTH_FUTURE_DETAIL,
+            "orders_fills_pnl": MISSING_TRUTH_PNL,
+        },
+    }
+    validate_universe_selection_payload(payload)
+    return payload
+
+
+def _sort_key(packet: FuturesProducerPacket) -> tuple[int, str]:
+    rank = packet.ranking.rank
+    sort_rank = rank if isinstance(rank, int) and rank > 0 else 10_000
+    return (sort_rank, packet.candidate.candidate_id)
+
+
+def _universe_row(packet: FuturesProducerPacket) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "row_id": packet.candidate.candidate_id,
+        "symbol": packet.candidate.symbol,
+        "rank": packet.ranking.rank if packet.ranking.rank is not None else 0,
+        "exchange": packet.candidate.exchange,
+        "notes": "futures_upstream_adapter_v1",
+    }
+    return row
+
+
+def _ranking_row(packet: FuturesProducerPacket) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "row_id": f"r-{packet.candidate.candidate_id}",
+        "symbol": packet.candidate.symbol,
+        "rank": packet.ranking.rank if packet.ranking.rank is not None else 0,
+        "notes": "futures_upstream_adapter_v1",
+    }
+    if packet.ranking.score is not None:
+        row["display_score"] = packet.ranking.score
+    return row
+
+
+def _selected_future_row(packet: FuturesProducerPacket, *, selection_reason: str) -> dict[str, Any]:
+    return {
+        "row_id": f"s-{packet.candidate.candidate_id}",
+        "symbol": packet.candidate.symbol,
+        "rank": packet.ranking.rank if packet.ranking.rank is not None else 1,
+        "truth_status": "PERSISTED",
+        "selection_reason": selection_reason,
+        "notes": "futures_upstream_adapter_v1 — non-authorizing observability truth",
+    }
+
+
+def _market_snapshot_from_packet(packet: FuturesProducerPacket) -> dict[str, Any]:
+    provenance = packet.provenance
+    return {
+        "truth_status": "PERSISTED",
+        "source_kind": "futures_upstream_adapter_v1",
+        "snapshot_id": provenance.dataset_id,
+        "exchange": packet.candidate.exchange,
+        "captured_at": None,
+    }
+
+
+def map_futures_packets_to_universe_selection_readmodel(
+    upstream_input: FuturesUniverseUpstreamInputV1,
+) -> FuturesUniverseUpstreamAdapterResultV1:
+    """Map governed FuturesProducerPacket inputs to a contract-valid readmodel payload."""
+    rejection_reasons: list[str] = []
+    exclusions: list[EligibilityExclusionV1] = []
+
+    if is_forbidden_upstream_source(
+        upstream_source_kind=upstream_input.upstream_source_kind,
+        upstream_producer_id=upstream_input.upstream_producer_id,
+    ):
+        rejection_reasons.append(REASON_MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH)
+        payload = _missing_truth_payload(
+            source_run_id=upstream_input.source_run_id,
+            source_stage=upstream_input.source_stage,
+            generated_at=upstream_input.generated_at,
+            evidence_links=upstream_input.evidence_links,
+            fixture_marked=upstream_input.fixture_marked,
+            rejection_reasons=tuple(rejection_reasons),
+        )
+        return FuturesUniverseUpstreamAdapterResultV1(
+            status="missing_truth",
+            payload=payload,
+            rejection_reasons=tuple(rejection_reasons),
+            eligibility_exclusions=(),
+        )
+
+    if not upstream_input.packets:
+        rejection_reasons.append(REASON_UPSTREAM_SOURCE_EMPTY)
+        payload = _missing_truth_payload(
+            source_run_id=upstream_input.source_run_id,
+            source_stage=upstream_input.source_stage,
+            generated_at=upstream_input.generated_at,
+            evidence_links=upstream_input.evidence_links,
+            fixture_marked=upstream_input.fixture_marked,
+            rejection_reasons=tuple(rejection_reasons),
+        )
+        return FuturesUniverseUpstreamAdapterResultV1(
+            status="missing_truth",
+            payload=payload,
+            rejection_reasons=tuple(rejection_reasons),
+            eligibility_exclusions=(),
+        )
+
+    eligible_packets: list[FuturesProducerPacket] = []
+    for packet in upstream_input.packets:
+        eligible, reason = evaluate_packet_eligibility(packet)
+        if eligible:
+            eligible_packets.append(packet)
+        elif reason is not None:
+            exclusions.append(
+                EligibilityExclusionV1(
+                    candidate_id=packet.candidate.candidate_id,
+                    symbol=packet.candidate.symbol,
+                    reason=reason,
+                )
+            )
+
+    eligible_packets.sort(key=_sort_key)
+    universe_packets = eligible_packets[:MAX_UNIVERSE_ROWS]
+    ranking_packets = eligible_packets[:MAX_RANKING_ROWS]
+
+    universe_rows = [_universe_row(packet) for packet in universe_packets]
+    ranking_rows = [_ranking_row(packet) for packet in ranking_packets]
+
+    eligible_by_id = {packet.candidate.candidate_id: packet for packet in eligible_packets}
+    packets_by_id = {packet.candidate.candidate_id: packet for packet in upstream_input.packets}
+    selected_packet: FuturesProducerPacket | None = None
+    selection_reason = "upstream_top_ranked_eligible"
+
+    if upstream_input.selected_candidate_id:
+        selected_id = upstream_input.selected_candidate_id.strip()
+        raw_packet = packets_by_id.get(selected_id)
+        if raw_packet is None:
+            rejection_reasons.append(REASON_SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE)
+        else:
+            eligible, reason = evaluate_packet_eligibility(raw_packet)
+            if not eligible:
+                if _is_spot_symbol(raw_packet.candidate.symbol) or (
+                    raw_packet.candidate.market_type not in ELIGIBLE_MARKET_TYPES
+                ):
+                    rejection_reasons.append(REASON_SPOT_OR_NON_DERIVATIVE_SELECTED_FUTURE_REJECTED)
+                elif reason is not None:
+                    rejection_reasons.append(reason)
+                else:
+                    rejection_reasons.append(REASON_SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE)
+            elif selected_id not in {packet.candidate.candidate_id for packet in universe_packets}:
+                rejection_reasons.append(REASON_SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE)
+            else:
+                selected_packet = raw_packet
+                selection_reason = "upstream_explicit_selection"
+    elif ranking_packets:
+        selected_packet = ranking_packets[0]
+        selection_reason = "upstream_top_ranked_eligible"
+
+    has_universe = bool(universe_rows)
+    has_ranking = bool(ranking_rows)
+    has_selected = selected_packet is not None
+
+    if not has_universe and not has_ranking:
+        rejection_reasons.append(REASON_UPSTREAM_SOURCE_EMPTY)
+        payload = _missing_truth_payload(
+            source_run_id=upstream_input.source_run_id,
+            source_stage=upstream_input.source_stage,
+            generated_at=upstream_input.generated_at,
+            evidence_links=upstream_input.evidence_links,
+            fixture_marked=upstream_input.fixture_marked,
+            rejection_reasons=tuple(rejection_reasons),
+        )
+        return FuturesUniverseUpstreamAdapterResultV1(
+            status="missing_truth",
+            payload=payload,
+            rejection_reasons=tuple(rejection_reasons),
+            eligibility_exclusions=tuple(exclusions),
+        )
+
+    selected_block: dict[str, Any]
+    if has_selected and selected_packet is not None:
+        selected_block = _selected_future_row(selected_packet, selection_reason=selection_reason)
+    else:
+        selected_block = {"truth_status": "NOT_PERSISTED"}
+
+    snapshot_packet = selected_packet or (universe_packets[0] if universe_packets else None)
+    if snapshot_packet is not None and has_selected:
+        market_snapshot = _market_snapshot_from_packet(snapshot_packet)
+        future_detail_status = "AVAILABLE"
+    else:
+        market_snapshot = {
+            "truth_status": "NOT_PERSISTED",
+            "source_kind": "NOT_PERSISTED",
+            "snapshot_id": None,
+            "exchange": None,
+            "captured_at": None,
+        }
+        future_detail_status = MISSING_TRUTH_FUTURE_DETAIL
+
+    links = [item.strip() for item in upstream_input.evidence_links if item and item.strip()]
+    payload: dict[str, Any] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": upstream_input.generated_at,
+        "source_run_id": upstream_input.source_run_id.strip(),
+        "source_stage": upstream_input.source_stage.strip().lower(),
+        "non_authorizing": True,
+        "fixture_marked": upstream_input.fixture_marked,
+        "universe": universe_rows,
+        "ranking": ranking_rows,
+        "selected_future": selected_block,
+        "market_snapshot": market_snapshot,
+        "evidence": {
+            "producer_contract": PRODUCER_CONTRACT,
+            "upstream_adapter": UPSTREAM_ADAPTER_CONTRACT,
+            "storage_target": STORAGE_RELATIVE_PATH,
+            "manifest_verify_rc_expected": 0,
+            "links": links,
+            "rejection_reasons": list(rejection_reasons),
+            "eligibility_exclusions": [
+                {"candidate_id": item.candidate_id, "symbol": item.symbol, "reason": item.reason}
+                for item in exclusions
+            ],
+        },
+        "missing_truth": {
+            "universe": "PERSISTED" if has_universe else MISSING_TRUTH_UNIVERSE,
+            "ranking": "PERSISTED" if has_ranking else MISSING_TRUTH_RANKING,
+            "selected_future": "PERSISTED" if has_selected else MISSING_TRUTH_SELECTED,
+            "future_detail": future_detail_status,
+            "orders_fills_pnl": MISSING_TRUTH_PNL,
+        },
+    }
+    validate_universe_selection_payload(payload)
+
+    status = "ok" if has_universe and has_ranking and has_selected else "partial"
+    return FuturesUniverseUpstreamAdapterResultV1(
+        status=status,
+        payload=payload,
+        rejection_reasons=tuple(rejection_reasons),
+        eligibility_exclusions=tuple(exclusions),
+    )
+
+
+def map_futures_packet_sequence(
+    *,
+    source_run_id: str,
+    source_stage: str,
+    generated_at: str,
+    packets: Sequence[FuturesProducerPacket],
+    upstream_source_kind: str | None = None,
+    upstream_producer_id: str | None = None,
+    selected_candidate_id: str | None = None,
+    evidence_links: tuple[str, ...] = (),
+    fixture_marked: bool = False,
+) -> FuturesUniverseUpstreamAdapterResultV1:
+    """Convenience wrapper for tuple/sequence packet inputs."""
+    return map_futures_packets_to_universe_selection_readmodel(
+        FuturesUniverseUpstreamInputV1(
+            source_run_id=source_run_id,
+            source_stage=source_stage,
+            generated_at=generated_at,
+            packets=tuple(packets),
+            upstream_source_kind=upstream_source_kind,
+            upstream_producer_id=upstream_producer_id,
+            selected_candidate_id=selected_candidate_id,
+            evidence_links=evidence_links,
+            fixture_marked=fixture_marked,
+        )
+    )

--- a/tests/webui/test_futures_universe_upstream_adapter_v1.py
+++ b/tests/webui/test_futures_universe_upstream_adapter_v1.py
@@ -1,0 +1,458 @@
+"""U1 — futures_universe_upstream_adapter_v1 contract/static tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
+    MAX_RANKING_ROWS,
+    MISSING_TRUTH_RANKING,
+    MISSING_TRUTH_SELECTED,
+    MISSING_TRUTH_UNIVERSE,
+    validate_universe_selection_payload,
+)
+from src.webui.workflow_dashboard_readmodel_v1.futures_universe_upstream_adapter_v1 import (
+    REASON_INELIGIBLE_INSTRUMENT_METADATA_INCOMPLETE,
+    REASON_INELIGIBLE_MARKET_TYPE,
+    REASON_INELIGIBLE_SPOT_SYMBOL,
+    REASON_MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH,
+    REASON_SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE,
+    REASON_SPOT_OR_NON_DERIVATIVE_SELECTED_FUTURE_REJECTED,
+    REASON_UPSTREAM_SOURCE_EMPTY,
+    FuturesUniverseUpstreamInputV1,
+    map_futures_packet_sequence,
+    map_futures_packets_to_universe_selection_readmodel,
+)
+from trading.master_v2.double_play_futures_input import (
+    FuturesFreshnessState,
+    FuturesMarketType,
+)
+from trading.master_v2.double_play_futures_input_producer import (
+    FuturesProducerCandidate,
+    FuturesProducerDerivatives,
+    FuturesProducerInstrumentMetadata,
+    FuturesProducerLiquidity,
+    FuturesProducerMarketDataProvenance,
+    FuturesProducerOpportunity,
+    FuturesProducerPacket,
+    FuturesProducerRanking,
+    FuturesProducerVolatility,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+ADAPTER_MODULE = (
+    PROJECT_ROOT
+    / "src"
+    / "webui"
+    / "workflow_dashboard_readmodel_v1"
+    / "futures_universe_upstream_adapter_v1.py"
+)
+
+GENERATED_AT = "2026-06-08T16:30:00Z"
+SOURCE_RUN_ID = "fixture_upstream_u1_v1"
+SOURCE_STAGE = "paper"
+
+
+def _candidate(**overrides: object) -> FuturesProducerCandidate:
+    base: dict = {
+        "candidate_id": "c-eth",
+        "instrument_id": "inst-eth-perp",
+        "symbol": "ETHUSDT",
+        "market_type": FuturesMarketType.PERPETUAL,
+        "exchange": "binance_futures",
+        "base_currency": "ETH",
+        "quote_currency": "USDT",
+        "live_authorization": False,
+    }
+    base.update(overrides)
+    return FuturesProducerCandidate(**base)
+
+
+def _ranking(**overrides: object) -> FuturesProducerRanking:
+    base: dict = {
+        "source_universe_size": 50,
+        "selected_top_n": 20,
+        "rank": 1,
+        "score": 0.91,
+        "score_components_complete": True,
+        "is_top_n_member": True,
+    }
+    base.update(overrides)
+    return FuturesProducerRanking(**base)
+
+
+def _instrument(**overrides: object) -> FuturesProducerInstrumentMetadata:
+    base: dict = {
+        "complete": True,
+        "contract_size_known": True,
+        "tick_size_known": True,
+        "step_size_known": True,
+        "min_qty_known": True,
+        "min_notional_known": True,
+        "margin_asset_known": True,
+        "settlement_asset_known": True,
+        "leverage_bounds_known": True,
+        "missing_fields": (),
+    }
+    base.update(overrides)
+    return FuturesProducerInstrumentMetadata(**base)
+
+
+def _provenance(**overrides: object) -> FuturesProducerMarketDataProvenance:
+    base: dict = {
+        "complete": True,
+        "freshness_state": FuturesFreshnessState.FRESH,
+        "dataset_id": "ds-u1-fixture",
+        "source": "fixture",
+        "mark_available": True,
+        "index_available": True,
+        "last_available": True,
+        "ohlcv_available": True,
+        "funding_available": True,
+        "open_interest_available": True,
+        "missing_fields": (),
+    }
+    base.update(overrides)
+    return FuturesProducerMarketDataProvenance(**base)
+
+
+def _volatility() -> FuturesProducerVolatility:
+    return FuturesProducerVolatility(
+        realized_volatility=0.4,
+        atr_or_rolling_range=100.0,
+        volatility_regime="medium",
+        dynamic_scope_usable=True,
+    )
+
+
+def _liquidity() -> FuturesProducerLiquidity:
+    return FuturesProducerLiquidity(
+        spread_bps=1.2,
+        average_spread_bps=1.5,
+        volume=1_000_000.0,
+        quote_volume=40_000_000.0,
+        liquidity_regime="deep",
+        spread_quality="tight",
+    )
+
+
+def _derivatives() -> FuturesProducerDerivatives:
+    return FuturesProducerDerivatives(
+        funding_available=True,
+        funding_rate=0.0001,
+        funding_regime="neutral",
+        open_interest_available=True,
+        open_interest=1e9,
+        open_interest_regime="high",
+    )
+
+
+def _opportunity() -> FuturesProducerOpportunity:
+    return FuturesProducerOpportunity(
+        opportunity_score=0.8,
+        inactivity_score=0.1,
+        movement_above_fee_slippage_breakeven=True,
+        chop_risk="low",
+        candidate_is_inactive=False,
+    )
+
+
+def _packet(**overrides: object) -> FuturesProducerPacket:
+    parts: dict = {
+        "candidate": _candidate(),
+        "ranking": _ranking(),
+        "instrument": _instrument(),
+        "provenance": _provenance(),
+        "volatility": _volatility(),
+        "liquidity": _liquidity(),
+        "derivatives": _derivatives(),
+        "opportunity": _opportunity(),
+    }
+    parts.update(overrides)
+    return FuturesProducerPacket(**parts)
+
+
+def _input(
+    packets: tuple[FuturesProducerPacket, ...],
+    **overrides: object,
+) -> FuturesUniverseUpstreamInputV1:
+    base: dict = {
+        "source_run_id": SOURCE_RUN_ID,
+        "source_stage": SOURCE_STAGE,
+        "generated_at": GENERATED_AT,
+        "packets": packets,
+        "fixture_marked": True,
+    }
+    base.update(overrides)
+    return FuturesUniverseUpstreamInputV1(**base)
+
+
+def test_tc1_accepts_futures_only_packet() -> None:
+    packets = (
+        _packet(
+            candidate=_candidate(candidate_id="c-eth", symbol="ETHUSDT"),
+            ranking=_ranking(rank=1, score=0.91),
+        ),
+        _packet(
+            candidate=_candidate(
+                candidate_id="c-sol",
+                instrument_id="inst-sol-perp",
+                symbol="SOLUSDT",
+                base_currency="SOL",
+            ),
+            ranking=_ranking(rank=2, score=0.87),
+        ),
+        _packet(
+            candidate=_candidate(
+                candidate_id="c-avax",
+                instrument_id="inst-avax-perp",
+                symbol="AVAXUSDT",
+                base_currency="AVAX",
+            ),
+            ranking=_ranking(rank=3, score=0.82),
+        ),
+    )
+    result = map_futures_packets_to_universe_selection_readmodel(_input(packets))
+
+    assert result.status == "ok"
+    assert not result.rejection_reasons
+    contract = validate_universe_selection_payload(result.payload)
+    assert len(contract.universe) == 3
+    assert len(contract.ranking) == 3
+    assert contract.selected_future is not None
+    assert contract.selected_future.symbol == "ETHUSDT"
+    assert contract.missing_truth.universe == "PERSISTED"
+    assert contract.missing_truth.ranking == "PERSISTED"
+    assert contract.missing_truth.selected_future == "PERSISTED"
+    assert result.payload["non_authorizing"] is True
+
+
+def test_tc2_rejects_spot_selected_truth() -> None:
+    spot_packet = _packet(
+        candidate=_candidate(
+            candidate_id="c-btc-spot",
+            instrument_id="inst-btc-spot",
+            symbol="BTC/USD",
+            market_type=FuturesMarketType.UNKNOWN,
+            exchange="kraken",
+            base_currency="BTC",
+            quote_currency="USD",
+        ),
+        instrument=_instrument(complete=False),
+        ranking=_ranking(rank=1, score=0.99),
+    )
+    futures_packet = _packet(
+        candidate=_candidate(candidate_id="c-eth", symbol="ETHUSDT"),
+        ranking=_ranking(rank=2, score=0.9),
+    )
+    result = map_futures_packets_to_universe_selection_readmodel(
+        _input(
+            (spot_packet, futures_packet),
+            selected_candidate_id="c-btc-spot",
+        )
+    )
+
+    assert result.payload["selected_future"]["truth_status"] == "NOT_PERSISTED"
+    assert REASON_SPOT_OR_NON_DERIVATIVE_SELECTED_FUTURE_REJECTED in result.rejection_reasons
+    assert result.payload["missing_truth"]["selected_future"] == MISSING_TRUTH_SELECTED
+    assert len(result.payload["universe"]) >= 1
+    assert all(row["symbol"] != "BTC/USD" for row in result.payload["universe"])
+
+
+def test_tc2_rejects_btc_eur_spot_selected() -> None:
+    spot_packet = _packet(
+        candidate=_candidate(
+            candidate_id="c-btc-eur",
+            symbol="BTC/EUR",
+            market_type=FuturesMarketType.UNKNOWN,
+            exchange="kraken",
+            quote_currency="EUR",
+        ),
+        instrument=_instrument(complete=False),
+    )
+    result = map_futures_packets_to_universe_selection_readmodel(
+        _input((spot_packet,), selected_candidate_id="c-btc-eur")
+    )
+
+    assert result.status == "missing_truth"
+    assert REASON_UPSTREAM_SOURCE_EMPTY in result.rejection_reasons or (
+        REASON_SPOT_OR_NON_DERIVATIVE_SELECTED_FUTURE_REJECTED in result.rejection_reasons
+    )
+    assert result.payload["selected_future"]["truth_status"] == "NOT_PERSISTED"
+
+
+def test_tc3_rejects_market_ranking_funnel_as_truth() -> None:
+    result = map_futures_packet_sequence(
+        source_run_id=SOURCE_RUN_ID,
+        source_stage=SOURCE_STAGE,
+        generated_at=GENERATED_AT,
+        packets=(_packet(),),
+        upstream_source_kind="market_ranking_funnel_readmodel.v0",
+        fixture_marked=True,
+    )
+
+    assert result.status == "missing_truth"
+    assert REASON_MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH in result.rejection_reasons
+    assert result.payload["missing_truth"]["universe"] == MISSING_TRUTH_UNIVERSE
+    assert result.payload["universe"] == []
+
+
+def test_tc3_rejects_market_surface_producer_marker() -> None:
+    result = map_futures_packet_sequence(
+        source_run_id=SOURCE_RUN_ID,
+        source_stage=SOURCE_STAGE,
+        generated_at=GENERATED_AT,
+        packets=(_packet(),),
+        upstream_producer_id="market_surface",
+        fixture_marked=True,
+    )
+
+    assert result.status == "missing_truth"
+    assert REASON_MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH in result.rejection_reasons
+
+
+def test_tc4_missing_upstream_data_returns_missing_truth() -> None:
+    result = map_futures_packets_to_universe_selection_readmodel(_input(()))
+
+    assert result.status == "missing_truth"
+    assert REASON_UPSTREAM_SOURCE_EMPTY in result.rejection_reasons
+    assert result.payload["universe"] == []
+    assert result.payload["ranking"] == []
+    assert result.payload["selected_future"] == {"truth_status": "NOT_PERSISTED"}
+    validate_universe_selection_payload(result.payload)
+
+
+def test_tc5_ranking_cap_and_eligibility() -> None:
+    packets: list[FuturesProducerPacket] = []
+    for index in range(1, 23):
+        packets.append(
+            _packet(
+                candidate=_candidate(
+                    candidate_id=f"c-fut-{index:02d}",
+                    instrument_id=f"inst-fut-{index:02d}",
+                    symbol=f"FUT{index:02d}USDT",
+                    base_currency=f"FUT{index:02d}",
+                ),
+                ranking=_ranking(rank=index, score=1.0 - index * 0.01),
+            )
+        )
+    packets.append(
+        _packet(
+            candidate=_candidate(
+                candidate_id="c-spot-btc",
+                symbol="BTC/EUR",
+                market_type=FuturesMarketType.UNKNOWN,
+                exchange="kraken",
+                quote_currency="EUR",
+            ),
+            instrument=_instrument(complete=False),
+            ranking=_ranking(rank=0, score=9.99),
+        )
+    )
+    packets.append(
+        _packet(
+            candidate=_candidate(
+                candidate_id="c-incomplete",
+                symbol="DOGEUSDT",
+                instrument_id="inst-doge",
+                base_currency="DOGE",
+            ),
+            instrument=_instrument(complete=False),
+            ranking=_ranking(rank=99, score=0.01),
+        )
+    )
+
+    result = map_futures_packets_to_universe_selection_readmodel(_input(tuple(packets)))
+
+    assert len(result.payload["ranking"]) == MAX_RANKING_ROWS
+    ranking_symbols = {row["symbol"] for row in result.payload["ranking"]}
+    assert "BTC/EUR" not in ranking_symbols
+    assert "DOGEUSDT" not in ranking_symbols
+    assert any(
+        item.reason in (REASON_INELIGIBLE_SPOT_SYMBOL, REASON_INELIGIBLE_MARKET_TYPE)
+        for item in result.eligibility_exclusions
+        if item.symbol == "BTC/EUR"
+    )
+    assert any(
+        item.reason == REASON_INELIGIBLE_INSTRUMENT_METADATA_INCOMPLETE
+        for item in result.eligibility_exclusions
+        if item.candidate_id == "c-incomplete"
+    )
+
+
+def test_tc6_selected_not_in_universe_rejected() -> None:
+    eligible = _packet(
+        candidate=_candidate(candidate_id="c-eth", symbol="ETHUSDT"),
+        ranking=_ranking(rank=1),
+    )
+    result = map_futures_packets_to_universe_selection_readmodel(
+        _input((eligible,), selected_candidate_id="c-missing")
+    )
+
+    assert result.payload["selected_future"]["truth_status"] == "NOT_PERSISTED"
+    assert REASON_SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE in result.rejection_reasons
+    assert result.payload["missing_truth"]["selected_future"] == MISSING_TRUTH_SELECTED
+
+
+def test_tc7_contract_compatibility() -> None:
+    packets = (
+        _packet(
+            candidate=_candidate(candidate_id="c-sol", symbol="SOLUSDT", base_currency="SOL"),
+            ranking=_ranking(rank=1, score=0.95),
+        ),
+        _packet(
+            candidate=_candidate(
+                candidate_id="c-eth",
+                symbol="ETHUSDT",
+            ),
+            ranking=_ranking(rank=2, score=0.9),
+        ),
+    )
+    result = map_futures_packets_to_universe_selection_readmodel(_input(packets))
+    contract = validate_universe_selection_payload(result.payload)
+
+    assert contract.schema_name == "universe_selection_readmodel.v1"
+    assert contract.non_authorizing is True
+    assert contract.selected_future is not None
+    assert contract.selected_future.symbol == "SOLUSDT"
+
+
+def test_adapter_module_has_no_forbidden_imports() -> None:
+    tree = ast.parse(ADAPTER_MODULE.read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+    forbidden_fragments = (
+        "market_ranking_funnel",
+        "market_surface",
+        "scan_markets",
+        "run_market_scan",
+        "src.execution",
+        "src.risk",
+        "src.governance",
+    )
+    for fragment in forbidden_fragments:
+        assert not any(fragment in name for name in imported), fragment
+
+
+def test_spot_symbol_excluded_from_universe_even_with_perpetual_market_type() -> None:
+    """BTC/USD with PERPETUAL market_type still rejected via spot symbol guard."""
+    packet = _packet(
+        candidate=_candidate(
+            candidate_id="c-btc-usd",
+            symbol="BTC/USD",
+            market_type=FuturesMarketType.PERPETUAL,
+        ),
+    )
+    result = map_futures_packets_to_universe_selection_readmodel(_input((packet,)))
+
+    assert result.status == "missing_truth"
+    assert any(
+        item.reason == REASON_INELIGIBLE_SPOT_SYMBOL for item in result.eligibility_exclusions
+    )


### PR DESCRIPTION
## Summary

- Adds pure U1 adapter `futures_universe_upstream_adapter_v1` mapping `FuturesProducerPacket` inputs to `universe_selection_readmodel.v1` payloads.
- Adds static contract tests (TC1–TC7) covering futures eligibility, spot rejection, forbidden upstream sources, Missing Truth, Top-20 cap, and schema compatibility.
- No production wiring, hooks, dashboard, or runtime changes.

## Scope

**Changed files (2 only):**
- `src/webui/workflow_dashboard_readmodel_v1/futures_universe_upstream_adapter_v1.py`
- `tests/webui/test_futures_universe_upstream_adapter_v1.py`

**Not changed:** producer hooks, dashboard reader/builder, templates, workflow YAML, `src/execution/**`, `src/risk/**`, `src/governance/**`, bounded observation adapters.

## Futures-first semantics

- Eligible instruments: `futures`, `perpetual`, `swap` with `instrument.complete == true`.
- Spot symbols (`BTC/USD`, `BTC/EUR`, `ETH/USD`, slash-pairs) rejected from universe/ranking/selected truth.
- Empty or invalid upstream → Mode-B Missing Truth (`NOT_PERSISTED`), no dummy fill.
- Top-20 ranking cap enforced; selected future only when eligible and present in universe.

## Forbidden sources rejected

- `market_ranking_funnel_readmodel.v0`, `market_surface`, and dummy source kinds are rejected as Observability truth.
- Adapter has no imports from market surface, ranking funnel, scanners, execution, risk, or governance.

## Adapter side-effect-free

- Pure in-memory mapping functions only: no file I/O, network, exchange calls, archive writes, or runtime start.

## Contract compatibility

- Every adapter exit path validates via `validate_universe_selection_payload()`.
- Reuses existing `universe_selection_readmodel.v1` schema — no new SSOT.

## Real futures data gap

- No operational upstream producer yet; adapter prepares governed mapping for future U2/U3 integration.
- `Real futures data source available now: false` (by design for U1).

## Safety boundaries

- Non-authorizing observability mapping only; no order/live/scheduler authority.
- No dashboard fake-data; Missing Truth is valid operator-visible state.

## Tests

```bash
uv run pytest \
  tests/webui/test_futures_universe_upstream_adapter_v1.py \
  tests/webui/test_universe_selection_producer_hook_reader_chain_v1.py \
  tests/webui/test_universe_selection_reader_v1.py -q --tb=short
```

Result: **24 passed**

## Evidence bundles

- Implementation: `.../implementation/futures_universe_top20_selection_upstream_contract_u1_bounded_write_tests_v1_20260608T160600Z/`
- Review: `.../review/futures_universe_top20_selection_upstream_contract_u1_post_implementation_review_no_run_v1_20260608T160717Z/`

## No-Live statement

No Live, Testnet, Paper, Shadow, or scheduler runtime start. No orders, secrets, or execution/risk/governance changes. **Auto-merge not requested.**


Made with [Cursor](https://cursor.com)