### PR TITLE
fix(tests): align offline realtime pipeline contracts

### DIFF
--- a/tests/test_offline_realtime_ma_crossover_script.py
+++ b/tests/test_offline_realtime_ma_crossover_script.py
@@ -259,7 +259,7 @@ class TestPipelineBuilder:
 
         assert "synth_result" in components
         assert "feed" in components
-        assert "strategy" in components
+        assert "strategy_params" in components
         assert "pipeline" in components
         assert "env_config" in components
         assert "run_id" in components
@@ -269,8 +269,8 @@ class TestPipelineBuilder:
         assert components["internal_symbol"] == "BTCEUR"
 
         # Prüfe Strategie-Parameter
-        assert components["strategy"].fast_window == 10
-        assert components["strategy"].slow_window == 30
+        assert components["strategy_params"]["fast_window"] == 10
+        assert components["strategy_params"]["slow_window"] == 30
 
     def test_build_pipeline_different_symbols(self):
         """Test: Pipeline mit verschiedenen Symbolen."""
@@ -325,7 +325,7 @@ class TestPipelineExecution:
         # Pipeline ausführen
         perf_metrics = run_pipeline(
             pipeline=components["pipeline"],
-            strategy=components["strategy"],
+            strategy_params=components["strategy_params"],
             feed=components["feed"],
             symbol=components["internal_symbol"],
         )
@@ -361,7 +361,7 @@ class TestPipelineExecution:
         components_fast = build_offline_ma_crossover_pipeline(args_fast)
         perf_fast = run_pipeline(
             pipeline=components_fast["pipeline"],
-            strategy=components_fast["strategy"],
+            strategy_params=components_fast["strategy_params"],
             feed=components_fast["feed"],
             symbol=components_fast["internal_symbol"],
         )
@@ -373,7 +373,7 @@ class TestPipelineExecution:
         components_slow = build_offline_ma_crossover_pipeline(args_slow)
         perf_slow = run_pipeline(
             pipeline=components_slow["pipeline"],
-            strategy=components_slow["strategy"],
+            strategy_params=components_slow["strategy_params"],
             feed=components_slow["feed"],
             symbol=components_slow["internal_symbol"],
         )
@@ -421,7 +421,7 @@ class TestIntegration:
         started_at = datetime.now()
         perf_metrics = run_pipeline(
             pipeline=components["pipeline"],
-            strategy=components["strategy"],
+            strategy_params=components["strategy_params"],
             feed=components["feed"],
             symbol=components["internal_symbol"],
         )

--- a/tests/test_optuna_integration.py
+++ b/tests/test_optuna_integration.py
@@ -178,14 +178,14 @@ def test_create_sampler_invalid_raises():
 
 @pytest.mark.skipif(not OPTUNA_AVAILABLE, reason="Optuna not installed")
 @pytest.mark.skipif(not STUDY_RUNNER_AVAILABLE, reason="run_optuna_study.py not available")
-def test_suggest_params_from_schema(mock_strategy):
+def test_suggest_params_from_schema(sample_param_schema):
     """Test parameter suggestion from schema."""
     # Create a study and trial
     study = optuna.create_study(direction="maximize")
     trial = study.ask()
 
     # Suggest params
-    params = suggest_params_from_schema(trial, mock_strategy)
+    params = suggest_params_from_schema(trial, sample_param_schema)
 
     # Check all params are present
     assert "fast_window" in params
@@ -209,28 +209,24 @@ def test_suggest_params_from_schema(mock_strategy):
 
 @pytest.mark.skipif(not OPTUNA_AVAILABLE, reason="Optuna not installed")
 @pytest.mark.skipif(not STUDY_RUNNER_AVAILABLE, reason="run_optuna_study.py not available")
-def test_suggest_params_from_schema_empty_raises(mock_strategy):
+def test_suggest_params_from_schema_empty_raises():
     """Test that empty schema raises ValueError."""
-    mock_strategy.parameter_schema = []
-
     study = optuna.create_study(direction="maximize")
     trial = study.ask()
 
     with pytest.raises(ValueError, match="has no parameter_schema"):
-        suggest_params_from_schema(trial, mock_strategy)
+        suggest_params_from_schema(trial, [])
 
 
 @pytest.mark.skipif(not OPTUNA_AVAILABLE, reason="Optuna not installed")
 @pytest.mark.skipif(not STUDY_RUNNER_AVAILABLE, reason="run_optuna_study.py not available")
-def test_suggest_params_from_schema_none_raises(mock_strategy):
+def test_suggest_params_from_schema_none_raises():
     """Test that None schema raises ValueError."""
-    mock_strategy.parameter_schema = None
-
     study = optuna.create_study(direction="maximize")
     trial = study.ask()
 
     with pytest.raises(ValueError, match="has no parameter_schema"):
-        suggest_params_from_schema(trial, mock_strategy)
+        suggest_params_from_schema(trial, None)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes pre-existing main test drift blocking PR #4250 FULL CI matrix (not caused by sweep engine changes).

- **Production contract (canonical):** `build_offline_ma_crossover_pipeline()` returns `strategy_params` dict; `run_pipeline(..., strategy_params=...)` uses `load_strategy()` signal path.
- **Legacy in tests:** expected `components["strategy"]` object and `run_pipeline(strategy=...)`.
- **Optuna contract (canonical):** `suggest_params_from_schema(trial, schema: List[Param])` in `scripts/run_optuna_study.py`.
- **Legacy in tests:** passed mock strategy object instead of schema list.

## Scope

- `tests/test_offline_realtime_ma_crossover_script.py`
- `tests/test_optuna_integration.py`

PR #4250 branch/files untouched.

## Local checks

- 7 previously failing nodes: PASS (py3.11)
- Full focused owner `tests/test_offline_realtime_ma_crossover_script.py`: 17 passed
- ruff format --check / ruff check: PASS

## Safety

- No production code changes
- No assertions weakened, skipped, or xfailed
- No legacy API reintroduced
- No runtime / pipeline / backtest / trading runs

## Durable bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/ci_fix/offline_realtime_ma_crossover_contract_test_drift_narrow_fix_separate_pr_no_run_v1_<UTC>`


Made with [Cursor](https://cursor.com)