### PR TITLE
fix(shadow): route extended bounded runs through adapter

### DIFF
--- a/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
@@ -27,6 +27,11 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.ops import bounded_daemon_paper_shadow_24h_approval_v0 as contract_24h
+from scripts.ops.shadow_247_futures_start_wrapper_skeleton_v0 import (
+    BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES,
+    BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP,
+    EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0,
+)
 from scripts.ops.primary_evidence_retention_v0 import (
     verify_manifest_sha256,
     write_manifest_sha256 as _write_manifest_sha256,
@@ -253,6 +258,10 @@ def _default_max_steps(duration_minutes: int, max_steps: int | None) -> int:
     return min(DEFAULT_MAX_STEPS, max(1, duration_minutes * 12))
 
 
+def extended_tier_active(duration_minutes: int) -> bool:
+    return duration_minutes > MAX_DURATION_MINUTES
+
+
 def build_plan(
     *,
     mode: str,
@@ -264,6 +273,7 @@ def build_plan(
     step_interval_seconds: float,
     run_id: str,
     contract_profile: str = "",
+    extended_tier: bool = False,
 ) -> AdapterPlan:
     wrapper_evidence = staging_root / WRAPPER_EVIDENCE_DIR
     review_out = staging_root / "review" / "REVIEW_RESULT.json"
@@ -291,6 +301,14 @@ def build_plan(
                 "--candidate-24h-bounded-shadow-validation",
                 "--candidate-24h-confirm-token",
                 CANDIDATE_24H_BOUNDED_SHADOW_CONFIRM_TOKEN_V0,
+            ]
+        )
+    elif extended_tier:
+        wrapper_cmd.extend(
+            [
+                "--extended-bounded-shadow-validation",
+                "--extended-confirm-token",
+                EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0,
             ]
         )
     review_cmd = _python_cmd(repo_root, REVIEW_SCRIPT) + [
@@ -823,17 +841,29 @@ def main(
     else:
         if args.duration_minutes is None:
             args.duration_minutes = DEFAULT_DURATION_MINUTES
-        if args.duration_minutes <= 0 or args.duration_minutes > MAX_DURATION_MINUTES:
+        if args.duration_minutes <= 0:
+            print("duration-minutes must be > 0", file=sys.stderr)
+            return USAGE_EXIT
+        if args.duration_minutes > BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES:
             print(
-                f"duration-minutes must be between 1 and {MAX_DURATION_MINUTES} inclusive",
+                "duration-minutes must be between 1 and "
+                f"{BOUNDED_SHADOW_EXTENDED_DURATION_CAP_MINUTES} inclusive",
                 file=sys.stderr,
             )
             return USAGE_EXIT
-        max_steps_cap = MAX_STEPS_CAP
+        max_steps_cap = (
+            BOUNDED_SHADOW_EXTENDED_MAX_STEPS_CAP
+            if extended_tier_active(args.duration_minutes)
+            else MAX_STEPS_CAP
+        )
 
     if args.duration_minutes <= 0:
         print("duration-minutes must be > 0", file=sys.stderr)
         return USAGE_EXIT
+
+    extended_tier = profile != contract_24h.CONTRACT_PROFILE and extended_tier_active(
+        args.duration_minutes
+    )
 
     max_steps = _default_max_steps(args.duration_minutes, args.max_steps)
     if profile == contract_24h.CONTRACT_PROFILE and args.max_steps is None:
@@ -865,6 +895,7 @@ def main(
         step_interval_seconds=args.step_interval_seconds,
         run_id=run_id,
         contract_profile=profile,
+        extended_tier=extended_tier,
     )
 
     if args.execute:

--- a/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
@@ -584,11 +584,94 @@ def test_default_profile_unchanged_still_10_minutes(tmp_path: Path) -> None:
     assert plan.get("contract_profile", "") == ""
 
 
-def test_default_profile_rejects_duration_11(tmp_path: Path) -> None:
+def test_default_profile_delegates_duration_11_to_extended_tier(tmp_path: Path) -> None:
+    """Duration 11+ is accepted via extended-tier wrapper delegation (not standard tier)."""
     mod = _load_adapter()
     staging = _staging(tmp_path)
-    rc = mod.main(_base_argv(staging) + ["--duration-minutes", "11"])
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(_base_argv(staging) + ["--duration-minutes", "11", "--json"])
+    assert rc == 0, buf.getvalue()
+    plan = json.loads(buf.getvalue())
+    joined = json.dumps(plan["commands"])
+    joined_lower = joined.lower()
+    assert "extended-bounded-shadow-validation" in joined_lower
+    assert "extended-confirm-token" in joined_lower
+    assert mod.EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0 in joined
+
+
+def test_extended_tier_plan_30_minutes_delegates_to_wrapper(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(_base_argv(staging) + ["--duration-minutes", "30", "--json"])
+    assert rc == 0, buf.getvalue()
+    plan = json.loads(buf.getvalue())
+    assert plan["duration_minutes"] == 30
+    assert plan["wrapper_script"] == mod.WRAPPER_SCRIPT
+    joined = json.dumps(plan["commands"])
+    joined_lower = joined.lower()
+    assert "shadow_247_futures_start_wrapper_skeleton_v0.py" in joined_lower
+    assert "bounded-shadow-dry-run" in joined_lower
+    assert "extended-bounded-shadow-validation" in joined_lower
+    assert mod.EXTENDED_BOUNDED_SHADOW_CONFIRM_TOKEN_V0 in joined
+    assert "candidate-24h-bounded-shadow-validation" not in joined_lower
+
+
+def test_standard_tier_10_minutes_has_no_extended_flags(tmp_path: Path) -> None:
+    plan = _plan_dict(_staging(tmp_path))
+    joined = json.dumps(plan["commands"]).lower()
+    assert plan["duration_minutes"] == 10
+    assert "extended-bounded-shadow-validation" not in joined
+    assert "extended-confirm-token" not in joined
+
+
+def test_extended_tier_accepts_duration_at_cap_60(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(_base_argv(staging) + ["--duration-minutes", "60", "--json"])
+    assert rc == 0, buf.getvalue()
+    plan = json.loads(buf.getvalue())
+    assert plan["duration_minutes"] == 60
+
+
+def test_extended_tier_rejects_duration_above_cap(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    rc = mod.main(_base_argv(staging) + ["--duration-minutes", "61"])
     assert rc != 0
+
+
+def test_extended_tier_rejects_non_positive_duration(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    rc = mod.main(_base_argv(staging) + ["--duration-minutes", "0"])
+    assert rc != 0
+
+
+def test_extended_tier_active_helper_boundary() -> None:
+    mod = _load_adapter()
+    assert mod.extended_tier_active(10) is False
+    assert mod.extended_tier_active(11) is True
+    assert mod.extended_tier_active(30) is True
+    assert mod.extended_tier_active(60) is True
+
+
+def test_extended_tier_plan_has_single_wrapper_route(tmp_path: Path) -> None:
+    mod = _load_adapter()
+    staging = _staging(tmp_path)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = mod.main(_base_argv(staging) + ["--duration-minutes", "30", "--json"])
+    assert rc == 0
+    plan = json.loads(buf.getvalue())
+    wrapper_argv = plan["commands"]["wrapper_bounded_dry_run"]
+    assert any("shadow_247_futures_start_wrapper_skeleton_v0.py" in part for part in wrapper_argv)
+    assert wrapper_argv.count("--extended-bounded-shadow-validation") == 1
+    assert wrapper_argv.count("--extended-confirm-token") == 1
 
 
 def test_24h_profile_plan_only_default_duration_1440(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- **PE-SHADOW-EXT-01**: Der kanonische Adapter `run_shadow_bounded_observation_adapter_v0.py` delegiert bounded Dauer >10 Minuten (bis 60) automatisch an den vorhandenen Extended-Tier des Wrappers.
- Bisher war für 30-Minuten-Läufe ein manueller direkter Wrapper-Bypass nötig; nun reicht `--duration-minutes 30` über den Adapter.
- Standard-Tier (≤10 Minuten) bleibt semantisch unverändert; Extended-Gates und Confirm-Token werden fail-closed wiederverwendet.

## Constraints
- NO_RUN / NO_NETWORK / NO_LIVE — nur statische Plan-/Test-Validierung
- Keine Änderung an Wrapper-Semantik, Risk, Trading, CI-Selector oder geschützten Surfaces

## Test plan
- [x] Fokussierte Tests: `tests/ops/test_run_shadow_bounded_observation_adapter_v0.py` (59 passed)
- [x] Standard-Tier 10 Min: keine Extended-Flags
- [x] 30 Min: Extended-Tier aktiv, kanonische Wrapper-Delegation
- [x] >60 Min / ungültige Dauer: abgelehnt
- [x] ruff format/check auf geänderten Dateien

## CI
- Erwarteter Modus: **FOCUSED**
- FULL_CI_TRIGGER_FOUND=false (nur ops-Adapter + ops-Tests geändert)

Made with [Cursor](https://cursor.com)