### PR TITLE
feat(ops): wire GLB019 result into six-node validation context

### DIFF
--- a/src/ops/offline_master_v2_replay_six_node_validation_graph_binding_v0.py
+++ b/src/ops/offline_master_v2_replay_six_node_validation_graph_binding_v0.py
@@ -32,6 +32,9 @@ from src.ops.durable_completion_validation.graph import (
     execute_proof_binding_validation_graph,
 )
 from src.ops.durable_completion_validation.models import ValidationContext
+from src.ops.durable_completion_validation.validators.event_stream import (
+    evaluate_glb019_event_stream_validation,
+)
 from trading.master_v2.offline_double_play_scenario_replay_v0 import (
     SYNTHETIC_FUTURES_INSTRUMENT,
     OfflineDoublePlayScenarioReplayInputV0,
@@ -116,6 +119,9 @@ def build_validation_context_from_completion_integration_input(
     pe25_result = evaluate_operator_closure_lifecycle_integration(
         integration_input.pe25_closure_integration_input
     )
+    glb019_result = evaluate_glb019_event_stream_validation(
+        integration_input.glb019_event_stream_validation_input
+    )
     return ValidationContext(
         integration_input=integration_input,
         pe31_result=pe31_result,
@@ -123,6 +129,7 @@ def build_validation_context_from_completion_integration_input(
         pe37_result=pe37_result,
         pe25_result=pe25_result,
         admission_result=admission_result,
+        glb019_result=glb019_result,
     )
 
 

--- a/tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py
+++ b/tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py
@@ -17,12 +17,16 @@ from src.ops.durable_completion_validation.graph import (
     PROOF_BINDING_VALIDATION_GRAPH,
     PROOF_BINDING_VALIDATION_ORDER,
     VALIDATOR_COMPLETION_CHAIN,
+    VALIDATOR_EVENT_STREAM,
     VALIDATOR_OPERATOR_CLOSURE,
     VALIDATOR_RECONCILIATION,
     VALIDATOR_RECOVERY,
     VALIDATOR_TRACEABILITY,
     VALIDATOR_WALLCLOCK,
     execute_proof_binding_validation_graph,
+)
+from src.ops.durable_completion_validation.validators.event_stream import (
+    evaluate_glb019_event_stream_validation,
 )
 from src.ops.durable_completion_validation.models import ValidationContext
 from src.ops.durable_completion_validation.validators.completion_chain import (
@@ -182,12 +186,14 @@ def test_legacy_ops_only_unchanged() -> None:
 
 def test_six_node_validation_graph_unchanged() -> None:
     assert VALIDATOR_WALLCLOCK in PROOF_BINDING_VALIDATION_ORDER
+    assert VALIDATOR_EVENT_STREAM in PROOF_BINDING_VALIDATION_ORDER
     assert VALIDATOR_COMPLETION_CHAIN in PROOF_BINDING_VALIDATION_ORDER
     assert PROOF_BINDING_VALIDATION_GRAPH[VALIDATOR_COMPLETION_CHAIN] == (
         VALIDATOR_OPERATOR_CLOSURE,
         VALIDATOR_TRACEABILITY,
         VALIDATOR_RECOVERY,
         VALIDATOR_WALLCLOCK,
+        VALIDATOR_EVENT_STREAM,
     )
 
 
@@ -215,14 +221,50 @@ def test_replay_sourced_six_node_validation_graph_passes(integration_input) -> N
     graph_result = execute_proof_binding_validation_graph(context)
     assert graph_result.fail_reasons == ()
     assert set(context.completed_validators) == set(PROOF_BINDING_VALIDATION_ORDER)
-    assert context.completed_validators == {
-        VALIDATOR_RECONCILIATION,
-        VALIDATOR_RECOVERY,
-        VALIDATOR_TRACEABILITY,
-        VALIDATOR_OPERATOR_CLOSURE,
-        VALIDATOR_WALLCLOCK,
-        VALIDATOR_COMPLETION_CHAIN,
-    }
+
+
+def test_replay_builder_wires_glb019_result_present(integration_input) -> None:
+    context = build_validation_context_from_completion_integration_input(integration_input)
+    assert context.glb019_result is not None
+    assert context.glb019_result["validation_pass"] is True
+
+
+def test_replay_builder_glb019_result_matches_canonical_evaluation(integration_input) -> None:
+    context = build_validation_context_from_completion_integration_input(integration_input)
+    expected = evaluate_glb019_event_stream_validation(
+        integration_input.glb019_event_stream_validation_input
+    )
+    assert context.glb019_result == expected
+
+
+def test_replay_builder_glb019_identity_digest_coherence(integration_input) -> None:
+    context = build_validation_context_from_completion_integration_input(integration_input)
+    proof = integration_input.glb019_event_stream_proof
+    assert context.glb019_result is not None
+    assert proof.validation_input_digest == context.glb019_result["validation_input_digest"]
+    assert proof.validation_result_digest == context.glb019_result["validation_result_digest"]
+    assert proof.event_stream_identity == context.glb019_result["event_stream_identity"]
+
+
+def test_replay_builder_glb019_result_missing_fail_closed_graph(integration_input) -> None:
+    context = build_validation_context_from_completion_integration_input(integration_input)
+    context.glb019_result = None
+    graph_result = execute_proof_binding_validation_graph(context)
+    assert any("glb019_result required" in reason for reason in graph_result.fail_reasons)
+    assert VALIDATOR_EVENT_STREAM not in context.completed_validators
+    assert VALIDATOR_COMPLETION_CHAIN not in context.completed_validators
+
+
+def test_replay_builder_incoherent_glb019_proof_fail_closed(integration_input) -> None:
+    bad_proof = replace(
+        integration_input.glb019_event_stream_proof,
+        validation_result_digest="0" * 64,
+    )
+    bad = replace(integration_input, glb019_event_stream_proof=bad_proof)
+    context = build_validation_context_from_completion_integration_input(bad)
+    graph_result = execute_proof_binding_validation_graph(context)
+    assert graph_result.fail_reasons
+    assert VALIDATOR_EVENT_STREAM not in context.completed_validators
 
 
 def test_replay_sourced_six_node_graph_node_order_preserved(integration_input) -> None:


### PR DESCRIPTION
## Summary

- Wire `glb019_result` into `build_validation_context_from_completion_integration_input` using the canonical `evaluate_glb019_event_stream_validation` path
- Align offline six-node replay validation context with the integration contract graph (closes GLB019 A2C gap)
- Extend existing offline master binding contract tests for presence, coherence, identity/digest binding, and fail-closed behavior

## Scope & Safety

- **FUTURES_ONLY** — offline explicit-input binding only
- No production trading, execution, risk-authority, runtime, or scheduler semantics changed
- No new files or parallel owners
- 2-file diff: production owner + existing test owner

## CI classification

- Selector: **FOCUSED** (`offline_master_v2_replay_six_node_validation_graph_binding_focused`)
- No selector/workflow/timeout changes

## Tests

- `tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py` — 41 passed
- `tests/ops/test_durable_completion_validation_graph_v1.py -k glb019` — 17 passed
- `tests/ci/test_ci_diff_aware_test_selection_v1.py -k offline_master_v2_replay_six_node` — 2 passed
- ruff format/check — pass

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/glb019_a2c_offline_six_node_validation_context_wiring_v0_20260625T030357Z`

MANIFEST_VERIFY_RC=0


Made with [Cursor](https://cursor.com)