### PR TITLE
Add PRB scheduled scorecard implemented-posture docs drift guard

### DIFF
--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -3114,7 +3114,7 @@ PARALLEL_OPERATOR_STATUS_INDEX_CREATED=false
 | Scheduled workflow variable gates + residual schedule boundaries | `docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md` — **§ GH Schedule Governance Minimal RC v0** |
 | Read-only manual-only / residual schedule recommender | `scripts/ops/recommend_manual_only_workflows.py` (reference only; **no** script change in SLICE-GH-0) |
 | Manual-only recommender tests | `tests/ops/test_recommend_manual_only_workflows.py` (GH-001 manual-only contract merged #3911) |
-| Residual PRB scheduled YAML contract tests | `tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py` |
+| Residual PRB scheduled YAML contract + implemented-posture docs drift guard tests | `tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py` |
 | Ops Cockpit / OE / CV / ER / OC prior releases | this document — § Operator Experience …, § Cybersecurity Visibility …, § Ops Cockpit …; ER SSOT in `PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md` |
 
 **Release scope (complete):** **2 PRs** merged — minimal explicit sub-go-gated workflow governance without batch YAML, without new status hubs, and without lifting STOP_IDLE / preflight / retention enforcement.
@@ -3128,7 +3128,19 @@ PARALLEL_OPERATOR_STATUS_INDEX_CREATED=false
 | **SLICE-GH-2** (optional) | Static test guard after GH-001 if needed | none | **deferred** (GH-001 yaml-shape guard merged #3911) |
 | **SLICE-GH-CI** | Single-workflow manual-only: `.github&#47;workflows&#47;ci.yml` (`schedule:` removed; `workflow_dispatch`, `pull_request`, `push`, `merge_group` retained) | **one file** | **complete** (#3958) |
 
-**Residual schedules on `main` (post GH-001..004 + GH-CI + PRCC + PRK/PRBD Option2 + PRBJ Option B):** **5** workflows retain active `schedule:` — `prbc-stability-gate.yml`, `prbd-live-readiness-scorecard.yml`, `prbe-shadow-testnet-scorecard.yml`, `prbg-execution-evidence.yml`, `prbi-live-pilot-scorecard.yml`. **8** are **manual-only** (no active `schedule:`; other triggers retained): `ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`, `prbj-testnet-exec-events.yml`. Recommender inventory set remains **13** files (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **5** have active schedules. **No batch YAML wave.** **No schedule reactivation** for PR #3896 manual-only set.
+**Residual schedules on `main` (post GH-001..004 + GH-CI + PRCC + PRK/PRBD Option2 + PRBJ Option B):** **5** workflows retain active `schedule:` on the PRB scorecard chain (implemented posture — **not** manual-only); **8** are **manual-only** (GH-CI side; no active `schedule:`; other triggers retained). Recommender inventory set remains **13** files (`RESIDUAL_SCHEDULE_WORKFLOW_FILES`); **5** active schedules + **8** manual-only. **No batch YAML wave.** **No schedule reactivation** for PR #3896 manual-only set.
+
+**PRB scheduled scorecard implemented posture (5 active schedules — cron table must match `PRB_SCHEDULED_WORKFLOWS` in contract test):**
+
+| Workflow file | Cron (UTC) | Scorecard script |
+|---------------|------------|------------------|
+| `prbc-stability-gate.yml` | `57 2 * * *` | `scripts/ci/stability_gate.py` |
+| `prbd-live-readiness-scorecard.yml` | `7 3 * * *` | `scripts/ci/live_readiness_scorecard.py` |
+| `prbe-shadow-testnet-scorecard.yml` | `29 2 * * *` | `scripts/ci/shadow_testnet_readiness_scorecard.py` |
+| `prbg-execution-evidence.yml` | `19 2 * * *` | `scripts/ci/execution_evidence_producer.py` |
+| `prbi-live-pilot-scorecard.yml` | `39 2 * * *` | `scripts/ci/live_pilot_scorecard.py` |
+
+**Manual-only inventory (8 — GH-CI side; distinct from PRB scheduled chain above):** `ci.yml`, `pro-prk-nightly-selfcheck.yml`, `real-market-forward-evidence-smoke.yml`, `audit.yml`, `pru-required-checks-drift-detector.yml`, `prcc-aws-export-smoke.yml`, `prk-prj-status-report.yml`, `prbj-testnet-exec-events.yml`.
 
 **Durable operator pointers (archive only — not repo-ingested):**
 
@@ -3171,6 +3183,12 @@ CI_YML_SCHEDULE_FREE_CONFIRMED=true
 GH_CI_SCHEDULE_MANUAL_ONLY_DOCS_DRIFT_GUARD_IMPLEMENTED=true
 GH_CI_SCHEDULE_MANUAL_ONLY=true
 GH_CI_CANDIDATE_WORKFLOW=ci.yml
+RESIDUAL_PRB_SCHEDULED_SCORECARD_DOCS_DRIFT_GUARD_IMPLEMENTED=true
+PRB_SCHEDULED_WORKFLOWS_POSTURE_CONFIRMED=true
+CI_AUDIT_PRB_SCHEDULED_POSTURE_ALIGNED=true
+VARIABLE_GATES_PRB_SCHEDULED_POSTURE_ALIGNED=true
+PRB_SCHEDULED_COUNT_5_CONFIRMED=true
+GH_CI_MANUAL_ONLY_COUNT_8_PRESERVED=true
 WORKFLOW_DISPATCH_EXECUTED=false
 RECOMMENDER_READ_ONLY=true
 PREFLIGHT_REMAINS_BLOCKED=true

--- a/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
+++ b/docs/ops/CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md
@@ -205,9 +205,25 @@ RECOMMENDER_READ_ONLY=true
 | `prbg-execution-evidence.yml` | `19 2 * * *` | `scripts/ci/execution_evidence_producer.py` |
 | `prbi-live-pilot-scorecard.yml` | `39 2 * * *` | `scripts/ci/live_pilot_scorecard.py` |
 
-**Static contract test owner:** `tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py` — offline YAML parse only; **no** workflow dispatch, **no** secret/credential reads, **no** runtime or exchange execution authority.
+**Static contract test owner:** `tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py` — offline YAML parse only; **no** workflow dispatch, **no** secret/credential reads, **no** runtime or exchange execution authority; PRB scheduled implemented-posture docs drift guard (symmetric to GH-CI manual-only drift guard #4143).
+
+**Implemented posture (5 active schedules — distinct from 8 manual-only GH-CI side):** PRBC/PRBD/PRBE/PRBG/PRBI retain active `schedule:` on `main`; cron values below must stay aligned with `PRB_SCHEDULED_WORKFLOWS` in the contract test module.
 
 **Chain note (runtime — not executed by contract test):** PRBC → PRBD → PRBE; PRBG parallel; PRBI consumes upstream artifacts.
+
+```text
+RESIDUAL_PRB_SCHEDULED_SCORECARD_DOCS_DRIFT_GUARD_IMPLEMENTED=true
+PRB_SCHEDULED_WORKFLOWS_POSTURE_CONFIRMED=true
+VARIABLE_GATES_PRB_SCHEDULED_POSTURE_ALIGNED=true
+CI_AUDIT_PRB_SCHEDULED_POSTURE_ALIGNED=true
+PRB_SCHEDULED_COUNT_5_CONFIRMED=true
+GH_CI_MANUAL_ONLY_COUNT_8_PRESERVED=true
+RESIDUAL_ACTIVE_SCHEDULE_COUNT=5
+RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=8
+GH_CI_SCHEDULE_MANUAL_ONLY_DOCS_DRIFT_GUARD_IMPLEMENTED=true
+WORKFLOW_YAML_TOUCHED=false
+WORKFLOW_DISPATCH_EXECUTED=false
+```
 
 ---
 

--- a/tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py
+++ b/tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py
@@ -56,6 +56,35 @@ PRB_SCHEDULED_WORKFLOWS: dict[str, dict[str, str | bool]] = {
     },
 }
 
+PRB_SECTION_HEADING = "## Residual PRB scheduled scorecard YAML contract v0"
+GH_SCHEDULE_GOVERNANCE_HEADING = "## GH Schedule Governance Minimal RC v0"
+PRB_DRIFT_GUARD_PACKAGE_MARKER = (
+    "RESIDUAL_PRB_SCHEDULED_SCORECARD_DOCS_DRIFT_GUARD_IMPLEMENTED=true"
+)
+PRB_SCHEDULED_POSTURE_MARKER = "PRB_SCHEDULED_WORKFLOWS_POSTURE_CONFIRMED=true"
+CI_AUDIT_PRB_ALIGNED_MARKER = "CI_AUDIT_PRB_SCHEDULED_POSTURE_ALIGNED=true"
+VARIABLE_GATES_PRB_ALIGNED_MARKER = "VARIABLE_GATES_PRB_SCHEDULED_POSTURE_ALIGNED=true"
+PRB_SCHEDULED_COUNT_5_MARKER = "PRB_SCHEDULED_COUNT_5_CONFIRMED=true"
+GH_CI_MANUAL_ONLY_COUNT_8_MARKER = "GH_CI_MANUAL_ONLY_COUNT_8_PRESERVED=true"
+GH_CI_DRIFT_GUARD_MARKER = "GH_CI_SCHEDULE_MANUAL_ONLY_DOCS_DRIFT_GUARD_IMPLEMENTED=true"
+CANONICAL_RESIDUAL_ACTIVE_COUNT_LINE = "RESIDUAL_ACTIVE_SCHEDULE_COUNT=5"
+CANONICAL_MANUAL_ONLY_COUNT_LINE = "RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=8"
+STALE_RESIDUAL_ACTIVE_COUNT_LINE = "RESIDUAL_ACTIVE_SCHEDULE_COUNT=6"
+STALE_MANUAL_ONLY_COUNT_LINE = "RESIDUAL_MANUAL_ONLY_RESIDUAL_COUNT=7"
+
+GH001_MANUAL_ONLY_FORMER_RESIDUAL = frozenset(
+    {
+        "ci.yml",
+        "pro-prk-nightly-selfcheck.yml",
+        "real-market-forward-evidence-smoke.yml",
+        "audit.yml",
+        "pru-required-checks-drift-detector.yml",
+        "prcc-aws-export-smoke.yml",
+        "prk-prj-status-report.yml",
+        "prbj-testnet-exec-events.yml",
+    }
+)
+
 _SECRETS_TOKEN_RE = re.compile(r"\$\{\{\s*secrets\.([A-Za-z0-9_]+)\s*\}\}")
 _FORBIDDEN_PROMOTION_TOKENS = ("live_ready", "futures_ready", "gate_passed")
 _FORBIDDEN_BRANCH_PROTECTION_TOKENS = (
@@ -122,6 +151,35 @@ def _schedule_cron_entries(triggers: dict[str, Any]) -> list[str]:
 
 def _secret_names_in_text(text: str) -> set[str]:
     return set(_SECRETS_TOKEN_RE.findall(text))
+
+
+def _prb_section(text: str) -> str:
+    start = text.find(PRB_SECTION_HEADING)
+    assert start != -1, f"missing {PRB_SECTION_HEADING}"
+    end = text.find("\n## ", start + len(PRB_SECTION_HEADING))
+    return text[start:] if end == -1 else text[start:end]
+
+
+def _prb_machine_block(section: str) -> str:
+    fence = section.find("```text")
+    assert fence != -1, "PRB section missing machine block"
+    end = section.find("```", fence + 7)
+    assert end != -1
+    return section[fence:end]
+
+
+def _gh_schedule_governance_machine_block(text: str) -> str:
+    start = text.find(GH_SCHEDULE_GOVERNANCE_HEADING)
+    assert start != -1
+    fence = text.find("```text", start)
+    assert fence != -1
+    end = text.find("```", fence + 7)
+    assert end != -1
+    return text[fence:end]
+
+
+def _scheduled_workflow_files() -> frozenset[str]:
+    return frozenset(str(spec["workflow_file"]) for spec in PRB_SCHEDULED_WORKFLOWS.values())
 
 
 @pytest.mark.parametrize("prb_id", sorted(PRB_SCHEDULED_WORKFLOWS))
@@ -261,3 +319,68 @@ def test_docs_owner_crosslinks_residual_prb_contract_test() -> None:
     assert test_path in audit
     for prb_id in PRB_SCHEDULED_WORKFLOWS:
         assert str(PRB_SCHEDULED_WORKFLOWS[prb_id]["workflow_file"]) in gates
+
+
+def test_prb_docs_drift_guard_package_marker_v0() -> None:
+    assert PRB_DRIFT_GUARD_PACKAGE_MARKER in Path(__file__).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("doc_path", [VARIABLE_GATES_DOC, CI_AUDIT_DOC])
+def test_prb_scheduled_cron_table_matches_workflow_inventory(doc_path: Path) -> None:
+    """Docs cron table must match PRB_SCHEDULED_WORKFLOWS constants."""
+    text = doc_path.read_text(encoding="utf-8")
+    for spec in PRB_SCHEDULED_WORKFLOWS.values():
+        workflow_file = str(spec["workflow_file"])
+        expected_cron = str(spec["expected_cron"])
+        scorecard_script = str(spec["scorecard_script"])
+        assert workflow_file in text
+        assert expected_cron in text
+        assert scorecard_script in text
+
+
+@pytest.mark.parametrize("doc_path", [VARIABLE_GATES_DOC, CI_AUDIT_DOC])
+def test_prb_docs_machine_block_markers_aligned(doc_path: Path) -> None:
+    text = doc_path.read_text(encoding="utf-8")
+    if doc_path == VARIABLE_GATES_DOC:
+        block = _prb_machine_block(_prb_section(text))
+    else:
+        block = _gh_schedule_governance_machine_block(text)
+    for marker in (
+        PRB_DRIFT_GUARD_PACKAGE_MARKER,
+        PRB_SCHEDULED_POSTURE_MARKER,
+        CI_AUDIT_PRB_ALIGNED_MARKER,
+        VARIABLE_GATES_PRB_ALIGNED_MARKER,
+        PRB_SCHEDULED_COUNT_5_MARKER,
+        GH_CI_MANUAL_ONLY_COUNT_8_MARKER,
+        CANONICAL_RESIDUAL_ACTIVE_COUNT_LINE,
+        CANONICAL_MANUAL_ONLY_COUNT_LINE,
+        GH_CI_DRIFT_GUARD_MARKER,
+    ):
+        assert marker in block, f"missing {marker} in {doc_path.name}"
+    assert STALE_RESIDUAL_ACTIVE_COUNT_LINE not in block
+    assert STALE_MANUAL_ONLY_COUNT_LINE not in block
+
+
+def test_prb_scheduled_posture_not_mixed_with_gh_ci_manual_only_inventory() -> None:
+    """PRB scheduled chain must stay separate from the 8 manual-only GH-CI side."""
+    gates_section = _prb_section(VARIABLE_GATES_DOC.read_text(encoding="utf-8"))
+    audit = CI_AUDIT_DOC.read_text(encoding="utf-8")
+    scheduled_files = _scheduled_workflow_files()
+    for manual_only in GH001_MANUAL_ONLY_FORMER_RESIDUAL:
+        assert manual_only not in scheduled_files
+        assert f"| `{manual_only}` |" not in gates_section
+        assert f"| `{manual_only}` |" not in audit
+    for workflow_file in scheduled_files:
+        assert workflow_file not in GH001_MANUAL_ONLY_FORMER_RESIDUAL
+
+
+@pytest.mark.parametrize("prb_id", sorted(PRB_SCHEDULED_WORKFLOWS))
+def test_prb_yaml_implemented_posture_requires_active_schedule_not_manual_only(
+    prb_id: str,
+) -> None:
+    """Drift guard confirms YAML still has active schedule — no doc-only manual-only flip."""
+    workflow_file = str(PRB_SCHEDULED_WORKFLOWS[prb_id]["workflow_file"])
+    assert workflow_file not in GH001_MANUAL_ONLY_FORMER_RESIDUAL
+    text = _workflow_text(prb_id)
+    assert re.search(r"^\s*schedule\s*:", text, re.MULTILINE)
+    assert "workflow_dispatch" in text


### PR DESCRIPTION
## Summary

- Add symmetric **implemented-posture docs drift guard** for the **5 active scheduled PRB scorecard** workflows (PRBC/PRBD/PRBE/PRBG/PRBI), complementing GH-CI manual-only drift guard (#4143).
- Align `CI_AUDIT_KNOWN_ISSUES.md` and `CI_SCHEDULED_WORKFLOW_VARIABLE_GATES.md` with `PRB_SCHEDULED_WORKFLOWS` cron/script inventory and machine-block markers.
- Extend `test_residual_prb_scheduled_scorecard_workflow_contract_v0.py` with static guards for cron-table parity, count markers (5 scheduled + 8 manual-only), and separation from GH-CI manual-only posture.

## Non-authorizing boundaries

- **Docs/tests only** — no `.github/workflows/*.yml` changes, no workflow dispatch, no runtime/scheduler/adapter start, no orderflow, no enforcement activation, no preflight lift.

## Test plan

- [x] `python3 scripts/ops/validate_docs_token_policy.py --tracked-docs`
- [x] `python3 -m ruff format --check tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py`
- [x] `python3 -m ruff check tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py`
- [x] `python3 -m pytest tests/ci/test_residual_prb_scheduled_scorecard_workflow_contract_v0.py tests/ops/test_recommend_manual_only_workflows.py -q`

Made with [Cursor](https://cursor.com)