### PR TITLE
docs(tech-debt): close pandas fillna downcasting warning

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -161,10 +161,10 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
 
 ### Pandas FutureWarnings (Phase 59)
 
-- [ ] Pandas `.fillna` Downcasting Warnings beheben
+- [x] Pandas `.fillna` Downcasting Warnings beheben
   - Fundstelle: Diverse `src&#47;strategies&#47;*.py`
   - Kontext: `.shift(1).fillna(False)` Pattern löst FutureWarning in pandas 2.x aus
-  - Status: implemented in PR #1036 (merge `7394f78c`, mergedAt 2026-01-28T05:58:36Z)
+  - Status: closed (PR #1036, merge `7394f78c`; Strategie-Pattern auf `shift(1, fill_value=False)` migriert, pytest FutureWarning-Filter entfernt; Regression `tests/test_fillna_downcasting_regression.py`)
   - Aktueller Status: Warning behoben; keine pandas-Downcasting `FutureWarning` Filter mehr nötig
   - Vorschlag: (historisch) Bei pandas 3.0 Migration auf `.astype(bool)` umstellen
   - Priorität: Niedrig (erledigt; Regression-Test deckt Verhalten ab)


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_TECH_DEBT_PANDAS_FILLNA_BACKLOG_CLOSE_V1`
- PR #1036 bereits gemerged (`7394f78c`, 2026-01-28): pytest FutureWarning-Filter für pandas Downcasting entfernt nach Code-Fix
- Implementierung verifiziert: Strategie-Pattern auf `shift(1, fill_value=False).astype(bool)` migriert; Regression `tests/test_fillna_downcasting_regression.py`
- stale Backlog-SSOT-Eintrag „Pandas `.fillna` Downcasting Warnings“ geschlossen (`[ ]` → `[x]`, Status → `closed`)
- Docs-only, offline, no-run, non-authorizing
- Reuse-before-new und Reuse Drift Guard angewendet
- Docs Token Policy Guard: RC=0 (1 Datei gescannt, all passed)
- Keine Produktivcode-, Test-, Runtime-, Preflight- oder Authority-Änderung

## Changed files

- `docs/TECH_DEBT_BACKLOG.md`

## Test plan

- [x] `git diff --check` — OK
- [x] `validate_docs_token_policy.py --changed --base origin/main` — RC=0
- [x] `check_docs_drift_guard.py --base origin/main` — RC=0
- [x] `verify_docs_reference_targets.sh --changed --base origin/main` — RC=0
- [x] `check_repo_truth_claims.py` — RC=0
- [ ] pytest (bewusst nicht ausgeführt — docs-only slice)

Made with [Cursor](https://cursor.com)