### PR TITLE
docs(tests): U2b observability truth promotion bounded prep (stop conditions, no promotion)

### DIFF
--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -195,6 +195,46 @@ MARKET_DASHBOARD_TOUCHED=false
 
 **Non-authorizing:** Docs/tests-only residual review guard only; does **not** authorize required-check configuration changes, branch-protection edits, workflow YAML mutation, `workflow_dispatch`, `gh run rerun`, runtime/scheduler/daemon execution, paper/shadow/testnet/live, Preflight lift, order/cancel/execution/arming, JSONL ingest, evidence dataset mutation, Market Dashboard authority changes, or Master V2 / Double Play / Bull-Bear / Risk / KillSwitch / Scope / Capital / trading-logic changes.
 
+## Docs Token Policy Guard standard check integration — docs/tests-only guard v1
+
+**Operator-GO:** `GO_DOCS_TOKEN_POLICY_GUARD_STANDARD_CHECK_INTEGRATION_NARROW_FIX_NO_RUN_V1`
+
+**Purpose:** Anchor the Docs Token Policy Guard as **mandatory standard check #1** for every docs-only or docs+tests PR. Prevents recurring `docs-token-policy-gate` CI failures from forgotten local preflight. **Docs/tests/check-plan visibility only** — no workflow mutation, no required-check configuration change, no promotion, no runtime.
+
+**Canonical repo owners (reuse — do not duplicate):**
+
+| Concern | Owner |
+|---------|-------|
+| Validator + `--changed` semantics | `scripts/ops/validate_docs_token_policy.py` |
+| Local preflight wrapper | `scripts/ops/preflight_docs_token_policy_changed.sh` |
+| Operator runbook (standard check table) | `docs/ops/runbooks/RUNBOOK_DOCS_TOKEN_POLICY_GATE.md` — **§ Standard local checks for docs / docs+tests PRs** |
+| Gate catalog + mandatory preflight index | `docs/ops/GATES_OVERVIEW.md` — **§ Docs / docs+tests PR — mandatory local preflight** |
+| CI required context | `.github/workflows/docs-token-policy-gate.yml` → check `docs-token-policy-gate` |
+| Smoke tests | `tests/ops/test_validate_docs_token_policy.py`; `tests/ops/test_validate_docs_token_policy_smoke.py` |
+
+```text
+DOCS_TOKEN_POLICY_GUARD_STANDARD_CHECK_INTEGRATION_V1=true
+DOCS_TOKEN_POLICY_GUARD_MANDATORY_FOR_DOCS_PR=true
+DOCS_TOKEN_POLICY_GUARD_MANDATORY_FOR_DOCS_TESTS_PR=true
+DOCS_TOKEN_POLICY_PREFLIGHT_COMMAND=preflight_docs_token_policy_changed.sh
+DOCS_TOKEN_POLICY_VALIDATOR=validate_docs_token_policy.py
+DOCS_TOKEN_POLICY_CI_REQUIRED_CONTEXT=docs-token-policy-gate
+STANDARD_CHECK_INTEGRATED=true
+NO_WORKFLOW_MUTATION=true
+NO_REQUIRED_CHECK_CONFIG_CHANGE=true
+TRUTH_PROMOTION_EXECUTED=false
+OBSERVABILITY_TRUTH_ALLOWED_CHANGED=false
+REAL_METADATA_SOURCE_MARKED_CHANGED=false
+```
+
+**Standard local sequence (before push):**
+
+1. `bash scripts&#47;ops&#47;preflight_docs_token_policy_changed.sh` (or `python3 scripts&#47;ops&#47;validate_docs_token_policy.py --changed --base origin&#47;main`)
+2. PR-scoped pytest for touched contract tests (docs+tests PRs)
+3. Ruff on touched Python files (when applicable)
+
+**Non-authorizing:** Docs/check-plan integration only; does **not** authorize workflow edits, branch-protection changes, truth promotion, flag mutation, runtime/live/paper/shadow/testnet, or trading logic changes.
+
 ## Primary evidence retention invariant residual static review — docs/tests-only guard v1
 
 **Operator-GO:** `GO_PRIMARY_EVIDENCE_RETENTION_INVARIANT_RESIDUAL_STATIC_REVIEW_NO_RUN_V1` · **Planning bundle (archive only):** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/systemwide_next_safe_scope_ranking_after_ci_docs_required_check_truth_map_residual_review_merge_no_run_v1_20260612T005020Z/`

--- a/docs/ops/GATES_OVERVIEW.md
+++ b/docs/ops/GATES_OVERVIEW.md
@@ -9,6 +9,19 @@
 
 > Token-Policy Hinweis: Inline illustrative Pfade im Fließtext **nicht** als `a&#47;b&#47;c` schreiben, sondern Slashes als `&#47;` encoden (z.B. `docs&#47;ops&#47;GATES_OVERVIEW.md`). Befehle in Code-Fences sind OK.
 
