### PR TITLE
Fix U5B Kraken probe fetcher and byte cap policy

### DIFF
--- a/docs/webui/observability/REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md
+++ b/docs/webui/observability/REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md
@@ -159,6 +159,7 @@ Charter markers remain fail-closed. **U5b probe CLI** is an isolated manual oper
 - Explicit confirm token: `CONFIRM_VIEW_ONLY_PUBLIC_MARKET_DATA_PROBE_V1`
 - Public GET allowlist only: `/derivatives/api/v3/instruments`, `/derivatives/api/v3/tickers`
 - urllib-only, one-shot, no daemon, no auth, no readmodel write
+- **Response byte-cap policy (bounded, not unbounded):** CLI default `--max-response-bytes` stays conservative (`262144`). Hard cap `3145728`. Manual Kraken instruments probe requires operator to set an explicit limit **at or above** `2097152` (live instruments payload observed ~1.2 MiB; tickers ~163 KiB). Exceeding cap fails with `INSTRUMENTS_RESPONSE_EXCEEDS_MAX_RESPONSE_BYTES` including observed/required bytes — no retry loop, no host workaround.
 - CI/tests: mocked/offline only; live network requires manual operator CLI with confirm token
 - Sibling pattern: `capture_public_rest_binance_book_ticker_v0.py` (spot reference only)
 

