### PR TITLE
Market dashboard ranking funnel operator pointer

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -213,6 +213,23 @@ Non-authority invariants remain unchanged:
 - `API_ENDPOINT_CREATED=false`
 - `DOUBLE_PLAY_ROUTE_CHANGED=false`
 
+#### Operator enablement (ranking funnel v1)
+
+**Default off / operator-gated / fail-closed:** Ranking funnel SSR on **`GET`** **`&#47;market`** stays **disabled** until **both** env gates below are explicitly set. Empty-state markers, absent row markers, or **`#market-v0-ranking-funnel-ssr`** region **absent when gates are off** is **expected** — **not** a template defect, **not** Dashboard Truth GO, **not** Provider Truth, **no** runtime, Testnet, Paper, or Shadow authority.
+
+**Required env chain (both steps for ranking funnel rows on `GET` `/market`):**
+
+| Step | Env var(s) | Notes |
+|------|------------|-------|
+| 1 | `PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED=1` | Master ranking-funnel gate |
+| 2 | `PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT=<path>` | Offline bundle root for `market_ranking_funnel_readmodel.v0` |
+
+**Bundle/readmodel readiness:** Bundle must expose valid `market_ranking_funnel_readmodel.v0` JSON with `readmodel_id`, `generated_at_iso`, `source`, `stale`/`stale_reason`, and `stages.universe[]`/`shortlist[]`/`selected[]` before row markers replace empty-state UI. Fixture target: `tests/fixtures/market_ranking_funnel_readmodel_v0/`. **`GET`** **`&#47;market`** must **not** derive Provider Truth from funnel display.
+
+**Troubleshooting (missing/stale funnel rows):** Walk the env chain top-down before assuming SSR regression. Verify bundle root path and readmodel JSON validity. Distinguish **empty-state markers present** (gate on, no rows — expected display empty state) from **absent funnel region** (gate off — expected). Cross-check **`tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`**, **`tests/webui/test_market_ranking_funnel_readmodel_v0.py`**, and existing charter/env tests in **`tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`**.
+
+**Protected boundaries:** read-only SSR only — **no dashboard truth grant**, **no provider truth**, **no** Live/Testnet/Order/Cancel/Execute/Arming/Preflight authority, **no** runtime/scheduler activation. **Market-Airport excluded.** **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — ranking funnel does not alter Double Play routes, markers, or decision logic. **No run, Testnet, Paper, or Shadow authorization** is granted by enabling this display path.
+
 ### Marker / IA crosswalk policy v0
 
 `market_v0.html` deliberately exposes many `data-market-v0-*` markers for SSR structure, visual grouping, and regression tests. `MARKET_SURFACE_V0.md` is the canonical product/contract surface, not a complete attribute registry: it should describe marker families and authority boundaries rather than duplicate every template attribute.

--- a/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
+++ b/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
@@ -124,3 +124,43 @@ def test_market_surface_run_projection_operator_pointer_env_boundary_v0() -> Non
 
     for token in required_boundary_tokens:
         assert token.lower() in run_projection.lower()
+
+
+def test_market_surface_ranking_funnel_operator_pointer_env_boundary_v0() -> None:
+    """Ranking funnel operator enablement tokens stay pinned in MARKET_SURFACE_V0."""
+    surface = (PROJECT_ROOT / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")
+
+    section_start = surface.index("### Market Ranking Funnel SSR v0 landed")
+    section_end = surface.index("### Marker / IA crosswalk policy v0")
+    ranking_funnel = surface[section_start:section_end]
+
+    assert "Operator enablement (ranking funnel v1)" in ranking_funnel
+
+    required_env_tokens = [
+        "PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED=1",
+        "PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT",
+    ]
+
+    for token in required_env_tokens:
+        assert token in ranking_funnel
+
+    required_boundary_tokens = [
+        "default off",
+        "operator-gated",
+        "fail-closed",
+        "GET",
+        "&#47;market",
+        "no provider truth",
+        "no dashboard truth",
+        "Market-Airport excluded",
+        "Master V2 / Double Play protected",
+        "no run",
+        "testnet",
+        "paper",
+        "shadow",
+        "test_market_dashboard_readonly_structure_contract_v0.py",
+        "test_market_ranking_funnel_readmodel_v0.py",
+    ]
+
+    for token in required_boundary_tokens:
+        assert token.lower() in ranking_funnel.lower()


### PR DESCRIPTION
## Summary
- docs/tests-only slice: add **`#### Operator enablement (ranking funnel v1)`** under § Market Ranking Funnel SSR v0 landed in `docs/webui/MARKET_SURFACE_V0.md`
- extend `tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py` with static operator-pointer env-boundary test
- exact two-file scope; no `src/`, templates, routes, or runtime changes

## Boundaries
- no Provider Truth / Dashboard Truth GO
- no runs / testnet / paper / shadow authorization
- Market-Airport excluded
- Master V2 / Double Play protected
- Market Depth operator pointer remains deferred

## Test plan
- [x] `python3 -m ruff format --check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`
- [x] `python3 -m ruff check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`
- [x] `python3 -m pytest tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py -q`


Made with [Cursor](https://cursor.com)