### PR TITLE
Market Dashboard operator view redesign using existing assets

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -31,6 +31,15 @@ Keine Kopplung an OPS Cockpit (`/ops`). Keine Trading-Aktionen.
 
 **Read-only / non-authorizing:** Keine Orders, keine Paper-/Testnet-/Live‑Aktivierung, keine Scope/Capital‑Billigung, kein Bypass von Risk/KillSwitch‑Enforcement, keine Ausführungs‑ oder Strategieautorität. Keine Schlussfolgerung auf Futures‑„Readiness“ oder Provider‑Bereitschaft über diese View hinaus.
 
+### Operator overview IA v1 (display-only redesign)
+
+- **`GET &#47;market`** exposes **`data-market-operator-overview-v1`** with operator story steps **Observe → Rank → Select → Explain → Double-Play status** (`data-market-operator-story-v1`).
+- System bar: **`data-market-operator-system-bar-v1`** — read-only, live locked, trading authority=false, data source, instrument, snapshot.
+- Guardrails moved to collapsible secondary section: **`data-market-guardrails-secondary-v1`**; diagnostics: **`data-market-diagnostics-secondary-v1`**.
+- Top20/ranking table reuses **`market_ranking_funnel_readmodel_v0`** (`data-market-top20-ranking-v1`, `data-market-ranking-source-mode-v1`).
+- Explain readout reuses **`build_static_dashboard_display_dict()`** display-only (`data-market-ai-decision-readout-v1`) — **no** trading signal.
+- **`GET &#47;market&#47;double-play`**: Bull/Bear cards (`data-double-play-bull-bear-cards-v1`), compact scope/capital/risk cards (`data-double-play-scope-capital-risk-v1`); depth/diagnostics secondary.
+
 ### Lane taxonomy cross-reference (non-authorizing)
 
 This document is the **canonical Market Surface v0** owner for **`GET &#47;market`**, **`GET &#47;api&#47;market&#47;*`**, and related SSR read-only routes. Lane indexing and forbidden promotions are defined in [Runtime Lane Taxonomy + Authority Levels Contract v0](../ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md) **§7h**:

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -35,6 +35,7 @@ from .market_depth_runtime_v0 import (
     depth_chart_enabled_explicitly_on,
     market_depth_json_payload_v0,
 )
+from .double_play_dashboard_display_json_route_v0 import build_static_dashboard_display_dict
 from .market_ranking_funnel_runtime_v0 import build_market_ranking_funnel_display_context
 from .market_tape_readmodel_v0.gate import (
     enabled_explicitly_on as _market_tape_enabled_explicitly_on,
@@ -688,6 +689,52 @@ def build_market_depth_display_context() -> Dict[str, Any]:
     }
 
 