+## Docs / docs+tests PR — mandatory local preflight
+
+Jeder PR mit geänderten `*.md` (reine Docs-PR **oder** docs+tests-PR) **muss** vor Push lokal den Docs Token Policy Guard ausführen. Das ist **Standard-Check #1** — nicht optional.
+
+| # | Standard-Check | Lokal (kanonisch) | CI Required Context |
+|---|----------------|-------------------|---------------------|
+| 1 | **Docs Token Policy** | `bash scripts&#47;ops&#47;preflight_docs_token_policy_changed.sh` **oder** `python3 scripts&#47;ops&#47;validate_docs_token_policy.py --changed --base origin&#47;main` | `docs-token-policy-gate` |
+| 2 | Docs Reference Targets (bei `.md`-Diff) | `bash scripts&#47;ops&#47;verify_docs_reference_targets.sh --changed --base origin&#47;main` | `docs-reference-targets-gate` |
+| 3 | PR-scoped pytest (docs+tests) | betroffene Contract-/Boundary-Tests | je nach Diff |
+| 4 | Ruff (bei `.py`-Diff) | `ruff check` / `ruff format --check` auf berührte Dateien | `Lint Gate` |
+
+Runbook: `docs&#47;ops&#47;runbooks&#47;RUNBOOK_DOCS_TOKEN_POLICY_GATE.md` · CI-Audit: `docs&#47;ops&#47;CI_AUDIT_KNOWN_ISSUES.md` (§ Docs Token Policy Guard standard check integration).
+
 ## Gate Catalog (Table)
 
 **Legend**

--- a/docs/ops/runbooks/RUNBOOK_DOCS_TOKEN_POLICY_GATE.md
+++ b/docs/ops/runbooks/RUNBOOK_DOCS_TOKEN_POLICY_GATE.md
@@ -51,6 +51,26 @@ Autofix v2 (`scripts/ops/autofix_docs_token_policy_inline_code_v2.py`) is **opti
 
 ---
 
+## Standard local checks for docs / docs+tests PRs
+
+Every PR that changes `*.md` (docs-only **or** docs+tests) **must** run the Docs Token Policy Guard locally **before push**. This is a **required standard check** — not optional preflight.
+
+| Step | Command | Expected |
+|------|---------|----------|
+| 1 — Docs Token Policy (mandatory) | `bash scripts/ops/preflight_docs_token_policy_changed.sh` | Exit 0 |
+| 1 alt — direct validator | `python3 scripts/ops/validate_docs_token_policy.py --changed --base origin/main` | Exit 0, no violations |
+| 2 — Docs reference targets (when `.md` changed) | `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main` | Exit 0 |
+| 3 — Targeted pytest (docs+tests PRs) | run PR-scoped contract tests | all pass |
+| 4 — Ruff (when `.py` changed) | `ruff check` / `ruff format --check` on touched Python files | Exit 0 |
+
+**CI required check:** `docs-token-policy-gate` (`.github/workflows/docs-token-policy-gate.yml`). A local Step 1 failure predicts the same CI failure.
+
+**Common fix:** encode illustrative inline-code slashes as `&#47;` (e.g. `{ARCHIVE_ROOT}&#47;planning&#47;`, `tests&#47;webui&#47;test_foo.py`).
+
+See also: `docs/ops/GATES_OVERVIEW.md` (**G-DOCS-TOKEN**) and `docs/ops/CI_AUDIT_KNOWN_ISSUES.md` (**§ Docs Token Policy Guard standard check integration**).
+
+---
+
 ## When This Gate Triggers
 
 The gate scans changed Markdown files (`.md`) for inline-code tokens (single backticks: `` `token` ``) containing `/` and enforces:

