### PR TITLE
test(performance): make metric timestamps deterministic

### DIFF
--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -21,8 +21,9 @@ Setup requirements:
 """
 
 import pytest
-import time
 from unittest.mock import patch
+
+_FIXED_TIMESTAMP = 1_700_000_000.0
 from src.core.performance import (
     PerformanceMonitor,
     PerformanceMetric,
@@ -259,7 +260,7 @@ class TestPerformanceMetric:
     def test_create_metric(self):
         """Test creating a performance metric."""
         metric = PerformanceMetric(
-            name="test_op", duration_ms=100.0, timestamp=time.time(), metadata={"key": "value"}
+            name="test_op", duration_ms=100.0, timestamp=_FIXED_TIMESTAMP, metadata={"key": "value"}
         )
 
         assert metric.name == "test_op"
@@ -268,7 +269,7 @@ class TestPerformanceMetric:
 
     def test_metric_default_metadata(self):
         """Test metric with default empty metadata."""
-        metric = PerformanceMetric(name="test_op", duration_ms=100.0, timestamp=time.time())
+        metric = PerformanceMetric(name="test_op", duration_ms=100.0, timestamp=_FIXED_TIMESTAMP)
 
         assert metric.metadata == {}
 


### PR DESCRIPTION
## Summary

- Ersetzt zwei `time.time()`-Wall-Clock-Stellen in `TestPerformanceMetric` durch feste deterministische Timestamp-Konstante `_FIXED_TIMESTAMP = 1_700_000_000.0`
- Timestamp-Einheit (Unix-Epoch-Sekunden, `float`) und `PerformanceMetric`-Semantik unverändert
- Exakter Dateiscope: `tests/test_performance.py` only
- Produktionscode unberührt (`src/core/performance.py`)

## CI / Selection

- `ACTUAL_CI_MODE=FOCUSED`
- `FULL_SUITE_EXECUTED=false`
- `SELECTOR_TOUCH_REQUIRED=false`
- `EXISTING_TEST_GLOB_SUFFICIENT=true`

## Futures-only Guard

- `FUTURES_ONLY=true`
- `MARKET_DIRECTION_CLASSIFICATION=MARKET_AGNOSTIC_WITH_FUTURES_VALUE`
- Keine Bitcoin/BTC/XBT/Spot/Synthetic-Spot-Bezüge eingeführt

## Lokale Checks

- `ruff format --check tests/test_performance.py`: PASS
- `ruff check tests/test_performance.py`: PASS
- `pytest -q tests/test_performance.py`: 22 passed
- `TestPerformanceMetric.test_create_metric` x3 separate Prozesse: PASS
- `TestPerformanceMetric.test_metric_default_metadata` x3 separate Prozesse: PASS

## Safety Flags

- `PRODUCTION_CODE_TOUCHED=false`
- `TEST_ASSERTIONS_WEAKENED=false`
- `SLEEP_ADDED=false` / `RETRY_ADDED=false`
- `PIPELINE_EXECUTED=false` / `RUNTIME_STARTED=false`
- `PREFLIGHT_REMAINS_BLOCKED=true` / `EXECUTION_AUTHORIZED=false`

## Durable Bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/performance_metric_timestamp_determinism_v1_20260617T011727Z`


Made with [Cursor](https://cursor.com)