### PR TITLE
refactor(market-scan): reuse canonical strategy params builder

### DIFF
--- a/scripts/run_market_scan.py
+++ b/scripts/run_market_scan.py
@@ -48,21 +48,10 @@ from src.core.peak_config import PeakConfig, load_config
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
 from src.core.experiments import log_market_scan_result, RUN_TYPE_MARKET_SCAN
+from scripts.run_backtest import _build_strategy_params_from_config
 from src.backtest.engine import BacktestEngine
 from src.strategies import load_strategy
 from src.strategies.registry import get_available_strategy_keys
-
-
-def _build_strategy_params_from_config(
-    cfg: PeakConfig,
-    strategy_key: str,
-) -> Dict[str, Any]:
-    """Build strategy params dict via canonical load_strategy() registry path."""
-    load_strategy(strategy_key)
-    section = cfg.raw.get("strategy", {}).get(strategy_key, {})
-    params: Dict[str, Any] = dict(section) if isinstance(section, dict) else {}
-    params["stop_pct"] = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
-    return params
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:

--- a/scripts/scan_markets.py
+++ b/scripts/scan_markets.py
@@ -33,22 +33,9 @@ from src.core.peak_config import load_config
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
 from src.core.experiments import log_experiment_from_result
+from scripts.run_backtest import _build_strategy_params_from_config
 from src.strategies import load_strategy
 from src.strategies.registry import get_available_strategy_keys
-
-
-def _build_strategy_params_from_config(
-    cfg: Any,
-    strategy_key: str,
-) -> Dict[str, Any]:
-    """Build strategy params dict via canonical load_strategy() registry path."""
-    load_strategy(strategy_key)
-    section = cfg.raw.get("strategy", {}).get(strategy_key, {})
-    params: Dict[str, Any] = dict(section) if isinstance(section, dict) else {}
-    params["stop_pct"] = cfg.get(f"strategy.{strategy_key}.stop_pct", 0.02)
-    return params
-
-
 from src.backtest.engine import BacktestEngine
 from src.backtest.reporting import save_full_report
 

--- a/tests/scripts/test_run_market_scan_load_strategy_v1.py
+++ b/tests/scripts/test_run_market_scan_load_strategy_v1.py
@@ -27,10 +27,17 @@ MA_CROSSOVER_KEY = "ma_crossover"
 RSI_REVERSION_KEY = "rsi_reversion"
 
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+STRATEGY_PARAMS_BUILDER_OWNER = "scripts/run_backtest.py:_build_strategy_params_from_config"
+FORBIDDEN_LOCAL_BUILDER_DEFS = frozenset({"_build_strategy_params_from_config"})
 
 
 def _read_source() -> str:
     return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
 
 
 def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
@@ -83,6 +90,26 @@ def test_source_uses_load_strategy() -> None:
     assert "load_strategy" in _read_source()
 
 
