### PR TITLE
feat: remodel market dashboard IA v2

### DIFF
--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -28,6 +28,8 @@
   data-market-operator-real-values-v1="true"
   data-market-detail-click-required="false"
   data-market-single-page-unified-v1="true"
+  data-market-remodel-ia-v2="true"
+  data-market-trading-authority-v1="false"
 >
   <header
     class="flex flex-wrap items-center justify-between gap-3 py-3 border-b border-slate-800/80"
@@ -44,20 +46,24 @@
     </div>
   </header>
 
-  <nav
-    class="flex flex-wrap gap-1 py-2 border-b border-slate-800/60 text-[11px]"
-    aria-label="Market terminal sections"
-    data-market-terminal-tabs-v1="true"
+  <section
+    class="flex flex-wrap items-center gap-2 py-2 border-b border-slate-800/60 text-[10px] font-semibold uppercase tracking-wide"
+    aria-label="Operator overview"
+    data-market-remodel-operator-overview-v2="true"
+    data-market-operator-overview-v1="true"
+    data-market-operator-story-v1="true"
   >
-    <span class="rounded-md border border-sky-800/50 bg-sky-950/35 px-2.5 py-1 text-sky-200/95 font-semibold">Übersicht</span>
-    <span class="rounded-md border border-slate-800/60 bg-slate-950/40 px-2.5 py-1 text-slate-500" title="Read-only stub">Märkte</span>
-    <span class="rounded-md border border-slate-800/60 bg-slate-950/40 px-2.5 py-1 text-slate-500" title="Read-only stub">Einblicke</span>
-    <span class="rounded-md border border-slate-800/60 bg-slate-950/40 px-2.5 py-1 text-slate-500" title="Read-only stub">Alarme</span>
-  </nav>
+    <span class="rounded-full border border-emerald-800/50 bg-emerald-950/40 px-2 py-0.5 text-emerald-200/95" data-market-remodel-operator-safety-v2="true">Safety · read-only</span>
+    <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-slate-300" data-market-remodel-operator-lane-v2="true">Lane · dashboard</span>
+    <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-slate-300" data-market-remodel-operator-freshness-v2="true">Freshness · SSR</span>
+    <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-slate-300" data-market-remodel-operator-readiness-v2="true">Readiness · display</span>
+    <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-slate-300" data-market-remodel-operator-blocked-v2="true">Blocked · live</span>
+    <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-slate-300" data-market-remodel-operator-authority-v2="true">Authority · false</span>
+  </section>
 
   {% include "partials/market_primary_operator_hero_v1.html" %}
 
-  <div class="mt-4 grid grid-cols-1 lg:grid-cols-4 gap-4" data-market-terminal-secondary-grid-v1="true">
+  <div class="mt-4 grid grid-cols-1 lg:grid-cols-4 gap-4" data-market-terminal-secondary-grid-v1="true" data-market-remodel-secondary-grid-v2="true">
     <div class="lg:col-span-1 order-2 lg:order-1">
       {% include "partials/market_watchlist_compact_v1.html" %}
     </div>
@@ -67,6 +73,14 @@
       {% include "partials/futures_market_compact_v1.html" %}
     </div>
   </div>
+
+  <details class="mt-4 rounded-xl border border-slate-800/60 bg-slate-950/30 px-3 py-2" data-market-remodel-detail-anchors-v2="true">
+    <summary class="cursor-pointer text-xs font-semibold text-slate-500">Double-Play / F5 detail anchors (read-only)</summary>
+    <div class="mt-4 space-y-6">
+      {% include "partials/double_play_market_panel_v0.html" %}
+      {% include "partials/futures_read_only_market_panel_v0.html" %}
+    </div>
+  </details>
 
   {% include "partials/market_diagnostics_drawer_v1.html" %}
 </div>

--- a/templates/peak_trade_dashboard/partials/double_play_market_compact_v1.html
+++ b/templates/peak_trade_dashboard/partials/double_play_market_compact_v1.html
@@ -8,6 +8,7 @@
   data-double-play-bull-bear-cards-v1="true"
   data-double-play-market-readonly="true"
   data-double-play-market-no-authority="true"
+  data-market-remodel-secondary-double-play-v2="true"
 >
   <h2 id="market-terminal-dp-compact-h2" class="text-[11px] font-semibold uppercase tracking-wide text-amber-200/90 m-0 mb-2">Double Play · display-only</h2>
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-[11px]">

--- a/templates/peak_trade_dashboard/partials/futures_market_compact_v1.html
+++ b/templates/peak_trade_dashboard/partials/futures_market_compact_v1.html
@@ -9,6 +9,7 @@
   data-f5-market-dashboard-readonly="true"
   data-f5-market-dashboard-no-authority="true"
   data-f5-summary="true"
