### PR TITLE
refactor(backtest): migrate parameter and signal fallbacks to load_strategy

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -219,13 +219,18 @@ def _build_strategy_params_from_config(
 ) -> Dict[str, Any]:
     """Build strategy params dict via canonical load_strategy() registry path."""
     if strategy_key in STRATEGY_REGISTRY:
-        load_strategy(strategy_key)
-        section = cfg.raw.get("strategy", {}).get(strategy_key, {})
-        params: Dict[str, Any] = dict(section) if isinstance(section, dict) else {}
+        loader_key = strategy_key
+        section_key = strategy_key
     else:
         spec = get_strategy_spec(strategy_key)
-        instance = spec.cls.from_config(cfg, section=spec.config_section)
-        params = dict(instance.config)
+        section_key = spec.config_section.rsplit(".", 1)[-1]
+        loader_key = section_key if section_key in STRATEGY_REGISTRY else strategy_key
+
+    load_strategy(loader_key)
+    section = cfg.raw.get("strategy", {}).get(section_key, {})
+    if not section and section_key != strategy_key:
+        section = cfg.raw.get("strategy", {}).get(strategy_key, {})
+    params: Dict[str, Any] = dict(section) if isinstance(section, dict) else {}
     params["stop_pct"] = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
     return params
 
@@ -233,18 +238,15 @@ def _build_strategy_params_from_config(
 def _resolve_strategy_signal_fn(
     strategy_name: str,
 ) -> Callable[[pd.DataFrame, Dict[str, Any]], pd.Series]:
-    """Canonical load_strategy() with OOP-registry-only alias fallback."""
+    """Resolve signal callable via canonical load_strategy() path."""
     if strategy_name in STRATEGY_REGISTRY:
         return load_strategy(strategy_name)
 
     spec = get_strategy_spec(strategy_name)
-    strategy_cls = spec.cls
-
-    def generate_signals(df: pd.DataFrame, params: Dict[str, Any]) -> pd.Series:
-        strategy = strategy_cls(config=dict(params))
-        return strategy.generate_signals(df)
-
-    return generate_signals
+    loader_key = spec.config_section.rsplit(".", 1)[-1]
+    if loader_key in STRATEGY_REGISTRY:
+        return load_strategy(loader_key)
+    return load_strategy(strategy_name)
 
 
 def resolve_backtest_symbol(cfg: PeakConfig) -> str:

--- a/tests/scripts/test_run_backtest_load_strategy_v1.py
+++ b/tests/scripts/test_run_backtest_load_strategy_v1.py
@@ -96,7 +96,40 @@ def test_build_strategy_params_includes_stop_pct_default_for_registry_key() -> N
 def test_build_strategy_params_source_uses_load_strategy_for_registry_path() -> None:
     source = inspect.getsource(run_backtest_script._build_strategy_params_from_config)
     assert "load_strategy" in source
-    assert "STRATEGY_REGISTRY" in source
+    assert "spec.cls.from_config" not in source
+
+
+def test_resolve_strategy_signal_fn_source_uses_load_strategy_only() -> None:
+    source = inspect.getsource(run_backtest_script._resolve_strategy_signal_fn)
+    assert "load_strategy" in source
+    assert "spec.cls.from_config" not in source
+    assert "generate_signals(df" not in source
+
+
+def test_build_strategy_params_calls_load_strategy_for_alias_key() -> None:
+    from src.core.peak_config import PeakConfig
+
+    raw = {
+        "environment": {"mode": "backtest"},
+        "research": {"allow_r_and_d_strategies": True},
+        "strategy": {"el_karoui_vol_model": {}},
+    }
+    cfg = PeakConfig(raw=raw)
+
+    with patch.object(run_backtest_script, "load_strategy") as load_mock:
+        load_mock.return_value = MagicMock()
+        params = run_backtest_script._build_strategy_params_from_config(cfg, EL_KAROUI_ALIAS_KEY)
+
+    load_mock.assert_called_once_with("el_karoui_vol_model")
+    assert params["stop_pct"] == 0.02
+
+
+def test_resolve_strategy_signal_fn_calls_load_strategy_for_alias_key() -> None:
+    with patch.object(run_backtest_script, "load_strategy") as load_mock:
+        load_mock.return_value = MagicMock()
+        run_backtest_script._resolve_strategy_signal_fn(EL_KAROUI_ALIAS_KEY)
+
+    load_mock.assert_called_once_with("el_karoui_vol_model")
 
 
 def test_build_strategy_params_calls_load_strategy_for_registry_validation() -> None:
@@ -218,7 +251,7 @@ def test_signal_equivalence_vs_create_strategy_from_config(
     pd.testing.assert_series_equal(canonical, legacy)
 
 
-def test_el_karoui_alias_resolves_via_oop_fallback() -> None:
+def test_el_karoui_alias_resolves_via_load_strategy() -> None:
     from src.core.peak_config import PeakConfig
     from src.strategies.registry import create_strategy_from_config
 


### PR DESCRIPTION
## Summary
- Migrate remaining OOP alias parameter and signal fallbacks in `scripts/run_backtest.py` to the canonical `load_strategy()` path
- Resolve OOP-registry-only alias keys (e.g. `el_karoui_vol_v1`) via `spec.config_section` → canonical `STRATEGY_REGISTRY` loader key
- Extend existing contract tests in `tests/scripts/test_run_backtest_load_strategy_v1.py` to assert no `from_config` bypass remains

## Test plan
- [x] `ruff format --check scripts/run_backtest.py tests/scripts/test_run_backtest_load_strategy_v1.py`
- [x] `ruff check scripts/run_backtest.py tests/scripts/test_run_backtest_load_strategy_v1.py`
- [x] `pytest tests/scripts/test_run_backtest_load_strategy_v1.py -q` (23 passed, no backtest runtime)


Made with [Cursor](https://cursor.com)