### PR TITLE
fix(scripts): migrate run_full_portfolio to canonical load_strategy()

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -48,6 +48,12 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
   - Kontext: Legacy-Funktion für Backwards Compatibility
   - Vorschlag: Prüfen, ob alle Pipelines auf BollingerBandsStrategy (OOP) umgestellt sind, dann entfernen
 
+- [x] `run_full_portfolio.py`: Legacy-`*_signals`-Imports auf kanonischen `load_strategy()`-Pfad migriert
+  - Fundstelle: `scripts/run_full_portfolio.py`
+  - Kontext: Script importierte entfernte Legacy-Exports (`ma_crossover_signals` u.a.) und war beim Import gebrochen
+  - Status: closed (PR feat/run-full-portfolio-load-strategy-migration-v1; offline Tests `tests/scripts/test_run_full_portfolio_load_strategy_v1.py`)
+  - Fundstellen: `scripts/run_full_portfolio.py`, `src/strategies/__init__.py` (`load_strategy`), `tests/scripts/test_run_full_portfolio_load_strategy_v1.py`
+
 ---
 
 ## Kategorie B – Daten-Integration & Exchange

--- a/scripts/run_full_portfolio.py
+++ b/scripts/run_full_portfolio.py
@@ -15,6 +15,7 @@ Strategien:
 
 import sys
 from pathlib import Path
+from typing import Callable, Dict, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -22,17 +23,42 @@ import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
 
-from src.core import get_config, list_strategies
-from src.strategies import (
-    ma_crossover_signals,
-    momentum_signals,
-    rsi_signals,
-    bollinger_signals,
-    macd_signals,
-    ecm_signals,
-)
+from src.core import get_config, get_strategy_cfg, list_strategies
+from src.strategies import load_strategy
 from src.portfolio import PortfolioManager
 from src.backtest.stats import validate_for_live_trading
+
+DEMO_PORTFOLIO_STRATEGY_NAMES: tuple[str, ...] = (
+    "ma_crossover",
+    "momentum_1h",
+    "rsi_strategy",
+    "bollinger_bands",
+    "macd",
+    "ecm_cycle",
+)
+
+
+def resolve_portfolio_strategy(strategy_name: str) -> Tuple[Callable, Dict]:
+    """
+    Resolve strategy signal function and params via canonical loaders.
+
+    Raises:
+        ValueError: Unknown strategy name (load_strategy fail-closed).
+        KeyError: Strategy not defined in config.toml (get_strategy_cfg fail-closed).
+    """
+    signal_fn = load_strategy(strategy_name)
+    params = get_strategy_cfg(strategy_name)
+    return signal_fn, params
+
+
+def add_configured_strategies(
+    pm: PortfolioManager,
+    strategy_names: tuple[str, ...] = DEMO_PORTFOLIO_STRATEGY_NAMES,
+) -> None:
+    """Add each configured strategy to the portfolio via canonical load_strategy()."""
+    for name in strategy_names:
+        signal_fn, params = resolve_portfolio_strategy(name)
+        pm.add_strategy(name, signal_fn, params=params)
 
 
 def create_rich_dummy_data(n_bars: int = 1000) -> pd.DataFrame:
@@ -183,21 +209,9 @@ def main():
     # Alle Strategien hinzufügen
     print(f"\n📥 Lade Strategien...")
 
