### PR TITLE
refactor(script): migrate momentum strategy resolution to load_strategy

### DIFF
--- a/scripts/run_momentum_realistic.py
+++ b/scripts/run_momentum_realistic.py
@@ -20,7 +20,7 @@ import numpy as np
 from datetime import datetime, timedelta
 
 from src.core import get_config, get_strategy_cfg
-from src.strategies import STRATEGY_REGISTRY, load_strategy
+from src.strategies import load_strategy
 
 MOMENTUM_STRATEGY_KEY = "momentum_1h"
 from src.backtest.engine import BacktestEngine
@@ -28,8 +28,8 @@ from src.backtest.stats import validate_for_live_trading
 
 
 def _strategy_module(strategy_key: str):
-    module_name = STRATEGY_REGISTRY[strategy_key]
-    return importlib.import_module(f"src.strategies.{module_name}")
+    generate_signals = load_strategy(strategy_key)
+    return importlib.import_module(generate_signals.__module__)
 
 
 def create_dummy_data(n_bars: int = 300) -> pd.DataFrame:

--- a/tests/scripts/test_run_momentum_realistic_load_strategy_v1.py
+++ b/tests/scripts/test_run_momentum_realistic_load_strategy_v1.py
@@ -9,12 +9,15 @@ import importlib
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from types import ModuleType
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
+
+import scripts.run_momentum_realistic as momentum_script
 
 TARGET_SCRIPT = project_root / "scripts/run_momentum_realistic.py"
 MOMENTUM_KEY = "momentum_1h"
@@ -25,9 +28,8 @@ def _read_source() -> str:
 
 
 def test_module_imports_without_main_side_effects() -> None:
-    module = importlib.import_module("scripts.run_momentum_realistic")
-    with patch.object(module, "main") as main_mock:
-        importlib.reload(module)
+    with patch.object(momentum_script, "main") as main_mock:
+        importlib.reload(momentum_script)
     main_mock.assert_not_called()
 
 
@@ -38,24 +40,59 @@ def test_source_has_no_direct_momentum_module_import() -> None:
             pytest.fail("direct momentum module import remains")
 
 
-def test_source_uses_load_strategy_and_registry_key() -> None:
+def test_source_has_no_strategy_registry_import_or_assignment() -> None:
+    tree = ast.parse(_read_source())
+    imported = {
+        alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module == "src.strategies"
+        for alias in node.names
+    }
+    assert "STRATEGY_REGISTRY" not in imported
+    assigned_names = {
+        node.targets[0].id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    }
+    assert "STRATEGY_REGISTRY" not in assigned_names
+
+
+def test_source_has_no_direct_strategy_registry_subscript_access() -> None:
+    assert "STRATEGY_REGISTRY[" not in _read_source()
+
+
+def test_source_uses_load_strategy_and_momentum_key() -> None:
     source = _read_source()
     assert "load_strategy" in source
     assert MOMENTUM_KEY in source
     assert "MOMENTUM_STRATEGY_KEY" in source
-    assert "STRATEGY_REGISTRY" in source
 
 
-def test_strategy_module_resolver_uses_registry_path() -> None:
-    import scripts.run_momentum_realistic as momentum_script
+def test_strategy_module_delegates_to_load_strategy() -> None:
+    fake_module = ModuleType("src.strategies.momentum")
+    fake_module.get_strategy_description = MagicMock(return_value="desc")
+    fake_callable = MagicMock(__module__="src.strategies.momentum")
 
+    with patch.object(momentum_script, "load_strategy", return_value=fake_callable) as load_mock:
+        with patch.object(
+            momentum_script.importlib, "import_module", return_value=fake_module
+        ) as import_mock:
+            mod = momentum_script._strategy_module(MOMENTUM_KEY)
+
+    load_mock.assert_called_once_with(MOMENTUM_KEY)
+    import_mock.assert_called_once_with("src.strategies.momentum")
+    assert mod is fake_module
+
+
+def test_strategy_module_resolver_returns_momentum_module() -> None:
     mod = momentum_script._strategy_module(MOMENTUM_KEY)
     assert mod.__name__ == "src.strategies.momentum"
     assert hasattr(mod, "get_strategy_description")
 
 
-def test_get_strategy_description_equivalence_via_registry_module() -> None:
-    import scripts.run_momentum_realistic as momentum_script
+def test_get_strategy_description_equivalence_via_load_strategy_module() -> None:
     from src.strategies.momentum import get_strategy_description as direct
 
     params = {
@@ -75,11 +112,37 @@ def test_load_strategy_momentum_key_resolves() -> None:
     assert callable(load_strategy(MOMENTUM_KEY))
 
 
+def test_unknown_strategy_fails_closed_via_load_strategy() -> None:
+    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+        momentum_script._strategy_module("definitely_not_a_strategy_xyz")
+
+
 def test_unknown_strategy_fails_closed() -> None:
     from src.strategies import load_strategy
 
     with pytest.raises(ValueError, match="Unbekannte Strategie"):
         load_strategy("definitely_not_a_strategy_xyz")
+
+
+def test_main_call_site_uses_strategy_module_with_momentum_key() -> None:
+    tree = ast.parse(_read_source())
+    found = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "get_strategy_description":
+            parent_call = func.value
+            if (
+                isinstance(parent_call, ast.Call)
+                and isinstance(parent_call.func, ast.Name)
+                and parent_call.func.id == "_strategy_module"
+                and len(parent_call.args) == 1
+                and isinstance(parent_call.args[0], ast.Name)
+                and parent_call.args[0].id == "MOMENTUM_STRATEGY_KEY"
+            ):
+                found = True
+    assert found
 
 
 def test_import_smoke_no_main_execution() -> None:


### PR DESCRIPTION
## Summary
- Migriert `_strategy_module()` in `scripts/run_momentum_realistic.py` vom direkten `STRATEGY_REGISTRY[strategy_key]`-Zugriff auf den kanonischen `load_strategy()`-Pfad.
- Erhält den bestehenden Modul-Rückgabe-Contract für `get_strategy_description()` über `generate_signals.__module__`.
- Ergänzt fokussierte Offline-Contract-Tests in `tests/scripts/test_run_momentum_realistic_load_strategy_v1.py`.

## Test plan
- [x] `python3 -m pytest -q tests/scripts/test_run_momentum_realistic_load_strategy_v1.py`
- [x] `ruff format --check scripts/run_momentum_realistic.py tests/scripts/test_run_momentum_realistic_load_strategy_v1.py`
- [x] `ruff check scripts/run_momentum_realistic.py tests/scripts/test_run_momentum_realistic_load_strategy_v1.py`
- [ ] CI FOCUSED checks grün


Made with [Cursor](https://cursor.com)