### PR TITLE
Market dashboard run projection operator pointer

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -56,6 +56,23 @@ Dashboard ≠ Freigabe. Market Surface v0 is **review input only** for operators
 
 `MARKET_DASHBOARD_IS_PROJECTION_ONLY=true` — this surface must not be promoted to approval, gate clearance, or execution authority.
 
+#### Operator enablement (run projection v1)
+
+**Default off / operator-gated / fail-closed:** Registry run projection on **`GET`** **`&#47;market`** stays **disabled** until **both** env gates below are explicitly set. Projection panel and `data-market-v0-run-projection-*` markers **absent when gates are off** is **expected** — **not** a template defect, **not** Dashboard Truth GO, **not** Provider Truth, **no** runtime, Testnet, Paper, or Shadow authority.
+
+**Required env chain (both steps for projection panel on `GET` `/market`):**
+
+| Step | Env var(s) | Notes |
+|------|------------|-------|
+| 1 | `PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED=1` | Master run-projection gate |
+| 2 | `PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON=<path>` | Post-closeout projection payload v0 (`peak_trade.post_closeout_projection_payload.v0`) |
+
+**Payload/registry readiness:** Payload must expose `projection_ready=true`, valid `registry_pointer`, and `consumers.market_dashboard_projection_allowed=true` before `data-market-v0-run-projection-ready="true"`. Registry JSON is read-only at the pointer; UI shows basename labels only — **no** archive walks. **`GET`** **`&#47;market`** must **not** derive Provider Truth from projection display.
+
+**Troubleshooting (missing/stale projection):** Walk the env chain top-down before assuming SSR regression. Verify payload path, registry pointer, and readiness flags. Distinguish **absent markers** (gate off — expected) from **`data-market-v0-run-projection-ready="false"`** (gate on but payload/registry not ready). Cross-check **`tests/webui/test_market_registry_projection_overlay_v0.py`**, **`tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`**, and **`tests/ops/test_market_dashboard_readonly_run_projection_spec_v0.py`**.
+
+**Protected boundaries:** read-only SSR only — **no dashboard truth grant**, **no provider truth**, **no** Live/Testnet/Order/Cancel/Execute/Arming/Preflight authority, **no** runtime/scheduler activation. **Market-Airport excluded.** **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — run projection does not alter Double Play routes, markers, or decision logic.
+
 ## Safety banner and stable markers
 
 Das HTML-Template für **`GET &#47;market`** rendert oberhalb der Chart-Fläche ein **sichtbares** Safety-Banner (**read-only**, **non-authorizing**) mit Quellen-spezifischem Kurztext (`source=dummy` \| `source=kraken`).

--- a/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
+++ b/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
@@ -87,3 +87,40 @@ def test_market_surface_single_page_consolidation_operator_pointer_env_boundary_
 
     for token in required_boundary_tokens:
         assert token.lower() in consolidation.lower()
+
+
+def test_market_surface_run_projection_operator_pointer_env_boundary_v0() -> None:
+    """Run projection operator enablement tokens stay pinned in MARKET_SURFACE_V0."""
+    surface = (PROJECT_ROOT / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")
+
+    section_start = surface.index("### Post-Closeout Registry run projection (env-gated SSR v0)")
+    section_end = surface.index("## Safety banner and stable markers")
+    run_projection = surface[section_start:section_end]
+
+    assert "Operator enablement (run projection v1)" in run_projection
+    assert "PEAK_TRADE_MARKET_RUN_PROJECTION_" in run_projection
+
+    required_env_tokens = [
+        "PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED=1",
+        "PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON",
+    ]
+
+    for token in required_env_tokens:
+        assert token in run_projection
+
+    required_boundary_tokens = [
+        "default off",
+        "operator-gated",
+        "fail-closed",
+        "&#47;market",
+        "no provider truth",
+        "no dashboard truth",
+        "Market-Airport excluded",
+        "Master V2 / Double Play protected",
+        "test_market_registry_projection_overlay_v0.py",
+        "test_market_dashboard_readonly_structure_contract_v0.py",
+        "test_market_dashboard_readonly_run_projection_spec_v0.py",
+    ]
+
+    for token in required_boundary_tokens:
+        assert token.lower() in run_projection.lower()


### PR DESCRIPTION
## Summary
- docs/tests-only operator enablement checklist for env-gated Post-Closeout Registry run projection on `GET /market`
- Extends `MARKET_SURFACE_V0.md` with `#### Operator enablement (run projection v1)` (env chain, fail-closed troubleshooting, protected boundaries)
- Extends `test_market_surface_ranking_funnel_env_schema_boundary_v0.py` with static run-projection env-boundary assertions

## Scope
- **Exact two-file scope:** `docs/webui/MARKET_SURFACE_V0.md`, `tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`
- **No** `src/`, templates, routes, or runtime changes
- **No** Provider Truth / Dashboard Truth GO
- **No** runs, testnet, paper, or shadow
- Market-Airport excluded
- Master V2 / Double Play protected

## Test plan
- [x] `python3 -m ruff format --check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py` (RC=0)
- [x] `python3 -m ruff check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py` (RC=0)
- [x] `python3 -m pytest tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py -q` (3 passed)


Made with [Cursor](https://cursor.com)