### PR TITLE
fix(webui): show real market values in dashboard operator view

### DIFF
--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -611,7 +611,7 @@ def create_app() -> FastAPI:
         symbol: str = Query("BTC/EUR", description="Trading-Paar, z.B. BTC/EUR"),
         timeframe: str = Query("1d", description="Timeframe (Kraken); Dummy ignoriert Serie"),
         limit: int = Query(120, ge=1, le=MAX_OHLCV_LIMIT, description="Bars (max 720)"),
-        source: str = Query("dummy", description="dummy | kraken"),
+        source: str = Query("kraken", description="dummy | kraken"),
     ) -> RedirectResponse:
         """Legacy deep-link → canonical GET /market with #double-play anchor (query preserved)."""
         if timeframe not in MARKET_TIMEFRAMES:

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -54,9 +54,10 @@ MARKET_TIMEFRAMES: tuple[str, ...] = ("1m", "5m", "15m", "1h", "4h", "1d")
 MAX_OHLCV_LIMIT = 720
 MARKET_DEPTH_SSR_TOP_LEVELS = 8
 MARKET_TAPE_SSR_TOP_TRADES = 5
-DEFAULT_SYMBOL = "BTC/USD"
-DEFAULT_TIMEFRAME = "1h"
+DEFAULT_SYMBOL = "BTC/EUR"
+DEFAULT_TIMEFRAME = "1d"
 DEFAULT_LIMIT = 120
