### PR TITLE
chore: ignore local cursor-heavy cache paths

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,14 @@
+.git/
+.venv/
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.cache/
+htmlcov/
+dist/
+build/
+*.pyc
+*.pyo
+*.dylib
+*.so


### PR DESCRIPTION
Adds .cursorignore entries for local virtualenv, Python caches, build artifacts, and binary extension files after Cursor recovery.

Scope:
- Adds .cursorignore only
- Excludes .venv/, cache directories, build outputs, Python bytecode, and native binary artifacts from Cursor indexing
- No runtime, trading, CI, workflow, or authority changes

Validation:
- Worktree was clean before branch creation
- Repo-local .venv was removed from workspace and archived outside the repo
- No Peak_Trade code paths changed

Made with [Cursor](https://cursor.com)