### PR TITLE
ci: narrow Fast Lane for fixture-only ops tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -291,41 +293,44 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.static_contract_changed == 'true' && needs.changes.outputs.run_matrix != 'true' && needs.changes.outputs.workflow_only != 'true' }}
         run: |
           set -euo pipefail
+          PYTEST_ARGS=(-q --tb=short -m "not network and not external_tools")
+          NARROW=false; declare -a EXTRA=()
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ needs.changes.outputs.docs_or_static_contract_only }}" = "true" ]; then NARROW=true
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+            git fetch origin "${BASE_REF}" --depth=1
+            while IFS= read -r path; do
+              [ -z "$path" ] && continue
+              case "$path" in
+                src/ops/*_contract_v0.py|src/ops/*_contract_v1.py) NARROW=false; break ;;
+                tests/ops/test_*.py|tests/webui/test_*structure_contract*.py) EXTRA+=("$path") ;;
+                tests/ci/*|docs/*|out/*|*.md) ;;
+                *) NARROW=false; break ;;
+              esac
+            done < <(git diff --name-only "origin/${BASE_REF}...HEAD")
+          fi
+          if [ "$NARROW" = "true" ]; then
+            shopt -s nullglob; ci_contract=(tests/ci/test_ci_*contract*.py); shopt -u nullglob
+            (( ${#ci_contract[@]} )) || { echo "tests/ci contract subset empty — fail closed"; exit 1; }
+            VALID=(); for t in "${EXTRA[@]}"; do [ -f "$t" ] && VALID+=("$t"); done
+            pytest "${ci_contract[@]}" "${VALID[@]}" "${PYTEST_ARGS[@]}"
+            exit 0
+          fi
           shopt -s nullglob
           webui_structure_contract=(tests/webui/test_*structure_contract*.py)
           shopt -u nullglob
-          # Parallel shards (previously monolithic: pytest tests/ci tests/ops "${webui_structure_contract[@]}").
-          PYTEST_ARGS=(-q --tb=short -m "not network and not external_tools")
           OPS_SHARD_COUNT=8
           SHARD_FAIL=0
           mapfile -t OPS_FILES < <(find tests/ops -name 'test_*.py' -type f | LC_ALL=C sort)
-          if (( ${#OPS_FILES[@]} == 0 )); then
-            echo "tests/ops shard inventory empty"
-            exit 1
-          fi
-          (
-            echo "[shard=tests/ci+webui] starting"
-            pytest tests/ci "${webui_structure_contract[@]}" "${PYTEST_ARGS[@]}"
-          ) &
-          PID_CI=$!
+          (( ${#OPS_FILES[@]} )) || { echo "tests/ops shard inventory empty"; exit 1; }
+          ( pytest tests/ci "${webui_structure_contract[@]}" "${PYTEST_ARGS[@]}" ) & PID_CI=$!
           PIDS_OPS=()
           for ((shard_idx = 0; shard_idx < OPS_SHARD_COUNT; shard_idx++)); do
-            (
-              shard_files=()
-              for i in "${!OPS_FILES[@]}"; do
-                if (( i % OPS_SHARD_COUNT == shard_idx )); then
-                  shard_files+=("${OPS_FILES[i]}")
-                fi
-              done
-              echo "[shard=tests/ops/${shard_idx}] files=${#shard_files[@]}"
-              pytest "${shard_files[@]}" "${PYTEST_ARGS[@]}"
-            ) &
-            PIDS_OPS+=("$!")
+            ( shard_files=(); for i in "${!OPS_FILES[@]}"; do
+                (( i % OPS_SHARD_COUNT == shard_idx )) && shard_files+=("${OPS_FILES[i]}")
+              done; pytest "${shard_files[@]}" "${PYTEST_ARGS[@]}" ) & PIDS_OPS+=("$!")
           done
           wait "$PID_CI" || SHARD_FAIL=1
-          for pid in "${PIDS_OPS[@]}"; do
-            wait "$pid" || SHARD_FAIL=1
-          done
+          for pid in "${PIDS_OPS[@]}"; do wait "$pid" || SHARD_FAIL=1; done
           exit "$SHARD_FAIL"
 
       - name: WebUI bounded pytest (market/observability surface)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,15 +295,22 @@ jobs:
           set -euo pipefail
           PYTEST_ARGS=(-q --tb=short -m "not network and not external_tools")
           NARROW=false; declare -a EXTRA=()
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ needs.changes.outputs.docs_or_static_contract_only }}" = "true" ]; then NARROW=true
+          # narrow_fast_lane_gate: canonical selector outputs + strict changed-file allowlist (fail-closed)
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ needs.changes.outputs.tests_execute_no_op }}" = "true" ] && [ "${{ needs.changes.outputs.static_contract_changed }}" = "true" ] && [ "${{ needs.changes.outputs.run_matrix }}" != "true" ]; then
+            NARROW=true
             BASE_REF="${{ github.event.pull_request.base.ref }}"
             git fetch origin "${BASE_REF}" --depth=1
             while IFS= read -r path; do
               [ -z "$path" ] && continue
               case "$path" in
-                src/ops/*_contract_v0.py|src/ops/*_contract_v1.py) NARROW=false; break ;;
+                .github/workflows/ci.yml) ;;
+                tests/ci/*) ;;
+                docs/*|out/*|*.md) ;;
                 tests/ops/test_*.py|tests/webui/test_*structure_contract*.py) EXTRA+=("$path") ;;
-                tests/ci/*|docs/*|out/*|*.md) ;;
+                .github/workflows/*) NARROW=false; break ;;
+                src/*) NARROW=false; break ;;
+                requirements.txt|pyproject.toml|uv.lock|pytest.ini|Makefile) NARROW=false; break ;;
+                requirements*.txt) NARROW=false; break ;;
                 *) NARROW=false; break ;;
               esac
             done < <(git diff --name-only "origin/${BASE_REF}...HEAD")

--- a/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
+++ b/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
@@ -330,9 +330,9 @@ def test_fast_lane_runs_static_contract_tests_when_applicable() -> None:
     assert "Static contract tests (tests/ci, tests/ops, WebUI structure-contract" in text
     assert "needs.changes.outputs.static_contract_changed == 'true'" in text
     assert "needs.changes.outputs.run_matrix != 'true'" in text
-    assert "pytest tests/ci tests/ops" in text
-    assert "webui_structure_contract=(tests/webui/test_*structure_contract*.py)" in text
-    assert '"${webui_structure_contract[@]}"' in text
+    assert "needs.changes.outputs.docs_or_static_contract_only" in text
+    assert "tests/ci/test_ci_*contract*.py" in text
+    assert "OPS_SHARD_COUNT=8" in text
 
 
 def test_fast_lane_webui_bounded_pytest_modules() -> None:

--- a/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
+++ b/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
@@ -8,6 +8,8 @@ webui_surface / non_webui_code buckets (Market/Observability path gating).
 from __future__ import annotations
 
 import fnmatch
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -47,6 +49,10 @@ NON_WEBUI_CODE_GLOBS = (
     "pytest.ini",
     "Makefile",
 )
+SELECTOR = Path("scripts/ops/ci_test_selection_v1.py")
+_BOOT_CI_YML = ".github/workflows/ci.yml"
+_BOOT_CONTRACT = "tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py"
+_BOOT = (_BOOT_CI_YML, _BOOT_CONTRACT)
 WEBUI_BOUNDED_PYTEST_MODULES = (
     "tests/webui/test_workflow_dashboard_readmodel_v1.py",
     "tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py",
@@ -209,6 +215,36 @@ def _run_matrix_for_paths(paths: list[str], *, force_matrix: bool = False) -> bo
     return any(_matches_non_webui_code(p) for p in paths)
 
 
+def _run_selector(*files: str) -> dict[str, str]:
+    cmd = [sys.executable, str(SELECTOR), "--event-name", "pull_request"]
+    if files:
+        cmd.extend(["--files", *files])
+    out = subprocess.check_output(cmd, text=True)
+    return {k: v for line in out.splitlines() for k, _, v in [line.partition("=")]}
+
+
+def _narrow_gate(paths: list[str], *, no_op: bool, static: bool, matrix: bool) -> bool:
+    if not (no_op and static and not matrix) or not paths:
+        return False
+    for path in paths:
+        if path.startswith("src/") or (
+            path.startswith(".github/workflows/") and path != _BOOT_CI_YML
+        ):
+            return False
+        if _matches_non_webui_code(path) and path not in _BOOT:
+            return False
+        if not (
+            path in _BOOT
+            or path.startswith("tests/ci/")
+            or path.startswith(("docs/", "out/"))
+            or path.endswith(".md")
+            or fnmatch.fnmatch(path, "tests/ops/test_*.py")
+            or fnmatch.fnmatch(path, "tests/webui/test_*structure_contract*.py")
+        ):
+            return False
+    return True
+
+
 def test_changes_job_exports_static_contract_outputs() -> None:
     text = _ci_text()
     assert "static_contract_changed:" in text
@@ -327,12 +363,15 @@ def test_strategy_smoke_gated_on_tests_execute_full_not_code_changed() -> None:
 
 def test_fast_lane_runs_static_contract_tests_when_applicable() -> None:
     text = _ci_text()
-    assert "Static contract tests (tests/ci, tests/ops, WebUI structure-contract" in text
+    narrow = text.split("narrow_fast_lane_gate", 1)[1].split("OPS_SHARD_COUNT", 1)[0]
     assert "needs.changes.outputs.static_contract_changed == 'true'" in text
     assert "needs.changes.outputs.run_matrix != 'true'" in text
-    assert "needs.changes.outputs.docs_or_static_contract_only" in text
+    assert "needs.changes.outputs.tests_execute_no_op" in narrow
+    assert ".github/workflows/ci.yml" in narrow
     assert "tests/ci/test_ci_*contract*.py" in text
+    assert "tests/ci contract subset empty — fail closed" in text
     assert "OPS_SHARD_COUNT=8" in text
+    assert "docs_or_static_contract_only" not in narrow
 
 
 def test_fast_lane_webui_bounded_pytest_modules() -> None:
@@ -468,6 +507,32 @@ def test_contract_only_v1_run_matrix_semantics(
 ) -> None:
     assert _is_contract_only_fast_lane_candidate(paths) is expect_contract_only
     assert _run_matrix_for_paths(paths) is expect_run_matrix
+
+
+def test_case_1_ci_bootstrap_narrow() -> None:
+    sel = _run_selector(_BOOT_CI_YML, _BOOT_CONTRACT)
+    assert (
+        sel["tests_execute_no_op"] == "true"
+        and sel["test_selection_reason"] == "docs_workflow_or_static_contract_only"
+    )
+    assert _narrow_gate(list(_BOOT), no_op=True, static=True, matrix=False)
+
+
+@pytest.mark.parametrize(
+    ("paths", "no_op", "static", "matrix", "expect"),
+    [
+        ([_BOOT_CI_YML, ".github/workflows/other.yml"], True, True, False, False),
+        (["src/ops/example.py"], True, True, False, False),
+        (["tests/ops/test_foo.py", "src/ops/example.py"], True, True, False, False),
+        (["pyproject.toml"], True, False, False, False),
+        (["unknown/path.txt"], True, False, False, False),
+        (list(_BOOT), False, True, False, False),
+        ([_BOOT_CI_YML], True, False, False, False),
+        (list(_BOOT), True, True, True, False),
+    ],
+)
+def test_narrow_gate_fail_closed_cases(paths, no_op, static, matrix, expect) -> None:
+    assert _narrow_gate(paths, no_op=no_op, static=static, matrix=matrix) is expect
 
 
 def test_force_matrix_overrides_contract_only_v1_paths() -> None:


### PR DESCRIPTION
## Summary
- **Ursache:** Reine `tests/ops/**`-Fixture-/Static-Contract-Diffs lösten in Fast-Lane einen pauschalen vollständigen `tests/ops`-Sweep (8 Shards) aus, obwohl die Matrix bereits NO_OP/FOCUSED wählt.
- **Fix:** Neue begrenzte Dispatch-Regel im bestehenden Static-Contract-Step: bei `docs_or_static_contract_only` ohne `src/ops/*_contract_*` nur `tests/ci/test_ci_*contract*.py` plus konkret geänderte `tests/ops`/WebUI-Structure-Contract-Owner.
- **`src/ops/**`, UNKNOWN und riskante Diffs** bleiben fail-closed auf dem umfassenden 8-Shard-Sweep.
- **Required-Kontexte unverändert** (Fast-Lane, tests 3.9/3.10/3.11, strategy-smoke, PR Gate).
- Keine Handelslogik, kein Master V2 / Double Play, kein Risk/KillSwitch, keine Execution-/Live-Semantik, kein Sharding, kein neuer Workflow.

## Lokale Contract-Ergebnisse
- `tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py` + `test_ci_diff_aware_test_selection_v1.py`: 150 passed
- `check_required_ci_contexts_present.sh`: PASS
- YAML parse: PASS
- Docs token policy guard: PASS
- Ruff format/check (Python): PASS
- Implementation-PR Selector: NO_OP (`docs_workflow_or_static_contract_only`), FULL_CI_TRIGGER_FOUND=false

## Durable Bundle
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/ci_fast_lane_fixture_static_contract_dispatch_v1_20260621T150329Z`

## Test plan
- [ ] Fast-Lane completes <20m on this CI-infra PR
- [ ] PE38 fixture-only PR re-run shows bounded Fast-Lane (no full tests/ops sweep)
- [ ] Required contexts unchanged and PR Gate SUCCESS


Made with [Cursor](https://cursor.com)