### PR TITLE
ops: add demo instrument rules binding contract

### DIFF
--- a/src/ops/order_capability_demo_instrument_rules_binding_contract_v1.py
+++ b/src/ops/order_capability_demo_instrument_rules_binding_contract_v1.py
@@ -234,7 +234,9 @@ def _validate_offline_rules(
     return reasons, instrument_rules_offline_bound
 
 
-def _validate_unsafe_authority_flags(inp: OrderCapabilityDemoInstrumentRulesBindingInput) -> list[str]:
+def _validate_unsafe_authority_flags(
+    inp: OrderCapabilityDemoInstrumentRulesBindingInput,
+) -> list[str]:
     if inp.execute_authorized or inp.order_authorized or inp.cancel_authorized:
         return [REASON_UNSAFE_AUTHORITY_FLAGS]
     return []
@@ -345,18 +347,15 @@ def evaluate_order_capability_demo_instrument_rules_binding(
     reasons.extend(cap_reasons)
 
     deduped_reasons = list(dict.fromkeys(reasons))
-    binding_prepared = (
-        instrument_rules_offline_bound
-        and not any(
-            code
-            in {
-                REASON_DEMO_HOST_MISMATCH,
-                REASON_LIVE_HOST_REJECTED,
-                REASON_CREDENTIAL_CLASS_REJECTED,
-                REASON_MISSING_INSTRUMENT,
-            }
-            for code in deduped_reasons
-        )
+    binding_prepared = instrument_rules_offline_bound and not any(
+        code
+        in {
+            REASON_DEMO_HOST_MISMATCH,
+            REASON_LIVE_HOST_REJECTED,
+            REASON_CREDENTIAL_CLASS_REJECTED,
+            REASON_MISSING_INSTRUMENT,
+        }
+        for code in deduped_reasons
     )
 
     operator_prep_allowed = (
@@ -371,7 +370,10 @@ def evaluate_order_capability_demo_instrument_rules_binding(
         if (
             instrument_rules_offline_bound
             and REASON_INFEASIBLE_UNDER_CAP_ENVELOPE in deduped_reasons
-            and len([code for code in deduped_reasons if code != REASON_INFEASIBLE_UNDER_CAP_ENVELOPE]) == 0
+            and len(
+                [code for code in deduped_reasons if code != REASON_INFEASIBLE_UNDER_CAP_ENVELOPE]
+            )
+            == 0
         ):
             return _immutable_authority_fields(
                 verdict=DemoInstrumentRulesBindingVerdictKind.INFEASIBLE_UNDER_CAP,
@@ -479,9 +481,13 @@ def validate_order_capability_demo_instrument_rules_binding_result(
     ):
         raise DemoInstrumentRulesBindingError("order/cancel/execute authority must remain false")
     if not result.value_redacted or not result.no_secret_material:
-        raise DemoInstrumentRulesBindingError("value_redacted and no_secret_material must remain true")
+        raise DemoInstrumentRulesBindingError(
+            "value_redacted and no_secret_material must remain true"
+        )
     if result.cancelallorders_allowed or result.batchorder_allowed:
-        raise DemoInstrumentRulesBindingError("cancelallorders and batchorder must remain disallowed")
+        raise DemoInstrumentRulesBindingError(
+            "cancelallorders and batchorder must remain disallowed"
+        )
     if result.blocker_min_size_not_verified_offline != (not result.min_size_verified_offline):
         raise DemoInstrumentRulesBindingError(
             "blocker_min_size_not_verified_offline must mirror min_size_verified_offline"
@@ -501,7 +507,9 @@ def validate_order_capability_demo_instrument_rules_binding_result(
                 "INFEASIBLE_UNDER_CAP requires INFEASIBLE_UNDER_CAP_ENVELOPE reason"
             )
         if result.cap_feasible:
-            raise DemoInstrumentRulesBindingError("INFEASIBLE_UNDER_CAP requires cap_feasible=false")
+            raise DemoInstrumentRulesBindingError(
+                "INFEASIBLE_UNDER_CAP requires cap_feasible=false"
+            )
     else:
         if not result.reason_codes:
             raise DemoInstrumentRulesBindingError("FAIL_CLOSED requires non-empty reason_codes")

--- a/src/ops/order_capability_demo_instrument_rules_binding_contract_v1.py
+++ b/src/ops/order_capability_demo_instrument_rules_binding_contract_v1.py
@@ -1,0 +1,507 @@
+"""Order-Capability demo instrument rules offline binding contract (v1).
+
+Pure offline evaluation of demo host, credential class, instrument canonical binding,
+and manifest-verified instrument rule fields. Does not authorize network, secrets,
+order submission, cancel, live, preflight lift, or execute.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+from src.ops.bounded_futures_private_readonly_contract_v0 import DEMO_FUTURES_HOST
+from src.ops.bounded_futures_testnet_contract_v0 import DEFAULT_INSTRUMENT
+
+PACKAGE_MARKER = "ORDER_CAPABILITY_DEMO_INSTRUMENT_RULES_BINDING_CONTRACT_V1=true"
+SCHEMA_VERSION = "order_capability_demo_instrument_rules_binding_result.v1"
+AUTHORITY_IMPACT = "NO_AUTHORITY_CHANGE"
+
+REQUIRED_DEMO_HOST = DEMO_FUTURES_HOST
+ALLOWED_CREDENTIAL_CLASS = "kraken_futures_demo_only"
+DEFAULT_MAX_NOTIONAL_EUR = Decimal("10.0")
+
+FORBIDDEN_HOST_MARKERS = frozenset(
+    {
+        "live",
+        "prod",
+        "production",
+        "mainnet",
+        "futures.kraken.com",
+    }
+)
+FORBIDDEN_CREDENTIAL_MARKERS = frozenset(
+    {
+        "live",
+        "prod",
+        "production",
+        "mainnet",
+        "spot",
+        "kraken_spot",
+        "kraken_futures_live",
+    }
+)
+FORBIDDEN_SERIALIZATION_KEYS = frozenset(
+    {
+        "api_key",
+        "api_secret",
+        "secret",
+        "password",
+        "token",
+        "credential",
+        "credentials",
+        "private_key",
+    }
+)
+
+REASON_DEMO_HOST_MISMATCH = "DEMO_HOST_MISMATCH"
+REASON_LIVE_HOST_REJECTED = "LIVE_HOST_REJECTED"
+REASON_CREDENTIAL_CLASS_REJECTED = "CREDENTIAL_CLASS_REJECTED"
+REASON_MISSING_INSTRUMENT = "MISSING_INSTRUMENT"
+REASON_OFFLINE_RULES_NOT_BOUND = "OFFLINE_RULES_NOT_BOUND"
+REASON_MISSING_MIN_SIZE = "MISSING_MIN_SIZE"
+REASON_MISSING_QTY_STEP = "MISSING_QTY_STEP"
+REASON_MISSING_PRICE_TICK = "MISSING_PRICE_TICK"
+REASON_MISSING_QTY_PRECISION = "MISSING_QTY_PRECISION"
+REASON_MISSING_PRICE_PRECISION = "MISSING_PRICE_PRECISION"
+REASON_MIN_SIZE_NOT_POSITIVE = "MIN_SIZE_NOT_POSITIVE"
+REASON_INFEASIBLE_UNDER_CAP_ENVELOPE = "INFEASIBLE_UNDER_CAP_ENVELOPE"
+REASON_CAP_FEASIBILITY_INPUT_MISSING = "CAP_FEASIBILITY_INPUT_MISSING"
+REASON_FORBIDDEN_ENDPOINT_CANCELALLORDERS = "FORBIDDEN_ENDPOINT_CANCELALLORDERS"
+REASON_FORBIDDEN_ENDPOINT_BATCHORDER = "FORBIDDEN_ENDPOINT_BATCHORDER"
+REASON_UNSAFE_AUTHORITY_FLAGS = "UNSAFE_AUTHORITY_FLAGS"
+REASON_SECRET_MATERIAL_REJECTED = "SECRET_MATERIAL_REJECTED"
+
+BLOCKER_MIN_SIZE_NOT_VERIFIED_OFFLINE = "BLOCKER_MIN_SIZE_NOT_VERIFIED_OFFLINE"
+
+
+class DemoInstrumentRulesBindingError(ValueError):
+    """Fail-closed demo instrument rules binding evaluation or validation error."""
+
+
+class DemoInstrumentRulesBindingVerdictKind(str, Enum):
+    BINDING_SATISFIED_FOR_DRY_ONLY = "BINDING_SATISFIED_FOR_DRY_ONLY"
+    INFEASIBLE_UNDER_CAP = "INFEASIBLE_UNDER_CAP"
+    FAIL_CLOSED = "FAIL_CLOSED"
+
+
+@dataclass(frozen=True)
+class DemoInstrumentOfflineRulesBound:
+    min_size: Decimal | None
+    qty_step: Decimal | None
+    price_tick: Decimal | None
+    qty_precision: int | None
+    price_precision: int | None
+    min_notional: Decimal | None = None
+    offline_bound: bool = False
+    source_ref: str = ""
+
+
+@dataclass(frozen=True)
+class OrderCapabilityDemoInstrumentRulesBindingInput:
+    demo_host: str = ""
+    credential_class: str = ""
+    instrument: str = ""
+    offline_rules: DemoInstrumentOfflineRulesBound | None = None
+    cap_max_notional_eur: Decimal = DEFAULT_MAX_NOTIONAL_EUR
+    reference_price_usd: Decimal | None = None
+    fx_rate_usd_per_eur: Decimal | None = None
+    cancelallorders: bool = False
+    batchorder: bool = False
+    execute_authorized: bool = False
+    order_authorized: bool = False
+    cancel_authorized: bool = False
+
+
+@dataclass(frozen=True)
+class OrderCapabilityDemoInstrumentRulesBindingResult:
+    verdict: DemoInstrumentRulesBindingVerdictKind
+    reason_codes: tuple[str, ...]
+    blockers: tuple[str, ...]
+    violations: tuple[str, ...]
+    demo_instrument_rules_binding_prepared: bool
+    instrument_rules_offline_bound: bool
+    min_size_verified_offline: bool
+    cap_feasible: bool
+    operator_side_qty_price_decision_prep_allowed_next: bool
+    demo_mutation_execute_allowed_now: bool
+    order_authorized_now: bool
+    cancel_authorized_now: bool
+    execute_authorized_now: bool
+    authority_impact: str
+    blocker_min_size_not_verified_offline: bool
+    value_redacted: bool
+    no_secret_material: bool
+    cancelallorders_allowed: bool
+    batchorder_allowed: bool
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def _normalize_host(host: str) -> str:
+    normalized = _normalize(host)
+    if normalized.startswith("https://"):
+        normalized = normalized[len("https://") :]
+    if normalized.startswith("http://"):
+        normalized = normalized[len("http://") :]
+    return normalized.split("/", 1)[0]
+
+
+def _contains_forbidden_marker(value: str, markers: frozenset[str]) -> bool:
+    normalized = _normalize(value)
+    return any(marker in normalized for marker in markers)
+
+
+def _positive_decimal(value: Decimal | None) -> bool:
+    if value is None:
+        return False
+    try:
+        return value > 0
+    except Exception:
+        return False
+
+
+def _validate_demo_host(demo_host: str) -> list[str]:
+    normalized = _normalize_host(demo_host)
+    if not normalized:
+        return [REASON_DEMO_HOST_MISMATCH]
+    if normalized == REQUIRED_DEMO_HOST:
+        return []
+    if _contains_forbidden_marker(normalized, FORBIDDEN_HOST_MARKERS):
+        return [REASON_LIVE_HOST_REJECTED]
+    return [REASON_DEMO_HOST_MISMATCH]
+
+
+def _validate_credential_class(credential_class: str) -> list[str]:
+    normalized = _normalize(credential_class).replace(" ", "_")
+    if not normalized:
+        return [REASON_CREDENTIAL_CLASS_REJECTED]
+    if _contains_forbidden_marker(normalized, FORBIDDEN_CREDENTIAL_MARKERS):
+        return [REASON_CREDENTIAL_CLASS_REJECTED]
+    if normalized != ALLOWED_CREDENTIAL_CLASS:
+        return [REASON_CREDENTIAL_CLASS_REJECTED]
+    return []
+
+
+def _validate_instrument(instrument: str) -> list[str]:
+    if not instrument.strip():
+        return [REASON_MISSING_INSTRUMENT]
+    return []
+
+
+def _validate_offline_rules(
+    rules: DemoInstrumentOfflineRulesBound | None,
+) -> tuple[list[str], bool]:
+    if rules is None:
+        return [REASON_OFFLINE_RULES_NOT_BOUND], False
+
+    reasons: list[str] = []
+    if not rules.offline_bound:
+        reasons.append(REASON_OFFLINE_RULES_NOT_BOUND)
+    if not rules.source_ref.strip():
+        reasons.append(REASON_OFFLINE_RULES_NOT_BOUND)
+    if not _positive_decimal(rules.min_size):
+        reasons.append(REASON_MISSING_MIN_SIZE)
+        if rules.min_size is not None and rules.min_size <= 0:
+            reasons.append(REASON_MIN_SIZE_NOT_POSITIVE)
+    if not _positive_decimal(rules.qty_step):
+        reasons.append(REASON_MISSING_QTY_STEP)
+    if not _positive_decimal(rules.price_tick):
+        reasons.append(REASON_MISSING_PRICE_TICK)
+    if rules.qty_precision is None or rules.qty_precision < 0:
+        reasons.append(REASON_MISSING_QTY_PRECISION)
+    if rules.price_precision is None or rules.price_precision < 0:
+        reasons.append(REASON_MISSING_PRICE_PRECISION)
+
+    min_size_verified = not any(
+        code
+        in {
+            REASON_OFFLINE_RULES_NOT_BOUND,
+            REASON_MISSING_MIN_SIZE,
+            REASON_MIN_SIZE_NOT_POSITIVE,
+            REASON_MISSING_QTY_STEP,
+            REASON_MISSING_PRICE_TICK,
+            REASON_MISSING_QTY_PRECISION,
+            REASON_MISSING_PRICE_PRECISION,
+        }
+        for code in reasons
+    )
+    instrument_rules_offline_bound = min_size_verified
+    return reasons, instrument_rules_offline_bound
+
+
+def _validate_unsafe_authority_flags(inp: OrderCapabilityDemoInstrumentRulesBindingInput) -> list[str]:
+    if inp.execute_authorized or inp.order_authorized or inp.cancel_authorized:
+        return [REASON_UNSAFE_AUTHORITY_FLAGS]
+    return []
+
+
+def _validate_forbidden_endpoints(inp: OrderCapabilityDemoInstrumentRulesBindingInput) -> list[str]:
+    reasons: list[str] = []
+    if inp.cancelallorders:
+        reasons.append(REASON_FORBIDDEN_ENDPOINT_CANCELALLORDERS)
+    if inp.batchorder:
+        reasons.append(REASON_FORBIDDEN_ENDPOINT_BATCHORDER)
+    return reasons
+
+
+def _estimate_cap_feasibility(
+    *,
+    rules: DemoInstrumentOfflineRulesBound | None,
+    cap_max_notional_eur: Decimal,
+    reference_price_usd: Decimal | None,
+    fx_rate_usd_per_eur: Decimal | None,
+    instrument_rules_offline_bound: bool,
+) -> tuple[bool, list[str]]:
+    if not instrument_rules_offline_bound or rules is None:
+        return False, [REASON_CAP_FEASIBILITY_INPUT_MISSING]
+
+    if reference_price_usd is None or fx_rate_usd_per_eur is None:
+        return False, [REASON_CAP_FEASIBILITY_INPUT_MISSING]
+    if not _positive_decimal(reference_price_usd) or not _positive_decimal(fx_rate_usd_per_eur):
+        return False, [REASON_CAP_FEASIBILITY_INPUT_MISSING]
+    if cap_max_notional_eur <= 0:
+        return False, [REASON_INFEASIBLE_UNDER_CAP_ENVELOPE]
+
+    min_notional_estimate_usd = rules.min_size * reference_price_usd  # type: ignore[operator]
+    cap_usd = cap_max_notional_eur * fx_rate_usd_per_eur
+
+    if rules.min_notional is not None and rules.min_notional > cap_usd:
+        return False, [REASON_INFEASIBLE_UNDER_CAP_ENVELOPE]
+    if min_notional_estimate_usd > cap_usd:
+        return False, [REASON_INFEASIBLE_UNDER_CAP_ENVELOPE]
+    return True, []
+
+
+def _immutable_authority_fields(
+    *,
+    verdict: DemoInstrumentRulesBindingVerdictKind,
+    reason_codes: list[str],
+    blockers: list[str],
+    demo_instrument_rules_binding_prepared: bool,
+    instrument_rules_offline_bound: bool,
+    min_size_verified_offline: bool,
+    cap_feasible: bool,
+    operator_side_qty_price_decision_prep_allowed_next: bool,
+    cancelallorders: bool,
+    batchorder: bool,
+) -> OrderCapabilityDemoInstrumentRulesBindingResult:
+    deduped_reasons = tuple(dict.fromkeys(reason_codes))
+    deduped_blockers = tuple(dict.fromkeys(blockers))
+    return OrderCapabilityDemoInstrumentRulesBindingResult(
+        verdict=verdict,
+        reason_codes=deduped_reasons,
+        blockers=deduped_blockers,
+        violations=deduped_reasons,
+        demo_instrument_rules_binding_prepared=demo_instrument_rules_binding_prepared,
+        instrument_rules_offline_bound=instrument_rules_offline_bound,
+        min_size_verified_offline=min_size_verified_offline,
+        cap_feasible=cap_feasible,
+        operator_side_qty_price_decision_prep_allowed_next=operator_side_qty_price_decision_prep_allowed_next,
+        demo_mutation_execute_allowed_now=False,
+        order_authorized_now=False,
+        cancel_authorized_now=False,
+        execute_authorized_now=False,
+        authority_impact=AUTHORITY_IMPACT,
+        blocker_min_size_not_verified_offline=not min_size_verified_offline,
+        value_redacted=True,
+        no_secret_material=True,
+        cancelallorders_allowed=False,
+        batchorder_allowed=False,
+    )
+
+
+def evaluate_order_capability_demo_instrument_rules_binding(
+    inp: OrderCapabilityDemoInstrumentRulesBindingInput,
+) -> OrderCapabilityDemoInstrumentRulesBindingResult:
+    """Evaluate demo instrument rules offline binding without authorizing execute or orders."""
+    reasons: list[str] = []
+    blockers: list[str] = []
+
+    reasons.extend(_validate_demo_host(inp.demo_host))
+    reasons.extend(_validate_credential_class(inp.credential_class))
+    reasons.extend(_validate_instrument(inp.instrument))
+    reasons.extend(_validate_unsafe_authority_flags(inp))
+    reasons.extend(_validate_forbidden_endpoints(inp))
+
+    rule_reasons, instrument_rules_offline_bound = _validate_offline_rules(inp.offline_rules)
+    reasons.extend(rule_reasons)
+
+    min_size_verified_offline = instrument_rules_offline_bound
+    if not min_size_verified_offline:
+        blockers.append(BLOCKER_MIN_SIZE_NOT_VERIFIED_OFFLINE)
+
+    cap_feasible, cap_reasons = _estimate_cap_feasibility(
+        rules=inp.offline_rules,
+        cap_max_notional_eur=inp.cap_max_notional_eur,
+        reference_price_usd=inp.reference_price_usd,
+        fx_rate_usd_per_eur=inp.fx_rate_usd_per_eur,
+        instrument_rules_offline_bound=instrument_rules_offline_bound,
+    )
+    reasons.extend(cap_reasons)
+
+    deduped_reasons = list(dict.fromkeys(reasons))
+    binding_prepared = (
+        instrument_rules_offline_bound
+        and not any(
+            code
+            in {
+                REASON_DEMO_HOST_MISMATCH,
+                REASON_LIVE_HOST_REJECTED,
+                REASON_CREDENTIAL_CLASS_REJECTED,
+                REASON_MISSING_INSTRUMENT,
+            }
+            for code in deduped_reasons
+        )
+    )
+
+    operator_prep_allowed = (
+        binding_prepared
+        and min_size_verified_offline
+        and cap_feasible
+        and not blockers
+        and not deduped_reasons
+    )
+
+    if deduped_reasons:
+        if (
+            instrument_rules_offline_bound
+            and REASON_INFEASIBLE_UNDER_CAP_ENVELOPE in deduped_reasons
+            and len([code for code in deduped_reasons if code != REASON_INFEASIBLE_UNDER_CAP_ENVELOPE]) == 0
+        ):
+            return _immutable_authority_fields(
+                verdict=DemoInstrumentRulesBindingVerdictKind.INFEASIBLE_UNDER_CAP,
+                reason_codes=deduped_reasons,
+                blockers=blockers,
+                demo_instrument_rules_binding_prepared=binding_prepared,
+                instrument_rules_offline_bound=instrument_rules_offline_bound,
+                min_size_verified_offline=min_size_verified_offline,
+                cap_feasible=False,
+                operator_side_qty_price_decision_prep_allowed_next=False,
+                cancelallorders=inp.cancelallorders,
+                batchorder=inp.batchorder,
+            )
+        return _immutable_authority_fields(
+            verdict=DemoInstrumentRulesBindingVerdictKind.FAIL_CLOSED,
+            reason_codes=deduped_reasons,
+            blockers=blockers,
+            demo_instrument_rules_binding_prepared=False,
+            instrument_rules_offline_bound=instrument_rules_offline_bound,
+            min_size_verified_offline=min_size_verified_offline,
+            cap_feasible=cap_feasible,
+            operator_side_qty_price_decision_prep_allowed_next=False,
+            cancelallorders=inp.cancelallorders,
+            batchorder=inp.batchorder,
+        )
+
+    return _immutable_authority_fields(
+        verdict=DemoInstrumentRulesBindingVerdictKind.BINDING_SATISFIED_FOR_DRY_ONLY,
+        reason_codes=[],
+        blockers=[],
+        demo_instrument_rules_binding_prepared=True,
+        instrument_rules_offline_bound=True,
+        min_size_verified_offline=True,
+        cap_feasible=True,
+        operator_side_qty_price_decision_prep_allowed_next=operator_prep_allowed,
+        cancelallorders=inp.cancelallorders,
+        batchorder=inp.batchorder,
+    )
+
+
+def default_order_capability_demo_instrument_rules_binding_input() -> (
+    OrderCapabilityDemoInstrumentRulesBindingInput
+):
+    return OrderCapabilityDemoInstrumentRulesBindingInput()
+
+
+def reject_secret_like_mapping(mapping: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    for key in mapping:
+        if key.lower() in FORBIDDEN_SERIALIZATION_KEYS:
+            reasons.append(REASON_SECRET_MATERIAL_REJECTED)
+    return reasons
+
+
+def serialize_order_capability_demo_instrument_rules_binding_result(
+    result: OrderCapabilityDemoInstrumentRulesBindingResult,
+) -> dict[str, Any]:
+    validate_order_capability_demo_instrument_rules_binding_result(result)
+    data: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "contract_marker": PACKAGE_MARKER,
+        "verdict": result.verdict.value,
+        "reason_codes": list(result.reason_codes),
+        "blockers": list(result.blockers),
+        "violations": list(result.violations),
+        "demo_instrument_rules_binding_prepared": result.demo_instrument_rules_binding_prepared,
+        "instrument_rules_offline_bound": result.instrument_rules_offline_bound,
+        "min_size_verified_offline": result.min_size_verified_offline,
+        "cap_feasible": result.cap_feasible,
+        "operator_side_qty_price_decision_prep_allowed_next": (
+            result.operator_side_qty_price_decision_prep_allowed_next
+        ),
+        "demo_mutation_execute_allowed_now": result.demo_mutation_execute_allowed_now,
+        "order_authorized_now": result.order_authorized_now,
+        "cancel_authorized_now": result.cancel_authorized_now,
+        "execute_authorized_now": result.execute_authorized_now,
+        "authority_impact": result.authority_impact,
+        "blocker_min_size_not_verified_offline": result.blocker_min_size_not_verified_offline,
+        "value_redacted": result.value_redacted,
+        "no_secret_material": result.no_secret_material,
+        "cancelallorders_allowed": result.cancelallorders_allowed,
+        "batchorder_allowed": result.batchorder_allowed,
+        "default_instrument_reference": DEFAULT_INSTRUMENT,
+        "required_demo_host": REQUIRED_DEMO_HOST,
+        "allowed_credential_class": ALLOWED_CREDENTIAL_CLASS,
+    }
+    for key in data:
+        if key.lower() in FORBIDDEN_SERIALIZATION_KEYS:
+            raise DemoInstrumentRulesBindingError(
+                f"serialized result must not include forbidden key {key!r}"
+            )
+    return data
+
+
+def validate_order_capability_demo_instrument_rules_binding_result(
+    result: OrderCapabilityDemoInstrumentRulesBindingResult,
+) -> None:
+    if result.authority_impact != AUTHORITY_IMPACT:
+        raise DemoInstrumentRulesBindingError("authority_impact must remain NO_AUTHORITY_CHANGE")
+    if (
+        result.order_authorized_now
+        or result.cancel_authorized_now
+        or result.execute_authorized_now
+        or result.demo_mutation_execute_allowed_now
+    ):
+        raise DemoInstrumentRulesBindingError("order/cancel/execute authority must remain false")
+    if not result.value_redacted or not result.no_secret_material:
+        raise DemoInstrumentRulesBindingError("value_redacted and no_secret_material must remain true")
+    if result.cancelallorders_allowed or result.batchorder_allowed:
+        raise DemoInstrumentRulesBindingError("cancelallorders and batchorder must remain disallowed")
+    if result.blocker_min_size_not_verified_offline != (not result.min_size_verified_offline):
+        raise DemoInstrumentRulesBindingError(
+            "blocker_min_size_not_verified_offline must mirror min_size_verified_offline"
+        )
+    if result.verdict == DemoInstrumentRulesBindingVerdictKind.BINDING_SATISFIED_FOR_DRY_ONLY:
+        if result.reason_codes or result.violations:
+            raise DemoInstrumentRulesBindingError("BINDING_SATISFIED must have empty reason_codes")
+        if not result.instrument_rules_offline_bound or not result.min_size_verified_offline:
+            raise DemoInstrumentRulesBindingError(
+                "BINDING_SATISFIED requires offline-bound instrument rules"
+            )
+        if not result.cap_feasible:
+            raise DemoInstrumentRulesBindingError("BINDING_SATISFIED requires cap_feasible=true")
+    elif result.verdict == DemoInstrumentRulesBindingVerdictKind.INFEASIBLE_UNDER_CAP:
+        if REASON_INFEASIBLE_UNDER_CAP_ENVELOPE not in result.reason_codes:
+            raise DemoInstrumentRulesBindingError(
+                "INFEASIBLE_UNDER_CAP requires INFEASIBLE_UNDER_CAP_ENVELOPE reason"
+            )
+        if result.cap_feasible:
+            raise DemoInstrumentRulesBindingError("INFEASIBLE_UNDER_CAP requires cap_feasible=false")
+    else:
+        if not result.reason_codes:
+            raise DemoInstrumentRulesBindingError("FAIL_CLOSED requires non-empty reason_codes")

--- a/tests/ops/test_order_capability_demo_instrument_rules_binding_contract_v1.py
+++ b/tests/ops/test_order_capability_demo_instrument_rules_binding_contract_v1.py
@@ -1,0 +1,341 @@
+"""Offline tests for order_capability_demo_instrument_rules_binding_contract_v1.
+
+Class-4 scoped: no network, credentials, orders, or Testnet execute.
+"""
+
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from src.ops.bounded_futures_testnet_contract_v0 import DEFAULT_INSTRUMENT
+from src.ops.order_capability_demo_instrument_rules_binding_contract_v1 import (
+    ALLOWED_CREDENTIAL_CLASS,
+    AUTHORITY_IMPACT,
+    BLOCKER_MIN_SIZE_NOT_VERIFIED_OFFLINE,
+    DemoInstrumentOfflineRulesBound,
+    DemoInstrumentRulesBindingError,
+    DemoInstrumentRulesBindingVerdictKind,
+    FORBIDDEN_SERIALIZATION_KEYS,
+    PACKAGE_MARKER,
+    REASON_CAP_FEASIBILITY_INPUT_MISSING,
+    REASON_CREDENTIAL_CLASS_REJECTED,
+    REASON_DEMO_HOST_MISMATCH,
+    REASON_FORBIDDEN_ENDPOINT_BATCHORDER,
+    REASON_FORBIDDEN_ENDPOINT_CANCELALLORDERS,
+    REASON_INFEASIBLE_UNDER_CAP_ENVELOPE,
+    REASON_LIVE_HOST_REJECTED,
+    REASON_MISSING_INSTRUMENT,
+    REASON_OFFLINE_RULES_NOT_BOUND,
+    REASON_SECRET_MATERIAL_REJECTED,
+    REASON_UNSAFE_AUTHORITY_FLAGS,
+    REQUIRED_DEMO_HOST,
+    OrderCapabilityDemoInstrumentRulesBindingInput,
+    default_order_capability_demo_instrument_rules_binding_input,
+    evaluate_order_capability_demo_instrument_rules_binding,
+    reject_secret_like_mapping,
+    serialize_order_capability_demo_instrument_rules_binding_result,
+    validate_order_capability_demo_instrument_rules_binding_result,
+)
+
+CONTRACT_MODULE = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "ops"
+    / "order_capability_demo_instrument_rules_binding_contract_v1.py"
+)
+
+TEST_PACKAGE_MARKER = "ORDER_CAPABILITY_DEMO_INSTRUMENT_RULES_BINDING_CONTRACT_V1_TEST=true"
+OPERATOR_GO_BINDING = (
+    "GO_ORDER_CAPABILITY_DEMO_INSTRUMENT_RULES_BINDING_CONTRACT_IMPL_TESTS_ONLY_NO_RUN_V1"
+)
+
+
+def _complete_offline_rules(**overrides: object) -> DemoInstrumentOfflineRulesBound:
+    base = {
+        "min_size": Decimal("0.001"),
+        "qty_step": Decimal("0.001"),
+        "price_tick": Decimal("0.5"),
+        "qty_precision": 3,
+        "price_precision": 1,
+        "min_notional": None,
+        "offline_bound": True,
+        "source_ref": "synthetic_offline_fixture_only_not_exchange_truth",
+    }
+    base.update(overrides)
+    return DemoInstrumentOfflineRulesBound(**base)
+
+
+def _valid_input(**overrides: object) -> OrderCapabilityDemoInstrumentRulesBindingInput:
+    base = {
+        "demo_host": REQUIRED_DEMO_HOST,
+        "credential_class": ALLOWED_CREDENTIAL_CLASS,
+        "instrument": DEFAULT_INSTRUMENT,
+        "offline_rules": _complete_offline_rules(),
+        "cap_max_notional_eur": Decimal("10.0"),
+        "reference_price_usd": Decimal("100.0"),
+        "fx_rate_usd_per_eur": Decimal("1.0"),
+        "cancelallorders": False,
+        "batchorder": False,
+        "execute_authorized": False,
+        "order_authorized": False,
+        "cancel_authorized": False,
+    }
+    base.update(overrides)
+    return OrderCapabilityDemoInstrumentRulesBindingInput(**base)
+
+
+def test_package_marker_present() -> None:
+    assert TEST_PACKAGE_MARKER
+    assert OPERATOR_GO_BINDING
+    assert PACKAGE_MARKER in CONTRACT_MODULE.read_text(encoding="utf-8")
+
+
+def test_default_missing_rules_fail_closed() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        default_order_capability_demo_instrument_rules_binding_input()
+    )
+    assert result.verdict == DemoInstrumentRulesBindingVerdictKind.FAIL_CLOSED
+    assert result.min_size_verified_offline is False
+    assert result.blocker_min_size_not_verified_offline is True
+    assert BLOCKER_MIN_SIZE_NOT_VERIFIED_OFFLINE in result.blockers
+    assert result.execute_authorized_now is False
+    assert result.order_authorized_now is False
+    assert result.cancel_authorized_now is False
+    validate_order_capability_demo_instrument_rules_binding_result(result)
+
+
+def test_demo_host_required_accepts_demo_futures() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(demo_host="https://demo-futures.kraken.com/derivatives/api/v3")
+    )
+    assert REASON_DEMO_HOST_MISMATCH not in result.reason_codes
+    assert result.verdict == DemoInstrumentRulesBindingVerdictKind.BINDING_SATISFIED_FOR_DRY_ONLY
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "futures.kraken.com",
+        "live-futures.kraken.com",
+        "prod.kraken.com",
+        "",
+    ],
+)
+def test_live_prod_host_rejected(host: str) -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(_valid_input(demo_host=host))
+    assert result.verdict == DemoInstrumentRulesBindingVerdictKind.FAIL_CLOSED
+    assert REASON_DEMO_HOST_MISMATCH in result.reason_codes or REASON_LIVE_HOST_REJECTED in result.reason_codes
+
+
+def test_credential_class_kraken_futures_demo_only_accepted() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(_valid_input())
+    assert REASON_CREDENTIAL_CLASS_REJECTED not in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "credential_class",
+    [
+        "kraken_futures_live",
+        "kraken_spot",
+        "live",
+        "production",
+        "spot_only",
+        "",
+    ],
+)
+def test_credential_class_alternates_rejected(credential_class: str) -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(credential_class=credential_class)
+    )
+    assert result.verdict == DemoInstrumentRulesBindingVerdictKind.FAIL_CLOSED
+    assert REASON_CREDENTIAL_CLASS_REJECTED in result.reason_codes
+
+
+def test_required_instrument_rules_missing_blocks_operator_decision_prep() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(offline_rules=_complete_offline_rules(qty_step=None, offline_bound=True))
+    )
+    assert result.operator_side_qty_price_decision_prep_allowed_next is False
+    assert result.demo_instrument_rules_binding_prepared is False
+    assert result.instrument_rules_offline_bound is False
+
+
+def test_synthetic_complete_offline_bound_rules_binding_prepared_without_authority_lift() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(_valid_input())
+    assert result.verdict == DemoInstrumentRulesBindingVerdictKind.BINDING_SATISFIED_FOR_DRY_ONLY
+    assert result.demo_instrument_rules_binding_prepared is True
+    assert result.instrument_rules_offline_bound is True
+    assert result.min_size_verified_offline is True
+    assert result.cap_feasible is True
+    assert result.operator_side_qty_price_decision_prep_allowed_next is True
+    assert result.order_authorized_now is False
+    assert result.cancel_authorized_now is False
+    assert result.execute_authorized_now is False
+    assert result.demo_mutation_execute_allowed_now is False
+    validate_order_capability_demo_instrument_rules_binding_result(result)
+
+
+def test_cap_infeasible_under_min_size_times_reference_price() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(
+            offline_rules=_complete_offline_rules(min_size=Decimal("0.01")),
+            reference_price_usd=Decimal("100001.0"),
+            cap_max_notional_eur=Decimal("10.0"),
+            fx_rate_usd_per_eur=Decimal("1.08"),
+        )
+    )
+    assert result.verdict == DemoInstrumentRulesBindingVerdictKind.INFEASIBLE_UNDER_CAP
+    assert REASON_INFEASIBLE_UNDER_CAP_ENVELOPE in result.reason_codes
+    assert result.cap_feasible is False
+    assert result.operator_side_qty_price_decision_prep_allowed_next is False
+
+
+def test_cap_infeasible_when_min_notional_exceeds_cap() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(
+            offline_rules=_complete_offline_rules(min_notional=Decimal("500.0")),
+            reference_price_usd=Decimal("1.0"),
+            cap_max_notional_eur=Decimal("10.0"),
+            fx_rate_usd_per_eur=Decimal("1.0"),
+        )
+    )
+    assert result.verdict == DemoInstrumentRulesBindingVerdictKind.INFEASIBLE_UNDER_CAP
+    assert REASON_INFEASIBLE_UNDER_CAP_ENVELOPE in result.reason_codes
+
+
+def test_no_secret_material_invariant() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(_valid_input())
+    data = serialize_order_capability_demo_instrument_rules_binding_result(result)
+    assert data["value_redacted"] is True
+    assert data["no_secret_material"] is True
+    for key in data:
+        assert key.lower() not in FORBIDDEN_SERIALIZATION_KEYS
+    secret_reasons = reject_secret_like_mapping({"api_key": "redacted"})
+    assert REASON_SECRET_MATERIAL_REJECTED in secret_reasons
+
+
+def test_authority_impact_always_no_authority_change() -> None:
+    default_result = evaluate_order_capability_demo_instrument_rules_binding(
+        default_order_capability_demo_instrument_rules_binding_input()
+    )
+    ok_result = evaluate_order_capability_demo_instrument_rules_binding(_valid_input())
+    assert default_result.authority_impact == AUTHORITY_IMPACT
+    assert ok_result.authority_impact == AUTHORITY_IMPACT
+
+
+def test_cancelallorders_and_batchorder_not_allowed() -> None:
+    cancel_all = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(cancelallorders=True)
+    )
+    batch = evaluate_order_capability_demo_instrument_rules_binding(_valid_input(batchorder=True))
+    assert REASON_FORBIDDEN_ENDPOINT_CANCELALLORDERS in cancel_all.reason_codes
+    assert cancel_all.cancelallorders_allowed is False
+    assert REASON_FORBIDDEN_ENDPOINT_BATCHORDER in batch.reason_codes
+    assert batch.batchorder_allowed is False
+
+
+def test_unsafe_authority_flags_fail_closed() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(execute_authorized=True)
+    )
+    assert REASON_UNSAFE_AUTHORITY_FLAGS in result.reason_codes
+    assert result.execute_authorized_now is False
+
+
+def test_missing_instrument_fail_closed() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(_valid_input(instrument=""))
+    assert REASON_MISSING_INSTRUMENT in result.reason_codes
+
+
+def test_offline_rules_not_bound_fail_closed() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(offline_rules=_complete_offline_rules(offline_bound=False))
+    )
+    assert REASON_OFFLINE_RULES_NOT_BOUND in result.reason_codes
+    assert result.min_size_verified_offline is False
+
+
+def test_cap_feasibility_input_missing_when_reference_price_absent() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(
+        _valid_input(reference_price_usd=None)
+    )
+    assert REASON_CAP_FEASIBILITY_INPUT_MISSING in result.reason_codes
+    assert result.cap_feasible is False
+
+
+def test_deterministic_output_same_input() -> None:
+    inp = _valid_input()
+    first = evaluate_order_capability_demo_instrument_rules_binding(inp)
+    second = evaluate_order_capability_demo_instrument_rules_binding(inp)
+    assert first == second
+
+
+def test_machine_summary_shape_stable() -> None:
+    result = evaluate_order_capability_demo_instrument_rules_binding(_valid_input())
+    data = serialize_order_capability_demo_instrument_rules_binding_result(result)
+    required_keys = {
+        "schema_version",
+        "contract_marker",
+        "verdict",
+        "reason_codes",
+        "blockers",
+        "violations",
+        "demo_instrument_rules_binding_prepared",
+        "instrument_rules_offline_bound",
+        "min_size_verified_offline",
+        "cap_feasible",
+        "operator_side_qty_price_decision_prep_allowed_next",
+        "demo_mutation_execute_allowed_now",
+        "order_authorized_now",
+        "cancel_authorized_now",
+        "execute_authorized_now",
+        "authority_impact",
+        "blocker_min_size_not_verified_offline",
+        "value_redacted",
+        "no_secret_material",
+    }
+    assert required_keys.issubset(data.keys())
+
+
+def test_validate_result_raises_on_tampered_authority() -> None:
+    ok = evaluate_order_capability_demo_instrument_rules_binding(_valid_input())
+    tampered = OrderCapabilityDemoInstrumentRulesBindingInput  # noqa: F841
+    bad = type(ok)(
+        verdict=ok.verdict,
+        reason_codes=ok.reason_codes,
+        blockers=ok.blockers,
+        violations=ok.violations,
+        demo_instrument_rules_binding_prepared=ok.demo_instrument_rules_binding_prepared,
+        instrument_rules_offline_bound=ok.instrument_rules_offline_bound,
+        min_size_verified_offline=ok.min_size_verified_offline,
+        cap_feasible=ok.cap_feasible,
+        operator_side_qty_price_decision_prep_allowed_next=ok.operator_side_qty_price_decision_prep_allowed_next,
+        demo_mutation_execute_allowed_now=True,
+        order_authorized_now=ok.order_authorized_now,
+        cancel_authorized_now=ok.cancel_authorized_now,
+        execute_authorized_now=ok.execute_authorized_now,
+        authority_impact=ok.authority_impact,
+        blocker_min_size_not_verified_offline=ok.blocker_min_size_not_verified_offline,
+        value_redacted=ok.value_redacted,
+        no_secret_material=ok.no_secret_material,
+        cancelallorders_allowed=ok.cancelallorders_allowed,
+        batchorder_allowed=ok.batchorder_allowed,
+    )
+    with pytest.raises(DemoInstrumentRulesBindingError):
+        validate_order_capability_demo_instrument_rules_binding_result(bad)
+
+
+def test_no_execution_risk_layer_imports() -> None:
+    tree = ast.parse(CONTRACT_MODULE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("src.execution")
+                assert not alias.name.startswith("src.risk_layer")
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert not node.module.startswith("src.execution")
+            assert not node.module.startswith("src.risk_layer")

--- a/tests/ops/test_order_capability_demo_instrument_rules_binding_contract_v1.py
+++ b/tests/ops/test_order_capability_demo_instrument_rules_binding_contract_v1.py
@@ -128,7 +128,10 @@ def test_demo_host_required_accepts_demo_futures() -> None:
 def test_live_prod_host_rejected(host: str) -> None:
     result = evaluate_order_capability_demo_instrument_rules_binding(_valid_input(demo_host=host))
     assert result.verdict == DemoInstrumentRulesBindingVerdictKind.FAIL_CLOSED
-    assert REASON_DEMO_HOST_MISMATCH in result.reason_codes or REASON_LIVE_HOST_REJECTED in result.reason_codes
+    assert (
+        REASON_DEMO_HOST_MISMATCH in result.reason_codes
+        or REASON_LIVE_HOST_REJECTED in result.reason_codes
+    )
 
 
 def test_credential_class_kraken_futures_demo_only_accepted() -> None:


### PR DESCRIPTION
## Summary
- add offline fail-closed demo instrument rules binding contract
- add tests for demo-host, credential-class, required rules, cap feasibility, secret-boundary and NO_AUTHORITY_CHANGE invariants

## Safety
- no network
- no secrets
- no credential presence check
- no order/cancel/execute authority
- min-size blocker remains true/default fail-closed
- no live/arming/preflight

## Tests
- pytest new contract
- pytest side/qty/price + safety-cancel regression
- ruff check

## Lint gate
- after PR creation, explicitly inspect PR checks/status and verify the lint gate/check has started or completed

Made with [Cursor](https://cursor.com)