### PR TITLE
refactor(scan): migrate runner binding to load_strategy

### DIFF
--- a/scripts/run_market_scan.py
+++ b/scripts/run_market_scan.py
@@ -50,17 +50,17 @@ from src.core.risk import build_risk_manager_from_config
 from src.core.experiments import log_market_scan_result, RUN_TYPE_MARKET_SCAN
 from src.backtest.engine import BacktestEngine
 from src.strategies import load_strategy
-from src.strategies.registry import get_available_strategy_keys, get_strategy_spec
+from src.strategies.registry import get_available_strategy_keys
 
 
 def _build_strategy_params_from_config(
     cfg: PeakConfig,
     strategy_key: str,
 ) -> Dict[str, Any]:
-    """Build strategy params dict matching from_config() effective values."""
-    spec = get_strategy_spec(strategy_key)
-    instance = spec.cls.from_config(cfg, section=spec.config_section)
-    params: Dict[str, Any] = dict(instance.config)
+    """Build strategy params dict via canonical load_strategy() registry path."""
+    load_strategy(strategy_key)
+    section = cfg.raw.get("strategy", {}).get(strategy_key, {})
+    params: Dict[str, Any] = dict(section) if isinstance(section, dict) else {}
     params["stop_pct"] = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
     return params
 

--- a/tests/scripts/test_run_market_scan_load_strategy_v1.py
+++ b/tests/scripts/test_run_market_scan_load_strategy_v1.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 
 import ast
 import importlib
+import inspect
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import numpy as np
 import pandas as pd
@@ -97,6 +98,56 @@ def test_build_strategy_params_includes_section_and_stop_pct() -> None:
     assert params["stop_pct"] == 0.03
 
 
+def test_build_strategy_params_source_uses_load_strategy_not_from_config_bypass() -> None:
+    source = inspect.getsource(market_scan_runner._build_strategy_params_from_config)
+    assert "load_strategy" in source
+    assert "get_strategy_spec" not in source
+    assert ".from_config" not in source
+
+
+def test_build_strategy_params_calls_load_strategy_for_registry_validation() -> None:
+    cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
+
+    with patch.object(market_scan_runner, "load_strategy") as load_mock:
+        load_mock.return_value = MagicMock()
+        params = market_scan_runner._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
+
+    load_mock.assert_called_once_with(MA_CROSSOVER_KEY)
+    assert params["fast_window"] == 10
+    assert params["stop_pct"] == 0.02
+
+
+def test_build_strategy_params_isolated_per_strategy_key() -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "backtest"},
+            "strategy": {
+                MA_CROSSOVER_KEY: {"fast_window": 10, "slow_window": 50, "price_col": "close"},
+                RSI_REVERSION_KEY: {
+                    "rsi_period": 14,
+                    "oversold": 30,
+                    "overbought": 70,
+                },
+            },
+        }
+    )
+    ma_params = market_scan_runner._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
+    rsi_params = market_scan_runner._build_strategy_params_from_config(cfg, RSI_REVERSION_KEY)
+
+    assert "rsi_period" not in ma_params
+    assert "fast_window" not in rsi_params
+    assert ma_params["fast_window"] == 10
+    assert rsi_params["rsi_period"] == 14
+
+
+def test_build_strategy_params_unknown_strategy_fails_closed() -> None:
+    cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
+    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+        market_scan_runner._build_strategy_params_from_config(cfg, "definitely_not_a_strategy_xyz")
+
+
 def test_load_strategy_ma_crossover_matches_create_strategy_from_config_signals() -> None:
     from src.strategies import load_strategy
     from src.strategies.registry import create_strategy_from_config
@@ -169,7 +220,8 @@ def test_scan_symbol_forward_calls_load_strategy_with_params() -> None:
 
     assert "error" not in result
     assert result["signal"] == 1.0
-    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
+    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
+    assert load_strategy_mock.call_count == 2
     assert captured["params"]["fast_window"] == 10
     assert captured["params"]["slow_window"] == 50
     assert captured["params"]["stop_pct"] == 0.02
@@ -218,7 +270,8 @@ def test_scan_symbol_backtest_lite_calls_load_strategy_with_params() -> None:
 
     assert "error" not in result
     assert result["signal"] == 0.0
-    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
+    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
+    assert load_strategy_mock.call_count == 2
     assert captured["params"]["fast_window"] == 10
     assert call_count >= 1
 
@@ -257,7 +310,7 @@ def test_isolated_signal_fn_binding_per_scan_call() -> None:
             cfg=cfg,
         )
 
-    assert load_strategy_mock.call_count == 2
+    assert load_strategy_mock.call_count == 4
 
 
 def test_main_dry_run_calls_load_strategy_not_executed() -> None:


### PR DESCRIPTION
## Summary
- Migriert `_build_strategy_params_from_config` in `scripts/run_market_scan.py` vom direkten `get_strategy_spec(...).cls.from_config(...)`-Bypass auf den kanonischen `load_strategy()`-Registry-Pfad (Referenzmuster: `scan_markets.py`).
- Erweitert den bestehenden Contract-Test-Owner `tests/scripts/test_run_market_scan_load_strategy_v1.py` um Parameter-Binding-, Isolations- und Fail-Closed-Nachweise.

## Test plan
- [x] `ruff format --check` auf geänderten Dateien
- [x] `ruff check` auf geänderten Dateien
- [x] `pytest tests/scripts/test_run_market_scan_load_strategy_v1.py` (19 passed, offline, no-run)


Made with [Cursor](https://cursor.com)