### PR TITLE
feat(backtest): migrate canonical runner to load_strategy()

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -36,7 +36,7 @@ import sys
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Any, Callable, Dict, Optional
 
 import pandas as pd
 import numpy as np
@@ -52,9 +52,10 @@ from src.backtest.engine import BacktestEngine
 from src.backtest.stats import compute_backtest_stats, validate_for_live_trading
 from src.data import DataNormalizer, CsvLoader, KrakenCsvLoader
 from src.core.experiments import log_backtest_result
+from src.strategies import STRATEGY_REGISTRY, load_strategy
 from src.strategies.registry import (
     get_available_strategy_keys,
-    create_strategy_from_config,
+    get_strategy_spec,
 )
 from src.experiments.evidence_chain import (
     ensure_run_dir,
@@ -174,6 +175,71 @@ Beispiele:
     )
 
     return parser.parse_args()
+
+
+def _validate_strategy_registry_gates(key: str, cfg: PeakConfig) -> None:
+    """Mirror registry environment/tier gates (fail-closed)."""
+    spec = get_strategy_spec(key)
+
+    env_mode = cfg.get("environment.mode")
+    if not env_mode:
+        env_mode = cfg.get("env.mode")
+    if not env_mode:
+        env_mode = cfg.get("runtime.environment")
+    if not env_mode:
+        env_mode = cfg.get("environment.runtime_environment")
+    if not env_mode:
+        env_mode = "backtest"
+
+    if env_mode == "live" and not spec.is_live_ready:
+        raise ValueError(
+            f"Strategy '{key}' cannot be used in LIVE mode (IS_LIVE_READY=False). "
+            f"This strategy is R&D-only and not validated for live trading."
+        )
+
+    if spec.tier == "r_and_d":
+        allow_rnd = cfg.get("research.allow_r_and_d_strategies", False)
+        if not allow_rnd:
+            raise ValueError(
+                f"Strategy '{key}' is R&D-only (TIER=r_and_d) and requires "
+                f"'research.allow_r_and_d_strategies = true' in config."
+            )
+
+    if env_mode not in spec.allowed_environments:
+        allowed_str = ", ".join(spec.allowed_environments)
+        raise ValueError(
+            f"Strategy '{key}' not allowed in environment '{env_mode}'. "
+            f"Allowed environments: {allowed_str}"
+        )
+
+
+def _build_strategy_params_from_config(
+    cfg: PeakConfig,
+    strategy_key: str,
+) -> Dict[str, Any]:
+    """Build strategy params dict matching from_config() effective values."""
+    spec = get_strategy_spec(strategy_key)
+    instance = spec.cls.from_config(cfg, section=spec.config_section)
+    params: Dict[str, Any] = dict(instance.config)
+    params["stop_pct"] = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
+    return params
+
+
+def _resolve_strategy_signal_fn(
+    strategy_name: str,
+) -> Callable[[pd.DataFrame, Dict[str, Any]], pd.Series]:
+    """Canonical load_strategy() with OOP-registry-only alias fallback."""
+    if strategy_name in STRATEGY_REGISTRY:
+        return load_strategy(strategy_name)
+
+    spec = get_strategy_spec(strategy_name)
+    strategy_cls = spec.cls
+
+    def generate_signals(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
+        strategy = strategy_cls(config=dict(params))
+        return strategy.generate_signals(df)
+
+    return generate_signals
 
 
 def resolve_backtest_symbol(cfg: PeakConfig) -> str:
@@ -417,12 +483,25 @@ def main() -> int:
     if args.verbose:
         print(f"  Strategie: {strategy_name}")
 
-    # Strategie-Parameter aus Config holen
+    # Registry gates (same fail-closed posture as legacy create_strategy_from_config)
+    try:
+        _validate_strategy_registry_gates(strategy_name, cfg)
+    except KeyError as e:
+        print(f"\nFEHLER: Strategie nicht gefunden: {e}")
+        available = ", ".join(get_available_strategy_keys())
+        print(f"  Verfügbare Strategien: {available}")
+        return 1
+    except ValueError as e:
+        print(f"\nFEHLER: Strategie nicht erlaubt: {e}")
+        return 1
+
+    # Strategie-Parameter aus Config holen (matches from_config effective values)
     strategy_section = f"strategy.{strategy_name}"
-    strategy_params = cfg.get(strategy_section, {})
-    if not strategy_params:
+    raw_section = cfg.raw.get("strategy", {}).get(strategy_name, {})
+    if not raw_section:
         print(f"\nWARNUNG: Keine Config-Sektion [{strategy_section}] gefunden.")
         print("  Nutze Default-Parameter.")
+    strategy_params = _build_strategy_params_from_config(cfg, strategy_name)
 
     # 3. Daten laden
     print("\n[3/7] Daten laden...")
@@ -451,21 +530,15 @@ def main() -> int:
             print(f"  Position Sizer: {position_sizer}")
             print(f"  Risk Manager: {risk_manager}")
 
-        # OOP-Strategie aus Registry erstellen
-        # Alle Strategien sind jetzt OOP-basiert (migriert in Phase 7)
-        strategy = create_strategy_from_config(strategy_name, cfg)
+        strategy_signal_fn = _resolve_strategy_signal_fn(strategy_name)
         if args.verbose:
-            print(f"  Strategie: {strategy}")
+            print(f"  Strategie-Key: {strategy_name}")
+            print(f"  Strategy-Params: {strategy_params}")
 
-        # Backtest mit OOP-Strategie
         engine = BacktestEngine(
             core_position_sizer=position_sizer,
             risk_manager=risk_manager,
         )
-
-        # Wrapper-Funktion für Engine (erwartet (df, params) -> signals)
-        def strategy_signal_fn(data, params):
-            return strategy.generate_signals(data)
 
         result = engine.run_realistic(
             df=df,

--- a/tests/scripts/test_run_backtest_load_strategy_v1.py
+++ b/tests/scripts/test_run_backtest_load_strategy_v1.py
@@ -1,0 +1,316 @@
+"""
+run_backtest.py: canonical load_strategy() migration (offline, fail-closed).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+import scripts.run_backtest as run_backtest_script
+
+TARGET_SCRIPT = project_root / "scripts/run_backtest.py"
+MA_CROSSOVER_KEY = "ma_crossover"
+MOMENTUM_KEY = "momentum_1h"
+RSI_REVERSION_KEY = "rsi_reversion"
+EL_KAROUI_ALIAS_KEY = "el_karoui_vol_v1"
+
+FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+
+
+def _read_source() -> str:
+    return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
+    np.random.seed(42)
+    index = pd.date_range("2024-01-01", periods=n, freq="h")
+    close = 100.0 + np.cumsum(np.random.randn(n))
+    return pd.DataFrame(
+        {
+            "open": close * 0.999,
+            "high": close * 1.002,
+            "low": close * 0.998,
+            "close": close,
+            "volume": np.full(n, 1000.0),
+        },
+        index=index,
+    )
+
+
+def test_module_imports_without_main_side_effects() -> None:
+    with patch.object(run_backtest_script, "main") as main_mock:
+        importlib.reload(run_backtest_script)
+    main_mock.assert_not_called()
+
+
+def test_source_has_no_create_strategy_from_config() -> None:
+    tree = ast.parse(_read_source())
+    imported = {
+        alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module
+        for alias in node.names
+    }
+    assert "create_strategy_from_config" not in imported
+
+
+def test_source_uses_load_strategy() -> None:
+    assert "load_strategy" in _read_source()
+
+
+def test_source_has_no_parallel_strategy_registry_assignment() -> None:
+    tree = ast.parse(_read_source())
+    assigned_names = {
+        node.targets[0].id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    }
+    assert "STRATEGY_REGISTRY" not in assigned_names
+
+
+def test_build_strategy_params_matches_from_config_defaults() -> None:
+    from src.core.peak_config import PeakConfig
+
+    raw = {"environment": {"mode": "backtest"}, "strategy": {}}
+    cfg = PeakConfig(raw=raw)
+    params = run_backtest_script._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
+    assert params["fast_window"] == 20
+    assert params["slow_window"] == 50
+    assert params["price_col"] == "close"
+    assert params["stop_pct"] == 0.02
+
+
+def test_build_strategy_params_includes_explicit_section_values() -> None:
+    from src.core.peak_config import PeakConfig
+
+    raw = {
+        "environment": {"mode": "backtest"},
+        "strategy": {
+            MA_CROSSOVER_KEY: {
+                "fast_window": 10,
+                "slow_window": 50,
+                "price_col": "close",
+                "stop_pct": 0.03,
+            },
+        },
+    }
+    cfg = PeakConfig(raw=raw)
+    params = run_backtest_script._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
+    assert params["fast_window"] == 10
+    assert params["slow_window"] == 50
+    assert params["stop_pct"] == 0.03
+
+
+@pytest.mark.parametrize(
+    "strategy_key,strategy_section,n_bars",
+    [
+        (
+            MA_CROSSOVER_KEY,
+            {MA_CROSSOVER_KEY: {"fast_window": 10, "slow_window": 50, "price_col": "close"}},
+            80,
+        ),
+        (
+            MOMENTUM_KEY,
+            {
+                MOMENTUM_KEY: {
+                    "lookback_period": 15,
+                    "entry_threshold": 0.02,
+                    "exit_threshold": -0.01,
+                }
+            },
+            120,
+        ),
+        (
+            RSI_REVERSION_KEY,
+            {RSI_REVERSION_KEY: {"rsi_period": 14, "oversold": 30, "overbought": 70}},
+            120,
+        ),
+    ],
+)
+def test_signal_equivalence_vs_create_strategy_from_config(
+    strategy_key: str,
+    strategy_section: dict,
+    n_bars: int,
+) -> None:
+    from src.core.peak_config import PeakConfig
+    from src.strategies.registry import create_strategy_from_config
+
+    raw = {"environment": {"mode": "backtest"}, "strategy": strategy_section}
+    cfg = PeakConfig(raw=raw)
+    df = _sample_ohlcv(n_bars)
+
+    legacy = create_strategy_from_config(strategy_key, cfg).generate_signals(df)
+    params = run_backtest_script._build_strategy_params_from_config(cfg, strategy_key)
+    canonical = run_backtest_script._resolve_strategy_signal_fn(strategy_key)(df, params)
+
+    pd.testing.assert_series_equal(canonical, legacy)
+
+
+def test_el_karoui_alias_resolves_via_oop_fallback() -> None:
+    from src.core.peak_config import PeakConfig
+    from src.strategies.registry import create_strategy_from_config
+
+    raw = {
+        "environment": {"mode": "backtest"},
+        "research": {"allow_r_and_d_strategies": True},
+        "strategy": {"el_karoui_vol_model": {}},
+    }
+    cfg = PeakConfig(raw=raw)
+    df = _sample_ohlcv(120)
+
+    legacy = create_strategy_from_config(EL_KAROUI_ALIAS_KEY, cfg).generate_signals(df)
+    params = run_backtest_script._build_strategy_params_from_config(cfg, EL_KAROUI_ALIAS_KEY)
+    canonical = run_backtest_script._resolve_strategy_signal_fn(EL_KAROUI_ALIAS_KEY)(df, params)
+
+    pd.testing.assert_series_equal(canonical, legacy)
+
+
+def test_registry_gates_block_r_and_d_without_flag() -> None:
+    from src.core.peak_config import PeakConfig
+
+    raw = {"environment": {"mode": "backtest"}, "strategy": {"ehlers_cycle_filter": {}}}
+    cfg = PeakConfig(raw=raw)
+    with pytest.raises(ValueError, match="R&D-only"):
+        run_backtest_script._validate_strategy_registry_gates("ehlers_cycle_filter", cfg)
+
+
+def test_main_backtest_path_passes_full_params_to_signal_fn() -> None:
+    from src.core.peak_config import PeakConfig
+
+    raw = {
+        "environment": {"mode": "backtest"},
+        "strategy": {
+            MA_CROSSOVER_KEY: {"fast_window": 10, "slow_window": 50, "price_col": "close"}
+        },
+    }
+    cfg = PeakConfig(raw=raw)
+    captured: dict[str, object] = {}
+
+    def fake_signal_fn(df, params):
+        captured["params"] = dict(params)
+        captured["df_len"] = len(df)
+        return pd.Series(0, index=df.index)
+
+    mock_result = MagicMock()
+    mock_result.stats = {
+        "total_return": 0.0,
+        "max_drawdown": 0.0,
+        "sharpe": 0.0,
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "profit_factor": 0.0,
+    }
+    mock_result.equity_curve = pd.Series(
+        [10000.0, 10000.0], index=pd.date_range("2024-01-01", periods=2, freq="h")
+    )
+
+    with (
+        patch.object(run_backtest_script, "parse_args") as parse_mock,
+        patch.object(run_backtest_script, "load_config", return_value=cfg),
+        patch.object(run_backtest_script, "load_ohlcv_data", return_value=_sample_ohlcv()),
+        patch.object(
+            run_backtest_script, "build_position_sizer_from_config", return_value=MagicMock()
+        ),
+        patch.object(
+            run_backtest_script, "build_risk_manager_from_config", return_value=MagicMock()
+        ),
+        patch.object(
+            run_backtest_script, "_resolve_strategy_signal_fn", return_value=fake_signal_fn
+        ),
+        patch.object(
+            run_backtest_script.BacktestEngine, "run_realistic", return_value=mock_result
+        ) as run_mock,
+        patch.object(run_backtest_script, "log_backtest_result", return_value="reg-1"),
+        patch.object(run_backtest_script, "ensure_run_dir", return_value=Path("/tmp/run")),
+        patch.object(
+            run_backtest_script, "write_config_snapshot", return_value=Path("/tmp/cfg.json")
+        ),
+        patch.object(run_backtest_script, "write_stats_json", return_value=Path("/tmp/stats.json")),
+        patch.object(run_backtest_script, "write_equity_csv", return_value=Path("/tmp/eq.csv")),
+        patch.object(run_backtest_script, "write_trades_parquet_optional", return_value=None),
+        patch.object(
+            run_backtest_script, "write_report_snippet_md", return_value=Path("/tmp/snippet.md")
+        ),
+        patch("pathlib.Path.exists", return_value=True),
+    ):
+        args = MagicMock()
+        args.config = "config.toml"
+        args.strategy = MA_CROSSOVER_KEY
+        args.data_file = None
+        args.start_date = None
+        args.end_date = None
+        args.bars = 80
+        args.tag = None
+        args.verbose = False
+        args.save_report = None
+        args.run_id = "test-run"
+        args.results_dir = "results"
+        args.tracker = "null"
+        args.no_report = True
+        parse_mock.return_value = args
+
+        rc = run_backtest_script.main()
+
+    assert rc == 0
+    run_mock.assert_called_once()
+    call_kwargs = run_mock.call_args.kwargs
+    assert call_kwargs["strategy_params"]["fast_window"] == 10
+    assert call_kwargs["strategy_params"]["slow_window"] == 50
+    assert call_kwargs["strategy_params"]["stop_pct"] == 0.02
+    call_kwargs["strategy_signal_fn"](call_kwargs["df"], call_kwargs["strategy_params"])
+    assert captured["params"]["fast_window"] == 10
+    assert captured["params"]["slow_window"] == 50
+
+
+def test_unknown_strategy_fails_closed_at_gates() -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg = PeakConfig(raw={"environment": {"mode": "backtest"}})
+    with pytest.raises(KeyError):
+        run_backtest_script._validate_strategy_registry_gates("definitely_not_a_strategy_xyz", cfg)
+
+
+def test_load_strategy_no_network_calls() -> None:
+    from src.strategies import load_strategy
+
+    with patch("urllib.request.urlopen") as urlopen:
+        load_strategy(MA_CROSSOVER_KEY)
+        load_strategy(MOMENTUM_KEY)
+    urlopen.assert_not_called()
+
+
+def test_import_smoke_no_main_execution() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import scripts.run_backtest"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_help_smoke() -> None:
+    result = subprocess.run(
+        [sys.executable, str(TARGET_SCRIPT), "--help"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "NO-LIVE" in result.stdout


### PR DESCRIPTION
## Summary
- Migrates `scripts/run_backtest.py` from `create_strategy_from_config` + param-ignoring signal closure to canonical `load_strategy()` binding
- Preserves registry environment/tier gates and `from_config`-equivalent parameter resolution
- Adds focused offline equivalence tests in `tests/scripts/test_run_backtest_load_strategy_v1.py`

## Test plan
- [x] `pytest tests/scripts/test_run_backtest_load_strategy_v1.py`
- [x] `pytest tests/scripts/test_run_backtest_help_smoke.py`
- [x] Related loader migration regression tests (realistic runners, sweep_parameters)
- [x] `ruff format --check` / `ruff check` on changed files
- [x] Docs token policy guards (no .md changes)


Made with [Cursor](https://cursor.com)