### PR TITLE
feat(demo_order_pipeline): registry logging fail-closed migration v1

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -132,10 +132,9 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
 
 ### Registry-Logging
 
-- [ ] Registry-Logging in `demo_order_pipeline_backtest.py` implementieren
-  - Fundstelle: `scripts&#47;demo_order_pipeline_backtest.py` (Zeile 306) (illustrative)
-  - Kontext: Registry-Logging für automatisches Tracking
-  - Vorschlag: Integration mit `src&#47;core&#47;experiments.py`
+- [x] Registry-Logging in `demo_order_pipeline_backtest.py` implementieren
+  - Fundstelle: `scripts&#47;demo_order_pipeline_backtest.py` (illustrative)
+  - Kontext: Registry-Logging für automatisches Tracking via `log_backtest_result` (fail-closed `load_strategy`, kanonische Registry-Hints)
 
 ---
 

--- a/scripts/demo_order_pipeline_backtest.py
+++ b/scripts/demo_order_pipeline_backtest.py
@@ -29,7 +29,7 @@ import sys
 import argparse
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 # Pfad-Setup
 CURRENT_DIR = Path(__file__).resolve().parent
@@ -41,7 +41,56 @@ import pandas as pd
 import numpy as np
 
 from src.backtest.engine import BacktestEngine
