### PR TITLE
docs: record Kraken public min_notional permanent block

### DIFF
--- a/docs/webui/observability/FUTURES_UNIVERSE_GOVERNED_METADATA_SNAPSHOT_TEMPLATE_V1.md
+++ b/docs/webui/observability/FUTURES_UNIVERSE_GOVERNED_METADATA_SNAPSHOT_TEMPLATE_V1.md
@@ -148,6 +148,8 @@ Required `*_known` flags (all **true**):
 
 Underlying values (`tick_size`, `lot_size`, `min_notional`, margin constraints when known) must be explicit — **no silent defaults**.
 
+**Kraken public-view candidate bundles:** When `missing_provider_metadata_policy.allowed_missing_provider_metadata` includes `min_notional` only, `instrument.complete` may remain `false` while `candidate_validation_complete=true`. This is **not** strict-upstream-ready. Canonical normative record: [REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md](REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md) §12.12 — **no parallel SSOT**.
+
 ### Provenance completeness
 
 ```

--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -66,6 +66,7 @@ Additive Workflow Dashboard V1 panel — **diagnostic-only**, **not** observabil
 - **Markers:** `data-workflow-panel-kraken-metadata-coverage-v1="true"`, `data-kraken-metadata-coverage-diagnostic-only="true"`, `data-kraken-metadata-coverage-not-truth="true"`, `data-kraken-metadata-coverage-not-selected-future="true"`, `data-kraken-metadata-coverage-strict-upstream-blocked="true"`.
 - **Coexistence:** separate from Projection Coverage (`data-workflow-panel-projection-coverage-v1`); Missing Truth panels unchanged.
 - **Strict upstream:** `bundle_to_upstream_input` remains blocked when `min_notional_unknown` — panel does not lift upstream or truth gates.
+- **Permanent block reference:** Kraken public `/instruments` supplies no provider-authentic `min_notional` — see [REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md](REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md) §12.12.
 
 ### Universe Selection Persistence Contract v1 (Slice 1 — schema/docs only)
 

--- a/docs/webui/observability/REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md
+++ b/docs/webui/observability/REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md
@@ -339,3 +339,64 @@ Missing Kraken fields must remain in `missing_fields` — **no BTC&#47;USD subst
 ### 12.11 U5D Offline Transform Validation CLI
 
 **U5d offline validation record:** Manual operator CLI `transform_kraken_futures_raw_to_u2c_candidate_v1.py` reads durable U5C raw instruments/tickers + U5B probe report and emits **`u5d_u2c_candidate_validation.v1`** validation artifact only. Requires confirm token **`CONFIRM_U5D_OFFLINE_TRANSFORM_VALIDATION_V1`**. No network, no snapshot intake, no loader, no readmodel write, no dashboard wiring. **`GOVERNED_SNAPSHOT_ACCEPTED=false`** until separate operator acceptance.
+
+### 12.12 Kraken Public View — min_notional Permanent Block (normative)
+
+**Permanent-block record (docs/tests-only):** Normative statement that Kraken Futures **public** `/derivatives/api/v3/instruments` evidence does **not** supply a provider-authentic `min_notional` field. This section does **not** authorize enrichment, transform execution, loader writes, dashboard truth, strict-upstream lift, or selected tradable future creation.
+
+#### 12.12.1 Status (machine markers)
+
+```
+KRAKEN_PUBLIC_MIN_NOTIONAL_PROVIDER_FIELD_PRESENT=false
+PROVIDER_AUTHENTIC_MIN_NOTIONAL_SOURCE_FOUND=false
+OFFLINE_MIN_NOTIONAL_ENRICHMENT_FEASIBLE=false
+STRICT_UPSTREAM_REMAINS_BLOCKED_FOR_PUBLIC_VIEW=true
+MISSING_PROVIDER_METADATA_NOT_IN_PUBLIC_VIEW=min_notional
+IMPACT_MID_SIZE_MAPS_TO_MIN_QTY_NOT_MIN_NOTIONAL=true
+PRICE_QTY_MIN_NOTIONAL_HEURISTIC_FORBIDDEN=true
+TICK_SIZE_CONTRACT_SIZE_MIN_NOTIONAL_HEURISTIC_FORBIDDEN=true
+CVC_DIAGNOSTIC_PATH_NON_TRUTH_ONLY=true
+```
+
+#### 12.12.2 Provider evidence (U5C public instruments)
+
+| Fact | Rule |
+|------|------|
+| `min_notional` in raw `/instruments` JSON | **Absent** — no provider field to map |
+| `MISSING_PROVIDER_METADATA_NOT_IN_PUBLIC_VIEW` | Canonical code constant in `scripts/ops/u2c_packet_shape_v1.py` — **`min_notional` only** |
+| `extract_kraken_provider_instrument_fields` | Sets `missing_provider_metadata=["min_notional"]` when provider field absent |
+| `impactMidSize` | Maps to **`min_qty`** only (`kraken_instruments.impactMidSize`) — **not** `min_notional` |
+| `tickSize`, `contractSize`, `contractValueTradePrecision` | Sizing/precision fields — **not** exchange min-order-notional semantics |
+
+Offline U5C/U5D/U2c evidence may show `candidate_validation_complete=true` while `instrument.complete=false` and `min_notional_known=false` — this is **expected** for Kraken public-view-only bundles.
+
+#### 12.12.3 Forbidden enrichment shortcuts
+
+| Forbidden | Reason |
+|-----------|--------|
+| Dummy `min_notional` / dummy fills | Silent defaults forbidden (U2c §instrument completeness) |
+| `impactMidSize` relabelled as `min_notional` | Semantic drift; collides with existing `min_qty` mapping |
+| Ticker `last`/`markPrice` × `min_qty` or `impactMidSize` | Price/Qty heuristic without provider `min_notional` basis |
+| `tickSize` × `contractSize` as `min_notional` | Sizing math — not provider min-order-notional |
+| `instrument.complete` force | Strict validation must remain fail-closed |
+| `bundle_to_upstream_input` execute on public-view CVC bundles | `REASON_INSTRUMENT_INCOMPLETE` — all packets blocked until authentic `min_notional` exists |
+| Dashboard truth / selected tradable future from CVC or diagnostic panels | Non-truth paths only |
+
+#### 12.12.4 Strict upstream vs CVC diagnostic path
+
+| Path | Behavior |
+|------|----------|
+| Strict (`bundle_to_upstream_input`, `evaluate_packet_eligibility`) | **Fail-closed** when `instrument.complete=false` or `min_notional_known=false` |
+| CVC projection (`project_governed_candidate_validation_bundle_v1`) | Additive **non-truth** bridge only — `strict_upstream_blocked=true`, `observability_truth_allowed=false` |
+| Kraken metadata coverage panel (PR #4073) | Diagnostic-only display — does **not** lift upstream or truth gates |
+
+CVC and diagnostic surfaces **must not** weaken strict upstream gates or promote public-view bundles to observability truth.
+
+#### 12.12.5 Tests (boundary guards)
+
+| Test module | Purpose |
+|-------------|---------|
+| `tests/ops/test_u2c_packet_shape_v1.py` | `MISSING_PROVIDER_METADATA_NOT_IN_PUBLIC_VIEW`; `impactMidSize` ≠ `min_notional` |
+| `tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py` | §12.12 markers present; no forbidden heuristic language |
+| `tests/ops/test_transform_kraken_futures_raw_to_u2c_candidate_v1.py` | U5d rows keep `missing_provider_metadata=["min_notional"]` |
+| `tests/webui/test_candidate_validation_readmodel_projection_v1.py` | Strict path still blocked for CVC bundles |

--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -229,6 +229,7 @@ Governed bundles with `u2b_candidate_validation_only=true` and `candidate_valida
 - Produces contract-valid readmodel-shaped JSON with `observability_truth_allowed=false`, `selected_future.truth_status=NOT_PERSISTED`
 - **Does not** authorize readmodel persist, dashboard wiring, truth-GO, or selected tradable future
 - Strict upstream (`bundle_to_upstream_input`, `evaluate_packet_eligibility`) remains unchanged and fail-closed
