### PR TITLE
feat(durable-completion): bind completion proof chain cross-slice digests into graph validation

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -382,8 +382,6 @@ def _is_durable_completion_rebundle_path(path: str) -> bool:
 def _is_durable_completion_validator_rebinding_scope(files: list[str]) -> bool:
     if not files:
         return False
-    if DURABLE_COMPLETION_FACADE_PATH in files:
-        return False
     if any(path in DURABLE_COMPLETION_FULL_REFACTOR_SRC_PATHS for path in files):
         return False
     if not any(
@@ -409,6 +407,8 @@ def _is_durable_completion_validator_rebinding_scope(files: list[str]) -> bool:
         if path.startswith("src/ops/durable_completion_validation/") and path.endswith(".py"):
             continue
         if path in DURABLE_COMPLETION_VALIDATOR_REBINDING_TEST_PATHS:
+            continue
+        if path == DURABLE_COMPLETION_FACADE_PATH and has_validator_subpath:
             continue
         return False
     return True

--- a/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -1736,122 +1736,15 @@ def _build_pe25_closure_input_from_completion(
 def _validate_completion_proof_chain(
     integration_input: DurableRunPrimaryEvidenceCompletionIntegrationInput,
 ) -> list[str]:
-    fail_reasons: list[str] = []
-    chain = integration_input.completion_proof_chain
-    pe31_proof = integration_input.pe31_reconciliation_review_integration_proof
-    pe22_proof = integration_input.pe22_risk_killswitch_flatten_proof
-    pe23_proof = integration_input.pe23_capital_slot_ratchet_release_proof
-    pe24_proof = integration_input.pe24_pilot_envelope_lifecycle_proof
-    pe35_proof = integration_input.pe35_handoff_recovery_boundary_proof
-    pe37_proof = integration_input.pe37_traceability_proof
-    pe25_proof = integration_input.pe25_operator_closure_proof
-    pe21_proof = integration_input.pe21_proof
-    pe31_pe21_proof = integration_input.pe31_reconciliation_review_integration_input.pe21_reconciliation_primary_evidence_integration_proof
-    pe21_input_digest = compute_pe21_integration_input_digest(
-        integration_input.pe21_integration_input
+    from src.ops.durable_completion_validation.validators.completion_chain import (
+        validate_completion_proof_chain_binding,
     )
 
-    digest_fields = (
-        ("completion_referenced_pe31_proof_digest", chain.completion_referenced_pe31_proof_digest),
-        ("completion_referenced_pe22_proof_digest", chain.completion_referenced_pe22_proof_digest),
-        ("completion_referenced_pe23_proof_digest", chain.completion_referenced_pe23_proof_digest),
-        ("completion_referenced_pe24_proof_digest", chain.completion_referenced_pe24_proof_digest),
-        (
-            "completion_referenced_pe35_boundary_result_digest",
-            chain.completion_referenced_pe35_boundary_result_digest,
-        ),
-        (
-            "completion_referenced_pe37_boundary_result_digest",
-            chain.completion_referenced_pe37_boundary_result_digest,
-        ),
-        ("pe37_traceability_identity", chain.pe37_traceability_identity),
-        (
-            "completion_referenced_pe25_closure_result_digest",
-            chain.completion_referenced_pe25_closure_result_digest,
-        ),
-        ("pe25_closure_input_digest", chain.pe25_closure_input_digest),
-        (
-            "closure_referenced_admission_proof_digest",
-            chain.closure_referenced_admission_proof_digest,
-        ),
-        (
-            "pe31_referenced_pe21_integration_proof_digest",
-            chain.pe31_referenced_pe21_integration_proof_digest,
-        ),
-        (
-            "completion_referenced_pe21_integration_proof_digest",
-            chain.completion_referenced_pe21_integration_proof_digest,
-        ),
-        ("shared_pe21_integration_input_digest", chain.shared_pe21_integration_input_digest),
-        ("shared_traceability_identity", chain.shared_traceability_identity),
+    return list(
+        validate_completion_proof_chain_binding(
+            ValidationContext(integration_input=integration_input)
+        ).fail_reasons
     )
-    for field_name, value in digest_fields:
-        if not value:
-            fail_reasons.append(f"completion_proof_chain: {field_name} required")
-        elif not _valid_sha256_digest(value):
-            fail_reasons.append(
-                f"completion_proof_chain: {field_name} must be 64-char lowercase sha256 hex"
-            )
-
-    if chain.completion_referenced_pe31_proof_digest != pe31_proof.integration_proof_digest:
-        fail_reasons.append(
-            "completion_proof_chain: completion_referenced_pe31_proof_digest mismatch"
-        )
-    if chain.completion_referenced_pe22_proof_digest != pe22_proof.integration_proof_digest:
-        fail_reasons.append(
-            "completion_proof_chain: completion_referenced_pe22_proof_digest mismatch"
-        )
-    if chain.completion_referenced_pe23_proof_digest != pe23_proof.integration_proof_digest:
-        fail_reasons.append(
-            "completion_proof_chain: completion_referenced_pe23_proof_digest mismatch"
-        )
-    if chain.completion_referenced_pe24_proof_digest != pe24_proof.integration_proof_digest:
-        fail_reasons.append(
-            "completion_proof_chain: completion_referenced_pe24_proof_digest mismatch"
-        )
-    if chain.completion_referenced_pe35_boundary_result_digest != pe35_proof.boundary_result_digest:
-        fail_reasons.append(
-            "completion_proof_chain: completion_referenced_pe35_boundary_result_digest mismatch"
-        )
-    if chain.completion_referenced_pe37_boundary_result_digest != pe37_proof.boundary_result_digest:
-        fail_reasons.append(
-            "completion_proof_chain: completion_referenced_pe37_boundary_result_digest mismatch"
-        )
-    if chain.pe37_traceability_identity != pe37_proof.traceability_identity:
-        fail_reasons.append("completion_proof_chain: pe37_traceability_identity mismatch")
-    if chain.completion_referenced_pe25_closure_result_digest != pe25_proof.closure_result_digest:
-        fail_reasons.append(
-            "completion_proof_chain: completion_referenced_pe25_closure_result_digest mismatch"
-        )
-    if chain.pe25_closure_input_digest != pe25_proof.closure_input_digest:
-        fail_reasons.append("completion_proof_chain: pe25_closure_input_digest mismatch")
-    if (
-        chain.closure_referenced_admission_proof_digest
-        != pe25_proof.admission_integration_proof_digest
-    ):
-        fail_reasons.append(
-            "completion_proof_chain: closure_referenced_admission_proof_digest mismatch"
-        )
-    if (
-        chain.pe31_referenced_pe21_integration_proof_digest
-        != pe31_pe21_proof.integration_proof_digest
-    ):
-        fail_reasons.append(
-            "completion_proof_chain: pe31_referenced_pe21_integration_proof_digest mismatch"
-        )
-    if (
-        chain.completion_referenced_pe21_integration_proof_digest
-        != pe21_proof.integration_proof_digest
-    ):
-        fail_reasons.append(
-            "completion_proof_chain: completion_referenced_pe21_integration_proof_digest mismatch"
-        )
-    if chain.shared_pe21_integration_input_digest != pe21_input_digest:
-        fail_reasons.append("completion_proof_chain: shared_pe21_integration_input_digest mismatch")
-    if chain.shared_traceability_identity != integration_input.durable_run_root.run_root_digest:
-        fail_reasons.append("completion_proof_chain: shared_traceability_identity mismatch")
-
-    return fail_reasons
 
 
 def _validate_gap4_completion_proof(

--- a/src/ops/durable_completion_validation/graph.py
+++ b/src/ops/durable_completion_validation/graph.py
@@ -12,12 +12,18 @@ VALIDATOR_RECONCILIATION = "reconciliation"
 VALIDATOR_RECOVERY = "recovery"
 VALIDATOR_TRACEABILITY = "traceability"
 VALIDATOR_OPERATOR_CLOSURE = "operator_closure"
+VALIDATOR_COMPLETION_CHAIN = "completion_chain"
 
 PROOF_BINDING_VALIDATION_GRAPH: dict[str, tuple[str, ...]] = {
     VALIDATOR_RECONCILIATION: (),
     VALIDATOR_RECOVERY: (),
     VALIDATOR_TRACEABILITY: (VALIDATOR_RECOVERY,),
     VALIDATOR_OPERATOR_CLOSURE: (VALIDATOR_TRACEABILITY, VALIDATOR_RECOVERY),
+    VALIDATOR_COMPLETION_CHAIN: (
+        VALIDATOR_OPERATOR_CLOSURE,
+        VALIDATOR_TRACEABILITY,
+        VALIDATOR_RECOVERY,
+    ),
 }
 
 PROOF_BINDING_VALIDATION_ORDER: tuple[str, ...] = (
@@ -25,6 +31,7 @@ PROOF_BINDING_VALIDATION_ORDER: tuple[str, ...] = (
     VALIDATOR_RECOVERY,
     VALIDATOR_TRACEABILITY,
     VALIDATOR_OPERATOR_CLOSURE,
+    VALIDATOR_COMPLETION_CHAIN,
 )
 
 ValidatorFn = Callable[[ValidationContext], ValidationResult]
@@ -52,6 +59,7 @@ def proof_binding_validation_graph_is_cycle_free() -> bool:
 
 def _load_validators() -> dict[str, ValidatorFn]:
     from src.ops.durable_completion_validation.validators import (
+        completion_chain,
         operator_closure,
         reconciliation,
         recovery,
@@ -63,6 +71,7 @@ def _load_validators() -> dict[str, ValidatorFn]:
         VALIDATOR_RECOVERY: recovery.validate_recovery_proof_binding,
         VALIDATOR_TRACEABILITY: traceability.validate_traceability_proof_binding,
         VALIDATOR_OPERATOR_CLOSURE: operator_closure.validate_operator_closure_proof_binding,
+        VALIDATOR_COMPLETION_CHAIN: completion_chain.validate_completion_proof_chain_binding,
     }
 
 

--- a/src/ops/durable_completion_validation/validators/completion_chain.py
+++ b/src/ops/durable_completion_validation/validators/completion_chain.py
@@ -1,0 +1,130 @@
+"""Completion proof chain cross-slice digest binding validator."""
+
+from __future__ import annotations
+
+from src.ops.bounded_futures_testnet_position_order_reconciliation_primary_evidence_integration_contract_v0 import (
+    compute_integration_input_digest as compute_pe21_integration_input_digest,
+)
+from src.ops.durable_completion_validation.identity import sorted_unique, valid_sha256_digest
+from src.ops.durable_completion_validation.models import ValidationContext, ValidationResult
+
+
+def validate_completion_proof_chain_binding(context: ValidationContext) -> ValidationResult:
+    """Graph completion_chain node: cross-slice completion proof chain digest coherence."""
+    fail_reasons: list[str] = []
+    integration_input = context.integration_input
+    chain = integration_input.completion_proof_chain
+    pe31_proof = integration_input.pe31_reconciliation_review_integration_proof
+    pe22_proof = integration_input.pe22_risk_killswitch_flatten_proof
+    pe23_proof = integration_input.pe23_capital_slot_ratchet_release_proof
+    pe24_proof = integration_input.pe24_pilot_envelope_lifecycle_proof
+    pe35_proof = integration_input.pe35_handoff_recovery_boundary_proof
+    pe37_proof = integration_input.pe37_traceability_proof
+    pe25_proof = integration_input.pe25_operator_closure_proof
+    pe21_proof = integration_input.pe21_proof
+    pe31_pe21_proof = integration_input.pe31_reconciliation_review_integration_input.pe21_reconciliation_primary_evidence_integration_proof
+    pe21_input_digest = compute_pe21_integration_input_digest(
+        integration_input.pe21_integration_input
+    )
+
+    digest_fields = (
+        ("completion_referenced_pe31_proof_digest", chain.completion_referenced_pe31_proof_digest),
+        ("completion_referenced_pe22_proof_digest", chain.completion_referenced_pe22_proof_digest),
+        ("completion_referenced_pe23_proof_digest", chain.completion_referenced_pe23_proof_digest),
+        ("completion_referenced_pe24_proof_digest", chain.completion_referenced_pe24_proof_digest),
+        (
+            "completion_referenced_pe35_boundary_result_digest",
+            chain.completion_referenced_pe35_boundary_result_digest,
+        ),
+        (
+            "completion_referenced_pe37_boundary_result_digest",
+            chain.completion_referenced_pe37_boundary_result_digest,
+        ),
+        ("pe37_traceability_identity", chain.pe37_traceability_identity),
+        (
+            "completion_referenced_pe25_closure_result_digest",
+            chain.completion_referenced_pe25_closure_result_digest,
+        ),
+        ("pe25_closure_input_digest", chain.pe25_closure_input_digest),
+        (
+            "closure_referenced_admission_proof_digest",
+            chain.closure_referenced_admission_proof_digest,
+        ),
+        (
+            "pe31_referenced_pe21_integration_proof_digest",
+            chain.pe31_referenced_pe21_integration_proof_digest,
+        ),
+        (
+            "completion_referenced_pe21_integration_proof_digest",
+            chain.completion_referenced_pe21_integration_proof_digest,
+        ),
+        ("shared_pe21_integration_input_digest", chain.shared_pe21_integration_input_digest),
+        ("shared_traceability_identity", chain.shared_traceability_identity),
+    )
+    for field_name, value in digest_fields:
+        if not value:
+            fail_reasons.append(f"completion_proof_chain: {field_name} required")
+        elif not valid_sha256_digest(value):
+            fail_reasons.append(
+                f"completion_proof_chain: {field_name} must be 64-char lowercase sha256 hex"
+            )
+
+    if chain.completion_referenced_pe31_proof_digest != pe31_proof.integration_proof_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe31_proof_digest mismatch"
+        )
+    if chain.completion_referenced_pe22_proof_digest != pe22_proof.integration_proof_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe22_proof_digest mismatch"
+        )
+    if chain.completion_referenced_pe23_proof_digest != pe23_proof.integration_proof_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe23_proof_digest mismatch"
+        )
+    if chain.completion_referenced_pe24_proof_digest != pe24_proof.integration_proof_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe24_proof_digest mismatch"
+        )
+    if chain.completion_referenced_pe35_boundary_result_digest != pe35_proof.boundary_result_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe35_boundary_result_digest mismatch"
+        )
+    if chain.completion_referenced_pe37_boundary_result_digest != pe37_proof.boundary_result_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe37_boundary_result_digest mismatch"
+        )
+    if chain.pe37_traceability_identity != pe37_proof.traceability_identity:
+        fail_reasons.append("completion_proof_chain: pe37_traceability_identity mismatch")
+    if chain.completion_referenced_pe25_closure_result_digest != pe25_proof.closure_result_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe25_closure_result_digest mismatch"
+        )
+    if chain.pe25_closure_input_digest != pe25_proof.closure_input_digest:
+        fail_reasons.append("completion_proof_chain: pe25_closure_input_digest mismatch")
+    if (
+        chain.closure_referenced_admission_proof_digest
+        != pe25_proof.admission_integration_proof_digest
+    ):
+        fail_reasons.append(
+            "completion_proof_chain: closure_referenced_admission_proof_digest mismatch"
+        )
+    if (
+        chain.pe31_referenced_pe21_integration_proof_digest
+        != pe31_pe21_proof.integration_proof_digest
+    ):
+        fail_reasons.append(
+            "completion_proof_chain: pe31_referenced_pe21_integration_proof_digest mismatch"
+        )
+    if (
+        chain.completion_referenced_pe21_integration_proof_digest
+        != pe21_proof.integration_proof_digest
+    ):
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe21_integration_proof_digest mismatch"
+        )
+    if chain.shared_pe21_integration_input_digest != pe21_input_digest:
+        fail_reasons.append("completion_proof_chain: shared_pe21_integration_input_digest mismatch")
+    if chain.shared_traceability_identity != integration_input.durable_run_root.run_root_digest:
+        fail_reasons.append("completion_proof_chain: shared_traceability_identity mismatch")
+
+    return ValidationResult(fail_reasons=tuple(sorted_unique(fail_reasons)))

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -631,6 +631,28 @@ def test_selector_pe56_graph_wiring_rebinding_bounded_focused_targets() -> None:
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" not in targets
 
 
+PE60_DURABLE_COMPLETION_DELEGATION_FILES = (
+    "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "src/ops/durable_completion_validation/graph.py",
+    "src/ops/durable_completion_validation/validators/completion_chain.py",
+    "tests/ops/test_durable_completion_validation_graph_v1.py",
+)
+
+
+def test_selector_pe60_completion_chain_delegation_rebinding_bounded_focused_targets() -> None:
+    sel = _run_selector(*PE60_DURABLE_COMPLETION_DELEGATION_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "durable_completion_focused"
+    targets = _targets(sel)
+    assert targets == ["tests/ops/test_durable_completion_validation_graph_v1.py"]
+    assert (
+        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+        not in targets
+    )
+    assert sel["tests_execute_full"] == "false"
+    assert sel["tests_execute_no_op"] == "false"
+
+
 def test_fast_lane_skips_full_static_sweep_when_focused() -> None:
     text = _ci_text()
     static_if = text.split("name: Static contract tests", 1)[1].split("run:", 1)[0]

--- a/tests/ops/test_durable_completion_validation_graph_v1.py
+++ b/tests/ops/test_durable_completion_validation_graph_v1.py
@@ -16,6 +16,7 @@ from src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_int
 from src.ops.durable_completion_validation.graph import (
     PROOF_BINDING_VALIDATION_GRAPH,
     PROOF_BINDING_VALIDATION_ORDER,
+    VALIDATOR_COMPLETION_CHAIN,
     VALIDATOR_OPERATOR_CLOSURE,
     VALIDATOR_RECONCILIATION,
     VALIDATOR_RECOVERY,
@@ -54,6 +55,9 @@ from src.ops.durable_completion_validation.validators.traceability import (
 from src.ops.durable_completion_validation.validators.operator_closure import (
     validate_operator_closure_proof_binding,
 )
+from src.ops.durable_completion_validation.validators.completion_chain import (
+    validate_completion_proof_chain_binding,
+)
 
 
 def _minimal_context(**overrides: Any) -> ValidationContext:
@@ -82,6 +86,7 @@ def test_graph_missing_validator_is_fail_closed() -> None:
         VALIDATOR_RECONCILIATION: lambda _ctx: ValidationResult(),
         VALIDATOR_RECOVERY: lambda _ctx: ValidationResult(),
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(),
+        VALIDATOR_COMPLETION_CHAIN: lambda _ctx: ValidationResult(),
     }
     result = execute_proof_binding_validation_graph(
         context,
@@ -102,11 +107,15 @@ def test_graph_missing_dependency_is_fail_closed() -> None:
         VALIDATOR_RECOVERY: failing_recovery,
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
         VALIDATOR_OPERATOR_CLOSURE: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
+        VALIDATOR_COMPLETION_CHAIN: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
     }
     result = execute_proof_binding_validation_graph(context, validators=validators)
     assert any("dependency failed for 'traceability'" in reason for reason in result.fail_reasons)
     assert any(
         "dependency failed for 'operator_closure'" in reason for reason in result.fail_reasons
+    )
+    assert any(
+        "dependency failed for 'completion_chain'" in reason for reason in result.fail_reasons
     )
     assert VALIDATOR_TRACEABILITY not in context.completed_validators
     assert VALIDATOR_OPERATOR_CLOSURE not in context.completed_validators
@@ -123,6 +132,7 @@ def test_graph_exception_is_fail_closed() -> None:
         VALIDATOR_RECOVERY: lambda _ctx: ValidationResult(),
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(),
         VALIDATOR_OPERATOR_CLOSURE: lambda _ctx: ValidationResult(),
+        VALIDATOR_COMPLETION_CHAIN: lambda _ctx: ValidationResult(),
     }
     result = execute_proof_binding_validation_graph(context, validators=validators)
     assert any(
@@ -138,6 +148,7 @@ def test_graph_aggregates_fail_reasons_from_executed_validators() -> None:
         VALIDATOR_RECOVERY: lambda _ctx: ValidationResult(fail_reasons=("beta",)),
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(fail_reasons=("gamma",)),
         VALIDATOR_OPERATOR_CLOSURE: lambda _ctx: ValidationResult(fail_reasons=("delta",)),
+        VALIDATOR_COMPLETION_CHAIN: lambda _ctx: ValidationResult(fail_reasons=("epsilon",)),
     }
     result = execute_proof_binding_validation_graph(context, validators=validators)
     assert set(result.fail_reasons) == {
@@ -145,6 +156,7 @@ def test_graph_aggregates_fail_reasons_from_executed_validators() -> None:
         "beta",
         "validation_graph: dependency failed for 'traceability': ['recovery']",
         "validation_graph: dependency failed for 'operator_closure': ['traceability', 'recovery']",
+        "validation_graph: dependency failed for 'completion_chain': ['operator_closure', 'traceability', 'recovery']",
     }
 
 
@@ -336,6 +348,64 @@ def test_graph_operator_closure_validator_missing_closure_id_fail_closed() -> No
     result = execute_proof_binding_validation_graph(context)
     assert any("closure_id required" in reason for reason in result.fail_reasons)
     assert VALIDATOR_OPERATOR_CLOSURE not in context.completed_validators
+
+
+def test_completion_proof_chain_validator_matches_input_validation_path() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    direct = validate_completion_proof_chain_binding(
+        ValidationContext(integration_input=integration_input)
+    )
+    input_fail_reasons = validate_durable_run_primary_evidence_completion_integration_input(
+        integration_input
+    )
+    chain_reasons = [
+        reason for reason in input_fail_reasons if reason.startswith("completion_proof_chain:")
+    ]
+    assert list(direct.fail_reasons) == chain_reasons
+
+
+def _replace_completion_proof_chain(integration_input, **overrides):
+    chain = replace(integration_input.completion_proof_chain, **overrides)
+    return replace(integration_input, completion_proof_chain=chain)
+
+
+def test_graph_completion_chain_validator_composes_binding() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    assert not validate_completion_proof_chain_binding(
+        ValidationContext(integration_input=integration_input)
+    ).fail_reasons
+
+
+def test_graph_completion_chain_validator_pe35_digest_drift_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = _replace_completion_proof_chain(
+        integration_input,
+        completion_referenced_pe35_boundary_result_digest="0" * 64,
+    )
+    pe25_input = bad.pe25_closure_integration_input
+    pe37_input = bad.pe37_traceability_boundary_input
+    pe35_input = bad.pe35_handoff_staleness_revocation_recovery_boundary_input
+    context = ValidationContext(
+        integration_input=bad,
+        pe31_result=evaluate_reconciliation_review_lifecycle_integration(
+            bad.pe31_reconciliation_review_integration_input
+        ),
+        pe35_result=evaluate_handoff_staleness_revocation_recovery_boundary(pe35_input),
+        pe37_result=evaluate_durable_evidence_traceability_boundary(pe37_input),
+        pe25_result=evaluate_operator_closure_lifecycle_integration(pe25_input),
+        admission_result={
+            "integration_pass": True,
+            "integration_proof_digest": (
+                bad.pe25_operator_closure_proof.admission_integration_proof_digest
+            ),
+        },
+    )
+    result = execute_proof_binding_validation_graph(context)
+    assert any(
+        "completion_referenced_pe35_boundary_result_digest mismatch" in reason
+        for reason in result.fail_reasons
+    )
+    assert VALIDATOR_COMPLETION_CHAIN not in context.completed_validators
 
 
 def test_evaluate_graph_compatibility_happy_path() -> None:


### PR DESCRIPTION
## Summary
- Extrahiert Completion-Proof-Chain-Binding in `completion_chain`-Validator und hängt ihn an den Proof-Binding-Validierungsgraphen.
- Delegiert die Integrations-Input-Validierung an den gemeinsamen Graph-Pfad; Tests decken Parität und PE-35-Drift ab.

## Test plan
- [x] `ruff format --check` / `ruff check` auf die 4 geänderten Dateien
- [x] `validate_docs_token_policy.py --changed --base origin/main`
- [x] `pytest tests/ops/test_durable_completion_validation_graph_v1.py -q` (21 passed)
- [x] `ci_test_selection_v1.py --files` (FOCUSED / durable_completion_focused)


Made with [Cursor](https://cursor.com)