### PR TITLE
Add futures producer packet fixture source

### DIFF
--- a/src/webui/workflow_dashboard_readmodel_v1/futures_producer_packet_fixture_source_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/futures_producer_packet_fixture_source_v1.py
@@ -1,0 +1,369 @@
+"""U2a — offline fixture loader for FuturesProducerPacket bundles (read-only, no I/O beyond path read)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from trading.master_v2.double_play_futures_input import FuturesFreshnessState, FuturesMarketType
+from trading.master_v2.double_play_futures_input_producer import (
+    FuturesProducerCandidate,
+    FuturesProducerDerivatives,
+    FuturesProducerInstrumentMetadata,
+    FuturesProducerLiquidity,
+    FuturesProducerMarketDataProvenance,
+    FuturesProducerOpportunity,
+    FuturesProducerPacket,
+    FuturesProducerRanking,
+    FuturesProducerVolatility,
+    producer_packet_has_runtime_handles,
+)
+
+from .futures_universe_upstream_adapter_v1 import (
+    FORBIDDEN_UPSTREAM_SOURCE_MARKERS,
+    FuturesUniverseUpstreamInputV1,
+    is_forbidden_upstream_source,
+)
+
+FIXTURE_SCHEMA_NAME = "futures_producer_packet_fixture.v1"
+FIXTURE_SCHEMA_VERSION = 1
+FIXTURE_SOURCE_KIND = "fixture"
+FIXTURE_PRODUCER_ID = "futures_producer_packet_fixture_source_v1"
+FIXTURE_SOURCE_CONTRACT = "futures_producer_packet_fixture_source.v1"
+
+REASON_FIXTURE_NOT_MARKED = "FIXTURE_NOT_MARKED"
+REASON_OBSERVABILITY_TRUTH_CLAIMED = "OBSERVABILITY_TRUTH_CLAIMED"
+REASON_NON_AUTHORIZING_REQUIRED = "NON_AUTHORIZING_REQUIRED"
+REASON_FORBIDDEN_UPSTREAM_SOURCE = "FORBIDDEN_UPSTREAM_SOURCE"
+REASON_FIXTURE_SCHEMA_INVALID = "FIXTURE_SCHEMA_INVALID"
+REASON_FIXTURE_PACKET_RUNTIME_HANDLE = "FIXTURE_PACKET_RUNTIME_HANDLE"
+REASON_FIXTURE_MISSING_REQUIRED_FIELD = "FIXTURE_MISSING_REQUIRED_FIELD"
+
+
+class FuturesProducerPacketFixtureSourceError(ValueError):
+    """Raised when a fixture bundle violates U2a safety or schema rules."""
+
+
+@dataclass(frozen=True)
+class FuturesProducerPacketFixtureBundleV1:
+    """Loaded fixture bundle — never observability truth; tests and explicit callers only."""
+
+    source_kind: str
+    producer_id: str
+    generated_at: str
+    source_run_id: str
+    source_stage: str
+    fixture_only: bool
+    observability_truth_allowed: bool
+    non_authorizing: bool
+    universe: dict[str, Any]
+    ranking: dict[str, Any]
+    selected_future: dict[str, Any]
+    packets: tuple[FuturesProducerPacket, ...]
+    selected_candidate_id: str | None = None
+    fixture_path: str | None = None
+
+
+def fixture_root_under(project_root: Path) -> Path:
+    return (
+        project_root
+        / "tests"
+        / "fixtures"
+        / "workflow_dashboard_readmodel_v1"
+        / "futures_producer_packet_v1"
+    )
+
+
+def assert_fixture_not_observability_truth(bundle: FuturesProducerPacketFixtureBundleV1) -> None:
+    """Fail closed when a bundle claims production observability truth."""
+    if bundle.observability_truth_allowed:
+        msg = f"{REASON_OBSERVABILITY_TRUTH_CLAIMED}: fixture must not claim observability truth"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    if not bundle.fixture_only:
+        msg = f"{REASON_FIXTURE_NOT_MARKED}: fixture_only must be true"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    if not bundle.non_authorizing:
+        msg = f"{REASON_NON_AUTHORIZING_REQUIRED}: non_authorizing must be true"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+
+
+def _require_mapping(data: dict[str, Any], key: str) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict):
+        msg = f"{REASON_FIXTURE_MISSING_REQUIRED_FIELD}: missing or invalid '{key}' object"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    return value
+
+
+def _require_bool(data: dict[str, Any], key: str) -> bool:
+    if key not in data:
+        msg = f"{REASON_FIXTURE_MISSING_REQUIRED_FIELD}: missing '{key}'"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    value = data[key]
+    if not isinstance(value, bool):
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: '{key}' must be boolean"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    return value
+
+
+def _require_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        msg = f"{REASON_FIXTURE_MISSING_REQUIRED_FIELD}: missing or empty '{key}'"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    return value.strip()
+
+
+def _parse_market_type(raw: str) -> FuturesMarketType:
+    try:
+        return FuturesMarketType(raw.strip().lower())
+    except ValueError as exc:
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: invalid market_type '{raw}'"
+        raise FuturesProducerPacketFixtureSourceError(msg) from exc
+
+
+def _parse_freshness_state(raw: str) -> FuturesFreshnessState:
+    try:
+        return FuturesFreshnessState(raw.strip().lower())
+    except ValueError as exc:
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: invalid freshness_state '{raw}'"
+        raise FuturesProducerPacketFixtureSourceError(msg) from exc
+
+
+def _parse_tuple_str(value: Any, *, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: '{field}' must be a string array"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    return tuple(value)
+
+
+def _parse_candidate(raw: dict[str, Any]) -> FuturesProducerCandidate:
+    return FuturesProducerCandidate(
+        candidate_id=_require_str(raw, "candidate_id"),
+        instrument_id=_require_str(raw, "instrument_id"),
+        symbol=_require_str(raw, "symbol"),
+        market_type=_parse_market_type(_require_str(raw, "market_type")),
+        exchange=_require_str(raw, "exchange"),
+        base_currency=_require_str(raw, "base_currency"),
+        quote_currency=_require_str(raw, "quote_currency"),
+        live_authorization=bool(raw.get("live_authorization", False)),
+    )
+
+
+def _parse_ranking(raw: dict[str, Any]) -> FuturesProducerRanking:
+    return FuturesProducerRanking(
+        source_universe_size=raw.get("source_universe_size"),
+        selected_top_n=raw.get("selected_top_n"),
+        rank=raw.get("rank"),
+        score=raw.get("score"),
+        score_components_complete=bool(raw.get("score_components_complete", False)),
+        is_top_n_member=bool(raw.get("is_top_n_member", False)),
+    )
+
+
+def _parse_instrument(raw: dict[str, Any]) -> FuturesProducerInstrumentMetadata:
+    return FuturesProducerInstrumentMetadata(
+        complete=bool(raw.get("complete", False)),
+        contract_size_known=bool(raw.get("contract_size_known", False)),
+        tick_size_known=bool(raw.get("tick_size_known", False)),
+        step_size_known=bool(raw.get("step_size_known", False)),
+        min_qty_known=bool(raw.get("min_qty_known", False)),
+        min_notional_known=bool(raw.get("min_notional_known", False)),
+        margin_asset_known=bool(raw.get("margin_asset_known", False)),
+        settlement_asset_known=bool(raw.get("settlement_asset_known", False)),
+        leverage_bounds_known=bool(raw.get("leverage_bounds_known", False)),
+        missing_fields=_parse_tuple_str(raw.get("missing_fields"), field="missing_fields"),
+    )
+
+
+def _parse_provenance(raw: dict[str, Any]) -> FuturesProducerMarketDataProvenance:
+    return FuturesProducerMarketDataProvenance(
+        complete=bool(raw.get("complete", False)),
+        freshness_state=_parse_freshness_state(_require_str(raw, "freshness_state")),
+        dataset_id=raw.get("dataset_id"),
+        source=raw.get("source"),
+        mark_available=bool(raw.get("mark_available", False)),
+        index_available=bool(raw.get("index_available", False)),
+        last_available=bool(raw.get("last_available", False)),
+        ohlcv_available=bool(raw.get("ohlcv_available", False)),
+        funding_available=bool(raw.get("funding_available", False)),
+        open_interest_available=bool(raw.get("open_interest_available", False)),
+        missing_fields=_parse_tuple_str(raw.get("missing_fields"), field="missing_fields"),
+    )
+
+
+def _parse_volatility(raw: dict[str, Any]) -> FuturesProducerVolatility:
+    return FuturesProducerVolatility(
+        realized_volatility=raw.get("realized_volatility"),
+        atr_or_rolling_range=raw.get("atr_or_rolling_range"),
+        volatility_regime=raw.get("volatility_regime"),
+        dynamic_scope_usable=bool(raw.get("dynamic_scope_usable", False)),
+    )
+
+
+def _parse_liquidity(raw: dict[str, Any]) -> FuturesProducerLiquidity:
+    return FuturesProducerLiquidity(
+        spread_bps=raw.get("spread_bps"),
+        average_spread_bps=raw.get("average_spread_bps"),
+        volume=raw.get("volume"),
+        quote_volume=raw.get("quote_volume"),
+        liquidity_regime=raw.get("liquidity_regime"),
+        spread_quality=raw.get("spread_quality"),
+    )
+
+
+def _parse_derivatives(raw: dict[str, Any]) -> FuturesProducerDerivatives:
+    return FuturesProducerDerivatives(
+        funding_available=bool(raw.get("funding_available", False)),
+        funding_rate=raw.get("funding_rate"),
+        funding_regime=raw.get("funding_regime"),
+        open_interest_available=bool(raw.get("open_interest_available", False)),
+        open_interest=raw.get("open_interest"),
+        open_interest_regime=raw.get("open_interest_regime"),
+    )
+
+
+def _parse_opportunity(raw: dict[str, Any]) -> FuturesProducerOpportunity:
+    return FuturesProducerOpportunity(
+        opportunity_score=raw.get("opportunity_score"),
+        inactivity_score=raw.get("inactivity_score"),
+        movement_above_fee_slippage_breakeven=raw.get("movement_above_fee_slippage_breakeven"),
+        chop_risk=raw.get("chop_risk"),
+        candidate_is_inactive=bool(raw.get("candidate_is_inactive", False)),
+    )
+
+
+def _parse_packet(raw: dict[str, Any]) -> FuturesProducerPacket:
+    packet = FuturesProducerPacket(
+        candidate=_parse_candidate(_require_mapping(raw, "candidate")),
+        ranking=_parse_ranking(_require_mapping(raw, "ranking")),
+        instrument=_parse_instrument(_require_mapping(raw, "instrument")),
+        provenance=_parse_provenance(_require_mapping(raw, "provenance")),
+        volatility=_parse_volatility(_require_mapping(raw, "volatility")),
+        liquidity=_parse_liquidity(_require_mapping(raw, "liquidity")),
+        derivatives=_parse_derivatives(_require_mapping(raw, "derivatives")),
+        opportunity=_parse_opportunity(_require_mapping(raw, "opportunity")),
+        dashboard_label=raw.get("dashboard_label"),
+        ai_summary=raw.get("ai_summary"),
+    )
+    if producer_packet_has_runtime_handles(packet):
+        msg = f"{REASON_FIXTURE_PACKET_RUNTIME_HANDLE}: packet contains runtime handles"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    return packet
+
+
+def _validate_fixture_governance(data: dict[str, Any]) -> tuple[str, str]:
+    schema_name = _require_str(data, "schema_name")
+    if schema_name != FIXTURE_SCHEMA_NAME:
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: schema_name must be {FIXTURE_SCHEMA_NAME}"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    if data.get("schema_version") != FIXTURE_SCHEMA_VERSION:
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: schema_version must be {FIXTURE_SCHEMA_VERSION}"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+
+    fixture_only = _require_bool(data, "fixture_only")
+    observability_truth_allowed = _require_bool(data, "observability_truth_allowed")
+    non_authorizing = _require_bool(data, "non_authorizing")
+    if not fixture_only or observability_truth_allowed or not non_authorizing:
+        msg = (
+            f"{REASON_FIXTURE_NOT_MARKED}: requires fixture_only=true, "
+            "observability_truth_allowed=false, non_authorizing=true"
+        )
+        raise FuturesProducerPacketFixtureSourceError(msg)
+
+    source_kind = _require_str(data, "source_kind")
+    producer_id = _require_str(data, "producer_id")
+    if is_forbidden_upstream_source(
+        upstream_source_kind=source_kind,
+        upstream_producer_id=producer_id,
+    ):
+        msg = f"{REASON_FORBIDDEN_UPSTREAM_SOURCE}: source_kind/producer_id forbidden"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    if (
+        source_kind in FORBIDDEN_UPSTREAM_SOURCE_MARKERS
+        or producer_id in FORBIDDEN_UPSTREAM_SOURCE_MARKERS
+    ):
+        msg = f"{REASON_FORBIDDEN_UPSTREAM_SOURCE}: source markers forbidden"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    return source_kind, producer_id
+
+
+def load_futures_producer_packet_fixture(path: Path) -> FuturesProducerPacketFixtureBundleV1:
+    """Load and validate a fixture JSON file from an explicit path (read-only)."""
+    raw_text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: invalid JSON"
+        raise FuturesProducerPacketFixtureSourceError(msg) from exc
+    if not isinstance(data, dict):
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: root must be object"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+
+    source_kind, producer_id = _validate_fixture_governance(data)
+    universe = _require_mapping(data, "universe")
+    ranking = _require_mapping(data, "ranking")
+    selected_future = _require_mapping(data, "selected_future")
+
+    packets_raw = data.get("packets")
+    if packets_raw is None:
+        msg = f"{REASON_FIXTURE_MISSING_REQUIRED_FIELD}: missing 'packets'"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+    if not isinstance(packets_raw, list):
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: 'packets' must be array"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+
+    packets = tuple(_parse_packet(item) for item in packets_raw if isinstance(item, dict))
+    if len(packets) != len(packets_raw):
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: each packet must be an object"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+
+    selected_candidate_id = data.get("selected_candidate_id")
+    if selected_candidate_id is not None and (
+        not isinstance(selected_candidate_id, str) or not selected_candidate_id.strip()
+    ):
+        msg = f"{REASON_FIXTURE_SCHEMA_INVALID}: selected_candidate_id must be non-empty string"
+        raise FuturesProducerPacketFixtureSourceError(msg)
+
+    bundle = FuturesProducerPacketFixtureBundleV1(
+        source_kind=source_kind,
+        producer_id=producer_id,
+        generated_at=_require_str(data, "generated_at"),
+        source_run_id=_require_str(data, "source_run_id"),
+        source_stage=_require_str(data, "source_stage"),
+        fixture_only=True,
+        observability_truth_allowed=False,
+        non_authorizing=True,
+        universe=universe,
+        ranking=ranking,
+        selected_future=selected_future,
+        packets=packets,
+        selected_candidate_id=selected_candidate_id.strip()
+        if isinstance(selected_candidate_id, str)
+        else None,
+        fixture_path=str(path),
+    )
+    assert_fixture_not_observability_truth(bundle)
+    return bundle
+
+
+def bundle_to_upstream_input(
+    bundle: FuturesProducerPacketFixtureBundleV1,
+) -> FuturesUniverseUpstreamInputV1:
+    """Map a validated fixture bundle to U1 upstream input — always fixture_marked."""
+    assert_fixture_not_observability_truth(bundle)
+    return FuturesUniverseUpstreamInputV1(
+        source_run_id=bundle.source_run_id,
+        source_stage=bundle.source_stage,
+        generated_at=bundle.generated_at,
+        packets=bundle.packets,
+        upstream_source_kind=bundle.source_kind,
+        upstream_producer_id=bundle.producer_id,
+        selected_candidate_id=bundle.selected_candidate_id,
+        evidence_links=(),
+        fixture_marked=True,
+    )

--- a/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_forbidden_market_surface.json
+++ b/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_forbidden_market_surface.json
@@ -1,0 +1,103 @@
+{
+  "schema_name": "futures_producer_packet_fixture.v1",
+  "schema_version": 1,
+  "source_kind": "market_ranking_funnel_readmodel.v0",
+  "producer_id": "market_surface",
+  "generated_at": "2026-06-08T17:02:00Z",
+  "source_run_id": "fixture_u2a_forbidden_market_surface",
+  "source_stage": "paper",
+  "fixture_only": true,
+  "observability_truth_allowed": false,
+  "non_authorizing": true,
+  "selected_candidate_id": "c-eth",
+  "universe": {
+    "conceptual_size": 50,
+    "eligible_packet_count": 1,
+    "notes": "forbidden upstream source — loader must reject"
+  },
+  "ranking": {
+    "selected_top_n": 20,
+    "notes": "forbidden source marker test"
+  },
+  "selected_future": {
+    "candidate_id": "c-eth",
+    "symbol": "ETHUSDT",
+    "notes": "must never reach U1 as observability truth"
+  },
+  "packets": [
+    {
+      "candidate": {
+        "candidate_id": "c-eth",
+        "instrument_id": "inst-eth-perp",
+        "symbol": "ETHUSDT",
+        "market_type": "perpetual",
+        "exchange": "binance_futures",
+        "base_currency": "ETH",
+        "quote_currency": "USDT",
+        "live_authorization": false
+      },
+      "ranking": {
+        "source_universe_size": 50,
+        "selected_top_n": 20,
+        "rank": 1,
+        "score": 0.91,
+        "score_components_complete": true,
+        "is_top_n_member": true
+      },
+      "instrument": {
+        "complete": true,
+        "contract_size_known": true,
+        "tick_size_known": true,
+        "step_size_known": true,
+        "min_qty_known": true,
+        "min_notional_known": true,
+        "margin_asset_known": true,
+        "settlement_asset_known": true,
+        "leverage_bounds_known": true,
+        "missing_fields": []
+      },
+      "provenance": {
+        "complete": true,
+        "freshness_state": "fresh",
+        "dataset_id": "ds-u2a-forbidden",
+        "source": "fixture",
+        "mark_available": true,
+        "index_available": true,
+        "last_available": true,
+        "ohlcv_available": true,
+        "funding_available": true,
+        "open_interest_available": true,
+        "missing_fields": []
+      },
+      "volatility": {
+        "realized_volatility": 0.4,
+        "atr_or_rolling_range": 100.0,
+        "volatility_regime": "medium",
+        "dynamic_scope_usable": true
+      },
+      "liquidity": {
+        "spread_bps": 1.2,
+        "average_spread_bps": 1.5,
+        "volume": 1000000.0,
+        "quote_volume": 40000000.0,
+        "liquidity_regime": "deep",
+        "spread_quality": "tight"
+      },
+      "derivatives": {
+        "funding_available": true,
+        "funding_rate": 0.0001,
+        "funding_regime": "neutral",
+        "open_interest_available": true,
+        "open_interest": 1000000000.0,
+        "open_interest_regime": "high"
+      },
+      "opportunity": {
+        "opportunity_score": 0.8,
+        "inactivity_score": 0.1,
+        "movement_above_fee_slippage_breakeven": true,
+        "chop_risk": "low",
+        "candidate_is_inactive": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_missing_empty.json
+++ b/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_missing_empty.json
@@ -1,0 +1,28 @@
+{
+  "schema_name": "futures_producer_packet_fixture.v1",
+  "schema_version": 1,
+  "source_kind": "fixture",
+  "producer_id": "futures_producer_packet_fixture_source_v1",
+  "generated_at": "2026-06-08T17:04:00Z",
+  "source_run_id": "fixture_u2a_missing_empty",
+  "source_stage": "paper",
+  "fixture_only": true,
+  "observability_truth_allowed": false,
+  "non_authorizing": true,
+  "selected_candidate_id": null,
+  "universe": {
+    "conceptual_size": 50,
+    "eligible_packet_count": 0,
+    "notes": "empty upstream — Missing Truth expected, no dummy rows"
+  },
+  "ranking": {
+    "selected_top_n": 20,
+    "notes": "empty ranking expected"
+  },
+  "selected_future": {
+    "candidate_id": null,
+    "symbol": null,
+    "notes": "NOT_PERSISTED expected via U1 mapping"
+  },
+  "packets": []
+}

--- a/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_selected_not_in_universe.json
+++ b/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_selected_not_in_universe.json
@@ -1,0 +1,103 @@
+{
+  "schema_name": "futures_producer_packet_fixture.v1",
+  "schema_version": 1,
+  "source_kind": "fixture",
+  "producer_id": "futures_producer_packet_fixture_source_v1",
+  "generated_at": "2026-06-08T17:03:00Z",
+  "source_run_id": "fixture_u2a_selected_not_in_universe",
+  "source_stage": "paper",
+  "fixture_only": true,
+  "observability_truth_allowed": false,
+  "non_authorizing": true,
+  "selected_candidate_id": "c-missing",
+  "universe": {
+    "conceptual_size": 50,
+    "eligible_packet_count": 1,
+    "notes": "selected id not present in universe packets"
+  },
+  "ranking": {
+    "selected_top_n": 20,
+    "notes": "non-authorizing internal ranking"
+  },
+  "selected_future": {
+    "candidate_id": "c-missing",
+    "symbol": "SOLUSDT",
+    "notes": "selected not in universe — U1 must reject selected truth"
+  },
+  "packets": [
+    {
+      "candidate": {
+        "candidate_id": "c-eth",
+        "instrument_id": "inst-eth-perp",
+        "symbol": "ETHUSDT",
+        "market_type": "perpetual",
+        "exchange": "binance_futures",
+        "base_currency": "ETH",
+        "quote_currency": "USDT",
+        "live_authorization": false
+      },
+      "ranking": {
+        "source_universe_size": 50,
+        "selected_top_n": 20,
+        "rank": 1,
+        "score": 0.91,
+        "score_components_complete": true,
+        "is_top_n_member": true
+      },
+      "instrument": {
+        "complete": true,
+        "contract_size_known": true,
+        "tick_size_known": true,
+        "step_size_known": true,
+        "min_qty_known": true,
+        "min_notional_known": true,
+        "margin_asset_known": true,
+        "settlement_asset_known": true,
+        "leverage_bounds_known": true,
+        "missing_fields": []
+      },
+      "provenance": {
+        "complete": true,
+        "freshness_state": "fresh",
+        "dataset_id": "ds-u2a-not-in-universe",
+        "source": "fixture",
+        "mark_available": true,
+        "index_available": true,
+        "last_available": true,
+        "ohlcv_available": true,
+        "funding_available": true,
+        "open_interest_available": true,
+        "missing_fields": []
+      },
+      "volatility": {
+        "realized_volatility": 0.4,
+        "atr_or_rolling_range": 100.0,
+        "volatility_regime": "medium",
+        "dynamic_scope_usable": true
+      },
+      "liquidity": {
+        "spread_bps": 1.2,
+        "average_spread_bps": 1.5,
+        "volume": 1000000.0,
+        "quote_volume": 40000000.0,
+        "liquidity_regime": "deep",
+        "spread_quality": "tight"
+      },
+      "derivatives": {
+        "funding_available": true,
+        "funding_rate": 0.0001,
+        "funding_regime": "neutral",
+        "open_interest_available": true,
+        "open_interest": 1000000000.0,
+        "open_interest_regime": "high"
+      },
+      "opportunity": {
+        "opportunity_score": 0.8,
+        "inactivity_score": 0.1,
+        "movement_above_fee_slippage_breakeven": true,
+        "chop_risk": "low",
+        "candidate_is_inactive": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_spot_invalid.json
+++ b/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_spot_invalid.json
@@ -1,0 +1,177 @@
+{
+  "schema_name": "futures_producer_packet_fixture.v1",
+  "schema_version": 1,
+  "source_kind": "fixture",
+  "producer_id": "futures_producer_packet_fixture_source_v1",
+  "generated_at": "2026-06-08T17:01:00Z",
+  "source_run_id": "fixture_u2a_spot_invalid",
+  "source_stage": "paper",
+  "fixture_only": true,
+  "observability_truth_allowed": false,
+  "non_authorizing": true,
+  "selected_candidate_id": "c-btc-spot",
+  "universe": {
+    "conceptual_size": 50,
+    "eligible_packet_count": 1,
+    "notes": "spot packet present for negative test only"
+  },
+  "ranking": {
+    "selected_top_n": 20,
+    "notes": "non-authorizing internal ranking"
+  },
+  "selected_future": {
+    "candidate_id": "c-btc-spot",
+    "symbol": "BTC/USD",
+    "notes": "invalid spot selected — must be rejected by U1"
+  },
+  "packets": [
+    {
+      "candidate": {
+        "candidate_id": "c-eth",
+        "instrument_id": "inst-eth-perp",
+        "symbol": "ETHUSDT",
+        "market_type": "perpetual",
+        "exchange": "binance_futures",
+        "base_currency": "ETH",
+        "quote_currency": "USDT",
+        "live_authorization": false
+      },
+      "ranking": {
+        "source_universe_size": 50,
+        "selected_top_n": 20,
+        "rank": 2,
+        "score": 0.9,
+        "score_components_complete": true,
+        "is_top_n_member": true
+      },
+      "instrument": {
+        "complete": true,
+        "contract_size_known": true,
+        "tick_size_known": true,
+        "step_size_known": true,
+        "min_qty_known": true,
+        "min_notional_known": true,
+        "margin_asset_known": true,
+        "settlement_asset_known": true,
+        "leverage_bounds_known": true,
+        "missing_fields": []
+      },
+      "provenance": {
+        "complete": true,
+        "freshness_state": "fresh",
+        "dataset_id": "ds-u2a-spot-eth",
+        "source": "fixture",
+        "mark_available": true,
+        "index_available": true,
+        "last_available": true,
+        "ohlcv_available": true,
+        "funding_available": true,
+        "open_interest_available": true,
+        "missing_fields": []
+      },
+      "volatility": {
+        "realized_volatility": 0.4,
+        "atr_or_rolling_range": 100.0,
+        "volatility_regime": "medium",
+        "dynamic_scope_usable": true
+      },
+      "liquidity": {
+        "spread_bps": 1.2,
+        "average_spread_bps": 1.5,
+        "volume": 1000000.0,
+        "quote_volume": 40000000.0,
+        "liquidity_regime": "deep",
+        "spread_quality": "tight"
+      },
+      "derivatives": {
+        "funding_available": true,
+        "funding_rate": 0.0001,
+        "funding_regime": "neutral",
+        "open_interest_available": true,
+        "open_interest": 1000000000.0,
+        "open_interest_regime": "high"
+      },
+      "opportunity": {
+        "opportunity_score": 0.8,
+        "inactivity_score": 0.1,
+        "movement_above_fee_slippage_breakeven": true,
+        "chop_risk": "low",
+        "candidate_is_inactive": false
+      }
+    },
+    {
+      "candidate": {
+        "candidate_id": "c-btc-spot",
+        "instrument_id": "inst-btc-spot",
+        "symbol": "BTC/USD",
+        "market_type": "unknown",
+        "exchange": "kraken",
+        "base_currency": "BTC",
+        "quote_currency": "USD",
+        "live_authorization": false
+      },
+      "ranking": {
+        "source_universe_size": 50,
+        "selected_top_n": 20,
+        "rank": 1,
+        "score": 0.99,
+        "score_components_complete": true,
+        "is_top_n_member": true
+      },
+      "instrument": {
+        "complete": false,
+        "contract_size_known": false,
+        "tick_size_known": false,
+        "step_size_known": false,
+        "min_qty_known": false,
+        "min_notional_known": false,
+        "margin_asset_known": false,
+        "settlement_asset_known": false,
+        "leverage_bounds_known": false,
+        "missing_fields": ["contract_size"]
+      },
+      "provenance": {
+        "complete": false,
+        "freshness_state": "unknown",
+        "dataset_id": "ds-u2a-spot-btc",
+        "source": "fixture",
+        "mark_available": false,
+        "index_available": false,
+        "last_available": false,
+        "ohlcv_available": false,
+        "funding_available": false,
+        "open_interest_available": false,
+        "missing_fields": ["ohlcv"]
+      },
+      "volatility": {
+        "realized_volatility": null,
+        "atr_or_rolling_range": null,
+        "volatility_regime": null,
+        "dynamic_scope_usable": false
+      },
+      "liquidity": {
+        "spread_bps": null,
+        "average_spread_bps": null,
+        "volume": null,
+        "quote_volume": null,
+        "liquidity_regime": null,
+        "spread_quality": null
+      },
+      "derivatives": {
+        "funding_available": false,
+        "funding_rate": null,
+        "funding_regime": null,
+        "open_interest_available": false,
+        "open_interest": null,
+        "open_interest_regime": null
+      },
+      "opportunity": {
+        "opportunity_score": null,
+        "inactivity_score": null,
+        "movement_above_fee_slippage_breakeven": null,
+        "chop_risk": null,
+        "candidate_is_inactive": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_valid_minimal.json
+++ b/tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/futures_packet_valid_minimal.json
@@ -1,0 +1,251 @@
+{
+  "schema_name": "futures_producer_packet_fixture.v1",
+  "schema_version": 1,
+  "source_kind": "fixture",
+  "producer_id": "futures_producer_packet_fixture_source_v1",
+  "generated_at": "2026-06-08T17:00:00Z",
+  "source_run_id": "fixture_u2a_valid_minimal",
+  "source_stage": "paper",
+  "fixture_only": true,
+  "observability_truth_allowed": false,
+  "non_authorizing": true,
+  "selected_candidate_id": "c-eth",
+  "universe": {
+    "conceptual_size": 50,
+    "eligible_packet_count": 3,
+    "notes": "bounded test fixture — not production truth"
+  },
+  "ranking": {
+    "selected_top_n": 20,
+    "notes": "non-authorizing internal ranking"
+  },
+  "selected_future": {
+    "candidate_id": "c-eth",
+    "symbol": "ETHUSDT",
+    "notes": "fixture selected future within eligible universe"
+  },
+  "packets": [
+    {
+      "candidate": {
+        "candidate_id": "c-eth",
+        "instrument_id": "inst-eth-perp",
+        "symbol": "ETHUSDT",
+        "market_type": "perpetual",
+        "exchange": "binance_futures",
+        "base_currency": "ETH",
+        "quote_currency": "USDT",
+        "live_authorization": false
+      },
+      "ranking": {
+        "source_universe_size": 50,
+        "selected_top_n": 20,
+        "rank": 1,
+        "score": 0.91,
+        "score_components_complete": true,
+        "is_top_n_member": true
+      },
+      "instrument": {
+        "complete": true,
+        "contract_size_known": true,
+        "tick_size_known": true,
+        "step_size_known": true,
+        "min_qty_known": true,
+        "min_notional_known": true,
+        "margin_asset_known": true,
+        "settlement_asset_known": true,
+        "leverage_bounds_known": true,
+        "missing_fields": []
+      },
+      "provenance": {
+        "complete": true,
+        "freshness_state": "fresh",
+        "dataset_id": "ds-u2a-valid-eth",
+        "source": "fixture",
+        "mark_available": true,
+        "index_available": true,
+        "last_available": true,
+        "ohlcv_available": true,
+        "funding_available": true,
+        "open_interest_available": true,
+        "missing_fields": []
+      },
+      "volatility": {
+        "realized_volatility": 0.4,
+        "atr_or_rolling_range": 100.0,
+        "volatility_regime": "medium",
+        "dynamic_scope_usable": true
+      },
+      "liquidity": {
+        "spread_bps": 1.2,
+        "average_spread_bps": 1.5,
+        "volume": 1000000.0,
+        "quote_volume": 40000000.0,
+        "liquidity_regime": "deep",
+        "spread_quality": "tight"
+      },
+      "derivatives": {
+        "funding_available": true,
+        "funding_rate": 0.0001,
+        "funding_regime": "neutral",
+        "open_interest_available": true,
+        "open_interest": 1000000000.0,
+        "open_interest_regime": "high"
+      },
+      "opportunity": {
+        "opportunity_score": 0.8,
+        "inactivity_score": 0.1,
+        "movement_above_fee_slippage_breakeven": true,
+        "chop_risk": "low",
+        "candidate_is_inactive": false
+      }
+    },
+    {
+      "candidate": {
+        "candidate_id": "c-sol",
+        "instrument_id": "inst-sol-perp",
+        "symbol": "SOLUSDT",
+        "market_type": "perpetual",
+        "exchange": "binance_futures",
+        "base_currency": "SOL",
+        "quote_currency": "USDT",
+        "live_authorization": false
+      },
+      "ranking": {
+        "source_universe_size": 50,
+        "selected_top_n": 20,
+        "rank": 2,
+        "score": 0.87,
+        "score_components_complete": true,
+        "is_top_n_member": true
+      },
+      "instrument": {
+        "complete": true,
+        "contract_size_known": true,
+        "tick_size_known": true,
+        "step_size_known": true,
+        "min_qty_known": true,
+        "min_notional_known": true,
+        "margin_asset_known": true,
+        "settlement_asset_known": true,
+        "leverage_bounds_known": true,
+        "missing_fields": []
+      },
+      "provenance": {
+        "complete": true,
+        "freshness_state": "fresh",
+        "dataset_id": "ds-u2a-valid-sol",
+        "source": "fixture",
+        "mark_available": true,
+        "index_available": true,
+        "last_available": true,
+        "ohlcv_available": true,
+        "funding_available": true,
+        "open_interest_available": true,
+        "missing_fields": []
+      },
+      "volatility": {
+        "realized_volatility": 0.55,
+        "atr_or_rolling_range": 8.0,
+        "volatility_regime": "medium",
+        "dynamic_scope_usable": true
+      },
+      "liquidity": {
+        "spread_bps": 1.5,
+        "average_spread_bps": 1.8,
+        "volume": 800000.0,
+        "quote_volume": 30000000.0,
+        "liquidity_regime": "deep",
+        "spread_quality": "tight"
+      },
+      "derivatives": {
+        "funding_available": true,
+        "funding_rate": 0.0002,
+        "funding_regime": "neutral",
+        "open_interest_available": true,
+        "open_interest": 500000000.0,
+        "open_interest_regime": "high"
+      },
+      "opportunity": {
+        "opportunity_score": 0.75,
+        "inactivity_score": 0.12,
+        "movement_above_fee_slippage_breakeven": true,
+        "chop_risk": "low",
+        "candidate_is_inactive": false
+      }
+    },
+    {
+      "candidate": {
+        "candidate_id": "c-avax",
+        "instrument_id": "inst-avax-perp",
+        "symbol": "AVAXUSDT",
+        "market_type": "perpetual",
+        "exchange": "binance_futures",
+        "base_currency": "AVAX",
+        "quote_currency": "USDT",
+        "live_authorization": false
+      },
+      "ranking": {
+        "source_universe_size": 50,
+        "selected_top_n": 20,
+        "rank": 3,
+        "score": 0.82,
+        "score_components_complete": true,
+        "is_top_n_member": true
+      },
+      "instrument": {
+        "complete": true,
+        "contract_size_known": true,
+        "tick_size_known": true,
+        "step_size_known": true,
+        "min_qty_known": true,
+        "min_notional_known": true,
+        "margin_asset_known": true,
+        "settlement_asset_known": true,
+        "leverage_bounds_known": true,
+        "missing_fields": []
+      },
+      "provenance": {
+        "complete": true,
+        "freshness_state": "fresh",
+        "dataset_id": "ds-u2a-valid-avax",
+        "source": "fixture",
+        "mark_available": true,
+        "index_available": true,
+        "last_available": true,
+        "ohlcv_available": true,
+        "funding_available": true,
+        "open_interest_available": true,
+        "missing_fields": []
+      },
+      "volatility": {
+        "realized_volatility": 0.48,
+        "atr_or_rolling_range": 2.5,
+        "volatility_regime": "medium",
+        "dynamic_scope_usable": true
+      },
+      "liquidity": {
+        "spread_bps": 1.8,
+        "average_spread_bps": 2.0,
+        "volume": 600000.0,
+        "quote_volume": 20000000.0,
+        "liquidity_regime": "deep",
+        "spread_quality": "tight"
+      },
+      "derivatives": {
+        "funding_available": true,
+        "funding_rate": 0.00015,
+        "funding_regime": "neutral",
+        "open_interest_available": true,
+        "open_interest": 200000000.0,
+        "open_interest_regime": "medium"
+      },
+      "opportunity": {
+        "opportunity_score": 0.7,
+        "inactivity_score": 0.15,
+        "movement_above_fee_slippage_breakeven": true,
+        "chop_risk": "low",
+        "candidate_is_inactive": false
+      }
+    }
+  ]
+}

--- a/tests/webui/test_futures_producer_packet_fixture_source_v1.py
+++ b/tests/webui/test_futures_producer_packet_fixture_source_v1.py
@@ -1,0 +1,221 @@
+"""U2a — futures_producer_packet_fixture_source_v1 contract/static tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from src.webui.workflow_dashboard_readmodel_v1.futures_producer_packet_fixture_source_v1 import (
+    FIXTURE_PRODUCER_ID,
+    FIXTURE_SOURCE_KIND,
+    REASON_FORBIDDEN_UPSTREAM_SOURCE,
+    REASON_OBSERVABILITY_TRUTH_CLAIMED,
+    FuturesProducerPacketFixtureBundleV1,
+    FuturesProducerPacketFixtureSourceError,
+    assert_fixture_not_observability_truth,
+    bundle_to_upstream_input,
+    fixture_root_under,
+    load_futures_producer_packet_fixture,
+)
+from src.webui.workflow_dashboard_readmodel_v1.futures_universe_upstream_adapter_v1 import (
+    REASON_MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH,
+    REASON_SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE,
+    REASON_SPOT_OR_NON_DERIVATIVE_SELECTED_FUTURE_REJECTED,
+    REASON_UPSTREAM_SOURCE_EMPTY,
+    map_futures_packets_to_universe_selection_readmodel,
+)
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
+    MISSING_TRUTH_SELECTED,
+    MISSING_TRUTH_UNIVERSE,
+    validate_universe_selection_payload,
+)
+from trading.master_v2.double_play_futures_input import FuturesMarketType
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_ROOT = fixture_root_under(PROJECT_ROOT)
+SOURCE_MODULE = (
+    PROJECT_ROOT
+    / "src"
+    / "webui"
+    / "workflow_dashboard_readmodel_v1"
+    / "futures_producer_packet_fixture_source_v1.py"
+)
+
+FORBIDDEN_SPOT_SYMBOLS = ("BTC/USD", "BTC/EUR", "ETH/USD")
+
+
+def _fixture_path(name: str) -> Path:
+    return FIXTURE_ROOT / name
+
+
+def test_tc1_valid_fixture_loads_and_u1_accepts() -> None:
+    bundle = load_futures_producer_packet_fixture(
+        _fixture_path("futures_packet_valid_minimal.json")
+    )
+
+    assert bundle.source_kind == FIXTURE_SOURCE_KIND
+    assert bundle.producer_id == FIXTURE_PRODUCER_ID
+    assert bundle.fixture_only is True
+    assert bundle.observability_truth_allowed is False
+    assert bundle.non_authorizing is True
+    assert len(bundle.packets) == 3
+    assert all(
+        packet.candidate.market_type
+        in (FuturesMarketType.PERPETUAL, FuturesMarketType.FUTURES, FuturesMarketType.SWAP)
+        for packet in bundle.packets
+    )
+
+    upstream = bundle_to_upstream_input(bundle)
+    assert upstream.fixture_marked is True
+    result = map_futures_packets_to_universe_selection_readmodel(upstream)
+
+    assert result.status == "ok"
+    contract = validate_universe_selection_payload(result.payload)
+    assert contract.selected_future is not None
+    assert contract.selected_future.symbol == "ETHUSDT"
+    assert contract.selected_future.symbol not in FORBIDDEN_SPOT_SYMBOLS
+    assert result.payload["fixture_marked"] is True
+
+
+def test_tc2_fixture_only_is_not_real_truth() -> None:
+    bundle = load_futures_producer_packet_fixture(
+        _fixture_path("futures_packet_valid_minimal.json")
+    )
+
+    assert bundle.observability_truth_allowed is False
+    assert_fixture_not_observability_truth(bundle)
+
+    bad_bundle = FuturesProducerPacketFixtureBundleV1(
+        source_kind=FIXTURE_SOURCE_KIND,
+        producer_id=FIXTURE_PRODUCER_ID,
+        generated_at=bundle.generated_at,
+        source_run_id=bundle.source_run_id,
+        source_stage=bundle.source_stage,
+        fixture_only=True,
+        observability_truth_allowed=True,
+        non_authorizing=True,
+        universe=bundle.universe,
+        ranking=bundle.ranking,
+        selected_future=bundle.selected_future,
+        packets=bundle.packets,
+    )
+    with pytest.raises(
+        FuturesProducerPacketFixtureSourceError, match=REASON_OBSERVABILITY_TRUTH_CLAIMED
+    ):
+        assert_fixture_not_observability_truth(bad_bundle)
+
+    with pytest.raises(
+        FuturesProducerPacketFixtureSourceError, match=REASON_OBSERVABILITY_TRUTH_CLAIMED
+    ):
+        bundle_to_upstream_input(bad_bundle)
+
+
+def test_tc3_spot_invalid_fixture_rejected_by_u1_without_dummy_selected() -> None:
+    bundle = load_futures_producer_packet_fixture(_fixture_path("futures_packet_spot_invalid.json"))
+    result = map_futures_packets_to_universe_selection_readmodel(bundle_to_upstream_input(bundle))
+
+    assert result.payload["selected_future"]["truth_status"] == "NOT_PERSISTED"
+    assert REASON_SPOT_OR_NON_DERIVATIVE_SELECTED_FUTURE_REJECTED in result.rejection_reasons
+    assert result.payload["missing_truth"]["selected_future"] == MISSING_TRUTH_SELECTED
+    assert all(row["symbol"] != "BTC/USD" for row in result.payload["universe"])
+    assert "BTC/USD" not in {row["symbol"] for row in result.payload["ranking"]}
+
+
+def test_tc4_forbidden_market_surface_rejected_at_load() -> None:
+    with pytest.raises(
+        FuturesProducerPacketFixtureSourceError, match=REASON_FORBIDDEN_UPSTREAM_SOURCE
+    ):
+        load_futures_producer_packet_fixture(
+            _fixture_path("futures_packet_forbidden_market_surface.json")
+        )
+
+
+def test_tc4b_forbidden_source_also_rejected_by_u1_if_bypassed() -> None:
+    valid = load_futures_producer_packet_fixture(_fixture_path("futures_packet_valid_minimal.json"))
+    upstream = bundle_to_upstream_input(valid)
+    bypassed = type(upstream)(
+        source_run_id=upstream.source_run_id,
+        source_stage=upstream.source_stage,
+        generated_at=upstream.generated_at,
+        packets=upstream.packets,
+        upstream_source_kind="market_ranking_funnel_readmodel.v0",
+        upstream_producer_id="market_surface",
+        selected_candidate_id=upstream.selected_candidate_id,
+        evidence_links=upstream.evidence_links,
+        fixture_marked=upstream.fixture_marked,
+    )
+    result = map_futures_packets_to_universe_selection_readmodel(bypassed)
+
+    assert result.status == "missing_truth"
+    assert REASON_MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH in result.rejection_reasons
+    assert result.payload["missing_truth"]["universe"] == MISSING_TRUTH_UNIVERSE
+
+
+def test_tc5_selected_not_in_universe_rejected() -> None:
+    bundle = load_futures_producer_packet_fixture(
+        _fixture_path("futures_packet_selected_not_in_universe.json")
+    )
+    result = map_futures_packets_to_universe_selection_readmodel(bundle_to_upstream_input(bundle))
+
+    assert result.payload["selected_future"]["truth_status"] == "NOT_PERSISTED"
+    assert REASON_SELECTED_FUTURE_NOT_IN_ELIGIBLE_UNIVERSE in result.rejection_reasons
+    assert result.payload["missing_truth"]["selected_future"] == MISSING_TRUTH_SELECTED
+
+
+def test_tc6_empty_fixture_returns_missing_truth_no_dummy() -> None:
+    bundle = load_futures_producer_packet_fixture(
+        _fixture_path("futures_packet_missing_empty.json")
+    )
+    assert bundle.packets == ()
+
+    result = map_futures_packets_to_universe_selection_readmodel(bundle_to_upstream_input(bundle))
+
+    assert result.status == "missing_truth"
+    assert REASON_UPSTREAM_SOURCE_EMPTY in result.rejection_reasons
+    assert result.payload["universe"] == []
+    assert result.payload["ranking"] == []
+    assert result.payload["selected_future"] == {"truth_status": "NOT_PERSISTED"}
+    validate_universe_selection_payload(result.payload)
+
+
+def test_tc6b_missing_packets_key_raises() -> None:
+    path = _fixture_path("futures_packet_missing_empty.json")
+    raw = path.read_text(encoding="utf-8").replace('"packets": []', '"packets_removed": []')
+    broken = path.parent / "_broken_missing_packets.json"
+    broken.write_text(raw, encoding="utf-8")
+    try:
+        with pytest.raises(FuturesProducerPacketFixtureSourceError, match="packets"):
+            load_futures_producer_packet_fixture(broken)
+    finally:
+        broken.unlink(missing_ok=True)
+
+
+def test_tc7_no_forbidden_imports_in_fixture_source_module() -> None:
+    tree = ast.parse(SOURCE_MODULE.read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+    forbidden_fragments = (
+        "market_ranking_funnel",
+        "market_surface",
+        "scan_markets",
+        "run_market_scan",
+        "src.execution",
+        "src.risk",
+        "src.governance",
+        "universe_selection_producer_v1",
+    )
+    for fragment in forbidden_fragments:
+        assert not any(fragment in name for name in imported), fragment
+
+
+def test_tc7b_loader_is_read_only_no_archive_producer_import() -> None:
+    source_text = SOURCE_MODULE.read_text(encoding="utf-8")
+    assert "write_universe_selection_readmodel" not in source_text
+    assert "maybe_write_missing_truth_after_bounded_closeout" not in source_text
+    assert "build_exchange_client" not in source_text

--- a/tests/webui/test_futures_universe_upstream_adapter_v1.py
+++ b/tests/webui/test_futures_universe_upstream_adapter_v1.py
@@ -456,3 +456,21 @@ def test_spot_symbol_excluded_from_universe_even_with_perpetual_market_type() ->
     assert any(
         item.reason == REASON_INELIGIBLE_SPOT_SYMBOL for item in result.eligibility_exclusions
     )
+
+
+def test_u2a_valid_fixture_chain_through_u1_adapter() -> None:
+    from src.webui.workflow_dashboard_readmodel_v1.futures_producer_packet_fixture_source_v1 import (
+        bundle_to_upstream_input,
+        fixture_root_under,
+        load_futures_producer_packet_fixture,
+    )
+
+    fixture_path = fixture_root_under(PROJECT_ROOT) / "futures_packet_valid_minimal.json"
+    bundle = load_futures_producer_packet_fixture(fixture_path)
+    result = map_futures_packets_to_universe_selection_readmodel(bundle_to_upstream_input(bundle))
+
+    assert result.status == "ok"
+    contract = validate_universe_selection_payload(result.payload)
+    assert contract.selected_future is not None
+    assert contract.selected_future.symbol == "ETHUSDT"
+    assert result.payload["fixture_marked"] is True


### PR DESCRIPTION
## Summary

Adds U2a offline fixture source for `FuturesProducerPacket`-like inputs: a read-only JSON loader, bounded test fixtures, and static tests proving U1 adapter compatibility. No production wiring, no closeout hooks, no dashboard changes.

## Scope

- `src/webui/workflow_dashboard_readmodel_v1/futures_producer_packet_fixture_source_v1.py` — read-only loader/validator
- `tests/fixtures/workflow_dashboard_readmodel_v1/futures_producer_packet_v1/*.json` — 5 bounded fixtures
- `tests/webui/test_futures_producer_packet_fixture_source_v1.py` — TC1–TC7 contract tests
- `tests/webui/test_futures_universe_upstream_adapter_v1.py` — U2a→U1 chain test

## Fixture-only statement

All fixtures require `fixture_only=true`, `observability_truth_allowed=false`, and `non_authorizing=true`. Loader enforces these flags; `bundle_to_upstream_input()` always sets `fixture_marked=true`. Fixture data must not be treated as real Observability truth.

## Futures-first semantics

Positive fixtures use PERPETUAL futures-style symbols (ETHUSDT, SOLUSDT, AVAXUSDT). Spot slash pairs (BTC/USD) appear only in negative fixtures. Selected future must be eligible and in universe; empty upstream returns Missing Truth without dummy rows.

## Forbidden sources rejected

Loader rejects forbidden upstream markers (`market_ranking_funnel_readmodel.v0`, `market_surface`, etc.). U1 adapter rejects bypassed forbidden sources. No `/market` surface or funnel promotion.

## U1 adapter compatibility

Valid minimal fixture loads → `bundle_to_upstream_input()` → `map_futures_packets_to_universe_selection_readmodel()` → status `ok`, selected ETHUSDT.

## Contract compatibility

Output validated via `validate_universe_selection_payload()` in tests.

## Real futures data gap

No real offline futures instrument catalog exists yet. U2a provides test-only fixture source; production paths remain Missing Truth until governed source lands (U2b/U3).

## Safety boundaries

- No `src/execution`, `src/risk`, `src/governance` changes
- No bounded observation adapter hooks
- No scheduler/runtime/Live/Testnet start logic
- No workflow YAML or docs changes
- No dashboard/template wiring

## Tests

```bash
uv run pytest \
  tests/webui/test_futures_producer_packet_fixture_source_v1.py \
  tests/webui/test_futures_universe_upstream_adapter_v1.py \
  tests/webui/test_universe_selection_producer_hook_reader_chain_v1.py \
  -q
```

26 tests passed locally.

## Evidence bundles

- Implementation: `planning/.../implementation/futures_universe_top20_selection_upstream_u2a_fixture_source_bounded_write_tests_v1_20260608T162310Z/`
- Review: `planning/.../review/futures_universe_top20_selection_upstream_u2a_fixture_source_post_implementation_review_no_run_v1_20260608T162506Z/`

## No-Live statement

Non-authorizing, fixture-only, read-only loader. No Live arming, no orders, no exchange calls, no runtime start, no auto-merge requested.


Made with [Cursor](https://cursor.com)