### PR TITLE
test(p85): stabilize result staleness clock

### DIFF
--- a/tests/ops/test_p85_result_reader.py
+++ b/tests/ops/test_p85_result_reader.py
@@ -13,16 +13,29 @@ from src.ops.p85_result_reader import (
     read_p85_exchange_observation,
 )
 
+_FIXED_NOW = 1_700_000_000.0
 
-def _write_p85(base: Path, payload: dict, *, age_offset_sec: float = 0.0) -> Path:
+
+def _write_p85(
+    base: Path,
+    payload: dict,
+    *,
+    age_offset_sec: float = 0.0,
+    reference_now: float = _FIXED_NOW,
+) -> Path:
     d = base / "out" / "ops" / "run_x"
     d.mkdir(parents=True)
     p = d / "P85_RESULT.json"
     p.write_text(json.dumps(payload), encoding="utf-8")
     if age_offset_sec:
-        old = time.time() - age_offset_sec
-        os.utime(p, (old, old))
+        mtime = reference_now - age_offset_sec
+        os.utime(p, (mtime, mtime))
     return p
+
+
+def _read_p85(tmp_path: Path, **kwargs):
+    with patch("src.ops.p85_result_reader.time.time", return_value=_FIXED_NOW):
+        return read_p85_exchange_observation(tmp_path, **kwargs)
 
 
 def test_reader_ok_when_fresh_and_connectivity_true(tmp_path: Path) -> None:
@@ -34,7 +47,7 @@ def test_reader_ok_when_fresh_and_connectivity_true(tmp_path: Path) -> None:
         },
         age_offset_sec=60.0,
     )
-    out = read_p85_exchange_observation(tmp_path)
+    out = _read_p85(tmp_path)
     assert out["exchange"] == "ok"
     assert out["data_source"] == "p85_result_json"
     assert out["stale"] is False
@@ -49,7 +62,7 @@ def test_reader_degraded_when_connectivity_false(tmp_path: Path) -> None:
         {"connectivity": {"ok": False, "error": "x"}},
         age_offset_sec=10.0,
     )
-    out = read_p85_exchange_observation(tmp_path)
+    out = _read_p85(tmp_path)
     assert out["exchange"] == "degraded"
     assert out["observation_reason"] == "p85_connectivity_ok_false"
 
@@ -60,7 +73,7 @@ def test_reader_unknown_when_stale(tmp_path: Path) -> None:
         {"connectivity": {"ok": True}},
         age_offset_sec=4000.0,
     )
-    out = read_p85_exchange_observation(tmp_path)
+    out = _read_p85(tmp_path)
     assert out["exchange"] == "unknown"
     assert out["stale"] is True
     assert out["observation_reason"] == "artifact_stale"
@@ -68,16 +81,15 @@ def test_reader_unknown_when_stale(tmp_path: Path) -> None:
 
 def test_reader_ok_when_artifact_age_equals_max_age_boundary(tmp_path: Path) -> None:
     """Boundary: age_sec == max_age_sec must not use the stale early-return (strict >)."""
-    fixed_now = 1_700_000_000.0
     max_age = 250.0
-    mtime = fixed_now - max_age
+    mtime = _FIXED_NOW - max_age
     d = tmp_path / "out" / "ops" / "run_boundary"
     d.mkdir(parents=True)
     p = d / "P85_RESULT.json"
     p.write_text(json.dumps({"connectivity": {"ok": True}}), encoding="utf-8")
     os.utime(p, (mtime, mtime))
 
-    with patch("src.ops.p85_result_reader.time.time", return_value=fixed_now):
+    with patch("src.ops.p85_result_reader.time.time", return_value=_FIXED_NOW):
         out = read_p85_exchange_observation(tmp_path, max_age_sec=max_age)
 
     assert out["stale"] is False
@@ -105,7 +117,7 @@ def test_reader_unknown_when_no_file(tmp_path: Path) -> None:
 
 def test_reader_unknown_when_connectivity_not_dict(tmp_path: Path) -> None:
     _write_p85(tmp_path, {"connectivity": "bad"}, age_offset_sec=10.0)
-    out = read_p85_exchange_observation(tmp_path)
+    out = _read_p85(tmp_path)
     assert out["exchange"] == "unknown"
     assert out["observation_reason"] == "connectivity_missing_or_invalid"
 
@@ -128,6 +140,6 @@ def test_reader_picks_newest_file_by_mtime(tmp_path: Path) -> None:
 
 def test_reader_unknown_when_ok_not_boolean(tmp_path: Path) -> None:
     _write_p85(tmp_path, {"connectivity": {"ok": "yes"}}, age_offset_sec=10.0)
-    out = read_p85_exchange_observation(tmp_path)
+    out = _read_p85(tmp_path)
     assert out["exchange"] == "unknown"
     assert out["observation_reason"] == "connectivity_ok_not_boolean"

--- a/tests/webui/test_ops_cockpit.py
+++ b/tests/webui/test_ops_cockpit.py
@@ -1726,7 +1726,11 @@ def test_dependencies_state_exchange_unknown_when_p85_stale(tmp_path: Path) -> N
     """Stale P85 artifact yields exchange unknown (conservative)."""
     import json
     import os