-    strategies_to_add = [
-        ("ma_crossover", ma_crossover_signals),
-        ("momentum_1h", momentum_signals),
-        ("rsi_strategy", rsi_signals),
-        ("bollinger_bands", bollinger_signals),
-        ("macd", macd_signals),
-        ("ecm_cycle", ecm_signals),
-    ]
-
-    for name, signal_fn in strategies_to_add:
-        try:
-            pm.add_strategy(name, signal_fn)
-            print(f"  ✅ {name}")
-        except KeyError as e:
-            print(f"  ❌ {name}: {e}")
+    add_configured_strategies(pm)
+    for name in DEMO_PORTFOLIO_STRATEGY_NAMES:
+        print(f"  ✅ {name}")
 
     # Daten erstellen
     print("\n📊 Erstelle reichhaltige Testdaten...")

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -40,6 +40,7 @@ def load_strategy(strategy_name: str):
     """
     Lädt die Strategie dynamisch.
     Erwartet: Modul hat eine Funktion generate_signals(df, params)
+    oder eine OOP-Strategie in der Registry (Fallback).
     """
     if strategy_name not in STRATEGY_REGISTRY:
         raise ValueError(
@@ -51,7 +52,26 @@ def load_strategy(strategy_name: str):
     # Dynamisch importieren
     module = __import__(f"src.strategies.{module_name}", fromlist=["generate_signals"])
 
-    return module.generate_signals
+    if hasattr(module, "generate_signals") and callable(module.generate_signals):
+        return module.generate_signals
+
+    try:
+        from src.strategies.registry import get_strategy_spec
+
+        spec = get_strategy_spec(strategy_name)
+    except KeyError as exc:
+        raise ValueError(
+            f"Strategie '{strategy_name}' hat keine generate_signals-Funktion "
+            f"und ist nicht in der OOP-Registry registriert."
+        ) from exc
+
+    strategy_cls = spec.cls
+
+    def generate_signals(df, params):
+        strategy = strategy_cls(config=dict(params))
+        return strategy.generate_signals(df)
+
+    return generate_signals
 
 
 __all__ = [

--- a/tests/scripts/test_run_full_portfolio_load_strategy_v1.py
+++ b/tests/scripts/test_run_full_portfolio_load_strategy_v1.py
@@ -1,0 +1,117 @@
+"""
+run_full_portfolio: canonical load_strategy() migration (offline, fail-closed).
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+import scripts.run_full_portfolio as portfolio_script
+from src.portfolio import PortfolioManager
+
+LEGACY_SIGNAL_IMPORTS = (
+    "ma_crossover_signals",
+    "momentum_signals",
+    "rsi_signals",
+    "bollinger_signals",
+    "macd_signals",
+    "ecm_signals",
+)
+
+
+def test_module_imports_without_main_side_effects() -> None:
+    with patch.object(portfolio_script, "main") as main_mock:
+        import importlib
+
+        importlib.reload(portfolio_script)
+    main_mock.assert_not_called()
+
+
+def test_source_has_no_legacy_signal_imports() -> None:
+    source = Path(portfolio_script.__file__).read_text(encoding="utf-8")
+    for legacy_name in LEGACY_SIGNAL_IMPORTS:
+        assert legacy_name not in source
+
+
+def test_source_has_no_parallel_strategy_registry() -> None:
+    source = Path(portfolio_script.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    assigned_names = {
+        node.targets[0].id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    }
+    assert "STRATEGY_REGISTRY" not in assigned_names
+    assert "load_strategy" in source
+
+
+def test_resolve_portfolio_strategy_loads_all_demo_strategies() -> None:
+    for name in portfolio_script.DEMO_PORTFOLIO_STRATEGY_NAMES:
+        signal_fn, params = portfolio_script.resolve_portfolio_strategy(name)
+        assert callable(signal_fn)
+        assert isinstance(params, dict)
+        assert params
+
+
+def test_resolve_portfolio_strategy_passes_config_params() -> None:
+    signal_fn, params = portfolio_script.resolve_portfolio_strategy("ma_crossover")
+    assert callable(signal_fn)
+    assert "fast_period" in params or "fast_window" in params
+
+
+def test_unknown_strategy_fails_closed() -> None:
+    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+        portfolio_script.resolve_portfolio_strategy("definitely_not_a_strategy_xyz")
+
+
+def test_missing_config_strategy_fails_closed() -> None:
+    with patch.object(
+        portfolio_script, "load_strategy", return_value=lambda df, p: df["close"] * 0
+    ):
+        with pytest.raises(KeyError, match="nicht in config.toml"):
+            portfolio_script.resolve_portfolio_strategy("definitely_not_a_strategy_xyz")
+
+
+def test_no_silent_strategy_fallback_on_unknown_name() -> None:
+    with patch.object(portfolio_script, "load_strategy") as load_mock:
+        load_mock.side_effect = ValueError("Unbekannte Strategie 'bad_name'")
+        with pytest.raises(ValueError, match="Unbekannte Strategie"):
+            portfolio_script.resolve_portfolio_strategy("bad_name")
+    load_mock.assert_called_once_with("bad_name")
+
+
+def test_resolve_portfolio_strategy_no_network_calls() -> None:
+    with patch("urllib.request.urlopen") as urlopen:
+        portfolio_script.resolve_portfolio_strategy("ma_crossover")
+    urlopen.assert_not_called()
+
+
+def test_add_configured_strategies_registers_all_demo_strategies() -> None:
+    pm = PortfolioManager()
+    portfolio_script.add_configured_strategies(pm)
+    loaded_names = [allocation.name for allocation in pm.strategies]
+    assert loaded_names == list(portfolio_script.DEMO_PORTFOLIO_STRATEGY_NAMES)
+
+
+def test_offline_portfolio_backtest_with_dummy_data() -> None:
+    pm = PortfolioManager()
+    pm.total_capital = 10_000.0
+    portfolio_script.add_configured_strategies(pm)
+
+    df = portfolio_script.create_rich_dummy_data(n_bars=300)
+    result = pm.run_backtest(df=df, allocation_method="equal")
+
+    assert len(result.strategy_results) == len(portfolio_script.DEMO_PORTFOLIO_STRATEGY_NAMES)
+    assert len(result.portfolio_equity) >= len(df)
+    assert result.stats["total_trades"] >= 0


### PR DESCRIPTION
## Summary
- Entfernt gebrochene Legacy-Imports (`ma_crossover_signals`, `momentum_signals`, `rsi_signals`, `bollinger_signals`, `macd_signals`, `ecm_signals`) aus `scripts/run_full_portfolio.py`.
- Lädt alle 6 Demo-Strategien über den kanonischen Pfad `load_strategy()` + `get_strategy_cfg()`; kleiner OOP-Fallback in `src/strategies/__init__.py` für Module ohne modulweite `generate_signals` (`bollinger`, `macd`).
- Fail-closed bei unbekannten Strategienamen (`ValueError`) und fehlender Config (`KeyError`); kein stiller Fallback.
- Offline-Tests in `tests/scripts/test_run_full_portfolio_load_strategy_v1.py` (Import, Loader, Dummy-Portfolio-Backtest ohne Netzwerk/Runtime).

## Safety / Scope
- Keine Strategy-/Portfolio-Semantikänderung (nur Loader-Wiring).
- Kein Portfolio-/Backtest-/Live-Run in diesem Auftrag.
- Tech-Debt-Eintrag in `docs/TECH_DEBT_BACKLOG.md` geschlossen.
- Reuse-before-new: bestehender `load_strategy()`-Vertrag wiederverwendet; kein paralleles Registry-SSOT im Script.
- Reuse Drift Guard: keine Workflow-/Required-Check-/Runtime-Oberflächen berührt.

## Marker
RUN_FULL_PORTFOLIO_LOAD_STRATEGY_MIGRATION_V1=true
CANONICAL_LOAD_STRATEGY_REUSED=true
LEGACY_STRATEGY_EXPORT_IMPORTS_REMAIN=false
UNKNOWN_STRATEGY_FAILS_CLOSED=true
INVALID_STRATEGY_PARAMS_FAIL_CLOSED=true
SILENT_STRATEGY_FALLBACK=false
IMPORT_SIDE_EFFECTS_PRESENT=false
NETWORK_USED=false
PORTFOLIO_RUN_STARTED=false

## Test plan
- [x] `pytest tests/scripts/test_run_full_portfolio_load_strategy_v1.py`
- [x] `pytest tests/test_new_strategies.py`
- [x] `ruff format --check` / `ruff check` auf geänderte Python-Dateien
- [x] `git diff --check`
- [x] Import-Smoke ohne Main-Ausführung
- [x] Docs token policy guard (geänderte Markdown)


Made with [Cursor](https://cursor.com)