### PR TITLE
Align U2C candidate packets with U2B loader validation

### DIFF
--- a/scripts/ops/build_u2c_governed_snapshot_candidate_v1.py
+++ b/scripts/ops/build_u2c_governed_snapshot_candidate_v1.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""U2C: build governed snapshot candidate bundle from U5D validation (nested U2B packet shape).
+
+Emits futures_producer_packet_governed.v1.json with nested FuturesProducerPacket entries,
+metadata table artifacts, and MANIFEST_VERIFY.log containing MANIFEST_VERIFY_RC=0.
+
+Not loader write, readmodel write, dashboard wiring, truth-GO, or trading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import finalize_durable_bundle_manifest
+from scripts.ops.u2c_packet_shape_v1 import flat_row_to_nested_packet
+
+CONFIRM_TOKEN = "CONFIRM_U2C_GOVERNED_SNAPSHOT_CANDIDATE_BUILD_V1"
+GOVERNED_SCHEMA_NAME = "futures_producer_packet_governed.v1"
+GOVERNED_SOURCE_KIND = "governed_metadata_snapshot"
+PRODUCER_ID = "u2c_governed_snapshot_candidate_build_v1"
+SOURCE_STAGE = "paper"
+SOURCE_STAGE_REASON = "public_view_only_market_data_packaged_for_paper_stage_candidate"
+MARKET_DATA_SOURCE_STAGE = "market_data_view_only"
+TOP_N = 20
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_u5d(path: Path) -> Mapping[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _die(f"ERR: cannot read U5D validation JSON {path}: {exc}")
+    if not isinstance(data, dict):
+        _die(f"ERR: U5D validation root must be object: {path}")
+    if data.get("schema") != "u5d_u2c_candidate_validation_v1":
+        _die("ERR: expected schema u5d_u2c_candidate_validation_v1")
+    return data
+
+
+def _rank_lookup(top20: Sequence[Mapping[str, Any]]) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    for item in top20:
+        sym = str(item.get("symbol") or "")
+        rank = item.get("rank")
+        if sym and isinstance(rank, int):
+            out[sym] = rank
+    return out
+
+
+def build_governed_snapshot_candidate_bundle(
+    *,
+    confirm: str,
+    u5d_validation_path: Path,
+    output_dir: Path,
+    archive_root: Path,
+    bundle_id: str,
+    evidence_links: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    if confirm != CONFIRM_TOKEN:
+        _die("ERR: confirm token required for governed snapshot candidate build")
+
+    u5d = _load_u5d(u5d_validation_path)
+    packet_rows = u5d.get("packet_candidates") or []
+    top20_raw = u5d.get("top20_ranking_candidate") or []
+    if not isinstance(packet_rows, list) or not packet_rows:
+        _die("ERR: packet_candidates missing or empty in U5D validation")
+
+    output_dir = output_dir.expanduser().resolve()
+    archive_root = archive_root.expanduser().resolve()
+    try:
+        output_dir.relative_to(archive_root)
+    except ValueError:
+        _die("ERR: output_dir must be under archive_root")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated_at = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fetched_at = str(u5d.get("fetched_at") or generated_at)
+    rank_by_symbol = _rank_lookup(top20_raw)
+    universe_size = len(packet_rows)
+
+    nested_packets: List[Dict[str, Any]] = []
+    for row in packet_rows:
+        if not isinstance(row, Mapping):
+            continue
+        symbol = str(row.get("symbol") or "")
+        if not symbol:
+            continue
+        nested_packets.append(
+            flat_row_to_nested_packet(
+                row,
+                candidate_id=f"c-{symbol}",
+                source_universe_size=universe_size,
+                rank=rank_by_symbol.get(symbol),
+                selected_top_n=TOP_N,
+            )
+        )
+
+    if not nested_packets:
+        _die("ERR: no nested packets produced")
+
+    metadata_table_path = output_dir / "metadata_table.v1.json"
+    metadata_rows = [
+        {
+            "instrument_id": p["candidate"]["instrument_id"],
+            "symbol": p["candidate"]["symbol"],
+            "market_type": p["candidate"]["market_type"],
+            "exchange": p["candidate"]["exchange"],
+            "base_currency": p["candidate"]["base_currency"],
+            "quote_currency": p["candidate"]["quote_currency"],
+            "instrument_complete": p["instrument"]["complete"],
+            "provenance_complete": p["provenance"]["complete"],
+        }
+        for p in nested_packets
+    ]
+    metadata_table_path.write_text(
+        json.dumps(
+            {
+                "schema": "metadata_table.v1",
+                "bundle_id": bundle_id,
+                "row_count": len(metadata_rows),
+                "rows": metadata_rows,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    metadata_table_ref_path = output_dir / "metadata_table_ref.v1.json"
+    metadata_table_ref_path.write_text(
+        json.dumps(
+            {
+                "schema": "metadata_table_ref.v1",
+                "bundle_id": bundle_id,
+                "metadata_table_ref": str(metadata_table_path.resolve()),
+                "row_count": len(metadata_rows),
+                "source_stage": SOURCE_STAGE,
+                "market_data_source_stage": MARKET_DATA_SOURCE_STAGE,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    links: List[str] = []
+    if evidence_links:
+        links.extend(str(p) for p in evidence_links)
+    input_paths = u5d.get("input_paths") or {}
+    if isinstance(input_paths, dict):
+        for key in ("probe_report", "raw_instruments", "raw_tickers"):
+            val = input_paths.get(key)
+            if isinstance(val, str) and val.strip():
+                links.append(val.strip())
+    links.append(str(u5d_validation_path.resolve()))
+    # stable dedupe
+    seen: set[str] = set()
+    deduped_links: List[str] = []
+    for link in links:
+        if link not in seen:
+            seen.add(link)
+            deduped_links.append(link)
+
+    evidence_links_path = output_dir / "evidence_links.v1.json"
+    evidence_links_path.write_text(
+        json.dumps(
+            {
+                "schema": "evidence_links.v1",
+                "bundle_id": bundle_id,
+                "source_stage": SOURCE_STAGE,
+                "market_data_source_stage": MARKET_DATA_SOURCE_STAGE,
+                "evidence_links": deduped_links,
+                "input_checksums": u5d.get("input_checksums") or {},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    top20_path = output_dir / "top20_ranking_candidate.v1.json"
+    top20_path.write_text(
+        json.dumps(
+            {
+                "schema": "top20_ranking_candidate.v1",
+                "bundle_id": bundle_id,
+                "candidate_count": len(top20_raw),
+                "ranking_basis": "vol24h_desc",
+                "candidates": list(top20_raw),
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    governed_path = output_dir / "futures_producer_packet_governed.v1.json"
+    governed_doc: Dict[str, Any] = {
+        "schema_name": GOVERNED_SCHEMA_NAME,
+        "schema_version": 1,
+        "bundle_id": bundle_id,
+        "source_kind": GOVERNED_SOURCE_KIND,
+        "producer_id": PRODUCER_ID,
+        "provider": u5d.get("provider") or "kraken_futures",
+        "generated_at": generated_at,
+        "source_run_id": bundle_id,
+        "source_stage": SOURCE_STAGE,
+        "source_stage_reason": SOURCE_STAGE_REASON,
+        "market_data_source_stage": MARKET_DATA_SOURCE_STAGE,
+        "fixture_only": False,
+        "observability_truth_allowed": False,
+        "non_authorizing": True,
+        "real_metadata_source_marked": True,
+        "candidate_phase": True,
+        "GOVERNED_SNAPSHOT_ACCEPTED_FOR_INTAKE": False,
+        "metadata_table_ref": str(metadata_table_path.resolve()),
+        "metadata_refresh_utc": fetched_at,
+        "evidence_links": deduped_links,
+        "candidate_packet_count": len(nested_packets),
+        "selected_candidate_id": None,
+        "universe": {
+            "conceptual_size": universe_size,
+            "eligible_packet_count": len(nested_packets),
+            "notes": "U2c governed snapshot candidate bundle — nested U2B packet shape",
+        },
+        "ranking": {
+            "selected_top_n": TOP_N,
+            "ranking_basis": "vol24h_desc",
+            "notes": "non-authorizing candidate ranking",
+            "u5b_alphabetical_preview_not_used": True,
+        },
+        "selected_future": {
+            "candidate_id": None,
+            "symbol": None,
+            "notes": "no selected tradable future — candidate bundle only",
+        },
+        "packets": nested_packets,
+    }
+    governed_path.write_text(json.dumps(governed_doc, indent=2) + "\n", encoding="utf-8")
+
+    safety_flags_path = output_dir / "candidate_safety_flags.v1.json"
+    safety_flags_path.write_text(
+        json.dumps(
+            {
+                "schema": "candidate_safety_flags.v1",
+                "CANDIDATE_BUNDLE_ONLY": True,
+                "GOVERNED_SNAPSHOT_ACCEPTED_FOR_INTAKE": False,
+                "SNAPSHOT_INTAKE_EXECUTED": False,
+                "LOADER_RUN_EXECUTED": False,
+                "READMODEL_WRITE_EXECUTED": False,
+                "DASHBOARD_WIRING_EXECUTED": False,
+                "TRUTH_GO_GRANTED": False,
+                "LIVE_AUTHORIZED": False,
+                "PREFLIGHT_LIFT_AUTHORIZED": False,
+                "SELECTED_TRADABLE_FUTURE_CREATED": False,
+                "NOT_TRADING": True,
+                "NOT_TRUTH_GO": True,
+                "NOT_SELECTED_TRADABLE_FUTURE": True,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = finalize_durable_bundle_manifest(output_dir)
+    if manifest_rc != 0:
+        _die(f"ERR: bundle manifest finalize failed rc={manifest_rc} msg={manifest_msg}")
+
+    summary = {
+        "bundle_id": bundle_id,
+        "output_dir": str(output_dir),
+        "candidate_packet_count": len(nested_packets),
+        "top20_candidate_count": len(top20_raw),
+        "manifest_verify_rc": manifest_rc,
+        "nested_packet_shape": True,
+        "source_stage": SOURCE_STAGE,
+        "market_data_source_stage": MARKET_DATA_SOURCE_STAGE,
+    }
+    (output_dir / "build_summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
+    return summary
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build U2C governed snapshot candidate bundle (nested U2B packet shape)."
+    )
+    parser.add_argument("--u5d-validation", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--archive-root", type=Path, required=True)
+    parser.add_argument("--bundle-id", type=str, required=True)
+    parser.add_argument("--evidence-link", action="append", default=[])
+    parser.add_argument(
+        "--confirm-governed-snapshot-candidate-build",
+        required=True,
+        choices=[CONFIRM_TOKEN],
+    )
+    ns = parser.parse_args(argv)
+    try:
+        build_governed_snapshot_candidate_bundle(
+            confirm=ns.confirm_governed_snapshot_candidate_build,
+            u5d_validation_path=ns.u5d_validation,
+            output_dir=ns.output_dir,
+            archive_root=ns.archive_root,
+            bundle_id=ns.bundle_id,
+            evidence_links=tuple(ns.evidence_link),
+        )
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/primary_evidence_retention_v0.py
+++ b/scripts/ops/primary_evidence_retention_v0.py
@@ -134,6 +134,32 @@ def finalize_primary_evidence_root(root: Path) -> tuple[bool, str]:
     return verify_manifest_sha256(root)
 
 
+def write_manifest_verify_log(root: Path, *, verify_ok: bool, verify_msg: str = "") -> int:
+    """Write MANIFEST_VERIFY.log with explicit MANIFEST_VERIFY_RC (U2b + template §6)."""
+    rc = 0 if verify_ok else 1
+    status = "OK" if verify_ok else "FAILED"
+    body = (
+        f"verify_ok={str(verify_ok).lower()}\n"
+        f"message={verify_msg}\n"
+        f"MANIFEST_VERIFY_RC={rc}\n"
+        f"STATUS={status}\n"
+    )
+    (root / MANIFEST_VERIFY_LOG_FILENAMES[0]).write_text(body, encoding="utf-8")
+    return rc
+
+
+def finalize_durable_bundle_manifest(root: Path) -> tuple[int, str]:
+    """Write MANIFEST.sha256, verify, persist MANIFEST_VERIFY.log with RC, re-hash."""
+    write_manifest_sha256(root)
+    verify_ok, verify_msg = verify_manifest_sha256(root)
+    rc = write_manifest_verify_log(root, verify_ok=verify_ok, verify_msg=verify_msg)
+    write_manifest_sha256(root)
+    final_ok, final_msg = verify_manifest_sha256(root)
+    if not final_ok:
+        return 1, final_msg
+    return rc, verify_msg
+
+
 def validate_durable_primary_evidence_root(
     root: Path,
     *,

--- a/scripts/ops/u2c_packet_shape_v1.py
+++ b/scripts/ops/u2c_packet_shape_v1.py
@@ -1,0 +1,146 @@
+"""U2C → U2B packet shape alignment: flat Kraken rows → nested FuturesProducerPacket JSON."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+
+
+def normalize_market_type(raw: str) -> str:
+    """Map U5D contract labels to U2b FuturesMarketType string values."""
+    value = (raw or "").strip().lower()
+    if value in {"future", "futures", "futures_inverse", "dated_future"}:
+        return "futures"
+    if value in {"perpetual", "flexible_futures", "swap"}:
+        return "perpetual"
+    return value or "perpetual"
+
+
+def flat_row_to_nested_packet(
+    row: Mapping[str, Any],
+    *,
+    candidate_id: str,
+    source_universe_size: int,
+    rank: Optional[int] = None,
+    selected_top_n: int = 20,
+) -> Dict[str, Any]:
+    """Convert a flat U5D packet_candidate row to nested FuturesProducerPacket JSON."""
+    symbol = str(row.get("symbol") or row.get("instrument_id") or "")
+    market_type = normalize_market_type(
+        str(row.get("market_type") or row.get("contract_type") or "perpetual")
+    )
+    missing = list(row.get("missing_fields") or [])
+
+    tick_known = row.get("tick_size") is not None
+    contract_known = row.get("contract_size") is not None
+    min_qty_known = row.get("min_qty") is not None
+    min_notional_known = row.get("min_notional") is not None
+    margin_known = row.get("margin_asset") is not None
+    settlement_known = row.get("settlement_asset") is not None
+    leverage_known = row.get("max_leverage") is not None
+    known_flags = (
+        tick_known,
+        contract_known,
+        min_qty_known,
+        min_notional_known,
+        margin_known,
+        settlement_known,
+        leverage_known,
+    )
+    instrument_complete = all(known_flags) and not missing
+
+    last_available = row.get("last_price") is not None
+    mark_available = row.get("mark_price") is not None
+    index_available = row.get("index_price") is not None
+    funding_available = row.get("funding_rate") is not None
+    oi_available = row.get("open_interest") is not None
+    fetched_at = str(row.get("fetched_at") or "")
+    provenance_missing: List[str] = []
+    if not fetched_at:
+        provenance_missing.append("fetched_at")
+    if not last_available and not mark_available:
+        provenance_missing.append("price")
+    provenance_complete = not provenance_missing and bool(fetched_at)
+
+    vol = row.get("vol24h")
+    spread = row.get("spread")
+    spread_bps: Optional[float] = None
+    if isinstance(spread, (int, float)) and row.get("display_price"):
+        try:
+            spread_bps = (float(spread) / float(row["display_price"])) * 10000.0
+        except (TypeError, ValueError, ZeroDivisionError):
+            spread_bps = None
+
+    return {
+        "candidate": {
+            "candidate_id": candidate_id,
+            "instrument_id": str(row.get("instrument_id") or symbol),
+            "symbol": symbol,
+            "market_type": market_type,
+            "exchange": str(row.get("exchange") or row.get("provider") or "kraken_futures"),
+            "base_currency": str(row.get("base_currency") or ""),
+            "quote_currency": str(row.get("quote_currency") or ""),
+            "live_authorization": False,
+        },
+        "ranking": {
+            "source_universe_size": source_universe_size,
+            "selected_top_n": selected_top_n,
+            "rank": rank,
+            "score": None,
+            "score_components_complete": False,
+            "is_top_n_member": rank is not None and rank <= selected_top_n,
+        },
+        "instrument": {
+            "complete": instrument_complete,
+            "contract_size_known": contract_known,
+            "tick_size_known": tick_known,
+            "step_size_known": contract_known,
+            "min_qty_known": min_qty_known,
+            "min_notional_known": min_notional_known,
+            "margin_asset_known": margin_known,
+            "settlement_asset_known": settlement_known,
+            "leverage_bounds_known": leverage_known,
+            "missing_fields": missing,
+        },
+        "provenance": {
+            "complete": provenance_complete,
+            "freshness_state": "fresh" if fetched_at else "unknown",
+            "dataset_id": f"u2c-{symbol}",
+            "source": "governed_metadata_snapshot",
+            "mark_available": mark_available,
+            "index_available": index_available,
+            "last_available": last_available,
+            "ohlcv_available": False,
+            "funding_available": funding_available,
+            "open_interest_available": oi_available,
+            "missing_fields": provenance_missing,
+        },
+        "volatility": {
+            "realized_volatility": None,
+            "atr_or_rolling_range": None,
+            "volatility_regime": None,
+            "dynamic_scope_usable": False,
+        },
+        "liquidity": {
+            "spread_bps": spread_bps,
+            "average_spread_bps": spread_bps,
+            "volume": vol if isinstance(vol, (int, float)) else None,
+            "quote_volume": None,
+            "liquidity_regime": None,
+            "spread_quality": None,
+        },
+        "derivatives": {
+            "funding_available": funding_available,
+            "funding_rate": row.get("funding_rate"),
+            "funding_regime": None,
+            "open_interest_available": oi_available,
+            "open_interest": row.get("open_interest"),
+            "open_interest_regime": None,
+        },
+        "opportunity": {
+            "opportunity_score": None,
+            "inactivity_score": None,
+            "movement_above_fee_slippage_breakeven": None,
+            "chop_risk": None,
+            "candidate_is_inactive": not bool(row.get("active", True)),
+        },
+    }

--- a/tests/ops/test_build_u2c_governed_snapshot_candidate_v1.py
+++ b/tests/ops/test_build_u2c_governed_snapshot_candidate_v1.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    parse_manifest_verify_log_rc,
+    verify_manifest_sha256,
+)
+from src.webui.workflow_dashboard_readmodel_v1.futures_producer_packet_real_metadata_source_v1 import (
+    FuturesProducerPacketRealMetadataSourceError,
+    load_futures_producer_packet_governed,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BUILD = _REPO_ROOT / "scripts/ops/build_u2c_governed_snapshot_candidate_v1.py"
+_U5D_FIXTURES = _REPO_ROOT / "tests/fixtures/u5d_offline_transform_v1/minimal"
+_CONFIRM_BUILD = "CONFIRM_U2C_GOVERNED_SNAPSHOT_CANDIDATE_BUILD_V1"
+_SCRATCH = _REPO_ROOT / "tests" / "_durable_archive_scratch"
+
+
+def _load_build_mod() -> Any:
+    spec = importlib.util.spec_from_file_location("_u2c_build", _BUILD)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _durable_archive_root(tmp_path: Path) -> Path:
+    candidate = tmp_path / "archive_root"
+    candidate.mkdir(parents=True, exist_ok=True)
+    if not str(candidate).startswith("/tmp"):
+        return candidate
+    _SCRATCH.mkdir(parents=True, exist_ok=True)
+    durable = _SCRATCH / str(uuid.uuid4())
+    durable.mkdir(parents=True, exist_ok=True)
+    return durable
+
+
+def _complete_flat_row(symbol: str, *, vol24h: float, rank: int) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "instrument_id": symbol,
+        "provider": "kraken_futures",
+        "exchange": "kraken_futures",
+        "market_type": "perpetual",
+        "contract_type": "perpetual",
+        "base_currency": symbol[3:6],
+        "quote_currency": "USD",
+        "active": True,
+        "tick_size": 0.05,
+        "contract_size": 1,
+        "min_qty": 0.001,
+        "min_notional": 1.0,
+        "margin_asset": "USD",
+        "settlement_asset": "USD",
+        "max_leverage": 50,
+        "fetched_at": "2026-06-08T18:00:00Z",
+        "last_price": 100.0 + rank,
+        "mark_price": 100.0 + rank,
+        "index_price": 100.0 + rank,
+        "vol24h": vol24h,
+        "bid": 99.0 + rank,
+        "ask": 101.0 + rank,
+        "spread": 2.0,
+        "funding_rate": 0.0001,
+        "open_interest": 1000.0,
+        "missing_fields": [],
+        "degraded_fields": [],
+    }
+
+
+@pytest.fixture
+def build_mod() -> Any:
+    return _load_build_mod()
+
+
+def test_per_file_ok_manifest_without_rc_line_is_rejected(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "artifact.json").write_text("{}\n", encoding="utf-8")
+    (bundle_dir / "MANIFEST_VERIFY.log").write_text("./artifact.json: OK\n", encoding="utf-8")
+    rc, msg, _ = parse_manifest_verify_log_rc(bundle_dir)
+    assert rc is None
+    assert "MANIFEST_VERIFY_RC missing" in msg
+
+
+def test_build_writes_manifest_verify_rc_zero(build_mod: Any, tmp_path: Path) -> None:
+    archive = _durable_archive_root(tmp_path)
+    u5d_path = archive / "runtime" / "u5d" / "u5d_u2c_candidate_validation.v1.json"
+    u5d_path.parent.mkdir(parents=True)
+    rows = [
+        _complete_flat_row("PF_ETHUSD", vol24h=200.0, rank=1),
+        _complete_flat_row("PF_XBTUSD", vol24h=100.0, rank=2),
+    ]
+    u5d_path.write_text(
+        json.dumps(
+            {
+                "schema": "u5d_u2c_candidate_validation_v1",
+                "provider": "kraken_futures",
+                "fetched_at": "2026-06-08T18:00:00Z",
+                "packet_candidates": rows,
+                "top20_ranking_candidate": [
+                    {"rank": 1, "symbol": "PF_ETHUSD", "vol24h": 200.0},
+                    {"rank": 2, "symbol": "PF_XBTUSD", "vol24h": 100.0},
+                ],
+                "input_paths": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out_dir = archive / "governed_metadata" / "test_bundle_v1"
+    summary = build_mod.build_governed_snapshot_candidate_bundle(
+        confirm=_CONFIRM_BUILD,
+        u5d_validation_path=u5d_path,
+        output_dir=out_dir,
+        archive_root=archive,
+        bundle_id="test_bundle_v1",
+    )
+    assert summary["manifest_verify_rc"] == 0
+    rc, _, _ = parse_manifest_verify_log_rc(out_dir)
+    assert rc == 0
+    ok, msg = verify_manifest_sha256(out_dir)
+    assert ok, msg
+
+    governed = json.loads((out_dir / "futures_producer_packet_governed.v1.json").read_text())
+    packet = governed["packets"][0]
+    assert "candidate" in packet
+    assert "instrument" in packet
+    assert "provenance" in packet
+    assert governed["selected_future"]["symbol"] is None
+    assert governed["GOVERNED_SNAPSHOT_ACCEPTED_FOR_INTAKE"] is False
+
+
+def test_u2b_validate_only_parses_built_fixture_bundle(build_mod: Any, tmp_path: Path) -> None:
+    archive = _durable_archive_root(tmp_path)
+    u5d_path = archive / "runtime" / "u5d" / "u5d_u2c_candidate_validation.v1.json"
+    u5d_path.parent.mkdir(parents=True)
+    rows = [
+        _complete_flat_row("PF_ETHUSD", vol24h=300.0, rank=1),
+        _complete_flat_row("PF_XBTUSD", vol24h=200.0, rank=2),
+    ]
+    u5d_path.write_text(
+        json.dumps(
+            {
+                "schema": "u5d_u2c_candidate_validation_v1",
+                "provider": "kraken_futures",
+                "fetched_at": "2026-06-08T18:00:00Z",
+                "packet_candidates": rows,
+                "top20_ranking_candidate": [
+                    {"rank": 1, "symbol": "PF_ETHUSD", "vol24h": 300.0},
+                    {"rank": 2, "symbol": "PF_XBTUSD", "vol24h": 200.0},
+                ],
+                "input_paths": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    evidence = archive / "runs" / "paper" / "evidence"
+    evidence.mkdir(parents=True)
+    (evidence / "CLOSEOUT.md").write_text("# evidence\n", encoding="utf-8")
+
+    out_dir = archive / "governed_metadata" / "u2b_fixture_bundle_v1"
+    build_mod.build_governed_snapshot_candidate_bundle(
+        confirm=_CONFIRM_BUILD,
+        u5d_validation_path=u5d_path,
+        output_dir=out_dir,
+        archive_root=archive,
+        bundle_id="u2b_fixture_bundle_v1",
+        evidence_links=(str(evidence.resolve()),),
+    )
+    bundle_path = out_dir / "futures_producer_packet_governed.v1.json"
+    bundle = load_futures_producer_packet_governed(bundle_path, archive_root=archive)
+    assert len(bundle.packets) == 2
+    assert bundle.source_stage == "paper"
+    assert bundle.non_authorizing is True
+    assert bundle.observability_truth_allowed is False
+    assert bundle.selected_candidate_id is None
+
+
+def test_u2b_rejects_per_file_ok_only_manifest_on_fixture_path(
+    build_mod: Any, tmp_path: Path
+) -> None:
+    archive = _durable_archive_root(tmp_path)
+    u5d_path = archive / "runtime" / "u5d" / "u5d_u2c_candidate_validation.v1.json"
+    u5d_path.parent.mkdir(parents=True)
+    rows = [_complete_flat_row("PF_ETHUSD", vol24h=100.0, rank=1)]
+    u5d_path.write_text(
+        json.dumps(
+            {
+                "schema": "u5d_u2c_candidate_validation_v1",
+                "provider": "kraken_futures",
+                "fetched_at": "2026-06-08T18:00:00Z",
+                "packet_candidates": rows,
+                "top20_ranking_candidate": [{"rank": 1, "symbol": "PF_ETHUSD", "vol24h": 100.0}],
+                "input_paths": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out_dir = archive / "governed_metadata" / "bad_manifest_bundle_v1"
+    build_mod.build_governed_snapshot_candidate_bundle(
+        confirm=_CONFIRM_BUILD,
+        u5d_validation_path=u5d_path,
+        output_dir=out_dir,
+        archive_root=archive,
+        bundle_id="bad_manifest_bundle_v1",
+    )
+    (out_dir / "MANIFEST_VERIFY.log").write_text("./README.md: OK\n", encoding="utf-8")
+    bundle_path = out_dir / "futures_producer_packet_governed.v1.json"
+    with pytest.raises(
+        FuturesProducerPacketRealMetadataSourceError,
+        match="MANIFEST_VERIFY_RC_INVALID",
+    ):
+        load_futures_producer_packet_governed(bundle_path, archive_root=archive)
+
+
+def test_build_from_u5d_minimal_fixture_nested_shape(build_mod: Any, tmp_path: Path) -> None:
+    transform = importlib.util.spec_from_file_location(
+        "_u5d",
+        _REPO_ROOT / "scripts/ops/transform_kraken_futures_raw_to_u2c_candidate_v1.py",
+    )
+    assert transform is not None and transform.loader is not None
+    u5d_mod = importlib.util.module_from_spec(transform)
+    transform.loader.exec_module(u5d_mod)
+
+    archive = _durable_archive_root(tmp_path)
+    u5d_out = archive / "runtime" / "u5d_minimal"
+    artifact = u5d_mod.run_offline_transform_validation(
+        confirm="CONFIRM_U5D_OFFLINE_TRANSFORM_VALIDATION_V1",
+        raw_instruments=_U5D_FIXTURES / "kraken_futures_instruments.raw.v1.json",
+        raw_tickers=_U5D_FIXTURES / "kraken_futures_tickers.raw.v1.json",
+        probe_report=_U5D_FIXTURES / "kraken_futures_public_market_data_probe_report.v1.json",
+        output_dir=u5d_out,
+    )
+    assert len(artifact["packet_candidates"]) == 3
+
+    out_dir = archive / "governed_metadata" / "from_minimal_u5d_v1"
+    summary = build_mod.build_governed_snapshot_candidate_bundle(
+        confirm=_CONFIRM_BUILD,
+        u5d_validation_path=u5d_out / "u5d_u2c_candidate_validation.v1.json",
+        output_dir=out_dir,
+        archive_root=archive,
+        bundle_id="from_minimal_u5d_v1",
+    )
+    assert summary["nested_packet_shape"] is True
+    governed = json.loads((out_dir / "futures_producer_packet_governed.v1.json").read_text())
+    assert all("candidate" in p for p in governed["packets"])
+    assert "BTC/USD" not in json.dumps(governed)

--- a/tests/ops/test_u2c_packet_shape_v1.py
+++ b/tests/ops/test_u2c_packet_shape_v1.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SHAPE = _REPO_ROOT / "scripts/ops/u2c_packet_shape_v1.py"
+
+
+def _load_shape_mod() -> Any:
+    spec = importlib.util.spec_from_file_location("_u2c_shape", _SHAPE)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def shape() -> Any:
+    return _load_shape_mod()
+
+
+def test_normalize_market_type_maps_future_labels(shape: Any) -> None:
+    assert shape.normalize_market_type("future") == "futures"
+    assert shape.normalize_market_type("flexible_futures") == "perpetual"
+    assert shape.normalize_market_type("perpetual") == "perpetual"
+
+
+def test_flat_row_produces_nested_futures_producer_packet_shape(shape: Any) -> None:
+    row = {
+        "symbol": "PF_ETHUSD",
+        "instrument_id": "PF_ETHUSD",
+        "market_type": "perpetual",
+        "exchange": "kraken_futures",
+        "base_currency": "ETH",
+        "quote_currency": "USD",
+        "tick_size": 0.05,
+        "contract_size": 1,
+        "min_qty": 0.001,
+        "min_notional": 1.0,
+        "margin_asset": "USD",
+        "settlement_asset": "USD",
+        "max_leverage": 50,
+        "fetched_at": "2026-06-08T18:00:00Z",
+        "last_price": 3500.0,
+        "mark_price": 3500.0,
+        "index_price": 3500.0,
+        "vol24h": 1000.0,
+        "bid": 3499.0,
+        "ask": 3501.0,
+        "spread": 2.0,
+        "funding_rate": 0.0001,
+        "open_interest": 1000.0,
+        "active": True,
+        "missing_fields": [],
+    }
+    packet = shape.flat_row_to_nested_packet(
+        row,
+        candidate_id="c-PF_ETHUSD",
+        source_universe_size=3,
+        rank=1,
+    )
+    assert "candidate" in packet
+    assert "ranking" in packet
+    assert "instrument" in packet
+    assert "provenance" in packet
+    assert packet["candidate"]["symbol"] == "PF_ETHUSD"
+    assert packet["candidate"]["live_authorization"] is False
+    assert packet["ranking"]["rank"] == 1
+    assert packet["ranking"]["score"] is None
+    assert packet["instrument"]["complete"] is True
+    assert packet["provenance"]["freshness_state"] == "fresh"
+    assert "strategy_score" not in str(packet)
+
+
+def test_incomplete_flat_row_keeps_instrument_incomplete(shape: Any) -> None:
+    row = {
+        "symbol": "PF_ADAUSD",
+        "instrument_id": "PF_ADAUSD",
+        "market_type": "perpetual",
+        "exchange": "kraken_futures",
+        "base_currency": "ADA",
+        "quote_currency": "USD",
+        "tick_size": 0.0001,
+        "contract_size": 1,
+        "fetched_at": "2026-06-08T18:00:00Z",
+        "last_price": 1.0,
+        "missing_fields": ["vol24h"],
+        "active": True,
+    }
+    packet = shape.flat_row_to_nested_packet(
+        row,
+        candidate_id="c-PF_ADAUSD",
+        source_universe_size=1,
+    )
+    assert packet["instrument"]["complete"] is False
+    assert packet["instrument"]["missing_fields"] == ["vol24h"]


### PR DESCRIPTION
## Summary
- Add U2C flat-row → nested FuturesProducerPacket conversion and governed snapshot candidate build script.
- Future candidate bundles write `MANIFEST_VERIFY.log` with explicit `MANIFEST_VERIFY_RC=0` via shared manifest helper.
- Add fixture/mocked tests proving U2b validate-only loader can parse built bundles; per-file-OK-only logs remain rejected.

## Test plan
- [x] `pytest tests/ops/test_u2c_packet_shape_v1.py tests/ops/test_build_u2c_governed_snapshot_candidate_v1.py`
- [x] `pytest tests/ops/test_transform_kraken_futures_raw_to_u2c_candidate_v1.py tests/webui/test_futures_producer_packet_real_metadata_source_v1.py`
- [x] `ruff check` + `ruff format --check` on changed Python files
- [ ] No durable evidence mutation; no loader write/readmodel/dashboard/truth/live/trading


Made with [Cursor](https://cursor.com)