### PR TITLE
fix(ci): install selector dependencies in changes job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,16 @@ jobs:
             echo "docs_or_static_contract_only=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies for test selection
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
       - name: Diff-aware test selection (fail-closed)
         id: test_selection
         env:


### PR DESCRIPTION
## Summary

- **Root cause:** `pytest --collect-only` inside the `changes` job's diff-aware selector ran without installed Python dependencies, causing collection failures before test selection could complete.
- **Scope:** Minimal dependency bootstrap in the existing `changes` job only — `actions/setup-python@v5` (3.11) and `pip install -r requirements.txt` immediately before the diff-aware selector step.
- **No semantic changes** to selector logic, partitions, timeouts, Python matrix, required checks, coverage, or trading/runtime behavior.
- A **ci.yml-only** diff selects `NO_OP` (`docs_workflow_or_static_contract_only`; `tests_execute_full=false`).
- **PR #4536** (GLB-019 A2/B graph integration) should be rebased onto `main` only after this bootstrap merges.

## Test plan

- [x] YAML syntax valid
- [x] `check_required_ci_contexts_present.sh` passes
- [x] Static selector proof: `NO_OP` / `docs_workflow_or_static_contract_only` for ci.yml-only diff
- [ ] CI required checks terminal SUCCESS/SKIPPED (no FULL suite path)


Made with [Cursor](https://cursor.com)