--- a/scripts/ops/probe_kraken_futures_public_market_data_v1.py
+++ b/scripts/ops/probe_kraken_futures_public_market_data_v1.py
@@ -48,7 +48,9 @@ FORBIDDEN_PATH_SUBSTRINGS: Tuple[str, ...] = (
 FORBIDDEN_HOST_NETLOCS: frozenset[str] = frozenset({"api.kraken.com"})
 
 MAX_TIMEOUT_SECONDS = 15.0
-MAX_RESPONSE_BYTES_DEFAULT = 1_048_576
+MAX_RESPONSE_BYTES_HARD_CAP = 3_145_728
+MIN_RECOMMENDED_MAX_RESPONSE_BYTES_FOR_INSTRUMENTS = 2_097_152
+MAX_RESPONSE_BYTES_CLI_DEFAULT = 262_144
 
 _INELIGIBLE_SPOT_SYMBOL_EXACT: frozenset[str] = frozenset(
     {"BTC/USD", "BTC-USD", "ETH/USD", "BTC/EUR"}
@@ -62,7 +64,7 @@ _FUTURES_TYPE_MARKERS: Tuple[str, ...] = (
 )
 
 
-PublicGetFetcher = Callable[[str, float, int], Tuple[int, bytes]]
+PublicGetFetcher = Callable[..., Tuple[int, bytes]]
 
 
 def _die(msg: str, code: int = 2) -> None:
@@ -122,7 +124,27 @@ def validate_probe_url(url: str, *, rest_base_url: str = REST_BASE_URL) -> List[
     return reasons
 
 
-def _read_body_capped(resp: Any, max_response_bytes: int) -> bytes:
+def _byte_cap_error_message(*, url: str, observed_bytes: int, max_response_bytes: int) -> str:
+    path = parse.urlparse(url).path or ""
+    if path.endswith("/instruments"):
+        code = "INSTRUMENTS_RESPONSE_EXCEEDS_MAX_RESPONSE_BYTES"
+    elif path.endswith("/tickers"):
+        code = "TICKERS_RESPONSE_EXCEEDS_MAX_RESPONSE_BYTES"
+    else:
+        code = "RESPONSE_EXCEEDS_MAX_RESPONSE_BYTES"
+    msg = (
+        f"ERR: {code}: endpoint={path or 'unknown'} "
+        f"observed_bytes={observed_bytes} max_response_bytes={max_response_bytes}"
+    )
+    if path.endswith("/instruments"):
+        msg += (
+            f" minimum_recommended_max_response_bytes="
+            f"{MIN_RECOMMENDED_MAX_RESPONSE_BYTES_FOR_INSTRUMENTS}"
+        )
+    return msg
+
+
+def _read_body_capped(resp: Any, max_response_bytes: int, *, url: str = "") -> bytes:
     out = bytearray()
     while len(out) <= max_response_bytes:
         chunk = resp.read(min(65536, max(0, max_response_bytes - len(out) + 1)))
@@ -130,7 +152,13 @@ def _read_body_capped(resp: Any, max_response_bytes: int) -> bytes:
             break
         out.extend(chunk)
         if len(out) > max_response_bytes:
-            raise ValueError("ERR: HTTP response body exceeds max_response_bytes")
+            raise ValueError(
+                _byte_cap_error_message(
+                    url=url,
+                    observed_bytes=len(out),
+                    max_response_bytes=max_response_bytes,
+                )
+            )
     return bytes(out)
 
 
@@ -148,9 +176,9 @@ def kraken_futures_public_fetch_v1(
     try:
         with request.urlopen(req, timeout=bounded_timeout) as resp:
             code = int(getattr(resp, "status", resp.getcode()))
-            return code, _read_body_capped(resp, max_response_bytes)
+            return code, _read_body_capped(resp, max_response_bytes, url=url)
     except error.HTTPError as exc:
-        return int(exc.code), _read_body_capped(exc, max_response_bytes)
+        return int(exc.code), _read_body_capped(exc, max_response_bytes, url=url)
     except (error.URLError, TimeoutError, OSError, ValueError) as exc:
         raise ValueError(f"fetch failed: {exc}") from exc
 
@@ -282,8 +310,8 @@ def run_probe(
         _die("ERR: confirm token required for network probe")
     if timeout_seconds <= 0 or timeout_seconds > MAX_TIMEOUT_SECONDS:
         _die(f"ERR: timeout_seconds must be in (0, {MAX_TIMEOUT_SECONDS}]")
-    if max_response_bytes <= 0 or max_response_bytes > MAX_RESPONSE_BYTES_DEFAULT:
-        _die("ERR: max_response_bytes out of allowed bounds")
+    if max_response_bytes <= 0 or max_response_bytes > MAX_RESPONSE_BYTES_HARD_CAP:
+        _die(f"ERR: max_response_bytes out of allowed bounds (1..{MAX_RESPONSE_BYTES_HARD_CAP}]")
 
     at = fetched_at or _utc_now_z()
     endpoint_results: Dict[str, Mapping[str, Any]] = {}
@@ -295,7 +323,14 @@ def run_probe(
         block = validate_probe_url(url)
         if block:
             _die(f"ERR: {block[0]}")
-        status, raw = fetcher(url, timeout_seconds, max_response_bytes)
+        try:
+            status, raw = fetcher(
+                url,
+                timeout_seconds=timeout_seconds,
+                max_response_bytes=max_response_bytes,
+            )
+        except ValueError as exc:
+            _die(str(exc))
         if status < 200 or status >= 300:
             _die(f"ERR: HTTP {status} from {ep}")
         try:
@@ -367,7 +402,16 @@ def main(argv: Optional[List[str]] = None) -> int:
         help=f"Must be {CONFIRM_TOKEN!r}.",
     )
     parser.add_argument("--timeout-seconds", type=float, default=10.0)
-    parser.add_argument("--max-response-bytes", type=int, default=262144)
+    parser.add_argument(
+        "--max-response-bytes",
+        type=int,
+        default=MAX_RESPONSE_BYTES_CLI_DEFAULT,
+        help=(
+            f"Hard-capped response body limit (max {MAX_RESPONSE_BYTES_HARD_CAP}). "
+            f"Manual Kraken instruments probe requires at least "
+            f"{MIN_RECOMMENDED_MAX_RESPONSE_BYTES_FOR_INSTRUMENTS}."
+        ),
+    )
     parser.add_argument(
         "--output-dir",
         type=Path,

--- a/tests/ops/test_probe_kraken_futures_public_market_data_v1.py
+++ b/tests/ops/test_probe_kraken_futures_public_market_data_v1.py
@@ -77,7 +77,7 @@ def _tickers_body(**overrides: Any) -> Dict[str, Any]:
     return base
 
 
-def _mock_fetcher_ok() -> Callable[[str, float, int], Tuple[int, bytes]]:
+def _mock_fetcher_ok() -> Callable[..., Tuple[int, bytes]]:
     responses: Dict[str, Tuple[int, bytes]] = {
         "/derivatives/api/v3/instruments": (
             200,
@@ -89,13 +89,56 @@ def _mock_fetcher_ok() -> Callable[[str, float, int], Tuple[int, bytes]]:
         ),
     }
 
-    def _fetch(url: str, timeout_seconds: float, max_response_bytes: int) -> Tuple[int, bytes]:
+    def _fetch(
+        url: str,
+        *,
+        timeout_seconds: float,
+        max_response_bytes: int,
+    ) -> Tuple[int, bytes]:
         for ep, payload in responses.items():
             if url.endswith(ep.split("/derivatives/api/v3", 1)[-1]):
                 raw = payload[1]
                 if len(raw) > max_response_bytes:
-                    raise ValueError("ERR: HTTP response body exceeds max_response_bytes")
+                    raise ValueError(
+                        f"ERR: RESPONSE_EXCEEDS_MAX_RESPONSE_BYTES: "
+                        f"observed_bytes={len(raw)} max_response_bytes={max_response_bytes}"
+                    )
                 return payload
+        raise ValueError(f"unexpected url: {url}")
+
+    return _fetch
+
+
+def _mock_fetcher_large_instruments(
+    instruments_byte_size: int,
+) -> Callable[..., Tuple[int, bytes]]:
+    pad = "x" * max(0, instruments_byte_size - 200)
+    instruments_body = _instruments_body(
+        instruments=[
+            {"symbol": "PF_XBTUSD", "type": "flexible_futures", "tradeable": True, "pad": pad},
+            {"symbol": "PF_ETHUSD", "type": "flexible_futures", "tradeable": True},
+        ]
+    )
+    inst_raw = json.dumps(instruments_body).encode("utf-8")
+
+    def _fetch(
+        url: str,
+        *,
+        timeout_seconds: float,
+        max_response_bytes: int,
+    ) -> Tuple[int, bytes]:
+        if url.endswith("/instruments"):
+            if len(inst_raw) > max_response_bytes:
+                raise ValueError(
+                    "ERR: INSTRUMENTS_RESPONSE_EXCEEDS_MAX_RESPONSE_BYTES: "
+                    f"observed_bytes={len(inst_raw)} max_response_bytes={max_response_bytes}"
+                )
+            return 200, inst_raw
+        if url.endswith("/tickers"):
+            tick_raw = json.dumps(_tickers_body()).encode("utf-8")
+            if len(tick_raw) > max_response_bytes:
+                raise ValueError("tickers exceed cap")
+            return 200, tick_raw
         raise ValueError(f"unexpected url: {url}")
 
     return _fetch
@@ -179,8 +222,24 @@ def test_run_probe_mocked_success(mod: Any, capsys: pytest.CaptureFixture[str]) 
     assert "NOT_LIVE_AUTHORIZATION=true" in out
 
 
+def test_run_probe_default_fetcher_keyword_args_regression(mod: Any) -> None:
+    report = mod.run_probe(
+        confirm=_CONFIRM,
+        timeout_seconds=5.0,
+        max_response_bytes=65536,
+        fetched_at="2026-06-08T20:00:00Z",
+        fetcher=_mock_fetcher_ok(),
+    )
+    assert report["instruments_count"] == 3
+
+
 def test_run_probe_rejects_http_error(mod: Any) -> None:
-    def _fetch_fail(url: str, timeout_seconds: float, max_response_bytes: int) -> Tuple[int, bytes]:
+    def _fetch_fail(
+        url: str,
+        *,
+        timeout_seconds: float,
+        max_response_bytes: int,
+    ) -> Tuple[int, bytes]:
         return 503, b"{}"
 
     with pytest.raises(SystemExit):
@@ -199,6 +258,64 @@ def test_kraken_fetch_blocks_forbidden_host(mod: Any) -> None:
             "https://api.kraken.com/derivatives/api/v3/instruments",
             timeout_seconds=3.0,
             max_response_bytes=8192,
+        )
+
+
+def test_kraken_fetch_requires_keyword_only_args(mod: Any) -> None:
+    with pytest.raises(TypeError):
+        mod.kraken_futures_public_fetch_v1(
+            "https://futures.kraken.com/derivatives/api/v3/instruments",
+            3.0,
+            8192,
+        )
+
+
+def test_byte_cap_exceeded_instruments_error(mod: Any) -> None:
+    fetcher = _mock_fetcher_large_instruments(instruments_byte_size=400_000)
+
+    with pytest.raises(SystemExit):
+        mod.run_probe(
+            confirm=_CONFIRM,
+            timeout_seconds=5.0,
+            max_response_bytes=262_144,
+            fetched_at="2026-06-08T20:00:00Z",
+            fetcher=fetcher,
+        )
+
+
+def test_manual_larger_byte_cap_accepted(mod: Any) -> None:
+    fetcher = _mock_fetcher_large_instruments(instruments_byte_size=400_000)
+    report = mod.run_probe(
+        confirm=_CONFIRM,
+        timeout_seconds=5.0,
+        max_response_bytes=2_097_152,
+        fetched_at="2026-06-08T20:00:00Z",
+        fetcher=fetcher,
+    )
+    assert report["instruments_count"] >= 1
+
+
+def test_max_response_bytes_hard_cap_rejected(mod: Any) -> None:
+    with pytest.raises(SystemExit):
+        mod.run_probe(
+            confirm=_CONFIRM,
+            timeout_seconds=5.0,
+            max_response_bytes=mod.MAX_RESPONSE_BYTES_HARD_CAP + 1,
+            fetched_at="2026-06-08T20:00:00Z",
+            fetcher=_mock_fetcher_ok(),
+        )
+
+
+def test_read_body_capped_instruments_error_message(mod: Any) -> None:
+    class _Resp:
+        def read(self, n: int) -> bytes:
+            return b"x" * n
+
+    with pytest.raises(ValueError, match="INSTRUMENTS_RESPONSE_EXCEEDS_MAX_RESPONSE_BYTES"):
+        mod._read_body_capped(
+            _Resp(),
+            100,
+            url="https://futures.kraken.com/derivatives/api/v3/instruments",
         )
 
 


### PR DESCRIPTION
## Summary
- Fixes the U5B Kraken Futures public probe keyword-only fetcher invocation (`run_probe` now passes `timeout_seconds` and `max_response_bytes` as keyword args).
- Documents and enforces an explicit bounded byte-cap policy for manual Kraken instruments probes (conservative CLI default `262144`, hard cap `3145728`, recommended manual minimum `2097152`).
- Improves byte-cap diagnostics with `INSTRUMENTS_RESPONSE_EXCEEDS_MAX_RESPONSE_BYTES` including observed/required bytes.
- Adds mocked regression tests for fetcher contract, byte-cap failure, larger manual cap acceptance, and hard-cap rejection.

## Test plan
- [x] `pytest tests/ops/test_probe_kraken_futures_public_market_data_v1.py tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py -q` (23 passed)
- [x] `ruff check` + `ruff format --check` on changed Python files
- [x] `validate_docs_token_policy.py --changed --base origin/main`
- [x] No probe rerun, no network in tests
- [x] Active paper run not touched

## Safety / scope
No probe rerun, no dashboard wiring, no readmodel write, no snapshot intake, no truth/preflight/live authorization, no trading logic, no runtime/scheduler/execution/risk/governance touch. Reuse-before-new and Reuse Drift Guard checked.

Made with [Cursor](https://cursor.com)