### PR TITLE
docs(section5): enforce criteria precedence over final lines

### DIFF
--- a/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
+++ b/docs/ops/planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md
@@ -3424,6 +3424,69 @@ PATH_B_LIFT_DISCUSSION_READY=false
 
 This criteria-reflection block records the bounded Section-5 Criteria-SSOT repo-internal write/lift applied posture for Gap 2 (canonical job set) only. Criteria-SSOT repo-internal write/lift applied for this slice (A-02/C-02). Criteria-reflection does not verify or enable the canonical job set, does not lift preflight, and does not authorize runtime, scheduler execution, Paper, Shadow, Testnet, Live, AWS, broker, or exchange activity.
 
+## SECTION5 Criteria-Block-Precedence vs Class4 Final Machine Lines GLB-015 Authority Boundary v0
+
+SECTION5_CRITERIA_BLOCK_CLASS4_FINAL_LINES_GLB015_BOUNDARY_V0=true
+SECTION5_CRITERIA_BLOCK_PRECEDENCE_GUARD_V0=true
+CRITERIA_SSOT_REMAINS_AUTHORITATIVE=true
+CLASS4_FINAL_MACHINE_LINES_NON_AUTHORIZING_REFLECTION=true
+CONTRADICTORY_FINAL_LINES_FAIL_CLOSED=true
+DOCUMENTATION_NOT_APPROVAL=true
+EVIDENCE_NOT_AUTHORIZATION=true
+MAPPING_NOT_APPROVAL=true
+FML_NOT_CRITERIA_UPDATE=true
+STATIC_TESTS_NOT_PREFLIGHT_LIFT=true
+OWNER_NAMING_NOT_APPROVAL_RECORD=true
+GLB015_STATIC_BOUNDARY_SLICE_DOCS_TESTS_ONLY=true
+DOCS_ONLY_EXECUTE_SLICE=true
+ALL_EIGHT_SECTION5_GAPS_CLOSED=false
+ALL_GAPS_CLOSED=false
+GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false
+PREFLIGHT_REMAINS_BLOCKED=true
+READY_FOR_OPERATOR_ARMING=false
+EXECUTION_AUTHORIZED=false
+LIVE_AUTHORIZED=false
+AUTHORITY_LIFT=false
+PREFLIGHT_LIFT_EXECUTED=false
+SECTION5_GAP_CLOSURE_EXECUTED=false
+
+This boundary contract closes the static **Documentation-vs-Approval** misread class for [GLB-015](../specs/MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md) §6.5 / §6.5.1. It does **not** close the eight SECTION5 gaps, does **not** lift preflight, and does **not** authorize runtime, arming, execution, or live.
+
+### Criteria-Block-Precedence (authoritative SSOT)
+
+The per-gap **Criteria Contract v0** blocks in this document (Status, §2a.1, Gap 1–7 criteria sections, and their Criteria-SSOT reflection blocks) are the **single source of truth** for closure and verification posture.
+
+- `*_VERIFIED=false` in a criteria block remains **false** until a canonical criteria update with required evidence and explicit approval sets it true.
+- `GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false` remains **blocking** until criteria-SSOT updates with required evidence and approval.
+- `PREFLIGHT_REMAINS_BLOCKED=true` in criteria blocks **takes precedence** over any positive Class4 reflection or summary line elsewhere in this document.
+- Missing criteria values must **not** be inferred from positive Final Machine Lines or governed reflection blocks.
+
+### Class4 Final Machine Lines (non-authorizing reflection)
+
+The **Final Machine Lines** block at the end of this document is a **Class4 governed archival reflection** surface only. Final Machine Lines are **reporting outputs**, not criteria updates.
+
+- Final Machine Lines **must not** override criteria-block SSOT values.
+- `VERIFIED=true`, `ALL_GAPS_CLOSED=true`, or `READY_FOR_OPERATOR_ARMING=true` appearing in Final Machine Lines is **not authorizing** when the corresponding criteria block does not confirm it.
+- When criteria tokens and Final Machine Lines **contradict**, evaluation is **fail-closed** on the criteria status.
+- Contradictory positive Final Machine Lines must **not** be used as closure, approval, arming, execution, or live evidence.
+
+### GLB-015 Documentation-vs-Approval boundary
+
+Per [GLB-015](../specs/MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md): **Documentation ≠ Approval**; **Evidence ≠ Authorization**; **Mapping ≠ Approval**; **Class4/FML reflection ≠ Criteria update**; **Static tests ≠ Preflight lift**; **Owner naming ≠ Approval record**.
+
+**GLB-015** remains **BLOCKED** in the register until the canonical boundary contract and static guard prevent this misread class. This slice closes only the **static boundary**, not underlying SECTION5 gap approvals.
+
+### Fail-closed evaluation rule
+
+| Condition | Result |
+|---|---|
+| Criteria `false` + Final Lines `true` | **Not closed**, **not verified**, **not arming-ready** |
+| Missing criteria value | **Do not** derive positive from reflection |
+| Contradictory doc locations | **Safe negative** interpretation |
+| Default when uncertain | **No positive authorization** |
+
+Static guard: `tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py` (`SECTION5_CRITERIA_BLOCK_PRECEDENCE_GLB015_BOUNDARY_GUARD_V1`). Register guard: `tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py` (`GLB015_SECTION5_CRITERIA_PRECEDENCE_CROSSLINK_GUARD_V1`). **Docs/tests-only**; **no** preflight lift; **no** authority lift.
+
 ## Final Machine Lines
 
 SECTION5_OWNER_MAP_CONTRACT_V0_COMPLETE=true

