### PR TITLE
test(webui): harden knowledge endpoint collection

### DIFF
--- a/tests/test_webui_knowledge_endpoints.py
+++ b/tests/test_webui_knowledge_endpoints.py
@@ -15,6 +15,10 @@ from __future__ import annotations
 import os
 import pytest
 from unittest.mock import Mock, patch, MagicMock
+
+# Skip if FastAPI not installed - must be done before any FastAPI imports
+pytest.importorskip("fastapi")
+
 from fastapi.testclient import TestClient
 
 # Check if chromadb is available


### PR DESCRIPTION
## Summary
- Add `pytest.importorskip("fastapi")` before `TestClient` import in `tests/test_webui_knowledge_endpoints.py`
- Aligns collection behavior with canonical pattern from execution-watch and live-web API collection fixes (PRs #4271–#4273)
- Prevents `ModuleNotFoundError` during pytest collection in CI environments without optional FastAPI web stack

## Test plan
- [x] `python -m pytest --collect-only -q tests/test_webui_knowledge_endpoints.py` (36 tests collected, RC=0)
- [x] `python -m pytest -q tests/test_webui_knowledge_endpoints.py` (35 passed, 1 skipped, RC=0)
- [x] `git diff --check`
- [x] `ruff format --check tests/test_webui_knowledge_endpoints.py`
- [x] `ruff check tests/test_webui_knowledge_endpoints.py`


Made with [Cursor](https://cursor.com)