### PR TITLE
Add env-gated tape readmodel SSR v0 on GET /market

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -73,6 +73,26 @@ Dashboard ≠ Freigabe. Market Surface v0 is **review input only** for operators
 
 **Protected boundaries:** read-only SSR only — **no dashboard truth grant**, **no provider truth**, **no** Live/Testnet/Order/Cancel/Execute/Arming/Preflight authority, **no** runtime/scheduler activation. **Market-Airport excluded.** **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — run projection does not alter Double Play routes, markers, or decision logic.
 
+### Market tape readmodel SSR (env-gated v0)
+
+**`GET`** **`&#47;market`** only (not **`GET &#47;market&#47;double-play`**) may render an env-gated **read-only** tape panel from offline fixture bundles via `build_market_tape_display_context()` in `src/webui/market_surface.py` (gate resolution in `src/webui/market_tape_readmodel_v0/gate.py`). **No** new route, **no** provider fetch, **no** order/fill/position truth.
+
+- **Gate (default off):** `PEAK_TRADE_MARKET_TAPE_ENABLED=1` and `PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT=<path>` — fail-closed when missing/invalid.
+- **Markers:** `data-market-v0-tape="true"`, `data-market-v0-tape-readonly="true"`, `data-market-v0-tape-authority="false"`, `data-market-v0-tape-non-authorizing="true"`, `data-market-v0-tape-evidence-only="true"`, boundary mirrors `data-market-v0-tape-*-truth-blocked="true"`, `data-market-v0-tape-enabled`, `data-market-v0-tape-ready`, `data-market-v0-tape-readmodel-id` — **absent** when gate disabled; **never** on **`GET &#47;market&#47;double-play`**.
+- **Boundaries:** read-only SSR; **no** dashboard truth grant, **no** provider truth, **no** trading readiness, **no** selected-future truth, **no** order/fill/position truth; **no** runtime/scheduler activation.
+- **Orthogonal:** OHLCV/depth/ranking/run-projection SSR unchanged; F5 owner remains [Futures Read-only Market Dashboard Contract v0](../ops/specs/FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md).
+
+#### Operator enablement (tape readmodel SSR v0)
+
+**Default off / operator-gated / fail-closed:** Tape SSR on **`GET`** **`&#47;market`** stays **disabled** until **both** env gates below are explicitly set. Panel **absent** when gates are off is **expected** — **not** a template defect, **not** Dashboard Truth GO, **not** Provider Truth, **no** runtime, Testnet, Paper, or Shadow authority.
+
+| Step | Env var(s) | Notes |
+|------|------------|-------|
+| 1 | `PEAK_TRADE_MARKET_TAPE_ENABLED=1` | Master tape gate |
+| 2 | `PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT=<path>` | Offline fixture root with `tape.json` |
+
+**Troubleshooting:** Distinguish **absent markers** (gate off — expected) from **`data-market-v0-tape-ready="false"`** (gate on but bundle/build not ready). Cross-check **`tests/webui/test_market_tape_ssr_v0.py`** and **`tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`**.
+
 ## Safety banner and stable markers
 
 Das HTML-Template für **`GET &#47;market`** rendert oberhalb der Chart-Fläche ein **sichtbares** Safety-Banner (**read-only**, **non-authorizing**) mit Quellen-spezifischem Kurztext (`source=dummy` \| `source=kraken`).