-from src.strategies import load_strategy
+from src.core.experiments import log_backtest_result
+from src.strategies import STRATEGY_REGISTRY, load_strategy
+
+
+def get_available_strategy_hint_keys() -> list[str]:
+    return sorted(STRATEGY_REGISTRY.keys())
+
+
+def format_available_strategy_hints() -> str:
+    return ", ".join(get_available_strategy_hint_keys())
+
+
+def get_default_strategy_params(name: str) -> Dict[str, Any]:
+    defaults: Dict[str, Dict[str, Any]] = {
+        "ma_crossover": {
+            "fast_period": 10,
+            "slow_period": 30,
+            "stop_pct": 0.02,
+        },
+        "rsi_reversion": {
+            "rsi_period": 14,
+            "oversold": 30,
+            "overbought": 70,
+            "stop_pct": 0.02,
+        },
+        "macd": {
+            "fast_ema": 12,
+            "slow_ema": 26,
+            "signal_ema": 9,
+            "stop_pct": 0.02,
+        },
+        "momentum_1h": {
+            "lookback_period": 20,
+            "entry_threshold": 0.02,
+            "exit_threshold": -0.01,
+            "stop_pct": 0.02,
+        },
+        "bollinger_bands": {
+            "bb_period": 20,
+            "bb_std": 2.0,
+            "stop_pct": 0.02,
+        },
+        "breakout": {
+            "lookback_breakout": 20,
+            "stop_pct": 0.02,
+        },
+    }
+    if name not in defaults:
+        raise ValueError(f"Unbekannte Strategie '{name}'")
+    return dict(defaults[name])
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
@@ -172,7 +221,7 @@ def generate_sample_data(
     return df
 
 
-def main(argv: Optional[List[str]] = None) -> None:
+def main(argv: Optional[List[str]] = None) -> int:
     args = parse_args(argv)
 
     print("\n" + "=" * 70)
@@ -195,21 +244,16 @@ def main(argv: Optional[List[str]] = None) -> None:
     print(f"   Zeitraum: {df.index[0]} bis {df.index[-1]}")
     print(f"   Preis-Range: {df['close'].min():.2f} - {df['close'].max():.2f}")
 
-    # 2. Strategie laden
+    # 2. Strategie laden (kanonisch, fail-closed)
     print(f"\n🎯 Lade Strategie: {args.strategy}")
     try:
         strategy_fn = load_strategy(args.strategy)
-    except Exception as e:
+        strategy_params = get_default_strategy_params(args.strategy)
+    except ValueError as e:
         print(f"❌ Fehler beim Laden der Strategie: {e}")
-        print("   Verfuegbare Strategien: ma_crossover, rsi_reversion, macd, momentum, bollinger")
-        return
+        print(f"   Verfuegbare Strategien: {format_available_strategy_hints()}")
+        return 1
 
-    # Strategie-Parameter (Standard-Werte)
-    strategy_params = {
-        "fast_period": 10,
-        "slow_period": 30,
-        "stop_pct": 0.02,
-    }
     print(f"   Parameter: {strategy_params}")
 
     # 3. Backtest mit Order-Layer ausfuehren
@@ -312,13 +356,27 @@ def main(argv: Optional[List[str]] = None) -> None:
     print("✅ Order-Pipeline-Backtest Demo abgeschlossen!")
     print("=" * 70)
 
+    start_date_str = df.index[0].strftime("%Y-%m-%d")
+    end_date_str = df.index[-1].strftime("%Y-%m-%d")
+
+    registry_run_id = log_backtest_result(
+        result=result,
+        strategy_name=args.strategy,
+        tag=args.tag,
+        data_source="synthetic",
+        symbol=args.symbol,
+        timeframe=args.timeframe,
+        start_date=start_date_str,
+        end_date=end_date_str,
+        extra_metadata={"runner": "demo_order_pipeline_backtest.py"},
+    )
+    print(f"\n📝 Registry-Run-ID: {registry_run_id}")
     if args.tag:
-        print(f"\n📝 Tag: {args.tag}")
-        # NOTE: Siehe docs/TECH_DEBT_BACKLOG.md (Eintrag "Registry-Logging: demo_order_pipeline_backtest.py")
-        # log_backtest_run(..., tag=args.tag)
+        print(f"   Tag: {args.tag}")
 
     print()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/scripts/test_demo_order_pipeline_backtest_registry_logging_fail_closed_v1.py
+++ b/tests/scripts/test_demo_order_pipeline_backtest_registry_logging_fail_closed_v1.py
@@ -1,0 +1,247 @@
+"""
+demo_order_pipeline_backtest: registry logging + fail-closed strategy loading (offline).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+import scripts.demo_order_pipeline_backtest as demo_script
+from scripts.demo_order_pipeline_backtest import (
+    format_available_strategy_hints,
+    generate_sample_data,
+    get_available_strategy_hint_keys,
+    main,
+    parse_args,
+)
+from src.strategies import STRATEGY_REGISTRY, load_strategy
+
+
+def test_module_imports_without_main_side_effects() -> None:
+    with patch.object(demo_script, "main") as main_mock:
+        importlib.reload(demo_script)
+    main_mock.assert_not_called()
+
+
+def test_source_uses_load_strategy() -> None:
+    source = Path(demo_script.__file__).read_text(encoding="utf-8")
+    assert "load_strategy" in source
+    assert "log_backtest_result" in source
+
+
+def test_source_has_no_strategy_map() -> None:
+    source = Path(demo_script.__file__).read_text(encoding="utf-8")
+    assert "strategy_map" not in source
+
+
+def test_source_has_no_parallel_strategy_registry_assignment() -> None:
+    source = Path(demo_script.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    assigned_names = {
+        node.targets[0].id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    }
+    assert "STRATEGY_REGISTRY" not in assigned_names
+
+
+def test_source_has_no_broad_except_return_on_strategy_load() -> None:
+    source = Path(demo_script.__file__).read_text(encoding="utf-8")
+    assert "except Exception as e:" not in source
+    assert "log_backtest_run" not in source
+
+
+def test_strategy_hints_from_canonical_registry() -> None:
+    hints = get_available_strategy_hint_keys()
+    assert hints == sorted(STRATEGY_REGISTRY.keys())
+
+
+def test_strategy_hints_deterministically_sorted() -> None:
+    hints = get_available_strategy_hint_keys()
+    assert hints == sorted(hints)
+
+
+def test_obsolete_non_canonical_names_not_in_hints() -> None:
+    hints = get_available_strategy_hint_keys()
+    assert "momentum" not in hints
+    assert "bollinger" not in hints
+    assert "momentum_1h" in hints
+    assert "bollinger_bands" in hints
+
+
+def test_format_available_strategy_hints_matches_registry() -> None:
+    expected = ", ".join(sorted(STRATEGY_REGISTRY.keys()))
+    assert format_available_strategy_hints() == expected
+
+
+def test_unknown_strategy_fails_closed_via_load_strategy() -> None:
+    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+        load_strategy("definitely_not_a_strategy_xyz")
+
+
+def test_unknown_strategy_main_returns_non_zero_exit() -> None:
+    exit_code = main(["--strategy", "definitely_not_a_strategy_xyz", "--bars", "50"])
+    assert exit_code == 1
+
+
+def test_no_silent_strategy_fallback_on_unknown_name() -> None:
+    with patch.object(demo_script, "load_strategy") as load_mock:
+        load_mock.side_effect = ValueError("Unbekannte Strategie 'bad_name'")
+        exit_code = main(["--strategy", "bad_name", "--bars", "50"])
+    load_mock.assert_called_once_with("bad_name")
+    assert exit_code == 1
+
+
+def test_invalid_strategy_params_fail_closed() -> None:
+    df = generate_sample_data(symbol="BTC/EUR", bars=80)
+    strategy_fn = load_strategy("macd")
+    invalid_params = {
+        "fast_ema": 30,
+        "slow_ema": 10,
+        "signal_ema": 9,
+        "stop_pct": 0.02,
+    }
+    with pytest.raises(ValueError, match="fast_ema"):
+        strategy_fn(df, invalid_params)
+
+
+def test_log_backtest_result_called_once_on_success() -> None:
+    mock_result = MagicMock()
+    mock_result.stats = {
+        "total_return": 0.1,
+        "cagr": 0.05,
+        "max_drawdown": -0.02,
+        "sharpe": 1.0,
+        "total_trades": 3,
+        "win_rate": 0.5,
+        "profit_factor": 1.2,
+        "total_orders": 4,
+        "filled_orders": 3,
+        "rejected_orders": 1,
+        "total_fees": 1.5,
+    }
+    mock_result.trades = pd.DataFrame()
+    mock_engine = MagicMock()
+    mock_engine.run_with_order_layer.return_value = mock_result
+    mock_engine.execution_results = []
+
+    with (
+        patch.object(demo_script, "BacktestEngine", return_value=mock_engine),
+        patch.object(demo_script, "load_strategy", return_value=lambda df, p: df["close"] * 0),
+        patch.object(demo_script, "log_backtest_result", return_value="run-test-123") as log_mock,
+    ):
+        exit_code = main(["--strategy", "ma_crossover", "--bars", "50", "--tag", "unit-test"])
+
+    assert exit_code == 0
+    log_mock.assert_called_once()
+    kwargs = log_mock.call_args.kwargs
+    assert kwargs["strategy_name"] == "ma_crossover"
+    assert kwargs["tag"] == "unit-test"
+    assert kwargs["symbol"] == "BTC/EUR"
+    assert kwargs["timeframe"] == "1h"
+    assert kwargs["data_source"] == "synthetic"
+    assert kwargs["extra_metadata"]["runner"] == "demo_order_pipeline_backtest.py"
+
+
+def test_log_backtest_result_not_called_on_strategy_error() -> None:
+    with (
+        patch.object(
+            demo_script,
+            "load_strategy",
+            side_effect=ValueError("Unbekannte Strategie 'bad'"),
+        ),
+        patch.object(demo_script, "log_backtest_result") as log_mock,
+        patch.object(demo_script, "BacktestEngine") as engine_mock,
+    ):
+        exit_code = main(["--strategy", "bad", "--bars", "50"])
+    assert exit_code == 1
+    log_mock.assert_not_called()
+    engine_mock.assert_not_called()
+
+
+def test_logging_error_not_swallowed() -> None:
+    mock_result = MagicMock()
+    mock_result.stats = {
+        "total_return": 0.0,
+        "max_drawdown": 0.0,
+        "sharpe": 0.0,
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "profit_factor": 0.0,
+        "total_orders": 0,
+        "filled_orders": 0,
+        "rejected_orders": 0,
+        "total_fees": 0.0,
+    }
+    mock_result.trades = pd.DataFrame()
+    mock_engine = MagicMock()
+    mock_engine.run_with_order_layer.return_value = mock_result
+    mock_engine.execution_results = []
+
+    with (
+        patch.object(demo_script, "BacktestEngine", return_value=mock_engine),
+        patch.object(demo_script, "load_strategy", return_value=lambda df, p: df["close"] * 0),
+        patch.object(
+            demo_script,
+            "log_backtest_result",
+            side_effect=RuntimeError("registry write failed"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="registry write failed"):
+            main(["--strategy", "ma_crossover", "--bars", "50"])
+
+
+def test_no_real_registry_write_when_mocked() -> None:
+    mock_result = MagicMock()
+    mock_result.stats = {
+        "total_return": 0.0,
+        "max_drawdown": 0.0,
+        "sharpe": 0.0,
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "profit_factor": 0.0,
+        "total_orders": 0,
+        "filled_orders": 0,
+        "rejected_orders": 0,
+        "total_fees": 0.0,
+    }
+    mock_result.trades = pd.DataFrame()
+    mock_engine = MagicMock()
+    mock_engine.run_with_order_layer.return_value = mock_result
+    mock_engine.execution_results = []
+
+    with (
+        patch.object(demo_script, "BacktestEngine", return_value=mock_engine),
+        patch.object(demo_script, "load_strategy", return_value=lambda df, p: df["close"] * 0),
+        patch.object(demo_script, "log_backtest_result", return_value="mock-run-id") as log_mock,
+        patch("src.core.experiments.append_experiment_record") as append_mock,
+    ):
+        main(["--strategy", "ma_crossover", "--bars", "50"])
+
+    log_mock.assert_called_once()
+    append_mock.assert_not_called()
+
+
+def test_resolve_strategy_no_network_calls() -> None:
+    with patch("urllib.request.urlopen") as urlopen:
+        load_strategy("ma_crossover")
+    urlopen.assert_not_called()
+
+
+def test_parse_args_defaults_unchanged() -> None:
+    args = parse_args([])
+    assert args.strategy == "ma_crossover"
+    assert args.symbol == "BTC/EUR"
+    assert args.bars == 200


### PR DESCRIPTION
## Summary

- **`demo_order_pipeline_backtest.py`**: uses canonical `load_strategy()` (fail-closed on unknown names), registry-derived strategy hints (`get_available_strategy_hint_keys` / `format_available_strategy_hints`), and `log_backtest_result` for experiment registry logging with runner metadata.
- **No semantic changes** to backtest/order-layer execution paths beyond strategy resolution and logging; synthetic data generation and CLI defaults unchanged.
- **Offline tests** in `tests/scripts/test_demo_order_pipeline_backtest_registry_logging_fail_closed_v1.py` (19 cases) cover imports, AST guards, fail-closed exits, logging call shape, and no accidental registry writes when mocked.
- **Tech debt**: closes Registry-Logging item for `demo_order_pipeline_backtest.py` in `docs/TECH_DEBT_BACKLOG.md`.

## Test plan

- [x] `pytest -q tests/scripts/test_demo_order_pipeline_backtest_registry_logging_fail_closed_v1.py`
- [x] `ruff format --check` / `ruff check` on touched Python files
- [x] `git diff --check`
- [x] `bash scripts/ops/preflight_docs_token_policy_changed.sh && python3 scripts/ops/validate_docs_token_policy.py --base origin/main`


Made with [Cursor](https://cursor.com)