### PR TITLE
refactor(research): reuse canonical registry gate validation

### DIFF
--- a/scripts/research_run_strategy.py
+++ b/scripts/research_run_strategy.py
@@ -49,7 +49,11 @@ import pandas as pd
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts.run_backtest import _build_strategy_params_from_config, load_ohlcv_data
+from scripts.run_backtest import (
+    _build_strategy_params_from_config,
+    _validate_strategy_registry_gates,
+    load_ohlcv_data,
+)
 from src.core.peak_config import load_config, PeakConfig
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
@@ -65,42 +69,6 @@ from src.strategies.registry import (
     get_strategy_spec,
     list_strategies,
 )
-
-
-def _validate_strategy_registry_gates(key: str, cfg: PeakConfig) -> None:
-    """Mirror registry environment/tier gates (fail-closed)."""
-    spec = get_strategy_spec(key)
-
-    env_mode = cfg.get("environment.mode")
-    if not env_mode:
-        env_mode = cfg.get("env.mode")
-    if not env_mode:
-        env_mode = cfg.get("runtime.environment")
-    if not env_mode:
-        env_mode = cfg.get("environment.runtime_environment")
-    if not env_mode:
-        env_mode = "backtest"
-
-    if env_mode == "live" and not spec.is_live_ready:
-        raise ValueError(
-            f"Strategy '{key}' cannot be used in LIVE mode (IS_LIVE_READY=False). "
-            f"This strategy is R&D-only and not validated for live trading."
-        )
-
-    if spec.tier == "r_and_d":
-        allow_rnd = cfg.get("research.allow_r_and_d_strategies", False)
-        if not allow_rnd:
-            raise ValueError(
-                f"Strategy '{key}' is R&D-only (TIER=r_and_d) and requires "
-                f"'research.allow_r_and_d_strategies = true' in config."
-            )
-
-    if env_mode not in spec.allowed_environments:
-        allowed_str = ", ".join(spec.allowed_environments)
-        raise ValueError(
-            f"Strategy '{key}' not allowed in environment '{env_mode}'. "
-            f"Allowed environments: {allowed_str}"
-        )
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/scripts/test_research_run_strategy_load_strategy_v1.py
+++ b/tests/scripts/test_research_run_strategy_load_strategy_v1.py
@@ -29,8 +29,10 @@ TREND_FOLLOWING_KEY = "trend_following"
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
 DATA_LOADER_OWNER = "scripts/run_backtest.py:load_ohlcv_data"
 STRATEGY_PARAMS_BUILDER_OWNER = "scripts/run_backtest.py:_build_strategy_params_from_config"
+CANONICAL_REGISTRY_GATE_OWNER = "scripts/run_backtest.py:_validate_strategy_registry_gates"
 FORBIDDEN_LOCAL_LOADER_DEFS = frozenset({"load_ohlcv_data", "generate_dummy_ohlcv"})
 FORBIDDEN_LOCAL_BUILDER_DEFS = frozenset({"_build_strategy_params_from_config"})
+FORBIDDEN_LOCAL_REGISTRY_GATE_DEFS = frozenset({"_validate_strategy_registry_gates"})
 
 
 def _read_source() -> str:
@@ -547,6 +549,121 @@ def test_unknown_strategy_fails_closed() -> None:
 
     with pytest.raises(ValueError, match="Unbekannte Strategie"):
         load_strategy("definitely_not_a_research_run_strategy_xyz")
