### PR TITLE
docs(tech-debt): close sharpe weighted allocation backlog

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -18,7 +18,7 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
   - Evidence: `docs/ops/evidence/EV_TECH_DEBT_A_ALLOC_20260128.md`
   - Fundstellen: `src/backtest/engine.py`, `tests/backtest/test_engine_allocations.py`, `tests/backtest/test_engine_two_pass_allocation.py`
 
-- [ ] `sharpe_weighted` Allocation-Methode implementieren
+- [x] `sharpe_weighted` Allocation-Methode implementieren
   - Fundstelle: `src&#47;backtest&#47;engine.py` (Zeile 1319) (illustrative)
   - Kontext: Portfolio-Allocation basierend auf historischer Sharpe-Ratio
   - Vorschlag: Benötigt historische Backtests als Input


### PR DESCRIPTION
## Summary
- Schließt den stale Backlog-Eintrag `sharpe_weighted` Allocation-Methode implementieren in `docs/TECH_DEBT_BACKLOG.md` (Checkbox `[ ]` → `[x]`).
- Funktionale Implementierung bereits durch PR #1030 (merge `af02a6d5`) und Docs/Evidence PR #1031 (merge `c6fc8036`) abgedeckt; keine Produktionscode-Änderung.

## Test plan
- [x] `python3 scripts/ops/validate_docs_token_policy.py --changed --base origin/main` → RC=0
- [x] Diff fail-closed: ausschließlich `docs/TECH_DEBT_BACKLOG.md`, 1 Zeile


Made with [Cursor](https://cursor.com)