### PR TITLE
Add offline Market Tape readmodel v0 contract slice

### DIFF
--- a/src/webui/market_tape_readmodel_v0/__init__.py
+++ b/src/webui/market_tape_readmodel_v0/__init__.py
@@ -1,0 +1,34 @@
+"""Read-only Market Trades / Tape readmodel v0.
+
+This package is intentionally pure/offline for v0:
+- no provider calls
+- no network
+- no trading-side handles
+- no dashboard polling
+"""
+
+from .builder import (
+    AUTHORITY_BOUNDARY,
+    MarketTapeReadmodelError,
+    build_market_tape_readmodel_v0,
+    to_json_dict,
+)
+from .gate import (
+    ENV_BUNDLE_ROOT,
+    ENV_ENABLED,
+    enabled_explicitly_on,
+    resolve_market_tape_readmodel_payload_v0,
+    resolved_bundle_root_or_none,
+)
+
+__all__ = [
+    "AUTHORITY_BOUNDARY",
+    "ENV_BUNDLE_ROOT",
+    "ENV_ENABLED",
+    "MarketTapeReadmodelError",
+    "build_market_tape_readmodel_v0",
+    "enabled_explicitly_on",
+    "resolve_market_tape_readmodel_payload_v0",
+    "resolved_bundle_root_or_none",
+    "to_json_dict",
+]

