### PR TITLE
ci: provide base history to matrix contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,8 @@ jobs:
       - name: Checkout
         if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_no_op != 'true' }}
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_no_op != 'true' }}

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -72,6 +72,26 @@ def test_ci_workflow_job_timeouts_do_not_exceed_25_minute_hard_cap() -> None:
         assert int(match.group(1)) <= 25, "CI job exceeds 25-minute hard cap"
 
 
+def _job_checkout_step_block(job_name: str, *, next_job: str) -> str:
+    text = _ci_text()
+    job_block = text.split(f"  {job_name}:", 1)[1].split(f"  {next_job}:", 1)[0]
+    return job_block.split("- name: Checkout", 1)[1].split("\n      - name:", 1)[0]
+
+
+def test_changes_job_checkout_fetch_depth_zero_unchanged() -> None:
+    assert "fetch-depth: 0" in _job_checkout_step_block(
+        "changes", next_job="ci-required-contexts-contract"
+    )
+
+
+def test_fast_lane_checkout_fetch_depth_zero_unchanged() -> None:
+    assert "fetch-depth: 0" in _job_checkout_step_block("fast-lane", next_job="tests")
+
+
+def test_tests_job_matrix_checkout_fetch_depth_zero_for_live_patch_contract() -> None:
+    assert "fetch-depth: 0" in _job_checkout_step_block("tests", next_job="strategy-smoke")
+
+
 def test_changes_job_exports_test_selection_outputs() -> None:
     text = _ci_text()
     for key in (


### PR DESCRIPTION
## Summary
- Run 28127898522 was correctly FOCUSED and sharded in the `changes` job, but `ci_owner` failed early with 26 tests because the matrix checkout used shallow history (`fetch-depth: 1`).
- `changes` and `fast-lane` already used `fetch-depth: 0`; live GLB-019 patch collection (`merge-base` + three-dot diff) failed only in matrix jobs.
- This bootstrap PR aligns **only** the matrix `tests` checkout to full history. No timeout, matrix, sharding, required-check, selector-policy, or test-target changes.
- PR #4536 is intentionally untouched until this bootstrap PR merges.

## Test plan
- [x] YAML parse
- [x] Workflow contract tests for checkout fetch-depth + timeout 17 + sharding unchanged
- [x] Bounded reproduction: shallow merge-base rc=1 vs full-history FOCUSED selector on PR head
- [ ] CI required checks on this bootstrap PR


Made with [Cursor](https://cursor.com)