### PR TITLE
perf(strategy): vectorize el karoui regime classification

### DIFF
--- a/src/strategies/el_karoui/vol_model.py
+++ b/src/strategies/el_karoui/vol_model.py
@@ -413,7 +413,19 @@ class ElKarouiVolModel:
         vol = self.calculate_realized_vol(returns)
         percentiles = self.calculate_vol_percentile(vol)
 
-        regimes = percentiles.apply(lambda x: self.regime_for_percentile(x).value)
+        if len(percentiles) == 0:
+            return pd.Series([], dtype=np.float64, index=percentiles.index, name=percentiles.name)
+
+        low = self.config.low_threshold
+        high = self.config.high_threshold
+        valid = percentiles.notna()
+        regimes = pd.Series(
+            VolRegime.MEDIUM.value,
+            index=percentiles.index,
+            name=percentiles.name,
+        )
+        regimes = regimes.mask(valid & (percentiles < low), VolRegime.LOW.value)
+        regimes = regimes.mask(valid & (percentiles > high), VolRegime.HIGH.value)
 
         return regimes
 

--- a/tests/strategies/el_karoui/test_vol_model.py
+++ b/tests/strategies/el_karoui/test_vol_model.py
@@ -495,3 +495,194 @@ class TestModelRepr:
         assert "window=" in repr_str
         assert "thresholds=" in repr_str
         assert "target=" in repr_str
