### PR TITLE
fix: restore market dashboard IA v2 render context

### DIFF
--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -1180,6 +1180,99 @@ def build_market_primary_values_display_context(
     }
 
 
+def build_market_v0_page_template_context(
+    *,
+    get_project_status: Callable[[], Dict[str, Any]],
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    source: Literal["kraken", "dummy"],
+    payload: Dict[str, Any],
+    data_unavailable: bool,
+) -> Dict[str, Any]:
+    """SSR template context for GET /market (display-only; always includes primary_values)."""
+
+    primary_values = build_market_primary_values_display_context(
+        symbol=symbol,
+        timeframe=timeframe,
+        limit=limit,
+        source=source,
+        payload=payload,
+        data_unavailable=data_unavailable,
+    )
+    proj_status = get_project_status()
+    market_depth = build_market_depth_display_context()
+    run_projection = build_market_run_projection_display_context()
+    market_tape = build_market_tape_display_context()
+    ranking_funnel = build_market_ranking_funnel_display_context()
+    operator_overview = build_market_operator_overview_display_context(
+        ranking_funnel=ranking_funnel,
+    )
+    ranking_watchlist = build_market_ranking_watchlist_display_context(
+        ranking_funnel=ranking_funnel,
+        operator_overview=operator_overview,
+        selected_symbol=symbol,
+        source=source,
+        timeframe=timeframe,
+        limit=limit,
+    )
+    instrument_header = build_market_instrument_header_display_context(
+        symbol=symbol,
+        timeframe=timeframe,
+        limit=limit,
+        source=source,
+        payload=payload,
+        market_depth=market_depth,
+    )
+    futures_metrics_strip = build_market_futures_metrics_strip_display_context(
+        source=source,
+        payload=payload,
+        market_depth=market_depth,
+    )
+    active_paper_run = build_market_active_paper_run_display_context()
+    market_single_page_consolidation = build_market_single_page_consolidation_display_context()
+    workflow_dashboard: Dict[str, Any] | None = None
+    last_paper_run_panel: Dict[str, Any] | None = None
+    if market_single_page_consolidation["section_visible"]:
+        workflow_dashboard = build_workflow_dashboard_display_context()
+        last_paper_run_panel = build_last_paper_run_panel_display_context()
+    dp_display = build_static_dashboard_display_dict()
+    f5_dashboard = build_futures_read_only_market_dashboard_display_context()
+    encoded_symbol = quote(symbol, safe="")
+    legacy_demo_href = (
+        f"/market?source={source}&symbol={encoded_symbol}&timeframe={timeframe}&limit={limit}"
+    )
+    return {
+        "status": proj_status,
+        "payload": payload,
+        "market_depth": market_depth,
+        "run_projection": run_projection,
+        "market_tape": market_tape,
+        "ranking_funnel": ranking_funnel,
+        "ranking_watchlist": ranking_watchlist,
+        "operator_overview": operator_overview,
+        "instrument_header": instrument_header,
+        "futures_metrics_strip": futures_metrics_strip,
+        "active_paper_run": active_paper_run,
+        "market_single_page_consolidation": market_single_page_consolidation,
+        "workflow_dashboard": workflow_dashboard,
+        "last_paper_run_panel": last_paper_run_panel,
+        "dp_display": dp_display,
+        "f5_dashboard": f5_dashboard,
+        "double_play_json_url": "/api/master-v2/double-play/dashboard-display.json",
+        "legacy_demo_href": legacy_demo_href,
+        "page_title": PAGE_TITLE,
+        "primary_values": primary_values,
+        "data_unavailable": data_unavailable,
+        "query": {
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "limit": limit,
+            "source": source,
+        },
+    }
+
+
 def create_market_router(
     templates: Jinja2Templates,
     get_project_status: Callable[[], Dict[str, Any]],
@@ -1229,88 +1322,18 @@ def create_market_router(
         payload, data_unavailable = build_market_payload_for_page(
             symbol=symbol, timeframe=timeframe, limit=limit, source=src
         )
-        primary_values = build_market_primary_values_display_context(
-            symbol=symbol,
-            timeframe=timeframe,
-            limit=limit,
-            source=src,
-            payload=payload,
-            data_unavailable=data_unavailable,
-        )
-        proj_status = get_project_status()
-        market_depth = build_market_depth_display_context()
-        run_projection = build_market_run_projection_display_context()
-        market_tape = build_market_tape_display_context()
-        ranking_funnel = build_market_ranking_funnel_display_context()
-        operator_overview = build_market_operator_overview_display_context(
-            ranking_funnel=ranking_funnel,
-        )
-        ranking_watchlist = build_market_ranking_watchlist_display_context(
-            ranking_funnel=ranking_funnel,
-            operator_overview=operator_overview,
-            selected_symbol=symbol,
-            source=src,
-            timeframe=timeframe,
-            limit=limit,
-        )
-        instrument_header = build_market_instrument_header_display_context(
-            symbol=symbol,
-            timeframe=timeframe,
-            limit=limit,
-            source=src,
-            payload=payload,
-            market_depth=market_depth,
-        )
-        futures_metrics_strip = build_market_futures_metrics_strip_display_context(
-            source=src,
-            payload=payload,
-            market_depth=market_depth,
-        )
-        active_paper_run = build_market_active_paper_run_display_context()
-        market_single_page_consolidation = build_market_single_page_consolidation_display_context()
-        workflow_dashboard: Dict[str, Any] | None = None
-        last_paper_run_panel: Dict[str, Any] | None = None
-        if market_single_page_consolidation["section_visible"]:
-            workflow_dashboard = build_workflow_dashboard_display_context()
-            last_paper_run_panel = build_last_paper_run_panel_display_context()
-        dp_display = build_static_dashboard_display_dict()
-        f5_dashboard = build_futures_read_only_market_dashboard_display_context()
-        encoded_symbol = quote(symbol, safe="")
-        legacy_demo_href = (
-            f"/market?source={src}&symbol={encoded_symbol}&timeframe={timeframe}&limit={limit}"
-        )
         return templates.TemplateResponse(
             request,
             "market_v0.html",
-            {
-                "status": proj_status,
-                "payload": payload,
-                "market_depth": market_depth,
-                "run_projection": run_projection,
-                "market_tape": market_tape,
-                "ranking_funnel": ranking_funnel,
-                "ranking_watchlist": ranking_watchlist,
-                "operator_overview": operator_overview,
-                "instrument_header": instrument_header,
-                "futures_metrics_strip": futures_metrics_strip,
-                "active_paper_run": active_paper_run,
-                "market_single_page_consolidation": market_single_page_consolidation,
-                "workflow_dashboard": workflow_dashboard,
-                "last_paper_run_panel": last_paper_run_panel,
-                "dp_display": dp_display,
-                "f5_dashboard": f5_dashboard,
-                "double_play_json_url": "/api/master-v2/double-play/dashboard-display.json",
-                "legacy_demo_href": legacy_demo_href,
-                "page_title": PAGE_TITLE,
-                "primary_values": primary_values,
-                "data_unavailable": data_unavailable,
-                "query": {
-                    "symbol": symbol,
-                    "timeframe": timeframe,
-                    "limit": limit,
-                    "source": src,
-                },
-            },
+            build_market_v0_page_template_context(
+                get_project_status=get_project_status,
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+                source=src,
+                payload=payload,
+                data_unavailable=data_unavailable,
+            ),
         )
 
     return router

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -23,6 +23,11 @@ from fastapi.testclient import TestClient
 pytestmark = pytest.mark.web
 
 from src.webui.app import create_app
+from src.webui.market_surface import (
+    DEFAULT_SYMBOL,
+    build_market_payload_for_page,
+    build_market_v0_page_template_context,
+)
 from tests.fixtures.ops import market_registry_projection_overlay_v0 as overlay_fixtures
 
 FORM_ACTION_RE = re.compile(
@@ -1889,3 +1894,41 @@ def test_market_remodel_ia_v2_chart_primary_landmark_heading(client: TestClient)
         chart_window,
         re.IGNORECASE,
     )
+
+
+def test_market_remodel_ia_v2_primary_values_ssr_render_wiring(client: TestClient) -> None:
+    """IA v2 hero/watchlist/diagnostics partials require primary_values in SSR context."""
+    html = _html(client, "/market")
+
+    assert 'data-market-primary-market-values-v1="true"' in html
+    assert 'data-market-primary-values-panel-v1="true"' in html
+    assert 'data-market-terminal-watchlist-v1="true"' in html
+    assert 'data-market-remodel-diagnostics-freshness-v2="true"' in html
+
+    hero_idx = html.index('data-market-primary-values-panel-v1="true"')
+    hero_window = html[hero_idx : hero_idx + 4000]
+    assert DEFAULT_SYMBOL in hero_window
+
+
+def test_build_market_v0_page_template_context_includes_primary_values() -> None:
+    """Context builder must always expose primary_values for /market template includes."""
+    payload, data_unavailable = build_market_payload_for_page(
+        symbol=DEFAULT_SYMBOL,
+        timeframe="1d",
+        limit=120,
+        source="dummy",
+    )
+    context = build_market_v0_page_template_context(
+        get_project_status=lambda: {"ok": True},
+        symbol=DEFAULT_SYMBOL,
+        timeframe="1d",
+        limit=120,
+        source="dummy",
+        payload=payload,
+        data_unavailable=data_unavailable,
+    )
+
+    primary_values = context.get("primary_values")
+    assert isinstance(primary_values, dict)
+    assert primary_values.get("symbol") == DEFAULT_SYMBOL
+    assert primary_values.get("status") in {"available", "unavailable"}


### PR DESCRIPTION
## Summary
- Centralizes GET `/market` SSR template context in `build_market_v0_page_template_context()` so `primary_values` is always available for IA v2 hero, watchlist, and diagnostics partials.
- Adds regression tests (SSR + context-builder unit) to prevent `jinja2.exceptions.UndefinedError: 'primary_values' is undefined`.

## Root Cause
IA v2 templates (`market_primary_operator_hero_v1.html`, `market_watchlist_compact_v1.html`, `market_diagnostics_drawer_v1.html`) require `primary_values` in the Jinja context. A stale local uvicorn process without reloaded Python modules returned HTTP 500; context wiring is now explicit and regression-tested.

## Safety Scope
- Render/context wiring only — no trading logic, authority, scheduler, or runtime changes.
- Read-only display values via existing `build_market_primary_values_display_context()`.
- No Live / Paper / Shadow / Testnet / Observation runs.
- No Preflight lift / Authority lift / Market-Airport.

## Test Plan
- [x] `pytest tests/webui/test_market_dashboard_readonly_structure_contract_v0.py -q` (96 passed)
- [x] `pytest tests/webui/test_market_canonical_short_url_title_real_values_ui_v1.py -q` (10 passed)
- [x] `validate_docs_token_policy.py --changed --base origin/main`
- [x] `check_docs_drift_guard.py --base origin/main`
- [x] `ruff check` / `ruff format --check` on changed Python files
- [ ] Operator restart of stale local uvicorn if HTTP 500 persists after merge

## Durable Bundle Path
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/market_dashboard_remodel_ia_v2_render_recovery_narrow_fix_no_run_v1_20260612T161155Z`

## No Live / No Run / No Authority Lift
Confirmed — read-only SSR context fix only.

Made with [Cursor](https://cursor.com)