### PR TITLE
feat(research): add quiet mode to sweep strategy CLI

### DIFF
--- a/docs/TECH_DEBT_BACKLOG.md
+++ b/docs/TECH_DEBT_BACKLOG.md
@@ -207,7 +207,7 @@ Dieses Dokument sammelt bewusst aufgeschobene Tech-Debt-Items und größere TODO
   - Kontext: siehe `docs/PERFORMANCE_NOTES.md`, Abschnitt 5
   - Idee: „Benchmark-/Silent"-Mode für Logs
   - Vorschlag: Batch-weiser Output statt einzelner Log-Zeilen
-  - Fortschritt (PR feat/research-run-logging-silent-mode-v1): `--quiet` für `scripts/sweep_parameters.py` über kanonischen Owner `src/sweeps/engine.py` (`SweepRunOutputMode`, `apply_sweep_run_logging`); verbleibend: `research_cli.py`, `run_sweep_strategy.py`, `run_strategy_sweep.py`, Batch-Output
+  - Fortschritt (PR feat/research-run-logging-silent-mode-v1): `--quiet` für `scripts/sweep_parameters.py`; (PR feat/research-run-quiet-run-sweep-strategy-v1): `--quiet` für `scripts/run_sweep_strategy.py` über kanonischen Owner `src/sweeps/engine.py` (`SweepRunOutputMode`, `apply_sweep_run_logging`); verbleibend: `research_cli.py`, `run_strategy_sweep.py`, Batch-Output
 
 ### pandas-Optimierungen
 

--- a/scripts/run_sweep_strategy.py
+++ b/scripts/run_sweep_strategy.py
@@ -55,7 +55,7 @@ import json
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -69,6 +69,11 @@ from src.sweeps import (
     SweepEngine,
     SweepSummary,
     expand_parameter_grid,
+)
+from src.sweeps.engine import (
+    SweepRunOutputMode,
+    apply_sweep_run_logging,
+    restore_sweep_run_logging,
 )
 from src.strategies.registry import (
     get_available_strategy_keys,
@@ -226,6 +231,12 @@ Examples:
         "-v",
         action="store_true",
         help="Ausführliche Ausgabe",
+    )
+    output_group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Silent-Modus: hochfrequente Progress-/INFO-Ausgaben unterdrücken (Warnungen/Fehler bleiben).",
     )
 
     # Config
