### PR TITLE
Market dashboard Chart.js template wiring docs tests v1

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -378,6 +378,20 @@ MARKET_DASHBOARD_READ_ONLY_NON_AUTHORITY=true
 
 **v1.2 Implementierung (später):** Lokaler Chart.js‑Fallback **nur** nach obiger Checkliste und **separatem** Implementierungs-Charter — **nicht** als Micro-Contract ohne CDN‑Blocking‑Evidenz.
 
+#### Chart.js vendor fallback template wiring v1 (implemented)
+
+**UI-only / fail-closed / non-authorizing:** CDN-primary bleibt **jsdelivr** (`chart.js@4.4.1`). Lokaler Vendor-Fallback wird **nur** bei CDN-`<script>`-`onerror` über `peakTradeChartjsVendorFallbackV0` nachgeladen — Pfad **`/static/vendor/chartjs/4.4.1/chart.umd.min.js`**. **Kein** eager local `<script>` in SSR. Nach erfolgreichem lokalen Load setzt die Shell **`data-chartjs-vendor-fallback-v0="true"`** (**diagnostisch**, getrennt von **`data-chartjs-cdn-load-error`**). Betroffene Shells: **`#market-v0-shell`**, **`#double-play-market-v0-shell`**, **`#r-and-d-charts-shell`**. **Keine** Provider Truth, **keine** Dashboard Truth, **keine** Trading Readiness, **keine** Live-/Preflight-/Execution-/Order-/Cancel-Autorität. **Market-Airport excluded.** **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — Wiring ändert keine Trading-Logik.
+
+```
+CHARTJS_VENDOR_ADDED=true
+CHARTJS_LOCAL_FALLBACK_WIRING_V1=true
+CHARTJS_LOCAL_FALLBACK_EAGER_SSR=false
+MARKET_DASHBOARD_READ_ONLY_NON_AUTHORITY=true
+DASHBOARD_AUTHORITY_CHANGED=false
+```
+
+Cross-check: **`tests/webui/test_chartjs_vendor_fallback_wiring_contract_v0.py`**, **`tests/ops/test_chartjs_vendor_asset_integrity_v0.py`**.
+
 #### CDN-blocking evidence criteria (v1)
 
 **Charter context:** Erweiterung unter **`CHARTJS_LOCAL_FALLBACK_PLANNING_CHARTER_V0`** — criteria only; **keine** Implementierung in diesem Slice.

--- a/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
+++ b/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
@@ -320,11 +320,37 @@
       </div>
 
       <script type="application/json" id="dp-market-ssr-payload">{{ payload | tojson }}</script>
+      <script data-chartjs-vendor-fallback-loader-v0="true">
+        (function () {
+          window.peakTradeChartjsVendorFallbackV0 = function (shellId) {
+            var shell = document.getElementById(shellId);
+            if (
+              !shell ||
+              shell.getAttribute("data-chartjs-vendor-fallback-v0") === "true" ||
+              typeof window.Chart !== "undefined"
+            ) {
+              return;
+            }
+            var scr = document.createElement("script");
+            scr.src = "/static/vendor/chartjs/4.4.1/chart.umd.min.js";
+            scr.setAttribute("data-chartjs-vendor-fallback-script-v0", "true");
+            scr.onload = function () {
+              shell.setAttribute("data-chartjs-vendor-fallback-v0", "true");
+              document.dispatchEvent(
+                new CustomEvent("peak-trade-chartjs-vendor-fallback-ready", {
+                  detail: { shellId: shellId },
+                })
+              );
+            };
+            document.head.appendChild(scr);
+          };
+        })();
+      </script>
       <script
         id="peak-trade-double-play-chartjs-cdn-v0"
         src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
         data-chartjs-cdn-script-v0="true"
