### PR TITLE
perf(ci): focus strategy and regime owner tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       tests_execute_focused: ${{ steps.test_selection.outputs.tests_execute_focused }}
       tests_execute_no_op: ${{ steps.test_selection.outputs.tests_execute_no_op }}
       focused_pytest_targets: ${{ steps.test_selection.outputs.focused_pytest_targets }}
+      focused_module_imports: ${{ steps.test_selection.outputs.focused_module_imports }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -320,7 +321,7 @@ jobs:
   # ============================================================================
   # Always creates test jobs for all required Python versions (3.9, 3.10, 3.11).
   # On docs-only / workflow-only / static-contract-only PRs, jobs short-circuit SUCCESS (NO_OP).
-  # FOCUSED runs bounded pytest on 3.11 and import smoke on 3.9/3.10.
+  # FOCUSED runs bounded pytest on all matrix versions plus module import smoke.
   # FULL runs the repository test suite with coverage on 3.11.
   # ============================================================================
   tests:
@@ -347,6 +348,7 @@ jobs:
           echo "tests_execute_focused=${{ needs.changes.outputs.tests_execute_focused }}"
           echo "tests_execute_no_op=${{ needs.changes.outputs.tests_execute_no_op }}"
           echo "focused_pytest_targets=${{ needs.changes.outputs.focused_pytest_targets }}"
+          echo "focused_module_imports=${{ needs.changes.outputs.focused_module_imports }}"
 
       - name: NO_OP — skip full matrix tests (diff-aware)
         if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_no_op == 'true' }}
@@ -421,8 +423,8 @@ jobs:
         run: |
           pytest tests/ -v --tb=short -m "not network and not external_tools"
 
-      - name: Run focused tests (3.11)
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' && matrix.python-version == '3.11' }}
+      - name: Run focused tests (matrix)
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' }}
         run: |
           set -euo pipefail
           TARGETS="${{ needs.changes.outputs.focused_pytest_targets }}"
@@ -430,12 +432,15 @@ jobs:
             echo "FOCUSED mode without explicit targets — fail-closed to tests/ci/"
             TARGETS="tests/ci/"
           fi
-          pytest $TARGETS -v --tb=short -m "not network and not external_tools"
+          mapfile -t VALIDATED_TARGETS < <(python3 scripts/ops/ci_test_selection_v1.py --emit-validated-pytest-targets "$TARGETS")
+          pytest "${VALIDATED_TARGETS[@]}" -v --tb=short -m "not network and not external_tools"
 
-      - name: Focused compatibility import smoke (3.9/3.10)
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' && matrix.python-version != '3.11' }}
+      - name: Focused module import smoke
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' && needs.changes.outputs.focused_module_imports != '' }}
         run: |
-          python -c "import importlib; importlib.import_module('src'); print('import smoke ok on Python ${{ matrix.python-version }}')"
+          set -euo pipefail
+          python3 scripts/ops/ci_test_selection_v1.py --import-smoke-modules "${{ needs.changes.outputs.focused_module_imports }}"
+          echo "import smoke ok on Python ${{ matrix.python-version }}"
 
       - name: Run tests with coverage (FULL only)
         if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true') && matrix.python-version == '3.11' && needs.changes.outputs.tests_execute_no_op != 'true' }}

--- a/config/ci/file_category_mapping.yaml
+++ b/config/ci/file_category_mapping.yaml
@@ -32,6 +32,13 @@ categories:
     globs:
       - "tests/**"
     runtime_class: minutes
+  strategy_regime_owner_focused:
+    mode: FOCUSED
+    globs:
+      - "src/strategies/**"
+      - "src/regime/**"
+    runtime_class: minutes
+    notes: "Single owner prod file + exactly one canonical test owner in diff; blocked for registry/shared paths"
   central_src:
     mode: FULL
     globs:

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import os
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -22,7 +23,44 @@ FULL_CATEGORIES = frozenset(
     }
 )
 NO_OP_CATEGORIES = frozenset({"docs_only", "workflow_only", "static_contract"})
