### PR TITLE
Pin tape operator-pointer env boundary in MARKET_SURFACE_V0

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -84,14 +84,22 @@ Dashboard ≠ Freigabe. Market Surface v0 is **review input only** for operators
 
 #### Operator enablement (tape readmodel SSR v0)
 
-**Default off / operator-gated / fail-closed:** Tape SSR on **`GET`** **`&#47;market`** stays **disabled** until **both** env gates below are explicitly set. Panel **absent** when gates are off is **expected** — **not** a template defect, **not** Dashboard Truth GO, **not** Provider Truth, **no** runtime, Testnet, Paper, or Shadow authority.
+**Default off / operator-gated / fail-closed / offline-only:** Tape SSR on **`GET`** **`&#47;market`** stays **disabled** until **both** env gates below are explicitly set. Tape panel and `data-market-v0-tape-*` markers **absent when gates are off** is **expected** — **not** a template defect, **not** Dashboard Truth GO, **not** Provider Truth, **not** trading readiness, **not** selected-future truth, **not** order/fill/position truth, **no** runtime, Testnet, Paper, or Shadow authority. Tape rows are **diagnostic / operator-context only** — offline fixture evidence, **no** provider fetch, **no** network, **no** browser requirement.
+
+**Required env chain (both steps for tape SSR v0 on `GET` `/market`):**
 
 | Step | Env var(s) | Notes |
 |------|------------|-------|
 | 1 | `PEAK_TRADE_MARKET_TAPE_ENABLED=1` | Master tape gate |
-| 2 | `PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT=<path>` | Offline fixture root with `tape.json` |
+| 2 | `PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT=<path>` | Offline fixture root with `tape.json` (`market_tape_readmodel.v0`) |
 
-**Troubleshooting:** Distinguish **absent markers** (gate off — expected) from **`data-market-v0-tape-ready="false"`** (gate on but bundle/build not ready). Cross-check **`tests/webui/test_market_tape_ssr_v0.py`** and **`tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`**.
+**Bundle/readmodel readiness:** Bundle must expose valid `tape.json` under the root before `data-market-v0-tape-ready="true"` and Top trades subset rows populate. Fixture target: `tests/fixtures/market_tape_readmodel_v0/`. **`GET`** **`&#47;market`** must **not** derive Provider Truth from tape display. **No** `fills.json` and **no** workflow-pipeline fills alias for tape data.
+
+**Troubleshooting (missing/stale tape):** Walk the env chain top-down before assuming SSR regression. Verify bundle root path and `tape.json` validity. Distinguish **absent markers** (gate off — expected) from **`data-market-v0-tape-ready="false"`** (gate on but bundle/build not ready). Cross-check **`tests/webui/test_market_tape_ssr_v0.py`**, **`tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`**, **`tests/webui/test_market_tape_readmodel_v0.py`**, and **`tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`**.
+
+**Protected boundaries:** read-only SSR only — **no dashboard truth grant**, **no provider truth**, **no** trading readiness, **no** selected-future truth, **no** order/fill/position truth, **no** Live/Testnet/Order/Cancel/Execute/Arming/Preflight authority, **no** runtime/scheduler activation. **Market-Airport excluded** — not a dependency for tape enablement. **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — tape operator enablement does not alter Double Play routes, markers, or decision logic; **no Double-Play authority**. **No run, Testnet, Paper, or Shadow authorization** is granted by enabling this display path.
+
+Do **not** add a new Observability/Evidence/readiness **hub** solely for tape; reuse **Market Surface v0** navigation patterns already described in **Verwandte read-only WebUI-Fläche**.
 
 ## Safety banner and stable markers
 

--- a/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
+++ b/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
@@ -126,6 +126,61 @@ def test_market_surface_run_projection_operator_pointer_env_boundary_v0() -> Non
         assert token.lower() in run_projection.lower()
 
 
+def test_market_surface_tape_operator_pointer_env_boundary_v0() -> None:
+    """Tape readmodel SSR operator enablement tokens stay pinned in MARKET_SURFACE_V0."""
+    surface = (PROJECT_ROOT / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")
+
+    section_start = surface.index("### Market tape readmodel SSR (env-gated v0)")
+    section_end = surface.index("## Safety banner and stable markers")
+    tape = surface[section_start:section_end]
+
+    assert "Operator enablement (tape readmodel SSR v0)" in tape
+    assert "PEAK_TRADE_MARKET_TAPE_" in tape
+
+    required_env_tokens = [
+        "PEAK_TRADE_MARKET_TAPE_ENABLED=1",
+        "PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT",
+    ]
+
+    for token in required_env_tokens:
+        assert token in tape
+
+    required_boundary_tokens = [
+        "default off",
+        "operator-gated",
+        "fail-closed",
+        "offline-only",
+        "offline fixture",
+        "diagnostic",
+        "operator-context",
+        "GET",
+        "&#47;market",
+        "no provider truth",
+        "no dashboard truth",
+        "trading readiness",
+        "selected-future truth",
+        "order/fill/position truth",
+        "fills.json",
+        "workflow-pipeline fills",
+        "Market-Airport excluded",
+        "Master V2 / Double Play protected",
+        "no Double-Play authority",
+        "no run",
+        "testnet",
+        "paper",
+        "shadow",
+        "network",
+        "browser requirement",
+        "test_market_tape_ssr_v0.py",
+        "test_market_dashboard_readonly_structure_contract_v0.py",
+        "test_market_tape_readmodel_v0.py",
+        "test_market_surface_ranking_funnel_env_schema_boundary_v0.py",
+    ]
+
+    for token in required_boundary_tokens:
+        assert token.lower() in tape.lower()
+
+
 def test_market_surface_ranking_funnel_operator_pointer_env_boundary_v0() -> None:
     """Ranking funnel operator enablement tokens stay pinned in MARKET_SURFACE_V0."""
     surface = (PROJECT_ROOT / "docs/webui/MARKET_SURFACE_V0.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Extend tape SSR operator enablement section in `MARKET_SURFACE_V0.md` to depth/run-projection parity (boundaries, triage, test crosslinks).
- Add `test_market_surface_tape_operator_pointer_env_boundary_v0()` drift-lock test alongside existing Market Surface operator-pointer guards.

## Scope
- **2 files only:** docs + ops test. No src/template/route/runtime changes.

## Test plan
- [x] `python3 -m ruff format --check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`
- [x] `python3 -m ruff check tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`
- [x] `pytest tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py` (16 passed)


Made with [Cursor](https://cursor.com)