### PR TITLE
test(resilience): stabilize half-open circuit breaker clock

### DIFF
--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -78,58 +78,83 @@ class TestCircuitBreaker:
 
     def test_circuit_breaker_half_open_recovery(self):
         """Test circuit transitions to HALF_OPEN and recovers."""
-        breaker = CircuitBreaker(failure_threshold=2, recovery_timeout=0.1, name="recovery_test")
-
         call_count = [0]
+        fake_now = [1_000_000.0]
 
-        @breaker.call
-        def sometimes_failing():
-            call_count[0] += 1
-            # Fail first 2 times, then succeed
-            if call_count[0] <= 2:
-                raise ValueError("Failing")
-            return "success"
+        def fake_time() -> float:
+            return fake_now[0]
 
-        # Cause 2 failures to open circuit
-        for _ in range(2):
-            with pytest.raises(ValueError):
+        with patch("src.core.resilience.time.time", fake_time):
+            breaker = CircuitBreaker(
+                failure_threshold=2, recovery_timeout=0.1, name="recovery_test"
+            )
+
+            @breaker.call
+            def sometimes_failing():
+                call_count[0] += 1
+                # Fail first 2 times, then succeed
+                if call_count[0] <= 2:
+                    raise ValueError("Failing")
+                return "success"
+
+            # Cause 2 failures to open circuit
+            for _ in range(2):
+                with pytest.raises(ValueError):
+                    sometimes_failing()
+
+            assert breaker.state == CircuitState.OPEN
+
+            # Still open before recovery timeout elapses
+            with pytest.raises(Exception, match="CircuitBreaker.*is OPEN"):
                 sometimes_failing()
+            assert call_count[0] == 2
 
-        assert breaker.state == CircuitState.OPEN
+            # Advance past recovery_timeout (0.1s) without wall-clock wait
+            fake_now[0] += 0.11
 
-        # Wait for recovery timeout
-        time.sleep(0.15)
+            # Next call should transition to HALF_OPEN and succeed
+            result = sometimes_failing()
 
-        # Next call should transition to HALF_OPEN and succeed
-        result = sometimes_failing()
-
-        assert result == "success"
-        assert breaker.state == CircuitState.CLOSED
-        assert breaker.stats.success_count == 1
+            assert result == "success"
+            assert breaker.state == CircuitState.CLOSED
+            assert breaker.stats.success_count == 1
 
     def test_circuit_breaker_half_open_failure(self):
         """Test circuit reopens if recovery attempt fails."""
-        breaker = CircuitBreaker(failure_threshold=2, recovery_timeout=0.1, name="reopen_test")
+        call_count = [0]
+        fake_now = [1_000_000.0]
 
-        @breaker.call
-        def always_fails():
-            raise ValueError("Always fails")
+        def fake_time() -> float:
+            return fake_now[0]
 
-        # Cause 2 failures to open circuit
-        for _ in range(2):
+        with patch("src.core.resilience.time.time", fake_time):
+            breaker = CircuitBreaker(failure_threshold=2, recovery_timeout=0.1, name="reopen_test")
+
+            @breaker.call
+            def always_fails():
+                call_count[0] += 1
+                raise ValueError("Always fails")
+
+            # Cause 2 failures to open circuit
+            for _ in range(2):
+                with pytest.raises(ValueError):
+                    always_fails()
+
+            assert breaker.state == CircuitState.OPEN
+
+            # Still open before recovery timeout elapses
+            with pytest.raises(Exception, match="CircuitBreaker.*is OPEN"):
+                always_fails()
+            assert call_count[0] == 2
+
+            # Advance past recovery_timeout (0.1s) without wall-clock wait
+            fake_now[0] += 0.11
+
+            # Recovery attempt should fail and reopen circuit
             with pytest.raises(ValueError):
                 always_fails()
 
-        assert breaker.state == CircuitState.OPEN
-
-        # Wait for recovery timeout
-        time.sleep(0.15)
-
-        # Recovery attempt should fail and reopen circuit
-        with pytest.raises(ValueError):
-            always_fails()
-
-        assert breaker.state == CircuitState.OPEN
+            assert breaker.state == CircuitState.OPEN
 
     def test_circuit_breaker_manual_reset(self):
         """Test manual reset of circuit breaker."""


