### PR TITLE
test(ops): stabilize wp1d operator ux timestamps

### DIFF
--- a/tests/ops/test_wp1d_operator_ux.py
+++ b/tests/ops/test_wp1d_operator_ux.py
@@ -8,7 +8,7 @@ Tests:
 """
 
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -118,14 +118,32 @@ class TestSessionRegistry:
         assert summary["by_status"]["running"] == 1
         assert summary["by_status"]["completed"] == 1
 
-    def test_sessions_sorted_by_time(self):
+    def test_sessions_sorted_by_time(self, monkeypatch):
         """Test sessions sorted by start time (newest first)."""
         registry = SessionRegistry()
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        utcnow_sequence = [
+            base,
+            base,
+            base + timedelta(seconds=1),
+            base + timedelta(seconds=1),
+            base + timedelta(seconds=2),
+            base + timedelta(seconds=2),
+        ]
+        utcnow_index = [0]
+
+        def fake_utcnow():
+            ts = utcnow_sequence[utcnow_index[0]]
+            utcnow_index[0] += 1
+            return ts
+
+        class FakeDateTime:
+            utcnow = staticmethod(fake_utcnow)
+
+        monkeypatch.setattr("src.live.ops.registry.datetime", FakeDateTime)
 
         registry.create_session("shadow_001")
-        time.sleep(0.01)  # Ensure different timestamps
         registry.create_session("shadow_002")
-        time.sleep(0.01)
         registry.create_session("shadow_003")
 
         sessions = registry.list_sessions()
@@ -139,30 +157,40 @@ class TestSessionRegistry:
 class TestStatusOverview:
     """Test status overview."""
 
-    def test_start_tracking(self):
+    def test_start_tracking(self, monkeypatch):
         """Test start tracking."""
+        monotonic_values = iter([100.0, 100.0, 100.15])
+        monkeypatch.setattr(
+            "src.live.ops.status.time.monotonic",
+            lambda: next(monotonic_values),
+        )
+
         overview = StatusOverview()
         overview.start()
-
-        time.sleep(0.1)  # Let some time pass
 
         status = overview.get_status()
 
-        assert status.system_uptime_s >= 0.1
-        assert status.data_feed_uptime_s >= 0.1
+        assert status.system_uptime_s == pytest.approx(0.15)
+        assert status.data_feed_uptime_s == pytest.approx(0.15)
 
-    def test_record_reconnect(self):
+    def test_record_reconnect(self, monkeypatch):
         """Test record reconnect."""
+        monotonic_values = iter([100.0, 100.05, 100.05, 100.20])
+        monkeypatch.setattr(
+            "src.live.ops.status.time.monotonic",
+            lambda: next(monotonic_values),
+        )
+
         overview = StatusOverview()
         overview.start()
-
-        time.sleep(0.05)
 
         overview.record_reconnect()
 
         status = overview.get_status()
 
         assert status.last_reconnect_ts is not None
+        assert status.system_uptime_s == pytest.approx(0.20)
+        assert status.data_feed_uptime_s == pytest.approx(0.15)
         # Data feed uptime should reset after reconnect
         assert status.data_feed_uptime_s < status.system_uptime_s
 


### PR DESCRIPTION
## Summary
- **GO-Token:** GO_WP1D_OPERATOR_UX_TIMESTAMP_V1
- **Planning-Bundle:** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/systemwide_next_safe_scope_ranking_after_p91_audit_timestamp_order_closeout_no_run_v1_20260616T014216Z`
- **Implementation-Bundle:** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/wp1d_operator_ux_timestamp_v1_20260616T014619Z`

Stabilisiert WP1D-Operator-UX-Tests deterministisch (tests-only): entfernt reale `time.sleep`-Abhängigkeiten in Session-Sortierung und Uptime-Verträgen.

## Root Cause je Zieltest
| Test | Produktionsowner | Ursache |
|------|------------------|---------|
| `test_sessions_sorted_by_time` | `src/live/ops/registry.py` (`list_sessions`, Sort key `started_at`) | Wall-clock sleep für unterschiedliche `datetime.utcnow()`-Werte |
| `test_start_tracking` | `src/live/ops/status.py` (`get_status`, `time.monotonic()`) | Sleep ≥0.1s für Uptime-Elapsed |
| `test_record_reconnect` | `src/live/ops/status.py` (monotonic uptime + reconnect) | Sleep 0.05s für unterschiedliche system vs. feed uptime |

## Testowner & Zieltests
- **TEST_OWNER:** `tests/ops/test_wp1d_operator_ux.py`
- **TARGET_TESTS:** `test_sessions_sorted_by_time`, `test_start_tracking`, `test_record_reconnect`
- **TARGET_SLEEP_LOCATIONS:** lines 126, 128, 147, 159 (removed)

## EXPECTED_FILES
- `tests/ops/test_wp1d_operator_ux.py` (only file changed)

## Strategien
- **Session-Timestamp:** `monkeypatch` ersetzt `src.live.ops.registry.datetime` mit `FakeDateTime.utcnow`-Sequenz (base, base+1s, base+2s für `started_at`)
- **Uptime-Clock:** `monkeypatch` auf `src.live.ops.status.time.monotonic` mit festen Start-/Endwerten
- Kein sleep, Retry, skip, xfail oder Flaky-Marker
- Contract-Preservation: exakte Sortierreihenfolge; exakte Uptime-Werte via `pytest.approx`

## Lokale Tests & Determinismus
- Target tests x2: 3/3 PASS
- Full owner x2: 21/21 PASS
- Ruff format/check: PASS

## CI
- `tests/ops/**` → `static_contract` → selector NO_OP; `FULL_CI_TRIGGER_FOUND=false`
- Bounded tests-only diff; no production/dependency/workflow touch

## Safety
```
PREFLIGHT_REMAINS_BLOCKED=true
READY_FOR_OPERATOR_ARMING=false
EXECUTION_AUTHORIZED=false
LIVE_AUTHORIZED=false
PRODUCTION_CODE_TOUCH=false
TESTS_ONLY=true
WALL_CLOCK_SLEEPS_REMOVED=true
ALL_PLANNED_TARGET_SLEEPS_REMOVED=true
SESSION_TIMESTAMPS_EXPLICITLY_CONTROLLED=true
UPTIME_CLOCK_EXPLICITLY_CONTROLLED=true
AUTO_MERGE=false
MERGE_EXECUTED=false
POLLING_EXECUTED=false
```


Made with [Cursor](https://cursor.com)