### PR TITLE
refactor(ops): promote testnet wallclock duration evidence

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -37,6 +37,7 @@ FOCUSED_CATEGORIES = frozenset(
         "reconciliation_primary_evidence_focused",
         "bounded_network_testnet_preflight_focused",
         "runtime_wallclock_evidence_emitter_focused",
+        "testnet_wallclock_duration_evidence_focused",
         "wallclock_focused",
         "ci_infra_focused",
     }
@@ -264,6 +265,28 @@ CANONICAL_RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_FOCUSED_TESTS: tuple[str, ...] = (
 
 REQUIRED_RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_TEST_OWNERS: tuple[str, ...] = (
     "tests/ops/test_runtime_wallclock_evidence_emitter_contract_v0.py",
+)
+
+TESTNET_WALLCLOCK_DURATION_EVIDENCE_OWNER = (
+    "src/ops/testnet_wallclock_duration_evidence_contract_v0.py"
+)
+TESTNET_WALLCLOCK_DURATION_EVIDENCE_TEST_OWNER = (
+    "tests/ops/test_testnet_wallclock_duration_evidence_contract_v0.py"
+)
+
+TESTNET_WALLCLOCK_DURATION_EVIDENCE_CI_POLICY_PATHS = frozenset(
+    {
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    }
+)
+
+CANONICAL_TESTNET_WALLCLOCK_DURATION_EVIDENCE_FOCUSED_TESTS: tuple[str, ...] = (
+    "tests/ops/test_testnet_wallclock_duration_evidence_contract_v0.py",
+)
+
+REQUIRED_TESTNET_WALLCLOCK_DURATION_EVIDENCE_TEST_OWNERS: tuple[str, ...] = (
+    "tests/ops/test_testnet_wallclock_duration_evidence_contract_v0.py",
 )
 
 WALLCLOCK_OWNER = "src/ops/wallclock_session_evidence_v0.py"
@@ -755,6 +778,58 @@ def _try_runtime_wallclock_evidence_emitter_focused(files: list[str]) -> Selecti
     )
 
 
+def _is_testnet_wallclock_duration_evidence_scoped_path(path: str) -> bool:
+    return path in {
+        TESTNET_WALLCLOCK_DURATION_EVIDENCE_OWNER,
+        TESTNET_WALLCLOCK_DURATION_EVIDENCE_TEST_OWNER,
+    }
+
+
+def _is_testnet_wallclock_duration_evidence_rebundle_path(path: str) -> bool:
+    return (
+        _is_testnet_wallclock_duration_evidence_scoped_path(path)
+        or path in TESTNET_WALLCLOCK_DURATION_EVIDENCE_CI_POLICY_PATHS
+    )
+
+
+def _testnet_wallclock_duration_evidence_focused_targets() -> tuple[str, ...]:
+    for path in REQUIRED_TESTNET_WALLCLOCK_DURATION_EVIDENCE_TEST_OWNERS:
+        if not _repo_path_exists(path):
+            return ()
+    targets: list[str] = []
+    for path in CANONICAL_TESTNET_WALLCLOCK_DURATION_EVIDENCE_FOCUSED_TESTS:
+        if _repo_path_exists(path):
+            targets.append(path)
+    if len(targets) < len(REQUIRED_TESTNET_WALLCLOCK_DURATION_EVIDENCE_TEST_OWNERS):
+        return ()
+    return tuple(sorted(targets))
+
+
+def _try_testnet_wallclock_duration_evidence_focused(files: list[str]) -> SelectionResult | None:
+    if not files:
+        return None
+    if not any(_is_testnet_wallclock_duration_evidence_scoped_path(f) for f in files):
+        return None
+    if not all(_is_testnet_wallclock_duration_evidence_rebundle_path(f) for f in files):
+        return None
+    files_set = set(files)
+    if (
+        TESTNET_WALLCLOCK_DURATION_EVIDENCE_OWNER in files_set
+        and TESTNET_WALLCLOCK_DURATION_EVIDENCE_TEST_OWNER not in files_set
+    ):
+        return None
+    targets = _testnet_wallclock_duration_evidence_focused_targets()
+    if not targets:
+        return None
+    modules: tuple[str, ...] = ("src.ops.testnet_wallclock_duration_evidence_contract_v0",)
+    return SelectionResult(
+        "FOCUSED",
+        "testnet_wallclock_duration_evidence_focused",
+        targets,
+        modules,
+    )
+
+
 def _is_wallclock_scoped_path(path: str) -> bool:
     if path == WALLCLOCK_OWNER:
         return True
