### PR TITLE
Add scheduler/supervisor durable closeout pre-invoke validation parity

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -502,6 +502,9 @@ PREFLIGHT_DURABLE_CLOSEOUT_ADAPTER_VALIDATION_SSOT_V0=true
 PREFLIGHT_DURABLE_CLOSEOUT_ADAPTER_VALIDATION_DOCS_TESTS_ONLY=true
 DURABLE_CLOSEOUT_IDENTICAL_SOURCE_DEST_REJECTED=true
 DURABLE_CLOSEOUT_ADAPTER_PRE_INVOKE_VALIDATION=true
+SCHEDULER_SUPERVISOR_DURABLE_CLOSEOUT_PRE_INVOKE_VALIDATION=true
+VALIDATE_DURABLE_CLOSEOUT_PATHS_REUSED=true
+HELPER_PARALLEL_LOGIC_CREATED=false
 BOUNDED_ADAPTER_OBSERVATION_CLOSEOUT_DECOUPLED=true
 DURABLE_CLOSEOUT_FORCE_REQUIRES_DISTINCT_PATHS=true
 BLOCKER_HINT_MACHINE_READABLE=true
@@ -523,7 +526,7 @@ Static guard: [test_durable_closeout_copy_verify_v0.py](../../../tests/ops/test_
 
 ### PR #4128 — bounded adapter closeout validation (decoupled from observation PASS)
 
-Paper and Shadow bounded observation adapters ([run_paper_only_bounded_observation_adapter_v0.py](../../../scripts/ops/run_paper_only_bounded_observation_adapter_v0.py), [run_shadow_bounded_observation_adapter_v0.py](../../../scripts/ops/run_shadow_bounded_observation_adapter_v0.py)) call `validate_durable_closeout_invoke_paths()` **before** invoking the helper when `--invoke-durable-closeout-v0` is set. The adapter **reuses** `_validate_source_dest_distinct` and `_dest_has_content` from the helper module — **no parallel guard logic**.
+Paper, Shadow, and Testnet bounded observation adapters ([run_paper_only_bounded_observation_adapter_v0.py](../../../scripts/ops/run_paper_only_bounded_observation_adapter_v0.py), [run_shadow_bounded_observation_adapter_v0.py](../../../scripts/ops/run_shadow_bounded_observation_adapter_v0.py), [run_testnet_bounded_observation_adapter_v0.py](../../../scripts/ops/run_testnet_bounded_observation_adapter_v0.py)) call `validate_durable_closeout_invoke_paths()` **before** invoking the helper when `--invoke-durable-closeout-v0` is set. The adapter **reuses** `_validate_source_dest_distinct` and `_dest_has_content` from the helper module — **no parallel guard logic**.
 
 When validation blocks closeout copy:
 
@@ -533,6 +536,20 @@ When validation blocks closeout copy:
 - `BOUNDED_ADAPTER_OBSERVATION_CLOSEOUT_DECOUPLED=true` — observation/review **PASS** does **not** imply closeout copy **PASS**; operators must treat closeout status separately.
 
 Static guard: [test_bounded_adapter_invoke_durable_closeout_v0.py](../../../tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py).
+
+### Scheduler and supervisor attach-hook closeout pre-invoke validation (taxonomy §6a.0.8.1)
+
+Scheduler completion ([run_scheduler.py](../../../scripts/run_scheduler.py) with `--invoke-durable-closeout-after-completion-v0`) and supervisor evidence pack ([pack_online_readiness_supervisor_evidence_v0.py](../../../scripts/ops/pack_online_readiness_supervisor_evidence_v0.py) with `--invoke-durable-closeout-after-pack-v0`) call the same shared `validate_durable_closeout_invoke_paths()` **before** invoking [durable_closeout_copy_verify_v0.py](../../../scripts/ops/durable_closeout_copy_verify_v0.py) — **reuse only**; **no parallel guard logic** (`SCHEDULER_SUPERVISOR_DURABLE_CLOSEOUT_PRE_INVOKE_VALIDATION=true`; `VALIDATE_DURABLE_CLOSEOUT_PATHS_REUSED=true`; `HELPER_PARALLEL_LOGIC_CREATED=false`).
+
+When validation blocks closeout copy:
+
+- `SCHEDULER_DURABLE_CLOSEOUT_VALIDATION_BLOCKED=true` or `SUPERVISOR_PACK_DURABLE_CLOSEOUT_VALIDATION_BLOCKED=true`
+- `SCHEDULER_DURABLE_CLOSEOUT_STATUS=blocked` or `SUPERVISOR_PACK_DURABLE_CLOSEOUT_STATUS=blocked`
+- `SCHEDULER_DURABLE_CLOSEOUT_HELPER_RC=not_run` or `SUPERVISOR_PACK_DURABLE_CLOSEOUT_HELPER_RC=not_run`
+
+Static guards: [test_scheduler_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py); [test_supervisor_pack_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py).
+
+**Force-scope note:** bounded adapters expose `--durable-closeout-force`; scheduler and supervisor attach hooks do **not** expose a separate force flag in this slice — non-empty dest without force remains blocked (same as bounded adapters without force).
 
 ### `--durable-closeout-force` (adapter) vs `--force` (helper)
 
@@ -555,6 +572,8 @@ When closeout copy is blocked, adapters emit machine-readable hints for operator
 Machine line shapes (non-authorizing):
 
 - `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT=<token>`
+- `SCHEDULER_DURABLE_CLOSEOUT_BLOCKER_HINT=<token>`
+- `SUPERVISOR_PACK_DURABLE_CLOSEOUT_BLOCKER_HINT=<token>`
 - `BLOCKER_HINT=<token>` in adapter `START_RETURN_CODE` artifact when execute returns blocked closeout
 
 Hints point to **snapshot-source recovery** or appropriate force scope; they **do not** authorize runtime, lift Preflight **BLOCKED**, or clear **HOLD**.

--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -1264,6 +1264,9 @@ NO_MARKET_GLOBAL_ENABLEMENT_IN_PRECHECK=true
 POST_CLOSEOUT_AUTOMATION_HOOK_OWNER_PRECHECK_DOCS_TESTS_ONLY=true
 TAXONOMY_PREFLIGHT_2B3_CLOSEOUT_VALIDATION_CROSSLINK_V0=true
 DURABLE_CLOSEOUT_ADAPTER_PRE_INVOKE_VALIDATION=true
+SCHEDULER_SUPERVISOR_DURABLE_CLOSEOUT_PRE_INVOKE_VALIDATION=true
+VALIDATE_DURABLE_CLOSEOUT_PATHS_REUSED=true
+HELPER_PARALLEL_LOGIC_CREATED=false
 BOUNDED_ADAPTER_OBSERVATION_CLOSEOUT_DECOUPLED=true
 DURABLE_CLOSEOUT_IDENTICAL_SOURCE_DEST_REJECTED=true
 DURABLE_CLOSEOUT_FORCE_REQUIRES_DISTINCT_PATHS=true
@@ -1286,13 +1289,16 @@ PREFLIGHT_REMAINS_BLOCKED=true
 | `scheduler_completion` | [run_scheduler.py](../../../scripts/run_scheduler.py) | `--invoke-durable-closeout-after-completion-v0` (+ `--durable-closeout-dest-dir`, `--evidence-dir`) | `finalize_scheduler_completion_evidence()` return path — **after** scheduler loop exit, **not** before job dispatch | Run completion; durable evidence root when `--primary-evidence-enforce`; `finalize_primary_evidence_root()` success; `scheduler_completion_closeout_v0.json`; `MANIFEST.sha256` verify RC=0 |
 | `paper_bounded_adapter` | [run_paper_only_bounded_observation_adapter_v0.py](../../../scripts/ops/run_paper_only_bounded_observation_adapter_v0.py) | `--invoke-durable-closeout-v0` (+ `--durable-closeout-dest-dir`) | Archive/closeout artifact finalization — **after** review and durable retention | Adapter execute complete; durable archive outside `/tmp`; manifest verify RC=0; bounded review when applicable |
 | `shadow_bounded_adapter` | [run_shadow_bounded_observation_adapter_v0.py](../../../scripts/ops/run_shadow_bounded_observation_adapter_v0.py) | `--invoke-durable-closeout-v0` (shared bounded-adapter CLI wiring) | Archive/closeout artifact finalization — **after** review and durable retention | Adapter execute complete; durable archive outside `/tmp`; manifest verify RC=0; bounded review when applicable |
+| `testnet_bounded_adapter` | [run_testnet_bounded_observation_adapter_v0.py](../../../scripts/ops/run_testnet_bounded_observation_adapter_v0.py) | `--invoke-durable-closeout-v0` (shared bounded-adapter CLI wiring; PR **#4131**) | Archive/closeout artifact finalization — **after** review and durable retention | Adapter execute complete; durable archive outside `/tmp`; manifest verify RC=0; bounded review when applicable |
 | `supervisor_evidence_pack` | [pack_online_readiness_supervisor_evidence_v0.py](../../../scripts/ops/pack_online_readiness_supervisor_evidence_v0.py) | `--invoke-durable-closeout-after-pack-v0` (+ `--durable-closeout-dest-dir`) | Pack finalization — **after** supervisor STOP and copy into durable archive root | Operator-invoked pack complete; `supervisor_session_closeout_v0.json`; optional `finalize_primary_evidence_root()` when `--primary-evidence-enforce`; manifest verify RC=0 |
 
 `DURABLE_CLOSEOUT_ATTACH_HOOK_V0_IMPLEMENTED=true` — narrow attach hooks ship on `main` and call **only** [durable_closeout_copy_verify_v0.py](../../../scripts/ops/durable_closeout_copy_verify_v0.py). `DURABLE_CLOSEOUT_ATTACH_HOOK_V0_DEFAULT_OFF=true` — hooks require explicit operator flags. `DURABLE_CLOSEOUT_ATTACH_HOOK_V0_NON_AUTHORIZING=true` — hook invocation does **not** complete §2b.1 by itself, lift gates, or authorize runtime.
 
-**Adapter closeout validation (Preflight §2b.3; PR #4128 on `main`):**
+**Attach-hook closeout pre-invoke validation (Preflight §2b.3; bounded adapters PR #4128/#4131; scheduler/supervisor parity on `main`):**
 
-Paper and Shadow bounded adapter attach hooks (`paper_bounded_adapter`, `shadow_bounded_adapter`) must satisfy closeout pre-invoke validation before helper invoke when `--invoke-durable-closeout-v0` is set. Adapters call `validate_durable_closeout_invoke_paths()` and **reuse** helper `_validate_source_dest_distinct` and `_dest_has_content` — **no parallel guard logic** (`DURABLE_CLOSEOUT_ADAPTER_PRE_INVOKE_VALIDATION=true`). PR **#4127** fail-closed helper guard rejects identical/equivalent `--source-dir` and `--dest-dir` (`DURABLE_CLOSEOUT_IDENTICAL_SOURCE_DEST_REJECTED=true`).
+Paper, Shadow, and Testnet bounded adapter attach hooks call `validate_durable_closeout_invoke_paths()` and **reuse** helper `_validate_source_dest_distinct` and `_dest_has_content` — **no parallel guard logic** (`DURABLE_CLOSEOUT_ADAPTER_PRE_INVOKE_VALIDATION=true`). PR **#4127** fail-closed helper guard rejects identical/equivalent `--source-dir` and `--dest-dir` (`DURABLE_CLOSEOUT_IDENTICAL_SOURCE_DEST_REJECTED=true`).
+
+Scheduler completion (`scheduler_completion`) and supervisor evidence pack (`supervisor_evidence_pack`) attach hooks call the same shared `validate_durable_closeout_invoke_paths()` before helper invoke (`SCHEDULER_SUPERVISOR_DURABLE_CLOSEOUT_PRE_INVOKE_VALIDATION=true`; `VALIDATE_DURABLE_CLOSEOUT_PATHS_REUSED=true`; `HELPER_PARALLEL_LOGIC_CREATED=false`). Machine line prefixes: `SCHEDULER_DURABLE_CLOSEOUT_*`, `SUPERVISOR_PACK_DURABLE_CLOSEOUT_*`.
 
 When validation blocks closeout copy:
 
@@ -1309,7 +1315,7 @@ When validation blocks closeout copy:
 | `durable_closeout_identical_source_dest` | Copy from a **separate snapshot source directory**; ensure dest is a **distinct** durable path outside `/tmp`. |
 | `durable_closeout_dest_non_empty_without_force` | Use a fresh dest, or `--durable-closeout-force` only with **distinct** source/dest. |
 
-Machine line shapes (non-authorizing): `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT=<token>`; `BLOCKER_HINT=<token>` in adapter `START_RETURN_CODE` artifact when execute returns blocked closeout. Hints **do not** lift Preflight **BLOCKED**, authorize runtime, Live, orders, or arming.
+Machine line shapes (non-authorizing): `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT=<token>`; `SCHEDULER_DURABLE_CLOSEOUT_BLOCKER_HINT=<token>`; `SUPERVISOR_PACK_DURABLE_CLOSEOUT_BLOCKER_HINT=<token>`; `BLOCKER_HINT=<token>` in adapter `START_RETURN_CODE` artifact when execute returns blocked closeout. Hints **do not** lift Preflight **BLOCKED**, authorize runtime, Live, orders, or arming.
 
 **Authoritative status hierarchy (post-recovery vs historical pre-recovery FAIL):** `AUTHORITATIVE_STATUS_HIERARCHY_V0=true`; `HISTORICAL_PRE_RECOVERY_FAIL_NOT_CURRENT_STATUS=true`. When durable bundles contain divergent status — for example historical `RUN_CLOSEOUT.md` or `RESULT_SUMMARY.env` recording a **pre-recovery FAIL** while later snapshot-recovery artifacts show **PASS** — **authoritative current status** (when `MANIFEST_VERIFY_RC=0` on the recovery/analysis bundle) is:
 
@@ -1319,7 +1325,7 @@ Machine line shapes (non-authorizing): `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER
 
 Pre-recovery `RUN_CLOSEOUT.md` / `RESULT_SUMMARY.env` FAIL lines are **traceability only** and must **not** override current PASS when recovery PASS + analysis PASS + `MANIFEST_VERIFY_RC=0` are present. **Evidence ≠ approval**; Preflight remains **BLOCKED** (`PREFLIGHT_REMAINS_BLOCKED=true`; `PREFLIGHT_BLOCKED_LIFTED=false`; no-live / no-order / no-arming).
 
-Static guards: [test_durable_closeout_copy_verify_v0.py](../../../tests/ops/test_durable_closeout_copy_verify_v0.py); [test_bounded_adapter_invoke_durable_closeout_v0.py](../../../tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py); [test_paper_shadow_247_preflight_contract_v0.py](../../../tests/ops/test_paper_shadow_247_preflight_contract_v0.py) §2b.3.
+Static guards: [test_durable_closeout_copy_verify_v0.py](../../../tests/ops/test_durable_closeout_copy_verify_v0.py); [test_bounded_adapter_invoke_durable_closeout_v0.py](../../../tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py); [test_scheduler_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py); [test_supervisor_pack_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py); [test_paper_shadow_247_preflight_contract_v0.py](../../../tests/ops/test_paper_shadow_247_preflight_contract_v0.py) §2b.3.
 
 **Forbidden attach points (always):**
 

--- a/scripts/ops/pack_online_readiness_supervisor_evidence_v0.py
+++ b/scripts/ops/pack_online_readiness_supervisor_evidence_v0.py
@@ -78,14 +78,30 @@ def emit_supervisor_pack_durable_closeout_machine_lines(
     invoked: bool,
     exit_code: int,
     dest_dir: Optional[Path],
+    source_dir: Optional[Path] = None,
+    validation_blocked: bool = False,
+    blocker_hint: str = "",
 ) -> None:
     print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_REQUESTED={'true' if requested else 'false'}")
     print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_INVOKED={'true' if invoked else 'false'}")
+    print(
+        "SUPERVISOR_PACK_DURABLE_CLOSEOUT_VALIDATION_BLOCKED="
+        f"{'true' if validation_blocked else 'false'}"
+    )
+    if blocker_hint:
+        print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_BLOCKER_HINT={blocker_hint}")
+        print(f"BLOCKER_HINT={blocker_hint}")
     print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_EXIT_CODE={exit_code}")
     if dest_dir is not None:
         print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_DEST_DIR={dest_dir.resolve()}")
     else:
         print("SUPERVISOR_PACK_DURABLE_CLOSEOUT_DEST_DIR=")
+    if validation_blocked:
+        print("SUPERVISOR_PACK_DURABLE_CLOSEOUT_STATUS=blocked")
+        if source_dir is not None:
+            print(f"SUPERVISOR_PACK_DURABLE_CLOSEOUT_SOURCE_DIR={source_dir.resolve()}")
+        print("SUPERVISOR_PACK_DURABLE_CLOSEOUT_HELPER_RC=not_run")
+        print("SUPERVISOR_PACK_DURABLE_CLOSEOUT_NON_AUTHORIZING=true")
 
 
 def invoke_supervisor_pack_durable_closeout_after_pack(
@@ -93,13 +109,23 @@ def invoke_supervisor_pack_durable_closeout_after_pack(
     source_dir: Path,
     dest_dir: Path,
     durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
+    force: bool = False,
 ) -> int:
     """Invoke canonical durable closeout helper after supervisor evidence pack."""
     from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
         _default_durable_closeout_invoker,
         build_durable_closeout_invoke_argv,
+        validate_durable_closeout_invoke_paths,
     )
 
+    ok, msg, _blocker = validate_durable_closeout_invoke_paths(
+        source_dir,
+        dest_dir,
+        force=force,
+    )
+    if not ok:
+        print(msg, file=sys.stderr)
+        return 1
     invoker = durable_closeout_invoker or _default_durable_closeout_invoker
     return invoker(build_durable_closeout_invoke_argv(source_dir=source_dir, dest_dir=dest_dir))
 
@@ -135,6 +161,27 @@ def maybe_invoke_supervisor_pack_durable_closeout_after_pack(
         )
         return 1
     assert dest_dir is not None
+    from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
+        validate_durable_closeout_invoke_paths,
+    )
+
+    ok, validation_msg, blocker_hint = validate_durable_closeout_invoke_paths(
+        archive_root,
+        dest_dir,
+        force=False,
+    )
+    if not ok:
+        emit_supervisor_pack_durable_closeout_machine_lines(
+            requested=True,
+            invoked=False,
+            exit_code=1,
+            dest_dir=dest_dir,
+            source_dir=archive_root,
+            validation_blocked=True,
+            blocker_hint=blocker_hint,
+        )
+        print(validation_msg, file=sys.stderr)
+        return 1
     hook_rc = invoke_supervisor_pack_durable_closeout_after_pack(
         source_dir=archive_root,
         dest_dir=dest_dir,
@@ -145,6 +192,7 @@ def maybe_invoke_supervisor_pack_durable_closeout_after_pack(
         invoked=True,
         exit_code=hook_rc,
         dest_dir=dest_dir,
+        source_dir=archive_root,
     )
     return hook_rc
 

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -140,14 +140,29 @@ def emit_scheduler_durable_closeout_machine_lines(
     invoked: bool,
     exit_code: int,
     dest_dir: Optional[Path],
+    source_dir: Optional[Path] = None,
+    validation_blocked: bool = False,
+    blocker_hint: str = "",
 ) -> None:
     print(f"SCHEDULER_DURABLE_CLOSEOUT_REQUESTED={'true' if requested else 'false'}")
     print(f"SCHEDULER_DURABLE_CLOSEOUT_INVOKED={'true' if invoked else 'false'}")
+    print(
+        f"SCHEDULER_DURABLE_CLOSEOUT_VALIDATION_BLOCKED={'true' if validation_blocked else 'false'}"
+    )
+    if blocker_hint:
+        print(f"SCHEDULER_DURABLE_CLOSEOUT_BLOCKER_HINT={blocker_hint}")
+        print(f"BLOCKER_HINT={blocker_hint}")
     print(f"SCHEDULER_DURABLE_CLOSEOUT_EXIT_CODE={exit_code}")
     if dest_dir is not None:
         print(f"SCHEDULER_DURABLE_CLOSEOUT_DEST_DIR={dest_dir.resolve()}")
     else:
         print("SCHEDULER_DURABLE_CLOSEOUT_DEST_DIR=")
+    if validation_blocked:
+        print("SCHEDULER_DURABLE_CLOSEOUT_STATUS=blocked")
+        if source_dir is not None:
+            print(f"SCHEDULER_DURABLE_CLOSEOUT_SOURCE_DIR={source_dir.resolve()}")
+        print("SCHEDULER_DURABLE_CLOSEOUT_HELPER_RC=not_run")
+        print("SCHEDULER_DURABLE_CLOSEOUT_NON_AUTHORIZING=true")
 
 
 def invoke_scheduler_durable_closeout_after_completion(
@@ -155,13 +170,23 @@ def invoke_scheduler_durable_closeout_after_completion(
     source_dir: Path,
     dest_dir: Path,
     durable_closeout_invoker: Optional[Callable[[list[str]], int]] = None,
+    force: bool = False,
 ) -> int:
     """Invoke canonical durable closeout helper after scheduler completion evidence."""
     from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
         _default_durable_closeout_invoker,
         build_durable_closeout_invoke_argv,
+        validate_durable_closeout_invoke_paths,
     )
 
+    ok, msg, _blocker = validate_durable_closeout_invoke_paths(
+        source_dir,
+        dest_dir,
+        force=force,
+    )
+    if not ok:
+        print(msg, file=sys.stderr)
+        return 1
     invoker = durable_closeout_invoker or _default_durable_closeout_invoker
     return invoker(build_durable_closeout_invoke_argv(source_dir=source_dir, dest_dir=dest_dir))
 
@@ -197,6 +222,27 @@ def maybe_invoke_scheduler_durable_closeout_after_completion(
         )
         return 1
     assert dest_dir is not None
+    from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
+        validate_durable_closeout_invoke_paths,
+    )
+
+    ok, validation_msg, blocker_hint = validate_durable_closeout_invoke_paths(
+        evidence_dir,
+        dest_dir,
+        force=False,
+    )
+    if not ok:
+        emit_scheduler_durable_closeout_machine_lines(
+            requested=True,
+            invoked=False,
+            exit_code=1,
+            dest_dir=dest_dir,
+            source_dir=evidence_dir,
+            validation_blocked=True,
+            blocker_hint=blocker_hint,
+        )
+        print(validation_msg, file=sys.stderr)
+        return 1
     hook_rc = invoke_scheduler_durable_closeout_after_completion(
         source_dir=evidence_dir,
         dest_dir=dest_dir,
@@ -207,6 +253,7 @@ def maybe_invoke_scheduler_durable_closeout_after_completion(
         invoked=True,
         exit_code=hook_rc,
         dest_dir=dest_dir,
+        source_dir=evidence_dir,
     )
     return hook_rc
 

--- a/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
+++ b/tests/ops/test_paper_shadow_247_preflight_contract_v0.py
@@ -250,9 +250,14 @@ def test_preflight_section_2b3_durable_closeout_adapter_validation_ssot_v0() -> 
     assert "#4128" in section
     assert "durable_closeout_copy_verify_v0.py" in section
     assert "run_paper_only_bounded_observation_adapter_v0.py" in section
+    assert "run_scheduler.py" in section
+    assert "pack_online_readiness_supervisor_evidence_v0.py" in section
     assert "validate_durable_closeout_invoke_paths" in section
+    assert "SCHEDULER_SUPERVISOR_DURABLE_CLOSEOUT_PRE_INVOKE_VALIDATION=true" in section
     assert "test_durable_closeout_copy_verify_v0.py" in section
     assert "test_bounded_adapter_invoke_durable_closeout_v0.py" in section
+    assert "test_scheduler_durable_closeout_hook_pass_through_v0.py" in section
+    assert "test_supervisor_pack_durable_closeout_hook_pass_through_v0.py" in section
 
 
 def test_preflight_section_2b3_durable_closeout_force_and_blocker_hints_v0() -> None:
@@ -262,6 +267,8 @@ def test_preflight_section_2b3_durable_closeout_force_and_blocker_hints_v0() -> 
     assert "durable_closeout_identical_source_dest" in section
     assert "durable_closeout_dest_non_empty_without_force" in section
     assert "BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER_HINT" in section
+    assert "SCHEDULER_DURABLE_CLOSEOUT_BLOCKER_HINT" in section
+    assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_BLOCKER_HINT" in section
     assert "snapshot source" in section.lower() or "snapshot-source" in section.lower()
 
 

--- a/tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py
+++ b/tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py
@@ -152,9 +152,14 @@ def test_taxonomy_section_6a08_1_preflight_2b3_closeout_validation_crosslink_v0(
     assert "#4128" in section
     assert "#4127" in section
     assert "validate_durable_closeout_invoke_paths" in section
+    assert "SCHEDULER_SUPERVISOR_DURABLE_CLOSEOUT_PRE_INVOKE_VALIDATION=true" in section
+    assert "run_scheduler.py" in section
+    assert "pack_online_readiness_supervisor_evidence_v0.py" in section
     assert "--durable-closeout-force" in section
     assert "BLOCKER_HINT" in section
     assert "durable_closeout_identical_source_dest" in section
+    assert "test_scheduler_durable_closeout_hook_pass_through_v0.py" in section
+    assert "test_supervisor_pack_durable_closeout_hook_pass_through_v0.py" in section
     assert "AUTHORITATIVE_STATUS_HIERARCHY_V0=true" in section
     assert "MACHINE_SUMMARY.env" in section
     assert "MANIFEST_VERIFY_RC=0" in section

--- a/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
+++ b/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
@@ -309,6 +309,11 @@ def test_spec_section_6a08_1_preflight_2b3_closeout_validation_crosslink_v0() ->
     assert "AUTHORITATIVE_STATUS_HIERARCHY_V0=true" in section
     assert "MACHINE_SUMMARY.env" in section
     assert "PREFLIGHT_REMAINS_BLOCKED=true" in section
+    assert "SCHEDULER_SUPERVISOR_DURABLE_CLOSEOUT_PRE_INVOKE_VALIDATION=true" in section
+    assert "run_scheduler.py" in section
+    assert "pack_online_readiness_supervisor_evidence_v0.py" in section
+    assert "test_scheduler_durable_closeout_hook_pass_through_v0.py" in section
+    assert "test_supervisor_pack_durable_closeout_hook_pass_through_v0.py" in section
 
 
 def test_preflight_crosslinks_taxonomy_spec() -> None:

--- a/tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py
+++ b/tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py
@@ -264,3 +264,86 @@ def test_maybe_invoke_emits_machine_lines(rs, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "SCHEDULER_DURABLE_CLOSEOUT_REQUESTED=false" in out
     assert "SCHEDULER_DURABLE_CLOSEOUT_INVOKED=false" in out
+
+
+def test_maybe_invoke_identical_paths_blocks_without_helper_call(rs, tmp_path, capsys):
+    source = tmp_path / "evidence"
+    source.mkdir()
+    (source / "scheduler_completion_closeout_v0.json").write_text("{}\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = rs.maybe_invoke_scheduler_durable_closeout_after_completion(
+        evidence_dir=source,
+        invoke_durable_closeout_after_completion_v0=True,
+        durable_closeout_dest_dir=source,
+        completion_evidence_finalized=True,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 1
+    assert calls == []
+    out = capsys.readouterr()
+    assert "SCHEDULER_DURABLE_CLOSEOUT_STATUS=blocked" in out.out
+    assert (
+        "SCHEDULER_DURABLE_CLOSEOUT_BLOCKER_HINT=durable_closeout_identical_source_dest" in out.out
+    )
+    assert "SCHEDULER_DURABLE_CLOSEOUT_INVOKED=false" in out.out
+    assert "SCHEDULER_DURABLE_CLOSEOUT_HELPER_RC=not_run" in out.out
+
+
+def test_maybe_invoke_prepopulated_dest_without_force_blocks_with_hint(rs, tmp_path, capsys):
+    source = tmp_path / "evidence"
+    source.mkdir()
+    (source / "scheduler_completion_closeout_v0.json").write_text("{}\n", encoding="utf-8")
+    dest = _durable_dest(tmp_path, "prepopulated")
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "prestart.env").write_text("SCHEDULER_ONLY=true\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = rs.maybe_invoke_scheduler_durable_closeout_after_completion(
+        evidence_dir=source,
+        invoke_durable_closeout_after_completion_v0=True,
+        durable_closeout_dest_dir=dest,
+        completion_evidence_finalized=True,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 1
+    assert calls == []
+    out = capsys.readouterr()
+    assert (
+        "SCHEDULER_DURABLE_CLOSEOUT_BLOCKER_HINT="
+        "durable_closeout_dest_non_empty_without_force" in out.out
+    )
+    assert "SCHEDULER_DURABLE_CLOSEOUT_STATUS=blocked" in out.out
+
+
+def test_invoke_identical_paths_blocks_without_helper_call(rs, tmp_path, capsys):
+    source = tmp_path / "evidence"
+    source.mkdir()
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = rs.invoke_scheduler_durable_closeout_after_completion(
+        source_dir=source,
+        dest_dir=source,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 1
+    assert calls == []
+    err = capsys.readouterr().err.lower()
+    assert "identical" in err or "same" in err
+
+
+def test_source_uses_validate_durable_closeout_invoke_paths(rs):
+    text = RUN_SCHEDULER.read_text(encoding="utf-8")
+    assert "validate_durable_closeout_invoke_paths" in text

--- a/tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py
+++ b/tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py
@@ -308,6 +308,88 @@ def test_maybe_invoke_emits_machine_lines(pm, tmp_path: Path, capsys):
     assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_INVOKED=false" in out
 
 
+def test_maybe_invoke_identical_paths_blocks_without_helper_call(pm, tmp_path, capsys):
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    (archive / CLOSEOUT_FILENAME).write_text("{}\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = pm.maybe_invoke_supervisor_pack_durable_closeout_after_pack(
+        archive_root=archive,
+        invoke_durable_closeout_after_pack_v0=True,
+        durable_closeout_dest_dir=archive,
+        pack_evidence_finalized=True,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 1
+    assert calls == []
+    out = capsys.readouterr()
+    assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_STATUS=blocked" in out.out
+    assert (
+        "SUPERVISOR_PACK_DURABLE_CLOSEOUT_BLOCKER_HINT=durable_closeout_identical_source_dest"
+        in out.out
+    )
+    assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_INVOKED=false" in out.out
+    assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_HELPER_RC=not_run" in out.out
+
+
+def test_maybe_invoke_prepopulated_dest_without_force_blocks_with_hint(pm, tmp_path, capsys):
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    (archive / CLOSEOUT_FILENAME).write_text("{}\n", encoding="utf-8")
+    dest = _durable_dest(tmp_path, "prepopulated")
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "prestart.env").write_text("SUPERVISOR_ONLY=true\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = pm.maybe_invoke_supervisor_pack_durable_closeout_after_pack(
+        archive_root=archive,
+        invoke_durable_closeout_after_pack_v0=True,
+        durable_closeout_dest_dir=dest,
+        pack_evidence_finalized=True,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 1
+    assert calls == []
+    out = capsys.readouterr()
+    assert (
+        "SUPERVISOR_PACK_DURABLE_CLOSEOUT_BLOCKER_HINT="
+        "durable_closeout_dest_non_empty_without_force" in out.out
+    )
+    assert "SUPERVISOR_PACK_DURABLE_CLOSEOUT_STATUS=blocked" in out.out
+
+
+def test_invoke_identical_paths_blocks_without_helper_call(pm, tmp_path):
+    source = tmp_path / "archive"
+    source.mkdir()
+    calls: list[list[str]] = []
+
+    def _recording_invoker(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    rc = pm.invoke_supervisor_pack_durable_closeout_after_pack(
+        source_dir=source,
+        dest_dir=source,
+        durable_closeout_invoker=_recording_invoker,
+    )
+    assert rc == 1
+    assert calls == []
+
+
+def test_source_uses_validate_durable_closeout_invoke_paths(pm):
+    text = PACK_SCRIPT.read_text(encoding="utf-8")
+    assert "validate_durable_closeout_invoke_paths" in text
+
+
 def test_pack_script_no_direct_chain_owners(pm):
     text = PACK_SCRIPT.read_text(encoding="utf-8")
     assert "build_generic_evidence_run_registry_v1" not in text


### PR DESCRIPTION
## Summary

- Extend durable closeout **pre-invoke validation parity** to scheduler completion and supervisor evidence pack attach hooks (taxonomy §6a.0.8.1).
- Reuse shared `validate_durable_closeout_invoke_paths()` from bounded adapter module — **no parallel helper logic**.
- Fail closed on identical/equivalent source/dest and non-empty dest without force; emit `SCHEDULER_DURABLE_CLOSEOUT_*` / `SUPERVISOR_PACK_DURABLE_CLOSEOUT_*` machine lines with `BLOCKER_HINT`.
- Sync Preflight §2b.3 and Runtime Lane Taxonomy §6a.0.8.1 docs/tests.

## Context

Ranking bundle: `planning/systemwide_next_safe_scope_ranking_after_testnet_bounded_adapter_durable_closeout_parity_merge_no_run_v1_20260611T173116Z`

Tri-Lane bounded adapter closeout chain (#4127–#4131) is complete. Scheduler and supervisor hooks previously invoked `durable_closeout_copy_verify_v0.py` without pre-invoke path validation.

## Changed files

- `scripts/run_scheduler.py`
- `scripts/ops/pack_online_readiness_supervisor_evidence_v0.py`
- `docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md` §2b.3
- `docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md` §6a.0.8.1
- `tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py`
- `tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py`
- `tests/ops/test_paper_shadow_247_preflight_contract_v0.py`
- `tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py`
- `tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py`

## Flags

```
SCHEDULER_SUPERVISOR_PRE_INVOKE_PARITY_IMPLEMENTED=true
VALIDATE_DURABLE_CLOSEOUT_PATHS_REUSED=true
HELPER_PARALLEL_LOGIC_CREATED=false
IDENTICAL_SOURCE_DEST_FAIL_CLOSED=true
EQUIVALENT_SOURCE_DEST_FAIL_CLOSED=true
NO_RUN_STARTED=true
PROTECTED_SCOPE_CHECK_PASS=true
PREFLIGHT_REMAINS_BLOCKED=true
```

## Test plan

- [x] `ruff format --check` (affected files) RC=0
- [x] `ruff check` (affected files) RC=0
- [x] pytest subset: durable closeout, bounded adapter invoke, scheduler/supervisor hook pass-through, preflight §2b.3, taxonomy §6a.0.8.1 (180 passed)

## Boundaries

- **No** runtime start (scheduler/supervisor/paper/shadow/testnet/live)
- **No** Preflight lift, orders, arming, execution
- **No** trading logic / Master V2 / Risk-KillSwitch changes
- **No** parallel SSOT / new helper module

Made with [Cursor](https://cursor.com)