-        onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('double-play-market-v0-shell');if(s)s.setAttribute('data-chartjs-cdn-load-error','true');"
+        onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('double-play-market-v0-shell');if(s){s.setAttribute('data-chartjs-cdn-load-error','true');if(window.peakTradeChartjsVendorFallbackV0)window.peakTradeChartjsVendorFallbackV0('double-play-market-v0-shell');}"
       ></script>
       <script>
         (function () {
@@ -525,6 +551,11 @@
           }
 
           syncChartJsLineState();
+          document.addEventListener("peak-trade-chartjs-vendor-fallback-ready", function (ev) {
+            if (ev.detail && ev.detail.shellId === "double-play-market-v0-shell") {
+              syncChartJsLineState();
+            }
+          });
 
           var payloadEl = document.getElementById("dp-market-ssr-payload");
           if (!payloadEl) {

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -1478,11 +1478,37 @@
   </div>
 
   <script type="application/json" id="market-v0-payload">{{ payload | tojson }}</script>
+  <script data-chartjs-vendor-fallback-loader-v0="true">
+    (function () {
+      window.peakTradeChartjsVendorFallbackV0 = function (shellId) {
+        var shell = document.getElementById(shellId);
+        if (
+          !shell ||
+          shell.getAttribute("data-chartjs-vendor-fallback-v0") === "true" ||
+          typeof window.Chart !== "undefined"
+        ) {
+          return;
+        }
+        var scr = document.createElement("script");
+        scr.src = "/static/vendor/chartjs/4.4.1/chart.umd.min.js";
+        scr.setAttribute("data-chartjs-vendor-fallback-script-v0", "true");
+        scr.onload = function () {
+          shell.setAttribute("data-chartjs-vendor-fallback-v0", "true");
+          document.dispatchEvent(
+            new CustomEvent("peak-trade-chartjs-vendor-fallback-ready", {
+              detail: { shellId: shellId },
+            })
+          );
+        };
+        document.head.appendChild(scr);
+      };
+    })();
+  </script>
   <script
     id="peak-trade-market-chartjs-cdn-v0"
     src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
     data-chartjs-cdn-script-v0="true"
-    onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('market-v0-shell');if(s)s.setAttribute('data-chartjs-cdn-load-error','true');"
+    onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('market-v0-shell');if(s){s.setAttribute('data-chartjs-cdn-load-error','true');if(window.peakTradeChartjsVendorFallbackV0)window.peakTradeChartjsVendorFallbackV0('market-v0-shell');}"
   ></script>
   <script>
     (function () {
@@ -1557,6 +1583,11 @@
       }
 
       syncChartJsLine();
+      document.addEventListener("peak-trade-chartjs-vendor-fallback-ready", function (ev) {
+        if (ev.detail && ev.detail.shellId === "market-v0-shell") {
+          syncChartJsLine();
+        }
+      });
 
       var el = document.getElementById("market-v0-payload");
       if (!el) {

--- a/templates/peak_trade_dashboard/r_and_d_charts.html
+++ b/templates/peak_trade_dashboard/r_and_d_charts.html
@@ -109,11 +109,37 @@
     </section>
   </div>
   <script type="application/json" id="r-and-d-charts-payload">{{ charts | tojson }}</script>
+  <script data-chartjs-vendor-fallback-loader-v0="true">
+    (function () {
+      window.peakTradeChartjsVendorFallbackV0 = function (shellId) {
+        var shell = document.getElementById(shellId);
+        if (
+          !shell ||
+          shell.getAttribute("data-chartjs-vendor-fallback-v0") === "true" ||
+          typeof window.Chart !== "undefined"
+        ) {
+          return;
+        }
+        var scr = document.createElement("script");
+        scr.src = "/static/vendor/chartjs/4.4.1/chart.umd.min.js";
+        scr.setAttribute("data-chartjs-vendor-fallback-script-v0", "true");
+        scr.onload = function () {
+          shell.setAttribute("data-chartjs-vendor-fallback-v0", "true");
+          document.dispatchEvent(
+            new CustomEvent("peak-trade-chartjs-vendor-fallback-ready", {
+              detail: { shellId: shellId },
+            })
+          );
+        };
+        document.head.appendChild(scr);
+      };
+    })();
+  </script>
   <script
     id="peak-trade-r-and-d-chartjs-cdn-v0"
     src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
     data-chartjs-cdn-script-v0="true"
-    onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('r-and-d-charts-shell');if(s)s.setAttribute('data-chartjs-cdn-load-error','true');"
+    onerror="this.setAttribute('data-chartjs-cdn-load-error','true');var s=document.getElementById('r-and-d-charts-shell');if(s){s.setAttribute('data-chartjs-cdn-load-error','true');if(window.peakTradeChartjsVendorFallbackV0)window.peakTradeChartjsVendorFallbackV0('r-and-d-charts-shell');}"
   ></script>
   <script>
     (function () {
@@ -126,6 +152,8 @@
         return;
       }
       if (payload.empty || payload.no_plot_points) return;
+
+      function drawRdCharts() {
       const grid = document.documentElement.classList.contains("dark")
         ? "rgba(148, 163, 184, 0.15)"
         : "rgba(148, 163, 184, 0.2)";
@@ -209,6 +237,14 @@
           },
         });
       }
+      }
+
+      drawRdCharts();
+      document.addEventListener("peak-trade-chartjs-vendor-fallback-ready", function (ev) {
+        if (ev.detail && ev.detail.shellId === "r-and-d-charts-shell") {
+          drawRdCharts();
+        }
+      });
     })();
   </script>
   {% endif %}

