### PR TITLE
feat(market): persist matrix view state in url

### DIFF
--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -17,6 +17,7 @@ Legacy Spot/Synthetic nur explizit via ``source=kraken`` oder ``source=dummy`` m
 
 from __future__ import annotations
 
+import functools
 import importlib.util
 import json
 import logging
@@ -94,6 +95,9 @@ CANONICAL_MATRIX_TEMPLATE_OWNER = (
 CANONICAL_RANKING_FUNNEL_OWNER = "src/webui/market_ranking_funnel_runtime_v0.py"
 CANONICAL_ELIGIBILITY_OWNER = "src/webui/market_instrument_eligibility_v0.py"
 CANONICAL_STYLE_OWNER = CANONICAL_MATRIX_TEMPLATE_OWNER
+CANONICAL_URL_BUILDER_OWNER = "src/webui/market_surface.py"
+CANONICAL_FILTER_OWNER = "src/webui/market_surface.py"
+CANONICAL_SORT_OWNER = "src/webui/market_surface.py"
 CANONICAL_CLIENT_INTERACTION_OWNER = CANONICAL_MATRIX_TEMPLATE_OWNER
 CANONICAL_WORKSPACE_TEMPLATE_OWNER = (
     "templates/peak_trade_dashboard/partials/market_primary_operator_hero_v1.html"
@@ -127,6 +131,14 @@ AVAILABLE_SORT_FIELDS: tuple[str, ...] = (
     "volume",
 )
 AVAILABLE_FILTER_FIELDS: tuple[str, ...] = ("symbol", "f5_status", "freshness")
+ALLOWED_FRESHNESS_FILTER_VALUES: frozenset[str] = frozenset({"fresh", "stale"})
+MATRIX_VIEW_QUERY_PARAM_NAMES: tuple[str, ...] = (
+    "matrix_filter_symbol",
+    "matrix_filter_f5_status",
+    "matrix_filter_freshness",
+    "matrix_sort_field",
+    "matrix_sort_direction",
+)
 
 MARKET_SINGLE_PAGE_CONSOLIDATION_ENABLED_ENV = (
     "PEAK_TRADE_MARKET_SINGLE_PAGE_CONSOLIDATION_V1_ENABLED"
@@ -245,13 +257,12 @@ def _sanitize_matrix_filter_symbol(raw: str | None) -> str:
 
 
 def _sanitize_matrix_filter_f5_status(raw: str | None) -> str:
-    value = (raw or "").strip()[:64]
-    return value
+    return (raw or "").strip()[:64]
 
 
 def _sanitize_matrix_filter_freshness(raw: str | None) -> str:
     value = (raw or "").strip().lower()
-    return value if value in {"fresh", "stale"} else ""
+    return value if value in ALLOWED_FRESHNESS_FILTER_VALUES else ""
 
 
 def _sanitize_matrix_sort_field(raw: str | None) -> str:
@@ -332,6 +343,393 @@ def build_market_canonical_href(
         include_default_top_n=include_default_top_n,
     )
     return f"{CANONICAL_MARKET_ROUTE}?{urlencode(params)}"
+
+
+def _merge_market_view_extras(
+    base: MarketViewQueryExtras | None,
+    *,
+    matrix_filter_symbol: str | None = None,
+    matrix_filter_f5_status: str | None = None,
+    matrix_filter_freshness: str | None = None,
+    matrix_sort_field: str | None = None,
+    matrix_sort_direction: str | None = None,
+    clear_filters: bool = False,
+    clear_sort: bool = False,
+) -> MarketViewQueryExtras:
+    current = base or MarketViewQueryExtras()
+    if clear_filters:
+        return MarketViewQueryExtras(
+            matrix_sort_field="" if clear_sort else current.matrix_sort_field,
+            matrix_sort_direction="" if clear_sort else current.matrix_sort_direction,
+        )
+    if clear_sort:
+        return MarketViewQueryExtras(
+            matrix_filter_symbol=current.matrix_filter_symbol,
+            matrix_filter_f5_status=current.matrix_filter_f5_status,
+            matrix_filter_freshness=current.matrix_filter_freshness,
+        )
+    return MarketViewQueryExtras(
+        matrix_filter_symbol=(
+            matrix_filter_symbol
+            if matrix_filter_symbol is not None
+            else current.matrix_filter_symbol
+        ),
+        matrix_filter_f5_status=(
+            matrix_filter_f5_status
+            if matrix_filter_f5_status is not None
+            else current.matrix_filter_f5_status
+        ),
+        matrix_filter_freshness=(
+            matrix_filter_freshness
+            if matrix_filter_freshness is not None
+            else current.matrix_filter_freshness
+        ),
+        matrix_sort_field=(
+            matrix_sort_field if matrix_sort_field is not None else current.matrix_sort_field
+        ),
+        matrix_sort_direction=(
+            matrix_sort_direction
+            if matrix_sort_direction is not None
+            else current.matrix_sort_direction
+        ),
+    )
+
+
+def normalize_matrix_view_extras(
+    extras: MarketViewQueryExtras | None,
+    *,
+    allowed_f5_statuses: tuple[str, ...] | list[str] = (),
+) -> MarketViewQueryExtras:
+    """Fail-closed normalization for matrix view-only query state."""
+    base = extras or MarketViewQueryExtras()
+    f5 = base.matrix_filter_f5_status
+    if f5 and allowed_f5_statuses and f5 not in allowed_f5_statuses:
+        f5 = ""
+    sort_field = base.matrix_sort_field
+    if sort_field and sort_field not in AVAILABLE_SORT_FIELDS:
+        sort_field = ""
+    sort_direction = base.matrix_sort_direction
+    if sort_direction and sort_direction not in {"asc", "desc"}:
+        sort_direction = ""
+    if sort_field and not sort_direction:
+        sort_direction = "asc" if sort_field == "rank" else "desc"
+    if sort_direction and not sort_field:
+        sort_direction = ""
+    return MarketViewQueryExtras(
+        matrix_filter_symbol=_sanitize_matrix_filter_symbol(base.matrix_filter_symbol),
+        matrix_filter_f5_status=f5,
+        matrix_filter_freshness=_sanitize_matrix_filter_freshness(base.matrix_filter_freshness),
+        matrix_sort_field=sort_field,
+        matrix_sort_direction=sort_direction,
+    )
+
+
+def resolve_matrix_sort_state(extras: MarketViewQueryExtras) -> tuple[str, str, bool]:
+    """Return active sort field, direction, and whether sort params were explicit."""
+    explicit = bool(extras.matrix_sort_field or extras.matrix_sort_direction)
+    field = extras.matrix_sort_field or "rank"
+    if field not in AVAILABLE_SORT_FIELDS:
+        field = "rank"
+        explicit = False
+    direction = extras.matrix_sort_direction or ("asc" if field == "rank" else "desc")
+    if direction not in {"asc", "desc"}:
+        direction = "asc" if field == "rank" else "desc"
+        explicit = False
+    return field, direction, explicit
+
+
+def _matrix_row_matches_view_filters(row: dict[str, Any], extras: MarketViewQueryExtras) -> bool:
+    sym_q = extras.matrix_filter_symbol.strip().upper()
+    if sym_q and sym_q not in str(row.get("symbol") or "").upper():
+        return False
+    f5 = extras.matrix_filter_f5_status
+    if f5 and str(row.get("f5_status") or "") != f5:
+        return False
+    freshness = extras.matrix_filter_freshness
+    if freshness and str(row.get("freshness_filter") or "") != freshness:
+        return False
+    return True
+
+
+def _matrix_row_sort_key(row: dict[str, Any], field: str) -> tuple[int, Any]:
+    if field == "symbol":
+        return (0, str(row.get("symbol") or "").lower())
+    if field == "f5_status":
+        return (0, str(row.get("f5_status") or "").lower())
+    attr = {
+        "rank": "rank_sort",
+        "score": "score_sort",
+        "last_price": "last_price_sort",
+        "change": "change_sort",
+        "volume": "volume_sort",
+    }.get(field, "rank_sort")
+    value = row.get(attr)
+    if value is None:
+        return (1, "")
+    if isinstance(value, (int, float)):
+        return (0, value)
+    return (0, str(value).lower())
+
+
+def sort_matrix_rows(
+    rows: list[dict[str, Any]],
+    *,
+    field: str,
+    direction: str,
+) -> list[dict[str, Any]]:
+    dir_mult = -1 if direction == "desc" else 1
+
+    def _cmp(a: dict[str, Any], b: dict[str, Any]) -> int:
+        ak = _matrix_row_sort_key(a, field)
+        bk = _matrix_row_sort_key(b, field)
+        if ak[0] != bk[0]:
+            return ak[0] - bk[0]
+        if ak[1] == bk[1]:
+            ar = _matrix_row_sort_key(a, "rank")
+            br = _matrix_row_sort_key(b, "rank")
+            if ar[1] == br[1]:
+                return 0
+            if ar[1] == "":
+                return 1
+            if br[1] == "":
+                return -1
+            return (ar[1] > br[1]) - (ar[1] < br[1])
+        if ak[1] < bk[1]:
+            return -1 * dir_mult
+        return 1 * dir_mult
+
+    return sorted(rows, key=functools.cmp_to_key(_cmp))
+
+
+def apply_matrix_view_state(
+    rows: list[dict[str, Any]],
+    extras: MarketViewQueryExtras | None,
+    *,
+    allowed_f5_statuses: tuple[str, ...] | list[str],
+) -> tuple[list[dict[str, Any]], MarketViewQueryExtras, str, str, bool]:
+    normalized = normalize_matrix_view_extras(extras, allowed_f5_statuses=allowed_f5_statuses)
+    filtered = [row for row in rows if _matrix_row_matches_view_filters(row, normalized)]
+    sort_field, sort_direction, explicit_sort = resolve_matrix_sort_state(normalized)
+    if explicit_sort:
+        filtered = sort_matrix_rows(filtered, field=sort_field, direction=sort_direction)
+    no_results = len(filtered) == 0 and len(rows) > 0
+    return filtered, normalized, sort_field, sort_direction, no_results
+
+
+def build_market_matrix_view_href(
+    *,
+    source: str,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    top_n: int = DEFAULT_TOP_N,
+    extras: MarketViewQueryExtras | None = None,
+    matrix_filter_symbol: str | None = None,
+    matrix_filter_f5_status: str | None = None,
+    matrix_filter_freshness: str | None = None,
+    matrix_sort_field: str | None = None,
+    matrix_sort_direction: str | None = None,
+    clear_filters: bool = False,
+    clear_sort: bool = False,
+    include_default_top_n: bool = False,
+) -> str:
+    merged = _merge_market_view_extras(
+        extras,
+        matrix_filter_symbol=matrix_filter_symbol,
+        matrix_filter_f5_status=matrix_filter_f5_status,
+        matrix_filter_freshness=matrix_filter_freshness,
+        matrix_sort_field=matrix_sort_field,
+        matrix_sort_direction=matrix_sort_direction,
+        clear_filters=clear_filters,
+        clear_sort=clear_sort,
+    )
+    return build_market_canonical_href(
+        source=source,
+        symbol=symbol,
+        timeframe=timeframe,
+        limit=limit,
+        top_n=top_n,
+        extras=merged,
+        include_default_top_n=include_default_top_n,
+    )
+
+
+def build_market_matrix_sort_toggle_href(
+    *,
+    field: str,
+    source: str,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    top_n: int,
+    extras: MarketViewQueryExtras | None,
+    active_sort_field: str,
+    active_sort_direction: str,
+) -> str:
+    if field not in AVAILABLE_SORT_FIELDS:
+        field = "rank"
+    if field == active_sort_field:
+        next_direction = "desc" if active_sort_direction == "asc" else "asc"
+    else:
+        next_direction = "asc" if field == "rank" else "desc"
+    return build_market_matrix_view_href(
+        source=source,
+        symbol=symbol,
+        timeframe=timeframe,
+        limit=limit,
+        top_n=top_n,
+        extras=extras,
+        matrix_sort_field=field,
+        matrix_sort_direction=next_direction,
+    )
+
+
+def build_market_matrix_reset_filters_href(
+    *,
+    source: str,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    top_n: int,
+    extras: MarketViewQueryExtras | None,
+) -> str:
+    return build_market_matrix_view_href(
+        source=source,
+        symbol=symbol,
+        timeframe=timeframe,
+        limit=limit,
+        top_n=top_n,
+        extras=extras,
+        clear_filters=True,
+    )
+
+
+def build_market_matrix_reset_sort_href(
+    *,
+    source: str,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    top_n: int,
+    extras: MarketViewQueryExtras | None,
+) -> str:
+    return build_market_matrix_view_href(
+        source=source,
+        symbol=symbol,
+        timeframe=timeframe,
+        limit=limit,
+        top_n=top_n,
+        extras=extras,
+        clear_sort=True,
+    )
+
+
+def build_market_matrix_control_hrefs(
+    *,
+    source: str,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    top_n: int,
+    extras: MarketViewQueryExtras,
+    active_sort_field: str,
+    active_sort_direction: str,
+    f5_filter_values: list[str],
+) -> dict[str, Any]:
+    return {
+        "reset_filters": build_market_matrix_reset_filters_href(
+            source=source,
+            symbol=symbol,
+            timeframe=timeframe,
+            limit=limit,
+            top_n=top_n,
+            extras=extras,
+        ),
+        "reset_sort": build_market_matrix_reset_sort_href(
+            source=source,
+            symbol=symbol,
+            timeframe=timeframe,
+            limit=limit,
+            top_n=top_n,
+            extras=extras,
+        ),
+        "sort": {
+            field: build_market_matrix_sort_toggle_href(
+                field=field,
+                source=source,
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+                top_n=top_n,
+                extras=extras,
+                active_sort_field=active_sort_field,
+                active_sort_direction=active_sort_direction,
+            )
+            for field in AVAILABLE_SORT_FIELDS
+        },
+        "f5_status": {
+            "all": build_market_matrix_view_href(
+                source=source,
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+                top_n=top_n,
+                extras=extras,
+                matrix_filter_f5_status="",
+            ),
+            **{
+                status: build_market_matrix_view_href(
+                    source=source,
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    limit=limit,
+                    top_n=top_n,
+                    extras=extras,
+                    matrix_filter_f5_status=status,
+                )
+                for status in f5_filter_values
+            },
+        },
+        "freshness": {
+            "all": build_market_matrix_view_href(
+                source=source,
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+                top_n=top_n,
+                extras=extras,
+                matrix_filter_freshness="",
+            ),
+            "fresh": build_market_matrix_view_href(
+                source=source,
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+                top_n=top_n,
+                extras=extras,
+                matrix_filter_freshness="fresh",
+            ),
+            "stale": build_market_matrix_view_href(
+                source=source,
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+                top_n=top_n,
+                extras=extras,
+                matrix_filter_freshness="stale",
+            ),
+        },
+        "filter_form_action": CANONICAL_MARKET_ROUTE,
+        "filter_form_fields": _market_query_params(
+            source=source,
+            symbol=symbol,
+            timeframe=timeframe,
+            limit=limit,
+            top_n=top_n,
+            extras=extras,
+            include_default_top_n=top_n != DEFAULT_TOP_N,
+        ),
+    }
 
 
 def _is_eligible_ranking_row(row: dict[str, Any]) -> bool:
@@ -1350,13 +1748,35 @@ def build_market_governed_top20_display_context(
 
     snapshot_available = snapshot_status in ("ready", "stale")
     f5_filter_values = sorted({str(r["f5_status"]) for r in rows})
+    producer_rows = rows
+    display_rows, resolved_extras, active_sort_field, active_sort_direction, filter_no_results = (
+        apply_matrix_view_state(
+            rows,
+            extras,
+            allowed_f5_statuses=f5_filter_values,
+        )
+    )
+    matrix_control_hrefs = build_market_matrix_control_hrefs(
+        source=source,
+        symbol=selected_symbol,
+        timeframe=timeframe,
+        limit=limit,
+        top_n=top_n,
+        extras=resolved_extras,
+        active_sort_field=active_sort_field,
+        active_sort_direction=active_sort_direction,
+        f5_filter_values=f5_filter_values,
+    )
     return {
         "section_visible": True,
         "snapshot_available": snapshot_available,
         "snapshot_status": snapshot_status,
         "display_status": "ready" if snapshot_available else snapshot_status,
-        "rows": rows,
-        "row_count": len(rows),
+        "rows": display_rows,
+        "producer_rows": producer_rows,
+        "row_count": len(producer_rows),
+        "visible_row_count": len(display_rows),
+        "filter_no_results": filter_no_results,
         "top_n": top_n,
         "top_n_default": DEFAULT_TOP_N,
         "top_n_selectable": True,
@@ -1378,6 +1798,10 @@ def build_market_governed_top20_display_context(
         "available_filter_fields": AVAILABLE_FILTER_FIELDS,
         "default_sort_field": "rank",
         "default_sort_direction": "asc",
+        "active_sort_field": active_sort_field,
+        "active_sort_direction": active_sort_direction,
+        "resolved_matrix_view_query": resolved_extras,
+        "matrix_control_hrefs": matrix_control_hrefs,
     }
 
 
@@ -1958,13 +2382,14 @@ def _find_governed_row_for_symbol(
     governed_top20: Dict[str, Any],
     symbol: str,
 ) -> dict[str, Any] | None:
-    rows = governed_top20.get("rows") if isinstance(governed_top20.get("rows"), list) else []
-    normalized = _normalize_symbol_for_match(symbol)
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        if _normalize_symbol_for_match(str(row.get("symbol") or "")) == normalized:
-            return row
+    for key in ("producer_rows", "rows"):
+        rows = governed_top20.get(key) if isinstance(governed_top20.get(key), list) else []
+        normalized = _normalize_symbol_for_match(symbol)
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            if _normalize_symbol_for_match(str(row.get("symbol") or "")) == normalized:
+                return row
     return None
 
 
@@ -2245,6 +2670,9 @@ def build_market_v0_page_template_context(
         top_n=top_n,
         extras=extras,
     )
+    resolved_view_query = governed_top20.get("resolved_matrix_view_query")
+    if not isinstance(resolved_view_query, MarketViewQueryExtras):
+        resolved_view_query = extras or MarketViewQueryExtras()
     selected_instrument_workspace = build_market_selected_instrument_workspace_display_context(
         symbol=symbol,
         source=source,
@@ -2288,7 +2716,7 @@ def build_market_v0_page_template_context(
                 source=source,
                 timeframe=timeframe,
                 limit=limit,
-                extras=extras,
+                extras=resolved_view_query,
             ),
             50: build_market_top_n_toggle_href(
                 top_n=50,
@@ -2296,7 +2724,7 @@ def build_market_v0_page_template_context(
                 source=source,
                 timeframe=timeframe,
                 limit=limit,
-                extras=extras,
+                extras=resolved_view_query,
             ),
         },
         "double_play_json_url": "/api/master-v2/double-play/dashboard-display.json",
@@ -2311,13 +2739,13 @@ def build_market_v0_page_template_context(
             "limit": limit,
             "source": source,
             "top_n": top_n,
-            "matrix_filter_symbol": extras.matrix_filter_symbol if extras else "",
-            "matrix_filter_f5_status": extras.matrix_filter_f5_status if extras else "",
-            "matrix_filter_freshness": extras.matrix_filter_freshness if extras else "",
-            "matrix_sort_field": extras.matrix_sort_field if extras else "",
-            "matrix_sort_direction": extras.matrix_sort_direction if extras else "",
+            "matrix_filter_symbol": resolved_view_query.matrix_filter_symbol,
+            "matrix_filter_f5_status": resolved_view_query.matrix_filter_f5_status,
+            "matrix_filter_freshness": resolved_view_query.matrix_filter_freshness,
+            "matrix_sort_field": resolved_view_query.matrix_sort_field,
+            "matrix_sort_direction": resolved_view_query.matrix_sort_direction,
         },
-        "matrix_view_query": extras or MarketViewQueryExtras(),
+        "matrix_view_query": resolved_view_query,
     }
 
 

--- a/templates/peak_trade_dashboard/partials/market_governed_top20_primary_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_governed_top20_primary_v1.html
@@ -68,56 +68,77 @@
     </div>
   </div>
 
-  {% if governed_top20.snapshot_available and governed_top20.rows %}
+  {% if governed_top20.snapshot_available and governed_top20.producer_rows %}
   <div
     class="mb-1.5 flex flex-wrap items-end gap-1.5 text-[10px]"
     data-market-governed-matrix-filters-v1="true"
+    data-market-matrix-url-state-v1="true"
     aria-label="Matrix filters (view-only)"
   >
-    <label class="flex flex-col gap-0.5 text-slate-400">
-      <span class="uppercase tracking-wide">Symbol</span>
-      <input
-        type="search"
-        class="rounded border border-slate-700/70 bg-slate-900/80 px-2 py-1 font-mono text-slate-200 min-w-[8rem]"
-        placeholder="filter symbol…"
-        data-market-matrix-filter-symbol-v1="true"
-        autocomplete="off"
-      />
-    </label>
-    <label class="flex flex-col gap-0.5 text-slate-400">
+    <form
+      method="get"
+      action="{{ governed_top20.matrix_control_hrefs.filter_form_action|e }}"
+      class="flex flex-col gap-0.5 text-slate-400"
+      data-market-matrix-filter-form-v1="true"
+    >
+      {% for name, value in governed_top20.matrix_control_hrefs.filter_form_fields %}
+      {% if name != 'matrix_filter_symbol' %}
+      <input type="hidden" name="{{ name|e }}" value="{{ value|e }}">
+      {% endif %}
+      {% endfor %}
+      <label class="flex flex-col gap-0.5">
+        <span class="uppercase tracking-wide">Symbol</span>
+        <input
+          type="search"
+          name="matrix_filter_symbol"
+          class="rounded border border-slate-700/70 bg-slate-900/80 px-2 py-1 font-mono text-slate-200 min-w-[8rem]"
+          placeholder="filter symbol…"
+          value="{{ matrix_view_query.matrix_filter_symbol|e }}"
+          data-market-matrix-filter-symbol-v1="true"
+          autocomplete="off"
+        />
+      </label>
+    </form>
+    <div class="flex flex-col gap-0.5 text-slate-400" data-market-matrix-filter-f5-status-v1="true">
       <span class="uppercase tracking-wide" title="F5 metadata status applied uniformly to all rows in this snapshot">F5 status</span>
-      <select
-        class="rounded border border-slate-700/70 bg-slate-900/80 px-2 py-1 font-mono text-slate-200"
-        data-market-matrix-filter-f5-status-v1="true"
-      >
-        <option value="">all</option>
+      <div class="flex flex-wrap gap-1">
+        <a
+          href="{{ governed_top20.matrix_control_hrefs.f5_status.all|e }}"
+          class="rounded border px-2 py-1 font-mono no-underline {% if not matrix_view_query.matrix_filter_f5_status %}border-violet-500/70 bg-violet-950/50 text-violet-100{% else %}border-slate-700/70 bg-slate-900/80 text-slate-300 hover:text-slate-100{% endif %}"
+          {% if not matrix_view_query.matrix_filter_f5_status %}aria-current="true"{% endif %}
+        >all</a>
         {% for status in governed_top20.f5_filter_values %}
-        <option value="{{ status|e }}">{{ status|e }}</option>
+        <a
+          href="{{ governed_top20.matrix_control_hrefs.f5_status[status]|e }}"
+          class="rounded border px-2 py-1 font-mono no-underline {% if matrix_view_query.matrix_filter_f5_status == status %}border-violet-500/70 bg-violet-950/50 text-violet-100{% else %}border-slate-700/70 bg-slate-900/80 text-slate-300 hover:text-slate-100{% endif %}"
+          {% if matrix_view_query.matrix_filter_f5_status == status %}aria-current="true"{% endif %}
+        >{{ status|e }}</a>
         {% endfor %}
-      </select>
-    </label>
-    <label class="flex flex-col gap-0.5 text-slate-400">
+      </div>
+    </div>
+    <div class="flex flex-col gap-0.5 text-slate-400" data-market-matrix-filter-freshness-v1="true">
       <span class="uppercase tracking-wide" title="Freshness flag from ranking snapshot producer">Freshness</span>
-      <select
-        class="rounded border border-slate-700/70 bg-slate-900/80 px-2 py-1 font-mono text-slate-200"
-        data-market-matrix-filter-freshness-v1="true"
-      >
-        <option value="">all</option>
-        <option value="fresh">fresh</option>
-        <option value="stale">stale</option>
-      </select>
-    </label>
-    <button
-      type="button"
-      class="rounded border border-slate-700/70 bg-slate-900/80 px-2 py-1 text-slate-300 hover:text-slate-100"
+      <div class="flex flex-wrap gap-1">
+        {% for label, key in [('all', 'all'), ('fresh', 'fresh'), ('stale', 'stale')] %}
+        <a
+          href="{{ governed_top20.matrix_control_hrefs.freshness[key]|e }}"
+          class="rounded border px-2 py-1 font-mono no-underline {% if (key == 'all' and not matrix_view_query.matrix_filter_freshness) or matrix_view_query.matrix_filter_freshness == key %}border-violet-500/70 bg-violet-950/50 text-violet-100{% else %}border-slate-700/70 bg-slate-900/80 text-slate-300 hover:text-slate-100{% endif %}"
+          {% if (key == 'all' and not matrix_view_query.matrix_filter_freshness) or matrix_view_query.matrix_filter_freshness == key %}aria-current="true"{% endif %}
+        >{{ label|e }}</a>
+        {% endfor %}
+      </div>
+    </div>
+    <a
+      href="{{ governed_top20.matrix_control_hrefs.reset_filters|e }}"
+      class="rounded border border-slate-700/70 bg-slate-900/80 px-2 py-1 text-slate-300 hover:text-slate-100 no-underline"
       data-market-matrix-reset-filters-v1="true"
-    >Reset filters</button>
-    <button
-      type="button"
-      class="rounded border border-slate-700/70 bg-slate-900/80 px-2 py-1 text-slate-300 hover:text-slate-100"
+    >Reset filters</a>
+    <a
+      href="{{ governed_top20.matrix_control_hrefs.reset_sort|e }}"
+      class="rounded border border-slate-700/70 bg-slate-900/80 px-2 py-1 text-slate-300 hover:text-slate-100 no-underline"
       data-market-matrix-reset-sort-v1="true"
       title="Restore governed ranking order (rank ascending)"
-    >Reset sort</button>
+    >Reset sort</a>
   </div>
 
   <div class="overflow-x-auto" data-market-governed-top20-table-v1="true" data-market-futures-selector-table-v1="true" data-market-governed-matrix-table-v1="true">
@@ -125,25 +146,25 @@
       <thead class="sticky top-0 z-10 bg-slate-950/95 backdrop-blur-sm">
         <tr class="text-left text-slate-400 border-b border-slate-800/70">
           <th class="pr-2 py-1 font-normal">
-            <button type="button" class="text-left text-inherit bg-transparent border-0 p-0 cursor-pointer hover:text-slate-200" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="rank" title="Governed rank (default order)">Rank</button>
+            <a href="{{ governed_top20.matrix_control_hrefs.sort.rank|e }}" class="text-sky-300/95 no-underline hover:underline {% if governed_top20.active_sort_field == 'rank' %}font-semibold text-violet-100{% endif %}" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="rank" title="Governed rank (default order)" {% if governed_top20.active_sort_field == 'rank' %}aria-current="true"{% endif %}>Rank</a>
           </th>
           <th class="pr-2 py-1 font-normal">
-            <button type="button" class="text-left text-inherit bg-transparent border-0 p-0 cursor-pointer hover:text-slate-200" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="symbol">Futures symbol</button>
+            <a href="{{ governed_top20.matrix_control_hrefs.sort.symbol|e }}" class="text-sky-300/95 no-underline hover:underline {% if governed_top20.active_sort_field == 'symbol' %}font-semibold text-violet-100{% endif %}" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="symbol" {% if governed_top20.active_sort_field == 'symbol' %}aria-current="true"{% endif %}>Futures symbol</a>
           </th>
           <th class="pr-2 py-1 font-normal text-right">
-            <button type="button" class="text-right w-full text-inherit bg-transparent border-0 p-0 cursor-pointer hover:text-slate-200" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="score" title="Producer display_score">Score</button>
+            <a href="{{ governed_top20.matrix_control_hrefs.sort.score|e }}" class="text-sky-300/95 no-underline hover:underline {% if governed_top20.active_sort_field == 'score' %}font-semibold text-violet-100{% endif %}" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="score" title="Producer display_score" {% if governed_top20.active_sort_field == 'score' %}aria-current="true"{% endif %}>Score</a>
           </th>
           <th class="pr-2 py-1 font-normal">
-            <button type="button" class="text-left text-inherit bg-transparent border-0 p-0 cursor-pointer hover:text-slate-200" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="f5_status" title="F5 metadata status (snapshot-level)">Eligibility / F5</button>
+            <a href="{{ governed_top20.matrix_control_hrefs.sort.f5_status|e }}" class="text-sky-300/95 no-underline hover:underline {% if governed_top20.active_sort_field == 'f5_status' %}font-semibold text-violet-100{% endif %}" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="f5_status" title="F5 metadata status (snapshot-level)" {% if governed_top20.active_sort_field == 'f5_status' %}aria-current="true"{% endif %}>Eligibility / F5</a>
           </th>
           <th class="pr-2 py-1 font-normal text-right">
-            <button type="button" class="text-right w-full text-inherit bg-transparent border-0 p-0 cursor-pointer hover:text-slate-200" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="last_price" title="Last close from futures OHLCV readmodel when available">Last price</button>
+            <a href="{{ governed_top20.matrix_control_hrefs.sort.last_price|e }}" class="text-sky-300/95 no-underline hover:underline {% if governed_top20.active_sort_field == 'last_price' %}font-semibold text-violet-100{% endif %}" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="last_price" title="Last close from futures OHLCV readmodel when available" {% if governed_top20.active_sort_field == 'last_price' %}aria-current="true"{% endif %}>Last price</a>
           </th>
           <th class="pr-2 py-1 font-normal text-right">
-            <button type="button" class="text-right w-full text-inherit bg-transparent border-0 p-0 cursor-pointer hover:text-slate-200" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="change" title="Bar-over-bar % change from OHLCV when available">Change</button>
+            <a href="{{ governed_top20.matrix_control_hrefs.sort.change|e }}" class="text-sky-300/95 no-underline hover:underline {% if governed_top20.active_sort_field == 'change' %}font-semibold text-violet-100{% endif %}" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="change" title="Bar-over-bar % change from OHLCV when available" {% if governed_top20.active_sort_field == 'change' %}aria-current="true"{% endif %}>Change</a>
           </th>
           <th class="pr-2 py-1 font-normal text-right">
-            <button type="button" class="text-right w-full text-inherit bg-transparent border-0 p-0 cursor-pointer hover:text-slate-200" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="volume" title="Last bar volume from OHLCV when available">Volume</button>
+            <a href="{{ governed_top20.matrix_control_hrefs.sort.volume|e }}" class="text-sky-300/95 no-underline hover:underline {% if governed_top20.active_sort_field == 'volume' %}font-semibold text-violet-100{% endif %}" data-market-matrix-sort-v1="true" data-market-matrix-sort-field="volume" title="Last bar volume from OHLCV when available" {% if governed_top20.active_sort_field == 'volume' %}aria-current="true"{% endif %}>Volume</a>
           </th>
           <th class="pr-2 py-1 font-normal">Freshness</th>
           <th class="py-1 font-normal">Data status</th>
@@ -204,9 +225,9 @@
       </tbody>
     </table>
     <p class="m-0 mt-2 text-[10px] text-slate-500" data-market-governed-matrix-row-summary-v1="true">
-      <span data-market-matrix-visible-count-v1="true">{{ governed_top20.row_count }}</span> row(s) visible · producer-defined count · ranking order preserved · no padding to {{ governed_top20.top_n }}
+      <span data-market-matrix-visible-count-v1="{{ governed_top20.visible_row_count }}">{{ governed_top20.visible_row_count }}</span> row(s) visible · producer-defined count · ranking order preserved · no padding to {{ governed_top20.top_n }}
     </p>
-    <p class="m-0 mt-1 text-[10px] text-amber-200/90 hidden" role="status" data-market-governed-matrix-no-results-v1="true">
+    <p class="m-0 mt-1 text-[10px] text-amber-200/90{% if not governed_top20.filter_no_results %} hidden{% endif %}" role="status" data-market-governed-matrix-no-results-v1="true">
       No rows match the current filters (view-only; snapshot unchanged).
     </p>
   </div>
@@ -217,127 +238,10 @@
       <li><strong>Score</strong> — producer <code>display_score</code> from ranking funnel (not recomputed).</li>
       <li><strong>Eligibility</strong> — governed <code>selected</code> stage row; F5 status from futures read-only dashboard metadata.</li>
       <li><strong>Last price / Change / Volume</strong> — from futures OHLCV readmodel when gate+bundle provide series; otherwise em dash.</li>
-      <li><strong>Sort / Filter</strong> — client-side display only; does not mutate snapshot, ranking, or authority.</li>
+      <li><strong>Sort / Filter</strong> — URL-backed GET view state only; does not mutate snapshot, ranking, or authority.</li>
       <li>Liquidity, Regime, Bull/Bear, Scope — not shown (no canonical per-row owner in this slice).</li>
     </ul>
   </details>
-
-  <script>
-  (function () {
-    var root = document.getElementById("market-governed-top20-primary-v1");
-    if (!root) return;
-    var tbody = root.querySelector("[data-market-governed-matrix-tbody-v1]");
-    if (!tbody) return;
-    var rows = Array.prototype.slice.call(tbody.querySelectorAll("[data-market-governed-matrix-row-v1]"));
-    var defaultOrder = rows.map(function (r) { return r; });
-    var sortField = root.getAttribute("data-market-matrix-sort-initial-field") || root.getAttribute("data-market-matrix-default-sort-field") || "rank";
-    var sortDir = root.getAttribute("data-market-matrix-sort-initial-direction") || root.getAttribute("data-market-matrix-default-sort-direction") || "asc";
-    var symbolInput = root.querySelector("[data-market-matrix-filter-symbol-v1]");
-    var f5Select = root.querySelector("[data-market-matrix-filter-f5-status-v1]");
-    var freshSelect = root.querySelector("[data-market-matrix-filter-freshness-v1]");
-    if (symbolInput) {
-      var initSym = root.getAttribute("data-market-matrix-filter-initial-symbol") || "";
-      if (initSym) symbolInput.value = initSym;
-    }
-    if (f5Select) {
-      var initF5 = root.getAttribute("data-market-matrix-filter-initial-f5-status") || "";
-      if (initF5) f5Select.value = initF5;
-    }
-    if (freshSelect) {
-      var initFresh = root.getAttribute("data-market-matrix-filter-initial-freshness") || "";
-      if (initFresh) freshSelect.value = initFresh;
-    }
-    var noResults = root.querySelector("[data-market-governed-matrix-no-results-v1]");
-    var visibleCount = root.querySelector("[data-market-matrix-visible-count-v1]");
-
-    function parseSortValue(row, field) {
-      var attr = "data-market-matrix-sort-" + field.replace(/_/g, "-");
-      var raw = row.getAttribute(attr);
-      if (raw === "" || raw === null) return null;
-      if (field === "symbol" || field === "f5_status") return String(raw).toLowerCase();
-      var num = Number(raw);
-      return Number.isFinite(num) ? num : null;
-    }
-
-    function compareRows(a, b) {
-      var av = parseSortValue(a, sortField);
-      var bv = parseSortValue(b, sortField);
-      var dir = sortDir === "desc" ? -1 : 1;
-      if (av === null && bv === null) {
-        var ar = parseSortValue(a, "rank");
-        var br = parseSortValue(b, "rank");
-        if (ar === null && br === null) return 0;
-        if (ar === null) return 1;
-        if (br === null) return -1;
-        return (ar - br) * dir;
-      }
-      if (av === null) return 1;
-      if (bv === null) return -1;
-      if (av < bv) return -1 * dir;
-      if (av > bv) return 1 * dir;
-      var ar2 = parseSortValue(a, "rank");
-      var br2 = parseSortValue(b, "rank");
-      if (ar2 === null || br2 === null) return 0;
-      return ar2 - br2;
-    }
-
-    function rowMatchesFilters(row) {
-      var symQ = symbolInput && symbolInput.value ? symbolInput.value.trim().toUpperCase() : "";
-      if (symQ && row.getAttribute("data-market-matrix-row-symbol").toUpperCase().indexOf(symQ) === -1) return false;
-      var f5 = f5Select && f5Select.value ? f5Select.value : "";
-      if (f5 && row.getAttribute("data-market-matrix-row-f5-status") !== f5) return false;
-      var fr = freshSelect && freshSelect.value ? freshSelect.value : "";
-      if (fr && row.getAttribute("data-market-matrix-row-freshness") !== fr) return false;
-      return true;
-    }
-
-    function applyView() {
-      var visible = 0;
-      rows.forEach(function (row) {
-        var show = rowMatchesFilters(row);
-        row.style.display = show ? "" : "none";
-        if (show) visible += 1;
-      });
-      if (visibleCount) visibleCount.textContent = String(visible);
-      if (noResults) noResults.classList.toggle("hidden", visible > 0);
-      var sorted = rows.slice().sort(compareRows);
-      sorted.forEach(function (row) { tbody.appendChild(row); });
-    }
-
-    function resetSort() {
-      sortField = root.getAttribute("data-market-matrix-default-sort-field") || "rank";
-      sortDir = root.getAttribute("data-market-matrix-default-sort-direction") || "asc";
-      defaultOrder.forEach(function (row) { tbody.appendChild(row); });
-      applyView();
-    }
-
-    root.querySelectorAll("[data-market-matrix-sort-v1]").forEach(function (btn) {
-      btn.addEventListener("click", function () {
-        var field = btn.getAttribute("data-market-matrix-sort-field");
-        if (!field) return;
-        if (sortField === field) {
-          sortDir = sortDir === "asc" ? "desc" : "asc";
-        } else {
-          sortField = field;
-          sortDir = field === "rank" ? "asc" : "desc";
-        }
-        applyView();
-      });
-    });
-    if (symbolInput) symbolInput.addEventListener("input", applyView);
-    if (f5Select) f5Select.addEventListener("change", applyView);
-    if (freshSelect) freshSelect.addEventListener("change", applyView);
-    var resetFilters = root.querySelector("[data-market-matrix-reset-filters-v1]");
-    if (resetFilters) resetFilters.addEventListener("click", function () {
-      if (symbolInput) symbolInput.value = "";
-      if (f5Select) f5Select.value = "";
-      if (freshSelect) freshSelect.value = "";
-      applyView();
-    });
-    var resetSortBtn = root.querySelector("[data-market-matrix-reset-sort-v1]");
-    if (resetSortBtn) resetSortBtn.addEventListener("click", resetSort);
-  })();
-  </script>
   {% elif governed_top20.snapshot_status == 'malformed' %}
   <p class="m-0 text-sm text-rose-200/90" role="alert" data-market-governed-top20-malformed-state-v1="true">
     <strong>Governed snapshot invalid/malformed</strong> — ranking bundle could not be loaded. No partial or synthetic list shown.

--- a/tests/webui/test_market_dashboard_matrix_url_state_v1.py
+++ b/tests/webui/test_market_dashboard_matrix_url_state_v1.py
@@ -1,0 +1,391 @@
+"""Matrix URL view-state contract on canonical GET /market (SSR, view-only)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Iterator
+from html import unescape
+from pathlib import Path
+from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+from src.webui.futures_read_only_market_dashboard_runtime_v0 import (
+    ENV_BUNDLE_ROOT as F5_ENV_BUNDLE_ROOT,
+    ENV_ENABLED as F5_ENV_ENABLED,
+)
+from src.webui.market_futures_ohlcv_runtime_v0 import (
+    ENV_BUNDLE_ROOT as OHLCV_ENV_BUNDLE_ROOT,
+    ENV_ENABLED as OHLCV_ENV_ENABLED,
+)
+from src.webui.market_ranking_funnel_runtime_v0 import (
+    ENV_BUNDLE_ROOT as RANKING_ENV_BUNDLE_ROOT,
+    ENV_ENABLED as RANKING_ENV_ENABLED,
+)
+from src.webui.market_surface import (
+    AVAILABLE_SORT_FIELDS,
+    CANONICAL_FILTER_OWNER,
+    CANONICAL_MARKET_ROUTE,
+    CANONICAL_MATRIX_TEMPLATE_OWNER,
+    CANONICAL_SORT_OWNER,
+    CANONICAL_URL_BUILDER_OWNER,
+    DEFAULT_TOP_N,
+    MATRIX_VIEW_QUERY_PARAM_NAMES,
+    apply_matrix_view_state,
+    build_market_canonical_href,
+    build_market_governed_top20_display_context,
+    build_market_matrix_reset_filters_href,
+    build_market_matrix_reset_sort_href,
+    build_market_matrix_sort_toggle_href,
+    build_market_matrix_view_href,
+    build_market_view_query_extras,
+    normalize_matrix_view_extras,
+    normalize_top_n,
+    MarketViewQueryExtras,
+    resolve_matrix_sort_state,
+    sort_matrix_rows,
+)
+
+RANKING_FIXTURE = (
+    project_root / "tests" / "fixtures" / "market_ranking_funnel_readmodel_v0" / "complete_minimal"
+).resolve()
+OHLCV_FIXTURE = (
+    project_root / "tests" / "fixtures" / "market_futures_ohlcv_readmodel_v0" / "complete_minimal"
+).resolve()
+F5_FIXTURE = (
+    project_root
+    / "tests"
+    / "fixtures"
+    / "futures_read_only_market_dashboard_v0"
+    / "complete_minimal"
+).resolve()
+
+FORBIDDEN_AUTHORITY_RE = re.compile(
+    r'(?:type=["\']submit["\']|data-market-(?:order|execute|arm))',
+    re.IGNORECASE,
+)
+SIDE_ROUTE_RE = re.compile(r'href=["\']/(?:market/50|top50|market/top50)', re.IGNORECASE)
+SCRIPT_BLOCK_RE = re.compile(r"<script\b", re.IGNORECASE)
+
+
+@pytest.fixture()
+def client_full(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.setenv(RANKING_ENV_ENABLED, "1")
+    monkeypatch.setenv(RANKING_ENV_BUNDLE_ROOT, str(RANKING_FIXTURE))
+    monkeypatch.setenv(OHLCV_ENV_ENABLED, "1")
+    monkeypatch.setenv(OHLCV_ENV_BUNDLE_ROOT, str(OHLCV_FIXTURE))
+    monkeypatch.setenv(F5_ENV_ENABLED, "1")
+    monkeypatch.setenv(F5_ENV_BUNDLE_ROOT, str(F5_FIXTURE))
+    kraken_mock = MagicMock(
+        side_effect=AssertionError("fetch_ohlcv_df must not run on futures-first /market")
+    )
+    monkeypatch.setattr("src.data.kraken.fetch_ohlcv_df", kraken_mock)
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _html(client: TestClient, path: str = "/market") -> str:
+    resp = client.get(path)
+    assert resp.status_code == 200, f"{path} -> {resp.status_code}"
+    return resp.text
+
+
+def _governed_ctx(monkeypatch: pytest.MonkeyPatch, **kwargs: object) -> dict[str, object]:
+    monkeypatch.setenv(RANKING_ENV_ENABLED, "1")
+    monkeypatch.setenv(RANKING_ENV_BUNDLE_ROOT, str(RANKING_FIXTURE))
+    monkeypatch.setenv(OHLCV_ENV_ENABLED, "1")
+    monkeypatch.setenv(OHLCV_ENV_BUNDLE_ROOT, str(OHLCV_FIXTURE))
+    monkeypatch.setenv(F5_ENV_ENABLED, "1")
+    monkeypatch.setenv(F5_ENV_BUNDLE_ROOT, str(F5_FIXTURE))
+    from src.webui.futures_read_only_market_dashboard_runtime_v0 import (
+        build_futures_read_only_market_dashboard_display_context,
+    )
+    from src.webui.market_futures_ohlcv_runtime_v0 import build_market_futures_ohlcv_display_context
+    from src.webui.market_ranking_funnel_runtime_v0 import (
+        build_market_ranking_funnel_display_context,
+    )
+
+    return build_market_governed_top20_display_context(
+        ranking_funnel=build_market_ranking_funnel_display_context(),
+        f5_dashboard=build_futures_read_only_market_dashboard_display_context(),
+        futures_ohlcv=build_market_futures_ohlcv_display_context(),
+        **kwargs,
+    )
+
+
+def test_canonical_owner_constants() -> None:
+    assert CANONICAL_URL_BUILDER_OWNER.endswith("market_surface.py")
+    assert CANONICAL_FILTER_OWNER.endswith("market_surface.py")
+    assert CANONICAL_SORT_OWNER.endswith("market_surface.py")
+    assert CANONICAL_MATRIX_TEMPLATE_OWNER.endswith("market_governed_top20_primary_v1.html")
+    assert MATRIX_VIEW_QUERY_PARAM_NAMES == (
+        "matrix_filter_symbol",
+        "matrix_filter_f5_status",
+        "matrix_filter_freshness",
+        "matrix_sort_field",
+        "matrix_sort_direction",
+    )
+
+
+def test_canonical_href_deterministic_order_and_encoding() -> None:
+    extras = build_market_view_query_extras(
+        matrix_filter_symbol="ETH/US",
+        matrix_filter_freshness="fresh",
+        matrix_sort_field="score",
+        matrix_sort_direction="desc",
+    )
+    href = build_market_canonical_href(
+        source="futures",
+        symbol="ETHUSDT",
+        timeframe="1d",
+        limit=120,
+        top_n=50,
+        extras=extras,
+        include_default_top_n=True,
+    )
+    assert href.startswith("/market?")
+    assert href == build_market_canonical_href(
+        source="futures",
+        symbol="ETHUSDT",
+        timeframe="1d",
+        limit=120,
+        top_n=50,
+        extras=extras,
+        include_default_top_n=True,
+    )
+    assert "matrix_filter_symbol=ETH%2FUS" in href or "matrix_filter_symbol=ETH/US" in href
+
+
+def test_invalid_matrix_values_fail_closed() -> None:
+    normalized = normalize_matrix_view_extras(
+        build_market_view_query_extras(
+            matrix_filter_f5_status="not_a_real_status",
+            matrix_filter_freshness="ancient",
+            matrix_sort_field="free_field",
+            matrix_sort_direction="sideways",
+        ),
+        allowed_f5_statuses=("futures_metadata_partial",),
+    )
+    assert normalized.matrix_filter_f5_status == ""
+    assert normalized.matrix_filter_freshness == ""
+    assert normalized.matrix_sort_field == ""
+    assert normalized.matrix_sort_direction == ""
+
+
+def test_top_n_invalid_values_fail_closed() -> None:
+    for bad in (99, "abc", 0, -1, "null", 99999):
+        assert normalize_top_n(bad) == DEFAULT_TOP_N
+
+
+def test_symbol_filter_ssr_reduces_visible_rows(client_full: TestClient) -> None:
+    body = _html(client_full, "/market?matrix_filter_symbol=ZZZZNOTFOUND")
+    assert 'data-market-matrix-visible-count-v1="0"' in body
+    assert 'data-market-governed-matrix-no-results-v1="true"' in body
+    assert "hidden" not in body.split('data-market-governed-matrix-no-results-v1="true"')[1][:80]
+
+
+def test_freshness_filter_ssr(client_full: TestClient) -> None:
+    body = _html(client_full, "/market?matrix_filter_freshness=fresh")
+    assert 'data-market-matrix-filter-freshness-v1="true"' in body
+    assert 'aria-current="true"' in body
+    assert 'data-market-matrix-visible-count-v1="8"' in body
+
+
+def test_sort_by_score_desc_ssr(client_full: TestClient) -> None:
+    body = _html(client_full, "/market?matrix_sort_field=score&matrix_sort_direction=desc")
+    first_row = body.split('data-market-governed-matrix-row-v1="true"', 1)[1]
+    assert "ETHUSDT" in first_row or "SOLUSDT" in first_row
+    assert 'data-market-matrix-sort-field="score"' in body
+    assert 'href="/market?' in body
+
+
+def test_reset_filters_and_sort_hrefs_preserve_other_state() -> None:
+    extras = build_market_view_query_extras(
+        matrix_filter_symbol="ETH",
+        matrix_filter_freshness="fresh",
+        matrix_sort_field="symbol",
+        matrix_sort_direction="desc",
+    )
+    reset_filters = build_market_matrix_reset_filters_href(
+        source="futures",
+        symbol="ETHUSDT",
+        timeframe="1d",
+        limit=120,
+        top_n=50,
+        extras=extras,
+    )
+    assert "matrix_filter_symbol=" not in reset_filters
+    assert "matrix_sort_field=symbol" in reset_filters
+    reset_sort = build_market_matrix_reset_sort_href(
+        source="futures",
+        symbol="ETHUSDT",
+        timeframe="1d",
+        limit=120,
+        top_n=50,
+        extras=extras,
+    )
+    assert "matrix_filter_symbol=ETH" in reset_sort
+    assert "matrix_sort_field=" not in reset_sort
+
+
+def test_sort_toggle_href_flips_direction() -> None:
+    extras = build_market_view_query_extras(
+        matrix_sort_field="score",
+        matrix_sort_direction="desc",
+    )
+    toggled = build_market_matrix_sort_toggle_href(
+        field="score",
+        source="futures",
+        symbol="ETHUSDT",
+        timeframe="1d",
+        limit=120,
+        top_n=20,
+        extras=extras,
+        active_sort_field="score",
+        active_sort_direction="desc",
+    )
+    assert "matrix_sort_field=score" in toggled
+    assert "matrix_sort_direction=asc" in toggled
+
+
+def test_combined_url_state_reload_reproducible(
+    client_full: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PEAK_TRADE_FIXED_GENERATED_AT_UTC", "2026-06-16T22:00:00Z")
+    path = (
+        "/market?top_n=50&symbol=ETHUSDT&matrix_filter_symbol=ETH"
+        "&matrix_filter_freshness=fresh&matrix_sort_field=symbol&matrix_sort_direction=desc"
+    )
+    bodies = [_html(client_full, path) for _ in range(3)]
+    assert bodies[0] == bodies[1] == bodies[2]
+    assert 'data-market-governed-top-n="50"' in bodies[0]
+    assert 'value="ETH"' in bodies[0]
+    assert SIDE_ROUTE_RE.search(bodies[0]) is None
+
+
+def test_top_n_change_preserves_matrix_query(client_full: TestClient) -> None:
+    path = (
+        "/market?symbol=SOLUSDT&top_n=20&matrix_filter_symbol=SOL"
+        "&matrix_filter_freshness=fresh&matrix_sort_field=volume&matrix_sort_direction=desc"
+    )
+    body = _html(client_full, path)
+    top50_match = re.search(r'href=["\'](/market\?[^"\']*top_n=50[^"\']*)["\']', body)
+    assert top50_match is not None
+    href = unescape(top50_match.group(1))
+    assert "matrix_filter_symbol=SOL" in href
+    assert "matrix_sort_field=volume" in href
+
+
+def test_symbol_selection_preserves_matrix_query(client_full: TestClient) -> None:
+    path = "/market?symbol=ETHUSDT&matrix_filter_symbol=ET&matrix_sort_field=rank"
+    body = _html(client_full, path)
+    sol_link = re.search(
+        r'href=["\'](/market\?[^"\']*symbol=SOLUSDT[^"\']*)["\']',
+        body,
+        re.IGNORECASE,
+    )
+    assert sol_link is not None
+    href = unescape(sol_link.group(1))
+    assert "matrix_filter_symbol=ET" in href
+
+
+def test_ssr_controls_without_inline_script(client_full: TestClient) -> None:
+    body = _html(client_full)
+    matrix = body.split('data-market-matrix-url-state-v1="true"', 1)[1][:12000]
+    assert SCRIPT_BLOCK_RE.search(matrix) is None
+    assert 'method="get"' in matrix
+    assert 'data-market-matrix-filter-form-v1="true"' in matrix
+    assert 'data-market-matrix-reset-filters-v1="true"' in matrix
+    assert 'data-market-matrix-reset-sort-v1="true"' in matrix
+    assert FORBIDDEN_AUTHORITY_RE.search(matrix) is None
+
+
+def test_no_bitcoin_spot_or_parallel_route(client_full: TestClient) -> None:
+    body = _html(
+        client_full,
+        "/market?top_n=50&matrix_filter_symbol=ETH&matrix_sort_field=symbol",
+    )
+    assert "BTCUSDT" not in body
+    assert "XBT" not in body
+    assert "BTC/EUR" not in body
+    assert SIDE_ROUTE_RE.search(body) is None
+
+
+def test_apply_matrix_view_state_unit(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = _governed_ctx(monkeypatch)
+    rows = ctx["producer_rows"]
+    filtered, normalized, field, direction, no_results = apply_matrix_view_state(
+        rows,
+        build_market_view_query_extras(matrix_filter_symbol="ETH"),
+        allowed_f5_statuses=ctx["f5_filter_values"],
+    )
+    assert len(filtered) < len(rows)
+    assert no_results is False
+    assert field == "rank"
+    assert direction == "asc"
+
+
+def test_sort_matrix_rows_tie_break_by_rank() -> None:
+    rows = [
+        {"rank_sort": 2, "score_sort": 1.0, "symbol": "B"},
+        {"rank_sort": 1, "score_sort": 1.0, "symbol": "A"},
+    ]
+    sorted_rows = sort_matrix_rows(rows, field="score", direction="asc")
+    assert [r["symbol"] for r in sorted_rows] == ["A", "B"]
+
+
+def test_resolve_matrix_sort_state_defaults() -> None:
+    field, direction, explicit = resolve_matrix_sort_state(MarketViewQueryExtras())
+    assert field == "rank"
+    assert direction == "asc"
+    assert explicit is False
+
+
+def test_matrix_view_href_unknown_params_not_propagated() -> None:
+    href = build_market_matrix_view_href(
+        source="futures",
+        symbol="ETHUSDT",
+        timeframe="1d",
+        limit=120,
+        top_n=20,
+        extras=build_market_view_query_extras(matrix_filter_symbol="ETH"),
+    )
+    parsed = parse_qs(urlparse(href).query)
+    assert set(parsed.keys()).issubset(
+        {
+            "source",
+            "symbol",
+            "timeframe",
+            "limit",
+            "top_n",
+            *MATRIX_VIEW_QUERY_PARAM_NAMES,
+        }
+    )
+
+
+def test_determinism_combined_query_state(client_full: TestClient) -> None:
+    path = (
+        "/market?top_n=50&symbol=ETHUSDT&matrix_filter_symbol=E"
+        "&matrix_filter_freshness=fresh&matrix_sort_field=score&matrix_sort_direction=desc"
+    )
+
+    def _snap() -> tuple[int, int, str]:
+        body = _html(client_full, path)
+        visible = body.split('data-market-matrix-visible-count-v1="')[1].split('"', 1)[0]
+        producer = body.split('data-market-governed-top20-row-count="')[1].split('"', 1)[0]
+        return int(visible), int(producer), body.count('data-market-governed-matrix-row-v1="true"')
+
+    assert _snap() == _snap() == _snap()

--- a/tests/webui/test_market_dashboard_topn_navigation_visual_density_v1.py
+++ b/tests/webui/test_market_dashboard_topn_navigation_visual_density_v1.py
@@ -185,7 +185,7 @@ def test_query_preservation_in_top50_toggle_href(client_full: TestClient) -> Non
     path = (
         "/market?symbol=SOLUSDT&top_n=20"
         "&matrix_filter_symbol=SOL"
-        "&matrix_filter_f5_status=futures_metadata_ready"
+        "&matrix_filter_f5_status=futures_metadata_partial"
         "&matrix_filter_freshness=fresh"
         "&matrix_sort_field=symbol"
         "&matrix_sort_direction=desc"
@@ -195,7 +195,7 @@ def test_query_preservation_in_top50_toggle_href(client_full: TestClient) -> Non
     top50 = hrefs[50]
     assert "symbol=SOLUSDT" in top50
     assert "matrix_filter_symbol=SOL" in top50
-    assert "matrix_filter_f5_status=futures_metadata_ready" in top50
+    assert "matrix_filter_f5_status=futures_metadata_partial" in top50
     assert "matrix_filter_freshness=fresh" in top50
     assert "matrix_sort_field=symbol" in top50
     assert "matrix_sort_direction=desc" in top50


### PR DESCRIPTION
## Summary
- Matrix filter/sort/Top-N controls on canonical `GET /market` are now SSR GET forms/links with URL-backed view state instead of client-only JS toggles.
- Server-side `apply_matrix_view_state` filters/sorts governed rows while preserving selected instrument via `producer_rows`.
- Fail-closed normalization for invalid F5/freshness/sort params; query preservation across Top-N, selection, filters, and sort resets.

## Canonical URL parameters
- `top_n` (20|50, default 20)
- `symbol` (selected futures instrument)
- `matrix_filter_symbol`, `matrix_filter_f5_status`, `matrix_filter_freshness`
- `matrix_sort_field`, `matrix_sort_direction`

Example shareable URL:
`http://127.0.0.1:8765/market?top_n=50&symbol=ETHUSDT&matrix_filter_symbol=ETH&matrix_filter_f5_status=futures_metadata_partial&matrix_filter_freshness=fresh&matrix_sort_field=score&matrix_sort_direction=desc`

## Safety / scope
- View-only / read-only; no orders, execution, or authority semantics changed
- Futures-only; no Bitcoin/Spot/Synthetic-Spot
- Single route `/market`; no parallel matrix
- **No** `scripts/ops/ci_test_selection_v1.py` touch (FOCUSED CI via existing market dashboard glob)

## Tests
- New: `tests/webui/test_market_dashboard_matrix_url_state_v1.py` (19 tests)
- Updated: top-N query preservation uses valid F5 allowlist value
- Local: 64 related market dashboard tests passed

## Durable bundle
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/market_dashboard_matrix_url_state_v1_20260616T224716Z`

## Test plan
- [x] Focused pytest for matrix URL state contract
- [x] Existing Top-N / matrix / governed Top20 tests green
- [x] CI selector simulation → FOCUSED
- [ ] Operator visual review of combined preview URL
- [ ] Wait for CI checks green (no auto-merge)

Commit: `778552c8d1d3f2a9bc2914025ac553a7969208f5`

Made with [Cursor](https://cursor.com)