### PR TITLE
ops: add order-capability retention layout validation

### DIFF
--- a/scripts/ops/primary_evidence_retention_v0.py
+++ b/scripts/ops/primary_evidence_retention_v0.py
@@ -14,6 +14,7 @@ EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true
 VALIDATE_DURABLE_PRIMARY_EVIDENCE_ROOT_V0=true
 PRIMARY_EVIDENCE_RETENTION_HARD_GATE_EXTENSION_V0=true
 VALIDATE_DURABLE_LIFECYCLE_CLOSEOUT_ROOT_V0=true
+VALIDATE_ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_ROOT_V0=true
 ```
 """
 
@@ -44,6 +45,14 @@ PAPER_BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS = (
     "runtime_out/evidence_manifest.json",
     "logs/scheduler_stdout.log",
     "logs/scheduler_stderr.log",
+    MANIFEST_FILENAME,
+)
+
+# Order-Capability offline dry-validation durable run roots (no network; non-authorizing).
+ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_REQUIRED_REL_PATHS = (
+    "RUN_METADATA.json",
+    "ORDER_CAPABILITY_DRY_VALIDATION_RESULT.json",
+    "CLOSEOUT.md",
     MANIFEST_FILENAME,
 )
 
@@ -212,6 +221,38 @@ def validate_durable_primary_evidence_root(
         return False, msg, {"checks": checks, "issues": issues}
 
     return True, "", {"checks": checks, "issues": []}
+
+
+def validate_order_capability_offline_durable_run_root(
+    run_root: Path | str,
+) -> tuple[bool, list[str]]:
+    """Validate order-cap offline dry-validation durable run root.
+
+    Machine marker: ``VALIDATE_ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_ROOT_V0=true``
+
+    Does not require review/REVIEW_RESULT.json (offline contract lane).
+    """
+    root = Path(run_root)
+    issues: list[str] = []
+
+    ok, msg = require_durable_archive_root(root)
+    if not ok:
+        issues.append(msg)
+        return False, issues
+
+    for rel in ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_REQUIRED_REL_PATHS:
+        if not (root / rel).is_file():
+            issues.append(f"missing durable required file: {rel}")
+
+    if issues:
+        return False, issues
+
+    ok, msg = verify_manifest_sha256(root)
+    if not ok:
+        issues.append(msg)
+        return False, issues
+
+    return True, []
 
 
 def parse_manifest_verify_log_rc(root: Path) -> tuple[int | None, str, str]:

--- a/scripts/ops/run_order_capability_dry_validation_adapter_v1.py
+++ b/scripts/ops/run_order_capability_dry_validation_adapter_v1.py
@@ -21,6 +21,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from scripts.ops.primary_evidence_retention_v0 import (
     require_durable_archive_root,
+    validate_order_capability_offline_durable_run_root,
     verify_manifest_sha256,
     write_manifest_sha256,
 )
@@ -134,9 +135,9 @@ def write_durable_evidence(args: argparse.Namespace) -> tuple[int, str]:
     )
     (dest / "CLOSEOUT.md").write_text(_closeout_markdown(result_payload), encoding="utf-8")
     write_manifest_sha256(dest)
-    manifest_ok, manifest_msg = verify_manifest_sha256(dest)
-    if not manifest_ok:
-        return VALIDATION_EXIT, manifest_msg
+    layout_ok, layout_issues = validate_order_capability_offline_durable_run_root(dest)
+    if not layout_ok:
+        return VALIDATION_EXIT, "; ".join(layout_issues)
     return 0, str(dest)
 
 

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CANONICAL_OWNER = (
@@ -257,6 +260,22 @@ def test_order_capability_offline_durable_run_required_rel_paths_defined() -> No
     )
 
 
+def _durable_archive(tmp_path: Path) -> Path:
+    path = REPO_ROOT / "tests" / ".pytest_archive_roots" / tmp_path.name
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_durable_archive_roots():
+    yield
+    archive_roots = REPO_ROOT / "tests" / ".pytest_archive_roots"
+    if archive_roots.is_dir():
+        shutil.rmtree(archive_roots, ignore_errors=True)
+
+
 def test_shared_helper_validate_order_capability_offline_durable_run_root_marker() -> None:
     text = SHARED_HELPER.read_text(encoding="utf-8")
     assert "def validate_order_capability_offline_durable_run_root" in text
@@ -273,7 +292,7 @@ def test_validate_order_capability_offline_durable_run_root_passes_minimal_layou
         write_manifest_sha256,
     )
 
-    root = tmp_path / "order_cap_run"
+    root = _durable_archive(tmp_path) / "order_cap_run"
     root.mkdir()
     for rel in ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_REQUIRED_REL_PATHS:
         if rel == MANIFEST_FILENAME:
@@ -294,7 +313,7 @@ def test_validate_order_capability_offline_durable_run_root_fail_closed_missing_
         validate_order_capability_offline_durable_run_root,
     )
 
-    root = tmp_path / "incomplete"
+    root = _durable_archive(tmp_path) / "incomplete"
     root.mkdir()
     (root / "RUN_METADATA.json").write_text("{}", encoding="utf-8")
     ok, issues = validate_order_capability_offline_durable_run_root(root)

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -243,6 +243,65 @@ def test_shared_helper_module_exists() -> None:
     assert "def finalize_primary_evidence_root" in text
 
 
+def test_order_capability_offline_durable_run_required_rel_paths_defined() -> None:
+    from scripts.ops.primary_evidence_retention_v0 import (
+        MANIFEST_FILENAME,
+        ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_REQUIRED_REL_PATHS,
+    )
+
+    assert ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_REQUIRED_REL_PATHS == (
+        "RUN_METADATA.json",
+        "ORDER_CAPABILITY_DRY_VALIDATION_RESULT.json",
+        "CLOSEOUT.md",
+        MANIFEST_FILENAME,
+    )
+
+
+def test_shared_helper_validate_order_capability_offline_durable_run_root_marker() -> None:
+    text = SHARED_HELPER.read_text(encoding="utf-8")
+    assert "def validate_order_capability_offline_durable_run_root" in text
+    assert "VALIDATE_ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_ROOT_V0=true" in text
+
+
+def test_validate_order_capability_offline_durable_run_root_passes_minimal_layout(
+    tmp_path: Path,
+) -> None:
+    from scripts.ops.primary_evidence_retention_v0 import (
+        MANIFEST_FILENAME,
+        ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_REQUIRED_REL_PATHS,
+        validate_order_capability_offline_durable_run_root,
+        write_manifest_sha256,
+    )
+
+    root = tmp_path / "order_cap_run"
+    root.mkdir()
+    for rel in ORDER_CAPABILITY_OFFLINE_DURABLE_RUN_REQUIRED_REL_PATHS:
+        if rel == MANIFEST_FILENAME:
+            continue
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}", encoding="utf-8")
+    write_manifest_sha256(root)
+    ok, issues = validate_order_capability_offline_durable_run_root(root)
+    assert ok is True
+    assert issues == []
+
+
+def test_validate_order_capability_offline_durable_run_root_fail_closed_missing_file(
+    tmp_path: Path,
+) -> None:
+    from scripts.ops.primary_evidence_retention_v0 import (
+        validate_order_capability_offline_durable_run_root,
+    )
+
+    root = tmp_path / "incomplete"
+    root.mkdir()
+    (root / "RUN_METADATA.json").write_text("{}", encoding="utf-8")
+    ok, issues = validate_order_capability_offline_durable_run_root(root)
+    assert ok is False
+    assert any("missing durable required file" in issue for issue in issues)
+
+
 def test_canonical_owner_references_scheduler_completion_opt_in() -> None:
     text = _owner_text()
     assert "run_scheduler.py" in text

--- a/tests/ops/test_run_order_capability_dry_validation_adapter_v1.py
+++ b/tests/ops/test_run_order_capability_dry_validation_adapter_v1.py
@@ -157,6 +157,13 @@ def test_write_evidence_creates_durable_bundle(tmp_path: Path) -> None:
     assert (dest / "MANIFEST.sha256").is_file()
     ok, _msg = mod.verify_manifest(dest)
     assert ok is True
+    from scripts.ops.primary_evidence_retention_v0 import (
+        validate_order_capability_offline_durable_run_root,
+    )
+
+    layout_ok, layout_issues = validate_order_capability_offline_durable_run_root(dest)
+    assert layout_ok is True
+    assert layout_issues == []
     payload = json.loads(
         (dest / "ORDER_CAPABILITY_DRY_VALIDATION_RESULT.json").read_text(encoding="utf-8")
     )
@@ -167,3 +174,29 @@ def test_write_evidence_creates_durable_bundle(tmp_path: Path) -> None:
         "order_submission_executed=true"
         not in (dest / "CLOSEOUT.md").read_text(encoding="utf-8").lower()
     )
+
+
+def test_write_evidence_fail_closed_when_layout_validation_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mod = _load_adapter()
+    archive = _durable_archive(tmp_path)
+    monkeypatch.setattr(
+        mod,
+        "validate_order_capability_offline_durable_run_root",
+        lambda _dest: (False, ["missing durable required file: CLOSEOUT.md"]),
+    )
+    rc = mod.main(
+        _base_argv(archive)
+        + [
+            "--write-evidence",
+            "--operator-go-token",
+            REQUIRED_OPERATOR_GO_TOKEN,
+        ]
+    )
+    assert rc != 0
+
+
+def test_order_capability_dry_validation_adapter_references_offline_layout_validation() -> None:
+    text = ADAPTER_SCRIPT.read_text(encoding="utf-8")
+    assert "validate_order_capability_offline_durable_run_root" in text


### PR DESCRIPTION
## Summary

Add canonical order-capability offline durable run path constant and dedicated layout validation helper in `primary_evidence_retention_v0.py`. Wire dry-validation adapter to fail-closed validate hook after evidence write. Extend invariant and adapter tests.

Ranks 1–3 of evidence retention gap closure — validation only, no authority lift.

## Safety / Authority

- **Authority impact:** NO_AUTHORITY_CHANGE
- No network, secrets, order submit, cancel, arming, testnet execute
- Adapter semantics unchanged (`--no-network`, `--no-order`, operator GO token)
- Does not use `validate_durable_primary_evidence_root()` (no review/REVIEW_RESULT.json gate)

## Tests

```bash
.venv/bin/python -m pytest tests/ops/test_primary_evidence_retention_invariant_contract_v0.py tests/ops/test_run_order_capability_dry_validation_adapter_v1.py -q
```

**70 passed** in 0.27s (impl bundle evidence)

Ruff check + format: PASS (4 files)

## Evidence Bundles

- Gap closure prep: `…/planning/order_capability_evidence_retention_gap_closure_prep_no_run_v1_20260609T163358Z`
- Impl prep: `…/planning/order_capability_evidence_retention_gap_closure_impl_prep_no_run_v1_20260609T163548Z`
- Impl: `…/implementation/order_capability_evidence_retention_gap_closure_impl_v1_20260609T163740Z`
- Post-impl review: `…/review/order_capability_evidence_retention_gap_closure_post_impl_review_no_run_v1_20260609T163903Z`
- Commit/PR prep: `order_capability_evidence_retention_gap_closure_commit_pr_prep_no_run_v1_20260609T164120Z`

## Deferred Gates

- ArmedGate boundary map
- Operator arming evidence bundle template
- Chain handoff closeout
- Testnet charter
- PE2 hard-gate order-cap row
- Kill-switch runtime binding (blocked placeholder)

## Fast-Lane expectation

- `static_contract_changed=true` (tests/ops/** matches ci.yml filter)
- `scripts/ops/**` also matches `code` / `non_webui_code` → **`run_matrix=true` expected**
- `cursor_auto_pr.yml` contract_only classifier: **false** (paths are not `*_contract_v1.py` only)
- Expected dispatch: `force_matrix=true` from auto-PR workflow; full matrix CI plausible
- No workflow changes in this PR

## Blockers

None identified for commit/PR slice.

Made with [Cursor](https://cursor.com)