### PR TITLE
Add contract-only fast lane for v1 ops contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   # - run_fast: always true. run_fast_lane: alias.
   # - docs_only: true when ONLY docs/out/*.md changed (no code, workflow, or static-contract paths).
   # - workflow_only: true when ONLY .github/workflows changed.
-  # - static_contract_changed: tests/ci/**, tests/ops/**, or tests/webui/test_*_structure_contract*.py (not full-matrix code).
+  # - static_contract_changed: tests/ci/**, tests/ops/**, tests/webui/test_*_structure_contract*.py, src/ops/*_contract_v0.py, src/ops/*_contract_v1.py (not full-matrix code).
   # - docs_or_static_contract_only: no src/scripts/config/workflow code paths; docs and/or static-contract only.
   # - webui_surface_changed: Market/Observability/WebUI surface paths (bounded Fast-Lane lane).
   # - webui_surface_only: webui_surface without non_webui_code (Case D — skip full matrix, bounded WebUI pytest).
@@ -65,7 +65,7 @@ jobs:
             code:
               # Picomatch extglob: offline ops contract modules use static_contract + Fast-Lane (PR #3984 lineage).
               - 'src/!(ops)/**'
-              - 'src/ops/!(*_contract_v0.py)'
+              - 'src/ops/!(*_contract_v0.py|*_contract_v1.py)'
               - 'templates/**'
               # Picomatch extglob (dorny/paths-filter): separate `!` lines do not exclude
               # matched files from `tests/**` (see PR #3728 validation). Split buckets:
@@ -90,7 +90,7 @@ jobs:
               - 'tests/ops/test_*_env_schema_boundary*.py'
             non_webui_code:
               - 'src/!(ops|webui)/**'
-              - 'src/ops/!(*_contract_v0.py)'
+              - 'src/ops/!(*_contract_v0.py|*_contract_v1.py)'
               - 'templates/!(peak_trade_dashboard)/**'
               - 'tests/!(ci|ops|webui|fixtures)/**'
               - 'scripts/**'
@@ -107,6 +107,7 @@ jobs:
               - 'tests/ops/**'
               - 'tests/webui/test_*_structure_contract*.py'
               - 'src/ops/*_contract_v0.py'
+              - 'src/ops/*_contract_v1.py'
             docs:
               - 'docs/**'
               - 'out/**'

--- a/.github/workflows/cursor_auto_pr.yml
+++ b/.github/workflows/cursor_auto_pr.yml
@@ -101,6 +101,39 @@ jobs:
 
             core.info(`CREATED: PR #${pr.data.number} ${pr.data.html_url}`);
 
+      - name: Checkout for contract-only classification
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Classify contract-only fast-lane candidate
+        id: classify
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          CHANGED="$(git diff --name-only origin/main...HEAD 2>/dev/null || true)"
+          if [ -z "$CHANGED" ]; then
+            echo "contract_only=false"
+            echo "contract_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CONTRACT_ONLY=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              src/ops/*_contract_v1.py) ;;
+              tests/ops/test_*_contract_v1.py) ;;
+              *)
+                echo "excluded path: $f"
+                CONTRACT_ONLY=false
+                break
+                ;;
+            esac
+          done <<< "$CHANGED"
+          echo "contract_only=${CONTRACT_ONLY}" >> "$GITHUB_OUTPUT"
+          echo "changed_files:"
+          echo "$CHANGED"
+
       - name: Dispatch required checks (workflow_dispatch)
         uses: actions/github-script@v7
         with:
@@ -110,10 +143,15 @@ jobs:
             const repo  = context.repo.repo;
             const ref   = context.ref.replace('refs/heads/', '');
 