-FOCUSED_CATEGORIES = frozenset({"scripts_focused", "tests_focused"})
+FOCUSED_CATEGORIES = frozenset(
+    {"scripts_focused", "tests_focused", "strategy_regime_owner_focused"}
+)
+
+# Paths that always force FULL when changed (never self-FOCUSED).
+CI_SELECTOR_FULL_PATHS = frozenset(
+    {
+        "scripts/ops/ci_test_selection_v1.py",
+        "config/ci/file_category_mapping.yaml",
+    }
+)
+
+# Shared / registry / framework prod paths — never strategy_regime_owner_focused.
+STRATEGY_REGIME_OWNER_BLOCKED_PROD = frozenset(
+    {
+        "src/strategies/__init__.py",
+        "src/strategies/composite.py",
+        "src/strategies/registry.py",
+        "src/strategies/base.py",
+        "src/strategies/diagnostics.py",
+        "src/strategies/regime_aware_portfolio.py",
+        "src/regime/__init__.py",
+        "src/regime/base.py",
+        "src/regime/switching.py",
+        "src/regime/config.py",
+    }
+)
+
+# Explicit canonical test owners (fail-closed when prod is listed).
+CANONICAL_STRATEGY_REGIME_TEST_OWNERS: dict[str, str] = {
+    "src/strategies/vol_breakout.py": "tests/test_strategies_phase27.py",
+    "src/strategies/vol_regime_filter.py": "tests/test_strategy_vol_regime_filter.py",
+    "src/regime/detectors.py": "tests/test_regime_detection.py",
+    "src/strategies/el_karoui/vol_model.py": "tests/strategies/el_karoui/test_vol_model.py",
+}
+
+_REPO_RELATIVE_PATH = re.compile(r"^[A-Za-z0-9_./-]+$")
+_IMPORT_MODULE = re.compile(r"^[a-zA-Z0-9_.]+$")
 
 
 @dataclass(frozen=True)
@@ -30,6 +68,7 @@ class SelectionResult:
     mode: str
     reason: str
     focused_pytest_targets: tuple[str, ...]
