### PR TITLE
test(web): harden execution watch api v0.2 collection

### DIFF
--- a/tests/live/test_execution_watch_api_v0_2.py
+++ b/tests/live/test_execution_watch_api_v0_2.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
+# Skip if FastAPI not installed - must be done before any FastAPI imports
+pytest.importorskip("fastapi")
+
 from fastapi.testclient import TestClient
 
 from src.webui.app import create_app


### PR DESCRIPTION
## Summary
- Add `pytest.importorskip("fastapi")` before FastAPI/TestClient imports in `tests/live/test_execution_watch_api_v0_2.py`
- Mirrors the canonical collection-hardening pattern from PR #4272 (`tests/live/test_execution_watch_api_v0.py`)
- Prevents pytest collection failures in environments without the optional FastAPI web stack

## Test plan
- [x] `python -m pytest --collect-only -q tests/live/test_execution_watch_api_v0_2.py`
- [x] `python -m pytest -q tests/live/test_execution_watch_api_v0_2.py`
- [x] `git diff --check`
- [x] `ruff format --check tests/live/test_execution_watch_api_v0_2.py`
- [x] `ruff check tests/live/test_execution_watch_api_v0_2.py`


Made with [Cursor](https://cursor.com)