### PR TITLE
fix(ci): classify additive glb019 integration changes

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -102,7 +102,13 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.ops.durable_completion_integration_partitions_v0 import (  # noqa: E402
+    GLB019_A2B_ALLOWED_FILES,
     INTEGRATION_TEST_OWNER,
+    Glb019A2bChangeContractOutcome,
+    Glb019A2bChangeContractResult,
+    classify_glb019_a2b_additive_patch,
+    collect_glb019_a2b_patch_text,
+    evaluate_glb019_a2b_change_contract,
     expand_partitions_to_pytest_targets,
     integration_owner_node_count,
     integration_partition_inventory,
@@ -130,6 +136,27 @@ DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER = (
 DURABLE_COMPLETION_INTEGRATION_TEST_OWNER = "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
 DURABLE_COMPLETION_GRAPH_WIRING_PATH = "src/ops/durable_completion_validation/graph.py"
 DURABLE_COMPLETION_PUBLIC_API_PATH = "src/ops/durable_completion_validation/__init__.py"
+
+GLB019_A2B_SELECTOR_OWNER = "scripts/ops/ci_test_selection_v1.py"
+
+GLB019_A2B_CLOSED_FILESET = GLB019_A2B_ALLOWED_FILES
+
+GLB019_A2B_PROD_RELEVANT_FILES = frozenset(
+    {
+        DURABLE_COMPLETION_FACADE_PATH,
+        DURABLE_COMPLETION_INTEGRATION_TEST_OWNER,
+        DURABLE_COMPLETION_GRAPH_WIRING_PATH,
+        "src/ops/durable_completion_validation/validators/event_stream.py",
+        DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER,
+    }
+)
+
+GLB019_A2B_BOOTSTRAP_ONLY_FILES = frozenset(
+    {
+        DURABLE_COMPLETION_INTEGRATION_PARTITIONS_HELPER,
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    }
+)
 
 CANONICAL_DURABLE_COMPLETION_FOCUSED_TESTS: tuple[str, ...] = (
     DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER,
@@ -884,6 +911,8 @@ def _is_durable_completion_integration_partition_rebundle_path(
 ) -> bool:
     if _is_durable_completion_rebundle_path(path):
         return True
+    if path == DURABLE_COMPLETION_INTEGRATION_PARTITIONS_HELPER:
+        return True
     if path in DURABLE_COMPLETION_INTEGRATION_PE_PROD_PATHS:
         return DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER in files
     return False
@@ -1018,10 +1047,26 @@ def _is_durable_completion_validator_rebinding_scope(files: list[str]) -> bool:
     return True
 
 
-def _durable_completion_focused_targets(files: list[str] | None = None) -> tuple[str, ...]:
+def _durable_completion_focused_targets(
+    files: list[str] | None = None,
+    *,
+    patch_text: str | None = None,
+) -> tuple[str, ...]:
     graph_owner = DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER
     if not _repo_path_exists(graph_owner):
         return ()
+    if files and patch_text:
+        glb019_partitions = classify_glb019_a2b_additive_patch(patch_text, repo_root=_REPO_ROOT)
+        if glb019_partitions is not None:
+            contract_test = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
+            targets: list[str] = [graph_owner]
+            if _repo_path_exists(contract_test):
+                targets.append(contract_test)
+            try:
+                targets.extend(expand_partitions_to_pytest_targets(glb019_partitions))
+            except (KeyError, RuntimeError, OSError, ValueError):
+                return ()
+            return tuple(sorted(set(targets)))
     if files and _is_durable_completion_wallclock_binding_rebinding_scope(files):
         return _durable_completion_wallclock_binding_focused_targets(files)
     if files and not _requires_durable_completion_integration_test_owner(files):
@@ -2020,8 +2065,141 @@ def _try_offline_master_v2_double_play_scenario_replay_focused(
     )
 
 
-def _try_durable_completion_focused(files: list[str]) -> SelectionResult | None:
+def _normalize_changed_files(files: list[str]) -> tuple[str, ...]:
+    return tuple(sorted({PurePosixPath(f).as_posix() for f in files if f.strip()}))
+
+
+def _is_glb019_a2b_structural_contract_candidate(changed_files: list[str]) -> bool:
+    """True only when changed_files may activate the GLB-019 A2/B structural contract."""
+    normalized = _normalize_changed_files(changed_files)
+    if not normalized:
+        return False
+    if GLB019_A2B_SELECTOR_OWNER in normalized:
+        return False
+    if any(path.startswith(".github/workflows/") for path in normalized):
+        return False
+    if not all(path in GLB019_A2B_CLOSED_FILESET for path in normalized):
+        return False
+    if not any(path in GLB019_A2B_PROD_RELEVANT_FILES for path in normalized):
+        return False
+    if all(path in GLB019_A2B_BOOTSTRAP_ONLY_FILES for path in normalized):
+        return False
+    return True
+
+
+def _is_established_durable_completion_rebinding_scope(files: list[str]) -> bool:
+    if _is_durable_completion_wallclock_binding_rebinding_scope(files):
+        return True
+    if _is_durable_completion_validator_rebinding_scope(files):
+        return True
     if not files:
+        return False
+    files_set = set(files)
+    if (
+        DURABLE_COMPLETION_FACADE_PATH in files_set
+        and DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER in files_set
+        and any(
+            path.startswith("src/ops/durable_completion_validation/") and path.endswith(".py")
+            for path in files
+        )
+        and all(_is_durable_completion_rebundle_path(path) for path in files)
+    ):
+        return True
+    return False
+
+
+def _is_glb019_partition_bootstrap_plus_central_prod_mix(changed_files: list[str]) -> bool:
+    """Fail-closed only for GLB-019 partition bootstrap mixed with central completion prod."""
+    normalized = list(_normalize_changed_files(changed_files))
+    if not normalized:
+        return False
+    if _is_glb019_a2b_structural_contract_candidate(normalized):
+        return False
+    central_prod_paths = {DURABLE_COMPLETION_FACADE_PATH, DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}
+    if not any(path in central_prod_paths for path in normalized):
+        return False
+    bootstrap_slice = frozenset(
+        {
+            DURABLE_COMPLETION_INTEGRATION_PARTITIONS_HELPER,
+            "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+            GLB019_A2B_SELECTOR_OWNER,
+        }
+    )
+    if not any(path in bootstrap_slice for path in normalized):
+        return False
+    if _is_established_durable_completion_rebinding_scope(normalized):
+        return False
+    return True
+
+
+def _glb019_a2b_unparseable_fallback_targets() -> tuple[str, ...]:
+    targets: list[str] = []
+    for path in (
+        DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER,
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+        DURABLE_COMPLETION_INTEGRATION_TEST_OWNER,
+    ):
+        if _repo_path_exists(path):
+            targets.append(path)
+    return tuple(sorted(set(targets)))
+
+
+def _selection_result_for_glb019_a2b_change_contract(
+    files: list[str],
+    contract: Glb019A2bChangeContractResult,
+    *,
+    patch_text: str | None,
+) -> SelectionResult | None:
+    if contract.outcome == Glb019A2bChangeContractOutcome.PASS:
+        targets = _durable_completion_focused_targets(files, patch_text=patch_text)
+        if not targets:
+            return None
+        return SelectionResult(
+            "FOCUSED",
+            "glb019_a2b_additive_change_contract",
+            targets,
+            (
+                "src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0",
+                "src.ops.durable_completion_validation",
+            ),
+        )
+    if contract.outcome == Glb019A2bChangeContractOutcome.REJECT:
+        return SelectionResult("FULL", "durable_completion_foreign_path_requires_full", ())
+    if contract.outcome == Glb019A2bChangeContractOutcome.UNAVAILABLE_OR_UNPARSEABLE:
+        targets = _glb019_a2b_unparseable_fallback_targets()
+        if not targets:
+            return None
+        return SelectionResult(
+            "FOCUSED",
+            "durable_completion_focused",
+            targets,
+            (
+                "src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0",
+                "src.ops.durable_completion_validation",
+            ),
+        )
+    return None
+
+
+def _effective_glb019_patch_text(
+    changed_files: list[str],
+    patch_text: str | None,
+) -> str | None:
+    if not patch_text:
+        return None
+    if not _is_glb019_a2b_structural_contract_candidate(changed_files):
+        return None
+    return patch_text
+
+
+def _try_durable_completion_focused(
+    files: list[str],
+    *,
+    patch_text: str | None = None,
+) -> SelectionResult | None:
+    if not files:
+        return None
+    if _is_glb019_partition_bootstrap_plus_central_prod_mix(files):
         return None
     if not _has_durable_completion_integration_partition_scope(files):
         return None
@@ -2029,9 +2207,38 @@ def _try_durable_completion_focused(files: list[str]) -> SelectionResult | None:
         _is_durable_completion_integration_partition_rebundle_path(f, files=files) for f in files
     ):
         return None
-    targets = _durable_completion_focused_targets(files)
+    patch_text = _effective_glb019_patch_text(files, patch_text)
+    central_prod_paths = {DURABLE_COMPLETION_FACADE_PATH, DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}
+    has_central_prod = any(path in central_prod_paths for path in files)
+    if has_central_prod and _is_glb019_a2b_structural_contract_candidate(files):
+        if patch_text:
+            contract = evaluate_glb019_a2b_change_contract(patch_text, repo_root=_REPO_ROOT)
+            glb019_selection = _selection_result_for_glb019_a2b_change_contract(
+                files,
+                contract,
+                patch_text=patch_text,
+            )
+            if glb019_selection is not None:
+                return glb019_selection
+            return None
+        if len(files) == 1 and files[0] in central_prod_paths:
+            return None
+    glb019_contract = (
+        classify_glb019_a2b_additive_patch(patch_text, repo_root=_REPO_ROOT) if patch_text else None
+    )
+    targets = _durable_completion_focused_targets(files, patch_text=patch_text)
     if not targets:
         return None
+    if glb019_contract is not None:
+        return SelectionResult(
+            "FOCUSED",
+            "glb019_a2b_additive_change_contract",
+            targets,
+            (
+                "src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0",
+                "src.ops.durable_completion_validation",
+            ),
+        )
     integration_required = _requires_durable_completion_integration_test_owner(files)
     if _is_durable_completion_wallclock_binding_rebinding_scope(files):
         modules: tuple[str, ...] = (
@@ -2358,7 +2565,11 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
 
 
 def resolve_selection(
-    files: list[str], *, force_full: bool = False, event_name: str = "pull_request"
+    files: list[str],
+    *,
+    force_full: bool = False,
+    event_name: str = "pull_request",
+    patch_text: str | None = None,
 ) -> SelectionResult:
     normalized = sorted({PurePosixPath(f).as_posix() for f in files if f.strip()})
     if force_full or event_name in {"push", "merge_group", "schedule"}:
@@ -2416,9 +2627,17 @@ def resolve_selection(
     if offline_master_v2_replay is not None:
         return offline_master_v2_replay
 
-    durable_completion = _try_durable_completion_focused(normalized)
+    effective_patch = _effective_glb019_patch_text(normalized, patch_text)
+    durable_completion = _try_durable_completion_focused(normalized, patch_text=effective_patch)
     if durable_completion is not None:
         return durable_completion
+
+    ci_bootstrap = _try_ci_bootstrap_focused(normalized)
+    if ci_bootstrap is not None:
+        return ci_bootstrap
+
+    if _is_glb019_partition_bootstrap_plus_central_prod_mix(normalized):
+        return SelectionResult("FULL", "durable_completion_foreign_path_requires_full", ())
 
     preflight_assembly = _try_preflight_assembly_focused(normalized)
     if preflight_assembly is not None:
@@ -2457,10 +2676,6 @@ def resolve_selection(
     wallclock = _try_wallclock_focused(normalized)
     if wallclock is not None:
         return wallclock
-
-    ci_bootstrap = _try_ci_bootstrap_focused(normalized)
-    if ci_bootstrap is not None:
-        return ci_bootstrap
 
     ci_infra = _try_ci_infra_focused(normalized)
     if ci_infra is not None:
@@ -2629,6 +2844,17 @@ def main(argv: list[str] | None = None) -> int:
         metavar="MODULES",
         help="Import listed Python modules (space-separated)",
     )
+    parser.add_argument(
+        "--patch-file",
+        type=Path,
+        default=None,
+        help="Unified diff patch for GLB-019 A2/B change-contract classification (tests/probes)",
+    )
+    parser.add_argument(
+        "--diff-base-ref",
+        default=os.environ.get("DIFF_BASE_REF", "origin/main"),
+        help="Base ref for merge-base patch collection (CI path)",
+    )
     args = parser.parse_args(argv)
 
     if args.emit_validated_pytest_targets is not None:
@@ -2650,7 +2876,25 @@ def main(argv: list[str] | None = None) -> int:
         raw = os.environ.get("CHANGED_FILES", "")
         files = [ln.strip() for ln in raw.splitlines() if ln.strip()]
 
-    result = resolve_selection(files, force_full=args.force_full, event_name=args.event_name)
+    patch_text: str | None = None
+    if args.patch_file is not None:
+        if not args.patch_file.is_file():
+            print(f"missing patch file: {args.patch_file}", file=sys.stderr)
+            return 1
+        patch_text = args.patch_file.read_text(encoding="utf-8")
+    elif _is_glb019_a2b_structural_contract_candidate(files):
+        patch_text = collect_glb019_a2b_patch_text(
+            base_ref=args.diff_base_ref,
+            repo_root=_REPO_ROOT,
+            changed_files=files,
+        )
+
+    result = resolve_selection(
+        files,
+        force_full=args.force_full,
+        event_name=args.event_name,
+        patch_text=patch_text,
+    )
     lines = result.github_output_lines()
     if args.github_output:
         out_path = os.environ.get("GITHUB_OUTPUT")

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -55,11 +55,13 @@ CI_MAPPING_FULL_PATHS = frozenset({"config/ci/file_category_mapping.yaml"})
 DURABLE_COMPLETION_INTEGRATION_PARTITIONS_HELPER = (
     "scripts/ops/durable_completion_integration_partitions_v0.py"
 )
+CI_GLB019_SYNTHETIC_PATCH_BUILDER = "tests/ci/_glb019_synthetic_patch_builder_v0.py"
 CI_BOOTSTRAP_FOCUSED_PATHS = frozenset(
     {
         "scripts/ops/ci_test_selection_v1.py",
         DURABLE_COMPLETION_INTEGRATION_PARTITIONS_HELPER,
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+        CI_GLB019_SYNTHETIC_PATCH_BUILDER,
     }
 )
 

--- a/scripts/ops/durable_completion_integration_partitions_v0.py
+++ b/scripts/ops/durable_completion_integration_partitions_v0.py
@@ -603,7 +603,8 @@ def _is_allowed_validation_context_glb019_delta(after_stmt: ast.stmt) -> bool:
     if not isinstance(after_stmt, ast.Assign):
         return True
     if not (
-        isinstance(after_stmt.value, ast.Call) and _call_name(after_stmt.value) == "ValidationContext"
+        isinstance(after_stmt.value, ast.Call)
+        and _call_name(after_stmt.value) == "ValidationContext"
     ):
         return True
     call = after_stmt.value
@@ -1017,8 +1018,9 @@ def evaluate_glb019_a2b_change_contract(
             return Glb019A2bChangeContractResult(
                 Glb019A2bChangeContractOutcome.UNAVAILABLE_OR_UNPARSEABLE
             )
-        if path in _GLB019_STRICT_EVALUATE_ASSIGNMENT_PATHS and not _module_glb019_structural_constraints_valid(
-            after_tree
+        if (
+            path in _GLB019_STRICT_EVALUATE_ASSIGNMENT_PATHS
+            and not _module_glb019_structural_constraints_valid(after_tree)
         ):
             return Glb019A2bChangeContractResult(Glb019A2bChangeContractOutcome.REJECT)
         if not validator(before_tree, after_tree):

--- a/scripts/ops/durable_completion_integration_partitions_v0.py
+++ b/scripts/ops/durable_completion_integration_partitions_v0.py
@@ -6,10 +6,14 @@ Kein Cross-Call-State; rein statische Inventar- und Expansionshilfe für CI-Sele
 
 from __future__ import annotations
 
+import ast
+import enum
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from functools import lru_cache
+from pathlib import Path
 from typing import Final
 
 INTEGRATION_TEST_OWNER: Final = "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
@@ -369,3 +373,714 @@ def estimate_partition_seconds(partitions: frozenset[str]) -> int:
         eval_estimate = len(nodes) * eval_ratio
         total += eval_estimate * 21 + (len(nodes) - eval_estimate) * 0.5
     return int(total)
+
+
+GLB019_A2B_ALLOWED_FILES: Final[frozenset[str]] = frozenset(
+    {
+        COMPLETION_FACADE_PATH,
+        INTEGRATION_TEST_OWNER,
+        "src/ops/durable_completion_validation/graph.py",
+        "src/ops/durable_completion_validation/validators/event_stream.py",
+        "tests/ops/test_durable_completion_validation_graph_v1.py",
+        "scripts/ops/durable_completion_integration_partitions_v0.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    }
+)
+
+GLB019_A2B_ADDITIVE_PARTITIONS: Final[frozenset[str]] = frozenset(
+    {
+        *CORE_ALWAYS_PARTITIONS,
+        "core_cross_chain",
+        "pe38_readiness",
+    }
+)
+
+_GLB019_FACADE_IMPORTS: Final[frozenset[str]] = frozenset(
+    {
+        "Glb019EventStreamProofBinding",
+        "Glb019EventStreamValidationInput",
+        "compute_glb019_event_stream_validation_input_digest",
+        "default_minimal_glb019_proof_binding",
+        "default_minimal_glb019_validation_input",
+        "evaluate_glb019_event_stream_validation",
+        "validate_glb019_event_stream_validation_input",
+    }
+)
+
+_GLB019_FACADE_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "glb019_event_stream_validation_input",
+        "glb019_event_stream_proof",
+    }
+)
+
+_GLB019_FACADE_NEW_FUNCTION: Final = "_validate_glb019_event_stream_binding"
+
+_GLB019_FACADE_INPUT_CLASS: Final = "DurableRunPrimaryEvidenceCompletionIntegrationInput"
+
+_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def _parse_unified_diff(patch_text: str) -> dict[str, list[str]]:
+    by_path: dict[str, list[str]] = {}
+    current_path: str | None = None
+    for raw_line in patch_text.splitlines():
+        if raw_line.startswith("diff --git "):
+            parts = raw_line.split()
+            current_path = None
+            for part in parts[2:4]:
+                if part.startswith("b/"):
+                    current_path = part[2:]
+                    break
+                if part.startswith("a/"):
+                    continue
+            if current_path:
+                by_path.setdefault(current_path, [])
+            continue
+        if current_path is None:
+            continue
+        if raw_line.startswith(("--- ", "+++ ", "index ", "new file mode", "deleted file mode")):
+            continue
+        if raw_line.startswith("@@"):
+            by_path[current_path].append(raw_line)
+            continue
+        if raw_line.startswith(("+", "-", " ")):
+            by_path[current_path].append(raw_line)
+    return by_path
+
+
+def _apply_unified_hunks(base_text: str, hunk_lines: list[str]) -> str:
+    base_lines = base_text.splitlines(keepends=True)
+    if base_text and not base_lines:
+        base_lines = [base_text]
+    if not base_text:
+        base_lines = []
+    out: list[str] = []
+    src_idx = 0
+    hunk_idx = 0
+    while hunk_idx < len(hunk_lines):
+        header = hunk_lines[hunk_idx]
+        if not header.startswith("@@"):
+            hunk_idx += 1
+            continue
+        match = _HUNK_HEADER.match(header)
+        if not match:
+            raise ValueError(f"invalid hunk header: {header!r}")
+        old_start = int(match.group(1))
+        hunk_idx += 1
+        while src_idx < old_start - 1:
+            out.append(base_lines[src_idx])
+            src_idx += 1
+        while hunk_idx < len(hunk_lines) and not hunk_lines[hunk_idx].startswith("@@"):
+            line = hunk_lines[hunk_idx]
+            if line.startswith(" "):
+                if src_idx < len(base_lines):
+                    out.append(base_lines[src_idx])
+                    src_idx += 1
+            elif line.startswith("-"):
+                src_idx += 1
+            elif line.startswith("+"):
+                out.append(line[1:] + ("\n" if not line[1:].endswith("\n") else ""))
+            hunk_idx += 1
+    out.extend(base_lines[src_idx:])
+    return "".join(out)
+
+
+def _base_file_text(repo_root: Path, path: str) -> str:
+    proc = subprocess.run(
+        ["git", "show", f"origin/main:{path}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0:
+        return proc.stdout
+    file_path = repo_root / path
+    return file_path.read_text(encoding="utf-8") if file_path.is_file() else ""
+
+
+def _apply_patch_for_file(repo_root: Path, path: str, hunk_lines: list[str]) -> str:
+    base_text = _base_file_text(repo_root, path)
+    return _apply_unified_hunks(base_text, hunk_lines)
+
+
+def _module_defs(tree: ast.Module) -> dict[str, ast.AST]:
+    out: dict[str, ast.AST] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            out[node.name] = node
+    return out
+
+
+def _class_field_names(class_node: ast.ClassDef) -> set[str]:
+    names: set[str] = set()
+    for node in class_node.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def _function_calls(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return names
+
+
+def _stmt_fingerprint(stmt: ast.stmt) -> str:
+    return ast.dump(stmt, include_attributes=False)
+
+
+def _call_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _is_glb019_evaluate_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call) and _call_name(node) == "evaluate_glb019_event_stream_validation"
+    )
+
+
+_GLB019_ALLOWED_RETURN_DICT_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "glb019_event_stream_proof",
+        "glb019_event_stream_validation_input_digest",
+    }
+)
+
+_GLB019_ALLOWED_CALL_KEYWORDS: Final[frozenset[str]] = frozenset(
+    {
+        "glb019_result",
+        "glb019_event_stream_validation_input",
+        "glb019_event_stream_proof",
+    }
+)
+
+
+def _strip_glb019_dict_keys(node: ast.Dict) -> None:
+    keep_keys: list[ast.expr | None] = []
+    keep_values: list[ast.expr] = []
+    for key, value in zip(node.keys, node.values):
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            if key.value in _GLB019_ALLOWED_RETURN_DICT_KEYS:
+                continue
+        keep_keys.append(key)
+        keep_values.append(value)
+    node.keys = keep_keys
+    node.values = keep_values
+
+
+def _strip_allowed_glb019_call_keywords(node: ast.Call) -> None:
+    node.keywords = [kw for kw in node.keywords if kw.arg not in _GLB019_ALLOWED_CALL_KEYWORDS]
+
+
+def _clone_statement(stmt: ast.stmt) -> ast.stmt:
+    return ast.parse(ast.unparse(stmt)).body[0]  # type: ignore[return-value]
+
+
+def _strip_allowed_glb019_from_statement(stmt: ast.stmt) -> ast.stmt:
+    cloned = _clone_statement(stmt)
+    for node in ast.walk(cloned):
+        if isinstance(node, ast.Dict):
+            _strip_glb019_dict_keys(node)
+        if isinstance(node, ast.Call):
+            _strip_allowed_glb019_call_keywords(node)
+    return cloned
+
+
+def _is_allowed_validation_context_glb019_delta(after_stmt: ast.stmt) -> bool:
+    if not isinstance(after_stmt, ast.Assign):
+        return True
+    if not (
+        isinstance(after_stmt.value, ast.Call) and _call_name(after_stmt.value) == "ValidationContext"
+    ):
+        return True
+    call = after_stmt.value
+    glb019_keywords = [kw for kw in call.keywords if kw.arg == "glb019_result"]
+    if not glb019_keywords:
+        return True
+    if len(glb019_keywords) != 1:
+        return False
+    keyword = glb019_keywords[0]
+    return isinstance(keyword.value, ast.Name) and keyword.value.id == "glb019_result"
+
+
+def _is_allowed_additive_glb019_statement(stmt: ast.stmt) -> bool:
+    if not _is_allowed_validation_context_glb019_delta(stmt):
+        return False
+    if (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    ):
+        target_name = stmt.targets[0].id
+        if target_name == "glb019_result" and _is_glb019_evaluate_call(stmt.value):
+            return True
+        if target_name == "glb019_validation_input":
+            return isinstance(stmt.value, ast.Call) and _call_name(stmt.value) == (
+                "default_minimal_glb019_validation_input"
+            )
+        if target_name == "glb019_proof":
+            return isinstance(stmt.value, ast.Call) and _call_name(stmt.value) == (
+                "default_minimal_glb019_proof_binding"
+            )
+        if target_name == "expected_completion_identity_digest":
+            return isinstance(stmt.value, ast.Call) and _call_name(stmt.value) == (
+                "compute_completion_identity_digest"
+            )
+    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        call = stmt.value
+        if _call_name(call) == "extend" and call.args:
+            arg = call.args[0]
+            if (
+                isinstance(arg, ast.Call)
+                and _call_name(arg) == "_validate_glb019_event_stream_binding"
+            ):
+                return True
+    return False
+
+
+def _statements_equivalent_modulo_allowed_glb019(
+    before_stmt: ast.stmt,
+    after_stmt: ast.stmt,
+) -> bool:
+    if _stmt_fingerprint(before_stmt) == _stmt_fingerprint(after_stmt):
+        return True
+    before_norm = _strip_allowed_glb019_from_statement(before_stmt)
+    after_norm = _strip_allowed_glb019_from_statement(after_stmt)
+    return _stmt_fingerprint(before_norm) == _stmt_fingerprint(after_norm)
+
+
+def function_statements_preserved_with_allowed_glb019(
+    before_fn: ast.FunctionDef,
+    after_fn: ast.FunctionDef,
+) -> bool:
+    """True when baseline general statements match head after removing allowed GLB-019 additions."""
+    before_remaining = list(before_fn.body)
+    for after_stmt in after_fn.body:
+        if _is_allowed_additive_glb019_statement(after_stmt):
+            continue
+        if not before_remaining:
+            return False
+        before_stmt = before_remaining[0]
+        if not _statements_equivalent_modulo_allowed_glb019(before_stmt, after_stmt):
+            return False
+        before_remaining.pop(0)
+    return not before_remaining
+
+
+def function_statement_diff_debug(
+    before_fn: ast.FunctionDef,
+    after_fn: ast.FunctionDef,
+) -> dict[str, list[str]]:
+    baseline = [_stmt_fingerprint(stmt) for stmt in before_fn.body]
+    head = [_stmt_fingerprint(stmt) for stmt in after_fn.body]
+    allowed_removed = [
+        _stmt_fingerprint(stmt)
+        for stmt in after_fn.body
+        if _is_allowed_additive_glb019_statement(stmt)
+    ]
+    head_without_allowed: list[str] = []
+    before_remaining = list(before_fn.body)
+    mismatch: list[str] = []
+    for after_stmt in after_fn.body:
+        if _is_allowed_additive_glb019_statement(after_stmt):
+            continue
+        head_without_allowed.append(_stmt_fingerprint(after_stmt))
+        if not before_remaining:
+            mismatch.append(f"extra_head:{_stmt_fingerprint(after_stmt)}")
+            continue
+        before_stmt = before_remaining[0]
+        if not _statements_equivalent_modulo_allowed_glb019(before_stmt, after_stmt):
+            mismatch.append(
+                f"baseline={_stmt_fingerprint(before_stmt)} head={_stmt_fingerprint(after_stmt)}"
+            )
+        before_remaining.pop(0)
+    for stmt in before_remaining:
+        mismatch.append(f"missing_head:{_stmt_fingerprint(stmt)}")
+    return {
+        "BASELINE_GENERAL_STATEMENTS": baseline,
+        "HEAD_STATEMENTS": head,
+        "REMOVED_ALLOWED_GLB019_FINGERPRINTS": allowed_removed,
+        "HEAD_STATEMENTS_WITH_ALLOWED_GLB019_REMOVED": head_without_allowed,
+        "REMAINING_DIFFERENCE": mismatch,
+    }
+
+
+def _parse_function_from_module(module_src: str, function_name: str) -> ast.FunctionDef:
+    module = ast.parse(module_src)
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return node
+    raise ValueError(f"missing function: {function_name}")
+
+
+def _existing_modified_functions_preserve_general_statements(
+    before: ast.Module,
+    after: ast.Module,
+) -> bool:
+    before_defs = _module_defs(before)
+    after_defs = _module_defs(after)
+    for name, before_fn in before_defs.items():
+        if name not in after_defs:
+            continue
+        after_fn = after_defs[name]
+        if not isinstance(before_fn, ast.FunctionDef) or not isinstance(after_fn, ast.FunctionDef):
+            continue
+        if _stmt_fingerprint_list(before_fn) == _stmt_fingerprint_list(after_fn):
+            continue
+        if not function_statements_preserved_with_allowed_glb019(before_fn, after_fn):
+            return False
+    return True
+
+
+def _stmt_fingerprint_list(fn: ast.FunctionDef) -> list[str]:
+    return [_stmt_fingerprint(stmt) for stmt in fn.body]
+
+
+def _validate_facade_ast(before: ast.Module, after: ast.Module) -> bool:
+    before_defs = _module_defs(before)
+    after_defs = _module_defs(after)
+    new_funcs = set(after_defs) - set(before_defs)
+    removed_funcs = set(before_defs) - set(after_defs)
+    if removed_funcs:
+        return False
+    if new_funcs != {_GLB019_FACADE_NEW_FUNCTION}:
+        return False
+    before_input = before_defs.get(_GLB019_FACADE_INPUT_CLASS)
+    after_input = after_defs.get(_GLB019_FACADE_INPUT_CLASS)
+    if not isinstance(before_input, ast.ClassDef) or not isinstance(after_input, ast.ClassDef):
+        return False
+    added_fields = _class_field_names(after_input) - _class_field_names(before_input)
+    removed_fields = _class_field_names(before_input) - _class_field_names(after_input)
+    if removed_fields:
+        return False
+    if added_fields != _GLB019_FACADE_FIELDS:
+        return False
+    new_import_names: set[str] = set()
+    for node in after.body:
+        if isinstance(node, ast.ImportFrom) and node.module and "event_stream" in node.module:
+            for alias in node.names:
+                name = alias.asname or alias.name
+                new_import_names.add(name)
+    if not _GLB019_FACADE_IMPORTS.issubset(new_import_names):
+        return False
+    validate_fn = after_defs.get(
+        "validate_durable_run_primary_evidence_completion_integration_input"
+    )
+    evaluate_fn = after_defs.get("evaluate_durable_run_primary_evidence_completion_integration")
+    dict_fn = after_defs.get("_integration_input_dict")
+    default_fn = after_defs.get("default_minimal_completion_integration_input")
+    if not all(
+        isinstance(fn, ast.FunctionDef) for fn in (validate_fn, evaluate_fn, dict_fn, default_fn)
+    ):
+        return False
+    validate_calls = _function_calls(validate_fn)
+    if "_validate_glb019_event_stream_binding" not in validate_calls:
+        return False
+    if not _existing_modified_functions_preserve_general_statements(before, after):
+        return False
+    glb019_assignments = [
+        stmt
+        for stmt in evaluate_fn.body  # type: ignore[union-attr]
+        if isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+        and stmt.targets[0].id == "glb019_result"
+        and _is_glb019_evaluate_call(stmt.value)
+    ]
+    if len(glb019_assignments) != 1:
+        return False
+    dict_src = ast.unparse(dict_fn)
+    if (
+        "glb019_event_stream_proof" not in dict_src
+        or "glb019_event_stream_validation_input_digest" not in dict_src
+    ):
+        return False
+    default_src = ast.unparse(default_fn)
+    if (
+        "glb019_event_stream_validation_input=" not in default_src
+        or "glb019_event_stream_proof=" not in default_src
+    ):
+        return False
+    return True
+
+
+def _validate_graph_ast(before: ast.Module, after: ast.Module) -> bool:
+    before_src = ast.unparse(before)
+    after_src = ast.unparse(after)
+    if (
+        "VALIDATOR_EVENT_STREAM" not in after_src
+        or "validate_glb019_event_stream_proof" not in after_src
+    ):
+        return False
+    if "VALIDATOR_WALLCLOCK" not in after_src:
+        return False
+    for token in ("VALIDATOR_EVENT_STREAM", "event_stream"):
+        if after_src.count(token) <= before_src.count(token):
+            return False
+    return True
+
+
+def _validate_event_stream_ast(before: ast.Module, after: ast.Module) -> bool:
+    before_defs = _module_defs(before)
+    after_defs = _module_defs(after)
+    if set(before_defs) != set(after_defs):
+        return False
+    fn = after_defs.get("validate_glb019_event_stream_proof")
+    if not isinstance(fn, ast.FunctionDef):
+        return False
+    src = ast.unparse(fn)
+    if "glb019_result is None" not in src:
+        return False
+    if " or {}" in src:
+        return False
+    return True
+
+
+def _validate_integration_test_ast(before: ast.Module, after: ast.Module) -> bool:
+    before_defs = _module_defs(before)
+    after_defs = _module_defs(after)
+    if set(before_defs) - set(after_defs):
+        return False
+    new_defs = set(after_defs) - set(before_defs)
+    if not new_defs:
+        return False
+    if any(not name.startswith("test_glb019_") for name in new_defs):
+        return False
+    for name in before_defs:
+        if ast.unparse(before_defs[name]) != ast.unparse(after_defs[name]):
+            return False
+    return True
+
+
+def _validate_graph_test_ast(before: ast.Module, after: ast.Module) -> bool:
+    before_defs = _module_defs(before)
+    after_defs = _module_defs(after)
+    removed = set(before_defs) - set(after_defs)
+    if removed != {"test_glb019_no_production_graph_activation"}:
+        return False
+    new_names = set(after_defs) - set(before_defs)
+    allowed_new = {
+        "test_graph_event_stream_production_activation",
+        "test_glb019_production_graph_happy_path",
+        "test_glb019_missing_glb019_result_fail_closed",
+        "test_glb019_graph_missing_result_blocks_completion_chain",
+        "_glb019_result_for",
+        "_graph_context",
+    }
+    if set(new_names) != allowed_new:
+        return False
+    for name in set(before_defs) & set(after_defs):
+        before_fn = before_defs[name]
+        after_fn = after_defs[name]
+        if ast.unparse(before_fn) == ast.unparse(after_fn):
+            continue
+        after_src = ast.unparse(after_fn)
+        before_src = ast.unparse(before_fn)
+        if name == "_minimal_context":
+            if "glb019_result=" not in after_src or "ValidationContext(" not in after_src:
+                return False
+            continue
+        if "ValidationContext(" in before_src and "_graph_context(" in after_src:
+            continue
+        if "VALIDATOR_EVENT_STREAM" in after_src and "VALIDATOR_EVENT_STREAM" not in before_src:
+            continue
+        if name.startswith("test_glb019_"):
+            continue
+        if before_src != after_src and not (
+            "glb019" in after_src
+            or "VALIDATOR_EVENT_STREAM" in after_src
+            or "_graph_context" in after_src
+        ):
+            return False
+    return True
+
+
+def _validate_partitions_ast(before: ast.Module, after: ast.Module) -> bool:
+    before_src = ast.unparse(before)
+    after_src = ast.unparse(after)
+    if before_src == after_src:
+        return False
+    if after_src.count("glb019") <= before_src.count("glb019"):
+        return False
+    if "event_stream" not in after_src:
+        return False
+    if not (
+        "glb019' in base or 'event_stream' in base" in after_src
+        or 'glb019" in base or "event_stream" in base' in after_src
+    ):
+        return False
+    return len(after_src) > len(before_src)
+
+
+def _validate_ci_selector_test_ast(before: ast.Module, after: ast.Module) -> bool:
+    before_src = ast.unparse(before)
+    after_src = ast.unparse(after)
+    if before_src == after_src:
+        return False
+    if "assert len(nodes) == 238" in before_src and "assert len(nodes) == 246" in after_src:
+        return before_src.replace("238", "246") == after_src
+    return False
+
+
+_FILE_AST_VALIDATORS = {
+    COMPLETION_FACADE_PATH: _validate_facade_ast,
+    "src/ops/durable_completion_validation/graph.py": _validate_graph_ast,
+    "src/ops/durable_completion_validation/validators/event_stream.py": _validate_event_stream_ast,
+    INTEGRATION_TEST_OWNER: _validate_integration_test_ast,
+    "tests/ops/test_durable_completion_validation_graph_v1.py": _validate_graph_test_ast,
+    "scripts/ops/durable_completion_integration_partitions_v0.py": _validate_partitions_ast,
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py": _validate_ci_selector_test_ast,
+}
+
+
+class Glb019A2bChangeContractOutcome(enum.Enum):
+    PASS = "pass"
+    REJECT = "reject"
+    UNAVAILABLE_OR_UNPARSEABLE = "unavailable_or_unparseable"
+
+
+@dataclass(frozen=True)
+class Glb019A2bChangeContractResult:
+    outcome: Glb019A2bChangeContractOutcome
+    partitions: frozenset[str] | None = None
+
+
+_GLB019_STRICT_EVALUATE_ASSIGNMENT_PATHS: Final[frozenset[str]] = frozenset(
+    {
+        COMPLETION_FACADE_PATH,
+    }
+)
+
+
+def _module_glb019_structural_constraints_valid(module: ast.Module) -> bool:
+    """Fail closed on forbidden GLB-019 evaluate assignment targets in prod facade."""
+    for node in ast.walk(module):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and _is_glb019_evaluate_call(node.value)
+            and node.targets[0].id != "glb019_result"
+        ):
+            return False
+    return True
+
+
+def evaluate_glb019_a2b_change_contract(
+    patch_text: str,
+    *,
+    repo_root: Path | None = None,
+) -> Glb019A2bChangeContractResult:
+    """Tri-state GLB-019 A2/B structural contract: PASS, REJECT, or UNAVAILABLE."""
+    if not patch_text.strip():
+        return Glb019A2bChangeContractResult(
+            Glb019A2bChangeContractOutcome.UNAVAILABLE_OR_UNPARSEABLE
+        )
+    root = repo_root or Path.cwd()
+    try:
+        by_path = _parse_unified_diff(patch_text)
+    except ValueError:
+        return Glb019A2bChangeContractResult(
+            Glb019A2bChangeContractOutcome.UNAVAILABLE_OR_UNPARSEABLE
+        )
+    if not by_path:
+        return Glb019A2bChangeContractResult(
+            Glb019A2bChangeContractOutcome.UNAVAILABLE_OR_UNPARSEABLE
+        )
+    if not set(by_path) <= GLB019_A2B_ALLOWED_FILES:
+        return Glb019A2bChangeContractResult(Glb019A2bChangeContractOutcome.REJECT)
+    if not GLB019_A2B_ALLOWED_FILES.issubset(set(by_path)):
+        return Glb019A2bChangeContractResult(Glb019A2bChangeContractOutcome.REJECT)
+    for path, hunk_lines in by_path.items():
+        validator = _FILE_AST_VALIDATORS.get(path)
+        if validator is None:
+            return Glb019A2bChangeContractResult(Glb019A2bChangeContractOutcome.REJECT)
+        try:
+            before_text = _base_file_text(root, path)
+            after_text = _apply_patch_for_file(root, path, hunk_lines)
+            before_tree = ast.parse(before_text)
+            after_tree = ast.parse(after_text)
+        except (OSError, SyntaxError, ValueError):
+            return Glb019A2bChangeContractResult(
+                Glb019A2bChangeContractOutcome.UNAVAILABLE_OR_UNPARSEABLE
+            )
+        if path in _GLB019_STRICT_EVALUATE_ASSIGNMENT_PATHS and not _module_glb019_structural_constraints_valid(
+            after_tree
+        ):
+            return Glb019A2bChangeContractResult(Glb019A2bChangeContractOutcome.REJECT)
+        if not validator(before_tree, after_tree):
+            return Glb019A2bChangeContractResult(Glb019A2bChangeContractOutcome.REJECT)
+    return Glb019A2bChangeContractResult(
+        Glb019A2bChangeContractOutcome.PASS,
+        GLB019_A2B_ADDITIVE_PARTITIONS,
+    )
+
+
+def classify_glb019_a2b_additive_patch(
+    patch_text: str,
+    *,
+    repo_root: Path | None = None,
+) -> frozenset[str] | None:
+    """Return bounded GLB-019 partition ids when patch matches the additive A2/B contract."""
+    result = evaluate_glb019_a2b_change_contract(patch_text, repo_root=repo_root)
+    if result.outcome == Glb019A2bChangeContractOutcome.PASS:
+        return result.partitions
+    return None
+
+
+def collect_glb019_a2b_patch_text(
+    *,
+    base_ref: str = "origin/main",
+    repo_root: Path | None = None,
+    changed_files: list[str] | None = None,
+) -> str | None:
+    """Collect merge-base unified diff for GLB-019 contract paths (CI path)."""
+    root = repo_root or Path.cwd()
+    if changed_files is not None:
+        diff_paths = sorted(set(changed_files) & GLB019_A2B_ALLOWED_FILES)
+        if not diff_paths:
+            return None
+    else:
+        diff_paths = sorted(GLB019_A2B_ALLOWED_FILES)
+    merge_base = subprocess.run(
+        ["git", "merge-base", base_ref, "HEAD"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if merge_base.returncode != 0 or not merge_base.stdout.strip():
+        return None
+    mb = merge_base.stdout.strip()
+    diff = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--no-ext-diff",
+            "--unified=0",
+            f"{mb}...HEAD",
+            "--",
+            *diff_paths,
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if diff.returncode not in {0, 1}:
+        return None
+    text = diff.stdout
+    return text if text.strip() else None

--- a/tests/ci/_glb019_synthetic_patch_builder_v0.py
+++ b/tests/ci/_glb019_synthetic_patch_builder_v0.py
@@ -1,0 +1,631 @@
+"""Deterministic synthetic GLB-019 A2/B patch builder for selector contract tests (v0)."""
+
+from __future__ import annotations
+
+import difflib
+import subprocess
+from collections.abc import Callable
+from functools import lru_cache
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_FACADE_PATH = "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+_INTEGRATION_TEST_OWNER = "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+_GRAPH_PATH = "src/ops/durable_completion_validation/graph.py"
+_EVENT_STREAM_PATH = "src/ops/durable_completion_validation/validators/event_stream.py"
+_GRAPH_TEST_OWNER = "tests/ops/test_durable_completion_validation_graph_v1.py"
+_PARTITIONS_PATH = "scripts/ops/durable_completion_integration_partitions_v0.py"
+_CI_SELECTOR_TEST = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
+
+_GLB019_A2B_ALLOWED_FILES: tuple[str, ...] = (
+    _FACADE_PATH,
+    _INTEGRATION_TEST_OWNER,
+    _GRAPH_PATH,
+    _EVENT_STREAM_PATH,
+    _GRAPH_TEST_OWNER,
+    _PARTITIONS_PATH,
+    _CI_SELECTOR_TEST,
+)
+
+
+def _git_origin_main_text(path: str) -> str:
+    return subprocess.check_output(
+        ["git", "show", f"origin/main:{path}"],
+        cwd=_REPO_ROOT,
+        text=True,
+    )
+
+
+def _format_git_unified_diff(path: str, before: str, after: str) -> str:
+    if before == after:
+        return ""
+    before_lines = before.splitlines(keepends=True)
+    after_lines = after.splitlines(keepends=True)
+    if before and not before.endswith("\n"):
+        before_lines = [line + "\n" for line in before.splitlines()]
+    if after and not after.endswith("\n"):
+        after_lines = [line + "\n" for line in after.splitlines()]
+    diff_lines = list(
+        difflib.unified_diff(
+            before_lines,
+            after_lines,
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+        )
+    )
+    if not diff_lines:
+        return ""
+    return f"diff --git a/{path} b/{path}\n" + "".join(diff_lines)
+
+
+def _mutate_partitions(before: str) -> str:
+    needle = '    if "wallclock" in base:\n        return "wallclock"\n\n'
+    insert = (
+        '    if "wallclock" in base:\n'
+        '        return "wallclock"\n\n'
+        '    if "glb019" in base or "event_stream" in base:\n'
+        '        return "pe38_readiness"\n\n'
+    )
+    if needle not in before:
+        raise ValueError("partitions anchor missing")
+    return before.replace(needle, insert, 1)
+
+
+def _mutate_event_stream(before: str) -> str:
+    needle = (
+        "def validate_glb019_event_stream_proof(context: ValidationContext) -> ValidationResult:\n"
+        '    """Bind canonical GLB-019 validation result into durable completion proof graph."""\n'
+        "    fail_reasons: list[str] = []\n"
+        "    integration_input = context.integration_input\n"
+        "    glb019_result = context.glb019_result or {}\n"
+    )
+    replacement = (
+        "def validate_glb019_event_stream_proof(context: ValidationContext) -> ValidationResult:\n"
+        '    """Bind canonical GLB-019 validation result into durable completion proof graph."""\n'
+        "    if context.glb019_result is None:\n"
+        "        return ValidationResult(\n"
+        "            fail_reasons=(\n"
+        '                "glb019_event_stream_validation: glb019_result required in validation context",\n'
+        "            )\n"
+        "        )\n"
+        "    fail_reasons: list[str] = []\n"
+        "    integration_input = context.integration_input\n"
+        "    glb019_result = context.glb019_result\n"
+    )
+    if needle not in before:
+        raise ValueError("event_stream anchor missing")
+    return before.replace(needle, replacement, 1)
+
+
+def _mutate_graph(before: str) -> str:
+    out = before
+    replacements = [
+        (
+            'VALIDATOR_WALLCLOCK = "wallclock"\n',
+            'VALIDATOR_WALLCLOCK = "wallclock"\nVALIDATOR_EVENT_STREAM = "event_stream"\n',
+        ),
+        (
+            "    VALIDATOR_WALLCLOCK: (),\n",
+            "    VALIDATOR_WALLCLOCK: (),\n    VALIDATOR_EVENT_STREAM: (),\n",
+        ),
+        (
+            "        VALIDATOR_WALLCLOCK,\n",
+            "        VALIDATOR_WALLCLOCK,\n        VALIDATOR_EVENT_STREAM,\n",
+        ),
+        ("    VALIDATOR_WALLCLOCK,\n", "    VALIDATOR_WALLCLOCK,\n    VALIDATOR_EVENT_STREAM,\n"),
+        ("        completion_chain,\n", "        completion_chain,\n        event_stream,\n"),
+        (
+            "        VALIDATOR_WALLCLOCK: wallclock.validate_wallclock_proof_binding,\n",
+            "        VALIDATOR_WALLCLOCK: wallclock.validate_wallclock_proof_binding,\n"
+            "        VALIDATOR_EVENT_STREAM: event_stream.validate_glb019_event_stream_proof,\n",
+        ),
+    ]
+    for old, new in replacements:
+        if old not in out:
+            raise ValueError(f"graph anchor missing: {old!r}")
+        out = out.replace(old, new, 1)
+    return out
+
+
+def _mutate_ci_selector_test(before: str) -> str:
+    return before.replace("assert len(nodes) == 238", "assert len(nodes) == 246", 1)
+
+
+_SYNTHETIC_INTEGRATION_TESTS = """
+
+
+def test_glb019_happy_path_passes_non_authorizing() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    result = evaluate_durable_run_primary_evidence_completion_integration(integration_input)
+    assert result["integration_pass"] is True
+    assert result["fail_reasons"] == []
+    assert integration_input.non_authorizing is True
+    assert integration_input.glb019_event_stream_proof.event_stream_non_authorizing is True
+    assert result["operative_run_completion_recorded"] is False
+    assert result["authority_lift"] is False
+
+
+def test_glb019_missing_validation_input_fail_closed() -> None:
+    from types import SimpleNamespace
+
+    integration_input = default_minimal_completion_integration_input()
+    legacy = SimpleNamespace(
+        **{
+            field.name: getattr(integration_input, field.name)
+            for field in integration_input.__dataclass_fields__.values()
+            if field.name != "glb019_event_stream_validation_input"
+        }
+    )
+    fail_reasons = validate_durable_run_primary_evidence_completion_integration_input(legacy)  # type: ignore[arg-type]
+    assert any("glb019_event_stream_validation_input required" in reason for reason in fail_reasons)
+
+
+def test_glb019_missing_proof_fail_closed() -> None:
+    from types import SimpleNamespace
+
+    integration_input = default_minimal_completion_integration_input()
+    legacy = SimpleNamespace(
+        **{
+            field.name: getattr(integration_input, field.name)
+            for field in integration_input.__dataclass_fields__.values()
+            if field.name != "glb019_event_stream_proof"
+        }
+    )
+    fail_reasons = validate_durable_run_primary_evidence_completion_integration_input(legacy)  # type: ignore[arg-type]
+    assert any("glb019_event_stream_proof required" in reason for reason in fail_reasons)
+
+
+def test_glb019_run_identity_drift_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        glb019_event_stream_validation_input=replace(
+            integration_input.glb019_event_stream_validation_input,
+            run_identity_digest="0" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("run_identity_digest drift" in reason for reason in result["fail_reasons"])
+
+
+def test_glb019_source_revision_drift_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        glb019_event_stream_validation_input=replace(
+            integration_input.glb019_event_stream_validation_input,
+            source_revision="1" * 40,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("source_revision mismatch" in reason for reason in result["fail_reasons"])
+
+
+def test_glb019_proof_digest_drift_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        glb019_event_stream_proof=replace(
+            integration_input.glb019_event_stream_proof,
+            validation_result_digest="0" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("validation_result_digest mismatch" in reason for reason in result["fail_reasons"])
+
+
+def test_glb019_digest_sensitivity() -> None:
+    base = default_minimal_completion_integration_input()
+    variant = replace(
+        base,
+        glb019_event_stream_validation_input=replace(
+            base.glb019_event_stream_validation_input,
+            correlation_id="glb019-digest-variant-v0",
+        ),
+    )
+    assert compute_completion_integration_input_digest(
+        base
+    ) != compute_completion_integration_input_digest(variant)
+
+
+def test_glb019_deterministic_repeat() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    first = evaluate_durable_run_primary_evidence_completion_integration(integration_input)
+    second = evaluate_durable_run_primary_evidence_completion_integration(integration_input)
+    assert first == second
+    assert first["integration_input_digest"] == second["integration_input_digest"]
+"""
+
+
+def _mutate_integration_test_owner(before: str) -> str:
+    if not before.endswith("\n"):
+        before += "\n"
+    return before + _SYNTHETIC_INTEGRATION_TESTS
+
+
+_GRAPH_TEST_HELPERS = """
+
+def _glb019_result_for(integration_input):
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        evaluate_glb019_event_stream_validation,
+    )
+
+    return evaluate_glb019_event_stream_validation(
+        integration_input.glb019_event_stream_validation_input
+    )
+
+
+def _graph_context(integration_input, **overrides: Any) -> ValidationContext:
+    context = ValidationContext(
+        integration_input=integration_input,
+        glb019_result=_glb019_result_for(integration_input),
+    )
+    for key, value in overrides.items():
+        setattr(context, key, value)
+    return context
+"""
+
+_GRAPH_TEST_EVENT_STREAM_ACTIVATION = """
+
+def test_graph_event_stream_production_activation() -> None:
+    from src.ops.durable_completion_validation import graph
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        validate_glb019_event_stream_proof,
+    )
+
+    assert VALIDATOR_EVENT_STREAM in graph.PROOF_BINDING_VALIDATION_GRAPH
+    assert VALIDATOR_EVENT_STREAM in graph.PROOF_BINDING_VALIDATION_ORDER
+    assert VALIDATOR_EVENT_STREAM in graph._load_validators()
+    assert (
+        graph._load_validators()[VALIDATOR_EVENT_STREAM].__name__
+        == validate_glb019_event_stream_proof.__name__
+    )
+    assert VALIDATOR_EVENT_STREAM in PROOF_BINDING_VALIDATION_GRAPH[VALIDATOR_COMPLETION_CHAIN]
+
+"""
+
+_GRAPH_TEST_PRODUCTION_HAPPY = """
+
+def test_glb019_production_graph_happy_path() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        validate_glb019_event_stream_proof,
+    )
+
+    context = _minimal_context()
+    assert not validate_glb019_event_stream_proof(context).fail_reasons
+    result = execute_proof_binding_validation_graph(context)
+    assert VALIDATOR_EVENT_STREAM in context.completed_validators
+    assert not any("glb019" in reason for reason in result.fail_reasons)
+
+
+def test_glb019_missing_glb019_result_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        validate_glb019_event_stream_proof,
+    )
+
+    context = _glb019_proof_context(glb019_result=None)
+    result = validate_glb019_event_stream_proof(context)
+    assert any("glb019_result required" in reason for reason in result.fail_reasons)
+
+
+def test_glb019_graph_missing_result_blocks_completion_chain() -> None:
+    context = _glb019_proof_context(glb019_result=None)
+    result = execute_proof_binding_validation_graph(context)
+    assert any("glb019_result required" in reason for reason in result.fail_reasons)
+    assert VALIDATOR_EVENT_STREAM not in context.completed_validators
+    assert VALIDATOR_COMPLETION_CHAIN not in context.completed_validators
+
+"""
+
+
+def _mutate_graph_test(before: str) -> str:
+    out = before
+    out = out.replace(
+        "    VALIDATOR_COMPLETION_CHAIN,\n    VALIDATOR_OPERATOR_CLOSURE,",
+        "    VALIDATOR_COMPLETION_CHAIN,\n    VALIDATOR_EVENT_STREAM,\n    VALIDATOR_OPERATOR_CLOSURE,",
+        1,
+    )
+    anchor = (
+        "def _cached_default_minimal_completion_integration_input():\n"
+        '    """Module-scoped cache: building minimal integration input runs full offline evidence chain."""\n'
+        "    return default_minimal_completion_integration_input()\n\n\n"
+    )
+    if anchor not in out:
+        raise ValueError("graph test helper anchor missing")
+    out = out.replace(anchor, anchor + _GRAPH_TEST_HELPERS.lstrip("\n"), 1)
+    out = out.replace(
+        "    context = ValidationContext(integration_input=integration_input)\n",
+        "    context = ValidationContext(\n"
+        "        integration_input=integration_input,\n"
+        "        glb019_result=_glb019_result_for(integration_input),\n"
+        "    )\n",
+        1,
+    )
+    out = out.replace(
+        "    assert PROOF_BINDING_VALIDATION_ORDER.index(VALIDATOR_WALLCLOCK) < (\n"
+        "        PROOF_BINDING_VALIDATION_ORDER.index(VALIDATOR_COMPLETION_CHAIN)\n"
+        "    )\n",
+        "    assert PROOF_BINDING_VALIDATION_ORDER.index(VALIDATOR_WALLCLOCK) < (\n"
+        "        PROOF_BINDING_VALIDATION_ORDER.index(VALIDATOR_EVENT_STREAM)\n"
+        "    )\n"
+        "    assert PROOF_BINDING_VALIDATION_ORDER.index(VALIDATOR_EVENT_STREAM) < (\n"
+        "        PROOF_BINDING_VALIDATION_ORDER.index(VALIDATOR_COMPLETION_CHAIN)\n"
+        "    )\n",
+        1,
+    )
+    out = out.replace(
+        "def test_graph_missing_validator_is_fail_closed() -> None:",
+        _GRAPH_TEST_EVENT_STREAM_ACTIVATION.lstrip("\n")
+        + "def test_graph_missing_validator_is_fail_closed() -> None:",
+        1,
+    )
+    for old_block in (
+        "        VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(),\n        VALIDATOR_COMPLETION_CHAIN:",
+        "        VALIDATOR_WALLCLOCK: lambda _ctx: ValidationResult(),\n        VALIDATOR_COMPLETION_CHAIN:",
+    ):
+        new_block = old_block.replace(
+            "VALIDATOR_COMPLETION_CHAIN:",
+            "VALIDATOR_EVENT_STREAM: lambda _ctx: ValidationResult(),\n        VALIDATOR_COMPLETION_CHAIN:",
+        )
+        if old_block not in out:
+            raise ValueError(f"graph test partial validator anchor missing: {old_block!r}")
+        out = out.replace(old_block, new_block, 1)
+    replacements = [
+        (
+            "    bad = _replace_pe21_manifest_entries(integration_input, entries)\n"
+            "    context = ValidationContext(\n        integration_input=bad,",
+            "    bad = _replace_pe21_manifest_entries(integration_input, entries)\n"
+            "    context = _graph_context(\n        bad,",
+        ),
+        (
+            "    context = ValidationContext(\n        integration_input=bad,\n"
+            "        pe35_result=evaluate_handoff_staleness_revocation_recovery_boundary(pe35_input),",
+            "    context = _graph_context(\n        bad,\n"
+            "        pe35_result=evaluate_handoff_staleness_revocation_recovery_boundary(pe35_input),",
+        ),
+        (
+            "    context = ValidationContext(\n        integration_input=bad,\n"
+            "        pe31_result=evaluate_reconciliation_review_lifecycle_integration(",
+            "    context = _graph_context(\n        bad,\n"
+            "        pe31_result=evaluate_reconciliation_review_lifecycle_integration(",
+        ),
+        (
+            "    context = ValidationContext(integration_input=bad)\n"
+            "    result = execute_proof_binding_validation_graph(context)\n"
+            '    assert any("wallclock_proof:" in reason for reason in result.fail_reasons)',
+            "    context = _graph_context(integration_input=bad)\n"
+            "    result = execute_proof_binding_validation_graph(context)\n"
+            '    assert any("wallclock_proof:" in reason for reason in result.fail_reasons)',
+        ),
+    ]
+    for old, new in replacements:
+        if old not in out:
+            raise ValueError(f"graph test context anchor missing: {old[:40]!r}")
+        out = out.replace(old, new, 1)
+    out = out.replace(
+        "    graph_result = execute_proof_binding_validation_graph(ValidationContext(integration_input=bad))",
+        "    graph_result = execute_proof_binding_validation_graph(_graph_context(bad))",
+        1,
+    )
+    old_no_prod = """def test_glb019_no_production_graph_activation() -> None:
+    from src.ops.durable_completion_validation import graph
+
+    assert "event_stream" not in graph.PROOF_BINDING_VALIDATION_GRAPH
+    assert "event_stream" not in graph.PROOF_BINDING_VALIDATION_ORDER
+    graph_source = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "ops"
+        / "durable_completion_validation"
+        / "graph.py"
+    ).read_text(encoding="utf-8")
+    assert "event_stream" not in graph_source
+
+
+"""
+    if old_no_prod not in out:
+        raise ValueError("graph test no-production anchor missing")
+    out = out.replace(old_no_prod, _GRAPH_TEST_PRODUCTION_HAPPY.lstrip("\n"), 1)
+    return out
+
+
+_FACADE_IMPORT_BLOCK = """from src.ops.durable_completion_validation.validators.event_stream import (
+    Glb019EventStreamProofBinding,
+    Glb019EventStreamValidationInput,
+    compute_validation_input_digest as compute_glb019_event_stream_validation_input_digest,
+    default_minimal_glb019_proof_binding,
+    default_minimal_glb019_validation_input,
+    evaluate_glb019_event_stream_validation,
+    validate_glb019_event_stream_validation_input,
+)
+"""
+
+_FACADE_VALIDATE_BINDING_FN = """
+
+def _validate_glb019_event_stream_binding(
+    integration_input: DurableRunPrimaryEvidenceCompletionIntegrationInput,
+    *,
+    completion_identity_digest: str,
+    manifest_identity_digest: str,
+    run_identity_digest: str,
+) -> list[str]:
+    fail_reasons: list[str] = []
+    validation_input = getattr(integration_input, "glb019_event_stream_validation_input", None)
+    proof = getattr(integration_input, "glb019_event_stream_proof", None)
+    if validation_input is None:
+        fail_reasons.append("glb019_event_stream_validation_input required")
+        return fail_reasons
+    if proof is None:
+        fail_reasons.append("glb019_event_stream_proof required")
+        return fail_reasons
+
+    fail_reasons.extend(validate_glb019_event_stream_validation_input(validation_input))
+    if validation_input.source_revision != integration_input.source_revision:
+        fail_reasons.append(
+            "glb019_event_stream_validation_input: source_revision mismatch with completion input"
+        )
+    if validation_input.run_identity_digest != run_identity_digest:
+        fail_reasons.append("glb019_event_stream_validation_input: run_identity_digest drift")
+    if validation_input.manifest_identity_digest != manifest_identity_digest:
+        fail_reasons.append("glb019_event_stream_validation_input: manifest_identity_digest drift")
+    if validation_input.completion_identity_digest != completion_identity_digest:
+        fail_reasons.append(
+            "glb019_event_stream_validation_input: completion_identity_digest drift"
+        )
+
+    glb019_result = evaluate_glb019_event_stream_validation(validation_input)
+    prefix = "glb019_event_stream_proof"
+    if proof.source_revision != integration_input.source_revision:
+        fail_reasons.append(f"{prefix}: source_revision mismatch")
+    if proof.validation_input_digest != glb019_result["validation_input_digest"]:
+        fail_reasons.append(f"{prefix}: validation_input_digest mismatch")
+    if proof.validation_result_digest != glb019_result["validation_result_digest"]:
+        fail_reasons.append(f"{prefix}: validation_result_digest mismatch")
+    if proof.event_stream_identity != glb019_result["event_stream_identity"]:
+        fail_reasons.append(f"{prefix}: event_stream_identity mismatch")
+    if not glb019_result["validation_pass"]:
+        fail_reasons.append("glb019_event_stream_validation: canonical evaluation failed")
+        fail_reasons.extend(
+            f"glb019_event_stream_validation: {reason}"
+            for reason in glb019_result.get("fail_reasons", [])
+        )
+    return _sorted_unique(fail_reasons)
+
+
+"""
+
+
+def _mutate_facade(before: str) -> str:
+    out = before
+    out = out.replace(
+        "    evaluate_wallclock_duration_evidence,\n)\nfrom src.ops.wallclock_session_evidence_v0 import (",
+        "    evaluate_wallclock_duration_evidence,\n)\n"
+        + _FACADE_IMPORT_BLOCK
+        + "from src.ops.wallclock_session_evidence_v0 import (",
+        1,
+    )
+    out = out.replace(
+        "    contract_versions: ContractVersionsInput\n    futures_only: bool = True",
+        "    contract_versions: ContractVersionsInput\n"
+        "    glb019_event_stream_validation_input: Glb019EventStreamValidationInput\n"
+        "    glb019_event_stream_proof: Glb019EventStreamProofBinding\n"
+        "    futures_only: bool = True",
+        1,
+    )
+    out = out.replace(
+        "    return _sorted_unique(fail_reasons)\n\n\ndef _validate_pe38_readiness_review_integration_proof(",
+        "    return _sorted_unique(fail_reasons)\n"
+        + _FACADE_VALIDATE_BINDING_FN
+        + "def _validate_pe38_readiness_review_integration_proof(",
+        1,
+    )
+    out = out.replace(
+        "            artifact_checksums=integration_input.artifact_checksums,\n        )\n    )\n\n    post_write = integration_input.post_write_verification",
+        "            artifact_checksums=integration_input.artifact_checksums,\n        )\n    )\n"
+        "    expected_completion_identity_digest = compute_completion_identity_digest(\n"
+        "        run_root_digest=durable_root.run_root_digest,\n"
+        "        manifest_digest=integration_input.manifest_proof.manifest_digest,\n"
+        "        source_revision=integration_input.source_revision,\n"
+        "    )\n"
+        "    fail_reasons.extend(\n"
+        "        _validate_glb019_event_stream_binding(\n"
+        "            integration_input,\n"
+        "            completion_identity_digest=expected_completion_identity_digest,\n"
+        "            manifest_identity_digest=integration_input.manifest_proof.manifest_digest,\n"
+        "            run_identity_digest=run_identity.run_identity_digest,\n"
+        "        )\n"
+        "    )\n\n    post_write = integration_input.post_write_verification",
+        1,
+    )
+    out = out.replace(
+        '        "futures_only": integration_input.futures_only,\n        "gap2a1_enforcement": asdict(integration_input.gap2a1_enforcement),',
+        '        "futures_only": integration_input.futures_only,\n'
+        '        "glb019_event_stream_proof": asdict(integration_input.glb019_event_stream_proof),\n'
+        '        "glb019_event_stream_validation_input_digest": (\n'
+        "            compute_glb019_event_stream_validation_input_digest(\n"
+        "                integration_input.glb019_event_stream_validation_input\n"
+        "            )\n"
+        "        ),\n"
+        '        "gap2a1_enforcement": asdict(integration_input.gap2a1_enforcement),',
+        1,
+    )
+    out = out.replace(
+        "    pe25_result = evaluate_operator_closure_lifecycle_integration(\n"
+        "        integration_input.pe25_closure_integration_input\n"
+        "    )\n"
+        "    from src.ops.durable_completion_validation.graph import execute_proof_binding_validation_graph",
+        "    pe25_result = evaluate_operator_closure_lifecycle_integration(\n"
+        "        integration_input.pe25_closure_integration_input\n"
+        "    )\n"
+        "    glb019_result = evaluate_glb019_event_stream_validation(\n"
+        "        integration_input.glb019_event_stream_validation_input\n"
+        "    )\n"
+        "    from src.ops.durable_completion_validation.graph import execute_proof_binding_validation_graph",
+        1,
+    )
+    out = out.replace(
+        "            admission_result=admission_result,\n        )\n    )",
+        "            admission_result=admission_result,\n            glb019_result=glb019_result,\n        )\n    )",
+        1,
+    )
+    out = out.replace(
+        "        source_revision=source_revision,\n    )\n    pe23_proof = default_minimal_pe23_integration_proof(",
+        "        source_revision=source_revision,\n    )\n"
+        "    glb019_validation_input = default_minimal_glb019_validation_input(\n"
+        "        source_revision=source_revision,\n"
+        "        completion_identity_digest=completion_identity_digest,\n"
+        "        manifest_identity_digest=manifest_digest,\n"
+        "        run_identity_digest=run_identity_digest,\n"
+        "        correlation_id=run_id,\n"
+        "    )\n"
+        "    glb019_result = evaluate_glb019_event_stream_validation(glb019_validation_input)\n"
+        "    glb019_proof = default_minimal_glb019_proof_binding(glb019_validation_input, glb019_result)\n"
+        "    pe23_proof = default_minimal_pe23_integration_proof(",
+        1,
+    )
+    out = out.replace(
+        "        safety_snapshot=default_minimal_safety_snapshot(),\n        contract_versions=ContractVersionsInput(",
+        "        safety_snapshot=default_minimal_safety_snapshot(),\n"
+        "        glb019_event_stream_validation_input=glb019_validation_input,\n"
+        "        glb019_event_stream_proof=glb019_proof,\n"
+        "        contract_versions=ContractVersionsInput(",
+        1,
+    )
+    return out
+
+
+_MUTATORS: dict[str, Callable[[str], str]] = {
+    _PARTITIONS_PATH: _mutate_partitions,
+    _EVENT_STREAM_PATH: _mutate_event_stream,
+    _GRAPH_PATH: _mutate_graph,
+    _CI_SELECTOR_TEST: _mutate_ci_selector_test,
+    _INTEGRATION_TEST_OWNER: _mutate_integration_test_owner,
+    _GRAPH_TEST_OWNER: _mutate_graph_test,
+    _FACADE_PATH: _mutate_facade,
+}
+
+
+@lru_cache(maxsize=1)
+def synthetic_glb019_a2b_positive_patch_text() -> str:
+    chunks: list[str] = []
+    for path in _GLB019_A2B_ALLOWED_FILES:
+        before = _git_origin_main_text(path)
+        after = _MUTATORS[path](before)
+        chunk = _format_git_unified_diff(path, before, after)
+        if not chunk:
+            raise ValueError(f"synthetic patch produced no diff for {path}")
+        chunks.append(chunk.rstrip("\n"))
+    return "\n".join(chunks) + "\n"
+
+
+def synthetic_glb019_a2b_reject_patch_text() -> str:
+    patch = synthetic_glb019_a2b_positive_patch_text()
+    return patch.replace(
+        "    glb019_result = evaluate_glb019_event_stream_validation(validation_input)",
+        "    pe21_result = evaluate_glb019_event_stream_validation(validation_input)",
+        1,
+    )

--- a/tests/ci/_glb019_synthetic_patch_builder_v0.py
+++ b/tests/ci/_glb019_synthetic_patch_builder_v0.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import difflib
-import subprocess
 from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
+
+from scripts.ops.durable_completion_integration_partitions_v0 import _base_file_text
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -29,12 +30,14 @@ _GLB019_A2B_ALLOWED_FILES: tuple[str, ...] = (
 )
 
 
-def _git_origin_main_text(path: str) -> str:
-    return subprocess.check_output(
-        ["git", "show", f"origin/main:{path}"],
-        cwd=_REPO_ROOT,
-        text=True,
-    )
+def _baseline_text(path: str) -> str:
+    text = _base_file_text(_REPO_ROOT, path)
+    if not text.strip():
+        raise RuntimeError(
+            f"unable to resolve baseline for {path!r}: "
+            "tried git show origin/main and workspace file"
+        )
+    return text
 
 
 def _format_git_unified_diff(path: str, before: str, after: str) -> str:
@@ -613,7 +616,7 @@ _MUTATORS: dict[str, Callable[[str], str]] = {
 def synthetic_glb019_a2b_positive_patch_text() -> str:
     chunks: list[str] = []
     for path in _GLB019_A2B_ALLOWED_FILES:
-        before = _git_origin_main_text(path)
+        before = _baseline_text(path)
         after = _MUTATORS[path](before)
         chunk = _format_git_unified_diff(path, before, after)
         if not chunk:

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -429,6 +430,52 @@ def test_selector_glb019_partition_bootstrap_plus_central_prod_full() -> None:
     )
     assert sel["test_selection_mode"] == "FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
+
+
+_FACADE_PATH = "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
+_SELECTOR_OWNER = "scripts/ops/ci_test_selection_v1.py"
+
+
+def test_selector_glb019_a2b_selector_owner_plus_central_facade_selects_full() -> None:
+    sel = _run_selector(_SELECTOR_OWNER, _FACADE_PATH)
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
+
+
+def test_selector_glb019_a2b_selector_owner_plus_facade_explicit_patch_still_full() -> None:
+    assert GLB019_A2B_FROZEN_PATCH.is_file()
+    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8")
+    sel = _run_selector_with_patch(patch, _SELECTOR_OWNER, _FACADE_PATH, *GLB019_A2B_FILESET)
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
+
+
+def test_selector_glb019_a2b_selector_partitions_helper_plus_central_facade_selects_full() -> None:
+    sel = _run_selector(
+        _SELECTOR_OWNER,
+        _PARTITIONS_HELPER,
+        _FACADE_PATH,
+    )
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
+
+
+def test_selector_glb019_a2b_central_facade_without_structural_contract_selects_full() -> None:
+    sel = _run_selector(_FACADE_PATH)
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["tests_execute_full"] == "true"
+
+
+def test_selector_glb019_a2b_eligible_fileset_structural_contract_failure_selects_full() -> None:
+    assert GLB019_A2B_FROZEN_PATCH.is_file()
+    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8").replace(
+        "glb019_result = evaluate_glb019_event_stream_validation(",
+        "pe21_result = evaluate_glb019_event_stream_validation(",
+        1,
+    )
+    sel = _run_selector_with_patch(patch, *GLB019_A2B_FILESET)
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["tests_execute_full"] == "true"
 
 
 def test_selector_ci_bootstrap_deterministic_regardless_of_file_order() -> None:
@@ -910,6 +957,219 @@ def test_selector_glb019_mixed_validation_and_facade_selects_integration_owner()
     )
     assert sel["test_selection_reason"] == "durable_completion_focused"
     assert _INTEGRATION_OWNER in _targets(sel)
+
+
+GLB019_A2B_FROZEN_PATCH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "ci"
+    / "glb019_a2b_additive_frozen_patch_v0.patch"
+)
+GLB019_A2B_FROZEN_PATCH_SHA256 = "fbac232eb308dc92904b0f0b541fc8587e463f3884b74a9db263011ca1094a59"
+
+GLB019_A2B_FILESET = (
+    "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "src/ops/durable_completion_validation/graph.py",
+    "src/ops/durable_completion_validation/validators/event_stream.py",
+    "tests/ops/test_durable_completion_validation_graph_v1.py",
+    "scripts/ops/durable_completion_integration_partitions_v0.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
+
+def _run_selector_with_patch(
+    patch_text: str,
+    *files: str,
+    force_full: bool = False,
+    event_name: str = "pull_request",
+) -> dict[str, str]:
+    with tempfile.NamedTemporaryFile("w", suffix=".patch", delete=False) as handle:
+        handle.write(patch_text)
+        patch_path = Path(handle.name)
+    try:
+        cmd = [
+            sys.executable,
+            str(SELECTOR),
+            "--event-name",
+            event_name,
+            "--patch-file",
+            str(patch_path),
+        ]
+        if files:
+            cmd.extend(["--files", *files])
+        if force_full:
+            cmd.append("--force-full")
+        out = subprocess.check_output(cmd, text=True)
+    finally:
+        patch_path.unlink(missing_ok=True)
+    result: dict[str, str] = {}
+    for line in out.splitlines():
+        key, _, value = line.partition("=")
+        result[key] = value
+    return result
+
+
+def test_selector_glb019_a2b_frozen_patch_additive_contract_focused() -> None:
+    assert GLB019_A2B_FROZEN_PATCH.is_file()
+    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8")
+    import hashlib
+
+    assert hashlib.sha256(patch.encode("utf-8")).hexdigest() == GLB019_A2B_FROZEN_PATCH_SHA256
+    sel = _run_selector_with_patch(patch, *GLB019_A2B_FILESET)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
+    assert sel["tests_execute_full"] == "false"
+    targets = _targets(sel)
+    assert _GRAPH_OWNER in targets
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
+    assert _INTEGRATION_OWNER not in targets
+    assert any(t.startswith(f"{_INTEGRATION_OWNER}::test_") for t in targets)
+
+
+def test_selector_glb019_a2b_change_contract_unknown_file_selects_full() -> None:
+    assert GLB019_A2B_FROZEN_PATCH.is_file()
+    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8") + (
+        "\ndiff --git a/src/ops/unknown_contract_v0.py b/src/ops/unknown_contract_v0.py\n"
+        "+++ b/src/ops/unknown_contract_v0.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+pass\n"
+    )
+    sel = _run_selector_with_patch(patch, *GLB019_A2B_FILESET, "src/ops/unknown_contract_v0.py")
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
+
+
+def _parse_function_body(body: str, *, name: str = "sample_fn") -> "ast.FunctionDef":
+    import ast
+
+    indented = "\n".join(f"    {line}" for line in body.strip().splitlines())
+    module = ast.parse(f"def {name}():\n{indented}\n")
+    fn = module.body[0]
+    assert isinstance(fn, ast.FunctionDef)
+    return fn
+
+
+def test_glb019_statement_diff_additive_assignment_preserves_general_statements() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        function_statements_preserved_with_allowed_glb019,
+    )
+
+    before = _parse_function_body(
+        "guard_a()\nevaluate_existing_chain()\nbuild_existing_context()\n",
+    )
+    after = _parse_function_body(
+        "guard_a()\n"
+        "glb019_result = evaluate_glb019_event_stream_validation(integration_input)\n"
+        "evaluate_existing_chain()\n"
+        "build_existing_context()\n",
+    )
+    assert function_statements_preserved_with_allowed_glb019(before, after)
+
+
+def test_glb019_statement_diff_central_deletion_selects_full() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        function_statements_preserved_with_allowed_glb019,
+    )
+
+    before = _parse_function_body(
+        "guard_a()\nevaluate_existing_chain()\nbuild_existing_context()\n",
+    )
+    after = _parse_function_body(
+        "glb019_result = evaluate_glb019_event_stream_validation(integration_input)\n"
+        "evaluate_existing_chain()\n"
+        "build_existing_context()\n",
+    )
+    assert not function_statements_preserved_with_allowed_glb019(before, after)
+
+
+def test_glb019_statement_diff_reorder_selects_full() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        function_statements_preserved_with_allowed_glb019,
+    )
+
+    before = _parse_function_body(
+        "guard_a()\nfirst_existing()\nsecond_existing()\n",
+    )
+    after = _parse_function_body(
+        "guard_a()\n"
+        "glb019_result = evaluate_glb019_event_stream_validation(integration_input)\n"
+        "second_existing()\n"
+        "first_existing()\n",
+    )
+    assert not function_statements_preserved_with_allowed_glb019(before, after)
+
+
+def test_glb019_statement_diff_call_argument_mutation_selects_full() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        function_statements_preserved_with_allowed_glb019,
+    )
+
+    before = _parse_function_body(
+        "guard_a()\nevaluate_existing_chain(mode='baseline')\n",
+    )
+    after = _parse_function_body(
+        "guard_a()\n"
+        "glb019_result = evaluate_glb019_event_stream_validation(integration_input)\n"
+        "evaluate_existing_chain(mode='mutated')\n",
+    )
+    assert not function_statements_preserved_with_allowed_glb019(before, after)
+
+
+def test_glb019_statement_diff_validation_context_only_glb019_keyword_allowed() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        function_statements_preserved_with_allowed_glb019,
+    )
+
+    before = _parse_function_body(
+        "context = ValidationContext(integration_input=integration_input)\nreturn context\n",
+    )
+    after = _parse_function_body(
+        "glb019_result = evaluate_glb019_event_stream_validation(integration_input)\n"
+        "context = ValidationContext(\n"
+        "    integration_input=integration_input,\n"
+        "    glb019_result=glb019_result,\n"
+        ")\n"
+        "return context\n",
+    )
+    assert function_statements_preserved_with_allowed_glb019(before, after)
+
+
+def test_glb019_statement_diff_validation_context_keyword_mutation_selects_full() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        function_statements_preserved_with_allowed_glb019,
+    )
+
+    before = _parse_function_body(
+        "context = ValidationContext(integration_input=integration_input)\nreturn context\n",
+    )
+    after = _parse_function_body(
+        "glb019_result = evaluate_glb019_event_stream_validation(integration_input)\n"
+        "context = ValidationContext(\n"
+        "    integration_input=mutated_input,\n"
+        "    glb019_result=glb019_result,\n"
+        ")\n"
+        "return context\n",
+    )
+    assert not function_statements_preserved_with_allowed_glb019(before, after)
+
+
+def test_selector_glb019_a2b_change_contract_unparseable_patch_selects_full() -> None:
+    sel = _run_selector_with_patch("not a unified diff", *GLB019_A2B_FILESET)
+    assert _INTEGRATION_OWNER in _targets(sel)
+
+
+def test_selector_glb019_a2b_change_contract_classify_unit() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        GLB019_A2B_ADDITIVE_PARTITIONS,
+        classify_glb019_a2b_additive_patch,
+    )
+
+    assert GLB019_A2B_FROZEN_PATCH.is_file()
+    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8")
+    assert classify_glb019_a2b_additive_patch(patch) == GLB019_A2B_ADDITIVE_PARTITIONS
+    assert classify_glb019_a2b_additive_patch("") is None
+    assert classify_glb019_a2b_additive_patch("corrupt") is None
 
 
 PR4512_MASTER_V2_BINDING_CONTRACT_FILES = (

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -359,6 +359,40 @@ def test_selector_ci_bootstrap_contract_test_only_focused() -> None:
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
 
 
+GLB019_CI_BOOTSTRAP_PR_FILES = (
+    "scripts/ops/ci_test_selection_v1.py",
+    "scripts/ops/durable_completion_integration_partitions_v0.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    "tests/ci/_glb019_synthetic_patch_builder_v0.py",
+)
+
+
+def test_selector_glb019_ci_bootstrap_pr_four_file_diff_focused() -> None:
+    sel = _run_selector(*GLB019_CI_BOOTSTRAP_PR_FILES)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_bootstrap_focused"
+    assert _targets(sel) == ["tests/ci/test_ci_diff_aware_test_selection_v1.py"]
+    assert sel["tests_execute_full"] == "false"
+
+
+def test_selector_glb019_ci_bootstrap_pr_four_files_plus_unknown_ci_helper_full() -> None:
+    sel = _run_selector(*GLB019_CI_BOOTSTRAP_PR_FILES, "tests/ci/test_unknown_helper_v0.py")
+    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
+
+
+def test_selector_glb019_ci_bootstrap_pr_four_files_plus_workflow_ci_infra_focused() -> None:
+    sel = _run_selector(*GLB019_CI_BOOTSTRAP_PR_FILES, ".github/workflows/ci.yml")
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_infra_focused"
+    assert sel["tests_execute_full"] == "false"
+    assert sel["tests_execute_focused"] == "true"
+    targets = _targets(sel)
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
+    assert "tests/ci/test_workflows_no_pull_request_target_contract_v0.py" in targets
+    assert "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py" in targets
+
+
 GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES = (
     "scripts/ops/ci_test_selection_v1.py",
     "scripts/ops/durable_completion_integration_partitions_v0.py",

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -443,8 +443,7 @@ def test_selector_glb019_a2b_selector_owner_plus_central_facade_selects_full() -
 
 
 def test_selector_glb019_a2b_selector_owner_plus_facade_explicit_patch_still_full() -> None:
-    assert GLB019_A2B_FROZEN_PATCH.is_file()
-    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8")
+    patch = _synthetic_glb019_a2b_positive_patch_text()
     sel = _run_selector_with_patch(patch, _SELECTOR_OWNER, _FACADE_PATH, *GLB019_A2B_FILESET)
     assert sel["test_selection_mode"] == "FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
@@ -467,12 +466,7 @@ def test_selector_glb019_a2b_central_facade_without_structural_contract_selects_
 
 
 def test_selector_glb019_a2b_eligible_fileset_structural_contract_failure_selects_full() -> None:
-    assert GLB019_A2B_FROZEN_PATCH.is_file()
-    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8").replace(
-        "glb019_result = evaluate_glb019_event_stream_validation(",
-        "pe21_result = evaluate_glb019_event_stream_validation(",
-        1,
-    )
+    patch = _synthetic_glb019_a2b_reject_patch_text()
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FILESET)
     assert sel["test_selection_mode"] == "FULL"
     assert sel["tests_execute_full"] == "true"
