### PR TITLE
docs(tech-debt): close test_live_web collection error

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -173,12 +173,11 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
 
 ### test_live_web.py Collection Error
 
-- [ ] test_live_web.py reparieren oder entfernen
+- [x] test_live_web.py reparieren oder entfernen
   - Fundstelle: `tests&#47;test_live_web.py`
-  - Kontext: Fehler bei Test-Collection (vermutlich fehlende Dependency)
-  - Aktueller Status: In pytest-Runs mit `--ignore=tests&#47;test_live_web.py` übersprungen
-  - Vorschlag: Prüfen, ob Test noch benötigt wird, sonst entfernen
-  - Priorität: Niedrig
+  - Kontext: Fehler bei Test-Collection (vorschneller Modul-Import vor `pytest.importorskip`)
+  - Status: closed (PR #4271, merge `157e037f`; Collection verifiziert, 39 Tests gesammelt)
+  - Fundstellen: `tests&#47;test_live_web.py`
 
 ---
 


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_TECH_DEBT_TEST_LIVE_WEB_BACKLOG_CLOSE_V1`
- Schließt den veralteten TECH_DEBT-Backlog-Eintrag „test_live_web.py Collection Error“ als SSOT-Sync nach bereits gemerged PR #4271
- PR #4271 bereits gemerged; Collection verifiziert (39 Tests gesammelt, RC=0)
- Backlog-SSOT-Drift geschlossen: Eintrag war noch `[ ]` offen trotz abgeschlossenem Fix
- Docs-only, no-run, non-authorizing — keine Produktivcode-, Test-, Runtime-, Preflight- oder Authority-Änderung

## Reuse-before-new / Reuse Drift Guard

- Reuse-before-new: bestehende Owner `docs/TECH_DEBT_BACKLOG.md` + Implementation-Bundle `test_live_web_collection_fix_v1_20260614T173255Z`
- Reuse Drift Guard: keine parallele SSOT-Fläche; kein Reopen geschlossener Lanes; nur stale Backlog-Eintrag aktualisiert

## Validation

- `git diff --check`: RC=0
- Docs Token Policy Guard (`validate_docs_token_policy.py --changed --base origin/main`): RC=0 (1 file scanned, all passed)
- Docs Drift Guard: RC=0
- Docs Reference Targets Guard: RC=0 (77 references, all exist)
- Repo Truth Claims Guard: RC=0 (9 checks)

## Changed files

- `docs/TECH_DEBT_BACKLOG.md` (only)

## Test plan

- [x] Docs Token Policy Guard
- [x] Docs Drift / Reference Targets / Truth Claims Guards
- [x] Statische Verifikation: nur vorgesehener Backlog-Eintrag geändert
- [ ] Kein pytest / keine Runtime (bewusst no-run)


Made with [Cursor](https://cursor.com)