### PR TITLE
refactor(ops): reuse canonical runtime wallclock fields

### DIFF
--- a/src/ops/runtime_wallclock_evidence_emitter_contract_v0.py
+++ b/src/ops/runtime_wallclock_evidence_emitter_contract_v0.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from src.ops.testnet_wallclock_duration_evidence_contract_v0 import (
+    REQUIRED_WALLCLOCK_FIELD_NAMES,
+)
 from src.ops.wallclock_session_evidence_v0 import evaluate_wallclock_evidence_fields
 
 PACKAGE_MARKER = "RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_CONTRACT_V0=true"
@@ -20,23 +23,6 @@ CHARTER_BUNDLE_SUFFIX = (
 )
 EMITTER_ARTIFACT_FILENAME = "WALLCLOCK_EVIDENCE.json"
 EVIDENCE_SOURCE_REPO_NATIVE = "repo_native_session"
-
-REQUIRED_WALLCLOCK_FIELD_NAMES: tuple[str, ...] = (
-    "planned_duration_seconds",
-    "min_required_wall_clock_seconds",
-    "start_wall_clock_iso",
-    "end_wall_clock_iso",
-    "start_monotonic_seconds",
-    "end_monotonic_seconds",
-    "elapsed_wall_clock_seconds",
-    "elapsed_monotonic_seconds",
-    "wall_clock_slack_seconds",
-    "duration_proven",
-    "duration_evidence_valid",
-    "early_exit_detected",
-    "early_exit_reason",
-    "invalid_if_elapsed_below_min",
-)
 
 
 def evaluate_runtime_session_wallclock_emitter_evidence(

--- a/tests/ops/test_runtime_wallclock_evidence_emitter_contract_v0.py
+++ b/tests/ops/test_runtime_wallclock_evidence_emitter_contract_v0.py
@@ -97,11 +97,42 @@ def test_canonical_owner_imported_not_duplicated() -> None:
         and node.name.startswith("evaluate_runtime_session_wallclock_emitter")
     ]
     assert local_evaluators == []
+    local_field_name_constants = [
+        node.targets[0].id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "REQUIRED_WALLCLOCK_FIELD_NAMES"
+    ]
+    assert local_field_name_constants == []
+    test_module_imports = [
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("tests.")
+    ]
+    assert test_module_imports == []
     text = Path(__file__).read_text(encoding="utf-8")
     assert "from src.ops.runtime_wallclock_evidence_emitter_contract_v0 import" in text
     assert evaluate_runtime_session_wallclock_emitter_evidence.__module__ == (
         "src.ops.runtime_wallclock_evidence_emitter_contract_v0"
     )
+
+    contract_tree = ast.parse(CONTRACT_MODULE.read_text(encoding="utf-8"))
+    src_local_field_name_constants = [
+        node.targets[0].id
+        for node in ast.walk(contract_tree)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "REQUIRED_WALLCLOCK_FIELD_NAMES"
+    ]
+    assert src_local_field_name_constants == []
+    contract_source = CONTRACT_MODULE.read_text(encoding="utf-8")
+    assert "from src.ops.testnet_wallclock_duration_evidence_contract_v0 import" in contract_source
+    import src.ops.testnet_wallclock_duration_evidence_contract_v0 as canonical_owner
+
+    assert REQUIRED_WALLCLOCK_FIELD_NAMES == canonical_owner.REQUIRED_WALLCLOCK_FIELD_NAMES
 
 
 def test_emitter_evaluator_uses_wallclock_session_evidence_ssot() -> None:


### PR DESCRIPTION
## Summary
- Kanonischer Owner: `src/ops/testnet_wallclock_duration_evidence_contract_v0.py` (`REQUIRED_WALLCLOCK_FIELD_NAMES`); Reuse-before-new statt paralleler Konstante.
- Entfernt lokale Duplikat-Definition in `runtime_wallclock_evidence_emitter_contract_v0.py`; Direktimport aus kanonischem Owner.
- AST-/Source-Drift-Guard in `test_runtime_wallclock_evidence_emitter_contract_v0.py` (Direktimport, keine lokale Neudefinition, kein Test-to-Test-Import).
- Runtime-/Emitter-Semantik, Feldreihenfolge, Signaturen und Fehlercodes unverändert.
- Exakter Zwei-Dateien-Scope: `src/ops/runtime_wallclock_evidence_emitter_contract_v0.py`, `tests/ops/test_runtime_wallclock_evidence_emitter_contract_v0.py`.

## CI selector
- Modus: **FOCUSED**
- Reason: `runtime_wallclock_evidence_emitter_focused`
- `tests_execute_full=false`, `FULL_CI_TRIGGER_FOUND=false`

## Validation (Python 3.9 / 3.10 / 3.11)
- ruff format --check: PASS (beide Dateien)
- ruff check: PASS (beide Dateien)
- pytest emitter contract + kanonische Wallclock-Owner-Regressionen + Shadow-Feldname-Guard: 20 passed je Interpreter

## Boundaries
FUTURES_ONLY, NO_RUN, NO_NETWORK, NO_LIVE

## Test plan
- [x] FOCUSED CI selector auf Zwei-Dateien-Diff
- [x] Emitter contract tests (3.9/3.10/3.11)
- [x] Kanonischer Owner Drift-Guard Regression
- [x] Shadow canonical field owner guard

Made with [Cursor](https://cursor.com)