### PR TITLE
fix(ci): raise tests job timeout to 40 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
   tests:
     name: tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     needs: changes
     # IMPORTANT: No job-level if condition - matrix jobs must always be created
     # to satisfy branch protection rules (e.g., "tests (3.11)" check)


### PR DESCRIPTION
## Summary

Forensisch bestätigter statischer CI-Timeout-Gap: pull_request `tests (3.11)`-Jobs wurden nach ~1215s am 20-Minuten-Job-Limit abgebrochen, während der Test-Step mit **14804 passed** erfolgreich war. Kein deterministischer Test- oder PR-Fehler.

Dieser PR ändert **ausschließlich** `timeout-minutes: 20 → 40` im kanonischen `tests`-Job in `.github/workflows/ci.yml`.

- Keine Reduktion des Testumfangs
- Keine Coverage-Deaktivierung
- Keine Änderung an pytest-/Coverage-Kommandos, Matrix, Triggern oder Required-Check-Namen

PR #4223 und dessen laufender Job `81228739749` wurden **nicht** berührt.

## Local checks

| Check | RC |
|-------|-----|
| git diff --check | 0 |
| YAML syntax | 0 |
| static timeout contract | 0 |
| test/coverage command drift | 0 |
| focused workflow tests (82) | 0 |
| docs token policy preflight | 0 |
| docs token policy validator | 0 (workflow-only diff) |


Made with [Cursor](https://cursor.com)