### PR TITLE
fix(ops): bind pe21 input into completion integration digest

### DIFF
--- a/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -2386,6 +2386,9 @@ def _integration_input_dict(
         "non_authorizing": integration_input.non_authorizing,
         "pe16_archive": asdict(integration_input.pe16_archive),
         "pe21_proof": asdict(integration_input.pe21_proof),
+        "pe21_integration_input_digest": compute_pe21_integration_input_digest(
+            integration_input.pe21_integration_input
+        ),
         "pe31_integration_input_digest": compute_pe31_integration_input_digest(
             integration_input.pe31_reconciliation_review_integration_input
         ),

--- a/tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -412,6 +412,55 @@ def test_global_safety_flags_remain_blocked() -> None:
     assert GLOBAL_RUN_COMPLETION_READINESS is False
 
 
+def test_completion_integration_input_digest_deterministic_for_identical_inputs() -> None:
+    left = default_minimal_completion_integration_input(source_revision=VALID_COMMIT_SHA)
+    right = default_minimal_completion_integration_input(source_revision=VALID_COMMIT_SHA)
+    assert compute_completion_integration_input_digest(
+        left
+    ) == compute_completion_integration_input_digest(right)
+
+
+def test_completion_integration_input_digest_sensitive_to_pe21_integration_input() -> None:
+    base = default_minimal_completion_integration_input(source_revision=VALID_COMMIT_SHA)
+    pe21_input = replace(
+        base.pe21_integration_input,
+        source_revision="1234567890123456789012345678901234567890",
+    )
+    variant = replace(base, pe21_integration_input=pe21_input)
+    assert compute_completion_integration_input_digest(
+        base
+    ) != compute_completion_integration_input_digest(variant)
+
+
+def test_completion_integration_input_digest_sensitive_to_pe21_reconciliation_binding() -> None:
+    base = default_minimal_completion_integration_input()
+    recon = base.pe21_integration_input.reconciliation_binding
+    bad_recon = replace(recon, reconciled=not recon.reconciled)
+    pe21_input = replace(base.pe21_integration_input, reconciliation_binding=bad_recon)
+    variant = replace(base, pe21_integration_input=pe21_input)
+    assert compute_completion_integration_input_digest(
+        base
+    ) != compute_completion_integration_input_digest(variant)
+
+
+def test_completion_integration_input_digest_still_sensitive_to_pe31_integration_input() -> None:
+    base = default_minimal_completion_integration_input()
+    pe31_input = replace(
+        base.pe31_reconciliation_review_integration_input,
+        source_revision="1234567890123456789012345678901234567890",
+    )
+    variant = replace(base, pe31_reconciliation_review_integration_input=pe31_input)
+    assert compute_completion_integration_input_digest(
+        base
+    ) != compute_completion_integration_input_digest(variant)
+
+
+def test_completion_integration_input_digest_includes_pe21_integration_input_digest_field() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    payload = serialize_completion_integration_input_canonical(integration_input)
+    assert '"pe21_integration_input_digest"' in payload
+
+
 def test_deterministic_identical_inputs_same_payload_and_digest() -> None:
     left = default_minimal_completion_integration_input(source_revision=VALID_COMMIT_SHA)
     right = default_minimal_completion_integration_input(source_revision=VALID_COMMIT_SHA)


### PR DESCRIPTION
## Summary
- bindet pe21_integration_input über kanonischen PE-21-Digest-Helper
- verhindert gleiche Completion-Integration-Digests bei abweichendem PE-21-Input
- keine Evaluate-Semantikänderung, kein Cache, keine Memoization

## CI
- FOCUSED Selector / durable_completion_focused
- 14 path-äquivalente Node-IDs
- Timing: 394s (Budget 840s)
- PRE_PR_VERIFIER_RC=0
- keine Runtime-/Trading-Ausführung