--- a/docs/ops/specs/MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md
+++ b/docs/ops/specs/MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md
@@ -204,6 +204,20 @@ The repository may contain **material planning, closeout, merge, and evidence-ch
 
 Until explicit operator/reviewer confirmation exists, **BLOCKED** remains.
 
+### 6.5.1 GLB-015 — SECTION5 Criteria-Block-Precedence vs Class4 Final Machine Lines (clarification)
+
+When [Section 5 Preflight Gap Owner Map Contract v0](../planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md) contains both **criteria-SSOT blocks** (Gap 1–7, §2a.1, Status) and **Class4 Final Machine Lines**, the criteria blocks are **authoritative** for verification and closure posture. Final Machine Lines are **non-authorizing reflection** only.
+
+- Criteria `*_VERIFIED=false`, `GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false`, `ALL_GAPS_CLOSED=false`, and `PREFLIGHT_REMAINS_BLOCKED=true` **take precedence** over contradictory positive Final Machine Lines.
+- **Documentation ≠ Approval**; **Evidence ≠ Authorization**; **Mapping ≠ Approval**; **Class4/FML reflection ≠ Criteria update**; **Static tests ≠ Preflight lift**; **Owner naming ≠ Approval record**.
+- Contradictory positive Final Machine Lines must **not** be used as closure, approval, arming, execution, or live evidence; evaluation is **fail-closed** on criteria status.
+- **GLB-015** remains **BLOCKED** until operator/reviewer confirms this boundary; this clarification **does not** close **GLB-015** by itself, **does not** clear Preflight **BLOCKED**, and **does not** grant arming, execution, or live authority.
+
+**Canonical read-order (existing surfaces; no new surface):**
+
+- [Section 5 Preflight Gap Owner Map Contract v0](../planning/SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md) — **SECTION5 Criteria-Block-Precedence vs Class4 Final Machine Lines GLB-015 Authority Boundary v0**
+- Static guards: `tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py`, `tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py`
+
 ### 6.6 GLB-008/009/012/013 Repo-Internal Status/Lift Applied Reflection v0
 
 GLB_STATUS_REPO_INTERNAL_WRITE_LIFT_V0=true

