### PR TITLE
feat(durable-completion): compose PE-35 handoff input validation into graph recovery proof binding (PE-57)

### DIFF
--- a/src/ops/durable_completion_validation/graph.py
+++ b/src/ops/durable_completion_validation/graph.py
@@ -60,7 +60,7 @@ def _load_validators() -> dict[str, ValidatorFn]:
 
     return {
         VALIDATOR_RECONCILIATION: reconciliation.validate_reconciliation_proof_binding,
-        VALIDATOR_RECOVERY: recovery.validate_pe35_recovery_boundary_proof,
+        VALIDATOR_RECOVERY: recovery.validate_recovery_proof_binding,
         VALIDATOR_TRACEABILITY: traceability.validate_pe37_traceability_proof,
         VALIDATOR_OPERATOR_CLOSURE: operator_closure.validate_pe25_operator_closure_proof,
     }

--- a/src/ops/durable_completion_validation/validators/recovery.py
+++ b/src/ops/durable_completion_validation/validators/recovery.py
@@ -12,11 +12,12 @@ from src.ops.bounded_futures_testnet_handoff_staleness_revocation_recovery_bound
     BOUNDARY_OWNER as PE35_INTEGRATION_OWNER,
     compute_boundary_input_digest as compute_pe35_boundary_input_digest,
     compute_boundary_result_digest as compute_pe35_boundary_result_digest,
+    validate_handoff_staleness_revocation_recovery_boundary_input,
 )
 from src.ops.bounded_futures_testnet_operator_review_handoff_boundary_contract_v0 import (
     compute_boundary_input_digest as compute_pe34_boundary_input_digest,
 )
-from src.ops.durable_completion_validation.identity import valid_sha256_digest
+from src.ops.durable_completion_validation.identity import sorted_unique, valid_sha256_digest
 from src.ops.durable_completion_validation.models import ValidationContext, ValidationResult
 
 
@@ -189,3 +190,13 @@ def validate_pe35_recovery_boundary_proof(context: ValidationContext) -> Validat
         fail_reasons.append("pe35_proof: authority_lift must remain false")
 
     return ValidationResult(fail_reasons=tuple(fail_reasons))
+
+
+def validate_recovery_proof_binding(context: ValidationContext) -> ValidationResult:
+    """Graph recovery node: PE-35 handoff input validation plus PE-35 proof binding."""
+    fail_reasons: list[str] = []
+    pe35_input = context.integration_input.pe35_handoff_staleness_revocation_recovery_boundary_input
+    fail_reasons.extend(validate_handoff_staleness_revocation_recovery_boundary_input(pe35_input))
+    pe35_proof = validate_pe35_recovery_boundary_proof(context)
+    fail_reasons.extend(pe35_proof.fail_reasons)
+    return ValidationResult(fail_reasons=tuple(sorted_unique(fail_reasons)))

--- a/tests/ops/test_durable_completion_validation_graph_v1.py
+++ b/tests/ops/test_durable_completion_validation_graph_v1.py
@@ -32,6 +32,12 @@ from src.ops.bounded_futures_testnet_position_order_reconciliation_primary_evide
 from src.ops.bounded_futures_testnet_reconciliation_review_lifecycle_integration_contract_v0 import (
     evaluate_reconciliation_review_lifecycle_integration,
 )
+from src.ops.bounded_futures_testnet_handoff_staleness_revocation_recovery_boundary_contract_v0 import (
+    evaluate_handoff_staleness_revocation_recovery_boundary,
+)
+from src.ops.durable_completion_validation.validators.recovery import (
+    validate_recovery_proof_binding,
+)
 from src.ops.durable_completion_validation.validators.reconciliation import (
     validate_pe21_reconciliation_result_manifest_integrity,
     validate_reconciliation_proof_binding,
@@ -200,6 +206,38 @@ def test_graph_reconciliation_validator_missing_fill_manifest_fail_closed() -> N
         "pe21_fill_state_manifest: FILL_STATE_SNAPSHOT.json manifest entry required" in reason
         for reason in result.fail_reasons
     )
+
+
+def _replace_pe34_handoff(integration_input, **overrides):
+    pe35_input = integration_input.pe35_handoff_staleness_revocation_recovery_boundary_input
+    pe34_handoff = replace(pe35_input.pe34_handoff, **overrides)
+    pe35_input = replace(pe35_input, pe34_handoff=pe34_handoff)
+    return replace(
+        integration_input,
+        pe35_handoff_staleness_revocation_recovery_boundary_input=pe35_input,
+    )
+
+
+def test_graph_recovery_validator_composes_pe35_handoff_input_validation() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    pe35_input = integration_input.pe35_handoff_staleness_revocation_recovery_boundary_input
+    context = ValidationContext(
+        integration_input=integration_input,
+        pe35_result=evaluate_handoff_staleness_revocation_recovery_boundary(pe35_input),
+    )
+    assert not validate_recovery_proof_binding(context).fail_reasons
+
+
+def test_graph_recovery_validator_missing_pe34_handoff_id_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = _replace_pe34_handoff(integration_input, handoff_id="")
+    pe35_input = bad.pe35_handoff_staleness_revocation_recovery_boundary_input
+    context = ValidationContext(
+        integration_input=bad,
+        pe35_result=evaluate_handoff_staleness_revocation_recovery_boundary(pe35_input),
+    )
+    result = execute_proof_binding_validation_graph(context)
+    assert any("handoff_id required" in reason for reason in result.fail_reasons)
 
 
 def test_evaluate_graph_compatibility_happy_path() -> None:


### PR DESCRIPTION
## Summary

- Closes PE-57: graph recovery node ran only `validate_pe35_recovery_boundary_proof` while completion input validation composes full PE-35 handoff input checks (including PE-34 handoff boundary validation).
- Adds `validate_recovery_proof_binding` to chain PE-35 handoff input validation + PE-35 proof binding fail-closed at the recovery graph node.
- Offline, non-authorizing, bounded to durable completion validation graph owner.

## Changed files

1. `src/ops/durable_completion_validation/validators/recovery.py`
2. `src/ops/durable_completion_validation/graph.py`
3. `tests/ops/test_durable_completion_validation_graph_v1.py`

## Test plan

- [x] `tests/ops/test_durable_completion_validation_graph_v1.py` (14 passed locally)
- [x] CI selector: FOCUSED on graph test owner only


Made with [Cursor](https://cursor.com)