### PR TITLE
feat(research): migrate parameter sweep to load_strategy()

### DIFF
--- a/scripts/sweep_parameters.py
+++ b/scripts/sweep_parameters.py
@@ -42,7 +42,7 @@ from src.core.risk import build_risk_manager_from_config
 from src.core.experiments import log_experiment_from_result
 from src.backtest.engine import BacktestEngine
 from src.backtest.result import BacktestResult
-from src.strategies.registry import create_strategy_from_config
+from src.strategies import load_strategy
 
 
 def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
@@ -221,6 +221,17 @@ def build_param_grid(
     return param_names, combos
 
 
+def _build_strategy_params_from_config(
+    cfg: PeakConfig,
+    strategy_key: str,
+) -> Dict[str, Any]:
+    """Build strategy params dict from config section (mirrors from_config inputs)."""
+    section = cfg.raw.get("strategy", {}).get(strategy_key, {})
+    params: Dict[str, Any] = dict(section) if isinstance(section, dict) else {}
+    params["stop_pct"] = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
+    return params
+
+
 def run_backtest_for_params(
     base_cfg: PeakConfig,
     strategy_key: str,
@@ -254,21 +265,16 @@ def run_backtest_for_params(
     # Daten laden
     data = load_data_for_symbol(symbol, n_bars=n_bars)
 
-    # Strategie erstellen
-    strategy = create_strategy_from_config(strategy_key, cfg)
+    strategy_params = _build_strategy_params_from_config(cfg, strategy_key)
+    base_signal_fn = load_strategy(strategy_key)
 
     # Position Sizer & Risk Manager
     position_sizer = build_position_sizer_from_config(cfg)
     risk_manager = build_risk_manager_from_config(cfg, section="risk_management")
 
-    # Wrapper für Legacy-API
     def strategy_signal_fn(df, params):
-        sigs = strategy.generate_signals(df)
+        sigs = base_signal_fn(df, params)
         return sigs.replace(-1, 0)  # Long-Only
-
-    # Stop-Loss aus Config
-    stop_pct = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
-    strategy_params = {"stop_pct": stop_pct}
 
     # Backtest durchführen
     engine = BacktestEngine(core_position_sizer=position_sizer, risk_manager=risk_manager)

--- a/tests/scripts/test_sweep_parameters_load_strategy_v1.py
+++ b/tests/scripts/test_sweep_parameters_load_strategy_v1.py
@@ -1,0 +1,270 @@
+"""
+sweep_parameters: canonical load_strategy() migration (offline, fail-closed).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+import scripts.sweep_parameters as sweep_script
+
+TARGET_SCRIPT = project_root / "scripts/sweep_parameters.py"
+MA_CROSSOVER_KEY = "ma_crossover"
+MOMENTUM_KEY = "momentum_1h"
+
+FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+
+
+def _read_source() -> str:
+    return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
+    np.random.seed(42)
+    index = pd.date_range("2024-01-01", periods=n, freq="h")
+    close = 100.0 + np.cumsum(np.random.randn(n))
+    return pd.DataFrame(
+        {
+            "open": close * 0.999,
+            "high": close * 1.002,
+            "low": close * 0.998,
+            "close": close,
+            "volume": np.full(n, 1000.0),
+        },
+        index=index,
+    )
+
+
+def _minimal_cfg(strategy_key: str, **strategy_params: object) -> MagicMock:
+    raw = {
+        "strategy": {
+            strategy_key: dict(strategy_params),
+        },
+    }
+    cfg = MagicMock()
+    cfg.raw = raw
+
+    def _get(path: str, default=None):
+        node = raw
+        for part in path.split("."):
+            if not isinstance(node, dict) or part not in node:
+                return default
+            node = node[part]
+        return node
+
+    cfg.get.side_effect = _get
+    cfg.with_overrides.return_value = cfg
+    return cfg
+
+
+def test_module_imports_without_main_side_effects() -> None:
+    with patch.object(sweep_script, "main") as main_mock:
+        importlib.reload(sweep_script)
+    main_mock.assert_not_called()
+
+
+def test_source_has_no_create_strategy_from_config() -> None:
+    source = _read_source()
+    for forbidden in FORBIDDEN_IMPORTS:
+        assert forbidden not in source
+
+
+def test_source_uses_load_strategy() -> None:
+    assert "load_strategy" in _read_source()
+
+
+def test_source_has_no_parallel_strategy_registry() -> None:
+    tree = ast.parse(_read_source())
+    assigned_names = {
+        node.targets[0].id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    }
+    assert "STRATEGY_REGISTRY" not in assigned_names
+
+
+def test_build_strategy_params_includes_section_and_stop_pct() -> None:
+    cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
+    params = sweep_script._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
+    assert params["fast_window"] == 10
+    assert params["slow_window"] == 50
+    assert params["price_col"] == "close"
+    assert params["stop_pct"] == 0.02
+
+
+def test_load_strategy_ma_crossover_matches_create_strategy_from_config_signals() -> None:
+    from src.core.peak_config import PeakConfig
+    from src.strategies import load_strategy
+    from src.strategies.registry import create_strategy_from_config
+
+    raw = {
+        "environment": {"mode": "backtest"},
+        "strategy": {
+            MA_CROSSOVER_KEY: {
+                "fast_window": 10,
+                "slow_window": 50,
+                "price_col": "close",
+                "stop_pct": 0.03,
+            },
+        },
+    }
+    cfg = PeakConfig(raw=raw)
+    df = _sample_ohlcv()
+
+    legacy = create_strategy_from_config(MA_CROSSOVER_KEY, cfg).generate_signals(df)
+    legacy = legacy.replace(-1, 0)
+
+    params = sweep_script._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
+    canonical = load_strategy(MA_CROSSOVER_KEY)(df, params).replace(-1, 0)
+
+    pd.testing.assert_series_equal(canonical, legacy)
+
+
+def test_load_strategy_momentum_matches_create_strategy_from_config_signals() -> None:
+    from src.core.peak_config import PeakConfig
+    from src.strategies import load_strategy
+    from src.strategies.registry import create_strategy_from_config
+
+    raw = {
+        "environment": {"mode": "backtest"},
+        "strategy": {
+            MOMENTUM_KEY: {
+                "lookback_period": 15,
+                "entry_threshold": 0.02,
+                "exit_threshold": -0.01,
+                "stop_pct": 0.02,
+            },
+        },
+    }
+    cfg = PeakConfig(raw=raw)
+    df = _sample_ohlcv(n=120)
+
+    legacy = create_strategy_from_config(MOMENTUM_KEY, cfg).generate_signals(df)
+    legacy = legacy.replace(-1, 0)
+
+    params = sweep_script._build_strategy_params_from_config(cfg, MOMENTUM_KEY)
+    canonical = load_strategy(MOMENTUM_KEY)(df, params).replace(-1, 0)
+
+    pd.testing.assert_series_equal(canonical, legacy)
+
+
+def test_run_backtest_for_params_calls_load_strategy_and_passes_full_params() -> None:
+    cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
+    captured: dict[str, object] = {}
+
+    def fake_signal_fn(df, params):
+        captured["params"] = dict(params)
+        return pd.Series(0, index=df.index)
+
+    mock_result = MagicMock()
+    mock_result.stats = {"total_return": 0.0, "sharpe": 0.0, "total_trades": 0}
+    mock_result.metadata = {}
+
+    def fake_run_realistic(**kwargs):
+        captured["params"] = dict(kwargs["strategy_params"])
+        kwargs["strategy_signal_fn"](kwargs["df"], kwargs["strategy_params"])
+        return mock_result
+
+    with (
+        patch.object(sweep_script, "load_data_for_symbol", return_value=_sample_ohlcv()),
+        patch.object(sweep_script, "load_strategy", return_value=fake_signal_fn) as load_mock,
+        patch.object(sweep_script, "build_position_sizer_from_config", return_value=MagicMock()),
+        patch.object(sweep_script, "build_risk_manager_from_config", return_value=MagicMock()),
+        patch.object(sweep_script.BacktestEngine, "run_realistic", side_effect=fake_run_realistic),
+    ):
+        sweep_script.run_backtest_for_params(
+            base_cfg=cfg,
+            strategy_key=MA_CROSSOVER_KEY,
+            symbol="BTC/EUR",
+            param_names=["fast_window", "slow_window"],
+            param_values=(10, 50),
+            n_bars=80,
+        )
+
+    load_mock.assert_called_once_with(MA_CROSSOVER_KEY)
+    assert captured["params"]["fast_window"] == 10
+    assert captured["params"]["slow_window"] == 50
+    assert captured["params"]["stop_pct"] == 0.02
+
+
+def test_run_backtest_for_params_applies_long_only_wrapper() -> None:
+    cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50)
+
+    def fake_signal_fn(df, params):
+        return pd.Series([1, -1, 0], index=df.index[:3])
+
+    mock_result = MagicMock()
+    mock_result.stats = {}
+    mock_result.metadata = {}
+
+    with (
+        patch.object(sweep_script, "load_data_for_symbol", return_value=_sample_ohlcv()[:3]),
+        patch.object(sweep_script, "load_strategy", return_value=fake_signal_fn),
+        patch.object(sweep_script, "build_position_sizer_from_config", return_value=MagicMock()),
+        patch.object(sweep_script, "build_risk_manager_from_config", return_value=MagicMock()),
+        patch.object(
+            sweep_script.BacktestEngine, "run_realistic", return_value=mock_result
+        ) as run_mock,
+    ):
+        sweep_script.run_backtest_for_params(
+            base_cfg=cfg,
+            strategy_key=MA_CROSSOVER_KEY,
+            symbol="BTC/EUR",
+            param_names=["fast_window"],
+            param_values=(10,),
+            n_bars=3,
+        )
+
+    signal_fn = run_mock.call_args.kwargs["strategy_signal_fn"]
+    df = _sample_ohlcv()[:3]
+    out = signal_fn(df, {"stop_pct": 0.02})
+    assert out.tolist() == [1, 0, 0]
+
+
+def test_unknown_strategy_fails_closed() -> None:
+    from src.strategies import load_strategy
+
+    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+        load_strategy("definitely_not_a_strategy_xyz")
+
+
+def test_load_strategy_no_network_calls() -> None:
+    from src.strategies import load_strategy
+
+    with patch("urllib.request.urlopen") as urlopen:
+        load_strategy(MA_CROSSOVER_KEY)
+        load_strategy(MOMENTUM_KEY)
+    urlopen.assert_not_called()
+
+
+def test_import_smoke_no_main_execution() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import scripts.sweep_parameters"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_help_smoke(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        sweep_script.parse_args(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Hyperparameter-Sweeps" in out


### PR DESCRIPTION
## Summary
- Migrates `scripts/sweep_parameters.py` from `create_strategy_from_config()` to the canonical `load_strategy()` signal binding
- Adds `_build_strategy_params_from_config()` to mirror config-section params for `run_realistic()` while preserving sweep grids, long-only wrapper, and result aggregation
- Adds focused offline tests in `tests/scripts/test_sweep_parameters_load_strategy_v1.py` with signal equivalence proofs for `ma_crossover` and `momentum_1h`

## Test plan
- [x] `pytest tests/scripts/test_sweep_parameters_load_strategy_v1.py`
- [x] `pytest tests/test_sweep_run_contract.py`
- [x] `pytest tests/scripts/test_realistic_backtest_runners_load_strategy_v1.py`
- [x] ruff format/check on changed files
- [x] diff-aware CI mode: FOCUSED


Made with [Cursor](https://cursor.com)