### PR TITLE
perf(strategy): vectorize vol regime rolling percentile

### DIFF
--- a/src/strategies/vol_regime_filter.py
+++ b/src/strategies/vol_regime_filter.py
@@ -23,6 +23,7 @@ import pandas as pd
 import numpy as np
 
 from .base import BaseStrategy, StrategyMetadata
+from .vol_breakout import _rolling_last_pct_rank
 
 
 class VolRegimeFilter(BaseStrategy):
@@ -434,9 +435,11 @@ class VolRegimeFilter(BaseStrategy):
         # Perzentil-basierter Filter
         if self.vol_percentile_low is not None or self.vol_percentile_high is not None:
             # Rolling Perzentil berechnen
-            vol_percentile = vol.rolling(
-                window=self.lookback_percentile, min_periods=self.vol_window
-            ).apply(lambda x: pd.Series(x).rank(pct=True).iloc[-1] * 100, raw=False)
+            vol_percentile = _rolling_last_pct_rank(
+                vol,
+                window=self.lookback_percentile,
+                min_periods=self.vol_window,
+            )
 
             if self.vol_percentile_low is not None:
                 # Blockiere wenn Vol-Perzentil unter dem Minimum

--- a/tests/test_strategy_vol_regime_filter.py
+++ b/tests/test_strategy_vol_regime_filter.py
@@ -9,8 +9,72 @@ import pytest
 import pandas as pd
 import numpy as np
 
+from src.strategies.vol_breakout import _rolling_last_pct_rank
 from src.strategies.vol_regime_filter import VolRegimeFilter, generate_signals
 from src.strategies.base import BaseStrategy
+
+
+def _legacy_rolling_last_pct_rank_reference(
+    series: pd.Series,
+    window: int,
+    min_periods: int,
+) -> pd.Series:
+    """Test-only reference for legacy rolling().apply(rank(pct=True)) semantics."""
+    return series.rolling(window=window, min_periods=min_periods).apply(
+        lambda x: pd.Series(x).rank(pct=True).iloc[-1] * 100,
+        raw=False,
+    )
+
+
+def _assert_pct_rank_series_equal(actual: pd.Series, expected: pd.Series) -> None:
+    pd.testing.assert_series_equal(actual, expected, check_names=False)
+    assert actual.index.equals(expected.index)
+    pd.testing.assert_index_equal(actual.index, expected.index)
+    assert actual.dtype == expected.dtype
+    assert actual.isna().equals(expected.isna())
+
+
+def _reference_vol_regime_filter_filter_signals(
+    vol_filter: VolRegimeFilter,
+    data: pd.DataFrame,
+) -> pd.Series:
+    """Independent filter-mode reference using legacy rolling percentile semantics."""
+    vol = vol_filter._compute_volatility(data)
+    filter_signal = pd.Series(1, index=data.index, dtype=int)
+
+    if vol_filter.vol_percentile_low is not None or vol_filter.vol_percentile_high is not None:
+        vol_percentile = _legacy_rolling_last_pct_rank_reference(
+            vol,
+            window=vol_filter.lookback_percentile,
+            min_periods=vol_filter.vol_window,
+        )
+        if vol_filter.vol_percentile_low is not None:
+            filter_signal = filter_signal.where(vol_percentile >= vol_filter.vol_percentile_low, 0)
+        if vol_filter.vol_percentile_high is not None:
+            filter_signal = filter_signal.where(vol_percentile <= vol_filter.vol_percentile_high, 0)
+
+    if vol_filter.min_vol is not None:
+        filter_signal = filter_signal.where(vol >= vol_filter.min_vol, 0)
+    if vol_filter.max_vol is not None:
+        filter_signal = filter_signal.where(vol <= vol_filter.max_vol, 0)
+
+    if vol_filter.atr_threshold is not None:
+        if vol_filter.vol_method != "atr":
+            if "high" in data.columns and "low" in data.columns:
+                atr = vol_filter._compute_atr(data)
+                filter_signal = filter_signal.where(atr >= vol_filter.atr_threshold, 0)
+        else:
+            filter_signal = filter_signal.where(vol >= vol_filter.atr_threshold, 0)
+
+    if vol_filter.invert:
+        filter_signal = 1 - filter_signal
+
+    for i in range(min(vol_filter.min_bars, len(data))):
+        filter_signal.iloc[i] = 0
+
+    filter_signal = filter_signal.fillna(0).astype(int)
+    filter_signal.name = "vol_filter"
+    return filter_signal
 
 
 # ============================================================================
@@ -544,3 +608,126 @@ class TestVolRegimeNewFeatures:
         # from_config sollte regime_mode=True setzen wenn Thresholds vorhanden
         # Hier testen wir nur die Instanz
         assert filter_auto.low_vol_threshold == 50.0
