### PR TITLE
test(ci): isolate completion facade owner patch context

### DIFF
--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -972,7 +972,8 @@ def test_selector_glb019_a2b_probe_partition_union_bounded() -> None:
 
 
 def test_selector_completion_facade_full_integration_owner() -> None:
-    sel = _run_selector(
+    sel = _run_selector_with_patch(
+        "",
         "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
         _GRAPH_OWNER,
     )


### PR DESCRIPTION
## Summary

- Behebt verbleibende Test-Harness-Context-Leakage in `test_selector_completion_facade_full_integration_owner`.
- Stellt expliziten deterministischen leeren Patchkontext via `_run_selector_with_patch("", ...)` her — analog PR #4539.
- Erwartungen und Assertions unverändert; keine Produktions-, Selector-, Partitions-, Workflow- oder Trading-Semantikänderung.

## Kontext

Follow-up zu PR #4539. Blocker-Fix für PR #4536: Der Test übernahm bisher den vollständigen Branch-Patch statt isolierter Facade-Subset-Semantik.

## Test plan

- [x] `test_selector_completion_facade_full_integration_owner` PASS
- [x] Verwandte Facade-Harness-Tests PASS
- [x] Ruff format/check PASS
- [x] CI-Selector FOCUSED / `ci_bootstrap_focused` / `tests_execute_full=false`


Made with [Cursor](https://cursor.com)