### PR TITLE
Guard bounded observation adapter closeout validation

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -29,6 +29,10 @@ if str(_REPO_ROOT) not in sys.path:
 from scripts.ops import bounded_daemon_paper_shadow_24h_approval_v0 as contract_24h
 from scripts.ops import gap4_req_a_paper_hold_binding_approval_v0 as contract_gap4
 from scripts.ops import paper_l2_120min_hold_binding_approval_v0 as contract_l2_120min
+from scripts.ops.durable_closeout_copy_verify_v0 import (
+    _dest_has_content,
+    _validate_source_dest_distinct,
+)
 from scripts.ops.primary_evidence_retention_v0 import (
     is_under_tmp,
     verify_manifest_sha256,
@@ -564,6 +568,27 @@ def validate_durable_closeout_invoke_cli_args(args: argparse.Namespace) -> list[
     return issues
 
 
+def validate_durable_closeout_invoke_paths(
+    source_dir: Path,
+    dest_dir: Path,
+    *,
+    force: bool = False,
+) -> tuple[bool, str, str]:
+    """Validate adapter closeout paths before helper invoke (reuses helper guards)."""
+    ok, msg = _validate_source_dest_distinct(source_dir, dest_dir)
+    if not ok:
+        return False, msg, "durable_closeout_identical_source_dest"
+    if _dest_has_content(dest_dir) and not force:
+        return (
+            False,
+            "destination exists and is non-empty "
+            "(use --durable-closeout-force only when source and dest differ, "
+            "or copy from a separate snapshot source directory)",
+            "durable_closeout_dest_non_empty_without_force",
+        )
+    return True, "", ""
+
+
 ARCHIVE_POINTER_FILENAME = "ARCHIVE_POINTER.md"
 
 
@@ -630,6 +655,7 @@ def build_durable_closeout_invoke_argv(
     chain_run_id: str | None = None,
     require_durable_pointer_evidence: bool = False,
     durable_pointer_patterns: Sequence[str] = (),
+    force: bool = False,
 ) -> list[str]:
     argv = [
         sys.executable,
@@ -641,6 +667,8 @@ def build_durable_closeout_invoke_argv(
     ]
     if is_under_tmp(source_dir):
         argv.append("--allow-tmp-source")
+    if force:
+        argv.append("--force")
     if run_local_post_closeout_chain_v0:
         if chain_archive_root is None:
             raise ValueError("chain_archive_root is required when run_local_post_closeout_chain_v0")
@@ -677,6 +705,15 @@ def invoke_durable_closeout_after_archive(
     pointer_patterns = (
         resolve_bounded_adapter_durable_pointer_patterns(args) if args is not None else ()
     )
+    force = bool(args and getattr(args, "durable_closeout_force", False))
+    ok, msg, _blocker = validate_durable_closeout_invoke_paths(
+        source_dir,
+        dest_dir,
+        force=force,
+    )
+    if not ok:
+        print(msg, file=sys.stderr)
+        return 1
     invoker = durable_closeout_invoker or _default_durable_closeout_invoker
     return invoker(
         build_durable_closeout_invoke_argv(
@@ -687,6 +724,7 @@ def invoke_durable_closeout_after_archive(
             chain_run_id=chain_run_id,
             require_durable_pointer_evidence=pointer_required,
             durable_pointer_patterns=pointer_patterns,
+            force=force,
         )
     )
 
@@ -697,9 +735,26 @@ def emit_bounded_adapter_durable_closeout_machine_lines(
     rc: int,
     source_dir: Path,
     dest_dir: Path | None,
+    validation_blocked: bool = False,
+    blocker_hint: str = "",
 ) -> None:
     print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_INVOKED={'true' if invoked else 'false'}")
-    if not invoked:
+    print(
+        "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_VALIDATION_BLOCKED="
+        f"{'true' if validation_blocked else 'false'}"
+    )
+    if blocker_hint:
+        print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT={blocker_hint}")
+    print("BOUNDED_ADAPTER_OBSERVATION_CLOSEOUT_DECOUPLED=true")
+    if not invoked and not validation_blocked:
+        return
+    if validation_blocked:
+        print("BOUNDED_ADAPTER_DURABLE_CLOSEOUT_STATUS=blocked")
+        print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_SOURCE_DIR={source_dir.resolve()}")
+        if dest_dir is not None:
+            print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_DEST_DIR={dest_dir.resolve()}")
+        print("BOUNDED_ADAPTER_DURABLE_CLOSEOUT_HELPER_RC=not_run")
+        print("BOUNDED_ADAPTER_DURABLE_CLOSEOUT_NON_AUTHORIZING=true")
         return
     status = "pass" if rc == 0 else "failed"
     print(f"BOUNDED_ADAPTER_DURABLE_CLOSEOUT_STATUS={status}")
@@ -816,6 +871,34 @@ def maybe_invoke_durable_closeout_after_archive(
             print(handoff_msg, file=sys.stderr)
             return VALIDATION_EXIT
     dest_dir = Path(ctx.args.durable_closeout_dest_dir).expanduser().resolve()
+    force = bool(getattr(ctx.args, "durable_closeout_force", False))
+    ok, validation_msg, blocker_hint = validate_durable_closeout_invoke_paths(
+        archive_dest,
+        dest_dir,
+        force=force,
+    )
+    if not ok:
+        emit_bounded_adapter_durable_closeout_machine_lines(
+            invoked=False,
+            rc=0,
+            source_dir=archive_dest,
+            dest_dir=dest_dir,
+            validation_blocked=True,
+            blocker_hint=blocker_hint,
+        )
+        emit_bounded_adapter_local_post_closeout_chain_machine_lines(
+            requested=chain_requested,
+            passthrough=False,
+            chain_archive_root=chain_archive_root,
+            chain_run_id=chain_run_id,
+        )
+        emit_bounded_adapter_durable_pointer_machine_lines(
+            required=pointer_required,
+            pattern_count=pointer_pattern_count,
+            archive_pointer_handoff=archive_pointer_handoff,
+        )
+        print(validation_msg, file=sys.stderr)
+        return VALIDATION_EXIT
     rc = invoke_durable_closeout_after_archive(
         source_dir=archive_dest,
         dest_dir=dest_dir,
@@ -1221,6 +1304,14 @@ def add_bounded_adapter_durable_closeout_cli_args(parser: argparse.ArgumentParse
         type=Path,
         default=None,
         help="Durable material closeout destination (required with --invoke-durable-closeout-v0).",
+    )
+    parser.add_argument(
+        "--durable-closeout-force",
+        action="store_true",
+        help=(
+            "Pass --force to durable_closeout_copy_verify_v0.py when source and dest differ "
+            "and destination is pre-populated."
+        ),
     )
     parser.add_argument(
         "--run-local-post-closeout-chain-v0",

--- a/tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py
+++ b/tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py
@@ -52,6 +52,7 @@ def _durable_args(**overrides: object) -> argparse.Namespace:
     base = {
         "invoke_durable_closeout_v0": False,
         "durable_closeout_dest_dir": None,
+        "durable_closeout_force": False,
         "run_local_post_closeout_chain_v0": False,
         "chain_archive_root": None,
         "chain_run_id": "",
@@ -484,6 +485,7 @@ def test_paper_and_shadow_expose_cli_flags(paper, shadow):
     for flags in (paper_flags, shadow_flags):
         assert "--invoke-durable-closeout-v0" in flags
         assert "--durable-closeout-dest-dir" in flags
+        assert "--durable-closeout-force" in flags
         assert "--run-local-post-closeout-chain-v0" in flags
         assert "--chain-archive-root" in flags
         assert "--chain-run-id" in flags
@@ -511,3 +513,158 @@ def test_shadow_chain_validation_delegates_same_rules(shadow, tmp_path):
         )
     )
     assert any("requires --invoke-durable-closeout-v0" in issue for issue in issues)
+
+
+def test_validate_identical_source_dest_blocked(paper, tmp_path):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    (archive_source / "note.txt").write_text("x\n", encoding="utf-8")
+    ok, msg, blocker = paper.validate_durable_closeout_invoke_paths(
+        archive_source,
+        archive_source,
+    )
+    assert ok is False
+    assert "same path" in msg
+    assert blocker == "durable_closeout_identical_source_dest"
+
+
+def test_validate_realpath_equivalent_source_dest_blocked(paper, tmp_path):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    (archive_source / "note.txt").write_text("x\n", encoding="utf-8")
+    dest_alias = tmp_path / "dest_alias"
+    dest_alias.symlink_to(archive_source, target_is_directory=True)
+    ok, _msg, blocker = paper.validate_durable_closeout_invoke_paths(
+        archive_source,
+        dest_alias,
+    )
+    assert ok is False
+    assert blocker == "durable_closeout_identical_source_dest"
+
+
+def test_validate_prepopulated_dest_without_force_blocked(paper, tmp_path):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    (archive_source / "note.txt").write_text("x\n", encoding="utf-8")
+    durable_dest = _durable_dest(tmp_path, "prepopulated")
+    durable_dest.mkdir(parents=True, exist_ok=True)
+    (durable_dest / "prestart.env").write_text("PAPER_ONLY=true\n", encoding="utf-8")
+    ok, msg, blocker = paper.validate_durable_closeout_invoke_paths(
+        archive_source,
+        durable_dest,
+    )
+    assert ok is False
+    assert "non-empty" in msg
+    assert blocker == "durable_closeout_dest_non_empty_without_force"
+
+
+def test_maybe_invoke_identical_paths_blocks_without_helper_call(paper, tmp_path, capsys):
+    archive_dest = tmp_path / "archive_dest"
+    archive_dest.mkdir()
+    (archive_dest / "note.txt").write_text("x\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    args = _durable_args(
+        invoke_durable_closeout_v0=True,
+        durable_closeout_dest_dir=archive_dest,
+    )
+    ctx = paper.ExecuteContext(
+        args=args,
+        repo_root=REPO_ROOT,
+        staging_root=tmp_path / "staging",
+        archive_root=tmp_path / "archive",
+        runtime_out=tmp_path / "staging" / "runtime_out",
+        logs_dir=tmp_path / "staging" / "logs",
+        plan_dir=tmp_path / "staging" / "plan",
+        review_dir=tmp_path / "staging" / "review",
+        temp_jobs=tmp_path / "staging" / "plan" / "temp_jobs.toml",
+        run_id="paper_run",
+    )
+    rc = paper.maybe_invoke_durable_closeout_after_archive(
+        ctx,
+        archive_dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == paper.VALIDATION_EXIT
+    assert calls == []
+    out = capsys.readouterr()
+    assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_STATUS=blocked" in out.out
+    assert (
+        "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT=durable_closeout_identical_source_dest"
+        in out.out
+    )
+    assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_INVOKED=false" in out.out
+    assert "BOUNDED_ADAPTER_OBSERVATION_CLOSEOUT_DECOUPLED=true" in out.out
+
+
+def test_maybe_invoke_prepopulated_dest_without_force_blocks_with_hint(paper, tmp_path, capsys):
+    archive_dest = tmp_path / "archive_dest"
+    archive_dest.mkdir()
+    (archive_dest / "note.txt").write_text("x\n", encoding="utf-8")
+    durable_dest = _durable_dest(tmp_path, "prepopulated_invoke")
+    durable_dest.mkdir(parents=True, exist_ok=True)
+    (durable_dest / "prestart.env").write_text("PAPER_ONLY=true\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    args = _durable_args(
+        invoke_durable_closeout_v0=True,
+        durable_closeout_dest_dir=durable_dest,
+    )
+    ctx = paper.ExecuteContext(
+        args=args,
+        repo_root=REPO_ROOT,
+        staging_root=tmp_path / "staging",
+        archive_root=tmp_path / "archive",
+        runtime_out=tmp_path / "staging" / "runtime_out",
+        logs_dir=tmp_path / "staging" / "logs",
+        plan_dir=tmp_path / "staging" / "plan",
+        review_dir=tmp_path / "staging" / "review",
+        temp_jobs=tmp_path / "staging" / "plan" / "temp_jobs.toml",
+        run_id="paper_run",
+    )
+    rc = paper.maybe_invoke_durable_closeout_after_archive(
+        ctx,
+        archive_dest,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == paper.VALIDATION_EXIT
+    assert calls == []
+    out = capsys.readouterr()
+    assert (
+        "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT="
+        "durable_closeout_dest_non_empty_without_force" in out.out
+    )
+    assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_STATUS=blocked" in out.out
+
+
+def test_invoke_separate_snapshot_source_with_force_passes(paper, tmp_path):
+    archive_source = tmp_path / "archive_run"
+    archive_source.mkdir()
+    (archive_source / "AFTER_FIXTURE_CLOSEOUT.md").write_text("# closeout\n", encoding="utf-8")
+    (archive_source / "note.txt").write_text("x\n", encoding="utf-8")
+    durable_dest = _durable_dest(tmp_path, "force_snapshot")
+    durable_dest.mkdir(parents=True, exist_ok=True)
+    (durable_dest / "prestart.env").write_text("PAPER_ONLY=true\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = paper.invoke_durable_closeout_after_archive(
+        source_dir=archive_source,
+        dest_dir=durable_dest,
+        args=_durable_args(durable_closeout_force=True),
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    assert "--force" in calls[0]


### PR DESCRIPTION
## Summary

- **Problem:** PR #4127 protects the durable closeout helper against identical/equivalent source/dest, but the bounded observation adapter could still invoke closeout with pre-populated dest or equal paths and produce START_RC=1 / stale FAIL artifacts while observation remained PASS (Paper-L2 @ 130028Z).
- **Solution:** Adapter closeout path validation reusing PR #4127 helper guards (`_validate_source_dest_distinct`, `_dest_has_content`) before helper invoke; machine-readable `BLOCKER_HINT` + `STATUS=blocked`; optional `--durable-closeout-force` passthrough for distinct snapshot copy.

## Safety

- No run, no live, no trading logic changes
- No Master V2 / Double Play / Bull-Bear / Risk-KillSwitch / Execution-Order surface changes
- Scope limited to bounded observation adapter closeout validation + tests

## Test plan

- [x] `ruff format --check` on changed files (RC=0)
- [x] `ruff check` on changed files (RC=0)
- [x] `pytest tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py tests/ops/test_durable_closeout_copy_verify_v0.py` (62 passed, RC=0)
- [x] Protected-scope diff check PASS (adapter + tests only)

Made with [Cursor](https://cursor.com)