### PR TITLE
Guard durable closeout copy verify identical source dest

### DIFF
--- a/scripts/ops/durable_closeout_copy_verify_v0.py
+++ b/scripts/ops/durable_closeout_copy_verify_v0.py
@@ -305,11 +305,11 @@ def plan_and_execute(
     if is_under_tmp(source_dir) and not allow_tmp_source:
         return _fail(result, "source under /tmp requires --allow-tmp-source")
 
-    ok, msg = _validate_dest_outside_tmp(dest_dir)
+    ok, msg = _validate_source_dest_distinct(source_dir, dest_dir)
     if not ok:
         return _fail(result, msg)
 
-    ok, msg = _validate_source_dest_distinct(source_dir, dest_dir)
+    ok, msg = _validate_dest_outside_tmp(dest_dir)
     if not ok:
         return _fail(result, msg)
 

--- a/scripts/ops/durable_closeout_copy_verify_v0.py
+++ b/scripts/ops/durable_closeout_copy_verify_v0.py
@@ -166,6 +166,22 @@ def _validate_dest_outside_tmp(dest: Path) -> tuple[bool, str]:
     return True, ""
 
 
+def _validate_source_dest_distinct(source_dir: Path, dest_dir: Path) -> tuple[bool, str]:
+    """Fail closed when source and dest resolve to the same directory."""
+    try:
+        source_resolved = source_dir.resolve()
+        dest_resolved = dest_dir.resolve()
+    except OSError as exc:
+        return False, f"cannot resolve source/dest paths: {exc}"
+    if source_resolved == dest_resolved:
+        return False, (
+            "source-dir and dest-dir resolve to the same path "
+            "(use a separate snapshot source directory with a distinct dest-dir, "
+            "or --force only when source and dest differ)"
+        )
+    return True, ""
+
+
 def _safe_dest_child(dest: Path, relative: Path) -> Path:
     dest_resolved = dest.resolve()
     target = (dest / relative).resolve()
@@ -293,8 +309,17 @@ def plan_and_execute(
     if not ok:
         return _fail(result, msg)
 
+    ok, msg = _validate_source_dest_distinct(source_dir, dest_dir)
+    if not ok:
+        return _fail(result, msg)
+
     if _dest_has_content(dest_dir) and not force:
-        return _fail(result, "destination exists and is non-empty (use --force to overwrite)")
+        return _fail(
+            result,
+            "destination exists and is non-empty "
+            "(use --force only when source-dir and dest-dir differ, "
+            "or copy from a separate snapshot source directory)",
+        )
 
     if require_closeout_report and _find_closeout_report(source_dir) is None:
         return _fail(result, f"no {CLOSEOUT_GLOB} closeout report in source")

--- a/tests/ops/test_durable_closeout_copy_verify_v0.py
+++ b/tests/ops/test_durable_closeout_copy_verify_v0.py
@@ -379,6 +379,95 @@ def test_non_dry_copy_verifies_manifest(helper, tmp_path):
         _cleanup_archive_like_dest(dest)
 
 
+def test_identical_source_dest_path_rejected(helper, tmp_path, capsys):
+    src = _minimal_source(tmp_path)
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(src),
+                *_tmp_source_args(),
+                "--dry-run",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "same path" in err
+        assert "snapshot source" in err
+    finally:
+        pass
+
+
+def test_realpath_equivalent_source_dest_rejected(helper, tmp_path, capsys):
+    src = _minimal_source(tmp_path)
+    dest_alias = tmp_path / "dest_alias"
+    dest_alias.symlink_to(src, target_is_directory=True)
+    try:
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest_alias),
+                *_tmp_source_args(),
+                "--dry-run",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "same path" in err
+    finally:
+        pass
+
+
+def test_separate_snapshot_source_to_dest_with_force_succeeds(helper, tmp_path):
+    snapshot_src = _minimal_source(tmp_path, with_closeout=True)
+    dest = _archive_like_dest(tmp_path, "snapshot_dest")
+    try:
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "prestart.env").write_text("PAPER_ONLY=true\n", encoding="utf-8")
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(snapshot_src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
+                "--force",
+            ]
+        )
+        assert rc == 0
+        assert (dest / "AFTER_FIXTURE_CLOSEOUT.md").is_file()
+        assert (dest / "MANIFEST.sha256").is_file()
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
+def test_non_empty_dest_without_force_rejected_with_operator_hint(helper, tmp_path, capsys):
+    src = _minimal_source(tmp_path)
+    dest = _archive_like_dest(tmp_path, "prepopulated_dest")
+    try:
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "prestart.env").write_text("PAPER_ONLY=true\n", encoding="utf-8")
+        rc = helper.main(
+            [
+                "--source-dir",
+                str(src),
+                "--dest-dir",
+                str(dest),
+                *_tmp_source_args(),
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "non-empty" in err
+        assert "snapshot source" in err
+    finally:
+        _cleanup_archive_like_dest(dest)
+
+
 def test_duplicate_dest_without_force_fails(helper, tmp_path):
     src = _minimal_source(tmp_path)
     dest = _archive_like_dest(tmp_path, "dup")


### PR DESCRIPTION
## Summary

- **Problem:** Paper-L2 120min observation PASS, but closeout produced a resolved historical pre-recovery FAIL because `durable_closeout_dest_non_empty_without_force` and an identical-path retry (`source==dest`) required manual snapshot-source recovery.
- **Solution:** Fail-closed guard in `durable_closeout_copy_verify_v0` when `source-dir` and `dest-dir` resolve to the same path; clearer operator hints for non-empty dest without `--force`; regression tests for identical/realpath-equivalent paths and separate snapshot copy with `--force`.

## Safety

- No run, no live, no trading logic changes
- No Master V2 / Double Play / Bull-Bear / Risk-KillSwitch / Execution-Order surface changes
- Scope limited to durable closeout helper + ops tests

## Test plan

- [x] `ruff format --check` on changed Python files (RC=0)
- [x] `ruff check` on changed Python files (RC=0)
- [x] `pytest tests/ops/test_durable_closeout_copy_verify_v0.py` (30 passed, RC=0)
- [x] Protected-scope diff check PASS (only helper + test files)

Made with [Cursor](https://cursor.com)