### PR TITLE
fix(ci): enforce pre-pr validation before cursor auto-pr

### DIFF
--- a/.github/workflows/cursor_auto_pr.yml
+++ b/.github/workflows/cursor_auto_pr.yml
@@ -20,6 +20,20 @@ jobs:
   create_pr_if_missing:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout for PRE_PR enforcement
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Enforce PRE_PR validation (fail-closed)
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          python3 scripts/ops/verify_pre_pr_validation_result_v0.py \
+            --result-file .cursor/PRE_PR_VALIDATION_RESULT.env \
+            --base-ref origin/main \
+            --check-diff-sha
+
       - name: Create PR if missing
         uses: actions/github-script@v7
         with:
@@ -101,11 +115,6 @@ jobs:
 
             core.info(`CREATED: PR #${pr.data.number} ${pr.data.html_url}`);
 
-      - name: Checkout for contract-only classification
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
       - name: Classify contract-only fast-lane candidate
         id: classify
         run: |
@@ -178,4 +187,3 @@ jobs:
                 );
               }
             }
-

--- a/scripts/ops/verify_pre_pr_validation_result_v0.py
+++ b/scripts/ops/verify_pre_pr_validation_result_v0.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Fail-closed verifier for PRE_PR_HARD_BOUNDED_VALIDATION result surfaces (v0).
+
+Reads the canonical machine-readable result file (default: .cursor/PRE_PR_VALIDATION_RESULT.env)
+and enforces the global agent-progress-checkpoint PRE_PR contract before Auto-PR dispatch.
+
+Exit 0 only when all required fields pass. Exit 1 with stderr diagnostics otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CANONICAL_RESULT_PATH = Path(".cursor/PRE_PR_VALIDATION_RESULT.env")
+
+ALLOWED_VERDICTS = frozenset(
+    {
+        "PRE_PR_VALIDATION_PASS",
+        "PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED",
+    }
+)
+
+REQUIRED_TRUE_FIELDS = (
+    "FINAL_DIFF_FROZEN",
+    "FINAL_FILES_MATCH",
+    "FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED",
+    "REUSE_BEFORE_NEW_CHECKED",
+    "COMMIT_ALLOWED",
+    "PUSH_ALLOWED",
+    "PR_ALLOWED",
+)
+
+REQUIRED_PASS_FIELDS = ("LOCAL_GATE_BATCH_RESULT",)
+
+REQUIRED_FALSE_FIELDS = ("UNVALIDATED_FILES_REMAIN",)
+
+TARGET_MAX_SECONDS = 840
+HARD_STOP_SECONDS = 900
+MINIMUM_SAFETY_MARGIN_SECONDS = 180
+
+
+def _parse_env_file(text: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"invalid line (expected KEY=value): {raw_line!r}")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not re.fullmatch(r"[A-Z0-9_]+", key):
+            raise ValueError(f"invalid key: {key!r}")
+        data[key] = value
+    return data
+
+
+def _is_true(value: str) -> bool:
+    return value.lower() in {"true", "1", "yes"}
+
+
+def _is_false(value: str) -> bool:
+    return value.lower() in {"false", "0", "no"}
+
+
+def _parse_int_field(data: dict[str, str], key: str) -> int | None:
+    if key not in data or data[key] in {"", "N/A"}:
+        return None
+    return int(data[key])
+
+
+def _diff_sha256(base_ref: str) -> str:
+    proc = subprocess.run(
+        ["git", "diff", f"{base_ref}...HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode not in {0, 1}:
+        raise RuntimeError(proc.stderr.strip() or "git diff failed")
+    digest = hashlib.sha256(proc.stdout.encode("utf-8")).hexdigest()
+    return digest
+
+
+def verify_pre_pr_validation_result(
+    data: dict[str, str],
+    *,
+    check_diff_sha: bool = False,
+    base_ref: str = "origin/main",
+    repo_root: Path | None = None,
+) -> list[str]:
+    """Return a list of blocking error messages. Empty list means PASS."""
+    errors: list[str] = []
+
+    verdict = data.get("PRE_PR_VALIDATION_VERDICT", "").strip()
+    if not verdict:
+        errors.append("missing PRE_PR_VALIDATION_VERDICT")
+    elif verdict == "PRE_PR_VALIDATION_FAIL_CLOSED":
+        errors.append("PRE_PR_VALIDATION_VERDICT=PRE_PR_VALIDATION_FAIL_CLOSED")
+    elif verdict not in ALLOWED_VERDICTS:
+        errors.append(f"unknown PRE_PR_VALIDATION_VERDICT={verdict!r}")
+
+    for key in REQUIRED_TRUE_FIELDS:
+        if key not in data:
+            errors.append(f"missing {key}")
+        elif not _is_true(data[key]):
+            errors.append(f"{key} must be true (got {data[key]!r})")
+
+    for key in REQUIRED_PASS_FIELDS:
+        if data.get(key) != "PASS":
+            errors.append(f"{key} must be PASS (got {data.get(key)!r})")
+
+    for key in REQUIRED_FALSE_FIELDS:
+        if key not in data:
+            errors.append(f"missing {key}")
+        elif not _is_false(data[key]):
+            errors.append(f"{key} must be false (got {data[key]!r})")
+
+    manifest_rc = data.get("MANIFEST_VERIFY_RC")
+    if manifest_rc is None:
+        errors.append("missing MANIFEST_VERIFY_RC")
+    elif manifest_rc != "0":
+        errors.append(f"MANIFEST_VERIFY_RC must be 0 (got {manifest_rc!r})")
+
+    timing_required_raw = data.get("TIMING_PROOF_REQUIRED", "").lower()
+    timing_required = timing_required_raw in {"true", "1", "yes"}
+    timing_not_required = timing_required_raw in {"false", "0", "no"}
+
+    if not timing_required and not timing_not_required:
+        errors.append(
+            f"TIMING_PROOF_REQUIRED must be true or false (got {data.get('TIMING_PROOF_REQUIRED')!r})"
+        )
+
+    if timing_required:
+        if verdict != "PRE_PR_VALIDATION_PASS":
+            errors.append(
+                "TIMING_PROOF_REQUIRED=true requires PRE_PR_VALIDATION_VERDICT=PRE_PR_VALIDATION_PASS"
+            )
+        timing_status = data.get("TIMING_PROOF_STATUS", "")
+        if timing_status != "PASS":
+            errors.append(f"TIMING_PROOF_STATUS must be PASS (got {timing_status!r})")
+        wallclock = _parse_int_field(data, "TIMING_WALLCLOCK_SECONDS")
+        if wallclock is None:
+            errors.append("missing TIMING_WALLCLOCK_SECONDS")
+        elif wallclock > TARGET_MAX_SECONDS:
+            errors.append(
+                f"TIMING_WALLCLOCK_SECONDS={wallclock} exceeds TARGET_MAX_SECONDS={TARGET_MAX_SECONDS}"
+            )
+        hard_stop = _parse_int_field(data, "TIMING_HARD_STOP_SECONDS")
+        if hard_stop is not None and hard_stop > HARD_STOP_SECONDS:
+            errors.append(
+                f"TIMING_HARD_STOP_SECONDS={hard_stop} exceeds allowed {HARD_STOP_SECONDS}"
+            )
+        margin = _parse_int_field(data, "TIMING_SAFETY_MARGIN_SECONDS")
+        if margin is not None and margin < MINIMUM_SAFETY_MARGIN_SECONDS:
+            errors.append(
+                f"TIMING_SAFETY_MARGIN_SECONDS={margin} below minimum {MINIMUM_SAFETY_MARGIN_SECONDS}"
+            )
+        if data.get("FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED", "").lower() != "true":
+            errors.append("TIMING_PROOF_REQUIRED=true requires FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED=true")
+    else:
+        if verdict != "PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED":
+            errors.append(
+                "TIMING_PROOF_REQUIRED=false requires "
+                "PRE_PR_VALIDATION_VERDICT=PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED"
+            )
+        justification = data.get("TIMING_PROOF_STATUS", "")
+        has_text_justification = bool(data.get("TIMING_PROOF_NOT_REQUIRED_JUSTIFICATION", "").strip())
+        if justification != "TIMING_PROOF_NOT_REQUIRED_JUSTIFIED" and not has_text_justification:
+            errors.append(
+                "TIMING_PROOF_REQUIRED=false requires TIMING_PROOF_STATUS="
+                "TIMING_PROOF_NOT_REQUIRED_JUSTIFIED or TIMING_PROOF_NOT_REQUIRED_JUSTIFICATION"
+            )
+        # Hard-stop / fail timing must never coexist with timing-not-required pass.
+        if data.get("TIMING_PROOF_STATUS") == "FAIL":
+            errors.append("TIMING_PROOF_STATUS=FAIL cannot pass when timing proof was required")
+        wallclock = _parse_int_field(data, "TIMING_WALLCLOCK_SECONDS")
+        if wallclock is not None and wallclock >= HARD_STOP_SECONDS:
+            errors.append(
+                f"TIMING_WALLCLOCK_SECONDS={wallclock} reached hard stop; cannot claim timing not required"
+            )
+
+    if check_diff_sha:
+        expected = data.get("FINAL_DIFF_SHA256", "").strip()
+        if not expected:
+            errors.append("missing FINAL_DIFF_SHA256 for diff verification")
+        else:
+            root = repo_root or Path.cwd()
+            try:
+                actual = _diff_sha256(base_ref)
+            except (RuntimeError, subprocess.SubprocessError) as exc:
+                errors.append(f"could not compute diff sha256: {exc}")
+            else:
+                if actual != expected:
+                    errors.append(
+                        f"FINAL_DIFF_SHA256 mismatch: expected {expected}, actual {actual}"
+                    )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--result-file",
+        type=Path,
+        default=CANONICAL_RESULT_PATH,
+        help="Path to PRE_PR_VALIDATION_RESULT.env (default: .cursor/PRE_PR_VALIDATION_RESULT.env)",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Base ref for optional diff SHA verification",
+    )
+    parser.add_argument(
+        "--check-diff-sha",
+        action="store_true",
+        help="Verify FINAL_DIFF_SHA256 matches git diff against base-ref",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root for git operations (default: cwd)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.result_file.is_file():
+        print(
+            f"PRE_PR_VALIDATION_FAIL_CLOSED: missing result file: {args.result_file}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        data = _parse_env_file(args.result_file.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        print(f"PRE_PR_VALIDATION_FAIL_CLOSED: {exc}", file=sys.stderr)
+        return 1
+
+    errors = verify_pre_pr_validation_result(
+        data,
+        check_diff_sha=args.check_diff_sha,
+        base_ref=args.base_ref,
+        repo_root=args.repo_root,
+    )
+    if errors:
+        print("PRE_PR_VALIDATION_FAIL_CLOSED:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(f"PRE_PR_VALIDATION_OK verdict={data.get('PRE_PR_VALIDATION_VERDICT')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/verify_pre_pr_validation_result_v0.py
+++ b/scripts/ops/verify_pre_pr_validation_result_v0.py
@@ -163,7 +163,9 @@ def verify_pre_pr_validation_result(
                 f"TIMING_SAFETY_MARGIN_SECONDS={margin} below minimum {MINIMUM_SAFETY_MARGIN_SECONDS}"
             )
         if data.get("FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED", "").lower() != "true":
-            errors.append("TIMING_PROOF_REQUIRED=true requires FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED=true")
+            errors.append(
+                "TIMING_PROOF_REQUIRED=true requires FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED=true"
+            )
     else:
         if verdict != "PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED":
             errors.append(
@@ -171,7 +173,9 @@ def verify_pre_pr_validation_result(
                 "PRE_PR_VALIDATION_VERDICT=PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED"
             )
         justification = data.get("TIMING_PROOF_STATUS", "")
-        has_text_justification = bool(data.get("TIMING_PROOF_NOT_REQUIRED_JUSTIFICATION", "").strip())
+        has_text_justification = bool(
+            data.get("TIMING_PROOF_NOT_REQUIRED_JUSTIFICATION", "").strip()
+        )
         if justification != "TIMING_PROOF_NOT_REQUIRED_JUSTIFIED" and not has_text_justification:
             errors.append(
                 "TIMING_PROOF_REQUIRED=false requires TIMING_PROOF_STATUS="

--- a/tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py
+++ b/tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py
@@ -53,7 +53,7 @@ def _valid_timing_not_required_data(**overrides: str) -> dict[str, str]:
         TIMING_PROOF_STATUS="TIMING_PROOF_NOT_REQUIRED_JUSTIFIED",
         TIMING_PROOF_NOT_REQUIRED_JUSTIFICATION="selector NO_OP small FOCUSED",
     )
-  # remove timing pass-only fields that are not required
+    # remove timing pass-only fields that are not required
     base.pop("TIMING_WALLCLOCK_SECONDS", None)
     base.update(overrides)
     return base

--- a/tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py
+++ b/tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py
@@ -1,0 +1,214 @@
+"""Contract tests for cursor_auto_pr PRE_PR validation enforcement (v0).
+
+Static workflow structure plus fail-closed verifier semantics. Never dispatches
+workflows, never calls GitHub APIs, and never touches runtime or trading paths.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "cursor_auto_pr.yml"
+VERIFIER = REPO_ROOT / "scripts" / "ops" / "verify_pre_pr_validation_result_v0.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ops"))
+from verify_pre_pr_validation_result_v0 import (  # noqa: E402
+    verify_pre_pr_validation_result,
+)
+
+
+def _valid_pass_data(**overrides: str) -> dict[str, str]:
+    base = {
+        "PRE_PR_VALIDATION_VERDICT": "PRE_PR_VALIDATION_PASS",
+        "FINAL_DIFF_FROZEN": "true",
+        "FINAL_FILES_MATCH": "true",
+        "FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED": "true",
+        "REUSE_BEFORE_NEW_CHECKED": "true",
+        "LOCAL_GATE_BATCH_RESULT": "PASS",
+        "UNVALIDATED_FILES_REMAIN": "false",
+        "COMMIT_ALLOWED": "true",
+        "PUSH_ALLOWED": "true",
+        "PR_ALLOWED": "true",
+        "MANIFEST_VERIFY_RC": "0",
+        "TIMING_PROOF_REQUIRED": "true",
+        "TIMING_PROOF_STATUS": "PASS",
+        "TIMING_WALLCLOCK_SECONDS": "120",
+        "TIMING_HARD_STOP_SECONDS": "900",
+        "TIMING_SAFETY_MARGIN_SECONDS": "180",
+        "FINAL_DIFF_SHA256": "abc",
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_timing_not_required_data(**overrides: str) -> dict[str, str]:
+    base = _valid_pass_data(
+        PRE_PR_VALIDATION_VERDICT="PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED",
+        TIMING_PROOF_REQUIRED="false",
+        TIMING_PROOF_STATUS="TIMING_PROOF_NOT_REQUIRED_JUSTIFIED",
+        TIMING_PROOF_NOT_REQUIRED_JUSTIFICATION="selector NO_OP small FOCUSED",
+    )
+  # remove timing pass-only fields that are not required
+    base.pop("TIMING_WALLCLOCK_SECONDS", None)
+    base.update(overrides)
+    return base
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_cursor_auto_pr_workflow_enforces_pre_pr_before_create_pr() -> None:
+    text = _workflow_text()
+    enforce_idx = text.index("Enforce PRE_PR validation (fail-closed)")
+    create_idx = text.index("Create PR if missing")
+    dispatch_idx = text.index("Dispatch required checks (workflow_dispatch)")
+    assert enforce_idx < create_idx < dispatch_idx
+
+
+def test_cursor_auto_pr_workflow_checks_out_before_enforcement() -> None:
+    text = _workflow_text()
+    checkout_idx = text.index("Checkout for PRE_PR enforcement")
+    enforce_idx = text.index("Enforce PRE_PR validation (fail-closed)")
+    assert checkout_idx < enforce_idx
+
+
+def test_cursor_auto_pr_workflow_invokes_canonical_verifier() -> None:
+    text = _workflow_text()
+    assert "verify_pre_pr_validation_result_v0.py" in text
+    assert ".cursor/PRE_PR_VALIDATION_RESULT.env" in text
+    assert "--check-diff-sha" in text
+
+
+def test_verifier_module_exists() -> None:
+    assert VERIFIER.is_file()
+
+
+def test_full_valid_pass_allows() -> None:
+    assert verify_pre_pr_validation_result(_valid_pass_data()) == []
+
+
+def test_fail_closed_verdict_blocks() -> None:
+    data = _valid_pass_data(PRE_PR_VALIDATION_VERDICT="PRE_PR_VALIDATION_FAIL_CLOSED")
+    errors = verify_pre_pr_validation_result(data)
+    assert any("FAIL_CLOSED" in e for e in errors)
+
+
+def test_missing_verdict_blocks() -> None:
+    data = _valid_pass_data()
+    del data["PRE_PR_VALIDATION_VERDICT"]
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_timing_fail_with_pass_verdict_blocks() -> None:
+    data = _valid_pass_data(TIMING_PROOF_STATUS="FAIL")
+    errors = verify_pre_pr_validation_result(data)
+    assert any("TIMING_PROOF_STATUS" in e for e in errors)
+
+
+def test_timing_hard_stop_wallclock_blocks() -> None:
+    data = _valid_pass_data(TIMING_WALLCLOCK_SECONDS="900")
+    errors = verify_pre_pr_validation_result(data)
+    assert any("900" in e for e in errors)
+
+
+def test_timing_required_without_pass_blocks() -> None:
+    data = _valid_pass_data(
+        PRE_PR_VALIDATION_VERDICT="PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED",
+        TIMING_PROOF_REQUIRED="true",
+    )
+    errors = verify_pre_pr_validation_result(data)
+    assert errors
+
+
+def test_timing_not_required_without_justification_blocks() -> None:
+    data = _valid_timing_not_required_data(TIMING_PROOF_STATUS="PASS")
+    data.pop("TIMING_PROOF_NOT_REQUIRED_JUSTIFICATION", None)
+    errors = verify_pre_pr_validation_result(data)
+    assert errors
+
+
+def test_timing_not_required_valid_pass() -> None:
+    assert verify_pre_pr_validation_result(_valid_timing_not_required_data()) == []
+
+
+def test_final_files_match_false_blocks() -> None:
+    data = _valid_pass_data(FINAL_FILES_MATCH="false")
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_path_equivalence_false_blocks() -> None:
+    data = _valid_pass_data(FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED="false")
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_local_gate_not_pass_blocks() -> None:
+    data = _valid_pass_data(LOCAL_GATE_BATCH_RESULT="FAIL")
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_manifest_verify_rc_nonzero_blocks() -> None:
+    data = _valid_pass_data(MANIFEST_VERIFY_RC="1")
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_commit_allowed_false_blocks() -> None:
+    data = _valid_pass_data(COMMIT_ALLOWED="false")
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_push_allowed_false_blocks() -> None:
+    data = _valid_pass_data(PUSH_ALLOWED="false")
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_pr_allowed_false_blocks() -> None:
+    data = _valid_pass_data(PR_ALLOWED="false")
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_unvalidated_files_remain_true_blocks() -> None:
+    data = _valid_pass_data(UNVALIDATED_FILES_REMAIN="true")
+    assert verify_pre_pr_validation_result(data)
+
+
+def test_timing_not_required_with_hard_stop_wallclock_blocks() -> None:
+    data = _valid_timing_not_required_data(TIMING_WALLCLOCK_SECONDS="900")
+    errors = verify_pre_pr_validation_result(data)
+    assert any("hard stop" in e for e in errors)
+
+
+def test_cli_missing_result_file_exits_nonzero(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(VERIFIER),
+            "--result-file",
+            str(tmp_path / "missing.env"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 1
+    assert "missing result file" in proc.stderr
+
+
+def test_required_check_names_unchanged_in_ci_yml() -> None:
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "timeout-minutes: 17" in ci
+    assert "timeout-minutes: 25" not in ci
+    assert "timeout-minutes: 30" not in ci
+    assert "timeout-minutes: 40" not in ci
+
+
+def test_cursor_auto_pr_workflow_does_not_mutate_matrix_or_required_contexts() -> None:
+    text = _workflow_text()
+    assert "strategy:" not in text
+    assert "\n        matrix:" not in text
+    assert "required_status" not in text.lower()


### PR DESCRIPTION
## Summary

Technical fail-closed guard for `PRE_PR_HARD_BOUNDED_VALIDATION` on the Cursor Auto-PR path after incident **PR #4529** (`PRE_PR_FAIL_CLOSED_RESULT_IGNORED`).

- **`cursor_auto_pr.yml`**: checkout + enforce step runs **before** PR creation and workflow dispatch
- **`scripts/ops/verify_pre_pr_validation_result_v0.py`**: canonical verifier for `.cursor/PRE_PR_VALIDATION_RESULT.env`
- **Contract tests**: `tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py` (24 cases)

## Format correction (2026-06-23)

**Lint Gate failure cause:** `ruff format --check` on two Python files (no semantic change).

**Fix commit:** `style(ci): format pre-pr enforcement contracts` (`bf14e795`)

**Re-validated Pre-PR evidence:**
- `PRE_PR_VALIDATION_PASS`
- `FINAL_DIFF_SHA256=06fc9085b0fafaa28977a08b15a419799684ed927db87d43c03fc3db8495fed1`
- `ruff format --check` PASS, `ruff check` PASS
- 82 contract tests in 1.35s (path-equivalent timing PASS)
- Selector: FOCUSED / `focused_script_or_test_diff`

## Incident context

PR #4529 received `PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED` after a timing probe exceeded **900s** and local validation used a non-equivalent `-k` filtered subset. Text-only global rule was insufficient; Auto-PR had no technical gate.

## Invariants preserved

- No timeout increase (17-minute cap unchanged)
- No required-check name changes
- No matrix changes
- No test coverage reduction
- No trading/execution semantics changes

## Test plan

- [x] Enforcement contract tests (24)
- [x] Workflow + timeout contracts
- [x] Ruff format/check after correction
- [ ] GitHub CI confirmation (post-format push)