### PR TITLE
docs(tech-debt): close timeframe inference backlog

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -88,7 +88,7 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
   - Kontext: Später echten Exchange-Client integrieren (z.B. Kraken)
   - Vorschlag: Integration mit `src&#47;exchange&#47;kraken_testnet.py` oder `src&#47;exchange&#47;ccxt_client.py`
 
-- [ ] Timeframe aus Daten ableiten in `run_shadow_execution.py`
+- [x] Timeframe aus Daten ableiten in `run_shadow_execution.py`
   - Fundstelle: `scripts&#47;run_shadow_execution.py` (Zeile 502) (illustrative)
   - Kontext: Timeframe aktuell hardcoded, sollte aus Daten abgeleitet werden
   - Vorschlag: Automatische Erkennung aus DataFrame-Index oder Config


### PR DESCRIPTION
## Summary
- Schließt den Backlog-Eintrag „Timeframe aus Daten ableiten in `run_shadow_execution.py`“ (Checkbox `[ ]` → `[x]`).
- Implementierung bereits via PR #1021 (Merge `3d6aee01aee77373a190a509e93a38c7d5298ffc`) und Evidence/Docs via PR #1022 (Merge `7b16a509e9ffcf56c9a5996ba6bcc5af3e0b8eec`).
- Kanonischer Implementierungsowner: `scripts/run_shadow_execution.py` (`infer_timeframe_from_index`).
- Kanonischer Test-Owner: `tests/test_timeframe_infer.py`.
- Statische Verifikation ohne Test-/Runtime-Ausführung.
- Docs-only und non-authorizing.

## Test plan
- [x] `validate_docs_token_policy.py --changed --base origin/main`
- [ ] CI (kein lokaler Test-/Runtime-Lauf)


Made with [Cursor](https://cursor.com)