+
+
+# =============================================================================
+# GOLDEN REFERENCE: regime_series apply semantics
+# =============================================================================
+
+
+def _legacy_regime_for_percentile_value_reference(
+    percentile: float,
+    low_threshold: float,
+    high_threshold: float,
+) -> str:
+    """Test-only reference for legacy element-wise regime_for_percentile().value mapping."""
+    if pd.isna(percentile):
+        return VolRegime.MEDIUM.value
+    if percentile < low_threshold:
+        return VolRegime.LOW.value
+    if percentile > high_threshold:
+        return VolRegime.HIGH.value
+    return VolRegime.MEDIUM.value
+
+
+def _legacy_regime_series_apply_reference(
+    percentiles: pd.Series,
+    low_threshold: float,
+    high_threshold: float,
+) -> pd.Series:
+    """Test-only reference mirroring percentiles.apply(regime_for_percentile).value."""
+    if len(percentiles) == 0:
+        return pd.Series([], dtype=np.float64, index=percentiles.index, name=percentiles.name)
+    return percentiles.apply(
+        lambda x: _legacy_regime_for_percentile_value_reference(x, low_threshold, high_threshold)
+    )
+
+
+def _assert_regime_series_equal(actual: pd.Series, expected: pd.Series) -> None:
+    pd.testing.assert_series_equal(actual, expected, check_names=True)
+    assert actual.index.equals(expected.index)
+    assert actual.dtype == expected.dtype
+    assert actual.isna().equals(expected.isna())
+
+
+class TestRegimeSeriesGoldenReference:
+    """Golden-Reference-Tests für ElKarouiVolModel.regime_series apply-Pfad."""
+
+    @pytest.mark.parametrize(
+        ("percentile_values", "low_threshold", "high_threshold", "expected_values"),
+        [
+            pytest.param([], 0.30, 0.70, [], id="empty"),
+            pytest.param([0.50], 0.30, 0.70, ["normal"], id="single_element"),
+            pytest.param(
+                [0.29, 0.30, 0.31],
+                0.30,
+                0.70,
+                ["low", "normal", "normal"],
+                id="low_boundary_neighbors",
+            ),
+            pytest.param(
+                [0.69, 0.70, 0.71],
+                0.30,
+                0.70,
+                ["normal", "normal", "high"],
+                id="high_boundary_neighbors",
+            ),
+            pytest.param(
+                [0.10, 0.50, 0.90], 0.30, 0.70, ["low", "normal", "high"], id="all_regime_classes"
+            ),
+            pytest.param(
+                [np.nan, 0.50, np.nan], 0.30, 0.70, ["normal", "normal", "normal"], id="nan_values"
+            ),
+            pytest.param(
+                [np.inf, -np.inf, 0.50], 0.30, 0.70, ["high", "low", "normal"], id="infinity_values"
+            ),
+            pytest.param([0.50] * 6, 0.30, 0.70, ["normal"] * 6, id="constant"),
+            pytest.param([0.10, 0.90] * 4, 0.30, 0.70, ["low", "high"] * 4, id="alternating"),
+        ],
+    )
+    def test_legacy_regime_series_apply_reference_semantics(
+        self,
+        percentile_values: list[float],
+        low_threshold: float,
+        high_threshold: float,
+        expected_values: list[str],
+    ) -> None:
+        idx = pd.date_range("2024-01-01", periods=max(len(percentile_values), 1), freq="D")[
+            : len(percentile_values)
+        ]
+        percentiles = pd.Series(percentile_values, index=idx, name="vol_percentile", dtype=float)
+        actual = _legacy_regime_series_apply_reference(percentiles, low_threshold, high_threshold)
+        if len(percentile_values) == 0:
+            assert len(actual) == 0
+            assert actual.dtype == np.float64
+        else:
+            assert actual.tolist() == expected_values
+            assert pd.api.types.is_string_dtype(actual)
+        assert actual.name == "vol_percentile"
+
+    @pytest.mark.parametrize(
+        ("returns_values", "series_name"),
+        [
+            pytest.param([], "empty_returns", id="empty_series"),
+            pytest.param([0.01], "single_return", id="single_element"),
+            pytest.param(
+                list(np.random.RandomState(42).randn(100) * 0.005), "low_vol", id="low_vol"
+            ),
+            pytest.param(
+                list(np.random.RandomState(42).randn(100) * 0.04), "high_vol", id="high_vol"
+            ),
+            pytest.param(
+                list(np.random.RandomState(7).randn(150) * 0.015), "mixed_vol", id="mixed_vol"
+            ),
+        ],
+    )
+    def test_regime_series_matches_legacy_reference(
+        self,
+        returns_values: list[float],
+        series_name: str,
+    ) -> None:
+        idx = pd.date_range("2024-06-01", periods=max(len(returns_values), 1), freq="D")[
+            : len(returns_values)
+        ]
+        returns = pd.Series(returns_values, index=idx, name=series_name, dtype=float)
+        config = ElKarouiVolConfig(
+            vol_window=10,
+            lookback_window=50,
+            low_threshold=0.30,
+            high_threshold=0.70,
+        )
+        model = ElKarouiVolModel(config)
+
+        vol = model.calculate_realized_vol(returns)
+        percentiles = model.calculate_vol_percentile(vol)
+        expected = _legacy_regime_series_apply_reference(
+            percentiles, config.low_threshold, config.high_threshold
+        )
+        actual = model.regime_series(returns)
+        _assert_regime_series_equal(actual, expected)
+
+    def test_regime_series_non_trivial_index(self) -> None:
+        idx = pd.Index([10, 20, 30, 40, 50, 60, 70, 80, 90, 100], name="bar")
+        returns = pd.Series(
+            np.random.RandomState(7).randn(10) * 0.02, index=idx, name="custom_returns"
+        )
+        model = ElKarouiVolModel(
+            ElKarouiVolConfig(
+                vol_window=5, lookback_window=10, low_threshold=0.30, high_threshold=0.70
+            )
+        )
+        vol = model.calculate_realized_vol(returns)
+        percentiles = model.calculate_vol_percentile(vol)
+        expected = _legacy_regime_series_apply_reference(
+            percentiles, model.config.low_threshold, model.config.high_threshold
+        )
+        actual = model.regime_series(returns)
+        _assert_regime_series_equal(actual, expected)
+
+    def test_regime_series_from_config_dict_parity(self) -> None:
+        returns = pd.Series(
+            np.random.RandomState(11).randn(80) * 0.015,
+            index=pd.date_range("2024-03-01", periods=80, freq="D"),
+            name="cfg_returns",
+        )
+        config_dict = {
+            "vol_window": 8,
+            "lookback_window": 40,
+            "low_threshold": 0.25,
+            "high_threshold": 0.75,
+        }
+        model = ElKarouiVolModel.from_config_dict(config_dict)
+        vol = model.calculate_realized_vol(returns)
+        percentiles = model.calculate_vol_percentile(vol)
+        expected = _legacy_regime_series_apply_reference(
+            percentiles, model.config.low_threshold, model.config.high_threshold
+        )
+        actual = model.regime_series(returns)
+        _assert_regime_series_equal(actual, expected)
+
+    def test_regime_series_from_default_parity(self) -> None:
+        returns = pd.Series(
+            np.random.RandomState(13).randn(120) * 0.012,
+            index=pd.date_range("2024-04-01", periods=120, freq="D"),
+            name="default_returns",
+        )
+        model = ElKarouiVolModel.from_default()
+        vol = model.calculate_realized_vol(returns)
+        percentiles = model.calculate_vol_percentile(vol)
+        expected = _legacy_regime_series_apply_reference(
+            percentiles, model.config.low_threshold, model.config.high_threshold
+        )
+        actual = model.regime_series(returns)
+        _assert_regime_series_equal(actual, expected)


### PR DESCRIPTION
## Summary
- Ersetzt `percentiles.apply(lambda x: self.regime_for_percentile(x).value)` in `ElKarouiVolModel.regime_series` durch maskenbasierte Vektorisierung (`notna`, `<`, `>` mit identischer Priorität).
- Ergänzt unabhängige Golden-Reference-Tests im bestehenden Testowner mit Grenz-, NaN-, leerer-Serie-, Index- und Factory-Paritätsfällen.

## Test plan
- [x] Golden Reference vor Migration: 17/17 PASS
- [x] Golden Reference nach Migration: 17/17 PASS
- [x] `python3 -m pytest -q tests/strategies/el_karoui/test_vol_model.py` (57/57)
- [x] Loader/Factory-Tests El Karoui (12/12)
- [x] Import-Check OK
- [x] ruff format/check OK


Made with [Cursor](https://cursor.com)