### PR TITLE
docs(webui): define chartjs cdn evidence capture charter

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -419,6 +419,47 @@ MARKET_DASHBOARD_READ_ONLY_NON_AUTHORITY=true
 
 **Protected boundaries:** read-only evidence criteria only — **no dashboard truth grant**, **no provider truth**, **no vendor fallback authorization**. **Market-Airport excluded.** **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — evidence criteria do not alter Double Play routes, markers, or decision logic. **No run, Testnet, Paper, or Shadow authorization** is granted by documenting these criteria.
 
+#### CDN-blocking evidence capture charter (v1)
+
+**Charter context:** Erweiterung unter **`CHARTJS_LOCAL_FALLBACK_PLANNING_CHARTER_V0`** — capture charter only; **keine** Evidence-Erhebung in diesem Slice.
+
+**Docs-only / fail-closed / no authority:** Dieser Abschnitt normiert die **spätere** operatorische Evidence-Capture-Prozedur — **nicht** als automatische Erhebung oder Vendor-Fallback-Freigabe. **Diese Änderung startet keine Capture-Erhebung.** **Kein** Browser-Render, **kein** Netzwerkzugriff, **keine** Vendor-Datei wird durch diese Dokumentation erzeugt. **Vendor-Fallback bleibt nicht autorisiert**; erfordert später separate **Evidence Review**, **Vendor-Decision**-GO und **Vendor-Implementation**-GO plus Implementierungs-PR. **Keine** Provider Truth, **keine** Dashboard Truth, **keine** Trading Readiness, **keine** Live-/Preflight-Lift-/Execution-/Order-/Cancel-Autorität. **Keine** Secrets/Credentials/Operator-Env-Lesung in der Capture-Prozedur. **Keine** Runtime-/Scheduler-/Exchange-Ausführung wird durch diese Änderung gestartet. Orthogonal zu #4101 Chart.js CDN diagnostics operator pointer, #4104 CDN-blocking evidence criteria, Operator-Pointer-Kette #4097–#4103 — **none** grant vendor fallback, provider truth, dashboard truth, or trading authorization.
+
+**Phase separation (strict — do not conflate):**
+
+| Phase | Purpose | Browser/Network | Vendor | Authority |
+|-------|---------|-----------------|--------|-----------|
+| **1. Prep** | Capture charter prep in durable archive | no | no | no |
+| **2. Docs-Execute** | Embed capture charter on `main` (this section) | no | no | no |
+| **3. Capture** | Operator evidence capture under separate GO | **yes if blocking reproduced** | no | no |
+| **4. Review** | Read-only review of capture bundle | no | no | no |
+| **5. Vendor-Decision** | Separate decision GO after verified evidence | no | no | no |
+| **6. Vendor-Implementation** | Separate impl GO + PR (vendor asset + template) | optional offline test | **yes** | no trading authority |
+
+**Minimum capture artifacts (future durable bundle — not `/tmp`):**
+
+| Artifact field | Required | Notes |
+|----------------|----------|-------|
+| **Zeitpunkt/UTCSTAMP** | yes | ISO-8601 compact timestamp at observation |
+| **Umgebung** | yes | OS, browser, high-level network posture — **no secrets** |
+| **Renderpfad** | yes | Route + shell (`GET` `/market`, `/market/double-play`, or R&amp;D charts) |
+| **Erwartete Wirkung** | yes | Expected chart/CDN behavior before load |
+| **Beobachtete Wirkung** | yes | Observed CDN script load failure + marker state |
+| **Chart.js-CDN-Kausalitätsabgrenzung** | yes | Why failure is CDN load, not other failure class |
+| **Ausschluss App-Code/Test-Fixture/lokaler Host/Operator-Fehlbedienung** | yes | Explicit rejection of regression, fixture, host, operator error |
+| **Reproduktionshinweis** | yes | Minimal steps for independent replay |
+| **Operator-Attestation** | yes | Signed operator record — not inferred from static tests |
+| **`MANIFEST.sha256`** | yes | SHA-256 of all bundle files except manifest files |
+| **`MANIFEST_VERIFY.txt`** | yes | Per-file OK/FAIL + `MANIFEST_VERIFY_RC=0` |
+
+**Capture procedure summary (future — separately authorized):** Walk #4101 CDN diagnostics markers (`data-chartjs-cdn-load-error`, `data-chartjs-cdn-monitored-v0`, `data-chartjs-cdn-script-v0`, `data-market-chart-status`) and #4104 sufficient/insufficient conditions; record environment, render path, expected vs observed effect, CDN causality distinction, exclusions, reproduction hint, operator attestation; write durable archive bundle; verify manifest before claiming evidence raised.
+
+**When later Capture GO is sensible:** Only when capture charter is on `main`, operator reproduces CDN script load failure under controlled conditions, attribution markers correlate, SSR-empty and client-render-error are ruled out, and operator accepts browser + network **only** under separate **`GO_MARKET_DASHBOARD_CHARTJS_CDN_BLOCKING_EVIDENCE_CAPTURE_READONLY_BROWSER_NO_VENDOR_V1`**.
+
+**When capture does NOT authorize vendor fallback:** Manifest verification failure; distinction shows SSR-empty or render-error; blocking attributed to app regression, fixture, host, or operator error; static pytest/HTML structure proof only; review not completed; separate Vendor-Decision or Vendor-Implementation GO not issued.
+
+**Protected boundaries:** read-only capture charter only — **no dashboard truth grant**, **no provider truth**, **no vendor fallback authorization**. **Market-Airport excluded.** **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — capture charter does not alter Double Play routes, markers, or decision logic. **No run, Testnet, Paper, or Shadow authorization** is granted by documenting this charter.
+
 ## Double-Play Market Dashboard v1 SSR
 
 **Route:** **`GET &#47;market&#47;double-play`**

