### PR TITLE
Add U5D offline transform validation script

### DIFF
--- a/docs/webui/observability/REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md
+++ b/docs/webui/observability/REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md
@@ -173,6 +173,7 @@ Charter markers remain fail-closed. **U5b probe CLI** is an isolated manual oper
 | **U5** | This market-data source charter (docs-only) | this document |
 | **U5b** | Kraken Futures public probe (isolated CLI + mocked tests) | `probe_kraken_futures_public_market_data_v1.py` |
 | **U5c** | U5b raw evidence → U2c governed snapshot candidate transform contract (docs/tests-only) | §12 this document |
+| **U5d** | Offline transform candidate validation CLI (no network; confirm token) | `transform_kraken_futures_raw_to_u2c_candidate_v1.py` |
 | U2b write / Truth-GO | Governed snapshot intake | not authorized |
 
 ## 11. Tests
@@ -182,6 +183,7 @@ Charter markers remain fail-closed. **U5b probe CLI** is an isolated manual oper
 | `tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py` | Doc existence, machine markers, U4b cross-link |
 | `tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py` | Charter boundary, U5c transform contract, forbidden provider ids, no dummy substitution |
 | `tests/ops/test_probe_kraken_futures_public_market_data_v1.py` | U5b probe CLI boundary, mocked HTTP, confirm token, no network in CI |
+| `tests/ops/test_transform_kraken_futures_raw_to_u2c_candidate_v1.py` | U5d offline transform validation CLI, fixture-only, no network |
 
 ## 12. U5C Transform Contract to U2c Governed Snapshot Candidate
 
@@ -305,7 +307,7 @@ Missing Kraken fields must remain in `missing_fields` — **no BTC&#47;USD subst
 | Gate | Marker / outcome |
 |------|------------------|
 | 1. Raw Capture PASS | U5b bundle + raw JSON artifacts + `MANIFEST_VERIFY_RC=0` |
-| 2. Transform Validation PASS | Future transform script validates mapping — **not authorized in this slice** |
+| 2. Transform Validation PASS | U5d offline validation CLI (`transform_kraken_futures_raw_to_u2c_candidate_v1.py`) — manual operator GO only; **no transform execution in CI** |
 | 3. Candidate MANIFEST RC=0 | Candidate bundle integrity |
 | 4. Operator Acceptance | Explicit durable acceptance — `GOVERNED_SNAPSHOT_ACCEPTED=true` only then |
 | 5. U2b Loader Validation PASS | `futures_producer_packet_real_metadata_source_v1.py` |
@@ -324,4 +326,9 @@ Missing Kraken fields must remain in `missing_fields` — **no BTC&#47;USD subst
 |-------------|---------|
 | `tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py` | U5c §12 markers, intake-not-ready, forbidden shortcuts, reuse chain |
 | `tests/ops/test_probe_kraken_futures_public_market_data_v1.py` | U5b probe remains view-only, preview not governed |
+| `tests/ops/test_transform_kraken_futures_raw_to_u2c_candidate_v1.py` | U5d offline validation artifact markers, no network, no intake |
 | `tests/webui/test_futures_producer_packet_real_metadata_source_v1.py` | U2b loader rejection reasons (unchanged — referenced by gates) |
+
+### 12.11 U5D Offline Transform Validation CLI
+
+**U5d offline validation record:** Manual operator CLI `transform_kraken_futures_raw_to_u2c_candidate_v1.py` reads durable U5C raw instruments/tickers + U5B probe report and emits **`u5d_u2c_candidate_validation.v1`** validation artifact only. Requires confirm token **`CONFIRM_U5D_OFFLINE_TRANSFORM_VALIDATION_V1`**. No network, no snapshot intake, no loader, no readmodel write, no dashboard wiring. **`GOVERNED_SNAPSHOT_ACCEPTED=false`** until separate operator acceptance.

