### PR TITLE
refactor(demo): migrate composite binding to load_strategy

### DIFF
--- a/scripts/demo_phase40_portfolio_backtest.py
+++ b/scripts/demo_phase40_portfolio_backtest.py
@@ -38,6 +38,7 @@ from src.core.peak_config import load_config, PeakConfig
 from src.backtest.engine import BacktestEngine
 from src.backtest.stats import compute_basic_stats
 from src.strategies import load_strategy
+from src.strategies.base import BaseStrategy
 from src.strategies.registry import get_strategy_spec
 
 BREAKOUT_STRATEGY_KEY = "breakout"
@@ -153,6 +154,38 @@ def _apply_vol_regime_filter(
     filter_mask = vol_filter_fn(data, vol_params)
     aligned_filter = filter_mask.reindex(signals.index, fill_value=0)
     return signals * aligned_filter
+
+
+def _composite_component_from_load_strategy(
+    strategy_key: str,
+    signal_params: Dict[str, Any],
+    signal_fn,
+) -> BaseStrategy:
+    """Bindet eine kanonische load_strategy()-Signalfunktion für Composite-Portfolio."""
+    load_strategy(strategy_key)
+
+    class _LoadStrategyCompositeComponent(BaseStrategy):
+        KEY = strategy_key
+
+        def __init__(self, key: str, params: Dict[str, Any], fn) -> None:
+            super().__init__(config=dict(params))
+            self._registry_key = key
+            self._signal_fn = fn
+
+        @property
+        def key(self) -> str:
+            return self._registry_key
+
+        def generate_signals(self, data: pd.DataFrame) -> pd.Series:
+            return self._signal_fn(data, self.config)
+
+        @classmethod
+        def from_config(cls, cfg, section: str = "") -> BaseStrategy:
+            raise NotImplementedError(
+                "Demo composite components are bound via load_strategy() only."
+            )
+
+    return _LoadStrategyCompositeComponent(strategy_key, signal_params, signal_fn)
 
 
 # ============================================================================
@@ -299,16 +332,37 @@ def run_composite_backtest(
     ma_fn = load_strategy(MA_CROSSOVER_STRATEGY_KEY)
     composite_fn = load_strategy(COMPOSITE_STRATEGY_KEY)
 
-    rsi_strategy = get_strategy_spec(RSI_REVERSION_STRATEGY_KEY).cls(config=COMPOSITE_RSI_CONFIG)
-    breakout_strategy = get_strategy_spec(BREAKOUT_STRATEGY_KEY).cls(
-        config=COMPOSITE_BREAKOUT_CONFIG
+    ma_signal_params = {
+        "fast_period": COMPOSITE_MA_CONFIG["fast_window"],
+        "slow_period": COMPOSITE_MA_CONFIG["slow_window"],
+    }
+    composite_components = (
+        (
+            RSI_REVERSION_STRATEGY_KEY,
+            COMPOSITE_RSI_CONFIG,
+            rsi_fn,
+            COMPOSITE_WEIGHTS[0],
+        ),
+        (
+            BREAKOUT_STRATEGY_KEY,
+            COMPOSITE_BREAKOUT_CONFIG,
+            breakout_fn,
+            COMPOSITE_WEIGHTS[1],
+        ),
+        (
+            MA_CROSSOVER_STRATEGY_KEY,
+            ma_signal_params,
+            ma_fn,
+            COMPOSITE_WEIGHTS[2],
+        ),
     )
-    ma_strategy = get_strategy_spec(MA_CROSSOVER_STRATEGY_KEY).cls(config=COMPOSITE_MA_CONFIG)
     composite_params: Dict[str, Any] = {
         "strategies": [
-            (rsi_strategy, COMPOSITE_WEIGHTS[0]),
-            (breakout_strategy, COMPOSITE_WEIGHTS[1]),
-            (ma_strategy, COMPOSITE_WEIGHTS[2]),
+            (
+                _composite_component_from_load_strategy(key, signal_params, signal_fn),
+                weight,
+            )
+            for key, signal_params, signal_fn, weight in composite_components
         ],
         "aggregation": COMPOSITE_AGGREGATION,
         "signal_threshold": COMPOSITE_SIGNAL_THRESHOLD,
@@ -324,14 +378,9 @@ def run_composite_backtest(
     )
 
     # Komponenten-Signale für Analyse
-    ma_signal_params = {
-        "fast_period": COMPOSITE_MA_CONFIG["fast_window"],
-        "slow_period": COMPOSITE_MA_CONFIG["slow_window"],
-    }
     component_signals = {
-        rsi_strategy.key: rsi_fn(df, COMPOSITE_RSI_CONFIG),
-        breakout_strategy.key: breakout_fn(df, COMPOSITE_BREAKOUT_CONFIG),
-        ma_strategy.key: ma_fn(df, ma_signal_params),
+        key: signal_fn(df, signal_params)
+        for key, signal_params, signal_fn, _weight in composite_components
     }
 
     logger.info("\nKomponenten-Signal-Verteilung:")

--- a/tests/scripts/test_demo_phase40_portfolio_backtest_load_strategy_v1.py
+++ b/tests/scripts/test_demo_phase40_portfolio_backtest_load_strategy_v1.py
@@ -272,6 +272,95 @@ def test_cli_help_smoke_no_run() -> None:
     assert "breakout" in result.stdout
 
 
+def _function_source(function_name: str) -> str:
+    tree = ast.parse(_read_source())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return ast.get_source_segment(_read_source(), node) or ""
+    raise AssertionError(f"Function {function_name} not found")
+
+
+def test_run_composite_backtest_has_no_spec_cls_binding() -> None:
+    source = _function_source("run_composite_backtest")
+    assert ".cls(" not in source
+    assert "get_strategy_spec(" not in source or "composite_spec" in source
+
+
+def test_run_composite_backtest_uses_load_strategy_component_binding() -> None:
+    source = _function_source("run_composite_backtest")
+    assert "_composite_component_from_load_strategy" in source
+    assert "load_strategy(RSI_REVERSION_STRATEGY_KEY)" in source
+    assert "load_strategy(BREAKOUT_STRATEGY_KEY)" in source
+    assert "load_strategy(MA_CROSSOVER_STRATEGY_KEY)" in source
+    assert "load_strategy(COMPOSITE_STRATEGY_KEY)" in source
+
+
+def test_composite_component_binding_matches_direct_oop_output() -> None:
+    from src.strategies import load_strategy
+    from src.strategies.breakout import BreakoutStrategy
+    from src.strategies.composite import CompositeStrategy
+    from src.strategies.ma_crossover import MACrossoverStrategy
+    from src.strategies.rsi_reversion import RsiReversionStrategy
+
+    df = _sample_ohlcv()
+    ma_signal_params = {
+        "fast_period": COMPOSITE_MA_CONFIG["fast_window"],
+        "slow_period": COMPOSITE_MA_CONFIG["slow_window"],
+    }
+    rsi_fn = load_strategy(RSI_REVERSION_STRATEGY_KEY)
+    breakout_fn = load_strategy(BREAKOUT_STRATEGY_KEY)
+    ma_fn = load_strategy(MA_CROSSOVER_STRATEGY_KEY)
+    composite_fn = load_strategy(COMPOSITE_STRATEGY_KEY)
+
+    legacy_components = (
+        RsiReversionStrategy(rsi_window=14, lower=30, upper=70),
+        BreakoutStrategy(lookback_breakout=20, stop_loss_pct=0.02),
+        MACrossoverStrategy(fast_window=20, slow_window=50),
+    )
+    legacy = CompositeStrategy(
+        strategies=[
+            (legacy_components[0], COMPOSITE_WEIGHTS[0]),
+            (legacy_components[1], COMPOSITE_WEIGHTS[1]),
+            (legacy_components[2], COMPOSITE_WEIGHTS[2]),
+        ],
+        aggregation=COMPOSITE_AGGREGATION,
+        signal_threshold=COMPOSITE_SIGNAL_THRESHOLD,
+    ).generate_signals(df)
+
+    bound_params = {
+        "strategies": [
+            (
+                phase40_script._composite_component_from_load_strategy(
+                    RSI_REVERSION_STRATEGY_KEY,
+                    COMPOSITE_RSI_CONFIG,
+                    rsi_fn,
+                ),
+                COMPOSITE_WEIGHTS[0],
+            ),
+            (
+                phase40_script._composite_component_from_load_strategy(
+                    BREAKOUT_STRATEGY_KEY,
+                    COMPOSITE_BREAKOUT_CONFIG,
+                    breakout_fn,
+                ),
+                COMPOSITE_WEIGHTS[1],
+            ),
+            (
+                phase40_script._composite_component_from_load_strategy(
+                    MA_CROSSOVER_STRATEGY_KEY,
+                    ma_signal_params,
+                    ma_fn,
+                ),
+                COMPOSITE_WEIGHTS[2],
+            ),
+        ],
+        "aggregation": COMPOSITE_AGGREGATION,
+        "signal_threshold": COMPOSITE_SIGNAL_THRESHOLD,
+    }
+    bound = composite_fn(df, bound_params)
+    pd.testing.assert_series_equal(bound, legacy)
+
+
 def test_run_functions_use_backtest_engine_with_mocked_run() -> None:
     df = _sample_ohlcv()
     with patch.object(phase40_script, "BacktestEngine") as engine_cls:


### PR DESCRIPTION
## Summary

- Entfernt den verbleibenden `get_strategy_spec().cls()`-Binding-Bypass in `run_composite_backtest` und bindet Composite-Komponenten über den kanonischen `load_strategy()`-Pfad.
- Führt `_composite_component_from_load_strategy` ein, damit `CompositeStrategy` weiterhin über die Legacy-Composite-API (`composite_fn(data, composite_params)`) arbeitet, ohne direkte Registry-Klassenkonstruktion im Demo-Script.
- Erweitert den bestehenden kanonischen Test-Owner um AST-Guards und einen Äquivalenztest für die gebundene Composite-Signalgenerierung.

## Test plan

- [x] `ruff format --check` auf geänderte Dateien
- [x] `ruff check` auf geänderte Dateien
- [x] `pytest tests/scripts/test_demo_phase40_portfolio_backtest_load_strategy_v1.py`
- [ ] CI FOCUSED selection erwartet (`scripts/` + `tests/scripts/` Diff)


Made with [Cursor](https://cursor.com)