### PR TITLE
fix(ci): cap all workflow hard timeouts at 25 minutes

### DIFF
--- a/.github/workflows/ci-export-pack-download-verify.yml
+++ b/.github/workflows/ci-export-pack-download-verify.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   export-pack-verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 25
     permissions:
       contents: read
     # Skip on PR when not enabled (vars); always run on workflow_dispatch (secrets not allowed in job.if)

--- a/.github/workflows/ci-scheduled-paper-and-export-smoke.yml
+++ b/.github/workflows/ci-scheduled-paper-and-export-smoke.yml
@@ -15,7 +15,7 @@ jobs:
   paper_tests_audit_evidence:
     if: vars.PT_SCHEDULED_PAPER_TESTS_ENABLED == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -39,7 +39,7 @@ jobs:
   export_pack_verify:
     if: vars.PT_SCHEDULED_EXPORT_VERIFY_ENABLED == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,7 @@ jobs:
   tests:
     name: tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 25
     needs: changes
     # IMPORTANT: No job-level if condition - matrix jobs must always be created
     # to satisfy branch protection rules (e.g., "tests (3.11)" check)

--- a/.github/workflows/full_audit_weekly.yml
+++ b/.github/workflows/full_audit_weekly.yml
@@ -8,7 +8,7 @@ jobs:
   full-audit:
     name: Full Audit (Security + Quality)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
 
     steps:
       - name: 📥 Checkout code

--- a/.github/workflows/offline_suites.yml
+++ b/.github/workflows/offline_suites.yml
@@ -29,7 +29,7 @@ jobs:
       (github.event.schedule == '0 2 * * *') ||
       (github.event_name == 'workflow_dispatch' && (github.event.inputs.suite_type == 'daily' || github.event.inputs.suite_type == 'both'))
 
-    timeout-minutes: 30
+    timeout-minutes: 25
 
     steps:
       - name: 📥 Checkout Repository
@@ -92,7 +92,7 @@ jobs:
       (github.event.schedule == '0 3 * * 1') ||
       (github.event_name == 'workflow_dispatch' && (github.event.inputs.suite_type == 'weekly' || github.event.inputs.suite_type == 'both'))
 
-    timeout-minutes: 90
+    timeout-minutes: 25
 
     steps:
       - name: 📥 Checkout Repository

--- a/.github/workflows/paper_session_audit_evidence.yml
+++ b/.github/workflows/paper_session_audit_evidence.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   paper_session:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 25
 
     env:
       # Hard safety: no live/testnet

--- a/.github/workflows/paper_tests_audit_evidence.yml
+++ b/.github/workflows/paper_tests_audit_evidence.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   paper_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
 
     env:
       # Hard safety: never live/testnet from this workflow

--- a/.github/workflows/prbj-testnet-exec-events.yml
+++ b/.github/workflows/prbj-testnet-exec-events.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   run-testnet:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 25
     if: ${{ github.event_name != 'schedule' || vars.KRAKEN_TESTNET_CRON_ENABLED == 'true' }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test-health-automation.yml
+++ b/.github/workflows/test-health-automation.yml
@@ -75,7 +75,7 @@ jobs:
     name: "Health Check: ${{ github.event.inputs.profile || 'scheduled' }}"
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.profile != 'ALL_PROFILES'
-    timeout-minutes: 30
+    timeout-minutes: 25
 
     steps:
       - name: 📥 Checkout repository
@@ -197,7 +197,7 @@ jobs:
     name: "Health Check: ALL_PROFILES (Manual)"
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.profile == 'ALL_PROFILES'
-    timeout-minutes: 60
+    timeout-minutes: 25
 
     strategy:
       fail-fast: false
@@ -259,7 +259,7 @@ jobs:
     name: "Nightly Health Suite"
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
-    timeout-minutes: 45
+    timeout-minutes: 25
 
     steps:
       - name: 📥 Checkout repository
@@ -418,7 +418,7 @@ jobs:
     name: "R&D Experimental Check"
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
-    timeout-minutes: 30
+    timeout-minutes: 25
 
     steps:
       - name: 📥 Checkout repository

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -35,6 +35,8 @@ FOCUSED_CATEGORIES = frozenset(
         "risk_killswitch_focused",
         "tiny_order_focused",
         "reconciliation_primary_evidence_focused",
+        "wallclock_focused",
+        "ci_infra_focused",
     }
 )
 