--- a/tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py
+++ b/tests/ops/test_master_v2_go_live_blocker_register_core_doc_contract_v0.py
@@ -82,6 +82,26 @@ def test_glb015_repo_docs_not_final_approval_blocked_v0() -> None:
     assert "does not clear Preflight BLOCKED" in text
 
 
+def test_glb015_section5_criteria_precedence_crosslink_guard_v1() -> None:
+    text = _read(BLOCKER_REGISTER)
+    plain = _plain(BLOCKER_REGISTER)
+    section = plain.split("6.5.1 GLB-015")[1].split("6.6 GLB-008")[0]
+
+    assert "SECTION5_PREFLIGHT_GAP_OWNER_MAP_CONTRACT_V0.md" in text
+    assert "Criteria-Block-Precedence" in section
+    assert "Final Machine Lines" in section
+    assert "non-authorizing" in section.lower()
+    assert "Documentation" in section and "Approval" in section
+    assert "Evidence" in section and "Authorization" in section
+    assert "Static tests" in section or "static tests" in section.lower()
+    assert "fail-closed" in section.lower()
+    assert "does not close GLB-015 by itself" in section
+    assert "test_section5_preflight_gap_owner_map_contract_v0.py" in text
+    assert "PREFLIGHT_REMAINS_BLOCKED" in section
+    assert "ALL_GAPS_CLOSED" in section
+    assert "arming" in section.lower()
+
+
 def test_no_green_claim_rule_v0() -> None:
     text = _plain(BLOCKER_REGISTER)
     assert "7. No-Green Claim Rule" in text

--- a/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
+++ b/tests/ops/test_section5_preflight_gap_owner_map_contract_v0.py
@@ -1566,3 +1566,74 @@ def test_section5_tier1_canonical_tag_bounded_enforce_observed_final_line_reflec
     assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true" in block_lines
     assert "GAP2A1_TIER1_ENFORCEMENT_LIFTED=true" in block_lines
     assert "READY_FOR_OPERATOR_ARMING=true" in block_lines
