### PR TITLE
refactor(forward-signals): reuse canonical strategy params builder

### DIFF
--- a/scripts/generate_forward_signals.py
+++ b/scripts/generate_forward_signals.py
@@ -32,6 +32,7 @@ import pandas as pd
 
 from src.core.peak_config import load_config, PeakConfig
 from src.core.experiments import log_generic_experiment
+from scripts.run_backtest import _build_strategy_params_from_config
 from src.forward.signals import ForwardSignal, save_signals_to_csv
 from src.strategies import load_strategy
 from src.strategies.registry import get_available_strategy_keys, get_strategy_spec
@@ -226,18 +227,6 @@ def _validate_strategy_registry_gates(key: str, cfg: PeakConfig) -> None:
             f"Strategy '{key}' not allowed in environment '{env_mode}'. "
             f"Allowed environments: {allowed_str}"
         )
-
-
-def _build_strategy_params_from_config(
-    cfg: PeakConfig,
-    strategy_key: str,
-) -> Dict[str, Any]:
-    """Build strategy params dict via canonical load_strategy() registry path."""
-    load_strategy(strategy_key)
-    section = cfg.raw.get("strategy", {}).get(strategy_key, {})
-    params: Dict[str, Any] = dict(section) if isinstance(section, dict) else {}
-    params["stop_pct"] = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
-    return params
 
 
 def enforce_strategy_selection(cfg: PeakConfig, strategy_key: str) -> None:

--- a/scripts/run_forward_signals.py
+++ b/scripts/run_forward_signals.py
@@ -42,6 +42,7 @@ from typing import Any, Dict
 from src.core.peak_config import load_config, PeakConfig
 from src.core.experiments import log_forward_signal_run, RUN_TYPE_FORWARD_SIGNAL
 from src.exchange import build_exchange_client_from_config
+from scripts.run_backtest import _build_strategy_params_from_config
 from src.strategies import load_strategy
 from src.strategies.registry import get_available_strategy_keys, get_strategy_spec
 from src.notifications import Alert, ConsoleNotifier, FileNotifier, CombinedNotifier
@@ -85,18 +86,6 @@ def _validate_strategy_registry_gates(key: str, cfg: PeakConfig) -> None:
             f"Strategy '{key}' not allowed in environment '{env_mode}'. "
             f"Allowed environments: {allowed_str}"
         )
-
-
-def _build_strategy_params_from_config(
-    cfg: PeakConfig,
-    strategy_key: str,
-) -> Dict[str, Any]:
-    """Build strategy params dict via canonical load_strategy() registry path."""
-    load_strategy(strategy_key)
-    section = cfg.raw.get("strategy", {}).get(strategy_key, {})
-    params: Dict[str, Any] = dict(section) if isinstance(section, dict) else {}
-    params["stop_pct"] = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
-    return params
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:

--- a/tests/scripts/test_generate_forward_signals_load_strategy_v1.py
+++ b/tests/scripts/test_generate_forward_signals_load_strategy_v1.py
@@ -28,10 +28,17 @@ MOMENTUM_KEY = "momentum_1h"
 RSI_REVERSION_KEY = "rsi_reversion"
 
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+STRATEGY_PARAMS_BUILDER_OWNER = "scripts/run_backtest.py:_build_strategy_params_from_config"
+FORBIDDEN_LOCAL_BUILDER_DEFS = frozenset({"_build_strategy_params_from_config"})
 
 
 def _read_source() -> str:
     return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
 
 
 def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
@@ -84,6 +91,26 @@ def test_source_has_no_parallel_strategy_registry() -> None:
     assert "STRATEGY_REGISTRY" not in assigned_names
 
 
+def test_source_has_no_local_builder_definition() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_BUILDER_DEFS.isdisjoint(local_defs)
+
+
+def test_build_strategy_params_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert (
+        forward_script._build_strategy_params_from_config
+        is run_backtest_script._build_strategy_params_from_config
+    )
+
+
+def test_source_imports_canonical_strategy_params_builder() -> None:
+    source = _read_source()
+    assert "_build_strategy_params_from_config" in source
+    assert "scripts.run_backtest" in source
+
+
 def test_build_strategy_params_includes_section_and_stop_pct() -> None:
     from src.core.peak_config import PeakConfig
 
@@ -107,13 +134,15 @@ def test_build_strategy_params_includes_section_and_stop_pct() -> None:
 
 
 def test_build_strategy_params_source_uses_load_strategy_not_from_config_bypass() -> None:
-    source = inspect.getsource(forward_script._build_strategy_params_from_config)
+    import scripts.run_backtest as run_backtest_script
+
+    source = inspect.getsource(run_backtest_script._build_strategy_params_from_config)
     assert "load_strategy" in source
-    assert "get_strategy_spec" not in source
-    assert ".from_config" not in source
+    assert "spec.cls.from_config" not in source
 
 
 def test_build_strategy_params_calls_load_strategy_for_registry_validation() -> None:
+    import scripts.run_backtest as run_backtest_script
     from src.core.peak_config import PeakConfig
 
     cfg = PeakConfig(
@@ -129,7 +158,7 @@ def test_build_strategy_params_calls_load_strategy_for_registry_validation() -> 
         }
     )
 
-    with patch.object(forward_script, "load_strategy") as load_mock:
+    with patch.object(run_backtest_script, "load_strategy") as load_mock:
         load_mock.return_value = MagicMock()
         params = forward_script._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
 
@@ -172,8 +201,84 @@ def test_build_strategy_params_unknown_strategy_fails_closed() -> None:
             "strategy": {MA_CROSSOVER_KEY: {"fast_window": 10, "slow_window": 50}},
         }
     )
-    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+    with pytest.raises(KeyError):
         forward_script._build_strategy_params_from_config(cfg, "definitely_not_a_strategy_xyz")
+
+
+def test_main_forwards_config_to_canonical_builder(tmp_path) -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg_path = tmp_path / "cfg.toml"
+    cfg_path.write_text("[environment]\nmode = 'backtest'\n", encoding="utf-8")
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "backtest"},
+            "strategy": {
+                MA_CROSSOVER_KEY: {
+                    "fast_window": 10,
+                    "slow_window": 50,
+                    "price_col": "close",
+                },
+            },
+        }
+    )
+    captured: dict[str, object] = {}
+
+    def capture_builder(config, strategy_key):
+        captured["cfg"] = config
+        captured["strategy_key"] = strategy_key
+        return {"fast_window": 10, "slow_window": 50, "stop_pct": 0.02}
+
+    ohlcv_meta = {
+        "symbol": "BTC/EUR",
+        "ohlcv_source": "dummy",
+        "timeframe": "1h",
+        "n_bars_requested": 200,
+        "bars_loaded": 80,
+        "kraken_pagination_used": None,
+        "kraken_bars_shortfall": None,
+    }
+
+    with (
+        patch.object(forward_script, "load_config", return_value=cfg),
+        patch.object(forward_script, "load_data_for_symbol") as load_data,
+        patch.object(
+            forward_script,
+            "_build_strategy_params_from_config",
+            side_effect=capture_builder,
+        ),
+        patch.object(
+            forward_script,
+            "load_strategy",
+            return_value=lambda df, params: pd.Series([1.0], index=df.index[-1:]),
+        ),
+        patch.object(forward_script, "log_generic_experiment"),
+        patch.object(forward_script, "save_signals_to_csv") as save_csv,
+    ):
+        load_data.return_value = (_sample_ohlcv(), ohlcv_meta)
+        save_csv.return_value = pd.DataFrame({"symbol": ["BTC/EUR"]})
+
+        out_dir = tmp_path / "forward"
+        code = forward_script.main(
+            [
+                "--strategy",
+                MA_CROSSOVER_KEY,
+                "--symbols",
+                "BTC/EUR",
+                "--config-path",
+                str(cfg_path),
+                "--output-dir",
+                str(out_dir),
+                "--run-name",
+                "probe_builder_forward",
+                "--n-bars",
+                "80",
+            ]
+        )
+
+    assert code == 0
+    assert captured["cfg"] is cfg
+    assert captured["strategy_key"] == MA_CROSSOVER_KEY
 
 
 def test_load_strategy_ma_crossover_matches_create_strategy_from_config_signals() -> None:
@@ -293,8 +398,7 @@ def test_main_calls_load_strategy_and_passes_full_params(tmp_path, monkeypatch) 
         )
 
     assert code == 0
-    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
-    assert load_strategy_mock.call_count == 2
+    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
     assert captured["params"]["fast_window"] == 10
     assert captured["params"]["slow_window"] == 50
     assert captured["params"]["stop_pct"] == 0.02
@@ -352,8 +456,7 @@ def test_isolated_signal_fn_binding_per_symbol(tmp_path, monkeypatch) -> None:
         )
 
     assert code == 0