@@ -959,13 +953,10 @@ def test_selector_glb019_mixed_validation_and_facade_selects_integration_owner()
     assert _INTEGRATION_OWNER in _targets(sel)
 
 
-GLB019_A2B_FROZEN_PATCH = (
-    Path(__file__).resolve().parents[1]
-    / "fixtures"
-    / "ci"
-    / "glb019_a2b_additive_frozen_patch_v0.patch"
+from tests.ci._glb019_synthetic_patch_builder_v0 import (
+    synthetic_glb019_a2b_positive_patch_text as _synthetic_glb019_a2b_positive_patch_text,
+    synthetic_glb019_a2b_reject_patch_text as _synthetic_glb019_a2b_reject_patch_text,
 )
-GLB019_A2B_FROZEN_PATCH_SHA256 = "fbac232eb308dc92904b0f0b541fc8587e463f3884b74a9db263011ca1094a59"
 
 GLB019_A2B_FILESET = (
     "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
@@ -1011,11 +1002,7 @@ def _run_selector_with_patch(
 
 
 def test_selector_glb019_a2b_frozen_patch_additive_contract_focused() -> None:
-    assert GLB019_A2B_FROZEN_PATCH.is_file()
-    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8")
-    import hashlib
-
-    assert hashlib.sha256(patch.encode("utf-8")).hexdigest() == GLB019_A2B_FROZEN_PATCH_SHA256
+    patch = _synthetic_glb019_a2b_positive_patch_text()
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FILESET)
     assert sel["test_selection_mode"] == "FOCUSED"
     assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
@@ -1028,8 +1015,7 @@ def test_selector_glb019_a2b_frozen_patch_additive_contract_focused() -> None:
 
 
 def test_selector_glb019_a2b_change_contract_unknown_file_selects_full() -> None:
-    assert GLB019_A2B_FROZEN_PATCH.is_file()
-    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8") + (
+    patch = _synthetic_glb019_a2b_positive_patch_text() + (
         "\ndiff --git a/src/ops/unknown_contract_v0.py b/src/ops/unknown_contract_v0.py\n"
         "+++ b/src/ops/unknown_contract_v0.py\n"
         "@@ -0,0 +1 @@\n"
@@ -1165,8 +1151,7 @@ def test_selector_glb019_a2b_change_contract_classify_unit() -> None:
         classify_glb019_a2b_additive_patch,
     )
 
-    assert GLB019_A2B_FROZEN_PATCH.is_file()
-    patch = GLB019_A2B_FROZEN_PATCH.read_text(encoding="utf-8")
+    patch = _synthetic_glb019_a2b_positive_patch_text()
     assert classify_glb019_a2b_additive_patch(patch) == GLB019_A2B_ADDITIVE_PARTITIONS
     assert classify_glb019_a2b_additive_patch("") is None
     assert classify_glb019_a2b_additive_patch("corrupt") is None


### PR DESCRIPTION
## Summary
- PR4504 wallclock, PE55, and PR4451 rebinding contracts remain FOCUSED; the removed global selector-owner + central-prod FULL gate no longer preempts them.
- Only the concrete GLB-019 partition bootstrap plus central prod mix stays FULL (`durable_completion_foreign_path_requires_full`).
- Real GLB-019 A2/B filesets require structural PASS via tri-state `evaluate_glb019_a2b_change_contract`; REJECT selects FULL, unparseable patches keep the full integration owner in focused targets.
- Explicit `--patch-file` cannot bypass eligibility and is ignored outside true A2/B structural candidates.

## Scope boundaries
- No production runtime change
- No workflow change
- No integration test owner expansion beyond selector governance
- No CI timeout increase
- Protected A2/B worktree unchanged (`fbac232e…`)

## Test plan
- [x] `tests/ci/test_ci_diff_aware_test_selection_v1.py` (228 tests)
- [x] Frozen A2/B patch probe PASS / FOCUSED partitions
- [x] PRE-PR verifier + manifest verify


Made with [Cursor](https://cursor.com)