+    focused_module_imports: tuple[str, ...] = ()
 
     def github_output_lines(self) -> list[str]:
         lines = [
@@ -43,11 +82,34 @@ class SelectionResult:
             lines.append(f"focused_pytest_targets={' '.join(self.focused_pytest_targets)}")
         else:
             lines.append("focused_pytest_targets=")
+        if self.focused_module_imports:
+            lines.append(f"focused_module_imports={' '.join(self.focused_module_imports)}")
+        else:
+            lines.append("focused_module_imports=")
         return lines
+
+
+def _requires_full_ci_selector_change(files: list[str]) -> bool:
+    normalized = {PurePosixPath(f).as_posix() for f in files}
+    if normalized & CI_SELECTOR_FULL_PATHS:
+        return True
+    if any(f.startswith("tests/ci/test_ci_diff_aware_test_selection") for f in normalized):
+        return True
+    if ".github/workflows/ci.yml" in normalized and (
+        "scripts/ops/ci_test_selection_v1.py" in normalized
+        or "config/ci/file_category_mapping.yaml" in normalized
+        or any(f.startswith("tests/ci/test_ci_diff_aware_test_selection") for f in normalized)
+    ):
+        return True
+    return False
 
 
 def categorize(path: str) -> str:
     p = PurePosixPath(path).as_posix()
+    if p in CI_SELECTOR_FULL_PATHS:
+        return "ci_selector_change"
+    if p.startswith("tests/ci/test_ci_diff_aware_test_selection"):
+        return "ci_selector_change"
     if p.startswith("src/ops/") and (
         fnmatch.fnmatch(p, "src/ops/*_contract_v0.py")
         or fnmatch.fnmatch(p, "src/ops/*_contract_v1.py")
@@ -61,6 +123,8 @@ def categorize(path: str) -> str:
         return "static_contract"
     if p == "pytest.ini" or p.endswith("/conftest.py") or p == "tests/conftest.py":
         return "global_test_infra"
+    if _is_strategy_regime_owner_prod(p):
+        return "strategy_regime_owner_focused"
     if p.startswith("src/"):
         return "central_src"
     if p.startswith("scripts/"):
@@ -86,8 +150,148 @@ def categorize(path: str) -> str:
     return "unknown"
 
 
+def _is_strategy_regime_owner_prod(path: str) -> bool:
+    if path.endswith("__init__.py"):
+        return False
+    if path in STRATEGY_REGIME_OWNER_BLOCKED_PROD:
+        return False
+    if path.startswith("src/strategies/") and path.endswith(".py"):
+        return True
+    if path.startswith("src/regime/") and path.endswith(".py"):
+        return True
+    return False
+
+
+def _is_canonical_test_owner(path: str) -> bool:
+    if not (path.startswith("tests/") and path.endswith(".py")):
+        return False
+    if path.startswith("tests/ci/") or path.startswith("tests/ops/"):
+        return False
+    return True
+
+
 def _repo_path_exists(path: str) -> bool:
     return Path(path).is_file()
+
+
+def _prod_path_to_import_module(prod_path: str) -> str:
+    return prod_path[:-3].replace("/", ".")
+
+
+def _validate_repo_relative_path(path: str) -> bool:
+    if not path or not _REPO_RELATIVE_PATH.match(path):
+        return False
+    if path.startswith("/") or ".." in path.split("/"):
+        return False
+    return path.startswith("tests/") and path.endswith(".py")
+
+
+def _validate_import_module(module: str) -> bool:
+    return bool(module and _IMPORT_MODULE.match(module))
+
+
+def _discover_load_strategy_contract_tests(prod_path: str) -> tuple[str, ...]:
+    module = _prod_path_to_import_module(prod_path)
+    import_markers = (
+        f"from {module} import",
+        f"import {module}",
+    )
+    found: list[str] = []
+    scripts_tests = Path("tests/scripts")
+    if not scripts_tests.is_dir():
+        return ()
+    for candidate in sorted(scripts_tests.glob("test_*load_strategy*.py")):
+        rel = candidate.as_posix()
+        if not _repo_path_exists(rel):
+            continue
+        text = candidate.read_text(encoding="utf-8", errors="replace")
+        if any(marker in text for marker in import_markers):
+            found.append(rel)
+    return tuple(found)
+
+
+def _expected_canonical_test_owner(prod_path: str) -> str | None:
+    if prod_path in CANONICAL_STRATEGY_REGIME_TEST_OWNERS:
+        return CANONICAL_STRATEGY_REGIME_TEST_OWNERS[prod_path]
+    if not prod_path.startswith("src/"):
+        return None
+    rel = PurePosixPath(prod_path[len("src/") :])
+    if len(rel.parts) >= 2:
+        return f"tests/{rel.parent}/test_{rel.stem}.py"
+    return None
+
+
+def _strategy_regime_focused_targets(
+    prod_path: str, test_path: str, all_files: list[str]
+) -> tuple[str, ...] | None:
+    if not (_is_strategy_regime_owner_prod(prod_path) and _is_canonical_test_owner(test_path)):
+        return None
+    expected_owner = _expected_canonical_test_owner(prod_path)
+    if (
+        expected_owner is None
+        or test_path != expected_owner
+        or not _repo_path_exists(expected_owner)
+    ):
+        return None
+    if len([f for f in all_files if _is_strategy_regime_owner_prod(f)]) != 1:
+        return None
+    test_files = [f for f in all_files if _is_canonical_test_owner(f)]
+    if len(test_files) != 1 or test_files[0] != test_path:
+        return None
+    extra = [f for f in all_files if f not in {prod_path, test_path}]
+    if extra:
+        return None
+
+    targets: list[str] = []
+    seen: set[str] = set()
+
+    def add(path: str) -> None:
+        if path not in seen and _validate_repo_relative_path(path) and _repo_path_exists(path):
+            seen.add(path)
+            targets.append(path)
+
+    add(test_path)
+    for load_test in _discover_load_strategy_contract_tests(prod_path):
+        add(load_test)
+    if not targets:
+        return None
+    return tuple(sorted(targets))
+
+
+def _try_strategy_regime_owner_focused(files: list[str]) -> SelectionResult | None:
+    categories = {categorize(f) for f in files}
+    if "ci_selector_change" in categories:
+        return None
+    if categories & FULL_CATEGORIES:
+        return None
+    if categories & NO_OP_CATEGORIES:
+        return None
+
+    prod_files = sorted(f for f in files if _is_strategy_regime_owner_prod(f))
+    test_files = sorted(f for f in files if _is_canonical_test_owner(f))
+    if len(prod_files) != 1 or len(test_files) != 1:
+        return None
+
+    other = [f for f in files if f not in prod_files and f not in test_files]
+    if other:
+        return None
+
+    prod_path = prod_files[0]
+    test_path = test_files[0]
+    targets = _strategy_regime_focused_targets(prod_path, test_path, files)
+    if not targets:
+        return None
+
+    module = _prod_path_to_import_module(prod_path)
+    if not _validate_import_module(module):
+        return None
+
+    return SelectionResult(
+        "FOCUSED",
+        "strategy_regime_owner_focused",
+        targets,
+        (module,),
+    )
 
 
 def _focused_targets(files: list[str]) -> tuple[str, ...]:
@@ -115,17 +319,20 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
 
     if not targets and any(categorize(f) in FOCUSED_CATEGORIES for f in files):
         add("tests/ci/test_ci_diff_aware_test_selection_v1.py")
-    return tuple(targets)
+    return tuple(sorted(targets))
 
 
 def resolve_selection(
     files: list[str], *, force_full: bool = False, event_name: str = "pull_request"
 ) -> SelectionResult:
-    normalized = [PurePosixPath(f).as_posix() for f in files if f.strip()]
+    normalized = sorted({PurePosixPath(f).as_posix() for f in files if f.strip()})
     if force_full or event_name in {"push", "merge_group", "schedule"}:
         return SelectionResult("FULL", "force_full_or_non_pr_event", ())
     if not normalized:
         return SelectionResult("FULL", "empty_diff_fail_closed", ())
+
+    if _requires_full_ci_selector_change(normalized):
+        return SelectionResult("FULL", "ci_selector_or_contract_change_requires_full", ())
 
     categories = {categorize(f) for f in normalized}
 
@@ -135,6 +342,13 @@ def resolve_selection(
 
     if categories <= NO_OP_CATEGORIES:
         return SelectionResult("NO_OP", "docs_workflow_or_static_contract_only", ())
+
+    strategy_focused = _try_strategy_regime_owner_focused(normalized)
+    if strategy_focused is not None:
+        return strategy_focused
+
+    if "strategy_regime_owner_focused" in categories:
+        return SelectionResult("FULL", "strategy_regime_owner_incomplete_or_ambiguous", ())
 
     if categories <= (NO_OP_CATEGORIES | FOCUSED_CATEGORIES):
         return SelectionResult(
@@ -146,6 +360,32 @@ def resolve_selection(
     return SelectionResult("FULL", "mixed_or_unclassified_fail_closed", ())
 
 
+def emit_validated_pytest_targets(raw: str) -> int:
+    for part in raw.split():
+        if not _validate_repo_relative_path(part) or not _repo_path_exists(part):
+            print(f"invalid pytest target: {part!r}", file=sys.stderr)
+            return 1
+        print(part)
+    return 0
+
+
+def run_import_smoke(modules: str) -> int:
+    import importlib
+
+    repo_root = Path(__file__).resolve().parents[2]
+    root_str = str(repo_root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+
+    for part in modules.split():
+        if not _validate_import_module(part):
+            print(f"invalid import module: {part!r}", file=sys.stderr)
+            return 1
+        importlib.import_module(part)
+        print(f"import smoke ok: {part}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="CI diff-aware test selection v1")
     parser.add_argument("--files", nargs="*", default=None, help="Changed file paths")
@@ -153,7 +393,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--force-full", action="store_true")
     parser.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME", "pull_request"))
     parser.add_argument("--github-output", action="store_true")
+    parser.add_argument(
+        "--emit-validated-pytest-targets",
+        metavar="TARGETS",
+        help="Print validated repo-relative pytest paths (one per line)",
+    )
+    parser.add_argument(
+        "--import-smoke-modules",
+        metavar="MODULES",
+        help="Import listed Python modules (space-separated)",
+    )
     args = parser.parse_args(argv)
+
+    if args.emit_validated_pytest_targets is not None:
+        return emit_validated_pytest_targets(args.emit_validated_pytest_targets)
+
+    if args.import_smoke_modules is not None:
+        return run_import_smoke(args.import_smoke_modules)
 
     files: list[str] = []
     if args.files_file and args.files_file.exists():

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -34,6 +34,16 @@ def _run_selector(
     return result
 
 
+def _targets(sel: dict[str, str]) -> list[str]:
+    raw = sel.get("focused_pytest_targets", "")
+    return sorted(raw.split()) if raw else []
+
+
+def _modules(sel: dict[str, str]) -> list[str]:
+    raw = sel.get("focused_module_imports", "")
+    return sorted(raw.split()) if raw else []
+
+
 def test_required_tests_job_has_no_job_level_if() -> None:
     text = _ci_text()
     tests_block = text.split("  tests:", 1)[1].split("  strategy-smoke:", 1)[0]
@@ -55,6 +65,7 @@ def test_changes_job_exports_test_selection_outputs() -> None:
         "tests_execute_focused",
         "tests_execute_no_op",
         "focused_pytest_targets",
+        "focused_module_imports",
     ):
         assert (
             f"{key}:"
@@ -70,8 +81,23 @@ def test_tests_job_has_no_op_step() -> None:
 def test_tests_job_has_focused_and_full_steps() -> None:
     text = _ci_text()
     assert "Run full test suite" in text
-    assert "Run focused tests (3.11)" in text
+    assert "Run focused tests (matrix)" in text
     assert "Run tests with coverage (FULL only)" in text
+
+
+def test_tests_job_focused_runs_on_all_matrix_versions() -> None:
+    text = _ci_text()
+    focused_step = text.split("name: Run focused tests (matrix)", 1)[1].split("\n      - name:", 1)[
+        0
+    ]
+    assert "matrix.python-version == '3.11'" not in focused_step
+    assert "tests_execute_focused == 'true'" in focused_step
+
+
+def test_tests_job_focused_module_import_smoke_step() -> None:
+    assert "Focused module import smoke" in _ci_text()
+    assert "focused_module_imports" in _ci_text()
+    assert "--import-smoke-modules" in _ci_text()
 
 
 def test_selector_docs_only_no_op() -> None:
@@ -89,6 +115,22 @@ def test_selector_central_src_full() -> None:
     sel = _run_selector("src/strategies/__init__.py")
     assert sel["test_selection_mode"] == "FULL"
     assert sel["tests_execute_full"] == "true"
+
+
+def test_selector_registry_init_full() -> None:
+    sel = _run_selector(
+        "src/strategies/__init__.py",
+        "tests/test_strategy_vol_regime_filter.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_composite_full() -> None:
+    sel = _run_selector(
+        "src/strategies/composite.py",
+        "tests/test_strategy_composite.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
 
 
 def test_selector_dependencies_full() -> None:
@@ -117,16 +159,175 @@ def test_selector_scripts_focused_omits_nonexistent_test_paths() -> None:
         "scripts/run_offline_realtime_ma_crossover.py",
     )
     assert sel["test_selection_mode"] == "FOCUSED"
-    targets = sel["focused_pytest_targets"].split()
+    targets = _targets(sel)
     assert "tests/scripts/test_run_momentum_realistic_load_strategy_v1.py" in targets
     assert "tests/scripts/test_run_offline_realtime_ma_crossover_load_strategy_v1.py" in targets
     assert "tests/scripts/test_run_momentum_realistic.py" not in targets
     assert "tests/scripts/test_run_offline_realtime_ma_crossover.py" not in targets
 
 
+def test_selector_strategy_vol_breakout_owner_focused() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "strategy_regime_owner_focused"
+    assert "tests/test_strategies_phase27.py" in _targets(sel)
+    assert _modules(sel) == ["src.strategies.vol_breakout"]
+
+
+def test_selector_strategy_vol_regime_filter_owner_focused() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_regime_filter.py",
+        "tests/test_strategy_vol_regime_filter.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert "tests/test_strategy_vol_regime_filter.py" in _targets(sel)
+    assert _modules(sel) == ["src.strategies.vol_regime_filter"]
+
+
+def test_selector_regime_detectors_owner_focused() -> None:
+    sel = _run_selector(
+        "src/regime/detectors.py",
+        "tests/test_regime_detection.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert "tests/test_regime_detection.py" in _targets(sel)
+    assert _modules(sel) == ["src.regime.detectors"]
+
+
+def test_selector_el_karoui_vol_model_owner_focused() -> None:
+    sel = _run_selector(
+        "src/strategies/el_karoui/vol_model.py",
+        "tests/strategies/el_karoui/test_vol_model.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert "tests/strategies/el_karoui/test_vol_model.py" in _targets(sel)
+    assert _modules(sel) == ["src.strategies.el_karoui.vol_model"]
+
+
+def test_selector_strategy_owner_includes_load_strategy_contract_tests() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+    )
+    targets = _targets(sel)
+    assert "tests/scripts/test_demo_strategy_research_load_strategy_v1.py" in targets
+
+
+def test_selector_focused_targets_sorted_deterministically() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+    )
+    assert _targets(sel) == sorted(_targets(sel))
+
+
+def test_selector_prod_only_without_test_owner_full() -> None:
+    sel = _run_selector("src/strategies/vol_breakout.py")
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "strategy_regime_owner_incomplete_or_ambiguous"
+
+
+def test_selector_two_prod_files_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "src/strategies/vol_regime_filter.py",
+        "tests/test_strategies_phase27.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_strategy_plus_foreign_test_owner_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategy_vol_regime_filter.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_strategy_plus_conftest_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+        "tests/conftest.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_strategy_plus_dependency_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+        "requirements.txt",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_strategy_plus_pyproject_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+        "pyproject.toml",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_strategy_plus_workflow_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+        ".github/workflows/lint.yml",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_ci_selector_self_full() -> None:
+    sel = _run_selector(
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "ci_selector_or_contract_change_requires_full"
+
+
+def test_selector_ci_workflow_change_self_full() -> None:
+    sel = _run_selector(
+        ".github/workflows/ci.yml",
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_strategy_plus_core_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+        "src/core/foo.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_multiple_test_owners_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+        "tests/test_strategy_vol_regime_filter.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
 def test_selector_unknown_fail_closed_full() -> None:
     sel = _run_selector("misc/unclassified.bin")
     assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_empty_diff_fail_closed_full() -> None:
+    sel = _run_selector()
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "empty_diff_fail_closed"
 
 
 def test_selector_force_full() -> None:
@@ -139,14 +340,68 @@ def test_selector_push_event_full() -> None:
     assert sel["test_selection_mode"] == "FULL"
 
 
+def test_selector_merge_group_event_full() -> None:
+    sel = _run_selector(
+        "src/strategies/vol_breakout.py",
+        "tests/test_strategies_phase27.py",
+        event_name="merge_group",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_import_smoke_cli_ok() -> None:
+    out = subprocess.check_output(
+        [sys.executable, str(SELECTOR), "--import-smoke-modules", "src.strategies.vol_breakout"],
+        text=True,
+    )
+    assert "import smoke ok: src.strategies.vol_breakout" in out
+
+
+def test_selector_import_smoke_cli_rejects_invalid_module() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SELECTOR), "--import-smoke-modules", "src;rm -rf /"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+
+
+def test_selector_emit_validated_pytest_targets_ok() -> None:
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            str(SELECTOR),
+            "--emit-validated-pytest-targets",
+            "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+        ],
+        text=True,
+    )
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in out
+
+
+def test_selector_emit_validated_pytest_targets_rejects_injection() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SELECTOR),
+            "--emit-validated-pytest-targets",
+            "tests/ci/foo.py; echo pwned",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+
+
 def test_mapping_file_exists() -> None:
     assert MAPPING.is_file()
-    assert "docs_only:" in MAPPING.read_text(encoding="utf-8")
+    text = MAPPING.read_text(encoding="utf-8")
+    assert "docs_only:" in text
+    assert "strategy_regime_owner_focused:" in text
 
 
 def test_workflow_only_does_not_run_full_pytest_step_unconditionally() -> None:
     text = _ci_text()
-    assert "workflow_only == 'true'" not in text.split("Run full test suite", 1)[0] or True
     full_step = text.split("name: Run full test suite", 1)[1].split("\n      - name:", 1)[0]
     assert "tests_execute_full == 'true'" in full_step
     assert "workflow_only == 'true'" not in full_step


### PR DESCRIPTION
## Summary
- Erweitert `scripts/ops/ci_test_selection_v1.py` um die interne Kategorie `strategy_regime_owner_focused`: typische eng begrenzte Strategy-/Regime-Vectorization-Diffs (1 Prod-Datei + 1 kanonischer Testowner) laufen künftig **FOCUSED** statt FULL.
- `.github/workflows/ci.yml` führt FOCUSED-Tests auf **allen Matrix-Versionen (3.9/3.10/3.11)** aus und ergänzt validierten **Modul-Import-Smoke** (`focused_module_imports`).
- **Required-Check-Namen unverändert** (`tests (3.9/3.10/3.11)`, `strategy-smoke`, Fast-Lane, PR Gate). Keine job-level `if:` auf Matrix-Jobs. Branch Protection unverändert.
- **Dieser Selector-PR bleibt FULL** (fail-closed Guard für Selector-/Contract-Änderungen).

## Verhalten
| Diff-Typ | Modus |
|----------|-------|
| Typischer Vectorization-Owner (z. B. `vol_breakout.py` + Owner-Test) | FOCUSED (~3–6 min erwartet) |
| Registry/`__init__.py`, Dependencies, CI-Selector, mehrere Owner, unbekannt | FULL (~23 min) |
| Docs/Workflow-only | NO_OP (unverändert) |

## Erhaltene Abdeckung bei FOCUSED
- Python 3.9/3.10/3.11: kanonischer Testowner + Modul-Import
- Relevante `load_strategy`-Contract-Tests (deterministisch, direkter Modulimport)
- Ruff/Lint über bestehende Workflows unverändert
- strategy-smoke: Required-Kontext bleibt sichtbar; Step-Skip bei FOCUSED (wie bisher)

## Test plan
- [x] `pytest tests/ci/test_ci_diff_aware_test_selection_v1.py` (44 Tests)
- [x] `./scripts/ops/check_required_ci_contexts_present.sh`
- [x] Ruff format/check auf geänderte Python-Dateien
- [ ] CI auf PR (FULL erwartet für diesen PR)


Made with [Cursor](https://cursor.com)