### PR DESCRIPTION
## Summary

- **GO-Token:** `GO_RESILIENCE_CIRCUIT_BREAKER_UNIT_HALF_OPEN_FAKE_CLOCK_V1`
- **Planning-Bundle:** `planning/systemwide_next_safe_scope_ranking_after_resilience_metrics_latency_fake_clock_closeout_no_run_v1_20260616T010553Z`
- **Root Cause:** Die beiden Half-Open-Unit-Tests in `tests/test_resilience.py` warteten mit `time.sleep(0.15)` auf `recovery_timeout=0.1`. Der Produktionsvertrag in `src/core/resilience.py` ist korrekt; nur die Tests waren nondeterministisch/langsam.
- **Testowner:** `tests/test_resilience.py`
- **Zieltests:** `test_circuit_breaker_half_open_recovery`, `test_circuit_breaker_half_open_failure`
- **EXPECTED_FILES:** `tests/test_resilience.py`

## Strategie

- `fake_now` + `patch("src.core.resilience.time.time")` — gleiches Muster wie `tests/test_resilience_integration.py::test_circuit_breaker_recovery`
- Kein `sleep`, kein Retry, kein `xfail`, kein `skip`, kein Flaky-Marker
- Vor Timeout-Fortschritt: Circuit bleibt `OPEN`, fail-fast
- Nach `fake_now += 0.11`: HALF_OPEN-Probe
  - Erfolg → `CLOSED`
  - Fehler → erneut `OPEN`

## Lokale fokussierte Tests

- `tests/test_resilience.py::TestCircuitBreaker::test_circuit_breaker_half_open_recovery` — PASSED
- `tests/test_resilience.py::TestCircuitBreaker::test_circuit_breaker_half_open_failure` — PASSED
- Vollständiger Testowner `tests/test_resilience.py`: 28 passed (2× separat, deterministisch)
- Ruff format/check: passed

## CI

- **Modus:** FOCUSED (`test_selection_mode=FOCUSED`, `FULL_CI_TRIGGER_FOUND=false`)
- Nur Testdatei geändert; kein Full-CI-Trigger

## Implementation-Bundle

`implementation/resilience_circuit_breaker_unit_half_open_fake_clock_v1_20260616T010828Z`

## Safety

| Key | Value |
|-----|-------|
| ROOT_CAUSE_PROVEN | true |
| TESTS_ONLY | true |
| PRODUCTION_CODE_TOUCH | false |
| WALL_CLOCK_SLEEP_REMOVED | true |
| BOTH_TARGET_SLEEPS_REMOVED | true |
| REPLACEMENT_CONTRACT_DETERMINISTIC | true |
| TEST_ASSERTIONS_WEAKENED | false |
| RETRY_LOOP_ADDED | false |
| FLAKY_MARKER_ADDED | false |
| XFAIL_ADDED | false |
| SKIP_ADDED | false |
| CIRCUIT_BREAKER_API_PRESERVED | true |
| RECOVERY_TIMEOUT_SEMANTICS_PRESERVED | true |
| HALF_OPEN_SUCCESS_SEMANTICS_PRESERVED | true |
| HALF_OPEN_FAILURE_SEMANTICS_PRESERVED | true |
| STATE_TRANSITION_SEMANTICS_PRESERVED | true |
| FAILURE_COUNTER_SEMANTICS_PRESERVED | true |
| BOUNDARY_SEMANTICS_EXPLICIT | true |
| TEST_ISOLATION_PRESERVED | true |
| EXISTING_FAKE_CLOCK_PATTERN_REUSED | true |
| NEW_CLOCK_SURFACE_CREATED | false |
| NEW_HELPER_SURFACE_CREATED | false |
| NEW_FIXTURE_SURFACE_CREATED | false |
| PREFLIGHT_REMAINS_BLOCKED | true |
| EXECUTION_AUTHORIZED | false |
| LIVE_AUTHORIZED | false |
| AUTO_MERGE | false |


Made with [Cursor](https://cursor.com)