### PR TITLE
test(performance): stabilize exception perf clock

### DIFF
--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -347,15 +347,20 @@ class TestPerformanceIntegration:
     def test_exception_handling_in_context(self):
         """Test that metrics are recorded even when exceptions occur."""
         monitor = PerformanceMonitor()
+        fake_now = [0.0]
 
-        try:
-            with monitor.measure("failing_op"):
-                time.sleep(0.01)
-                raise ValueError("Test error")
-        except ValueError:
-            pass
+        def fake_perf_counter() -> float:
+            return fake_now[0]
+
+        with patch("src.core.performance.time.perf_counter", fake_perf_counter):
+            try:
+                with monitor.measure("failing_op"):
+                    fake_now[0] += 0.01
+                    raise ValueError("Test error")
+            except ValueError:
+                pass
 
         # Metric should still be recorded
         metrics = monitor.get_metrics("failing_op")
         assert len(metrics["failing_op"]) == 1
-        assert metrics["failing_op"][0].duration_ms >= 10.0
+        assert metrics["failing_op"][0].duration_ms == 10.0


### PR DESCRIPTION
## Summary

Replace the single wall-clock `time.sleep(0.01)` in `test_exception_handling_in_context` with a controlled `perf_counter` sequence, reusing the established pattern from prior measure/timer slices.

## Root Cause

`test_exception_handling_in_context` used `time.sleep(0.01)` inside `monitor.measure("failing_op")` before raising `ValueError`. Production `_PerformanceContext` measures duration via `time.perf_counter()` in `__enter__`/`__exit__` (`src/core/performance.py`), so wall-clock sleep was unnecessary and scheduler-sensitive.

## Production / Binding

| Field | Value |
|-------|-------|
| Production owner | `src/core/performance.py` |
| perf_counter binding | `time.perf_counter` |
| Lookup site | `src.core.performance.time.perf_counter` |

## Target Test

| Field | Value |
|-------|-------|
| Test owner | `tests/test_performance.py` |
| Class | `TestPerformanceIntegration` |
| Test | `test_exception_handling_in_context` |
| Former sleep | line 353 `time.sleep(0.01)` |

## Exception Contract

- Type: `ValueError("Test error")` — preserved
- Propagation: `try/except ValueError` in test — preserved
- Production `__exit__` returns `False` — not swallowed, not wrapped

## Metric / Duration Semantics

- `_PerformanceContext.__exit__` records metric on exception path (finally-equivalent)
- Controlled times: start=0.0, end=0.01 → duration=10.0ms exact
- Assertion strengthened: `>= 10.0` → `== 10.0`

## Non-Target Sleeps

6 `time.sleep` calls in `test_multiple_operations_tracking` and `test_nested_measurements` unchanged. Measure and global-timer tests untouched.

## Local Verification

- Target test x5: 5/5 PASS
- Full `tests/test_performance.py`: 22/22 PASS
- `ruff check tests/test_performance.py`: RC=0
- `ruff format --check tests/test_performance.py`: RC=0

## CI

- DIFF_AWARE_CI_MODE=FOCUSED
- FULL_CI_TRIGGER_FOUND=false

## Safety

- TESTS_ONLY=true, PRODUCTION_CODE_TOUCH=false
- No runtime/paper/shadow/testnet/live starts

## Durable Bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/performance_monitor_exception_perf_counter_fake_clock_v1_20260616T025500Z`

MANIFEST_VERIFY_RC=0

## Test plan

- [ ] CI focused checks pass
- [ ] Operator review diff scope (single file, single test)


Made with [Cursor](https://cursor.com)