--- a/docs/webui/observability/FUTURES_UNIVERSE_GOVERNED_METADATA_SNAPSHOT_TEMPLATE_V1.md
+++ b/docs/webui/observability/FUTURES_UNIVERSE_GOVERNED_METADATA_SNAPSHOT_TEMPLATE_V1.md
@@ -247,8 +247,83 @@ All tests must pass. Docs preflight must pass if markdown changed.
 | U2c Truth-GO form | Inactive operator form prep | not started |
 | Truth enablement | Separate bounded slice | **not authorized** |
 
-## 14. Tests
+## 14. U2b observability truth promotion — bounded prep (stop conditions, no promotion)
+
+This section documents **static stop conditions and preconditions** for a **future**, operator-authorized observability-truth-promotion slice. It does **not** authorize promotion, flag changes, readmodel rewrites, or Truth-GO.
+
+### 14.1 Status (machine markers — prep-only)
+
+```
+TRUTH_PROMOTION_EXECUTED=false
+OBSERVABILITY_TRUTH_PROMOTION_BOUNDED_PREP_ONLY=true
+CANONICAL_GOVERNED_CANDIDATE_BUNDLE_ID=u2c_kraken_governed_snapshot_candidate_post_pr4067_v1_20260608T234112Z
+OPERATOR_TRUTH_GO_RECORD_REQUIRED=true
+TRUTH_PROMOTION_STOP_S1_STRICT_INSTRUMENT_COMPLETE=active_when_zero_without_policy
+TRUTH_PROMOTION_STOP_S2_MIN_NOTIONAL_MISSING=active_when_all_packets_missing
+TRUTH_PROMOTION_STOP_S3_OPERATOR_TRUTH_GO_RECORD=active_until_durable_record
+TRUTH_PROMOTION_STOP_S5_TRUTH_GO_GRANTED=false
+MISSING_TRUTH_FAIL_CLOSED_INTENTIONAL=true
+observability_truth_allowed=false
+real_metadata_source_marked=true
+```
+
+### 14.2 Canonical candidate lineage (archive reference, non-normative)
+
+| Field | Value |
+|-------|-------|
+| **Recommended canonical bundle** | `u2c_kraken_governed_snapshot_candidate_post_pr4067_v1_20260608T234112Z` |
+| **Archive path** | `{ARCHIVE_ROOT}/governed_metadata/u2c_kraken_governed_snapshot_candidate_post_pr4067_v1_20260608T234112Z/` |
+| **Lineage predecessors** | `..._v1_20260608T223345Z` → `..._aligned_v1_20260608T230742Z` → `..._completeness_aligned_v1_20260608T233741Z` → **post_pr4067** |
+| **Readmodel evidence link** | `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` links governed packet under post_pr4067 bundle |
+| **Candidate shape** | 332 packets, Top-20 ranking candidate; `schema_name=futures_producer_packet_governed.v1`, `source_kind=governed_metadata_snapshot` |
+| **Promotion in this prep** | **not executed** — lineage documented for later bounded GO only |
+
+### 14.3 Hard preconditions before any future Truth-GO
+
+| # | Precondition | Enforced by |
+|---|--------------|-------------|
+| P1 | Durable **Operator Truth-GO Decision Record** under `{ARCHIVE_ROOT}/planning/` with explicit scoped GO token | Operator — **required**; template alone is insufficient |
+| P2 | U2c §11 all ten operator confirmations recorded in that durable record | U2c charter |
+| P3 | `TRUTH_GO_GRANTED=true` only inside an explicit Operator GO record — **never** from prep docs or candidate build | `candidate_safety_flags.v1.json` + operator record |
+| P4 | Policy decision on `min_notional` / strict completeness documented before `observability_truth_allowed=true` | Operator + U4b/U5c §12.12 |
+| P5 | `MANIFEST_VERIFY_RC=0` on canonical candidate bundle **and** readmodels dir at promotion-write time | `primary_evidence_retention_v0.py` |
+| P6 | Full universe/U2b regression green at Truth-GO time | `tests/webui/test_universe_selection*.py`, U2b loader/chain tests |
+| P7 | Separate bounded Truth-Promotion GO token — distinct from Live/Trading/Execute authorization | Operator |
+
+**`OPERATOR_TRUTH_GO_RECORD_REQUIRED=true`** — promotion remains blocked until P1 is satisfied.
+
+### 14.4 Stop conditions (promotion must not proceed while active)
+
+| ID | Stop condition | Active when |
+|----|----------------|-------------|
+| **S1** | `strict_instrument_complete_count=0` without documented policy exception | Canonical build_summary shows zero strict-complete instruments |
+| **S2** | `min_notional` missing on all governed packets without operator acceptance | Public-view Kraken metadata — see REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md §12.12 |
+| **S3** | No durable Operator Truth-GO Record | P1 unsatisfied |
+| **S4** | `MANIFEST_VERIFY_RC ≠ 0` on candidate or readmodel | Integrity gate |
+| **S5** | `TRUTH_GO_GRANTED=false` in `candidate_safety_flags.v1.json` | Default candidate safety |
+| **S6** | `observability_truth_allowed` would be set without bounded Truth-GO | Code + contract |
+| **S7** | Operator explicitly requires Slice 4 run verification first | Separate O2 GO |
+| **S8** | Metadata older than accepted freshness policy | Operator freshness acceptance |
+
+**Current archive posture (2026-06-08 candidates):** S1, S2, S3, S5 active — promotion is **correctly blocked**.
+
+### 14.5 Fail-closed Missing Truth (expected behavior)
+
+While `real_metadata_source_marked=true` and `observability_truth_allowed=false`:
+
+- U2b loader may validate governed bundles and persist readmodel-shaped payloads with **`observability_truth_allowed=false`**.
+- Reader returns **`LOAD_ERROR_REAL_METADATA_NOT_OBSERVABILITY_TRUTH`** — SSR/dashboard must show **Missing Truth** for universe/ranking/selected_future.
+- **No dummy fill**, no BTC/slash substitution, no funnel/market_surface upstream — intentional fail-closed until Operator Truth-GO + policy gates clear.
+
+### 14.6 Explicit non-goals (this prep section)
+
+- Not observability truth promotion execution
+- Not `observability_truth_allowed=true` or `real_metadata_source_marked` mutation
+- Not Slice 4 run verification, metadata refresh, or source-policy implementation
+- Not dummy `min_notional` fill or forced `instrument.complete`
+
+## 15. Tests
 
 | Test module | Purpose |
 |-------------|---------|
