### PR TITLE
feat(master-v2): bind display projection digest to completion evidence (GAP_003)

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -210,13 +210,19 @@ MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_SCOPED_PATHS = fr
         *OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_CI_POLICY_PATHS,
     }
 )
-CANONICAL_MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FOCUSED_TESTS: tuple[
+CANONICAL_MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FOCUSED_TARGETS: tuple[
     str, ...
 ] = (
     OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_TRADING_TEST_OWNER,
     OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_OPS_TEST_OWNER,
     MASTER_V2_BINDING_CONTRACT_TEST_OWNER,
-    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_CI_SELECTOR_TARGETS: tuple[
+    str, ...
+] = (
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_replay_display_projection_digest_completion_evidence_five_file_diff_focused",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_replay_display_projection_digest_completion_evidence_with_ci_policy_focused",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_replay_display_projection_digest_completion_evidence_foreign_path_escalates_full",
 )
 
 OFFLINE_MASTER_V2_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_OWNER_PATH = (
@@ -1546,14 +1552,30 @@ def _is_master_v2_replay_display_projection_digest_completion_evidence_scope(
     return True
 
 
-def _master_v2_replay_display_projection_digest_completion_evidence_focused_targets() -> tuple[
-    str, ...
-]:
-    return tuple(
-        path
-        for path in CANONICAL_MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FOCUSED_TESTS
-        if _repo_path_exists(path)
-    )
+def _master_v2_replay_display_projection_digest_completion_evidence_focused_targets(
+    files: list[str] | None = None,
+) -> tuple[str, ...]:
+    targets: list[str] = []
+    for (
+        target
+    ) in CANONICAL_MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FOCUSED_TARGETS:
+        path, node = _split_pytest_target(target)
+        if node is None:
+            if _repo_path_exists(path):
+                targets.append(target)
+        elif _repo_pytest_target_exists(target):
+            targets.append(target)
+    if files and any(
+        path in OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_CI_POLICY_PATHS for path in files
+    ):
+        for (
+            ci_target
+        ) in MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_CI_SELECTOR_TARGETS:
+            if _repo_pytest_target_exists(ci_target):
+                targets.append(ci_target)
+    if not targets:
+        return ()
+    return tuple(sorted(set(targets)))
 
 
 def _try_master_v2_replay_display_projection_digest_completion_evidence_focused(
@@ -1561,7 +1583,7 @@ def _try_master_v2_replay_display_projection_digest_completion_evidence_focused(
 ) -> SelectionResult | None:
     if not _is_master_v2_replay_display_projection_digest_completion_evidence_scope(files):
         return None
-    targets = _master_v2_replay_display_projection_digest_completion_evidence_focused_targets()
+    targets = _master_v2_replay_display_projection_digest_completion_evidence_focused_targets(files)
     if not targets:
         return None
     return SelectionResult(

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -36,6 +36,7 @@ FOCUSED_CATEGORIES = frozenset(
         "tiny_order_focused",
         "reconciliation_primary_evidence_focused",
         "master_v2_binding_contract_focused",
+        "master_v2_replay_display_projection_digest_completion_evidence_focused",
         "offline_master_v2_double_play_scenario_replay_focused",
         "offline_master_v2_replay_six_node_validation_graph_binding_focused",
         "bounded_master_v2_testnet_completion_path_wiring_focused",
@@ -196,6 +197,25 @@ OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_CATEGORIZE_PATHS = frozenset(
 CANONICAL_OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_FOCUSED_TESTS: tuple[str, ...] = (
     OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_TRADING_TEST_OWNER,
     OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_OPS_TEST_OWNER,
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
+MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_SCOPED_PATHS = frozenset(
+    {
+        DURABLE_COMPLETION_FACADE_PATH,
+        OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER_PATH,
+        MASTER_V2_BINDING_CONTRACT_TEST_OWNER,
+        OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_TRADING_TEST_OWNER,
+        OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_OPS_TEST_OWNER,
+        *OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_CI_POLICY_PATHS,
+    }
+)
+CANONICAL_MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FOCUSED_TESTS: tuple[
+    str, ...
+] = (
+    OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_TRADING_TEST_OWNER,
+    OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_OPS_TEST_OWNER,
+    MASTER_V2_BINDING_CONTRACT_TEST_OWNER,
     "tests/ci/test_ci_diff_aware_test_selection_v1.py",
 )
 
@@ -1506,6 +1526,56 @@ def _try_master_v2_binding_contract_focused(files: list[str]) -> SelectionResult
     )
 
 
+def _is_master_v2_replay_display_projection_digest_completion_evidence_scope(
+    files: list[str],
+) -> bool:
+    if not files:
+        return False
+    required = {
+        DURABLE_COMPLETION_FACADE_PATH,
+        OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER_PATH,
+        MASTER_V2_BINDING_CONTRACT_TEST_OWNER,
+        OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_TRADING_TEST_OWNER,
+        OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_OPS_TEST_OWNER,
+    }
+    if not required.issubset(set(files)):
+        return False
+    for path in files:
+        if path not in MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_SCOPED_PATHS:
+            return False
+    return True
+
+
+def _master_v2_replay_display_projection_digest_completion_evidence_focused_targets() -> (
+    tuple[str, ...]
+):
+    return tuple(
+        path
+        for path in CANONICAL_MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FOCUSED_TESTS
+        if _repo_path_exists(path)
+    )
+
+
+def _try_master_v2_replay_display_projection_digest_completion_evidence_focused(
+    files: list[str],
+) -> SelectionResult | None:
+    if not _is_master_v2_replay_display_projection_digest_completion_evidence_scope(files):
+        return None
+    targets = _master_v2_replay_display_projection_digest_completion_evidence_focused_targets()
+    if not targets:
+        return None
+    return SelectionResult(
+        "FOCUSED",
+        "master_v2_replay_display_projection_digest_completion_evidence_focused",
+        targets,
+        (
+            "trading.master_v2.offline_double_play_scenario_replay_v0",
+            "src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0",
+            "src.ops.durable_completion_validation",
+        ),
+    )
+
+
 def _is_offline_master_v2_replay_six_node_validation_graph_binding_scope(files: list[str]) -> bool:
     if not files:
         return False
@@ -2159,6 +2229,12 @@ def resolve_selection(
     master_v2_binding = _try_master_v2_binding_contract_focused(normalized)
     if master_v2_binding is not None:
         return master_v2_binding
+
+    master_v2_replay_display_projection = (
+        _try_master_v2_replay_display_projection_digest_completion_evidence_focused(normalized)
+    )
+    if master_v2_replay_display_projection is not None:
+        return master_v2_replay_display_projection
 
     offline_master_v2_replay_six_node = (
         _try_offline_master_v2_replay_six_node_validation_graph_binding_focused(normalized)

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1546,9 +1546,9 @@ def _is_master_v2_replay_display_projection_digest_completion_evidence_scope(
     return True
 
 
-def _master_v2_replay_display_projection_digest_completion_evidence_focused_targets() -> (
-    tuple[str, ...]
-):
+def _master_v2_replay_display_projection_digest_completion_evidence_focused_targets() -> tuple[
+    str, ...
+]:
     return tuple(
         path
         for path in CANONICAL_MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FOCUSED_TESTS

--- a/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -536,6 +536,7 @@ MASTER_V2_BINDING_DIGEST_FIELD_NAMES: tuple[str, ...] = (
     "capital_slot_state_digest",
     "inactivity_exit_state_digest",
     "execution_intent_digest",
+    "dashboard_display_projection_digest",
 )
 
 MASTER_V2_COMPLETION_CHAIN_BINDING_FIELD_NAMES: tuple[str, ...] = (
@@ -551,6 +552,7 @@ MASTER_V2_COMPLETION_CHAIN_BINDING_FIELD_NAMES: tuple[str, ...] = (
     "completion_referenced_capital_slot_state_digest",
     "completion_referenced_inactivity_exit_state_digest",
     "completion_referenced_execution_intent_digest",
+    "completion_referenced_dashboard_display_projection_digest",
 )
 
 MASTER_V2_BINDING_TO_COMPLETION_CHAIN_FIELD_NAMES: tuple[tuple[str, str], ...] = tuple(
@@ -583,6 +585,7 @@ class MasterV2DecisionStateDigestBinding:
     capital_slot_state_digest: str
     inactivity_exit_state_digest: str
     execution_intent_digest: str
+    dashboard_display_projection_digest: str
 
 
 @dataclass(frozen=True)
@@ -615,6 +618,7 @@ class CompletionProofChainBinding:
     completion_referenced_capital_slot_state_digest: str | None = None
     completion_referenced_inactivity_exit_state_digest: str | None = None
     completion_referenced_execution_intent_digest: str | None = None
+    completion_referenced_dashboard_display_projection_digest: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
+++ b/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
@@ -900,10 +900,19 @@ def run_offline_double_play_scenario_replay_v0(
         records.append(record)
         prior_volatility_estimate = rules.volatility_estimate
 
+    display_digest = (
+        _dashboard_display_projection_digest(final_dashboard_display_snapshot)
+        if final_dashboard_display_snapshot is not None
+        else None
+    )
+    if records and display_digest is None:
+        fail_reasons.append("dashboard_display_projection_digest missing")
+
     binding = build_master_v2_decision_state_digest_binding_from_replay(
         records=tuple(records),
         selected_future_id=inp.selected_future_id,
         source_revision=inp.source_revision,
+        dashboard_display_projection_digest=display_digest,
     )
 
     required_events = {
@@ -942,11 +951,6 @@ def run_offline_double_play_scenario_replay_v0(
         final_side_state=final_side,
         final_active_side=derive_active_side(final_side),
     )
-    display_digest = (
-        _dashboard_display_projection_digest(final_dashboard_display_snapshot)
-        if final_dashboard_display_snapshot is not None
-        else None
-    )
     return OfflineDoublePlayScenarioReplayResultV0(
         layer_version=OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_LAYER_VERSION,
         replay_pass=summary.replay_pass,
@@ -965,11 +969,14 @@ def build_master_v2_decision_state_digest_binding_from_replay(
     records: tuple[OfflineDoublePlayScenarioReplayTickRecordV0, ...],
     selected_future_id: str,
     source_revision: str,
+    dashboard_display_projection_digest: str | None = None,
 ) -> MasterV2DecisionStateDigestBinding | None:
     if not records:
         return None
     final = records[-1]
     if final.decision_snapshot is None or final.master_v2_decision_digest is None:
+        return None
+    if not dashboard_display_projection_digest:
         return None
     return MasterV2DecisionStateDigestBinding(
         binding_owner=MASTER_V2_DECISION_STATE_DIGEST_BINDING_OWNER,
@@ -986,6 +993,7 @@ def build_master_v2_decision_state_digest_binding_from_replay(
         capital_slot_state_digest=final.capital_slot_state_digest,
         inactivity_exit_state_digest=final.inactivity_exit_state_digest,
         execution_intent_digest=final.execution_intent_digest,
+        dashboard_display_projection_digest=dashboard_display_projection_digest,
     )
 
 
@@ -1007,6 +1015,10 @@ def replay_result_digest_coherent(result: OfflineDoublePlayScenarioReplayResultV
         ("capital_slot_state_digest", final.capital_slot_state_digest),
         ("inactivity_exit_state_digest", final.inactivity_exit_state_digest),
         ("execution_intent_digest", final.execution_intent_digest),
+        (
+            "dashboard_display_projection_digest",
+            result.dashboard_display_projection_digest or "",
+        ),
     )
     for field, expected in pairs:
         if getattr(binding, field) != expected:

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -850,6 +850,7 @@ def test_selector_master_v2_replay_display_projection_digest_completion_evidence
         "tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py"
         in targets
     )
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" not in targets
 
 
 def test_selector_master_v2_replay_display_projection_digest_completion_evidence_with_ci_policy_focused() -> (
@@ -865,7 +866,20 @@ def test_selector_master_v2_replay_display_projection_digest_completion_evidence
         sel["test_selection_reason"]
         == "master_v2_replay_display_projection_digest_completion_evidence_focused"
     )
-    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
+    targets = _targets(sel)
+    assert (
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_replay_display_projection_digest_completion_evidence_five_file_diff_focused"
+        in targets
+    )
+    assert (
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_replay_display_projection_digest_completion_evidence_with_ci_policy_focused"
+        in targets
+    )
+    assert (
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_replay_display_projection_digest_completion_evidence_foreign_path_escalates_full"
+        in targets
+    )
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" not in targets
 
 
 def test_selector_master_v2_replay_display_projection_digest_completion_evidence_foreign_path_escalates_full() -> (

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -817,6 +817,68 @@ def test_selector_offline_master_v2_double_play_foreign_path_escalates_full() ->
     assert sel["test_selection_reason"].endswith("requires_full")
 
 
+MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FILES = (
+    "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+    "tests/ops/test_master_v2_decision_digest_completion_chain_binding_contract_v0.py",
+    "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py",
+    "tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py",
+)
+
+
+def test_selector_master_v2_replay_display_projection_digest_completion_evidence_five_file_diff_focused() -> (
+    None
+):
+    sel = _run_selector(*MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert (
+        sel["test_selection_reason"]
+        == "master_v2_replay_display_projection_digest_completion_evidence_focused"
+    )
+    assert sel["tests_execute_full"] == "false"
+    assert sel["tests_execute_focused"] == "true"
+    targets = _targets(sel)
+    assert (
+        "tests/ops/test_master_v2_decision_digest_completion_chain_binding_contract_v0.py"
+        in targets
+    )
+    assert (
+        "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py"
+        in targets
+    )
+    assert (
+        "tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py"
+        in targets
+    )
+
+
+def test_selector_master_v2_replay_display_projection_digest_completion_evidence_with_ci_policy_focused() -> (
+    None
+):
+    sel = _run_selector(
+        *MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FILES,
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert (
+        sel["test_selection_reason"]
+        == "master_v2_replay_display_projection_digest_completion_evidence_focused"
+    )
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
+
+
+def test_selector_master_v2_replay_display_projection_digest_completion_evidence_foreign_path_escalates_full() -> (
+    None
+):
+    sel = _run_selector(
+        *MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FILES,
+        "src/trading/master_v2/double_play_state.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"].endswith("requires_full")
+
+
 OFFLINE_MASTER_V2_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_FILES = (
     "src/ops/offline_master_v2_replay_six_node_validation_graph_binding_v0.py",
     "tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py",

--- a/tests/ops/test_master_v2_decision_digest_completion_chain_binding_contract_v0.py
+++ b/tests/ops/test_master_v2_decision_digest_completion_chain_binding_contract_v0.py
@@ -73,6 +73,13 @@ def _sample_master_v2_binding(*, source_revision: str) -> MasterV2DecisionStateD
         execution_intent_digest=_component_digest(
             "execution_intent", zero_order=True, orders_allowed=False
         ),
+        dashboard_display_projection_digest=_component_digest(
+            "dashboard_display_projection",
+            overall_status="display_warning",
+            panel_statuses=(("futures_input", "display_ready"),),
+            display_only=True,
+            live_authorization=False,
+        ),
     )
 
 
@@ -134,6 +141,10 @@ def test_complete_master_v2_binding_accepted() -> None:
         ("capital_slot_state_digest", "completion_referenced_capital_slot_state_digest"),
         ("inactivity_exit_state_digest", "completion_referenced_inactivity_exit_state_digest"),
         ("execution_intent_digest", "completion_referenced_execution_intent_digest"),
+        (
+            "dashboard_display_projection_digest",
+            "completion_referenced_dashboard_display_projection_digest",
+        ),
     ],
 )
 def test_master_v2_fields_bound_through_integration_and_validator(
@@ -165,6 +176,16 @@ def test_invalid_digest_format_fail_closed() -> None:
     bad = replace(integration_input, master_v2_decision_state_digest_binding=bad_binding)
     reasons = validate_durable_run_primary_evidence_completion_integration_input(bad)
     assert any("master_v2_decision_digest" in reason for reason in reasons)
+
+
+def test_missing_display_projection_digest_fail_closed() -> None:
+    integration_input = _with_master_v2_binding(default_minimal_completion_integration_input())
+    binding = integration_input.master_v2_decision_state_digest_binding
+    assert binding is not None
+    bad_binding = replace(binding, dashboard_display_projection_digest="")
+    bad = replace(integration_input, master_v2_decision_state_digest_binding=bad_binding)
+    reasons = validate_durable_run_primary_evidence_completion_integration_input(bad)
+    assert any("dashboard_display_projection_digest" in reason for reason in reasons)
 
 
 def test_digest_drift_fail_closed() -> None:

--- a/tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py
+++ b/tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py
@@ -101,6 +101,10 @@ def test_replay_output_accepted_by_completion_binding(integration_input) -> None
         ("capital_slot_state_digest", "completion_referenced_capital_slot_state_digest"),
         ("inactivity_exit_state_digest", "completion_referenced_inactivity_exit_state_digest"),
         ("execution_intent_digest", "completion_referenced_execution_intent_digest"),
+        (
+            "dashboard_display_projection_digest",
+            "completion_referenced_dashboard_display_projection_digest",
+        ),
     ],
 )
 def test_all_master_v2_fields_bound(
@@ -256,3 +260,47 @@ def test_replay_graph_binding_zero_order_boundary(replay_result) -> None:
         assert record.cancels == 0
         assert record.fills == 0
         assert record.positions_opened == 0
+
+
+def test_replay_display_projection_digest_bound_in_decision_state_binding(
+    replay_result: OfflineDoublePlayScenarioReplayResultV0,
+) -> None:
+    binding = replay_result.master_v2_decision_state_digest_binding
+    assert binding is not None
+    assert replay_result.dashboard_display_projection_digest is not None
+    assert (
+        binding.dashboard_display_projection_digest
+        == replay_result.dashboard_display_projection_digest
+    )
+
+
+def test_replay_display_projection_digest_bound_in_completion_chain(
+    integration_input,
+) -> None:
+    binding = integration_input.master_v2_decision_state_digest_binding
+    chain = integration_input.completion_proof_chain
+    assert binding is not None
+    assert (
+        chain.completion_referenced_dashboard_display_projection_digest
+        == binding.dashboard_display_projection_digest
+    )
+
+
+def test_replay_display_projection_digest_drift_fail_closed(integration_input) -> None:
+    bad_chain = replace(
+        integration_input.completion_proof_chain,
+        completion_referenced_dashboard_display_projection_digest="0" * 64,
+    )
+    bad = replace(integration_input, completion_proof_chain=bad_chain)
+    reasons = validate_completion_proof_chain_binding(
+        ValidationContext(integration_input=bad)
+    ).fail_reasons
+    assert any("dashboard_display_projection_digest" in reason for reason in reasons)
+
+
+def test_replay_sourced_six_node_graph_includes_display_projection_digest(
+    integration_input,
+) -> None:
+    proof = prove_offline_replay_six_node_validation_graph_binding_v0()
+    assert proof.binding_pass, proof.fail_reasons
+    assert proof.six_node_graph_pass is True

--- a/tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py
+++ b/tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py
@@ -398,3 +398,19 @@ def test_replay_display_evidence_in_result_not_parallel_surface() -> None:
     assert hasattr(result, "dashboard_display_projection_digest")
     assert result.dashboard_display_snapshot is not None
     assert result.dashboard_display_projection_digest is not None
+
+
+def test_replay_binding_carries_display_projection_digest() -> None:
+    result = _run_default()
+    binding = result.master_v2_decision_state_digest_binding
+    assert binding is not None
+    assert binding.dashboard_display_projection_digest == result.dashboard_display_projection_digest
+    assert len(binding.dashboard_display_projection_digest) == 64
+
+
+def test_replay_result_digest_coherent_includes_display_projection() -> None:
+    result = _run_default()
+    assert replay_result_digest_coherent(result)
+    binding = result.master_v2_decision_state_digest_binding
+    assert binding is not None
+    assert binding.dashboard_display_projection_digest == result.dashboard_display_projection_digest


### PR DESCRIPTION
## Summary

- **GAP_003**: `GAP_003_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_BINDING`
- Verdrahtet `dashboard_display_projection_digest` aus dem kanonischen Replay-Result in `MasterV2DecisionStateDigestBinding` und `CompletionProofChainBinding`.
- Completion-/Six-Node-Evidence kann die read-only Display-Projection deterministisch und fail-closed nachvollziehen.
- Keine Änderung an Handels-, Display-Projektions- oder Authority-Semantik.

## Owners

| Rolle | Owner |
|-------|-------|
| Replay / Digest-Erzeugung | `offline_double_play_scenario_replay_v0.py` |
| Decision-State-Binding | `bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py` |
| Completion-Proof-Chain | `CompletionProofChainBinding` + `default_minimal_completion_proof_chain` |
| Six-Node-Evidence | `offline_master_v2_replay_six_node_validation_graph_binding_v0.py` |

## Test plan

- [x] Replay binding contract (35 Tests, lokal)
- [x] Digest/completion chain contract erweitert
- [x] Ops replay completion binding erweitert (Display-Digest Drift/Missing)
- [x] ruff format/check
- [ ] PR-CI (FULL-Trigger wegen `durable_completion` Contract-Pfad)

## CI

```
test_selection_mode=FULL
test_selection_reason=durable_completion_foreign_path_requires_full
```

Ursache: Änderung an kanonischem `bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py` — nicht umgangen.

## Evidence

- Planning: `.../planning/entry_01_gap003_replay_display_projection_digest_completion_evidence_20260623T094500Z`
- Implementation: `.../implementation/entry_02_gap003_replay_display_projection_digest_completion_evidence_20260623T094500Z`


Made with [Cursor](https://cursor.com)