+
+
+# ============================================================================
+# GOLDEN REFERENCE: ROLLING PERCENTILE RANK (CAND-VRF-ROLL-PCT)
+# ============================================================================
+
+
+class TestVolRegimeFilterRollingPercentileGolden:
+    """Golden-reference contracts for vol percentile rolling rank semantics."""
+
+    @pytest.mark.parametrize(
+        ("values", "window", "min_periods"),
+        [
+            pytest.param([1.0, 2.0, 3.0, 4.0, 5.0], 3, 2, id="normal_ascending"),
+            pytest.param([5.0, 4.0, 3.0, 2.0, 1.0], 3, 2, id="descending"),
+            pytest.param([1.0, 2.0, 2.0, 2.0, 3.0], 4, 2, id="ties"),
+            pytest.param([1.0, np.nan, 3.0, 4.0, 5.0], 3, 2, id="nan_in_window"),
+            pytest.param([1.0, 2.0], 5, 2, id="partial_window"),
+            pytest.param([2.0, 2.0, 2.0], 3, 3, id="exact_window"),
+            pytest.param(list(range(1, 9)), 4, 2, id="multi_window"),
+            pytest.param([7.0] * 6, 4, 2, id="constant_input"),
+        ],
+    )
+    def test_vol_percentile_rank_matches_legacy_reference(
+        self,
+        values: list[float],
+        window: int,
+        min_periods: int,
+    ) -> None:
+        idx = pd.date_range("2024-01-01", periods=len(values), freq="h", tz="UTC")
+        series = pd.Series(values, index=idx, dtype=float)
+        expected = _legacy_rolling_last_pct_rank_reference(series, window, min_periods)
+        actual = _rolling_last_pct_rank(series, window, min_periods)
+        _assert_pct_rank_series_equal(actual, expected)
+
+    @pytest.mark.parametrize(
+        "data_factory",
+        [
+            pytest.param(create_ohlcv_data, id="ohlcv"),
+            pytest.param(create_mixed_volatility_data, id="mixed_vol"),
+            pytest.param(create_low_volatility_data, id="low_vol"),
+            pytest.param(create_high_volatility_data, id="high_vol"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "vol_method",
+        ["atr", "std", "realized", "range"],
+    )
+    def test_generate_signals_matches_independent_legacy_reference(
+        self,
+        data_factory,
+        vol_method: str,
+    ) -> None:
+        df = data_factory(200)
+        vol_filter = VolRegimeFilter(
+            vol_window=14,
+            vol_method=vol_method,
+            vol_percentile_low=25,
+            vol_percentile_high=75,
+            lookback_percentile=50,
+            min_bars=20,
+        )
+        actual = vol_filter.generate_signals(df)
+        expected = _reference_vol_regime_filter_filter_signals(vol_filter, df)
+        pd.testing.assert_series_equal(actual, expected)
+        assert actual.index.equals(expected.index)
+        assert actual.dtype == expected.dtype
+        assert actual.isna().equals(expected.isna())
+
+    def test_vol_regime_filter_percentile_on_computed_vol_matches_legacy_reference(
+        self,
+    ) -> None:
+        df = create_ohlcv_data(200)
+        vol_filter = VolRegimeFilter(vol_window=14, lookback_percentile=50)
+        vol = vol_filter._compute_volatility(df)
+        expected_pct = _legacy_rolling_last_pct_rank_reference(
+            vol,
+            window=vol_filter.lookback_percentile,
+            min_periods=vol_filter.vol_window,
+        )
+        actual_pct = _rolling_last_pct_rank(
+            vol,
+            window=vol_filter.lookback_percentile,
+            min_periods=vol_filter.vol_window,
+        )
+        _assert_pct_rank_series_equal(actual_pct, expected_pct)
+
+    def test_vol_regime_filter_generate_signals_uses_canonical_helper(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        df = create_ohlcv_data(200)
+        vol_filter = VolRegimeFilter(
+            vol_window=14,
+            vol_percentile_low=25,
+            vol_percentile_high=75,
+            lookback_percentile=50,
+        )
+        calls: list[tuple[int, int]] = []
+
+        def _spy(series: pd.Series, window: int, min_periods: int) -> pd.Series:
+            calls.append((window, min_periods))
+            return _rolling_last_pct_rank(series, window=window, min_periods=min_periods)
+
+        apply_calls: list[object] = []
+        original_apply = pd.core.window.rolling.Rolling.apply
+
+        def _apply_spy(self, func, *args, **kwargs):
+            apply_calls.append(func)
+            return original_apply(self, func, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "src.strategies.vol_regime_filter._rolling_last_pct_rank",
+            _spy,
+        )
+        monkeypatch.setattr(pd.core.window.rolling.Rolling, "apply", _apply_spy)
+
+        signals = vol_filter.generate_signals(df)
+
+        assert signals is not None
+        assert len(calls) == 1
+        assert calls[0] == (vol_filter.lookback_percentile, vol_filter.vol_window)
+        assert not apply_calls


### PR DESCRIPTION
## Summary
- Ersetzt `rolling().apply(rank pct)` in `VolRegimeFilter.generate_signals` durch den kanonischen Helper `_rolling_last_pct_rank` aus `vol_breakout.py`.
- Ergänzt unabhängige Golden-Reference-Tests (Legacy-`apply`-Semantik) für Perzentilrang, Signaloutput und Helper-Wiring.

## Test plan
- [x] Golden-Reference vor Migration (25/25)
- [x] Golden-Reference nach Migration (26/26)
- [x] `tests/test_strategy_vol_regime_filter.py` (53/53)
- [x] `test_load_strategy_vol_regime_filter_matches_direct_oop_output`
- [x] `ruff format --check` und `ruff check` auf erwarteten Dateien


Made with [Cursor](https://cursor.com)