-| `tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py` | Template existence, machine markers, charter cross-link |
+| `tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py` | Template existence, machine markers, charter cross-link, §14 stop-condition markers |

--- a/docs/webui/observability/FUTURES_UNIVERSE_GOVERNED_METADATA_SNAPSHOT_TEMPLATE_V1.md
+++ b/docs/webui/observability/FUTURES_UNIVERSE_GOVERNED_METADATA_SNAPSHOT_TEMPLATE_V1.md
@@ -272,9 +272,9 @@ real_metadata_source_marked=true
 | Field | Value |
 |-------|-------|
 | **Recommended canonical bundle** | `u2c_kraken_governed_snapshot_candidate_post_pr4067_v1_20260608T234112Z` |
-| **Archive path** | `{ARCHIVE_ROOT}/governed_metadata/u2c_kraken_governed_snapshot_candidate_post_pr4067_v1_20260608T234112Z/` |
+| **Archive path** | `{ARCHIVE_ROOT}&#47;governed_metadata&#47;u2c_kraken_governed_snapshot_candidate_post_pr4067_v1_20260608T234112Z&#47;` |
 | **Lineage predecessors** | `..._v1_20260608T223345Z` → `..._aligned_v1_20260608T230742Z` → `..._completeness_aligned_v1_20260608T233741Z` → **post_pr4067** |