+
+
+CRITERIA_PRECEDENCE_GLB015_BOUNDARY_HEADER = "## SECTION5 Criteria-Block-Precedence vs Class4 Final Machine Lines GLB-015 Authority Boundary v0"
+
+
+def _criteria_precedence_glb015_boundary_section(text: str) -> str:
+    return text.split(CRITERIA_PRECEDENCE_GLB015_BOUNDARY_HEADER, 1)[1].split(
+        "## Final Machine Lines", 1
+    )[0]
+
+
+def test_section5_criteria_block_precedence_glb015_boundary_guard_v1() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    section = _criteria_precedence_glb015_boundary_section(text)
+    blocker_register = (
+        ROOT / "docs" / "ops" / "specs" / "MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md"
+    ).read_text(encoding="utf-8")
+    block = _final_machine_lines(text)
+    gap1 = _gap1_section(text)
+    gap2a1 = _gap2a1_section(text)
+
+    for token in (
+        "SECTION5_CRITERIA_BLOCK_CLASS4_FINAL_LINES_GLB015_BOUNDARY_V0=true",
+        "SECTION5_CRITERIA_BLOCK_PRECEDENCE_GUARD_V0=true",
+        "CRITERIA_SSOT_REMAINS_AUTHORITATIVE=true",
+        "CLASS4_FINAL_MACHINE_LINES_NON_AUTHORIZING_REFLECTION=true",
+        "CONTRADICTORY_FINAL_LINES_FAIL_CLOSED=true",
+        "DOCUMENTATION_NOT_APPROVAL=true",
+        "EVIDENCE_NOT_AUTHORIZATION=true",
+        "MAPPING_NOT_APPROVAL=true",
+        "FML_NOT_CRITERIA_UPDATE=true",
+        "STATIC_TESTS_NOT_PREFLIGHT_LIFT=true",
+        "OWNER_NAMING_NOT_APPROVAL_RECORD=true",
+        "ALL_EIGHT_SECTION5_GAPS_CLOSED=false",
+        "ALL_GAPS_CLOSED=false",
+        "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false",
+        "PREFLIGHT_REMAINS_BLOCKED=true",
+        "READY_FOR_OPERATOR_ARMING=false",
+        "EXECUTION_AUTHORIZED=false",
+        "LIVE_AUTHORIZED=false",
+        "AUTHORITY_LIFT=false",
+        "PREFLIGHT_LIFT_EXECUTED=false",
+        "SECTION5_GAP_CLOSURE_EXECUTED=false",
+    ):
+        assert token in section
+
+    assert "6.5.1 GLB-015" in blocker_register
+    assert "Criteria-Block-Precedence" in blocker_register
+    assert "MASTER_V2_GO_LIVE_BLOCKER_REGISTER_V0.md" in section
+    assert "test_master_v2_go_live_blocker_register_core_doc_contract_v0.py" in section
+
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=false" in gap1
+    assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=false" in gap2a1
+    block_lines = {line.strip() for line in block.splitlines()}
+    assert "GAP1_EXECUTE_ENTRYPOINT_VERIFIED=true" in block_lines
+    assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true" in block_lines
+    assert "PREFLIGHT_REMAINS_BLOCKED=false" in block_lines
+    assert "ALL_GAPS_CLOSED=true" in block_lines
+    assert "READY_FOR_OPERATOR_ARMING=true" in block_lines
+
+    section_lines = {line.strip() for line in section.splitlines()}
+    assert "READY_FOR_OPERATOR_ARMING=true" not in section_lines
+    assert "PREFLIGHT_REMAINS_BLOCKED=false" not in section_lines
+    assert "ALL_GAPS_CLOSED=true" not in section_lines
+    assert "GAP2A1_PRIMARY_EVIDENCE_ENFORCED=true" not in section_lines
+
+    collapsed = section.replace("**", "")
+    assert "single source of truth" in collapsed.lower()
+    assert "non-authorizing" in collapsed.lower()
+    assert "fail-closed" in collapsed.lower()
+    assert "does not close the eight section5 gaps" in collapsed.lower()


### PR DESCRIPTION
## Summary

- **BUNDLE-SECTION5-GLB015-CRITERIA-AUTHORITY-001** — static closure for **GLB-015** Documentation-vs-Approval authority boundary and **SECTION5 Criteria-Block-Precedence** over Class4 Final Machine Lines
- **GO_TOKEN:** `GO_SECTION5_CRITERIA_BLOCK_CLASS4_FINAL_LINES_GLB015_BOUNDARY_CLOSURE_DOCS_TESTS_NO_RUN_V1`
- Docs/Tests-only, offline, no-run: Criteria-SSOT blocks remain authoritative; Class4 Final Lines remain non-authorizing reflection
- Documentation ≠ Approval; Evidence ≠ Authorization; no change to actual gap verification values; no Preflight-, Arming-, Execution-, or Live-Freigabe
- Reuse-before-new: extends canonical SECTION5 Gap Owner Map + GLB-015 register + existing static test owners (no new doc/test files)

## Validation

- Focused pytest: `test_section5_criteria_block_precedence_glb015_boundary_guard_v1`, `test_glb015_section5_criteria_precedence_crosslink_guard_v1` — **PASS**
- `ruff format --check` + `ruff check` on changed Python test files — **PASS**
- Docs Token Policy Guard (`--changed --base main`) — **PASS** (no policy violations on changed tracked docs scope)

## Test plan

- [x] Criteria-SSOT precedence documented in SECTION5 owner map
- [x] GLB-015 §6.5.1 crosslink in blocker register
- [x] Static guards assert fail-closed semantics and contradiction proof (criteria false vs FML true)
- [x] No criteria values flipped to verified/closed/ready
- [x] No production code touched


Made with [Cursor](https://cursor.com)