### PR TITLE
fix(ops): require shadow wallclock durable evidence

### DIFF
--- a/scripts/ops/primary_evidence_retention_v0.py
+++ b/scripts/ops/primary_evidence_retention_v0.py
@@ -25,6 +25,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+from src.ops.wallclock_session_evidence_v0 import (
+    WALLCLOCK_EVIDENCE_FILENAME,
+    evaluate_wallclock_evidence_fields,
+)
+
 MANIFEST_FILENAME = "MANIFEST.sha256"
 
 # Bounded observation durable run roots (Shadow/Testnet adapter parity; Preflight §2a.1).
@@ -36,6 +41,12 @@ BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS = (
     "logs/wrapper_stdout.log",
     "logs/wrapper_stderr.log",
     MANIFEST_FILENAME,
+)
+
+# Post-#4489 bounded Shadow closeout extends the shared bounded durable contract.
+BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS: tuple[str, ...] = (
+    *BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS,
+    WALLCLOCK_EVIDENCE_FILENAME,
 )
 
 # Paper bounded observation durable run roots (scheduler composition; Preflight §2a.1).
@@ -194,6 +205,23 @@ def validate_durable_primary_evidence_root(
         checks[key] = present
         if not present:
             issues.append(f"missing durable required file: {rel}")
+
+    if WALLCLOCK_EVIDENCE_FILENAME in required_rel_paths:
+        wallclock_path = root / WALLCLOCK_EVIDENCE_FILENAME
+        if wallclock_path.is_file():
+            try:
+                wallclock_payload = json.loads(wallclock_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                msg = f"WALLCLOCK_EVIDENCE.json invalid: {exc}"
+                checks["durable_wallclock_evidence_valid"] = False
+                issues.append(msg)
+            else:
+                evaluation = evaluate_wallclock_evidence_fields(wallclock_payload)
+                wallclock_valid = bool(evaluation.get("duration_evidence_valid"))
+                checks["durable_wallclock_evidence_valid"] = wallclock_valid
+                if not wallclock_valid:
+                    reasons = evaluation.get("fail_reasons", [])
+                    issues.append(f"WALLCLOCK_EVIDENCE.json failed validation: {reasons}")
 
     if issues:
         return False, issues[0], {"checks": checks, "issues": issues}

--- a/scripts/ops/review_shadow_bounded_observation_evidence_v0.py
+++ b/scripts/ops/review_shadow_bounded_observation_evidence_v0.py
@@ -22,7 +22,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from scripts.ops.primary_evidence_retention_v0 import validate_durable_primary_evidence_root
+from scripts.ops.primary_evidence_retention_v0 import (
+    BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS,
+    validate_durable_primary_evidence_root,
+)
 from scripts.ops.run_paper_only_bounded_observation_adapter_v0 import (
     FINAL_MACHINE_LINES_FILENAME,
     REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY,
@@ -326,7 +329,10 @@ def review_evidence(
 
     if durable_run_root is not None:
         durable_root = durable_run_root.resolve()
-        ok, msg, durable_detail = validate_durable_primary_evidence_root(durable_root)
+        ok, msg, durable_detail = validate_durable_primary_evidence_root(
+            durable_root,
+            required_rel_paths=BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS,
+        )
         result["durable_run_root"] = str(durable_root)
         result["durable_checks"] = durable_detail.get("checks", {})
         durable_issues = list(durable_detail.get("issues", []))

--- a/tests/ops/test_bounded_observation_review_durable_primary_evidence_contract_v0.py
+++ b/tests/ops/test_bounded_observation_review_durable_primary_evidence_contract_v0.py
@@ -19,6 +19,8 @@ from src.ops.wallclock_session_evidence_v0 import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_GIT_SHA_PREFIX = "0123456789ab"
+REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY = "REPO_HEAD_SHA_PREFIX"
 PREFLIGHT = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
 SHARED_HELPER = REPO_ROOT / "scripts" / "ops" / "primary_evidence_retention_v0.py"
 SHADOW_REVIEW = REPO_ROOT / "scripts" / "ops" / "review_shadow_bounded_observation_evidence_v0.py"
@@ -151,6 +153,7 @@ def _write_shadow_staging_bundle(staging: Path) -> None:
                 "NO_BROKER": True,
                 "NO_NETWORK": True,
                 "NO_ORDER_SUBMISSION": True,
+                "git_sha_prefix": CANONICAL_GIT_SHA_PREFIX,
             }
         )
         + "\n",
@@ -160,6 +163,15 @@ def _write_shadow_staging_bundle(staging: Path) -> None:
     logs.mkdir(parents=True, exist_ok=True)
     (logs / "wrapper_stdout.log").write_text("stdout\n", encoding="utf-8")
     (logs / "wrapper_stderr.log").write_text("stderr\n", encoding="utf-8")
+    (staging / "RUN_METADATA.json").write_text(
+        json.dumps({"repo_head_sha_prefix": CANONICAL_GIT_SHA_PREFIX}, indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    (staging / "FINAL_MACHINE_LINES.txt").write_text(
+        f"{REPO_HEAD_SHA_PREFIX_MACHINE_LINE_KEY}={CANONICAL_GIT_SHA_PREFIX}\n",
+        encoding="utf-8",
+    )
 
 
 def _write_testnet_staging_bundle(staging: Path) -> None:
@@ -210,7 +222,15 @@ def _write_durable_bounded_bundle(
         _write_shadow_staging_bundle(durable)
     else:
         _write_testnet_staging_bundle(durable)
-    (durable / "RUN_METADATA.json").write_text('{"run_id": "test"}\n', encoding="utf-8")
+    (durable / "RUN_METADATA.json").write_text(
+        json.dumps(
+            {"run_id": "test", "repo_head_sha_prefix": CANONICAL_GIT_SHA_PREFIX},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     review_dir = durable / "review"
     review_dir.mkdir(parents=True, exist_ok=True)
     (review_dir / "REVIEW_RESULT.json").write_text(

--- a/tests/ops/test_bounded_observation_review_durable_primary_evidence_contract_v0.py
+++ b/tests/ops/test_bounded_observation_review_durable_primary_evidence_contract_v0.py
@@ -6,10 +6,17 @@ import importlib.util
 import json
 import shutil
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import NamedTuple
 
 import pytest
+
+from src.ops.wallclock_session_evidence_v0 import (
+    WALLCLOCK_EVIDENCE_FILENAME,
+    build_wallclock_evidence_from_manifest_fields,
+    write_wallclock_evidence,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PREFLIGHT = REPO_ROOT / "docs" / "ops" / "runbooks" / "PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md"
@@ -105,6 +112,30 @@ def _durable_root(tmp_path: Path) -> Path:
     return path
 
 
+def _parse_utc_iso(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+def _format_utc_iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+
+
+def _write_valid_shadow_wallclock_evidence(durable: Path, *, duration_minutes: int = 10) -> None:
+    start_iso = "2026-06-22T10:00:00Z"
+    planned_seconds = duration_minutes * 60
+    end_dt = _parse_utc_iso(start_iso) + timedelta(seconds=planned_seconds + 1)
+    evidence = build_wallclock_evidence_from_manifest_fields(
+        utc_started=start_iso,
+        utc_completed=_format_utc_iso(end_dt),
+        duration_minutes=duration_minutes,
+        start_monotonic_seconds=1000.0,
+        end_monotonic_seconds=1000.0 + planned_seconds + 1.0,
+    )
+    write_wallclock_evidence(durable / WALLCLOCK_EVIDENCE_FILENAME, evidence)
+
+
 def _write_shadow_staging_bundle(staging: Path) -> None:
     evidence = staging / "wrapper_evidence"
     evidence.mkdir(parents=True, exist_ok=True)
@@ -169,7 +200,12 @@ def _write_testnet_staging_bundle(staging: Path) -> None:
     (logs / "wrapper_stderr.log").write_text("stderr\n", encoding="utf-8")
 
 
-def _write_durable_bounded_bundle(durable: Path, *, lane: str) -> None:
+def _write_durable_bounded_bundle(
+    durable: Path,
+    *,
+    lane: str,
+    include_wallclock: bool = True,
+) -> None:
     if lane == "shadow":
         _write_shadow_staging_bundle(durable)
     else:
@@ -181,6 +217,8 @@ def _write_durable_bounded_bundle(durable: Path, *, lane: str) -> None:
         json.dumps({"verdict": "PASS"}) + "\n",
         encoding="utf-8",
     )
+    if lane == "shadow" and include_wallclock:
+        _write_valid_shadow_wallclock_evidence(durable)
     sys.path.insert(0, str(REPO_ROOT))
     from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
 
@@ -262,6 +300,87 @@ def test_shadow_review_durable_run_root_passes_with_valid_archive(tmp_path: Path
     assert result["durable_checks"]["manifest_sha256_verify"] is True
 
 
+def test_shadow_review_durable_run_root_fails_closed_without_wallclock_evidence(
+    tmp_path: Path,
+) -> None:
+    review_mod = _load_module(
+        SHADOW_REVIEW, "review_shadow_bounded_observation_evidence_v0_durable_no_wallclock"
+    )
+    staging = Path("/tmp") / f"peak_trade_shadow_review_staging_no_wallclock_{tmp_path.name}"
+    staging.mkdir(parents=True, exist_ok=True)
+    durable = _durable_root(tmp_path)
+    _write_shadow_staging_bundle(staging)
+    _write_durable_bounded_bundle(durable, lane="shadow", include_wallclock=False)
+    result = review_mod.review_evidence(staging, durable_run_root=durable)
+    assert result["verdict"] == review_mod.REVIEW_REQUIRED
+    assert result["checks"]["durable_primary_evidence_valid"] is False
+    assert any("WALLCLOCK_EVIDENCE.json" in issue for issue in result["issues"])
+
+
+def test_shadow_review_durable_run_root_fails_closed_on_invalid_wallclock_evidence(
+    tmp_path: Path,
+) -> None:
+    review_mod = _load_module(
+        SHADOW_REVIEW, "review_shadow_bounded_observation_evidence_v0_durable_bad_wallclock"
+    )
+    staging = Path("/tmp") / f"peak_trade_shadow_review_staging_bad_wallclock_{tmp_path.name}"
+    staging.mkdir(parents=True, exist_ok=True)
+    durable = _durable_root(tmp_path)
+    _write_shadow_staging_bundle(staging)
+    _write_durable_bounded_bundle(durable, lane="shadow", include_wallclock=False)
+    (durable / WALLCLOCK_EVIDENCE_FILENAME).write_text("{not-json", encoding="utf-8")
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+    write_manifest_sha256(durable)
+    result = review_mod.review_evidence(staging, durable_run_root=durable)
+    assert result["verdict"] == review_mod.REVIEW_REQUIRED
+    assert result["checks"]["durable_primary_evidence_valid"] is False
+    assert any("WALLCLOCK_EVIDENCE.json invalid" in issue for issue in result["issues"])
+
+
+def test_shadow_review_durable_run_root_fails_closed_on_wrong_wallclock_relative_path(
+    tmp_path: Path,
+) -> None:
+    review_mod = _load_module(
+        SHADOW_REVIEW, "review_shadow_bounded_observation_evidence_v0_durable_wrong_wallclock_path"
+    )
+    staging = Path("/tmp") / f"peak_trade_shadow_review_staging_wrong_wallclock_{tmp_path.name}"
+    staging.mkdir(parents=True, exist_ok=True)
+    durable = _durable_root(tmp_path)
+    _write_shadow_staging_bundle(staging)
+    _write_durable_bounded_bundle(durable, lane="shadow", include_wallclock=False)
+    wrong_dir = durable / "logs"
+    wrong_dir.mkdir(parents=True, exist_ok=True)
+    _write_valid_shadow_wallclock_evidence(wrong_dir)
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+    write_manifest_sha256(durable)
+    result = review_mod.review_evidence(staging, durable_run_root=durable)
+    assert result["verdict"] == review_mod.REVIEW_REQUIRED
+    assert result["checks"]["durable_primary_evidence_valid"] is False
+    assert any("WALLCLOCK_EVIDENCE.json" in issue for issue in result["issues"])
+
+
+def test_bounded_shadow_durable_required_rel_paths_extends_shared_contract_without_duplicates() -> (
+    None
+):
+    from scripts.ops.primary_evidence_retention_v0 import (
+        BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS,
+        BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS,
+    )
+
+    assert WALLCLOCK_EVIDENCE_FILENAME in BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS
+    assert WALLCLOCK_EVIDENCE_FILENAME not in BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS
+    assert len(BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS) == len(
+        set(BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS)
+    )
+    assert set(BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS).issubset(
+        set(BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS)
+    )
+
+
 def test_testnet_review_durable_run_root_passes_with_valid_archive(tmp_path: Path) -> None:
     review_mod = _load_module(
         TESTNET_REVIEW, "review_testnet_bounded_observation_evidence_v0_durable_pass"
@@ -294,13 +413,19 @@ def test_shadow_review_durable_run_root_fails_closed_under_tmp(tmp_path: Path) -
 
 def test_validate_durable_primary_evidence_root_fails_on_manifest_mismatch(tmp_path: Path) -> None:
     sys.path.insert(0, str(REPO_ROOT))
-    from scripts.ops.primary_evidence_retention_v0 import validate_durable_primary_evidence_root
+    from scripts.ops.primary_evidence_retention_v0 import (
+        BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS,
+        validate_durable_primary_evidence_root,
+    )
 
     durable = _durable_root(tmp_path)
     _write_durable_bounded_bundle(durable, lane="shadow")
     tampered = durable / "RUN_METADATA.json"
     tampered.write_text('{"run_id": "tampered"}\n', encoding="utf-8")
-    ok, reason, detail = validate_durable_primary_evidence_root(durable)
+    ok, reason, detail = validate_durable_primary_evidence_root(
+        durable,
+        required_rel_paths=BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS,
+    )
     assert ok is False
     assert "checksum mismatch" in reason or any("checksum mismatch" in i for i in detail["issues"])
 

--- a/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
+++ b/tests/ops/test_primary_evidence_retention_invariant_contract_v0.py
@@ -260,6 +260,19 @@ def test_order_capability_offline_durable_run_required_rel_paths_defined() -> No
     )
 
 
+def test_bounded_shadow_durable_run_required_rel_paths_include_wallclock_evidence() -> None:
+    from scripts.ops.primary_evidence_retention_v0 import (
+        BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS,
+        BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS,
+        PAPER_BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS,
+    )
+    from src.ops.wallclock_session_evidence_v0 import WALLCLOCK_EVIDENCE_FILENAME
+
+    assert WALLCLOCK_EVIDENCE_FILENAME in BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS
+    assert WALLCLOCK_EVIDENCE_FILENAME not in BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS
+    assert WALLCLOCK_EVIDENCE_FILENAME not in PAPER_BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS
+
+
 def _durable_archive(tmp_path: Path) -> Path:
     path = REPO_ROOT / "tests" / ".pytest_archive_roots" / tmp_path.name
     if path.exists():


### PR DESCRIPTION
## Summary

- Schließt den post-#4489 Gap: bounded Shadow-Closeout emittiert `WALLCLOCK_EVIDENCE.json`, die kanonische Durable-Required-Paths-Liste bildete dieses Artefakt noch nicht ab.
- Erweitert den bestehenden Owner `scripts/ops/primary_evidence_retention_v0.py` um `BOUNDED_SHADOW_DURABLE_RUN_REQUIRED_REL_PATHS` (Erweiterung von `BOUNDED_DURABLE_RUN_REQUIRED_REL_PATHS`, kein paralleler Validator/Surface).
- `review_shadow_bounded_observation_evidence_v0.py` nutzt die Shadow-Erweiterung fail-closed inkl. JSON-/Wallclock-Feldvalidierung; Paper- und Testnet-Verträge bleiben unverändert.

## Reuse-Entscheidung

- Kanonischer Owner: `scripts/ops/primary_evidence_retention_v0.py`
- Kanonische Testowner: `tests/ops/test_bounded_observation_review_durable_primary_evidence_contract_v0.py`, `tests/ops/test_primary_evidence_retention_invariant_contract_v0.py`
- Keine neuen Completion-/Readiness-/Map-/Index-/Package-/Handoff-/Pointer-Surfaces

## CI

- Selector-Modus: **FOCUSED** (`FULL_CI_TRIGGER_FOUND=false`)
- Keine Run-/Runtime-/Trading-Mutation

## Test plan

- [x] post-#4489 Shadow-Artefatsatz mit `WALLCLOCK_EVIDENCE.json` → PASS (durable validation)
- [x] ohne `WALLCLOCK_EVIDENCE.json` → FAIL_CLOSED
- [x] invalide `WALLCLOCK_EVIDENCE.json` → FAIL_CLOSED
- [x] falscher relativer Ablagepfad → FAIL_CLOSED
- [x] Paper-/Testnet-Required-Paths unverändert
- [x] ruff format/check auf geänderten Dateien
- [x] Selector-Simulation FOCUSED


Made with [Cursor](https://cursor.com)