### PR TITLE
docs(tech-debt): close risk parity allocation backlog

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -10,11 +10,11 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
 
 ### Backtest-Engine: Portfolio-Allocation-Methoden
 
-- [ ] `risk_parity` Allocation-Methode implementieren
+- [x] `risk_parity` Allocation-Methode implementieren
   - Fundstelle: `src&#47;backtest&#47;engine.py` (Zeile 1318) (illustrative)
   - Kontext: Portfolio-Allocation-Methode für gleiches Risk-Level pro Strategie
   - Vorschlag: Implementierung basierend auf Volatility/Risk-Metriken
-  - Status: implemented (Code PR #1030, merge `af02a6d5`) + Docs/Evidence PR #1031 (merge `c6fc8036`)
+  - Status: closed (PR #1030, merge `af02a6d5`; zwei-pass inverse-vol Allocation in `src/backtest/engine.py`; Evidence PR #1031 merge `c6fc8036`; Tests `tests/backtest/test_engine_allocations.py`, `tests/backtest/test_engine_two_pass_allocation.py`)
   - Evidence: `docs/ops/evidence/EV_TECH_DEBT_A_ALLOC_20260128.md`
   - Fundstellen: `src/backtest/engine.py`, `tests/backtest/test_engine_allocations.py`, `tests/backtest/test_engine_two_pass_allocation.py`
 


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_TECH_DEBT_RISK_PARITY_ALLOCATION_BACKLOG_CLOSE_V1`
- PR #1030/#1031 bereits gemerged: risk_parity zwei-pass Allocation in `src/backtest/engine.py`
- Implementierung verifiziert: Tests `tests/backtest/test_engine_allocations.py`, `tests/backtest/test_engine_two_pass_allocation.py`
- stale Backlog-SSOT-Eintrag „risk_parity Allocation-Methode“ geschlossen (`[ ]` → `[x]`, Status → `closed`)
- Docs-only, offline, no-run, non-authorizing
- Docs Token Policy Guard: RC=0
- Keine Produktivcode-, Test-, Runtime-, Preflight- oder Authority-Änderung

## Changed files

- `docs/TECH_DEBT_BACKLOG.md`

## Test plan

- [x] `validate_docs_token_policy.py --changed --base origin/main` — RC=0
- [ ] pytest (bewusst nicht ausgeführt — docs-only slice)

Made with [Cursor](https://cursor.com)