### PR TITLE
Sync preflight contract durable closeout adapter validation

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -495,6 +495,90 @@ PREFLIGHT_REMAINS_BLOCKED=true
 READY_FOR_OPERATOR_ARMING=false
 ```
 
+## 2b.3 Durable closeout adapter validation operator SSOT v0
+
+```
+PREFLIGHT_DURABLE_CLOSEOUT_ADAPTER_VALIDATION_SSOT_V0=true
+PREFLIGHT_DURABLE_CLOSEOUT_ADAPTER_VALIDATION_DOCS_TESTS_ONLY=true
+DURABLE_CLOSEOUT_IDENTICAL_SOURCE_DEST_REJECTED=true
+DURABLE_CLOSEOUT_ADAPTER_PRE_INVOKE_VALIDATION=true
+BOUNDED_ADAPTER_OBSERVATION_CLOSEOUT_DECOUPLED=true
+DURABLE_CLOSEOUT_FORCE_REQUIRES_DISTINCT_PATHS=true
+BLOCKER_HINT_MACHINE_READABLE=true
+AUTHORITATIVE_STATUS_HIERARCHY_V0=true
+HISTORICAL_PRE_RECOVERY_FAIL_NOT_CURRENT_STATUS=true
+PREFLIGHT_REMAINS_BLOCKED=true
+PRE_FLIGHT_BLOCKED_LIFTED=false
+READY_FOR_OPERATOR_ARMING=false
+CLOSEOUT_DOES_NOT_AUTHORIZE_RUNTIME=true
+```
+
+**Purpose:** Operator/SSOT sync after PR **#4127** (helper identical/equivalent source-dest guard) and PR **#4128** (bounded observation adapter closeout pre-invoke validation). This section documents runtime guard semantics already on `main`; it **does not** re-implement helpers, **does not** lift Preflight **BLOCKED**, and **does not** authorize Paper/Shadow/Testnet/Live/scheduler/daemon execution.
+
+### PR #4127 — helper source/dest guard (reuse; no parallel logic)
+
+[durable_closeout_copy_verify_v0.py](../../../scripts/ops/durable_closeout_copy_verify_v0.py) fail-closed rejects **identical or equivalent** `--source-dir` and `--dest-dir` paths (`_validate_source_dest_distinct`). Resolved paths that are the same directory are **rejected** regardless of narrative or observation PASS. Operators must use a **separate snapshot source directory** with a **distinct** durable destination, or satisfy helper `--force` **only when source and dest actually differ** (not as a bypass for identical paths).
+
+Static guard: [test_durable_closeout_copy_verify_v0.py](../../../tests/ops/test_durable_closeout_copy_verify_v0.py).
+
+### PR #4128 — bounded adapter closeout validation (decoupled from observation PASS)
+
+Paper and Shadow bounded observation adapters ([run_paper_only_bounded_observation_adapter_v0.py](../../../scripts/ops/run_paper_only_bounded_observation_adapter_v0.py), [run_shadow_bounded_observation_adapter_v0.py](../../../scripts/ops/run_shadow_bounded_observation_adapter_v0.py)) call `validate_durable_closeout_invoke_paths()` **before** invoking the helper when `--invoke-durable-closeout-v0` is set. The adapter **reuses** `_validate_source_dest_distinct` and `_dest_has_content` from the helper module — **no parallel guard logic**.
+
+When validation blocks closeout copy:
+
+- `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_VALIDATION_BLOCKED=true`
+- `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_STATUS=blocked`
+- `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_HELPER_RC=not_run`
+- `BOUNDED_ADAPTER_OBSERVATION_CLOSEOUT_DECOUPLED=true` — observation/review **PASS** does **not** imply closeout copy **PASS**; operators must treat closeout status separately.
+
+Static guard: [test_bounded_adapter_invoke_durable_closeout_v0.py](../../../tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py).
+
+### `--durable-closeout-force` (adapter) vs `--force` (helper)
+
+| Flag | Surface | Safe use |
+|------|---------|----------|
+| `--durable-closeout-force` | bounded adapter (`--invoke-durable-closeout-v0`) | Only when `--durable-closeout-dest-dir` is **non-empty** and source/dest are **distinct** paths (for example overwrite of an existing durable tree from a separate snapshot source). **Not** a bypass for identical/equivalent source==dest. |
+| `--force` | [durable_closeout_copy_verify_v0.py](../../../scripts/ops/durable_closeout_copy_verify_v0.py) | Same rule: distinct source/dest required; permits overwrite when destination already has content. |
+
+Unsafe pattern (blocked): same resolved path for archive source and durable closeout destination with or without force flags.
+
+### `BLOCKER_HINT` (machine-readable operator recovery)
+
+When closeout copy is blocked, adapters emit machine-readable hints for operator recovery:
+
+| Token | Meaning | Operator recovery |
+|-------|---------|-------------------|
+| `durable_closeout_identical_source_dest` | Source and dest resolve to the same path | Copy from a **separate snapshot source directory**; ensure dest is a **distinct** durable path outside `/tmp`. |
+| `durable_closeout_dest_non_empty_without_force` | Destination exists and is non-empty without `--durable-closeout-force` | Use a fresh dest, or `--durable-closeout-force` only with **distinct** source/dest (or separate snapshot source). |
+
+Machine line shapes (non-authorizing):
+
+- `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT=<token>`
+- `BLOCKER_HINT=<token>` in adapter `START_RETURN_CODE` artifact when execute returns blocked closeout
+
+Hints point to **snapshot-source recovery** or appropriate force scope; they **do not** authorize runtime, lift Preflight **BLOCKED**, or clear **HOLD**.
+
+### Authoritative status hierarchy (post-recovery vs historical pre-recovery FAIL)
+
+When durable run/closeout bundles contain **divergent** status fields — for example historical `RUN_CLOSEOUT.md` or `RESULT_SUMMARY.env` recording a **pre-recovery FAIL** (identical source/dest, missing force, or `/tmp`-only closeout) while later **snapshot-recovery** artifacts show **PASS**:
+
+**Authoritative current status** (when `MANIFEST_VERIFY_RC=0` on the recovery/analysis bundle):
+
+1. **`MACHINE_SUMMARY.env`** in the recovery or post-run analysis bundle
+2. **Recovery artifacts** (for example snapshot-source re-copy, durable closeout verify RC=0, analysis bundle verdict)
+3. **Post-run analysis bundle** with verified manifest
+
+**Subordinate / historical only:**
+
+- Pre-recovery `RUN_CLOSEOUT.md` / `RESULT_SUMMARY.env` FAIL lines — **traceability only**; must **not** be promoted as the current run FAIL when recovery PASS + analysis PASS + `MANIFEST_VERIFY_RC=0` are present.
+
+**Paper-L2 120min hold-binding context (observed):** bounded observation may **PASS** while closeout copy was **blocked** until snapshot-source recovery; `NEXT_TEST_NECESSITY=false` after analysis PASS does **not** imply Preflight lift.
+
+This hierarchy is **operator SSOT for status interpretation** only — **Evidence ≠ approval**; Preflight remains **BLOCKED** (`PREFLIGHT_REMAINS_BLOCKED=true`; `PRE_FLIGHT_BLOCKED_LIFTED=false`).
+
+Cross-reference: §2b.2 helper fail-closed rules; §2a.1 primary evidence hard gate; §2b.1 material closeout completeness.
+
 ## 2c. Preflight Gate Repo-Internal Write/Lift Applied Reflection v0
 
 PREFLIGHT_GATE_REPO_INTERNAL_WRITE_LIFT_V0=true

--- a/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
+++ b/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
@@ -219,3 +219,75 @@ def test_preflight_section_2b2_eer1_readiness_review_index_v0() -> None:
     section_lines = {line.strip() for line in section.splitlines()}
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true" not in section_lines
     assert "READY_FOR_OPERATOR_ARMING=true" not in section_lines
+
+
+def _section_2b3(text: str | None = None) -> str:
+    body = text if text is not None else _read_contract()
+    return body.split("## 2b.3 Durable closeout adapter validation operator SSOT v0", 1)[1].split(
+        "## 2c. Preflight Gate Repo-Internal Write/Lift Applied Reflection v0", 1
+    )[0]
+
+
+def test_preflight_section_2b3_durable_closeout_adapter_validation_ssot_v0() -> None:
+    text = _read_contract()
+    assert "## 2b.3 Durable closeout adapter validation operator SSOT v0" in text
+    section = _section_2b3(text)
+    for token in (
+        "PREFLIGHT_DURABLE_CLOSEOUT_ADAPTER_VALIDATION_SSOT_V0=true",
+        "PREFLIGHT_DURABLE_CLOSEOUT_ADAPTER_VALIDATION_DOCS_TESTS_ONLY=true",
+        "DURABLE_CLOSEOUT_IDENTICAL_SOURCE_DEST_REJECTED=true",
+        "DURABLE_CLOSEOUT_ADAPTER_PRE_INVOKE_VALIDATION=true",
+        "BOUNDED_ADAPTER_OBSERVATION_CLOSEOUT_DECOUPLED=true",
+        "DURABLE_CLOSEOUT_FORCE_REQUIRES_DISTINCT_PATHS=true",
+        "BLOCKER_HINT_MACHINE_READABLE=true",
+        "AUTHORITATIVE_STATUS_HIERARCHY_V0=true",
+        "HISTORICAL_PRE_RECOVERY_FAIL_NOT_CURRENT_STATUS=true",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "PRE_FLIGHT_BLOCKED_LIFTED=false",
+    ):
+        assert token in section
+    assert "#4127" in section
+    assert "#4128" in section
+    assert "durable_closeout_copy_verify_v0.py" in section
+    assert "run_paper_only_bounded_observation_adapter_v0.py" in section
+    assert "validate_durable_closeout_invoke_paths" in section
+    assert "test_durable_closeout_copy_verify_v0.py" in section
+    assert "test_bounded_adapter_invoke_durable_closeout_v0.py" in section
+
+
+def test_preflight_section_2b3_durable_closeout_force_and_blocker_hints_v0() -> None:
+    section = _section_2b3()
+    assert "--durable-closeout-force" in section
+    assert "BLOCKER_HINT" in section
+    assert "durable_closeout_identical_source_dest" in section
+    assert "durable_closeout_dest_non_empty_without_force" in section
+    assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT" in section
+    assert "snapshot source" in section.lower() or "snapshot-source" in section.lower()
+
+
+def test_preflight_section_2b3_authoritative_hierarchy_and_non_authorizing_v0() -> None:
+    text = _read_contract()
+    section = _section_2b3(text)
+    assert "MACHINE_SUMMARY.env" in section
+    assert "MANIFEST_VERIFY_RC=0" in section
+    assert "RUN_CLOSEOUT.md" in section
+    assert "RESULT_SUMMARY.env" in section
+    assert "historical" in section.lower() or "pre-recovery" in section.lower()
+    assert "does **not** lift Preflight **BLOCKED**" in section or (
+        "Preflight remains **BLOCKED**" in section
+    )
+    collapsed = section.replace("**", "")
+    assert "Evidence ≠ approval" in collapsed or "Evidence != approval" in collapsed
+    assert text.index("## 2b.2 Closeout Enforcement Planning Contract v0") < text.index(
+        "## 2b.3 Durable closeout adapter validation operator SSOT v0"
+    )
+
+
+def test_preflight_section_2b3_adjacent_section_ordering_v0() -> None:
+    text = _read_contract()
+    assert text.index("## 2b.2 Closeout Enforcement Planning Contract v0") < text.index(
+        "## 2b.3 Durable closeout adapter validation operator SSOT v0"
+    )
+    assert text.index("## 2b.3 Durable closeout adapter validation operator SSOT v0") < text.index(
+        "## 2c. Preflight Gate Repo-Internal Write/Lift Applied Reflection v0"
+    )


### PR DESCRIPTION
## Summary
- PR #4127 and #4128 merged durable closeout helper guards and bounded adapter closeout pre-invoke validation; Preflight contract was stale on operator SSOT tokens.
- Adds Preflight §2b.3 documenting `--durable-closeout-force`, `BLOCKER_HINT`, observation/closeout decoupling, PR #4127/#4128 guard semantics, and authoritative status hierarchy after snapshot recovery.
- Extends static contract tests in `tests/ops/test_paper_shadow_247_preflight_contract_v0.py`.

## Safety
- docs/tests-only; no run, no live, no trading logic
- no Master V2 / Double Play / Bull/Bear / Risk/KillSwitch / Execution/Order changes
- Preflight remains BLOCKED; no Preflight lift

## Checks
- `ruff format --check` on changed test file: RC=0
- `ruff check` on changed test file: RC=0
- `pytest tests/ops/test_paper_shadow_247_preflight_contract_v0.py tests/ops/test_mandatory_durable_closeout_contract_v0.py tests/ops/test_closeout_enforcement_planning_contract_v0.py`: 51 passed


Made with [Cursor](https://cursor.com)