+
+
+# ---------------------------------------------------------------------------
+# Registry gates — canonical _validate_strategy_registry_gates reuse
+# ---------------------------------------------------------------------------
+
+
+def test_source_has_no_local_registry_gate_definition() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_REGISTRY_GATE_DEFS.isdisjoint(local_defs)
+
+
+def test_validate_strategy_registry_gates_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert (
+        research_runner._validate_strategy_registry_gates
+        is run_backtest_script._validate_strategy_registry_gates
+    )
+
+
+def test_source_imports_canonical_registry_gate_validator() -> None:
+    source = _read_source()
+    assert "_validate_strategy_registry_gates" in source
+    assert "scripts.run_backtest" in source
+
+
+def test_registry_gates_block_r_and_d_without_flag() -> None:
+    from src.core.peak_config import PeakConfig
+
+    raw = {"environment": {"mode": "backtest"}, "strategy": {"ehlers_cycle_filter": {}}}
+    cfg = PeakConfig(raw=raw)
+    with pytest.raises(ValueError, match="R&D-only"):
+        research_runner._validate_strategy_registry_gates("ehlers_cycle_filter", cfg)
+
+
+def test_unknown_strategy_fails_closed_at_registry_gates() -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg = PeakConfig(raw={"environment": {"mode": "backtest"}})
+    with pytest.raises(KeyError):
+        research_runner._validate_strategy_registry_gates("definitely_not_a_strategy_xyz", cfg)
+
+
+def test_main_invokes_registry_gates_before_strategy_params(tmp_path, monkeypatch) -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg_path = tmp_path / "cfg.toml"
+    cfg_path.write_text("[environment]\nmode = 'backtest'\n", encoding="utf-8")
+    cfg = PeakConfig(
+        raw={
+            "environment": {"mode": "backtest"},
+            "strategy": {
+                MA_CROSSOVER_KEY: {
+                    "fast_window": 10,
+                    "slow_window": 50,
+                    "price_col": "close",
+                },
+            },
+        }
+    )
+    call_order: list[str] = []
+    gate_mock = MagicMock(side_effect=lambda key, config: call_order.append("gates"))
+    builder_mock = MagicMock(
+        side_effect=lambda config, strategy_key: (
+            call_order.append("builder"),
+            {"fast_window": 10, "slow_window": 50, "stop_pct": 0.02},
+        )[1]
+    )
+    mock_result = MagicMock()
+    mock_result.stats = {
+        "total_return": 0.0,
+        "max_drawdown": 0.0,
+        "sharpe": 0.0,
+        "cagr": 0.0,
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "profit_factor": 0.0,
+    }
+    mock_result.equity_curve = pd.Series([100.0, 100.0])
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "research_run_strategy.py",
+            "--config",
+            str(cfg_path),
+            "--strategy",
+            MA_CROSSOVER_KEY,
+            "--no-registry",
+        ],
+    )
+
+    with (
+        patch.object(research_runner, "load_config", return_value=cfg),
+        patch.object(research_runner, "_validate_strategy_registry_gates", gate_mock),
+        patch.object(research_runner, "_build_strategy_params_from_config", builder_mock),
+        patch.object(research_runner, "load_ohlcv_data", return_value=_sample_ohlcv()),
+        patch.object(
+            research_runner,
+            "load_strategy",
+            return_value=lambda df, params: pd.Series(0, index=df.index),
+        ),
+        patch.object(research_runner, "build_position_sizer_from_config", return_value=MagicMock()),
+        patch.object(research_runner, "build_risk_manager_from_config", return_value=MagicMock()),
+        patch.object(research_runner, "BacktestEngine") as engine_cls,
+    ):
+        engine_cls.return_value.run_realistic.return_value = mock_result
+        code = research_runner.main()
+
+    assert code == 0
+    gate_mock.assert_called_once_with(MA_CROSSOVER_KEY, cfg)
+    builder_mock.assert_called_once_with(cfg, MA_CROSSOVER_KEY)
+    assert call_order == ["gates", "builder"]
 
 
 def test_load_strategy_no_network_calls() -> None:


### PR DESCRIPTION
## Summary

- **SINGLE-Entscheidung**: Nur `scripts/research_run_strategy.py` migriert; gemeinsames Research+Sweep-Bundle verworfen (heterogene Domänen).
- **Lokale Duplikation entfernt**: `_validate_strategy_registry_gates` aus `scripts/research_run_strategy.py` entfernt.
- **Kanonischer Owner**: `scripts/run_backtest.py:_validate_strategy_registry_gates` — unverändert, per Import wiederverwendet.
- **Semantikmatrix (bewiesen)**: Identische Zeilen-/Semantik zu kanonischem Validator — env-mode-Auflösung, live-ready-Gate, R&D-tier-Gate, allowed-environments-Gate, Fail-fast-Reihenfolge, ValueError/KeyError-Verhalten, unveränderte Config-Weitergabe, Gate vor `_build_strategy_params_from_config` und `load_strategy`.
- **Testowner**: `tests/scripts/test_research_run_strategy_load_strategy_v1.py` erweitert (32 Tests, alle grün lokal).
- **CI_MODE_REQUIRED=FOCUSED**
- **CI_MODE_REASON**: single research script consumer reusing an existing canonical registry gate validator with explicit test ownership and no src or central infrastructure changes
- **CI_SELECTOR_ACTUAL_MODE=FOCUSED**
- Offline/no-run; keine Trading-, Risk- oder Runtime-Fläche berührt.
- Keine neue Registry-/Gate-/Helper-Surface.
- `scripts/run_sweep.py` ausdrücklich ausgeschlossen (verbleibender separater Kandidat).

## Test plan

- [x] `pytest tests/scripts/test_research_run_strategy_load_strategy_v1.py -q` (32 passed)
- [x] `ruff format --check` und `ruff check` auf geänderten Dateien
- [x] CI selector simulation → FOCUSED


Made with [Cursor](https://cursor.com)