### PR TITLE
feat(webui): active Paper run panel on Market Dashboard /market

### DIFF
--- a/src/webui/market_active_paper_run_runtime_v0.py
+++ b/src/webui/market_active_paper_run_runtime_v0.py
@@ -1,0 +1,247 @@
+"""SSR-only active Paper run panel for GET /market (env-gated, bridge/staging evidence)."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ENV_ENABLED = "PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_ENABLED"
+ENV_BRIDGE_ROOT = "PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_BRIDGE_ROOT"
+ENV_DETAIL_URL = "PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_DETAIL_URL"
+FIXED_GEN_ENV = "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
+ACTIVE_IDLE_MINUTES = 10
+
+
+def enabled_explicitly_on() -> bool:
+    raw = os.environ.get(ENV_ENABLED)
+    return raw is not None and raw.strip() == "1"
+
+
+def resolved_bridge_root_or_none() -> Path | None:
+    raw = os.environ.get(ENV_BRIDGE_ROOT)
+    if raw is None or not str(raw).strip():
+        return None
+    path = Path(raw).expanduser()
+    try:
+        path = path.resolve(strict=True)
+    except OSError:
+        return None
+    if not path.is_dir():
+        return None
+    return path
+
+
+def _now_utc() -> datetime:
+    fixed = (os.environ.get(FIXED_GEN_ENV) or "").strip()
+    if fixed:
+        return datetime.fromisoformat(fixed.replace("Z", "+00:00"))
+    return datetime.now(timezone.utc)
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _last_event_row(events_path: Path) -> dict[str, str]:
+    try:
+        with events_path.open(encoding="utf-8", newline="") as f:
+            rows = list(csv.DictReader(f))
+    except OSError:
+        return {}
+    if not rows:
+        return {}
+    return {k: (v or "") for k, v in rows[-1].items()}
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _count_fills(runtime_out: Path) -> int | None:
+    fills_path = runtime_out / "fills.json"
+    data = _load_json(fills_path)
+    if data is None:
+        return None
+    fills = data.get("fills")
+    if isinstance(fills, list):
+        return len(fills)
+    return None
+
+
+def _base_context(*, gate_enabled: bool, display_status: str) -> dict[str, Any]:
+    return {
+        "section_visible": False,
+        "gate_enabled": gate_enabled,
+        "display_status": display_status,
+        "non_authorizing": True,
+        "evidence_only": True,
+        "not_live": True,
+        "not_preflight_lift": True,
+        "run_id": "",
+        "mode": "",
+        "is_active": False,
+        "strategy_name": "",
+        "symbol_display": "",
+        "started_at": "",
+        "elapsed_seconds": None,
+        "heartbeat_iteration": None,
+        "heartbeat_ts_utc": "",
+        "heartbeat_reason": "",
+        "last_event_time": "",
+        "cash": None,
+        "equity": None,
+        "orders_executed": 0,
+        "fills_count": None,
+        "no_trade": True,
+        "evidence_root_label": "",
+        "detail_url": "",
+        "live_authorized": False,
+        "ready_for_operator_arming": False,
+        "preflight_lift_authorized": False,
+        "operator_truth_go_granted": False,
+        "summary_line": "",
+    }
+
+
+def build_market_active_paper_run_display_context() -> dict[str, Any]:
+    """SSR-only active Paper run panel for GET /market (fail closed by default)."""
+
+    if not enabled_explicitly_on():
+        ctx = _base_context(gate_enabled=False, display_status="disabled")
+        ctx["summary_line"] = "Active Paper run panel disabled (env gate off)."
+        return ctx
+
+    bridge_root = resolved_bridge_root_or_none()
+    if bridge_root is None:
+        ctx = _base_context(gate_enabled=True, display_status="unconfigured")
+        ctx["summary_line"] = "Active Paper run bridge root unconfigured."
+        return ctx
+
+    meta = _load_json(bridge_root / "meta.json")
+    pointer = _load_json(bridge_root / "evidence_pointer.json")
+    if meta is None or pointer is None:
+        ctx = _base_context(gate_enabled=True, display_status="bridge_unreadable")
+        ctx["summary_line"] = "Bridge meta/evidence_pointer unreadable."
+        return ctx
+
+    if pointer.get("view_only") is not True or pointer.get("fake_data") is True:
+        ctx = _base_context(gate_enabled=True, display_status="pointer_guard_failed")
+        ctx["summary_line"] = "Bridge pointer failed view-only guard."
+        return ctx
+
+    events_row = _last_event_row(bridge_root / "events.csv")
+    heartbeat = pointer.get("heartbeat_snapshot")
+    if not isinstance(heartbeat, dict):
+        hb_path_raw = pointer.get("heartbeat_file") or pointer.get("runtime_out")
+        if hb_path_raw:
+            hb_file = Path(str(hb_path_raw)) / "scheduler_heartbeat_freshness_v0.json"
+            if hb_file.is_file():
+                heartbeat = _load_json(hb_file)
+
+    runtime_out_raw = pointer.get("runtime_out")
+    runtime_out = Path(str(runtime_out_raw)).expanduser() if runtime_out_raw else None
+    fills_count = _count_fills(runtime_out) if runtime_out and runtime_out.is_dir() else None
+
+    run_id = str(meta.get("run_id") or pointer.get("run_id") or "").strip()
+    started_at = str(meta.get("started_at") or "").strip()
+    last_event_time = events_row.get("ts_event") or events_row.get("ts_bar") or ""
+    if isinstance(heartbeat, dict) and not last_event_time:
+        last_event_time = str(heartbeat.get("ts_utc") or "")
+
+    now = _now_utc()
+    started_dt = _parse_ts(started_at)
+    elapsed_seconds = int((now - started_dt).total_seconds()) if started_dt else None
+    last_event_dt = _parse_ts(last_event_time)
+    is_active = meta.get("ended_at") in (None, "") and last_event_dt is not None
+    if is_active and last_event_dt is not None:
+        idle = (now - last_event_dt).total_seconds()
+        is_active = idle <= ACTIVE_IDLE_MINUTES * 60
+
+    cash_raw = events_row.get("cash") or events_row.get("equity")
+    cash: float | None = None
+    if cash_raw not in ("", None):
+        try:
+            cash = float(cash_raw)
+        except (TypeError, ValueError):
+            cash = None
+
+    detail_url = (os.environ.get(ENV_DETAIL_URL) or "").strip()
+    if not detail_url and run_id:
+        detail_url = f"http://127.0.0.1:8010/watch/runs/{run_id}"
+
+    evidence_root_label = ""
+    if runtime_out_raw:
+        evidence_root_label = Path(str(runtime_out_raw)).name
+
+    iteration = None
+    reason = ""
+    hb_ts = ""
+    if isinstance(heartbeat, dict):
+        iteration = heartbeat.get("iteration")
+        reason = str(heartbeat.get("reason") or "")
+        hb_ts = str(heartbeat.get("ts_utc") or "")
+
+    return {
+        "section_visible": True,
+        "gate_enabled": True,
+        "display_status": "ready",
+        "non_authorizing": True,
+        "evidence_only": True,
+        "not_live": True,
+        "not_preflight_lift": True,
+        "run_id": run_id,
+        "mode": str(meta.get("mode") or pointer.get("mode") or "paper").upper(),
+        "is_active": is_active,
+        "strategy_name": str(meta.get("strategy_name") or ""),
+        "symbol_display": str(meta.get("symbol") or ""),
+        "started_at": started_at,
+        "elapsed_seconds": elapsed_seconds,
+        "heartbeat_iteration": iteration,
+        "heartbeat_ts_utc": hb_ts,
+        "heartbeat_reason": reason,
+        "last_event_time": last_event_time,
+        "cash": cash,
+        "equity": cash,
+        "orders_executed": 0,
+        "fills_count": fills_count,
+        "no_trade": fills_count == 0 if fills_count is not None else True,
+        "evidence_root_label": evidence_root_label,
+        "detail_url": detail_url,
+        "live_authorized": False,
+        "ready_for_operator_arming": False,
+        "preflight_lift_authorized": False,
+        "operator_truth_go_granted": False,
+        "summary_line": (
+            f"Active Paper run {run_id} — iteration {iteration or '—'} — "
+            f"{'active' if is_active else 'idle/stale'} (bridge evidence, view-only)"
+        ),
+    }
+
+
+__all__ = [
+    "ENV_BRIDGE_ROOT",
+    "ENV_DETAIL_URL",
+    "ENV_ENABLED",
+    "build_market_active_paper_run_display_context",
+    "enabled_explicitly_on",
+    "resolved_bridge_root_or_none",
+]

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from .market_active_paper_run_runtime_v0 import build_market_active_paper_run_display_context
 from .market_depth_runtime_v0 import market_depth_json_payload_v0
 from .market_ranking_funnel_runtime_v0 import build_market_ranking_funnel_display_context
 
@@ -564,6 +565,7 @@ def create_market_router(
         market_depth = build_market_depth_display_context()
         run_projection = build_market_run_projection_display_context()
         ranking_funnel = build_market_ranking_funnel_display_context()
+        active_paper_run = build_market_active_paper_run_display_context()
         return templates.TemplateResponse(
             request,
             "market_v0.html",
@@ -573,6 +575,7 @@ def create_market_router(
                 "market_depth": market_depth,
                 "run_projection": run_projection,
                 "ranking_funnel": ranking_funnel,
+                "active_paper_run": active_paper_run,
                 "query": {
                     "symbol": symbol,
                     "timeframe": timeframe,

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -113,12 +113,66 @@
       data-market-v0-paper-run-truth-separation-v0="true"
     >
       <strong class="text-violet-200/95">Market Surface ≠ Paper Run Truth.</strong>
-      Default symbol (e.g. BTC/USD) and dummy OHLCV are not the last Paper Run instrument.
-      View-only last run:
+      Default symbol (e.g. BTC/USD) and dummy OHLCV are chart fixtures only — not Futures truth or Paper runtime authority.
+      {% if not active_paper_run.section_visible %}
+      View-only last run archive:
       <a href="/observability" class="text-sky-300/90 underline underline-offset-2 font-mono">GET /observability</a>
       (env-gated Last Paper Run panel).
+      {% endif %}
     </p>
   </section>
+
+  {% if active_paper_run.section_visible %}
+  <section
+    role="region"
+    aria-labelledby="market-v0-landmark-active-paper-run-h2"
+    class="rounded-xl border border-emerald-900/45 bg-gradient-to-br from-emerald-950/35 via-slate-950/40 to-slate-950/20 px-3 py-3 sm:px-4 text-xs text-emerald-100/95 shadow-md shadow-black/20"
+    data-market-v0-active-paper-run="true"
+    data-market-v0-active-paper-run-readonly="true"
+    data-market-v0-active-paper-run-authority="false"
+    data-market-v0-active-paper-run-non-authorizing="true"
+    data-market-v0-active-paper-run-evidence-only="true"
+    data-market-v0-active-paper-run-not-live="true"
+    data-market-v0-active-paper-run-enabled="{{ 'true' if active_paper_run.gate_enabled else 'false' }}"
+    data-market-v0-active-paper-run-active="{{ 'true' if active_paper_run.is_active else 'false' }}"
+  >
+    <div class="flex flex-wrap items-center justify-between gap-2 mb-2">
+      <h2 id="market-v0-landmark-active-paper-run-h2" class="font-semibold text-emerald-200/95 tracking-wide uppercase text-[11px] m-0">
+        Active Paper Run — View Only — Non Authorizing
+      </h2>
+      <div class="flex flex-wrap gap-1.5">
+        <span class="inline-flex items-center rounded-md border border-emerald-800/50 bg-emerald-950/45 px-2 py-0.5 text-[10px] font-semibold text-emerald-100/90">NOT LIVE</span>
+        <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-950/55 px-2 py-0.5 text-[10px] font-semibold text-slate-200/90">NOT PREFLIGHT LIFT</span>
+        <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-950/55 px-2 py-0.5 text-[10px] font-semibold text-slate-200/90">EVIDENCE ONLY</span>
+      </div>
+    </div>
+    <p class="text-[11px] text-emerald-100/90 m-0 mb-2 leading-snug">{{ active_paper_run.summary_line|e }}</p>
+    <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-[11px] m-0">
+      <div><dt class="inline text-slate-400">run_id</dt> <dd class="inline font-mono text-slate-100">{{ active_paper_run.run_id|e }}</dd></div>
+      <div><dt class="inline text-slate-400">mode</dt> <dd class="inline text-slate-100">{{ active_paper_run.mode|e }}</dd></div>
+      <div><dt class="inline text-slate-400">is_active</dt> <dd class="inline text-slate-100">{{ active_paper_run.is_active }}</dd></div>
+      <div><dt class="inline text-slate-400">elapsed_s</dt> <dd class="inline text-slate-100">{{ active_paper_run.elapsed_seconds if active_paper_run.elapsed_seconds is not none else "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">heartbeat_iter</dt> <dd class="inline text-slate-100">{{ active_paper_run.heartbeat_iteration if active_paper_run.heartbeat_iteration is not none else "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">heartbeat_ts</dt> <dd class="inline font-mono text-slate-100">{{ active_paper_run.heartbeat_ts_utc|e or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">last_event</dt> <dd class="inline font-mono text-slate-100">{{ active_paper_run.last_event_time|e or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">reason</dt> <dd class="inline text-slate-100">{{ active_paper_run.heartbeat_reason|e or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">equity/cash</dt> <dd class="inline text-slate-100">{{ active_paper_run.equity if active_paper_run.equity is not none else "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">orders</dt> <dd class="inline text-slate-100">{{ active_paper_run.orders_executed }}</dd></div>
+      <div><dt class="inline text-slate-400">fills</dt> <dd class="inline text-slate-100">{{ active_paper_run.fills_count if active_paper_run.fills_count is not none else "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">no_trade</dt> <dd class="inline text-slate-100">{{ active_paper_run.no_trade }}</dd></div>
+      <div><dt class="inline text-slate-400">paper_symbol</dt> <dd class="inline font-mono text-slate-100">{{ active_paper_run.symbol_display|e or "—" }} <span class="text-slate-500">(display metadata, not Futures truth)</span></dd></div>
+      <div><dt class="inline text-slate-400">evidence_root</dt> <dd class="inline font-mono text-slate-100">{{ active_paper_run.evidence_root_label|e or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">LIVE_AUTHORIZED</dt> <dd class="inline text-slate-100">{{ active_paper_run.live_authorized }}</dd></div>
+      <div><dt class="inline text-slate-400">PREFLIGHT_LIFT</dt> <dd class="inline text-slate-100">{{ active_paper_run.preflight_lift_authorized }}</dd></div>
+    </dl>
+    {% if active_paper_run.detail_url %}
+    <p class="mt-2 mb-0 text-[11px]">
+      Detail (Run UI companion):
+      <a href="{{ active_paper_run.detail_url|e }}" class="text-sky-300/90 underline underline-offset-2 font-mono break-all">{{ active_paper_run.detail_url|e }}</a>
+    </p>
+    {% endif %}
+  </section>
+  {% endif %}
 
   {% if run_projection.section_visible %}
   <section

--- a/tests/webui/test_market_active_paper_run_runtime_v0.py
+++ b/tests/webui/test_market_active_paper_run_runtime_v0.py
@@ -1,0 +1,122 @@
+"""Market active Paper run panel on GET /market (env-gated, view-only)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+
+
+@pytest.fixture()
+def client_default(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.delenv("PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_BRIDGE_ROOT", raising=False)
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def bridge_root(tmp_path: Path) -> Path:
+    root = tmp_path / "bridge_run"
+    root.mkdir()
+    (root / "meta.json").write_text(
+        json.dumps(
+            {
+                "run_id": "paper_2h_sanity_first_bounded_20260608T192744Z",
+                "mode": "paper",
+                "strategy_name": "high_vol_no_trade",
+                "symbol": "BTC",
+                "timeframe": "1m",
+                "started_at": "2026-06-08T19:27:44+00:00",
+                "ended_at": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "evidence_pointer.json").write_text(
+        json.dumps(
+            {
+                "view_only": True,
+                "non_authorizing": True,
+                "no_live": True,
+                "evidence_pointer": True,
+                "fake_data": False,
+                "run_id": "paper_2h_sanity_first_bounded_20260608T192744Z",
+                "mode": "paper",
+                "runtime_out": str(tmp_path / "runtime_out"),
+                "heartbeat_snapshot": {
+                    "iteration": 53,
+                    "ts_utc": "2026-06-08T19:57:13Z",
+                    "reason": "idle_no_due_jobs",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runtime_out = tmp_path / "runtime_out"
+    runtime_out.mkdir()
+    (runtime_out / "fills.json").write_text(
+        '{"fills":[],"schema_version":"p7.fills.v0"}\n',
+        encoding="utf-8",
+    )
+    (root / "events.csv").write_text(
+        "step,ts_bar,ts_event,cash,equity,position_size\n"
+        "53,2026-06-08T19:57:13Z,2026-06-08T19:57:13Z,1000.0,1000.0,0.0\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture()
+def client_bridge_on(
+    monkeypatch: pytest.MonkeyPatch, bridge_root: Path
+) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_BRIDGE_ROOT", str(bridge_root))
+    monkeypatch.setenv("PEAK_TRADE_FIXED_GENERATED_AT_UTC", "2026-06-08T19:58:00+00:00")
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def test_market_active_paper_run_panel_disabled_by_default(client_default: TestClient) -> None:
+    response = client_default.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert 'data-market-v0-active-paper-run="true"' not in html
+
+
+def test_market_active_paper_run_panel_renders_with_bridge(client_bridge_on: TestClient) -> None:
+    html = client_bridge_on.get("/market").text
+    assert 'data-market-v0-active-paper-run="true"' in html
+    assert "Active Paper Run — View Only — Non Authorizing" in html
+    assert "NOT LIVE" in html
+    assert "NOT PREFLIGHT LIFT" in html
+    assert "EVIDENCE ONLY" in html
+    assert "paper_2h_sanity_first_bounded_20260608T192744Z" in html
+    assert "display metadata, not Futures truth" in html
+    assert "fetch(" not in html
+
+
+def test_market_double_play_unchanged_without_active_panel(client_bridge_on: TestClient) -> None:
+    response = client_bridge_on.get("/market/double-play")
+    assert response.status_code == 200
+    html = response.text
+    assert 'data-market-v0-active-paper-run="true"' not in html

--- a/tests/webui/test_market_active_paper_run_runtime_v0.py
+++ b/tests/webui/test_market_active_paper_run_runtime_v0.py
@@ -85,9 +85,7 @@ def bridge_root(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def client_bridge_on(
-    monkeypatch: pytest.MonkeyPatch, bridge_root: Path
-) -> Iterator[TestClient]:
+def client_bridge_on(monkeypatch: pytest.MonkeyPatch, bridge_root: Path) -> Iterator[TestClient]:
     monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
     monkeypatch.setenv("PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_ENABLED", "1")
     monkeypatch.setenv("PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_BRIDGE_ROOT", str(bridge_root))


### PR DESCRIPTION
## Summary
- Adds env-gated SSR panel on `GET /market` for the active bounded Paper run using real bridge/staging evidence (`PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_ENABLED=1` + `PEAK_TRADE_MARKET_ACTIVE_PAPER_RUN_BRIDGE_ROOT`).
- Shows run_id, active status, heartbeat/progress, equity/cash, orders/fills/no-trade, safety flags (NOT LIVE / NOT PREFLIGHT LIFT / EVIDENCE ONLY), and optional Run UI detail link.
- No trading/execution/risk changes; `/market/double-play` unchanged.

## Test plan
- [x] `uv run pytest tests/webui/test_market_active_paper_run_runtime_v0.py -q`
- [x] `uv run ruff check` on touched files
- [x] Manual curl `http://127.0.0.1:8000/market` with bridge env (operator local)


Made with [Cursor](https://cursor.com)