### PR TITLE
test(ops): add remote runtime reciprocal to dynamic scope guard

### DIFF
--- a/tests/ops/test_futures_dynamic_scope_envelope_contract_static_crosslink_contract_v0.py
+++ b/tests/ops/test_futures_dynamic_scope_envelope_contract_static_crosslink_contract_v0.py
@@ -14,6 +14,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SPECS = REPO_ROOT / "docs" / "ops" / "specs"
 RUNBOOKS = REPO_ROOT / "docs" / "ops" / "runbooks"
+REMOTE_RUNTIME_DOCS_GUARD = (
+    REPO_ROOT / "tests" / "ops" / "test_remote_runtime_contract_docs_guard_v0.py"
+)
 
 THIS_MODULE = Path(__file__).name
 DSE_CONTRACT = SPECS / "FUTURES_DYNAMIC_SCOPE_ENVELOPE_CONTRACT_V0.md"
@@ -319,3 +322,10 @@ def test_futures_dynamic_scope_envelope_no_duplicate_canonical_owner_candidates_
     assert dse_matches == [DSE_CONTRACT], (
         f"unexpected dynamic scope envelope owner set: {dse_matches}"
     )
+
+
+def test_futures_dynamic_scope_envelope_reciprocal_remote_runtime_docs_guard_v0() -> None:
+    guard_text = REMOTE_RUNTIME_DOCS_GUARD.read_text(encoding="utf-8")
+    assert THIS_MODULE in guard_text
+    owner_text = Path(__file__).read_text(encoding="utf-8")
+    assert "test_remote_runtime_contract_docs_guard_v0.py" in owner_text


### PR DESCRIPTION
## Summary
- Completes GAP-DSE-STATIC-003 by adding the missing bidirectional reciprocal anchor in the canonical DSE peer static crosslink test.
- Reuses the existing Pure-Stack reciprocal pattern: peer test references `test_remote_runtime_contract_docs_guard_v0.py` after PR #4278 registered the DSE owner one-way in `RECIPROCAL_OWNER_TESTS`.
- Tests-only, static, offline-deterministic, non-authorizing guard slice; no docs, workflow, manifest, or production code changes.

## Test plan
- [x] `python3 -m pytest -q tests/ops/test_futures_dynamic_scope_envelope_contract_static_crosslink_contract_v0.py`
- [x] `python3 -m pytest -q tests/ops/test_remote_runtime_contract_docs_guard_v0.py`
- [x] `ruff format --check tests/ops/test_futures_dynamic_scope_envelope_contract_static_crosslink_contract_v0.py`
- [x] `ruff check tests/ops/test_futures_dynamic_scope_envelope_contract_static_crosslink_contract_v0.py`


Made with [Cursor](https://cursor.com)