### PR TITLE
guard: validate-paths cross-surface parity matrix for durable closeout attach hooks

### DIFF
--- a/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
+++ b/docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md
@@ -549,6 +549,8 @@ When validation blocks closeout copy:
 
 Static guards: [test_scheduler_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py); [test_supervisor_pack_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py).
 
+Cross-surface validate-paths parity matrix static guard: [test_post_closeout_hook_attach_readiness_bridge_v0.py](../../../tests/ops/test_post_closeout_hook_attach_readiness_bridge_v0.py) (`VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_GUARD_V0=true`; all five §6a.0.8.1 attach surfaces including Testnet; Shadow/Testnet Paper import delegation; Scheduler/Supervisor invoke-time import; `NEW_PARALLEL_VALIDATION_LOGIC_CREATED=false`).
+
 **Force-scope note:** bounded adapters expose `--durable-closeout-force`; scheduler and supervisor attach hooks do **not** expose a separate force flag in this slice — non-empty dest without force remains blocked (same as bounded adapters without force).
 
 ### `--durable-closeout-force` (adapter) vs `--force` (helper)

--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -1300,6 +1300,8 @@ Paper, Shadow, and Testnet bounded adapter attach hooks call `validate_durable_c
 
 Scheduler completion (`scheduler_completion`) and supervisor evidence pack (`supervisor_evidence_pack`) attach hooks call the same shared `validate_durable_closeout_invoke_paths()` before helper invoke (`SCHEDULER_SUPERVISOR_DURABLE_CLOSEOUT_PRE_INVOKE_VALIDATION=true`; `VALIDATE_DURABLE_CLOSEOUT_PATHS_REUSED=true`; `HELPER_PARALLEL_LOGIC_CREATED=false`). Machine line prefixes: `SCHEDULER_DURABLE_CLOSEOUT_*`, `SUPERVISOR_PACK_DURABLE_CLOSEOUT_*`.
 
+**Cross-surface validate-paths parity matrix (static guards only):** `VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_GUARD_V0=true`; `ALL_FIVE_ATTACH_HOOK_SURFACES_VALIDATE_PATHS_MATRIX_COVERED=true`; `TESTNET_VALIDATE_PATHS_SURFACE_INCLUDED=true`; Shadow/Testnet delegate to Paper `validate_durable_closeout_invoke_paths()` import chain (`SHADOW_VALIDATE_PATHS_IMPORT_CHAIN_GUARDED=true`); Scheduler/Supervisor import the same function at invoke (`SCHEDULER_VALIDATE_PATHS_SURFACE_GUARDED=true`; `SUPERVISOR_VALIDATE_PATHS_SURFACE_GUARDED=true`); `NEW_PARALLEL_VALIDATION_LOGIC_CREATED=false`. Static matrix: [test_post_closeout_hook_attach_readiness_bridge_v0.py](../../../tests/ops/test_post_closeout_hook_attach_readiness_bridge_v0.py); [test_post_closeout_automation_hook_owner_precheck_v0.py](../../../tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py).
+
 When validation blocks closeout copy:
 
 - `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_VALIDATION_BLOCKED=true`
@@ -1325,7 +1327,7 @@ Machine line shapes (non-authorizing): `BOUNDED_ADAPTER_DURABLE_CLOSEOUT_BLOCKER
 
 Pre-recovery `RUN_CLOSEOUT.md` / `RESULT_SUMMARY.env` FAIL lines are **traceability only** and must **not** override current PASS when recovery PASS + analysis PASS + `MANIFEST_VERIFY_RC=0` are present. **Evidence ≠ approval**; Preflight remains **BLOCKED** (`PREFLIGHT_REMAINS_BLOCKED=true`; `PREFLIGHT_BLOCKED_LIFTED=false`; no-live / no-order / no-arming).
 
-Static guards: [test_durable_closeout_copy_verify_v0.py](../../../tests/ops/test_durable_closeout_copy_verify_v0.py); [test_bounded_adapter_invoke_durable_closeout_v0.py](../../../tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py); [test_scheduler_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py); [test_supervisor_pack_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py); [test_paper_shadow_247_preflight_contract_v0.py](../../../tests/ops/test_paper_shadow_247_preflight_contract_v0.py) §2b.3.
+Static guards: [test_durable_closeout_copy_verify_v0.py](../../../tests/ops/test_durable_closeout_copy_verify_v0.py); [test_bounded_adapter_invoke_durable_closeout_v0.py](../../../tests/ops/test_bounded_adapter_invoke_durable_closeout_v0.py); [test_scheduler_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_scheduler_durable_closeout_hook_pass_through_v0.py); [test_supervisor_pack_durable_closeout_hook_pass_through_v0.py](../../../tests/ops/test_supervisor_pack_durable_closeout_hook_pass_through_v0.py); [test_post_closeout_hook_attach_readiness_bridge_v0.py](../../../tests/ops/test_post_closeout_hook_attach_readiness_bridge_v0.py) (validate-paths cross-surface parity matrix); [test_paper_shadow_247_preflight_contract_v0.py](../../../tests/ops/test_paper_shadow_247_preflight_contract_v0.py) §2b.3.
 
 **Forbidden attach points (always):**
 

