### PR TITLE
feat(experiments): Monte-Carlo robustness equity_loader integration

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -108,6 +108,8 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
   - Fundstelle: `scripts&#47;run_monte_carlo_robustness.py` (Zeile 139) (illustrative)
   - Kontext: Vollständige Implementierung, die Equity-Curves aus Backtest-Results lädt
   - Vorschlag: Integration mit Backtest-Registry
+  - Status: implemented (feat/monte-carlo-equity-loader-integration-v1) — `load_returns_for_config` nutzt kanonischen `equity_loader`; kein stiller Dummy-Fallback im Standardpfad; Synthetic nur via `--use-dummy-data`
+  - Fundstellen: `scripts/run_monte_carlo_robustness.py`, `src/experiments/equity_loader.py`, `tests/scripts/test_run_monte_carlo_robustness_equity_loader_integration_v1.py`
 
 ### Registry-Logging
 

--- a/scripts/run_monte_carlo_robustness.py
+++ b/scripts/run_monte_carlo_robustness.py
@@ -51,6 +51,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from src.experiments.dummy_returns_timeline import create_dummy_returns
+from src.experiments.equity_loader import equity_to_returns, load_equity_curves_from_run_dir
 from src.experiments.ohlcv_returns_file import load_close_returns_from_ohlcv_parquet
 from src.experiments.monte_carlo import (
     MonteCarloConfig,
@@ -99,24 +100,23 @@ def load_returns_for_config(
     use_dummy_data: bool = False,
     dummy_bars: int = 500,
     shared_returns: Optional[pd.Series] = None,
-) -> Optional[pd.Series]:
+) -> pd.Series:
     """
     Lädt Returns für eine Top-N-Konfiguration.
 
     Args:
         config: Config-Dict aus load_top_n_configs_for_sweep
         experiments_dir: Verzeichnis mit Experiment-Ergebnissen
-        use_dummy_data: Wenn True, werden Dummy-Daten verwendet
-        dummy_bars: Anzahl Bars für Dummy-Daten
+        use_dummy_data: Wenn True, werden explizite Synthetic-Returns verwendet
+        dummy_bars: Anzahl Bars für Synthetic-Returns (--use-dummy-data)
+        shared_returns: Optional OHLCV-CLI-Returns (--ohlcv-file), überschreibt alle anderen Quellen
 
     Returns:
-        Returns-Serie oder None
+        Returns-Serie (DatetimeIndex)
 
-    Note:
-        Aktuell ist dies eine vereinfachte Implementierung. In einer vollständigen
-        Implementierung würde man die Equity-Curves aus den Backtest-Result-Objekten
-        laden. Für Phase 45 verwenden wir Dummy-Daten oder Approximationen.
-        ``shared_returns`` (aus ``--ohlcv-file``) überschreibt Dummy-/Placeholder-Returns.
+    Raises:
+        ValueError: Wenn config_id nicht auflösbar ist oder Equity-Artefakte fehlen/ungültig sind
+        FileNotFoundError: Wenn keine unterstützten Equity-Artefakte im Run-Verzeichnis existieren
     """
     logger = logging.getLogger(__name__)
     if shared_returns is not None:
