### PR TITLE
feat(ops): add git provenance to final machine lines

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -88,6 +88,8 @@ VALIDATION_EXIT = 1
 TIMEOUT_EXIT = 124
 START_RETURN_CODE_ARTIFACT = "start_return_code.txt"
 FINAL_MACHINE_LINES_FILENAME = "FINAL_MACHINE_LINES.txt"
+REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY = "REPO_HEAD_SHA_PREFIX"
+REPO_HEAD_SHA_PREFIX_FAIL_CLOSED = "UNKNOWN_HEAD_MISSING"
 BOUNDED_ADAPTER_LANE_PAPER = "paper_only_bounded_observation_v0"
 DURABLE_CLOSEOUT_SCRIPT = _REPO_ROOT / "scripts" / "ops" / "durable_closeout_copy_verify_v0.py"
 
@@ -961,6 +963,15 @@ def _default_subprocess_runner(
     return int(proc.returncode or 0)
 
 
+def _machine_line_repo_head_sha_prefix(repo_head_sha_prefix: str | None) -> str:
+    if repo_head_sha_prefix is None:
+        return REPO_HEAD_SHA_PREFIX_FAIL_CLOSED
+    value = str(repo_head_sha_prefix).strip()
+    if not value:
+        return REPO_HEAD_SHA_PREFIX_FAIL_CLOSED
+    return value
+
+
 def build_bounded_adapter_final_machine_lines_v0(
     *,
     run_id: str,
@@ -968,6 +979,7 @@ def build_bounded_adapter_final_machine_lines_v0(
     execution_performed: bool,
     review_verdict: str | None = None,
     closeout_succeeded: bool = True,
+    repo_head_sha_prefix: str | None = None,
 ) -> dict[str, str]:
     """Deterministic non-authorizing FINAL_MACHINE_LINES payload for bounded adapters."""
     from scripts.ops.build_post_closeout_projection_payload_v0 import (
@@ -998,6 +1010,9 @@ def build_bounded_adapter_final_machine_lines_v0(
             "BROKER_EXCHANGE_CALLED": "false",
             "LIVE_AUTHORITY": "false",
             "TESTNET_AUTHORITY": "false",
+            REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY: _machine_line_repo_head_sha_prefix(
+                repo_head_sha_prefix
+            ),
         }
     )
     return lines
@@ -1011,6 +1026,7 @@ def _write_final_machine_lines_artifact(
     execution_performed: bool,
     review_verdict: str | None,
     closeout_succeeded: bool = True,
+    repo_head_sha_prefix: str | None = None,
 ) -> None:
     lines = build_bounded_adapter_final_machine_lines_v0(
         run_id=run_id,
@@ -1018,6 +1034,7 @@ def _write_final_machine_lines_artifact(
         execution_performed=execution_performed,
         review_verdict=review_verdict,
         closeout_succeeded=closeout_succeeded,
+        repo_head_sha_prefix=repo_head_sha_prefix,
     )
     staging_root.mkdir(parents=True, exist_ok=True)
     ordered = sorted(lines.items())

--- a/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_shadow_bounded_observation_adapter_v0.py
@@ -630,6 +630,7 @@ def _write_closeout_artifacts(
         execution_performed=True,
         review_verdict=str(review_payload.get("verdict") or "UNKNOWN"),
         closeout_succeeded=True,
+        repo_head_sha_prefix=repo_head_sha_prefix,
     )
 
 

--- a/tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py
+++ b/tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py
@@ -77,6 +77,17 @@ def _parse_machine_lines(path: Path) -> dict[str, str]:
     return parsed
 
 
+def _machine_line_keys_from_text(path: Path) -> list[str]:
+    keys: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, _ = line.partition("=")
+        keys.append(key.strip())
+    return keys
+
+
 def test_forbidden_post_closeout_chain_execute_script_absent() -> None:
     assert not FORBIDDEN_CHAIN_SCRIPT.exists()
 
@@ -101,6 +112,98 @@ def test_build_bounded_adapter_final_machine_lines_has_required_keys(
         assert key in lines
     for flag in SAFETY_FLAGS:
         assert lines[flag] == "false"
+
+
+@pytest.mark.parametrize(
+    "repo_head_sha_prefix,expected",
+    [
+        ("abcdef012345", "abcdef012345"),
+        ("UNKNOWN_REF_MISSING", "UNKNOWN_REF_MISSING"),
+        (None, "UNKNOWN_HEAD_MISSING"),
+        ("", "UNKNOWN_HEAD_MISSING"),
+        ("   ", "UNKNOWN_HEAD_MISSING"),
+    ],
+)
+def test_build_bounded_adapter_final_machine_lines_emits_repo_head_sha_prefix(
+    paper, repo_head_sha_prefix: str | None, expected: str
+) -> None:
+    lines = paper.build_bounded_adapter_final_machine_lines_v0(
+        run_id="fixture_run",
+        adapter_lane="shadow_bounded_observation_v0",
+        execution_performed=True,
+        review_verdict="PASS",
+        repo_head_sha_prefix=repo_head_sha_prefix,
+    )
+    assert paper.REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY in lines
+    assert lines[paper.REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY] == expected
+    assert lines[paper.REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY] != "18a79ede"
+
+
+def test_build_bounded_adapter_final_machine_lines_repo_head_key_is_deterministic(
+    paper,
+) -> None:
+    kwargs = {
+        "run_id": "fixture_run",
+        "adapter_lane": paper.BOUNDED_ADAPTER_LANE_PAPER,
+        "execution_performed": True,
+        "review_verdict": "PASS",
+        "repo_head_sha_prefix": "0123456789ab",
+    }
+    first = paper.build_bounded_adapter_final_machine_lines_v0(**kwargs)
+    second = paper.build_bounded_adapter_final_machine_lines_v0(**kwargs)
+    assert first == second
+    assert len(first) == len(set(first))
+
+
+def test_paper_write_closeout_artifacts_fail_closed_repo_head_sha_prefix(
+    paper, tmp_path: Path
+) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir(parents=True, exist_ok=True)
+    archive_dest = tmp_path / "archive" / "runs" / "paper" / "fixture_run"
+    ctx = paper.ExecuteContext(
+        args=type("Args", (), {})(),
+        repo_root=REPO_ROOT,
+        staging_root=staging,
+        archive_root=tmp_path / "archive",
+        runtime_out=staging / "runtime_out",
+        logs_dir=staging / "logs",
+        plan_dir=staging / "plan",
+        review_dir=staging / "review",
+        temp_jobs=staging / "jobs.toml",
+        run_id="fixture_run",
+    )
+    plan = paper.AdapterPlan(
+        adapter_version="test",
+        mode="execute",
+        staging_root=str(staging),
+        archive_root=str(tmp_path / "archive"),
+        duration_seconds=60,
+        poll_interval_seconds=30,
+        job_name="paper_shadow_247_paper_only_runtime_high_vol_no_trade_v0",
+        include_tags="paper_runtime",
+        run_id="fixture_run",
+        repo_root=str(REPO_ROOT),
+        source_jobs_toml=str(REPO_ROOT / "config/scheduler/jobs.toml"),
+        commands={},
+        retention_steps=[],
+        expected_artifacts=[],
+    )
+    paper._write_closeout_artifacts(
+        ctx,
+        plan,
+        archive_dest,
+        {"verdict": "PASS", "issues": []},
+    )
+    path = staging / paper.FINAL_MACHINE_LINES_FILENAME
+    assert path.is_file()
+    lines = _parse_machine_lines(path)
+    assert lines["ADAPTER_LANE"] == paper.BOUNDED_ADAPTER_LANE_PAPER
+    assert lines["REVIEW_VERDICT"] == "PASS"
+    assert lines[paper.REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY] == (
+        paper.REPO_HEAD_SHA_PREFIX_FAIL_CLOSED
+    )
+    assert len(_machine_line_keys_from_text(path)) == len(lines)
 
 
 def test_paper_write_closeout_artifacts_emits_final_machine_lines(paper, tmp_path: Path) -> None:
@@ -189,6 +292,8 @@ def test_shadow_write_closeout_artifacts_emits_final_machine_lines(shadow, tmp_p
     assert path.is_file()
     lines = _parse_machine_lines(path)
     assert lines["ADAPTER_LANE"] == shadow.BOUNDED_ADAPTER_LANE_SHADOW
+    metadata = json.loads((staging / "RUN_METADATA.json").read_text(encoding="utf-8"))
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
 
 
 def test_emitted_lines_accepted_by_projection_builder(builder, paper, tmp_path: Path) -> None:

--- a/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_shadow_bounded_observation_adapter_v0.py
@@ -1084,3 +1084,70 @@ def test_execute_run_metadata_includes_wrapper_repo_head_sha_prefix(tmp_path: Pa
     assert rc == 0
     metadata = json.loads((staging / "RUN_METADATA.json").read_text(encoding="utf-8"))
     assert metadata["repo_head_sha_prefix"] == expected_prefix
+
+
+def _parse_machine_lines(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def _write_closeout_machine_lines(
+    tmp_path: Path,
+    *,
+    repo_head_sha_prefix: str | None = None,
+) -> tuple[dict[str, str], dict[str, str]]:
+    metadata = _write_closeout_run_metadata(tmp_path, repo_head_sha_prefix=repo_head_sha_prefix)
+    staging = _staging(tmp_path)
+    lines = _parse_machine_lines(staging / "FINAL_MACHINE_LINES.txt")
+    return metadata, lines
+
+
+def test_final_machine_lines_repo_head_sha_prefix_matches_run_metadata(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(tmp_path, repo_head_sha_prefix="0123456789ab")
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
+
+
+def test_final_machine_lines_worktree_provenance_passthrough(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(tmp_path, repo_head_sha_prefix="111122223333")
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
+
+
+def test_final_machine_lines_detached_head_provenance_passthrough(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(tmp_path, repo_head_sha_prefix="deadbeefdead")
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
+
+
+def test_final_machine_lines_fail_closed_provenance_preserved(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(
+        tmp_path, repo_head_sha_prefix="UNKNOWN_REF_MISSING"
+    )
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
+
+
+def test_final_machine_lines_does_not_invent_plan_level_sha(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(
+        tmp_path, repo_head_sha_prefix="UNKNOWN_HEAD_MISSING"
+    )
+    assert lines["REPO_HEAD_SHA_PREFIX"] == "UNKNOWN_HEAD_MISSING"
+    assert lines["REPO_HEAD_SHA_PREFIX"] != "18a79ede"
+    assert "origin_main" not in json.dumps(lines).lower()
+
+
+def test_final_machine_lines_existing_keys_preserved(tmp_path: Path) -> None:
+    _, lines = _write_closeout_machine_lines(tmp_path)
+    for key in (
+        "ADAPTER_EXECUTED",
+        "ADAPTER_LANE",
+        "RUN_ID",
+        "REVIEW_VERDICT",
+        "BOUNDED_OBSERVATION_ONLY",
+        "CLOSEOUT_SUCCEEDED",
+    ):
+        assert key in lines
+    assert len(lines) == len(set(lines))


### PR DESCRIPTION
## Summary

- **Root cause:** `build_bounded_adapter_final_machine_lines_v0()` emitted safety/authority keys but no repository head identification, so bounded closeout bundles lacked git context at the machine-line tier despite PR #4483 adding `repo_head_sha_prefix` to `RUN_METADATA.json`.
- **Chain closed:** Wrapper `_read_git_sha_prefix()` → Shadow `RUN_METADATA.json["repo_head_sha_prefix"]` → shared builder → `FINAL_MACHINE_LINES.txt["REPO_HEAD_SHA_PREFIX"]`.
- **Canonical machine-line key:** `REPO_HEAD_SHA_PREFIX` (aligns with RUN_METADATA field `repo_head_sha_prefix`; distinct from legacy Real10m `MAIN_HEAD` which is a separate historical artifact key).
- **Changed files (4 only):**
  - `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py`
  - `scripts/ops/run_shadow_bounded_observation_adapter_v0.py`
  - `tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py`
  - `tests/ops/test_run_shadow_bounded_observation_adapter_v0.py`
- **Shared builder reuse:** Paper adapter owns `build_bounded_adapter_final_machine_lines_v0()`; shadow imports `_write_final_machine_lines_artifact` and passes runtime metadata provenance through.
- **Fail-closed:** Missing/empty provenance emits `UNKNOWN_HEAD_MISSING`; wrapper UNKNOWN sentinels pass through unchanged; no invented SHA or origin/main fallback.
- **No duplicated git resolution** in the machine-lines builder.

## Test plan

- [x] `ruff format --check` on 4 changed files
- [x] `ruff check` on 4 changed files
- [x] `tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py` — 13/13 passed
- [x] `tests/ops/test_run_shadow_bounded_observation_adapter_v0.py` — 86/87 passed (`test_adapter_help_works` pre-existing env failure on main: `ModuleNotFoundError: trading`)
- [x] `tests/ops/test_closeout_final_machine_lines_contract_v0.py` — 14/14 passed (Real10m contract)
- [x] FOCUSED provenance subset — 25/25 passed

**CI_MODE:** FOCUSED  
**FULL_CI_TRIGGER_FOUND:** false  
**Runtime/network/trading:** none  
**Durable Implementation Bundle:** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/pe_shadow_closeout_ml_v1_final_machine_lines_git_provenance_<UTC>`


Made with [Cursor](https://cursor.com)