### PR TITLE
feat(ops): add glb019 event stream validator contract

### DIFF
--- a/src/ops/durable_completion_validation/models.py
+++ b/src/ops/durable_completion_validation/models.py
@@ -19,4 +19,5 @@ class ValidationContext:
     pe37_result: dict[str, Any] | None = None
     pe25_result: dict[str, Any] | None = None
     admission_result: dict[str, Any] | None = None
+    glb019_result: dict[str, Any] | None = None
     completed_validators: set[str] = field(default_factory=set)

--- a/src/ops/durable_completion_validation/validators/__init__.py
+++ b/src/ops/durable_completion_validation/validators/__init__.py
@@ -1,8 +1,9 @@
 """Durable completion validator modules."""
 
-from . import operator_closure, reconciliation, recovery, traceability
+from . import event_stream, operator_closure, reconciliation, recovery, traceability
 
 __all__ = [
+    "event_stream",
     "operator_closure",
     "reconciliation",
     "recovery",

--- a/src/ops/durable_completion_validation/validators/event_stream.py
+++ b/src/ops/durable_completion_validation/validators/event_stream.py
@@ -1,0 +1,401 @@
+"""GLB-019 event stream static boundary validator for durable completion proof binding."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.ops.durable_completion_validation.identity import sorted_unique, valid_sha256_digest
+from src.ops.durable_completion_validation.models import ValidationContext, ValidationResult
+
+BOUNDARY_OWNER = "glb019_event_stream_static_boundary_v0"
+CONTRACT_VERSION = "v0"
+HASH_ALGORITHM = "sha256"
+
+REQUIRED_EVENT_CLASSES: tuple[str, ...] = (
+    "state_transition",
+    "gate_blocker_decision",
+    "risk_killswitch_abort_closeout",
+    "evidence_manifest_validation",
+    "promotion_readiness_visibility",
+)
+
+
+@dataclass(frozen=True)
+class EventStreamRecord:
+    event_class: str
+    event_id: str
+    sequence: int
+    timestamp_utc: str
+    source: str
+    correlation_id: str
+    schema_version: str
+    present: bool
+
+
+@dataclass(frozen=True)
+class Glb019EventStreamValidationInput:
+    boundary_owner: str
+    source_revision: str
+    completion_identity_digest: str
+    manifest_identity_digest: str
+    run_identity_digest: str
+    correlation_id: str
+    events: tuple[EventStreamRecord, ...]
+
+
+@dataclass(frozen=True)
+class Glb019EventStreamProofBinding:
+    boundary_owner: str
+    source_revision: str
+    validation_input_digest: str
+    validation_result_digest: str
+    glb019_validation_pass: bool
+    event_stream_boundary_satisfied: bool
+    durable_completion_event_stream_bound: bool
+    incomplete_event_stream_fail_closed: bool
+    event_stream_non_authorizing: bool
+    completion_identity_digest: str
+    manifest_identity_digest: str
+    run_identity_digest: str
+    correlation_id: str
+    event_stream_identity: str
+
+
+def _record_dict(record: EventStreamRecord) -> dict[str, Any]:
+    return asdict(record)
+
+
+def _validation_input_dict(validation_input: Glb019EventStreamValidationInput) -> dict[str, Any]:
+    return {
+        "boundary_owner": validation_input.boundary_owner,
+        "completion_identity_digest": validation_input.completion_identity_digest,
+        "contract_version": CONTRACT_VERSION,
+        "correlation_id": validation_input.correlation_id,
+        "events": [_record_dict(record) for record in validation_input.events],
+        "hash_algorithm": HASH_ALGORITHM,
+        "manifest_identity_digest": validation_input.manifest_identity_digest,
+        "run_identity_digest": validation_input.run_identity_digest,
+        "source_revision": validation_input.source_revision,
+    }
+
+
+def compute_validation_input_digest(validation_input: Glb019EventStreamValidationInput) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            _validation_input_dict(validation_input), sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def compute_event_stream_identity(
+    validation_input: Glb019EventStreamValidationInput,
+    *,
+    validation_pass: bool,
+) -> str:
+    payload = {
+        "correlation_id": validation_input.correlation_id,
+        "hash_algorithm": HASH_ALGORITHM,
+        "required_event_classes": list(REQUIRED_EVENT_CLASSES),
+        "validation_input_digest": compute_validation_input_digest(validation_input),
+        "validation_pass": validation_pass,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def compute_validation_result_digest(
+    validation_input: Glb019EventStreamValidationInput,
+    *,
+    validation_pass: bool,
+    fail_reasons: tuple[str, ...],
+) -> str:
+    payload = {
+        "boundary_owner": BOUNDARY_OWNER,
+        "event_stream_identity": compute_event_stream_identity(
+            validation_input,
+            validation_pass=validation_pass,
+        ),
+        "fail_reasons": list(fail_reasons),
+        "hash_algorithm": HASH_ALGORITHM,
+        "validation_input_digest": compute_validation_input_digest(validation_input),
+        "validation_pass": validation_pass,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def validate_glb019_event_stream_validation_input(
+    validation_input: Glb019EventStreamValidationInput,
+) -> list[str]:
+    fail_reasons: list[str] = []
+    prefix = "glb019_event_stream_input"
+
+    if validation_input.boundary_owner != BOUNDARY_OWNER:
+        fail_reasons.append(f"{prefix}: boundary_owner must be {BOUNDARY_OWNER!r}")
+    if not validation_input.source_revision:
+        fail_reasons.append(f"{prefix}: source_revision required")
+
+    for field_name in (
+        "completion_identity_digest",
+        "manifest_identity_digest",
+        "run_identity_digest",
+    ):
+        value = getattr(validation_input, field_name)
+        if not value:
+            fail_reasons.append(f"{prefix}: {field_name} required")
+        elif not valid_sha256_digest(value):
+            fail_reasons.append(f"{prefix}: {field_name} must be 64-char lowercase sha256 hex")
+
+    if not validation_input.correlation_id:
+        fail_reasons.append(f"{prefix}: correlation_id required")
+
+    if not validation_input.events:
+        fail_reasons.append(f"{prefix}: events required")
+
+    seen_ids: set[str] = set()
+    seen_sequences: set[int] = set()
+    for index, record in enumerate(validation_input.events):
+        rec_prefix = f"{prefix}: events[{index}]"
+        if not record.event_class:
+            fail_reasons.append(f"{rec_prefix}: event_class required")
+        if not record.event_id:
+            fail_reasons.append(f"{rec_prefix}: event_id required")
+        elif record.event_id in seen_ids:
+            fail_reasons.append(f"{rec_prefix}: duplicate event_id")
+        else:
+            seen_ids.add(record.event_id)
+
+        if record.sequence in seen_sequences:
+            fail_reasons.append(f"{rec_prefix}: duplicate sequence")
+        else:
+            seen_sequences.add(record.sequence)
+
+        if not record.timestamp_utc:
+            fail_reasons.append(f"{rec_prefix}: timestamp_utc required")
+        if not record.source:
+            fail_reasons.append(f"{rec_prefix}: source required")
+        if not record.schema_version:
+            fail_reasons.append(f"{rec_prefix}: schema_version required")
+        if record.correlation_id != validation_input.correlation_id:
+            fail_reasons.append(f"{rec_prefix}: correlation_id mismatch with validation input")
+
+    return sorted_unique(fail_reasons)
+
+
+def evaluate_glb019_event_stream_validation(
+    validation_input: Glb019EventStreamValidationInput,
+) -> dict[str, Any]:
+    """Canonical offline GLB-019 event stream validation — explicit input only."""
+    fail_reasons = validate_glb019_event_stream_validation_input(validation_input)
+
+    present_by_class: dict[str, list[EventStreamRecord]] = {}
+    for record in validation_input.events:
+        present_by_class.setdefault(record.event_class, []).append(record)
+
+    for event_class in REQUIRED_EVENT_CLASSES:
+        records = present_by_class.get(event_class, [])
+        if not records:
+            fail_reasons.append(
+                f"glb019_event_stream: missing mandatory event class {event_class!r}"
+            )
+            continue
+        if not any(record.present for record in records):
+            fail_reasons.append(
+                f"glb019_event_stream: mandatory event class {event_class!r} not present"
+            )
+
+    for event_class, records in present_by_class.items():
+        if event_class not in REQUIRED_EVENT_CLASSES:
+            fail_reasons.append(
+                f"glb019_event_stream: unknown event class {event_class!r} not in GLB-019 SSOT"
+            )
+        for record in records:
+            if record.present and not all(
+                (
+                    record.event_id,
+                    record.timestamp_utc,
+                    record.source,
+                    record.correlation_id,
+                    record.schema_version,
+                )
+            ):
+                fail_reasons.append(
+                    f"glb019_event_stream: incomplete identity fields for {event_class!r}"
+                )
+
+    sequences = sorted(record.sequence for record in validation_input.events)
+    if sequences != list(range(len(sequences))):
+        fail_reasons.append(
+            "glb019_event_stream: contradictory or non-contiguous sequence ordering"
+        )
+
+    fail_reasons = sorted_unique(fail_reasons)
+    validation_pass = not fail_reasons
+    event_stream_identity = compute_event_stream_identity(
+        validation_input,
+        validation_pass=validation_pass,
+    )
+    validation_result_digest = compute_validation_result_digest(
+        validation_input,
+        validation_pass=validation_pass,
+        fail_reasons=tuple(fail_reasons),
+    )
+
+    return {
+        "boundary_owner": BOUNDARY_OWNER,
+        "validation_pass": validation_pass,
+        "event_stream_boundary_satisfied": validation_pass,
+        "incomplete_event_stream_fail_closed": not validation_pass,
+        "event_stream_non_authorizing": True,
+        "validation_input_digest": compute_validation_input_digest(validation_input),
+        "validation_result_digest": validation_result_digest,
+        "event_stream_identity": event_stream_identity,
+        "fail_reasons": fail_reasons,
+    }
+
+
+def validate_glb019_event_stream_proof(context: ValidationContext) -> ValidationResult:
+    """Bind canonical GLB-019 validation result into durable completion proof graph."""
+    fail_reasons: list[str] = []
+    integration_input = context.integration_input
+    glb019_result = context.glb019_result or {}
+    proof = integration_input.glb019_event_stream_proof
+    validation_input = integration_input.glb019_event_stream_validation_input
+    prefix = "glb019_proof"
+
+    if proof.boundary_owner != BOUNDARY_OWNER:
+        fail_reasons.append(f"{prefix}: boundary_owner must be {BOUNDARY_OWNER!r}")
+    if proof.source_revision != integration_input.source_revision:
+        fail_reasons.append(f"{prefix}: source_revision mismatch")
+
+    if not proof.validation_input_digest:
+        fail_reasons.append(f"{prefix}: validation_input_digest required")
+    elif not valid_sha256_digest(proof.validation_input_digest):
+        fail_reasons.append(
+            f"{prefix}: validation_input_digest must be 64-char lowercase sha256 hex"
+        )
+    elif proof.validation_input_digest != compute_validation_input_digest(validation_input):
+        fail_reasons.append(f"{prefix}: validation_input_digest mismatch")
+
+    if not proof.validation_result_digest:
+        fail_reasons.append(f"{prefix}: validation_result_digest required")
+    elif not valid_sha256_digest(proof.validation_result_digest):
+        fail_reasons.append(
+            f"{prefix}: validation_result_digest must be 64-char lowercase sha256 hex"
+        )
+    elif proof.validation_result_digest != glb019_result.get("validation_result_digest"):
+        fail_reasons.append(
+            f"{prefix}: validation_result_digest mismatch with canonical evaluation"
+        )
+
+    identity_fields = (
+        ("completion_identity_digest", proof.completion_identity_digest),
+        ("manifest_identity_digest", proof.manifest_identity_digest),
+        ("run_identity_digest", proof.run_identity_digest),
+        ("correlation_id", proof.correlation_id),
+        ("event_stream_identity", proof.event_stream_identity),
+    )
+    for field_name, value in identity_fields:
+        if not value:
+            fail_reasons.append(f"{prefix}: {field_name} required")
+        elif field_name != "correlation_id" and not valid_sha256_digest(value):
+            fail_reasons.append(f"{prefix}: {field_name} must be 64-char lowercase sha256 hex")
+
+    if proof.completion_identity_digest != validation_input.completion_identity_digest:
+        fail_reasons.append(f"{prefix}: completion_identity_digest drift")
+    if proof.manifest_identity_digest != validation_input.manifest_identity_digest:
+        fail_reasons.append(f"{prefix}: manifest_identity_digest drift")
+    if proof.run_identity_digest != validation_input.run_identity_digest:
+        fail_reasons.append(f"{prefix}: run_identity_digest drift")
+    if proof.correlation_id != validation_input.correlation_id:
+        fail_reasons.append(f"{prefix}: correlation_id drift")
+
+    required_flags = (
+        ("glb019_validation_pass", True),
+        ("event_stream_boundary_satisfied", True),
+        ("durable_completion_event_stream_bound", True),
+        ("incomplete_event_stream_fail_closed", False),
+        ("event_stream_non_authorizing", True),
+    )
+    for field_name, expected in required_flags:
+        if getattr(proof, field_name) is not expected:
+            fail_reasons.append(f"{prefix}: {field_name} must be {expected}")
+
+    if not glb019_result.get("validation_pass"):
+        fail_reasons.append("glb019_event_stream_validation: canonical evaluation failed")
+        fail_reasons.extend(
+            f"glb019_event_stream_validation: {reason}"
+            for reason in glb019_result.get("fail_reasons", [])
+        )
+    elif proof.event_stream_identity != glb019_result.get("event_stream_identity"):
+        fail_reasons.append(f"{prefix}: event_stream_identity mismatch with canonical evaluation")
+
+    if proof.validation_result_digest and glb019_result.get("validation_result_digest"):
+        if proof.validation_result_digest != glb019_result["validation_result_digest"]:
+            fail_reasons.append(f"{prefix}: stale or superseded validation_result_digest")
+
+    return ValidationResult(fail_reasons=tuple(sorted_unique(fail_reasons)))
+
+
+def default_minimal_event_stream_records(*, correlation_id: str) -> tuple[EventStreamRecord, ...]:
+    return tuple(
+        EventStreamRecord(
+            event_class=event_class,
+            event_id=f"{event_class}-001",
+            sequence=index,
+            timestamp_utc="2026-06-23T00:00:00Z",
+            source="bounded_futures_testnet_durable_completion_offline_v0",
+            correlation_id=correlation_id,
+            schema_version=CONTRACT_VERSION,
+            present=True,
+        )
+        for index, event_class in enumerate(REQUIRED_EVENT_CLASSES)
+    )
+
+
+def default_minimal_glb019_validation_input(
+    *,
+    source_revision: str,
+    completion_identity_digest: str,
+    manifest_identity_digest: str,
+    run_identity_digest: str,
+    correlation_id: str,
+) -> Glb019EventStreamValidationInput:
+    return Glb019EventStreamValidationInput(
+        boundary_owner=BOUNDARY_OWNER,
+        source_revision=source_revision,
+        completion_identity_digest=completion_identity_digest,
+        manifest_identity_digest=manifest_identity_digest,
+        run_identity_digest=run_identity_digest,
+        correlation_id=correlation_id,
+        events=default_minimal_event_stream_records(correlation_id=correlation_id),
+    )
+
+
+def default_minimal_glb019_proof_binding(
+    validation_input: Glb019EventStreamValidationInput,
+    glb019_result: dict[str, Any],
+) -> Glb019EventStreamProofBinding:
+    if not glb019_result.get("validation_pass"):
+        raise ValueError("GLB-019 validation must pass for default minimal proof")
+    return Glb019EventStreamProofBinding(
+        boundary_owner=BOUNDARY_OWNER,
+        source_revision=validation_input.source_revision,
+        validation_input_digest=glb019_result["validation_input_digest"],
+        validation_result_digest=glb019_result["validation_result_digest"],
+        glb019_validation_pass=True,
+        event_stream_boundary_satisfied=True,
+        durable_completion_event_stream_bound=True,
+        incomplete_event_stream_fail_closed=False,
+        event_stream_non_authorizing=True,
+        completion_identity_digest=validation_input.completion_identity_digest,
+        manifest_identity_digest=validation_input.manifest_identity_digest,
+        run_identity_digest=validation_input.run_identity_digest,
+        correlation_id=validation_input.correlation_id,
+        event_stream_identity=glb019_result["event_stream_identity"],
+    )

--- a/tests/ops/test_durable_completion_validation_graph_v1.py
+++ b/tests/ops/test_durable_completion_validation_graph_v1.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from dataclasses import replace
@@ -71,8 +73,14 @@ from src.ops.testnet_wallclock_duration_evidence_contract_v0 import (
 from src.ops.wallclock_session_evidence_v0 import evaluate_wallclock_evidence_fields
 
 
+@lru_cache(maxsize=1)
+def _cached_default_minimal_completion_integration_input():
+    """Module-scoped cache: building minimal integration input runs full offline evidence chain."""
+    return default_minimal_completion_integration_input()
+
+
 def _minimal_context(**overrides: Any) -> ValidationContext:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     context = ValidationContext(integration_input=integration_input)
     for key, value in overrides.items():
         setattr(context, key, value)
@@ -186,7 +194,7 @@ def test_graph_aggregates_fail_reasons_from_executed_validators() -> None:
 
 
 def test_reconciliation_manifest_validator_matches_input_validation_path() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     direct = validate_pe21_reconciliation_result_manifest_integrity(integration_input)
     input_fail_reasons = validate_durable_run_primary_evidence_completion_integration_input(
         integration_input
@@ -200,7 +208,7 @@ def test_reconciliation_manifest_validator_matches_input_validation_path() -> No
 
 
 def test_fill_state_manifest_validator_matches_input_validation_path() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     direct = validate_pe21_reconciliation_result_manifest_integrity(integration_input)
     input_fail_reasons = validate_durable_run_primary_evidence_completion_integration_input(
         integration_input
@@ -226,7 +234,7 @@ def _replace_pe21_manifest_entries(integration_input, manifest_entries: tuple[Ma
 
 
 def test_graph_reconciliation_validator_composes_pe21_fill_manifest_integrity() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     context = ValidationContext(
         integration_input=integration_input,
         pe31_result=evaluate_reconciliation_review_lifecycle_integration(
@@ -237,7 +245,7 @@ def test_graph_reconciliation_validator_composes_pe21_fill_manifest_integrity() 
 
 
 def test_graph_reconciliation_validator_missing_fill_manifest_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     entries = tuple(
         entry
         for entry in integration_input.pe21_integration_input.primary_evidence_binding.manifest_entries
@@ -268,7 +276,7 @@ def _replace_pe34_handoff(integration_input, **overrides):
 
 
 def test_graph_recovery_validator_composes_pe35_handoff_input_validation() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     pe35_input = integration_input.pe35_handoff_staleness_revocation_recovery_boundary_input
     context = ValidationContext(
         integration_input=integration_input,
@@ -278,7 +286,7 @@ def test_graph_recovery_validator_composes_pe35_handoff_input_validation() -> No
 
 
 def test_graph_recovery_validator_missing_pe34_handoff_id_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     bad = _replace_pe34_handoff(integration_input, handoff_id="")
     pe35_input = bad.pe35_handoff_staleness_revocation_recovery_boundary_input
     context = ValidationContext(
@@ -297,7 +305,7 @@ def _replace_pe37_archive_binding(integration_input, **overrides):
 
 
 def test_graph_traceability_validator_composes_pe37_handoff_input_validation() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     pe37_input = integration_input.pe37_traceability_boundary_input
     context = ValidationContext(
         integration_input=integration_input,
@@ -307,7 +315,7 @@ def test_graph_traceability_validator_composes_pe37_handoff_input_validation() -
 
 
 def test_graph_traceability_validator_missing_pe16_archive_manifest_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     bad = _replace_pe37_archive_binding(integration_input, archive_manifest_digest="")
     pe37_input = bad.pe37_traceability_boundary_input
     pe35_input = bad.pe35_handoff_staleness_revocation_recovery_boundary_input
@@ -333,7 +341,7 @@ def _replace_pe25_closure_input(integration_input, **overrides):
 
 
 def test_graph_operator_closure_validator_composes_pe25_closure_input_validation() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     pe25_input = integration_input.pe25_closure_integration_input
     pe25_result = evaluate_operator_closure_lifecycle_integration(pe25_input)
     context = ValidationContext(
@@ -350,7 +358,7 @@ def test_graph_operator_closure_validator_composes_pe25_closure_input_validation
 
 
 def test_graph_operator_closure_validator_missing_closure_id_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     bad = _replace_pe25_closure_input(integration_input, closure_id="")
     pe25_input = bad.pe25_closure_integration_input
     pe37_input = bad.pe37_traceability_boundary_input
@@ -392,7 +400,7 @@ def test_graph_wallclock_validator_imports_canonical_owners_only() -> None:
 
 
 def test_wallclock_validator_happy_path_matches_integration_wallclock_checks() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     assert not validate_wallclock_proof_binding(
         ValidationContext(integration_input=integration_input)
     ).fail_reasons
@@ -413,14 +421,14 @@ def _replace_completion_proof_chain(integration_input, **overrides):
 
 
 def test_graph_wallclock_validator_composes_binding() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     assert not validate_wallclock_proof_binding(
         ValidationContext(integration_input=integration_input)
     ).fail_reasons
 
 
 def test_graph_wallclock_validator_missing_required_fields_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     incomplete_evidence = {
         key: value
         for key, value in integration_input.wallclock_evidence_proof.wallclock_evidence.items()
@@ -435,7 +443,7 @@ def test_graph_wallclock_validator_missing_required_fields_fail_closed() -> None
 
 
 def test_graph_wallclock_validator_semantic_drift_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     invalid_evidence = dict(integration_input.wallclock_evidence_proof.wallclock_evidence)
     invalid_evidence["elapsed_wall_clock_seconds"] = 0
     invalid_evidence["invalid_if_elapsed_below_min"] = True
@@ -448,7 +456,7 @@ def test_graph_wallclock_validator_semantic_drift_fail_closed() -> None:
 
 
 def test_graph_wallclock_validator_digest_coherence_drift_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     bad = _replace_completion_proof_chain(
         integration_input,
         completion_referenced_wallclock_evidence_digest="0" * 64,
@@ -461,7 +469,7 @@ def test_graph_wallclock_validator_digest_coherence_drift_fail_closed() -> None:
 
 
 def test_graph_wallclock_failure_blocks_completion_chain() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     bad = _replace_wallclock_evidence_proof(
         integration_input,
         duration_proven=False,
@@ -474,7 +482,7 @@ def test_graph_wallclock_failure_blocks_completion_chain() -> None:
 
 
 def test_completion_proof_chain_validator_matches_input_validation_path() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     direct = validate_completion_proof_chain_binding(
         ValidationContext(integration_input=integration_input)
     )
@@ -488,14 +496,14 @@ def test_completion_proof_chain_validator_matches_input_validation_path() -> Non
 
 
 def test_graph_completion_chain_validator_composes_binding() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     assert not validate_completion_proof_chain_binding(
         ValidationContext(integration_input=integration_input)
     ).fail_reasons
 
 
 def test_graph_completion_chain_validator_pe35_digest_drift_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     bad = _replace_completion_proof_chain(
         integration_input,
         completion_referenced_pe35_boundary_result_digest="0" * 64,
@@ -527,7 +535,7 @@ def test_graph_completion_chain_validator_pe35_digest_drift_fail_closed() -> Non
 
 
 def test_graph_completion_chain_validator_wallclock_digest_drift_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     bad = _replace_completion_proof_chain(
         integration_input,
         completion_referenced_wallclock_evidence_digest="0" * 64,
@@ -559,7 +567,7 @@ def test_graph_completion_chain_validator_wallclock_digest_drift_fail_closed() -
 
 
 def test_graph_completion_chain_validator_pe38_digest_drift_fail_closed() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     bad = _replace_completion_proof_chain(
         integration_input,
         completion_referenced_pe38_readiness_review_proof_digest="0" * 64,
@@ -591,14 +599,14 @@ def test_graph_completion_chain_validator_pe38_digest_drift_fail_closed() -> Non
 
 
 def test_evaluate_graph_compatibility_happy_path() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     result = evaluate_durable_run_primary_evidence_completion_integration(integration_input)
     assert result["integration_pass"] is True
     assert result["fail_reasons"] == []
 
 
 def test_evaluate_graph_compatibility_pe31_mismatch_fails() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     broken = replace(
         integration_input,
         pe31_reconciliation_review_integration_proof=replace(
@@ -617,7 +625,7 @@ def test_graph_testnet_completion_includes_wallclock_required_path_binding() -> 
     )
     from src.ops.wallclock_session_evidence_v0 import WALLCLOCK_EVIDENCE_FILENAME
 
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     artifact_paths = {entry.relative_path for entry in integration_input.artifact_checksums}
     assert WALLCLOCK_EVIDENCE_FILENAME in artifact_paths
     assert artifact_paths == set(BOUNDED_TESTNET_DURABLE_RUN_REQUIRED_REL_PATHS)
@@ -639,7 +647,7 @@ def test_graph_retention_review_completion_share_canonical_testnet_paths() -> No
         repo_root / "scripts" / "ops" / "review_testnet_bounded_observation_evidence_v0.py"
     ).read_text(encoding="utf-8")
     assert "BOUNDED_TESTNET_DURABLE_RUN_REQUIRED_REL_PATHS" in review_source
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     completion_paths = {entry.relative_path for entry in integration_input.artifact_checksums}
     assert completion_paths == set(BOUNDED_TESTNET_DURABLE_RUN_REQUIRED_REL_PATHS)
     assert WALLCLOCK_EVIDENCE_FILENAME in BOUNDED_TESTNET_DURABLE_RUN_REQUIRED_REL_PATHS
@@ -658,7 +666,7 @@ def test_graph_seven_vs_eight_path_drift_fail_closed() -> None:
     )
     from src.ops.wallclock_session_evidence_v0 import WALLCLOCK_EVIDENCE_FILENAME
 
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     seven_path_artifacts = tuple(
         entry
         for entry in integration_input.artifact_checksums
@@ -677,7 +685,7 @@ def test_graph_seven_vs_eight_path_drift_fail_closed() -> None:
 
 
 def test_legacy_ops_only_completion_chain_master_v2_binding_not_present() -> None:
-    integration_input = default_minimal_completion_integration_input()
+    integration_input = _cached_default_minimal_completion_integration_input()
     assert (
         classify_master_v2_binding_presence(
             binding=integration_input.master_v2_decision_state_digest_binding,
@@ -688,3 +696,281 @@ def test_legacy_ops_only_completion_chain_master_v2_binding_not_present() -> Non
     assert not validate_completion_proof_chain_binding(
         ValidationContext(integration_input=integration_input)
     ).fail_reasons
+
+
+_GLB019_TEST_DIGEST = "a" * 64
+_GLB019_CORRELATION_ID = "glb019-test-correlation-v0"
+
+FUTURES_ONLY = True
+BITCOIN_DIRECTION_ALLOWED = False
+LIVE_AUTHORIZED = False
+ORDERS_AUTHORIZED = False
+CREDENTIALS_ALLOWED = False
+ZERO_ORDER_REQUIRED = True
+
+
+def _glb019_validation_input(**overrides: Any):
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        default_minimal_glb019_validation_input,
+    )
+
+    base = default_minimal_glb019_validation_input(
+        source_revision="test-source-revision-v0",
+        completion_identity_digest=_GLB019_TEST_DIGEST,
+        manifest_identity_digest=_GLB019_TEST_DIGEST,
+        run_identity_digest=_GLB019_TEST_DIGEST,
+        correlation_id=_GLB019_CORRELATION_ID,
+    )
+    if not overrides:
+        return base
+    return replace(base, **overrides)
+
+
+def _glb019_proof_context(**overrides: Any) -> ValidationContext:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        default_minimal_glb019_proof_binding,
+        evaluate_glb019_event_stream_validation,
+    )
+
+    validation_input = _glb019_validation_input()
+    glb019_result = evaluate_glb019_event_stream_validation(validation_input)
+    proof = default_minimal_glb019_proof_binding(validation_input, glb019_result)
+    integration_input = SimpleNamespace(
+        source_revision=validation_input.source_revision,
+        glb019_event_stream_validation_input=validation_input,
+        glb019_event_stream_proof=proof,
+    )
+    context = ValidationContext(
+        integration_input=integration_input,
+        glb019_result=glb019_result,
+    )
+    for key, value in overrides.items():
+        setattr(context, key, value)
+    return context
+
+
+def test_glb019_canonical_export_present() -> None:
+    from src.ops.durable_completion_validation import validators
+
+    assert "event_stream" in validators.__all__
+    assert hasattr(validators, "event_stream")
+    assert validators.event_stream.validate_glb019_event_stream_proof.__name__ == (
+        "validate_glb019_event_stream_proof"
+    )
+
+
+def test_glb019_no_production_graph_activation() -> None:
+    from src.ops.durable_completion_validation import graph
+
+    assert "event_stream" not in graph.PROOF_BINDING_VALIDATION_GRAPH
+    assert "event_stream" not in graph.PROOF_BINDING_VALIDATION_ORDER
+    graph_source = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "ops"
+        / "durable_completion_validation"
+        / "graph.py"
+    ).read_text(encoding="utf-8")
+    assert "event_stream" not in graph_source
+
+
+def test_glb019_valid_event_stream_accepted() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        evaluate_glb019_event_stream_validation,
+        validate_glb019_event_stream_proof,
+    )
+
+    validation_input = _glb019_validation_input()
+    result = evaluate_glb019_event_stream_validation(validation_input)
+    assert result["validation_pass"] is True
+    assert result["fail_reasons"] == []
+    assert not validate_glb019_event_stream_proof(_glb019_proof_context()).fail_reasons
+
+
+def test_glb019_missing_event_stream_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        Glb019EventStreamValidationInput,
+        evaluate_glb019_event_stream_validation,
+    )
+
+    empty = Glb019EventStreamValidationInput(
+        boundary_owner="glb019_event_stream_static_boundary_v0",
+        source_revision="test-source-revision-v0",
+        completion_identity_digest=_GLB019_TEST_DIGEST,
+        manifest_identity_digest=_GLB019_TEST_DIGEST,
+        run_identity_digest=_GLB019_TEST_DIGEST,
+        correlation_id=_GLB019_CORRELATION_ID,
+        events=(),
+    )
+    result = evaluate_glb019_event_stream_validation(empty)
+    assert result["validation_pass"] is False
+    assert any("events required" in reason for reason in result["fail_reasons"])
+
+
+def test_glb019_empty_sequence_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        evaluate_glb019_event_stream_validation,
+    )
+
+    broken_input = replace(_glb019_validation_input(), events=())
+    result = evaluate_glb019_event_stream_validation(broken_input)
+    assert result["validation_pass"] is False
+    assert broken_input.events == ()
+
+
+def test_glb019_invalid_order_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        evaluate_glb019_event_stream_validation,
+    )
+
+    base_input = _glb019_validation_input()
+    reordered = tuple(
+        replace(record, sequence=index + 1) for index, record in enumerate(base_input.events)
+    )
+    broken = replace(base_input, events=reordered)
+    result = evaluate_glb019_event_stream_validation(broken)
+    assert result["validation_pass"] is False
+    assert any("sequence ordering" in reason for reason in result["fail_reasons"])
+
+
+def test_glb019_duplicate_event_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        evaluate_glb019_event_stream_validation,
+    )
+
+    base_input = _glb019_validation_input()
+    duplicate = replace(base_input.events[0], event_id=base_input.events[1].event_id)
+    broken = replace(base_input, events=(duplicate, *base_input.events[1:]))
+    result = evaluate_glb019_event_stream_validation(broken)
+    assert result["validation_pass"] is False
+    assert any("duplicate event_id" in reason for reason in result["fail_reasons"])
+
+
+def test_glb019_identity_mismatch_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        evaluate_glb019_event_stream_validation,
+    )
+
+    base_input = _glb019_validation_input()
+    mismatched = replace(
+        base_input.events[0],
+        correlation_id="other-correlation-id",
+    )
+    broken = replace(base_input, events=(mismatched, *base_input.events[1:]))
+    result = evaluate_glb019_event_stream_validation(broken)
+    assert result["validation_pass"] is False
+    assert any("correlation_id mismatch" in reason for reason in result["fail_reasons"])
+
+
+def test_glb019_manifest_mismatch_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        validate_glb019_event_stream_proof,
+    )
+
+    context = _glb019_proof_context()
+    broken_proof = replace(
+        context.integration_input.glb019_event_stream_proof,
+        manifest_identity_digest="b" * 64,
+    )
+    broken_integration = SimpleNamespace(
+        source_revision=context.integration_input.source_revision,
+        glb019_event_stream_validation_input=context.integration_input.glb019_event_stream_validation_input,
+        glb019_event_stream_proof=broken_proof,
+    )
+    result = validate_glb019_event_stream_proof(
+        replace(context, integration_input=broken_integration)
+    )
+    assert any("manifest_identity_digest drift" in reason for reason in result.fail_reasons)
+
+
+def test_glb019_owner_drift_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        validate_glb019_event_stream_proof,
+    )
+
+    context = _glb019_proof_context()
+    broken_proof = replace(
+        context.integration_input.glb019_event_stream_proof,
+        boundary_owner="wrong_owner",
+    )
+    broken_integration = SimpleNamespace(
+        source_revision=context.integration_input.source_revision,
+        glb019_event_stream_validation_input=context.integration_input.glb019_event_stream_validation_input,
+        glb019_event_stream_proof=broken_proof,
+    )
+    result = validate_glb019_event_stream_proof(
+        replace(context, integration_input=broken_integration)
+    )
+    assert any("boundary_owner must be" in reason for reason in result.fail_reasons)
+
+
+def test_glb019_deterministic_result_confirmed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        evaluate_glb019_event_stream_validation,
+    )
+
+    validation_input = _glb019_validation_input()
+    first = evaluate_glb019_event_stream_validation(validation_input)
+    second = evaluate_glb019_event_stream_validation(validation_input)
+    assert first == second
+
+
+def test_glb019_missing_event_class_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        evaluate_glb019_event_stream_validation,
+    )
+
+    base_input = _glb019_validation_input()
+    trimmed_events = tuple(
+        record for record in base_input.events if record.event_class != "state_transition"
+    )
+    broken_input = replace(base_input, events=trimmed_events)
+    result = evaluate_glb019_event_stream_validation(broken_input)
+    assert result["validation_pass"] is False
+    assert any("state_transition" in reason for reason in result["fail_reasons"])
+
+
+def test_glb019_proof_validation_result_digest_mismatch_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        validate_glb019_event_stream_proof,
+    )
+
+    context = _glb019_proof_context()
+    broken_proof = replace(
+        context.integration_input.glb019_event_stream_proof,
+        validation_result_digest="0" * 64,
+    )
+    broken_integration = SimpleNamespace(
+        source_revision=context.integration_input.source_revision,
+        glb019_event_stream_validation_input=context.integration_input.glb019_event_stream_validation_input,
+        glb019_event_stream_proof=broken_proof,
+    )
+    result = validate_glb019_event_stream_proof(
+        replace(context, integration_input=broken_integration)
+    )
+    assert any("validation_result_digest" in reason for reason in result.fail_reasons)
+
+
+def test_glb019_event_stream_validator_no_slice_b_integration_import() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    event_stream_source = (
+        repo_root
+        / "src"
+        / "ops"
+        / "durable_completion_validation"
+        / "validators"
+        / "event_stream.py"
+    ).read_text(encoding="utf-8")
+    assert (
+        "bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0"
+        not in event_stream_source
+    )
+
+
+def test_glb019_zero_order_and_safety_assertions() -> None:
+    assert FUTURES_ONLY is True
+    assert BITCOIN_DIRECTION_ALLOWED is False
+    assert LIVE_AUTHORIZED is False
+    assert ORDERS_AUTHORIZED is False
+    assert CREDENTIALS_ALLOWED is False
+    assert ZERO_ORDER_REQUIRED is True


### PR DESCRIPTION
## Summary
- Additiver GLB-019-Event-Stream-Validator (fail-closed, deterministisch)
- `ValidationContext`-Modell um `glb019_result` erweitert; Package-Export minimal erweitert
- 15 direkte GLB-019-Contract-Tests; vollständiger Validation-Graph-Testowner (50 Tests)
- Selector-Reason: `durable_completion_validation_graph_focused` (FOCUSED)
- Integration-Testowner nicht ausgewählt; keine produktive Graph-Aktivierung
- Kein Completion-Integration-Wiring, kein A2/B, kein Cache/Memoization in Produktionscode
- `PRE_PR_VERIFIER_RC=0`; alle ausgelösten GitHub-Jobs explizit höchstens 17 Minuten
- Keine Runtime-/Trading-Ausführung

## Test plan
- [x] 15 GLB-019-Contract-Tests (`-k glb019`)
- [x] Vollständiger Graph-Testowner (50 Tests)
- [x] Path-äquivalenter Selector-Lauf (251 Nodes, 74s)
- [x] `ruff format --check` / `ruff check` auf 4 Dateien
- [x] `verify_pre_pr_validation_result_v0.py --check-diff-sha`


Made with [Cursor](https://cursor.com)