@@ -589,6 +600,16 @@ def _write_sweep_diagnostics(
 def main(argv: Optional[List[str]] = None) -> int:
     """Main-Entry-Point für Strategy Sweep (Phase 20)."""
     args = parse_args(argv)
+    previous_log_level = apply_sweep_run_logging(args.quiet)
+    output = SweepRunOutputMode(quiet=args.quiet)
+    try:
+        return _run_main(args, output)
+    finally:
+        restore_sweep_run_logging(previous_log_level)
+
+
+def _run_main(args: argparse.Namespace, output: SweepRunOutputMode) -> int:
+    """Sweep-CLI-Hauptlogik (Logging-State wird von ``main`` wiederhergestellt)."""
 
     # List strategies mode
     if args.list_strategies:
@@ -606,30 +627,30 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(f"Verfügbar: {', '.join(sorted(available))}")
         return 1
 
-    print("\n" + "=" * 70)
-    print("Peak_Trade: Hyperparameter Sweep (Phase 20)")
-    print("=" * 70)
+    output.info("\n" + "=" * 70)
+    output.info("Peak_Trade: Hyperparameter Sweep (Phase 20)")
+    output.info("=" * 70)
 
     # 1) Parameter-Grid laden
-    print(f"\n[1/4] Parameter-Grid laden...")
+    output.info(f"\n[1/4] Parameter-Grid laden...")
     try:
         if args.grid:
             param_grid = load_parameter_grid(args.grid)
-            print(f"  Grid aus: {args.grid}")
+            output.info(f"  Grid aus: {args.grid}")
         elif args.params:
             param_grid = parse_cli_params(args.params)
-            print(f"  Grid aus CLI-Parametern")
+            output.info(f"  Grid aus CLI-Parametern")
         else:
             print("FEHLER: Kein Parameter-Grid angegeben.")
             print("  Verwende --grid <DATEI/JSON> oder --param KEY=VAL1,VAL2,...")
             return 1
 
         combinations = expand_parameter_grid(param_grid)
-        print(f"  Parameter: {list(param_grid.keys())}")
-        print(f"  Kombinationen: {len(combinations)}")
+        output.info(f"  Parameter: {list(param_grid.keys())}")
+        output.info(f"  Kombinationen: {len(combinations)}")
 
         if args.max_runs and len(combinations) > args.max_runs:
-            print(f"  Limitiert auf: {args.max_runs} Runs")
+            output.info(f"  Limitiert auf: {args.max_runs} Runs")
 
     except Exception as e:
         print(f"FEHLER beim Laden des Grids: {e}")
@@ -637,41 +658,41 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     # Dry-Run: nur Kombinationen anzeigen
     if args.dry_run:
-        print(f"\n[DRY-RUN] Folgende {len(combinations)} Kombinationen würden getestet:")
+        output.info(f"\n[DRY-RUN] Folgende {len(combinations)} Kombinationen würden getestet:")
         for i, combo in enumerate(combinations[:50], 1):
-            print(f"  {i:>3}. {combo}")
+            output.info(f"  {i:>3}. {combo}")
         if len(combinations) > 50:
-            print(f"  ... und {len(combinations) - 50} weitere")
+            output.info(f"  ... und {len(combinations) - 50} weitere")
         print("\n(Kein Backtest ausgeführt)")
         return 0
 
     # 2) Config validieren
-    print(f"\n[2/4] Config validieren...")
+    output.info(f"\n[2/4] Config validieren...")
     config_path = Path(args.config)
     if not config_path.exists():
         print(f"FEHLER: Config nicht gefunden: {config_path}")
         return 1
-    print(f"  Config: {config_path}")
+    output.info(f"  Config: {config_path}")
 
     # 3) Daten laden
-    print(f"\n[3/4] OHLCV-Daten laden...")
+    output.info(f"\n[3/4] OHLCV-Daten laden...")
     try:
         data = load_ohlcv_data(
             data_file=args.data_file,
             n_bars=args.bars,
-            verbose=args.verbose,
+            verbose=args.verbose and not args.quiet,
         )
-        print(f"  {len(data)} Bars geladen")
-        print(f"  Zeitraum: {data.index[0]} bis {data.index[-1]}")
+        output.info(f"  {len(data)} Bars geladen")
+        output.info(f"  Zeitraum: {data.index[0]} bis {data.index[-1]}")
     except Exception as e:
         print(f"FEHLER: {e}")
         return 1
 
     # 4) Sweep ausführen
-    print(f"\n[4/4] Sweep ausführen...")
-    print(f"  Strategie: {args.strategy}")
-    print(f"  Symbol: {args.symbol}")
-    print(f"  Timeframe: {args.timeframe}")
+    output.info(f"\n[4/4] Sweep ausführen...")
+    output.info(f"  Strategie: {args.strategy}")
+    output.info(f"  Symbol: {args.symbol}")
+    output.info(f"  Timeframe: {args.timeframe}")
 
     # Progress-Callback
     def progress_callback(current: int, total: int, params: Dict) -> None:
@@ -680,6 +701,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         else:
             pct = current / total * 100
             print(f"\r  Fortschritt: {current}/{total} ({pct:.0f}%)", end="", flush=True)
+
+    progress_cb: Optional[Callable[[int, int, Dict], None]] = None
+    if not args.quiet:
+        progress_cb = progress_callback
 
     try:
         config = SweepConfig(
@@ -696,8 +721,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         )
 
         engine = SweepEngine(
-            verbose=args.verbose,
-            progress_callback=None if args.verbose else progress_callback,
+            verbose=args.verbose and not args.quiet,
+            progress_callback=progress_cb,
         )
 
         def diagnostics_callback(

--- a/tests/test_sweep_run_contract.py
+++ b/tests/test_sweep_run_contract.py
@@ -368,3 +368,324 @@ def test_load_sweep_ohlcv_data_quiet_suppresses_info_but_keeps_warning(
     assert not any("Sweep data cache hit" in msg for msg in info_messages)
     assert not any("Sweep data cache miss" in msg for msg in info_messages)
     assert any("Sweep data cache corrupt" in msg for msg in warning_messages)
+
+
+def _run_sweep_strategy_common_mocks(monkeypatch, tmp_path, *, summary=None, engine_error=None):
+    """Shared offline mocks for run_sweep_strategy contract tests."""
+    import pandas as pd
+    from unittest.mock import MagicMock
+
+    import run_sweep_strategy as rss
+
+    cfg = ROOT / "config" / "config.test.toml"
+    if not cfg.is_file():
+        pytest.skip(f"fehlt: {cfg}")
+
+    index = pd.date_range("2024-01-01", periods=10, freq="1h", tz="UTC")
+    dummy_data = pd.DataFrame(
+        {
+            "open": [100.0] * 10,
+            "high": [101.0] * 10,
+            "low": [99.0] * 10,
+            "close": [100.5] * 10,
+            "volume": [500.0] * 10,
+        },
+        index=index,
+    )
+
+    if summary is None:
+        from src.sweeps.engine import SweepResult, SweepSummary
+
+        best = SweepResult(
+            params={"fast_window": 20},
+            stats={
+                "total_return": 0.05,
+                "sharpe": 1.2,
+                "max_drawdown": -0.1,
+                "total_trades": 3,
+            },
+            run_id="test_run",
+            success=True,
+        )
+        summary = SweepSummary(
+            sweep_id="sweep_test",
+            sweep_name="ma_crossover_sweep_test",
+            strategy_key="ma_crossover",
+            symbol="BTC/EUR",
+            timeframe="1h",
+            total_combinations=1,
+            runs_executed=1,
+            successful_runs=1,
+            failed_runs=0,
+            results=[best],
+            best_result=best,
+            duration_seconds=0.1,
+            started_at="2024-01-01T00:00:00Z",
+            completed_at="2024-01-01T00:00:01Z",
+        )
+
+    captured_configs: list = []
+
+    class MockEngine:
+        def __init__(self, verbose=False, progress_callback=None):
+            self.verbose = verbose
+            self.progress_callback = progress_callback
+
+        def run_sweep(self, config, data, skip_registry=False, diagnostics_callback=None):
+            captured_configs.append(config)
+            if engine_error is not None:
+                raise engine_error
+            if self.progress_callback:
+                self.progress_callback(1, 1, {"fast_window": 20})
+            return summary
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(rss, "SweepEngine", MockEngine)
+    monkeypatch.setattr(rss, "load_ohlcv_data", lambda **_kw: dummy_data)
+    return rss, cfg, captured_configs
+
+
+def test_run_sweep_strategy_quiet_flag_parsed() -> None:
+    import run_sweep_strategy as rss
+
+    args = rss.parse_args(["--quiet", "--strategy", "ma_crossover", "--param", "fast_window=20"])
+    assert args.quiet is True
+    args_short = rss.parse_args(["-q", "--strategy", "ma_crossover", "--param", "fast_window=20"])
+    assert args_short.quiet is True
+
+
+def test_run_sweep_strategy_default_mode_preserves_progress_output(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    rss, cfg, _ = _run_sweep_strategy_common_mocks(monkeypatch, tmp_path)
+
+    code = rss.main(
+        [
+            "--strategy",
+            "ma_crossover",
+            "--param",
+            "fast_window=20",
+            "--config",
+            str(cfg),
+            "--no-registry",
+            "--max-runs",
+            "1",
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "[1/4] Parameter-Grid laden" in out
+    assert "Fortschritt:" in out or "[1/1]" in out
+
+
+def test_run_sweep_strategy_quiet_mode_suppresses_high_frequency_output(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    rss, cfg, _ = _run_sweep_strategy_common_mocks(monkeypatch, tmp_path)
+
+    code = rss.main(
+        [
+            "--strategy",
+            "ma_crossover",
+            "--param",
+            "fast_window=20",
+            "--config",
+            str(cfg),
+            "--no-registry",
+            "--max-runs",
+            "1",
+            "--quiet",
+        ]
+    )
+    assert code == 0
+    captured = capsys.readouterr()
+    assert "[1/4] Parameter-Grid laden" not in captured.out
+    assert "Fortschritt:" not in captured.out
+    assert "[4/4] Sweep ausführen" not in captured.out
+
+
+def test_run_sweep_strategy_quiet_mode_preserves_completion_output(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    rss, cfg, _ = _run_sweep_strategy_common_mocks(monkeypatch, tmp_path)
+
+    code = rss.main(
+        [
+            "--strategy",
+            "ma_crossover",
+            "--param",
+            "fast_window=20",
+            "--config",
+            str(cfg),
+            "--no-registry",
+            "--max-runs",
+            "1",
+            "--quiet",
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "SWEEP ABGESCHLOSSEN" in out
+    assert "TOP" in out
+
+
+def test_run_sweep_strategy_quiet_mode_preserves_export_path_output(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    rss, cfg, _ = _run_sweep_strategy_common_mocks(monkeypatch, tmp_path)
+    export_path = tmp_path / "results.csv"
+
+    code = rss.main(
+        [
+            "--strategy",
+            "ma_crossover",
+            "--param",
+            "fast_window=20",
+            "--config",
+            str(cfg),
+            "--no-registry",
+            "--max-runs",
+            "1",
+            "--quiet",
+            "--export",
+            str(export_path),
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "Ergebnisse exportiert nach:" in out
+    assert str(export_path) in out
+
+
+def test_run_sweep_strategy_quiet_mode_preserves_errors(tmp_path, monkeypatch, capsys) -> None:
+    rss, cfg, _ = _run_sweep_strategy_common_mocks(
+        monkeypatch, tmp_path, engine_error=RuntimeError("simulated sweep failure")
+    )
+
+    code = rss.main(
+        [
+            "--strategy",
+            "ma_crossover",
+            "--param",
+            "fast_window=20",
+            "--config",
+            str(cfg),
+            "--no-registry",
+            "--max-runs",
+            "1",
+            "--quiet",
+        ]
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "FEHLER beim Sweep: simulated sweep failure" in out
+
+
+def test_run_sweep_strategy_quiet_mode_restores_logging_after_success() -> None:
+    import logging
+    from unittest.mock import patch
+
+    import run_sweep_strategy as rss
+    from src.sweeps.engine import logger as sweep_logger
+
+    baseline = sweep_logger.level
+    with patch.object(rss, "_run_main", return_value=0):
+        assert rss.main(["--quiet", "--list-strategies"]) == 0
+    assert sweep_logger.level == baseline
+
+
+def test_run_sweep_strategy_quiet_mode_restores_logging_after_exception() -> None:
+    import logging
+    from unittest.mock import patch
+
+    import run_sweep_strategy as rss
+    from src.sweeps.engine import logger as sweep_logger
+
+    baseline = sweep_logger.level
+    with patch.object(rss, "_run_main", side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError, match="boom"):
+            rss.main(["--quiet", "--list-strategies"])
+    assert sweep_logger.level == baseline
+
+
+def test_run_sweep_strategy_multiple_quiet_calls_do_not_duplicate_handlers() -> None:
+    import logging
+    from unittest.mock import patch
+
+    import run_sweep_strategy as rss
+    from src.sweeps.engine import logger as sweep_logger
+
+    baseline_handlers = len(sweep_logger.handlers)
+    with patch.object(rss, "_run_main", return_value=0):
+        rss.main(["--quiet", "--list-strategies"])
+        rss.main(["--quiet", "--list-strategies"])
+    assert len(sweep_logger.handlers) == baseline_handlers
+
+
+def test_run_sweep_strategy_quiet_does_not_change_sweep_config(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    rss, cfg, captured_default = _run_sweep_strategy_common_mocks(monkeypatch, tmp_path)
+    rss.main(
+        [
+            "--strategy",
+            "ma_crossover",
+            "--param",
+            "fast_window=20",
+            "--config",
+            str(cfg),
+            "--no-registry",
+            "--max-runs",
+            "1",
+        ]
+    )
+    capsys.readouterr()
+
+    rss2, cfg2, captured_quiet = _run_sweep_strategy_common_mocks(monkeypatch, tmp_path)
+    rss2.main(
+        [
+            "--strategy",
+            "ma_crossover",
+            "--param",
+            "fast_window=20",
+            "--config",
+            str(cfg2),
+            "--no-registry",
+            "--max-runs",
+            "1",
+            "--quiet",
+        ]
+    )
+    capsys.readouterr()
+
+    assert len(captured_default) == 1
+    assert len(captured_quiet) == 1
+    default_cfg = captured_default[0]
+    quiet_cfg = captured_quiet[0]
+    assert default_cfg.strategy_key == quiet_cfg.strategy_key
+    assert default_cfg.param_grid == quiet_cfg.param_grid
+    assert default_cfg.symbol == quiet_cfg.symbol
+    assert default_cfg.timeframe == quiet_cfg.timeframe
+    assert default_cfg.max_runs == quiet_cfg.max_runs
+    assert default_cfg.sort_by == quiet_cfg.sort_by
+    assert default_cfg.sort_ascending == quiet_cfg.sort_ascending
+    assert default_cfg.config_path == quiet_cfg.config_path
+
+
+def test_run_sweep_strategy_quiet_warning_visible_via_logger(caplog) -> None:
+    import logging
+
+    from src.sweeps.engine import (
+        apply_sweep_run_logging,
+        logger as sweep_logger,
+        restore_sweep_run_logging,
+    )
+
+    previous = apply_sweep_run_logging(quiet=True)
+    try:
+        with caplog.at_level(logging.WARNING, logger=sweep_logger.name):
+            sweep_logger.warning("quiet-mode-warning-check")
+    finally:
+        restore_sweep_run_logging(previous)
+
+    assert any("quiet-mode-warning-check" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Kanonischer Logging-/Output-Owner: `src/sweeps/engine.py` (`SweepRunOutputMode`, `apply_sweep_run_logging`, `restore_sweep_run_logging`)
- Unterstützter Entrypoint: `scripts/run_sweep_strategy.py` mit `--quiet` / `-q`
- Default-Verhalten unverändert: Phase-Schritte `[1/4]`–`[4/4]`, Grid-/Progress-Ausgaben und Fortschrittsanzeige bleiben sichtbar
- Quiet-Vertrag: hochfrequente per-Run-, Grid-, Parameter- und Progress-Ausgaben werden unterdrückt; Abschlussstatus (`SWEEP ABGESCHLOSSEN`), Ergebnistabelle, Export-Pfade bleiben sichtbar
- Warning-/Error-/Exception-Vertrag: Warnungen und Fehler bleiben sichtbar; Exceptions und Exit-Codes unverändert
- State-Restore: Logging-Level wird im `finally`-Pfad nach Erfolg und Exception wiederhergestellt; keine Handler-Duplizierung
- Gezielte Offline-Contract-Tests in `tests/test_sweep_run_contract.py` (Mocks/monkeypatch/capsys, kein echter Sweep/Backtest/Netzwerk)
- Backlog-Eintrag bleibt offen (`BACKLOG_ENTRY_CLOSED=false`); verbleibend: Phase-41-Pfade, `research_cli.py`, Batch-Output

## Test plan

- [x] `ruff format --check` auf geänderten Python-Dateien
- [x] `ruff check` auf geänderten Python-Dateien
- [x] `pytest tests/test_sweep_run_contract.py` (23 Tests, offline)
- [x] Docs Token Policy Guard (geänderte Docs)
- [x] `scripts/sweep_parameters.py`-Vertrag unverändert kompatibel

## Explizite Ausschlüsse

- Keine Phase-41-Änderungen
- Keine `research_cli.py`-Änderung
- Keine Batch-Output-Implementierung

Made with [Cursor](https://cursor.com)