### PR TITLE
refactor(sweep): reuse canonical parquet ohlcv loader

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -324,10 +324,10 @@ def load_ohlcv_data(
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Lädt OHLCV-Daten aus CSV oder generiert Dummy-Daten.
+    Lädt OHLCV-Daten aus CSV/Parquet oder generiert Dummy-Daten.
 
     Args:
-        data_file: Pfad zur CSV-Datei (None = Dummy-Daten)
+        data_file: Pfad zur CSV- oder Parquet-Datei (None = Dummy-Daten)
         start_date: Startdatum-Filter
         end_date: Enddatum-Filter
         n_bars: Anzahl Bars für Dummy-Daten
@@ -337,7 +337,7 @@ def load_ohlcv_data(
         Normalisierter OHLCV-DataFrame
     """
     if data_file:
-        # CSV laden
+        # CSV oder Parquet laden
         path = Path(data_file)
         if not path.exists():
             raise FileNotFoundError(f"Datei nicht gefunden: {data_file}")
@@ -345,17 +345,26 @@ def load_ohlcv_data(
         if verbose:
             print(f"  Lade Daten aus: {data_file}")
 
-        # Kraken-spezifisches Format erkennen
-        if "kraken" in str(path).lower():
-            loader = KrakenCsvLoader()
+        suffix = path.suffix.lower()
+        if suffix in {".parquet", ".pq"}:
+            df = pd.read_parquet(path)
+            df.columns = df.columns.str.lower()
+            if not isinstance(df.index, pd.DatetimeIndex) and "timestamp" in df.columns:
+                df = df.set_index(pd.DatetimeIndex(pd.to_datetime(df.pop("timestamp"), utc=True)))
+            normalizer = DataNormalizer()
+            df = normalizer.normalize(df)
         else:
-            loader = CsvLoader()
+            # Kraken-spezifisches Format erkennen
+            if "kraken" in str(path).lower():
+                loader = KrakenCsvLoader()
+            else:
+                loader = CsvLoader()
 
-        df = loader.load(str(path))
+            df = loader.load(str(path))
 
-        # Normalisieren
-        normalizer = DataNormalizer()
-        df = normalizer.normalize(df)
+            # Normalisieren
+            normalizer = DataNormalizer()
+            df = normalizer.normalize(df)
 
     else:
         # Dummy-Daten generieren

--- a/scripts/run_sweep_strategy.py
+++ b/scripts/run_sweep_strategy.py
@@ -53,17 +53,16 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-import numpy as np
 import pandas as pd
 
 # Projekt-Root zum Python-Path hinzufügen
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from scripts.run_backtest import load_ohlcv_data
 from src.sweeps import (
     SweepConfig,
     SweepEngine,
@@ -386,78 +385,6 @@ def parse_cli_params(params: List[str]) -> Dict[str, List[Any]]:
     return grid
 
 
-def generate_dummy_ohlcv(
-    n_bars: int = 500,
-    base_price: float = 50000.0,
-    volatility: float = 0.015,
-) -> pd.DataFrame:
-    """Generiert synthetische OHLCV-Daten für Tests."""
-    np.random.seed(42)  # Reproduzierbarkeit
-
-    end = datetime.now()
-    start = end - timedelta(hours=n_bars)
-    index = pd.date_range(start=start, periods=n_bars, freq="1h", tz="UTC")
-
-    returns = np.random.normal(0, volatility, n_bars)
-    trend = np.sin(np.linspace(0, 4 * np.pi, n_bars)) * 0.001
-    returns = returns + trend
-    close_prices = base_price * np.exp(np.cumsum(returns))
-
-    df = pd.DataFrame(index=index)
-    df["close"] = close_prices
-    df["open"] = df["close"].shift(1).fillna(base_price)
-
-    high_bump = np.random.uniform(0, 0.005, n_bars)
-    df["high"] = np.maximum(df["open"], df["close"]) * (1 + high_bump)
-
-    low_dip = np.random.uniform(0, 0.005, n_bars)
-    df["low"] = np.minimum(df["open"], df["close"]) * (1 - low_dip)
-
-    df["volume"] = np.random.uniform(100, 1000, n_bars)
-
-    return df[["open", "high", "low", "close", "volume"]]
-
-
-def load_ohlcv_data(
-    data_file: Optional[str],
-    n_bars: int,
-    verbose: bool = False,
-) -> pd.DataFrame:
-    """Lädt OHLCV-Daten aus CSV/Parquet oder generiert Dummy-Daten."""
-    if data_file:
-        from src.data import DataNormalizer, CsvLoader, KrakenCsvLoader
-
-        path = Path(data_file)
-        if not path.exists():
-            raise FileNotFoundError(f"Datei nicht gefunden: {data_file}")
-
-        if verbose:
-            print(f"  Lade Daten aus: {data_file}")
-
-        suffix = path.suffix.lower()
-        if suffix in {".parquet", ".pq"}:
-            df = pd.read_parquet(path)
-            df.columns = df.columns.str.lower()
-            if not isinstance(df.index, pd.DatetimeIndex) and "timestamp" in df.columns:
-                df = df.set_index(pd.DatetimeIndex(pd.to_datetime(df.pop("timestamp"), utc=True)))
-            normalizer = DataNormalizer()
-            return normalizer.normalize(df)
-
-        if "kraken" in str(path).lower():
-            loader = KrakenCsvLoader()
-        else:
-            loader = CsvLoader()
-
-        df = loader.load(str(path))
-        normalizer = DataNormalizer()
-        df = normalizer.normalize(df)
-        return df
-
-    if verbose:
-        print(f"  Generiere {n_bars} Dummy-Bars")
-    return generate_dummy_ohlcv(n_bars=n_bars)
-
-
 def list_strategies_detailed() -> None:
     """Zeigt alle verfügbaren Strategien mit Details an."""
     print("\n" + "=" * 70)
@@ -679,6 +606,8 @@ def _run_main(args: argparse.Namespace, output: SweepRunOutputMode) -> int:
     try:
         data = load_ohlcv_data(
             data_file=args.data_file,
+            start_date=None,
+            end_date=None,
             n_bars=args.bars,
             verbose=args.verbose and not args.quiet,
         )

--- a/tests/scripts/test_run_backtest_load_strategy_v1.py
+++ b/tests/scripts/test_run_backtest_load_strategy_v1.py
@@ -405,3 +405,94 @@ def test_cli_help_smoke() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert "NO-LIVE" in result.stdout
+
+
+def test_load_ohlcv_data_dummy_semantics_unchanged() -> None:
+    df = run_backtest_script.load_ohlcv_data(None, None, None, n_bars=120)
+    assert list(df.columns) == ["open", "high", "low", "close", "volume"]
+    assert len(df) == 120
+    assert isinstance(df.index, pd.DatetimeIndex)
+
+
+def test_load_ohlcv_data_missing_file_raises(tmp_path) -> None:
+    missing = tmp_path / "missing.csv"
+    with pytest.raises(FileNotFoundError, match="Datei nicht gefunden"):
+        run_backtest_script.load_ohlcv_data(str(missing), None, None, n_bars=10)
+
+
+def test_load_ohlcv_data_csv_path_uses_csv_loader_chain(tmp_path, monkeypatch) -> None:
+    csv_path = tmp_path / "btc_eur_1h.csv"
+    csv_path.write_text("timestamp,open,high,low,close,volume\n", encoding="utf-8")
+    raw_df = _sample_ohlcv()
+    normalized_df = raw_df.copy()
+    loader_calls: list[str] = []
+    normalize_calls: list[pd.DataFrame] = []
+
+    class FakeCsvLoader:
+        def load(self, path: str) -> pd.DataFrame:
+            loader_calls.append(path)
+            return raw_df
+
+    class FakeNormalizer:
+        def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
+            normalize_calls.append(df)
+            return normalized_df
+
+    monkeypatch.setattr(run_backtest_script, "CsvLoader", FakeCsvLoader)
+    monkeypatch.setattr(run_backtest_script, "DataNormalizer", FakeNormalizer)
+
+    result = run_backtest_script.load_ohlcv_data(str(csv_path), None, None, n_bars=10)
+
+    assert loader_calls == [str(csv_path)]
+    assert len(normalize_calls) == 1
+    assert result is normalized_df
+
+
+def test_load_ohlcv_data_parquet_uses_read_parquet_and_normalizer(tmp_path, monkeypatch) -> None:
+    parquet_path = tmp_path / "btc_eur_1h.parquet"
+    parquet_path.write_bytes(b"parquet-placeholder")
+    raw_df = _sample_ohlcv().rename_axis("timestamp").reset_index()
+    normalized_df = raw_df.set_index("timestamp")
+    read_calls: list[str] = []
+    normalize_calls: list[pd.DataFrame] = []
+
+    def fake_read_parquet(path, *args, **kwargs):
+        read_calls.append(str(path))
+        return raw_df.copy()
+
+    class FakeNormalizer:
+        def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
+            normalize_calls.append(df)
+            return normalized_df
+
+    monkeypatch.setattr(run_backtest_script.pd, "read_parquet", fake_read_parquet)
+    monkeypatch.setattr(run_backtest_script, "DataNormalizer", FakeNormalizer)
+
+    result = run_backtest_script.load_ohlcv_data(str(parquet_path), None, None, n_bars=10)
+
+    assert read_calls == [str(parquet_path)]
+    assert len(normalize_calls) == 1
+    assert list(normalize_calls[0].columns) == ["open", "high", "low", "close", "volume"]
+    assert isinstance(normalize_calls[0].index, pd.DatetimeIndex)
+    assert result is normalized_df
+
+
+@pytest.mark.parametrize("suffix", [".parquet", ".pq"])
+def test_load_ohlcv_data_parquet_suffixes_supported(tmp_path, monkeypatch, suffix) -> None:
+    parquet_path = tmp_path / f"btc_eur_1h{suffix}"
+    parquet_path.write_bytes(b"parquet-placeholder")
+    sample = _sample_ohlcv()
+
+    monkeypatch.setattr(
+        run_backtest_script.pd,
+        "read_parquet",
+        lambda path, *args, **kwargs: sample.copy(),
+    )
+    monkeypatch.setattr(
+        run_backtest_script,
+        "DataNormalizer",
+        lambda: MagicMock(normalize=lambda df: df),
+    )
+
+    result = run_backtest_script.load_ohlcv_data(str(parquet_path), None, None, n_bars=10)
+    assert len(result) == len(sample)

--- a/tests/test_sweep_run_contract.py
+++ b/tests/test_sweep_run_contract.py
@@ -689,3 +689,36 @@ def test_run_sweep_strategy_quiet_warning_visible_via_logger(caplog) -> None:
         restore_sweep_run_logging(previous)
 
     assert any("quiet-mode-warning-check" in r.message for r in caplog.records)
+
+
+SWEEP_STRATEGY_SCRIPT = ROOT / "scripts" / "run_sweep_strategy.py"
+SWEEP_STRATEGY_FORBIDDEN_LOCAL_LOADER_DEFS = frozenset({"load_ohlcv_data", "generate_dummy_ohlcv"})
+
+
+def _run_sweep_strategy_source() -> str:
+    return SWEEP_STRATEGY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _run_sweep_strategy_local_function_defs() -> set[str]:
+    import ast
+
+    tree = ast.parse(_run_sweep_strategy_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
+
+
+def test_run_sweep_strategy_source_has_no_local_loader_or_dummy_definitions() -> None:
+    local_defs = _run_sweep_strategy_local_function_defs()
+    assert SWEEP_STRATEGY_FORBIDDEN_LOCAL_LOADER_DEFS.isdisjoint(local_defs)
+
+
+def test_run_sweep_strategy_imports_canonical_data_loader() -> None:
+    source = _run_sweep_strategy_source()
+    assert "load_ohlcv_data" in source
+    assert "scripts.run_backtest" in source
+
+
+def test_run_sweep_strategy_load_ohlcv_data_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+    import scripts.run_sweep_strategy as run_sweep_strategy_script
+
+    assert run_sweep_strategy_script.load_ohlcv_data is run_backtest_script.load_ohlcv_data


### PR DESCRIPTION
## Summary

**Problem:** `scripts/run_sweep_strategy.py` besaß einen eigenständigen Parquet-/CSV-Loader (`load_ohlcv_data`, `generate_dummy_ohlcv`) parallel zum kanonischen Owner.

**Lösung:** Additive Parquet-Unterstützung (`.parquet`, `.pq`) in `scripts/run_backtest.py:load_ohlcv_data` und anschließende Wiederverwendung durch `scripts/run_sweep_strategy.py` via `from scripts.run_backtest import load_ohlcv_data`.

### Semantikmatrix CSV / Parquet

| Aspekt | CSV (kanonisch, unverändert) | Parquet (neu, aus sweep_strategy übernommen) |
|--------|------------------------------|-----------------------------------------------|
| Erkennung | Pfad-Suffix ≠ `.parquet`/`.pq` | Suffix `.parquet` oder `.pq` |
| Lesepfad | `KrakenCsvLoader` oder `CsvLoader` | `pd.read_parquet(path)` |
| Spalten | via Loader | `df.columns.str.lower()` |
| Index | via Loader + `DataNormalizer` | Wenn kein `DatetimeIndex` und Spalte `timestamp`: `set_index(pd.DatetimeIndex(pd.to_datetime(..., utc=True)))` |
| Normalisierung | `DataNormalizer().normalize(df)` | identisch |
| Datumsfilter | optional `start_date`/`end_date` | identisch (additiv; sweep_strategy übergibt `None`) |
| Dummy-Fallback | `generate_dummy_ohlcv(n_bars)` wenn `data_file=None` | unverändert |
| Fehler | `FileNotFoundError` bei fehlender Datei | identisch |

### Tests (lokal, fokussiert)

- `tests/scripts/test_run_backtest_load_strategy_v1.py` — 6 neue Contract-Tests für Dummy/CSV/Parquet
- `tests/test_sweep_run_contract.py` — 3 neue Contract-Tests für kanonischen Import
- Ergebnis: **9/9 passed**, `FOCUSED_TESTS_RC=0`
- Ruff: `RUFF_FORMAT_RC=0`, `RUFF_CHECK_RC=0`

### CI-Modus

- `CI_MODE_REQUIRED=FOCUSED`
- `CI_MODE_REASON=focused_script_or_test_diff — nur scripts/ und tests/ geändert, kein src/-Touch, kanonischer Shared-Owner-Impact bleibt innerhalb scripts_focused/tests_focused`
- `CI_SELECTOR_ACTUAL_MODE=FOCUSED`

### Safety

- Offline/no-run — keine Sweeps, Backtests, Runtime oder Exchange-API
- Keine Trading-/Risk-/Runtime-/Master-V2-Fläche berührt
- Keine neue Loader-/Storage-Abstraktion
- `scripts/run_sweep.py`, `scripts/run_optuna_study.py`, `scripts/research_run_strategy.py`, `scripts/research_compare_strategies.py` unverändert


Made with [Cursor](https://cursor.com)