@@ -1096,6 +1171,10 @@ def categorize(path: str) -> str:
         return "runtime_wallclock_evidence_emitter_focused"
     if _is_runtime_wallclock_evidence_emitter_scoped_path(p):
         return "runtime_wallclock_evidence_emitter_focused"
+    if p in TESTNET_WALLCLOCK_DURATION_EVIDENCE_CI_POLICY_PATHS:
+        return "testnet_wallclock_duration_evidence_focused"
+    if _is_testnet_wallclock_duration_evidence_scoped_path(p):
+        return "testnet_wallclock_duration_evidence_focused"
     if p in MARKET_DASHBOARD_CI_POLICY_PATHS:
         return "market_dashboard_focused"
     if _is_market_dashboard_scoped_path(p):
@@ -1361,6 +1440,12 @@ def resolve_selection(
     if runtime_wallclock_evidence_emitter is not None:
         return runtime_wallclock_evidence_emitter
 
+    testnet_wallclock_duration_evidence = _try_testnet_wallclock_duration_evidence_focused(
+        normalized
+    )
+    if testnet_wallclock_duration_evidence is not None:
+        return testnet_wallclock_duration_evidence
+
     wallclock = _try_wallclock_focused(normalized)
     if wallclock is not None:
         return wallclock
@@ -1425,6 +1510,19 @@ def resolve_selection(
         return SelectionResult(
             "FULL",
             "runtime_wallclock_evidence_emitter_incomplete_or_missing_test_owner",
+            (),
+        )
+
+    if any(_is_testnet_wallclock_duration_evidence_scoped_path(f) for f in normalized):
+        if not all(_is_testnet_wallclock_duration_evidence_rebundle_path(f) for f in normalized):
+            return SelectionResult(
+                "FULL",
+                "testnet_wallclock_duration_evidence_foreign_path_requires_full",
+                (),
+            )
+        return SelectionResult(
+            "FULL",
+            "testnet_wallclock_duration_evidence_incomplete_or_missing_test_owner",
             (),
         )
 

--- a/src/ops/testnet_wallclock_duration_evidence_contract_v0.py
+++ b/src/ops/testnet_wallclock_duration_evidence_contract_v0.py
@@ -1,0 +1,63 @@
+"""Repo-native Testnet wall-clock duration evidence contract (v0).
+
+Offline fail-closed evaluator for future Testnet execute duration evidence.
+Does not authorize Testnet execute, network access, credentials, or runtime start.
+Charter: testnet_wallclock_duration_guard_external_charter_no_run_v0_20260603T182859Z
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.ops.wallclock_session_evidence_v0 import evaluate_wallclock_evidence_fields
+
+PACKAGE_MARKER = "TESTNET_WALLCLOCK_DURATION_EVIDENCE_CONTRACT_V0=true"
+CLASS4_SCOPED_EXCEPTION_MARKER = "TESTNET_WALLCLOCK_DURATION_GUARD_CLASS4_SCOPED_EXCEPTION_V0=true"
+CHARTER_BUNDLE_SUFFIX = (
+    "testnet_wallclock_duration_guard_external_charter_no_run_v0_20260603T182859Z"
+)
+
+REQUIRED_WALLCLOCK_FIELD_NAMES: tuple[str, ...] = (
+    "planned_duration_seconds",
+    "min_required_wall_clock_seconds",
+    "start_wall_clock_iso",
+    "end_wall_clock_iso",
+    "start_monotonic_seconds",
+    "end_monotonic_seconds",
+    "elapsed_wall_clock_seconds",
+    "elapsed_monotonic_seconds",
+    "wall_clock_slack_seconds",
+    "duration_proven",
+    "duration_evidence_valid",
+    "early_exit_detected",
+    "early_exit_reason",
+    "invalid_if_elapsed_below_min",
+)
+
+
+def evaluate_wallclock_duration_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
+    """Fail-closed evaluator mirroring charter rules R1–R8 (offline, no I/O)."""
+    result: dict[str, Any] = {
+        "duration_proven": False,
+        "duration_evidence_valid": False,
+        "invalid_if_elapsed_below_min": True,
+        "fail_reasons": [],
+    }
+
+    projection_only = evidence.get("projection_ready") is True and "duration_proven" not in evidence
+    if projection_only:
+        result["fail_reasons"].append("projection_ready alone is not duration proof (R4)")
+
+    simulation_forbidden = evidence.get("simulation_forbidden")
+    real_sleep_used = evidence.get("real_sleep_used")
+    if simulation_forbidden is True and real_sleep_used is False:
+        result["fail_reasons"].append("simulation_forbidden but real_sleep_used=false (R6)")
+
+    field_eval = evaluate_wallclock_evidence_fields(evidence)
+    result["fail_reasons"].extend(field_eval["fail_reasons"])
+
+    if not result["fail_reasons"]:
+        result["duration_evidence_valid"] = True
+        result["duration_proven"] = True
+
+    return result

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -1548,3 +1548,83 @@ def test_selector_runtime_wallclock_evidence_emitter_import_modules() -> None:
 def test_selector_bounded_network_preflight_rules_unchanged() -> None:
     sel = _run_selector(*PR4497_BOUNDED_NETWORK_PREFLIGHT_FILES)
     assert sel["test_selection_reason"] == "bounded_network_testnet_preflight_focused"
+
+
+TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES: tuple[str, ...] = (
+    "src/ops/testnet_wallclock_duration_evidence_contract_v0.py",
+    "tests/ops/test_testnet_wallclock_duration_evidence_contract_v0.py",
+)
+
+
+def test_selector_testnet_wallclock_duration_evidence_owner_pair_focused() -> None:
+    sel = _run_selector(*TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "testnet_wallclock_duration_evidence_focused"
+    assert sel["tests_execute_full"] == "false"
+    assert sel["tests_execute_focused"] == "true"
+    assert sel["tests_execute_no_op"] == "false"
+    targets = _targets(sel)
+    assert TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES[1] in targets
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" not in targets
+
+
+def test_selector_testnet_wallclock_duration_evidence_owner_without_test_owner_full() -> None:
+    sel = _run_selector(TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES[0])
+    assert sel["test_selection_mode"] == "FULL"
+    assert (
+        sel["test_selection_reason"]
+        == "testnet_wallclock_duration_evidence_incomplete_or_missing_test_owner"
+    )
+
+
+def test_selector_testnet_wallclock_duration_evidence_plus_foreign_src_full() -> None:
+    sel = _run_selector(
+        *TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES,
+        "src/execution/live/orchestrator.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+    assert (
+        sel["test_selection_reason"]
+        == "testnet_wallclock_duration_evidence_foreign_path_requires_full"
+    )
+
+
+def test_selector_testnet_wallclock_duration_evidence_plus_dependency_full() -> None:
+    sel = _run_selector(*TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES, "requirements.txt")
+    assert sel["test_selection_mode"] == "FULL"
+    assert (
+        sel["test_selection_reason"]
+        == "testnet_wallclock_duration_evidence_foreign_path_requires_full"
+    )
+
+
+def test_selector_testnet_wallclock_duration_evidence_four_file_bundle_focused() -> None:
+    sel = _run_selector(
+        *TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES,
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "testnet_wallclock_duration_evidence_focused"
+    targets = _targets(sel)
+    assert TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES[1] in targets
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" not in targets
+
+
+def test_selector_testnet_wallclock_duration_evidence_ci_policy_only_not_owner_focused() -> None:
+    sel = _run_selector(
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_reason"] != "testnet_wallclock_duration_evidence_focused"
+
+
+def test_selector_testnet_wallclock_duration_evidence_import_modules() -> None:
+    sel = _run_selector(*TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES)
+    modules = _modules(sel)
+    assert modules == ["src.ops.testnet_wallclock_duration_evidence_contract_v0"]
+
+
+def test_selector_runtime_wallclock_evidence_emitter_rules_unchanged() -> None:
+    sel = _run_selector(*RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_FILES)
+    assert sel["test_selection_reason"] == "runtime_wallclock_evidence_emitter_focused"

--- a/tests/ops/test_testnet_wallclock_duration_evidence_contract_v0.py
+++ b/tests/ops/test_testnet_wallclock_duration_evidence_contract_v0.py
@@ -6,13 +6,19 @@ Charter: testnet_wallclock_duration_guard_external_charter_no_run_v0_20260603T18
 
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
-from typing import Any
 
 import pytest
 
+from src.ops.testnet_wallclock_duration_evidence_contract_v0 import (
+    evaluate_wallclock_duration_evidence,
+)
+from src.ops.wallclock_session_evidence_v0 import evaluate_wallclock_evidence_fields
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_MODULE = REPO_ROOT / "src" / "ops" / "testnet_wallclock_duration_evidence_contract_v0.py"
 RUN_TESTNET_SESSION = REPO_ROOT / "scripts" / "run_testnet_session.py"
 TESTNET_BOUNDED_ADAPTER = (
     REPO_ROOT / "scripts" / "ops" / "run_testnet_bounded_observation_adapter_v0.py"
@@ -76,81 +82,7 @@ THIRTY_MIN_PLANNED_SECONDS = 1800
 THIRTY_MIN_MIN_REQUIRED_SECONDS = THIRTY_MIN_PLANNED_SECONDS - DEFAULT_WALL_CLOCK_SLACK_SECONDS
 
 
-def _monotonic_tolerance(planned_duration_seconds: float) -> float:
-    return 5.0 if planned_duration_seconds > 60 else 2.0
-
-
-def evaluate_wallclock_duration_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
-    """Fail-closed reference evaluator mirroring charter rules R1–R8 (offline, no I/O)."""
-    result: dict[str, Any] = {
-        "duration_proven": False,
-        "duration_evidence_valid": False,
-        "invalid_if_elapsed_below_min": True,
-        "fail_reasons": [],
-    }
-
-    if evidence.get("invalid_if_elapsed_below_min") is not True:
-        result["fail_reasons"].append("invalid_if_elapsed_below_min must be true")
-
-    planned = evidence.get("planned_duration_seconds")
-    elapsed_wall = evidence.get("elapsed_wall_clock_seconds")
-    elapsed_mono = evidence.get("elapsed_monotonic_seconds")
-    min_required = evidence.get("min_required_wall_clock_seconds")
-    max_acceptable = evidence.get("max_acceptable_wall_clock_seconds")
-    start_iso = evidence.get("start_wall_clock_iso")
-    end_iso = evidence.get("end_wall_clock_iso")
-    early_exit = evidence.get("early_exit_detected")
-    early_reason = evidence.get("early_exit_reason")
-    projection_only = evidence.get("projection_ready") is True and "duration_proven" not in evidence
-
-    if projection_only:
-        result["fail_reasons"].append("projection_ready alone is not duration proof (R4)")
-
-    if not start_iso or not end_iso:
-        result["fail_reasons"].append("missing start/end wall-clock timestamps (R2)")
-
-    if planned is None or elapsed_wall is None:
-        result["fail_reasons"].append(
-            "planned_duration_seconds and elapsed_wall_clock_seconds required (R7)"
-        )
-    elif planned > 0 and min_required is not None and elapsed_wall < min_required:
-        result["fail_reasons"].append("elapsed below min_required_wall_clock_seconds (R1)")
-
-    if (
-        elapsed_wall is not None
-        and elapsed_mono is not None
-        and planned is not None
-        and abs(elapsed_wall - elapsed_mono) > _monotonic_tolerance(float(planned))
-    ):
-        result["fail_reasons"].append("wall-clock vs monotonic drift exceeds tolerance (R3)")
-
-    if early_exit is True and not early_reason:
-        result["fail_reasons"].append("early_exit_detected without early_exit_reason (R5)")
-
-    if (
-        early_exit is True
-        and elapsed_wall is not None
-        and min_required is not None
-        and elapsed_wall < min_required
-    ):
-        result["fail_reasons"].append("early exit before min_required elapsed (R5)")
-
-    simulation_forbidden = evidence.get("simulation_forbidden")
-    real_sleep_used = evidence.get("real_sleep_used")
-    if simulation_forbidden is True and real_sleep_used is False:
-        result["fail_reasons"].append("simulation_forbidden but real_sleep_used=false (R6)")
-
-    if max_acceptable is not None and elapsed_wall is not None and elapsed_wall > max_acceptable:
-        result["fail_reasons"].append("elapsed exceeds max_acceptable_wall_clock_seconds (R8)")
-
-    if not result["fail_reasons"]:
-        result["duration_evidence_valid"] = True
-        result["duration_proven"] = True
-
-    return result
-
-
-def _valid_thirty_min_evidence() -> dict[str, Any]:
+def _valid_thirty_min_evidence() -> dict[str, object]:
     return {
         "planned_duration_seconds": THIRTY_MIN_PLANNED_SECONDS,
         "min_required_wall_clock_seconds": THIRTY_MIN_MIN_REQUIRED_SECONDS,
@@ -178,6 +110,30 @@ def test_package_and_class4_markers_present() -> None:
     assert PACKAGE_MARKER in text
     assert _CLASS4_SCOPED_EXCEPTION_MARKER in text
     assert CHARTER_BUNDLE_SUFFIX in text
+
+
+def test_canonical_owner_imported_not_duplicated() -> None:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    local_evaluators = [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("evaluate_wallclock")
+    ]
+    assert local_evaluators == []
+    text = Path(__file__).read_text(encoding="utf-8")
+    assert "from src.ops.testnet_wallclock_duration_evidence_contract_v0 import" in text
+    assert evaluate_wallclock_duration_evidence.__module__ == (
+        "src.ops.testnet_wallclock_duration_evidence_contract_v0"
+    )
+
+
+def test_wallclock_binding_uses_canonical_evaluator() -> None:
+    contract_source = CONTRACT_MODULE.read_text(encoding="utf-8")
+    assert (
+        "from src.ops.wallclock_session_evidence_v0 import evaluate_wallclock_evidence_fields"
+        in contract_source
+    )
+    assert evaluate_wallclock_evidence_fields.__module__ == "src.ops.wallclock_session_evidence_v0"
 
 
 def test_required_wallclock_field_names_complete() -> None:


### PR DESCRIPTION
## Summary
- Promotes the last test-only `evaluate_wallclock_duration_evidence` evaluator into canonical `src/ops/testnet_wallclock_duration_evidence_contract_v0.py`.
- Rewires the existing test owner to import from the canonical owner (no local duplicate implementation).
- Reuses `wallclock_session_evidence_v0.evaluate_wallclock_evidence_fields` for field validation and wallclock semantics; adds only testnet-specific R4/R6 checks.
- Adds a focused CI rebundle lane (`testnet_wallclock_duration_evidence_focused`) without a general `productive_src` exception.

## Scope
- Exactly four files: canonical owner, canonical test owner, CI selector, CI selector tests.
- Fully offline and non-authorizing; no runtime, network, credentials, or order capability.

## Test plan
- [x] `ruff format --check` and `ruff check` on all changed Python files
- [x] Full canonical test owner: `tests/ops/test_testnet_wallclock_duration_evidence_contract_v0.py`
- [x] Full CI selector tests: `tests/ci/test_ci_diff_aware_test_selection_v1.py`
- [x] Selector simulation: owner pair → FOCUSED; final 4-file bundle → FOCUSED
- [x] Python 3.9 / 3.10 / 3.11 matrix (~6–8s each, well under 15-minute limit)
- [ ] Await required PR checks (FULL fallback, Python matrix, 25-minute timeout unchanged)


Made with [Cursor](https://cursor.com)