### PR TITLE
feat(durable-completion): compose PE-37 handoff input validation into graph traceability proof binding

### DIFF
--- a/src/ops/durable_completion_validation/graph.py
+++ b/src/ops/durable_completion_validation/graph.py
@@ -61,7 +61,7 @@ def _load_validators() -> dict[str, ValidatorFn]:
     return {
         VALIDATOR_RECONCILIATION: reconciliation.validate_reconciliation_proof_binding,
         VALIDATOR_RECOVERY: recovery.validate_recovery_proof_binding,
-        VALIDATOR_TRACEABILITY: traceability.validate_pe37_traceability_proof,
+        VALIDATOR_TRACEABILITY: traceability.validate_traceability_proof_binding,
         VALIDATOR_OPERATOR_CLOSURE: operator_closure.validate_pe25_operator_closure_proof,
     }
 

--- a/src/ops/durable_completion_validation/validators/traceability.py
+++ b/src/ops/durable_completion_validation/validators/traceability.py
@@ -8,6 +8,7 @@ from src.ops.bounded_futures_testnet_operator_review_admission_presentation_boun
 from src.ops.bounded_futures_testnet_operator_review_chain_durable_evidence_traceability_boundary_contract_v0 import (
     BOUNDARY_OWNER as PE37_BOUNDARY_OWNER,
     compute_boundary_input_digest as compute_pe37_boundary_input_digest,
+    validate_durable_evidence_traceability_boundary_input,
 )
 from src.ops.bounded_futures_testnet_handoff_staleness_revocation_recovery_boundary_contract_v0 import (
     compute_boundary_input_digest as compute_pe35_boundary_input_digest,
@@ -15,7 +16,7 @@ from src.ops.bounded_futures_testnet_handoff_staleness_revocation_recovery_bound
 from src.ops.bounded_futures_testnet_operator_review_handoff_boundary_contract_v0 import (
     compute_boundary_input_digest as compute_pe34_boundary_input_digest,
 )
-from src.ops.durable_completion_validation.identity import valid_sha256_digest
+from src.ops.durable_completion_validation.identity import sorted_unique, valid_sha256_digest
 from src.ops.durable_completion_validation.models import ValidationContext, ValidationResult
 
 
@@ -169,3 +170,13 @@ def validate_pe37_traceability_proof(context: ValidationContext) -> ValidationRe
         fail_reasons.append("pe37_proof: authority_lift must remain false")
 
     return ValidationResult(fail_reasons=tuple(fail_reasons))
+
+
+def validate_traceability_proof_binding(context: ValidationContext) -> ValidationResult:
+    """Graph traceability node: PE-37 handoff input validation plus PE-37 proof binding."""
+    fail_reasons: list[str] = []
+    pe37_input = context.integration_input.pe37_traceability_boundary_input
+    fail_reasons.extend(validate_durable_evidence_traceability_boundary_input(pe37_input))
+    pe37_proof = validate_pe37_traceability_proof(context)
+    fail_reasons.extend(pe37_proof.fail_reasons)
+    return ValidationResult(fail_reasons=tuple(sorted_unique(fail_reasons)))

--- a/tests/ops/test_durable_completion_validation_graph_v1.py
+++ b/tests/ops/test_durable_completion_validation_graph_v1.py
@@ -35,12 +35,18 @@ from src.ops.bounded_futures_testnet_reconciliation_review_lifecycle_integration
 from src.ops.bounded_futures_testnet_handoff_staleness_revocation_recovery_boundary_contract_v0 import (
     evaluate_handoff_staleness_revocation_recovery_boundary,
 )
+from src.ops.bounded_futures_testnet_operator_review_chain_durable_evidence_traceability_boundary_contract_v0 import (
+    evaluate_durable_evidence_traceability_boundary,
+)
 from src.ops.durable_completion_validation.validators.recovery import (
     validate_recovery_proof_binding,
 )
 from src.ops.durable_completion_validation.validators.reconciliation import (
     validate_pe21_reconciliation_result_manifest_integrity,
     validate_reconciliation_proof_binding,
+)
+from src.ops.durable_completion_validation.validators.traceability import (
+    validate_traceability_proof_binding,
 )
 
 
@@ -238,6 +244,43 @@ def test_graph_recovery_validator_missing_pe34_handoff_id_fail_closed() -> None:
     )
     result = execute_proof_binding_validation_graph(context)
     assert any("handoff_id required" in reason for reason in result.fail_reasons)
+
+
+def _replace_pe37_archive_binding(integration_input, **overrides):
+    pe37_input = integration_input.pe37_traceability_boundary_input
+    pe16 = replace(pe37_input.pe16_archive_binding, **overrides)
+    pe37_input = replace(pe37_input, pe16_archive_binding=pe16)
+    return replace(integration_input, pe37_traceability_boundary_input=pe37_input)
+
+
+def test_graph_traceability_validator_composes_pe37_handoff_input_validation() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    pe37_input = integration_input.pe37_traceability_boundary_input
+    context = ValidationContext(
+        integration_input=integration_input,
+        pe37_result=evaluate_durable_evidence_traceability_boundary(pe37_input),
+    )
+    assert not validate_traceability_proof_binding(context).fail_reasons
+
+
+def test_graph_traceability_validator_missing_pe16_archive_manifest_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = _replace_pe37_archive_binding(integration_input, archive_manifest_digest="")
+    pe37_input = bad.pe37_traceability_boundary_input
+    pe35_input = bad.pe35_handoff_staleness_revocation_recovery_boundary_input
+    context = ValidationContext(
+        integration_input=bad,
+        pe31_result=evaluate_reconciliation_review_lifecycle_integration(
+            bad.pe31_reconciliation_review_integration_input
+        ),
+        pe35_result=evaluate_handoff_staleness_revocation_recovery_boundary(pe35_input),
+        pe37_result=evaluate_durable_evidence_traceability_boundary(pe37_input),
+    )
+    result = execute_proof_binding_validation_graph(context)
+    assert any(
+        "pe16_archive: archive_manifest_digest required" in reason for reason in result.fail_reasons
+    )
+    assert VALIDATOR_TRACEABILITY not in context.completed_validators
 
 
 def test_evaluate_graph_compatibility_happy_path() -> None:


### PR DESCRIPTION
## Summary
- Wire PE-37 handoff input validation into the durable-completion validation graph traceability proof binding.
- Extend traceability validator and graph tests for the composed binding.

## Test plan
- [x] `pytest tests/ops/test_durable_completion_validation_graph_v1.py -q`
- [x] `ruff format --check` / `ruff check` on changed files
- [x] Docs token policy preflight (no changed Markdown)
- [x] CI diff-aware selection: FOCUSED (`durable_completion_focused`)


Made with [Cursor](https://cursor.com)