--- a/src/webui/market_tape_readmodel_v0/builder.py
+++ b/src/webui/market_tape_readmodel_v0/builder.py
@@ -1,0 +1,254 @@
+"""Pure fixture-backed Market Trades / Tape readmodel v0.
+
+Safety boundary:
+- read-only JSON-native readmodel builder
+- explicit bundle_root only; no /tmp default
+- no provider/network calls
+- no fill/order/position truth semantics
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+READMODEL_ID = "market_tape_readmodel.v0"
+DEFAULT_STALE_REASON = "offline_bundle_scan"
+
+AUTHORITY_BOUNDARY: dict[str, bool] = {
+    "non_authorizing": True,
+    "provider_truth_blocked": True,
+    "dashboard_truth_blocked": True,
+    "trading_readiness_blocked": True,
+    "selected_future_truth_blocked": True,
+    "order_fill_position_truth_blocked": True,
+    "slippage_liquidity_depth_truth_blocked": True,
+    "signal_strategy_readiness_blocked": True,
+}
+
+FORBIDDEN_TRADE_FIELDS = frozenset(
+    {
+        "order_id",
+        "client_order_id",
+        "fill_id",
+        "position",
+        "pnl",
+        "leverage",
+        "approval",
+        "approved",
+        "live_authorized",
+        "strategy_activation",
+        "execute",
+        "execution",
+        "slippage",
+        "liquidity",
+        "depth",
+        "fills",
+        "fills_count",
+    }
+)
+
+
+class MarketTapeReadmodelError(ValueError):
+    """Raised when a tape fixture cannot be converted into the v0 readmodel."""
+
+
+@dataclass(frozen=True)
+class TapeTrade:
+    trade_id: str | None
+    sequence: int
+    price: Decimal
+    size: Decimal
+    side: str
+    timestamp_iso: str
+
+    def to_json_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "sequence": self.sequence,
+            "price": _decimal_to_str(self.price),
+            "size": _decimal_to_str(self.size),
+            "side": self.side,
+            "timestamp_iso": self.timestamp_iso,
+        }
+        if self.trade_id is not None:
+            payload["trade_id"] = self.trade_id
+        return payload
+
+
+@dataclass(frozen=True)
+class MarketTapeReadmodel:
+    readmodel_id: str
+    symbol: str
+    source: str
+    limit: int
+    generated_at_iso: str
+    runtime_source_status: str
+    stale: bool
+    stale_reason: str
+    trades: tuple[TapeTrade, ...]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "readmodel_id": self.readmodel_id,
+            "symbol": self.symbol,
+            "source": self.source,
+            "limit": self.limit,
+            "generated_at_iso": self.generated_at_iso,
+            "runtime_source_status": self.runtime_source_status,
+            "stale": self.stale,
+            "stale_reason": self.stale_reason,
+            **AUTHORITY_BOUNDARY,
+            "tape": {
+                "trades": [trade.to_json_dict() for trade in self.trades],
+                "trades_returned": len(self.trades),
+                "trade_limit": self.limit,
+            },
+        }
+
+
+def build_market_tape_readmodel_v0(
+    *,
+    bundle_root: str | Path,
+    limit: int | None = None,
+    generated_at_iso: str | None = None,
+) -> MarketTapeReadmodel:
+    """Build a JSON-native tape readmodel from an explicit local fixture bundle."""
+
+    root = Path(bundle_root)
+    if not root.exists() or not root.is_dir():
+        raise MarketTapeReadmodelError(f"bundle_root does not exist or is not a directory: {root}")
+
+    payload_path = root / "tape.json"
+    if not payload_path.exists():
+        raise MarketTapeReadmodelError(f"missing tape fixture: {payload_path}")
+
+    try:
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise MarketTapeReadmodelError(f"malformed tape fixture JSON: {payload_path}") from exc
+
+    if not isinstance(payload, dict):
+        raise MarketTapeReadmodelError("tape fixture root must be an object")
+
+    symbol = _required_str(payload, "symbol")
+    source = _required_str(payload, "source")
+    requested_limit = _resolve_limit(payload=payload, explicit_limit=limit)
+
+    trades = _parse_trades(payload.get("trades"))
+    trades = tuple(sorted(trades, key=lambda trade: trade.sequence, reverse=True)[:requested_limit])
+
+    return MarketTapeReadmodel(
+        readmodel_id=READMODEL_ID,
+        symbol=symbol,
+        source=source,
+        limit=requested_limit,
+        generated_at_iso=generated_at_iso or _utc_now_iso(),
+        runtime_source_status="offline_bundle",
+        stale=True,
+        stale_reason=DEFAULT_STALE_REASON,
+        trades=trades,
+    )
+
+
+def to_json_dict(readmodel: MarketTapeReadmodel) -> dict[str, Any]:
+    return readmodel.to_json_dict()
+
+
+def _required_str(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise MarketTapeReadmodelError(f"missing or invalid string field: {key}")
+    return value
+
+
+def _resolve_limit(*, payload: dict[str, Any], explicit_limit: int | None) -> int:
+    raw = explicit_limit if explicit_limit is not None else payload.get("limit", 50)
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+        raise MarketTapeReadmodelError("limit must be a positive integer")
+    return raw
+
+
+def _parse_trades(raw: Any) -> list[TapeTrade]:
+    if not isinstance(raw, list):
+        raise MarketTapeReadmodelError("trades must be a list")
+
+    trades: list[TapeTrade] = []
+    for idx, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise MarketTapeReadmodelError(f"trades[{idx}] must be an object")
+
+        forbidden = sorted(FORBIDDEN_TRADE_FIELDS.intersection(item))
+        if forbidden:
+            raise MarketTapeReadmodelError(
+                f"trades[{idx}] contains forbidden fields: {', '.join(forbidden)}"
+            )
+
+        sequence = _int_field(item, "sequence", idx=idx)
+        price = _decimal_field(item, "price", idx=idx)
+        size = _decimal_field(item, "size", idx=idx)
+        side = _required_trade_str(item, "side", idx=idx)
+        timestamp_iso = _required_trade_str(item, "timestamp_iso", idx=idx)
+
+        if price <= 0:
+            raise MarketTapeReadmodelError(f"trades[{idx}].price must be positive")
+        if size <= 0:
+            raise MarketTapeReadmodelError(f"trades[{idx}].size must be positive")
+
+        trade_id_raw = item.get("trade_id")
+        trade_id: str | None = None
+        if trade_id_raw is not None:
+            if not isinstance(trade_id_raw, str) or not trade_id_raw.strip():
+                raise MarketTapeReadmodelError(f"trades[{idx}].trade_id must be a non-empty string")
+            trade_id = trade_id_raw
+
+        trades.append(
+            TapeTrade(
+                trade_id=trade_id,
+                sequence=sequence,
+                price=price,
+                size=size,
+                side=side,
+                timestamp_iso=timestamp_iso,
+            )
+        )
+
+    return trades
+
+
+def _required_trade_str(item: dict[str, Any], key: str, *, idx: int) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise MarketTapeReadmodelError(f"trades[{idx}].{key} must be a non-empty string")
+    return value
+
+
+def _int_field(item: dict[str, Any], key: str, *, idx: int) -> int:
+    value = item.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise MarketTapeReadmodelError(f"trades[{idx}].{key} must be an integer")
+    return value
+
+
+def _decimal_field(item: dict[str, Any], key: str, *, idx: int) -> Decimal:
+    raw_val = item.get(key)
+    if isinstance(raw_val, bool) or raw_val is None:
+        raise MarketTapeReadmodelError(f"trades[{idx}].{key} must be decimal-like")
+    try:
+        return Decimal(str(raw_val))
+    except (InvalidOperation, ValueError) as exc:
+        raise MarketTapeReadmodelError(f"trades[{idx}].{key} must be decimal-like") from exc
+
+
+def _decimal_to_str(value: Decimal) -> str:
+    normalized = value.normalize()
+    if normalized == normalized.to_integral():
+        return str(normalized.quantize(Decimal("1")))
+    return format(normalized, "f")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/webui/market_tape_readmodel_v0/gate.py
+++ b/src/webui/market_tape_readmodel_v0/gate.py
@@ -1,0 +1,127 @@
+"""Tape readmodel env gate resolution (default-off, fail-closed).
+
+Contract-only module: not wired to HTTP/SSR in this slice.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .builder import (
+    AUTHORITY_BOUNDARY,
+    MarketTapeReadmodelError,
+    READMODEL_ID,
+    build_market_tape_readmodel_v0,
+    to_json_dict,
+)
+
+ENV_ENABLED = "PEAK_TRADE_MARKET_TAPE_ENABLED"
+ENV_BUNDLE_ROOT = "PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT"
+FIXED_GEN_ENV = "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
+
+
+def generated_at_iso() -> str:
+    fixed = os.environ.get(FIXED_GEN_ENV)
+    if fixed:
+        return fixed.strip()
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def enabled_explicitly_on() -> bool:
+    raw = os.environ.get(ENV_ENABLED)
+    return raw is not None and raw.strip() == "1"
+
+
+def resolved_bundle_root_or_none() -> Path | None:
+    raw = os.environ.get(ENV_BUNDLE_ROOT)
+    if raw is None or not str(raw).strip():
+        return None
+    path = Path(raw).expanduser()
+    try:
+        path = path.resolve(strict=True)
+    except OSError:
+        return None
+    if not path.is_dir():
+        return None
+    return path
+
+
+def _base_envelope(*, ga: str, runtime_source_status: str, stale_reason: str) -> dict[str, Any]:
+    return {
+        "readmodel_id": READMODEL_ID,
+        "generated_at_iso": ga,
+        "source": "unavailable",
+        "runtime_source_status": runtime_source_status,
+        "stale": True,
+        "stale_reason": stale_reason,
+        **AUTHORITY_BOUNDARY,
+    }
+
+
+def _disabled_envelope(*, ga: str) -> dict[str, Any]:
+    envelope = _base_envelope(
+        ga=ga,
+        runtime_source_status="disabled",
+        stale_reason="source_disabled",
+    )
+    envelope["warnings"] = ["market_tape_source_disabled"]
+    envelope["errors"] = ["runtime_source_unavailable"]
+    return envelope
+
+
+def _unconfigured_envelope(*, ga: str) -> dict[str, Any]:
+    envelope = _base_envelope(
+        ga=ga,
+        runtime_source_status="unconfigured",
+        stale_reason="bundle_root_unconfigured",
+    )
+    envelope["warnings"] = ["market_tape_bundle_root_unconfigured"]
+    envelope["errors"] = ["runtime_source_unavailable"]
+    return envelope
+
+
+def _builder_error_envelope(*, ga: str) -> dict[str, Any]:
+    envelope = _base_envelope(
+        ga=ga,
+        runtime_source_status="builder_error",
+        stale_reason="bundle_build_failed",
+    )
+    envelope["warnings"] = ["market_tape_bundle_build_failed"]
+    envelope["errors"] = ["readmodel_build_failed"]
+    return envelope
+
+
+def resolve_market_tape_readmodel_payload_v0() -> tuple[int, dict[str, Any]]:
+    """Return ``(status_code, body)`` for gated tape resolution (no FastAPI types)."""
+
+    ga = generated_at_iso()
+    if not enabled_explicitly_on():
+        return 503, _disabled_envelope(ga=ga)
+
+    bundle_root = resolved_bundle_root_or_none()
+    if bundle_root is None:
+        return 503, _unconfigured_envelope(ga=ga)
+
+    try:
+        readmodel = build_market_tape_readmodel_v0(
+            bundle_root=bundle_root,
+            generated_at_iso=ga,
+        )
+    except MarketTapeReadmodelError:
+        return 503, _builder_error_envelope(ga=ga)
+
+    return 200, to_json_dict(readmodel)
+
+
+__all__ = [
+    "ENV_BUNDLE_ROOT",
+    "ENV_ENABLED",
+    "FIXED_GEN_ENV",
+    "enabled_explicitly_on",
+    "generated_at_iso",
+    "resolve_market_tape_readmodel_payload_v0",
+    "resolved_bundle_root_or_none",
+]