+            const contractOnly = '${{ steps.classify.outputs.contract_only }}' === 'true';
+            const forceMatrix = contractOnly ? 'false' : 'true';
+            core.info(
+              `contract_only_fast_lane_candidate=${contractOnly} → ci.yml force_matrix=${forceMatrix}`
+            );
             core.info("Single workflow_dispatch sequence for required checks (one pass per cursor_auto_pr run).");
 
             const workflows = [
-              { id: 'ci.yml', inputs: { force_matrix: 'true' } },
+              { id: 'ci.yml', inputs: { force_matrix: forceMatrix } },
               { id: 'lint_gate.yml' },
               { id: 'policy_critic_gate.yml' },
               { id: 'policy_tracked_reports_guard.yml' },

--- a/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
+++ b/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
@@ -21,7 +21,8 @@ CODE_TEST_GLOBS = (
 )
 STATIC_CONTRACT_WEBUI_GLOB = "tests/webui/test_*_structure_contract*.py"
 STATIC_OPS_CONTRACT_GLOB = "src/ops/*_contract_v0.py"
-SRC_OPS_NON_CONTRACT_GLOB = "src/ops/!(*_contract_v0.py)"
+STATIC_OPS_CONTRACT_V1_GLOB = "src/ops/*_contract_v1.py"
+SRC_OPS_NON_CONTRACT_GLOB = "src/ops/!(*_contract_v0.py|*_contract_v1.py)"
 SRC_NON_OPS_GLOB = "src/!(ops)/**"
 WEBUI_SURFACE_GLOBS = (
     "src/webui/**",
@@ -33,7 +34,7 @@ WEBUI_SURFACE_GLOBS = (
 )
 NON_WEBUI_CODE_GLOBS = (
     "src/!(ops|webui)/**",
-    "src/ops/!(*_contract_v0.py)",
+    "src/ops/!(*_contract_v0.py|*_contract_v1.py)",
     "templates/!(peak_trade_dashboard)/**",
     "tests/!(ci|ops|webui|fixtures)/**",
     "scripts/**",
@@ -127,10 +128,30 @@ def _matches_static_contract_ops_src(path: str) -> bool:
     return fnmatch.fnmatch(path, STATIC_OPS_CONTRACT_GLOB)
 
 
+def _matches_static_contract_ops_v1(path: str) -> bool:
+    return fnmatch.fnmatch(path, STATIC_OPS_CONTRACT_V1_GLOB)
+
+
+def _matches_static_contract_ops_offline(path: str) -> bool:
+    return _matches_static_contract_ops_src(path) or _matches_static_contract_ops_v1(path)
+
+
+def _is_contract_only_fast_lane_candidate(paths: list[str]) -> bool:
+    if not paths:
+        return False
+    for path in paths:
+        if fnmatch.fnmatch(path, STATIC_OPS_CONTRACT_V1_GLOB):
+            continue
+        if fnmatch.fnmatch(path, "tests/ops/test_*_contract_v1.py"):
+            continue
+        return False
+    return True
+
+
 def _matches_code_filter(path: str) -> bool:
     if path.startswith("templates/"):
         return True
-    if _matches_static_contract_ops_src(path):
+    if _matches_static_contract_ops_offline(path):
         return False
     if path.startswith("src/ops/"):
         return True
@@ -162,7 +183,7 @@ def _matches_non_webui_code(path: str) -> bool:
         return True
     if path.startswith("src/webui/"):
         return False
-    if _matches_static_contract_ops_src(path):
+    if _matches_static_contract_ops_offline(path):
         return False
     if path.startswith("src/ops/"):
         return True
@@ -214,6 +235,11 @@ def test_static_contract_includes_webui_structure_contract_whitelist() -> None:
 def test_static_contract_includes_ops_offline_contract_modules() -> None:
     static_block = _static_block()
     assert f"'{STATIC_OPS_CONTRACT_GLOB}'" in static_block
+
+
+def test_static_contract_includes_ops_contract_v1_modules() -> None:
+    static_block = _static_block()
+    assert f"'{STATIC_OPS_CONTRACT_V1_GLOB}'" in static_block
 
 
 def test_code_filter_narrows_src_ops_contract_v0_modules() -> None:
@@ -376,3 +402,79 @@ def test_webui_surface_and_non_webui_path_semantics_v1(
 )
 def test_run_matrix_semantics_for_path_sets_v1(paths: list[str], expect_run_matrix: bool) -> None:
     assert _run_matrix_for_paths(paths) is expect_run_matrix
+
+
+@pytest.mark.parametrize(
+    ("path", "expect_code", "expect_static", "expect_non_webui"),
+    [
+        ("src/ops/order_capability_payload_builder_contract_v1.py", False, True, False),
+        ("src/ops/order_capability_killswitch_abort_binding_contract_v1.py", False, True, False),
+        ("src/ops/order_capability_cancel_cleanup_failclosed_contract_v1.py", False, True, False),
+        ("tests/ops/test_order_capability_payload_builder_contract_v1.py", False, False, False),
+        ("src/execution/contracts.py", True, False, True),
+        ("src/risk_layer/kill_switch/foo.py", True, False, True),
+        ("scripts/ops/run_order_capability_foo.py", False, False, True),
+    ],
+)
+def test_contract_v1_path_semantics(
+    path: str,
+    expect_code: bool,
+    expect_static: bool,
+    expect_non_webui: bool,
+) -> None:
+    assert _matches_code_filter(path) is expect_code
+    assert _matches_static_contract_ops_offline(path) is expect_static
+    assert _matches_non_webui_code(path) is expect_non_webui
+
+
+@pytest.mark.parametrize(
+    ("paths", "expect_contract_only", "expect_run_matrix"),
+    [
+        (["src/ops/order_capability_payload_builder_contract_v1.py"], True, False),
+        (
+            [
+                "src/ops/order_capability_killswitch_abort_binding_contract_v1.py",
+                "tests/ops/test_order_capability_killswitch_abort_binding_contract_v1.py",
+            ],
+            True,
+            False,
+        ),
+        (
+            [
+                "src/ops/order_capability_cancel_cleanup_failclosed_contract_v1.py",
+                "tests/ops/test_order_capability_cancel_cleanup_failclosed_contract_v1.py",
+            ],
+            True,
+            False,
+        ),
+        (["src/execution/contracts.py"], False, True),
+        (["src/risk_layer/kill_switch/foo.py"], False, True),
+        (["scripts/ops/run_order_capability_foo.py"], False, True),
+        ([".github/workflows/ci.yml"], False, False),
+        (
+            [
+                "src/ops/order_capability_foo_contract_v1.py",
+                "src/runtime/bar.py",
+            ],
+            False,
+            True,
+        ),
+    ],
+)
+def test_contract_only_v1_run_matrix_semantics(
+    paths: list[str],
+    expect_contract_only: bool,
+    expect_run_matrix: bool,
+) -> None:
+    assert _is_contract_only_fast_lane_candidate(paths) is expect_contract_only
+    assert _run_matrix_for_paths(paths) is expect_run_matrix
+
+
+def test_force_matrix_overrides_contract_only_v1_paths() -> None:
+    paths = [
+        "src/ops/order_capability_payload_builder_contract_v1.py",
+        "tests/ops/test_order_capability_payload_builder_contract_v1.py",
+    ]
+    assert _is_contract_only_fast_lane_candidate(paths) is True
+    assert _run_matrix_for_paths(paths, force_matrix=False) is False
+    assert _run_matrix_for_paths(paths, force_matrix=True) is True


### PR DESCRIPTION
## Summary

- Extends existing static-contract fast-lane classification to v1 ops contracts.
- Adds governed `cursor_auto_pr` `force_matrix=false` only for strict contract-only file sets.
- Extends CI static contract tests for #4079/#4080 shapes, cancel_cleanup shape, and fail-closed negative cases.

## Scope

- `.github/workflows/ci.yml`
- `.github/workflows/cursor_auto_pr.yml`
- `tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py`

## Safety / Governance

- Lint Gate remains Always Run.
- Required contexts keep step-level skip-success semantics.
- `force_matrix` remains `true` for mixed/risky paths, `src/execution`, `src/risk_layer`, `scripts/ops`, workflows, and parser/diff failures.
- No branch-protection or required-check mutation.
- No runtime, execution, risk, trading, evidence, or order-capability contract changes.

## Evidence

- Implementation bundle:
  `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/ci_required_checks_contract_only_fast_lane_impl_v1_20260609T143853Z/`
- Post-impl review bundle:
  `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/review/ci_required_checks_contract_only_fast_lane_post_impl_review_no_run_v1_20260609T144236Z/`
- `MANIFEST_VERIFY_RC=0`.
- Local validation: 56 pytest, guard script, ruff format/check, Docs Token Policy Guard PASS.

## Authority

- `NO_AUTHORITY_CHANGE=true`.
- No Live/Preflight/Truth/Dashboard change.
- No network/secret/adapter/submit/cancel.


Made with [Cursor](https://cursor.com)