-| **Readmodel evidence link** | `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` links governed packet under post_pr4067 bundle |
+| **Readmodel evidence link** | `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json` links governed packet under post_pr4067 bundle |
 | **Candidate shape** | 332 packets, Top-20 ranking candidate; `schema_name=futures_producer_packet_governed.v1`, `source_kind=governed_metadata_snapshot` |
 | **Promotion in this prep** | **not executed** — lineage documented for later bounded GO only |
 
@@ -282,12 +282,12 @@ real_metadata_source_marked=true
 
 | # | Precondition | Enforced by |
 |---|--------------|-------------|
-| P1 | Durable **Operator Truth-GO Decision Record** under `{ARCHIVE_ROOT}/planning/` with explicit scoped GO token | Operator — **required**; template alone is insufficient |
+| P1 | Durable **Operator Truth-GO Decision Record** under `{ARCHIVE_ROOT}&#47;planning&#47;` with explicit scoped GO token | Operator — **required**; template alone is insufficient |
 | P2 | U2c §11 all ten operator confirmations recorded in that durable record | U2c charter |
 | P3 | `TRUTH_GO_GRANTED=true` only inside an explicit Operator GO record — **never** from prep docs or candidate build | `candidate_safety_flags.v1.json` + operator record |
 | P4 | Policy decision on `min_notional` / strict completeness documented before `observability_truth_allowed=true` | Operator + U4b/U5c §12.12 |
 | P5 | `MANIFEST_VERIFY_RC=0` on canonical candidate bundle **and** readmodels dir at promotion-write time | `primary_evidence_retention_v0.py` |
-| P6 | Full universe/U2b regression green at Truth-GO time | `tests/webui/test_universe_selection*.py`, U2b loader/chain tests |
+| P6 | Full universe/U2b regression green at Truth-GO time | `tests&#47;webui&#47;test_universe_selection*.py`, U2b loader/chain tests |
 | P7 | Separate bounded Truth-Promotion GO token — distinct from Live/Trading/Execute authorization | Operator |
 
 **`OPERATOR_TRUTH_GO_RECORD_REQUIRED=true`** — promotion remains blocked until P1 is satisfied.

--- a/tests/ops/test_validate_docs_token_policy_smoke.py
+++ b/tests/ops/test_validate_docs_token_policy_smoke.py
@@ -25,6 +25,33 @@ def test_validate_docs_token_policy_help_contains_no_live() -> None:
     assert "&#47;" in p.stdout
 
 