--- a/tests/fixtures/market_tape_readmodel_v0/complete_minimal/tape.json
+++ b/tests/fixtures/market_tape_readmodel_v0/complete_minimal/tape.json
@@ -1,0 +1,38 @@
+{
+  "symbol": "BTC/EUR",
+  "source": "fixture:complete_minimal",
+  "limit": 3,
+  "trades": [
+    {
+      "trade_id": "t-100",
+      "sequence": 100,
+      "price": "63010.00",
+      "size": "0.2",
+      "side": "buy",
+      "timestamp_iso": "2026-05-02T15:59:58Z"
+    },
+    {
+      "trade_id": "t-101",
+      "sequence": 101,
+      "price": "63020.00",
+      "size": "0.15",
+      "side": "sell",
+      "timestamp_iso": "2026-05-02T15:59:59Z"
+    },
+    {
+      "trade_id": "t-99",
+      "sequence": 99,
+      "price": "63000.00",
+      "size": "0.5",
+      "side": "buy",
+      "timestamp_iso": "2026-05-02T15:59:57Z"
+    },
+    {
+      "sequence": 98,
+      "price": "62990.00",
+      "size": "1.0",
+      "side": "sell",
+      "timestamp_iso": "2026-05-02T15:59:56Z"
+    }
+  ]
+}