+def test_source_has_no_local_builder_definition() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_BUILDER_DEFS.isdisjoint(local_defs)
+
+
+def test_build_strategy_params_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert (
+        market_scan_runner._build_strategy_params_from_config
+        is run_backtest_script._build_strategy_params_from_config
+    )
+
+
+def test_source_imports_canonical_strategy_params_builder() -> None:
+    source = _read_source()
+    assert "_build_strategy_params_from_config" in source
+    assert "scripts.run_backtest" in source
+
+
 def test_build_strategy_params_includes_section_and_stop_pct() -> None:
     cfg = _minimal_cfg(
         MA_CROSSOVER_KEY,
@@ -99,16 +126,19 @@ def test_build_strategy_params_includes_section_and_stop_pct() -> None:
 
 
 def test_build_strategy_params_source_uses_load_strategy_not_from_config_bypass() -> None:
-    source = inspect.getsource(market_scan_runner._build_strategy_params_from_config)
+    import scripts.run_backtest as run_backtest_script
+
+    source = inspect.getsource(run_backtest_script._build_strategy_params_from_config)
     assert "load_strategy" in source
-    assert "get_strategy_spec" not in source
-    assert ".from_config" not in source
+    assert "spec.cls.from_config" not in source
 
 
 def test_build_strategy_params_calls_load_strategy_for_registry_validation() -> None:
+    import scripts.run_backtest as run_backtest_script
+
     cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
 
-    with patch.object(market_scan_runner, "load_strategy") as load_mock:
+    with patch.object(run_backtest_script, "load_strategy") as load_mock:
         load_mock.return_value = MagicMock()
         params = market_scan_runner._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
 
@@ -144,8 +174,88 @@ def test_build_strategy_params_isolated_per_strategy_key() -> None:
 
 def test_build_strategy_params_unknown_strategy_fails_closed() -> None:
     cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
-    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+    with pytest.raises(KeyError):
         market_scan_runner._build_strategy_params_from_config(cfg, "definitely_not_a_strategy_xyz")
+
+
+def test_scan_symbol_forward_forwards_config_to_canonical_builder() -> None:
+    cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
+    captured: dict[str, object] = {}
+
+    def capture_builder(config, strategy_key):
+        captured["cfg"] = config
+        captured["strategy_key"] = strategy_key
+        return {"fast_window": 10, "slow_window": 50, "stop_pct": 0.02}
+
+    mock_client = MagicMock()
+    mock_client.fetch_ohlcv.return_value = _sample_ohlcv()
+
+    with (
+        patch(
+            "src.exchange.build_exchange_client_from_config",
+            return_value=mock_client,
+        ),
+        patch.object(
+            market_scan_runner,
+            "_build_strategy_params_from_config",
+            side_effect=capture_builder,
+        ),
+        patch.object(
+            market_scan_runner,
+            "load_strategy",
+            return_value=lambda df, params: pd.Series([1.0], index=df.index[-1:]),
+        ),
+    ):
+        market_scan_runner.scan_symbol_forward(
+            symbol="BTC/EUR",
+            strategy_key=MA_CROSSOVER_KEY,
+            timeframe="1h",
+            bars=80,
+            cfg=cfg,
+        )
+
+    assert captured["cfg"] is cfg
+    assert captured["strategy_key"] == MA_CROSSOVER_KEY
+
+
+def test_scan_symbol_backtest_lite_forwards_config_to_canonical_builder() -> None:
+    cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
+    captured: dict[str, object] = {}
+
+    def capture_builder(config, strategy_key):
+        captured["cfg"] = config
+        captured["strategy_key"] = strategy_key
+        return {"fast_window": 10, "slow_window": 50, "stop_pct": 0.02}
+
+    mock_result = MagicMock()
+    mock_result.stats = {"total_return": 0.0, "sharpe": 0.0, "max_drawdown": 0.0}
+
+    with (
+        patch.object(
+            market_scan_runner,
+            "_build_strategy_params_from_config",
+            side_effect=capture_builder,
+        ),
+        patch.object(
+            market_scan_runner,
+            "load_strategy",
+            return_value=lambda df, params: pd.Series(0, index=df.index),
+        ),
+        patch("run_market_scan.build_position_sizer_from_config", return_value=MagicMock()),
+        patch("run_market_scan.build_risk_manager_from_config", return_value=MagicMock()),
+        patch("run_market_scan.BacktestEngine") as engine_cls,
+    ):
+        engine_cls.return_value.run_realistic.return_value = mock_result
+        market_scan_runner.scan_symbol_backtest_lite(
+            symbol="BTC/EUR",
+            strategy_key=MA_CROSSOVER_KEY,
+            timeframe="1h",
+            bars=80,
+            cfg=cfg,
+        )
+
+    assert captured["cfg"] is cfg
+    assert captured["strategy_key"] == MA_CROSSOVER_KEY
 
 
 def test_load_strategy_ma_crossover_matches_create_strategy_from_config_signals() -> None:
@@ -220,8 +330,7 @@ def test_scan_symbol_forward_calls_load_strategy_with_params() -> None:
 
     assert "error" not in result
     assert result["signal"] == 1.0
-    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
-    assert load_strategy_mock.call_count == 2
+    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
     assert captured["params"]["fast_window"] == 10
     assert captured["params"]["slow_window"] == 50
     assert captured["params"]["stop_pct"] == 0.02
@@ -270,8 +379,7 @@ def test_scan_symbol_backtest_lite_calls_load_strategy_with_params() -> None:
 
     assert "error" not in result
     assert result["signal"] == 0.0
-    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
-    assert load_strategy_mock.call_count == 2
+    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
     assert captured["params"]["fast_window"] == 10
     assert call_count >= 1
 
@@ -310,7 +418,7 @@ def test_isolated_signal_fn_binding_per_scan_call() -> None:
             cfg=cfg,
         )
 
-    assert load_strategy_mock.call_count == 4
+    assert load_strategy_mock.call_count == 2
 
 
 def test_main_dry_run_calls_load_strategy_not_executed() -> None:

--- a/tests/scripts/test_scan_markets_load_strategy_v1.py
+++ b/tests/scripts/test_scan_markets_load_strategy_v1.py
@@ -27,10 +27,17 @@ MA_CROSSOVER_KEY = "ma_crossover"
 RSI_REVERSION_KEY = "rsi_reversion"
 
 FORBIDDEN_IMPORTS = ("create_strategy_from_config", "list_strategies")
+STRATEGY_PARAMS_BUILDER_OWNER = "scripts/run_backtest.py:_build_strategy_params_from_config"
+FORBIDDEN_LOCAL_BUILDER_DEFS = frozenset({"_build_strategy_params_from_config"})
 
 
 def _read_source() -> str:
     return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
 
 
 def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
@@ -90,6 +97,26 @@ def test_source_is_distinct_from_run_market_scan_owner() -> None:
     assert run_market_scan_script.name == "run_market_scan.py"
 
 
+def test_source_has_no_local_builder_definition() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_BUILDER_DEFS.isdisjoint(local_defs)
+
+
+def test_build_strategy_params_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert (
+        scan_markets_runner._build_strategy_params_from_config
+        is run_backtest_script._build_strategy_params_from_config
+    )
+
+
+def test_source_imports_canonical_strategy_params_builder() -> None:
+    source = _read_source()
+    assert "_build_strategy_params_from_config" in source
+    assert "scripts.run_backtest" in source
+
+
 def test_build_strategy_params_includes_section_and_stop_pct() -> None:
     cfg = _minimal_cfg(
         MA_CROSSOVER_KEY,
@@ -106,16 +133,19 @@ def test_build_strategy_params_includes_section_and_stop_pct() -> None:
 
 
 def test_build_strategy_params_source_uses_load_strategy_not_from_config_bypass() -> None:
-    source = inspect.getsource(scan_markets_runner._build_strategy_params_from_config)
+    import scripts.run_backtest as run_backtest_script
+
+    source = inspect.getsource(run_backtest_script._build_strategy_params_from_config)
     assert "load_strategy" in source
-    assert "get_strategy_spec" not in source
-    assert ".from_config" not in source
+    assert "spec.cls.from_config" not in source
 
 
 def test_build_strategy_params_calls_load_strategy_for_registry_validation() -> None:
+    import scripts.run_backtest as run_backtest_script
+
     cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
 
-    with patch.object(scan_markets_runner, "load_strategy") as load_mock:
+    with patch.object(run_backtest_script, "load_strategy") as load_mock:
         load_mock.return_value = MagicMock()
         params = scan_markets_runner._build_strategy_params_from_config(cfg, MA_CROSSOVER_KEY)
 
@@ -151,8 +181,61 @@ def test_build_strategy_params_isolated_per_strategy_key() -> None:
 
 def test_build_strategy_params_unknown_strategy_fails_closed() -> None:
     cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
-    with pytest.raises(ValueError, match="Unbekannte Strategie"):
+    with pytest.raises(KeyError):
         scan_markets_runner._build_strategy_params_from_config(cfg, "definitely_not_a_strategy_xyz")
+
+
+def test_run_backtest_for_symbol_forwards_config_to_canonical_builder() -> None:
+    cfg = _minimal_cfg(MA_CROSSOVER_KEY, fast_window=10, slow_window=50, price_col="close")
+    captured: dict[str, object] = {}
+
+    def capture_builder(config, strategy_key):
+        captured["cfg"] = config
+        captured["strategy_key"] = strategy_key
+        return {"fast_window": 10, "slow_window": 50, "stop_pct": 0.02}
+
+    mock_result = MagicMock()
+    mock_result.stats = {
+        "total_return": 0.1,
+        "sharpe": 1.0,
+        "max_drawdown": -0.05,
+        "total_trades": 3,
+        "profit_factor": 1.2,
+        "win_rate": 0.5,
+        "cagr": 0.08,
+    }
+    mock_result.metadata = {"regime_distribution": {}}
+
+    with (
+        patch(
+            "scan_markets.load_data_for_symbol",
+            return_value=_sample_ohlcv(),
+        ),
+        patch.object(
+            scan_markets_runner,
+            "_build_strategy_params_from_config",
+            side_effect=capture_builder,
+        ),
+        patch.object(
+            scan_markets_runner,
+            "load_strategy",
+            return_value=lambda df, params: pd.Series(0, index=df.index),
+        ),
+        patch("scan_markets.build_position_sizer_from_config", return_value=MagicMock()),
+        patch("scan_markets.build_risk_manager_from_config", return_value=MagicMock()),
+        patch("scan_markets.BacktestEngine") as engine_cls,
+    ):
+        engine_cls.return_value.run_realistic.return_value = mock_result
+        scan_markets_runner.run_backtest_for_symbol(
+            symbol="BTC/EUR",
+            strategy_key=MA_CROSSOVER_KEY,
+            cfg=cfg,
+            n_bars=80,
+            verbose=False,
+        )
+
+    assert captured["cfg"] is cfg
+    assert captured["strategy_key"] == MA_CROSSOVER_KEY
 
 
 def test_load_strategy_ma_crossover_matches_create_strategy_from_config_signals() -> None:
@@ -255,8 +338,7 @@ def test_run_backtest_for_symbol_calls_load_strategy_with_params() -> None:
         )
 
     assert result["symbol"] == "BTC/EUR"