--- a/scripts/ops/transform_kraken_futures_raw_to_u2c_candidate_v1.py
+++ b/scripts/ops/transform_kraken_futures_raw_to_u2c_candidate_v1.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""U5D: offline Kraken Futures raw payload → U2c candidate validation (no network).
+
+Reads durable U5C raw instruments/tickers + U5B probe report; emits validation artifact only.
+Not snapshot intake, loader, readmodel write, dashboard wiring, truth-GO, or trading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROBE_SCRIPT = _REPO_ROOT / "scripts/ops/probe_kraken_futures_public_market_data_v1.py"
+
+
+def _load_probe_mod() -> Any:
+    spec = importlib.util.spec_from_file_location("_kf_probe", _PROBE_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load probe module")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_PROBE = _load_probe_mod()
+is_futures_eligible_instrument = _PROBE.is_futures_eligible_instrument
+is_ineligible_spot_symbol = _PROBE.is_ineligible_spot_symbol
+
+CONFIRM_TOKEN = "CONFIRM_U5D_OFFLINE_TRANSFORM_VALIDATION_V1"
+SCHEMA = "u5d_u2c_candidate_validation_v1"
+PROVIDER = "kraken_futures"
+EXCHANGE = "kraken_futures"
+SOURCE_STAGE = "market_data_view_only"
+TOP_N = 20
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _parse_num(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_json(path: Path) -> Mapping[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _die(f"ERR: cannot read JSON {path}: {exc}")
+    if not isinstance(data, dict):
+        _die(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def _contract_type(inst: Mapping[str, Any]) -> str:
+    raw = str(inst.get("type") or inst.get("contract_type") or "").lower()
+    if "inverse" in raw:
+        return "future"
+    if "flexible" in raw or "perpetual" in raw:
+        return "perpetual"
+    return raw or "unknown"
+
+
+def _map_instrument_row(
+    inst: Mapping[str, Any],
+    tick: Optional[Mapping[str, Any]],
+    *,
+    fetched_at: str,
+) -> Dict[str, Any]:
+    symbol = str(inst.get("symbol") or "")
+    missing: List[str] = []
+    degraded: List[str] = []
+
+    last = _parse_num(tick.get("last")) if tick else None
+    mark = _parse_num(tick.get("markPrice")) if tick else None
+    index_px = _parse_num(tick.get("indexPrice")) if tick else None
+    vol24h = _parse_num(tick.get("vol24h")) if tick else None
+    bid = _parse_num(tick.get("bid")) if tick else None
+    ask = _parse_num(tick.get("ask")) if tick else None
+    funding = _parse_num(tick.get("fundingRate")) if tick else None
+    oi = _parse_num(tick.get("openInterest")) if tick else None
+
+    display_price = last
+    price_source = "last"
+    if display_price is None and mark is not None:
+        display_price = mark
+        price_source = "markPrice"
+        degraded.append("last_missing_markPrice_fallback")
+    elif display_price is None:
+        missing.append("last_price")
+        price_source = "unknown"
+
+    if vol24h is None or vol24h <= 0:
+        missing.append("vol24h")
+    if bid is None or ask is None:
+        missing.append("bid_ask")
+    if funding is None:
+        missing.append("funding_rate")
+    if oi is None:
+        missing.append("open_interest")
+
+    expiry = inst.get("lastTradingTime")
+    if expiry in (None, ""):
+        expiry = None
+
+    spread: Optional[float] = None
+    if bid is not None and ask is not None:
+        spread = ask - bid
+
+    return {
+        "provider": PROVIDER,
+        "exchange": EXCHANGE,
+        "instrument_id": symbol,
+        "symbol": symbol,
+        "contract_type": _contract_type(inst),
+        "market_type": _contract_type(inst),
+        "base_currency": inst.get("base"),
+        "quote_currency": inst.get("quote"),
+        "expiry": expiry,
+        "active": bool(inst.get("tradeable", False)),
+        "provider_tradable_display_only": bool(inst.get("tradeable", False)),
+        "tick_size": inst.get("tickSize"),
+        "contract_size": inst.get("contractSize"),
+        "last_price": last,
+        "mark_price": mark,
+        "index_price": index_px,
+        "display_price": display_price,
+        "display_price_source": price_source,
+        "vol24h": vol24h,
+        "bid": bid,
+        "ask": ask,
+        "spread": spread,
+        "funding_rate": funding,
+        "open_interest": oi,
+        "fetched_at": fetched_at,
+        "missing_fields": missing,
+        "degraded_fields": degraded,
+        "not_selected": True,
+        "not_signal": True,
+        "not_truth_go": True,
+        "not_tradable_authority": True,
+    }
+
+
+def _rank_key(row: Mapping[str, Any]) -> Tuple[int, float, str]:
+    vol = row.get("vol24h")
+    vol_sort = float(vol) if isinstance(vol, (int, float)) and vol > 0 else -1.0
+    has_vol = 1 if vol_sort > 0 else 0
+    return (-has_vol, -vol_sort, str(row.get("symbol") or ""))
+
+
+def build_top20_ranking_candidate(rows: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    eligible = [
+        r
+        for r in rows
+        if r.get("active") and isinstance(r.get("vol24h"), (int, float)) and r["vol24h"] > 0
+    ]
+    ranked = sorted(eligible, key=_rank_key)
+    out: List[Dict[str, Any]] = []
+    for rank, row in enumerate(ranked[:TOP_N], start=1):
+        out.append(
+            {
+                "rank": rank,
+                "symbol": row.get("symbol"),
+                "vol24h": row.get("vol24h"),
+                "display_price": row.get("display_price"),
+                "display_price_source": row.get("display_price_source"),
+                "ranking_method": "vol24h_liquidity_desc_symbol_tiebreak",
+                "preview_only": False,
+                "validation_only": True,
+                "not_selected": True,
+                "not_signal": True,
+                "not_truth_go": True,
+                "not_tradable_authority": True,
+                "not_alphabetical_preview": True,
+            }
+        )
+    return out
+
+
+def run_offline_transform_validation(
+    *,
+    confirm: str,
+    raw_instruments: Path,
+    raw_tickers: Path,
+    probe_report: Path,
+    output_dir: Path,
+) -> Dict[str, Any]:
+    if confirm != CONFIRM_TOKEN:
+        _die("ERR: confirm token required for offline transform validation")
+    for path in (raw_instruments, raw_tickers, probe_report):
+        if not path.is_file():
+            _die(f"ERR: required input missing: {path}")
+
+    inst_body = _load_json(raw_instruments)
+    tick_body = _load_json(raw_tickers)
+    report = _load_json(probe_report)
+
+    if report.get("schema") != "kraken_futures_public_market_data_probe_report_v1":
+        _die("ERR: probe report schema mismatch")
+
+    fetched_at = str(report.get("fetched_at") or "")
+    if not fetched_at:
+        _die("ERR: probe report missing fetched_at")
+
+    instruments = inst_body.get("instruments")
+    tickers = tick_body.get("tickers")
+    if not isinstance(instruments, list) or not instruments:
+        _die("ERR: instruments[] missing or empty")
+    if not isinstance(tickers, list) or not tickers:
+        _die("ERR: tickers[] missing or empty")
+
+    inst_by_symbol: Dict[str, Mapping[str, Any]] = {}
+    rejected: List[Dict[str, str]] = []
+    for inst in instruments:
+        if not isinstance(inst, Mapping):
+            continue
+        sym = str(inst.get("symbol") or "")
+        if not sym:
+            rejected.append({"symbol": sym, "reason": "MISSING_SYMBOL"})
+            continue
+        if is_ineligible_spot_symbol(sym):
+            rejected.append({"symbol": sym, "reason": "INELIGIBLE_SPOT_SYMBOL"})
+            continue
+        if not is_futures_eligible_instrument(inst):
+            rejected.append({"symbol": sym, "reason": "NON_FUTURES_INSTRUMENT"})
+            continue
+        if inst.get("isExpired") is True:
+            rejected.append({"symbol": sym, "reason": "EXPIRED_INSTRUMENT"})
+            continue
+        if not inst.get("tradeable", False):
+            rejected.append({"symbol": sym, "reason": "NOT_TRADEABLE"})
+            continue
+        inst_by_symbol[sym] = inst
+
+    tick_by_symbol: Dict[str, Mapping[str, Any]] = {}
+    orphan_tickers: List[Dict[str, str]] = []
+    for tick in tickers:
+        if not isinstance(tick, Mapping):
+            continue
+        sym = str(tick.get("symbol") or tick.get("tag") or "")
+        if not sym:
+            continue
+        tick_by_symbol[sym] = tick
+        if sym not in inst_by_symbol:
+            orphan_tickers.append({"symbol": sym, "reason": "ORPHAN_TICKER_NO_INSTRUMENT"})
+
+    packet_candidates: List[Dict[str, Any]] = []
+    unmatched_instruments: List[str] = []
+    for sym, inst in sorted(inst_by_symbol.items()):
+        tick = tick_by_symbol.get(sym)
+        if tick is None:
+            unmatched_instruments.append(sym)
+        packet_candidates.append(_map_instrument_row(inst, tick, fetched_at=fetched_at))
+
+    top20 = build_top20_ranking_candidate(packet_candidates)
+
+    probe_preview = report.get("top20_candidate_preview") or []
+    probe_preview_symbols = [
+        str(p.get("symbol")) for p in probe_preview if isinstance(p, Mapping) and p.get("symbol")
+    ]
+    governed_symbols = [str(t.get("symbol")) for t in top20]
+
+    artifact: Dict[str, Any] = {
+        "schema": SCHEMA,
+        "source_stage": SOURCE_STAGE,
+        "provider": PROVIDER,
+        "transform_validation_only": True,
+        "GOVERNED_SNAPSHOT_ACCEPTED": False,
+        "SNAPSHOT_INTAKE_EXECUTED": False,
+        "LOADER_RUN_EXECUTED": False,
+        "READMODEL_WRITE_EXECUTED": False,
+        "DASHBOARD_WIRING_EXECUTED": False,
+        "LIVE_AUTHORIZED": False,
+        "PREFLIGHT_LIFT_AUTHORIZED": False,
+        "OPERATOR_TRUTH_GO_GRANTED": False,
+        "selected_tradable_future_created": False,
+        "auth_used": False,
+        "no_secrets": True,
+        "no_orders": True,
+        "fetched_at": fetched_at,
+        "input_checksums": {
+            "raw_instruments_sha256": _sha256_file(raw_instruments),
+            "raw_tickers_sha256": _sha256_file(raw_tickers),
+            "probe_report_sha256": _sha256_file(probe_report),
+        },
+        "input_paths": {
+            "raw_instruments": str(raw_instruments.resolve()),
+            "raw_tickers": str(raw_tickers.resolve()),
+            "probe_report": str(probe_report.resolve()),
+        },
+        "join": {
+            "join_key": "symbol",
+            "instruments_eligible_count": len(inst_by_symbol),
+            "tickers_count": len(tick_by_symbol),
+            "matched_count": len(inst_by_symbol) - len(unmatched_instruments),
+            "unmatched_instruments": unmatched_instruments,
+            "orphan_tickers": orphan_tickers,
+            "rejected_symbols": rejected,
+        },
+        "packet_candidates": packet_candidates,
+        "top20_ranking_candidate": top20,
+        "ranking_notes": {
+            "primary_sort": "vol24h_desc",
+            "price_fallback": "markPrice_when_last_missing",
+            "tie_breaker": "symbol_asc",
+            "alphabetical_preview_forbidden": True,
+            "u5b_alphabetical_preview_not_reused": governed_symbols != probe_preview_symbols,
+        },
+        "safety_markers": {
+            "TRANSFORM_VALIDATION_ONLY": True,
+            "NOT_TRADING": True,
+            "NOT_TRUTH_GO": True,
+            "NOT_SELECTED_TRADABLE_FUTURE": True,
+            "NOT_SNAPSHOT_INTAKE": True,
+        },
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_json = output_dir / "u5d_u2c_candidate_validation.v1.json"
+    out_json.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    summary_lines = [
+        "# U5D Offline Transform Validation Summary",
+        "",
+        f"- schema: `{SCHEMA}`",
+        f"- source_stage: `{SOURCE_STAGE}`",
+        f"- eligible instruments: {len(inst_by_symbol)}",
+        f"- matched tickers: {len(inst_by_symbol) - len(unmatched_instruments)}",
+        f"- orphan tickers: {len(orphan_tickers)}",
+        f"- rejected symbols: {len(rejected)}",
+        f"- top20 candidate rows: {len(top20)}",
+        f"- GOVERNED_SNAPSHOT_ACCEPTED: false",
+        f"- transform_validation_only: true",
+        "",
+        "This artifact is validation-only — not governed snapshot acceptance.",
+    ]
+    (output_dir / "transform_summary.md").write_text(
+        "\n".join(summary_lines) + "\n", encoding="utf-8"
+    )
+
+    _emit_machine_lines(artifact)
+    return artifact
+
+
+def _emit_machine_lines(artifact: Mapping[str, Any]) -> None:
+    join = artifact.get("join") or {}
+    lines = [
+        "TRANSFORM_VALIDATION_ONLY=true",
+        "NOT_TRADING=true",
+        "NOT_TRUTH_GO=true",
+        "NOT_SELECTED_TRADABLE_FUTURE=true",
+        "GOVERNED_SNAPSHOT_ACCEPTED=false",
+        "SNAPSHOT_INTAKE_EXECUTED=false",
+        "LOADER_RUN_EXECUTED=false",
+        "READMODEL_WRITE_EXECUTED=false",
+        "DASHBOARD_WIRING_EXECUTED=false",
+        f"SOURCE_STAGE={SOURCE_STAGE}",
+        f"INSTRUMENTS_ELIGIBLE={join.get('instruments_eligible_count', 0)}",
+        f"MATCHED_COUNT={join.get('matched_count', 0)}",
+        f"TOP20_COUNT={len(artifact.get('top20_ranking_candidate') or [])}",
+        f"ORPHAN_TICKERS={len(join.get('orphan_tickers') or [])}",
+    ]
+    for line in lines:
+        print(line)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="U5D offline Kraken raw → U2c candidate validation (no network)."
+    )
+    parser.add_argument("--raw-instruments", type=Path, required=True)
+    parser.add_argument("--raw-tickers", type=Path, required=True)
+    parser.add_argument("--probe-report", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--confirm-offline-transform-validation",
+        required=True,
+        choices=[CONFIRM_TOKEN],
+        help=f"Must be {CONFIRM_TOKEN!r}.",
+    )
+    ns = parser.parse_args(argv)
+    try:
+        run_offline_transform_validation(
+            confirm=ns.confirm_offline_transform_validation,
+            raw_instruments=ns.raw_instruments,
+            raw_tickers=ns.raw_tickers,
+            probe_report=ns.probe_report,
+            output_dir=ns.output_dir,
+        )
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/u5d_offline_transform_v1/minimal/kraken_futures_instruments.raw.v1.json
+++ b/tests/fixtures/u5d_offline_transform_v1/minimal/kraken_futures_instruments.raw.v1.json
@@ -1,0 +1,54 @@
+{
+  "result": "success",
+  "instruments": [
+    {
+      "symbol": "PF_XBTUSD",
+      "type": "flexible_futures",
+      "tradeable": true,
+      "base": "XBT",
+      "quote": "USD",
+      "tickSize": 0.5,
+      "contractSize": 1,
+      "isExpired": false
+    },
+    {
+      "symbol": "PF_ETHUSD",
+      "type": "flexible_futures",
+      "tradeable": true,
+      "base": "ETH",
+      "quote": "USD",
+      "tickSize": 0.05,
+      "contractSize": 1,
+      "isExpired": false
+    },
+    {
+      "symbol": "PF_ADAUSD",
+      "type": "flexible_futures",
+      "tradeable": true,
+      "base": "ADA",
+      "quote": "USD",
+      "tickSize": 0.0001,
+      "contractSize": 1,
+      "isExpired": false
+    },
+    {
+      "symbol": "BTC/USD",
+      "type": "spot",
+      "tradeable": false,
+      "base": "BTC",
+      "quote": "USD",
+      "isExpired": false
+    },
+    {
+      "symbol": "FI_LTCUSD_250131",
+      "type": "futures_inverse",
+      "tradeable": true,
+      "base": "LTC",
+      "quote": "USD",
+      "lastTradingTime": "2025-01-31T00:00:00Z",
+      "isExpired": true,
+      "tickSize": 0.01,
+      "contractSize": 1
+    }
+  ]
+}

--- a/tests/fixtures/u5d_offline_transform_v1/minimal/kraken_futures_public_market_data_probe_report.v1.json
+++ b/tests/fixtures/u5d_offline_transform_v1/minimal/kraken_futures_public_market_data_probe_report.v1.json
@@ -1,0 +1,36 @@
+{
+  "schema": "kraken_futures_public_market_data_probe_report_v1",
+  "provider": "kraken_futures",
+  "provider_id": "kraken_futures_public_market_data_only",
+  "source_stage": "market_data_view_only",
+  "fetched_at": "2026-06-08T21:56:06Z",
+  "auth_used": false,
+  "no_orders": true,
+  "no_secrets": true,
+  "no_truth_go": true,
+  "no_selected_tradable_future": true,
+  "instruments_count": 5,
+  "futures_only_count": 3,
+  "tickers_count": 4,
+  "top20_candidate_preview": [
+    {
+      "rank": 1,
+      "symbol": "PF_ADAUSD",
+      "preview_only": true,
+      "not_selected": true
+    },
+    {
+      "rank": 2,
+      "symbol": "PF_ETHUSD",
+      "preview_only": true,
+      "not_selected": true
+    },
+    {
+      "rank": 3,
+      "symbol": "PF_XBTUSD",
+      "preview_only": true,
+      "not_selected": true
+    }
+  ],
+  "top20_candidate_preview_note": "preview only, not selected, not signal, not truth-go, not tradable authority"
+}

--- a/tests/fixtures/u5d_offline_transform_v1/minimal/kraken_futures_tickers.raw.v1.json
+++ b/tests/fixtures/u5d_offline_transform_v1/minimal/kraken_futures_tickers.raw.v1.json
@@ -1,0 +1,42 @@
+{
+  "result": "success",
+  "tickers": [
+    {
+      "symbol": "PF_XBTUSD",
+      "last": 100000.0,
+      "markPrice": 100001.0,
+      "indexPrice": 100000.5,
+      "vol24h": 5000.0,
+      "bid": 99990.0,
+      "ask": 100010.0,
+      "fundingRate": 0.0001,
+      "openInterest": 1000000.0
+    },
+    {
+      "symbol": "PF_ETHUSD",
+      "markPrice": 3500.0,
+      "indexPrice": 3500.1,
+      "vol24h": 8000.0,
+      "bid": 3499.0,
+      "ask": 3501.0,
+      "fundingRate": 0.0002,
+      "openInterest": 500000.0
+    },
+    {
+      "symbol": "PF_ADAUSD",
+      "last": 0.5,
+      "markPrice": 0.51,
+      "indexPrice": 0.505,
+      "vol24h": 0.0,
+      "bid": 0.49,
+      "ask": 0.51,
+      "openInterest": 10000.0
+    },
+    {
+      "symbol": "FI_LTCUSD_250131",
+      "markPrice": 80.0,
+      "vol24h": 10.0,
+      "openInterest": 100.0
+    }
+  ]
+}

--- a/tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py
+++ b/tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py
@@ -178,3 +178,11 @@ def test_governed_snapshot_template_links_u5c_transform_contract() -> None:
     doc = GOVERNED_SNAPSHOT_TEMPLATE_DOC.read_text(encoding="utf-8")
     assert "U5c transform contract" in doc
     assert "not** direct report-only intake" in doc
+
+
+def test_u5d_offline_transform_script_referenced_in_contract() -> None:
+    doc = MARKET_DATA_SOURCE_DOC.read_text(encoding="utf-8")
+    assert "transform_kraken_futures_raw_to_u2c_candidate_v1.py" in doc
+    assert "CONFIRM_U5D_OFFLINE_TRANSFORM_VALIDATION_V1" in doc or "U5d" in doc
+    assert "test_transform_kraken_futures_raw_to_u2c_candidate_v1.py" in doc
+    assert "u5d_u2c_candidate_validation_v1" in doc or "U5d offline" in doc

--- a/tests/ops/test_transform_kraken_futures_raw_to_u2c_candidate_v1.py
+++ b/tests/ops/test_transform_kraken_futures_raw_to_u2c_candidate_v1.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts/ops/transform_kraken_futures_raw_to_u2c_candidate_v1.py"
+_FIXTURES = _REPO_ROOT / "tests/fixtures/u5d_offline_transform_v1/minimal"
+_CONFIRM = "CONFIRM_U5D_OFFLINE_TRANSFORM_VALIDATION_V1"
+
+_FORBIDDEN_IN_SCRIPT = (
+    "import requests",
+    "import httpx",
+    "import aiohttp",
+    "urllib.request",
+    "urllib.error",
+    "websocket",
+    "time.sleep",
+    "while True",
+    "src.execution",
+    "src.live",
+    "src.scheduler",
+    "import ccxt",
+    "create_order",
+    "place_order",
+    "send_order",
+    "submit_order",
+    "cancel_order",
+)
+
+
+def _load_mod() -> Any:
+    spec = importlib.util.spec_from_file_location("_u5d_transform", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run(args: List[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def mod() -> Any:
+    return _load_mod()
+
+
+@pytest.fixture
+def fixture_paths(tmp_path: Path) -> dict[str, Path]:
+    return {
+        "instruments": _FIXTURES / "kraken_futures_instruments.raw.v1.json",
+        "tickers": _FIXTURES / "kraken_futures_tickers.raw.v1.json",
+        "probe": _FIXTURES / "kraken_futures_public_market_data_probe_report.v1.json",
+        "output": tmp_path / "out",
+    }
+
+
+def test_script_has_no_forbidden_imports_or_patterns() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    for frag in _FORBIDDEN_IN_SCRIPT:
+        assert frag not in text, f"forbidden fragment: {frag!r}"
+
+
+def test_cli_requires_exact_confirm_token(fixture_paths: dict[str, Path]) -> None:
+    cp = _run(
+        [
+            "--raw-instruments",
+            str(fixture_paths["instruments"]),
+            "--raw-tickers",
+            str(fixture_paths["tickers"]),
+            "--probe-report",
+            str(fixture_paths["probe"]),
+            "--output-dir",
+            str(fixture_paths["output"]),
+            "--confirm-offline-transform-validation",
+            "WRONG",
+        ]
+    )
+    assert cp.returncode != 0
+
+
+def test_run_offline_transform_validation_success(
+    mod: Any, fixture_paths: dict[str, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    artifact = mod.run_offline_transform_validation(
+        confirm=_CONFIRM,
+        raw_instruments=fixture_paths["instruments"],
+        raw_tickers=fixture_paths["tickers"],
+        probe_report=fixture_paths["probe"],
+        output_dir=fixture_paths["output"],
+    )
+    assert artifact["schema"] == "u5d_u2c_candidate_validation_v1"
+    assert artifact["source_stage"] == "market_data_view_only"
+    assert artifact["provider"] == "kraken_futures"
+    assert artifact["transform_validation_only"] is True
+    assert artifact["GOVERNED_SNAPSHOT_ACCEPTED"] is False
+    assert artifact["SNAPSHOT_INTAKE_EXECUTED"] is False
+    assert artifact["LOADER_RUN_EXECUTED"] is False
+    assert artifact["READMODEL_WRITE_EXECUTED"] is False
+    assert artifact["DASHBOARD_WIRING_EXECUTED"] is False
+    assert artifact["LIVE_AUTHORIZED"] is False
+    assert artifact["PREFLIGHT_LIFT_AUTHORIZED"] is False
+    assert artifact["selected_tradable_future_created"] is False
+
+    join = artifact["join"]
+    assert join["join_key"] == "symbol"
+    assert join["instruments_eligible_count"] == 3
+    assert join["matched_count"] == 3
+    assert any(r["reason"] == "INELIGIBLE_SPOT_SYMBOL" for r in join["rejected_symbols"])
+    assert any(r["reason"] == "EXPIRED_INSTRUMENT" for r in join["rejected_symbols"])
+    assert any(o["symbol"] == "FI_LTCUSD_250131" for o in join["orphan_tickers"])
+
+    top20 = artifact["top20_ranking_candidate"]
+    assert len(top20) == 2
+    assert top20[0]["symbol"] == "PF_ETHUSD"
+    assert top20[1]["symbol"] == "PF_XBTUSD"
+    assert all(t["not_alphabetical_preview"] for t in top20)
+    assert artifact["ranking_notes"]["u5b_alphabetical_preview_not_reused"] is True
+
+    eth = next(p for p in artifact["packet_candidates"] if p["symbol"] == "PF_ETHUSD")
+    assert eth["display_price"] == 3500.0
+    assert eth["display_price_source"] == "markPrice"
+    assert "last_missing_markPrice_fallback" in eth["degraded_fields"]
+
+    ada = next(p for p in artifact["packet_candidates"] if p["symbol"] == "PF_ADAUSD")
+    assert ada["vol24h"] == 0.0
+    assert "vol24h" in ada["missing_fields"]
+
+    out_json = fixture_paths["output"] / "u5d_u2c_candidate_validation.v1.json"
+    assert out_json.is_file()
+    assert (fixture_paths["output"] / "transform_summary.md").is_file()
+
+    out = capsys.readouterr().out
+    assert "TRANSFORM_VALIDATION_ONLY=true" in out
+    assert "NOT_TRADING=true" in out
+    assert "GOVERNED_SNAPSHOT_ACCEPTED=false" in out
+
+
+def test_slash_spot_symbols_rejected(
+    mod: Any, fixture_paths: dict[str, Path], tmp_path: Path
+) -> None:
+    artifact = mod.run_offline_transform_validation(
+        confirm=_CONFIRM,
+        raw_instruments=fixture_paths["instruments"],
+        raw_tickers=fixture_paths["tickers"],
+        probe_report=fixture_paths["probe"],
+        output_dir=tmp_path / "out2",
+    )
+    rejected = {r["symbol"]: r["reason"] for r in artifact["join"]["rejected_symbols"]}
+    assert rejected.get("BTC/USD") == "INELIGIBLE_SPOT_SYMBOL"
+    symbols = [p["symbol"] for p in artifact["packet_candidates"]]
+    assert "BTC/USD" not in symbols
+
+
+def test_top20_ranking_deterministic_by_vol24h(mod: Any) -> None:
+    rows = [
+        {"symbol": "PF_A", "active": True, "vol24h": 100.0},
+        {"symbol": "PF_B", "active": True, "vol24h": 200.0},
+        {"symbol": "PF_C", "active": True, "vol24h": 200.0},
+    ]
+    top = mod.build_top20_ranking_candidate(rows)
+    assert [t["symbol"] for t in top] == ["PF_B", "PF_C", "PF_A"]
+
+
+def test_missing_required_inputs_fail(
+    mod: Any, fixture_paths: dict[str, Path], tmp_path: Path
+) -> None:
+    with pytest.raises(SystemExit):
+        mod.run_offline_transform_validation(
+            confirm=_CONFIRM,
+            raw_instruments=tmp_path / "missing.json",
+            raw_tickers=fixture_paths["tickers"],
+            probe_report=fixture_paths["probe"],
+            output_dir=tmp_path / "out3",
+        )
+
+
+def test_cli_end_to_end_writes_outputs(fixture_paths: dict[str, Path], tmp_path: Path) -> None:
+    out_dir = tmp_path / "cli_out"
+    cp = _run(
+        [
+            "--raw-instruments",
+            str(fixture_paths["instruments"]),
+            "--raw-tickers",
+            str(fixture_paths["tickers"]),
+            "--probe-report",
+            str(fixture_paths["probe"]),
+            "--output-dir",
+            str(out_dir),
+            "--confirm-offline-transform-validation",
+            _CONFIRM,
+        ]
+    )
+    assert cp.returncode == 0, cp.stderr
+    payload = json.loads((out_dir / "u5d_u2c_candidate_validation.v1.json").read_text())
+    assert payload["schema"] == "u5d_u2c_candidate_validation_v1"
+    assert payload["selected_tradable_future_created"] is False
+    assert "strategy_score" not in json.dumps(payload)


### PR DESCRIPTION
## Summary
- Adds offline-only U5D transform validation CLI (`transform_kraken_futures_raw_to_u2c_candidate_v1.py`) for Kraken Futures raw instruments/tickers + U5B probe report
- Emits `u5d_u2c_candidate_validation.v1` validation artifacts with vol24h ranking, degraded/null field policy, and safety markers
- Extends U5C contract doc §12.11 and adds fixture-based tests (no network)

## Test plan
- [x] `pytest tests/ops/test_transform_kraken_futures_raw_to_u2c_candidate_v1.py`
- [x] `pytest tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py`
- [x] `ruff check` / `ruff format --check` on changed Python files
- [x] `validate_docs_token_policy.py --base origin/main`
- [x] No transform execution against durable evidence in this PR
- [x] No snapshot intake, loader, readmodel write, or dashboard wiring


Made with [Cursor](https://cursor.com)