### PR TITLE
fix(ci): partition durable completion integration coverage

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -51,10 +51,14 @@ FOCUSED_CATEGORIES = frozenset(
 # Mapping changes always force FULL (never self-FOCUSED).
 CI_MAPPING_FULL_PATHS = frozenset({"config/ci/file_category_mapping.yaml"})
 
-# Bounded canonical CI bootstrap selector + contract-test owner (self-FOCUSED).
+# Bounded canonical CI bootstrap selector + partition helper + contract-test owner (self-FOCUSED).
+DURABLE_COMPLETION_INTEGRATION_PARTITIONS_HELPER = (
+    "scripts/ops/durable_completion_integration_partitions_v0.py"
+)
 CI_BOOTSTRAP_FOCUSED_PATHS = frozenset(
     {
         "scripts/ops/ci_test_selection_v1.py",
+        DURABLE_COMPLETION_INTEGRATION_PARTITIONS_HELPER,
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     }
 )

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -93,6 +93,19 @@ MARKET_DASHBOARD_CI_POLICY_PATHS = frozenset(
 
 DURABLE_COMPLETION_FACADE_PATH = "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.durable_completion_integration_partitions_v0 import (  # noqa: E402
+    INTEGRATION_TEST_OWNER,
+    expand_partitions_to_pytest_targets,
+    integration_owner_node_count,
+    integration_partition_inventory,
+    partition_union_node_count,
+    partitions_for_changed_files,
+)
+
 DURABLE_COMPLETION_CI_POLICY_PATHS = frozenset(
     {
         "scripts/ops/ci_test_selection_v1.py",
@@ -128,6 +141,25 @@ CANONICAL_DURABLE_COMPLETION_VALIDATION_GRAPH_FOCUSED_TESTS: tuple[str, ...] = (
 REQUIRED_DURABLE_COMPLETION_TEST_OWNERS: tuple[str, ...] = (
     DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER,
     DURABLE_COMPLETION_INTEGRATION_TEST_OWNER,
+)
+
+DURABLE_COMPLETION_INTEGRATION_PE_PROD_PATHS = frozenset(
+    {
+        "src/ops/bounded_futures_testnet_position_order_reconciliation_primary_evidence_integration_contract_v0.py",
+        "src/ops/bounded_futures_testnet_reconciliation_review_lifecycle_integration_contract_v0.py",
+        "src/ops/bounded_futures_testnet_risk_killswitch_lifecycle_integration_contract_v0.py",
+        "src/ops/bounded_futures_testnet_capital_slot_ratchet_release_lifecycle_integration_contract_v0.py",
+        "src/ops/bounded_futures_testnet_pilot_envelope_lifecycle_integration_contract_v0.py",
+        "src/ops/bounded_futures_testnet_operator_closure_lifecycle_integration_contract_v0.py",
+        "src/ops/bounded_futures_testnet_handoff_staleness_revocation_recovery_boundary_contract_v0.py",
+        "src/ops/bounded_futures_testnet_operator_review_handoff_boundary_contract_v0.py",
+        "src/ops/bounded_futures_testnet_operator_review_admission_presentation_boundary_contract_v0.py",
+        "src/ops/bounded_futures_testnet_operator_review_admission_presentation_lifecycle_integration_contract_v0.py",
+        "src/ops/bounded_futures_testnet_operator_review_chain_durable_evidence_traceability_boundary_contract_v0.py",
+        "src/ops/bounded_futures_testnet_preflight_execution_readiness_review_lifecycle_integration_contract_v0.py",
+        "src/ops/testnet_wallclock_duration_evidence_contract_v0.py",
+        "src/ops/wallclock_session_evidence_v0.py",
+    }
 )
 
 DURABLE_COMPLETION_FULL_REFACTOR_SRC_PATHS = frozenset(
@@ -832,6 +864,27 @@ def _is_durable_completion_scoped_path(path: str) -> bool:
     return False
 
 
+def _has_durable_completion_integration_partition_scope(files: list[str]) -> bool:
+    if any(_is_durable_completion_scoped_path(f) for f in files):
+        return True
+    files_set = set(files)
+    if DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER not in files_set:
+        return False
+    return any(f in DURABLE_COMPLETION_INTEGRATION_PE_PROD_PATHS for f in files)
+
+
+def _is_durable_completion_integration_partition_rebundle_path(
+    path: str,
+    *,
+    files: list[str],
+) -> bool:
+    if _is_durable_completion_rebundle_path(path):
+        return True
+    if path in DURABLE_COMPLETION_INTEGRATION_PE_PROD_PATHS:
+        return DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER in files
+    return False
+
+
 def _is_durable_completion_validation_graph_only_scoped_path(path: str) -> bool:
     if path == DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER:
         return True
@@ -850,6 +903,8 @@ def _requires_durable_completion_integration_test_owner(files: list[str]) -> boo
             DURABLE_COMPLETION_GRAPH_WIRING_PATH,
             DURABLE_COMPLETION_PUBLIC_API_PATH,
         }:
+            return True
+        if path in DURABLE_COMPLETION_INTEGRATION_PE_PROD_PATHS:
             return True
         if _is_durable_completion_scoped_path(
             path
@@ -976,13 +1031,34 @@ def _durable_completion_focused_targets(files: list[str] | None = None) -> tuple
     for path in REQUIRED_DURABLE_COMPLETION_TEST_OWNERS:
         if not _repo_path_exists(path):
             return ()
-    full_targets: list[str] = []
-    for path in CANONICAL_DURABLE_COMPLETION_FOCUSED_TESTS:
-        if _repo_path_exists(path):
-            full_targets.append(path)
-    if len(full_targets) < len(REQUIRED_DURABLE_COMPLETION_TEST_OWNERS):
+    contract_test = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
+    targets: list[str] = [graph_owner]
+    if _repo_path_exists(contract_test):
+        targets.append(contract_test)
+    if not files:
+        targets.append(DURABLE_COMPLETION_INTEGRATION_TEST_OWNER)
+        return tuple(sorted(set(targets)))
+    if any(
+        path in files
+        for path in (DURABLE_COMPLETION_GRAPH_WIRING_PATH, DURABLE_COMPLETION_PUBLIC_API_PATH)
+    ):
+        targets.append(DURABLE_COMPLETION_INTEGRATION_TEST_OWNER)
+        return tuple(sorted(set(targets)))
+    partition_selection = partitions_for_changed_files(files)
+    if partition_selection is None:
+        targets.append(DURABLE_COMPLETION_INTEGRATION_TEST_OWNER)
+        return tuple(sorted(set(targets)))
+    if not partition_selection:
+        return tuple(sorted(set(targets)))
+    try:
+        selected_nodes = partition_union_node_count(partition_selection)
+        if selected_nodes >= integration_owner_node_count():
+            targets.append(DURABLE_COMPLETION_INTEGRATION_TEST_OWNER)
+        else:
+            targets.extend(expand_partitions_to_pytest_targets(partition_selection))
+    except (KeyError, RuntimeError, OSError, ValueError):
         return ()
-    return tuple(sorted(full_targets))
+    return tuple(sorted(set(targets)))
 
 
 def _is_preflight_assembly_scoped_path(path: str) -> bool:
@@ -1943,9 +2019,11 @@ def _try_offline_master_v2_double_play_scenario_replay_focused(
 def _try_durable_completion_focused(files: list[str]) -> SelectionResult | None:
     if not files:
         return None
-    if not any(_is_durable_completion_scoped_path(f) for f in files):
+    if not _has_durable_completion_integration_partition_scope(files):
         return None
-    if not all(_is_durable_completion_rebundle_path(f) for f in files):
+    if not all(
+        _is_durable_completion_integration_partition_rebundle_path(f, files=files) for f in files
+    ):
         return None
     targets = _durable_completion_focused_targets(files)
     if not targets:
@@ -2384,8 +2462,11 @@ def resolve_selection(
     if ci_infra is not None:
         return ci_infra
 
-    if any(_is_durable_completion_scoped_path(f) for f in normalized):
-        if not all(_is_durable_completion_rebundle_path(f) for f in normalized):
+    if _has_durable_completion_integration_partition_scope(normalized):
+        if not all(
+            _is_durable_completion_integration_partition_rebundle_path(f, files=normalized)
+            for f in normalized
+        ):
             return SelectionResult("FULL", "durable_completion_foreign_path_requires_full", ())
         return SelectionResult("FULL", "durable_completion_incomplete_or_missing_test_owner", ())
 

--- a/scripts/ops/durable_completion_integration_partitions_v0.py
+++ b/scripts/ops/durable_completion_integration_partitions_v0.py
@@ -1,0 +1,371 @@
+"""Fachliche Required-Coverage-Partitionen für den Completion-Integration-Testowner (v0).
+
+Deterministische Node-Klassifikation per pytest-Collect + Name-Regeln.
+Kein Cross-Call-State; rein statische Inventar- und Expansionshilfe für CI-Selector.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from functools import lru_cache
+from typing import Final
+
+INTEGRATION_TEST_OWNER: Final = "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+
+COMPLETION_FACADE_PATH: Final = "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+
+CORE_ALWAYS_PARTITIONS: Final[tuple[str, ...]] = (
+    "core_invariants",
+    "core_smoke",
+    "core_digest",
+)
+
+ALL_PARTITIONS: Final[tuple[str, ...]] = (
+    *CORE_ALWAYS_PARTITIONS,
+    "core_baseline_input",
+    "core_kwargs",
+    "core_cross_chain",
+    "pe21_reconciliation",
+    "pe31_review",
+    "pe22_risk_killswitch",
+    "pe23_capital",
+    "pe24_pilot",
+    "pe25_closure",
+    "pe35_handoff_recovery",
+    "pe37_traceability",
+    "pe38_readiness",
+    "wallclock",
+)
+
+_NODE_ID_RE = re.compile(r"<Function (test_[^>]+)>")
+
+
+def _base_node_id(node_id: str) -> str:
+    return node_id.split("[", 1)[0]
+
+
+def classify_integration_node_id(node_id: str) -> str:
+    """Map a collected pytest node id (test_name or test_name[param]) to one partition."""
+    base = _base_node_id(node_id)
+
+    if base in {
+        "test_package_marker_present",
+        "test_canonical_owners_referenced_not_duplicated",
+        "test_global_safety_flags_remain_blocked",
+        "test_contract_version_constants",
+        "test_default_safety_snapshot_matches_required_invariants",
+        "test_bounded_durable_run_required_paths_covered",
+        "test_completion_required_paths_bind_to_canonical_testnet_contract",
+        "test_generic_bounded_required_paths_not_testnet_completion_source_of_truth",
+        "test_full_testnet_artifact_set_passes",
+    }:
+        return "core_invariants"
+
+    if base.startswith("test_completion_integration_input_digest_"):
+        if "pe21" in base:
+            return "pe21_reconciliation"
+        if "pe31" in base:
+            return "pe31_review"
+        return "core_digest"
+
+    if base in {
+        "test_deterministic_identical_inputs_same_payload_and_digest",
+        "test_coherent_static_completion_happy_path_passes",
+        "test_valid_static_proof_remains_non_authorizing",
+        "test_no_input_mutation_from_evaluation",
+        "test_current_lifecycle_state_passes",
+        "test_manifest_digest_matches_canonical_entries",
+        "test_run_identity_digest_matches_canonical_inputs",
+    }:
+        return "core_smoke"
+
+    if base.startswith("test_reconciliation_result_") or any(
+        base.startswith(prefix)
+        for prefix in (
+            "test_missing_reconciliation",
+            "test_empty_reconciliation",
+            "test_wrong_reconciliation",
+            "test_alias_reconciliation",
+            "test_malformed_reconciliation",
+            "test_uppercase_reconciliation",
+            "test_duplicate_reconciliation",
+            "test_contradictory_reconciliation",
+            "test_fill_state",
+        )
+    ):
+        return "pe21_reconciliation"
+
+    if "wallclock" in base:
+        return "wallclock"
+
+    if "pe38" in base:
+        return "pe38_readiness"
+
+    if base.startswith("test_pe35_") or "pe35_pe21" in base or "semantics_remain_bound" in base:
+        return "pe35_handoff_recovery"
+
+    if (
+        base.startswith("test_pe37_")
+        or base == "test_completion_proof_chain_traceability_drift_fails"
+    ):
+        return "pe37_traceability"
+
+    if "pe25" in base:
+        return "pe25_closure"
+
+    if "pe31" in base:
+        return "pe31_review"
+
+    if "pe22" in base:
+        return "pe22_risk_killswitch"
+
+    if "pe23" in base:
+        return "pe23_capital"
+
+    if "pe24" in base:
+        return "pe24_pilot"
+
+    if "pe21" in base:
+        return "pe21_reconciliation"
+
+    if base.startswith("test_completion_proof_chain_"):
+        for tag, partition in (
+            ("pe31", "pe31_review"),
+            ("pe22", "pe22_risk_killswitch"),
+            ("pe23", "pe23_capital"),
+            ("pe24", "pe24_pilot"),
+            ("pe25", "pe25_closure"),
+            ("pe35", "pe35_handoff_recovery"),
+            ("pe37", "pe37_traceability"),
+            ("pe38", "pe38_readiness"),
+            ("wallclock", "wallclock"),
+        ):
+            if tag in base:
+                return partition
+        return "core_cross_chain"
+
+    if base in {
+        "test_unknown_extra_fields_fail",
+        "test_authority_override_fields_fail",
+        "test_completion_claim_without_proof_chain_fails",
+    }:
+        return "core_kwargs"
+
+    if base.startswith("test_gap") or base == "test_completion_true_with_incomplete_evidence_fails":
+        return "core_cross_chain"
+
+    if base.startswith("test_planned_or_simulated") or base.startswith(
+        "test_invalid_proof_lifecycle_states_fail"
+    ):
+        return "core_cross_chain"
+
+    return "core_baseline_input"
+
+
+@lru_cache(maxsize=1)
+def collect_integration_owner_node_ids() -> tuple[str, ...]:
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", INTEGRATION_TEST_OWNER, "--collect-only", "-q"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode not in {0, 5}:
+        raise RuntimeError(
+            f"pytest collect failed for {INTEGRATION_TEST_OWNER}: {proc.stderr or proc.stdout}"
+        )
+    nodes: list[str] = []
+    for line in proc.stdout.splitlines():
+        match = _NODE_ID_RE.search(line)
+        if match:
+            nodes.append(match.group(1))
+    return tuple(nodes)
+
+
+@lru_cache(maxsize=1)
+def integration_partition_inventory() -> dict[str, tuple[str, ...]]:
+    by_partition: dict[str, list[str]] = {name: [] for name in ALL_PARTITIONS}
+    unknown: list[str] = []
+    for node_id in collect_integration_owner_node_ids():
+        partition = classify_integration_node_id(node_id)
+        if partition not in by_partition:
+            unknown.append(node_id)
+            continue
+        by_partition[partition].append(node_id)
+    if unknown:
+        raise RuntimeError(f"unmapped integration nodes: {unknown[:5]}")
+    return {key: tuple(sorted(values)) for key, values in by_partition.items() if values}
+
+
+def integration_owner_node_count() -> int:
+    return len(collect_integration_owner_node_ids())
+
+
+def partition_union_node_count(partitions: frozenset[str]) -> int:
+    inventory = integration_partition_inventory()
+    seen: set[str] = set()
+    for partition in partitions:
+        if partition not in inventory:
+            raise KeyError(f"unknown partition: {partition}")
+        seen.update(inventory[partition])
+    return len(seen)
+
+
+def expand_partitions_to_pytest_targets(partitions: frozenset[str]) -> tuple[str, ...]:
+    inventory = integration_partition_inventory()
+    node_ids: set[str] = set()
+    for partition in sorted(partitions):
+        if partition not in inventory:
+            raise KeyError(f"unknown partition: {partition}")
+        node_ids.update(inventory[partition])
+    return tuple(sorted(f"{INTEGRATION_TEST_OWNER}::{node_id}" for node_id in sorted(node_ids)))
+
+
+def _file_text(path: str) -> str:
+    from pathlib import Path
+
+    return Path(path).read_text(encoding="utf-8")
+
+
+def partitions_for_changed_files(changed_files: list[str]) -> frozenset[str] | None:
+    """Return required partition ids, empty set for graph-only, None for full integration owner."""
+    from pathlib import Path
+
+    files = frozenset(changed_files)
+    partitions: set[str] = set(CORE_ALWAYS_PARTITIONS)
+
+    if INTEGRATION_TEST_OWNER in files:
+        return None
+
+    if COMPLETION_FACADE_PATH in files:
+        return None
+
+    integration_scoped = False
+    graph_only = True
+
+    path_rules: tuple[tuple[str, str], ...] = (
+        (
+            "src/ops/bounded_futures_testnet_position_order_reconciliation_primary_evidence_integration_contract_v0.py",
+            "pe21_reconciliation",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_reconciliation_review_lifecycle_integration_contract_v0.py",
+            "pe31_review",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_risk_killswitch_lifecycle_integration_contract_v0.py",
+            "pe22_risk_killswitch",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_capital_slot_ratchet_release_lifecycle_integration_contract_v0.py",
+            "pe23_capital",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_pilot_envelope_lifecycle_integration_contract_v0.py",
+            "pe24_pilot",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_operator_closure_lifecycle_integration_contract_v0.py",
+            "pe25_closure",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_handoff_staleness_revocation_recovery_boundary_contract_v0.py",
+            "pe35_handoff_recovery",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_operator_review_handoff_boundary_contract_v0.py",
+            "pe35_handoff_recovery",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_operator_review_admission_presentation_boundary_contract_v0.py",
+            "pe37_traceability",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_operator_review_admission_presentation_lifecycle_integration_contract_v0.py",
+            "pe37_traceability",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_operator_review_chain_durable_evidence_traceability_boundary_contract_v0.py",
+            "pe37_traceability",
+        ),
+        (
+            "src/ops/bounded_futures_testnet_preflight_execution_readiness_review_lifecycle_integration_contract_v0.py",
+            "pe38_readiness",
+        ),
+        (
+            "src/ops/testnet_wallclock_duration_evidence_contract_v0.py",
+            "wallclock",
+        ),
+        (
+            "src/ops/wallclock_session_evidence_v0.py",
+            "wallclock",
+        ),
+    )
+
+    validator_rules: tuple[tuple[str, str], ...] = (
+        (
+            "src/ops/durable_completion_validation/validators/reconciliation.py",
+            "pe21_reconciliation",
+        ),
+        ("src/ops/durable_completion_validation/validators/recovery.py", "pe35_handoff_recovery"),
+        ("src/ops/durable_completion_validation/validators/traceability.py", "pe37_traceability"),
+        ("src/ops/durable_completion_validation/validators/operator_closure.py", "pe25_closure"),
+        ("src/ops/durable_completion_validation/validators/event_stream.py", "pe38_readiness"),
+    )
+
+    for path, partition in path_rules:
+        if path in files:
+            partitions.add(partition)
+            integration_scoped = True
+            graph_only = False
+
+    for path, partition in validator_rules:
+        if path in files:
+            partitions.add(partition)
+            partitions.add("core_cross_chain")
+            integration_scoped = True
+            graph_only = False
+
+    dc_prefix = "src/ops/durable_completion_validation/"
+    for path in files:
+        if not path.startswith(dc_prefix):
+            continue
+        name = Path(path).name
+        if name == "graph.py":
+            continue
+        if name in {"models.py", "identity.py", "__init__.py"}:
+            if name == "__init__.py":
+                return None
+            integration_scoped = True
+            graph_only = False
+            partitions.update({"core_cross_chain", "core_baseline_input"})
+            continue
+        if name.startswith("validators/") or path.endswith(".py") and "/validators/" in path:
+            continue
+
+    if not integration_scoped:
+        return frozenset()
+
+    if len(partitions - set(CORE_ALWAYS_PARTITIONS)) > 3:
+        partitions.update({"core_baseline_input", "core_kwargs", "core_cross_chain"})
+
+    return frozenset(partitions)
+
+
+def estimate_partition_seconds(partitions: frozenset[str]) -> int:
+    """Conservative serial estimate from historical ~21s/evaluate, ~0.5s static."""
+    inventory = integration_partition_inventory()
+    owner_text = _file_text(INTEGRATION_TEST_OWNER)
+    evaluate_calls = owner_text.count(
+        "evaluate_durable_run_primary_evidence_completion_integration("
+    )
+    eval_ratio = evaluate_calls / max(integration_owner_node_count(), 1)
+
+    total = 0.0
+    for partition in partitions:
+        nodes = inventory.get(partition, ())
+        eval_estimate = len(nodes) * eval_ratio
+        total += eval_estimate * 21 + (len(nodes) - eval_estimate) * 0.5
+    return int(total)

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -358,6 +358,79 @@ def test_selector_ci_bootstrap_contract_test_only_focused() -> None:
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
 
 
+GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES = (
+    "scripts/ops/ci_test_selection_v1.py",
+    "scripts/ops/durable_completion_integration_partitions_v0.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+_PARTITIONS_HELPER = GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[1]
+
+
+def test_selector_glb019_partition_bootstrap_three_file_diff_focused() -> None:
+    sel = _run_selector(*GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_bootstrap_focused"
+    assert _targets(sel) == ["tests/ci/test_ci_diff_aware_test_selection_v1.py"]
+    assert sel["tests_execute_full"] == "false"
+    assert (
+        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+        not in _targets(sel)
+    )
+
+
+def test_selector_glb019_partition_bootstrap_selector_plus_helper_focused() -> None:
+    sel = _run_selector(
+        GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[0],
+        GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[1],
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_bootstrap_focused"
+
+
+def test_selector_glb019_partition_bootstrap_helper_plus_contract_focused() -> None:
+    sel = _run_selector(
+        GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[1],
+        GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[2],
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_bootstrap_focused"
+
+
+def test_selector_glb019_partition_bootstrap_helper_only_focused() -> None:
+    sel = _run_selector(_PARTITIONS_HELPER)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_bootstrap_focused"
+
+
+def test_selector_glb019_partition_bootstrap_plus_workflow_full() -> None:
+    sel = _run_selector(
+        *GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES,
+        ".github/workflows/ci.yml",
+    )
+    assert sel["test_selection_reason"] != "ci_bootstrap_focused"
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_infra_focused"
+    assert sel["tests_execute_full"] == "false"
+
+
+def test_selector_glb019_partition_bootstrap_plus_unknown_ci_script_full() -> None:
+    sel = _run_selector(
+        *GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES,
+        "scripts/ops/ci_unknown_bootstrap_probe_v0.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
+
+
+def test_selector_glb019_partition_bootstrap_plus_central_prod_full() -> None:
+    sel = _run_selector(
+        *GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES,
+        "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    )
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
+
+
 def test_selector_ci_bootstrap_deterministic_regardless_of_file_order() -> None:
     files_a = (
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -758,6 +758,77 @@ def test_selector_glb019_graph_wiring_still_selects_integration_owner() -> None:
     assert _INTEGRATION_OWNER in _targets(sel)
 
 
+def test_integration_partition_inventory_covers_all_nodes() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        ALL_PARTITIONS,
+        classify_integration_node_id,
+        collect_integration_owner_node_ids,
+        integration_partition_inventory,
+    )
+
+    nodes = collect_integration_owner_node_ids()
+    assert len(nodes) == 238
+    inventory = integration_partition_inventory()
+    assert set(inventory) <= set(ALL_PARTITIONS)
+    covered = [node for part in inventory.values() for node in part]
+    assert len(covered) == len(nodes)
+    assert len(set(covered)) == len(nodes)
+    for node in nodes:
+        assert classify_integration_node_id(node) in inventory
+
+
+def test_selector_pe21_prod_owner_partitioned_integration_nodes() -> None:
+    sel = _run_selector(
+        "src/ops/bounded_futures_testnet_position_order_reconciliation_primary_evidence_integration_contract_v0.py",
+        _GRAPH_OWNER,
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "durable_completion_focused"
+    targets = _targets(sel)
+    assert _GRAPH_OWNER in targets
+    assert _INTEGRATION_OWNER not in targets
+    assert any(t.startswith(f"{_INTEGRATION_OWNER}::test_pe21") for t in targets)
+    assert any("test_reconciliation_result_" in t for t in targets)
+
+
+def test_selector_wallclock_prod_owner_partitioned() -> None:
+    sel = _run_selector(
+        "src/ops/testnet_wallclock_duration_evidence_contract_v0.py",
+        _GRAPH_OWNER,
+    )
+    targets = _targets(sel)
+    assert _INTEGRATION_OWNER not in targets
+    assert any("wallclock" in t for t in targets)
+
+
+def test_selector_glb019_a2b_probe_partition_union_bounded() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        estimate_partition_seconds,
+        partitions_for_changed_files,
+    )
+
+    files = [
+        "src/ops/durable_completion_validation/validators/event_stream.py",
+        "src/ops/bounded_futures_testnet_preflight_execution_readiness_review_lifecycle_integration_contract_v0.py",
+        _GRAPH_OWNER,
+    ]
+    partitions = partitions_for_changed_files(files)
+    assert partitions is not None
+    assert "pe38_readiness" in partitions
+    assert estimate_partition_seconds(partitions) <= 840
+    sel = _run_selector(*files)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert _INTEGRATION_OWNER not in _targets(sel)
+
+
+def test_selector_completion_facade_full_integration_owner() -> None:
+    sel = _run_selector(
+        "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+        _GRAPH_OWNER,
+    )
+    assert _INTEGRATION_OWNER in _targets(sel)
+
+
 def test_selector_glb019_mixed_validation_and_facade_selects_integration_owner() -> None:
     sel = _run_selector(
         "src/ops/durable_completion_validation/validators/event_stream.py",


### PR DESCRIPTION
## Summary
- Partitions the canonical durable completion integration test owner (~238 nodes) into 16 fachliche contract groups with diff-aware selection for bounded Required CI.
- Narrow PE-/validator-specific diffs now run only affected partitions plus shared core/cross-chain nodes; central, mixed, or unclear diffs remain fail-closed on the full integration owner.
- Adds contract tests for inventory completeness, narrow/broad diff mapping, and A2/B probe path estimates (≤840s) without removing tests, assertions, or coverage.

## Test plan
- [x] `pytest tests/ci/test_ci_diff_aware_test_selection_v1.py` (206 passed)
- [x] Five representative integration nodes from A2/B partitions (179.6s)
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] PRE-PR verifier RC=0; MANIFEST_VERIFY_RC=0
- [x] Protected builder-cache worktree diff unchanged
- [x] Required check names, Python 3.9/3.10/3.11 matrix, and 17-minute timeouts unchanged


Made with [Cursor](https://cursor.com)