--- a/tests/fixtures/ops/generic_evidence_run_registry_v1/projection_consumer_v0.py
+++ b/tests/fixtures/ops/generic_evidence_run_registry_v1/projection_consumer_v0.py
@@ -29,6 +29,79 @@ CANONICAL_DURABLE_CLOSEOUT_ATTACH_HOOK_OWNERS_V0: dict[str, str] = {
     "supervisor_evidence_pack": "scripts/ops/pack_online_readiness_supervisor_evidence_v0.py",
 }
 
+VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_GUARD_MARKERS: tuple[str, ...] = (
+    "VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_GUARD_V0=true",
+    "ALL_FIVE_ATTACH_HOOK_SURFACES_VALIDATE_PATHS_MATRIX_COVERED=true",
+    "TESTNET_VALIDATE_PATHS_SURFACE_INCLUDED=true",
+    "SHADOW_VALIDATE_PATHS_IMPORT_CHAIN_GUARDED=true",
+    "SCHEDULER_VALIDATE_PATHS_SURFACE_GUARDED=true",
+    "SUPERVISOR_VALIDATE_PATHS_SURFACE_GUARDED=true",
+    "NEW_PARALLEL_VALIDATION_LOGIC_CREATED=false",
+)
+
+VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_V0: dict[str, dict[str, tuple[str, ...] | str]] = {
+    "paper_bounded_adapter": {
+        "rel_path": "scripts/ops/run_paper_only_bounded_observation_adapter_v0.py",
+        "binding_mode": "canonical_definer",
+        "required_in_source": (
+            "def validate_durable_closeout_invoke_paths(",
+            "_validate_source_dest_distinct",
+            "maybe_invoke_durable_closeout_after_archive",
+        ),
+        "forbidden_in_source": (),
+    },
+    "shadow_bounded_adapter": {
+        "rel_path": "scripts/ops/run_shadow_bounded_observation_adapter_v0.py",
+        "binding_mode": "paper_import_delegation",
+        "required_in_source": (
+            "from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import",
+            "maybe_invoke_durable_closeout_after_archive",
+            "validate_durable_closeout_invoke_cli_args",
+        ),
+        "forbidden_in_source": (
+            "def validate_durable_closeout_invoke_paths(",
+            "def _validate_source_dest_distinct(",
+        ),
+    },
+    "testnet_bounded_adapter": {
+        "rel_path": "scripts/ops/run_testnet_bounded_observation_adapter_v0.py",
+        "binding_mode": "paper_import_delegation",
+        "required_in_source": (
+            "from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import",
+            "maybe_invoke_durable_closeout_after_archive",
+            "validate_durable_closeout_invoke_cli_args",
+        ),
+        "forbidden_in_source": (
+            "def validate_durable_closeout_invoke_paths(",
+            "def _validate_source_dest_distinct(",
+        ),
+    },
+    "scheduler_completion": {
+        "rel_path": "scripts/run_scheduler.py",
+        "binding_mode": "paper_import_at_invoke",
+        "required_in_source": (
+            "validate_durable_closeout_invoke_paths",
+            "invoke_scheduler_durable_closeout_after_completion",
+        ),
+        "forbidden_in_source": (
+            "def validate_durable_closeout_invoke_paths(",
+            "def _validate_source_dest_distinct(",
+        ),
+    },
+    "supervisor_evidence_pack": {
+        "rel_path": "scripts/ops/pack_online_readiness_supervisor_evidence_v0.py",
+        "binding_mode": "paper_import_at_invoke",
+        "required_in_source": (
+            "validate_durable_closeout_invoke_paths",
+            "invoke_supervisor_pack_durable_closeout_after_pack",
+        ),
+        "forbidden_in_source": (
+            "def validate_durable_closeout_invoke_paths(",
+            "def _validate_source_dest_distinct(",
+        ),
+    },
+}
+
 POST_CLOSEOUT_AUTOMATION_HOOK_OWNER_PRECHECK_MARKERS: tuple[str, ...] = (
     "POST_CLOSEOUT_AUTOMATION_HOOK_OWNER_PRECHECK_V0=true",
     "HOOK_AUTOMATION_OWNER_STATUS=identified",
@@ -60,6 +133,8 @@ POST_CLOSEOUT_AUTOMATION_HOOK_OWNER_PRECHECK_MARKERS: tuple[str, ...] = (
     "AUTHORITATIVE_STATUS_HIERARCHY_V0=true",
     "HISTORICAL_PRE_RECOVERY_FAIL_NOT_CURRENT_STATUS=true",
     "PREFLIGHT_REMAINS_BLOCKED=true",
+    "VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_GUARD_V0=true",
+    "NEW_PARALLEL_VALIDATION_LOGIC_CREATED=false",
 )
 
 POST_CLOSEOUT_PROJECTION_AUTOMATION_CHARTER_MARKERS: tuple[str, ...] = (

--- a/tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py
+++ b/tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py
@@ -185,3 +185,19 @@ def test_preflight_section_2b3_crosslinks_taxonomy_6a08_1_v0() -> None:
     section = _section_2b3()
     assert "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md" in section
     assert "§6a.0.8.1" in section
+
+
+def test_validate_paths_cross_surface_parity_matrix_taxonomy_markers_v0() -> None:
+    section = _section_6a08_1()
+    for marker in pc.VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_GUARD_MARKERS:
+        assert marker in section
+    assert "test_post_closeout_hook_attach_readiness_bridge_v0.py" in section
+    assert "testnet_bounded_adapter" in section
+
+
+def test_validate_paths_cross_surface_parity_matrix_owner_alignment_v0() -> None:
+    owners = pc.CANONICAL_DURABLE_CLOSEOUT_ATTACH_HOOK_OWNERS_V0
+    matrix = pc.VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_V0
+    assert set(matrix) == set(owners)
+    for owner_id, rel_path in owners.items():
+        assert str(matrix[owner_id]["rel_path"]) == rel_path

--- a/tests/ops/test_post_closeout_hook_attach_readiness_bridge_v0.py
+++ b/tests/ops/test_post_closeout_hook_attach_readiness_bridge_v0.py
@@ -116,3 +116,27 @@ def test_bridge_section_has_no_gate_lift_markers() -> None:
         assert marker not in section
     assert "READY_FOR_START_AFTER_SLICE=false" in section
     assert "PREFLIGHT_BLOCKED_LIFTED=false" in section
+
+
+def test_validate_paths_cross_surface_parity_matrix_guard_v0() -> None:
+    owners = pc.CANONICAL_DURABLE_CLOSEOUT_ATTACH_HOOK_OWNERS_V0
+    matrix = pc.VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_V0
+    assert len(matrix) == 5
+    assert set(matrix) == set(owners)
+    assert "testnet_bounded_adapter" in matrix
+    for owner_id, spec in matrix.items():
+        rel_path = str(spec["rel_path"])
+        assert owners[owner_id] == rel_path
+        source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        for token in spec.get("required_in_source", ()):
+            assert token in source, f"{owner_id}: missing {token!r} in {rel_path}"
+        for forbidden in spec.get("forbidden_in_source", ()):
+            assert forbidden not in source, (
+                f"{owner_id}: parallel validation logic {forbidden!r} in {rel_path}"
+            )
+    shadow_spec = matrix["shadow_bounded_adapter"]
+    testnet_spec = matrix["testnet_bounded_adapter"]
+    assert shadow_spec["binding_mode"] == "paper_import_delegation"
+    assert testnet_spec["binding_mode"] == "paper_import_delegation"
+    assert matrix["scheduler_completion"]["binding_mode"] == "paper_import_at_invoke"
+    assert matrix["supervisor_evidence_pack"]["binding_mode"] == "paper_import_at_invoke"

--- a/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
+++ b/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
@@ -314,6 +314,9 @@ def test_spec_section_6a08_1_preflight_2b3_closeout_validation_crosslink_v0() ->
     assert "pack_online_readiness_supervisor_evidence_v0.py" in section
     assert "test_scheduler_durable_closeout_hook_pass_through_v0.py" in section
     assert "test_supervisor_pack_durable_closeout_hook_pass_through_v0.py" in section
+    assert "VALIDATE_PATHS_CROSS_SURFACE_PARITY_MATRIX_GUARD_V0=true" in section
+    assert "test_post_closeout_hook_attach_readiness_bridge_v0.py" in section
+    assert "NEW_PARALLEL_VALIDATION_LOGIC_CREATED=false" in section
     for owner_id in (
         "scheduler_completion",
         "paper_bounded_adapter",


### PR DESCRIPTION
## Summary

- Close static guard gap after PR #4133: unified **validate-paths cross-surface parity matrix** for all five §6a.0.8.1 durable-closeout attach-hook surfaces (Paper, Shadow, Testnet, Scheduler, Supervisor).
- Reuse-before-new: matrix fixture in existing `projection_consumer_v0.py`; bridge and hook-owner-precheck tests extended to assert per-surface `validate_durable_closeout_invoke_paths()` binding, Paper import delegation for Shadow/Testnet, invoke-time import for Scheduler/Supervisor, and no parallel local validation logic.
- Taxonomy §6a.0.8.1 + Preflight §2b.3 crosslink sync for parity matrix machine markers and static guard references.

## Test plan

- [x] `ruff format --check` on 4 affected Python files (RC=0)
- [x] `ruff check` on 4 affected Python files (RC=0)
- [x] `pytest` hook-owner-precheck + attach-readiness-bridge + taxonomy §6a.0.8.1 + bounded adapter durable closeout (64 passed)
- [x] No runs, no network, no runtime logic touched

Made with [Cursor](https://cursor.com)