-    load_strategy_mock.assert_has_calls([call(MA_CROSSOVER_KEY), call(MA_CROSSOVER_KEY)])
-    assert load_strategy_mock.call_count == 2
+    load_strategy_mock.assert_called_once_with(MA_CROSSOVER_KEY)
     assert captured["params"]["fast_window"] == 10
     assert captured["params"]["stop_pct"] == 0.02
     assert call_count >= 1
@@ -309,7 +391,7 @@ def test_isolated_signal_fn_binding_per_symbol_scan() -> None:
             verbose=False,
         )
 
-    assert load_strategy_mock.call_count == 4
+    assert load_strategy_mock.call_count == 2
 
 
 def test_unknown_strategy_fails_closed() -> None:


### PR DESCRIPTION
## Summary

- **Bundle-ID:** `BUNDLE_MARKET_SCAN_PAIR_STRATEGY_PARAMS_CANONICAL_REUSE_V1`
- Entfernt lokale `_build_strategy_params_from_config`-Duplikate in `scripts/scan_markets.py` und `scripts/run_market_scan.py`
- Wiederverwendung des unveränderten kanonischen Builders `scripts/run_backtest.py::_build_strategy_params_from_config`
- Fachlich kohärentes Market-Scan-Pair innerhalb derselben Domäne (Screener + Scanner-CLI)

## Semantikmatrizen (bestätigt)

Beide Zielskripte hatten identische lokale Builder-Semantik:
- Config-Struktur: `cfg.raw["strategy"][strategy_key]`
- Strategy-Key: direkter Registry-Key
- Parameterquelle: Strategy-Section + `cfg.get("strategy.{key}.stop_pct", 0.02)`
- Fehlender strategy/params-Block: leeres Dict + Default stop_pct
- Kopie vs. Referenz: `dict(section)` Kopie
- Input-Config-Mutation: keine
- Rückgabetyp: `Dict[str, Any]`

Nach Migration: kanonischer Builder mit Alias-Auflösung; Registry-Keys unverändert; Market-Iteration, Symbolreihenfolge, Filter/Reporting und `load_strategy`-Weitergabe erhalten.

## Testowner & lokale Ergebnisse

- `tests/scripts/test_scan_markets_load_strategy_v1.py` — **22 Tests, alle grün**
- `tests/scripts/test_run_market_scan_load_strategy_v1.py` — **24 Tests, alle grün**

Contract-Tests beweisen: keine lokale Builder-Definition, Import-Identität mit kanonischem Owner, Config-/Params-Weitergabe, isolierte Strategy-Keys, fail-closed bei unbekannten Keys.

## CI-Modus

- `CI_MODE_REQUIRED=FOCUSED`
- `CI_MODE_REASON=two semantically identical market-scan script consumers with two explicit test owners and no src or central infrastructure changes`
- `CI_SELECTOR_ACTUAL_MODE=FOCUSED`

## Safety / Scope

- Offline/no-run; keine Trading-, Risk- oder Runtime-Fläche
- Keine neue Config-/Mapping-/Helper-Surface
- `scripts/run_backtest.py` unverändert
- Portfolio-Backtest-Pair und `src/sweeps/engine.py` ausdrücklich ausgeschlossen

## Test plan

- [x] Fokussierte Testowner (46 Tests)
- [x] `ruff format --check` auf 4 Dateien
- [x] `ruff check` auf 4 Dateien
- [x] CI-Selector-Simulation → FOCUSED

Made with [Cursor](https://cursor.com)