### PR TITLE
Market Dashboard observe co-presence tape depth wiring

### DIFF
--- a/docs/webui/MARKET_SURFACE_V0.md
+++ b/docs/webui/MARKET_SURFACE_V0.md
@@ -39,6 +39,7 @@ Keine Kopplung an OPS Cockpit (`/ops`). Keine Trading-Aktionen.
 - Top20/ranking table reuses **`market_ranking_funnel_readmodel_v0`** (`data-market-top20-ranking-v1`, `data-market-ranking-source-mode-v1`).
 - Explain readout reuses **`build_static_dashboard_display_dict()`** display-only (`data-market-ai-decision-readout-v1`) — **no** trading signal.
 - **`GET &#47;market&#47;double-play`**: Bull/Bear cards (`data-double-play-bull-bear-cards-v1`), compact scope/capital/risk cards (`data-double-play-scope-capital-risk-v1`); depth/diagnostics secondary.
+- **Observe co-presence tape+depth (v1):** `#market-v0-observe-strip` embeds compact inline micro-tables from existing **`market_tape`** / **`market_depth`** SSR contexts (`#market-v0-observe-co-presence`, `#market-v0-observe-tape-inline`, `#market-v0-observe-depth-inline`). View-only IA wiring — **no** new readmodel SSOT, **no** trading authority, **no** Kraken/live data claim without explicit `source-mode` labeling (`data-market-v0-observe-source-mode-v1`). Full tape/depth panels remain detail anchors below.
 - Chronicle crosslink: **`docs/ops/CI_AUDIT_KNOWN_ISSUES.md`** § Market Dashboard Operator Overview IA v1 DOCS_TRUTH_MAP static crosslink v1; **`docs/ops/registry/DOCS_TRUTH_MAP.md`** Änderungsnachweis row (PR #4145 anchor); static guard in **`tests/ops/test_market_surface_ranking_funnel_env_schema_boundary_v0.py`**. **Display-only / SSR / no SPA / no order controls** — Kraken-like information architecture is view-IA only, not trading control.
 
 ### Lane taxonomy cross-reference (non-authorizing)

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -304,22 +304,133 @@
     data-market-observe-strip-v1="true"
     data-market-tape-or-observe-strip-v1="true"
     data-market-depth-display-only-v1="true"
+    data-market-v0-observe-display-only-v1="true"
   >
     <h2 id="market-v0-landmark-observe-strip-h2" class="text-xs font-semibold text-teal-200/95 m-0 mb-2">Observe · Tape &amp; Depth (display-only)</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-[11px]">
-      <div class="rounded-lg border border-teal-800/40 bg-slate-950/55 px-2.5 py-2" data-market-observe-tape-summary-v1="true">
-        <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Market tape</p>
-        {% if market_tape.section_visible %}
-        <p class="m-0 mt-1 text-slate-200">{{ market_tape.summary_line|e }}</p>
-        <p class="m-0 mt-1 text-slate-500 tabular-nums">Status: {{ market_tape.display_status|e }} · Trades: {{ market_tape.trade_count }}</p>
+    <p class="m-0 mb-2 flex flex-wrap gap-1.5 text-[9px] font-semibold uppercase tracking-wide" data-market-v0-observe-display-only-v1="true">
+      <span class="rounded border border-slate-700/70 bg-slate-900/80 px-1.5 py-0.5 text-slate-300">READ ONLY</span>
+      <span class="rounded border border-slate-700/70 bg-slate-900/80 px-1.5 py-0.5 text-slate-300">display-only</span>
+      <span class="rounded border border-slate-700/70 bg-slate-900/80 px-1.5 py-0.5 text-slate-300">no orders</span>
+      <span class="rounded border border-slate-700/70 bg-slate-900/80 px-1.5 py-0.5 text-slate-300">no execution</span>
+    </p>
+    {% if market_tape.section_visible and market_tape.tape_ready %}
+    {% set observe_tape_source_mode = "fixture_offline" %}
+    {% elif market_tape.section_visible %}
+    {% set observe_tape_source_mode = market_tape.display_status %}
+    {% else %}
+    {% set observe_tape_source_mode = "disabled" %}
+    {% endif %}
+    {% if market_depth.has_depth_levels %}
+    {% set observe_depth_source_mode = "fixture_offline" if market_depth.display_status == "ok" else market_depth.display_status %}
+    {% else %}
+    {% set observe_depth_source_mode = market_depth.display_status %}
+    {% endif %}
+    <div
+      id="market-v0-observe-co-presence"
+      class="grid grid-cols-1 md:grid-cols-2 gap-3 text-[11px]"
+      data-market-v0-observe-co-presence-v1="true"
+      data-market-v0-observe-source-mode-v1="tape:{{ observe_tape_source_mode|e }};depth:{{ observe_depth_source_mode|e }}"
+    >
+      <div
+        id="market-v0-observe-tape-inline"
+        class="rounded-lg border border-teal-800/40 bg-slate-950/55 px-2.5 py-2 flex flex-col gap-1.5"
+        data-market-v0-observe-tape-inline-v1="true"
+        data-market-observe-tape-summary-v1="true"
+        data-market-v0-observe-tape-source-mode-v1="{{ observe_tape_source_mode|e }}"
+      >
+        <div class="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-0.5">
+          <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Market tape</p>
+          <span class="text-[9px] font-mono text-slate-500" data-market-v0-observe-source-mode-v1="tape">source: {{ observe_tape_source_mode|e }}</span>
+        </div>
+        {% if market_tape.tape_ready and market_tape.top_trades %}
+        <table class="w-full text-[10px] tabular-nums border-collapse">
+          <thead>
+            <tr class="text-slate-400 text-left">
+              <th class="pr-2 font-normal">seq</th>
+              <th class="pr-2 font-normal">side</th>
+              <th class="pr-2 font-normal">price</th>
+              <th class="font-normal">size</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in market_tape.top_trades %}
+            <tr data-market-v0-observe-tape-row-v1="true">
+              <td class="pr-2 text-slate-200">{{ row.sequence|e }}</td>
+              <td class="pr-2 text-slate-200">{{ row.side|e }}</td>
+              <td class="pr-2 font-mono text-slate-200">{{ row.price|e }}</td>
+              <td class="font-mono text-slate-200">{{ row.size|e }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <p class="m-0 text-[10px] text-slate-500">Top-{{ market_tape.top_trades|length }} · offline fixture · not live market data.</p>
         {% else %}
-        <p class="m-0 mt-1 text-slate-400">Tape SSR off or unconfigured — fixture/offline display mode.</p>
+        <p class="m-0 text-slate-400" data-market-v0-observe-tape-empty-v1="true">
+          {% if market_tape.section_visible %}
+          Tape unavailable in this snapshot ({{ market_tape.display_status|e }}) — display-only; not live market data.
+          {% else %}
+          Tape SSR off — fixture/offline display mode; enable env gate for full panel below.
+          {% endif %}
+        </p>
+        {% endif %}
+        {% if market_tape.section_visible %}
+        <p class="m-0 text-[10px] text-slate-500 tabular-nums">{{ market_tape.summary_line|e }}</p>
+        {% endif %}
+        {% if market_tape.section_visible %}
+        <p class="m-0 text-[9px] text-teal-700/90"><a href="#market-v0-tape-ssr" class="text-teal-400/90 no-underline hover:underline">Full tape panel ↓</a></p>
         {% endif %}
       </div>
-      <div class="rounded-lg border border-amber-800/40 bg-slate-950/55 px-2.5 py-2" data-market-observe-depth-summary-v1="true">
-        <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Orderbook / depth</p>
-        <p class="m-0 mt-1 text-slate-200">{{ market_depth.summary_line|e }}</p>
-        <p class="m-0 mt-1 text-slate-500 tabular-nums">Status: {{ market_depth.display_status|e }} · display-only · no controls</p>
+      <div
+        id="market-v0-observe-depth-inline"
+        class="rounded-lg border border-amber-800/40 bg-slate-950/55 px-2.5 py-2 flex flex-col gap-1.5"
+        data-market-v0-observe-depth-inline-v1="true"
+        data-market-observe-depth-summary-v1="true"
+        data-market-v0-observe-depth-source-mode-v1="{{ observe_depth_source_mode|e }}"
+      >
+        <div class="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-0.5">
+          <p class="m-0 text-slate-400 font-semibold uppercase text-[10px]">Orderbook / depth</p>
+          <span class="text-[9px] font-mono text-slate-500" data-market-v0-observe-source-mode-v1="depth">source: {{ observe_depth_source_mode|e }}</span>
+        </div>
+        {% if market_depth.has_depth_levels %}
+        {% set observe_depth_rows = [market_depth.top_bids[:5]|length, market_depth.top_asks[:5]|length]|max %}
+        <table class="w-full text-[10px] tabular-nums border-collapse">
+          <thead>
+            <tr class="text-slate-400 text-left">
+              <th class="pr-2 font-normal">lvl</th>
+              <th class="pr-2 font-normal">bid px</th>
+              <th class="pr-2 font-normal">bid sz</th>
+              <th class="pr-2 font-normal">ask px</th>
+              <th class="font-normal">ask sz</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for i in range(observe_depth_rows) %}
+            <tr data-market-v0-observe-depth-row-v1="true">
+              <td class="pr-2 text-slate-400">{{ i + 1 }}</td>
+              <td class="pr-2 font-mono text-emerald-300/90">
+                {% if i < market_depth.top_bids|length %}{{ market_depth.top_bids[i].price|e }}{% else %}—{% endif %}
+              </td>
+              <td class="pr-2 font-mono text-slate-300">
+                {% if i < market_depth.top_bids|length %}{{ market_depth.top_bids[i].size|e }}{% else %}—{% endif %}
+              </td>
+              <td class="pr-2 font-mono text-rose-300/90">
+                {% if i < market_depth.top_asks|length %}{{ market_depth.top_asks[i].price|e }}{% else %}—{% endif %}
+              </td>
+              <td class="font-mono text-slate-300">
+                {% if i < market_depth.top_asks|length %}{{ market_depth.top_asks[i].size|e }}{% else %}—{% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <p class="m-0 text-[10px] text-slate-500">Top levels · offline bundle · not live orderbook · no order controls.</p>
+        {% else %}
+        <p class="m-0 text-slate-400" data-market-v0-observe-depth-empty-v1="true">
+          Depth ladder empty ({{ market_depth.display_status|e }}) — display-only; not live orderbook data.
+        </p>
+        {% endif %}
+        <p class="m-0 text-[10px] text-slate-500 tabular-nums">{{ market_depth.summary_line|e }}</p>
+        <p class="m-0 text-[9px] text-amber-700/90"><a href="#market-v0-depth-ssr" class="text-amber-400/90 no-underline hover:underline">Full depth panel ↓</a></p>
       </div>
     </div>
   </section>

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -1318,3 +1318,77 @@ def test_double_play_operator_detail_redesign_markers_v1(client: TestClient) -> 
 
     lowered = html.lower()
     assert "place order" not in lowered
+
+
+def test_market_observe_co_presence_tape_depth_inline_default_v1(client: TestClient) -> None:
+    """Observe strip surfaces co-presence inline tape/depth wiring with display-only markers."""
+    html = _html(client, "/market")
+
+    assert 'id="market-v0-observe-co-presence"' in html
+    assert 'data-market-v0-observe-co-presence-v1="true"' in html
+    assert 'id="market-v0-observe-tape-inline"' in html
+    assert 'data-market-v0-observe-tape-inline-v1="true"' in html
+    assert 'id="market-v0-observe-depth-inline"' in html
+    assert 'data-market-v0-observe-depth-inline-v1="true"' in html
+    assert 'data-market-v0-observe-display-only-v1="true"' in html
+    assert 'data-market-v0-observe-source-mode-v1=' in html
+    assert ">READ ONLY<" in html
+    assert ">display-only<" in html
+    assert ">no orders<" in html
+    assert ">no execution<" in html
+    assert 'data-market-v0-observe-tape-empty-v1="true"' in html
+    assert 'data-market-v0-observe-depth-empty-v1="true"' in html
+    assert 'data-market-v0-observe-tape-source-mode-v1="disabled"' in html
+    assert 'data-market-v0-observe-depth-source-mode-v1="disabled"' in html
+
+    observe_idx = html.index('id="market-v0-observe-strip"')
+    observe_window = html[observe_idx : observe_idx + 12000].lower()
+    assert "data-order-form" not in observe_window
+    assert "data-order-submit" not in observe_window
+    assert "place order" not in observe_window
+    assert "cancel order" not in observe_window
+    assert "arm order" not in observe_window
+    assert "leverage" not in observe_window
+    assert "margin control" not in observe_window
+
+    assert 'data-market-operator-overview-v1="true"' in html
+    assert 'data-market-observe-strip-v1="true"' in html
+    assert 'data-market-operator-step-v1="observe"' in html
+
+
+def test_market_observe_co_presence_tape_depth_inline_with_fixtures_v1(
+    client_depth_fixture_bundle_on: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fixture tape+depth bundles render inline micro-table rows in observe co-presence strip."""
+    fixture_root = (
+        project_root / "tests" / "fixtures" / "market_tape_readmodel_v0" / "complete_minimal"
+    )
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(fixture_root.resolve()))
+
+    html = _html(client_depth_fixture_bundle_on, "/market")
+
+    assert 'data-market-v0-observe-co-presence-v1="true"' in html
+    assert 'data-market-v0-observe-tape-inline-v1="true"' in html
+    assert 'data-market-v0-observe-depth-inline-v1="true"' in html
+    assert 'data-market-v0-observe-tape-source-mode-v1="fixture_offline"' in html
+    assert 'data-market-v0-observe-depth-source-mode-v1="fixture_offline"' in html
+    assert 'data-market-v0-observe-tape-row-v1="true"' in html
+    assert 'data-market-v0-observe-depth-row-v1="true"' in html
+    assert "63010" in html
+    assert "63000" in html
+    assert "63030" in html
+    assert 'data-market-v0-observe-tape-empty-v1="true"' not in html
+    assert 'data-market-v0-observe-depth-empty-v1="true"' not in html
+
+
+def test_double_play_excludes_market_observe_co_presence_markers_v1(client: TestClient) -> None:
+    """Double-Play must not carry /market-only observe co-presence inline markers."""
+    html = _html(client, "/market/double-play")
+    assert "market-v0-observe-co-presence" not in html
+    assert "market-v0-observe-tape-inline" not in html
+    assert "market-v0-observe-depth-inline" not in html
+    assert "data-market-v0-observe-co-presence-v1" not in html
+    assert "data-market-v0-observe-tape-inline-v1" not in html
+    assert "data-market-v0-observe-depth-inline-v1" not in html

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -1331,7 +1331,7 @@ def test_market_observe_co_presence_tape_depth_inline_default_v1(client: TestCli
     assert 'id="market-v0-observe-depth-inline"' in html
     assert 'data-market-v0-observe-depth-inline-v1="true"' in html
     assert 'data-market-v0-observe-display-only-v1="true"' in html
-    assert 'data-market-v0-observe-source-mode-v1=' in html
+    assert "data-market-v0-observe-source-mode-v1=" in html
     assert ">READ ONLY<" in html
     assert ">display-only<" in html
     assert ">no orders<" in html


### PR DESCRIPTION
## Summary

- Implements **Rank-1 slice: Observe Co-Presence Tape+Depth Wiring v1** from gap-review bundle `market_dashboard_kraken_like_operator_ux_gap_review_after_operator_overview_ia_v1_crosslink_guard_no_run_v1_20260611T222209Z`.
- Kraken-like **Observe** column on `GET /market`: `#market-v0-observe-strip` now surfaces compact inline tape + depth micro-tables (co-presence summary level), reusing existing `market_tape` / `market_depth` SSR contexts — **display-only**, no new data source or route.
- **Reuse-before-new:** template wiring only; full tape/depth panels retained as detail anchors below.
- **Reuse Drift Guard:** no parallel SSOT; markers follow existing `data-market-v0-*` families; `/market/double-play` excludes co-presence markers.

## Protected Scope Summary

| Check | Value |
|-------|-------|
| trading logic touched | false |
| Master V2 touched | false |
| Double Play decision logic touched | false |
| Bull/Bear logic touched | false |
| Risk/KillSwitch touched | false |
| Scope/Capital touched | false |
| workflow YAML touched | false |

- display-only / no-trading-authority / no order controls
- source-mode labeling (`disabled`, `fixture_offline`, `display_status`) — no live/Kraken claims without explicit mode

## Files changed

- `templates/peak_trade_dashboard/market_v0.html`
- `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- `docs/webui/MARKET_SURFACE_V0.md`

## Tests run

```
python3 -m pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q
73 passed
```

## Durable bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/market_dashboard_kraken_like_observe_co_presence_tape_depth_wiring_v1_no_run_20260611T222512Z`


Made with [Cursor](https://cursor.com)