### PR TITLE
fix(ci): focus tiny order lifecycle checks

### DIFF
--- a/config/ci/file_category_mapping.yaml
+++ b/config/ci/file_category_mapping.yaml
@@ -93,6 +93,17 @@ categories:
       - "tests/ci/test_ci_diff_aware_test_selection_v1.py"
     runtime_class: minutes
     notes: "Bounded PE-22 risk/killswitch + order-capability abort binding chain; central_src FULL preserved for unrelated src"
+  tiny_order_focused:
+    mode: FOCUSED
+    globs:
+      - "src/ops/bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py"
+      - "tests/ops/test_bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py"
+      - "tests/ops/test_order_capability_killswitch_abort_binding_contract_v1.py"
+      - "scripts/ops/ci_test_selection_v1.py"
+      - "config/ci/file_category_mapping.yaml"
+      - "tests/ci/test_ci_diff_aware_test_selection_v1.py"
+    runtime_class: minutes
+    notes: "Bounded PE-30 tiny-order lifecycle + order-capability abort binding chain; central_src FULL preserved for unrelated src"
   central_src:
     mode: FULL
     globs:

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -32,6 +32,7 @@ FOCUSED_CATEGORIES = frozenset(
         "durable_completion_focused",
         "preflight_assembly_focused",
         "risk_killswitch_focused",
+        "tiny_order_focused",
     }
 )
 
@@ -143,6 +144,32 @@ REQUIRED_RISK_KILLSWITCH_TEST_OWNERS: tuple[str, ...] = (
     "tests/ops/test_order_capability_killswitch_abort_binding_contract_v1.py",
 )
 