@@ -126,17 +126,29 @@ def load_returns_for_config(
         return shared_returns.copy()
 
     if use_dummy_data:
-        logger.info(f"Verwende Dummy-Daten für Config {config.get('config_id', 'unknown')}")
+        logger.info(
+            f"Verwende explizite Synthetic-Returns (--use-dummy-data) "
+            f"für Config {config.get('config_id', 'unknown')}"
+        )
         return create_dummy_returns(dummy_bars)
 
-    # NOTE: Siehe docs/TECH_DEBT_BACKLOG.md (Eintrag "Vollständige Monte-Carlo-Robustness-Implementierung")
-    # Aktuell: Placeholder - würde hier die Equity-Curve aus dem Experiment-Run laden
-    logger.warning(
-        f"load_returns_for_config ist noch nicht vollständig implementiert "
-        f"für config_id={config.get('config_id', 'unknown')}. "
-        f"Verwende Dummy-Daten als Fallback."
-    )
-    return create_dummy_returns(dummy_bars)
+    config_id = str(config.get("config_id", ""))
+    if not config_id or config_id.startswith("config_"):
+        raise ValueError(
+            "Top-N config has no usable experiment_id/config_id to resolve a run directory. "
+            f"config_id={config_id!r}. "
+            "Ensure sweep results include an experiment_id (directory name) or use --use-dummy-data."
+        )
+
+    run_dir = Path(experiments_dir) / config_id
+    try:
+        curves = load_equity_curves_from_run_dir(run_dir, max_curves=1)
+    except (FileNotFoundError, ValueError) as e:
+        raise ValueError(
+            f"Equity load failed for config_id={config_id!r}, run_dir={run_dir}: {e}"
+        ) from e
+
+    return equity_to_returns(curves[0])
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -337,16 +349,16 @@ def run_from_args(args: argparse.Namespace) -> int:
         logger.info("=" * 70)
 
         # Lade Returns
-        returns = load_returns_for_config(
-            config,
-            experiments_dir,
-            use_dummy_data=args.use_dummy_data,
-            dummy_bars=args.dummy_bars,
-            shared_returns=shared_returns,
-        )
-
-        if returns is None:
-            logger.warning(f"Konnte Returns für {config_id} nicht laden, überspringe")
+        try:
+            returns = load_returns_for_config(
+                config,
+                experiments_dir,
+                use_dummy_data=args.use_dummy_data,
+                dummy_bars=args.dummy_bars,
+                shared_returns=shared_returns,
+            )
+        except (FileNotFoundError, ValueError) as e:
+            logger.error(f"Returns-Load fehlgeschlagen für {config_id}: {e}")
             continue
 
         # Führe Monte-Carlo durch

--- a/tests/scripts/test_run_monte_carlo_robustness_equity_loader_integration_v1.py
+++ b/tests/scripts/test_run_monte_carlo_robustness_equity_loader_integration_v1.py
@@ -1,0 +1,167 @@
+"""
+Monte-Carlo robustness CLI: canonical equity_loader integration (fail-closed).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+import scripts.run_monte_carlo_robustness as mc_script
+
+
+def _write_events_parquet(run_dir: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "ts_bar": pd.date_range("2024-01-01", periods=10, freq="1h", tz="UTC"),
+            "equity": [
+                100.0,
+                101.0,
+                100.5,
+                102.0,
+                103.0,
+                104.0,
+                103.5,
+                105.0,
+                106.0,
+                107.0,
+            ],
+        }
+    )
+    df.to_parquet(run_dir / "events.parquet", index=False)
+
+
+def test_load_returns_for_config_uses_canonical_equity_loader(tmp_path: Path) -> None:
+    experiments_dir = tmp_path / "experiments"
+    experiments_dir.mkdir()
+    run_dir = experiments_dir / "expABC"
+    run_dir.mkdir()
+    _write_events_parquet(run_dir)
+
+    returns = mc_script.load_returns_for_config(
+        {"config_id": "expABC"},
+        experiments_dir,
+        use_dummy_data=False,
+    )
+    assert isinstance(returns, pd.Series)
+    assert isinstance(returns.index, pd.DatetimeIndex)
+    assert len(returns) >= 2
+
+
+def test_load_returns_for_config_missing_artifacts_fails_closed(tmp_path: Path) -> None:
+    experiments_dir = tmp_path / "experiments"
+    experiments_dir.mkdir()
+    run_dir = experiments_dir / "expABC"
+    run_dir.mkdir()
+
+    with pytest.raises(ValueError, match="Equity load failed"):
+        mc_script.load_returns_for_config(
+            {"config_id": "expABC"},
+            experiments_dir,
+            use_dummy_data=False,
+        )
+
+
+def test_load_returns_for_config_invalid_config_id_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="no usable experiment_id"):
+        mc_script.load_returns_for_config(
+            {"config_id": "config_1"},
+            tmp_path,
+            use_dummy_data=False,
+        )
+
+
+def test_load_returns_for_config_loader_error_no_silent_dummy_fallback(tmp_path: Path) -> None:
+    experiments_dir = tmp_path / "experiments"
+    experiments_dir.mkdir()
+    run_dir = experiments_dir / "expABC"
+    run_dir.mkdir()
+
+    with patch.object(
+        mc_script,
+        "load_equity_curves_from_run_dir",
+        side_effect=FileNotFoundError("no artifacts"),
+    ):
+        with pytest.raises(ValueError, match="Equity load failed"):
+            mc_script.load_returns_for_config(
+                {"config_id": "expABC"},
+                experiments_dir,
+                use_dummy_data=False,
+            )
+
+
+def test_load_returns_for_config_synthetic_only_with_explicit_opt_in(tmp_path: Path) -> None:
+    returns = mc_script.load_returns_for_config(
+        {"config_id": "ignored"},
+        tmp_path,
+        use_dummy_data=True,
+        dummy_bars=40,
+    )
+    assert len(returns) == 40
+
+
+def test_load_returns_for_config_default_path_does_not_use_synthetic(tmp_path: Path) -> None:
+    experiments_dir = tmp_path / "experiments"
+    experiments_dir.mkdir()
+    with pytest.raises(ValueError):
+        mc_script.load_returns_for_config(
+            {"config_id": "missing"},
+            experiments_dir,
+            use_dummy_data=False,
+        )
+
+
+def test_load_returns_for_config_no_network_calls(tmp_path: Path) -> None:
+    experiments_dir = tmp_path / "experiments"
+    experiments_dir.mkdir()
+    run_dir = experiments_dir / "expABC"
+    run_dir.mkdir()
+    _write_events_parquet(run_dir)
+
+    with patch("urllib.request.urlopen") as urlopen:
+        mc_script.load_returns_for_config(
+            {"config_id": "expABC"},
+            experiments_dir,
+            use_dummy_data=False,
+        )
+    urlopen.assert_not_called()
+
+
+@patch("scripts.run_monte_carlo_robustness.load_top_n_configs_for_sweep")
+def test_mc_equity_loader_integration_writes_report(mock_load, tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    experiments_dir = tmp_path / "experiments"
+    experiments_dir.mkdir()
+    run_dir = experiments_dir / "expABC"
+    run_dir.mkdir()
+    _write_events_parquet(run_dir)
+
+    mock_load.return_value = [{"config_id": "expABC", "rank": 1}]
+    out = tmp_path / "mc_out"
+    args = mc_script.build_parser().parse_args(
+        [
+            "--sweep-name",
+            "smoke",
+            "--top-n",
+            "1",
+            "--num-runs",
+            "20",
+            "--format",
+            "md",
+            "--output-dir",
+            str(out),
+            "--experiments-dir",
+            str(experiments_dir),
+        ]
+    )
+
+    rc = mc_script.run_from_args(args)
+    assert rc == 0
+    assert list(out.rglob("*.md"))


### PR DESCRIPTION
## Summary
Wire `scripts/run_monte_carlo_robustness.py` to the canonical equity loader and remove the silent dummy fallback from the standard returns-loading path.

## Why
`load_returns_for_config` still warned and fell back to synthetic returns even though `src/experiments/equity_loader.py` exists on main (Tech-Debt backlog gap).

## Changes
- Reuse `load_equity_curves_from_run_dir` + `equity_to_returns` for the regular Top-N config path (`config_id` → experiments run dir).
- Fail closed on missing/invalid equity artifacts with operator-readable errors.
- Keep synthetic returns only behind explicit `--use-dummy-data` (default disabled).
- Add focused integration tests under `tests/scripts/`.
- Update `docs/TECH_DEBT_BACKLOG.md` status for Monte-Carlo-Robustness integration.

## Verification
- `python3 -m pytest -q tests/scripts/test_run_monte_carlo_robustness_equity_loader_integration_v1.py tests/test_run_monte_carlo_robustness_cli_dummy_fallback_v0.py tests/experiments/test_equity_loader.py tests/test_runner_experiments_dir_cli_v0.py tests/test_runner_ohlcv_file_cli_v0.py`
- `ruff format --check` + `ruff check` on changed Python files
- `git diff --check`

## Safety / markers
- `CANONICAL_EQUITY_LOADER_REUSED=true`
- `SILENT_DUMMY_FALLBACK_STANDARD_PATH=false`
- `LOADER_FAILURE_FAILS_CLOSED=true`
- `SYNTHETIC_FALLBACK_DEFAULT_ENABLED=false`
- No runtime/Monte-Carlo production run, no workflow changes, no authority lift
- Reuse-before-new + Reuse Drift Guard: PASS

## Risk
LOW — research/offline returns-loading adapter only; no trading, execution, or Monte-Carlo algorithm semantic changes.

Made with [Cursor](https://cursor.com)