-    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
-    assert load_strategy_mock.call_count == 2
+    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
     assert call_count == 2
 
 

--- a/tests/scripts/test_run_forward_signals_load_strategy_v1.py
+++ b/tests/scripts/test_run_forward_signals_load_strategy_v1.py
@@ -27,10 +27,17 @@ MA_CROSSOVER_KEY = "ma_crossover"
 RSI_REVERSION_KEY = "rsi_reversion"
 
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+STRATEGY_PARAMS_BUILDER_OWNER = "scripts/run_backtest.py:_build_strategy_params_from_config"
+FORBIDDEN_LOCAL_BUILDER_DEFS = frozenset({"_build_strategy_params_from_config"})
 
 
 def _read_source() -> str:
     return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
 
 
 def _minimal_cfg(strategy_key: str, **strategy_params: object) -> MagicMock:
@@ -93,6 +100,26 @@ def test_source_uses_load_strategy() -> None:
     assert "load_strategy" in _read_source()
 
 
+def test_source_has_no_local_builder_definition() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_BUILDER_DEFS.isdisjoint(local_defs)
+
+
+def test_build_strategy_params_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert (
+        forward_runner._build_strategy_params_from_config
+        is run_backtest_script._build_strategy_params_from_config
+    )
+
+
+def test_source_imports_canonical_strategy_params_builder() -> None:
+    source = _read_source()
+    assert "_build_strategy_params_from_config" in source
+    assert "scripts.run_backtest" in source
+
+
 def test_build_strategy_params_includes_section_and_stop_pct() -> None:
     cfg = _minimal_cfg(
         MA_CROSSOVER_KEY,
@@ -109,16 +136,19 @@ def test_build_strategy_params_includes_section_and_stop_pct() -> None:
 
 
 def test_build_strategy_params_source_uses_load_strategy_not_from_config_bypass() -> None:
-    source = inspect.getsource(forward_runner._build_strategy_params_from_config)
+    import scripts.run_backtest as run_backtest_script
+
+    source = inspect.getsource(run_backtest_script._build_strategy_params_from_config)
     assert "load_strategy" in source
-    assert "get_strategy_spec" not in source
-    assert ".from_config" not in source
+    assert "spec.cls.from_config" not in source
 
 
 def test_build_strategy_params_calls_load_strategy_for_registry_validation() -> None:
+    import scripts.run_backtest as run_backtest_script
+
     cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
 
-    with patch.object(forward_runner, "load_strategy") as load_mock:
+    with patch.object(run_backtest_script, "load_strategy") as load_mock:
         load_mock.return_value = MagicMock()
         params = forward_runner._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
 
@@ -154,8 +184,69 @@ def test_build_strategy_params_isolated_per_strategy_key() -> None:
 
 def test_build_strategy_params_unknown_strategy_fails_closed() -> None:
     cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
-    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+    with pytest.raises(KeyError):
         forward_runner._build_strategy_params_from_config(cfg, "definitely_not_a_strategy_xyz")
+
+
+def test_main_forwards_config_to_canonical_builder(tmp_path) -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg_path = tmp_path / "cfg.toml"
+    cfg_path.write_text("[environment]\nmode = 'backtest'\n", encoding="utf-8")
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "backtest"},
+            "strategy": {
+                MA_CROSSOVER_KEY: {
+                    "fast_window": 10,
+                    "slow_window": 50,
+                    "price_col": "close",
+                },
+            },
+        }
+    )
+    captured: dict[str, object] = {}
+
+    def capture_builder(config, strategy_key):
+        captured["cfg"] = config
+        captured["strategy_key"] = strategy_key
+        return {"fast_window": 10, "slow_window": 50, "stop_pct": 0.02}
+
+    mock_client = MagicMock()
+    mock_client.get_name.return_value = "mock"
+    mock_client.fetch_ohlcv.return_value = _sample_ohlcv()
+
+    with (
+        patch.object(forward_runner, "load_config", return_value=cfg),
+        patch.object(forward_runner, "build_exchange_client_from_config", return_value=mock_client),
+        patch.object(
+            forward_runner,
+            "_build_strategy_params_from_config",
+            side_effect=capture_builder,
+        ),
+        patch.object(
+            forward_runner,
+            "load_strategy",
+            return_value=lambda df, params: pd.Series([1.0], index=df.index[-1:]),
+        ),
+        patch.object(forward_runner, "log_forward_signal_run", return_value="run-1"),
+    ):
+        code = forward_runner.main(
+            [
+                "--config",
+                str(cfg_path),
+                "--strategy",
+                MA_CROSSOVER_KEY,
+                "--symbol",
+                "BTC/EUR",
+                "--dry-run",
+                "--no-alerts",
+            ]
+        )
+
+    assert code == 0
+    assert captured["cfg"] is cfg
+    assert captured["strategy_key"] == MA_CROSSOVER_KEY
 
 
 def test_load_strategy_ma_crossover_matches_create_strategy_from_config_signals() -> None:
@@ -261,8 +352,7 @@ def test_main_calls_load_strategy_and_passes_full_params(tmp_path) -> None:
         )
 
     assert code == 0
-    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
-    assert load_strategy_mock.call_count == 2
+    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
     assert captured["params"]["fast_window"] == 10
     assert captured["params"]["slow_window"] == 50
     assert captured["params"]["stop_pct"] == 0.02
@@ -308,8 +398,7 @@ def test_isolated_signal_fn_binding_per_call(tmp_path) -> None:
         )
 
     assert code == 0
-    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
-    assert load_strategy_mock.call_count == 2
+    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
     assert call_count == 1
 
 


### PR DESCRIPTION
## Summary

- **Bundle-ID:** `BUNDLE_FORWARD_SIGNALS_STRATEGY_PARAMS_CANONICAL_REUSE_V1`
- Entfernt lokale `_build_strategy_params_from_config`-Duplikate in `scripts/run_forward_signals.py` und `scripts/generate_forward_signals.py`
- Wiederverwendung des kanonischen Builders `scripts/run_backtest.py::_build_strategy_params_from_config`
- Fachliche Kohärenz: beide Skripte gehören zur Forward-Signals-Domäne und nutzen dasselbe mechanische Reuse-Muster

## Semantikmatrizen (bestätigt)

Beide Zielskripte hatten identische vereinfachte lokale Builder (direkter `strategy_key`-Lookup, `load_strategy(strategy_key)`, `stop_pct` via `cfg.get`). Für Registry-Keys (`ma_crossover`, `rsi_reversion`, `momentum_1h`) ist das Verhalten mit dem kanonischen Owner äquivalent; Alias-Auflösung wird über den kanonischen Pfad konsistent abgedeckt.

| Aspekt | run_forward_signals | generate_forward_signals | Kanonisch |
|--------|---------------------|--------------------------|-----------|
| Config-Struktur | `cfg.raw["strategy"][key]` | identisch | + Alias/`section_key` |
| Strategy-Key | CLI `--strategy` | CLI `--strategy` | Registry + Spec |
| Parameterquelle | strategy-Section + stop_pct | identisch | identisch + Fallback |
| Fehlender strategy-Block | `{}` + default stop_pct | identisch | identisch |
| None vs leeres Dict | `dict(section)` oder `{}` | identisch | identisch |
| Input-Mutation | keine | keine | keine |
| Rückgabetyp | `Dict[str, Any]` | identisch | identisch |
| Unbekannter Key | `KeyError` (via Spec) | identisch | `KeyError` |

## Testowner & lokale Ergebnisse

- `tests/scripts/test_run_forward_signals_load_strategy_v1.py` — 21 Tests, alle PASS
- `tests/scripts/test_generate_forward_signals_load_strategy_v1.py` — 22 Tests, alle PASS

Contract-Assertions: keine lokale Builder-Definition, Import-Identität mit kanonischem Owner, Config-/Params-Weitergabe, AST/Source-Contracts.

## CI-Modus

- `CI_MODE_REQUIRED=FOCUSED`
- `CI_MODE_REASON=two semantically identical forward-signals script consumers with two explicit test owners and no src or central infrastructure changes`
- `CI_SELECTOR_ACTUAL_MODE=FOCUSED`

## Safety & Scope

- Offline/no-run; keine Trading-, Risk- oder Runtime-Fläche
- Keine neue Config-/Mapping-/Helper-Surface
- `scripts/run_backtest.py` unverändert
- Ausgeschlossen: Market-Scan, Portfolio, `src/sweeps/engine.py`, heterogene Bundle-Kandidaten

## Test plan

- [x] `python3 -m pytest -q tests/scripts/test_run_forward_signals_load_strategy_v1.py tests/scripts/test_generate_forward_signals_load_strategy_v1.py`
- [x] `ruff format --check` und `ruff check` auf den vier Bundle-Dateien
- [x] CI-Selector-Simulation → FOCUSED


Made with [Cursor](https://cursor.com)