+PE30_TINY_ORDER_OWNER = (
+    "src/ops/bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py"
+)
+PE30_TINY_ORDER_TEST_OWNER = (
+    "tests/ops/test_bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py"
+)
+
+TINY_ORDER_CI_POLICY_PATHS = frozenset(
+    {
+        "scripts/ops/ci_test_selection_v1.py",
+        "config/ci/file_category_mapping.yaml",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    }
+)
+
+CANONICAL_TINY_ORDER_FOCUSED_TESTS: tuple[str, ...] = (
+    "tests/ops/test_bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py",
+    "tests/ops/test_order_capability_killswitch_abort_binding_contract_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
+REQUIRED_TINY_ORDER_TEST_OWNERS: tuple[str, ...] = (
+    "tests/ops/test_bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py",
+    "tests/ops/test_order_capability_killswitch_abort_binding_contract_v1.py",
+)
+
 CANONICAL_MARKET_DASHBOARD_FOCUSED_TESTS: tuple[str, ...] = (
     "tests/webui/test_market_dashboard_no_bitcoin_futures_v1.py",
     "tests/webui/test_market_futures_only_canonical_completion_v1.py",
@@ -202,6 +229,9 @@ def _requires_full_ci_selector_change(files: list[str]) -> bool:
         return False
     scoped_rk = {f for f in normalized if _is_risk_killswitch_scoped_path(f)}
     if scoped_rk and all(_is_risk_killswitch_rebundle_path(f) for f in normalized):
+        return False
+    scoped_to = {f for f in normalized if _is_tiny_order_scoped_path(f)}
+    if scoped_to and all(_is_tiny_order_rebundle_path(f) for f in normalized):
         return False
     if normalized & CI_SELECTOR_FULL_PATHS:
         return True
@@ -363,6 +393,55 @@ def _try_risk_killswitch_focused(files: list[str]) -> SelectionResult | None:
     )
 
 
+def _is_tiny_order_scoped_path(path: str) -> bool:
+    if path == PE30_TINY_ORDER_OWNER:
+        return True
+    if path == PE30_TINY_ORDER_TEST_OWNER:
+        return True
+    return False
+
+
+def _is_tiny_order_rebundle_path(path: str) -> bool:
+    return _is_tiny_order_scoped_path(path) or path in TINY_ORDER_CI_POLICY_PATHS
+
+
+def _tiny_order_focused_targets() -> tuple[str, ...]:
+    for path in REQUIRED_TINY_ORDER_TEST_OWNERS:
+        if not _repo_path_exists(path):
+            return ()
+    targets: list[str] = []
+    for path in CANONICAL_TINY_ORDER_FOCUSED_TESTS:
+        if _repo_path_exists(path):
+            targets.append(path)
+    if len(targets) < len(REQUIRED_TINY_ORDER_TEST_OWNERS):
+        return ()
+    return tuple(sorted(targets))
+
+
+def _try_tiny_order_focused(files: list[str]) -> SelectionResult | None:
+    if not files:
+        return None
+    if not any(_is_tiny_order_scoped_path(f) for f in files):
+        return None
+    if not all(_is_tiny_order_rebundle_path(f) for f in files):
+        return None
+    files_set = set(files)
+    if PE30_TINY_ORDER_OWNER in files_set and PE30_TINY_ORDER_TEST_OWNER not in files_set:
+        return None
+    targets = _tiny_order_focused_targets()
+    if not targets:
+        return None
+    modules: tuple[str, ...] = (
+        "src.ops.bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0",
+    )
+    return SelectionResult(
+        "FOCUSED",
+        "tiny_order_focused",
+        targets,
+        modules,
+    )
+
+
 def _try_preflight_assembly_focused(files: list[str]) -> SelectionResult | None:
     if not files:
         return None
@@ -448,6 +527,10 @@ def categorize(path: str) -> str:
         return "risk_killswitch_focused"
     if _is_risk_killswitch_scoped_path(p):
         return "risk_killswitch_focused"
+    if p in TINY_ORDER_CI_POLICY_PATHS:
+        return "tiny_order_focused"
+    if _is_tiny_order_scoped_path(p):
+        return "tiny_order_focused"
     if p in MARKET_DASHBOARD_CI_POLICY_PATHS:
         return "market_dashboard_focused"
     if _is_market_dashboard_scoped_path(p):
@@ -693,6 +776,10 @@ def resolve_selection(
     if risk_killswitch is not None:
         return risk_killswitch
 
+    tiny_order = _try_tiny_order_focused(normalized)
+    if tiny_order is not None:
+        return tiny_order
+
     if any(_is_durable_completion_scoped_path(f) for f in normalized):
         if not all(_is_durable_completion_rebundle_path(f) for f in normalized):
             return SelectionResult("FULL", "durable_completion_foreign_path_requires_full", ())
@@ -707,6 +794,11 @@ def resolve_selection(
         if not all(_is_risk_killswitch_rebundle_path(f) for f in normalized):
             return SelectionResult("FULL", "risk_killswitch_foreign_path_requires_full", ())
         return SelectionResult("FULL", "risk_killswitch_incomplete_or_missing_test_owner", ())
+
+    if any(_is_tiny_order_scoped_path(f) for f in normalized):
+        if not all(_is_tiny_order_rebundle_path(f) for f in normalized):
+            return SelectionResult("FULL", "tiny_order_foreign_path_requires_full", ())
+        return SelectionResult("FULL", "tiny_order_incomplete_or_missing_test_owner", ())
 
     if _requires_full_ci_selector_change(normalized):
         return SelectionResult("FULL", "ci_selector_or_contract_change_requires_full", ())

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -875,3 +875,181 @@ def test_selector_pe53_import_modules() -> None:
 def test_mapping_file_includes_risk_killswitch_focused() -> None:
     text = MAPPING.read_text(encoding="utf-8")
     assert "risk_killswitch_focused:" in text
+
+
+PE54_TINY_ORDER_FILES = (
+    "src/ops/bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py",
+    "tests/ops/test_bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py",
+)
+
+
+def test_selector_pe54_tiny_order_fileset_focused() -> None:
+    sel = _run_selector(*PE54_TINY_ORDER_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "tiny_order_focused"
+    targets = _targets(sel)
+    assert (
+        "tests/ops/test_bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0.py"
+        in targets
+    )
+    assert "tests/ops/test_order_capability_killswitch_abort_binding_contract_v1.py" in targets
+    assert sel["tests_execute_full"] == "false"
+    assert sel["tests_execute_no_op"] == "false"
+
+
+def test_selector_pe54_owner_plus_test_owner_only_focused() -> None:
+    sel = _run_selector(*PE54_TINY_ORDER_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "tiny_order_focused"
+
+
+def test_selector_pe54_owner_without_test_owner_escalates_full() -> None:
+    sel = _run_selector(PE54_TINY_ORDER_FILES[0])
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "tiny_order_incomplete_or_missing_test_owner"
+
+
+def test_selector_pe54_test_owner_without_productive_owner_matches_scoped_focused() -> None:
+    sel = _run_selector(PE54_TINY_ORDER_FILES[1])
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "tiny_order_focused"
+
+
+def test_selector_pe54_plus_unknown_ops_src_escalates_full() -> None:
+    sel = _run_selector(
+        *PE54_TINY_ORDER_FILES,
+        "src/ops/bounded_futures_testnet_preflight_packet_contract_v0.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_pe54_plus_unknown_src_escalates_full() -> None:
+    sel = _run_selector(
+        *PE54_TINY_ORDER_FILES,
+        "src/execution/live/orchestrator.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_pe54_tiny_order_outside_owner_escalates_full() -> None:
+    sel = _run_selector(
+        *PE54_TINY_ORDER_FILES,
+        "src/risk/killswitch.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_pe54_runtime_touch_escalates_full() -> None:
+    sel = _run_selector(
+        PE54_TINY_ORDER_FILES[0],
+        "src/runtime/scheduler.py",
+        PE54_TINY_ORDER_FILES[1],
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_pe54_trading_strategy_master_v2_touch_escalates_full() -> None:
+    sel = _run_selector(
+        PE54_TINY_ORDER_FILES[0],
+        "src/strategies/vol_breakout.py",
+        PE54_TINY_ORDER_FILES[1],
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_pe54_packaging_change_escalates_full() -> None:
+    sel = _run_selector(
+        *PE54_TINY_ORDER_FILES,
+        "pyproject.toml",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_pe54_rebundle_with_ci_policy_focused() -> None:
+    sel = _run_selector(
+        *PE54_TINY_ORDER_FILES,
+        "scripts/ops/ci_test_selection_v1.py",
+        "config/ci/file_category_mapping.yaml",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "tiny_order_focused"
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
+
+
+def test_selector_pe54_missing_abort_test_owner_escalates_full(monkeypatch) -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "ci_test_selection_v1_to_missing_owner",
+        str(SELECTOR),
+    )
+    assert spec and spec.loader
+    sel_mod = importlib.util.module_from_spec(spec)
+    sys.modules["ci_test_selection_v1_to_missing_owner"] = sel_mod
+    spec.loader.exec_module(sel_mod)
+
+    original_exists = sel_mod._repo_path_exists
+
+    def fake_exists(path: str) -> bool:
+        if path == "tests/ops/test_order_capability_killswitch_abort_binding_contract_v1.py":
+            return False
+        return original_exists(path)
+
+    monkeypatch.setattr(sel_mod, "_repo_path_exists", fake_exists)
+    result = sel_mod.resolve_selection(list(PE54_TINY_ORDER_FILES))
+    assert result.mode == "FULL"
+    assert result.reason == "tiny_order_incomplete_or_missing_test_owner"
+
+
+def test_selector_pe54_import_modules() -> None:
+    sel = _run_selector(*PE54_TINY_ORDER_FILES)
+    modules = _modules(sel)
+    assert "src.ops.bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0" in modules
+
+
+def test_mapping_file_includes_tiny_order_focused() -> None:
+    text = MAPPING.read_text(encoding="utf-8")
+    assert "tiny_order_focused:" in text
+
+
+def test_selector_pe54_existing_durable_completion_focused_unchanged() -> None:
+    sel = _run_selector(
+        "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+        "tests/ops/test_durable_completion_validation_graph_v1.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "durable_completion_focused"
+
+
+def test_selector_pe54_existing_preflight_assembly_focused_unchanged() -> None:
+    sel = _run_selector(
+        "src/ops/bounded_futures_testnet_preflight_execution_readiness_assembly_lifecycle_integration_contract_v0.py",
+        "tests/ops/test_bounded_futures_testnet_preflight_execution_readiness_assembly_lifecycle_integration_contract_v0.py",
+        "tests/ops/test_bounded_futures_testnet_reconciliation_review_lifecycle_integration_contract_v0.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "preflight_assembly_focused"
+
+
+def test_selector_pe54_existing_risk_killswitch_focused_unchanged() -> None:
+    sel = _run_selector(*PE53_RISK_KILLSWITCH_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "risk_killswitch_focused"
+
+
+def test_selector_pe54_docs_only_diff_remains_no_op() -> None:
+    sel = _run_selector("docs/ops/CI_AUDIT_KNOWN_ISSUES.md")
+    assert sel["test_selection_mode"] == "NO_OP"
+    assert sel["test_selection_reason"] == "docs_workflow_or_static_contract_only"
+
+
+def test_selector_pe54_required_check_contexts_preserved() -> None:
+    text = _ci_text()
+    assert "'3.9'" in text
+    assert "'3.10'" in text
+    assert "'3.11'" in text
+    assert "Fast-Lane" in text
+    assert "pr-gate:" in text
+    assert "continue-on-error" not in text


### PR DESCRIPTION
## Summary

- Der PE-54-Preflight blockierte die Fachimplementierung korrekt: der geplante Zwei-Dateien-Diff (`bounded_futures_testnet_tiny_order_lifecycle_integration_contract_v0`) fiel unter `static_contract` und eskalierte fail-closed zu FULL (`productive_src_no_op_blocked_fail_closed`).
- Root Cause: fehlende explizite `tiny_order_focused`-Klassifikation im kanonischen Selector.
- Neue Kategorie `tiny_order_focused` in Mapping und `ci_test_selection_v1.py`, analog zu `risk_killswitch_focused` (PE-53).
- FOCUSED-Testowner-Satz: PE-30-Testowner, `test_order_capability_killswitch_abort_binding_contract_v1.py`, Selector-Contract-Tests.
- Fail-closed FULL bleibt für Owner ohne Testowner, fremde `src/ops`-Dateien, Packaging, Runtime, Trading/Master-V2 und unvollständige Mappings.

## Test plan

- [x] Geplanter PE-54-Diff → FOCUSED (`tiny_order_focused`)
- [x] Owner ohne Testowner → FULL
- [x] Unbekannte produktive Datei → FULL
- [x] Bestehende `durable_completion_focused`, `preflight_assembly_focused`, `risk_killswitch_focused` unverändert
- [x] Required Checks (Python 3.9/3.10/3.11, Fast-Lane, PR Gate) unverändert
- [x] 105 Selector-Tests grün; FOCUSED-Lauf 194 Tests in ~144s
- [x] Keine Fach-, Runtime-, Trading- oder Authority-Änderung

## Nach Merge

PE-54-Fachimplementierung (Abort-Enforcement in PE-30) auf aktuellem `main` neu starten.


Made with [Cursor](https://cursor.com)