### PR TITLE
test(ops): register rgb reciprocal in remote runtime guard

### DIFF
--- a/tests/ops/test_master_v2_runtime_governance_boundary_contract_static_v0.py
+++ b/tests/ops/test_master_v2_runtime_governance_boundary_contract_static_v0.py
@@ -14,6 +14,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SPECS = REPO_ROOT / "docs" / "ops" / "specs"
 RUNBOOKS = REPO_ROOT / "docs" / "ops" / "runbooks"
+REMOTE_RUNTIME_DOCS_GUARD = (
+    REPO_ROOT / "tests" / "ops" / "test_remote_runtime_contract_docs_guard_v0.py"
+)
+
+THIS_MODULE = Path(__file__).name
 
 RGB_CONTRACT = SPECS / "FUTURES_MASTER_V2_RUNTIME_GOVERNANCE_BOUNDARY_CONTRACT_V0.md"
 DSE_CONTRACT = SPECS / "FUTURES_DYNAMIC_SCOPE_ENVELOPE_CONTRACT_V0.md"
@@ -308,3 +313,10 @@ def test_runtime_governance_boundary_contract_no_duplicate_static_owners_v0() ->
     assert "NO_DUPLICATION_OF_PR3648_AUTHORITY_MAP_OWNER" in contract_text
     assert "NO_DUPLICATION_OF_PR3649_PURE_STACK_OWNER" in contract_text
     assert contract_text.count("MARKER:") >= len(MACHINE_MARKERS)
+
+
+def test_runtime_governance_boundary_reciprocal_remote_runtime_docs_guard_v0() -> None:
+    guard_text = REMOTE_RUNTIME_DOCS_GUARD.read_text(encoding="utf-8")
+    assert THIS_MODULE in guard_text
+    owner_text = Path(__file__).read_text(encoding="utf-8")
+    assert "test_remote_runtime_contract_docs_guard_v0.py" in owner_text

--- a/tests/ops/test_remote_runtime_contract_docs_guard_v0.py
+++ b/tests/ops/test_remote_runtime_contract_docs_guard_v0.py
@@ -2012,6 +2012,7 @@ RECIPROCAL_OWNER_TESTS = (
     "test_ops_cockpit_payload_top_level_contract.py",
     "test_master_v2_double_play_pure_stack_readiness_map_static_crosslink_contract_v0.py",
     "test_futures_dynamic_scope_envelope_contract_static_crosslink_contract_v0.py",
+    "test_master_v2_runtime_governance_boundary_contract_static_v0.py",
 )
 
 OPS_COCKPIT_OPERATOR_SUMMARY_SPEC = (
@@ -2087,6 +2088,16 @@ DSE_STATIC_CROSSLINK_GUARD = (
     / "tests"
     / "ops"
     / "test_futures_dynamic_scope_envelope_contract_static_crosslink_contract_v0.py"
+)
+FUTURES_MASTER_V2_RUNTIME_GOVERNANCE_BOUNDARY_CONTRACT = (
+    REPO_ROOT
+    / "docs"
+    / "ops"
+    / "specs"
+    / "FUTURES_MASTER_V2_RUNTIME_GOVERNANCE_BOUNDARY_CONTRACT_V0.md"
+)
+RGB_STATIC_CROSSLINK_GUARD = (
+    REPO_ROOT / "tests" / "ops" / "test_master_v2_runtime_governance_boundary_contract_static_v0.py"
 )
 
 FORBIDDEN_PARALLEL_DOC_FRAGMENTS = (
@@ -2233,7 +2244,10 @@ def test_reciprocal_owner_crosslinks_present() -> None:
     owner_text = Path(__file__).read_text(encoding="utf-8")
     for module_name in RECIPROCAL_OWNER_TESTS:
         assert module_name in owner_text, f"missing reciprocal owner {module_name!r}"
-        if module_name == DSE_STATIC_CROSSLINK_GUARD.name:
+        if module_name in (
+            DSE_STATIC_CROSSLINK_GUARD.name,
+            RGB_STATIC_CROSSLINK_GUARD.name,
+        ):
             continue
         peer_text = (REPO_ROOT / "tests" / "ops" / module_name).read_text(encoding="utf-8")
         assert THIS_MODULE in peer_text, f"{module_name} missing reciprocal link to {THIS_MODULE}"
@@ -2248,6 +2262,23 @@ def test_futures_dynamic_scope_envelope_static_crosslink_reciprocal_remote_runti
     contract_text = FUTURES_DYNAMIC_SCOPE_ENVELOPE_CONTRACT.read_text(encoding="utf-8")
     assert DSE_STATIC_CROSSLINK_GUARD.name in contract_text.replace("&#47;", "/")
     assert FUTURES_DYNAMIC_SCOPE_ENVELOPE_CONTRACT.name in peer_text
+
+
+def test_master_v2_runtime_governance_boundary_static_crosslink_reciprocal_remote_runtime_docs_guard_v0() -> (
+    None
+):
+    guard_text = Path(__file__).read_text(encoding="utf-8")
+    assert RGB_STATIC_CROSSLINK_GUARD.name in guard_text
+    peer_text = RGB_STATIC_CROSSLINK_GUARD.read_text(encoding="utf-8")
+    contract_text = FUTURES_MASTER_V2_RUNTIME_GOVERNANCE_BOUNDARY_CONTRACT.read_text(
+        encoding="utf-8"
+    )
+    contract_plain = contract_text.replace("&#47;", "/")
+    assert (
+        RGB_STATIC_CROSSLINK_GUARD.name in contract_plain
+        or "runtime_governance_boundary_contract_static" in contract_plain
+    )
+    assert FUTURES_MASTER_V2_RUNTIME_GOVERNANCE_BOUNDARY_CONTRACT.name in peer_text
 
 
 def test_no_parallel_remote_runtime_authority_docs_introduced() -> None:


### PR DESCRIPTION
## Summary
- Register `test_master_v2_runtime_governance_boundary_contract_static_v0.py` in `RECIPROCAL_OWNER_TESTS` of the canonical remote runtime docs guard (GAP-RGB-STATIC-002).
- Add bidirectional reciprocal anchors following the established DSE static crosslink pattern; tests-only, offline, non-authorizing.

## Test plan
- [x] Focused reciprocal tests pass locally
- [x] Full allowed test modules pass locally (`test_remote_runtime_contract_docs_guard_v0.py`, `test_master_v2_runtime_governance_boundary_contract_static_v0.py`)
- [x] `ruff format --check` and `ruff check` on changed files
- [ ] Await CI static-tests fast lane


Made with [Cursor](https://cursor.com)