--- a/tests/webui/test_chartjs_vendor_fallback_wiring_contract_v0.py
+++ b/tests/webui/test_chartjs_vendor_fallback_wiring_contract_v0.py
@@ -1,0 +1,124 @@
+"""Static structure contract for Chart.js vendor fallback wiring v0 (no browser, no network)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+
+CDN_PRIMARY_URL = "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+VENDOR_FALLBACK_PATH = "/static/vendor/chartjs/4.4.1/chart.umd.min.js"
+
+CHARTJS_SHELLS = (
+    ("/market", "market-v0-shell", "peak-trade-market-chartjs-cdn-v0"),
+    (
+        "/market/double-play",
+        "double-play-market-v0-shell",
+        "peak-trade-double-play-chartjs-cdn-v0",
+    ),
+)
+
+FORBIDDEN_AUTHORITY_TOKENS = (
+    "LIVE_AUTHORIZED_NOW=true",
+    "TRUTH_GO_AUTHORIZED",
+    "ORDER_AUTHORIZED_NOW",
+    "CANCEL_AUTHORIZED_NOW",
+    "EXECUTE_AUTHORIZED_NOW",
+    "PREFLIGHT_LIFT_AUTHORIZED",
+    "DASHBOARD_TRUTH_GO",
+    "PROVIDER_TRUTH_GO",
+    "TRADING_READINESS_GO",
+)
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def _html(client: TestClient, path: str) -> str:
+    response = client.get(path)
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    return response.text
+
+
+@pytest.mark.parametrize("path,cdn_id,shell_id", CHARTJS_SHELLS)
+def test_chartjs_cdn_primary_baseline_unchanged_v0(
+    client: TestClient, path: str, cdn_id: str, shell_id: str
+) -> None:
+    html = _html(client, path)
+    assert CDN_PRIMARY_URL in html
+    assert f'id="{cdn_id}"' in html
+    assert f'id="{shell_id}"' in html
+    assert 'data-chartjs-cdn-script-v0="true"' in html
+    assert 'data-chartjs-cdn-monitored-v0="true"' in html
+    assert "data-chartjs-cdn-load-error" in html
+    assert "onerror=" in html.lower()
+
+
+@pytest.mark.parametrize("path,shell_id", ((p, s) for p, s, _ in CHARTJS_SHELLS))
+def test_chartjs_vendor_fallback_wiring_onerror_only_v0(
+    client: TestClient, path: str, shell_id: str
+) -> None:
+    html = _html(client, path)
+    assert 'data-chartjs-vendor-fallback-loader-v0="true"' in html
+    assert "peakTradeChartjsVendorFallbackV0" in html
+    assert VENDOR_FALLBACK_PATH in html
+    assert f"peakTradeChartjsVendorFallbackV0('{shell_id}')" in html
+    assert "data-chartjs-vendor-fallback-v0" in html
+    assert "data-chartjs-vendor-fallback-script-v0" in html
+    assert "peak-trade-chartjs-vendor-fallback-ready" in html
+    assert f'<script src="{VENDOR_FALLBACK_PATH}"' not in html
+    assert (
+        re.search(
+            rf'id="{re.escape(shell_id)}"[^>]*data-chartjs-vendor-fallback-v0="true"',
+            html,
+        )
+        is None
+    )
+
+
+def test_chartjs_vendor_fallback_wiring_r_and_d_charts_v0(client: TestClient) -> None:
+    html = _html(client, "/r_and_d/charts")
+    if 'data-r-and-d-charts-empty="true"' in html:
+        pytest.skip("empty charts repo — fallback scripts only render with plot data")
+    assert 'data-chartjs-vendor-fallback-loader-v0="true"' in html
+    assert "peakTradeChartjsVendorFallbackV0('r-and-d-charts-shell')" in html
+    assert VENDOR_FALLBACK_PATH in html
+    assert f'<script src="{VENDOR_FALLBACK_PATH}"' not in html
+
+
+@pytest.mark.parametrize("path", (p for p, _, _ in CHARTJS_SHELLS))
+def test_chartjs_vendor_fallback_marker_non_authorizing_v0(client: TestClient, path: str) -> None:
+    html = _html(client, path)
+    for token in FORBIDDEN_AUTHORITY_TOKENS:
+        assert token not in html
+
+
+def test_chartjs_cdn_and_vendor_fallback_markers_distinct_v0(client: TestClient) -> None:
+    html = _html(client, "/market")
+    assert "data-chartjs-cdn-load-error" in html
+    assert "data-chartjs-vendor-fallback-v0" in html
+    assert html.index("data-chartjs-cdn-load-error") != html.index(
+        "data-chartjs-vendor-fallback-v0"
+    )
+
+
+def test_chartjs_vendor_fallback_docs_marker_documented_v0() -> None:
+    surface = (project_root / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")
+    assert "data-chartjs-vendor-fallback-v0" in surface
+    assert "non-authorizing" in surface.lower() or "non-authority" in surface.lower()


### PR DESCRIPTION
## Summary
- Wire Chart.js vendor fallback in market, double-play, and R&D chart shells: CDN jsdelivr remains primary; local `/static/vendor/chartjs/4.4.1/chart.umd.min.js` loads only on CDN `<script>` `onerror`.
- Set diagnostic non-authorizing marker `data-chartjs-vendor-fallback-v0="true"` on shell after successful local load; keep `data-chartjs-cdn-load-error` separate.
- Add static offline contract tests and document wiring in canonical `docs/webui/MARKET_SURFACE_V0.md`.

## Safety boundaries
- No browser/Playwright render, no network, no runtime/scheduler/daemon, no paper/shadow/testnet/live.
- No provider truth, dashboard truth, trading readiness, or execution/order/cancel/preflight authority.
- No vendor asset byte changes; integrity test unchanged.
- Master V2 / Double Play protected; Market-Airport excluded.
- No workflow YAML, required-checks, or branch-protection changes.

## Test plan
- [x] `pytest tests/ops/test_chartjs_vendor_asset_integrity_v0.py`
- [x] `pytest tests/webui/test_chartjs_vendor_fallback_wiring_contract_v0.py`
- [x] `pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py::test_market_and_double_play_chartjs_cdn_failure_attribution_v0`
- [x] `pytest tests/test_market_surface_api.py`
- [x] `ruff format --check` + `ruff check` on new Python test file

## Durable evidence
Prep bundle: `.../planning/market_dashboard_chartjs_template_wiring_prep_no_implementation_v1_20260610T202238Z`
Implementation bundle: created on execute (archive root `Peak_Trade_runtime_evidence_archive_20260520T161443Z`).

Made with [Cursor](https://cursor.com)