### PR TITLE
refactor(backtest): reuse canonical OHLCV loader in remaining runners

### DIFF
--- a/scripts/run_strategy_from_config.py
+++ b/scripts/run_strategy_from_config.py
@@ -22,10 +22,6 @@ from pathlib import Path
 # Projekt-Root zum Python-Path hinzufügen
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import pandas as pd
-import numpy as np
-from datetime import datetime, timedelta
-
 from src.core.peak_config import load_config
 from src.core.position_sizing import build_position_sizer_from_config
 from src.core.risk import build_risk_manager_from_config
@@ -34,6 +30,7 @@ from scripts.run_backtest import (
     _build_strategy_params_from_config,
     _resolve_strategy_signal_fn,
     _validate_strategy_registry_gates,
+    load_ohlcv_data,
 )
 from src.strategies.registry import (
     get_available_strategy_keys,
@@ -42,47 +39,6 @@ from src.strategies.registry import (
 )
 from src.backtest.engine import BacktestEngine
 from src.backtest.stats import validate_for_live_trading
-
-
-def create_dummy_data(n_bars: int = 200) -> pd.DataFrame:
-    """
-    Erstellt Dummy-OHLCV-Daten für Tests.
-
-    Simuliert verschiedene Marktbedingungen für flexible Strategie-Tests.
-    """
-    np.random.seed(42)
-
-    # Start-Zeitpunkt
-    start = datetime.now() - timedelta(hours=n_bars)
-    dates = pd.date_range(start, periods=n_bars, freq="1h")
-
-    # Preis-Simulation mit Trend, Oszillation und Noise
-    base_price = 50000
-
-    # Langfristiger Trend
-    trend = np.linspace(0, 3000, n_bars)
-
-    # Oszillation (für verschiedene Strategien)
-    cycle = np.sin(np.linspace(0, 4 * np.pi, n_bars)) * 2000
-
-    # Random Walk Noise
-    noise = np.random.randn(n_bars).cumsum() * 200
-
-    close_prices = base_price + trend + cycle + noise
-
-    # OHLC generieren
-    df = pd.DataFrame(
-        {
-            "open": close_prices * (1 + np.random.randn(n_bars) * 0.002),
-            "high": close_prices * (1 + abs(np.random.randn(n_bars)) * 0.003),
-            "low": close_prices * (1 - abs(np.random.randn(n_bars)) * 0.003),
-            "close": close_prices,
-            "volume": np.random.randint(10, 100, n_bars),
-        },
-        index=dates,
-    )
-
-    return df
 
 
 def print_report(result, strategy_name: str):
@@ -256,9 +212,9 @@ def main():
         print(f"\n❌ FEHLER beim Erstellen der Strategie: {e}")
         return
 
-    # Daten erstellen (später: von Kraken holen)
+    # Daten laden (kanonischer OHLCV-Loader)
     print(f"\n📥 Lade Daten ({args.bars} bars)...")
-    df = create_dummy_data(n_bars=args.bars)
+    df = load_ohlcv_data(None, None, None, n_bars=args.bars)
     print(f"  - Zeitraum: {df.index[0]} bis {df.index[-1]}")
     print(f"  - Bars: {len(df)}")
 

--- a/scripts/run_walkforward_backtest.py
+++ b/scripts/run_walkforward_backtest.py
@@ -50,17 +50,17 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, Sequence
 
 import pandas as pd
-import numpy as np
 
 # Projekt-Root zum Path hinzufügen
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+from scripts.run_backtest import load_ohlcv_data
 from src.backtest.walkforward import (
     WalkForwardConfig,
     run_walkforward_for_candidate_presets,
@@ -81,86 +81,6 @@ def setup_logging(verbose: bool = False) -> None:
         format="%(asctime)s | %(levelname)-7s | %(message)s",
         datefmt="%H:%M:%S",
     )
-
-
-def create_dummy_data(n_bars: int = 1000) -> pd.DataFrame:
-    """
-    Erstellt Dummy-OHLCV-Daten für Tests.
-
-    Args:
-        n_bars: Anzahl der Bars
-
-    Returns:
-        DataFrame mit OHLCV-Daten und DatetimeIndex
-    """
-    np.random.seed(42)
-
-    # Start-Zeitpunkt
-    start = datetime.now() - timedelta(hours=n_bars)
-    dates = pd.date_range(start, periods=n_bars, freq="1h")
-
-    # Preis-Simulation
-    base_price = 50000
-    trend = np.linspace(0, 5000, n_bars)
-    cycle = np.sin(np.linspace(0, 6 * np.pi, n_bars)) * 2000
-    noise = np.random.randn(n_bars).cumsum() * 200
-
-    close_prices = base_price + trend + cycle + noise
-
-    # OHLC generieren
-    df = pd.DataFrame(
-        {
-            "open": close_prices * (1 + np.random.randn(n_bars) * 0.002),
-            "high": close_prices * (1 + abs(np.random.randn(n_bars)) * 0.003),
-            "low": close_prices * (1 - abs(np.random.randn(n_bars)) * 0.003),
-            "close": close_prices,
-            "volume": np.random.randint(10, 100, n_bars),
-        },
-        index=dates,
-    )
-
-    return df
-
-
-def load_data_from_file(filepath: Path) -> pd.DataFrame:
-    """
-    Lädt OHLCV-Daten aus Datei (CSV oder Parquet).
-
-    Args:
-        filepath: Pfad zur Datei
-
-    Returns:
-        DataFrame mit OHLCV-Daten
-    """
-    if not filepath.exists():
-        raise FileNotFoundError(f"Daten-Datei nicht gefunden: {filepath}")
-
-    if filepath.suffix == ".parquet":
-        df = pd.read_parquet(filepath)
-    elif filepath.suffix == ".csv":
-        df = pd.read_csv(filepath, index_col=0, parse_dates=True)
-    else:
-        raise ValueError(f"Unsupported file format: {filepath.suffix}")
-
-    # Validierung
-    required_cols = ["open", "high", "low", "close", "volume"]
-    missing = [c for c in required_cols if c not in df.columns]
-    if missing:
-        raise ValueError(f"Fehlende Spalten: {missing}")
-
-    if not isinstance(df.index, pd.DatetimeIndex):
-        if "timestamp" in df.columns:
-            df = df.set_index(pd.to_datetime(df["timestamp"], utc=True))
-            df = df.drop(columns=["timestamp"], errors="ignore")
-        else:
-            raise ValueError(
-                "DataFrame muss einen DatetimeIndex oder eine 'timestamp'-Spalte haben"
-            )
-
-    if not df.index.is_monotonic_increasing:
-        df = df.sort_index()
-
-    return df
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -307,16 +227,25 @@ def run_from_args(args: argparse.Namespace) -> int:
     logger = logging.getLogger(__name__)
 
     try:
-        # 1. Daten laden
+        # 1. Daten laden (kanonischer OHLCV-Loader)
         logger.info("Lade Daten...")
         if args.use_dummy_data:
-            df = create_dummy_data(n_bars=args.dummy_bars)
-            logger.info(f"Dummy-Daten erstellt: {len(df)} Bars ({df.index[0]} - {df.index[-1]})")
+            data_file = None
         elif args.data_file:
-            df = load_data_from_file(Path(args.data_file))
-            logger.info(f"Daten geladen: {len(df)} Bars ({df.index[0]} - {df.index[-1]})")
+            data_file = args.data_file
         else:
             raise ValueError("Entweder --data-file oder --use-dummy-data muss angegeben werden")
+
+        df = load_ohlcv_data(
+            data_file=data_file,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            n_bars=args.dummy_bars,
+        )
+        if args.use_dummy_data:
+            logger.info(f"Dummy-Daten erstellt: {len(df)} Bars ({df.index[0]} - {df.index[-1]})")
+        else:
+            logger.info(f"Daten geladen: {len(df)} Bars ({df.index[0]} - {df.index[-1]})")
 
         # 2. Walk-Forward-Config erstellen
         wf_config = WalkForwardConfig(

--- a/tests/scripts/test_run_strategy_from_config_load_strategy_v1.py
+++ b/tests/scripts/test_run_strategy_from_config_load_strategy_v1.py
@@ -27,10 +27,17 @@ MOMENTUM_KEY = "momentum_1h"
 EL_KAROUI_ALIAS_KEY = "el_karoui_vol_v1"
 
 FORBIDDEN_IMPORTS = ("create_strategy_from_config",)
+DATA_LOADER_OWNER = "scripts/run_backtest.py:load_ohlcv_data"
+FORBIDDEN_LOCAL_LOADER_DEFS = frozenset({"load_ohlcv_data", "generate_dummy_ohlcv"})
 
 
 def _read_source() -> str:
     return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
 
 
 def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
@@ -70,6 +77,23 @@ def test_source_has_no_create_strategy_from_config() -> None:
 def test_source_uses_load_strategy_path() -> None:
     assert "_resolve_strategy_signal_fn" in _read_source()
     assert "_build_strategy_params_from_config" in _read_source()
+
+
+def test_source_has_no_local_loader_or_dummy_definitions() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_LOADER_DEFS.isdisjoint(local_defs)
+
+
+def test_source_imports_canonical_data_loader() -> None:
+    source = _read_source()
+    assert "load_ohlcv_data" in source
+    assert "scripts.run_backtest" in source
+
+
+def test_load_ohlcv_data_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert target_script.load_ohlcv_data is run_backtest_script.load_ohlcv_data
 
 
 def test_source_has_no_parallel_strategy_registry_assignment() -> None:
@@ -241,7 +265,7 @@ def test_main_passes_full_params_to_signal_fn() -> None:
     with (
         patch.object(target_script, "parse_args") as parse_mock,
         patch.object(target_script, "load_config", return_value=cfg),
-        patch.object(target_script, "create_dummy_data", return_value=_sample_ohlcv()),
+        patch.object(target_script, "load_ohlcv_data", return_value=_sample_ohlcv()),
         patch.object(target_script, "build_position_sizer_from_config", return_value=MagicMock()),
         patch.object(target_script, "build_risk_manager_from_config", return_value=MagicMock()),
         patch.object(target_script, "_resolve_strategy_signal_fn", return_value=fake_signal_fn),
@@ -268,6 +292,85 @@ def test_main_passes_full_params_to_signal_fn() -> None:
     call_kwargs["strategy_signal_fn"](call_kwargs["df"], call_kwargs["strategy_params"])
     assert captured["params"]["fast_window"] == 10
     assert captured["params"]["slow_window"] == 50
+
+
+def test_main_forwards_load_ohlcv_arguments_to_canonical_loader() -> None:
+    from src.core.peak_config import PeakConfig
+
+    raw = {
+        "environment": {"mode": "backtest"},
+        "strategy": {
+            MA_CROSSOVER_KEY: {"fast_window": 10, "slow_window": 50, "price_col": "close"}
+        },
+    }
+    cfg = PeakConfig(raw=raw)
+    captured: dict[str, object] = {}
+
+    def capture_loader(
+        data_file,
+        start_date,
+        end_date,
+        n_bars,
+        verbose=False,
+    ):
+        captured.update(
+            {
+                "data_file": data_file,
+                "start_date": start_date,
+                "end_date": end_date,
+                "n_bars": n_bars,
+                "verbose": verbose,
+            }
+        )
+        return _sample_ohlcv()
+
+    mock_result = MagicMock()
+    mock_result.stats = {
+        "total_return": 0.0,
+        "max_drawdown": 0.0,
+        "sharpe": 0.0,
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "profit_factor": 0.0,
+        "blocked_trades": 0,
+    }
+    mock_result.equity_curve = pd.Series(
+        [10000.0, 10000.0], index=pd.date_range("2024-01-01", periods=2, freq="h")
+    )
+    mock_result.trades = None
+    mock_result.metadata = {}
+
+    with (
+        patch.object(target_script, "parse_args") as parse_mock,
+        patch.object(target_script, "load_config", return_value=cfg),
+        patch.object(target_script, "load_ohlcv_data", side_effect=capture_loader),
+        patch.object(target_script, "build_position_sizer_from_config", return_value=MagicMock()),
+        patch.object(target_script, "build_risk_manager_from_config", return_value=MagicMock()),
+        patch.object(
+            target_script,
+            "_resolve_strategy_signal_fn",
+            return_value=lambda df, params: pd.Series(0, index=df.index),
+        ),
+        patch.object(target_script.BacktestEngine, "run_realistic", return_value=mock_result),
+    ):
+        args = MagicMock()
+        args.list_strategies = False
+        args.strategy = MA_CROSSOVER_KEY
+        args.bars = 120
+        args.run_name = None
+        args.no_report = True
+        args.no_plots = True
+        parse_mock.return_value = args
+
+        target_script.main()
+
+    assert captured == {
+        "data_file": None,
+        "start_date": None,
+        "end_date": None,
+        "n_bars": 120,
+        "verbose": False,
+    }
 
 
 def test_config_object_not_mutated_during_resolution() -> None:

--- a/tests/scripts/test_run_walkforward_backtest_load_ohlcv_v1.py
+++ b/tests/scripts/test_run_walkforward_backtest_load_ohlcv_v1.py
@@ -1,0 +1,230 @@
+"""
+run_walkforward_backtest: canonical load_ohlcv_data reuse (offline, fail-closed).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "scripts"))
+
+import run_walkforward_backtest as walkforward_runner
+
+TARGET_SCRIPT = project_root / "scripts/run_walkforward_backtest.py"
+DATA_LOADER_OWNER = "scripts/run_backtest.py:load_ohlcv_data"
+FORBIDDEN_LOCAL_LOADER_DEFS = frozenset(
+    {"load_ohlcv_data", "generate_dummy_ohlcv", "create_dummy_data", "load_data_from_file"}
+)
+
+
+def _read_source() -> str:
+    return TARGET_SCRIPT.read_text(encoding="utf-8")
+
+
+def _local_function_defs() -> set[str]:
+    tree = ast.parse(_read_source())
+    return {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
+
+
+def _sample_ohlcv(n: int = 80) -> pd.DataFrame:
+    np.random.seed(42)
+    index = pd.date_range("2024-01-01", periods=n, freq="h")
+    close = 100.0 + np.cumsum(np.random.randn(n))
+    return pd.DataFrame(
+        {
+            "open": close * 0.999,
+            "high": close * 1.002,
+            "low": close * 0.998,
+            "close": close,
+            "volume": np.full(n, 1000.0),
+        },
+        index=index,
+    )
+
+
+def test_module_imports_without_main_side_effects() -> None:
+    with patch.object(walkforward_runner, "main") as main_mock:
+        importlib.reload(walkforward_runner)
+    main_mock.assert_not_called()
+
+
+def test_source_has_no_local_loader_or_dummy_definitions() -> None:
+    local_defs = _local_function_defs()
+    assert FORBIDDEN_LOCAL_LOADER_DEFS.isdisjoint(local_defs)
+
+
+def test_source_imports_canonical_data_loader() -> None:
+    source = _read_source()
+    assert "load_ohlcv_data" in source
+    assert "scripts.run_backtest" in source
+
+
+def test_load_ohlcv_data_import_identity_is_canonical_owner() -> None:
+    import scripts.run_backtest as run_backtest_script
+
+    assert walkforward_runner.load_ohlcv_data is run_backtest_script.load_ohlcv_data
+
+
+def test_run_from_args_forwards_dummy_path_to_canonical_loader() -> None:
+    captured: dict[str, object] = {}
+    sample_df = _sample_ohlcv()
+
+    def capture_loader(
+        data_file,
+        start_date,
+        end_date,
+        n_bars,
+        verbose=False,
+    ):
+        captured.update(
+            {
+                "data_file": data_file,
+                "start_date": start_date,
+                "end_date": end_date,
+                "n_bars": n_bars,
+                "verbose": verbose,
+            }
+        )
+        return sample_df
+
+    args = MagicMock()
+    args.verbose = False
+    args.use_dummy_data = True
+    args.data_file = None
+    args.dummy_bars = 500
+    args.start_date = "2024-01-01"
+    args.end_date = "2024-06-01"
+    args.train_window = "90d"
+    args.test_window = "30d"
+    args.step_size = None
+    args.symbol = "BTC/EUR"
+    args.output_dir = "reports/walkforward"
+    args.sweep_name = "test_sweep"
+    args.candidate_presets = None
+    args.top_n = 1
+    args.metric_primary = "metric_sharpe_ratio"
+    args.metric_fallback = "metric_total_return"
+
+    with (
+        patch.object(walkforward_runner, "load_ohlcv_data", side_effect=capture_loader),
+        patch.object(
+            walkforward_runner,
+            "run_walkforward_for_top_n_from_sweep",
+            return_value=[],
+        ),
+    ):
+        rc = walkforward_runner.run_from_args(args)
+
+    assert rc == 0
+    assert captured == {
+        "data_file": None,
+        "start_date": "2024-01-01",
+        "end_date": "2024-06-01",
+        "n_bars": 500,
+        "verbose": False,
+    }
+
+
+def test_run_from_args_forwards_file_path_to_canonical_loader() -> None:
+    captured: dict[str, object] = {}
+    sample_df = _sample_ohlcv()
+
+    def capture_loader(
+        data_file,
+        start_date,
+        end_date,
+        n_bars,
+        verbose=False,
+    ):
+        captured.update(
+            {
+                "data_file": data_file,
+                "start_date": start_date,
+                "end_date": end_date,
+                "n_bars": n_bars,
+                "verbose": verbose,
+            }
+        )
+        return sample_df
+
+    args = MagicMock()
+    args.verbose = False
+    args.use_dummy_data = False
+    args.data_file = "data/btc_eur_1h.parquet"
+    args.dummy_bars = 1000
+    args.start_date = None
+    args.end_date = None
+    args.train_window = "90d"
+    args.test_window = "30d"
+    args.step_size = None
+    args.symbol = "BTC/EUR"
+    args.output_dir = "reports/walkforward"
+    args.sweep_name = "test_sweep"
+    args.candidate_presets = None
+    args.top_n = 1
+    args.metric_primary = "metric_sharpe_ratio"
+    args.metric_fallback = "metric_total_return"
+
+    with (
+        patch.object(walkforward_runner, "load_ohlcv_data", side_effect=capture_loader),
+        patch.object(
+            walkforward_runner,
+            "run_walkforward_for_top_n_from_sweep",
+            return_value=[],
+        ),
+    ):
+        rc = walkforward_runner.run_from_args(args)
+
+    assert rc == 0
+    assert captured == {
+        "data_file": "data/btc_eur_1h.parquet",
+        "start_date": None,
+        "end_date": None,
+        "n_bars": 1000,
+        "verbose": False,
+    }
+
+
+def test_run_from_args_requires_data_source() -> None:
+    args = MagicMock()
+    args.verbose = False
+    args.use_dummy_data = False
+    args.data_file = None
+
+    rc = walkforward_runner.run_from_args(args)
+    assert rc == 1
+
+
+def test_import_smoke_no_main_execution() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import run_walkforward_backtest"],
+        cwd=project_root / "scripts",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_help_smoke_no_run() -> None:
+    result = subprocess.run(
+        [sys.executable, str(TARGET_SCRIPT), "--help"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--use-dummy-data" in result.stdout
+    assert "--data-file" in result.stdout


### PR DESCRIPTION
## Summary

- Stellt `scripts/run_strategy_from_config.py` und `scripts/run_walkforward_backtest.py` auf den kanonischen OHLCV-Loader `scripts/run_backtest.py::load_ohlcv_data` um.
- Entfernt lokale Duplikate (`create_dummy_data`, `load_data_from_file`) und verdrahtet CLI-Pfade direkt auf den kanonischen Loader.
- Erweitert `tests/scripts/test_run_strategy_from_config_load_strategy_v1.py` und fügt `tests/scripts/test_run_walkforward_backtest_load_ohlcv_v1.py` für Import-Identity- und CLI-Wiring-Contract-Tests hinzu.

## Scope

**Production owners:**
- `scripts/run_strategy_from_config.py`
- `scripts/run_walkforward_backtest.py`

**Canonical owner:**
- `scripts/run_backtest.py::load_ohlcv_data`

**Test owners:**
- `tests/scripts/test_run_strategy_from_config_load_strategy_v1.py`
- `tests/scripts/test_run_walkforward_backtest_load_ohlcv_v1.py`

## CI

- **Mode:** FOCUSED (`focused_script_or_test_diff`)
- **FULL CI trigger:** none expected

## Safety status

- PREFLIGHT_REMAINS_BLOCKED=true
- READY_FOR_OPERATOR_ARMING=false
- EXECUTION_AUTHORIZED=false
- LIVE_AUTHORIZED=false
- AUTHORITY_LIFT=false
- MASTER_V2_TOUCH=false
- DOUBLE_PLAY_TOUCH=false
- TRADING_LOGIC_TOUCH=false
- RISK_TOUCH=false
- RUNTIME_STARTED=false
- RUN_STARTED=false
- EXCHANGE_API_CALLED=false
- ORDERS_SENT=false

## Durable bundle

Implementation bundle path will be recorded in PR follow-up / durable archive after merge review.

**GO token:** GO_REMAINING_BACKTEST_RUNNERS_OHLCV_CANONICAL_REUSE_V1

## Test plan

- [x] `pytest tests/scripts/test_run_strategy_from_config_load_strategy_v1.py tests/scripts/test_run_walkforward_backtest_load_ohlcv_v1.py`
- [x] `ruff format --check` on 4 scoped files
- [x] `ruff check` on 4 scoped files
- [x] diff-aware CI selector confirms FOCUSED


Made with [Cursor](https://cursor.com)