### PR TITLE
fix(ci): raise fast-lane timeout to 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
   fast-lane:
     name: Fast-Lane
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: changes
     steps:
       - name: Checkout

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -56,6 +56,20 @@ def test_tests_job_timeout_25_absolute_cap() -> None:
     )
 
 
+def test_fast_lane_job_timeout_25_absolute_cap() -> None:
+    assert re.search(
+        r"^\s*fast-lane:\n(?:.*\n)*?\s*timeout-minutes:\s*25\s*$", _ci_text(), re.MULTILINE
+    )
+    assert (
+        "timeout-minutes: 15" not in _ci_text().split("  fast-lane:", 1)[1].split("  tests:", 1)[0]
+    )
+
+
+def test_ci_workflow_job_timeouts_do_not_exceed_25_minute_hard_cap() -> None:
+    for match in re.finditer(r"timeout-minutes:\s*(\d+)", _ci_text()):
+        assert int(match.group(1)) <= 25, "CI job exceeds 25-minute hard cap"
+
+
 def test_changes_job_exports_test_selection_outputs() -> None:
     text = _ci_text()
     for key in (


### PR DESCRIPTION
## Summary

- **Root cause (PR #4508):** CI Fast-Lane job was deterministically cancelled after `timeout-minutes: 15` while pytest was still running (~89% in `test_durable_completion_validation_graph_v1.py`); no test failures.
- **Change:** Raise Fast-Lane job timeout from **15** to **25** minutes — the existing CI hard cap already used by the matrix `tests` job.
- **Scope:** CI infrastructure only — no functional/product files from PR #4508 touched.

## Unchanged (fail-closed preserved)

- Required check contexts
- Python matrix 3.9 / 3.10 / 3.11
- Test selection / coverage / safety gates
- Fast-Lane job name and dependencies

## Local validation

- `ruff format --check` + `ruff check` on `tests/ci/test_ci_diff_aware_test_selection_v1.py`
- CI contract tests: fast-lane timeout=25, no job >25m, required checks surfaces
- Selector (mixed workflow+test diff): `FULL` / `ci_bootstrap_mixed_diff_requires_full`

## Evidence

- Source diagnostic: `Peak_Trade_runtime_evidence_archive_20260520T161443Z/diagnostics/pr4508_ci_gate_fast_lane_recovery_v0_20260622T212231Z`
- Implementation bundle: `Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/ci_fast_lane_timeout_25_minutes_v0_*`

## Test plan

- [x] Contract test asserts Fast-Lane `timeout-minutes: 25`
- [x] Contract test asserts no CI job exceeds 25-minute cap
- [ ] CI / Fast-Lane completes within 25m on this PR
- [ ] After merge: rerun failed jobs on PR #4508 run 27983073415


Made with [Cursor](https://cursor.com)