### PR TITLE
test(ops): register state switch reciprocal guard

### DIFF
--- a/tests/ops/test_master_v2_state_switch_contract_static_v0.py
+++ b/tests/ops/test_master_v2_state_switch_contract_static_v0.py
@@ -14,6 +14,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SPECS = REPO_ROOT / "docs" / "ops" / "specs"
 RUNBOOKS = REPO_ROOT / "docs" / "ops" / "runbooks"
+REMOTE_RUNTIME_DOCS_GUARD = (
+    REPO_ROOT / "tests" / "ops" / "test_remote_runtime_contract_docs_guard_v0.py"
+)
+
+THIS_MODULE = Path(__file__).name
 
 SS_CONTRACT = SPECS / "FUTURES_DOUBLE_PLAY_STATE_SWITCH_CONTRACT_V0.md"
 DSE_CONTRACT = SPECS / "FUTURES_DYNAMIC_SCOPE_ENVELOPE_CONTRACT_V0.md"
@@ -310,3 +315,10 @@ def test_state_switch_contract_no_duplicate_static_owners_v0() -> None:
     assert "NO_DUPLICATION_OF_PR3648_STATE_SWITCH_VS_KILLSWITCH_OWNER" in contract_text
     assert "NO_DUPLICATION_OF_PR3649_PURE_STACK_READINESS_OWNER" in contract_text
     assert contract_text.count("MARKER:") >= len(MACHINE_MARKERS)
+
+
+def test_state_switch_contract_reciprocal_remote_runtime_docs_guard_v0() -> None:
+    guard_text = REMOTE_RUNTIME_DOCS_GUARD.read_text(encoding="utf-8")
+    assert THIS_MODULE in guard_text
+    owner_text = Path(__file__).read_text(encoding="utf-8")
+    assert "test_remote_runtime_contract_docs_guard_v0.py" in owner_text

--- a/tests/ops/test_remote_runtime_contract_docs_guard_v0.py
+++ b/tests/ops/test_remote_runtime_contract_docs_guard_v0.py
@@ -2013,6 +2013,7 @@ RECIPROCAL_OWNER_TESTS = (
     "test_master_v2_double_play_pure_stack_readiness_map_static_crosslink_contract_v0.py",
     "test_futures_dynamic_scope_envelope_contract_static_crosslink_contract_v0.py",
     "test_master_v2_runtime_governance_boundary_contract_static_v0.py",
+    "test_master_v2_state_switch_contract_static_v0.py",
 )
 
 OPS_COCKPIT_OPERATOR_SUMMARY_SPEC = (
@@ -2098,6 +2099,12 @@ FUTURES_MASTER_V2_RUNTIME_GOVERNANCE_BOUNDARY_CONTRACT = (
 )
 RGB_STATIC_CROSSLINK_GUARD = (
     REPO_ROOT / "tests" / "ops" / "test_master_v2_runtime_governance_boundary_contract_static_v0.py"
+)
+FUTURES_DOUBLE_PLAY_STATE_SWITCH_CONTRACT = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "FUTURES_DOUBLE_PLAY_STATE_SWITCH_CONTRACT_V0.md"
+)
+SS_STATIC_CROSSLINK_GUARD = (
+    REPO_ROOT / "tests" / "ops" / "test_master_v2_state_switch_contract_static_v0.py"
 )
 
 FORBIDDEN_PARALLEL_DOC_FRAGMENTS = (
@@ -2247,6 +2254,7 @@ def test_reciprocal_owner_crosslinks_present() -> None:
         if module_name in (
             DSE_STATIC_CROSSLINK_GUARD.name,
             RGB_STATIC_CROSSLINK_GUARD.name,
+            SS_STATIC_CROSSLINK_GUARD.name,
         ):
             continue
         peer_text = (REPO_ROOT / "tests" / "ops" / module_name).read_text(encoding="utf-8")
@@ -2279,6 +2287,21 @@ def test_master_v2_runtime_governance_boundary_static_crosslink_reciprocal_remot
         or "runtime_governance_boundary_contract_static" in contract_plain
     )
     assert FUTURES_MASTER_V2_RUNTIME_GOVERNANCE_BOUNDARY_CONTRACT.name in peer_text
+
+
+def test_master_v2_state_switch_contract_static_crosslink_reciprocal_remote_runtime_docs_guard_v0() -> (
+    None
+):
+    guard_text = Path(__file__).read_text(encoding="utf-8")
+    assert SS_STATIC_CROSSLINK_GUARD.name in guard_text
+    peer_text = SS_STATIC_CROSSLINK_GUARD.read_text(encoding="utf-8")
+    contract_text = FUTURES_DOUBLE_PLAY_STATE_SWITCH_CONTRACT.read_text(encoding="utf-8")
+    contract_plain = contract_text.replace("&#47;", "/")
+    assert (
+        SS_STATIC_CROSSLINK_GUARD.name in contract_plain
+        or "state_switch_contract_static" in contract_plain
+    )
+    assert FUTURES_DOUBLE_PLAY_STATE_SWITCH_CONTRACT.name in peer_text
 
 
 def test_no_parallel_remote_runtime_authority_docs_introduced() -> None:


### PR DESCRIPTION
## Summary
- Registriert `test_master_v2_state_switch_contract_static_v0.py` in `RECIPROCAL_OWNER_TESTS` des Remote-Runtime-Docs-Guards (GAP-SS-STATIC-002).
- Ergänzt reziproken Peer-Anker im State-Switch-Static-Test auf `test_remote_runtime_contract_docs_guard_v0.py`.
- Tests-only, statisch, offline-deterministisch, non-authorizing — folgt dem DSE/RGB-Reciprocal-Muster.

## Test plan
- [x] `python3 -m pytest -q tests/ops/test_remote_runtime_contract_docs_guard_v0.py`
- [x] `python3 -m pytest -q tests/ops/test_master_v2_state_switch_contract_static_v0.py`
- [x] `ruff format --check` und `ruff check` auf den beiden erlaubten Dateien


Made with [Cursor](https://cursor.com)