+  data-market-remodel-secondary-futures-v2="true"
 >
   <h2 id="market-terminal-futures-compact-h2" class="text-[11px] font-semibold uppercase tracking-wide text-slate-200 m-0 mb-2">Futures · display-only</h2>
   <p class="m-0 text-[11px] text-slate-300">{{ f5_dashboard.summary_line|e }}</p>

--- a/templates/peak_trade_dashboard/partials/market_diagnostics_drawer_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_diagnostics_drawer_v1.html
@@ -3,16 +3,30 @@
   class="rounded-xl border border-slate-800/70 bg-slate-950/40 px-3 py-2 mt-6"
   data-market-diagnostics-drawer-v1="true"
   data-market-diagnostics-secondary-v1="true"
-  data-market-operator-story-v1="true"
-  data-market-operator-overview-v1="true"
   data-market-guardrails-secondary-v1="true"
+  data-market-remodel-diagnostics-drawer-v2="true"
+  data-market-remodel-diagnostics-collapsed-default-v2="true"
 >
   <summary class="cursor-pointer text-sm font-semibold text-slate-400">Diagnostics / internals</summary>
-  <div class="mt-4 space-y-6" data-market-secondary-operator-panels-v1="true">
-    <p class="m-0 text-[11px] text-slate-500">F1–F5 panels, ranking, tape, depth, metadata — collapsed by default; read-only; no trading authority.</p>
+  <div class="mt-4 space-y-4" data-market-secondary-operator-panels-v1="true">
+    <p class="m-0 text-[11px] text-slate-500">Data-source, freshness, ranking, tape, depth, metadata — collapsed by default; read-only; no trading authority.</p>
+    <dl class="m-0 grid grid-cols-1 sm:grid-cols-2 gap-3 text-[11px] font-mono">
+      <div
+        class="rounded-lg border border-slate-800/70 bg-slate-950/55 px-3 py-2"
+        data-market-remodel-diagnostics-data-source-v2="true"
+      >
+        <dt class="text-slate-500 uppercase text-[10px] m-0">Data source</dt>
+        <dd class="m-0 mt-1 text-slate-200">{{ query.source|e }} · display-only · no provider truth</dd>
+      </div>
+      <div
+        class="rounded-lg border border-slate-800/70 bg-slate-950/55 px-3 py-2"
+        data-market-remodel-diagnostics-freshness-v2="true"
+      >
+        <dt class="text-slate-500 uppercase text-[10px] m-0">Freshness</dt>
+        <dd class="m-0 mt-1 text-slate-200">{% if primary_values.last_bar_ts %}{{ primary_values.last_bar_ts|e }}{% else %}{{ primary_values.generated_at_utc|e }}{% endif %} · SSR snapshot</dd>
+      </div>
+    </dl>
     <div class="hidden" aria-hidden="true" data-market-single-page-unified-v1="true"></div>
-    {% include "partials/double_play_market_panel_v0.html" %}
-    {% include "partials/futures_read_only_market_panel_v0.html" %}
     {% include "partials/market_legacy_operator_panels_v0.html" %}
   </div>
 </details>

--- a/templates/peak_trade_dashboard/partials/market_primary_close_chart_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_primary_close_chart_v1.html
@@ -1,5 +1,6 @@
 <!-- Primary close/OHLC chart — above-the-fold, diagnostics collapsed -->
 <section
+  data-market-chart-primary-v2="true"
   role="region"
   aria-labelledby="market-v0-landmark-close-chart-h2"
   class="bg-slate-900/40 rounded-lg border border-slate-800/80 ring-1 ring-sky-900/10 shadow-2xl shadow-black/40 p-3 sm:p-4 min-h-[60vh] lg:min-h-[560px]"

--- a/templates/peak_trade_dashboard/partials/market_safety_compact_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_safety_compact_v1.html
@@ -8,6 +8,7 @@
   data-market-non-authorizing="true"
   data-market-live-locked-v1="true"
   data-market-trading-authority-v1="false"
