### PR TITLE
docs(tech-debt): close optional plot generation backlog

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -192,7 +192,7 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
 
 ### Plot-Generation
 
-- [ ] Plot-Generation optional machen für Performance-Benchmarks
+- [x] Plot-Generation optional machen für Performance-Benchmarks
   - Kontext: siehe `docs/PERFORMANCE_NOTES.md`, Abschnitt 5
   - Idee: `--no-plots` Flag für reine Performance-Benchmarks
   - Vorschlag: Asynchrone Plot-Generierung (später)


### PR DESCRIPTION
## Summary

Schließt den stale Backlog-Eintrag **Plot-Generation optional machen für Performance-Benchmarks** in `docs/TECH_DEBT_BACKLOG.md` (Checkbox `[ ]` → `[x]`).

## Evidence

- **Backlog-Eintrag:** Plot-Generation optional machen für Performance-Benchmarks (`docs/TECH_DEBT_BACKLOG.md`, Zeile 195)
- **PR #1025** (MERGED): `1cf7c45c963066f57c26e693d9fafab815e15b78` — `techdebt(E): add --no-plots flag (no chart artifacts)`
- **PR #1026** (MERGED): `597b27035486b6849b0ec46c892713d382439529` — docs/ops evidence + backlog status

## Kanonische Implementierungs-Owner

- `scripts/run_strategy_from_config.py` — `--no-plots` → `save_plots_flag=not args.no_plots`
- `scripts/run_portfolio_backtest.py` — `--no-plots` → `save_plots_flag=not args.no_plots`
- `src/backtest/reporting.py` — `save_full_report(..., save_plots_flag=...)` mit Plot-Guard

## Test-Owner

- `tests/backtest/test_reporting_no_plots.py` — keine PNG-Artefakte, HTML ohne PNG-Refs
- `tests/scripts/test_no_plots_cli_wiring.py` — CLI-Flag und Wiring statisch verifiziert

## Verifikation

- Statische Verifikation des CLI-to-reporting-Durchgriffs (keine Test-/Runtime-Ausführung)
- Docs-only, non-authorizing
- Exakt eine Datei, exakt eine Checkbox-Änderung

## Test plan

- [ ] Docs token policy guard
- [ ] CI checks (kein manueller Rerun)


Made with [Cursor](https://cursor.com)