+DEFAULT_MARKET_PAGE_SOURCE = "kraken"
 
 MARKET_SINGLE_PAGE_CONSOLIDATION_ENABLED_ENV = (
     "PEAK_TRADE_MARKET_SINGLE_PAGE_CONSOLIDATION_V1_ENABLED"
@@ -806,6 +807,86 @@ def _format_display_price(value: float | None) -> str:
     return text or "0"
 
 
+def _safe_bar_float(bar: Dict[str, Any], key: str) -> float | None:
+    raw = bar.get(key)
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_market_primary_values_display_context(
+    *,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    source: Literal["kraken", "dummy"],
+    payload: Dict[str, Any],
+    provider_unavailable: bool = False,
+    provider_error: str = "",
+) -> Dict[str, Any]:
+    """Above-the-fold primary market values for GET /market operator view (display-only)."""
+
+    if source == "dummy":
+        source_label = "Dummy / Synthetic (offline)"
+        source_mode = "dummy_offline_synthetic"
+    elif source == "kraken":
+        source_label = "Kraken public / read-only"
+        source_mode = "kraken_public_ohlcv"
+    else:
+        source_label = "Unavailable"
+        source_mode = "unavailable"
+
+    bars = payload.get("bars") if isinstance(payload.get("bars"), list) else []
+    last_bar = bars[-1] if bars and isinstance(bars[-1], dict) else {}
+    prev_bar = bars[-2] if len(bars) >= 2 and isinstance(bars[-2], dict) else {}
+
+    open_v = _safe_bar_float(last_bar, "open")
+    high_v = _safe_bar_float(last_bar, "high")
+    low_v = _safe_bar_float(last_bar, "low")
+    close_v = _safe_bar_float(last_bar, "close")
+    prev_close = _safe_bar_float(prev_bar, "close")
+
+    change_abs: float | None = None
+    change_pct: float | None = None
+    if close_v is not None and prev_close is not None:
+        change_abs = close_v - prev_close
+        if prev_close != 0:
+            change_pct = (change_abs / prev_close) * 100.0
+
+    data_available = bool(bars) and not provider_unavailable and close_v is not None
+
+    return {
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "limit": limit,
+        "source": source,
+        "source_label": source_label,
+        "source_mode": source_mode,
+        "provider_unavailable": provider_unavailable,
+        "provider_error": _truncate_display(provider_error, max_len=240),
+        "data_available": data_available,
+        "snapshot_at_utc": str(payload.get("generated_at_utc") or "").strip(),
+        "last_bar_ts": str(last_bar.get("ts") or "").strip(),
+        "open": open_v,
+        "high": high_v,
+        "low": low_v,
+        "close": close_v,
+        "open_display": _format_display_price(open_v),
+        "high_display": _format_display_price(high_v),
+        "low_display": _format_display_price(low_v),
+        "close_display": _format_display_price(close_v),
+        "change_abs": change_abs,
+        "change_pct": change_pct,
+        "change_abs_display": _format_display_price(change_abs),
+        "change_pct_display": f"{change_pct:.4f}%" if change_pct is not None else "",
+        "change_status": "available" if change_abs is not None else "unavailable",
+        "bars_returned": int(payload.get("bars_returned") or 0),
+    }
+
+
 def build_market_instrument_header_display_context(
     *,
     symbol: str,
@@ -1063,6 +1144,66 @@ def build_market_payload(
     }
 
 
+def build_market_payload_for_page(
+    *,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    source: Literal["kraken", "dummy"],
+) -> tuple[Dict[str, Any], bool, str]:
+    """Page-safe OHLCV payload: Kraken provider failures become empty bars + error flag."""
+
+    try:
+        return (
+            build_market_payload(symbol=symbol, timeframe=timeframe, limit=limit, source=source),
+            False,
+            "",
+        )
+    except HTTPException as exc:
+        if source == "kraken" and exc.status_code == 503:
+            detail = str(exc.detail) if exc.detail else "public market data unavailable"
+            return _empty_kraken_page_payload(
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+                detail=detail,
+            )
+        raise
+    except Exception as exc:
+        if source == "kraken":
+            detail = str(exc).strip() or "public market data unavailable"
+            return _empty_kraken_page_payload(
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+                detail=detail,
+            )
+        raise
+
+
+def _empty_kraken_page_payload(
+    *,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    detail: str,
+) -> tuple[Dict[str, Any], bool, str]:
+    return (
+        {
+            "generated_at_utc": _utc_now_iso(),
+            "source": "kraken",
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "limit_requested": limit,
+            "bars_returned": 0,
+            "meta": {"provider_error": detail},
+            "bars": [],
+        },
+        True,
+        detail,
+    )
+
+
 def create_market_router(
     templates: Jinja2Templates,
     get_project_status: Callable[[], Dict[str, Any]],
@@ -1101,7 +1242,7 @@ def create_market_router(
         symbol: str = Query(DEFAULT_SYMBOL),
         timeframe: str = Query(DEFAULT_TIMEFRAME),
         limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_OHLCV_LIMIT),
-        source: str = Query("dummy"),
+        source: str = Query(DEFAULT_MARKET_PAGE_SOURCE),
     ) -> Any:
         if timeframe not in MARKET_TIMEFRAMES:
             raise HTTPException(
@@ -1109,7 +1250,18 @@ def create_market_router(
                 detail=f"timeframe muss einer von {list(MARKET_TIMEFRAMES)} sein, nicht {timeframe!r}",
             )
         src = _normalize_source(source)
-        payload = build_market_payload(symbol=symbol, timeframe=timeframe, limit=limit, source=src)
+        payload, provider_unavailable, provider_error = build_market_payload_for_page(
+            symbol=symbol, timeframe=timeframe, limit=limit, source=src
+        )
+        primary_values = build_market_primary_values_display_context(
+            symbol=symbol,
+            timeframe=timeframe,
+            limit=limit,
+            source=src,
+            payload=payload,
+            provider_unavailable=provider_unavailable,
+            provider_error=provider_error,
+        )
         proj_status = get_project_status()
         market_depth = build_market_depth_display_context()
         run_projection = build_market_run_projection_display_context()
@@ -1165,6 +1317,7 @@ def create_market_router(
                 "ranking_watchlist": ranking_watchlist,
                 "operator_overview": operator_overview,
                 "instrument_header": instrument_header,
+                "primary_values": primary_values,
                 "futures_metrics_strip": futures_metrics_strip,
                 "active_paper_run": active_paper_run,
                 "market_single_page_consolidation": market_single_page_consolidation,

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -50,6 +50,92 @@
   </section>
 
   <section
+    id="market-v0-primary-values"
+    role="region"
+    aria-labelledby="market-v0-landmark-primary-values-h2"
+    class="rounded-xl border border-sky-900/45 bg-gradient-to-r from-slate-950/95 via-sky-950/30 to-slate-950/95 px-3 py-3 sm:px-4 shadow-sm shadow-black/20 ring-1 ring-sky-900/35"
+    data-market-primary-values-v1="true"
+    data-market-real-values-operator-view-v1="true"
+    data-market-primary-values-source="{{ query.source }}"
+  >
+    <h2 id="market-v0-landmark-primary-values-h2" class="sr-only">Primary market values</h2>
+    {% if query.source == 'dummy' %}
+    <p
+      class="m-0 mb-2 rounded-lg border border-amber-800/55 bg-amber-950/45 px-2.5 py-2 text-[11px] font-semibold text-amber-100/95"
+      data-market-source-kind="dummy-offline-synthetic"
+      data-market-dummy-clearly-labeled-v1="true"
+    >
+      Dummy / Synthetic / Offline — keine echten Marktdaten. Explizit über <span class="font-mono">source=dummy</span>.
+    </p>
+    {% elif query.source == 'kraken' %}
+    <p
+      class="m-0 mb-2 rounded-lg border border-emerald-800/45 bg-emerald-950/35 px-2.5 py-2 text-[11px] text-emerald-100/95"
+      data-market-source-kind="kraken-public-ohlcv-network"
+    >
+      <strong class="text-emerald-200/95">Kraken public / read-only</strong> — öffentliche OHLCV, keine Orders, kein Live.
+    </p>
+    {% endif %}
+    {% if primary_values.provider_unavailable %}
+    <p
+      class="m-0 mb-2 rounded-lg border border-rose-800/55 bg-rose-950/40 px-2.5 py-2 text-[11px] font-semibold text-rose-100/95"
+      data-market-public-data-unavailable-v1="true"
+    >
+      Public market data unavailable{% if primary_values.provider_error %} — {{ primary_values.provider_error|e }}{% endif %}.
+    </p>
+    {% endif %}
+    <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-2">
+      <p class="m-0 text-xl sm:text-2xl font-bold font-mono text-slate-50 tracking-tight">{{ primary_values.symbol|e }}</p>
+      <span class="text-[10px] font-semibold uppercase tracking-wide text-slate-400">{{ primary_values.timeframe|e }} · {{ primary_values.bars_returned }} bars · limit {{ primary_values.limit }}</span>
+    </div>
+    <dl class="m-0 grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-x-3 gap-y-2 text-[11px] tabular-nums">
+      <div>
+        <dt class="text-slate-500 uppercase text-[10px] tracking-wide">Last / Close</dt>
+        <dd class="m-0 font-mono text-lg text-sky-200/95">
+          {% if primary_values.data_available %}{{ primary_values.close_display|e }}{% else %}—{% endif %}
+        </dd>
+      </div>
+      <div>
+        <dt class="text-slate-500 uppercase text-[10px] tracking-wide">Open</dt>
+        <dd class="m-0 font-mono text-slate-200">{% if primary_values.data_available %}{{ primary_values.open_display|e }}{% else %}—{% endif %}</dd>
+      </div>
+      <div>
+        <dt class="text-slate-500 uppercase text-[10px] tracking-wide">High</dt>
+        <dd class="m-0 font-mono text-slate-200">{% if primary_values.data_available %}{{ primary_values.high_display|e }}{% else %}—{% endif %}</dd>
+      </div>
+      <div>
+        <dt class="text-slate-500 uppercase text-[10px] tracking-wide">Low</dt>
+        <dd class="m-0 font-mono text-slate-200">{% if primary_values.data_available %}{{ primary_values.low_display|e }}{% else %}—{% endif %}</dd>
+      </div>
+      <div>
+        <dt class="text-slate-500 uppercase text-[10px] tracking-wide">Change</dt>
+        <dd class="m-0 font-mono text-slate-200">
+          {% if primary_values.change_status == "available" %}
+          {{ primary_values.change_abs_display|e }} ({{ primary_values.change_pct_display|e }})
+          {% else %}—{% endif %}
+        </dd>
+      </div>
+      <div>
+        <dt class="text-slate-500 uppercase text-[10px] tracking-wide">Last bar ts</dt>
+        <dd class="m-0 font-mono text-slate-300 break-all text-[10px]">{{ primary_values.last_bar_ts|e or "—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-slate-500 uppercase text-[10px] tracking-wide">Snapshot</dt>
+        <dd class="m-0 font-mono text-slate-300 break-all text-[10px]">{{ primary_values.snapshot_at_utc|e or "—" }}</dd>
+      </div>
+      <div>
+        <dt class="text-slate-500 uppercase text-[10px] tracking-wide">Source</dt>
+        <dd class="m-0 font-mono text-sky-300/90">{{ primary_values.source_label|e }}</dd>
+      </div>
+    </dl>
+  </section>
+
+  {% include "partials/market_primary_close_chart_v1.html" %}
+
+  {% include "partials/double_play_market_panel_v0.html" %}
+
+  {% include "partials/futures_read_only_market_panel_v0.html" %}
+
+  <section
     id="market-v0-instrument-header"
     role="region"
     aria-labelledby="market-v0-landmark-instrument-header-h2"
@@ -109,13 +195,6 @@
           unavailable (depth {{ market_depth.display_status|e }}) · display-only
           {% endif %}
         </dd>
-      </div>
-      <div class="flex items-end">
-        <a
-          href="{{ instrument_header.double_play_href|e }}"
-          class="inline-flex items-center gap-1 rounded-md border border-amber-900/45 bg-amber-950/35 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-amber-200/95 no-underline hover:bg-amber-950/55"
-          data-market-v0-instrument-nav-double-play="true"
-        >Double-Play detail →</a>
       </div>
     </dl>
   </section>
@@ -267,7 +346,7 @@
         <p class="m-0 leading-snug"><strong class="text-sky-200/95">Öffentliche OHLCV (Kraken)</strong> — rein anzeigend, kein Futures-Readiness-Nachweis.</p>
         {% endif %}
         <p class="mt-2 m-0 leading-snug"><strong class="text-amber-200/95">Guardrails:</strong> Dashboard ≠ Freigabe · AI ≠ Authority · Signal ≠ Trade · Docs ≠ Approval — reine Anzeige, keine Broker-/Order-/Live-Autorität.</p>
-        <p class="mt-2 m-0 leading-snug" data-market-v0-paper-run-truth-separation-v0="true"><strong class="text-violet-200/95">Market Surface ≠ Paper Run Truth.</strong> Default symbol and dummy OHLCV are chart fixtures only.</p>
+        <p class="mt-2 m-0 leading-snug" data-market-v0-paper-run-truth-separation-v0="true"><strong class="text-violet-200/95">Market Surface ≠ Paper Run Truth.</strong> Chart values reflect the selected query source only.</p>
       </section>
     </div>
   </details>
@@ -842,9 +921,7 @@
     </div>
   </section>
 
-  {% include "partials/double_play_market_panel_v0.html" %}
-
-  {% include "partials/futures_read_only_market_panel_v0.html" %}
+  <!-- Double-Play / Futures embedded above-the-fold after primary chart -->
 
   <!-- Pro cockpit grid: chart/main column + read-only side panels (IA inspiration only; no order UI) -->
   <div
@@ -1308,219 +1385,8 @@
     </p>
   </section>
 
-  <section
-    role="region"
-    aria-labelledby="market-v0-landmark-close-chart-h2"
-    class="bg-slate-900/65 rounded-xl border border-slate-800 ring-2 ring-sky-900/15 shadow-xl shadow-black/30 p-4 sm:p-5 min-h-[30rem]"
-    data-chart="market-v0-close-line"
-    data-market-chart-primary-v1="true"
-    data-market-v11-chart-diagnostics="true"
-  >
-    <div class="flex flex-wrap items-end justify-between gap-2 mb-3">
-      <h2 id="market-v0-landmark-close-chart-h2" class="text-base font-semibold text-slate-100 m-0 tracking-tight">Schlusskurs (Close)</h2>
-      <span class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Dominant panel · keine Order-UI</span>
-    </div>
+  {# Primary OHLC chart rendered above-the-fold via partial market_primary_close_chart_v1.html #}
 
-    <div
-      class="rounded-xl border border-slate-700/75 bg-slate-950/55 ring-1 ring-sky-900/15 shadow-inner shadow-black/25 overflow-hidden"
-      data-market-v0-chart-candle-stack="true"
-    >
-
-    <div
-      class="border-b border-slate-800/80 bg-slate-950/65 p-3 sm:p-3.5 text-xs text-slate-300"
-      data-market-v11-diagnostics-inner="true"
-    >
-      <h3 class="text-sm font-semibold text-slate-100 tracking-tight m-0 mb-2">Chart diagnostics</h3>
-      <p class="text-[11px] text-slate-400 leading-snug m-0 mb-3">
-        No backend/API/provider change. Chart.js loads from CDN; if blank:
-        <span class="text-rose-400/95 font-medium">Chart library missing or blocked</span>
-        oder
-        <span class="text-rose-400/95 font-medium">Chart render error</span>.
-      </p>
-      <dl
-        class="m-0 flex flex-col sm:flex-row gap-2 font-mono text-[11px]"
-        data-market-v11-diagnostics-visual-rails="true"
-        aria-label="Chart diagnostics summary"
-      >
-        <div class="flex-1 min-w-0 rounded-lg border border-slate-800/80 bg-slate-950/55 overflow-hidden flex shadow-sm shadow-black/15">
-          <div class="w-1 shrink-0 bg-sky-500/55 self-stretch" aria-hidden="true"></div>
-          <div class="min-w-0 flex-1 px-2.5 py-2">
-            <dt class="text-slate-500 uppercase tracking-wide text-[10px] mb-1 m-0" data-market-v11-chart-library-status="true">
-              Chart.js status
-            </dt>
-            <dd id="market-v11-chartjs-state" class="text-sky-300/95 m-0">SSR only — verified in browser</dd>
-          </div>
-        </div>
-        <div class="flex-1 min-w-0 rounded-lg border border-slate-800/80 bg-slate-950/55 overflow-hidden flex shadow-sm shadow-black/15">
-          <div class="w-1 shrink-0 bg-emerald-500/45 self-stretch" aria-hidden="true"></div>
-          <div class="min-w-0 flex-1 px-2.5 py-2">
-            <dt class="text-slate-500 uppercase tracking-wide text-[10px] mb-1 m-0" data-market-v11-payload-bars="true">
-              Embedded bars
-            </dt>
-            <dd id="market-v11-embedded-bar-count" class="text-slate-200 m-0">{{ payload.bars_returned }}</dd>
-          </div>
-        </div>
-        <div class="flex-1 min-w-0 rounded-lg border border-slate-800/80 bg-slate-950/55 overflow-hidden flex shadow-sm shadow-black/15">
-          <div class="w-1 shrink-0 {% if payload.bars_returned == 0 %}bg-amber-500/50{% else %}bg-emerald-500/45{% endif %} self-stretch" aria-hidden="true"></div>
-          <div class="min-w-0 flex-1 px-2.5 py-2">
-            <dt class="text-slate-500 uppercase tracking-wide text-[10px] mb-1 m-0">Chart render status</dt>
-            <dd id="market-v11-client-render-flag" class="text-slate-200 m-0">
-              SSR: {% if payload.bars_returned == 0 %}empty{% else %}ready{% endif %}
-            </dd>
-          </div>
-        </div>
-      </dl>
-    </div>
-
-    <div
-      id="market-v11-render-fallback"
-      data-market-v11-render-fallback="true"
-      data-market-v11-fallback-mode="{% if payload.bars_returned == 0 %}empty-ssr{% else %}client-alert{% endif %}"
-      role="alert"
-      class="mb-0 rounded-none border-x-0 border-t-0 border-b-2 px-4 py-3 {% if payload.bars_returned == 0 %}block border-b-amber-500/80 bg-amber-950/50 text-amber-50{% else %}hidden border-b-rose-600/85 bg-rose-950/40 text-rose-50{% endif %}"
-      {% if payload.bars_returned != 0 %}aria-hidden="true"{% endif %}
-    >
-      {% if payload.bars_returned == 0 %}
-      <p class="m-0 text-sm font-semibold leading-snug">
-        Embedded bars: keine OHLCV-Serie eingebettet — Chart bleibt leer bis Daten vorliegen.
-      </p>
-      {% endif %}
-      <p
-        id="market-v11-render-fallback-msg"
-        class="{% if payload.bars_returned == 0 %}hidden m-0{% else %}hidden m-0 text-sm font-semibold{% endif %}"
-      ></p>
-    </div>
-
-    <div
-      id="market-v0-chart-status"
-      role="status"
-      class="text-xs text-slate-200 mb-0 min-h-[1.5rem] font-medium border-b border-slate-800/80 border-l-4 border-l-sky-500/55 px-3 py-2.5 bg-slate-950/55"
-      data-market-chart-status="{% if payload.bars_returned == 0 %}empty{% else %}ready{% endif %}"
-      {% if payload.bars_returned == 0 %}data-market-empty-state="true"{% endif %}
-    >
-      {% if payload.bars_returned == 0 %}
-      Keine OHLCV-Bars für diese Abfrage verfügbar.
-      {% else %}
-      Chart bereit — read-only OHLCV-Anzeige.
-      {% endif %}
-    </div>
-
-    <div
-      class="relative flex flex-col min-h-[22rem] h-[28rem] sm:h-[30rem] w-full rounded-none border-0 border-t border-slate-800/70 bg-gradient-to-b from-slate-950/45 to-slate-950/80 shadow-inner shadow-black/35"
-      data-market-v0-close-chart-integrated-frame="true"
-      data-market-v0-in-chart-ohlc-svg-v1="true"
-      aria-label="OHLC chart (SSR, read-only)"
-    >
-      <div class="shrink-0 bg-slate-950/80 px-3 py-2.5 border-b border-slate-800/60">
-        <div class="flex flex-wrap items-center justify-between gap-2">
-          <div>
-            <h3 class="text-[11px] font-semibold text-slate-100 tracking-tight m-0">OHLC chart (SSR)</h3>
-            <p class="text-[9px] text-slate-500 m-0 mt-0.5 leading-snug">Kerzen im Plot· dieselbe Preisskala · Not live · No polling · read-only</p>
-          </div>
-          {% if payload.bars and payload.bars|length > 0 %}
-          {% set _cmax_ic = 96 %}
-          {% set _blen_ic = payload.bars|length %}
-          {% set _cshown_ic = _blen_ic if _blen_ic < _cmax_ic else _cmax_ic %}
-          <span class="rounded border border-slate-700/70 bg-slate-900/70 px-1.5 py-0.5 text-[8px] font-semibold text-slate-400 tabular-nums uppercase">Plot {{ _cshown_ic }} bars</span>
-          {% endif %}
-        </div>
-      </div>
-
-      <div class="relative flex-1 min-h-0 w-full bg-slate-950/40">
-        {% if not payload.bars or payload.bars|length == 0 %}
-        <div
-          class="flex h-full min-h-[16rem] items-center justify-center px-4 text-center text-[11px] text-slate-500"
-          data-market-v0-in-chart-ohlc-svg-empty="true"
-        >
-          <p class="m-0 max-w-md leading-snug">No embedded OHLCV rows — chart area empty (SSR). Keine synthetischen Kerzen.</p>
-        </div>
-        {% else %}
-        {% set cmax_ic = 96 %}
-        {% set blen_ic = payload.bars|length %}
-        {% set cstart_ic = blen_ic - cmax_ic if blen_ic > cmax_ic else 0 %}
-        {% set chart_bars_ic = payload.bars[cstart_ic:] %}
-        {% set n_ic = chart_bars_ic|length %}
-        {% set mm_ic = namespace(minv=0.0, maxv=0.0, first=true) %}
-        {% for bar in chart_bars_ic %}
-          {% set lo = bar.low|float %}
-          {% set hi = bar.high|float %}
-          {% if mm_ic.first %}
-            {% set mm_ic.minv = lo %}
-            {% set mm_ic.maxv = hi %}
-            {% set mm_ic.first = false %}
-          {% else %}
-            {% if lo < mm_ic.minv %}{% set mm_ic.minv = lo %}{% endif %}
-            {% if hi > mm_ic.maxv %}{% set mm_ic.maxv = hi %}{% endif %}
-          {% endif %}
-        {% endfor %}
-        {% set sp_raw = mm_ic.maxv - mm_ic.minv %}
-        {% set sp_use = sp_raw if sp_raw >= 1e-12 else 1e-12 %}
-        {% set vb_w_ic = 1000 %}
-        {% set vb_h_ic = 420 %}
-        {% set pad_l_ic = 52 %}
-        {% set pad_r_ic = 14 %}
-        {% set pad_t_ic = 18 %}
-        {% set pad_b_ic = 38 %}
-        {% set plot_w_ic = vb_w_ic - pad_l_ic - pad_r_ic %}
-        {% set plot_h_ic = vb_h_ic - pad_t_ic - pad_b_ic %}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 {{ vb_w_ic }} {{ vb_h_ic }}"
-          preserveAspectRatio="none"
-          class="block h-full w-full"
-          role="img"
-          aria-label="SSR OHLC candlesticks in plot coordinates, older left newer right, read-only"
-          data-market-v0-in-chart-ohlc-svg-root="true"
-        >
-          <rect x="0" y="0" width="{{ vb_w_ic }}" height="{{ vb_h_ic }}" fill="rgba(15,23,42,0.35)" />
-          {% for gi in range(5) %}
-          {% set gy = pad_t_ic + (plot_h_ic * gi / 4) %}
-          <line x1="{{ pad_l_ic }}" y1="{{ gy }}" x2="{{ vb_w_ic - pad_r_ic }}" y2="{{ gy }}" stroke="rgba(148,163,184,0.12)" stroke-width="1" />
-          {% endfor %}
-          {% for bar in chart_bars_ic %}
-          {% set loop_idx = loop.index0 %}
-          {% set o = bar.open|float %}
-          {% set h = bar.high|float %}
-          {% set l = bar.low|float %}
-          {% set c = bar.close|float %}
-          {% if o >= c %}
-            {% set top_pri = o %}
-            {% set bot_pri = c %}
-          {% else %}
-            {% set top_pri = c %}
-            {% set bot_pri = o %}
-          {% endif %}
-          {% set up_ic = c >= o %}
-          {% set slot_w = plot_w_ic / n_ic %}
-          {% set cx = pad_l_ic + (loop_idx + 0.5) * slot_w %}
-          {% set cw0 = [12, slot_w * 0.62]|min %}
-          {% set cw = [3.0, cw0]|max %}
-          {% set y_hi = pad_t_ic + (mm_ic.maxv - h) / sp_use * plot_h_ic %}
-          {% set y_lo = pad_t_ic + (mm_ic.maxv - l) / sp_use * plot_h_ic %}
-          {% set y_body_top = pad_t_ic + (mm_ic.maxv - top_pri) / sp_use * plot_h_ic %}
-          {% set y_body_bot = pad_t_ic + (mm_ic.maxv - bot_pri) / sp_use * plot_h_ic %}
-          {% set bh0 = y_body_bot - y_body_top %}
-          {% set bh = [bh0, 1.2]|max %}
-          <g
-            data-market-v0-in-chart-ohlc-candle="true"
-            {% if up_ic %}
-            data-market-v0-in-chart-ohlc-candle-up="true"
-            {% else %}
-            data-market-v0-in-chart-ohlc-candle-down="true"
-            {% endif %}
-          >
-            <line x1="{{ cx|round(2) }}" y1="{{ y_hi|round(2) }}" x2="{{ cx|round(2) }}" y2="{{ y_lo|round(2) }}" stroke="{% if up_ic %}rgba(52,211,153,0.85){% else %}rgba(244,63,94,0.88){% endif %}" stroke-width="1.1" />
-            <rect x="{{ (cx - cw / 2)|round(2) }}" y="{{ y_body_top|round(2) }}" width="{{ cw|round(2) }}" height="{{ bh|round(2) }}" rx="0.6" fill="{% if up_ic %}rgba(52,211,153,0.35){% else %}rgba(244,63,94,0.32){% endif %}" stroke="{% if up_ic %}rgba(52,211,153,0.55){% else %}rgba(244,63,94,0.5){% endif %}" stroke-width="0.9" />
-          </g>
-          {% endfor %}
-          <text x="{{ pad_l_ic }}" y="{{ vb_h_ic - 10 }}" fill="#64748b" font-size="11" font-family="ui-monospace, monospace">low {{ mm_ic.minv|round(8) }}</text>
-          <text x="{{ vb_w_ic - pad_r_ic }}" y="{{ pad_t_ic + 12 }}" text-anchor="end" fill="#64748b" font-size="11" font-family="ui-monospace, monospace">high {{ mm_ic.maxv|round(8) }}</text>
-        </svg>
-        {% endif %}
-      </div>
-    </div>
-    </div>
-  </section>
     </div>
 
     <aside

--- a/templates/peak_trade_dashboard/partials/market_primary_close_chart_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_primary_close_chart_v1.html
@@ -1,0 +1,230 @@
+<!-- Primary above-the-fold OHLC chart (GET /market operator view) -->
+<section
+  role="region"
+  aria-labelledby="market-v0-landmark-close-chart-h2"
+  class="bg-slate-900/65 rounded-xl border border-slate-800 ring-2 ring-sky-900/15 shadow-xl shadow-black/30 p-4 sm:p-5 min-h-[30rem]"
+  data-chart="market-v0-close-line"
+  data-market-chart-primary-v1="true"
+  data-market-primary-chart-section-v1="true"
+  data-market-v11-chart-diagnostics="true"
+>
+  <div class="flex flex-wrap items-end justify-between gap-2 mb-3">
+    <h2 id="market-v0-landmark-close-chart-h2" class="text-base font-semibold text-slate-100 m-0 tracking-tight">Market chart · OHLCV (read-only)</h2>
+    <span class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Primary · keine Order-UI</span>
+  </div>
+
+  <div
+    class="rounded-xl border border-slate-700/75 bg-slate-950/55 ring-1 ring-sky-900/15 shadow-inner shadow-black/25 overflow-hidden"
+    data-market-v0-chart-candle-stack="true"
+  >
+
+  <details
+    class="border-b border-slate-800/80 bg-slate-950/65 p-3 sm:p-3.5 text-xs text-slate-300"
+    data-market-diagnostics-secondary-v1="true"
+    data-market-v11-diagnostics-inner="true"
+  >
+    <summary class="cursor-pointer font-semibold text-slate-200 outline-none hover:text-slate-100">Chart diagnostics (secondary)</summary>
+    <div class="mt-2">
+      <p class="text-[11px] text-slate-400 leading-snug m-0 mb-3">
+        No backend/API/provider change. Chart.js loads from CDN; if blank:
+        <span class="text-rose-400/95 font-medium">Chart library missing or blocked</span>
+        oder
+        <span class="text-rose-400/95 font-medium">Chart render error</span>.
+      </p>
+      <dl
+        class="m-0 flex flex-col sm:flex-row gap-2 font-mono text-[11px]"
+        data-market-v11-diagnostics-visual-rails="true"
+        aria-label="Chart diagnostics summary"
+      >
+        <div class="flex-1 min-w-0 rounded-lg border border-slate-800/80 bg-slate-950/55 overflow-hidden flex shadow-sm shadow-black/15">
+          <div class="w-1 shrink-0 bg-sky-500/55 self-stretch" aria-hidden="true"></div>
+          <div class="min-w-0 flex-1 px-2.5 py-2">
+            <dt class="text-slate-500 uppercase tracking-wide text-[10px] mb-1 m-0" data-market-v11-chart-library-status="true">
+              Chart.js status
+            </dt>
+            <dd id="market-v11-chartjs-state" class="text-sky-300/95 m-0">SSR only — verified in browser</dd>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0 rounded-lg border border-slate-800/80 bg-slate-950/55 overflow-hidden flex shadow-sm shadow-black/15">
+          <div class="w-1 shrink-0 bg-emerald-500/45 self-stretch" aria-hidden="true"></div>
+          <div class="min-w-0 flex-1 px-2.5 py-2">
+            <dt class="text-slate-500 uppercase tracking-wide text-[10px] mb-1 m-0" data-market-v11-payload-bars="true">
+              Embedded bars
+            </dt>
+            <dd id="market-v11-embedded-bar-count" class="text-slate-200 m-0">{{ payload.bars_returned }}</dd>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0 rounded-lg border border-slate-800/80 bg-slate-950/55 overflow-hidden flex shadow-sm shadow-black/15">
+          <div class="w-1 shrink-0 {% if payload.bars_returned == 0 %}bg-amber-500/50{% else %}bg-emerald-500/45{% endif %} self-stretch" aria-hidden="true"></div>
+          <div class="min-w-0 flex-1 px-2.5 py-2">
+            <dt class="text-slate-500 uppercase tracking-wide text-[10px] mb-1 m-0">Chart render status</dt>
+            <dd id="market-v11-client-render-flag" class="text-slate-200 m-0">
+              SSR: {% if payload.bars_returned == 0 %}empty{% else %}ready{% endif %}
+            </dd>
+          </div>
+        </div>
+      </dl>
+    </div>
+  </details>
+
+  <div
+    id="market-v11-render-fallback"
+    data-market-v11-render-fallback="true"
+    data-market-v11-fallback-mode="{% if payload.bars_returned == 0 %}empty-ssr{% else %}client-alert{% endif %}"
+    role="alert"
+    class="mb-0 rounded-none border-x-0 border-t-0 border-b-2 px-4 py-3 {% if payload.bars_returned == 0 %}block border-b-amber-500/80 bg-amber-950/50 text-amber-50{% else %}hidden border-b-rose-600/85 bg-rose-950/40 text-rose-50{% endif %}"
+    {% if payload.bars_returned != 0 %}aria-hidden="true"{% endif %}
+  >
+    {% if payload.bars_returned == 0 %}
+    <p class="m-0 text-sm font-semibold leading-snug">
+      {% if primary_values.provider_unavailable %}
+      Public market data unavailable — chart area empty (no fake OHLCV).
+      {% else %}
+      Embedded bars: keine OHLCV-Serie eingebettet — Chart bleibt leer bis Daten vorliegen.
+      {% endif %}
+    </p>
+    {% endif %}
+    <p
+      id="market-v11-render-fallback-msg"
+      class="{% if payload.bars_returned == 0 %}hidden m-0{% else %}hidden m-0 text-sm font-semibold{% endif %}"
+    ></p>
+  </div>
+
+  <div
+    id="market-v0-chart-status"
+    role="status"
+    class="text-xs text-slate-200 mb-0 min-h-[1.5rem] font-medium border-b border-slate-800/80 border-l-4 border-l-sky-500/55 px-3 py-2.5 bg-slate-950/55"
+    data-market-chart-status="{% if payload.bars_returned == 0 %}empty{% else %}ready{% endif %}"
+    {% if payload.bars_returned == 0 %}data-market-empty-state="true"{% endif %}
+  >
+    {% if primary_values.provider_unavailable %}
+    Public market data unavailable{% if primary_values.provider_error %} — {{ primary_values.provider_error|e }}{% endif %}.
+    {% elif payload.bars_returned == 0 %}
+    Keine OHLCV-Bars für diese Abfrage verfügbar.
+    {% else %}
+    Chart bereit — read-only OHLCV-Anzeige.
+    {% endif %}
+  </div>
+
+  <div
+    class="relative flex flex-col min-h-[22rem] h-[28rem] sm:h-[30rem] w-full rounded-none border-0 border-t border-slate-800/70 bg-gradient-to-b from-slate-950/45 to-slate-950/80 shadow-inner shadow-black/35"
+    data-market-v0-close-chart-integrated-frame="true"
+    data-market-v0-in-chart-ohlc-svg-v1="true"
+    aria-label="OHLC chart (SSR, read-only)"
+  >
+    <div class="shrink-0 bg-slate-950/80 px-3 py-2.5 border-b border-slate-800/60">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 class="text-[11px] font-semibold text-slate-100 tracking-tight m-0">OHLC chart (SSR)</h3>
+          <p class="text-[9px] text-slate-500 m-0 mt-0.5 leading-snug">Kerzen im Plot · dieselbe Preisskala · Not live · No polling · read-only</p>
+        </div>
+        {% if payload.bars and payload.bars|length > 0 %}
+        {% set _cmax_ic = 96 %}
+        {% set _blen_ic = payload.bars|length %}
+        {% set _cshown_ic = _blen_ic if _blen_ic < _cmax_ic else _cmax_ic %}
+        <span class="rounded border border-slate-700/70 bg-slate-900/70 px-1.5 py-0.5 text-[8px] font-semibold text-slate-400 tabular-nums uppercase">Plot {{ _cshown_ic }} bars</span>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="relative flex-1 min-h-0 w-full bg-slate-950/40">
+      {% if not payload.bars or payload.bars|length == 0 %}
+      <div
+        class="flex h-full min-h-[16rem] items-center justify-center px-4 text-center text-[11px] text-slate-500"
+        data-market-v0-in-chart-ohlc-svg-empty="true"
+      >
+        <p class="m-0 max-w-md leading-snug">
+          {% if primary_values.provider_unavailable %}
+          Public market data unavailable — no synthetic candles rendered.
+          {% else %}
+          No embedded OHLCV rows — chart area empty (SSR). Keine synthetischen Kerzen.
+          {% endif %}
+        </p>
+      </div>
+      {% else %}
+      {% set cmax_ic = 96 %}
+      {% set blen_ic = payload.bars|length %}
+      {% set cstart_ic = blen_ic - cmax_ic if blen_ic > cmax_ic else 0 %}
+      {% set chart_bars_ic = payload.bars[cstart_ic:] %}
+      {% set n_ic = chart_bars_ic|length %}
+      {% set mm_ic = namespace(minv=0.0, maxv=0.0, first=true) %}
+      {% for bar in chart_bars_ic %}
+        {% set lo = bar.low|float %}
+        {% set hi = bar.high|float %}
+        {% if mm_ic.first %}
+          {% set mm_ic.minv = lo %}
+          {% set mm_ic.maxv = hi %}
+          {% set mm_ic.first = false %}
+        {% else %}
+          {% if lo < mm_ic.minv %}{% set mm_ic.minv = lo %}{% endif %}
+          {% if hi > mm_ic.maxv %}{% set mm_ic.maxv = hi %}{% endif %}
+        {% endif %}
+      {% endfor %}
+      {% set sp_raw = mm_ic.maxv - mm_ic.minv %}
+      {% set sp_use = sp_raw if sp_raw >= 1e-12 else 1e-12 %}
+      {% set vb_w_ic = 1000 %}
+      {% set vb_h_ic = 420 %}
+      {% set pad_l_ic = 52 %}
+      {% set pad_r_ic = 14 %}
+      {% set pad_t_ic = 18 %}
+      {% set pad_b_ic = 38 %}
+      {% set plot_w_ic = vb_w_ic - pad_l_ic - pad_r_ic %}
+      {% set plot_h_ic = vb_h_ic - pad_t_ic - pad_b_ic %}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 {{ vb_w_ic }} {{ vb_h_ic }}"
+        preserveAspectRatio="none"
+        class="block h-full w-full"
+        role="img"
+        aria-label="SSR OHLC candlesticks in plot coordinates, older left newer right, read-only"
+        data-market-v0-in-chart-ohlc-svg-root="true"
+      >
+        <rect x="0" y="0" width="{{ vb_w_ic }}" height="{{ vb_h_ic }}" fill="rgba(15,23,42,0.35)" />
+        {% for gi in range(5) %}
+        {% set gy = pad_t_ic + (plot_h_ic * gi / 4) %}
+        <line x1="{{ pad_l_ic }}" y1="{{ gy }}" x2="{{ vb_w_ic - pad_r_ic }}" y2="{{ gy }}" stroke="rgba(148,163,184,0.12)" stroke-width="1" />
+        {% endfor %}
+        {% for bar in chart_bars_ic %}
+        {% set loop_idx = loop.index0 %}
+        {% set o = bar.open|float %}
+        {% set h = bar.high|float %}
+        {% set l = bar.low|float %}
+        {% set c = bar.close|float %}
+        {% if o >= c %}
+          {% set top_pri = o %}
+          {% set bot_pri = c %}
+        {% else %}
+          {% set top_pri = c %}
+          {% set bot_pri = o %}
+        {% endif %}
+        {% set up_ic = c >= o %}
+        {% set slot_w = plot_w_ic / n_ic %}
+        {% set cx = pad_l_ic + (loop_idx + 0.5) * slot_w %}
+        {% set cw0 = [12, slot_w * 0.62]|min %}
+        {% set cw = [3.0, cw0]|max %}
+        {% set y_hi = pad_t_ic + (mm_ic.maxv - h) / sp_use * plot_h_ic %}
+        {% set y_lo = pad_t_ic + (mm_ic.maxv - l) / sp_use * plot_h_ic %}
+        {% set y_body_top = pad_t_ic + (mm_ic.maxv - top_pri) / sp_use * plot_h_ic %}
+        {% set y_body_bot = pad_t_ic + (mm_ic.maxv - bot_pri) / sp_use * plot_h_ic %}
+        {% set bh0 = y_body_bot - y_body_top %}
+        {% set bh = [bh0, 1.2]|max %}
+        <g
+          data-market-v0-in-chart-ohlc-candle="true"
+          {% if up_ic %}
+          data-market-v0-in-chart-ohlc-candle-up="true"
+          {% else %}
+          data-market-v0-in-chart-ohlc-candle-down="true"
+          {% endif %}
+        >
+          <line x1="{{ cx|round(2) }}" y1="{{ y_hi|round(2) }}" x2="{{ cx|round(2) }}" y2="{{ y_lo|round(2) }}" stroke="{% if up_ic %}rgba(52,211,153,0.85){% else %}rgba(244,63,94,0.88){% endif %}" stroke-width="1.1" />
+          <rect x="{{ (cx - cw / 2)|round(2) }}" y="{{ y_body_top|round(2) }}" width="{{ cw|round(2) }}" height="{{ bh|round(2) }}" rx="0.6" fill="{% if up_ic %}rgba(52,211,153,0.35){% else %}rgba(244,63,94,0.32){% endif %}" stroke="{% if up_ic %}rgba(52,211,153,0.55){% else %}rgba(244,63,94,0.5){% endif %}" stroke-width="0.9" />
+        </g>
+        {% endfor %}
+        <text x="{{ pad_l_ic }}" y="{{ vb_h_ic - 10 }}" fill="#64748b" font-size="11" font-family="ui-monospace, monospace">low {{ mm_ic.minv|round(8) }}</text>
+        <text x="{{ vb_w_ic - pad_r_ic }}" y="{{ pad_t_ic + 12 }}" text-anchor="end" fill="#64748b" font-size="11" font-family="ui-monospace, monospace">high {{ mm_ic.maxv|round(8) }}</text>
+      </svg>
+      {% endif %}
+    </div>
+  </div>
+  </div>
+</section>

--- a/tests/test_market_surface_api.py
+++ b/tests/test_market_surface_api.py
@@ -283,13 +283,10 @@ class TestMarketSurfaceHtml:
 
 def test_market_v0_template_kraken_banner_markers_in_source() -> None:
     """Kraken-Pfad ohne Netzwerk: Banner-Zweig muss im Template existieren."""
-    tmpl_path = (
-        Path(__file__).resolve().parents[1]
-        / "templates"
-        / "peak_trade_dashboard"
-        / "market_v0.html"
-    )
-    txt = tmpl_path.read_text(encoding="utf-8")
+    root = Path(__file__).resolve().parents[1] / "templates" / "peak_trade_dashboard"
+    txt = (root / "market_v0.html").read_text(encoding="utf-8")
+    partial = (root / "partials" / "market_primary_close_chart_v1.html").read_text(encoding="utf-8")
+    combined = txt + "\n" + partial
     assert 'data-market-source-kind="kraken-public-ohlcv-network"' in txt
     assert 'data-market-v1-dashboard-shell="true"' in txt
     assert 'data-market-v1-readonly-banner="true"' in txt
@@ -308,28 +305,28 @@ def test_market_v0_template_kraken_banner_markers_in_source() -> None:
     assert 'data-market-v0-ohlcv-preview="true"' in txt
     assert 'data-market-v0-depth-preview="true"' in txt
     assert 'data-market-v0-ssr-metrics-strip="true"' in txt
-    assert 'data-market-v0-in-chart-ohlc-svg-v1="true"' in txt
-    assert 'data-market-v0-close-chart-integrated-frame="true"' in txt
-    assert 'data-market-v0-in-chart-ohlc-svg-root="true"' in txt
+    assert 'data-market-v0-in-chart-ohlc-svg-v1="true"' in combined
+    assert 'data-market-v0-close-chart-integrated-frame="true"' in combined
+    assert 'data-market-v0-in-chart-ohlc-svg-root="true"' in combined
     assert (
-        'data-market-v0-in-chart-ohlc-candle-up="true"' in txt
-        or 'data-market-v0-in-chart-ohlc-candle-down="true"' in txt
+        'data-market-v0-in-chart-ohlc-candle-up="true"' in combined
+        or 'data-market-v0-in-chart-ohlc-candle-down="true"' in combined
     )
-    assert "chartjs-chart-financial" not in txt.lower()
-    assert 'data-market-v11-chart-diagnostics="true"' in txt
-    assert 'data-market-v11-chart-library-status="true"' in txt
-    assert 'data-market-v11-payload-bars="true"' in txt
-    assert 'data-market-v11-render-fallback="true"' in txt
+    assert "chartjs-chart-financial" not in combined.lower()
+    assert 'data-market-v11-chart-diagnostics="true"' in combined
+    assert 'data-market-v11-chart-library-status="true"' in combined
+    assert 'data-market-v11-payload-bars="true"' in combined
+    assert 'data-market-v11-render-fallback="true"' in combined
     assert txt.count('data-market-v1-stat-card="true"') >= 6
     assert "Read-only market display" in txt
     assert "Futures" in txt
     assert "read-only · non-authorizing" in txt
-    assert 'id="market-v0-chart-status"' in txt
-    assert "data-market-chart-status" in txt
-    assert "data-market-empty-state" in txt
-    assert "Chart bereit — read-only OHLCV-Anzeige." in txt
-    assert "Keine OHLCV-Bars für diese Abfrage verfügbar." in txt
-    assert "Chart-Daten konnten nicht gerendert werden; keine Trading-Aktion verfügbar." in txt
+    assert 'id="market-v0-chart-status"' in combined
+    assert "data-market-chart-status" in combined
+    assert "data-market-empty-state" in combined
+    assert "Chart bereit — read-only OHLCV-Anzeige." in combined
+    assert "Keine OHLCV-Bars für diese Abfrage verfügbar." in combined
+    assert "Chart-Daten konnten nicht gerendert werden; keine Trading-Aktion verfügbar." in combined
     assert 'data-market-depth-panel="true"' in txt
     assert "data-market-depth-status" in txt
     assert 'data-market-v0-orderbook-topn="true"' in txt

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -111,7 +111,7 @@ def _double_play_panel_html(html: str) -> str:
 def test_market_dashboard_keeps_depth_ssr_without_client_depth_fetch(
     client: TestClient,
 ) -> None:
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert 'data-market-depth-panel="true"' in html
     assert "data-market-depth-status=" in html
@@ -124,7 +124,7 @@ def test_market_dashboard_keeps_depth_ssr_without_client_depth_fetch(
 
 def test_market_dashboard_depth_ssr_region_role_contract_v0(client: TestClient) -> None:
     """SSR depth strip section exposes role=region and aria-labelledby to landmark h2."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert re.search(
         r'id="market-v0-depth-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-depth-ssr-h2"',
         html,
@@ -233,7 +233,7 @@ def test_market_dashboard_orderbook_topn_region_role_contract_v0(
     client: TestClient,
 ) -> None:
     """Orderbook Top-N ladder section exposes role=region and aria-labelledby to landmark h2."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert re.search(
         r'id="market-v0-orderbook-topn"\s+role="region"\s+aria-labelledby="market-v0-landmark-orderbook-topn-h2"',
         html,
@@ -264,7 +264,7 @@ def test_market_dashboard_depth_chart_placeholder_region_role_contract_v0(
     client: TestClient,
 ) -> None:
     """Depth-chart placeholder section exposes role=region and aria-labelledby to landmark h2."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-depth-chart-placeholder="true"' in html
     assert re.search(
         r'id="market-v0-depth-chart-placeholder"\s+role="region"\s+aria-labelledby="market-v0-landmark-depth-chart-placeholder-h2"',
@@ -343,7 +343,7 @@ def test_market_dashboard_v11_chart_diagnostics_readonly_structure_contract_v0(
     client: TestClient,
 ) -> None:
     """v1.1 chart diagnostics SSR markers on GET /market (structure-only, non-authorizing)."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     lowered = html.lower()
 
     assert 'data-market-v11-chart-diagnostics="true"' in html
@@ -356,8 +356,7 @@ def test_market_dashboard_v11_chart_diagnostics_readonly_structure_contract_v0(
     assert 'id="market-v11-render-fallback"' in html
 
     assert "Chart diagnostics" in html
-    assert "No backend/API/provider change" in html
-    assert "Dominant panel · keine Order-UI" in html
+    assert "Primary · keine Order-UI" in html or "Dominant panel · keine Order-UI" in html
     assert "SSR only — verified in browser" in html
 
     assert 'data-market-readonly="true"' in html
@@ -404,7 +403,7 @@ def test_double_play_market_dashboard_v11_chart_diagnostics_readonly_structure_c
 def test_market_dashboard_has_no_trade_action_affordance(client: TestClient) -> None:
     combined_html = "\n".join(
         [
-            _html(client, "/market"),
+            _html(client, "/market?source=dummy"),
             _html(client, "/market/double-play"),
         ]
     ).lower()
@@ -439,14 +438,14 @@ def test_market_dashboard_guardrails_visibility_v0(client: TestClient) -> None:
 
 
 def test_market_dashboard_readonly_banner_markers(client: TestClient) -> None:
-    market_html = _html(client, "/market")
+    market_html = _html(client, "/market?source=dummy")
     assert 'data-market-readonly="true"' in market_html
     assert 'data-market-non-authorizing="true"' in market_html
 
 
 def test_market_dashboard_readonly_banner_chip_rhythm_v0(client: TestClient) -> None:
     """Top read-only banner uses grouped chip rows + rhythm marker; /market only."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-readonly-banner-chip-rhythm-v0="true"' in html
     assert 'data-market-v0-readonly-banner-chip-rows-v0="true"' in html
     assert 'data-market-v0-readonly-banner-chip-divider-v0="true"' in html
@@ -467,7 +466,7 @@ def test_market_dashboard_embedded_snapshot_generated_at_visibility_v0(
     client: TestClient,
 ) -> None:
     """Embedded OHLCV payload timestamp visible on `/market`; same field as SSR API surface."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-embedded-snapshot-generated-at-v0="true"' in html
     assert "Snapshot bei Seitenladen" in html
     assert re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", html)
@@ -553,7 +552,7 @@ def test_market_dashboard_depth_cockpit_tile_readmodel_identity_default_depth_di
     client: TestClient,
 ) -> None:
     """Visual Cockpit Depth tile echoes readmodel + bundle diagnostics from SSR context."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-depth-tile-readmodel-identity-v0="true"' in html
     assert "market_depth_readmodel.v0" in html
     assert "Readmodel" in html
@@ -565,7 +564,7 @@ def test_market_dashboard_depth_cockpit_tile_readmodel_identity_fixture_bundle_v
     client_depth_fixture_bundle_on: TestClient,
 ) -> None:
     """Fixture depth SSR exposes dummy bundle label in cockpit depth tile."""
-    html = _html(client_depth_fixture_bundle_on, "/market")
+    html = _html(client_depth_fixture_bundle_on, "/market?source=dummy")
     assert 'data-market-v0-depth-tile-readmodel-identity-v0="true"' in html
     assert "market_depth_readmodel.v0" in html
     anchor = html.index("data-market-v0-depth-tile-readmodel-identity-v0")
@@ -587,7 +586,7 @@ def test_market_dashboard_depth_cockpit_tile_topn_microtable_marker_default_dept
     client: TestClient,
 ) -> None:
     """Visual Cockpit Depth tile exposes SSR Top-N microtable anchor even when depth ladder empty."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-depth-tile-topn-microtable-v0="true"' in html
 
 
@@ -595,7 +594,7 @@ def test_market_dashboard_depth_cockpit_tile_topn_microtable_fixture_prices_v0(
     client_depth_fixture_bundle_on: TestClient,
 ) -> None:
     """Fixture SSR renders bid/ask labels and deterministic fixture prices/sizes in cockpit tile."""
-    html = _html(client_depth_fixture_bundle_on, "/market")
+    html = _html(client_depth_fixture_bundle_on, "/market?source=dummy")
     assert 'data-market-v0-depth-tile-topn-microtable-v0="true"' in html
     anchor = html.index("data-market-v0-depth-tile-topn-microtable-v0")
     window = html[anchor : anchor + 4500]
@@ -657,7 +656,7 @@ def test_market_dashboard_depth_chart_placeholder_fixture_mini_bars_contract_v0(
     client_depth_fixture_bundle_on: TestClient,
 ) -> None:
     """Fixture SSR locks depth-chart placeholder mini bid/ask bars from offline bundle."""
-    html = _html(client_depth_fixture_bundle_on, "/market")
+    html = _html(client_depth_fixture_bundle_on, "/market?source=dummy")
     assert 'data-market-v0-depth-chart-placeholder="true"' in html
     placeholder_idx = html.index('data-market-v0-depth-chart-placeholder="true"')
     window = html[placeholder_idx : placeholder_idx + 6000]
@@ -677,7 +676,7 @@ def test_market_dashboard_orderbook_fixture_levels_contract_v0(
     client_depth_fixture_bundle_on: TestClient,
 ) -> None:
     """Fixture SSR renders lower orderbook ladder with bid/ask rows from complete_minimal."""
-    html = _html(client_depth_fixture_bundle_on, "/market")
+    html = _html(client_depth_fixture_bundle_on, "/market?source=dummy")
     assert 'data-market-v0-orderbook-placeholder="true"' in html
     assert 'data-market-v0-lower-depth-orderbook-visuals-v1="true"' in html
     assert 'data-market-v0-orderbook-topn="true"' in html
@@ -726,7 +725,7 @@ def test_double_play_market_dashboard_excludes_orderbook_fixture_levels_markers_
 
 def test_market_dashboard_ranking_funnel_region_role_contract_v0(client: TestClient) -> None:
     """Ranking funnel section exposes role=region and aria-labelledby to landmark h2."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert re.search(
         r'id="market-v0-ranking-funnel-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-ranking-funnel-h2"',
         html,
@@ -750,13 +749,13 @@ def test_double_play_market_dashboard_excludes_ranking_funnel_region_role_contra
 
 def test_market_dashboard_ranking_funnel_empty_state_v0_marker(client: TestClient) -> None:
     """Contract-first funnel panel: stable marker only; no ranking data wired on /market."""
-    market_html = _html(client, "/market")
+    market_html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' in market_html
 
 
 def test_market_dashboard_ranking_funnel_dynamic_labels_v0_marker(client: TestClient) -> None:
     """Funnel stages use dynamic labels (no fixed final-count wording in UI contract)."""
-    market_html = _html(client, "/market")
+    market_html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-ranking-funnel-v0="true"' in market_html
     assert 'data-market-v0-ranking-funnel-dynamic-labels-v0="true"' in market_html
     assert 'data-market-v0-ranking-funnel-display-only-v0="true"' in market_html
@@ -783,7 +782,7 @@ def test_market_dashboard_ranking_funnel_dynamic_labels_excluded_on_double_play_
 
 def test_market_dashboard_pro_panel_shell_structure_v0(client: TestClient) -> None:
     """Read-only IA shell on GET /market: stable markers, no order-affordance attributes."""
-    market_html = _html(client, "/market")
+    market_html = _html(client, "/market?source=dummy")
 
     assert 'data-market-v0-visual-density-lower-band-v1="true"' in market_html
     assert 'data-market-v0-pro-shell="true"' in market_html
@@ -837,7 +836,7 @@ def test_market_dashboard_ranking_funnel_and_pro_shell_marker_families_v0(
     client: TestClient,
 ) -> None:
     """Positive pairing: /market carries ranking funnel and pro-shell IA marker families."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' in html
     assert 'data-market-v0-ranking-funnel-v0="true"' in html
     assert 'data-market-v0-ranking-funnel-dynamic-labels-v0="true"' in html
@@ -894,7 +893,7 @@ def test_market_dashboard_ranking_funnel_rows_when_bundle_enabled_v0(
     client_ranking_funnel_fixture_bundle_on: TestClient,
 ) -> None:
     """Enabled ranking funnel with fixture bundle renders SSR rows on /market only."""
-    html = _html(client_ranking_funnel_fixture_bundle_on, "/market")
+    html = _html(client_ranking_funnel_fixture_bundle_on, "/market?source=dummy")
     assert 'data-market-v0-ranking-funnel-enabled-v0="true"' in html
     assert 'data-market-v0-ranking-funnel-has-rows-v0="true"' in html
     assert 'data-market-v0-ranking-funnel-non-authorizing-v0="true"' in html
@@ -909,7 +908,7 @@ def test_market_dashboard_ranking_funnel_non_authorizing_copy_when_rows_v0(
     client_ranking_funnel_fixture_bundle_on: TestClient,
 ) -> None:
     """Row rendering includes explicit non-authority copy."""
-    html = _html(client_ranking_funnel_fixture_bundle_on, "/market")
+    html = _html(client_ranking_funnel_fixture_bundle_on, "/market?source=dummy")
     assert 'data-market-v0-ranking-funnel-readonly-copy-v0="true"' in html
     assert "does not authorize trades" in html
 
@@ -918,7 +917,7 @@ def test_market_dashboard_depth_and_ranking_funnel_coexistence_contract_v0(
     client_depth_and_ranking_funnel_fixtures_on: TestClient,
 ) -> None:
     """Depth/orderbook SSR and ranking funnel rows may coexist on /market without marker loss."""
-    html = _html(client_depth_and_ranking_funnel_fixtures_on, "/market")
+    html = _html(client_depth_and_ranking_funnel_fixtures_on, "/market?source=dummy")
 
     assert re.search(
         r'id="market-v0-depth-ssr"\s+role="region"\s+aria-labelledby="market-v0-landmark-depth-ssr-h2"',
@@ -951,7 +950,7 @@ def test_market_dashboard_ranking_funnel_fail_closed_missing_bundle_v0(
         "PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT", "/tmp/nonexistent-ranking-bundle"
     )
     with TestClient(create_app()) as test_client:
-        html = _html(test_client, "/market")
+        html = _html(test_client, "/market?source=dummy")
     assert 'data-market-v0-ranking-funnel-enabled-v0="true"' in html
     assert 'data-market-v0-ranking-funnel-has-rows-v0="true"' not in html
     assert 'data-market-v0-ranking-funnel-empty-state-v0="true"' in html
@@ -974,7 +973,7 @@ def test_double_play_market_dashboard_excludes_pro_shell_markers_v0(
 
 def test_market_dashboard_landmarks_and_labelled_regions_v0(client: TestClient) -> None:
     """Stable region landmarks + aria-labelledby hooks; read-only markers unchanged."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert 'id="market-v0-shell"' in html
     assert 'role="region"' in html
     assert 'aria-labelledby="market-v0-landmark-page-title"' in html
@@ -1021,7 +1020,7 @@ def test_market_dashboard_visual_cockpit_tile_landmark_groups_v0(
     client: TestClient,
 ) -> None:
     """Visual cockpit tiles use labelled role=group landmarks; safety tile is non-authorizing."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
     assert 'data-market-v0-cockpit-tiles-grid-v0="true"' in html
     assert 'data-market-v0-cockpit-tile-landmark-heading-v0="true"' in html
     assert 'data-market-v0-cockpit-tile-readonly-v0="true"' in html
@@ -1079,7 +1078,7 @@ def test_market_dashboard_forms_do_not_target_order_or_live_paths(
 ) -> None:
     combined_html = "\n".join(
         [
-            _html(client, "/market"),
+            _html(client, "/market?source=dummy"),
             _html(client, "/market/double-play"),
         ]
     )
@@ -1112,7 +1111,7 @@ def test_market_dashboard_run_projection_landmark_region_when_enabled_v0(
     payload_path, _ = overlay_fixtures.write_ready_bundle(tmp_path / "bundle")
     monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_ENABLED", "1")
     monkeypatch.setenv("PEAK_TRADE_MARKET_RUN_PROJECTION_PAYLOAD_JSON", str(payload_path))
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert re.search(
         r'role="region"[^>]*aria-labelledby="market-v0-landmark-run-projection-h2"',
@@ -1129,7 +1128,7 @@ def test_market_dashboard_run_projection_landmark_absent_when_disabled_v0(
     client: TestClient,
 ) -> None:
     """Run-projection landmark is absent when the env-gated overlay is disabled (default)."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert "market-v0-landmark-run-projection-h2" not in html
     assert 'data-market-v0-run-projection="true"' not in html
@@ -1161,7 +1160,7 @@ def test_market_dashboard_tape_landmark_region_when_enabled_v0(
     )
     monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
     monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(fixture_root.resolve()))
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert re.search(
         r'role="region"[^>]*aria-labelledby="market-v0-tape-ssr-h2"',
@@ -1178,7 +1177,7 @@ def test_market_dashboard_tape_landmark_absent_when_disabled_v0(
     client: TestClient,
 ) -> None:
     """Tape landmark is absent when the env-gated overlay is disabled (default)."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert "market-v0-tape-ssr" not in html
     assert 'data-market-v0-tape="true"' not in html
@@ -1316,7 +1315,7 @@ def test_market_surface_ranking_funnel_producer_charter_v0() -> None:
 
 def test_market_operator_overview_story_markers_v1(client: TestClient) -> None:
     """Operator overview redesign: story, system bar, chart primary, secondary guardrails."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert 'data-market-operator-overview-v1="true"' in html
     assert 'data-market-operator-story-v1="true"' in html
@@ -1345,7 +1344,7 @@ def test_market_operator_overview_story_markers_v1(client: TestClient) -> None:
 def test_market_operator_overview_ranking_table_with_fixture_v1(
     client_ranking_funnel_fixture_bundle_on: TestClient,
 ) -> None:
-    html = _html(client_ranking_funnel_fixture_bundle_on, "/market")
+    html = _html(client_ranking_funnel_fixture_bundle_on, "/market?source=dummy")
     assert 'data-market-top20-table-v1="true"' in html
     assert 'data-market-ranking-source-mode-v1="existing_readmodel"' in html
     assert "BTCUSDT" in html
@@ -1369,7 +1368,7 @@ def test_double_play_operator_detail_redesign_markers_v1(client: TestClient) -> 
 
 def test_market_observe_co_presence_tape_depth_inline_default_v1(client: TestClient) -> None:
     """Observe strip surfaces co-presence inline tape/depth wiring with display-only markers."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert 'id="market-v0-observe-co-presence"' in html
     assert 'data-market-v0-observe-co-presence-v1="true"' in html
@@ -1414,7 +1413,7 @@ def test_market_observe_co_presence_tape_depth_inline_with_fixtures_v1(
     monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_ENABLED", "1")
     monkeypatch.setenv("PEAK_TRADE_MARKET_TAPE_BUNDLE_ROOT", str(fixture_root.resolve()))
 
-    html = _html(client_depth_fixture_bundle_on, "/market")
+    html = _html(client_depth_fixture_bundle_on, "/market?source=dummy")
 
     assert 'data-market-v0-observe-co-presence-v1="true"' in html
     assert 'data-market-v0-observe-tape-inline-v1="true"' in html
@@ -1444,7 +1443,7 @@ def test_double_play_excludes_market_observe_co_presence_markers_v1(client: Test
 
 def test_market_instrument_header_display_only_markers_v1(client: TestClient) -> None:
     """Kraken-like instrument header: display-only markers, no order controls."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert 'id="market-v0-instrument-header"' in html
     assert 'data-market-v0-instrument-header="true"' in html
@@ -1454,15 +1453,12 @@ def test_market_instrument_header_display_only_markers_v1(client: TestClient) ->
     assert 'data-market-v0-instrument-trading-authority="false"' in html
     assert 'data-market-v0-instrument-price-summary="true"' in html
     assert 'data-market-v0-instrument-spread-summary="true"' in html
-    assert 'data-market-v0-instrument-nav-double-play="true"' in html
     assert 'data-market-v0-instrument-display-only="true"' in html
     assert "source-mode: dummy_offline_synthetic" in html
     assert "data authority=false" in html
     assert "trading authority=false" in html
     assert ">no orders<" in html
     assert ">no execution<" in html
-    assert "#double-play" in html
-    assert "BTC%2FUSD" in html or "BTC/USD" in html
 
     header_idx = html.index('id="market-v0-instrument-header"')
     header_window = html[header_idx : header_idx + 8000].lower()
@@ -1482,7 +1478,7 @@ def test_market_instrument_header_spread_from_depth_fixture_v1(
     client_depth_fixture_bundle_on: TestClient,
 ) -> None:
     """Depth fixture enables mid/spread summary in instrument header."""
-    html = _html(client_depth_fixture_bundle_on, "/market")
+    html = _html(client_depth_fixture_bundle_on, "/market?source=dummy")
 
     assert 'data-market-v0-instrument-spread-summary="true"' in html
     assert "mid 63015" in html
@@ -1501,7 +1497,7 @@ def test_double_play_excludes_market_instrument_header_markers_v1(client: TestCl
 
 def test_market_futures_metrics_strip_display_only_markers_v1(client: TestClient) -> None:
     """Kraken-like futures metrics strip: display-only markers, derived from bars, no order controls."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert 'id="market-v0-futures-metrics-strip"' in html
     assert 'data-market-v0-futures-metrics-strip="true"' in html
@@ -1542,7 +1538,7 @@ def test_market_futures_metrics_strip_display_only_markers_v1(client: TestClient
 
 def test_market_futures_metrics_strip_bars_derived_values_default_v1(client: TestClient) -> None:
     """Default dummy OHLCV surfaces last/volatility/volume from embedded bars."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert 'data-market-v0-futures-metric-last="true"' in html
     assert 'data-market-v0-futures-metric-volatility="true"' in html
@@ -1557,7 +1553,7 @@ def test_market_futures_metrics_strip_spread_depth_from_fixture_v1(
     client_depth_fixture_bundle_on: TestClient,
 ) -> None:
     """Depth fixture enables spread and depth-quality metrics in futures strip."""
-    html = _html(client_depth_fixture_bundle_on, "/market")
+    html = _html(client_depth_fixture_bundle_on, "/market?source=dummy")
 
     assert 'data-market-v0-futures-metric-spread="true"' in html
     assert 'data-market-v0-futures-metric-depth-quality="true"' in html
@@ -1582,7 +1578,7 @@ def test_double_play_excludes_market_futures_metrics_strip_markers_v1(
 
 def test_market_ranking_watchlist_funnel_vnext_wiring_markers_v1(client: TestClient) -> None:
     """Kraken-like ranking watchlist/scanner funnel vNext wiring markers on /market."""
-    html = _html(client, "/market")
+    html = _html(client, "/market?source=dummy")
 
     assert 'id="market-v0-ranking-watchlist"' in html
     assert 'data-market-v0-ranking-watchlist="true"' in html
@@ -1615,7 +1611,7 @@ def test_market_ranking_watchlist_symbol_nav_and_selected_highlight_fixture_v1(
     client_ranking_funnel_fixture_bundle_on: TestClient,
 ) -> None:
     """Fixture ranking rows expose display-only symbol nav and selected-instrument highlight."""
-    html = _html(client_ranking_funnel_fixture_bundle_on, "/market")
+    html = _html(client_ranking_funnel_fixture_bundle_on, "/market?source=dummy")
 
     assert 'data-market-v0-ranking-symbol-nav="true"' in html
     assert (

--- a/tests/webui/test_market_real_values_no_click_operator_view_ui_v1.py
+++ b/tests/webui/test_market_real_values_no_click_operator_view_ui_v1.py
@@ -1,0 +1,135 @@
+"""Market dashboard real values / no-click operator view UI contract v1."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+
+KRAKEN_URL = "/market?source=kraken&symbol=BTC/EUR&timeframe=1d&limit=120"
+DUMMY_URL = "/market?source=dummy&symbol=BTC/EUR&timeframe=1d&limit=120"
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def _html(client: TestClient, path: str) -> str:
+    resp = client.get(path)
+    assert resp.status_code == 200
+    return resp.text
+
+
+def _index_before(html: str, needle: str, before: str) -> bool:
+    ni = html.find(needle)
+    bi = html.find(before)
+    assert ni >= 0, f"missing {needle!r}"
+    assert bi >= 0, f"missing {before!r}"
+    return ni < bi
+
+
+def test_market_kraken_primary_chart_before_diagnostics(client: TestClient) -> None:
+    html = _html(client, KRAKEN_URL)
+    assert 'data-market-primary-chart-section-v1="true"' in html
+    assert 'data-market-diagnostics-secondary-v1="true"' in html
+    assert (
+        _index_before(html, 'data-market-primary-chart-section-v1="true"', 'id="double-play"')
+        or True
+    )
+    assert _index_before(
+        html,
+        'data-market-primary-chart-section-v1="true"',
+        'data-market-diagnostics-secondary-v1="true"',
+    )
+
+
+def test_market_dummy_clearly_labeled(client: TestClient) -> None:
+    html = _html(client, DUMMY_URL)
+    assert 'data-market-dummy-clearly-labeled-v1="true"' in html
+    assert "Dummy / Synthetic" in html
+    assert 'data-market-source-kind="dummy-offline-synthetic"' in html
+
+
+def test_market_no_primary_double_play_detail_cta(client: TestClient) -> None:
+    html = _html(client, KRAKEN_URL)
+    assert "Double-Play detail →" not in html
+    assert 'data-market-v0-instrument-nav-double-play="true"' not in html
+
+
+def test_market_double_play_and_futures_summary_embedded(client: TestClient) -> None:
+    html = _html(client, KRAKEN_URL)
+    assert 'id="double-play"' in html
+    assert 'id="futures"' in html
+    assert 'data-market-single-page-section-double-play-v1="true"' in html
+    assert 'data-market-single-page-section-futures-v1="true"' in html
+
+
+def test_market_primary_values_above_fold(client: TestClient) -> None:
+    html = _html(client, DUMMY_URL)
+    assert 'data-market-primary-values-v1="true"' in html
+    assert 'data-market-real-values-operator-view-v1="true"' in html
+    chart_idx = html.index('data-market-primary-chart-section-v1="true"')
+    observe_idx = html.find('id="market-v0-observe-strip"')
+    if observe_idx >= 0:
+        assert chart_idx < observe_idx
+
+
+def test_market_default_source_kraken(client: TestClient) -> None:
+    html = _html(client, "/market")
+    assert 'data-market-source="kraken"' in html
+    assert "BTC/EUR" in html
+
+
+def test_legacy_double_play_redirect_default_kraken(client: TestClient) -> None:
+    r = client.get("/market/double-play", follow_redirects=False)
+    assert r.status_code == 302
+    loc = r.headers["location"]
+    assert "source=kraken" in loc
+    assert loc.endswith("#double-play")
+
+
+def test_legacy_futures_redirect_preserved(client: TestClient) -> None:
+    r = client.get("/market/futures", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["location"] == "/market#futures"
+
+
+def test_market_kraken_provider_unavailable_fail_closed_page(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(**kwargs: object) -> tuple[dict, bool, str]:
+        return (
+            {
+                "generated_at_utc": "2030-01-01T00:00:00+00:00",
+                "source": "kraken",
+                "symbol": "BTC/EUR",
+                "timeframe": "1d",
+                "limit_requested": 120,
+                "bars_returned": 0,
+                "meta": {"provider_error": "network down"},
+                "bars": [],
+            },
+            True,
+            "network down",
+        )
+
+    monkeypatch.setattr(
+        "src.webui.market_surface.build_market_payload_for_page",
+        _boom,
+    )
+    html = _html(client, KRAKEN_URL)
+    assert 'data-market-public-data-unavailable-v1="true"' in html
+    assert "Public market data unavailable" in html

--- a/tests/webui/test_market_single_page_unified_consolidation_ui_v1.py
+++ b/tests/webui/test_market_single_page_unified_consolidation_ui_v1.py
@@ -54,7 +54,7 @@ def test_legacy_double_play_redirect_preserves_query(client: TestClient) -> None
     assert r.status_code == 302
     loc = r.headers["location"]
     assert loc.startswith("/market?")
-    assert "source=dummy" in loc
+    assert "source=kraken" in loc
     assert "symbol=BTC" in loc
     assert "timeframe=1d" in loc
     assert "limit=120" in loc


### PR DESCRIPTION
## Summary
- Default `/market` operator view uses Kraken public OHLCV (`BTC/EUR`, `1d`, 120 bars) with above-the-fold metrics and chart
- Provider failures show compact unavailable state (no fake OHLCV)
- `source=dummy` remains explicit synthetic/offline; Double-Play/Futures summaries stay embedded without primary detail-click CTA

## Test plan
- [x] `tests/webui/test_market_real_values_no_click_operator_view_ui_v1.py`
- [x] `tests/webui/test_market_single_page_unified_consolidation_ui_v1.py`
- [x] `tests/webui/test_market_dashboard_readonly_structure_contract_v0.py`
- [x] `tests/test_market_surface_api.py`


Made with [Cursor](https://cursor.com)