### PR TITLE
Market dashboard Chart.js CDN diagnostics operator pointer

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -269,6 +269,18 @@ Dashboard markers remain non-authorizing: **Dashboard ≠ Freigabe**; no marker 
 - **Keine** Double‑Play‑Komposition oder Trading‑/Risk‑/Capital‑Interpretation durch diese Diagnosemarker.
 - **v0 CDN load attribution (template):** Die Chart.js‑Einbindung über **jsdelivr** setzt am `<script>`‑Tag ein **`onerror`**, markiert das Skript bei Ladefehler mit **`data-chartjs-cdn-load-error`** und spiegelt den Zustand auf den jeweiligen Dashboard‑Shell‑Container (**`data-chartjs-cdn-load-error`** auf **`#market-v0-shell`**, **`#double-play-market-v0-shell`**, bzw. **`#r-and-d-charts-shell`** wenn Diagramme geladen werden). Zusätzlich **`data-chartjs-cdn-monitored-v0="true"`** kennzeichnet Oberflächen mit dieser Überwachung. **Lokaler Vendor‑Chart.js‑Fallback** bleibt **separates** Arbeitspaket (siehe Hinweis zu **v1.2** unten); Oberflächen bleiben **read-only** und **non-authorizing**.
 
+#### Operator enablement (chart.js CDN diagnostics v1)
+
+**Diagnostic only / fail-closed / no authority:** Chart.js CDN diagnostics on **`GET`** **`&#47;market`** (and parallel Double-Play/R&amp;D shells) are **operator-facing troubleshooting signals only** — **not** env-gated SSR panels, **not** Dashboard Truth GO, **not** Provider Truth, **no** Live/Testnet/Order/Cancel/Execute/Arming/Preflight authority, **no** runtime/scheduler activation, **no run, Testnet, Paper, or Shadow authorization**.
+
+**Diagnostic markers (non-authorizing):** **`data-chartjs-cdn-load-error`**, **`data-chartjs-cdn-monitored-v0="true"`**, **`data-chartjs-cdn-script-v0="true"`**, **`data-market-chart-status`** (incl. **`#market-v0-chart-status`**), and **`data-market-v11-*`** chart render diagnostics mirror CDN load, SSR empty, and client render state — **display/troubleshooting only**; **`GET`** **`&#47;market`** must **not** derive Provider Truth from these markers.
+
+**Vendor fallback boundary:** **`CHARTJS_LOCAL_FALLBACK_PLANNING_CHARTER_V0`** remains **planning/charter context only** — **no** active local Chart.js vendor fallback is authorized by this operator pointer. **Vendor fallback stays deferred until CDN-blocking evidence** is operator-evidenced (existing v0 CDN load attribution); do **not** treat CDN load errors as trading blocks or readiness GO.
+
+**Troubleshooting (CDN blocked vs SSR empty vs render error):** Walk **Chart status states** (`ready`/`empty`/`error` on **`data-market-chart-status`**) first, then **CDN attribution** (`data-chartjs-cdn-load-error`, **`data-chartjs-cdn-monitored-v0`**, script tag **`data-chartjs-cdn-script-v0`**), then **v1.1 diagnostics** (`data-market-v11-*`). Cross-check **`tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`** and **`tests/test_market_surface_api.py`**. Distinguish **CDN script blocked** (CDN markers set) from **SSR empty bars** (`empty` status, no bars) from **client render failure** (`error` status) — **none** of these grant dashboard or provider authority. **Do not** escalate to local vendor fallback without charter + CDN-blocking evidence.
+
+**Protected boundaries:** read-only diagnostic path only — **no dashboard truth grant**, **no provider truth**. **Market-Airport excluded.** **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — CDN diagnostics operator enablement does not alter Double Play routes, markers, or decision logic.
+
 ### Chart.js local fallback planning charter v0
 
 **Status:** **planning-only** — **keine** Implementierung in diesem Charter-Slice. **Kanonischer Owner** bleibt dieses Dokument (**`docs&#47;webui&#47;MARKET_SURFACE_V0.md`**); **kein** paralleles Spec-, Dashboard- oder Vendor-Artefakt.

--- a/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
+++ b/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
@@ -209,3 +209,47 @@ def test_market_surface_market_depth_operator_pointer_env_boundary_v0() -> None:
 
     for token in required_boundary_tokens:
         assert token.lower() in market_depth.lower()
+
+
+def test_market_surface_chartjs_cdn_diagnostics_operator_pointer_env_boundary_v0() -> None:
+    """Chart.js CDN diagnostics operator enablement tokens stay pinned in MARKET_SURFACE_V0."""
+    surface = (PROJECT_ROOT / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")
+
+    section_start = surface.index("#### Operator enablement (chart.js CDN diagnostics v1)")
+    section_end = surface.index("### Chart.js local fallback planning charter v0")
+    chartjs_cdn = surface[section_start:section_end]
+
+    assert "Operator enablement (chart.js CDN diagnostics v1)" in chartjs_cdn
+
+    required_diagnostic_tokens = [
+        "data-chartjs-cdn-load-error",
+        "data-chartjs-cdn-monitored-v0",
+        "data-chartjs-cdn-script-v0",
+        "data-market-chart-status",
+        "data-market-v11",
+        "market-v0-chart-status",
+        "CHARTJS_LOCAL_FALLBACK_PLANNING_CHARTER_V0",
+    ]
+
+    for token in required_diagnostic_tokens:
+        assert token in chartjs_cdn
+
+    required_boundary_tokens = [
+        "diagnostic only",
+        "fail-closed",
+        "no authority",
+        "vendor fallback stays deferred until CDN-blocking evidence",
+        "no provider truth",
+        "no dashboard truth",
+        "Market-Airport excluded",
+        "Master V2 / Double Play protected",
+        "no run",
+        "testnet",
+        "paper",
+        "shadow",
+        "test_market_dashboard_readonly_structure_contract_v0.py",
+        "tests/test_market_surface_api.py",
+    ]
+
+    for token in required_boundary_tokens:
+        assert token.lower() in chartjs_cdn.lower()


### PR DESCRIPTION
## Summary
- docs/tests-only slice: operator enablement subsection for Chart.js CDN diagnostics in `docs/webui/MARKET_SURFACE_V0.md`
- static doc-boundary pins in `tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`
- exact two-file scope — no src/templates/runtime

## Boundaries
- no Provider Truth / no Dashboard Truth GO
- no runs/testnet/paper/shadow authorization
- no local Chart.js vendor fallback — vendor fallback deferred until CDN-blocking evidence
- Market-Airport excluded
- Master V2 / Double Play protected

## Test plan
- [x] `python3 -m ruff format --check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`
- [x] `python3 -m ruff check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`
- [x] `python3 -m pytest tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py -q`


Made with [Cursor](https://cursor.com)