### PR TITLE
feat(paper): persist git provenance in run metadata

### DIFF
--- a/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
+++ b/scripts/ops/run_paper_only_bounded_observation_adapter_v0.py
@@ -29,6 +29,9 @@ if str(_REPO_ROOT) not in sys.path:
 from scripts.ops import bounded_daemon_paper_shadow_24h_approval_v0 as contract_24h
 from scripts.ops import gap4_req_a_paper_hold_binding_approval_v0 as contract_gap4
 from scripts.ops import paper_l2_120min_hold_binding_approval_v0 as contract_l2_120min
+from scripts.ops.shadow_247_futures_start_wrapper_skeleton_v0 import (
+    _read_git_sha_prefix,
+)
 from scripts.ops.durable_closeout_copy_verify_v0 import (
     _dest_has_content,
     _validate_source_dest_distinct,
@@ -1051,6 +1054,7 @@ def _write_closeout_artifacts(
     review_payload: Mapping[str, Any],
 ) -> None:
     now = datetime.now(timezone.utc).isoformat()
+    repo_head_sha_prefix = _read_git_sha_prefix(Path(plan.repo_root))
     run_metadata = {
         "run_id": ctx.run_id,
         "adapter_version": plan.adapter_version,
@@ -1059,6 +1063,7 @@ def _write_closeout_artifacts(
         "duration_seconds": plan.duration_seconds,
         "poll_interval_seconds": plan.poll_interval_seconds,
         "review_verdict": review_payload.get("verdict"),
+        "repo_head_sha_prefix": repo_head_sha_prefix,
         "live_authority": False,
         "testnet_authority": False,
         "broker_authority": False,
@@ -1110,6 +1115,7 @@ def _write_closeout_artifacts(
         execution_performed=True,
         review_verdict=str(review_payload.get("verdict") or "UNKNOWN"),
         closeout_succeeded=True,
+        repo_head_sha_prefix=repo_head_sha_prefix,
     )
 
 

--- a/tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py
+++ b/tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py
@@ -158,6 +158,8 @@ def test_build_bounded_adapter_final_machine_lines_repo_head_key_is_deterministi
 def test_paper_write_closeout_artifacts_fail_closed_repo_head_sha_prefix(
     paper, tmp_path: Path
 ) -> None:
+    from unittest.mock import patch
+
     staging = tmp_path / "staging"
     staging.mkdir(parents=True, exist_ok=True)
     archive_dest = tmp_path / "archive" / "runs" / "paper" / "fixture_run"
@@ -189,12 +191,13 @@ def test_paper_write_closeout_artifacts_fail_closed_repo_head_sha_prefix(
         retention_steps=[],
         expected_artifacts=[],
     )
-    paper._write_closeout_artifacts(
-        ctx,
-        plan,
-        archive_dest,
-        {"verdict": "PASS", "issues": []},
-    )
+    with patch.object(paper, "_read_git_sha_prefix", return_value="UNKNOWN_HEAD_MISSING"):
+        paper._write_closeout_artifacts(
+            ctx,
+            plan,
+            archive_dest,
+            {"verdict": "PASS", "issues": []},
+        )
     path = staging / paper.FINAL_MACHINE_LINES_FILENAME
     assert path.is_file()
     lines = _parse_machine_lines(path)
@@ -203,6 +206,8 @@ def test_paper_write_closeout_artifacts_fail_closed_repo_head_sha_prefix(
     assert lines[paper.REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY] == (
         paper.REPO_HEAD_SHA_PREFIX_FAIL_CLOSED
     )
+    metadata = json.loads((staging / "RUN_METADATA.json").read_text(encoding="utf-8"))
+    assert metadata["repo_head_sha_prefix"] == paper.REPO_HEAD_SHA_PREFIX_FAIL_CLOSED
     assert len(_machine_line_keys_from_text(path)) == len(lines)
 
 

--- a/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
+++ b/tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py
@@ -12,6 +12,7 @@ import sys
 from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Mapping, Sequence
+from unittest.mock import patch
 
 import pytest
 
@@ -1063,3 +1064,226 @@ def test_l2_120min_execute_sets_hold_runtime_env_bridge_mocked(tmp_path: Path) -
         hold_outroot.resolve()
     )
     assert scheduler_extra_env.get(SCHEDULER_HOLD_RUNTIME_RUN_ID_ENV) == RUN_ID_L2
+
+
+def _parse_machine_lines(path: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def _write_closeout_run_metadata(
+    tmp_path: Path,
+    *,
+    repo_root: Path = ROOT,
+    repo_head_sha_prefix: str | None = None,
+) -> dict:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    staging.mkdir(parents=True, exist_ok=True)
+    archive_dest = _durable_archive(tmp_path) / "runs" / "paper" / "meta_test_run"
+    plan = mod.build_plan(
+        mode="execute",
+        staging_root=staging,
+        archive_root=_durable_archive(tmp_path),
+        repo_root=repo_root,
+        source_jobs_toml=ROOT / "config/scheduler/jobs.toml",
+        duration_seconds=7200,
+        poll_interval_seconds=30,
+        run_id="meta_test_run",
+    )
+    ctx = mod.ExecuteContext(
+        args=type("Args", (), {})(),
+        repo_root=repo_root,
+        staging_root=staging,
+        archive_root=_durable_archive(tmp_path),
+        runtime_out=staging / "runtime_out",
+        logs_dir=staging / "logs",
+        plan_dir=staging / "plan",
+        review_dir=staging / "review",
+        temp_jobs=staging / "plan" / "temp_jobs.toml",
+        run_id="meta_test_run",
+    )
+    review_payload = {"verdict": "PASS", "issues": []}
+    prefix = repo_head_sha_prefix if repo_head_sha_prefix is not None else "0123456789ab"
+    with patch.object(mod, "_read_git_sha_prefix", return_value=prefix) as resolver:
+        mod._write_closeout_artifacts(ctx, plan, archive_dest, review_payload)
+        resolver.assert_called_once_with(repo_root)
+    metadata_path = staging / "RUN_METADATA.json"
+    assert metadata_path.is_file()
+    return json.loads(metadata_path.read_text(encoding="utf-8"))
+
+
+def test_run_metadata_includes_repo_head_sha_prefix(tmp_path: Path) -> None:
+    metadata = _write_closeout_run_metadata(tmp_path)
+    assert "repo_head_sha_prefix" in metadata
+    assert metadata["repo_head_sha_prefix"] == "0123456789ab"
+
+
+def test_run_metadata_repo_head_sha_prefix_matches_wrapper_resolver(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    staging.mkdir(parents=True, exist_ok=True)
+    archive_dest = _durable_archive(tmp_path) / "runs" / "paper" / "meta_test_run"
+    plan = mod.build_plan(
+        mode="execute",
+        staging_root=staging,
+        archive_root=_durable_archive(tmp_path),
+        repo_root=ROOT,
+        source_jobs_toml=ROOT / "config/scheduler/jobs.toml",
+        duration_seconds=7200,
+        poll_interval_seconds=30,
+        run_id="meta_test_run",
+    )
+    ctx = mod.ExecuteContext(
+        args=type("Args", (), {})(),
+        repo_root=ROOT,
+        staging_root=staging,
+        archive_root=_durable_archive(tmp_path),
+        runtime_out=staging / "runtime_out",
+        logs_dir=staging / "logs",
+        plan_dir=staging / "plan",
+        review_dir=staging / "review",
+        temp_jobs=staging / "plan" / "temp_jobs.toml",
+        run_id="meta_test_run",
+    )
+    expected_prefix = "abcdef012345"
+    with patch.object(mod, "_read_git_sha_prefix", return_value=expected_prefix) as resolver:
+        mod._write_closeout_artifacts(ctx, plan, archive_dest, {"verdict": "PASS", "issues": []})
+        resolver.assert_called_once_with(ROOT)
+    metadata = json.loads((staging / "RUN_METADATA.json").read_text(encoding="utf-8"))
+    assert metadata["repo_head_sha_prefix"] == expected_prefix
+
+
+def test_run_metadata_uses_wrapper_resolver_not_adapter_git_logic(tmp_path: Path) -> None:
+    mod = _load_mod()
+    adapter_source = SCRIPT.read_text(encoding="utf-8")
+    assert "_resolve_git_metadata_dirs" not in adapter_source
+    assert "packed-refs" not in adapter_source
+    metadata = _write_closeout_run_metadata(tmp_path, repo_head_sha_prefix="wrapper_only_prefix")
+    assert metadata["repo_head_sha_prefix"] == "wrapper_only_prefix"
+
+
+def test_run_metadata_worktree_provenance_passthrough(tmp_path: Path) -> None:
+    metadata = _write_closeout_run_metadata(tmp_path, repo_head_sha_prefix="111122223333")
+    assert metadata["repo_head_sha_prefix"] == "111122223333"
+
+
+def test_run_metadata_detached_head_provenance_passthrough(tmp_path: Path) -> None:
+    metadata = _write_closeout_run_metadata(tmp_path, repo_head_sha_prefix="deadbeefdead")
+    assert metadata["repo_head_sha_prefix"] == "deadbeefdead"
+
+
+def test_run_metadata_fail_closed_provenance_preserved(tmp_path: Path) -> None:
+    metadata = _write_closeout_run_metadata(tmp_path, repo_head_sha_prefix="UNKNOWN_REF_MISSING")
+    assert metadata["repo_head_sha_prefix"] == "UNKNOWN_REF_MISSING"
+
+
+def test_run_metadata_does_not_invent_plan_level_sha(tmp_path: Path) -> None:
+    mod = _load_mod()
+    staging = _staging(tmp_path)
+    staging.mkdir(parents=True, exist_ok=True)
+    archive_dest = _durable_archive(tmp_path) / "runs" / "paper" / "meta_test_run"
+    plan = mod.build_plan(
+        mode="execute",
+        staging_root=staging,
+        archive_root=_durable_archive(tmp_path),
+        repo_root=ROOT,
+        source_jobs_toml=ROOT / "config/scheduler/jobs.toml",
+        duration_seconds=7200,
+        poll_interval_seconds=30,
+        run_id="meta_test_run",
+    )
+    ctx = mod.ExecuteContext(
+        args=type("Args", (), {})(),
+        repo_root=ROOT,
+        staging_root=staging,
+        archive_root=_durable_archive(tmp_path),
+        runtime_out=staging / "runtime_out",
+        logs_dir=staging / "logs",
+        plan_dir=staging / "plan",
+        review_dir=staging / "review",
+        temp_jobs=staging / "plan" / "temp_jobs.toml",
+        run_id="meta_test_run",
+    )
+    with patch.object(mod, "_read_git_sha_prefix", return_value="UNKNOWN_HEAD_MISSING"):
+        mod._write_closeout_artifacts(ctx, plan, archive_dest, {"verdict": "PASS", "issues": []})
+    metadata = json.loads((staging / "RUN_METADATA.json").read_text(encoding="utf-8"))
+    assert metadata["repo_head_sha_prefix"] == "UNKNOWN_HEAD_MISSING"
+    assert "origin_main" not in json.dumps(metadata).lower()
+
+
+def test_run_metadata_existing_fields_preserved(tmp_path: Path) -> None:
+    metadata = _write_closeout_run_metadata(tmp_path)
+    assert metadata["run_id"] == "meta_test_run"
+    assert metadata["adapter_version"]
+    assert metadata["staging_root"]
+    assert metadata["archive_path"]
+    assert metadata["duration_seconds"] == 7200
+    assert metadata["poll_interval_seconds"] == 30
+    assert metadata["review_verdict"] == "PASS"
+    assert metadata["live_authority"] is False
+    assert metadata["testnet_authority"] is False
+    assert metadata["broker_authority"] is False
+    assert metadata["utc"]
+
+
+def _write_closeout_machine_lines(
+    tmp_path: Path,
+    *,
+    repo_head_sha_prefix: str | None = None,
+) -> tuple[dict[str, str], dict[str, str]]:
+    metadata = _write_closeout_run_metadata(tmp_path, repo_head_sha_prefix=repo_head_sha_prefix)
+    staging = _staging(tmp_path)
+    lines = _parse_machine_lines(staging / "FINAL_MACHINE_LINES.txt")
+    return metadata, lines
+
+
+def test_final_machine_lines_repo_head_sha_prefix_matches_run_metadata(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(tmp_path, repo_head_sha_prefix="0123456789ab")
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
+
+
+def test_final_machine_lines_worktree_provenance_passthrough(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(tmp_path, repo_head_sha_prefix="111122223333")
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
+
+
+def test_final_machine_lines_detached_head_provenance_passthrough(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(tmp_path, repo_head_sha_prefix="deadbeefdead")
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
+
+
+def test_final_machine_lines_fail_closed_provenance_preserved(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(
+        tmp_path, repo_head_sha_prefix="UNKNOWN_REF_MISSING"
+    )
+    assert lines["REPO_HEAD_SHA_PREFIX"] == metadata["repo_head_sha_prefix"]
+
+
+def test_final_machine_lines_does_not_invent_plan_level_sha(tmp_path: Path) -> None:
+    metadata, lines = _write_closeout_machine_lines(
+        tmp_path, repo_head_sha_prefix="UNKNOWN_HEAD_MISSING"
+    )
+    assert lines["REPO_HEAD_SHA_PREFIX"] == "UNKNOWN_HEAD_MISSING"
+    assert lines["REPO_HEAD_SHA_PREFIX"] != "18a79ede"
+    assert "origin_main" not in json.dumps(lines).lower()
+
+
+def test_final_machine_lines_existing_keys_preserved(tmp_path: Path) -> None:
+    _, lines = _write_closeout_machine_lines(tmp_path)
+    for key in (
+        "ADAPTER_EXECUTED",
+        "ADAPTER_LANE",
+        "RUN_ID",
+        "REVIEW_VERDICT",
+        "BOUNDED_OBSERVATION_ONLY",
+        "CLOSEOUT_SUCCEEDED",
+    ):
+        assert key in lines
+    assert len(lines) == len(set(lines))


### PR DESCRIPTION
## Summary

- Closes paper/shadow bounded observation **producer-tier** git provenance asymmetry: paper `_write_closeout_artifacts()` now records `repo_head_sha_prefix` in `RUN_METADATA.json` and passes the same value to `FINAL_MACHINE_LINES.txt` as `REPO_HEAD_SHA_PREFIX`.
- Reuses the canonical wrapper helper `_read_git_sha_prefix` from `shadow_247_futures_start_wrapper_skeleton_v0.py` (same pattern as shadow adapter PR #4483); **no new resolver**, no `git rev-parse`, no plan-level/origin/main fallback, no adapter-local `.git`/HEAD/refs reads.
- Fail-closed sentinel semantics preserved (`UNKNOWN_HEAD_MISSING`, `UNKNOWN_REF_MISSING`, etc. pass through unchanged).

## Changed files (exact)

1. `scripts/ops/run_paper_only_bounded_observation_adapter_v0.py`
2. `tests/ops/test_run_paper_only_bounded_observation_adapter_v0.py`
3. `tests/ops/test_bounded_adapter_final_machine_lines_emit_v0.py` (crosslink regression for fail-closed closeout path)

## Test plan

- [x] `ruff format --check` on all 3 changed files — pass
- [x] `ruff check` on all 3 changed files — pass
- [x] Full canonical paper adapter test owner (`test_run_paper_only_bounded_observation_adapter_v0.py`) — **74 passed, 1 skipped**
- [x] Shared final machine lines test owner (`test_bounded_adapter_final_machine_lines_emit_v0.py`) — **13 passed**
- [x] Shadow provenance parity regression subset — **29 passed** (repo_head_sha / REPO_HEAD_SHA focused selection)

**CI_MODE=FOCUSED** | **FULL_CI_TRIGGER_FOUND=false**

## Safety

- No runtime, network, trading, credentials, or paper test data mutation.
- Shadow adapter, review consumer, wallclock evaluator, Master V2, execution/risk surfaces untouched.
- Durable Implementation Bundle: `implementation/pe_paper_adapter_meta_v1_run_metadata_git_provenance_parity_<UTC_TIMESTAMP>`


Made with [Cursor](https://cursor.com)