### PR TITLE
Add env-gated cumulative depth chart SSR on GET /market

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -781,6 +781,22 @@ Facts on **`main`** **after** SSR display v0:
 
 **Protected boundaries:** read-only SSR/API only — **no dashboard truth grant**, **no provider truth**, **no** Live/Testnet/Order/Cancel/Execute/Arming/Preflight authority, **no** runtime/scheduler activation. **Market-Airport excluded.** **`GET`** **`&#47;market&#47;double-play`** (**Master V2 / Double Play protected**) — market depth operator enablement does not alter Double Play routes, markers, or decision logic. **No run, Testnet, Paper, or Shadow authorization** is granted by enabling this display path.
 
+#### Cumulative depth chart SSR v0 (env-gated, `GET` `/market` only)
+
+**Default off / operator-gated / fail-closed / offline-only:** Cumulative depth chart visual on **`GET`** **`&#47;market`** stays **disabled** until **all three** env gates below are set (master depth gates **plus** chart sub-gate). **`data-market-v0-depth-chart-cumulative`** and related markers **absent when chart sub-gate is off** is **expected** — the non-cumulative placeholder mini-bars remain. **Not** Dashboard Truth, **not** Provider Truth, **not** trading readiness, **not** liquidity/slippage/depth/execution truth, **no** Chart.js, **no** network, **no** browser requirement.
+
+**Required env chain (all steps for cumulative chart SSR on `GET` `/market`):**
+
+| Step | Env var(s) | Notes |
+|------|------------|-------|
+| 1 | `PEAK_TRADE_MARKET_DEPTH_ENABLED=1` | Master market-depth gate |
+| 2 | `PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT=<path>` | Offline bundle root for `market_depth_readmodel.v0` |
+| 3 | `PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED=1` | Chart visual sub-gate (cumulative SSR only) |
+
+**Markers:** `data-market-v0-depth-chart-cumulative="true"`, `data-market-v0-depth-chart-readonly="true"`, `data-market-v0-depth-chart-authority="false"`, `data-market-v0-depth-chart-non-authorizing="true"`, boundary mirrors `data-market-v0-depth-chart-*-truth-blocked="true"`, `data-market-v0-depth-chart-enabled`, `data-market-v0-depth-chart-ready` — **absent** when sub-gate disabled; **never** on **`GET &#47;market&#47;double-play`**.
+
+**Boundaries:** read-only SSR SVG from offline Top-N fixture levels — **no** liquidity truth, **no** slippage truth, **no** depth truth, **no** execution readiness, **no Chart.js** for depth visualization, **no** Double-Play authority, **Market-Airport excluded**. Cross-check **`tests/webui/test_market_depth_chart_ssr_v0.py`** and **`tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`**.
+
 Do **not** add a new Observability/Evidence/readiness **hub** solely for depth; reuse **Market Surface v0** navigation patterns already described in **Verwandte read-only WebUI-Fläche**.
 
 ## Double-Play Market Dashboard konsumiert strukturierte Metadaten v2
@@ -826,8 +842,8 @@ Das HTML für **`GET &#47;market`** enthält beim Chart‑Bereich ein Status‑E
 ### Zielpanels (priorisierte Zielrichtung)
 
 - **Market‑/Chart‑Panel:** Zeitreihe/OHLCV‑Darstellung (read‑only); **Basis** weiterhin eingebetteter Market‑Payload bzw. **`GET`** **`&#47;api&#47;market&#47;ohlcv`**‑Semantik wie in diesem Dokument beschrieben. **Zusätzliche oder ersetzende** Chart-/Candle‑Datenquellen **über** diese kanonischen Pfade hinaus bedürfen eines **expliziten, kanonischen Readmodel‑/Route‑Vertrags** vor Implementierung.