+_RANKING_TABLE_STAGE_ORDER: tuple[str, ...] = ("universe", "shortlist", "selected")
+
+
+def build_market_operator_overview_display_context(
+    *,
+    ranking_funnel: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Display-only operator overview context for GET /market (no decision logic)."""
+
+    dp_display = build_static_dashboard_display_dict()
+    rows: list[dict[str, Any]] = []
+    stages = ranking_funnel.get("stages") if isinstance(ranking_funnel.get("stages"), dict) else {}
+    for stage_key in _RANKING_TABLE_STAGE_ORDER:
+        for row in stages.get(stage_key) or []:
+            if isinstance(row, dict):
+                rows.append({**row, "stage": stage_key})
+
+    if rows and ranking_funnel.get("gate_enabled"):
+        source_mode = "existing_readmodel"
+    elif rows:
+        source_mode = "mixed"
+    elif ranking_funnel.get("gate_enabled"):
+        source_mode = "fixture_offline"
+    else:
+        source_mode = "fixture_offline"
+
+    panels = {
+        p.get("name"): p
+        for p in (dp_display.get("panels") or [])
+        if isinstance(p, dict) and p.get("name")
+    }
+
+    return {
+        "dp_display": dp_display,
+        "ranking_source_mode": source_mode,
+        "ranking_table_rows": rows,
+        "ranking_table_count": len(rows),
+        "suitability_panel": panels.get("strategy_suitability") or {},
+        "composition_panel": panels.get("composition") or {},
+        "survival_panel": panels.get("survival_envelope") or {},
+        "futures_input_panel": panels.get("futures_input") or {},
+        "capital_ratchet_panel": panels.get("capital_slot_ratchet") or {},
+        "capital_release_panel": panels.get("capital_slot_release") or {},
+    }
+
+
 def build_market_payload(
     *,
     symbol: str,
@@ -761,6 +808,9 @@ def create_market_router(
         run_projection = build_market_run_projection_display_context()
         market_tape = build_market_tape_display_context()
         ranking_funnel = build_market_ranking_funnel_display_context()
+        operator_overview = build_market_operator_overview_display_context(
+            ranking_funnel=ranking_funnel,
+        )
         active_paper_run = build_market_active_paper_run_display_context()
         market_single_page_consolidation = build_market_single_page_consolidation_display_context()
         workflow_dashboard: Dict[str, Any] | None = None
@@ -778,6 +828,7 @@ def create_market_router(
                 "run_projection": run_projection,
                 "market_tape": market_tape,
                 "ranking_funnel": ranking_funnel,
+                "operator_overview": operator_overview,
                 "active_paper_run": active_paper_run,
                 "market_single_page_consolidation": market_single_page_consolidation,
                 "workflow_dashboard": workflow_dashboard,

--- a/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
+++ b/templates/peak_trade_dashboard/double_play_market_dashboard_v0.html
@@ -21,6 +21,7 @@
   data-double-play-market-source="{{ query.source }}"
   data-double-play-market-bars="{{ payload.bars_returned }}"
   data-double-play-market-symbol="{{ query.symbol }}"
+  data-double-play-operator-detail-v1="true"
 >
   <header
     class="rounded-2xl border border-slate-800/90 bg-gradient-to-br from-slate-950 via-slate-900/95 to-slate-950 px-5 py-4 shadow-xl shadow-black/35 ring-1 ring-slate-700/40"
@@ -87,6 +88,51 @@
 
   <section
     role="region"
+    aria-labelledby="double-play-market-v0-landmark-bull-bear-h2"
+    class="rounded-xl border border-slate-800/85 bg-slate-950/60 px-3 py-3 sm:px-4 ring-1 ring-slate-800/55"
+    data-double-play-bull-bear-cards-v1="true"
+  >
+    <h2 id="double-play-market-v0-landmark-bull-bear-h2" class="text-xs font-semibold text-slate-100 m-0 mb-2">Bull vs Bear · display-only</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-[11px]">
+      {% set suit = dp_display.panels | selectattr('name', 'equalto', 'strategy_suitability') | list %}
+      {% set comp = dp_display.panels | selectattr('name', 'equalto', 'composition') | list %}
+      <article class="rounded-lg border border-emerald-900/45 bg-emerald-950/20 px-3 py-2.5" data-double-play-bull-card-v1="true">
+        <p class="m-0 text-[10px] font-bold uppercase tracking-wide text-emerald-400/90">Bull / Long display</p>
+        <p class="m-0 mt-1 text-slate-200 leading-snug">
+          {% if suit and suit[0].summary %}{{ suit[0].summary }}{% else %}MODEL_ONLY — suitability panel unavailable in snapshot.{% endif %}
+        </p>
+        <p class="m-0 mt-1 text-slate-500">Dominant side: display-only · keine Signal-Autorität</p>
+      </article>
+      <article class="rounded-lg border border-rose-900/45 bg-rose-950/20 px-3 py-2.5" data-double-play-bear-card-v1="true">
+        <p class="m-0 text-[10px] font-bold uppercase tracking-wide text-rose-400/90">Bear / Short display</p>
+        <p class="m-0 mt-1 text-slate-200 leading-snug">
+          {% if comp and comp[0].summary %}{{ comp[0].summary }}{% else %}NONE / MODEL_ONLY — composition panel unavailable.{% endif %}
+        </p>
+        <p class="m-0 mt-1 text-slate-500">
+          {% if suit and suit[0].blockers %}Blockers: {{ suit[0].blockers | join("; ") }}{% else %}Keine Blocker im Display-Snapshot.{% endif %}
+        </p>
+      </article>
+    </div>
+  </section>
+
+  <section
+    role="region"
+    aria-labelledby="double-play-market-v0-landmark-scope-capital-risk-h2"
+    class="rounded-xl border border-slate-800/85 bg-slate-950/55 px-3 py-3 sm:px-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 text-[10px]"
+    data-double-play-scope-capital-risk-v1="true"
+  >
+    <h2 id="double-play-market-v0-landmark-scope-capital-risk-h2" class="sr-only">Scope Capital Risk status</h2>
+    {% for panel in dp_display.panels if panel.name in ['survival_envelope', 'capital_slot_ratchet', 'capital_slot_release', 'strategy_suitability'] %}
+    <article class="rounded-lg border border-slate-800/75 bg-slate-950/65 px-2.5 py-2" data-double-play-operator-card-v1="{{ panel.name }}">
+      <p class="m-0 text-slate-500 uppercase font-semibold">{{ panel.name | replace('_', ' ') }}</p>
+      <p class="m-0 mt-1 text-slate-200 font-semibold">{{ panel.status }}</p>
+      <p class="m-0 mt-1 text-slate-400 line-clamp-3">{{ panel.summary or "—" }}</p>
+    </article>
+    {% endfor %}
+  </section>
+
+  <section
+    role="region"
     aria-labelledby="double-play-market-v0-landmark-safety-h2"
     class="rounded-xl border border-amber-900/45 bg-gradient-to-br from-amber-950/40 via-slate-950/40 to-slate-950/25 px-3 py-3 sm:px-4 sm:py-3.5 shadow-md shadow-black/20 ring-1 ring-amber-950/30"
     data-double-play-market-safety="true"
@@ -146,17 +192,22 @@
     </ul>
   </section>
 
-  <section
-    id="double-play-market-v0-depth-ssr"
-    role="region"
-    aria-labelledby="double-play-market-v0-landmark-depth-ssr-h2"
-    class="rounded-xl border border-slate-800/85 bg-slate-950/60 px-3 py-3 sm:px-4 ring-1 ring-slate-800/55 shadow-md shadow-black/15 text-[11px] text-slate-300"
+  <details
+    class="rounded-xl border border-slate-800/85 bg-slate-950/60 px-3 py-3 sm:px-4 ring-1 ring-slate-800/55 text-[11px] text-slate-300"
+    data-double-play-market-depth-secondary-v1="true"
     data-double-play-market-depth-panel="true"
     data-double-play-market-depth-status="{{ market_depth.display_status }}"
     data-double-play-market-depth-non-authorizing="true"
     {% if market_depth.readmodel_id %}
     data-double-play-market-depth-readmodel-id="{{ market_depth.readmodel_id }}"
     {% endif %}
+  >
+    <summary class="cursor-pointer text-[10px] font-semibold uppercase tracking-wide text-slate-400 outline-none hover:text-slate-200">Depth (secondary · display-only)</summary>
+  <section
+    id="double-play-market-v0-depth-ssr"
+    role="region"
+    aria-labelledby="double-play-market-v0-landmark-depth-ssr-h2"
+    class="mt-2 text-[11px] text-slate-300"
   >
     <h2
       id="double-play-market-v0-landmark-depth-ssr-h2"
@@ -188,6 +239,7 @@
     </p>
     {% endif %}
   </section>
+  </details>
 
   <div
     class="flex flex-col gap-6 xl:grid xl:grid-cols-[minmax(0,1fr)_min(21rem,100%)] xl:items-start xl:gap-6"
@@ -273,9 +325,12 @@
       <div
         class="rounded-xl border border-slate-800/85 bg-slate-950/65 px-4 py-3 space-y-2.5 ring-1 ring-slate-800/50 shadow-md shadow-black/15"
         data-double-play-market-cockpit-diagnostics-secondary="true"
+        data-double-play-diagnostics-secondary-v1="true"
         data-market-v11-chart-diagnostics="true"
       >
-        <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-400 m-0 pb-1 border-b border-slate-800/70">Diagnostics</p>
+        <details>
+        <summary class="cursor-pointer text-[10px] font-semibold uppercase tracking-wide text-slate-400 outline-none hover:text-slate-200">Diagnostics (secondary)</summary>
+        <div class="mt-2 space-y-2.5">
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-2.5 text-[11px] font-mono text-slate-300" data-market-v11-diagnostics-inner="true">
           <div class="rounded-md border border-slate-800/75 bg-slate-950/55 px-2 py-1.5" data-market-v11-chart-library-status="true">
             <span class="text-slate-500 block text-[9px] uppercase tracking-wide mb-0.5">Chart.js</span>
@@ -317,6 +372,8 @@
           <span class="text-slate-600">·</span>
           <span class="font-mono text-slate-600">legacy: {{ legacy_demo_href }}</span>
         </div>
+        </div>
+        </details>
       </div>
 
       <script type="application/json" id="dp-market-ssr-payload">{{ payload | tojson }}</script>

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -19,109 +19,100 @@
   data-market-bars="{{ payload.bars_returned }}"
   data-market-symbol="{{ query.symbol }}"
   data-market-v0-one-page-link-cleanup-v1="true"
+  data-market-operator-overview-v1="true"
+  data-market-operator-story-v1="true"
 >
   <section
     role="region"
-    aria-labelledby="market-v0-landmark-readonly-constraints-h2"
-    class="rounded-xl border border-slate-600/55 bg-slate-900/60 px-3 py-3 sm:px-4 sm:py-3.5 shadow-sm shadow-black/25 ring-1 ring-slate-800/45"
+    aria-labelledby="market-v0-landmark-operator-system-bar-h2"
+    class="rounded-xl border border-slate-700/60 bg-slate-950/80 px-3 py-2.5 sm:px-4 shadow-sm shadow-black/20 ring-1 ring-slate-800/50"
+    data-market-operator-system-bar-v1="true"
+    data-market-readonly="true"
+    data-market-non-authorizing="true"
+    data-market-live-locked-v1="true"
+    data-market-trading-authority-v1="false"
+  >
+    <h2 id="market-v0-landmark-operator-system-bar-h2" class="sr-only">Operator system bar</h2>
+    <div class="flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-wide">
+      <span class="inline-flex items-center gap-1 rounded-full border border-emerald-800/55 bg-emerald-950/45 px-2 py-0.5 text-emerald-200/95">Read only</span>
+      <span class="inline-flex items-center gap-1 rounded-full border border-slate-700/70 bg-slate-950/65 px-2 py-0.5 text-slate-300">Live locked</span>
+      <span class="inline-flex items-center gap-1 rounded-full border border-slate-700/70 bg-slate-950/65 px-2 py-0.5 text-slate-300">Trading authority=false</span>
+      <span class="inline-flex items-center gap-1 rounded-full border border-slate-700/70 bg-slate-950/65 px-2 py-0.5 text-slate-300">Orders disabled</span>
+      <span class="inline-flex items-center gap-1 rounded-full border border-slate-700/70 bg-slate-950/65 px-2 py-0.5 text-slate-300">Execution disabled</span>
+    </div>
+    <dl class="mt-2 m-0 grid grid-cols-1 sm:grid-cols-3 gap-x-4 gap-y-1 text-[11px] tabular-nums">
+      <div><dt class="inline text-slate-500">Data source</dt> <dd class="inline font-mono text-sky-300/90">{{ query.source }}</dd></div>
+      <div><dt class="inline text-slate-500">Instrument</dt> <dd class="inline font-mono text-slate-100">{{ query.symbol }}</dd></div>
+      <div><dt class="inline text-slate-500">Snapshot</dt> <dd class="inline font-mono text-slate-300 break-all">{{ payload.generated_at_utc }}</dd></div>
+    </dl>
+  </section>
+
+  <nav
+    class="rounded-lg border border-slate-800/75 bg-slate-950/55 px-3 py-2 flex flex-wrap gap-2 text-[10px] font-semibold uppercase tracking-wide"
+    aria-label="Operator story"
+    data-market-operator-story-steps-v1="true"
+  >
+    <a href="#market-v0-observe-strip" class="rounded-md border border-teal-900/45 bg-teal-950/30 px-2 py-1 text-teal-200/90 no-underline hover:bg-teal-950/50" data-market-operator-step-v1="observe">Observe</a>
+    <a href="#market-v0-ranking-funnel-ssr" class="rounded-md border border-violet-900/45 bg-violet-950/30 px-2 py-1 text-violet-200/90 no-underline hover:bg-violet-950/50" data-market-operator-step-v1="rank">Rank</a>
+    <a href="#market-v0-landmark-close-chart-h2" class="rounded-md border border-sky-900/45 bg-sky-950/30 px-2 py-1 text-sky-200/90 no-underline hover:bg-sky-950/50" data-market-operator-step-v1="select">Select</a>
+    <a href="#market-v0-ai-decision-readout" class="rounded-md border border-cyan-900/45 bg-cyan-950/30 px-2 py-1 text-cyan-200/90 no-underline hover:bg-cyan-950/50" data-market-operator-step-v1="explain">Explain</a>
+    <a href="#market-v0-double-play-status" class="rounded-md border border-amber-900/45 bg-amber-950/30 px-2 py-1 text-amber-200/90 no-underline hover:bg-amber-950/50" data-market-operator-step-v1="double-play-status">Double-Play status</a>
+  </nav>
+
+  <details
+    class="rounded-xl border border-slate-700/55 bg-slate-950/45 px-3 py-2 text-xs text-slate-300"
+    data-market-guardrails-secondary-v1="true"
     data-market-v1-readonly-banner="true"
     data-market-v0-readonly-banner-chip-rhythm-v0="true"
   >
-    <h2 id="market-v0-landmark-readonly-constraints-h2" class="sr-only">Read-only market constraints</h2>
-    <div
-      class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-4 sm:gap-y-2.5"
-      data-market-v0-readonly-banner-chip-rows-v0="true"
-    >
-      <ul
-        class="m-0 p-0 list-none flex flex-wrap gap-2 sm:gap-2.5"
-        aria-label="Read-only posture"
+    <summary class="cursor-pointer font-semibold text-slate-200 outline-none hover:text-slate-100">Guardrails &amp; constraints (secondary)</summary>
+    <div class="mt-2 space-y-3">
+      <section
+        role="region"
+        aria-labelledby="market-v0-landmark-readonly-constraints-h2"
+        data-market-v0-readonly-banner-chip-rows-v0="true"
       >
-        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums ring-1 ring-inset ring-slate-700/35">
-          <span class="h-1.5 w-1.5 rounded-full bg-emerald-400/90 shrink-0" aria-hidden="true"></span>
-          Read-only market display
-        </li>
-        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums ring-1 ring-inset ring-slate-700/35">
-          <span class="h-1.5 w-1.5 rounded-full bg-slate-500 shrink-0" aria-hidden="true"></span>
-          No orders
-        </li>
-        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums ring-1 ring-inset ring-slate-700/35">
-          <span class="h-1.5 w-1.5 rounded-full bg-slate-500 shrink-0" aria-hidden="true"></span>
-          No strategy authority
-        </li>
-      </ul>
-      <div
-        role="presentation"
-        class="hidden sm:block sm:self-stretch w-px min-h-[1.75rem] bg-slate-600/35 shrink-0"
-        aria-hidden="true"
-        data-market-v0-readonly-banner-chip-divider-v0="true"
-      ></div>
-      <ul
-        class="m-0 p-0 list-none flex flex-wrap gap-2 sm:gap-2.5"
-        aria-label="Execution and risk boundaries"
+        <h2 id="market-v0-landmark-readonly-constraints-h2" class="sr-only">Read-only market constraints</h2>
+        <ul class="m-0 p-0 list-none flex flex-wrap gap-2 sm:gap-2.5" aria-label="Read-only posture">
+          <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95">Read-only market display</li>
+          <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95">No orders</li>
+          <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95">No strategy authority</li>
+        </ul>
+        <div
+          role="presentation"
+          class="hidden sm:block sm:self-stretch w-px min-h-[1.75rem] bg-slate-600/35 shrink-0 my-2"
+          aria-hidden="true"
+          data-market-v0-readonly-banner-chip-divider-v0="true"
+        ></div>
+        <ul class="m-0 p-0 list-none flex flex-wrap gap-2 sm:gap-2.5" aria-label="Execution and risk boundaries">
+          <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95">No Live/Testnet action</li>
+          <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95">No Risk/KillSwitch override</li>
+        </ul>
+      </section>
+      <section
+        role="region"
+        aria-labelledby="market-v0-landmark-safety-banner-h2"
+        class="rounded-lg border border-amber-900/35 bg-amber-950/20 px-2.5 py-2 text-[11px] text-amber-100/90"
+        data-market-safety-banner="true"
+        {% if query.source == 'dummy' %}
+        data-market-source-kind="dummy-offline-synthetic"
+        {% elif query.source == 'kraken' %}
+        data-market-source-kind="kraken-public-ohlcv-network"
+        {% endif %}
       >
-        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums ring-1 ring-inset ring-slate-700/35">
-          <span class="h-1.5 w-1.5 rounded-full bg-amber-400/85 shrink-0" aria-hidden="true"></span>
-          No Live/Testnet action
-        </li>
-        <li class="inline-flex items-center gap-1.5 rounded-full border border-slate-600/70 bg-slate-950/65 px-2.5 py-1 text-[11px] font-semibold text-slate-200/95 tabular-nums ring-1 ring-inset ring-slate-700/35">
-          <span class="h-1.5 w-1.5 rounded-full bg-rose-400/80 shrink-0" aria-hidden="true"></span>
-          No Risk/KillSwitch override
-        </li>
-      </ul>
+        <h2 id="market-v0-landmark-safety-banner-h2" class="font-semibold text-amber-200/95 m-0 mb-1">Market Surface v0 · read-only · non-authorizing</h2>
+        {% if query.source == 'dummy' %}
+        <p class="m-0 leading-snug"><strong class="text-sky-200/95">Dummy / Offline / synthetisch</strong> — keine Orders, kein Testnet, kein Live.</p>
+        {% elif query.source == 'kraken' %}
+        <p class="m-0 leading-snug"><strong class="text-sky-200/95">Öffentliche OHLCV (Kraken)</strong> — rein anzeigend, kein Futures-Readiness-Nachweis.</p>
+        {% endif %}
+        <p class="mt-2 m-0 leading-snug"><strong class="text-amber-200/95">Guardrails:</strong> Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval — reine Anzeige, keine Broker-/Order-/Live-Autorität.</p>
+        <p class="mt-2 m-0 leading-snug" data-market-v0-paper-run-truth-separation-v0="true"><strong class="text-violet-200/95">Market Surface ≠ Paper Run Truth.</strong> Default symbol and dummy OHLCV are chart fixtures only.</p>
+      </section>
     </div>
-  </section>
+  </details>
 
-  <section
-    role="region"
-    aria-labelledby="market-v0-landmark-safety-banner-h2"
-    class="rounded-xl border border-amber-900/45 bg-gradient-to-br from-amber-950/40 via-slate-950/40 to-slate-950/25 px-3 py-3 sm:px-4 sm:py-3.5 text-xs text-amber-100/95 shadow-md shadow-black/20 ring-1 ring-amber-950/30"
-    data-market-safety-banner="true"
-    {% if query.source == 'dummy' %}
-    data-market-source-kind="dummy-offline-synthetic"
-    {% elif query.source == 'kraken' %}
-    data-market-source-kind="kraken-public-ohlcv-network"
-    {% endif %}
-  >
-    <div class="flex flex-wrap items-center justify-between gap-2 mb-2">
-      <h2 id="market-v0-landmark-safety-banner-h2" class="font-semibold text-amber-200/95 tracking-wide uppercase text-[11px] m-0">
-        Market Surface v0 · read-only · non-authorizing
-      </h2>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="inline-flex items-center rounded-md border border-amber-800/50 bg-amber-950/45 px-2 py-0.5 text-[10px] font-semibold text-amber-100/90 tabular-nums">SSR only</span>
-        <span class="inline-flex items-center rounded-md border border-slate-700/70 bg-slate-950/55 px-2 py-0.5 text-[10px] font-semibold text-slate-200/90 tabular-nums">No order controls</span>
-      </div>
-    </div>
-    {% if query.source == 'dummy' %}
-    <p class="leading-snug text-amber-100/90 m-0 text-[11px]">
-      <span class="text-sky-200/95 font-semibold">Dummy / Offline / synthetisch</span>
-      — keine Orders, kein Testnet, kein Live, keine Paper-Aktivierung.
-      Keine Capital-/Scope-Freigabe, kein Risk-/KillSwitch-Bypass, keine Ausführungsautorität.
-    </p>
-    {% elif query.source == 'kraken' %}
-    <p class="leading-snug text-amber-100/90 m-0 text-[11px]">
-      <span class="text-sky-200/95 font-semibold">Öffentliche OHLCV über Netzwerk (Kraken)</span>
-      — rein anzeigend (read-only), non-authorizing, <strong class="font-medium text-amber-200">kein Nachweis von Futures‑Readiness</strong>.
-      Keine Orders, kein Testnet, kein Live.
-    </p>
-    {% endif %}
-    <p class="mt-2.5 rounded-lg border border-amber-800/35 bg-amber-950/25 px-2.5 py-2 leading-snug text-amber-100/90 m-0 text-[11px]">
-      <strong class="text-amber-200/95">Guardrails:</strong>
-      Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval — reine Anzeige, keine Broker-/Order-/Live-Autorität.
-    </p>
-    <p
-      class="mt-2 rounded-lg border border-violet-900/35 bg-violet-950/20 px-2.5 py-2 leading-snug text-violet-100/90 m-0 text-[11px]"
-      data-market-v0-paper-run-truth-separation-v0="true"
-    >
-      <strong class="text-violet-200/95">Market Surface ≠ Paper Run Truth.</strong>
-      Default symbol (e.g. BTC/USD) and dummy OHLCV are chart fixtures only — not Futures truth or Paper runtime authority.
-      {% if not active_paper_run.section_visible and not (market_single_page_consolidation.section_visible and last_paper_run_panel and last_paper_run_panel.section_visible) %}
-      View-only last run archive:
-      <a href="/observability" class="text-sky-300/90 underline underline-offset-2 font-mono">GET /observability</a>
-      (env-gated Last Paper Run panel).
-      {% endif %}
-    </p>
-  </section>
-
+  <!-- Pro cockpit grid moved below operator sections; chart hero is primary -->
   {% if market_single_page_consolidation.section_visible %}
   <div
     id="market-single-page-consolidation-v1"
@@ -306,6 +297,34 @@
   {% endif %}
 
   <section
+    id="market-v0-observe-strip"
+    role="region"
+    aria-labelledby="market-v0-landmark-observe-strip-h2"
+    class="rounded-xl border border-teal-900/40 bg-gradient-to-br from-teal-950/30 via-slate-950/40 to-slate-950/20 px-3 py-3 sm:px-4 text-xs"
+    data-market-observe-strip-v1="true"
+    data-market-tape-or-observe-strip-v1="true"
+    data-market-depth-display-only-v1="true"
+  >
+    <h2 id="market-v0-landmark-observe-strip-h2" class="text-xs font-semibold text-teal-200/95 m-0 mb-2">Observe · Tape &amp; Depth (display-only)</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-[11px]">
+      <div class="rounded-lg border border-teal-800/40 bg-slate-950/55 px-2.5 py-2" data-market-observe-tape-summary-v1="true">
+        <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Market tape</p>
+        {% if market_tape.section_visible %}
+        <p class="m-0 mt-1 text-slate-200">{{ market_tape.summary_line|e }}</p>
+        <p class="m-0 mt-1 text-slate-500 tabular-nums">Status: {{ market_tape.display_status|e }} · Trades: {{ market_tape.trade_count }}</p>
+        {% else %}
+        <p class="m-0 mt-1 text-slate-400">Tape SSR off or unconfigured — fixture/offline display mode.</p>
+        {% endif %}
+      </div>
+      <div class="rounded-lg border border-amber-800/40 bg-slate-950/55 px-2.5 py-2" data-market-observe-depth-summary-v1="true">
+        <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Orderbook / depth</p>
+        <p class="m-0 mt-1 text-slate-200">{{ market_depth.summary_line|e }}</p>
+        <p class="m-0 mt-1 text-slate-500 tabular-nums">Status: {{ market_depth.display_status|e }} · display-only · no controls</p>
+      </div>
+    </div>
+  </section>
+
+  <section
     id="market-v0-ranking-funnel-ssr"
     role="region"
     aria-labelledby="market-v0-landmark-ranking-funnel-h2"
@@ -314,9 +333,11 @@
     data-market-v0-ranking-funnel-dynamic-labels-v0="true"
     data-market-v0-ranking-funnel-stages-v0="true"
     data-market-v0-ranking-funnel-display-only-v0="true"
-    {% if ranking_funnel.gate_enabled %}data-market-v0-ranking-funnel-enabled-v0="true"{% endif %}
+    data-market-top20-ranking-v1="true"
+    data-market-ranking-source-mode-v1="{{ operator_overview.ranking_source_mode }}"
     {% if ranking_funnel.has_rows %}data-market-v0-ranking-funnel-has-rows-v0="true"{% else %}data-market-v0-ranking-funnel-empty-state-v0="true"{% endif %}
     {% if ranking_funnel.non_authorizing %}data-market-v0-ranking-funnel-non-authorizing-v0="true"{% endif %}
+    {% if ranking_funnel.gate_enabled %}data-market-v0-ranking-funnel-enabled-v0="true"{% endif %}
   >
     <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
       <div class="min-w-0 space-y-1">
@@ -390,6 +411,46 @@
       </div>
       {% endfor %}
     </div>
+    <div
+      class="mt-3 rounded-lg border border-violet-800/45 bg-slate-950/60 px-2.5 py-2.5 overflow-x-auto"
+      data-market-top20-table-v1="true"
+    >
+      <p class="m-0 mb-2 text-[10px] font-semibold uppercase tracking-wide text-violet-300/90">
+        Top20 / Universe table · source_mode={{ operator_overview.ranking_source_mode }} · count={{ operator_overview.ranking_table_count }}
+      </p>
+      {% if operator_overview.ranking_table_rows %}
+      <table class="w-full text-[10px] border-collapse tabular-nums">
+        <thead>
+          <tr class="text-left text-slate-400 border-b border-slate-800/70">
+            <th class="pr-2 py-1 font-normal">rank</th>
+            <th class="pr-2 py-1 font-normal">symbol</th>
+            <th class="pr-2 py-1 font-normal">stage</th>
+            <th class="pr-2 py-1 font-normal">score</th>
+            <th class="pr-2 py-1 font-normal">DP flag</th>
+            <th class="py-1 font-normal">source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in operator_overview.ranking_table_rows %}
+          <tr class="border-b border-slate-900/60 text-slate-200">
+            <td class="pr-2 py-1">{{ row.rank|e }}</td>
+            <td class="pr-2 py-1 font-mono">{{ row.symbol|e }}</td>
+            <td class="pr-2 py-1">{{ row.stage|e }}</td>
+            <td class="pr-2 py-1">{% if row.display_score is defined %}{{ row.display_score|e }}{% else %}—{% endif %}</td>
+            <td class="pr-2 py-1">display-only</td>
+            <td class="py-1 font-mono text-slate-400">{{ ranking_funnel.source or operator_overview.ranking_source_mode }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p class="m-0 text-[11px] text-slate-400 leading-snug">
+        Keine Ranking-Zeilen geladen — {{ operator_overview.ranking_source_mode }} · enable
+        <span class="font-mono text-slate-300">PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED=1</span>
+        + bundle root for fixture rows.
+      </p>
+      {% endif %}
+    </div>
     {% if ranking_funnel.has_rows %}
     <p class="text-[9px] text-slate-500 m-0 mt-2 leading-snug" data-market-v0-ranking-funnel-readonly-copy-v0="true">
       Ranking producer output is display-only. It does not authorize trades, signals, approvals, or live operation.
@@ -410,12 +471,65 @@
     {% endif %}
   </section>
 
+  <section
+    id="market-v0-ai-decision-readout"
+    role="region"
+    aria-labelledby="market-v0-landmark-ai-decision-readout-h2"
+    class="rounded-xl border border-cyan-900/40 bg-gradient-to-br from-cyan-950/25 via-slate-950/40 to-slate-950/20 px-3 py-3 sm:px-4"
+    data-market-ai-decision-readout-v1="true"
+    data-market-ai-decision-display-only-v1="true"
+  >
+    <h2 id="market-v0-landmark-ai-decision-readout-h2" class="text-xs font-semibold text-cyan-200/95 m-0 mb-2">Explain · Decision readout (display-only, keine Empfehlung)</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-[11px]">
+      <article class="rounded-lg border border-slate-800/75 bg-slate-950/55 px-2.5 py-2">
+        <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Was beobachtet das System?</p>
+        <p class="m-0 mt-1 text-slate-200">{{ operator_overview.futures_input_panel.summary or "—" }}</p>
+      </article>
+      <article class="rounded-lg border border-slate-800/75 bg-slate-950/55 px-2.5 py-2">
+        <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Warum interessant / nicht interessant?</p>
+        <p class="m-0 mt-1 text-slate-200">{{ operator_overview.suitability_panel.summary or "—" }}</p>
+      </article>
+      <article class="rounded-lg border border-slate-800/75 bg-slate-950/55 px-2.5 py-2">
+        <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Fehlende Daten / Gates</p>
+        <p class="m-0 mt-1 text-slate-200">
+          {% if operator_overview.suitability_panel.missing_inputs %}
+          Missing: {{ operator_overview.suitability_panel.missing_inputs | join(", ") }}
+          {% else %}Keine missing_inputs im Display-Snapshot.{% endif %}
+        </p>
+        <p class="m-0 mt-1 text-slate-400">
+          {% if operator_overview.suitability_panel.blockers %}
+          Blockers: {{ operator_overview.suitability_panel.blockers | join("; ") }}
+          {% else %}Keine Blocker gemeldet (display-only).{% endif %}
+        </p>
+      </article>
+      <article class="rounded-lg border border-slate-800/75 bg-slate-950/55 px-2.5 py-2">
+        <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Double-Play display suitability</p>
+        <p class="m-0 mt-1 text-slate-200">{{ operator_overview.composition_panel.summary or "—" }}</p>
+        <p class="m-0 mt-1 text-slate-500">Overall display status: {{ operator_overview.dp_display.overall_status }}</p>
+      </article>
+    </div>
+  </section>
+
+  <section
+    id="market-v0-double-play-status"
+    role="region"
+    aria-labelledby="market-v0-landmark-double-play-status-h2"
+    class="rounded-xl border border-amber-900/35 bg-amber-950/20 px-3 py-2.5 sm:px-4 text-[11px]"
+    data-market-double-play-status-v1="true"
+  >
+    <h2 id="market-v0-landmark-double-play-status-h2" class="text-xs font-semibold text-amber-200/95 m-0 mb-1">Double-Play Status</h2>
+    <p class="m-0 text-slate-300">
+      Display-only snapshot — kein Trading-Signal.
+      <a href="/market/double-play?source={{ query.source }}&amp;symbol={{ query.symbol | replace('/', '%2F') }}&amp;timeframe={{ query.timeframe }}&amp;limit={{ query.limit }}" class="text-sky-300/90 underline underline-offset-2 font-mono">Detail: /market/double-play</a>
+    </p>
+  </section>
+
   <!-- Pro cockpit grid: chart/main column + read-only side panels (IA inspiration only; no order UI) -->
   <div
     class="grid grid-cols-1 xl:grid-cols-12 gap-4 lg:gap-5 xl:gap-6 items-start"
     data-market-v0-pro-grid="true"
   >
-    <div class="xl:col-span-8 space-y-6 min-w-0" data-market-v0-chart-panel="true">
+    <div class="xl:col-span-8 space-y-6 min-w-0" data-market-v0-chart-panel="true" data-market-chart-primary-v1="true">
   <header class="relative overflow-hidden rounded-xl border border-sky-900/35 bg-gradient-to-br from-slate-900/95 via-slate-900/80 to-slate-950/90 p-4 sm:p-6 shadow-lg shadow-black/25 ring-1 ring-sky-900/20">
     <div class="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-[radial-gradient(ellipse_at_top,_rgba(56,189,248,0.12),_transparent_55%)]" aria-hidden="true"></div>
     <div class="relative flex flex-col gap-4">
@@ -877,6 +991,7 @@
     aria-labelledby="market-v0-landmark-close-chart-h2"
     class="bg-slate-900/65 rounded-xl border border-slate-800 ring-2 ring-sky-900/15 shadow-xl shadow-black/30 p-4 sm:p-5 min-h-[30rem]"
     data-chart="market-v0-close-line"
+    data-market-chart-primary-v1="true"
     data-market-v11-chart-diagnostics="true"
   >
     <div class="flex flex-wrap items-end justify-between gap-2 mb-3">
@@ -1557,8 +1672,13 @@
 
       </div>
 
+      <details
+        class="border-0 border-t border-slate-800/60 bg-slate-900/60 px-2.5 py-2.5 text-[10px] text-slate-400"
+        data-market-diagnostics-secondary-v1="true"
+      >
+        <summary class="cursor-pointer font-semibold text-slate-200 uppercase tracking-wide outline-none hover:text-slate-100">Diagnostics (secondary)</summary>
       <section
-        class="border-0 border-t border-slate-800/60 bg-slate-900/60 px-2.5 py-2.5 text-[10px] text-slate-400 space-y-2"
+        class="mt-2 space-y-2"
         data-market-v0-status-panel="true"
         data-market-v0-status-diagnostics-visual-rails-v1="true"
         aria-label="Market diagnostic status (read-only)"
@@ -1601,6 +1721,7 @@
           </div>
         </div>
       </section>
+      </details>
       </div>
     </aside>
   </div>

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -1268,3 +1268,53 @@ def test_market_surface_ranking_funnel_producer_charter_v0() -> None:
 
     for token in forbidden_promotions:
         assert token in forbidden_section
+
+
+def test_market_operator_overview_story_markers_v1(client: TestClient) -> None:
+    """Operator overview redesign: story, system bar, chart primary, secondary guardrails."""
+    html = _html(client, "/market")
+
+    assert 'data-market-operator-overview-v1="true"' in html
+    assert 'data-market-operator-story-v1="true"' in html
+    assert 'data-market-operator-system-bar-v1="true"' in html
+    assert 'data-market-live-locked-v1="true"' in html
+    assert 'data-market-trading-authority-v1="false"' in html
+    assert 'data-market-guardrails-secondary-v1="true"' in html
+    assert 'data-market-diagnostics-secondary-v1="true"' in html
+    assert 'data-market-chart-primary-v1="true"' in html
+    assert 'data-market-top20-ranking-v1="true"' in html
+    assert 'data-market-ranking-source-mode-v1="fixture_offline"' in html
+    assert 'data-market-observe-strip-v1="true"' in html
+    assert 'data-market-ai-decision-readout-v1="true"' in html
+    assert 'data-market-double-play-status-v1="true"' in html
+    assert 'data-market-operator-step-v1="observe"' in html
+    assert 'data-market-operator-step-v1="rank"' in html
+    assert 'data-market-operator-step-v1="explain"' in html
+
+    lowered = html.lower()
+    assert "place order" not in lowered
+    assert "data-order-form" not in lowered
+
+
+def test_market_operator_overview_ranking_table_with_fixture_v1(
+    client_ranking_funnel_fixture_bundle_on: TestClient,
+) -> None:
+    html = _html(client_ranking_funnel_fixture_bundle_on, "/market")
+    assert 'data-market-top20-table-v1="true"' in html
+    assert 'data-market-ranking-source-mode-v1="existing_readmodel"' in html
+    assert "BTCUSDT" in html
+
+
+def test_double_play_operator_detail_redesign_markers_v1(client: TestClient) -> None:
+    html = _html(client, "/market/double-play")
+
+    assert 'data-double-play-operator-detail-v1="true"' in html
+    assert 'data-double-play-bull-bear-cards-v1="true"' in html
+    assert 'data-double-play-bull-card-v1="true"' in html
+    assert 'data-double-play-bear-card-v1="true"' in html
+    assert 'data-double-play-scope-capital-risk-v1="true"' in html
+    assert 'data-double-play-diagnostics-secondary-v1="true"' in html
+    assert 'data-double-play-market-depth-panel="true"' in html
+
+    lowered = html.lower()
+    assert "place order" not in lowered


### PR DESCRIPTION
## Summary
- User feedback: current market dashboard is unacceptable as operator UI (debug-first, banners dominate).
- Inventory input bundle: `review/market_dashboard_human_readable_implementation_description_from_inventory_no_run_no_mutation_v1_20260611T214230Z`
- Reuse-before-new: restructured existing `market_v0.html`, `double_play_market_dashboard_v0.html`, `market_surface.py` display wiring, ranking/depth/tape readmodels, and `build_static_dashboard_display_dict()` — no parallel dashboard SSOT.
- Reuse Drift Guard: canonical owners unchanged; `REUSE_DRIFT_GUARD_PASS=true`; no new routes/readmodels.

## Protected scope
- trading logic touched=false
- Master V2 touched=false
- Double Play decision logic touched=false
- Bull/Bear logic touched=false
- Risk/KillSwitch touched=false
- Scope/Capital touched=false
- workflow YAML touched=false

## Changed files
- `templates/peak_trade_dashboard/market_v0.html`
- `templates/peak_trade_dashboard/double_play_market_dashboard_v0.html`
- `src/webui/market_surface.py` (display-only operator overview context)
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- `docs/webui/MARKET_SURFACE_V0.md`

## Safety
Display-only / read-only / non-authorizing. No order/cancel/execute/arm controls. No trading runtime started.

## Tests
- `pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py` — 70 passed
- `ruff format --check` + `ruff check` on `src/webui/market_surface.py`
- Local TestClient: `/market` and `/market/double-play` HTTP 200


Made with [Cursor](https://cursor.com)