### PR TITLE
test(ci): isolate glb019 facade subset patch context

### DIFF
--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -889,7 +889,8 @@ def test_selector_glb019_validation_only_models_context_field_focused() -> None:
 
 
 def test_selector_glb019_completion_facade_still_selects_integration_owner() -> None:
-    sel = _run_selector(
+    sel = _run_selector_with_patch(
+        "",
         "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
         _GRAPH_OWNER,
     )
@@ -979,7 +980,8 @@ def test_selector_completion_facade_full_integration_owner() -> None:
 
 
 def test_selector_glb019_mixed_validation_and_facade_selects_integration_owner() -> None:
-    sel = _run_selector(
+    sel = _run_selector_with_patch(
+        "",
         "src/ops/durable_completion_validation/validators/event_stream.py",
         "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
         _GRAPH_OWNER,


### PR DESCRIPTION
## Summary

- Fixes **Test-Harness-Context-Leakage** in two GLB-019 facade/mixed selector contract tests by using explicit empty patch context via `_run_selector_with_patch("", ...)` instead of implicit branch-wide patch context from `_run_selector(...)`.
- **Functional expectations unchanged** on main: both tests remain `FOCUSED` / `durable_completion_focused`.
- **Deterministic, isolated patch context** — no branch-wide git patch bleeds into facade subset assertions.
- **No production, selector, partitions, workflow, or trading semantics change** — single test file only.
- **Blocker fix for PR #4536**: enables later feature rebase without re-introducing harness leakage or GLB-019 AST contract breakage inside the feature slice.

## Test plan

- [x] `ruff format --check` + `ruff check` on `tests/ci/test_ci_diff_aware_test_selection_v1.py`
- [x] `test_selector_glb019_completion_facade_still_selects_integration_owner` PASS
- [x] `test_selector_glb019_mixed_validation_and_facade_selects_integration_owner` PASS
- [x] Neighbor tests (facade, mixed, foreign path, selector-owner, central facade) PASS
- [x] CI-equivalent selector: `FOCUSED` / `ci_bootstrap_focused` / `tests_execute_full=false`


Made with [Cursor](https://cursor.com)