### PR TITLE
ci: raise matrix hard timeout to 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
   tests:
     name: tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 17
+    timeout-minutes: 25
     needs: changes
     # IMPORTANT: No job-level if condition - matrix jobs must always be created
     # to satisfy branch protection rules (e.g., "tests (3.11)" check)

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -52,10 +52,12 @@ def test_required_tests_job_has_no_job_level_if() -> None:
     assert "if:" not in tests_block.split("steps:")[0]
 
 
-def test_tests_job_timeout_17_absolute_cap() -> None:
+def test_tests_job_timeout_25_absolute_cap() -> None:
     assert re.search(
-        r"^\s*tests:\n(?:.*\n)*?\s*timeout-minutes:\s*17\s*$", _ci_text(), re.MULTILINE
+        r"^\s*tests:\n(?:.*\n)*?\s*timeout-minutes:\s*25\s*$", _ci_text(), re.MULTILINE
     )
+    tests_block = _ci_text().split("  tests:", 1)[1].split("  strategy-smoke:", 1)[0]
+    assert "timeout-minutes: 17" not in tests_block
 
 
 def test_fast_lane_job_timeout_17_absolute_cap() -> None:


### PR DESCRIPTION
## Summary
- PR #4536 routes correctly as FOCUSED with glb019_a2b_additive_change_contract and active integration sharding (47 targets, 45 nodes, 5 parallel lanes).
- PR #4543 fixed matrix base history; run 28130147854 shows **no test failures** before cancel.
- All three matrix jobs (`tests 3.9/3.10/3.11`) were cancelled at the unchanged **17-minute** job limit while shards were still progressing.
- This bootstrap PR raises only the matrix `tests` job timeout to **25 minutes** (absolute hard cap).

## Unchanged
- Required-check contexts, Python 3.9/3.10/3.11 matrix, selector policy, sharding, test targets, Fast-Lane (17m), Evidence Validator, PR Gate
- No continue-on-error, no test skips, no target reduction

## Test plan
- [x] YAML parse
- [x] Workflow timeout contract tests (matrix 25m, fast-lane 17m, hard cap ≤25)
- [x] Matrix checkout fetch-depth contract unchanged
- [ ] CI required checks on this bootstrap PR

PR #4536 is intentionally untouched until this merges.


Made with [Cursor](https://cursor.com)