### PR TITLE
docs(tech-debt): close equity loader robustness backlog bundle

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -102,7 +102,7 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
 
 ### Vollständige Implementierungen
 
-- [ ] Vollständige Stress-Test-Implementierung
+- [x] Vollständige Stress-Test-Implementierung
   - Fundstelle: `src&#47;experiments&#47;stress_tests.py` (Zeile 389) (illustrative)
   - Kontext: Vollständige Implementierung, die Equity-Curves aus Backtest-Results lädt
   - Vorschlag: Integration mit Backtest-Registry für automatisches Laden
@@ -110,7 +110,7 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
   - Evidence: `docs/ops/evidence/EV_TECH_DEBT_C_20260128.md`
   - Fundstellen: `src/experiments/equity_loader.py`, `src/experiments/stress_tests.py`, `tests/experiments/test_equity_loader.py`
 
-- [ ] Vollständige Monte-Carlo-Implementierung
+- [x] Vollständige Monte-Carlo-Implementierung
   - Fundstelle: `src&#47;experiments&#47;monte_carlo.py` (Zeile 303) (illustrative)
   - Kontext: Vollständige Implementierung, die Equity-Curves aus Backtest-Results lädt
   - Vorschlag: Integration mit Backtest-Registry
@@ -118,14 +118,14 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
   - Evidence: `docs/ops/evidence/EV_TECH_DEBT_C_20260128.md`
   - Fundstellen: `src/experiments/equity_loader.py`, `src/experiments/monte_carlo.py`, `tests/experiments/test_equity_loader.py`
 
-- [ ] Vollständige Monte-Carlo-Robustness-Implementierung
+- [x] Vollständige Monte-Carlo-Robustness-Implementierung
   - Fundstelle: `scripts&#47;run_monte_carlo_robustness.py` (Zeile 139) (illustrative)
   - Kontext: Vollständige Implementierung, die Equity-Curves aus Backtest-Results lädt
   - Vorschlag: Integration mit Backtest-Registry
   - Status: implemented (feat/monte-carlo-equity-loader-integration-v1) — `load_returns_for_config` nutzt kanonischen `equity_loader`; kein stiller Dummy-Fallback im Standardpfad; Synthetic nur via `--use-dummy-data`
   - Fundstellen: `scripts/run_monte_carlo_robustness.py`, `src/experiments/equity_loader.py`, `tests/scripts/test_run_monte_carlo_robustness_equity_loader_integration_v1.py`
 
-- [ ] Vollständige Portfolio-Robustness-Returns-Loader-Implementierung
+- [x] Vollständige Portfolio-Robustness-Returns-Loader-Implementierung
   - Fundstelle: `scripts&#47;run_portfolio_robustness.py` (Zeile 99) (illustrative)
   - Kontext: Sweep-basierter Returns-Loader mit stiller None-Rückgabe bei Ladefehlern
   - Vorschlag: Kanonischen `equity_loader` via `load_returns_for_config` nutzen; fail-closed wie Monte-Carlo (#4215)


### PR DESCRIPTION
## Summary

Schließt genau vier zusammengehörige Kat-C-Backlog-Einträge in `docs/TECH_DEBT_BACKLOG.md`, deren funktionale Implementierung bereits vollständig im kanonischen `equity_loader`-Owner (`src/experiments/equity_loader.py`) und zugehörigen Tests vorliegt.

**Geschlossene Einträge:**
1. Vollständige Stress-Test-Implementierung
2. Vollständige Monte-Carlo-Implementierung
3. Vollständige Monte-Carlo-Robustness-Implementierung
4. Vollständige Portfolio-Robustness-Returns-Loader-Implementierung

**Gemeinsamer Implementierungsowner:** `src/experiments/equity_loader.py`

**Implementation Evidence:**
- PR #1023 (merge `d218e201`) — kanonischer `equity_loader`; Integration in `stress_tests.py` und `monte_carlo.py`
- PR #1024 (merge `acab43a1`) — Docs/Evidence für Stress-Test + Monte-Carlo
- PR #4215 (merge `115c8533`) — Monte-Carlo-Robustness CLI fail-closed via `load_returns_for_config`
- PR #4217 (merge `1b9d3555`) — Portfolio-Robustness fail-closed via `build_returns_loader` / `load_returns_for_config`

**Kanonische Test-Owner:**
- `tests/experiments/test_equity_loader.py`
- `tests/scripts/test_run_monte_carlo_robustness_equity_loader_integration_v1.py`
- `tests/scripts/test_run_portfolio_robustness_equity_loader_integration_v1.py`

Docs-only; keine Produktionscode-, Test- oder Workflow-Änderungen.

## Test plan

- [x] Docs Token Policy Guard (`validate_docs_token_policy.py --changed --base origin/main`) — RC=0
- [x] Diff-Validierung: exakt 1 Datei, exakt 4 Checkbox-Closes
- [ ] CI docs-token-policy-gate (automatisch)


Made with [Cursor](https://cursor.com)