### PR TITLE
refactor(research): reuse canonical ohlcv loader

### DIFF
--- a/scripts/research_compare_strategies.py
+++ b/scripts/research_compare_strategies.py
@@ -36,17 +36,16 @@ from __future__ import annotations
 import argparse
 import sys
 import uuid
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
-import numpy as np
 
 # Projekt-Root zum Path hinzufügen
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.run_backtest import load_ohlcv_data
 from src.core.peak_config import load_config, PeakConfig
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
@@ -56,7 +55,6 @@ from src.core.experiments import (
 )
 from src.backtest.engine import BacktestEngine
 from src.backtest.stats import validate_for_live_trading
-from src.data import DataNormalizer, CsvLoader, KrakenCsvLoader
 from src.strategies import load_strategy
 from src.strategies.registry import (
     get_available_strategy_keys,
@@ -183,86 +181,6 @@ Beispiele:
     )
 
     return parser.parse_args()
-
-
-def generate_dummy_ohlcv(
-    n_bars: int = 500,
-    base_price: float = 50000.0,
-    volatility: float = 0.015,
-) -> pd.DataFrame:
-    """
-    Generiert synthetische OHLCV-Daten für Research/Tests.
-
-    Die Daten enthalten sowohl Trends als auch Seitwärtsphasen.
-    """
-    np.random.seed(42)
-
-    end = datetime.now()
-    start = end - timedelta(hours=n_bars)
-    index = pd.date_range(start=start, periods=n_bars, freq="1h", tz="UTC")
-
-    returns = np.random.normal(0, volatility, n_bars)
-    trend = np.sin(np.linspace(0, 4 * np.pi, n_bars)) * 0.001
-    returns = returns + trend
-
-    close_prices = base_price * np.exp(np.cumsum(returns))
-
-    df = pd.DataFrame(index=index)
-    df["close"] = close_prices
-    df["open"] = df["close"].shift(1).fillna(base_price)
-
-    high_bump = np.random.uniform(0, 0.005, n_bars)
-    df["high"] = np.maximum(df["open"], df["close"]) * (1 + high_bump)
-
-    low_dip = np.random.uniform(0, 0.005, n_bars)
-    df["low"] = np.minimum(df["open"], df["close"]) * (1 - low_dip)
-
-    df["volume"] = np.random.uniform(100, 1000, n_bars)
-
-    return df[["open", "high", "low", "close", "volume"]]
-
-
-def load_ohlcv_data(
-    data_file: Optional[str],
-    start_date: Optional[str],
-    end_date: Optional[str],
-    n_bars: int,
-    verbose: bool = False,
-) -> pd.DataFrame:
-    """Lädt OHLCV-Daten aus CSV oder generiert Dummy-Daten."""
-    if data_file:
-        path = Path(data_file)
-        if not path.exists():
-            raise FileNotFoundError(f"Datei nicht gefunden: {data_file}")
-
-        if verbose:
-            print(f"  Lade Daten aus: {data_file}")
-
-        if "kraken" in str(path).lower():
-            loader = KrakenCsvLoader()
-        else:
-            loader = CsvLoader()
-
-        df = loader.load(str(path))
-        normalizer = DataNormalizer()
-        df = normalizer.normalize(df)
-    else:
-        if verbose:
-            print(f"  Generiere {n_bars} Dummy-Bars")
-        df = generate_dummy_ohlcv(n_bars=n_bars)
-
-    if start_date:
-        start_dt = pd.to_datetime(start_date).tz_localize("UTC")
-        df = df[df.index >= start_dt]
-
-    if end_date:
-        end_dt = pd.to_datetime(end_date).tz_localize("UTC")
-        df = df[df.index <= end_dt]
-
-    if len(df) == 0:
-        raise ValueError("Keine Daten nach Filterung übrig!")
-
-    return df
 
 
 def _build_strategy_params_from_config(

--- a/scripts/research_run_strategy.py
+++ b/scripts/research_run_strategy.py
@@ -39,17 +39,17 @@ from __future__ import annotations
 
 import argparse
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
-import numpy as np
 
 # Projekt-Root zum Path hinzufügen
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.run_backtest import load_ohlcv_data
 from src.core.peak_config import load_config, PeakConfig
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
@@ -59,7 +59,6 @@ from src.core.experiments import (
 )
 from src.backtest.engine import BacktestEngine
 from src.backtest.stats import validate_for_live_trading
-from src.data import DataNormalizer, CsvLoader, KrakenCsvLoader
 from src.strategies import load_strategy
 from src.strategies.registry import (
     get_available_strategy_keys,
@@ -260,123 +259,6 @@ def parse_custom_params(param_list: List[str]) -> Dict[str, Any]:
                     params[key] = value
 
     return params
-
-
-def generate_dummy_ohlcv(
-    n_bars: int = 500,
-    base_price: float = 50000.0,
-    volatility: float = 0.015,
-) -> pd.DataFrame:
-    """
-    Generiert synthetische OHLCV-Daten für Research/Tests.
-
-    Die Daten enthalten sowohl Trends als auch Seitwärtsphasen,
-    was für verschiedene Strategietypen geeignet ist.
-
-    Args:
-        n_bars: Anzahl Bars
-        base_price: Startpreis
-        volatility: Volatilität (Standardabweichung der Returns)
-
-    Returns:
-        OHLCV-DataFrame mit DatetimeIndex (UTC)
-    """
-    np.random.seed(42)  # Reproduzierbarkeit
-
-    # Zeitindex (stündlich)
-    end = datetime.now()
-    start = end - timedelta(hours=n_bars)
-    index = pd.date_range(start=start, periods=n_bars, freq="1h", tz="UTC")
-
-    # Random Walk für Close mit Trend-Komponente
-    returns = np.random.normal(0, volatility, n_bars)
-
-    # Trend + Zyklen für interessantere Strategietests
-    trend = np.sin(np.linspace(0, 4 * np.pi, n_bars)) * 0.001
-    returns = returns + trend
-
-    close_prices = base_price * np.exp(np.cumsum(returns))
-
-    # OHLC generieren
-    df = pd.DataFrame(index=index)
-    df["close"] = close_prices
-    df["open"] = df["close"].shift(1).fillna(base_price)
-
-    # High = max(open, close) + random bump
-    high_bump = np.random.uniform(0, 0.005, n_bars)
-    df["high"] = np.maximum(df["open"], df["close"]) * (1 + high_bump)
-
-    # Low = min(open, close) - random dip
-    low_dip = np.random.uniform(0, 0.005, n_bars)
-    df["low"] = np.minimum(df["open"], df["close"]) * (1 - low_dip)
-
-    # Volume
-    df["volume"] = np.random.uniform(100, 1000, n_bars)
-
-    return df[["open", "high", "low", "close", "volume"]]
-
-
-def load_ohlcv_data(
-    data_file: Optional[str],
-    start_date: Optional[str],
-    end_date: Optional[str],
-    n_bars: int,
-    verbose: bool = False,
-) -> pd.DataFrame:
-    """
-    Lädt OHLCV-Daten aus CSV oder generiert Dummy-Daten.
-
-    Args:
-        data_file: Pfad zur CSV-Datei (None = Dummy-Daten)
-        start_date: Startdatum-Filter
-        end_date: Enddatum-Filter
-        n_bars: Anzahl Bars für Dummy-Daten
-        verbose: Ausführliche Ausgabe
-
-    Returns:
-        Normalisierter OHLCV-DataFrame
-    """
-    if data_file:
-        path = Path(data_file)
-        if not path.exists():
-            raise FileNotFoundError(f"Datei nicht gefunden: {data_file}")
-
-        if verbose:
-            print(f"  Lade Daten aus: {data_file}")
-
-        # Kraken-spezifisches Format erkennen
-        if "kraken" in str(path).lower():
-            loader = KrakenCsvLoader()
-        else:
-            loader = CsvLoader()
-
-        df = loader.load(str(path))
-
-        # Normalisieren
-        normalizer = DataNormalizer()
-        df = normalizer.normalize(df)
-    else:
-        if verbose:
-            print(f"  Generiere {n_bars} Dummy-Bars")
-        df = generate_dummy_ohlcv(n_bars=n_bars)
-
-    # Datums-Filter anwenden
-    if start_date:
-        start_dt = pd.to_datetime(start_date).tz_localize("UTC")
-        df = df[df.index >= start_dt]
-        if verbose:
-            print(f"  Filter: >= {start_date}")
-
-    if end_date:
-        end_dt = pd.to_datetime(end_date).tz_localize("UTC")
-        df = df[df.index <= end_dt]
-        if verbose:
-            print(f"  Filter: <= {end_date}")
-
-    if len(df) == 0:
-        raise ValueError("Keine Daten nach Filterung übrig!")
-
-    return df
 
 
 def print_summary(

--- a/tests/scripts/test_research_compare_strategies_load_strategy_v1.py
+++ b/tests/scripts/test_research_compare_strategies_load_strategy_v1.py
@@ -28,10 +28,17 @@ TREND_FOLLOWING_KEY = "trend_following"
 MEAN_REVERSION_KEY = "mean_reversion"
 
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+DATA_LOADER_OWNER = "scripts/run_backtest.py:load_ohlcv_data"
+FORBIDDEN_LOCAL_LOADER_DEFS = frozenset({"load_ohlcv_data", "generate_dummy_ohlcv"})
 
 
 def _read_source() -> str:
     return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
 
 
 def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
@@ -82,6 +89,106 @@ def test_source_has_no_create_strategy_from_config() -> None:
 
 def test_source_uses_load_strategy() -> None:
     assert "load_strategy" in _read_source()
+
+
+def test_source_has_no_local_loader_or_dummy_definitions() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_LOADER_DEFS.isdisjoint(local_defs)
+
+
+def test_source_imports_canonical_data_loader() -> None:
+    source = _read_source()
+    assert "load_ohlcv_data" in source
+    assert "scripts.run_backtest" in source
+
+
+def test_load_ohlcv_data_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert compare_runner.load_ohlcv_data is run_backtest_script.load_ohlcv_data
+
+
+def test_main_forwards_load_ohlcv_arguments_to_canonical_loader(tmp_path, monkeypatch) -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg_path = tmp_path / "cfg.toml"
+    cfg_path.write_text("[environment]\nmode = 'backtest'\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def capture_loader(
+        data_file,
+        start_date,
+        end_date,
+        n_bars,
+        verbose=False,
+    ):
+        captured.update(
+            {
+                "data_file": data_file,
+                "start_date": start_date,
+                "end_date": end_date,
+                "n_bars": n_bars,
+                "verbose": verbose,
+            }
+        )
+        return _sample_ohlcv()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "research_compare_strategies.py",
+            "--config",
+            str(cfg_path),
+            "--strategies",
+            MA_CROSSOVER_KEY,
+            "--data-file",
+            "data/btc.csv",
+            "--start",
+            "2023-01-01",
+            "--end",
+            "2023-12-31",
+            "--bars",
+            "250",
+            "--no-registry",
+            "--verbose",
+        ],
+    )
+
+    with (
+        patch.object(compare_runner, "load_config") as load_config_mock,
+        patch.object(compare_runner, "load_ohlcv_data", side_effect=capture_loader),
+        patch.object(
+            compare_runner,
+            "run_single_backtest",
+            return_value={
+                "strategy": MA_CROSSOVER_KEY,
+                "description": "test",
+                "total_return": 0.0,
+                "max_drawdown": 0.0,
+                "sharpe": 0.0,
+                "win_rate": 0.0,
+                "profit_factor": 0.0,
+                "total_trades": 0,
+                "cagr": 0.0,
+                "live_ready": False,
+                "result": MagicMock(),
+            },
+        ),
+    ):
+        load_config_mock.return_value = PeakConfig(
+            raw={"environment": {"mode": "backtest"}, "strategy": {MA_CROSSOVER_KEY: {}}}
+        )
+        code = compare_runner.main()
+
+    assert code == 0
+    assert captured == {
+        "data_file": "data/btc.csv",
+        "start_date": "2023-01-01",
+        "end_date": "2023-12-31",
+        "n_bars": 250,
+        "verbose": True,
+    }
 
 
 def test_source_is_distinct_from_prior_migration_owners() -> None:

--- a/tests/scripts/test_research_run_strategy_load_strategy_v1.py
+++ b/tests/scripts/test_research_run_strategy_load_strategy_v1.py
@@ -27,10 +27,17 @@ MA_CROSSOVER_KEY = "ma_crossover"
 TREND_FOLLOWING_KEY = "trend_following"
 
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+DATA_LOADER_OWNER = "scripts/run_backtest.py:load_ohlcv_data"
+FORBIDDEN_LOCAL_LOADER_DEFS = frozenset({"load_ohlcv_data", "generate_dummy_ohlcv"})
 
 
 def _read_source() -> str:
     return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
 
 
 def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
@@ -81,6 +88,110 @@ def test_source_has_no_create_strategy_from_config() -> None:
 
 def test_source_uses_load_strategy() -> None:
     assert "load_strategy" in _read_source()
+
+
+def test_source_has_no_local_loader_or_dummy_definitions() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_LOADER_DEFS.isdisjoint(local_defs)
+
+
+def test_source_imports_canonical_data_loader() -> None:
+    source = _read_source()
+    assert "load_ohlcv_data" in source
+    assert "scripts.run_backtest" in source
+
+
+def test_load_ohlcv_data_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert research_runner.load_ohlcv_data is run_backtest_script.load_ohlcv_data
+
+
+def test_main_forwards_load_ohlcv_arguments_to_canonical_loader(tmp_path, monkeypatch) -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg_path = tmp_path / "cfg.toml"
+    cfg_path.write_text("[environment]\nmode = 'backtest'\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def capture_loader(
+        data_file,
+        start_date,
+        end_date,
+        n_bars,
+        verbose=False,
+    ):
+        captured.update(
+            {
+                "data_file": data_file,
+                "start_date": start_date,
+                "end_date": end_date,
+                "n_bars": n_bars,
+                "verbose": verbose,
+            }
+        )
+        return _sample_ohlcv()
+
+    mock_result = MagicMock()
+    mock_result.stats = {
+        "total_return": 0.0,
+        "max_drawdown": 0.0,
+        "sharpe": 0.0,
+        "cagr": 0.0,
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "profit_factor": 0.0,
+    }
+    mock_result.equity_curve = pd.Series([100.0, 100.0])
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "research_run_strategy.py",
+            "--config",
+            str(cfg_path),
+            "--strategy",
+            MA_CROSSOVER_KEY,
+            "--data-file",
+            "data/btc.csv",
+            "--start",
+            "2023-01-01",
+            "--end",
+            "2023-12-31",
+            "--bars",
+            "250",
+            "--no-registry",
+            "--verbose",
+        ],
+    )
+
+    with (
+        patch.object(research_runner, "load_config") as load_config_mock,
+        patch.object(research_runner, "load_ohlcv_data", side_effect=capture_loader),
+        patch.object(
+            research_runner,
+            "load_strategy",
+            return_value=lambda df, params: pd.Series(0, index=df.index),
+        ),
+        patch.object(research_runner, "build_position_sizer_from_config", return_value=MagicMock()),
+        patch.object(research_runner, "build_risk_manager_from_config", return_value=MagicMock()),
+        patch.object(research_runner, "BacktestEngine") as engine_cls,
+    ):
+        load_config_mock.return_value = PeakConfig(
+            raw={"environment": {"mode": "backtest"}, "strategy": {MA_CROSSOVER_KEY: {}}}
+        )
+        engine_cls.return_value.run_realistic.return_value = mock_result
+        code = research_runner.main()
+
+    assert code == 0
+    assert captured == {
+        "data_file": "data/btc.csv",
+        "start_date": "2023-01-01",
+        "end_date": "2023-12-31",
+        "n_bars": 250,
+        "verbose": True,
+    }
 
 
 def test_source_is_distinct_from_prior_migration_owners() -> None:


### PR DESCRIPTION
## Summary
- Entfernt lokale Duplikate von `load_ohlcv_data` und `generate_dummy_ohlcv` aus `scripts/research_run_strategy.py` und `scripts/research_compare_strategies.py`.
- Importiert stattdessen den kanonischen Loader aus `scripts/run_backtest.py` (gleiches Muster wie `scripts/run_optuna_study.py`).
- Erweitert die bestehenden Contract-Tests in `tests/scripts/test_research_*_load_strategy_v1.py` um AST-/Import-/Forwarding-Nachweise.

## CI-Mode
- **Erwartet:** FOCUSED
- **Selector:** FOCUSED (`focused_script_or_test_diff`)
- **Targets:** `tests/scripts/test_research_run_strategy_load_strategy_v1.py`, `tests/scripts/test_research_compare_strategies_load_strategy_v1.py`

## Test plan
- [x] `pytest -q tests/scripts/test_research_run_strategy_load_strategy_v1.py tests/scripts/test_research_compare_strategies_load_strategy_v1.py`
- [x] Optuna-Präzedenz: `test_data_loader_owner_is_run_backtest_load_ohlcv_data`
- [x] Import-Smoke: `scripts.research_run_strategy`, `scripts.research_compare_strategies`, `scripts.run_backtest`
- [x] Ruff format/check auf geänderte Dateien
- [x] `scripts/ops/ci_test_selection_v1.py` → FOCUSED


Made with [Cursor](https://cursor.com)