### PR TITLE
test(ops): make p85 reader mtime deterministic

### DIFF
--- a/tests/ops/test_p85_result_reader.py
+++ b/tests/ops/test_p85_result_reader.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -130,7 +129,7 @@ def test_reader_picks_newest_file_by_mtime(tmp_path: Path) -> None:
     p_old = old_dir / "P85_RESULT.json"
     p_new = new_dir / "P85_RESULT.json"
     p_old.write_text(json.dumps({"connectivity": {"ok": True}}), encoding="utf-8")
-    old_ts = time.time() - 5000.0
+    old_ts = _FIXED_NOW - 5000.0
     os.utime(p_old, (old_ts, old_ts))
     p_new.write_text(json.dumps({"connectivity": {"ok": False}}), encoding="utf-8")
     out = read_p85_exchange_observation(tmp_path)


### PR DESCRIPTION
## Summary

- Entfernt die letzte Wall-Clock-Abhängigkeit in `test_reader_picks_newest_file_by_mtime`: `time.time() - 5000.0` → `_FIXED_NOW - 5000.0`.
- Wiederverwendung der bestehenden deterministischen Zeitbasis `_FIXED_NOW` und des etablierten `os.utime`-Musters im selben Testowner.
- mtime-Reihenfolge und Assertions unverändert (ältere Datei explizit zurückdatieren, neuere Datei behält Schreib-mtime; Reader wählt weiterhin neueste Datei).

## Scope

- **Dateiscope:** ausschließlich `tests/ops/test_p85_result_reader.py`
- **Produktionscode:** `src/ops/p85_result_reader.py` unberührt

## CI

- Selector: `NO_OP` (Kategorie `static_contract` für `tests/ops/**`)
- Bounded CI: Fast-Lane `pytest tests/ci tests/ops` (kein Full-Matrix)
- `FULL_SUITE_EXECUTED=false`
- `SELECTOR_TOUCH_REQUIRED=false`

## Lokale Checks

- `ruff format --check` / `ruff check`: PASS
- `pytest -q tests/ops/test_p85_result_reader.py`: 9 passed
- `test_reader_picks_newest_file_by_mtime`: 3× in separaten Prozessen PASS
- Kein `time.time()` mehr im Testowner

## Safety

- `PRODUCTION_CODE_TOUCHED=false`
- `TEST_ASSERTIONS_WEAKENED=false`
- `SLEEP_ADDED=false` / `RETRY_ADDED=false`
- `PREFLIGHT_REMAINS_BLOCKED=true` / `EXECUTION_AUTHORIZED=false`

## Durable bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/p85_reader_mtime_deterministic_v1_20260617T003523Z`


Made with [Cursor](https://cursor.com)