### PR TITLE
GH-CI schedule manual-only implemented-posture docs drift guard

### DIFF
--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -3126,7 +3126,7 @@ PARALLEL_OPERATOR_STATUS_INDEX_CREATED=false
 | **SLICE-GH-0** | Docs-only governance start | **none** | **complete** (#3910) |
 | **SLICE-GH-001** | Single-workflow manual-only: `.github&#47;workflows&#47;pro-prk-nightly-selfcheck.yml` (`schedule:` removed; `workflow_dispatch` retained) | **one file** | **complete** (#3911) |
 | **SLICE-GH-2** (optional) | Static test guard after GH-001 if needed | none | **deferred** (GH-001 yaml-shape guard merged #3911) |
-| **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` (`schedule:` removed; `workflow_dispatch`, `pull_request`, `push`, `merge_group` retained) | **one file** | **pending PR** (GH-CI slice) |
+| **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` (`schedule:` removed; `workflow_dispatch`, `pull_request`, `push`, `merge_group` retained) | **one file** | **complete** (#3958) |
 
 **Residual schedules on `main` (post GH-001..004 + GH-CI + PRCC + PRK/PRBD Option2 + PRBJ Option B):** **5** workflows retain active `schedule:` — `prbc-stability-gate.yml`, `prbd-live-readiness-scorecard.yml`, `prbe-shadow-testnet-scorecard.yml`, `prbg-execution-evidence.yml`, `prbi-live-pilot-scorecard.yml`. **8** are **manual-only** (no active `schedule:`; other triggers retained): `ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`, `prbj-testnet-exec-events.yml`. Recommender inventory set remains **13** files (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **5** have active schedules. **No batch YAML wave.** **No schedule reactivation** for PR #3896 manual-only set.
 
@@ -3160,10 +3160,15 @@ GH001_SCHEDULE_REMOVED=true
 SLICE_GH_001_SEPARATE_SUB_GO=true
 BATCH_SCHEDULE_CHANGES=false
 SCHEDULE_REACTIVATION=false
-RESIDUAL_ACTIVE_SCHEDULE_COUNT=6
-RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=7
+RESIDUAL_ACTIVE_SCHEDULE_COUNT=5
+RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=8
 RESIDUAL_SCHEDULE_INVENTORY_COUNT=13
 GH001_CANDIDATE_WORKFLOW=pro-prk-nightly-selfcheck.yml
+SLICE_GH_CI_COMPLETE=true
+GH_CI_MERGED_PR3958=true
+GH_CI_SCHEDULE_REMOVED=true
+CI_YML_SCHEDULE_FREE_CONFIRMED=true
+GH_CI_SCHEDULE_MANUAL_ONLY_DOCS_DRIFT_GUARD_IMPLEMENTED=true
 GH_CI_SCHEDULE_MANUAL_ONLY=true
 GH_CI_CANDIDATE_WORKFLOW=ci.yml
 WORKFLOW_DISPATCH_EXECUTED=false

--- a/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
+++ b/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
@@ -148,7 +148,7 @@ AI-adjacent workflows (`infostream-automation`, `market_outlook_automation`) may
 |-------|-------|--------|
 | **SLICE-GH-0** | Docs-only governance start | **complete** (#3910) |
 | **SLICE-GH-001** | Single-workflow manual-only: `.github&#47;workflows&#47;pro-prk-nightly-selfcheck.yml` | **complete** (#3911) |
-| **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` | **pending PR** (GH-CI slice) |
+| **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` (`schedule:` removed; `workflow_dispatch`, `pull_request`, `push`, `merge_group` retained) | **complete** (#3958) |
 
 **Post GH-001..004 + GH-CI + PRCC + PRK/PRBD + PRBJ Option B schedule posture:** **8** residual inventory workflows are manual-only (`ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`, `prbj-testnet-exec-events.yml`); **`workflow_dispatch`** and other non-schedule triggers retained per workflow. Among `RESIDUAL_SCHEDULE_WORKFLOW_FILES`, **5** retain active `schedule:`. **No batch YAML wave.**
 
@@ -165,7 +165,7 @@ AI-adjacent workflows (`infostream-automation`, `market_outlook_automation`) may
 | Owner | Path |
 |-------|------|
 | Read-only CLI | `scripts/ops/recommend_manual_only_workflows.py` |
-| Static tests | `tests/ops/test_recommend_manual_only_workflows.py` (GH-001 manual-only contract merged #3911) |
+| Static tests | `tests/ops/test_recommend_manual_only_workflows.py` (GH-001 #3911; GH-CI #3958 implemented-posture docs drift guard) |
 
 **Planning bundle (archive — not repo-ingested):** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/gh_schedule_governance_minimal_rc_v0_final_closeout_handoff_20260602T204000Z/`
 
@@ -175,10 +175,16 @@ GH_SCHEDULE_GOVERNANCE_MINIMAL_RC_V0_CORE_DONE=true
 SLICE_GH0_DOCS_ONLY=true
 SLICE_GH001_COMPLETE=true
 GH001_MANUAL_ONLY=true
-RESIDUAL_ACTIVE_SCHEDULE_COUNT=6
-RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=7
+SLICE_GH_CI_COMPLETE=true
+GH_CI_MERGED_PR3958=true
+GH_CI_SCHEDULE_REMOVED=true
+CI_YML_SCHEDULE_FREE_CONFIRMED=true
+GH_CI_SCHEDULE_MANUAL_ONLY_DOCS_DRIFT_GUARD_IMPLEMENTED=true
+RESIDUAL_ACTIVE_SCHEDULE_COUNT=5
+RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=8
 RESIDUAL_SCHEDULE_INVENTORY_COUNT=13
 GH001_CANDIDATE_WORKFLOW=pro-prk-nightly-selfcheck.yml
+GH_CI_CANDIDATE_WORKFLOW=ci.yml
 WORKFLOW_DISPATCH_EXECUTED=false
 BATCH_SCHEDULE_CHANGES=false
 SCHEDULE_REACTIVATION=false

--- a/tests/ops/test_recommend_manual_only_workflows.py
+++ b/tests/ops/test_recommend_manual_only_workflows.py
@@ -20,6 +20,15 @@ SCRIPT = REPO_ROOT / "scripts" / "ops" / "recommend_manual_only_workflows.py"
 DOC = REPO_ROOT / "docs" / "ops" / "CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md"
 CI_AUDIT = REPO_ROOT / "docs" / "ops" / "CI_AUDIT_KNOWN_ISSUES.md"
 OPDS1_HEADING = "## Post-Release Operator Package Decision Contract v0"
+GH_SCHEDULE_GOVERNANCE_HEADING = "## GH Schedule Governance Minimal RC v0"
+GH_CI_DRIFT_GUARD_PACKAGE_MARKER = "GH_CI_SCHEDULE_MANUAL_ONLY_DOCS_DRIFT_GUARD_IMPLEMENTED=true"
+GH_CI_SLICE_ROW_TOKEN = "SLICE-GH-CI"
+GH_CI_MERGE_PR_REF = "#3958"
+FORBIDDEN_GH_CI_PENDING_PHRASE = "pending PR"
+CANONICAL_RESIDUAL_ACTIVE_COUNT_LINE = "RESIDUAL_ACTIVE_SCHEDULE_COUNT=5"
+CANONICAL_MANUAL_ONLY_COUNT_LINE = "RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=8"
+STALE_RESIDUAL_ACTIVE_COUNT_LINE = "RESIDUAL_ACTIVE_SCHEDULE_COUNT=6"
+STALE_MANUAL_ONLY_COUNT_LINE = "RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=7"
 
 EXPECTED_INTENTS = frozenset(
     {
@@ -225,6 +234,20 @@ def test_residual_all_json_covers_thirteen_without_duplicates() -> None:
     assert manual_only_count == RESIDUAL_MANUAL_ONLY_COUNT
 
 
+def _gh_ci_slice_table_rows(text: str) -> list[str]:
+    return [line for line in text.splitlines() if GH_CI_SLICE_ROW_TOKEN in line]
+
+
+def _gh_schedule_governance_machine_block(text: str) -> str:
+    start = text.find(GH_SCHEDULE_GOVERNANCE_HEADING)
+    assert start != -1
+    fence = text.find("```text", start)
+    assert fence != -1
+    end = text.find("```", fence + 7)
+    assert end != -1
+    return text[fence:end]
+
+
 def test_ci_manual_only_yaml_shape() -> None:
     """GH-CI: cron removed; dispatch and PR/push/merge_group retained."""
     text = CI_WORKFLOW.read_text(encoding="utf-8")
@@ -233,6 +256,34 @@ def test_ci_manual_only_yaml_shape() -> None:
     assert "pull_request:" in text
     assert "push:" in text
     assert "merge_group:" in text
+
+
+def test_gh_ci_docs_drift_guard_package_marker_v0() -> None:
+    assert GH_CI_DRIFT_GUARD_PACKAGE_MARKER in Path(__file__).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("doc_path", [DOC, CI_AUDIT])
+def test_gh_ci_slice_not_pending_pr_in_docs_drift_guard_v0(doc_path: Path) -> None:
+    """Docs must record SLICE-GH-CI complete (#3958), not pending PR."""
+    text = doc_path.read_text(encoding="utf-8")
+    rows = _gh_ci_slice_table_rows(text)
+    assert rows, f"missing {GH_CI_SLICE_ROW_TOKEN} table row in {doc_path.name}"
+    for row in rows:
+        assert FORBIDDEN_GH_CI_PENDING_PHRASE not in row, row
+        assert "complete" in row.lower(), row
+        assert GH_CI_MERGE_PR_REF in row, row
+
+
+@pytest.mark.parametrize("doc_path", [DOC, CI_AUDIT])
+def test_gh_ci_docs_residual_schedule_counts_drift_guard_v0(doc_path: Path) -> None:
+    """Docs machine block must match canonical 5 active / 8 manual-only counts."""
+    text = doc_path.read_text(encoding="utf-8")
+    block = _gh_schedule_governance_machine_block(text)
+    assert CANONICAL_RESIDUAL_ACTIVE_COUNT_LINE in block
+    assert CANONICAL_MANUAL_ONLY_COUNT_LINE in block
+    assert STALE_RESIDUAL_ACTIVE_COUNT_LINE not in block
+    assert STALE_MANUAL_ONLY_COUNT_LINE not in block
+    assert GH_CI_DRIFT_GUARD_PACKAGE_MARKER in block
 
 
 def test_pro_prk_nightly_selfcheck_manual_only_yaml_shape() -> None:
@@ -412,7 +463,7 @@ def test_github_workflows_active_schedule_allowlist_drift_guard_v0() -> None:
 
 
 def test_residual_active_schedule_allowlist_each_has_schedule_v0() -> None:
-    """Each of the 6 residual cron workflows must still expose schedule in on block."""
+    """Each of the 5 residual cron workflows must still expose schedule in on block."""
     pytest.importorskip("yaml")
     for fname in sorted(RESIDUAL_ACTIVE_SCHEDULE_ALLOWLIST):
         rec = _parse_workflow_file(fname)


### PR DESCRIPTION
## Summary

- Align GH Schedule Governance SSOT with implemented `ci.yml` manual-only posture (PR #3958): SLICE-GH-CI **complete**, not pending PR.
- Fix residual schedule count markers from stale 6/7 to canonical 5/8 (matches recommender tests).
- Add static docs drift guards in `test_recommend_manual_only_workflows.py` to fail closed on regression.

## Scope boundaries

- **Docs/tests only** — no `.github/workflows` YAML changes, no workflow dispatch, no runtime touch.
- Reuses existing CI audit + variable gates + recommender test owners only.

## Test plan

- [x] `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- [x] `ruff format --check` + `ruff check` on `tests/ops/test_recommend_manual_only_workflows.py`
- [x] `pytest tests/ops/test_recommend_manual_only_workflows.py` (37 passed)

## Machine markers

```
GH_CI_SCHEDULE_MANUAL_ONLY_DOCS_DRIFT_GUARD_IMPLEMENTED=true
CI_YML_SCHEDULE_FREE_CONFIRMED=true
SLICE_GH_CI_PENDING_PR_DOCS_DRIFT_FIXED=true
GH_CI_STATUS_COUNT_FIXED_5_OF_8=true
WORKFLOW_YAML_TOUCHED=false
WORKFLOW_RUN_TRIGGERED=false
```

Made with [Cursor](https://cursor.com)