-- **Orderbuch / Price‑Ladder‑Panel:** read‑only Bid/Ask‑Stufen dort, wo Daten verfügbar sind — **über** **`market_depth_readmodel.v0`** (**`depth.bids`** / **`depth.asks`**), **wenn** Market Depth über Env/Bundle (**`GET`** **`&#47;api&#47;market&#47;depth`**, SSR‑Kontext **`GET`** **`&#47;market`**) aktiv und gebaut wird; keine Order‑Handles. **Ist `main`:** Top‑N‑Ladder‑SSR auf **`GET`** **`&#47;market`** (**`data-market-v0-orderbook-*`**) — Details unter **[Market Depth display on GET /market (SSR v0 implemented)](#market-depth-display-on-get-market-ssr-v0-implemented)**; kumulative Depth‑Chart bleibt **deferred**.
-- **Depth‑Chart‑Panel:** kumulative Tiefe gegen Preis (**read‑only Diagramm**) als **Ableitung** aus derselben Bid/Ask‑Readmodel‑Form, sobald Panel‑Umsetzung ansteht — **ohne** neue Netz-/Provider‑Abfrage durch diesen Platzhalter‑Vertrag.
+- **Orderbuch / Price‑Ladder‑Panel:** read‑only Bid/Ask‑Stufen dort, wo Daten verfügbar sind — **über** **`market_depth_readmodel.v0`** (**`depth.bids`** / **`depth.asks`**), **wenn** Market Depth über Env/Bundle (**`GET`** **`&#47;api&#47;market&#47;depth`**, SSR‑Kontext **`GET`** **`&#47;market`**) aktiv und gebaut wird; keine Order‑Handles. **Ist `main`:** Top‑N‑Ladder‑SSR auf **`GET`** **`&#47;market`** (**`data-market-v0-orderbook-*`**) — Details unter **[Market Depth display on GET /market (SSR v0 implemented)](#market-depth-display-on-get-market-ssr-v0-implemented)**; kumulative Depth‑Chart SSR v0 unter **[Cumulative depth chart SSR v0](#cumulative-depth-chart-ssr-v0-env-gated-get-market-only)** (env sub-gate `PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED=1`).
+- **Depth‑Chart‑Panel:** kumulative Tiefe gegen Preis (**read‑only SSR SVG**) als **Ableitung** aus derselben Bid/Ask‑Readmodel‑Form — **implementiert** auf **`GET`** **`&#47;market`** when chart sub-gate on; **ohne** neue Netz-/Provider‑Abfrage, **ohne** Chart.js.
 - **Market‑Trades / Tape‑Panel:** **nur** nach Einführung eines **kanonischen, read‑only** Tape‑Readmodels (**derzeit nicht** Teil von Market Surface v0); **kein** Alias für Run‑Trade‑Listen anderer Apps — bis dahin ausdrücklich **nicht** implementierungspflichtig.
 - **Double‑Play / Master V2 Status‑Rail:** bestehendes **display‑only** Snapshot‑/`dp_display`‑Muster (**`GET`** **`&#47;market&#47;double-play`** bzw. JSON‑Parallelroute wie in diesem Dokument referenziert); **Diagnostics bleiben Anzeige**, nie Freigabe.
 

--- a/src/webui/market_depth_runtime_v0.py
+++ b/src/webui/market_depth_runtime_v0.py
@@ -16,7 +16,13 @@ from .market_depth_readmodel_v0.builder import READMODEL_ID
 
 ENV_ENABLED = "PEAK_TRADE_MARKET_DEPTH_ENABLED"
 ENV_BUNDLE_ROOT = "PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT"
+ENV_CHART_ENABLED = "PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED"
 FIXED_GEN_ENV = "PEAK_TRADE_FIXED_GENERATED_AT_UTC"
+
+
+def depth_chart_enabled_explicitly_on() -> bool:
+    raw = os.environ.get(ENV_CHART_ENABLED)
+    return raw is not None and raw.strip() == "1"
 
 
 def generated_at_iso() -> str:
@@ -108,8 +114,10 @@ def market_depth_json_payload_v0() -> tuple[int, dict[str, Any]]:
 
 __all__ = [
     "ENV_BUNDLE_ROOT",
+    "ENV_CHART_ENABLED",
     "ENV_ENABLED",
     "FIXED_GEN_ENV",
+    "depth_chart_enabled_explicitly_on",
     "enabled_explicitly_on",
     "generated_at_iso",
     "market_depth_json_payload_v0",

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -31,7 +31,10 @@ from fastapi.templating import Jinja2Templates
 
 from .last_paper_run_panel_runtime_v0 import build_last_paper_run_panel_display_context
 from .market_active_paper_run_runtime_v0 import build_market_active_paper_run_display_context
-from .market_depth_runtime_v0 import market_depth_json_payload_v0
+from .market_depth_runtime_v0 import (
+    depth_chart_enabled_explicitly_on,
+    market_depth_json_payload_v0,
+)
 from .market_ranking_funnel_runtime_v0 import build_market_ranking_funnel_display_context
 from .market_tape_readmodel_v0.gate import (
     enabled_explicitly_on as _market_tape_enabled_explicitly_on,
@@ -201,6 +204,80 @@ def _top_depth_level_rows(
                 asks_out.append(row)
 
     return bids_out, asks_out
+
+
+def _parse_depth_display_size(size_str: str) -> float:
+    try:
+        return float(str(size_str).replace(",", "").strip())
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _cumulative_depth_chart_svg_paths(
+    bid_rows: List[Dict[str, str]], ask_rows: List[Dict[str, str]]
+) -> Dict[str, Any]:
+    """Build stepped cumulative bid/ask SVG path data from offline Top-N rows only."""
+
+    bid_cums: List[float] = []
+    running = 0.0
+    for row in bid_rows:
+        running += _parse_depth_display_size(row.get("size", ""))
+        bid_cums.append(running)
+
+    ask_cums: List[float] = []
+    running = 0.0
+    for row in ask_rows:
+        running += _parse_depth_display_size(row.get("size", ""))
+        ask_cums.append(running)
+
+    max_c = max(bid_cums + ask_cums) if (bid_cums or ask_cums) else 0.0
+    if max_c <= 0:
+        return {"bid_path_d": "", "ask_path_d": "", "has_svg_paths": False}
+
+    baseline = 58.0
+    height = 48.0
+    center = 120.0
+    left = 8.0
+    right = 232.0
+
+    def y_for(cum: float) -> float:
+        return baseline - (cum / max_c) * height
+
+    bid_path = ""
+    if bid_cums:
+        step = (center - left) / max(len(bid_cums), 1)
+        parts = [f"M{center:.1f} {baseline:.1f}"]
+        x_prev = center
+        for i, cum in enumerate(bid_cums):
+            y = y_for(cum)
+            x = center - (i + 1) * step
+            parts.append(f"L{x_prev:.1f} {y:.1f}")
+            parts.append(f"L{x:.1f} {y:.1f}")
+            x_prev = x
+        parts.append(f"L{left:.1f} {baseline:.1f}")
+        parts.append(f"L{center:.1f} {baseline:.1f} Z")
+        bid_path = " ".join(parts)
+
+    ask_path = ""
+    if ask_cums:
+        step = (right - center) / max(len(ask_cums), 1)
+        parts = [f"M{center:.1f} {baseline:.1f}"]
+        x_prev = center
+        for i, cum in enumerate(ask_cums):
+            y = y_for(cum)
+            x = center + (i + 1) * step
+            parts.append(f"L{x_prev:.1f} {y:.1f}")
+            parts.append(f"L{x:.1f} {y:.1f}")
+            x_prev = x
+        parts.append(f"L{right:.1f} {baseline:.1f}")
+        parts.append(f"L{center:.1f} {baseline:.1f} Z")
+        ask_path = " ".join(parts)
+
+    return {
+        "bid_path_d": bid_path,
+        "ask_path_d": ask_path,
+        "has_svg_paths": bool(bid_path or ask_path),
+    }
 
 
 def _sanitize_depth_bundle_provenance(display_envelope: Dict[str, Any]) -> Dict[str, Any]:
@@ -585,6 +662,14 @@ def build_market_depth_display_context() -> Dict[str, Any]:
 
     has_depth_levels = len(top_bids) > 0 or len(top_asks) > 0
 
+    chart_gate_enabled = depth_chart_enabled_explicitly_on()
+    chart_cumulative_ready = chart_gate_enabled and depth_http_status == 200 and has_depth_levels
+    chart_svg = (
+        _cumulative_depth_chart_svg_paths(top_bids, top_asks)
+        if chart_cumulative_ready
+        else {"bid_path_d": "", "ask_path_d": "", "has_svg_paths": False}
+    )
+
     return {
         "depth_http_status": depth_http_status,
         "display_status": display_status,
@@ -594,6 +679,11 @@ def build_market_depth_display_context() -> Dict[str, Any]:
         "top_asks": top_asks,
         "top_levels_limit": top_limit,
         "has_depth_levels": has_depth_levels,
+        "chart_gate_enabled": chart_gate_enabled,
+        "chart_cumulative_ready": chart_cumulative_ready,
+        "chart_bid_path_d": chart_svg["bid_path_d"],
+        "chart_ask_path_d": chart_svg["ask_path_d"],
+        "chart_has_svg_paths": chart_svg["has_svg_paths"],
         **provenance_ctx,
     }
 

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -1312,15 +1312,70 @@
         aria-labelledby="market-v0-landmark-depth-chart-placeholder-h2"
         class="bg-gradient-to-br from-amber-950/22 via-slate-950/88 to-slate-900/85 px-2.5 py-2.5 text-[10px] text-slate-400 shadow-inner shadow-black/25"
         data-market-v0-depth-chart-placeholder="true"
+        {% if market_depth.chart_gate_enabled %}data-market-v0-depth-chart-enabled="true"{% endif %}
+        {% if market_depth.chart_cumulative_ready %}
+        data-market-v0-depth-chart-cumulative="true"
+        data-market-v0-depth-chart-ready="true"
+        data-market-v0-depth-chart-readonly="true"
+        data-market-v0-depth-chart-authority="false"
+        data-market-v0-depth-chart-non-authorizing="true"
+        data-market-v0-depth-chart-provider-truth-blocked="true"
+        data-market-v0-depth-chart-dashboard-truth-blocked="true"
+        data-market-v0-depth-chart-trading-readiness-blocked="true"
+        data-market-v0-depth-chart-selected-future-truth-blocked="true"
+        data-market-v0-depth-chart-liquidity-truth-blocked="true"
+        data-market-v0-depth-chart-slippage-truth-blocked="true"
+        data-market-v0-depth-chart-depth-truth-blocked="true"
+        data-market-v0-depth-chart-execution-readiness-blocked="true"
+        data-market-v0-depth-chart-double-play-protected="true"
+        data-market-v0-depth-chart-market-airport-excluded="true"
+        {% endif %}
       >
-        <h2 id="market-v0-landmark-depth-chart-placeholder-h2" class="sr-only" data-market-v0-depth-chart-placeholder-landmark-heading-v0="true">Depth chart placeholder (read-only, non-cumulative SSR)</h2>
+        <h2 id="market-v0-landmark-depth-chart-placeholder-h2" class="sr-only" data-market-v0-depth-chart-placeholder-landmark-heading-v0="true">{% if market_depth.chart_cumulative_ready %}Cumulative depth chart (read-only, offline fixture SSR){% else %}Depth chart placeholder (read-only, non-cumulative SSR){% endif %}</h2>
+        {% if market_depth.chart_cumulative_ready and market_depth.chart_has_svg_paths %}
+        <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
+          <p class="font-semibold text-slate-100 uppercase tracking-wide leading-snug m-0">
+            Cumulative depth (display-only, offline fixture)
+          </p>
+          <span class="inline-flex items-center rounded border border-amber-800/50 bg-amber-950/45 px-1.5 py-0.5 text-[9px] font-semibold text-amber-100/90 tabular-nums">Cumulative · not liquidity truth</span>
+        </div>
+        <div
+          class="mb-2 rounded-lg border border-slate-700/55 bg-slate-950/72 px-2 py-2 ring-1 ring-slate-800/45 shadow-inner shadow-black/15"
+          data-market-v0-depth-chart-cumulative-svg-v0="true"
+          role="img"
+          aria-label="Stepped cumulative bid and ask sizes from offline fixture, display only"
+        >
+          <svg viewBox="0 0 240 72" class="w-full h-[4.25rem]" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="mv0-dc-cum-bid" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stop-color="rgba(52,211,153,0.12)" />
+                <stop offset="100%" stop-color="rgba(52,211,153,0.38)" />
+              </linearGradient>
+              <linearGradient id="mv0-dc-cum-ask" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stop-color="rgba(244,63,94,0.38)" />
+                <stop offset="100%" stop-color="rgba(244,63,94,0.12)" />
+              </linearGradient>
+            </defs>
+            <line x1="120" y1="8" x2="120" y2="64" stroke="rgba(100,116,139,0.45)" stroke-width="0.9" stroke-dasharray="3 3" />
+            {% if market_depth.chart_bid_path_d %}
+            <path d="{{ market_depth.chart_bid_path_d|e }}" fill="url(#mv0-dc-cum-bid)" stroke="rgba(52,211,153,0.5)" stroke-width="0.85" />
+            {% endif %}
+            {% if market_depth.chart_ask_path_d %}
+            <path d="{{ market_depth.chart_ask_path_d|e }}" fill="url(#mv0-dc-cum-ask)" stroke="rgba(244,63,94,0.5)" stroke-width="0.85" />
+            {% endif %}
+            <line x1="8" y1="58" x2="232" y2="58" stroke="rgba(51,65,85,0.8)" stroke-width="0.75" />
+          </svg>
+        </div>
+        <p class="m-0 leading-snug">
+          Stepped cumulative sizes from offline Top-N fixture levels — <strong class="font-semibold text-slate-200">not</strong> live order-book depth, <strong class="font-semibold text-slate-200">not</strong> liquidity/slippage/execution truth, <strong class="font-semibold text-slate-200">no</strong> polling. Diagnostic operator context only.
+        </p>
+        {% elif market_depth.has_depth_levels and market_depth.top_bids and market_depth.top_asks %}
         <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
           <p class="font-semibold text-slate-100 uppercase tracking-wide leading-snug m-0">
             Displayed top-level depth (static)
           </p>
           <span class="inline-flex items-center rounded border border-amber-800/50 bg-amber-950/45 px-1.5 py-0.5 text-[9px] font-semibold text-amber-100/90 tabular-nums">Not cumulative</span>
         </div>
-        {% if market_depth.has_depth_levels and market_depth.top_bids and market_depth.top_asks %}
         {% set _mini = namespace(i=0) %}
         <div class="grid grid-cols-2 gap-2 mb-2" role="img" aria-label="Miniature SSR bid versus ask displayed sizes, top levels only">
           <div class="rounded-lg border border-emerald-900/30 bg-slate-950/65 p-2 space-y-1.5">
@@ -1355,7 +1410,16 @@
             {% endfor %}
           </div>
         </div>
+        <p class="m-0 leading-snug">
+          Visual impression only from SSR Top-N levels — <strong class="font-semibold text-slate-200">not</strong> a full cumulative depth chart, <strong class="font-semibold text-slate-200">no</strong> live feed, <strong class="font-semibold text-slate-200">no</strong> polling. Enable <code class="text-[9px]">PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED=1</code> for cumulative SSR visual.
+        </p>
         {% else %}
+        <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
+          <p class="font-semibold text-slate-100 uppercase tracking-wide leading-snug m-0">
+            Displayed top-level depth (static)
+          </p>
+          <span class="inline-flex items-center rounded border border-amber-800/50 bg-amber-950/45 px-1.5 py-0.5 text-[9px] font-semibold text-amber-100/90 tabular-nums">Not cumulative</span>
+        </div>
         <div
           class="mb-2 rounded-lg border border-slate-700/55 bg-slate-950/72 px-2 py-2 ring-1 ring-slate-800/45 shadow-inner shadow-black/15"
           data-market-v0-depth-chart-disabled-envelope="true"
@@ -1405,10 +1469,10 @@
             Decorative split · no level data · offline / disabled depth state.
           </p>
         </div>
-        {% endif %}
         <p class="m-0 leading-snug">
           Visual impression only from SSR Top-N levels — <strong class="font-semibold text-slate-200">not</strong> a full cumulative depth chart, <strong class="font-semibold text-slate-200">no</strong> live feed, <strong class="font-semibold text-slate-200">no</strong> polling. Canonical diagnostic strip remains the depth summary below.
         </p>
+        {% endif %}
       </section>
 
       <section

--- a/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
+++ b/tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py
@@ -237,6 +237,7 @@ def test_market_surface_market_depth_operator_pointer_env_boundary_v0() -> None:
     required_env_tokens = [
         "PEAK_TRADE_MARKET_DEPTH_ENABLED=1",
         "PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT",
+        "PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED=1",
     ]
 
     for token in required_env_tokens:
@@ -246,10 +247,15 @@ def test_market_surface_market_depth_operator_pointer_env_boundary_v0() -> None:
         "default off",
         "operator-gated",
         "fail-closed",
+        "offline-only",
         "GET",
         "&#47;market",
         "no provider truth",
         "no dashboard truth",
+        "liquidity",
+        "slippage",
+        "execution readiness",
+        "no Chart.js",
         "Market-Airport excluded",
         "Master V2 / Double Play protected",
         "no run",
@@ -260,6 +266,7 @@ def test_market_surface_market_depth_operator_pointer_env_boundary_v0() -> None:
         "test_market_depth_readmodel_v0.py",
         "test_market_depth_api_v0.py",
         "test_market_surface_api.py",
+        "test_market_depth_chart_ssr_v0.py",
     ]
 
     for token in required_boundary_tokens:

--- a/tests/webui/test_market_depth_chart_ssr_v0.py
+++ b/tests/webui/test_market_depth_chart_ssr_v0.py
@@ -1,0 +1,154 @@
+"""Web UI tests for env-gated cumulative market depth chart SSR v0 on GET /market."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+from src.webui.market_surface import build_market_depth_display_context
+
+FIXTURE_ROOT = (
+    project_root / "tests" / "fixtures" / "market_depth_readmodel_v0" / "complete_minimal"
+)
+MALFORMED_ROOT = (
+    project_root / "tests" / "fixtures" / "market_depth_readmodel_v0" / "malformed_levels"
+)
+
+CUMULATIVE_MARKERS = (
+    'data-market-v0-depth-chart-cumulative="true"',
+    'data-market-v0-depth-chart-ready="true"',
+    'data-market-v0-depth-chart-readonly="true"',
+    'data-market-v0-depth-chart-authority="false"',
+    'data-market-v0-depth-chart-non-authorizing="true"',
+    'data-market-v0-depth-chart-provider-truth-blocked="true"',
+    'data-market-v0-depth-chart-dashboard-truth-blocked="true"',
+    'data-market-v0-depth-chart-trading-readiness-blocked="true"',
+    'data-market-v0-depth-chart-selected-future-truth-blocked="true"',
+    'data-market-v0-depth-chart-liquidity-truth-blocked="true"',
+    'data-market-v0-depth-chart-slippage-truth-blocked="true"',
+    'data-market-v0-depth-chart-depth-truth-blocked="true"',
+    'data-market-v0-depth-chart-execution-readiness-blocked="true"',
+    'data-market-v0-depth-chart-double-play-protected="true"',
+    'data-market-v0-depth-chart-market-airport-excluded="true"',
+    'data-market-v0-depth-chart-cumulative-svg-v0="true"',
+)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_TAPE_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", raising=False)
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _html(client: TestClient, path: str = "/market") -> str:
+    response = client.get(path)
+    assert response.status_code == 200
+    return response.text
+
+
+def _enable_depth_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(FIXTURE_ROOT.resolve()))
+
+
+def test_chart_sub_gate_off_no_cumulative_markers(client: TestClient) -> None:
+    html = _html(client)
+    for marker in CUMULATIVE_MARKERS:
+        assert marker not in html
+    assert "data-market-v0-depth-chart-enabled" not in html
+
+
+def test_chart_sub_gate_off_depth_fixture_shows_non_cumulative_placeholder(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_depth_fixture(monkeypatch)
+    html = _html(client)
+    assert 'data-market-v0-depth-chart-placeholder="true"' in html
+    assert "Not cumulative" in html
+    assert 'data-market-v0-depth-chart-cumulative="true"' not in html
+
+
+def test_chart_gate_on_valid_fixture_shows_cumulative_ssr(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_depth_fixture(monkeypatch)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED", "1")
+    html = _html(client)
+
+    for marker in CUMULATIVE_MARKERS:
+        assert marker in html
+    assert 'data-market-v0-depth-chart-enabled="true"' in html
+    assert "Cumulative depth (display-only, offline fixture)" in html
+    assert "not liquidity truth" in html
+    svg_idx = html.index('data-market-v0-depth-chart-cumulative-svg-v0="true"')
+    chart_window = html[svg_idx : svg_idx + 4000]
+    assert "Chart(" not in chart_window
+    assert "fetch(" not in html
+    assert "/api/market/depth" not in html
+
+
+def test_chart_gate_on_depth_disabled_fail_closed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED", "1")
+    html = _html(client)
+    assert 'data-market-v0-depth-chart-cumulative="true"' not in html
+    assert 'data-market-v0-depth-chart-ready="true"' not in html
+
+
+def test_chart_gate_on_malformed_fixture_fail_closed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_BUNDLE_ROOT", str(MALFORMED_ROOT.resolve()))
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED", "1")
+    html = _html(client)
+    assert 'data-market-v0-depth-chart-cumulative="true"' not in html
+    assert 'data-market-v0-depth-chart-ready="true"' not in html
+
+
+def test_double_play_excludes_cumulative_depth_chart_markers(client: TestClient) -> None:
+    html = _html(client, "/market/double-play")
+    for marker in CUMULATIVE_MARKERS:
+        assert marker not in html
+    assert 'data-market-v0-depth-chart-cumulative="true"' not in html
+
+
+def test_build_market_depth_display_context_cumulative_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_depth_fixture(monkeypatch)
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED", "1")
+    ctx = build_market_depth_display_context()
+    assert ctx["chart_gate_enabled"] is True
+    assert ctx["chart_cumulative_ready"] is True
+    assert ctx["chart_has_svg_paths"] is True
+    assert "M120" in ctx["chart_bid_path_d"]
+    assert "M120" in ctx["chart_ask_path_d"]
+
+
+def test_build_market_depth_display_context_chart_gate_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_depth_fixture(monkeypatch)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED", raising=False)
+    ctx = build_market_depth_display_context()
+    assert ctx["chart_gate_enabled"] is False
+    assert ctx["chart_cumulative_ready"] is False


### PR DESCRIPTION
## Summary

- Adds `PEAK_TRADE_MARKET_DEPTH_CHART_ENABLED=1` sub-gate (default-off) for cumulative depth chart SSR on `GET /market` only
- Extends `build_market_depth_display_context()` with offline fixture cumulative SVG paths
- Evolves `#market-v0-depth-chart-placeholder` with non-authorizing boundary markers (no Chart.js, no new route)
- Documents cumulative chart in `MARKET_SURFACE_V0.md` and extends depth operator-pointer drift lock
- Adds `tests/webui/test_market_depth_chart_ssr_v0.py` (8 tests)

## Test plan

- [x] `pytest tests/webui/test_market_depth_chart_ssr_v0.py`
- [x] `pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- [x] `pytest tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py::test_market_surface_market_depth_operator_pointer_env_boundary_v0`
- [x] `ruff format` / `ruff check` on touched Python files

## Boundaries

- No authority change; no provider/dashboard/trading/liquidity/slippage/depth/execution truth
- Double Play protected; Market-Airport excluded; offline fixture only


Made with [Cursor](https://cursor.com)