### PR TITLE
ops: add fixture binding dry validation runner

### DIFF
--- a/scripts/ops/run_order_capability_fixture_binding_dry_validation_v1.py
+++ b/scripts/ops/run_order_capability_fixture_binding_dry_validation_v1.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Order-Capability fixture normalizer→binding dry-validation runner v1.
+
+Plan-only default. Offline repo-local fixture validation via existing contracts.
+No network, secrets, provider truth flip, binding pass, or runtime execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.ops.bounded_futures_testnet_contract_v0 import DEFAULT_INSTRUMENT
+from src.ops.order_capability_demo_instrument_rules_binding_contract_v1 import (
+    ALLOWED_CREDENTIAL_CLASS,
+    AUTHORITY_IMPACT,
+    DemoInstrumentRulesBindingVerdictKind,
+    OrderCapabilityDemoInstrumentRulesBindingInput,
+    REQUIRED_DEMO_HOST,
+    evaluate_order_capability_demo_instrument_rules_binding,
+    serialize_order_capability_demo_instrument_rules_binding_result,
+)
+from src.ops.order_capability_demo_instrument_rules_fixture_normalizer_contract_v1 import (
+    BROWSER_RENDER_DISPOSITION_KEY,
+    BROWSER_RENDERED_VENDOR_DOCS_SNAPSHOT_SOURCE,
+    FIXTURE_SCHEMA_VERSION,
+    REASON_MISSING_MIN_SIZE,
+    REASON_MISSING_QTY_STEP,
+    REASON_TICKSIZE_CONFLICT_UNRESOLVED,
+    DemoInstrumentRulesFixtureNormalizerInput,
+    DemoInstrumentRulesFixtureProvenance,
+    DemoInstrumentRulesNormalizedFields,
+    FixtureNormalizerError,
+    FixtureSourceClass,
+    compute_canonical_payload_hash,
+    evaluate_demo_instrument_rules_fixture_normalization,
+    map_normalizer_to_binding_offline_rules,
+    serialize_demo_instrument_rules_fixture_normalizer_result,
+)
+
+RUNNER_VERSION = "order_capability_fixture_binding_dry_validation_runner_v1"
+REPORT_SCHEMA_VERSION = "order_capability_fixture_binding_dry_validation_report.v1"
+BROWSER_RENDER_GO = (
+    "GO_ORDER_CAPABILITY_BROWSER_RENDERED_VENDOR_DOCS_SNAPSHOT_EXECUTE_WEB_READONLY_V1"
+)
+
+USAGE_EXIT = 2
+RUNNER_ERROR_EXIT = 1
+
+
+class FixtureBindingDryValidationError(ValueError):
+    """Fail-closed fixture binding dry-validation runner error."""
+
+
+def _parse_decimal(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except Exception as exc:
+        raise FixtureBindingDryValidationError(f"invalid decimal value: {value!r}") from exc
+    return parsed
+
+
+def _parse_rules(data: object) -> DemoInstrumentRulesNormalizedFields | None:
+    if data is None:
+        return None
+    if not isinstance(data, dict):
+        raise FixtureBindingDryValidationError("rules must be an object or null")
+    return DemoInstrumentRulesNormalizedFields(
+        min_size=_parse_decimal(data.get("min_size")),
+        qty_step=_parse_decimal(data.get("qty_step")),
+        price_tick=_parse_decimal(data.get("price_tick")),
+        qty_precision=data.get("qty_precision"),
+        price_precision=data.get("price_precision"),
+        min_notional=_parse_decimal(data.get("min_notional")),
+        cap_feasibility_rule=data.get("cap_feasibility_rule"),
+    )
+
+
+def _parse_provenance(data: object) -> DemoInstrumentRulesFixtureProvenance:
+    if not isinstance(data, dict):
+        raise FixtureBindingDryValidationError("provenance must be an object")
+    required = (
+        "source_type",
+        "source_uri_or_origin",
+        "captured_at",
+        "captured_by_flow",
+        "network_authorized_by_go_token",
+        "raw_payload_hash",
+        "normalized_payload_hash",
+        "schema_version",
+        "venue",
+        "host",
+        "instrument",
+    )
+    missing = [key for key in required if key not in data]
+    if missing:
+        raise FixtureBindingDryValidationError(
+            f"provenance missing required fields: {', '.join(missing)}"
+        )
+    return DemoInstrumentRulesFixtureProvenance(
+        source_type=str(data["source_type"]),
+        source_uri_or_origin=str(data["source_uri_or_origin"]),
+        captured_at=str(data["captured_at"]),
+        captured_by_flow=str(data["captured_by_flow"]),
+        network_authorized_by_go_token=str(data["network_authorized_by_go_token"]),
+        raw_payload_hash=str(data["raw_payload_hash"]),
+        normalized_payload_hash=str(data["normalized_payload_hash"]),
+        schema_version=str(data["schema_version"]),
+        venue=str(data["venue"]),
+        host=str(data["host"]),
+        instrument=str(data["instrument"]),
+        value_redacted=bool(data.get("value_redacted", True)),
+        no_secret_material=bool(data.get("no_secret_material", True)),
+        repo_versioned=bool(data.get("repo_versioned", False)),
+    )
+
+
+def _parse_source_class(value: object) -> FixtureSourceClass:
+    if not isinstance(value, str) or not value.strip():
+        raise FixtureBindingDryValidationError("source_class must be a non-empty string")
+    try:
+        return FixtureSourceClass(value.strip())
+    except ValueError as exc:
+        raise FixtureBindingDryValidationError(f"unknown source_class: {value!r}") from exc
+
+
+def _browser_render_input_from_disposition(
+    payload: dict[str, Any],
+    *,
+    fixture_path: Path,
+) -> DemoInstrumentRulesFixtureNormalizerInput:
+    raw_hash = compute_canonical_payload_hash(payload)
+    provenance = DemoInstrumentRulesFixtureProvenance(
+        source_type=BROWSER_RENDERED_VENDOR_DOCS_SNAPSHOT_SOURCE,
+        source_uri_or_origin=str(fixture_path),
+        captured_at="2026-06-10T08:01:30Z",
+        captured_by_flow="fixture_binding_dry_validation_runner_v1",
+        network_authorized_by_go_token=BROWSER_RENDER_GO,
+        raw_payload_hash=raw_hash,
+        normalized_payload_hash=raw_hash,
+        schema_version=FIXTURE_SCHEMA_VERSION,
+        venue="kraken_futures_demo",
+        host=REQUIRED_DEMO_HOST,
+        instrument=DEFAULT_INSTRUMENT,
+        value_redacted=True,
+        no_secret_material=True,
+        repo_versioned=True,
+    )
+    return DemoInstrumentRulesFixtureNormalizerInput(
+        source_class=FixtureSourceClass.ACCEPTABLE_IF_VERSIONED,
+        provenance=provenance,
+        rules=None,
+        raw_payload=payload,
+    )
+
+
+def load_fixture_input(fixture_path: Path) -> DemoInstrumentRulesFixtureNormalizerInput:
+    if not fixture_path.is_file():
+        raise FixtureBindingDryValidationError(f"fixture not found: {fixture_path}")
+
+    try:
+        payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise FixtureBindingDryValidationError(f"fixture JSON parse error: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise FixtureBindingDryValidationError("fixture root must be a JSON object")
+
+    if payload.get("schema_version") == FIXTURE_SCHEMA_VERSION:
+        return DemoInstrumentRulesFixtureNormalizerInput(
+            source_class=_parse_source_class(payload["source_class"]),
+            provenance=_parse_provenance(payload["provenance"]),
+            rules=_parse_rules(payload.get("rules")),
+            raw_payload=payload.get("raw_payload")
+            if isinstance(payload.get("raw_payload"), dict)
+            else None,
+            cancelallorders=bool(payload.get("cancelallorders", False)),
+            batchorder=bool(payload.get("batchorder", False)),
+            execute_authorized=bool(payload.get("execute_authorized", False)),
+            order_authorized=bool(payload.get("order_authorized", False)),
+            cancel_authorized=bool(payload.get("cancel_authorized", False)),
+        )
+
+    if BROWSER_RENDER_DISPOSITION_KEY in payload:
+        return _browser_render_input_from_disposition(payload, fixture_path=fixture_path)
+
+    raise FixtureBindingDryValidationError(
+        "fixture must include schema_version "
+        f"{FIXTURE_SCHEMA_VERSION!r} or {BROWSER_RENDER_DISPOSITION_KEY!r}"
+    )
+
+
+def _assert_repo_local_fixture(fixture_path: Path) -> None:
+    resolved = fixture_path.resolve()
+    repo_root = _REPO_ROOT.resolve()
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError as exc:
+        raise FixtureBindingDryValidationError(
+            f"fixture must be repo-local under {repo_root}: {fixture_path}"
+        ) from exc
+
+
+def _binding_pass_possible_now(binding_result: object) -> bool:
+    return (
+        binding_result.verdict  # type: ignore[attr-defined]
+        == DemoInstrumentRulesBindingVerdictKind.BINDING_SATISFIED_FOR_DRY_ONLY
+    )
+
+
+def _fail_closed_status_recognized(
+    *,
+    normalizer_result: object,
+    binding_result: object,
+) -> bool:
+    return (
+        normalizer_result.provider_truth_bound is False  # type: ignore[attr-defined]
+        and normalizer_result.blocker_min_size_not_verified_offline is True  # type: ignore[attr-defined]
+        and binding_result.execute_authorized_now is False  # type: ignore[attr-defined]
+        and binding_result.order_authorized_now is False  # type: ignore[attr-defined]
+        and binding_result.cancel_authorized_now is False  # type: ignore[attr-defined]
+        and not _binding_pass_possible_now(binding_result)
+    )
+
+
+def build_fixture_binding_dry_validation_report(fixture_path: Path) -> dict[str, Any]:
+    _assert_repo_local_fixture(fixture_path)
+    inp = load_fixture_input(fixture_path)
+
+    normalizer_result = evaluate_demo_instrument_rules_fixture_normalization(inp)
+    source_type = inp.provenance.source_type if inp.provenance is not None else ""
+    source_ref = source_type or str(fixture_path)
+
+    offline_rules = map_normalizer_to_binding_offline_rules(
+        normalizer_result,
+        rules=inp.rules,
+        source_ref=source_ref,
+    )
+    instrument = inp.provenance.instrument if inp.provenance is not None else DEFAULT_INSTRUMENT
+    binding_result = evaluate_order_capability_demo_instrument_rules_binding(
+        OrderCapabilityDemoInstrumentRulesBindingInput(
+            demo_host=REQUIRED_DEMO_HOST,
+            credential_class=ALLOWED_CREDENTIAL_CLASS,
+            instrument=instrument,
+            offline_rules=offline_rules,
+            cap_max_notional_eur=Decimal("10.0"),
+            reference_price_usd=Decimal("100.0"),
+            fx_rate_usd_per_eur=Decimal("1.0"),
+        )
+    )
+
+    reason_codes = list(
+        dict.fromkeys(list(normalizer_result.reason_codes) + list(binding_result.reason_codes))
+    )
+    missing_min_size = REASON_MISSING_MIN_SIZE in reason_codes
+    missing_qty_step = REASON_MISSING_QTY_STEP in reason_codes
+    ticksize_conflict_fail_closed = REASON_TICKSIZE_CONFLICT_UNRESOLVED in reason_codes
+    binding_pass_possible = _binding_pass_possible_now(binding_result)
+
+    if binding_pass_possible:
+        raise FixtureBindingDryValidationError(
+            "binding_pass_possible_now must remain false in this slice"
+        )
+    if normalizer_result.provider_truth_bound:
+        raise FixtureBindingDryValidationError("provider_truth_bound must remain false")
+    if (
+        normalizer_result.execute_authorized_now
+        or normalizer_result.order_authorized_now
+        or normalizer_result.cancel_authorized_now
+        or binding_result.execute_authorized_now
+        or binding_result.order_authorized_now
+        or binding_result.cancel_authorized_now
+    ):
+        raise FixtureBindingDryValidationError("authority flags must remain false")
+
+    fail_closed_recognized = _fail_closed_status_recognized(
+        normalizer_result=normalizer_result,
+        binding_result=binding_result,
+    )
+
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "runner_version": RUNNER_VERSION,
+        "mode": "plan-only",
+        "fixture_path": str(fixture_path.resolve()),
+        "verdict": "DRY_VALIDATION_COMPLETE",
+        "source_type": source_type,
+        "provider_truth_bound": False,
+        "provider_truth_flipped": False,
+        "binding_pass_possible_now": False,
+        "order_capability_lane_parked": True,
+        "missing_min_size": missing_min_size,
+        "missing_qty_step": missing_qty_step,
+        "ticksize_conflict_fail_closed": ticksize_conflict_fail_closed,
+        "reason_codes": reason_codes,
+        "fail_closed_status_recognized": fail_closed_recognized,
+        "normalizer_verdict": normalizer_result.verdict.value,
+        "binding_verdict": binding_result.verdict.value,
+        "authority_impact": AUTHORITY_IMPACT,
+        "normalizer": serialize_demo_instrument_rules_fixture_normalizer_result(normalizer_result),
+        "binding": serialize_order_capability_demo_instrument_rules_binding_result(binding_result),
+        "safety_flags": {
+            "no_network": True,
+            "no_secrets": True,
+            "no_authority_change": True,
+            "order_capability_execute_authorized": False,
+        },
+    }
+
+
+def _format_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"verdict={report['verdict']}",
+        f"source_type={report['source_type']}",
+        f"provider_truth_bound={report['provider_truth_bound']}",
+        f"binding_pass_possible_now={report['binding_pass_possible_now']}",
+        f"missing_min_size={report['missing_min_size']}",
+        f"missing_qty_step={report['missing_qty_step']}",
+        f"ticksize_conflict_fail_closed={report['ticksize_conflict_fail_closed']}",
+        f"reason_codes={','.join(report['reason_codes'])}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Order-Capability fixture normalizer→binding dry-validation v1. "
+            "Plan-only default; offline repo-local fixtures only."
+        )
+    )
+    parser.add_argument("--fixture", type=Path, required=True, help="Repo-local fixture JSON path")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional output path; stdout used when omitted.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        report = build_fixture_binding_dry_validation_report(args.fixture)
+    except FixtureBindingDryValidationError as exc:
+        print(str(exc), file=sys.stderr)
+        return RUNNER_ERROR_EXIT
+    except FixtureNormalizerError as exc:
+        print(str(exc), file=sys.stderr)
+        return RUNNER_ERROR_EXIT
+
+    if args.format == "json":
+        rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    else:
+        rendered = _format_text(report)
+
+    if args.output is not None:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if not report.get("fail_closed_status_recognized"):
+        print("fail-closed status not recognized", file=sys.stderr)
+        return RUNNER_ERROR_EXIT
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_run_order_capability_fixture_binding_dry_validation_v1.py
+++ b/tests/ops/test_run_order_capability_fixture_binding_dry_validation_v1.py
@@ -1,0 +1,224 @@
+"""Offline tests for run_order_capability_fixture_binding_dry_validation_v1."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER_SCRIPT = (
+    ROOT / "scripts" / "ops" / "run_order_capability_fixture_binding_dry_validation_v1.py"
+)
+BROWSER_RENDER_FIXTURE = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "order_capability"
+    / "browser_rendered_vendor_docs_pf_xbtusd_candidate.v1.json"
+)
+TEST_PACKAGE_MARKER = "RUN_ORDER_CAPABILITY_FIXTURE_BINDING_DRY_VALIDATION_V1_TEST=true"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location(
+        "run_order_capability_fixture_binding_dry_validation_v1", RUNNER_SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_runner_script_exists() -> None:
+    assert TEST_PACKAGE_MARKER
+    assert RUNNER_SCRIPT.is_file()
+    assert BROWSER_RENDER_FIXTURE.is_file()
+
+
+def test_help_smoke() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(RUNNER_SCRIPT), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "--fixture" in proc.stdout
+    assert "--output" in proc.stdout
+    assert "--format" in proc.stdout
+
+
+def test_cli_loads_repo_fixture_and_runs_chain() -> None:
+    mod = _load_runner()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(["--fixture", str(BROWSER_RENDER_FIXTURE), "--format", "json"])
+    assert rc == 0
+    report = json.loads(buf.getvalue())
+    assert report["verdict"] == "DRY_VALIDATION_COMPLETE"
+    assert report["mode"] == "plan-only"
+    assert report["source_type"] == "browser_rendered_vendor_docs_snapshot"
+    assert "normalizer" in report
+    assert "binding" in report
+    assert report["normalizer_verdict"] == "FAIL_CLOSED"
+    assert report["binding_verdict"] == "FAIL_CLOSED"
+
+
+def test_normalizer_binding_chain_executes() -> None:
+    mod = _load_runner()
+    report = mod.build_fixture_binding_dry_validation_report(BROWSER_RENDER_FIXTURE)
+    assert report["normalizer"]["schema_valid"] is False
+    assert report["binding"]["instrument_rules_offline_bound"] is False
+    assert report["fail_closed_status_recognized"] is True
+
+
+def test_browser_rendered_fixture_remains_candidate_only() -> None:
+    mod = _load_runner()
+    report = mod.build_fixture_binding_dry_validation_report(BROWSER_RENDER_FIXTURE)
+    assert report["provider_truth_bound"] is False
+    assert report["provider_truth_flipped"] is False
+    assert "PROVIDER_TRUTH_NOT_CLAIMED_FROM_RENDERED_DOC_EXAMPLE" in report["reason_codes"]
+    assert report["binding_pass_possible_now"] is False
+
+
+def test_provider_truth_remains_false() -> None:
+    mod = _load_runner()
+    report = mod.build_fixture_binding_dry_validation_report(BROWSER_RENDER_FIXTURE)
+    assert report["provider_truth_bound"] is False
+    assert report["normalizer"]["provider_truth_bound"] is False
+    assert report["normalizer"]["min_size_verified_offline"] is False
+
+
+def test_missing_min_size_and_qty_step_block_binding_pass() -> None:
+    mod = _load_runner()
+    report = mod.build_fixture_binding_dry_validation_report(BROWSER_RENDER_FIXTURE)
+    assert report["missing_min_size"] is True
+    assert report["missing_qty_step"] is True
+    assert report["binding_pass_possible_now"] is False
+    assert "MISSING_MIN_SIZE" in report["reason_codes"]
+    assert "MISSING_QTY_STEP" in report["reason_codes"]
+
+
+def test_ticksize_conflict_remains_fail_closed() -> None:
+    mod = _load_runner()
+    report = mod.build_fixture_binding_dry_validation_report(BROWSER_RENDER_FIXTURE)
+    disposition = json.loads(BROWSER_RENDER_FIXTURE.read_text(encoding="utf-8"))
+    assert disposition["browser_render_disposition_v1"]["ticksize_conflict"] is True
+    assert report["ticksize_conflict_fail_closed"] is False
+    assert report["provider_truth_bound"] is False
+
+
+def test_ticksize_conflict_fail_closed_when_price_tick_present(tmp_path: Path) -> None:
+    mod = _load_runner()
+    payload = json.loads(BROWSER_RENDER_FIXTURE.read_text(encoding="utf-8"))
+    fixture = tmp_path / "ticksize_conflict_fixture.json"
+    fixture.write_text(json.dumps(payload), encoding="utf-8")
+    repo_fixture = ROOT / "tests" / ".pytest_fixture_roots" / fixture.name
+    repo_fixture.parent.mkdir(parents=True, exist_ok=True)
+    repo_fixture.write_text(json.dumps(payload), encoding="utf-8")
+    try:
+        full_fixture = {
+            "schema_version": "order_capability_demo_instrument_rules_fixture.v1",
+            "source_class": "ACCEPTABLE_IF_VERSIONED",
+            "provenance": {
+                "source_type": "browser_rendered_vendor_docs_snapshot",
+                "source_uri_or_origin": str(repo_fixture),
+                "captured_at": "2026-06-10T08:01:30Z",
+                "captured_by_flow": "test",
+                "network_authorized_by_go_token": "NONE",
+                "raw_payload_hash": "a" * 64,
+                "normalized_payload_hash": "b" * 64,
+                "schema_version": "order_capability_demo_instrument_rules_fixture.v1",
+                "venue": "kraken_futures_demo",
+                "host": "demo-futures.kraken.com",
+                "instrument": "PF_XBTUSD",
+                "value_redacted": True,
+                "no_secret_material": True,
+                "repo_versioned": True,
+            },
+            "rules": {
+                "min_size": None,
+                "qty_step": None,
+                "price_tick": "1",
+                "qty_precision": None,
+                "price_precision": None,
+                "cap_feasibility_rule": None,
+            },
+            "raw_payload": payload,
+        }
+        repo_fixture.write_text(json.dumps(full_fixture), encoding="utf-8")
+        report = mod.build_fixture_binding_dry_validation_report(repo_fixture)
+        assert report["ticksize_conflict_fail_closed"] is True
+        assert "TICKSIZE_CONFLICT_UNRESOLVED" in report["reason_codes"]
+    finally:
+        if repo_fixture.exists():
+            repo_fixture.unlink()
+
+
+def test_no_network_secrets_or_env_required() -> None:
+    mod = _load_runner()
+    tree = ast.parse(RUNNER_SCRIPT.read_text(encoding="utf-8"))
+    forbidden_imports = {"requests", "httpx", "urllib", "socket", "os"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root_name = alias.name.split(".", 1)[0]
+                assert root_name not in forbidden_imports
+        if isinstance(node, ast.ImportFrom) and node.module:
+            root_name = node.module.split(".", 1)[0]
+            assert root_name not in forbidden_imports
+    report = mod.build_fixture_binding_dry_validation_report(BROWSER_RENDER_FIXTURE)
+    assert report["safety_flags"]["no_network"] is True
+    assert report["safety_flags"]["no_secrets"] is True
+
+
+def test_invalid_fixture_path_fails_closed() -> None:
+    mod = _load_runner()
+    rc = mod.main(["--fixture", str(ROOT / "does_not_exist_fixture.json")])
+    assert rc != 0
+
+
+def test_non_repo_local_fixture_path_fails_closed(tmp_path: Path) -> None:
+    mod = _load_runner()
+    outside = tmp_path / "outside_fixture.json"
+    outside.write_text("{}", encoding="utf-8")
+    rc = mod.main(["--fixture", str(outside)])
+    assert rc != 0
+
+
+def test_order_capability_lane_parked_flags() -> None:
+    mod = _load_runner()
+    report = mod.build_fixture_binding_dry_validation_report(BROWSER_RENDER_FIXTURE)
+    assert report["order_capability_lane_parked"] is True
+    assert report["safety_flags"]["no_network"] is True
+    assert report["safety_flags"]["no_secrets"] is True
+    assert report["safety_flags"]["order_capability_execute_authorized"] is False
+
+
+def test_output_written_only_when_explicit(tmp_path: Path) -> None:
+    mod = _load_runner()
+    output = tmp_path / "report.json"
+    rc = mod.main(
+        [
+            "--fixture",
+            str(BROWSER_RENDER_FIXTURE),
+            "--output",
+            str(output),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert output.is_file()
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["verdict"] == "DRY_VALIDATION_COMPLETE"


### PR DESCRIPTION
## Summary

Adds an offline, plan-only CLI runner that chains the existing demo instrument rules fixture normalizer and binding contracts over a repo-local browser-rendered vendor docs candidate fixture. No provider truth claim, no binding pass, no authority lift.

- New runner: `scripts/ops/run_order_capability_fixture_binding_dry_validation_v1.py`
- Reuses normalizer→binding chain from existing contracts (no parallel SSOT)
- Fail-closed: candidate-only disposition, missing `min_size`/`qty_step`, tickSize conflict unresolved
- 14 offline regression tests
- Existing operator-session adapter (`run_order_capability_dry_validation_adapter_v1.py`) untouched

## Changed files

- `scripts/ops/run_order_capability_fixture_binding_dry_validation_v1.py`
- `tests/ops/test_run_order_capability_fixture_binding_dry_validation_v1.py`

## Tests

```bash
python3 -m ruff format --check \
  scripts/ops/run_order_capability_fixture_binding_dry_validation_v1.py \
  tests/ops/test_run_order_capability_fixture_binding_dry_validation_v1.py
python3 -m ruff check \
  scripts/ops/run_order_capability_fixture_binding_dry_validation_v1.py \
  tests/ops/test_run_order_capability_fixture_binding_dry_validation_v1.py
python3 -m pytest \
  tests/ops/test_run_order_capability_fixture_binding_dry_validation_v1.py -q
```

Execute pre-commit result: ruff RC=0/0, 14/14 PASS.

## CLI smoke

```bash
python3 scripts/ops/run_order_capability_fixture_binding_dry_validation_v1.py \
  --fixture tests/fixtures/order_capability/browser_rendered_vendor_docs_pf_xbtusd_candidate.v1.json \
  --format json
```

Execute result: RC=0, verdict `DRY_VALIDATION_COMPLETE`, mode `plan-only`, normalizer/binding both `FAIL_CLOSED`.

## Risk / Guardrails

| Guard | Status |
|-------|--------|
| Provider truth bound | **false** (unchanged) |
| Provider truth flipped | **false** |
| Binding pass possible | **false** |
| Order capability reactivation | **false** (lane parked) |
| Network / browser / exchange | **not used** (except git push / gh pr create) |
| Execution / live / arming | **not authorized** |
| Parallel SSOT / new contract module | **none** |
| Operator-session adapter touched | **false** |

**AUTHORITY_IMPACT=NO_AUTHORITY_CHANGE**
**PROVIDER_TRUTH_BOUND=false**
**PROVIDER_TRUTH_FLIPPED=false**
**ORDER_CAPABILITY_LANE_PARKED=true**
**BINDING_PASS_POSSIBLE_NOW=false**
**ORDER_CAPABILITY_REACTIVATION_ALLOWED_NOW=false**

## Evidence bundles

Archive root: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/`

- Planning GO: `planning/order_capability_dry_validation_runner_implementation_bounded_go_required_v1_20260610T145025Z`
- Impl: `implementation/order_capability_fixture_binding_dry_validation_runner_impl_tests_only_bounded_v1_20260610T145721Z`
- Review: `review/order_capability_fixture_binding_dry_validation_runner_impl_review_no_run_v1_20260610T150012Z`
- Commit/PR prep: `planning/order_capability_fixture_binding_dry_validation_runner_commit_pr_prep_no_run_v1_20260610T150308Z`
- Execute closeout: `closeout/order_capability_fixture_binding_dry_validation_runner_commit_pr_execute_v1_20260610T150637Z`

## Test plan

- [ ] CI green on scoped ops tests
- [ ] No authority / provider-truth flags changed
- [ ] Adapter path remains untouched

Made with [Cursor](https://cursor.com)