### PR TITLE
fix(ci): decouple validation graph from completion integration tests

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -107,15 +107,27 @@ DURABLE_COMPLETION_CI_WORKFLOW_REBUNDLE_PATHS = frozenset(
     }
 )
 
+DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER = (
+    "tests/ops/test_durable_completion_validation_graph_v1.py"
+)
+DURABLE_COMPLETION_INTEGRATION_TEST_OWNER = "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+DURABLE_COMPLETION_GRAPH_WIRING_PATH = "src/ops/durable_completion_validation/graph.py"
+DURABLE_COMPLETION_PUBLIC_API_PATH = "src/ops/durable_completion_validation/__init__.py"
+
 CANONICAL_DURABLE_COMPLETION_FOCUSED_TESTS: tuple[str, ...] = (
-    "tests/ops/test_durable_completion_validation_graph_v1.py",
-    "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER,
+    DURABLE_COMPLETION_INTEGRATION_TEST_OWNER,
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
+CANONICAL_DURABLE_COMPLETION_VALIDATION_GRAPH_FOCUSED_TESTS: tuple[str, ...] = (
+    DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER,
     "tests/ci/test_ci_diff_aware_test_selection_v1.py",
 )
 
 REQUIRED_DURABLE_COMPLETION_TEST_OWNERS: tuple[str, ...] = (
-    "tests/ops/test_durable_completion_validation_graph_v1.py",
-    "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER,
+    DURABLE_COMPLETION_INTEGRATION_TEST_OWNER,
 )
 
 DURABLE_COMPLETION_FULL_REFACTOR_SRC_PATHS = frozenset(
@@ -133,10 +145,7 @@ DURABLE_COMPLETION_VALIDATOR_REBINDING_TEST_PATHS = frozenset(
     }
 )
 
-DURABLE_COMPLETION_COMPLETION_INTEGRATION_TEST_OWNER = "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
-DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER = (
-    "tests/ops/test_durable_completion_validation_graph_v1.py"
-)
+DURABLE_COMPLETION_COMPLETION_INTEGRATION_TEST_OWNER = DURABLE_COMPLETION_INTEGRATION_TEST_OWNER
 
 DURABLE_COMPLETION_WALLCLOCK_BINDING_REBINDING_TEST_PATHS = frozenset(
     {
@@ -816,10 +825,36 @@ def _is_durable_completion_scoped_path(path: str) -> bool:
     if path.startswith("src/ops/durable_completion_validation/") and path.endswith(".py"):
         return True
     if path in {
-        "tests/ops/test_durable_completion_validation_graph_v1.py",
-        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+        DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER,
+        DURABLE_COMPLETION_INTEGRATION_TEST_OWNER,
     }:
         return True
+    return False
+
+
+def _is_durable_completion_validation_graph_only_scoped_path(path: str) -> bool:
+    if path == DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER:
+        return True
+    if not path.startswith("src/ops/durable_completion_validation/"):
+        return False
+    if path in {DURABLE_COMPLETION_GRAPH_WIRING_PATH, DURABLE_COMPLETION_PUBLIC_API_PATH}:
+        return False
+    return path.endswith(".py")
+
+
+def _requires_durable_completion_integration_test_owner(files: list[str]) -> bool:
+    for path in files:
+        if path in {
+            DURABLE_COMPLETION_FACADE_PATH,
+            DURABLE_COMPLETION_INTEGRATION_TEST_OWNER,
+            DURABLE_COMPLETION_GRAPH_WIRING_PATH,
+            DURABLE_COMPLETION_PUBLIC_API_PATH,
+        }:
+            return True
+        if _is_durable_completion_scoped_path(
+            path
+        ) and not _is_durable_completion_validation_graph_only_scoped_path(path):
+            return True
     return False
 
 
@@ -925,22 +960,19 @@ def _is_durable_completion_validator_rebinding_scope(files: list[str]) -> bool:
 
 
 def _durable_completion_focused_targets(files: list[str] | None = None) -> tuple[str, ...]:
-    graph_owner = "tests/ops/test_durable_completion_validation_graph_v1.py"
+    graph_owner = DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER
     if not _repo_path_exists(graph_owner):
         return ()
     if files and _is_durable_completion_wallclock_binding_rebinding_scope(files):
         return _durable_completion_wallclock_binding_focused_targets(files)
-    if files and _is_durable_completion_validator_rebinding_scope(files):
-        targets: list[str] = [graph_owner]
-        if files and any(
-            path in DURABLE_COMPLETION_CI_POLICY_PATHS
-            or path in DURABLE_COMPLETION_CI_WORKFLOW_REBUNDLE_PATHS
-            for path in files
-        ):
-            ci_owner = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
-            if _repo_path_exists(ci_owner):
-                targets.append(ci_owner)
-        return tuple(sorted(set(targets)))
+    if files and not _requires_durable_completion_integration_test_owner(files):
+        validation_targets: list[str] = []
+        for path in CANONICAL_DURABLE_COMPLETION_VALIDATION_GRAPH_FOCUSED_TESTS:
+            if _repo_path_exists(path):
+                validation_targets.append(path)
+        if graph_owner not in validation_targets:
+            return ()
+        return tuple(sorted(validation_targets))
     for path in REQUIRED_DURABLE_COMPLETION_TEST_OWNERS:
         if not _repo_path_exists(path):
             return ()
@@ -1918,19 +1950,24 @@ def _try_durable_completion_focused(files: list[str]) -> SelectionResult | None:
     targets = _durable_completion_focused_targets(files)
     if not targets:
         return None
-    modules: tuple[str, ...] = ("src.ops.durable_completion_validation",)
+    integration_required = _requires_durable_completion_integration_test_owner(files)
     if _is_durable_completion_wallclock_binding_rebinding_scope(files):
-        modules = (
+        modules: tuple[str, ...] = (
             "src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0",
         )
-    elif not _is_durable_completion_validator_rebinding_scope(files):
+        reason = "durable_completion_focused"
+    elif integration_required:
         modules = (
             "src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0",
             "src.ops.durable_completion_validation",
         )
+        reason = "durable_completion_focused"
+    else:
+        modules = ("src.ops.durable_completion_validation",)
+        reason = "durable_completion_validation_graph_focused"
     return SelectionResult(
         "FOCUSED",
-        "durable_completion_focused",
+        reason,
         targets,
         modules,
     )

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -589,12 +589,12 @@ def test_selector_durable_completion_internal_validator_only_focused() -> None:
     sel = _run_selector(
         "src/ops/durable_completion_validation/validators/reconciliation.py",
         "tests/ops/test_durable_completion_validation_graph_v1.py",
-        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
     assert sel["test_selection_mode"] == "FOCUSED"
-    assert sel["test_selection_reason"] == "durable_completion_focused"
+    assert sel["test_selection_reason"] == "durable_completion_validation_graph_focused"
     targets = _targets(sel)
-    assert targets == ["tests/ops/test_durable_completion_validation_graph_v1.py"]
+    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
     assert (
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
         not in targets
@@ -613,7 +613,11 @@ def test_selector_pe55_fill_rebinding_bounded_focused_targets() -> None:
     assert sel["test_selection_mode"] == "FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
-    assert targets == ["tests/ops/test_durable_completion_validation_graph_v1.py"]
+    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
+    assert (
+        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+        in targets
+    )
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_no_op"] == "false"
 
@@ -621,10 +625,10 @@ def test_selector_pe55_fill_rebinding_bounded_focused_targets() -> None:
 def test_selector_pe55_fill_rebinding_import_modules_bounded() -> None:
     sel = _run_selector(*PE55_DURABLE_COMPLETION_FILL_REBINDING_FILES)
     modules = _modules(sel)
-    assert modules == ["src.ops.durable_completion_validation"]
+    assert "src.ops.durable_completion_validation" in modules
     assert (
         "src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0"
-        not in modules
+        in modules
     )
 
 
@@ -663,12 +667,12 @@ def test_selector_pe56_graph_wiring_rebinding_bounded_focused_targets() -> None:
     assert sel["test_selection_mode"] == "FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
-    assert targets == ["tests/ops/test_durable_completion_validation_graph_v1.py"]
+    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
     assert (
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
-        not in targets
+        in targets
     )
-    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" not in targets
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
 
 
 PE60_DURABLE_COMPLETION_DELEGATION_FILES = (
@@ -684,13 +688,84 @@ def test_selector_pe60_completion_chain_delegation_rebinding_bounded_focused_tar
     assert sel["test_selection_mode"] == "FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
-    assert targets == ["tests/ops/test_durable_completion_validation_graph_v1.py"]
+    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
     assert (
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
-        not in targets
+        in targets
     )
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_no_op"] == "false"
+
+
+GLB019_A1_FOUR_FILE_DIFF = (
+    "src/ops/durable_completion_validation/models.py",
+    "src/ops/durable_completion_validation/validators/__init__.py",
+    "src/ops/durable_completion_validation/validators/event_stream.py",
+    "tests/ops/test_durable_completion_validation_graph_v1.py",
+)
+
+_INTEGRATION_OWNER = "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+_GRAPH_OWNER = "tests/ops/test_durable_completion_validation_graph_v1.py"
+_CI_OWNER = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
+
+
+def test_selector_glb019_a1_four_file_diff_validation_graph_focused() -> None:
+    sel = _run_selector(*GLB019_A1_FOUR_FILE_DIFF)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "durable_completion_validation_graph_focused"
+    targets = _targets(sel)
+    assert _GRAPH_OWNER in targets
+    assert _CI_OWNER in targets
+    assert _INTEGRATION_OWNER not in targets
+    assert _modules(sel) == ["src.ops.durable_completion_validation"]
+
+
+def test_selector_glb019_validation_only_event_stream_validator_focused() -> None:
+    sel = _run_selector(
+        "src/ops/durable_completion_validation/validators/event_stream.py",
+        _GRAPH_OWNER,
+    )
+    assert sel["test_selection_reason"] == "durable_completion_validation_graph_focused"
+    assert _INTEGRATION_OWNER not in _targets(sel)
+
+
+def test_selector_glb019_validation_only_models_context_field_focused() -> None:
+    sel = _run_selector(
+        "src/ops/durable_completion_validation/models.py",
+        _GRAPH_OWNER,
+    )
+    assert sel["test_selection_reason"] == "durable_completion_validation_graph_focused"
+    assert _INTEGRATION_OWNER not in _targets(sel)
+
+
+def test_selector_glb019_completion_facade_still_selects_integration_owner() -> None:
+    sel = _run_selector(
+        "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+        _GRAPH_OWNER,
+    )
+    assert sel["test_selection_reason"] == "durable_completion_focused"
+    assert _INTEGRATION_OWNER in _targets(sel)
+
+
+def test_selector_glb019_graph_wiring_still_selects_integration_owner() -> None:
+    sel = _run_selector(
+        "src/ops/durable_completion_validation/graph.py",
+        "src/ops/durable_completion_validation/validators/reconciliation.py",
+        _GRAPH_OWNER,
+    )
+    assert sel["test_selection_reason"] == "durable_completion_focused"
+    assert _INTEGRATION_OWNER in _targets(sel)
+
+
+def test_selector_glb019_mixed_validation_and_facade_selects_integration_owner() -> None:
+    sel = _run_selector(
+        "src/ops/durable_completion_validation/validators/event_stream.py",
+        "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+        _GRAPH_OWNER,
+    )
+    assert sel["test_selection_reason"] == "durable_completion_focused"
+    assert _INTEGRATION_OWNER in _targets(sel)
 
 
 PR4512_MASTER_V2_BINDING_CONTRACT_FILES = (
@@ -703,8 +778,7 @@ PR4512_MASTER_V2_BINDING_CONTRACT_FILES = (
 _MASTER_V2_BINDING_OWNER = (
     "tests/ops/test_master_v2_decision_digest_completion_chain_binding_contract_v0.py"
 )
-_COMPLETION_OWNER = "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
-_GRAPH_OWNER = "tests/ops/test_durable_completion_validation_graph_v1.py"
+_COMPLETION_OWNER = _INTEGRATION_OWNER
 
 
 def test_selector_pr4512_master_v2_binding_contract_four_file_diff_focused() -> None:
@@ -1104,7 +1178,9 @@ def test_selector_pr4504_wallclock_binding_plus_ci_policy_includes_ci_owner() ->
 def test_selector_durable_completion_validator_rebinding_rules_unchanged() -> None:
     sel = _run_selector(*PE55_DURABLE_COMPLETION_FILL_REBINDING_FILES)
     assert sel["test_selection_mode"] == "FOCUSED"
-    assert _targets(sel) == ["tests/ops/test_durable_completion_validation_graph_v1.py"]
+    targets = _targets(sel)
+    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
+    assert _INTEGRATION_OWNER in targets
 
 
 def test_fast_lane_skips_full_static_sweep_when_focused() -> None:
@@ -1137,10 +1213,7 @@ def test_selector_pe55_full_diff_with_ci_workflow_rebundle_stays_focused() -> No
     targets = _targets(sel)
     assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
-    assert (
-        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
-        not in targets
-    )
+    assert _INTEGRATION_OWNER in targets
     assert sel["tests_execute_full"] == "false"
 
 


### PR DESCRIPTION
## Summary
- Behebt die zu breite `durable_completion_focused`-Kopplung: reine `durable_completion_validation`-Änderungen (Validatoren, Modelle, Graph-Testowner) wählen nicht mehr den vollständigen Completion-Integration-Testowner (~238 Nodes).
- Neue Selector-Reason `durable_completion_validation_graph_focused` bindet CI-/Selector-Contract-Tests plus vollständigen Validation-Graph-Testowner.
- Completion-Facade, `graph.py`-Wiring, Integration-Testowner-Datei und gemischte Diffs bleiben fail-closed auf vollem Integration-Pfad.

## A1-Probediff (read-only Klassifikation)
- **Vorher:** 483 Nodes (195 CI + 238 Integration + 50 Graph)
- **Nachher:** 245 Nodes (201 CI + 50 Graph), Integration entfällt
- Erwartete Laufzeitklasse: ~70–120s (innerhalb 840s-Budget)

## Test plan
- [x] `tests/ci/test_ci_diff_aware_test_selection_v1.py` (201 passed)
- [x] Path-äquivalenter Selector-Slice-Lauf ~9s
- [x] PRE_PR_VERIFIER_RC=0
- [x] A1-Worktree unverändert (Diff SHA `a5f7e743…`)
- [x] Keine Testabdeckungsreduktion, keine Timeout-Erhöhung, keine Workflow-Matrix-Änderung


Made with [Cursor](https://cursor.com)