--- a/tests/fixtures/market_tape_readmodel_v0/malformed_trades/tape.json
+++ b/tests/fixtures/market_tape_readmodel_v0/malformed_trades/tape.json
@@ -1,0 +1,14 @@
+{
+  "symbol": "BTC/EUR",
+  "source": "fixture:malformed",
+  "limit": 5,
+  "trades": [
+    {
+      "sequence": 1,
+      "price": "-1",
+      "size": "0.1",
+      "side": "buy",
+      "timestamp_iso": "2026-05-02T15:59:58Z"
+    }
+  ]
+}

--- a/tests/webui/test_market_tape_readmodel_v0.py
+++ b/tests/webui/test_market_tape_readmodel_v0.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.webui.market_tape_readmodel_v0 import (
+    AUTHORITY_BOUNDARY,
+    MarketTapeReadmodelError,
+    build_market_tape_readmodel_v0,
+    enabled_explicitly_on,
+    resolve_market_tape_readmodel_payload_v0,
+    to_json_dict,
+)
+from src.webui.market_tape_readmodel_v0.gate import ENV_BUNDLE_ROOT, ENV_ENABLED
+
+FIXTURE_ROOT = Path("tests/fixtures/market_tape_readmodel_v0")
+
+
+def test_market_tape_readmodel_builds_json_native_offline_bundle() -> None:
+    readmodel = build_market_tape_readmodel_v0(
+        bundle_root=FIXTURE_ROOT / "complete_minimal",
+        generated_at_iso="2026-05-02T16:00:00Z",
+    )
+
+    payload = to_json_dict(readmodel)
+
+    assert payload["readmodel_id"] == "market_tape_readmodel.v0"
+    assert payload["symbol"] == "BTC/EUR"
+    assert payload["source"] == "fixture:complete_minimal"
+    assert payload["limit"] == 3
+    assert payload["generated_at_iso"] == "2026-05-02T16:00:00Z"
+    assert payload["runtime_source_status"] == "offline_bundle"
+    assert payload["stale"] is True
+    assert payload["stale_reason"] == "offline_bundle_scan"
+    assert payload["non_authorizing"] is True
+    assert payload["provider_truth_blocked"] is True
+    assert payload["order_fill_position_truth_blocked"] is True
+    assert payload["slippage_liquidity_depth_truth_blocked"] is True
+
+    assert payload["tape"]["trade_limit"] == 3
+    assert payload["tape"]["trades_returned"] == 3
+    assert [trade["sequence"] for trade in payload["tape"]["trades"]] == [101, 100, 99]
+    assert payload["tape"]["trades"][0]["price"] == "63020"
+    assert json.loads(json.dumps(payload)) == payload
+
+
+def test_market_tape_readmodel_explicit_limit_truncates_sorted_trades() -> None:
+    payload = to_json_dict(
+        build_market_tape_readmodel_v0(
+            bundle_root=FIXTURE_ROOT / "complete_minimal",
+            limit=1,
+            generated_at_iso="2026-05-02T16:00:00Z",
+        )
+    )
+
+    assert payload["limit"] == 1
+    assert payload["tape"]["trades_returned"] == 1
+    assert payload["tape"]["trades"][0]["sequence"] == 101
+
+
+def test_market_tape_readmodel_rejects_missing_bundle_root() -> None:
+    with pytest.raises(MarketTapeReadmodelError, match="bundle_root does not exist"):
+        build_market_tape_readmodel_v0(bundle_root=FIXTURE_ROOT / "does_not_exist")
+
+
+def test_market_tape_readmodel_rejects_malformed_trades() -> None:
+    with pytest.raises(MarketTapeReadmodelError, match=r"trades\[0\]\.price must be positive"):
+        build_market_tape_readmodel_v0(bundle_root=FIXTURE_ROOT / "malformed_trades")
+
+
+def test_market_tape_readmodel_module_has_no_runtime_provider_imports() -> None:
+    builder_source = Path("src/webui/market_tape_readmodel_v0/builder.py").read_text(
+        encoding="utf-8"
+    )
+
+    forbidden_tokens = [
+        "ccxt",
+        "kraken",
+        "requests",
+        "httpx",
+        "aiohttp",
+        "subprocess",
+        "os.environ",
+    ]
+
+    for token in forbidden_tokens:
+        assert token not in builder_source
+
+
+_EXPECTED_TOP_LEVEL_KEYS = frozenset(
+    {
+        "readmodel_id",
+        "symbol",
+        "source",
+        "limit",
+        "generated_at_iso",
+        "runtime_source_status",
+        "stale",
+        "stale_reason",
+        "non_authorizing",
+        "provider_truth_blocked",
+        "dashboard_truth_blocked",
+        "trading_readiness_blocked",
+        "selected_future_truth_blocked",
+        "order_fill_position_truth_blocked",
+        "slippage_liquidity_depth_truth_blocked",
+        "signal_strategy_readiness_blocked",
+        "tape",
+    }
+)
+
+_FORBIDDEN_JSON_KEYS = frozenset(
+    {
+        "live_authorization",
+        "live_ready",
+        "testnet_ready",
+        "trading_ready",
+        "execute",
+        "execution",
+        "order",
+        "orders",
+        "approve",
+        "approved",
+        "promote",
+        "sign_off",
+        "enable_live",
+        "confirm_token",
+        "fills",
+        "fills_count",
+        "position",
+        "pnl",
+        "slippage",
+        "liquidity",
+        "depth",
+    }
+)
+
+
+def _collect_object_keys(obj: object, out: set[str]) -> None:
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(key, str):
+                out.add(key)
+            _collect_object_keys(value, out)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_object_keys(item, out)
+
+
+def test_market_tape_readmodel_rejects_missing_tape_json(tmp_path: Path) -> None:
+    empty_root = tmp_path / "bundle"
+    empty_root.mkdir()
+    with pytest.raises(MarketTapeReadmodelError, match="missing tape fixture"):
+        build_market_tape_readmodel_v0(bundle_root=empty_root)
+
+
+def test_market_tape_readmodel_rejects_invalid_tape_json(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "tape.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(MarketTapeReadmodelError, match="malformed tape fixture JSON"):
+        build_market_tape_readmodel_v0(bundle_root=root)
+
+
+def test_market_tape_readmodel_stable_top_level_keys_and_no_authority_keys() -> None:
+    payload = to_json_dict(
+        build_market_tape_readmodel_v0(
+            bundle_root=FIXTURE_ROOT / "complete_minimal",
+            generated_at_iso="2026-05-02T16:00:00Z",
+        )
+    )
+    assert set(payload.keys()) == _EXPECTED_TOP_LEVEL_KEYS
+    tape_keys = set(payload["tape"].keys())
+    assert tape_keys == frozenset({"trades", "trades_returned", "trade_limit"})
+    collected: set[str] = set()
+    _collect_object_keys(payload, collected)
+    assert collected.isdisjoint(_FORBIDDEN_JSON_KEYS)
+
+
+def test_market_tape_readmodel_authority_boundary_matches_module_constant() -> None:
+    payload = to_json_dict(
+        build_market_tape_readmodel_v0(
+            bundle_root=FIXTURE_ROOT / "complete_minimal",
+            generated_at_iso="2026-05-02T16:00:00Z",
+        )
+    )
+    for key, expected in AUTHORITY_BOUNDARY.items():
+        assert payload[key] is expected
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "order_id",
+        "client_order_id",
+        "fill_id",
+        "fills",
+        "fills_count",
+        "position",
+        "pnl",
+        "slippage",
+        "liquidity",
+        "depth",
+    ],
+)
+def test_market_tape_readmodel_rejects_forbidden_trade_fields_v0(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    fixture = {
+        "symbol": "BTC/EUR",
+        "source": "fixture:forbidden",
+        "limit": 5,
+        "trades": [
+            {
+                "sequence": 1,
+                "price": "63000",
+                "size": "0.1",
+                "side": "buy",
+                "timestamp_iso": "2026-05-02T15:59:58Z",
+                field: "forbidden",
+            }
+        ],
+    }
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "tape.json").write_text(json.dumps(fixture), encoding="utf-8")
+
+    with pytest.raises(MarketTapeReadmodelError, match="forbidden fields"):
+        build_market_tape_readmodel_v0(bundle_root=root)
+
+
+def test_market_tape_gate_defaults_disabled_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_ENABLED, raising=False)
+    monkeypatch.delenv(ENV_BUNDLE_ROOT, raising=False)
+
+    assert enabled_explicitly_on() is False
+    status_code, payload = resolve_market_tape_readmodel_payload_v0()
+    assert status_code == 503
+    assert payload["runtime_source_status"] == "disabled"
+    assert payload["stale_reason"] == "source_disabled"
+    assert payload["non_authorizing"] is True
+    assert "tape" not in payload
+
+
+def test_market_tape_gate_unconfigured_when_enabled_without_bundle_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ENV_ENABLED, "1")
+    monkeypatch.delenv(ENV_BUNDLE_ROOT, raising=False)
+
+    status_code, payload = resolve_market_tape_readmodel_payload_v0()
+    assert status_code == 503
+    assert payload["runtime_source_status"] == "unconfigured"
+    assert payload["stale_reason"] == "bundle_root_unconfigured"
+    assert "tape" not in payload
+
+
+def test_market_tape_gate_builds_when_enabled_with_bundle_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = FIXTURE_ROOT / "complete_minimal"
+    monkeypatch.setenv(ENV_ENABLED, "1")
+    monkeypatch.setenv(ENV_BUNDLE_ROOT, str(bundle.resolve()))
+    monkeypatch.setenv("PEAK_TRADE_FIXED_GENERATED_AT_UTC", "2026-05-02T16:00:00Z")
+
+    status_code, payload = resolve_market_tape_readmodel_payload_v0()
+    assert status_code == 200
+    assert payload["readmodel_id"] == "market_tape_readmodel.v0"
+    assert payload["tape"]["trades_returned"] == 3


### PR DESCRIPTION
## Summary
- Add `market_tape_readmodel.v0` pure offline fixture builder with explicit authority-boundary flags and forbidden trade-field guards.
- Add default-off env gate module (`PEAK_TRADE_MARKET_TAPE_ENABLED` / `PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT`) mirroring depth semantics — not wired to HTTP/SSR in this slice.
- Add fixtures and 22 contract tests covering fail-closed gate states, sorting, and fill-alias rejection.

## Test plan
- [x] `python3 -m ruff format --check src/webui/market_tape_readmodel_v0/ tests/webui/test_market_tape_readmodel_v0.py`
- [x] `python3 -m ruff check src/webui/market_tape_readmodel_v0/ tests/webui/test_market_tape_readmodel_v0.py`
- [x] `python3 -m pytest tests/webui/test_market_tape_readmodel_v0.py -q` (22 passed)

## Scope boundaries
- No templates, routes, browser, network, or runtime wiring
- No F5, depth chart, run projection, or Chart.js changes
- No fills.json / workflow-fill alias paths


Made with [Cursor](https://cursor.com)