@@ -218,6 +220,76 @@ REQUIRED_RECONCILIATION_PRIMARY_EVIDENCE_TEST_OWNERS: tuple[str, ...] = (
     "tests/ops/test_bounded_futures_testnet_position_order_reconciliation_primary_evidence_integration_contract_v0.py",
 )
 
+WALLCLOCK_OWNER = "src/ops/wallclock_session_evidence_v0.py"
+
+WALLCLOCK_CI_POLICY_PATHS = frozenset(
+    {
+        "scripts/ops/ci_test_selection_v1.py",
+        "config/ci/file_category_mapping.yaml",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    }
+)
+
+WALLCLOCK_SCRIPT_PATHS = frozenset(
+    {
+        "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py",
+        "scripts/ops/run_shadow_bounded_observation_adapter_v0.py",
+    }
+)
+
+CANONICAL_WALLCLOCK_FOCUSED_TESTS: tuple[str, ...] = (
+    "tests/ops/test_run_shadow_bounded_observation_adapter_v0.py",
+    "tests/ops/test_shadow_wallclock_duration_evidence_contract_v0.py",
+    "tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
+REQUIRED_WALLCLOCK_TEST_OWNERS: tuple[str, ...] = (
+    "tests/ops/test_run_shadow_bounded_observation_adapter_v0.py",
+    "tests/ops/test_shadow_wallclock_duration_evidence_contract_v0.py",
+    "tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py",
+)
+
+CI_INFRA_WORKFLOW_ALLOWLIST = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        ".github/workflows/ci-export-pack-download-verify.yml",
+        ".github/workflows/ci-scheduled-paper-and-export-smoke.yml",
+        ".github/workflows/full_audit_weekly.yml",
+        ".github/workflows/offline_suites.yml",
+        ".github/workflows/paper_session_audit_evidence.yml",
+        ".github/workflows/paper_tests_audit_evidence.yml",
+        ".github/workflows/prbj-testnet-exec-events.yml",
+        ".github/workflows/test-health-automation.yml",
+    }
+)
+
+CI_INFRA_CONTRACT_TEST_ALLOWLIST = frozenset(
+    {
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+        "tests/ci/test_workflows_no_pull_request_target_contract_v0.py",
+        "tests/ci/test_ci_scheduled_paper_export_smoke_workflow_contract_v0.py",
+        "tests/ci/test_class_a_shadow_paper_scheduled_probe_workflow_contract_v0.py",
+        "tests/ci/test_paper_session_audit_evidence_workflow_contract_v0.py",
+        "tests/ci/test_paper_tests_audit_evidence_workflow_contract_v0.py",
+        "tests/ci/test_prj_scheduled_shadow_paper_features_smoke_workflow_contract_v0.py",
+        "tests/ci/test_shadow_paper_smoke_workflow_contract_v0.py",
+    }
+)
+
+CI_INFRA_MINIMUM_CONTRACT_ANCHORS = frozenset(
+    {
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+        "tests/ci/test_workflows_no_pull_request_target_contract_v0.py",
+    }
+)
+
+CI_INFRA_CORE_FOCUSED_TESTS: tuple[str, ...] = (
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    "tests/ci/test_workflows_no_pull_request_target_contract_v0.py",
+    "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py",
+)
+
 CANONICAL_MARKET_DASHBOARD_FOCUSED_TESTS: tuple[str, ...] = (
     "tests/webui/test_market_dashboard_no_bitcoin_futures_v1.py",
     "tests/webui/test_market_futures_only_canonical_completion_v1.py",
@@ -304,6 +376,10 @@ def _requires_full_ci_selector_change(files: list[str]) -> bool:
         return False
     scoped_rpe = {f for f in normalized if _is_reconciliation_primary_evidence_scoped_path(f)}
     if scoped_rpe and all(_is_reconciliation_primary_evidence_rebundle_path(f) for f in normalized):
+        return False
+    if any(_is_ci_infra_scoped_path(f) for f in normalized) and all(
+        _is_ci_infra_rebundle_path(f) for f in normalized
+    ):
         return False
     if normalized <= CI_BOOTSTRAP_FOCUSED_PATHS:
         return False
@@ -519,6 +595,141 @@ def _tiny_order_focused_targets() -> tuple[str, ...]:
     return tuple(sorted(targets))
 
 
+def _is_wallclock_scoped_path(path: str) -> bool:
+    if path == WALLCLOCK_OWNER:
+        return True
+    if path in WALLCLOCK_SCRIPT_PATHS:
+        return True
+    if path in REQUIRED_WALLCLOCK_TEST_OWNERS:
+        return True
+    return False
+
+
+def _is_wallclock_rebundle_path(path: str) -> bool:
+    return _is_wallclock_scoped_path(path) or path in WALLCLOCK_CI_POLICY_PATHS
+
+
+def _wallclock_focused_targets() -> tuple[str, ...]:
+    for path in REQUIRED_WALLCLOCK_TEST_OWNERS:
+        if not _repo_path_exists(path):
+            return ()
+    targets: list[str] = []
+    for path in CANONICAL_WALLCLOCK_FOCUSED_TESTS:
+        if _repo_path_exists(path):
+            targets.append(path)
+    if len(targets) < len(REQUIRED_WALLCLOCK_TEST_OWNERS):
+        return ()
+    return tuple(sorted(targets))
+
+
+def _try_wallclock_focused(files: list[str]) -> SelectionResult | None:
+    if not files:
+        return None
+    if not any(_is_wallclock_scoped_path(f) for f in files):
+        return None
+    if not all(_is_wallclock_rebundle_path(f) for f in files):
+        return None
+    files_set = set(files)
+    if WALLCLOCK_OWNER in files_set and not set(REQUIRED_WALLCLOCK_TEST_OWNERS).issubset(files_set):
+        return None
+    targets = _wallclock_focused_targets()
+    if not targets:
+        return None
+    modules: tuple[str, ...] = ("src.ops.wallclock_session_evidence_v0",)
+    return SelectionResult(
+        "FOCUSED",
+        "wallclock_focused",
+        targets,
+        modules,
+    )
+
+
+def _is_ci_infra_workflow_path(path: str) -> bool:
+    return path in CI_INFRA_WORKFLOW_ALLOWLIST
+
+
+def _is_ci_infra_contract_test_path(path: str) -> bool:
+    return path in CI_INFRA_CONTRACT_TEST_ALLOWLIST
+
+
+def _is_ci_infra_scoped_path(path: str) -> bool:
+    return (
+        path in CI_BOOTSTRAP_FOCUSED_PATHS
+        or _is_ci_infra_workflow_path(path)
+        or _is_ci_infra_contract_test_path(path)
+    )
+
+
+def _is_ci_infra_rebundle_path(path: str) -> bool:
+    if path in CI_MAPPING_FULL_PATHS:
+        return False
+    return (
+        path in CI_BOOTSTRAP_FOCUSED_PATHS
+        or _is_ci_infra_workflow_path(path)
+        or _is_ci_infra_contract_test_path(path)
+        or path == "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py"
+    )
+
+
+def _ci_infra_focused_targets(files: list[str]) -> tuple[str, ...]:
+    targets: list[str] = []
+    seen: set[str] = set()
+
+    def add(path: str) -> None:
+        if path not in seen and _repo_path_exists(path):
+            seen.add(path)
+            targets.append(path)
+
+    for path in CI_INFRA_CORE_FOCUSED_TESTS:
+        add(path)
+    for path in files:
+        if _is_ci_infra_contract_test_path(path):
+            add(path)
+    if len([path for path in CI_INFRA_CORE_FOCUSED_TESTS if _repo_path_exists(path)]) < len(
+        CI_INFRA_CORE_FOCUSED_TESTS
+    ):
+        return ()
+    return tuple(sorted(targets))
+
+
+def _try_ci_infra_focused(files: list[str]) -> SelectionResult | None:
+    if not files:
+        return None
+    if not any(_is_ci_infra_scoped_path(f) for f in files):
+        return None
+    if not all(_is_ci_infra_rebundle_path(f) for f in files):
+        return None
+    for path in files:
+        if path.startswith(".github/workflows/") and not _is_ci_infra_workflow_path(path):
+            return None
+    has_workflow = any(_is_ci_infra_workflow_path(f) for f in files)
+    has_selector = any(f in CI_BOOTSTRAP_FOCUSED_PATHS for f in files)
+    has_contract = any(_is_ci_infra_contract_test_path(f) for f in files)
+    if has_workflow and not (has_selector or has_contract):
+        return None
+    if (has_workflow or has_selector) and not CI_INFRA_MINIMUM_CONTRACT_ANCHORS.issubset(
+        set(files)
+    ):
+        return None
+    targets = _ci_infra_focused_targets(files)
+    if not targets:
+        return None
+    return SelectionResult(
+        "FOCUSED",
+        "ci_infra_focused",
+        targets,
+    )
+
+
+def _has_ci_infra_substantive_intent(files: list[str]) -> bool:
+    has_workflow = any(_is_ci_infra_workflow_path(f) for f in files)
+    has_selector = any(f in CI_BOOTSTRAP_FOCUSED_PATHS for f in files)
+    has_contract = any(_is_ci_infra_contract_test_path(f) for f in files)
+    if has_workflow and not (has_selector or has_contract):
+        return False
+    return any(_is_ci_infra_scoped_path(f) for f in files)
+
+
 def _try_reconciliation_primary_evidence_focused(files: list[str]) -> SelectionResult | None:
     if not files:
         return None
@@ -721,6 +932,10 @@ def categorize(path: str) -> str:
         return "market_dashboard_focused"
     if _is_market_dashboard_scoped_path(p):
         return "market_dashboard_focused"
+    if p in WALLCLOCK_CI_POLICY_PATHS or _is_wallclock_scoped_path(p):
+        return "wallclock_focused"
+    if _is_ci_infra_contract_test_path(p):
+        return "ci_infra_focused"
     if p in CI_BOOTSTRAP_FOCUSED_PATHS:
         return "ci_bootstrap_focused"
     if p in CI_MAPPING_FULL_PATHS:
@@ -970,6 +1185,18 @@ def resolve_selection(
     if reconciliation_primary_evidence is not None:
         return reconciliation_primary_evidence
 
+    wallclock = _try_wallclock_focused(normalized)
+    if wallclock is not None:
+        return wallclock
+
+    ci_bootstrap = _try_ci_bootstrap_focused(normalized)
+    if ci_bootstrap is not None:
+        return ci_bootstrap
+
+    ci_infra = _try_ci_infra_focused(normalized)
+    if ci_infra is not None:
+        return ci_infra
+
     if any(_is_durable_completion_scoped_path(f) for f in normalized):
         if not all(_is_durable_completion_rebundle_path(f) for f in normalized):
             return SelectionResult("FULL", "durable_completion_foreign_path_requires_full", ())
@@ -999,12 +1226,20 @@ def resolve_selection(
             "FULL", "reconciliation_primary_evidence_incomplete_or_missing_test_owner", ()
         )
 
-    ci_bootstrap = _try_ci_bootstrap_focused(normalized)
-    if ci_bootstrap is not None:
-        return ci_bootstrap
+    if any(_is_wallclock_scoped_path(f) for f in normalized):
+        if not all(_is_wallclock_rebundle_path(f) for f in normalized):
+            return SelectionResult("FULL", "wallclock_foreign_path_requires_full", ())
+        return SelectionResult("FULL", "wallclock_incomplete_or_missing_test_owner", ())
 
     if any(_is_ci_bootstrap_scoped_path(f) for f in normalized):
         return SelectionResult("FULL", "ci_bootstrap_mixed_diff_requires_full", ())
+
+    if any(_is_ci_infra_scoped_path(f) for f in normalized) and _has_ci_infra_substantive_intent(
+        normalized
+    ):
+        if not all(_is_ci_infra_rebundle_path(f) for f in normalized):
+            return SelectionResult("FULL", "ci_infra_foreign_path_requires_full", ())
+        return SelectionResult("FULL", "ci_infra_incomplete_or_ambiguous", ())
 
     if _requires_full_ci_selector_change(normalized):
         return SelectionResult("FULL", "ci_mapping_or_workflow_selector_change_requires_full", ())

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -1290,3 +1290,107 @@ def test_selector_pe21_rebundle_with_ci_policy_focused() -> None:
 def test_mapping_file_includes_reconciliation_primary_evidence_focused() -> None:
     text = MAPPING.read_text(encoding="utf-8")
     assert "reconciliation_primary_evidence_focused:" in text
+
+
+PR4489_WALLCLOCK_FILES: tuple[str, ...] = (
+    "src/ops/wallclock_session_evidence_v0.py",
+    "scripts/ops/shadow_247_futures_start_wrapper_skeleton_v0.py",
+    "scripts/ops/run_shadow_bounded_observation_adapter_v0.py",
+    "tests/ops/test_run_shadow_bounded_observation_adapter_v0.py",
+    "tests/ops/test_shadow_wallclock_duration_evidence_contract_v0.py",
+    "tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py",
+)
+
+PR4491_CI_BOOTSTRAP_FILES: tuple[str, ...] = (
+    ".github/workflows/ci-export-pack-download-verify.yml",
+    ".github/workflows/ci-scheduled-paper-and-export-smoke.yml",
+    ".github/workflows/ci.yml",
+    ".github/workflows/full_audit_weekly.yml",
+    ".github/workflows/offline_suites.yml",
+    ".github/workflows/paper_session_audit_evidence.yml",
+    ".github/workflows/paper_tests_audit_evidence.yml",
+    ".github/workflows/prbj-testnet-exec-events.yml",
+    ".github/workflows/test-health-automation.yml",
+    "scripts/ops/ci_test_selection_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    "tests/ci/test_ci_scheduled_paper_export_smoke_workflow_contract_v0.py",
+    "tests/ci/test_class_a_shadow_paper_scheduled_probe_workflow_contract_v0.py",
+    "tests/ci/test_paper_session_audit_evidence_workflow_contract_v0.py",
+    "tests/ci/test_paper_tests_audit_evidence_workflow_contract_v0.py",
+    "tests/ci/test_prj_scheduled_shadow_paper_features_smoke_workflow_contract_v0.py",
+    "tests/ci/test_shadow_paper_smoke_workflow_contract_v0.py",
+    "tests/ci/test_workflows_no_pull_request_target_contract_v0.py",
+)
+
+
+def test_selector_case_pr4489_wallclock_diff_focused() -> None:
+    sel = _run_selector(*PR4489_WALLCLOCK_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "wallclock_focused"
+    assert sel["tests_execute_full"] == "false"
+    assert sel["tests_execute_focused"] == "true"
+    targets = _targets(sel)
+    assert "tests/ops/test_run_shadow_bounded_observation_adapter_v0.py" in targets
+    assert "tests/ops/test_shadow_wallclock_duration_evidence_contract_v0.py" in targets
+    assert "tests/ops/test_shadow_247_futures_start_wrapper_skeleton_v0.py" in targets
+
+
+def test_selector_case_pr4491_ci_bootstrap_diff_focused() -> None:
+    sel = _run_selector(*PR4491_CI_BOOTSTRAP_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_infra_focused"
+    assert sel["tests_execute_full"] == "false"
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
+    assert "tests/ci/test_workflows_no_pull_request_target_contract_v0.py" in _targets(sel)
+    assert "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py" in _targets(sel)
+
+
+def test_selector_case_ci_selector_change_full() -> None:
+    sel = _run_selector(
+        "scripts/ops/ci_test_selection_v1.py",
+        "config/ci/file_category_mapping.yaml",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_case_dependency_change_full() -> None:
+    sel = _run_selector("pyproject.toml")
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "category_dependencies_requires_full"
+
+
+def test_selector_case_central_shared_src_change_full() -> None:
+    sel = _run_selector("src/core/foo.py")
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "category_central_src_requires_full"
+
+
+def test_selector_case_docs_only_safe_no_op() -> None:
+    sel = _run_selector("docs/foo.md")
+    assert sel["test_selection_mode"] == "NO_OP"
+
+
+def test_selector_case_unknown_workflow_diff_full() -> None:
+    sel = _run_selector(
+        "scripts/ops/ci_test_selection_v1.py",
+        ".github/workflows/unknown-workflow.yml",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_case_unknown_src_diff_full() -> None:
+    sel = _run_selector("misc/unclassified.bin")
+    assert sel["test_selection_mode"] == "FULL"
+
+
+def test_selector_ci_workflow_change_self_focused_ci_infra() -> None:
+    sel = _run_selector(
+        ".github/workflows/ci.yml",
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+        "tests/ci/test_workflows_no_pull_request_target_contract_v0.py",
+        "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_infra_focused"

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -50,9 +50,9 @@ def test_required_tests_job_has_no_job_level_if() -> None:
     assert "if:" not in tests_block.split("steps:")[0]
 
 
-def test_tests_job_timeout_40_preserved() -> None:
+def test_tests_job_timeout_25_absolute_cap() -> None:
     assert re.search(
-        r"^\s*tests:\n(?:.*\n)*?\s*timeout-minutes:\s*40\s*$", _ci_text(), re.MULTILINE
+        r"^\s*tests:\n(?:.*\n)*?\s*timeout-minutes:\s*25\s*$", _ci_text(), re.MULTILINE
     )
 
 

--- a/tests/ci/test_ci_scheduled_paper_export_smoke_workflow_contract_v0.py
+++ b/tests/ci/test_ci_scheduled_paper_export_smoke_workflow_contract_v0.py
@@ -107,7 +107,7 @@ def test_workflow_jobs_have_expected_timeouts() -> None:
         assert isinstance(job_body, dict)
         timeout = job_body.get("timeout-minutes")
         assert isinstance(timeout, int)
-        assert 30 <= timeout <= 120
+        assert timeout == 25
 
 
 def test_workflow_schedule_gate_vars_present() -> None:

--- a/tests/ci/test_class_a_shadow_paper_scheduled_probe_workflow_contract_v0.py
+++ b/tests/ci/test_class_a_shadow_paper_scheduled_probe_workflow_contract_v0.py
@@ -150,7 +150,7 @@ def test_workflow_job_has_reasonable_timeout() -> None:
 
     timeout = job.get("timeout-minutes")
     assert isinstance(timeout, int)
-    assert 1 <= timeout <= 180
+    assert 1 <= timeout <= 25
 
 
 def test_workflow_uploads_probe_artifacts_without_readiness_claim() -> None:

--- a/tests/ci/test_paper_session_audit_evidence_workflow_contract_v0.py
+++ b/tests/ci/test_paper_session_audit_evidence_workflow_contract_v0.py
@@ -144,7 +144,7 @@ def test_workflow_jobs_have_defensive_env_and_evidence_flag() -> None:
 
         timeout = job_body.get("timeout-minutes")
         assert isinstance(timeout, int)
-        assert 25 <= timeout <= 90
+        assert timeout == 25
 
         env = job_body.get("env")
         assert isinstance(env, dict)

--- a/tests/ci/test_paper_tests_audit_evidence_workflow_contract_v0.py
+++ b/tests/ci/test_paper_tests_audit_evidence_workflow_contract_v0.py
@@ -127,7 +127,7 @@ def test_workflow_jobs_have_defensive_live_env_and_timeouts() -> None:
 
         timeout = job_body.get("timeout-minutes")
         assert isinstance(timeout, int)
-        assert 15 <= timeout <= 90
+        assert 15 <= timeout <= 25
 
         env = job_body.get("env")
         assert isinstance(env, dict)

--- a/tests/ci/test_prj_scheduled_shadow_paper_features_smoke_workflow_contract_v0.py
+++ b/tests/ci/test_prj_scheduled_shadow_paper_features_smoke_workflow_contract_v0.py
@@ -156,7 +156,7 @@ def test_workflow_jobs_have_reasonable_timeouts() -> None:
         assert isinstance(job_body, dict)
         timeout = job_body.get("timeout-minutes")
         assert isinstance(timeout, int)
-        assert 1 <= timeout <= 180
+        assert 1 <= timeout <= 25
 
 
 def test_workflow_uploads_smoke_artifacts_without_readiness_claim() -> None:

--- a/tests/ci/test_shadow_paper_smoke_workflow_contract_v0.py
+++ b/tests/ci/test_shadow_paper_smoke_workflow_contract_v0.py
@@ -121,7 +121,7 @@ def test_workflow_jobs_have_defensive_live_env_and_timeouts() -> None:
 
         timeout = job_body.get("timeout-minutes")
         assert isinstance(timeout, int)
-        assert 10 <= timeout <= 45
+        assert 10 <= timeout <= 25
 
         env = job_body.get("env")
         assert isinstance(env, dict)

--- a/tests/ci/test_workflows_no_pull_request_target_contract_v0.py
+++ b/tests/ci/test_workflows_no_pull_request_target_contract_v0.py
@@ -16,6 +16,9 @@ WORKFLOW_ROOT = REPO_ROOT / ".github" / "workflows"
 CHECKOUT_USES_PATTERN = re.compile(r"uses:\s*actions/checkout@v(\d+)\b")
 FORBIDDEN_CHECKOUT_VERSIONS = frozenset({"3", "4"})
 REQUIRED_CHECKOUT_VERSION = "5"
+TIMEOUT_MINUTES_PATTERN = re.compile(r"^\s*timeout-minutes:\s*(\d+)\s*$", re.MULTILINE)
+PEAK_TRADE_CI_ABSOLUTE_HARD_TIMEOUT_MINUTES = 25
+FORBIDDEN_EXPLICIT_TIMEOUT_MINUTES = frozenset({40})
 
 
 def _workflow_files() -> list[Path]:
@@ -145,3 +148,37 @@ def test_workflows_checkout_pin_uniform_v5_contract_requires_explicit_v5() -> No
             offenders.append(f"{workflow_path}: actions/checkout@v{', v'.join(non_v5)}")
 
     assert not offenders, f"checkout pins must use actions/checkout@v5: {offenders}"
+
+
+def _explicit_timeout_minutes_by_workflow() -> dict[str, list[int]]:
+    by_workflow: dict[str, list[int]] = {}
+    for workflow in _workflow_files():
+        values = [int(match) for match in TIMEOUT_MINUTES_PATTERN.findall(_workflow_text(workflow))]
+        if values:
+            by_workflow[workflow.relative_to(REPO_ROOT).as_posix()] = values
+    return by_workflow
+
+
+def test_workflows_absolute_hard_timeout_contract_caps_explicit_job_timeouts() -> None:
+    offenders: list[str] = []
+
+    for workflow_path, values in _explicit_timeout_minutes_by_workflow().items():
+        for value in values:
+            if value > PEAK_TRADE_CI_ABSOLUTE_HARD_TIMEOUT_MINUTES:
+                offenders.append(f"{workflow_path}: timeout-minutes={value}")
+
+    assert not offenders, (
+        "explicit workflow job timeouts must be <= "
+        f"{PEAK_TRADE_CI_ABSOLUTE_HARD_TIMEOUT_MINUTES} minutes: {offenders}"
+    )
+
+
+def test_workflows_absolute_hard_timeout_contract_forbids_legacy_40_minute_values() -> None:
+    offenders: list[str] = []
+
+    for workflow_path, values in _explicit_timeout_minutes_by_workflow().items():
+        for value in values:
+            if value in FORBIDDEN_EXPLICIT_TIMEOUT_MINUTES:
+                offenders.append(f"{workflow_path}: timeout-minutes={value}")
+
+    assert not offenders, f"legacy 40-minute workflow timeouts are forbidden: {offenders}"


### PR DESCRIPTION
## Summary
CI bootstrap bundle for Peak_Trade required-check governance:

- **25 minutes** is the absolute technical hard timeout for every explicit `timeout-minutes` value (no 40-minute legacy cap).
- **Diff-aware FOCUSED** selection prevents unnecessary ~18k full-matrix runs for bounded owner/testowner diffs.
- **PR #4489** (wallclock shadow evidence, 6 files) now selects **FOCUSED** via `wallclock_focused` instead of false-positive `central_src` → FULL.
- **This PR** selects **FOCUSED** via `ci_infra_focused` for its own CI-selector/workflow-timeout/contract-test diff (not FULL matrix).
- FULL remains fail-closed for central/ambiguous/dependency/unknown diffs; nightly/manual FULL preserved.

## Root cause (PR #4489 FULL)
`src/ops/wallclock_session_evidence_v0.py` fell through `classify_file()` to `central_src` (`src/**`) because it is not a `*_contract_v0.py` static-contract path and had no registered FOCUSED owner.

## Safety / scope boundaries
- Required-check context names unchanged.
- Python matrix 3.9 / 3.10 / 3.11 unchanged.
- No production/runtime/trading/paper/shadow/testnet logic changes.
- PR #4489 not modified; prior run `27937295124` was cancelled under the 25-minute operator limit.

## Test plan
- [x] ruff format/check on changed Python files
- [x] Full `tests/ci/test_ci_diff_aware_test_selection_v1.py` (204 contract tests incl. runtime budget + workflow timeout)
- [x] Selector simulation: PR #4489 diff → FOCUSED; PR #4491 diff → FOCUSED
- [ ] CI FOCUSED matrix checks on push