### PR TITLE
test(ops): freeze PE38 readiness fixtures

### DIFF
--- a/src/ops/bounded_futures_testnet_preflight_execution_readiness_review_lifecycle_integration_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_preflight_execution_readiness_review_lifecycle_integration_contract_v0.py
@@ -1677,6 +1677,7 @@ def default_minimal_integration_input(
     )
     from src.ops.bounded_futures_testnet_preflight_execution_readiness_assembly_lifecycle_integration_contract_v0 import (
         Pe25OperatorClosureProofBinding as Pe26Pe25ProofBinding,
+        _attach_coherent_pe31_bindings,
         compute_lifecycle_matrix_digest,
         default_minimal_assembly_input,
         default_minimal_pe37_traceability_proof,
@@ -1730,6 +1731,7 @@ def default_minimal_integration_input(
         pe37_traceability_boundary_input=pe37_boundary_input,
         pe37_traceability_proof=default_minimal_pe37_traceability_proof(pe37_boundary_input),
     )
+    pe26_input = _attach_coherent_pe31_bindings(pe26_input)
 
     pe26_result = evaluate_preflight_execution_readiness_assembly_lifecycle_integration(pe26_input)
     pe37_result = evaluate_durable_evidence_traceability_boundary(pe37_boundary_input)

--- a/tests/ops/test_report_readiness_gate_snapshot_v0.py
+++ b/tests/ops/test_report_readiness_gate_snapshot_v0.py
@@ -571,14 +571,38 @@ def test_real_smoke_pass_blocked_safe() -> None:
     assert "registry" not in payload
 
 
-@pytest.mark.skipif(not ARCHIVE_ROOT.is_dir(), reason="operator archive not present")
-def test_real_smoke_include_registry_pass_blocked_safe() -> None:
+def _build_frozen_include_registry_archive(root: Path) -> None:
+    """Deterministic archive for subprocess include-registry smoke (non-mutable)."""
+    from scripts.ops.build_readiness_evidence_ledger_v0 import (
+        DEFAULT_PAPER_RUN_ID,
+        DEFAULT_SHADOW_RUN_ID,
+        DEFAULT_TESTNET_RUN_ID,
+    )
+
+    ledger_helpers = importlib.util.spec_from_file_location(
+        "readiness_ledger_test_helpers",
+        ROOT / "tests/ops/test_build_readiness_evidence_ledger_v0.py",
+    )
+    assert ledger_helpers is not None and ledger_helpers.loader is not None
+    ledger_mod = importlib.util.module_from_spec(ledger_helpers)
+    ledger_helpers.loader.exec_module(ledger_mod)
+
+    ledger_mod._write_run_lane(root, "paper", DEFAULT_PAPER_RUN_ID, review_verdict=None)
+    ledger_mod._write_run_lane(root, "shadow", DEFAULT_SHADOW_RUN_ID, review_verdict="PASS")
+    ledger_mod._write_run_lane(root, "testnet", DEFAULT_TESTNET_RUN_ID, review_verdict="PASS")
+    for marker in ledger_mod.PLANNING_MARKERS:
+        ledger_mod._write_planning_surface(root, marker)
+
+
+def test_real_smoke_include_registry_pass_blocked_safe(tmp_path: Path) -> None:
+    archive = tmp_path / "frozen_include_registry_archive"
+    _build_frozen_include_registry_archive(archive)
     proc = subprocess.run(
         [
             sys.executable,
             str(SCRIPT),
             "--archive-root",
-            str(ARCHIVE_ROOT),
+            str(archive),
             "--fixed-generated-at-utc",
             "2026-05-21T00:00:00Z",
             "--include-registry",


### PR DESCRIPTION
## Summary
- Fixes 12 pre-existing fixture failures on main (PE-38 review lifecycle, bridge upstream, readiness snapshot).
- PE-38 builder: call `_attach_coherent_pe31_bindings()` after PE-26 replace to restore coherent embedded PE-31/PE-26 digest chain.
- Readiness snapshot: use frozen `tmp_path` archive instead of live operator archive for include-registry smoke.
- 12 target tests PASS under Python 3.9, 3.10, and 3.11.
- Bridge file 33/33 PASS under 3.9, 3.10, and 3.11.
- Snapshot file 26/26 PASS under 3.9, 3.10, and 3.11.
- Full PE-38 review lifecycle file 53/53 PASS under 3.11 only; 3.9/3.10 full file intentionally not re-run because cross-version targeted and file evidence already green.
- No productive Readiness/Admission/Authority semantics change.
- No CI/sharding/nightly change.
- FOCUSED-CI scope; no runtime/testnet/live.

## Test plan
- [x] 12 original baseline failures reproduced pre-fix
- [x] 12 target tests PASS 3.9/3.10/3.11
- [x] Bridge file 33/33 PASS 3.9/3.10/3.11
- [x] Snapshot file 26/26 PASS 3.9/3.10/3.11
- [x] Full PE-38 review file 53/53 PASS 3.11
- [x] ruff format/check on changed files
- [x] Docs token policy guard
- [x] Targeted PE-38 contract guards


Made with [Cursor](https://cursor.com)