### PR TITLE
ci: shard focused integration targets in matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,13 +496,91 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' }}
         run: |
           set -euo pipefail
+          export PYTHONUNBUFFERED=1
+          PYTEST_ARGS=(-v --tb=short -m "not network and not external_tools")
           TARGETS="${{ needs.changes.outputs.focused_pytest_targets }}"
           if [ -z "$TARGETS" ]; then
             echo "FOCUSED mode without explicit targets — fail-closed to tests/ci/"
             TARGETS="tests/ci/"
           fi
           mapfile -t VALIDATED_TARGETS < <(python3 scripts/ops/ci_test_selection_v1.py --emit-validated-pytest-targets "$TARGETS")
-          pytest "${VALIDATED_TARGETS[@]}" -v --tb=short -m "not network and not external_tools"
+          CI_OWNER="tests/ci/test_ci_diff_aware_test_selection_v1.py"
+          GRAPH_OWNER="tests/ops/test_durable_completion_validation_graph_v1.py"
+          INTEGRATION_SHARD_COUNT=3
+          INTEGRATION_NODES=()
+          OTHER_FILE_TARGETS=()
+          CI_TARGET=""
+          GRAPH_TARGET=""
+          for target in "${VALIDATED_TARGETS[@]}"; do
+            if [[ "$target" == *"::"* ]]; then
+              INTEGRATION_NODES+=("$target")
+            elif [[ "$target" == "$CI_OWNER" ]]; then
+              CI_TARGET="$target"
+            elif [[ "$target" == "$GRAPH_OWNER" ]]; then
+              GRAPH_TARGET="$target"
+            else
+              OTHER_FILE_TARGETS+=("$target")
+            fi
+          done
+          echo "focused-matrix target inventory validated=${#VALIDATED_TARGETS[@]} integration_nodes=${#INTEGRATION_NODES[@]} ci_owner=$([ -n "$CI_TARGET" ] && echo 1 || echo 0) graph_owner=$([ -n "$GRAPH_TARGET" ] && echo 1 || echo 0) other_files=${#OTHER_FILE_TARGETS[@]}"
+          if (( ${#INTEGRATION_NODES[@]} == 0 )); then
+            pytest "${VALIDATED_TARGETS[@]}" "${PYTEST_ARGS[@]}"
+            exit 0
+          fi
+          SHARD_FAIL=0
+          PIDS=()
+          LABELS=()
+          LOG_DIR="$(mktemp -d)"
+          _launch_focused_lane() {
+            local label="$1"
+            shift
+            local logfile="$LOG_DIR/${label}.log"
+            echo "focused-matrix parallel start label=${label} target_count=$#"
+            (
+              set -euo pipefail
+              pytest "$@" "${PYTEST_ARGS[@]}"
+            ) >"$logfile" 2>&1 &
+            PIDS+=("$!")
+            LABELS+=("$label")
+          }
+          if [ -n "$CI_TARGET" ]; then
+            _launch_focused_lane "ci_owner" "$CI_TARGET"
+          fi
+          if [ -n "$GRAPH_TARGET" ]; then
+            _launch_focused_lane "graph_owner" "$GRAPH_TARGET"
+          fi
+          if (( ${#OTHER_FILE_TARGETS[@]} > 0 )); then
+            _launch_focused_lane "other_files" "${OTHER_FILE_TARGETS[@]}"
+          fi
+          for ((shard_idx = 0; shard_idx < INTEGRATION_SHARD_COUNT; shard_idx++)); do
+            shard_targets=()
+            for ((i = shard_idx; i < ${#INTEGRATION_NODES[@]}; i += INTEGRATION_SHARD_COUNT)); do
+              shard_targets+=("${INTEGRATION_NODES[i]}")
+            done
+            echo "focused-matrix integration shard ${shard_idx} target_count=${#shard_targets[@]}"
+            if (( ${#shard_targets[@]} == 0 )); then
+              echo "focused-matrix integration shard ${shard_idx} empty — skip"
+              continue
+            fi
+            _launch_focused_lane "integration_shard_${shard_idx}" "${shard_targets[@]}"
+          done
+          for idx in "${!PIDS[@]}"; do
+            if ! wait "${PIDS[$idx]}"; then
+              SHARD_FAIL=1
+              echo "focused-matrix parallel failed label=${LABELS[$idx]}"
+              cat "$LOG_DIR/${LABELS[$idx]}.log"
+            fi
+          done
+          if (( SHARD_FAIL != 0 )); then
+            for label in "${LABELS[@]}"; do
+              echo "focused-matrix log dump label=${label}"
+              if [ -f "$LOG_DIR/${label}.log" ]; then
+                cat "$LOG_DIR/${label}.log"
+              fi
+            done
+            exit 1
+          fi
+          echo "focused-matrix parallel success lanes=${#PIDS[@]} integration_nodes=${#INTEGRATION_NODES[@]}"
 
       - name: Focused module import smoke
         if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' && needs.changes.outputs.focused_module_imports != '' }}

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -110,10 +110,119 @@ def test_tests_job_focused_runs_on_all_matrix_versions() -> None:
     assert "tests_execute_focused == 'true'" in focused_step
 
 
+def _focused_matrix_step_block() -> str:
+    return _ci_text().split("name: Run focused tests (matrix)", 1)[1].split("\n      - name:", 1)[0]
+
+
+def test_tests_job_focused_matrix_integration_parallel_sharding_contract() -> None:
+    block = _focused_matrix_step_block()
+    assert "INTEGRATION_SHARD_COUNT=3" in block
+    assert "PYTHONUNBUFFERED=1" in block
+    assert "_launch_focused_lane" in block
+    assert "integration_shard_" in block
+    assert "SHARD_FAIL=0" in block
+    assert "if (( ${#INTEGRATION_NODES[@]} == 0 )); then" in block
+    assert 'pytest "${VALIDATED_TARGETS[@]}" "${PYTEST_ARGS[@]}"' in block
+    assert 'wait "${PIDS[$idx]}"' in block
+    assert "exit 1" in block
+    assert "|| true" not in block
+
+
+def test_tests_job_focused_matrix_parallel_sharding_does_not_affect_full_suite_step() -> None:
+    text = _ci_text()
+    full_block = text.split("name: Run full test suite", 1)[1].split(
+        "name: Run focused tests (matrix)", 1
+    )[0]
+    assert "INTEGRATION_SHARD_COUNT" not in full_block
+    assert "pytest tests/ -v --tb=short" in full_block
+
+
+def test_focused_matrix_integration_shard_round_robin_distribution() -> None:
+    """45 integration nodes partition into three shards with no loss or duplication."""
+    integration_owner = (
+        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_"
+        "completion_integration_contract_v0.py"
+    )
+    nodes = [f"{integration_owner}::test_node_{i}" for i in range(45)]
+    shard_count = 3
+    shards: list[list[str]] = [[] for _ in range(shard_count)]
+    for idx, node in enumerate(nodes):
+        shards[idx % shard_count].append(node)
+    flattened = [node for shard in shards for node in shard]
+    assert len(flattened) == 45
+    assert len(flattened) == len(set(flattened))
+    assert all(len(shard) in {15, 15, 15} for shard in shards)
+
+
+def test_focused_matrix_glb019_a2b_target_groups_complete() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        GLB019_A2B_ADDITIVE_PARTITIONS,
+        expand_partitions_to_pytest_targets,
+    )
+    from tests.ci._glb019_synthetic_patch_builder_v0 import (
+        synthetic_glb019_a2b_positive_patch_text as patch_text,
+    )
+
+    expected_integration_nodes = sorted(
+        expand_partitions_to_pytest_targets(GLB019_A2B_ADDITIVE_PARTITIONS)
+    )
+    glb019_files = (
+        "scripts/ops/durable_completion_integration_partitions_v0.py",
+        "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+        "src/ops/durable_completion_validation/graph.py",
+        "src/ops/durable_completion_validation/validators/event_stream.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+        "tests/ops/test_durable_completion_validation_graph_v1.py",
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".patch", delete=False) as handle:
+        handle.write(patch_text())
+        patch_path = handle.name
+    try:
+        cmd = [
+            sys.executable,
+            str(SELECTOR),
+            "--event-name",
+            "pull_request",
+            "--files",
+            *glb019_files,
+            "--patch-file",
+            patch_path,
+        ]
+        out = subprocess.check_output(cmd, text=True)
+    finally:
+        Path(patch_path).unlink(missing_ok=True)
+    sel = {}
+    for line in out.splitlines():
+        key, _, value = line.partition("=")
+        sel[key] = value
+    targets = _targets(sel)
+    ci_owner = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
+    graph_owner = "tests/ops/test_durable_completion_validation_graph_v1.py"
+    integration_nodes = sorted(t for t in targets if "::" in t)
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
+    assert ci_owner in targets
+    assert graph_owner in targets
+    assert integration_nodes == expected_integration_nodes
+    assert len(targets) == 2 + len(expected_integration_nodes)
+
+
 def test_tests_job_focused_module_import_smoke_step() -> None:
     assert "Focused module import smoke" in _ci_text()
     assert "focused_module_imports" in _ci_text()
     assert "--import-smoke-modules" in _ci_text()
+
+
+def test_selector_ci_workflow_shard_bootstrap_focused() -> None:
+    sel = _run_selector(
+        ".github/workflows/ci.yml",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_reason"] == "ci_infra_focused"
+    assert sel["tests_execute_full"] == "false"
+    assert sel["tests_execute_focused"] == "true"
 
 
 def test_selector_docs_only_no_op() -> None:


### PR DESCRIPTION
## Summary
- Root cause: Run 28118680334 — PR #4536 FOCUSED path (331 items) exceeded the 17-minute `tests (3.x)` job cap due to serial execution of 45 slow integration nodes.
- Parallelizes the existing `Run focused tests (matrix)` step into five lanes: CI test owner, graph owner, and three deterministic integration shards (15 nodes each).
- Reuses the Fast-Lane `OPS_SHARD_COUNT` background-process pattern with fail-closed exit propagation.

## Unchanged
- 331 FOCUSED items / 45 integration nodes / 8 GLB-019 nodes — no target reduction
- `timeout-minutes: 17` on tests job
- Required check contexts (`tests (3.9/3.10/3.11)`, Fast-Lane, PR Gate, …)
- Python matrix 3.9 / 3.10 / 3.11
- Safety gates and selector production logic
- No trading / runtime semantics

## Bootstrap for
PR #4536 (`feat/durable-completion-glb019-slice-a2b-graph-integration-v0`)

## Test plan
- [x] Local CI test owner (238 tests)
- [x] Sharding contract tests
- [x] Parallel execution smoke: 45 integration nodes / 3 shards / ~497s wall clock
- [ ] GitHub matrix jobs terminal green under 17 minutes


Made with [Cursor](https://cursor.com)