--- a/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
+++ b/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
@@ -326,6 +326,82 @@ def test_market_surface_chartjs_cdn_blocking_evidence_criteria_env_boundary_v0()
         assert token.lower() not in cdn_evidence.lower()
 
 
+def test_market_surface_chartjs_cdn_blocking_evidence_capture_charter_env_boundary_v0() -> None:
+    """CDN-blocking evidence capture charter tokens stay pinned in MARKET_SURFACE_V0 charter."""
+    surface = (PROJECT_ROOT / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")
+
+    section_start = surface.index("#### CDN-blocking evidence capture charter (v1)")
+    section_end = surface.index("## Double-Play Market Dashboard v1 SSR")
+    capture_charter = surface[section_start:section_end]
+
+    assert "CDN-blocking evidence capture charter (v1)" in capture_charter
+
+    required_phase_tokens = [
+        "Prep",
+        "Docs-Execute",
+        "Capture",
+        "Review",
+        "Vendor-Decision",
+        "Vendor-Implementation",
+    ]
+
+    for token in required_phase_tokens:
+        assert token in capture_charter
+
+    required_artifact_tokens = [
+        "Zeitpunkt/UTCSTAMP",
+        "Umgebung",
+        "Renderpfad",
+        "erwartete Wirkung",
+        "beobachtete Wirkung",
+        "Chart.js-CDN-Kausalitätsabgrenzung",
+        "Operator-Attestation",
+        "MANIFEST.sha256",
+        "MANIFEST_VERIFY.txt",
+    ]
+
+    for token in required_artifact_tokens:
+        assert token.lower() in capture_charter.lower()
+
+    required_boundary_tokens = [
+        "capture-erhebung",
+        "browser-render",
+        "netzwerkzugriff",
+        "vendor-datei",
+        "vendor-fallback bleibt nicht autorisiert",
+        "no provider truth",
+        "no dashboard truth",
+        "trading readiness",
+        "preflight-lift",
+        "execution",
+        "order",
+        "cancel",
+        "secrets/credentials/operator-env",
+        "fail-closed",
+        "no authority",
+        "#4101",
+        "#4104",
+        "#4097",
+        "Market-Airport excluded",
+        "Master V2 / Double Play protected",
+    ]
+
+    for token in required_boundary_tokens:
+        assert token.lower() in capture_charter.lower()
+
+    forbidden_authority_tokens = [
+        "vendor_fallback_authorized_now=true",
+        "live_authorized=true",
+        "preflight_lift_authorized=true",
+        "execute_authorized=true",
+        "order_authorized=true",
+        "dashboard_truth_go_authorized=true",
+    ]
+
+    for token in forbidden_authority_tokens:
+        assert token.lower() not in capture_charter.lower()
+
+
 def test_market_surface_ssr_provenance_snapshot_operator_pointer_env_boundary_v0() -> None:
     """SSR provenance / snapshot triage operator enablement tokens stay pinned in MARKET_SURFACE_V0."""
     surface = (PROJECT_ROOT / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- bounded docs/tests-only
- erweitert bestehenden CHARTJS_LOCAL_FALLBACK_PLANNING_CHARTER_V0 / CDN-blocking evidence criteria Owner in MARKET_SURFACE_V0.md
- definiert CDN-blocking evidence capture charter (v1)
- trennt sechs Phasen: Prep, Docs-Execute, Capture, Review, Vendor-Decision, Vendor-Implementation
- definiert Capture-Artefakte inklusive UTCSTAMP, Umgebung, Renderpfad, erwartete/beobachtete Wirkung, Chart.js-CDN-Kausalitätsabgrenzung, Reproduktionshinweis, Operator-Attestation, MANIFEST.sha256 und MANIFEST_VERIFY.txt
- keine Capture-Erhebung
- kein Browser-Render
- kein Netzwerkzugriff außer GitHub PR/Push
- keine Vendor-Datei
- Vendor-Fallback bleibt nicht autorisiert
- Vendor-Fallback benötigt später separate Evidence Review + Vendor-Decision + Vendor-Implementation-GO
- keine Provider-Truth
- keine Dashboard-Truth
- keine Trading-Readiness
- keine Live-/Preflight-Lift-/Execution-/Order-/Cancel-Autorität
- keine Secrets/Credentials/Operator-Env
- orthogonal zu #4101/#4104/#4097–#4103

## Test plan

- [x] ruff format --check
- [x] ruff check
- [x] pytest Zieltest


Made with [Cursor](https://cursor.com)