+  data-market-remodel-secondary-safety-v2="true"
 >
   <h2 id="market-terminal-safety-compact-h2" class="text-[11px] font-semibold uppercase tracking-wide text-emerald-200/90 m-0 mb-2">Safety · read-only</h2>
   <ul class="m-0 p-0 list-none flex flex-wrap gap-1.5 text-[10px] font-semibold uppercase">

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -1790,7 +1790,6 @@ def test_market_remodel_ia_v2_master_v2_double_play_display_only_active(
     assert "<button" not in dp_window
 
 
-@pytest.mark.xfail(strict=False, reason=REMODEL_IA_V2_PENDING_REASON)
 def test_market_remodel_ia_v2_shell_and_landmark_markers(client: TestClient) -> None:
     """v2 remodel shell exposes canonical data-market-remodel-* landmark family."""
     html = _html(client, "/market")
@@ -1809,7 +1808,6 @@ def test_market_remodel_ia_v2_shell_and_landmark_markers(client: TestClient) -> 
         assert marker in html
 
 
-@pytest.mark.xfail(strict=False, reason=REMODEL_IA_V2_PENDING_REASON)
 def test_market_remodel_ia_v2_operator_overview_band_compact(client: TestClient) -> None:
     """Operator overview band: compact safety/lane/freshness row — no action controls."""
     html = _html(client, "/market")
@@ -1831,7 +1829,6 @@ def test_market_remodel_ia_v2_operator_overview_band_compact(client: TestClient)
     assert "<button" not in overview_lower
 
 
-@pytest.mark.xfail(strict=False, reason=REMODEL_IA_V2_PENDING_REASON)
 def test_market_remodel_ia_v2_secondary_grid_structure(client: TestClient) -> None:
     """Secondary grid: Double-Play, Safety/Guardrails, F5 compact panels above fold."""
     html = _html(client, "/market")
@@ -1846,7 +1843,6 @@ def test_market_remodel_ia_v2_secondary_grid_structure(client: TestClient) -> No
     assert REMODEL_IA_V2_SECONDARY_FUTURES_MARKER in grid_window
 
 
-@pytest.mark.xfail(strict=False, reason=REMODEL_IA_V2_PENDING_REASON)
 def test_market_remodel_ia_v2_no_duplicate_dp_f5_primary_in_diagnostics_drawer(
     client: TestClient,
 ) -> None:
@@ -1859,7 +1855,6 @@ def test_market_remodel_ia_v2_no_duplicate_dp_f5_primary_in_diagnostics_drawer(
         assert marker not in drawer
 
 
-@pytest.mark.xfail(strict=False, reason=REMODEL_IA_V2_PENDING_REASON)
 def test_market_remodel_ia_v2_diagnostics_secondary_not_operator_primary(
     client: TestClient,
 ) -> None:
@@ -1876,7 +1871,6 @@ def test_market_remodel_ia_v2_diagnostics_secondary_not_operator_primary(
     assert "data-market-remodel-diagnostics-freshness-v2=" in drawer
 
 
-@pytest.mark.xfail(strict=False, reason=REMODEL_IA_V2_PENDING_REASON)
 def test_market_remodel_ia_v2_chart_primary_landmark_heading(client: TestClient) -> None:
     """Primary chart is the leading landmark region before secondary panels."""
     html = _html(client, "/market")


### PR DESCRIPTION
## Summary

- Implements Market Dashboard Remodel IA v2 Slice 2 in existing `/market` templates and compact partials (reuse from #4162 terminal rebuild).
- Adds v2 landmark markers (`data-market-remodel-*-v2`, `data-market-chart-primary-v2`) for chart-first layout, compact operator overview band, secondary DP/Safety/F5 grid, and collapsed diagnostics drawer.
- Removes six xfail markers from structure contract tests — **94 passed, 0 xfailed** in `test_market_dashboard_readonly_structure_contract_v0.py`.
- Moves full Double-Play / F5 detail panels out of diagnostics drawer into collapsed detail anchors (no duplicate primary panels in drawer).

## Safety Scope

- Template/tests-only SSR markers and layout — **read-only / display-only / non-authorizing**
- **No** Live / Paper / Shadow / Testnet / Observation runs
- **No** runtime / scheduler / adapter start
- **No** Preflight lift / Authority lift
- **No** order / cancel / arming / execution authorization
- **No** Master V2 / Double Play / Bull-Bear / Risk / KillSwitch / Scope / Capital / Strategy / Signal / Position-Sizing logic changes
- **No** Market-Airport / parallel dashboard SSOT

## Test Plan

- [x] `python -m pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` → 94 passed, 0 xfailed
- [x] `python -m pytest tests/webui/test_market_terminal_layout_v1.py tests/webui/test_market_single_page_unified_consolidation_ui_v1.py -q` → pass
- [x] `python scripts/ops/validate_docs_token_policy.py --changed --base origin/main` → pass
- [x] `python scripts/ops/check_docs_drift_guard.py --base origin/main` → pass
- [x] `ruff check` / `ruff format --check` on changed Python file → pass

## Durable Bundle Path

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/market_dashboard_remodel_ia_v2_template_slice2_explicit_operator_go_no_run_v1_20260612T150838Z`

## No Live / No Run / No Authority Lift

This PR does not start trading, runtime, or workflow actions. Operator review only.


Made with [Cursor](https://cursor.com)