### PR TITLE
refactor(sweep): reuse canonical ohlcv loader

### DIFF
--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -32,17 +32,16 @@ import argparse
 import itertools
 import json
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import numpy as np
 import pandas as pd
 
 # Projekt-Root zum Python-Path hinzufügen
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.run_backtest import load_ohlcv_data
 from src.core.peak_config import PeakConfig, load_config
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
@@ -399,71 +398,6 @@ def load_parameter_grid(grid_arg: str) -> Dict[str, List[Any]]:
         raise ValueError(f"Konnte Grid nicht laden. Weder gültige Datei noch JSON-String: {e}")
 
 
-def generate_dummy_ohlcv(
-    n_bars: int = 500,
-    base_price: float = 50000.0,
-    volatility: float = 0.015,
-) -> pd.DataFrame:
-    """Generiert synthetische OHLCV-Daten für Tests."""
-    np.random.seed(42)  # Reproduzierbarkeit
-
-    end = datetime.now()
-    start = end - timedelta(hours=n_bars)
-    index = pd.date_range(start=start, periods=n_bars, freq="1h", tz="UTC")
-
-    returns = np.random.normal(0, volatility, n_bars)
-    trend = np.sin(np.linspace(0, 4 * np.pi, n_bars)) * 0.001
-    returns = returns + trend
-    close_prices = base_price * np.exp(np.cumsum(returns))
-
-    df = pd.DataFrame(index=index)
-    df["close"] = close_prices
-    df["open"] = df["close"].shift(1).fillna(base_price)
-
-    high_bump = np.random.uniform(0, 0.005, n_bars)
-    df["high"] = np.maximum(df["open"], df["close"]) * (1 + high_bump)
-
-    low_dip = np.random.uniform(0, 0.005, n_bars)
-    df["low"] = np.minimum(df["open"], df["close"]) * (1 - low_dip)
-
-    df["volume"] = np.random.uniform(100, 1000, n_bars)
-
-    return df[["open", "high", "low", "close", "volume"]]
-
-
-def load_ohlcv_data(
-    data_file: Optional[str],
-    n_bars: int,
-    verbose: bool = False,
-) -> pd.DataFrame:
-    """Lädt OHLCV-Daten aus CSV oder generiert Dummy-Daten."""
-    if data_file:
-        from src.data import DataNormalizer, CsvLoader, KrakenCsvLoader
-
-        path = Path(data_file)
-        if not path.exists():
-            raise FileNotFoundError(f"Datei nicht gefunden: {data_file}")
-
-        if verbose:
-            print(f"  Lade Daten aus: {data_file}")
-
-        if "kraken" in str(path).lower():
-            loader = KrakenCsvLoader()
-        else:
-            loader = CsvLoader()
-
-        df = loader.load(str(path))
-        normalizer = DataNormalizer()
-        df = normalizer.normalize(df)
-
-    else:
-        if verbose:
-            print(f"  Generiere {n_bars} Dummy-Bars")
-        df = generate_dummy_ohlcv(n_bars=n_bars)
-
-    return df
-
-
 def run_single_backtest(
     df: pd.DataFrame,
     strategy_key: str,
@@ -613,6 +547,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     try:
         df = load_ohlcv_data(
             data_file=args.data_file,
+            start_date=None,
+            end_date=None,
             n_bars=args.bars,
             verbose=args.verbose,
         )

--- a/tests/scripts/test_run_sweep_contract_v1.py
+++ b/tests/scripts/test_run_sweep_contract_v1.py
@@ -27,10 +27,17 @@ import scripts.run_sweep as run_sweep_script
 TARGET_SCRIPT = project_root / "scripts/run_sweep.py"
 MA_CROSSOVER_KEY = "ma_crossover"
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+DATA_LOADER_OWNER = "scripts/run_backtest.py:load_ohlcv_data"
+FORBIDDEN_LOCAL_LOADER_DEFS = frozenset({"load_ohlcv_data", "generate_dummy_ohlcv"})
 
 
 def _read_source() -> str:
     return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
 
 
 def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
@@ -118,6 +125,91 @@ def test_source_has_no_create_strategy_from_config() -> None:
 
 def test_source_uses_load_strategy() -> None:
     assert "load_strategy" in _read_source()
+
+
+def test_source_has_no_local_loader_or_dummy_definitions() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_LOADER_DEFS.isdisjoint(local_defs)
+
+
+def test_source_imports_canonical_data_loader() -> None:
+    source = _read_source()
+    assert "load_ohlcv_data" in source
+    assert "scripts.run_backtest" in source
+
+
+def test_load_ohlcv_data_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert run_sweep_script.load_ohlcv_data is run_backtest_script.load_ohlcv_data
+
+
+def test_main_forwards_load_ohlcv_arguments_to_canonical_loader(tmp_path, monkeypatch) -> None:
+    cfg_path = tmp_path / "cfg.toml"
+    cfg_path.write_text("[environment]\nmode = 'backtest'\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    sample_df = _sample_ohlcv()
+
+    def capture_loader(
+        data_file,
+        start_date,
+        end_date,
+        n_bars,
+        verbose=False,
+    ):
+        captured.update(
+            {
+                "data_file": data_file,
+                "start_date": start_date,
+                "end_date": end_date,
+                "n_bars": n_bars,
+                "verbose": verbose,
+            }
+        )
+        return sample_df
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_sweep.py",
+            "--config",
+            str(cfg_path),
+            "--strategy",
+            MA_CROSSOVER_KEY,
+            "--grid",
+            '{"fast_window":[5], "slow_window":[20]}',
+            "--data-file",
+            "data/btc.csv",
+            "--bars",
+            "250",
+            "--verbose",
+        ],
+    )
+
+    backtest_calls: list[dict[str, object]] = []
+
+    def capture_backtest(**kwargs):
+        backtest_calls.append(dict(kwargs))
+        return {}
+
+    with (
+        patch.object(run_sweep_script, "load_ohlcv_data", side_effect=capture_loader),
+        patch.object(run_sweep_script, "run_single_backtest", side_effect=capture_backtest),
+        patch.object(run_sweep_script, "log_sweep_run", return_value=1),
+    ):
+        rc = run_sweep_script.main()
+
+    assert rc == 0
+    assert captured == {
+        "data_file": "data/btc.csv",
+        "start_date": None,
+        "end_date": None,
+        "n_bars": 250,
+        "verbose": True,
+    }
+    assert len(backtest_calls) == 1
+    assert backtest_calls[0]["df"] is sample_df
 
 
 def test_run_single_backtest_has_no_long_only_replace_wrapper() -> None:


### PR DESCRIPTION
## Summary

- **Problem:** `scripts/run_sweep.py` enthielt eine lokale einfache OHLCV-Loader-Duplikation (`generate_dummy_ohlcv` / `load_ohlcv_data`).
- **Lösung:** Wiederverwendung des kanonischen Loaders `scripts/run_backtest.py:load_ohlcv_data` per Import; Aufrufstelle übergibt `start_date=None` / `end_date=None` (bisher kein Datumsfilter im Sweep-Skript).
- **Tests:** `tests/scripts/test_run_sweep_contract_v1.py` — statische Guards + isoliertes Monkeypatching (kein echter Sweep/Backtest).
- **Lokale Checks:** `pytest -q tests/scripts/test_run_sweep_contract_v1.py`, `ruff format --check`, `ruff check` auf den geänderten Dateien.

## CI

- **CI_MODE_REQUIRED:** FOCUSED
- **CI_MODE_REASON:** single offline sweep script reusing one canonical loader with one explicit contract-test owner and no central infrastructure trigger
- **Selector:** `test_selection_mode=FOCUSED`, `focused_pytest_targets=tests/scripts/test_run_sweep_contract_v1.py`

## Safety

- Offline / no-run: keine Sweep-, Backtest-, Trial-, Exchange- oder Runtime-Ausführung
- Keine Änderungen an Trading-/Risk-/Runtime-/Master-V2-/Execution-Flächen
- `scripts/run_backtest.py` unverändert
- `scripts/run_sweep_strategy.py` **nicht** gebündelt (separate Parquet-/Design-Variante)


Made with [Cursor](https://cursor.com)