### PR TITLE
docs(tech-debt): close stale macd bollinger backlog entries

### DIFF
--- a/docs/FEHLENDE_FEATURES_PEAK_TRADE.md
+++ b/docs/FEHLENDE_FEATURES_PEAK_TRADE.md
@@ -114,7 +114,7 @@ Geplante Phasen mit **noch nicht umgesetzten** Features:
 
 ### 5.3 Tech-Debt Backlog (TECH_DEBT_BACKLOG.md)
 
-- Legacy-Funktionen in `macd.py` / `bollinger.py` entfernen (nach Umstellung auf OOP)
+- Legacy-Funktionen in `macd.py` / `bollinger.py`: **abgeschlossen** — modulweite Legacy-APIs entfernt (PR #2600, PR #2601); kanonisch OOP via `MACDStrategy` / `BollingerBandsStrategy`
 - Ggf. weitere Dummy-Adapter durch echte Kraken/Exchange-Integration ersetzen (je nach Script)
 
 ### 5.4 Futures/Continuous (docs/markets)

--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -38,15 +38,17 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
 
 ### Legacy-API Cleanup
 
-- [ ] Legacy-Funktionen in `macd.py` entfernen
-  - Fundstelle: `src&#47;strategies&#47;macd.py` (Zeile 232) (illustrative)
-  - Kontext: Legacy-Funktion für Backwards Compatibility
-  - Vorschlag: Prüfen, ob alle Pipelines auf MACDStrategy (OOP) umgestellt sind, dann entfernen
+- [x] Legacy-Funktionen in `macd.py` entfernen
+  - Fundstelle: `src&#47;strategies&#47;macd.py` (illustrative)
+  - Kontext: Modulweite Legacy-API (`generate_signals`, `calculate_macd`) für Backwards Compatibility; kanonisch OOP via `MACDStrategy`
+  - Status: closed (PR #2601, merge `779978e1`; read-only Audit `legacy_macd_bollinger_pipeline_audit_no_run_v1_20260614T171547Z`)
+  - Fundstellen: `src/strategies/macd.py`, `src/strategies/registry.py`, `src/strategies/__init__.py` (`load_strategy` OOP-Fallback)
 
-- [ ] Legacy-Funktionen in `bollinger.py` entfernen
-  - Fundstelle: `src&#47;strategies&#47;bollinger.py` (Zeile 237) (illustrative)
-  - Kontext: Legacy-Funktion für Backwards Compatibility
-  - Vorschlag: Prüfen, ob alle Pipelines auf BollingerBandsStrategy (OOP) umgestellt sind, dann entfernen
+- [x] Legacy-Funktionen in `bollinger.py` entfernen
+  - Fundstelle: `src&#47;strategies&#47;bollinger.py` (illustrative)
+  - Kontext: Modulweite Legacy-API (`generate_signals`) für Backwards Compatibility; kanonisch OOP via `BollingerBandsStrategy`
+  - Status: closed (PR #2600, merge `f1cd4057`; read-only Audit `legacy_macd_bollinger_pipeline_audit_no_run_v1_20260614T171547Z`)
+  - Fundstellen: `src/strategies/bollinger.py`, `src/strategies/registry.py`, `src/strategies/__init__.py` (`load_strategy` OOP-Fallback)
 
 - [x] `run_full_portfolio.py`: Legacy-`*_signals`-Imports auf kanonischen `load_strategy()`-Pfad migriert
   - Fundstelle: `scripts/run_full_portfolio.py`

--- a/docs/analysis/FEHLENDE_FEATURES_PEAK_TRADE.md
+++ b/docs/analysis/FEHLENDE_FEATURES_PEAK_TRADE.md
@@ -133,7 +133,7 @@ Geplante Phasen mit **noch nicht umgesetzten** Features:
 | **v1.0 bewusst ausgenommen** | Live-Execution, Multi-Exchange, Web-Auth, WebSocket, ML-Strategien, Auto-Liquidation, 100 % Coverage, API-Doku, Skalierung. |
 | **Roadmap 2026** | Phasen 11–17 (Optimization, Streaming, Live, ML, Cloud, Risk-Parity, Community). |
 | **Research-Track** | Sweeps, Metriken, Heatmaps, Vol-Regime-Wrapper, Regime-adaptive Strategien, Auto-Portfolio, Nightly-Sweeps, Feature-Importance. |
-| **Stubs/Placeholder** | Kill-Switch RiskHook, PagerDuty, WP0C-Adapter, einige R&D-Strategien, `src&#47;features`, Meta-Labeling Feature-Engineering. |
+| **Stubs/Placeholder** | Kill-Switch RiskHook, PagerDuty, WP0C-Adapter, einige R&D-Strategien, `src&#47;features&#47;__init__.py`, Meta-Labeling Feature-Engineering. |
 
 ---
 

--- a/docs/analysis/FEHLENDE_FEATURES_PEAK_TRADE.md
+++ b/docs/analysis/FEHLENDE_FEATURES_PEAK_TRADE.md
@@ -106,7 +106,7 @@ Geplante Phasen mit **noch nicht umgesetzten** Features:
 
 ### 5.3 Tech-Debt Backlog (TECH_DEBT_BACKLOG.md)
 
-- Legacy-Funktionen in `macd.py` / `bollinger.py` entfernen (nach Umstellung auf OOP)
+- Legacy-Funktionen in `macd.py` / `bollinger.py`: **abgeschlossen** — modulweite Legacy-APIs entfernt (PR #2600, PR #2601); kanonisch OOP via `MACDStrategy` / `BollingerBandsStrategy`
 - Ggf. weitere Dummy-Adapter durch echte Kraken/Exchange-Integration ersetzen (je nach Script)
 
 ### 5.4 Futures/Continuous (docs/markets)

--- a/docs/features/FEHLENDE_FEATURES_PEAK_TRADE.md
+++ b/docs/features/FEHLENDE_FEATURES_PEAK_TRADE.md
@@ -106,7 +106,7 @@ Geplante Phasen mit **noch nicht umgesetzten** Features:
 
 ### 5.3 Tech-Debt Backlog (TECH_DEBT_BACKLOG.md)
 
-- Legacy-Funktionen in `macd.py` / `bollinger.py` entfernen (nach Umstellung auf OOP)
+- Legacy-Funktionen in `macd.py` / `bollinger.py`: **abgeschlossen** — modulweite Legacy-APIs entfernt (PR #2600, PR #2601); kanonisch OOP via `MACDStrategy` / `BollingerBandsStrategy`
 - Ggf. weitere Dummy-Adapter durch echte Kraken/Exchange-Integration ersetzen (je nach Script)
 
 ### 5.4 Futures/Continuous (docs/markets)


### PR DESCRIPTION
## Summary
- Close stale open TECH_DEBT_BACKLOG items for macd.py/bollinger.py legacy API removal (already completed in PR #2600/#2601).
- Mirror closure status in FEHLENDE_FEATURES docs (root, features/, analysis/).
- Read-only audit input: `legacy_macd_bollinger_pipeline_audit_no_run_v1_20260614T171547Z`.

## Test plan
- [x] `git diff --check`
- [x] `python3 scripts/ops/validate_docs_token_policy.py --changed --base origin/main`
- [x] `ruff format --check` / `ruff check`
- [x] Focused docs/truth tests (69 passed)


Made with [Cursor](https://cursor.com)