+- **Permanent block (Kraken public view):** Missing `min_notional` in public `/instruments` keeps strict upstream fail-closed; CVC/diagnostic paths do **not** lift gates. Canonical normative record: [REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md](REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md) §12.12
 
 **Tests:** `tests/webui/test_candidate_validation_readmodel_projection_v1.py`
 

--- a/tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py
+++ b/tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py
@@ -186,3 +186,31 @@ def test_u5d_offline_transform_script_referenced_in_contract() -> None:
     assert "CONFIRM_U5D_OFFLINE_TRANSFORM_VALIDATION_V1" in doc or "U5d" in doc
     assert "test_transform_kraken_futures_raw_to_u2c_candidate_v1.py" in doc
     assert "u5d_u2c_candidate_validation_v1" in doc or "U5d offline" in doc
+
+
+def test_real_futures_contract_documents_public_view_min_notional_permanent_block() -> None:
+    doc = MARKET_DATA_SOURCE_DOC.read_text(encoding="utf-8")
+    assert "### 12.12 Kraken Public View — min_notional Permanent Block" in doc
+    markers = (
+        "KRAKEN_PUBLIC_MIN_NOTIONAL_PROVIDER_FIELD_PRESENT=false",
+        "PROVIDER_AUTHENTIC_MIN_NOTIONAL_SOURCE_FOUND=false",
+        "OFFLINE_MIN_NOTIONAL_ENRICHMENT_FEASIBLE=false",
+        "STRICT_UPSTREAM_REMAINS_BLOCKED_FOR_PUBLIC_VIEW=true",
+        "MISSING_PROVIDER_METADATA_NOT_IN_PUBLIC_VIEW=min_notional",
+        "IMPACT_MID_SIZE_MAPS_TO_MIN_QTY_NOT_MIN_NOTIONAL=true",
+        "PRICE_QTY_MIN_NOTIONAL_HEURISTIC_FORBIDDEN=true",
+        "CVC_DIAGNOSTIC_PATH_NON_TRUTH_ONLY=true",
+    )
+    for marker in markers:
+        assert marker in doc
+    assert "impactMidSize" in doc
+    assert "kraken_instruments.impactMidSize" in doc
+    assert "bundle_to_upstream_input" in doc
+    forbidden = (
+        "Dummy `min_notional`",
+        "impactMidSize` relabelled as `min_notional`",
+        "instrument.complete` force",
+    )
+    for phrase in forbidden:
+        assert phrase in doc
+    assert "observability_truth_allowed=false" in doc

