### PR TITLE
test(resilience): stabilize retry backoff sleeps

### DIFF
--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -239,6 +239,7 @@ class TestRetryWithBackoff:
     def test_retry_with_backoff_success(self):
         """Test successful retry after failures."""
         call_count = [0]
+        delays = []
 
         @retry_with_backoff(max_attempts=3, base_delay=0.05)
         def eventually_works():
@@ -247,28 +248,33 @@ class TestRetryWithBackoff:
                 raise ConnectionError("Temporary failure")
             return "success"
 
-        start = time.time()
-        result = eventually_works()
-        duration = time.time() - start
+        with patch("src.core.resilience.time.sleep", side_effect=lambda d: delays.append(d)):
+            result = eventually_works()
 
         assert result == "success"
         assert call_count[0] == 3
-        # Should have delayed at least base_delay * 2 (for 2 retries)
-        assert duration >= 0.05
+        assert len(delays) == 2
+        assert delays[0] == pytest.approx(0.05, rel=0.01)
+        assert delays[1] == pytest.approx(0.10, rel=0.01)
 
     def test_retry_with_backoff_exhaustion(self):
         """Test all retries exhausted."""
         call_count = [0]
+        delays = []
 
         @retry_with_backoff(max_attempts=3, base_delay=0.01)
         def always_fails():
             call_count[0] += 1
             raise ValueError("Always fails")
 
-        with pytest.raises(ValueError, match="Always fails"):
-            always_fails()
+        with patch("src.core.resilience.time.sleep", side_effect=lambda d: delays.append(d)):
+            with pytest.raises(ValueError, match="Always fails"):
+                always_fails()
 
         assert call_count[0] == 3
+        assert len(delays) == 2
+        assert delays[0] == pytest.approx(0.01, rel=0.01)
+        assert delays[1] == pytest.approx(0.02, rel=0.01)
 
     def test_retry_exponential_backoff(self):
         """Test exponential backoff calculation."""
@@ -282,14 +288,10 @@ class TestRetryWithBackoff:
                 raise ValueError("Not yet")
             return "success"
 
-        # Patch time.sleep to track delays
-        original_sleep = time.sleep
-
         def mock_sleep(duration):
             delays.append(duration)
-            original_sleep(0.01)  # Small actual sleep
 
-        with patch("time.sleep", side_effect=mock_sleep):
+        with patch("src.core.resilience.time.sleep", side_effect=mock_sleep):
             result = track_delays()
 
         assert result == "success"
@@ -312,13 +314,10 @@ class TestRetryWithBackoff:
                 raise ValueError("Not yet")
             return "success"
 
-        original_sleep = time.sleep
-
         def mock_sleep(duration):
             delays.append(duration)
-            original_sleep(0.01)
 
-        with patch("time.sleep", side_effect=mock_sleep):
+        with patch("src.core.resilience.time.sleep", side_effect=mock_sleep):
             result = constant_delay()
 
         assert result == "success"
@@ -336,7 +335,7 @@ class TestRetryWithBackoff:
         def mock_sleep(duration):
             delays.append(duration)
 
-        with patch("time.sleep", side_effect=mock_sleep):
+        with patch("src.core.resilience.time.sleep", side_effect=mock_sleep):
             with pytest.raises(ValueError):
                 check_max_delay()
 


### PR DESCRIPTION
## Summary

Stabilize `TestRetryWithBackoff` by patching `src.core.resilience.time.sleep` at the production lookup site instead of relying on real wall-clock waits.

## Root Cause

`TestRetryWithBackoff` used real thread sleeps:
- `test_retry_with_backoff_success`: `time.time()` duration gate + unpatched exponential sleeps (0.05s, 0.10s)
- `test_retry_with_backoff_exhaustion`: implicit real sleeps (0.01s, 0.02s)
- `test_retry_exponential_backoff` / `test_retry_constant_backoff`: `original_sleep(0.01)` inside `mock_sleep`
- `test_retry_max_delay_cap`: patched `time.sleep` instead of lookup site

## Planning Source and Bundle Admissibility

- Planning bundle: `systemwide_next_safe_scope_ranking_after_performance_monitor_integration_multi_ops_perf_counter_fake_clock_closeout_no_run_v1_20260616T152444Z`
- SELECTED_RANK1=CAND-RESILIENCE-RETRY-BACKOFF-SLEEP-FAKE-CLOCK-V1
- GO token: GO_RESILIENCE_RETRY_BACKOFF_SLEEP_FAKE_CLOCK_V1
- SMALL_BUNDLE, FOCUSED CI, TESTS_ONLY

## Production Owner, Sleep Binding, Lookup Site

- Owner: `src/core/resilience.py:retry_with_backoff`
- Binding: `time.sleep(delay)` at line 318
- Lookup site: `src.core.resilience.time.sleep`

## Target Tests and Former Sleep Locations

| Test | Issue |
|------|-------|
| test_retry_with_backoff_success | time.time() gate + real sleeps |
| test_retry_with_backoff_exhaustion | implicit real sleeps |
| test_retry_exponential_backoff | original_sleep(0.01) x3 |
| test_retry_constant_backoff | original_sleep(0.01) x2 |
| test_retry_max_delay_cap | wrong patch target |

TARGET_SLEEP_COUNT=5

## Retry Attempt and Backoff Sequence

- test_retry_with_backoff_success: 3 calls, delays [0.05, 0.10]
- test_retry_with_backoff_exhaustion: 3 calls, delays [0.01, 0.02], then raise
- test_retry_exponential_backoff: 4 calls, delays [0.1, 0.2, 0.4]
- test_retry_constant_backoff: 3 calls, delays [0.1, 0.1]
- test_retry_max_delay_cap: 5 calls, delays [1.0, 2.0, 2.0, 2.0]

## Contracts Preserved

- Success/exhaustion semantics, exception types/propagation unchanged
- First attempt without sleep; no sleep after terminal success or exhaustion
- No jitter in production retry_with_backoff
- Non-target resilience sleeps unchanged (circuit breaker fake-time, integration test)

## Local Verification

- 5/5 target tests PASSED
- 6/6 TestRetryWithBackoff PASSED
- 28/28 tests/test_resilience.py PASSED
- Determinism: 5 consecutive runs PASSED
- ruff check: RC=0, ruff format --check: RC=0

## Diff-Aware CI

- DIFF_AWARE_CI_MODE=FOCUSED
- FULL_CI_TRIGGER_FOUND=false

## Safety

- TESTS_ONLY=true, PRODUCTION_CODE_TOUCH=false
- No risk/kill-switch/circuit-breaker/runtime/trading changes

## Durable Bundle

- Path: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/resilience_retry_backoff_sleep_fake_clock_v1_20260616T152909Z`
- MANIFEST_VERIFY_RC=0

## Test plan

- [x] Target tests isolated
- [x] Full TestRetryWithBackoff
- [x] Full tests/test_resilience.py
- [x] Determinism 5x
- [x] ruff check/format

Made with [Cursor](https://cursor.com)