@@ -84,6 +104,7 @@ Stabile `data-*`‑Marker (Anker für Anzeige und automatisierte Tests — **kei
 - `data-market-safety-banner="true"`
 - `data-market-surface-v0="true"`
 - **Registry run projection SSR v0 (**`GET`** **`&#47;market`**, env-gated):** `data-market-v0-run-projection="true"`, `data-market-v0-run-projection-readonly="true"`, `data-market-v0-run-projection-authority="false"`, `data-market-v0-run-projection-enabled`, `data-market-v0-run-projection-ready` — **absent** when gate disabled; **never** on **`GET &#47;market&#47;double-play`**.
+- **Market tape SSR v0 (**`GET`** **`&#47;market`**, env-gated):** `data-market-v0-tape="true"`, `data-market-v0-tape-readonly="true"`, `data-market-v0-tape-authority="false"`, `data-market-v0-tape-non-authorizing="true"`, `data-market-v0-tape-evidence-only="true"`, boundary `data-market-v0-tape-*-truth-blocked="true"`, `data-market-v0-tape-enabled`, `data-market-v0-tape-ready`, `data-market-v0-tape-readmodel-id` — **absent** when gate disabled; **never** on **`GET &#47;market&#47;double-play`**.
 - **Market Depth SSR v0 (**`GET`** **`&#47;market`**):** `data-market-depth-panel="true"`, `data-market-depth-status="<status>"` — bei Hilfs‑**HTTP 200** zeigt das Template **`display_status` `ok`**; sonst **`runtime_source_status`** aus Diagnose‑JSON (z. B. **`disabled`**, **`unconfigured`**, **`builder_error`**); optional `data-market-depth-readmodel-id`, `data-market-depth-summary`; **Darstellung/Test‑Anker**, **keine** operationalen Freigaben.
 - **`GET`** **`/market` · SSR Tiefen-Bundle-Provenienz (gleiche Region):** wenn das eingebettete Depth-Hilfstupel bereits **`generated_at_iso`**, **`stale`** / **`stale_reason`** (Fixture-/Diagnose‑Semantik) und ggf. Bundle-**`source`** liefert, rendert `/market` darunter einen **getrennten** Kurzblock **„Tiefen-Bundle-Provenienz“** (**nicht** der OHLC-**„Snapshot bei Seitenladen“** / **`generated_at_utc`**); Marker **`data-market-v0-depth-bundle-provenance-v0="true"`** plus **`data-market-v0-depth-bundle-stale`** — **display-only**.
 - **Embedded OHLCV payload snapshot time (`GET` `/market`):** sichtbarer Hinweis **„Snapshot bei Seitenladen“** mit dem gleichen Feld **`generated_at_utc`** wie im eingebetteten Market-Payload (und wie der JSON-Vertrag **`GET`** **`&#47;api&#47;market&#47;ohlcv`**); Marker **`data-market-v0-embedded-snapshot-generated-at-v0="true"`** — bezeichnet **SSR‑Zeitpunkt beim Seitenauftrag**, keine Live‑ oder Exchange‑**Freshness**‑Autorität.

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -8,6 +8,9 @@ Read-only Market Surface v0 — öffentliche OHLCV + minimale Chart-UI.
 GET /market embeds offline Market Depth read-model state SSR-only via
 ``market_depth_json_payload_v0`` (no in-page Depth JSON route, no fetch).
 
+GET /market may embed env-gated Tape readmodel SSR via
+``build_market_tape_display_context`` (offline fixture bundle only, default off).
+
 Keine Orders, kein OPS-Cockpit-Bezug. Dummy-Quelle für Offline/CI; Kraken über fetch_ohlcv_df.
 """
 
@@ -30,6 +33,10 @@ from .last_paper_run_panel_runtime_v0 import build_last_paper_run_panel_display_
 from .market_active_paper_run_runtime_v0 import build_market_active_paper_run_display_context
 from .market_depth_runtime_v0 import market_depth_json_payload_v0
 from .market_ranking_funnel_runtime_v0 import build_market_ranking_funnel_display_context
+from .market_tape_readmodel_v0.gate import (
+    enabled_explicitly_on as _market_tape_enabled_explicitly_on,
+    resolve_market_tape_readmodel_payload_v0,
+)
 from .workflow_dashboard_runtime_v1 import build_workflow_dashboard_display_context
 
 logger = logging.getLogger(__name__)
@@ -38,6 +45,7 @@ logger = logging.getLogger(__name__)
 MARKET_TIMEFRAMES: tuple[str, ...] = ("1m", "5m", "15m", "1h", "4h", "1d")
 MAX_OHLCV_LIMIT = 720
 MARKET_DEPTH_SSR_TOP_LEVELS = 8
+MARKET_TAPE_SSR_TOP_TRADES = 5
 DEFAULT_SYMBOL = "BTC/USD"
 DEFAULT_TIMEFRAME = "1h"
 DEFAULT_LIMIT = 120
@@ -466,6 +474,79 @@ def build_market_run_projection_display_context() -> Dict[str, Any]:
     return base
 
 
+def build_market_tape_display_context() -> Dict[str, Any]:
+    """SSR-only tape readmodel panel for GET /market (env-gated, read-only, default off)."""
+
+    base: Dict[str, Any] = {
+        "section_visible": False,
+        "gate_enabled": False,
+        "tape_ready": False,
+        "readmodel_id": "",
+        "display_status": "disabled",
+        "summary_line": "",
+        "symbol": "",
+        "trade_count": 0,
+        "top_trades": [],
+        "generated_at_iso": "",
+        "stale": True,
+        "stale_reason": "",
+    }
+
+    if not _market_tape_enabled_explicitly_on():
+        return base
+
+    base["gate_enabled"] = True
+    base["section_visible"] = True
+
+    http_status, payload = resolve_market_tape_readmodel_payload_v0()
+    base["readmodel_id"] = str(payload.get("readmodel_id", ""))
+    base["generated_at_iso"] = _truncate_display(payload.get("generated_at_iso"))
+    base["stale"] = payload.get("stale") is True
+    stale_reason = payload.get("stale_reason")
+    base["stale_reason"] = _truncate_display(stale_reason) if stale_reason else ""
+
+    if http_status == 200:
+        base["tape_ready"] = True
+        base["display_status"] = "ok"
+        base["symbol"] = _truncate_display(payload.get("symbol"))
+        tape_obj = payload.get("tape")
+        trades: List[Dict[str, str]] = []
+        trade_count = 0
+        if isinstance(tape_obj, dict):
+            raw_trades = tape_obj.get("trades")
+            if isinstance(raw_trades, list):
+                trade_count = len(raw_trades)
+                for row in raw_trades[:MARKET_TAPE_SSR_TOP_TRADES]:
+                    if not isinstance(row, dict):
+                        continue
+                    trades.append(
+                        {
+                            "sequence": _truncate_display(row.get("sequence")),
+                            "price": _truncate_display(row.get("price")),
+                            "size": _truncate_display(row.get("size")),
+                            "side": _truncate_display(row.get("side")),
+                        }
+                    )
+        base["trade_count"] = trade_count
+        base["top_trades"] = trades
+        sym = base["symbol"]
+        if sym:
+            base["summary_line"] = (
+                f"{sym} — {trade_count} trades (offline bundle, read-only display)"
+            )
+        else:
+            base["summary_line"] = f"{trade_count} trades (offline bundle, read-only display)"
+        return base
+
+    base["display_status"] = str(payload.get("runtime_source_status", "unavailable"))
+    warnings = payload.get("warnings")
+    if isinstance(warnings, list) and warnings:
+        base["summary_line"] = _truncate_display(warnings[0])
+    else:
+        base["summary_line"] = base["stale_reason"] or base["display_status"]
+    return base
+
+
 def build_market_depth_display_context() -> Dict[str, Any]:
     """SSR-only snapshot for templates: tuple from helper, unchanged semantics."""
 
@@ -588,6 +669,7 @@ def create_market_router(
         proj_status = get_project_status()
         market_depth = build_market_depth_display_context()
         run_projection = build_market_run_projection_display_context()
+        market_tape = build_market_tape_display_context()
         ranking_funnel = build_market_ranking_funnel_display_context()
         active_paper_run = build_market_active_paper_run_display_context()
         market_single_page_consolidation = build_market_single_page_consolidation_display_context()
@@ -604,6 +686,7 @@ def create_market_router(
                 "payload": payload,
                 "market_depth": market_depth,
                 "run_projection": run_projection,
+                "market_tape": market_tape,
                 "ranking_funnel": ranking_funnel,
                 "active_paper_run": active_paper_run,
                 "market_single_page_consolidation": market_single_page_consolidation,

--- a/src/webui/market_tape_readmodel_v0/gate.py
+++ b/src/webui/market_tape_readmodel_v0/gate.py
@@ -1,6 +1,6 @@
 """Tape readmodel env gate resolution (default-off, fail-closed).
 
-Contract-only module: not wired to HTTP/SSR in this slice.
+Shared by SSR display context on ``GET /market`` and future JSON routes.
 """
 
 from __future__ import annotations

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -241,6 +241,70 @@
   </section>
   {% endif %}
 
+  {% if market_tape.section_visible %}
+  <section
+    id="market-v0-tape-ssr"
+    role="region"
+    aria-labelledby="market-v0-tape-ssr-h2"
+    class="rounded-xl border border-teal-900/45 bg-gradient-to-br from-teal-950/35 via-slate-950/40 to-slate-950/20 px-3 py-2.5 sm:px-4 text-xs text-teal-100/95"
+    data-market-v0-tape="true"
+    data-market-v0-tape-readonly="true"
+    data-market-v0-tape-authority="false"
+    data-market-v0-tape-non-authorizing="true"
+    data-market-v0-tape-evidence-only="true"
+    data-market-v0-tape-provider-truth-blocked="true"
+    data-market-v0-tape-dashboard-truth-blocked="true"
+    data-market-v0-tape-trading-readiness-blocked="true"
+    data-market-v0-tape-selected-future-truth-blocked="true"
+    data-market-v0-tape-order-fill-position-truth-blocked="true"
+    data-market-v0-tape-enabled="{{ 'true' if market_tape.gate_enabled else 'false' }}"
+    data-market-v0-tape-ready="{{ 'true' if market_tape.tape_ready else 'false' }}"
+    {% if market_tape.readmodel_id %}data-market-v0-tape-readmodel-id="{{ market_tape.readmodel_id|e }}"{% endif %}
+  >
+    <h2 id="market-v0-tape-ssr-h2" class="font-semibold text-teal-200/95 tracking-wide uppercase text-[11px] m-0 mb-2">
+      Market tape (read-only)
+    </h2>
+    <p class="leading-snug text-teal-100/90 m-0 text-[11px] mb-2">
+      Read-only tape display. This panel does not authorize runtime, testnet, live trading, broker access, exchange access, or strategy execution. Tape rows are offline fixture evidence only — not order, fill, or position truth.
+    </p>
+    <dl class="m-0 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-[11px] tabular-nums">
+      <div><dt class="inline text-slate-400">status</dt> <dd class="inline text-slate-100">{{ market_tape.display_status|e }}</dd></div>
+      <div><dt class="inline text-slate-400">readmodel</dt> <dd class="inline text-slate-100">{{ market_tape.readmodel_id|e or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">symbol</dt> <dd class="inline text-slate-100">{{ market_tape.symbol|e or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">trades</dt> <dd class="inline text-slate-100">{{ market_tape.trade_count }}</dd></div>
+      <div><dt class="inline text-slate-400">generated_at</dt> <dd class="inline text-slate-100">{{ market_tape.generated_at_iso|e or "—" }}</dd></div>
+      <div><dt class="inline text-slate-400">stale</dt> <dd class="inline text-slate-100">{{ market_tape.stale }}</dd></div>
+    </dl>
+    <p class="mt-2 mb-0 text-[11px] text-teal-100/85 leading-snug">{{ market_tape.summary_line|e }}</p>
+    {% if market_tape.tape_ready and market_tape.top_trades %}
+    <div class="mt-2 pt-2 border-t border-teal-800/30">
+      <p class="m-0 mb-1 text-[10px] font-semibold uppercase tracking-wide text-teal-300/90">Top trades (display subset)</p>
+      <table class="w-full text-[10px] tabular-nums border-collapse">
+        <thead>
+          <tr class="text-slate-400 text-left">
+            <th class="pr-2 font-normal">seq</th>
+            <th class="pr-2 font-normal">side</th>
+            <th class="pr-2 font-normal">price</th>
+            <th class="font-normal">size</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in market_tape.top_trades %}
+          <tr>
+            <td class="pr-2 text-slate-200">{{ row.sequence|e }}</td>
+            <td class="pr-2 text-slate-200">{{ row.side|e }}</td>
+            <td class="pr-2 font-mono text-slate-200">{{ row.price|e }}</td>
+            <td class="font-mono text-slate-200">{{ row.size|e }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <p class="m-0 mt-1 text-[10px] text-slate-400">Top-{{ market_tape.top_trades|length }} Auszug · offline fixture · keine Ausführungs- oder Bereitschaftsaussage.</p>
+    </div>
+    {% endif %}
+  </section>
+  {% endif %}
+
   <section
     id="market-v0-ranking-funnel-ssr"
     role="region"

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -1108,6 +1108,55 @@ def test_double_play_market_dashboard_excludes_run_projection_landmark_v0(
     assert 'data-market-v0-run-projection="true"' not in html
 
 
+def test_market_dashboard_tape_landmark_region_when_enabled_v0(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tape SSR keeps IA/landmark parity when the env-gated overlay is enabled."""
+    fixture_root = (
+        project_root / "tests" / "fixtures" / "market_tape_readmodel_v0" / "complete_minimal"
+    )
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(fixture_root.resolve()))
+    html = _html(client, "/market")
+
+    assert re.search(
+        r'role="region"[^>]*aria-labelledby="market-v0-tape-ssr-h2"',
+        html,
+    )
+    assert 'id="market-v0-tape-ssr"' in html
+    assert 'data-market-v0-tape="true"' in html
+    assert 'data-market-v0-tape-readonly="true"' in html
+    assert 'data-market-v0-tape-authority="false"' in html
+    assert "Market tape (read-only)" in html
+
+
+def test_market_dashboard_tape_landmark_absent_when_disabled_v0(
+    client: TestClient,
+) -> None:
+    """Tape landmark is absent when the env-gated overlay is disabled (default)."""
+    html = _html(client, "/market")
+
+    assert "market-v0-tape-ssr" not in html
+    assert 'data-market-v0-tape="true"' not in html
+
+
+def test_double_play_market_dashboard_excludes_tape_landmark_v0(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Double-Play market surface must not inherit /market tape SSR landmarks."""
+    fixture_root = (
+        project_root / "tests" / "fixtures" / "market_tape_readmodel_v0" / "complete_minimal"
+    )
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(fixture_root.resolve()))
+    html = _html(client, "/market/double-play")
+
+    assert "market-v0-tape-ssr" not in html
+    assert 'data-market-v0-tape="true"' not in html
+
+
 MARKET_SURFACE_DOC = project_root / "docs" / "webui" / "MARKET_SURFACE_V0.md"
 STRUCTURE_CONTRACT_OWNER = "tests/webui/test_market_dashboard_readonly_structure_contract_v0.py"
 MARKET_DASHBOARD_MARKER_IA_CROSSWALK_DRIFT_LOCK_V0 = (

--- a/tests/webui/test_market_tape_ssr_v0.py
+++ b/tests/webui/test_market_tape_ssr_v0.py
@@ -1,0 +1,146 @@
+"""Web UI tests for env-gated market tape readmodel SSR v0 on GET /market."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+from src.webui.market_surface import build_market_tape_display_context
+
+FIXTURE_ROOT = project_root / "tests" / "fixtures" / "market_tape_readmodel_v0" / "complete_minimal"
+MALFORMED_ROOT = (
+    project_root / "tests" / "fixtures" / "market_tape_readmodel_v0" / "malformed_trades"
+)
+
+BOUNDARY_COPY = (
+    "Read-only tape display. This panel does not authorize runtime, testnet, live trading, "
+    "broker access, exchange access, or strategy execution. Tape rows are offline fixture "
+    "evidence only — not order, fill, or position truth."
+)
+
+TAPE_MARKERS = (
+    'data-market-v0-tape="true"',
+    'data-market-v0-tape-readonly="true"',
+    'data-market-v0-tape-authority="false"',
+    'data-market-v0-tape-non-authorizing="true"',
+    'data-market-v0-tape-evidence-only="true"',
+    'data-market-v0-tape-provider-truth-blocked="true"',
+    'data-market-v0-tape-dashboard-truth-blocked="true"',
+    'data-market-v0-tape-trading-readiness-blocked="true"',
+    'data-market-v0-tape-selected-future-truth-blocked="true"',
+    'data-market-v0-tape-order-fill-position-truth-blocked="true"',
+)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.delenv("PEAK_TRADE_MARKET_TAPE_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", raising=False)
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _html(client: TestClient, path: str = "/market") -> str:
+    response = client.get(path)
+    assert response.status_code == 200
+    return response.text
+
+
+def test_gate_disabled_no_tape_section(client: TestClient) -> None:
+    html = _html(client)
+    for marker in TAPE_MARKERS:
+        assert marker not in html
+    assert BOUNDARY_COPY not in html
+    assert "market-v0-tape-ssr" not in html
+
+
+def test_gate_enabled_valid_fixture_shows_panel(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(FIXTURE_ROOT.resolve()))
+    html = _html(client)
+
+    for marker in TAPE_MARKERS:
+        assert marker in html
+    assert 'data-market-v0-tape-enabled="true"' in html
+    assert 'data-market-v0-tape-ready="true"' in html
+    assert 'data-market-v0-tape-readmodel-id="market_tape_readmodel.v0"' in html
+    assert BOUNDARY_COPY in html
+    assert "BTC/EUR" in html
+    assert "Top trades (display subset)" in html
+    assert "63020" in html
+    assert str(FIXTURE_ROOT.resolve()) not in html
+    lowered = html.lower()
+    assert "trading_ready" not in lowered
+    assert "live_ready" not in lowered
+    assert "provider_ok" not in lowered
+
+
+def test_gate_enabled_invalid_fixture_fail_closed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(MALFORMED_ROOT.resolve()))
+    html = _html(client)
+
+    assert 'data-market-v0-tape="true"' in html
+    assert 'data-market-v0-tape-ready="false"' in html
+    assert 'data-market-v0-tape-readmodel-id="market_tape_readmodel.v0"' in html
+    assert "Top trades (display subset)" not in html
+    assert "63020.00" not in html
+
+
+def test_gate_enabled_missing_bundle_root_fail_closed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
+    monkeypatch.delenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", raising=False)
+    html = _html(client)
+
+    assert 'data-market-v0-tape-ready="false"' in html
+    assert "Top trades (display subset)" not in html
+
+
+def test_double_play_excludes_tape_markers(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(FIXTURE_ROOT.resolve()))
+    html = _html(client, "/market/double-play")
+    for marker in TAPE_MARKERS:
+        assert marker not in html
+    assert BOUNDARY_COPY not in html
+    assert "market-v0-tape-ssr" not in html
+
+
+def test_build_context_unit_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(FIXTURE_ROOT.resolve()))
+    ctx = build_market_tape_display_context()
+    assert ctx["section_visible"] is True
+    assert ctx["tape_ready"] is True
+    assert ctx["readmodel_id"] == "market_tape_readmodel.v0"
+    assert ctx["trade_count"] == 3
+
+
+def test_build_context_gate_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PEAK_TRADE_MARKET_TAPE_ENABLED", raising=False)
+    ctx = build_market_tape_display_context()
+    assert ctx["section_visible"] is False


### PR DESCRIPTION
## Summary
- Wire offline fixture-backed Market Tape readmodel SSR on `GET /market` via `build_market_tape_display_context()` (default-off, fail-closed).
- Add diagnostic `data-market-v0-tape-*` markers with explicit non-authorizing boundary mirrors; Double Play route excluded.
- Add SSR contract tests and minimal `MARKET_SURFACE_V0.md` operator enablement section.

## Test plan
- [x] `python3 -m ruff format --check` on touched Python files
- [x] `python3 -m ruff check` on touched Python files
- [x] `pytest tests/webui/test_market_tape_ssr_v0.py`
- [x] `pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py` (tape landmark cases)
- [x] `pytest tests/webui/test_market_registry_projection_overlay_v0.py` (regression)


Made with [Cursor](https://cursor.com)