+RUNBOOK_DOCS_TOKEN_POLICY = ROOT / "docs" / "ops" / "runbooks" / "RUNBOOK_DOCS_TOKEN_POLICY_GATE.md"
+GATES_OVERVIEW = ROOT / "docs" / "ops" / "GATES_OVERVIEW.md"
+CI_AUDIT = ROOT / "docs" / "ops" / "CI_AUDIT_KNOWN_ISSUES.md"
+
+
+def test_docs_token_policy_runbook_documents_standard_check_for_docs_prs() -> None:
+    doc = RUNBOOK_DOCS_TOKEN_POLICY.read_text(encoding="utf-8")
+    assert "Standard local checks for docs / docs+tests PRs" in doc
+    assert "preflight_docs_token_policy_changed.sh" in doc
+    assert "docs-token-policy-gate" in doc
+    assert "required standard check" in doc.lower()
+
+
+def test_gates_overview_documents_mandatory_docs_token_preflight() -> None:
+    doc = GATES_OVERVIEW.read_text(encoding="utf-8")
+    assert "Docs / docs+tests PR — mandatory local preflight" in doc
+    assert "preflight_docs_token_policy_changed.sh" in doc
+    assert "docs-token-policy-gate" in doc
+
+
+def test_ci_audit_documents_docs_token_policy_standard_check_integration() -> None:
+    doc = CI_AUDIT.read_text(encoding="utf-8")
+    assert "Docs Token Policy Guard standard check integration" in doc
+    assert "DOCS_TOKEN_POLICY_GUARD_STANDARD_CHECK_INTEGRATION_V1=true" in doc
+    assert "GO_DOCS_TOKEN_POLICY_GUARD_STANDARD_CHECK_INTEGRATION_NARROW_FIX_NO_RUN_V1" in doc
+
+
 def test_validate_docs_token_policy_main_returns_2_outside_git_repo(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
+++ b/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
@@ -118,3 +118,42 @@ def test_real_futures_market_data_source_contract_linked_from_charter() -> None:
     doc = REAL_SOURCE_CHARTER_DOC.read_text(encoding="utf-8")
     assert "REAL_FUTURES_MARKET_DATA_SOURCE_CONTRACT_V1.md" in doc
     assert MARKET_DATA_SOURCE_DOC.is_file()
+
+
+def test_u2b_truth_promotion_bounded_prep_stop_conditions_in_template() -> None:
+    doc = GOVERNED_SNAPSHOT_TEMPLATE_DOC.read_text(encoding="utf-8")
+    markers = (
+        "TRUTH_PROMOTION_EXECUTED=false",
+        "OBSERVABILITY_TRUTH_PROMOTION_BOUNDED_PREP_ONLY=true",
+        "OPERATOR_TRUTH_GO_RECORD_REQUIRED=true",
+        "TRUTH_PROMOTION_STOP_S1_STRICT_INSTRUMENT_COMPLETE=active_when_zero_without_policy",
+        "TRUTH_PROMOTION_STOP_S2_MIN_NOTIONAL_MISSING=active_when_all_packets_missing",
+        "TRUTH_PROMOTION_STOP_S3_OPERATOR_TRUTH_GO_RECORD=active_until_durable_record",
+        "TRUTH_PROMOTION_STOP_S5_TRUTH_GO_GRANTED=false",
+        "MISSING_TRUTH_FAIL_CLOSED_INTENTIONAL=true",
+    )
+    for marker in markers:
+        assert marker in doc
+    assert "S1" in doc and "S2" in doc and "S3" in doc and "S5" in doc
+    assert "LOAD_ERROR_REAL_METADATA_NOT_OBSERVABILITY_TRUTH" in doc
+    assert "Not observability truth promotion execution" in doc
+
+
+def test_u2b_canonical_candidate_lineage_documented_in_template() -> None:
+    doc = GOVERNED_SNAPSHOT_TEMPLATE_DOC.read_text(encoding="utf-8")
+    assert (
+        "CANONICAL_GOVERNED_CANDIDATE_BUNDLE_ID="
+        "u2c_kraken_governed_snapshot_candidate_post_pr4067_v1_20260608T234112Z"
+    ) in doc
+    assert "post_pr4067_v1_20260608T234112Z" in doc
+    assert "332 packets" in doc
+    assert "futures_producer_packet_governed.v1" in doc
+
+
+def test_u2b_operator_truth_go_record_required_before_promotion() -> None:
+    doc = GOVERNED_SNAPSHOT_TEMPLATE_DOC.read_text(encoding="utf-8")
+    assert "Operator Truth-GO Decision Record" in doc
+    assert "OPERATOR_TRUTH_GO_RECORD_REQUIRED=true" in doc
+    assert "template alone is insufficient" in doc
+    assert "observability_truth_allowed=true" in doc
+    assert "Separate bounded Truth-Promotion GO token" in doc


### PR DESCRIPTION
## Summary
- Extends `FUTURES_UNIVERSE_GOVERNED_METADATA_SNAPSHOT_TEMPLATE_V1.md` §14 with static stop conditions (S1–S8), canonical candidate lineage (`post_pr4067_v1_20260608T234112Z`), Operator Truth-GO record preconditions, and fail-closed Missing Truth expectations.
- Adds boundary tests in `test_workflow_dashboard_env_schema_boundary_v1.py` to lock prep markers — **no** promotion, **no** flag changes, **no** loader/runtime changes.

## Safety boundaries
- `TRUTH_PROMOTION_EXECUTED=false`
- No change to `observability_truth_allowed` or `real_metadata_source_marked`
- No network, runs, or trading logic touched

## Test plan
- [x] `pytest tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py`
- [x] `pytest tests/webui/test_universe_selection*.py`
- [x] `ruff check tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py`

Made with [Cursor](https://cursor.com)