### PR TITLE
test(alerting): stabilize lifecycle ttl clock

### DIFF
--- a/tests/execution/test_alerting_lifecycle.py
+++ b/tests/execution/test_alerting_lifecycle.py
@@ -206,24 +206,43 @@ def test_operator_state_ack_critical_suppression():
         assert state.is_acked("test_dedupe_key", severity="critical")
 
 
-def test_operator_state_ack_ttl_expiry():
+def test_operator_state_ack_ttl_expiry(monkeypatch):
     """Test ACK TTL expiry."""
     with tempfile.TemporaryDirectory() as tmpdir:
         state_path = Path(tmpdir) / "alerts_state.json"
         state = OperatorState(state_path=state_path, enabled=True)
 
+        base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        now_sequence = [
+            base,
+            base,
+            base + timedelta(milliseconds=500),
+            base + timedelta(seconds=1),
+            base + timedelta(seconds=1),
+        ]
+        now_index = [0]
+
+        def fake_now(tz=None):
+            ts = now_sequence[now_index[0]]
+            now_index[0] += 1
+            return ts
+
+        class FakeDateTime:
+            now = staticmethod(fake_now)
+            fromtimestamp = staticmethod(datetime.fromtimestamp)
+
+        monkeypatch.setattr(
+            "src.execution.alerting.operator_state.datetime",
+            FakeDateTime,
+        )
+
         # ACK with 1 second TTL
         state.ack("test_dedupe_key", ttl_seconds=1)
 
-        # Should be acked immediately
+        # Should be acked before TTL boundary
         assert state.is_acked("test_dedupe_key", severity="warn")
 
-        # Wait for expiry
-        import time
-
-        time.sleep(1.5)
-
-        # Should be expired
+        # Should be expired at or after TTL boundary
         assert not state.is_acked("test_dedupe_key", severity="warn")
 
 
@@ -252,24 +271,43 @@ def test_operator_state_unsnooze():
         assert not state.is_snoozed("test_rule")
 
 
-def test_operator_state_snooze_ttl_expiry():
+def test_operator_state_snooze_ttl_expiry(monkeypatch):
     """Test snooze TTL expiry."""
     with tempfile.TemporaryDirectory() as tmpdir:
         state_path = Path(tmpdir) / "alerts_state.json"
         state = OperatorState(state_path=state_path, enabled=True)
 
+        base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        now_sequence = [
+            base,
+            base,
+            base + timedelta(milliseconds=500),
+            base + timedelta(seconds=1),
+            base + timedelta(seconds=1),
+        ]
+        now_index = [0]
+
+        def fake_now(tz=None):
+            ts = now_sequence[now_index[0]]
+            now_index[0] += 1
+            return ts
+
+        class FakeDateTime:
+            now = staticmethod(fake_now)
+            fromtimestamp = staticmethod(datetime.fromtimestamp)
+
+        monkeypatch.setattr(
+            "src.execution.alerting.operator_state.datetime",
+            FakeDateTime,
+        )
+
         # Snooze with 1 second TTL
         state.snooze("test_rule", ttl_seconds=1)
 
-        # Should be snoozed immediately
+        # Should be snoozed before TTL boundary
         assert state.is_snoozed("test_rule")
 
-        # Wait for expiry
-        import time
-
-        time.sleep(1.5)
-
-        # Should be expired
+        # Should be expired at or after TTL boundary
         assert not state.is_snoozed("test_rule")
 
 


### PR DESCRIPTION
## Summary
- **GO-Token:** `GO_ALERTING_LIFECYCLE_TTL_FAKE_CLOCK_V1`
- **Planning-Bundle:** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/systemwide_next_safe_scope_ranking_after_wp1d_alerts_sort_timestamp_closeout_no_run_v1_20260616T020634Z`
- **Root Cause:** Zwei `time.sleep(1.5)`-Aufrufe in TTL-Expiry-Tests warteten auf echte Wall-Clock statt deterministischer Zeitsteuerung.
- **Produktionsowner:** `src/execution/alerting/operator_state.py` (`datetime.now(timezone.utc)`)
- **Testowner:** `tests/execution/test_alerting_lifecycle.py`
- **Zieltests:** `test_operator_state_ack_ttl_expiry`, `test_operator_state_snooze_ttl_expiry`
- **EXPECTED_FILES:** `tests/execution/test_alerting_lifecycle.py` (ausschließlich)

## Fake-Clock-Strategie
- WP1D-`FakeDateTime`-Muster (angepasst für `now()` statt `utcnow()`)
- `monkeypatch.setattr("src.execution.alerting.operator_state.datetime", FakeDateTime)`
- Feste Sequenz: `base`, `base` (_save), `base+500ms` (pre-expiry), `base+1s` (TTL-Grenze), `base+1s` (_save cleanup)
- `fromtimestamp` delegiert an echtes `datetime.fromtimestamp` (TTL-Math unverändert)

## TTL-/Expiry-Vertrag
- `ttl_seconds=1` → `expires_at = action_time + 1s`
- Vor Ablauf: `is_acked`/`is_snoozed` → `True`
- An Grenze (`now >= expires_at`): expired, Eintrag entfernt, `False`
- Kein sleep, Retry, skip, xfail oder Flaky-Marker

## Lokale Verifikation
- Zieltests je 2× isoliert: PASS
- Vollständiger Testowner 2×: 17/17 PASS
- `ruff format --check` + `ruff check`: PASS
- Determinismus: feste Zeitsequenz, keine Wall-Clock-Abhängigkeit

## CI
- **Modus:** FOCUSED (`focused_script_or_test_diff`)
- **FULL_CI_TRIGGER_FOUND:** false

## Implementation-Bundle
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/alerting_lifecycle_ttl_fake_clock_v1_20260616T021238Z`

## Safety
- PREFLIGHT_REMAINS_BLOCKED=true
- READY_FOR_OPERATOR_ARMING=false
- EXECUTION_AUTHORIZED=false
- LIVE_AUTHORIZED=false
- PRODUCTION_CODE_TOUCH=false
- TESTS_ONLY=true
- WALL_CLOCK_SLEEPS_REMOVED=true
- BOTH_TARGET_TTL_SLEEPS_REMOVED=true
- TTL_CLOCK_EXPLICITLY_CONTROLLED=true
- TTL_EXPIRY_DETERMINISTIC=true
- TEST_ASSERTIONS_WEAKENED=false
- AUTO_MERGE=false

## Test plan
- [x] `pytest tests/execution/test_alerting_lifecycle.py::test_operator_state_ack_ttl_expiry` (2×)
- [x] `pytest tests/execution/test_alerting_lifecycle.py::test_operator_state_snooze_ttl_expiry` (2×)
- [x] `pytest tests/execution/test_alerting_lifecycle.py` (2×)
- [x] ruff format/check auf EXPECTED_FILES

Made with [Cursor](https://cursor.com)