### PR TITLE
refactor(sweeps): reuse canonical registry gate validation

### DIFF
--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -41,7 +41,10 @@ import pandas as pd
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts.run_backtest import load_ohlcv_data
+from scripts.run_backtest import (
+    _validate_strategy_registry_gates,
+    load_ohlcv_data,
+)
 from src.core.peak_config import PeakConfig, load_config
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
@@ -136,42 +139,6 @@ def _resolve_stop_pct(
     if engine_stop_pct is not None:
         return float(engine_stop_pct)
     return _ENGINE_STOP_PCT_DEFAULT
-
-
-def _validate_strategy_registry_gates(strategy_key: str, cfg: PeakConfig) -> None:
-    """Mirror registry environment/tier gates (fail-closed)."""
-    spec = get_strategy_spec(strategy_key)
-
-    env_mode = cfg.get("environment.mode")
-    if not env_mode:
-        env_mode = cfg.get("env.mode")
-    if not env_mode:
-        env_mode = cfg.get("runtime.environment")
-    if not env_mode:
-        env_mode = cfg.get("environment.runtime_environment")
-    if not env_mode:
-        env_mode = "backtest"
-
-    if env_mode == "live" and not spec.is_live_ready:
-        raise ValueError(
-            f"Strategy '{strategy_key}' cannot be used in LIVE mode (IS_LIVE_READY=False). "
-            f"This strategy is R&D-only and not validated for live trading."
-        )
-
-    if spec.tier == "r_and_d":
-        allow_rnd = cfg.get("research.allow_r_and_d_strategies", False)
-        if not allow_rnd:
-            raise ValueError(
-                f"Strategy '{strategy_key}' is R&D-only (TIER=r_and_d) and requires "
-                f"'research.allow_r_and_d_strategies = true' in config."
-            )
-
-    if env_mode not in spec.allowed_environments:
-        allowed_str = ", ".join(spec.allowed_environments)
-        raise ValueError(
-            f"Strategy '{strategy_key}' not allowed in environment '{env_mode}'. "
-            f"Allowed environments: {allowed_str}"
-        )
 
 
 def _strategy_class_defaults(strategy_key: str) -> Dict[str, Any]:

--- a/tests/scripts/test_run_sweep_contract_v1.py
+++ b/tests/scripts/test_run_sweep_contract_v1.py
@@ -28,7 +28,9 @@ TARGET_SCRIPT = project_root / "scripts/run_sweep.py"
 MA_CROSSOVER_KEY = "ma_crossover"
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
 DATA_LOADER_OWNER = "scripts/run_backtest.py:load_ohlcv_data"
+CANONICAL_REGISTRY_GATE_OWNER = "scripts/run_backtest.py:_validate_strategy_registry_gates"
 FORBIDDEN_LOCAL_LOADER_DEFS = frozenset({"load_ohlcv_data", "generate_dummy_ohlcv"})
+FORBIDDEN_LOCAL_REGISTRY_GATE_DEFS = frozenset({"_validate_strategy_registry_gates"})
 
 
 def _read_source() -> str:
@@ -401,8 +403,86 @@ def test_closure_creates_fresh_load_strategy_binding_per_call() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Registry gates — _validate_strategy_registry_gates path preserved
+# Registry gates — canonical _validate_strategy_registry_gates reuse
 # ---------------------------------------------------------------------------
+
+
+def test_source_has_no_local_registry_gate_definition() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_REGISTRY_GATE_DEFS.isdisjoint(local_defs)
+
+
+def test_validate_strategy_registry_gates_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert (
+        run_sweep_script._validate_strategy_registry_gates
+        is run_backtest_script._validate_strategy_registry_gates
+    )
+
+
+def test_source_imports_canonical_registry_gate_validator() -> None:
+    source = _read_source()
+    assert "_validate_strategy_registry_gates" in source
+    assert "scripts.run_backtest" in source
+
+
+def test_unknown_strategy_fails_closed_at_registry_gates() -> None:
+    from src.core.peak_config import PeakConfig
+
+    cfg = PeakConfig(raw={"environment": {"mode": "backtest"}})
+    with pytest.raises(KeyError):
+        run_sweep_script._validate_strategy_registry_gates("definitely_not_a_strategy_xyz", cfg)
+
+
+def test_run_single_backtest_invokes_registry_gates_before_parameter_merge() -> None:
+    cfg = DummyConfig(
+        {
+            "environment": {"mode": "backtest"},
+            "strategy": {MA_CROSSOVER_KEY: {"fast_window": 10, "slow_window": 30}},
+        }
+    )
+    df = _sample_ohlcv()
+    call_order: list[str] = []
+    gate_mock = MagicMock(side_effect=lambda key, config: call_order.append("gates"))
+    defaults_mock = MagicMock(
+        side_effect=lambda key: (
+            call_order.append("defaults"),
+            {"fast_window": 20, "slow_window": 50},
+        )[1]
+    )
+    merge_mock = MagicMock(
+        side_effect=lambda key, params, **kwargs: (
+            call_order.append("merge"),
+            {"fast_window": 10, "slow_window": 30, "stop_pct": 0.02},
+        )[1]
+    )
+
+    with (
+        patch.object(
+            run_sweep_script, "build_position_sizer_from_config", return_value=MagicMock()
+        ),
+        patch.object(run_sweep_script, "build_risk_manager_from_config", return_value=MagicMock()),
+        patch.object(run_sweep_script, "_validate_strategy_registry_gates", gate_mock),
+        patch.object(run_sweep_script, "_strategy_class_defaults", defaults_mock),
+        patch.object(run_sweep_script, "_merge_effective_parameters", merge_mock),
+        patch.object(
+            run_sweep_script,
+            "load_strategy",
+            return_value=lambda data, params: pd.Series(0, index=data.index),
+        ),
+        patch.object(run_sweep_script.BacktestEngine, "run_realistic") as run_realistic,
+    ):
+        run_realistic.return_value = MagicMock(stats={})
+        run_sweep_script.run_single_backtest(
+            df=df,
+            strategy_key=MA_CROSSOVER_KEY,
+            params={"fast_window": 10, "slow_window": 30},
+            cfg=cfg,
+        )
+
+    gate_mock.assert_called_once_with(MA_CROSSOVER_KEY, cfg)
+    assert call_order == ["gates", "defaults", "merge"]
 
 
 def test_run_single_backtest_propagates_registry_gate_failure() -> None:


### PR DESCRIPTION
## Summary

- **SELECTED_OPTION=SINGLE** — letztes lokales Registry-Gate-Duplikat in der Reuse-Lane
- Entfernt lokale `_validate_strategy_registry_gates`-Definition aus `scripts/run_sweep.py`
- Importiert kanonischen Validator aus `scripts/run_backtest.py:_validate_strategy_registry_gates`
- Erweitert bestehenden Testowner `tests/scripts/test_run_sweep_contract_v1.py` (AST/Import-Identität, Gate-Reihenfolge, Fail-fast)

## Semantikmatrix (bestätigt)

| Aspekt | Verhalten |
|--------|-----------|
| Strategy-/Registry-Konfiguration | Unverändert; `PeakConfig`/`DummyConfig` unverändert weitergereicht |
| Strategy-Key-/Alias-Auflösung | Unverändert (Sweep-eigene Alias-Tabelle bleibt) |
| Aktivierte Gates | live-ready, R&D-tier, allowed_environments |
| Fehlende Registry-Einträge | `KeyError` via `get_strategy_spec` |
| Unbekannte Strategy-Keys | `KeyError` fail-closed |
| Duplicate-/Conflict-Verhalten | Sweep-Parameter-Normalisierung unberührt |
| Prüfreihenfolge | Gates vor `_strategy_class_defaults` / `_merge_effective_parameters` |
| Return-Verhalten | `None` (void gate) |
| Exception-Typen | `ValueError` (live/R&D/env), `KeyError` (unknown key) |
| Input-Config-Mutation | Keine Mutation im Gate-Pfad |
| Sweep-Runner-Weitergabe | `run_single_backtest` ruft importierten Validator mit `(strategy_key, cfg)` |

## Kanonischer Owner

`scripts/run_backtest.py:_validate_strategy_registry_gates` — unverändert

## Testowner & lokale Ergebnisse

- `tests/scripts/test_run_sweep_contract_v1.py`: **54 passed**
- `ruff format --check`: RC=0
- `ruff check`: RC=0

## CI

- `CI_MODE_REQUIRED=FOCUSED`
- `CI_MODE_REASON=single run-sweep script consumer reusing an existing canonical registry gate validator with explicit test ownership and no src or central infrastructure changes`
- `CI_SELECTOR_ACTUAL_MODE=FOCUSED`

## Safety

- offline/no-run; keine Trading-, Risk- oder Runtime-Fläche
- keine neue Registry-/Gate-/Helper-Surface
- `src/sweeps/engine.py` ausdrücklich unverändert
- Registry-Gates-Reuse-Lane nach Merge voraussichtlich **geschlossen** (kein weiteres konkretes Duplikat repo-weit)


Made with [Cursor](https://cursor.com)