--- a/tests/ops/test_u2c_packet_shape_v1.py
+++ b/tests/ops/test_u2c_packet_shape_v1.py
@@ -154,3 +154,28 @@ def test_incomplete_flat_row_keeps_instrument_incomplete(shape: Any) -> None:
     assert packet["instrument"]["candidate_validation_complete"] is False
     assert packet["instrument"]["missing_fields"] == []
     assert "min_qty" in packet["instrument"]["completeness_reason"]
+
+
+def test_missing_provider_metadata_not_in_public_view_includes_min_notional(shape: Any) -> None:
+    assert shape.MISSING_PROVIDER_METADATA_NOT_IN_PUBLIC_VIEW == frozenset({"min_notional"})
+    assert shape.CANDIDATE_VALIDATION_ALLOWED_MISSING_PROVIDER_METADATA == frozenset(
+        {"min_notional"}
+    )
+
+
+def test_extract_kraken_fields_never_sets_min_notional_from_impact_mid_size(shape: Any) -> None:
+    inst = {
+        "symbol": "PF_ETHUSD",
+        "quote": "USD",
+        "impactMidSize": 5.1,
+        "tickSize": 0.1,
+        "contractSize": 1,
+        "retailMarginLevels": [
+            {"numNonContractUnits": 0.0, "initialMargin": 0.01, "maintenanceMargin": 0.005}
+        ],
+    }
+    provider = shape.extract_kraken_provider_instrument_fields(inst)
+    assert "min_notional" not in provider
+    assert provider["min_qty"] == 5.1
+    assert provider["min_qty_source"] == "kraken_instruments.impactMidSize"
+    assert provider["missing_provider_metadata"] == ["min_notional"]


### PR DESCRIPTION
## Summary
- Additive §12.12 in `REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md` documenting the Kraken Futures public `/instruments` min_notional permanent block
- Brief cross-references in U2c template, universe selection readmodel, and observability hub (no parallel SSOT)
- Boundary tests in `test_u2c_packet_shape_v1.py` and `test_real_futures_market_data_source_contract_boundary_v1.py`

## Safety
- No live, no preflight lift, no dashboard truth, no selected tradable future
- No readmodel/loader/transform/upstream execute
- No dummy min_notional/fills; strict upstream remains blocked
- Docs/tests-only — no `scripts/ops` logic, `src/webui`, templates, workflows, runtime, execution, risk, or governance changes

## Tests
- `pytest tests/ops/test_u2c_packet_shape_v1.py tests/ops/test_real_futures_market_data_source_contract_boundary_v1.py` — 25 passed
- `ruff format --check` + `ruff check` on touched test files — pass

## Durable Evidence
- Implementation: `implementation/kraken_futures_public_view_min_notional_permanent_block_docs_tests_bounded_implementation_v1_20260609T033112Z/`
- Review: `review/kraken_futures_public_view_min_notional_permanent_block_docs_tests_bounded_pr_review_v1_20260609T033243Z/`
- PR bundle: `pr/kraken_futures_public_view_min_notional_permanent_block_docs_tests_create_pr_v1_<timestamp>/`

## Scope
Docs/tests-only bounded slice. No scripts/src/templates/workflows/runtime/execution/risk/governance changes.


Made with [Cursor](https://cursor.com)