-    import time
+    from unittest.mock import patch
+
+    fixed_now = 1_700_000_000.0
+    age_sec = 4000.0
+    mtime = fixed_now - age_sec
 
     p85_dir = tmp_path / "out" / "ops" / "p85_stale"
     p85_dir.mkdir(parents=True)
@@ -1735,9 +1739,9 @@ def test_dependencies_state_exchange_unknown_when_p85_stale(tmp_path: Path) -> N
         json.dumps({"connectivity": {"ok": True}, "overall_ok": True}),
         encoding="utf-8",
     )
-    old = time.time() - 4000.0
-    os.utime(p, (old, old))
-    payload = build_ops_cockpit_payload(repo_root=tmp_path)
+    os.utime(p, (mtime, mtime))
+    with patch("src.ops.p85_result_reader.time.time", return_value=fixed_now):
+        payload = build_ops_cockpit_payload(repo_root=tmp_path)
     dep = payload["dependencies_state"]
     assert dep["exchange"] == "unknown"
     assert dep["p85_exchange_observation"]["stale"] is True


### PR DESCRIPTION
## Summary

- Stabilisiert P85-Result-Reader-Stale-Time-Tests durch explizite Referenzzeit (`1_700_000_000.0`) und `patch("src.ops.p85_result_reader.time.time")` am Produktions-Lookup-Site (Zeile 88).
- `_write_p85` setzt `mtime` deterministisch via `os.utime`; Cockpit-Stale-Test patcht die Uhr beim Payload-Build.
- Tests-only, kein Produktionscode, FOCUSED CI.

## Root Cause

Stale-/Fresh-Tests leiteten Artefakt-`mtime` und `age_sec` von `time.time()` ab (`_write_p85`, Cockpit-Stale-Test). Das koppelte Freshness-Grenzen an die Systemuhr.

## Planning-Quelle und Bundle-Admissibility

- Planning-Bundle: `planning/systemwide_next_safe_scope_ranking_after_resilience_retry_backoff_sleep_fake_clock_closeout_no_run_v1_20260616T153912Z`
- `SELECTED_RANK1=CAND-P85-RESULT-READER-STALE-TIME-FAKE-CLOCK-V1`, `SMALL_BUNDLE`, `MANIFEST_VERIFY_RC=0`
- Beide Zieldateien teilen Owner `src/ops/p85_result_reader.py`, identischen Stale-Contract (`age_sec > max_age_sec`) und Patch-Mechanismus.

## Produktionsowner, Zeitquelle und Lookup-Site

- **Owner:** `src/ops/p85_result_reader.py`
- **Zeitquelle:** `time.time()`
- **Lookup-Site:** Zeile 88 `age_sec = time.time() - mtime`
- **Result-Timestamp:** `Path.stat().st_mtime`

## Testowner, Zieltests und ehemalige Zeitabhängigkeiten

- **Testowner:** `tests/ops/test_p85_result_reader.py`, `tests/webui/test_ops_cockpit.py`
- **Zieltests:** `test_reader_ok_when_fresh_and_connectivity_true`, `test_reader_degraded_when_connectivity_false`, `test_reader_unknown_when_stale`, `test_reader_ok_when_artifact_age_equals_max_age_boundary`, `test_reader_unknown_when_connectivity_not_dict`, `test_reader_unknown_when_ok_not_boolean`, `test_dependencies_state_exchange_unknown_when_p85_stale`
- **Ehemalige Abhängigkeiten:** `time.time()` in `_write_p85` mtime, Reader-Age-Lookup, Cockpit `time.time() - 4000`

## Referenzzeit, Schwellenwert und Boundary-Semantik

- **Referenzzeit:** `1_700_000_000.0`
- **Schwellenwert:** `3600.0` (Default), Boundary-Test `250.0`
- **Operator:** strikt `>` (`is_stale = age_sec > max_age_sec`)
- **Pre-Boundary:** age=60s → fresh
- **Exact-Boundary:** age==max_age → fresh
- **Post-Boundary:** age=4000s → stale

## Contracts (preserved)

- Fresh/Stale, Status/Reason, Missing/Malformed, Readiness — unverändert
- Nicht-Ziel-P85-Tests und P85-Artefakte unverändert

## Lokale Verifikation

- 7 Zieltests: passed
- `tests/ops/test_p85_result_reader.py`: 9/9 passed
- Determinismus: 5/5 Läufe passed
- `ruff check` / `ruff format --check`: RC=0

## Diff-aware CI

- `DIFF_AWARE_CI_MODE=FOCUSED`
- `FULL_CI_TRIGGER_FOUND=false`

## Safety

- `TESTS_ONLY=true`, `PRODUCTION_CODE_TOUCH=false`
- Keine Authority/Preflight/Promotion/Runtime-Änderungen

## Durable Bundle

- Pfad: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/p85_result_reader_stale_time_fake_clock_v1_20260616T154705Z`
- `MANIFEST_VERIFY_RC=0`

## Test plan

- [x] Zieltests isoliert und gemeinsam
- [x] Vollständiger `test_p85_result_reader.py`
- [x] 5x Determinismus
- [x] Ruff check/format auf geänderten Dateien

Made with [Cursor](https://cursor.com)