### PR TITLE
fix(ci): split bounded PR gates from exhaustive suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: false
         type: boolean
+      run_exhaustive_full:
+        description: 'Run EXHAUSTIVE_FULL suite (manual only; never default for PR paths)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -56,10 +61,15 @@ jobs:
       test_selection_mode: ${{ steps.test_selection.outputs.test_selection_mode }}
       test_selection_reason: ${{ steps.test_selection.outputs.test_selection_reason }}
       tests_execute_full: ${{ steps.test_selection.outputs.tests_execute_full }}
+      tests_execute_contract_focused: ${{ steps.test_selection.outputs.tests_execute_contract_focused }}
       tests_execute_focused: ${{ steps.test_selection.outputs.tests_execute_focused }}
+      tests_execute_pr_bounded_full: ${{ steps.test_selection.outputs.tests_execute_pr_bounded_full }}
+      tests_execute_exhaustive_full: ${{ steps.test_selection.outputs.tests_execute_exhaustive_full }}
+      tests_execute_invalid: ${{ steps.test_selection.outputs.tests_execute_invalid }}
       tests_execute_no_op: ${{ steps.test_selection.outputs.tests_execute_no_op }}
       focused_pytest_targets: ${{ steps.test_selection.outputs.focused_pytest_targets }}
       focused_module_imports: ${{ steps.test_selection.outputs.focused_module_imports }}
+      pr_bounded_pytest_targets: ${{ steps.test_selection.outputs.pr_bounded_pytest_targets }}
       fast_lane_contract_mode: ${{ steps.test_selection.outputs.fast_lane_contract_mode }}
       fast_lane_contract_pytest_targets: ${{ steps.test_selection.outputs.fast_lane_contract_pytest_targets }}
       matrix_contract_mode: ${{ steps.test_selection.outputs.matrix_contract_mode }}
@@ -193,8 +203,8 @@ jobs:
         run: |
           set -euo pipefail
           FORCE_ARGS=()
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.force_matrix }}" = "true" ]; then
-            FORCE_ARGS+=(--force-full)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.run_exhaustive_full }}" = "true" ]; then
+            FORCE_ARGS+=(--force-exhaustive)
           fi
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_REF="${{ github.event.pull_request.base.ref }}"
@@ -406,8 +416,9 @@ jobs:
   # ============================================================================
   # Always creates test jobs for all required Python versions (3.9, 3.10, 3.11).
   # On docs-only / workflow-only / static-contract-only PRs, jobs short-circuit SUCCESS (NO_OP).
-  # FOCUSED runs bounded pytest on all matrix versions plus module import smoke.
-  # FULL runs the repository test suite with coverage on 3.11.
+  # FOCUSED/CONTRACT_FOCUSED runs bounded pytest on mapped owners.
+  # PR_BOUNDED_FULL runs conservative bounded gates (never pytest tests/ exhaustive).
+  # EXHAUSTIVE_FULL is not reachable from normal PR events.
   # ============================================================================
   tests:
     name: tests (${{ matrix.python-version }})
@@ -429,9 +440,9 @@ jobs:
         run: |
           echo "test_selection_mode=${{ needs.changes.outputs.test_selection_mode }}"
           echo "test_selection_reason=${{ needs.changes.outputs.test_selection_reason }}"
-          echo "tests_execute_full=${{ needs.changes.outputs.tests_execute_full }}"
-          echo "tests_execute_focused=${{ needs.changes.outputs.tests_execute_focused }}"
-          echo "tests_execute_no_op=${{ needs.changes.outputs.tests_execute_no_op }}"
+          echo "tests_execute_pr_bounded_full=${{ needs.changes.outputs.tests_execute_pr_bounded_full }}"
+          echo "tests_execute_exhaustive_full=${{ needs.changes.outputs.tests_execute_exhaustive_full }}"
+          echo "tests_execute_contract_focused=${{ needs.changes.outputs.tests_execute_contract_focused }}"
           echo "matrix_contract_mode=${{ needs.changes.outputs.matrix_contract_mode }}"
           echo "matrix_contract_reason=${{ needs.changes.outputs.matrix_contract_reason }}"
           echo "matrix_contract_pytest_targets=${{ needs.changes.outputs.matrix_contract_pytest_targets }}"
@@ -443,6 +454,12 @@ jobs:
         run: |
           echo "NO_OP diff-aware selection — skipping full matrix for Python ${{ matrix.python-version }}"
           echo "reason=${{ needs.changes.outputs.test_selection_reason }}"
+
+      - name: Fail closed on invalid test selection
+        if: ${{ needs.changes.outputs.tests_execute_invalid == 'true' }}
+        run: |
+          echo "Invalid test selection — fail-closed"
+          exit 1
 
       - name: MATRIX_CONTRACT_FOCUSED — non-canonical version ack (diff-aware)
         if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.matrix_contract_mode == 'MATRIX_CONTRACT_FOCUSED' && matrix.python-version != '3.11' }}
@@ -481,7 +498,7 @@ jobs:
           pip install pytest pytest-cov
 
       - name: "Stability Smoke Tests (Fast Gate)"
-        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true') && needs.changes.outputs.tests_execute_no_op != 'true' }}
+        if: ${{ needs.changes.outputs.tests_execute_no_op != 'true' && (needs.changes.outputs.tests_execute_pr_bounded_full == 'true' || needs.changes.outputs.tests_execute_exhaustive_full == 'true' || needs.changes.outputs.tests_execute_contract_focused == 'true') }}
         id: stability_smoke
         shell: bash
         run: |
@@ -489,8 +506,15 @@ jobs:
           echo "Running fast stability smoke tests (<5s)..."
           pytest tests/test_stability_smoke.py tests/test_data_contracts.py tests/test_error_taxonomy.py tests/test_resilience.py -m smoke -v --tb=short
 
+      - name: "Import and collection smoke (matrix version gate)"
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_pr_bounded_full == 'true' }}
+        run: |
+          set -euo pipefail
+          python -c "import src"
+          pytest --collect-only -q tests/test_stability_smoke.py
+
       - name: "Smoke: RL v0.1 Contract Test"
-        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true') && needs.changes.outputs.tests_execute_no_op != 'true' && runner.os == 'Linux' }}
+        if: ${{ needs.changes.outputs.tests_execute_exhaustive_full == 'true' && needs.changes.outputs.tests_execute_no_op != 'true' && runner.os == 'Linux' }}
         id: rl_v0_1_smoke
         shell: bash
         run: |
@@ -498,7 +522,7 @@ jobs:
           pytest -q tests/test_rl_v0_1_smoke.py
 
       - name: Validate RL v0.1 Contract
-        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true') && needs.changes.outputs.tests_execute_no_op != 'true' && runner.os == 'Linux' }}
+        if: ${{ needs.changes.outputs.tests_execute_exhaustive_full == 'true' && needs.changes.outputs.tests_execute_no_op != 'true' && runner.os == 'Linux' }}
         id: rl_v0_1_contract
         shell: bash
         run: |
@@ -516,13 +540,30 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Run full test suite
-        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true') && needs.changes.outputs.tests_execute_no_op != 'true' && needs.changes.outputs.matrix_contract_mode != 'MATRIX_CONTRACT_FOCUSED' }}
+      - name: Run PR_BOUNDED_FULL tests (matrix)
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_pr_bounded_full == 'true' && needs.changes.outputs.matrix_contract_mode != 'MATRIX_CONTRACT_FOCUSED' }}
+        run: |
+          set -euo pipefail
+          PYTEST_ARGS=(-v --tb=short -m "not network and not external_tools")
+          if [ "${{ matrix.python-version }}" != "3.11" ]; then
+            pytest tests/test_stability_smoke.py tests/test_data_contracts.py tests/test_error_taxonomy.py tests/test_resilience.py -m smoke "${PYTEST_ARGS[@]}"
+            exit 0
+          fi
+          TARGETS="${{ needs.changes.outputs.pr_bounded_pytest_targets }}"
+          if [ -z "$TARGETS" ]; then
+            echo "PR_BOUNDED_FULL without explicit targets — fail-closed"
+            exit 1
+          fi
+          mapfile -t VALIDATED_TARGETS < <(python3 scripts/ops/ci_test_selection_v1.py --emit-validated-pytest-targets "$TARGETS")
+          pytest "${VALIDATED_TARGETS[@]}" "${PYTEST_ARGS[@]}"
+
+      - name: Run EXHAUSTIVE_FULL test suite
+        if: ${{ needs.changes.outputs.tests_execute_exhaustive_full == 'true' && needs.changes.outputs.tests_execute_no_op != 'true' && needs.changes.outputs.matrix_contract_mode != 'MATRIX_CONTRACT_FOCUSED' }}
         run: |
           pytest tests/ -v --tb=short -m "not network and not external_tools"
 
       - name: Run focused tests (matrix)
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' && (needs.changes.outputs.matrix_contract_mode != 'MATRIX_CONTRACT_FOCUSED' || matrix.python-version == '3.11') }}
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_contract_focused == 'true' && (needs.changes.outputs.matrix_contract_mode != 'MATRIX_CONTRACT_FOCUSED' || matrix.python-version == '3.11') }}
         run: |
           set -euo pipefail
           export PYTHONUNBUFFERED=1
@@ -612,14 +653,14 @@ jobs:
           echo "focused-matrix parallel success lanes=${#PIDS[@]} integration_nodes=${#INTEGRATION_NODES[@]}"
 
       - name: Focused module import smoke
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' && needs.changes.outputs.focused_module_imports != '' }}
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_contract_focused == 'true' && needs.changes.outputs.focused_module_imports != '' }}
         run: |
           set -euo pipefail
           python3 scripts/ops/ci_test_selection_v1.py --import-smoke-modules "${{ needs.changes.outputs.focused_module_imports }}"
           echo "import smoke ok on Python ${{ matrix.python-version }}"
 
-      - name: Run tests with coverage (FULL only)
-        if: ${{ (github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true') && matrix.python-version == '3.11' && needs.changes.outputs.tests_execute_no_op != 'true' }}
+      - name: Run tests with coverage (EXHAUSTIVE_FULL only)
+        if: ${{ needs.changes.outputs.tests_execute_exhaustive_full == 'true' && matrix.python-version == '3.11' && needs.changes.outputs.tests_execute_no_op != 'true' }}
         run: |
           pytest tests/ --cov=src --cov-report=xml --cov-report=term-missing -m "not network and not external_tools"
 
@@ -648,24 +689,24 @@ jobs:
     # to satisfy branch protection rules (e.g., "strategy-smoke" check)
 
     steps:
-      - name: Skip strategy smoke (NO_OP/FOCUSED diff-aware)
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_full != 'true' }}
+      - name: Skip strategy smoke (not EXHAUSTIVE_FULL)
+        if: ${{ github.event_name == 'pull_request' || needs.changes.outputs.tests_execute_exhaustive_full != 'true' }}
         run: |
           echo "Skipping strategy smoke — test_selection_mode=${{ needs.changes.outputs.test_selection_mode }}"
           echo "reason=${{ needs.changes.outputs.test_selection_reason }}"
 
       - name: Checkout
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.tests_execute_exhaustive_full == 'true' }}
         uses: actions/checkout@v5
 
       - name: Set up Python 3.11
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.tests_execute_exhaustive_full == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Cache pip
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.tests_execute_exhaustive_full == 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
@@ -674,31 +715,31 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install dependencies
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.tests_execute_exhaustive_full == 'true' }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest
 
       - name: Run strategy smoke pytest
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.tests_execute_exhaustive_full == 'true' }}
         run: |
           pytest tests/test_strategy_smoke_cli.py -v --tb=short
 
       - name: Create smoke results directory
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.tests_execute_exhaustive_full == 'true' }}
         run: |
           mkdir -p test_results/strategy_smoke
 
       - name: Run strategy smoke CLI
-        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.tests_execute_exhaustive_full == 'true' }}
         run: |
           python scripts/strategy_smoke_check.py \
             --output-json test_results/strategy_smoke/ci_smoke_latest.json \
             --output-md test_results/strategy_smoke/ci_smoke_latest.md
 
       - name: Upload smoke test artifacts
-        if: ${{ always() && (github.event_name != 'pull_request' || needs.changes.outputs.tests_execute_full == 'true') }}
+        if: ${{ always() && needs.changes.outputs.tests_execute_exhaustive_full == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: strategy-smoke-results

--- a/.github/workflows/test-health-automation.yml
+++ b/.github/workflows/test-health-automation.yml
@@ -471,7 +471,6 @@ jobs:
     name: exhaustive-full (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_exhaustive_full == 'true')
-    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-health-automation.yml
+++ b/.github/workflows/test-health-automation.yml
@@ -50,8 +50,15 @@ on:
         required: false
         default: false
         type: boolean
+      run_exhaustive_full:
+        description: 'Run EXHAUSTIVE_FULL pytest suite (all Python versions; explicit opt-in)'
+        required: false
+        default: false
+        type: boolean
 
-  # Scheduled cron removed (cost minimization); manual dispatch only.
+# Scheduled cron removed (cost minimization); EXHAUSTIVE_FULL nightly re-enabled below.
+  schedule:
+    - cron: '0 3 * * *'
 
 # ============================================================================
 # Environment: Offline/Test-Modus sicherstellen
@@ -456,3 +463,44 @@ jobs:
           path: reports/test_health/
           retention-days: 90
           if-no-files-found: warn
+
+  # ===========================================================================
+  # EXHAUSTIVE_FULL — nightly / explicit manual exhaustive suite (not a PR gate)
+  # ===========================================================================
+  exhaustive-full:
+    name: exhaustive-full (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_exhaustive_full == 'true')
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-cov
+
+      - name: Verify shard inventory (3.11 coordinator)
+        if: matrix.python-version == '3.11'
+        run: python3 scripts/ops/ci_full_suite_shard_v1.py --verify-completeness
+
+      - name: Run EXHAUSTIVE_FULL test suite
+        run: |
+          pytest tests/ -v --tb=short -m "not network and not external_tools"
+
+      - name: Run EXHAUSTIVE_FULL coverage (3.11 only)
+        if: matrix.python-version == '3.11'
+        run: |
+          pytest tests/ --cov=src --cov-report=xml --cov-report=term-missing -m "not network and not external_tools"

--- a/scripts/ops/ci_full_suite_shard_v1.py
+++ b/scripts/ops/ci_full_suite_shard_v1.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Deterministic FULL-suite test sharding for CI (v1).
+
+Partitions every ``tests/**/test_*.py`` file into exactly one shard using a
+stable CRC32 bucket. Used by EXHAUSTIVE_FULL nightly/manual runs only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zlib
+from pathlib import Path
+
+DEFAULT_SHARD_COUNT = 8
+MIN_SHARD_COUNT = 4
+MAX_SHARD_COUNT = 12
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "tests"
+
+
+def enumerate_test_files(tests_root: Path = TESTS_ROOT) -> list[str]:
+    files: list[str] = []
+    for path in sorted(tests_root.rglob("test_*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        files.append(rel)
+    return sorted(files, key=lambda item: item.encode("utf-8"))
+
+
+def shard_index(path: str, shard_count: int) -> int:
+    return zlib.crc32(path.encode("utf-8")) % shard_count
+
+
+def partition_files(shard_count: int, tests_root: Path = TESTS_ROOT) -> dict[int, list[str]]:
+    buckets: dict[int, list[str]] = {idx: [] for idx in range(shard_count)}
+    for path in enumerate_test_files(tests_root):
+        buckets[shard_index(path, shard_count)].append(path)
+    return buckets
+
+
+def verify_completeness(shard_count: int, tests_root: Path = TESTS_ROOT) -> None:
+    all_files = enumerate_test_files(tests_root)
+    buckets = partition_files(shard_count, tests_root)
+    assigned: list[str] = []
+    for idx in range(shard_count):
+        assigned.extend(buckets[idx])
+    if len(assigned) != len(all_files):
+        raise SystemExit(
+            f"shard completeness failed: assigned={len(assigned)} total={len(all_files)}"
+        )
+    if len(set(assigned)) != len(all_files):
+        duplicates = len(assigned) - len(set(assigned))
+        raise SystemExit(f"shard completeness failed: duplicate assignments={duplicates}")
+    missing = sorted(set(all_files) - set(assigned))
+    if missing:
+        raise SystemExit(f"shard completeness failed: unassigned={missing[:5]}")
+    empty = [idx for idx in range(shard_count) if not buckets[idx]]
+    if empty:
+        raise SystemExit(f"shard completeness failed: empty_shards={empty}")
+
+
+def _validate_shard_count(shard_count: int) -> int:
+    if not MIN_SHARD_COUNT <= shard_count <= MAX_SHARD_COUNT:
+        raise SystemExit(
+            f"shard_count must be in [{MIN_SHARD_COUNT}, {MAX_SHARD_COUNT}], got {shard_count}"
+        )
+    return shard_count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=DEFAULT_SHARD_COUNT,
+        help=f"Number of shards (default {DEFAULT_SHARD_COUNT})",
+    )
+    parser.add_argument(
+        "--print-shard-count",
+        action="store_true",
+        help="Print shard count and exit",
+    )
+    parser.add_argument(
+        "--emit-shard-files",
+        type=int,
+        metavar="SHARD_ID",
+        help="Emit test file paths for the given shard id (one per line)",
+    )
+    parser.add_argument(
+        "--verify-completeness",
+        action="store_true",
+        help="Fail unless every test file is assigned to exactly one shard",
+    )
+    parser.add_argument(
+        "--print-shard-sizes",
+        action="store_true",
+        help="Print shard id and file count (for inventory tooling)",
+    )
+    args = parser.parse_args(argv)
+    shard_count = _validate_shard_count(args.shard_count)
+
+    if args.print_shard_count:
+        print(shard_count)
+        return 0
+
+    if args.verify_completeness:
+        verify_completeness(shard_count)
+        return 0
+
+    if args.print_shard_sizes:
+        buckets = partition_files(shard_count)
+        for idx in range(shard_count):
+            print(f"{idx}\t{len(buckets[idx])}")
+        return 0
+
+    if args.emit_shard_files is not None:
+        shard_id = args.emit_shard_files
+        if not 0 <= shard_id < shard_count:
+            raise SystemExit(f"shard id out of range: {shard_id}")
+        for path in partition_files(shard_count)[shard_id]:
+            print(path)
+        return 0
+
+    parser.error("no action requested")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -915,9 +915,7 @@ class SelectionResult:
         else:
             lines.append("focused_module_imports=")
         if self.pr_bounded_pytest_targets:
-            lines.append(
-                f"pr_bounded_pytest_targets={' '.join(self.pr_bounded_pytest_targets)}"
-            )
+            lines.append(f"pr_bounded_pytest_targets={' '.join(self.pr_bounded_pytest_targets)}")
         else:
             lines.append("pr_bounded_pytest_targets=")
         return lines
@@ -964,8 +962,7 @@ def _finalize_selection_result(
         if _is_selector_self_change_bootstrap(files):
             bounded = tuple(
                 sorted(
-                    set(resolve_pr_bounded_full_targets(files))
-                    | set(result.focused_pytest_targets)
+                    set(resolve_pr_bounded_full_targets(files)) | set(result.focused_pytest_targets)
                 )
             )
             if not bounded:

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -811,6 +811,75 @@ CANONICAL_MARKET_DASHBOARD_FOCUSED_TESTS: tuple[str, ...] = (
 _REPO_RELATIVE_PATH = re.compile(r"^[A-Za-z0-9_./-]+$")
 _IMPORT_MODULE = re.compile(r"^[a-zA-Z0-9_.]+$")
 
+INVALID_SELECTION_MODE = "INVALID"
+PR_LIKE_EVENTS = frozenset({"pull_request", "merge_group", "push"})
+EXHAUSTIVE_AUTHORIZED_EVENTS = frozenset({"schedule", "workflow_dispatch"})
+
+PR_BOUNDED_FULL_VERSION_SMOKE_TARGETS: tuple[str, ...] = (
+    "tests/test_stability_smoke.py",
+    "tests/test_data_contracts.py",
+    "tests/test_error_taxonomy.py",
+    "tests/test_resilience.py",
+)
+
+PR_BOUNDED_FULL_PY311_CORE_TARGETS: tuple[str, ...] = (
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    "tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py",
+    "tests/ci/test_required_checks_config.py",
+    "tests/ci/test_required_checks_hygiene.py",
+    "tests/ci/test_workflows_no_pull_request_target_contract_v0.py",
+    "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py",
+    "tests/ci/test_pr_head_sha_required_checks_liveness_guard.py",
+)
+
+PR_BOUNDED_FULL_CI_CHANGE_EXTRA_TARGETS: tuple[str, ...] = (
+    "tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py",
+    "tests/ci/test_ci_scheduled_paper_export_smoke_workflow_contract_v0.py",
+    "tests/ci/test_class_a_shadow_paper_scheduled_probe_workflow_contract_v0.py",
+    "tests/ci/test_paper_session_audit_evidence_workflow_contract_v0.py",
+    "tests/ci/test_paper_tests_audit_evidence_workflow_contract_v0.py",
+    "tests/ci/test_prj_scheduled_shadow_paper_features_smoke_workflow_contract_v0.py",
+    "tests/ci/test_shadow_paper_smoke_workflow_contract_v0.py",
+)
+
+
+def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
+    """Conservative, deterministic PR_BOUNDED_FULL pytest targets (3.11 main lane)."""
+    targets: list[str] = []
+    seen: set[str] = set()
+
+    def add(path: str) -> None:
+        if path not in seen and _repo_path_exists(path):
+            seen.add(path)
+            targets.append(path)
+
+    for path in PR_BOUNDED_FULL_VERSION_SMOKE_TARGETS:
+        add(path)
+    for path in PR_BOUNDED_FULL_PY311_CORE_TARGETS:
+        add(path)
+
+    normalized = {PurePosixPath(f).as_posix() for f in files if f.strip()}
+    ci_central = {
+        ".github/workflows/ci.yml",
+        "scripts/ops/ci_test_selection_v1.py",
+        "config/ci/file_category_mapping.yaml",
+    }
+    if normalized & ci_central:
+        for path in CI_INFRA_CONTRACT_TEST_ALLOWLIST:
+            add(path)
+        for path in CI_INFRA_CORE_FOCUSED_TESTS:
+            add(path)
+        for path in PR_BOUNDED_FULL_CI_CHANGE_EXTRA_TARGETS:
+            add(path)
+
+    if not targets:
+        return ()
+    return tuple(sorted(targets))
+
+
+def _is_pr_like_event(event_name: str) -> bool:
+    return event_name in PR_LIKE_EVENTS
+
 
 @dataclass(frozen=True)
 class SelectionResult:
@@ -818,14 +887,24 @@ class SelectionResult:
     reason: str
     focused_pytest_targets: tuple[str, ...]
     focused_module_imports: tuple[str, ...] = ()
+    pr_bounded_pytest_targets: tuple[str, ...] = ()
 
     def github_output_lines(self) -> list[str]:
+        is_contract_focused = self.mode == "CONTRACT_FOCUSED"
+        is_pr_bounded = self.mode == "PR_BOUNDED_FULL"
+        is_exhaustive = self.mode == "EXHAUSTIVE_FULL"
+        is_invalid = self.mode == INVALID_SELECTION_MODE
+        is_no_op = self.mode == "NO_OP"
         lines = [
             f"test_selection_mode={self.mode}",
             f"test_selection_reason={self.reason}",
-            f"tests_execute_full={'true' if self.mode == 'FULL' else 'false'}",
-            f"tests_execute_focused={'true' if self.mode == 'FOCUSED' else 'false'}",
-            f"tests_execute_no_op={'true' if self.mode == 'NO_OP' else 'false'}",
+            f"tests_execute_full={'true' if is_exhaustive else 'false'}",
+            f"tests_execute_contract_focused={'true' if is_contract_focused else 'false'}",
+            f"tests_execute_focused={'true' if is_contract_focused else 'false'}",
+            f"tests_execute_pr_bounded_full={'true' if is_pr_bounded else 'false'}",
+            f"tests_execute_exhaustive_full={'true' if is_exhaustive else 'false'}",
+            f"tests_execute_no_op={'true' if is_no_op else 'false'}",
+            f"tests_execute_invalid={'true' if is_invalid else 'false'}",
         ]
         if self.focused_pytest_targets:
             lines.append(f"focused_pytest_targets={' '.join(self.focused_pytest_targets)}")
@@ -835,7 +914,122 @@ class SelectionResult:
             lines.append(f"focused_module_imports={' '.join(self.focused_module_imports)}")
         else:
             lines.append("focused_module_imports=")
+        if self.pr_bounded_pytest_targets:
+            lines.append(
+                f"pr_bounded_pytest_targets={' '.join(self.pr_bounded_pytest_targets)}"
+            )
+        else:
+            lines.append("pr_bounded_pytest_targets=")
         return lines
+
+
+def _is_selector_self_change_bootstrap(files: list[str]) -> bool:
+    normalized = {PurePosixPath(f).as_posix() for f in files if f.strip()}
+    return (
+        ".github/workflows/ci.yml" in normalized
+        and "scripts/ops/ci_test_selection_v1.py" in normalized
+    )
+
+
+def _finalize_selection_result(
+    result: SelectionResult,
+    files: list[str],
+    *,
+    event_name: str,
+    force_exhaustive: bool,
+) -> SelectionResult:
+    if force_exhaustive:
+        if event_name not in EXHAUSTIVE_AUTHORIZED_EVENTS:
+            return SelectionResult(
+                INVALID_SELECTION_MODE,
+                "force_exhaustive_on_unauthorized_event",
+                (),
+            )
+        return SelectionResult(
+            "EXHAUSTIVE_FULL",
+            "workflow_dispatch_explicit_exhaustive",
+            (),
+        )
+
+    if event_name == "schedule":
+        return SelectionResult("EXHAUSTIVE_FULL", "scheduled_nightly", ())
+
+    if result.mode == INVALID_SELECTION_MODE:
+        return result
+
+    if result.mode == "NO_OP":
+        return result
+
+    if result.mode == "FOCUSED":
+        if _is_selector_self_change_bootstrap(files):
+            bounded = tuple(
+                sorted(
+                    set(resolve_pr_bounded_full_targets(files))
+                    | set(result.focused_pytest_targets)
+                )
+            )
+            if not bounded:
+                return SelectionResult(
+                    INVALID_SELECTION_MODE,
+                    "pr_bounded_full_empty_targets_fail_closed",
+                    (),
+                )
+            return SelectionResult(
+                "PR_BOUNDED_FULL",
+                "selector_self_change_bootstrap",
+                (),
+                (),
+                bounded,
+            )
+        return SelectionResult(
+            "CONTRACT_FOCUSED",
+            result.reason,
+            result.focused_pytest_targets,
+            result.focused_module_imports,
+            result.pr_bounded_pytest_targets,
+        )
+
+    if result.mode == "FULL":
+        if _is_pr_like_event(event_name) or event_name == "workflow_dispatch":
+            bounded = resolve_pr_bounded_full_targets(files)
+            if not bounded:
+                return SelectionResult(
+                    INVALID_SELECTION_MODE,
+                    "pr_bounded_full_empty_targets_fail_closed",
+                    (),
+                )
+            return SelectionResult(
+                "PR_BOUNDED_FULL",
+                result.reason,
+                (),
+                (),
+                bounded,
+            )
+        return SelectionResult("EXHAUSTIVE_FULL", result.reason, ())
+
+    if result.mode in {"CONTRACT_FOCUSED", "PR_BOUNDED_FULL", "EXHAUSTIVE_FULL"}:
+        if result.mode == "EXHAUSTIVE_FULL" and _is_pr_like_event(event_name):
+            bounded = resolve_pr_bounded_full_targets(files)
+            if not bounded:
+                return SelectionResult(
+                    INVALID_SELECTION_MODE,
+                    "pr_event_exhaustive_blocked_fail_closed",
+                    (),
+                )
+            return SelectionResult(
+                "PR_BOUNDED_FULL",
+                "pr_event_exhaustive_blocked_fail_closed",
+                (),
+                (),
+                bounded,
+            )
+        return result
+
+    return SelectionResult(
+        INVALID_SELECTION_MODE,
+        f"incoherent_selection_mode_{result.mode}",
+        (),
+    )
 
 
 @dataclass(frozen=True)
@@ -2872,12 +3066,14 @@ def resolve_selection(
     files: list[str],
     *,
     force_full: bool = False,
+    force_exhaustive: bool = False,
     event_name: str = "pull_request",
     patch_text: str | None = None,
 ) -> SelectionResult:
     normalized = sorted({PurePosixPath(f).as_posix() for f in files if f.strip()})
-    if force_full or event_name in {"push", "merge_group", "schedule"}:
-        return SelectionResult("FULL", "force_full_or_non_pr_event", ())
+    exhaustive_requested = force_exhaustive or force_full
+    if exhaustive_requested and event_name in EXHAUSTIVE_AUTHORIZED_EVENTS:
+        return SelectionResult("EXHAUSTIVE_FULL", "force_exhaustive_authorized_event", ())
     if not normalized:
         return SelectionResult("FULL", "empty_diff_fail_closed", ())
 
@@ -3136,6 +3332,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--files", nargs="*", default=None, help="Changed file paths")
     parser.add_argument("--files-file", type=Path, default=None)
     parser.add_argument("--force-full", action="store_true")
+    parser.add_argument(
+        "--force-exhaustive",
+        action="store_true",
+        help="Select EXHAUSTIVE_FULL (schedule/workflow_dispatch only)",
+    )
     parser.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME", "pull_request"))
     parser.add_argument("--github-output", action="store_true")
     parser.add_argument(
@@ -3197,6 +3398,7 @@ def main(argv: list[str] | None = None) -> int:
     result = resolve_selection(
         files,
         force_full=args.force_full,
+        force_exhaustive=args.force_exhaustive,
         event_name=args.event_name,
         patch_text=patch_text,
     )
@@ -3206,6 +3408,13 @@ def main(argv: list[str] | None = None) -> int:
             matrix_contract.reason,
             matrix_contract.pytest_targets,
         )
+    result = _finalize_selection_result(
+        result,
+        files,
+        event_name=args.event_name,
+        force_exhaustive=args.force_exhaustive
+        or (args.force_full and args.event_name in EXHAUSTIVE_AUTHORIZED_EVENTS),
+    )
     lines = result.github_output_lines()
     lines.extend(matrix_contract.github_output_lines())
     lines.extend(resolve_fast_lane_contract_selection(files).github_output_lines())

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -1176,7 +1176,9 @@ def test_selector_market_dashboard_tests_only_focused() -> None:
 
 def test_workflow_only_does_not_run_full_pytest_step_unconditionally() -> None:
     text = _ci_text()
-    exhaustive_step = text.split("name: Run EXHAUSTIVE_FULL test suite", 1)[1].split("\n      - name:", 1)[0]
+    exhaustive_step = text.split("name: Run EXHAUSTIVE_FULL test suite", 1)[1].split(
+        "\n      - name:", 1
+    )[0]
     assert "tests_execute_exhaustive_full == 'true'" in exhaustive_step
     assert "workflow_only == 'true'" not in exhaustive_step
 
@@ -2382,7 +2384,10 @@ def test_selector_pe55_full_diff_with_ci_workflow_rebundle_stays_focused() -> No
     )
     assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
-    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in sel["pr_bounded_pytest_targets"]
+    assert (
+        "tests/ops/test_durable_completion_validation_graph_v1.py"
+        in sel["pr_bounded_pytest_targets"]
+    )
 
 
 def test_selector_durable_completion_facade_plus_graph_focused() -> None:

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -128,7 +128,12 @@ def test_changes_job_exports_test_selection_outputs() -> None:
         "test_selection_mode",
         "test_selection_reason",
         "tests_execute_full",
+        "tests_execute_contract_focused",
         "tests_execute_focused",
+        "tests_execute_pr_bounded_full",
+        "tests_execute_exhaustive_full",
+        "tests_execute_invalid",
+        "pr_bounded_pytest_targets",
         "tests_execute_no_op",
         "focused_pytest_targets",
         "focused_module_imports",
@@ -152,9 +157,10 @@ def test_tests_job_has_no_op_step() -> None:
 
 def test_tests_job_has_focused_and_full_steps() -> None:
     text = _ci_text()
-    assert "Run full test suite" in text
+    assert "Run EXHAUSTIVE_FULL test suite" in text
     assert "Run focused tests (matrix)" in text
-    assert "Run tests with coverage (FULL only)" in text
+    assert "Run tests with coverage (EXHAUSTIVE_FULL only)" in text
+    assert "Run PR_BOUNDED_FULL tests (matrix)" in text
 
 
 def test_tests_job_focused_runs_on_all_matrix_versions() -> None:
@@ -166,7 +172,7 @@ def test_tests_job_focused_runs_on_all_matrix_versions() -> None:
         "matrix_contract_mode != 'MATRIX_CONTRACT_FOCUSED' || matrix.python-version == '3.11'"
         in focused_step
     )
-    assert "tests_execute_focused == 'true'" in focused_step
+    assert "tests_execute_contract_focused == 'true'" in focused_step
 
 
 def test_tests_job_matrix_contract_focused_non_canonical_version_ack_step() -> None:
@@ -181,7 +187,7 @@ def test_tests_job_matrix_contract_focused_non_canonical_version_ack_step() -> N
 def test_tests_job_full_suite_excludes_matrix_contract_focused() -> None:
     full_block = (
         _ci_text()
-        .split("name: Run full test suite", 1)[1]
+        .split("name: Run EXHAUSTIVE_FULL test suite", 1)[1]
         .split("name: Run focused tests (matrix)", 1)[0]
     )
     assert "matrix_contract_mode != 'MATRIX_CONTRACT_FOCUSED'" in full_block
@@ -207,7 +213,7 @@ def test_tests_job_focused_matrix_integration_parallel_sharding_contract() -> No
 
 def test_tests_job_focused_matrix_parallel_sharding_does_not_affect_full_suite_step() -> None:
     text = _ci_text()
-    full_block = text.split("name: Run full test suite", 1)[1].split(
+    full_block = text.split("name: Run EXHAUSTIVE_FULL test suite", 1)[1].split(
         "name: Run focused tests (matrix)", 1
     )[0]
     assert "INTEGRATION_SHARD_COUNT" not in full_block
@@ -259,7 +265,7 @@ def test_focused_matrix_glb019_a2b_target_groups_complete() -> None:
     ci_owner = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
     graph_owner = "tests/ops/test_durable_completion_validation_graph_v1.py"
     integration_nodes = sorted(t for t in targets if "::" in t)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
     assert ci_owner in targets
     assert graph_owner in targets
@@ -278,7 +284,7 @@ def test_selector_ci_workflow_shard_bootstrap_focused() -> None:
         ".github/workflows/ci.yml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_infra_focused"
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_focused"] == "true"
@@ -297,8 +303,9 @@ def test_selector_workflow_only_no_op() -> None:
 
 def test_selector_central_src_full() -> None:
     sel = _run_selector("src/strategies/__init__.py")
-    assert sel["test_selection_mode"] == "FULL"
-    assert sel["tests_execute_full"] == "true"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert sel["tests_execute_full"] == "false"
 
 
 def test_selector_registry_init_full() -> None:
@@ -306,7 +313,7 @@ def test_selector_registry_init_full() -> None:
         "src/strategies/__init__.py",
         "tests/test_strategy_vol_regime_filter.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_composite_full() -> None:
@@ -314,22 +321,22 @@ def test_selector_composite_full() -> None:
         "src/strategies/composite.py",
         "tests/test_strategy_composite.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_dependencies_full() -> None:
     sel = _run_selector("requirements.txt")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_global_test_infra_full() -> None:
     sel = _run_selector("tests/conftest.py")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_scripts_focused() -> None:
     sel = _run_selector("scripts/demo_strategy_research.py")
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert (
         "tests/scripts/test_demo_strategy_research_load_strategy_v1.py"
         in sel["focused_pytest_targets"]
@@ -342,7 +349,7 @@ def test_selector_scripts_focused_omits_nonexistent_test_paths() -> None:
         "scripts/run_momentum_realistic.py",
         "scripts/run_offline_realtime_ma_crossover.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     targets = _targets(sel)
     assert "tests/scripts/test_run_momentum_realistic_load_strategy_v1.py" in targets
     assert "tests/scripts/test_run_offline_realtime_ma_crossover_load_strategy_v1.py" in targets
@@ -355,7 +362,7 @@ def test_selector_strategy_vol_breakout_owner_focused() -> None:
         "src/strategies/vol_breakout.py",
         "tests/test_strategies_phase27.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "strategy_regime_owner_focused"
     assert "tests/test_strategies_phase27.py" in _targets(sel)
     assert _modules(sel) == ["src.strategies.vol_breakout"]
@@ -366,7 +373,7 @@ def test_selector_strategy_vol_regime_filter_owner_focused() -> None:
         "src/strategies/vol_regime_filter.py",
         "tests/test_strategy_vol_regime_filter.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert "tests/test_strategy_vol_regime_filter.py" in _targets(sel)
     assert _modules(sel) == ["src.strategies.vol_regime_filter"]
 
@@ -376,7 +383,7 @@ def test_selector_regime_detectors_owner_focused() -> None:
         "src/regime/detectors.py",
         "tests/test_regime_detection.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert "tests/test_regime_detection.py" in _targets(sel)
     assert _modules(sel) == ["src.regime.detectors"]
 
@@ -386,7 +393,7 @@ def test_selector_el_karoui_vol_model_owner_focused() -> None:
         "src/strategies/el_karoui/vol_model.py",
         "tests/strategies/el_karoui/test_vol_model.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert "tests/strategies/el_karoui/test_vol_model.py" in _targets(sel)
     assert _modules(sel) == ["src.strategies.el_karoui.vol_model"]
 
@@ -410,7 +417,7 @@ def test_selector_focused_targets_sorted_deterministically() -> None:
 
 def test_selector_prod_only_without_test_owner_full() -> None:
     sel = _run_selector("src/strategies/vol_breakout.py")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "strategy_regime_owner_incomplete_or_ambiguous"
 
 
@@ -420,7 +427,7 @@ def test_selector_two_prod_files_full() -> None:
         "src/strategies/vol_regime_filter.py",
         "tests/test_strategies_phase27.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_strategy_plus_foreign_test_owner_full() -> None:
@@ -428,7 +435,7 @@ def test_selector_strategy_plus_foreign_test_owner_full() -> None:
         "src/strategies/vol_breakout.py",
         "tests/test_strategy_vol_regime_filter.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_strategy_plus_conftest_full() -> None:
@@ -437,7 +444,7 @@ def test_selector_strategy_plus_conftest_full() -> None:
         "tests/test_strategies_phase27.py",
         "tests/conftest.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_strategy_plus_dependency_full() -> None:
@@ -446,7 +453,7 @@ def test_selector_strategy_plus_dependency_full() -> None:
         "tests/test_strategies_phase27.py",
         "requirements.txt",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_strategy_plus_pyproject_full() -> None:
@@ -455,7 +462,7 @@ def test_selector_strategy_plus_pyproject_full() -> None:
         "tests/test_strategies_phase27.py",
         "pyproject.toml",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_strategy_plus_workflow_full() -> None:
@@ -464,12 +471,12 @@ def test_selector_strategy_plus_workflow_full() -> None:
         "tests/test_strategies_phase27.py",
         ".github/workflows/lint.yml",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_ci_bootstrap_selector_only_focused() -> None:
     sel = _run_selector("scripts/ops/ci_test_selection_v1.py")
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
     assert sel["tests_execute_full"] == "false"
@@ -480,7 +487,7 @@ def test_selector_ci_bootstrap_selector_plus_contract_focused() -> None:
         "scripts/ops/ci_test_selection_v1.py",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
     assert _targets(sel) == ["tests/ci/test_ci_diff_aware_test_selection_v1.py"]
     assert sel["tests_execute_full"] == "false"
@@ -491,7 +498,7 @@ def test_selector_ci_bootstrap_plus_workflow_full() -> None:
         "scripts/ops/ci_test_selection_v1.py",
         ".github/workflows/ci.yml",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
 
 
@@ -500,7 +507,7 @@ def test_selector_ci_bootstrap_plus_dependency_full() -> None:
         "scripts/ops/ci_test_selection_v1.py",
         "requirements.txt",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
 
 
@@ -509,7 +516,7 @@ def test_selector_ci_bootstrap_plus_central_src_full() -> None:
         "scripts/ops/ci_test_selection_v1.py",
         "src/core/foo.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
 
 
@@ -518,13 +525,13 @@ def test_selector_ci_bootstrap_plus_unknown_full() -> None:
         "scripts/ops/ci_test_selection_v1.py",
         "misc/unclassified.bin",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
 
 
 def test_selector_ci_bootstrap_contract_test_only_focused() -> None:
     sel = _run_selector("tests/ci/test_ci_diff_aware_test_selection_v1.py")
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
 
 
@@ -538,7 +545,7 @@ GLB019_CI_BOOTSTRAP_PR_FILES = (
 
 def test_selector_glb019_ci_bootstrap_pr_four_file_diff_focused() -> None:
     sel = _run_selector(*GLB019_CI_BOOTSTRAP_PR_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
     assert _targets(sel) == ["tests/ci/test_ci_diff_aware_test_selection_v1.py"]
     assert sel["tests_execute_full"] == "false"
@@ -546,20 +553,15 @@ def test_selector_glb019_ci_bootstrap_pr_four_file_diff_focused() -> None:
 
 def test_selector_glb019_ci_bootstrap_pr_four_files_plus_unknown_ci_helper_full() -> None:
     sel = _run_selector(*GLB019_CI_BOOTSTRAP_PR_FILES, "tests/ci/test_unknown_helper_v0.py")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
 
 
 def test_selector_glb019_ci_bootstrap_pr_four_files_plus_workflow_ci_infra_focused() -> None:
     sel = _run_selector(*GLB019_CI_BOOTSTRAP_PR_FILES, ".github/workflows/ci.yml")
-    assert sel["test_selection_mode"] == "FOCUSED"
-    assert sel["test_selection_reason"] == "ci_infra_focused"
-    assert sel["tests_execute_full"] == "false"
-    assert sel["tests_execute_focused"] == "true"
-    targets = _targets(sel)
-    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
-    assert "tests/ci/test_workflows_no_pull_request_target_contract_v0.py" in targets
-    assert "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py" in targets
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
 
 
 GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES = (
@@ -572,7 +574,7 @@ _PARTITIONS_HELPER = GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[1]
 
 def test_selector_glb019_partition_bootstrap_three_file_diff_focused() -> None:
     sel = _run_selector(*GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
     assert _targets(sel) == ["tests/ci/test_ci_diff_aware_test_selection_v1.py"]
     assert sel["tests_execute_full"] == "false"
@@ -587,7 +589,7 @@ def test_selector_glb019_partition_bootstrap_selector_plus_helper_focused() -> N
         GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[0],
         GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[1],
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
 
 
@@ -596,13 +598,13 @@ def test_selector_glb019_partition_bootstrap_helper_plus_contract_focused() -> N
         GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[1],
         GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES[2],
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
 
 
 def test_selector_glb019_partition_bootstrap_helper_only_focused() -> None:
     sel = _run_selector(_PARTITIONS_HELPER)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
 
 
@@ -611,10 +613,8 @@ def test_selector_glb019_partition_bootstrap_plus_workflow_full() -> None:
         *GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES,
         ".github/workflows/ci.yml",
     )
-    assert sel["test_selection_reason"] != "ci_bootstrap_focused"
-    assert sel["test_selection_mode"] == "FOCUSED"
-    assert sel["test_selection_reason"] == "ci_infra_focused"
-    assert sel["tests_execute_full"] == "false"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
 
 
 def test_selector_glb019_partition_bootstrap_plus_unknown_ci_script_full() -> None:
@@ -622,7 +622,7 @@ def test_selector_glb019_partition_bootstrap_plus_unknown_ci_script_full() -> No
         *GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES,
         "scripts/ops/ci_unknown_bootstrap_probe_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
 
 
@@ -631,7 +631,7 @@ def test_selector_glb019_partition_bootstrap_plus_central_prod_full() -> None:
         *GLB019_PARTITION_SELECTOR_BOOTSTRAP_FILES,
         "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
@@ -641,7 +641,7 @@ _SELECTOR_OWNER = "scripts/ops/ci_test_selection_v1.py"
 
 def test_selector_glb019_a2b_selector_owner_plus_central_facade_selects_full() -> None:
     sel = _run_selector(_SELECTOR_OWNER, _FACADE_PATH)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
@@ -656,7 +656,7 @@ _GLB019_SELECTOR_OWNER_FULL_REASONS = frozenset(
 def test_selector_glb019_a2b_selector_owner_plus_facade_explicit_patch_still_full() -> None:
     patch = _synthetic_glb019_a2b_positive_patch_text()
     sel = _run_selector_with_patch(patch, _SELECTOR_OWNER, _FACADE_PATH, *GLB019_A2B_FILESET)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -665,7 +665,7 @@ def test_selector_glb019_a2b_full_nine_file_pr_diff_focused() -> None:
         _synthetic_glb019_a2b_nine_file_patch_text(),
         *GLB019_A2B_FULL_PR_FILES,
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
     assert sel["tests_execute_full"] == "false"
 
@@ -675,7 +675,7 @@ def test_selector_glb019_a2b_full_nine_file_pr_explicit_git_diff_focused() -> No
         _synthetic_glb019_a2b_nine_file_patch_text(),
         *GLB019_A2B_FULL_PR_FILES,
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
     assert sel["tests_execute_full"] == "false"
     targets = _targets(sel)
@@ -708,7 +708,7 @@ def test_selector_glb019_a2b_live_collect_patch_contract_focused() -> None:
         _synthetic_glb019_a2b_nine_file_patch_text(),
         *GLB019_A2B_FULL_PR_FILES,
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
     assert sel["tests_execute_full"] == "false"
     targets = _targets(sel)
@@ -741,7 +741,7 @@ def test_selector_glb019_a2b_live_patch_selector_owner_ast_validator_accepts() -
 def test_selector_glb019_a2b_missing_selector_owner_hunks_full() -> None:
     patch = _synthetic_glb019_a2b_positive_patch_text()
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -758,7 +758,7 @@ def test_selector_glb019_a2b_removed_binding_check_full() -> None:
     mutated = canonical.replace(needle, "", 1)
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -776,7 +776,7 @@ def test_selector_glb019_a2b_removed_evaluate_call_full() -> None:
     mutated = canonical.replace(needle, "        return None\n", 1)
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -802,7 +802,7 @@ def test_selector_glb019_a2b_classify_bypass_reintroduced_full() -> None:
     mutated = canonical.replace(needle, "", 1)
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -818,7 +818,7 @@ def test_selector_glb019_a2b_extra_import_full() -> None:
     )
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -827,7 +827,7 @@ def test_selector_glb019_a2b_extra_module_level_assignment_full() -> None:
     mutated = 'CI_GLB019_SYNTHETIC_PATCH_BUILDER = "evil_probe_path"\n' + canonical
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -842,7 +842,7 @@ def test_selector_glb019_a2b_extra_structural_wrapper_branch_full() -> None:
     )
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -857,7 +857,7 @@ def test_selector_glb019_a2b_other_resolver_mutation_full() -> None:
     )
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -866,7 +866,7 @@ def test_selector_glb019_a2b_eight_file_subset_without_selector_owner_still_focu
         _synthetic_glb019_a2b_positive_patch_text(),
         *GLB019_A2B_FILESET,
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
     assert sel["tests_execute_full"] == "false"
 
@@ -878,7 +878,7 @@ def test_selector_glb019_a2b_selector_owner_resolve_selection_body_change_full()
     mutated = canonical.replace(needle, "    return True", 1)
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -890,7 +890,7 @@ def test_selector_glb019_a2b_selector_owner_reason_string_change_full() -> None:
     assert mutated != canonical
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -905,7 +905,7 @@ def test_selector_glb019_a2b_selector_owner_extra_ast_statement_full() -> None:
     )
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -916,7 +916,7 @@ def test_selector_glb019_a2b_selector_owner_missing_canonical_import_binding_ful
     mutated = canonical.replace(needle, "", 1)
     patch = _guarded_mixed_patch_with_selector_after(mutated)
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FULL_PR_FILES)
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in _GLB019_SELECTOR_OWNER_FULL_REASONS
 
 
@@ -932,7 +932,7 @@ def test_selector_glb019_a2b_full_pr_plus_unknown_foreign_path_full() -> None:
         *GLB019_A2B_FULL_PR_FILES,
         "src/ops/unknown_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
@@ -941,7 +941,7 @@ def test_selector_glb019_a2b_full_pr_plus_second_ci_file_full() -> None:
         *GLB019_A2B_FULL_PR_FILES,
         "scripts/ops/ci_unknown_bootstrap_probe_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in {
         "ci_bootstrap_mixed_diff_requires_full",
         "durable_completion_foreign_path_requires_full",
@@ -964,21 +964,23 @@ def test_selector_glb019_a2b_selector_partitions_helper_plus_central_facade_sele
         _PARTITIONS_HELPER,
         _FACADE_PATH,
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
 def test_selector_glb019_a2b_central_facade_without_structural_contract_selects_full() -> None:
     sel = _run_selector(_FACADE_PATH)
-    assert sel["test_selection_mode"] == "FULL"
-    assert sel["tests_execute_full"] == "true"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert sel["tests_execute_full"] == "false"
 
 
 def test_selector_glb019_a2b_eligible_fileset_structural_contract_failure_selects_full() -> None:
     patch = _synthetic_glb019_a2b_reject_patch_text()
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FILESET)
-    assert sel["test_selection_mode"] == "FULL"
-    assert sel["tests_execute_full"] == "true"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert sel["tests_execute_full"] == "false"
 
 
 def test_selector_ci_bootstrap_deterministic_regardless_of_file_order() -> None:
@@ -990,12 +992,12 @@ def test_selector_ci_bootstrap_deterministic_regardless_of_file_order() -> None:
     sel_a = _run_selector(*files_a)
     sel_b = _run_selector(*files_b)
     assert sel_a == sel_b
-    assert sel_a["test_selection_mode"] == "FOCUSED"
+    assert sel_a["test_selection_mode"] == "CONTRACT_FOCUSED"
 
 
 def test_selector_ci_mapping_only_full() -> None:
     sel = _run_selector("config/ci/file_category_mapping.yaml")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "ci_mapping_or_workflow_selector_change_requires_full"
 
 
@@ -1004,7 +1006,7 @@ def test_selector_ci_workflow_change_self_full() -> None:
         ".github/workflows/ci.yml",
         "scripts/ops/ci_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "ci_bootstrap_mixed_diff_requires_full"
 
 
@@ -1014,10 +1016,9 @@ def test_selector_gap_ci_017_full_pr_diff_ci_infra_focused() -> None:
         "scripts/ops/ci_test_selection_v1.py",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
-    assert sel["test_selection_reason"] == "ci_infra_focused"
-    assert sel["tests_execute_full"] == "false"
-    assert sel["tests_execute_focused"] == "true"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
 
 
 def test_selector_gap_ci_017_ci_workflow_timeout_rebundle_ci_infra_focused() -> None:
@@ -1025,7 +1026,7 @@ def test_selector_gap_ci_017_ci_workflow_timeout_rebundle_ci_infra_focused() -> 
         ".github/workflows/ci.yml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_infra_focused"
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_focused"] == "true"
@@ -1041,7 +1042,7 @@ def test_selector_strategy_plus_core_full() -> None:
         "tests/test_strategies_phase27.py",
         "src/core/foo.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_multiple_test_owners_full() -> None:
@@ -1050,37 +1051,37 @@ def test_selector_multiple_test_owners_full() -> None:
         "tests/test_strategies_phase27.py",
         "tests/test_strategy_vol_regime_filter.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_unknown_fail_closed_full() -> None:
     sel = _run_selector("misc/unclassified.bin")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_empty_diff_fail_closed_full() -> None:
     sel = _run_selector()
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "empty_diff_fail_closed"
 
 
 def test_selector_force_full() -> None:
-    sel = _run_selector("docs/foo.md", force_full=True)
-    assert sel["test_selection_mode"] == "FULL"
+    sel = _run_selector(event_name="workflow_dispatch", force_full=True)
+    assert sel["test_selection_mode"] == "EXHAUSTIVE_FULL"
 
 
-def test_selector_push_event_full() -> None:
+def test_selector_push_event_bounded_or_no_op() -> None:
     sel = _run_selector("docs/foo.md", event_name="push")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "NO_OP"
 
 
-def test_selector_merge_group_event_full() -> None:
+def test_selector_merge_group_event_bounded() -> None:
     sel = _run_selector(
         "src/strategies/vol_breakout.py",
         "tests/test_strategies_phase27.py",
         event_name="merge_group",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
 
 
 def test_selector_import_smoke_cli_ok() -> None:
@@ -1137,7 +1138,7 @@ def test_mapping_file_exists() -> None:
 
 def test_selector_market_dashboard_eligibility_only_focused() -> None:
     sel = _run_selector("src/webui/market_instrument_eligibility_v0.py")
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "market_dashboard_focused"
     assert "tests/webui/test_market_dashboard_no_bitcoin_futures_v1.py" in _targets(sel)
 
@@ -1153,7 +1154,7 @@ def test_selector_market_dashboard_rebundle_diff_focused() -> None:
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
     sel = _run_selector(*files)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "market_dashboard_focused"
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
     assert sel["tests_execute_full"] == "false"
@@ -1164,20 +1165,20 @@ def test_selector_market_dashboard_plus_central_src_full() -> None:
         "src/webui/market_surface.py",
         "src/execution/live/orchestrator.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_market_dashboard_tests_only_focused() -> None:
     sel = _run_selector("tests/webui/test_market_dashboard_no_bitcoin_futures_v1.py")
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "market_dashboard_focused"
 
 
 def test_workflow_only_does_not_run_full_pytest_step_unconditionally() -> None:
     text = _ci_text()
-    full_step = text.split("name: Run full test suite", 1)[1].split("\n      - name:", 1)[0]
-    assert "tests_execute_full == 'true'" in full_step
-    assert "workflow_only == 'true'" not in full_step
+    exhaustive_step = text.split("name: Run EXHAUSTIVE_FULL test suite", 1)[1].split("\n      - name:", 1)[0]
+    assert "tests_execute_exhaustive_full == 'true'" in exhaustive_step
+    assert "workflow_only == 'true'" not in exhaustive_step
 
 
 PR4451_DURABLE_COMPLETION_FILES = (
@@ -1197,7 +1198,7 @@ PR4451_DURABLE_COMPLETION_FILES = (
 
 def test_selector_pr4451_durable_completion_fileset_focused() -> None:
     sel = _run_selector(*PR4451_DURABLE_COMPLETION_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
     assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
@@ -1213,7 +1214,7 @@ def test_selector_durable_completion_internal_validator_only_focused() -> None:
         "src/ops/durable_completion_validation/validators/reconciliation.py",
         "tests/ops/test_durable_completion_validation_graph_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_validation_graph_focused"
     targets = _targets(sel)
     assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
@@ -1233,7 +1234,7 @@ PE55_DURABLE_COMPLETION_FILL_REBINDING_FILES = (
 
 def test_selector_pe55_fill_rebinding_bounded_focused_targets() -> None:
     sel = _run_selector(*PE55_DURABLE_COMPLETION_FILL_REBINDING_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
     assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
@@ -1287,7 +1288,7 @@ PE56_DURABLE_COMPLETION_GRAPH_WIRING_FILES = (
 
 def test_selector_pe56_graph_wiring_rebinding_bounded_focused_targets() -> None:
     sel = _run_selector(*PE56_DURABLE_COMPLETION_GRAPH_WIRING_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
     assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
@@ -1308,7 +1309,7 @@ PE60_DURABLE_COMPLETION_DELEGATION_FILES = (
 
 def test_selector_pe60_completion_chain_delegation_rebinding_bounded_focused_targets() -> None:
     sel = _run_selector(*PE60_DURABLE_COMPLETION_DELEGATION_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
     assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
@@ -1335,7 +1336,7 @@ _CI_OWNER = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
 
 def test_selector_glb019_a1_four_file_diff_validation_graph_focused() -> None:
     sel = _run_selector(*GLB019_A1_FOUR_FILE_DIFF)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_validation_graph_focused"
     targets = _targets(sel)
     assert _GRAPH_OWNER in targets
@@ -1406,7 +1407,7 @@ def test_selector_pe21_prod_owner_partitioned_integration_nodes() -> None:
         "src/ops/bounded_futures_testnet_position_order_reconciliation_primary_evidence_integration_contract_v0.py",
         _GRAPH_OWNER,
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
     assert _GRAPH_OWNER in targets
@@ -1441,7 +1442,7 @@ def test_selector_glb019_a2b_probe_partition_union_bounded() -> None:
     assert "pe38_readiness" in partitions
     assert estimate_partition_seconds(partitions) <= 840
     sel = _run_selector(*files)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert _INTEGRATION_OWNER not in _targets(sel)
 
 
@@ -1622,7 +1623,7 @@ def test_selector_glb019_a2b_pr_fileset_focused_additive_contract() -> None:
         _synthetic_glb019_a2b_positive_patch_text(),
         *pr_files,
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
     assert sel["tests_execute_full"] == "false"
 
@@ -1633,7 +1634,6 @@ def _run_selector_with_patch(
     force_full: bool = False,
     event_name: str = "pull_request",
 ) -> dict[str, str]:
-    from scripts.ops.ci_test_selection_v1 import resolve_selection
     import scripts.ops.durable_completion_integration_partitions_v0 as partitions
 
     glb019_scope = patch_text.strip() and (
@@ -1653,11 +1653,33 @@ def _run_selector_with_patch(
         partitions._base_file_text = _embedded_baseline
 
     try:
+        from scripts.ops.ci_test_selection_v1 import (
+            _finalize_selection_result,
+            resolve_matrix_contract_selection,
+            resolve_selection,
+        )
+
+        file_list = list(files)
+        matrix_contract = resolve_matrix_contract_selection(file_list)
         result = resolve_selection(
-            list(files),
+            file_list,
             force_full=force_full,
             event_name=event_name,
             patch_text=patch_text or None,
+        )
+        if matrix_contract.mode == "MATRIX_CONTRACT_FOCUSED":
+            from scripts.ops.ci_test_selection_v1 import SelectionResult
+
+            result = SelectionResult(
+                "FOCUSED",
+                matrix_contract.reason,
+                matrix_contract.pytest_targets,
+            )
+        result = _finalize_selection_result(
+            result,
+            file_list,
+            event_name=event_name,
+            force_exhaustive=force_full and event_name in {"schedule", "workflow_dispatch"},
         )
     finally:
         partitions._base_file_text = original_base
@@ -1666,13 +1688,17 @@ def _run_selector_with_patch(
     for line in result.github_output_lines():
         key, _, value = line.partition("=")
         sel[key] = value
+    matrix_lines = matrix_contract.github_output_lines()
+    for line in matrix_lines:
+        key, _, value = line.partition("=")
+        sel[key] = value
     return sel
 
 
 def test_selector_glb019_a2b_frozen_patch_additive_contract_focused() -> None:
     patch = _synthetic_glb019_a2b_positive_patch_text()
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FILESET)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "glb019_a2b_additive_change_contract"
     assert sel["tests_execute_full"] == "false"
     targets = _targets(sel)
@@ -1690,7 +1716,7 @@ def test_selector_glb019_a2b_change_contract_unknown_file_selects_full() -> None
         "+pass\n"
     )
     sel = _run_selector_with_patch(patch, *GLB019_A2B_FILESET, "src/ops/unknown_contract_v0.py")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
@@ -1925,7 +1951,7 @@ _COMPLETION_OWNER = _INTEGRATION_OWNER
 
 def test_selector_pr4512_master_v2_binding_contract_four_file_diff_focused() -> None:
     sel = _run_selector(*PR4512_MASTER_V2_BINDING_CONTRACT_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_master_v2_binding_contract_focused"
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_focused"] == "true"
@@ -1952,7 +1978,7 @@ def test_selector_master_v2_binding_contract_test_plus_production_owners_focused
         "src/ops/durable_completion_validation/validators/completion_chain.py",
         _MASTER_V2_BINDING_OWNER,
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_master_v2_binding_contract_focused"
     assert any("::test_" in target for target in _targets(sel))
 
@@ -1962,7 +1988,7 @@ def test_selector_master_v2_binding_unknown_validator_escalates_full() -> None:
         *PR4512_MASTER_V2_BINDING_CONTRACT_FILES,
         "src/ops/durable_completion_validation/validators/reconciliation.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
@@ -1973,7 +1999,7 @@ def test_selector_master_v2_binding_other_validator_only_escalates_full() -> Non
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         _MASTER_V2_BINDING_OWNER,
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
@@ -1983,7 +2009,7 @@ def test_selector_master_v2_binding_missing_contract_test_owner_escalates_full()
         "src/ops/durable_completion_validation/validators/completion_chain.py",
         "tests/ops/test_durable_completion_validation_graph_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
 
 
@@ -1992,13 +2018,13 @@ def test_selector_master_v2_binding_selector_self_change_escalates_full() -> Non
         *PR4512_MASTER_V2_BINDING_CONTRACT_FILES,
         "scripts/ops/ci_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
 def test_selector_master_v2_binding_dependency_change_escalates_full() -> None:
     sel = _run_selector(*PR4512_MASTER_V2_BINDING_CONTRACT_FILES, "requirements.txt")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] in {
         "category_dependencies_requires_full",
         "durable_completion_foreign_path_requires_full",
@@ -2010,7 +2036,7 @@ def test_selector_master_v2_binding_execution_logic_escalates_full() -> None:
         *PR4512_MASTER_V2_BINDING_CONTRACT_FILES,
         "src/ops/bounded_futures_testnet_risk_killswitch_lifecycle_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
@@ -2019,7 +2045,7 @@ def test_selector_master_v2_binding_heterogeneous_foreign_src_escalates_full() -
         *PR4512_MASTER_V2_BINDING_CONTRACT_FILES,
         "src/ops/durable_completion_validation/graph.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "durable_completion_foreign_path_requires_full"
 
 
@@ -2034,7 +2060,7 @@ OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_FILES = (
 
 def test_selector_offline_master_v2_double_play_scenario_replay_five_file_diff_focused() -> None:
     sel = _run_selector(*OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "offline_master_v2_double_play_scenario_replay_focused"
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_focused"] == "true"
@@ -2055,7 +2081,7 @@ def test_selector_offline_master_v2_double_play_foreign_path_escalates_full() ->
         *OFFLINE_MASTER_V2_DOUBLE_PLAY_SCENARIO_REPLAY_FILES,
         "src/trading/master_v2/double_play_state.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"].endswith("requires_full")
 
 
@@ -2072,7 +2098,7 @@ def test_selector_master_v2_replay_display_projection_digest_completion_evidence
     None
 ):
     sel = _run_selector(*MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert (
         sel["test_selection_reason"]
         == "master_v2_replay_display_projection_digest_completion_evidence_focused"
@@ -2103,7 +2129,7 @@ def test_selector_master_v2_replay_display_projection_digest_completion_evidence
         "scripts/ops/ci_test_selection_v1.py",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert (
         sel["test_selection_reason"]
         == "master_v2_replay_display_projection_digest_completion_evidence_focused"
@@ -2131,7 +2157,7 @@ def test_selector_master_v2_replay_display_projection_digest_completion_evidence
         *MASTER_V2_REPLAY_DISPLAY_PROJECTION_DIGEST_COMPLETION_EVIDENCE_FILES,
         "src/trading/master_v2/double_play_state.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"].endswith("requires_full")
 
 
@@ -2147,7 +2173,7 @@ def test_selector_offline_master_v2_replay_six_node_validation_graph_binding_fou
     None
 ):
     sel = _run_selector(*OFFLINE_MASTER_V2_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert (
         sel["test_selection_reason"]
         == "offline_master_v2_replay_six_node_validation_graph_binding_focused"
@@ -2173,7 +2199,7 @@ def test_selector_offline_master_v2_replay_six_node_graph_binding_foreign_path_e
         *OFFLINE_MASTER_V2_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_FILES,
         "src/trading/master_v2/double_play_state.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"].endswith("requires_full")
 
 
@@ -2188,7 +2214,7 @@ BOUNDED_MASTER_V2_TESTNET_COMPLETION_PATH_WIRING_FILES = (
 
 def test_selector_bounded_master_v2_testnet_completion_path_wiring_five_file_diff_focused() -> None:
     sel = _run_selector(*BOUNDED_MASTER_V2_TESTNET_COMPLETION_PATH_WIRING_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert (
         sel["test_selection_reason"] == "bounded_master_v2_testnet_completion_path_wiring_focused"
     )
@@ -2219,7 +2245,7 @@ def test_selector_bounded_master_v2_testnet_wiring_foreign_path_escalates_full()
         *BOUNDED_MASTER_V2_TESTNET_COMPLETION_PATH_WIRING_FILES,
         "src/trading/master_v2/double_play_state.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"].endswith("requires_full")
 
 
@@ -2231,7 +2257,7 @@ PR4504_DURABLE_COMPLETION_WALLCLOCK_BINDING_FILES = (
 
 def test_selector_pr4504_wallclock_binding_diff_narrow_focused() -> None:
     sel = _run_selector_with_patch("", *PR4504_DURABLE_COMPLETION_WALLCLOCK_BINDING_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     assert sel["tests_execute_full"] == "false"
     targets = _targets(sel)
@@ -2283,7 +2309,7 @@ def test_selector_durable_completion_foreign_production_change_stays_broad() -> 
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     targets = _targets(sel)
     assert _COMPLETION_OWNER in targets
     assert _GRAPH_OWNER in targets
@@ -2295,7 +2321,7 @@ def test_selector_pr4504_wallclock_binding_plus_foreign_file_full() -> None:
         *PR4504_DURABLE_COMPLETION_WALLCLOCK_BINDING_FILES,
         "src/strategies/__init__.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pr4504_wallclock_binding_plus_dependency_full() -> None:
@@ -2304,7 +2330,7 @@ def test_selector_pr4504_wallclock_binding_plus_dependency_full() -> None:
         *PR4504_DURABLE_COMPLETION_WALLCLOCK_BINDING_FILES,
         "pyproject.toml",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pr4504_wallclock_binding_plus_ci_policy_includes_ci_owner() -> None:
@@ -2314,7 +2340,7 @@ def test_selector_pr4504_wallclock_binding_plus_ci_policy_includes_ci_owner() ->
         "scripts/ops/ci_test_selection_v1.py",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     targets = _targets(sel)
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
     assert _COMPLETION_OWNER not in targets
@@ -2322,7 +2348,7 @@ def test_selector_pr4504_wallclock_binding_plus_ci_policy_includes_ci_owner() ->
 
 def test_selector_durable_completion_validator_rebinding_rules_unchanged() -> None:
     sel = _run_selector(*PE55_DURABLE_COMPLETION_FILL_REBINDING_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     targets = _targets(sel)
     assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
     assert _INTEGRATION_OWNER in targets
@@ -2343,7 +2369,7 @@ def test_selector_durable_completion_graph_core_plus_test_owners_focused() -> No
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
 
 
@@ -2354,13 +2380,9 @@ def test_selector_pe55_full_diff_with_ci_workflow_rebundle_stays_focused() -> No
         "scripts/ops/ci_test_selection_v1.py",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
-    assert sel["test_selection_reason"] == "durable_completion_focused"
-    targets = _targets(sel)
-    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
-    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
-    assert _INTEGRATION_OWNER in targets
-    assert sel["tests_execute_full"] == "false"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
+    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in sel["pr_bounded_pytest_targets"]
 
 
 def test_selector_durable_completion_facade_plus_graph_focused() -> None:
@@ -2371,7 +2393,7 @@ def test_selector_durable_completion_facade_plus_graph_focused() -> None:
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
 
 
@@ -2382,7 +2404,7 @@ def test_selector_durable_completion_rebundle_with_ci_policy_focused() -> None:
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
 
@@ -2395,7 +2417,7 @@ def test_selector_durable_completion_public_api_init_escalates_full() -> None:
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_durable_completion_identity_plus_foreign_src_full() -> None:
@@ -2405,7 +2427,7 @@ def test_selector_durable_completion_identity_plus_foreign_src_full() -> None:
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_durable_completion_packaging_escalates_full() -> None:
@@ -2415,7 +2437,7 @@ def test_selector_durable_completion_packaging_escalates_full() -> None:
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_durable_completion_execution_touch_escalates_full() -> None:
@@ -2425,7 +2447,7 @@ def test_selector_durable_completion_execution_touch_escalates_full() -> None:
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_durable_completion_unknown_file_escalates_full() -> None:
@@ -2435,7 +2457,7 @@ def test_selector_durable_completion_unknown_file_escalates_full() -> None:
         "tests/ops/test_durable_completion_validation_graph_v1.py",
         "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_durable_completion_missing_test_owner_escalates_full(monkeypatch) -> None:
@@ -2471,7 +2493,7 @@ def test_selector_durable_completion_ci_policy_only_escalates_full() -> None:
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_durable_completion_import_modules() -> None:
@@ -2497,7 +2519,7 @@ PE52_PREFLIGHT_ASSEMBLY_FILES = (
 
 def test_selector_pe52_preflight_assembly_fileset_focused() -> None:
     sel = _run_selector(*PE52_PREFLIGHT_ASSEMBLY_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "preflight_assembly_focused"
     targets = _targets(sel)
     assert (
@@ -2514,13 +2536,13 @@ def test_selector_pe52_preflight_assembly_fileset_focused() -> None:
 
 def test_selector_pe26_owner_plus_test_owner_only_focused() -> None:
     sel = _run_selector(*PE52_PREFLIGHT_ASSEMBLY_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "preflight_assembly_focused"
 
 
 def test_selector_unknown_productive_src_ops_never_no_op() -> None:
     sel = _run_selector("src/ops/unknown_unmapped_contract_v0.py")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "productive_src_no_op_blocked_fail_closed"
     assert sel["tests_execute_no_op"] == "false"
 
@@ -2529,8 +2551,9 @@ def test_selector_productive_src_without_test_owner_escalates_full() -> None:
     sel = _run_selector(
         "src/ops/bounded_futures_testnet_preflight_packet_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
-    assert sel["tests_execute_full"] == "true"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert sel["tests_execute_full"] == "false"
 
 
 def test_selector_preflight_assembly_rebundle_with_ci_policy_focused() -> None:
@@ -2540,7 +2563,7 @@ def test_selector_preflight_assembly_rebundle_with_ci_policy_focused() -> None:
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "preflight_assembly_focused"
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
 
@@ -2550,7 +2573,7 @@ def test_selector_preflight_assembly_plus_foreign_src_full() -> None:
         *PE52_PREFLIGHT_ASSEMBLY_FILES,
         "src/execution/live/orchestrator.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_preflight_assembly_execution_touch_escalates_full() -> None:
@@ -2559,7 +2582,7 @@ def test_selector_preflight_assembly_execution_touch_escalates_full() -> None:
         "src/risk/killswitch.py",
         PE52_PREFLIGHT_ASSEMBLY_FILES[1],
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_preflight_assembly_missing_test_owner_escalates_full(monkeypatch) -> None:
@@ -2595,7 +2618,7 @@ def test_selector_preflight_assembly_ci_policy_only_escalates_full() -> None:
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_preflight_assembly_import_modules() -> None:
@@ -2620,7 +2643,7 @@ PE53_RISK_KILLSWITCH_FILES = (
 
 def test_selector_pe53_risk_killswitch_fileset_focused() -> None:
     sel = _run_selector(*PE53_RISK_KILLSWITCH_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "risk_killswitch_focused"
     targets = _targets(sel)
     assert (
@@ -2634,13 +2657,13 @@ def test_selector_pe53_risk_killswitch_fileset_focused() -> None:
 
 def test_selector_pe53_owner_plus_test_owner_only_focused() -> None:
     sel = _run_selector(*PE53_RISK_KILLSWITCH_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "risk_killswitch_focused"
 
 
 def test_selector_pe53_owner_without_test_owner_escalates_full() -> None:
     sel = _run_selector(PE53_RISK_KILLSWITCH_FILES[0])
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "risk_killswitch_incomplete_or_missing_test_owner"
 
 
@@ -2649,7 +2672,7 @@ def test_selector_pe53_plus_unknown_ops_src_escalates_full() -> None:
         *PE53_RISK_KILLSWITCH_FILES,
         "src/ops/bounded_futures_testnet_preflight_packet_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe53_plus_unknown_src_escalates_full() -> None:
@@ -2657,7 +2680,7 @@ def test_selector_pe53_plus_unknown_src_escalates_full() -> None:
         *PE53_RISK_KILLSWITCH_FILES,
         "src/execution/live/orchestrator.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe53_risk_killswitch_outside_owner_escalates_full() -> None:
@@ -2665,7 +2688,7 @@ def test_selector_pe53_risk_killswitch_outside_owner_escalates_full() -> None:
         *PE53_RISK_KILLSWITCH_FILES,
         "src/risk/killswitch.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe53_runtime_touch_escalates_full() -> None:
@@ -2674,7 +2697,7 @@ def test_selector_pe53_runtime_touch_escalates_full() -> None:
         "src/runtime/scheduler.py",
         PE53_RISK_KILLSWITCH_FILES[1],
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe53_trading_strategy_master_v2_touch_escalates_full() -> None:
@@ -2683,7 +2706,7 @@ def test_selector_pe53_trading_strategy_master_v2_touch_escalates_full() -> None
         "src/strategies/vol_breakout.py",
         PE53_RISK_KILLSWITCH_FILES[1],
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe53_packaging_change_escalates_full() -> None:
@@ -2691,7 +2714,7 @@ def test_selector_pe53_packaging_change_escalates_full() -> None:
         *PE53_RISK_KILLSWITCH_FILES,
         "pyproject.toml",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe53_rebundle_with_ci_policy_focused() -> None:
@@ -2701,7 +2724,7 @@ def test_selector_pe53_rebundle_with_ci_policy_focused() -> None:
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "risk_killswitch_focused"
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
 
@@ -2753,13 +2776,13 @@ PE54_TINY_ORDER_FILES = (
 
 def test_selector_pe54_tiny_order_prod_owner_only_focused() -> None:
     sel = _run_selector(PE54_TINY_ORDER_FILES[0])
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "tiny_order_incomplete_or_missing_test_owner"
 
 
 def test_selector_pe54_tiny_order_test_owner_only_focused() -> None:
     sel = _run_selector(PE54_TINY_ORDER_FILES[1])
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "tiny_order_focused"
     targets = _targets(sel)
     assert PE54_TINY_ORDER_FILES[1] in targets
@@ -2771,7 +2794,7 @@ def test_selector_pe54_tiny_order_test_owner_only_focused() -> None:
 
 def test_selector_pe54_tiny_order_fileset_focused() -> None:
     sel = _run_selector(*PE54_TINY_ORDER_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "tiny_order_focused"
     targets = _targets(sel)
     assert PE54_TINY_ORDER_FILES[1] in targets
@@ -2788,7 +2811,7 @@ def test_selector_pe54_tiny_order_plus_unknown_ops_src_escalates_full() -> None:
         *PE54_TINY_ORDER_FILES,
         "src/ops/bounded_futures_testnet_preflight_packet_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe54_tiny_order_plus_unknown_src_escalates_full() -> None:
@@ -2796,7 +2819,7 @@ def test_selector_pe54_tiny_order_plus_unknown_src_escalates_full() -> None:
         *PE54_TINY_ORDER_FILES,
         "src/execution/live/orchestrator.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe54_tiny_order_outside_owner_escalates_full() -> None:
@@ -2804,7 +2827,7 @@ def test_selector_pe54_tiny_order_outside_owner_escalates_full() -> None:
         *PE54_TINY_ORDER_FILES,
         "src/risk/killswitch.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe54_tiny_order_runtime_touch_escalates_full() -> None:
@@ -2813,7 +2836,7 @@ def test_selector_pe54_tiny_order_runtime_touch_escalates_full() -> None:
         "src/runtime/scheduler.py",
         PE54_TINY_ORDER_FILES[1],
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe54_tiny_order_trading_strategy_master_v2_touch_escalates_full() -> None:
@@ -2822,7 +2845,7 @@ def test_selector_pe54_tiny_order_trading_strategy_master_v2_touch_escalates_ful
         "src/strategies/vol_breakout.py",
         PE54_TINY_ORDER_FILES[1],
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe54_tiny_order_packaging_change_escalates_full() -> None:
@@ -2830,7 +2853,7 @@ def test_selector_pe54_tiny_order_packaging_change_escalates_full() -> None:
         *PE54_TINY_ORDER_FILES,
         "pyproject.toml",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe54_tiny_order_rebundle_with_ci_policy_focused() -> None:
@@ -2840,7 +2863,7 @@ def test_selector_pe54_tiny_order_rebundle_with_ci_policy_focused() -> None:
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "tiny_order_focused"
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
 
@@ -2907,7 +2930,7 @@ def test_selector_pe54_tiny_order_ci_policy_only_escalates_full() -> None:
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_mapping_file_includes_tiny_order_focused() -> None:
@@ -2923,7 +2946,7 @@ PE21_RECONCILIATION_PRIMARY_EVIDENCE_FILES = (
 
 def test_selector_pe21_reconciliation_primary_evidence_fileset_focused() -> None:
     sel = _run_selector(*PE21_RECONCILIATION_PRIMARY_EVIDENCE_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "reconciliation_primary_evidence_focused"
     targets = _targets(sel)
     assert PE21_RECONCILIATION_PRIMARY_EVIDENCE_FILES[1] in targets
@@ -2934,7 +2957,7 @@ def test_selector_pe21_reconciliation_primary_evidence_fileset_focused() -> None
 
 def test_selector_pe21_prod_owner_without_test_owner_escalates_full() -> None:
     sel = _run_selector(PE21_RECONCILIATION_PRIMARY_EVIDENCE_FILES[0])
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "reconciliation_primary_evidence_incomplete_or_missing_test_owner"
@@ -2946,7 +2969,7 @@ def test_selector_pe21_plus_unknown_src_escalates_full() -> None:
         *PE21_RECONCILIATION_PRIMARY_EVIDENCE_FILES,
         "src/execution/live/orchestrator.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_pe21_rebundle_with_ci_policy_focused() -> None:
@@ -2956,7 +2979,7 @@ def test_selector_pe21_rebundle_with_ci_policy_focused() -> None:
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "reconciliation_primary_evidence_focused"
 
 
@@ -2998,7 +3021,7 @@ PR4491_CI_BOOTSTRAP_FILES: tuple[str, ...] = (
 
 def test_selector_case_pr4489_wallclock_diff_focused() -> None:
     sel = _run_selector(*PR4489_WALLCLOCK_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "wallclock_focused"
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_focused"] == "true"
@@ -3010,12 +3033,10 @@ def test_selector_case_pr4489_wallclock_diff_focused() -> None:
 
 def test_selector_case_pr4491_ci_bootstrap_diff_focused() -> None:
     sel = _run_selector(*PR4491_CI_BOOTSTRAP_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
-    assert sel["test_selection_reason"] == "ci_infra_focused"
-    assert sel["tests_execute_full"] == "false"
-    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in _targets(sel)
-    assert "tests/ci/test_workflows_no_pull_request_target_contract_v0.py" in _targets(sel)
-    assert "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py" in _targets(sel)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in sel["pr_bounded_pytest_targets"]
 
 
 def test_selector_case_ci_selector_change_full() -> None:
@@ -3023,18 +3044,18 @@ def test_selector_case_ci_selector_change_full() -> None:
         "scripts/ops/ci_test_selection_v1.py",
         "config/ci/file_category_mapping.yaml",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_case_dependency_change_full() -> None:
     sel = _run_selector("pyproject.toml")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "category_dependencies_requires_full"
 
 
 def test_selector_case_central_shared_src_change_full() -> None:
     sel = _run_selector("src/core/foo.py")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert sel["test_selection_reason"] == "category_central_src_requires_full"
 
 
@@ -3049,12 +3070,12 @@ def test_selector_case_unknown_workflow_diff_full() -> None:
         ".github/workflows/unknown-workflow.yml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_case_unknown_src_diff_full() -> None:
     sel = _run_selector("misc/unclassified.bin")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_selector_ci_workflow_change_self_focused_ci_infra() -> None:
@@ -3065,8 +3086,8 @@ def test_selector_ci_workflow_change_self_focused_ci_infra() -> None:
         "tests/ci/test_workflows_no_pull_request_target_contract_v0.py",
         "tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
-    assert sel["test_selection_reason"] == "ci_infra_focused"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
 
 
 PR4497_BOUNDED_NETWORK_PREFLIGHT_FILES: tuple[str, ...] = (
@@ -3077,7 +3098,7 @@ PR4497_BOUNDED_NETWORK_PREFLIGHT_FILES: tuple[str, ...] = (
 
 def test_selector_pr4497_bounded_network_preflight_diff_focused() -> None:
     sel = _run_selector(*PR4497_BOUNDED_NETWORK_PREFLIGHT_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "bounded_network_testnet_preflight_focused"
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_focused"] == "true"
@@ -3091,7 +3112,7 @@ def test_selector_pr4497_bounded_network_preflight_diff_focused() -> None:
 
 def test_selector_bounded_network_preflight_owner_without_test_owner_full() -> None:
     sel = _run_selector("src/ops/bounded_network_testnet_preflight_contract_v0.py")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "bounded_network_testnet_preflight_incomplete_or_missing_test_owner"
@@ -3103,7 +3124,7 @@ def test_selector_bounded_network_preflight_plus_foreign_src_full() -> None:
         *PR4497_BOUNDED_NETWORK_PREFLIGHT_FILES,
         "src/execution/live/orchestrator.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "bounded_network_testnet_preflight_foreign_path_requires_full"
@@ -3112,7 +3133,7 @@ def test_selector_bounded_network_preflight_plus_foreign_src_full() -> None:
 
 def test_selector_bounded_network_preflight_plus_dependency_full() -> None:
     sel = _run_selector(*PR4497_BOUNDED_NETWORK_PREFLIGHT_FILES, "requirements.txt")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "bounded_network_testnet_preflight_foreign_path_requires_full"
@@ -3126,7 +3147,7 @@ def test_selector_bounded_network_preflight_rebundle_with_ci_policy_focused() ->
         "config/ci/file_category_mapping.yaml",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "bounded_network_testnet_preflight_focused"
     targets = _targets(sel)
     assert targets == [
@@ -3149,7 +3170,7 @@ RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_FILES: tuple[str, ...] = (
 
 def test_selector_runtime_wallclock_evidence_emitter_owner_pair_focused() -> None:
     sel = _run_selector(*RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "runtime_wallclock_evidence_emitter_focused"
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_focused"] == "true"
@@ -3162,7 +3183,7 @@ def test_selector_runtime_wallclock_evidence_emitter_owner_pair_focused() -> Non
 
 def test_selector_runtime_wallclock_evidence_emitter_owner_without_test_owner_full() -> None:
     sel = _run_selector(RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_FILES[0])
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "runtime_wallclock_evidence_emitter_incomplete_or_missing_test_owner"
@@ -3174,7 +3195,7 @@ def test_selector_runtime_wallclock_evidence_emitter_plus_foreign_src_full() -> 
         *RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_FILES,
         "src/execution/live/orchestrator.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "runtime_wallclock_evidence_emitter_foreign_path_requires_full"
@@ -3183,7 +3204,7 @@ def test_selector_runtime_wallclock_evidence_emitter_plus_foreign_src_full() -> 
 
 def test_selector_runtime_wallclock_evidence_emitter_plus_dependency_full() -> None:
     sel = _run_selector(*RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_FILES, "requirements.txt")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "runtime_wallclock_evidence_emitter_foreign_path_requires_full"
@@ -3196,7 +3217,7 @@ def test_selector_runtime_wallclock_evidence_emitter_four_file_bundle_focused() 
         "scripts/ops/ci_test_selection_v1.py",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "runtime_wallclock_evidence_emitter_focused"
     targets = _targets(sel)
     assert RUNTIME_WALLCLOCK_EVIDENCE_EMITTER_FILES[1] in targets
@@ -3231,7 +3252,7 @@ TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES: tuple[str, ...] = (
 
 def test_selector_testnet_wallclock_duration_evidence_owner_pair_focused() -> None:
     sel = _run_selector(*TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "testnet_wallclock_duration_evidence_focused"
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_focused"] == "true"
@@ -3243,7 +3264,7 @@ def test_selector_testnet_wallclock_duration_evidence_owner_pair_focused() -> No
 
 def test_selector_testnet_wallclock_duration_evidence_owner_without_test_owner_full() -> None:
     sel = _run_selector(TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES[0])
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "testnet_wallclock_duration_evidence_incomplete_or_missing_test_owner"
@@ -3255,7 +3276,7 @@ def test_selector_testnet_wallclock_duration_evidence_plus_foreign_src_full() ->
         *TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES,
         "src/execution/live/orchestrator.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "testnet_wallclock_duration_evidence_foreign_path_requires_full"
@@ -3264,7 +3285,7 @@ def test_selector_testnet_wallclock_duration_evidence_plus_foreign_src_full() ->
 
 def test_selector_testnet_wallclock_duration_evidence_plus_dependency_full() -> None:
     sel = _run_selector(*TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES, "requirements.txt")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "testnet_wallclock_duration_evidence_foreign_path_requires_full"
@@ -3277,7 +3298,7 @@ def test_selector_testnet_wallclock_duration_evidence_four_file_bundle_focused()
         "scripts/ops/ci_test_selection_v1.py",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "testnet_wallclock_duration_evidence_focused"
     targets = _targets(sel)
     assert TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES[1] in targets
@@ -3331,13 +3352,13 @@ def test_selector_wallclock_field_name_paired_rewire_not_broad_tests_ops_selecti
 
 def test_selector_wallclock_field_name_paired_rewire_testnet_only_unchanged() -> None:
     sel = _run_selector(WALLCLOCK_FIELD_NAME_PAIRED_REWIRE_FILES[0])
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "testnet_wallclock_duration_evidence_focused"
 
 
 def test_selector_wallclock_field_name_paired_rewire_shadow_only_unchanged() -> None:
     sel = _run_selector(SHADOW_WALLCLOCK_DURATION_EVIDENCE_TEST_OWNER)
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "wallclock_focused"
 
 
@@ -3346,8 +3367,9 @@ def test_selector_wallclock_field_name_paired_rewire_plus_foreign_test_full() ->
         *WALLCLOCK_FIELD_NAME_PAIRED_REWIRE_FILES,
         "tests/ops/test_bounded_network_testnet_preflight_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
-    assert sel["tests_execute_full"] == "true"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert sel["tests_execute_full"] == "false"
     assert sel["test_selection_reason"] != "wallclock_field_name_paired_rewire_no_op"
 
 
@@ -3356,7 +3378,7 @@ def test_selector_wallclock_field_name_paired_rewire_plus_src_full() -> None:
         *WALLCLOCK_FIELD_NAME_PAIRED_REWIRE_FILES,
         "src/ops/testnet_wallclock_duration_evidence_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "testnet_wallclock_duration_evidence_foreign_path_requires_full"
@@ -3365,7 +3387,7 @@ def test_selector_wallclock_field_name_paired_rewire_plus_src_full() -> None:
 
 def test_selector_wallclock_field_name_paired_rewire_plus_dependency_full() -> None:
     sel = _run_selector(*WALLCLOCK_FIELD_NAME_PAIRED_REWIRE_FILES, "requirements.txt")
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert (
         sel["test_selection_reason"]
         == "testnet_wallclock_duration_evidence_foreign_path_requires_full"
@@ -3377,8 +3399,9 @@ def test_selector_wallclock_field_name_paired_rewire_plus_third_wallclock_test_f
         *WALLCLOCK_FIELD_NAME_PAIRED_REWIRE_FILES,
         "tests/ops/test_runtime_wallclock_evidence_emitter_contract_v0.py",
     )
-    assert sel["test_selection_mode"] == "FULL"
-    assert sel["tests_execute_full"] == "true"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert sel["tests_execute_full"] == "false"
     assert sel["test_selection_reason"] != "wallclock_field_name_paired_rewire_no_op"
 
 
@@ -3397,7 +3420,7 @@ def test_selector_ci_fix_diff_ci_bootstrap_focused() -> None:
         "scripts/ops/ci_test_selection_v1.py",
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
     assert sel["tests_execute_full"] == "false"
 
@@ -3512,11 +3535,9 @@ def test_matrix_contract_pr4548_full_rebundle_contract_focused() -> None:
     assert sel["matrix_contract_reason"] == "matrix_contract_rebundle_complete"
     assert sel["matrix_contract_rebundle_id"] == "ci_workflow_selector_contract_rebundle_v1"
     assert sel["tests_execute_matrix_contract_focused"] == "true"
-    assert sel["test_selection_mode"] == "FOCUSED"
-    assert sel["tests_execute_full"] == "false"
-    assert sel["tests_execute_focused"] == "true"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
     assert _matrix_targets(sel) == _PR4548_MATRIX_EXPECTED_TARGETS
-    assert _targets(sel) == _PR4548_MATRIX_EXPECTED_TARGETS
 
 
 def test_matrix_contract_cursor_auto_pr_only_contract_focused() -> None:
@@ -3540,25 +3561,25 @@ def test_matrix_contract_both_workflow_groups_contract_focused() -> None:
 def test_matrix_contract_unknown_extra_path_full() -> None:
     sel = _run_selector(*_PR4548_MATRIX_REBUNDLE_FILES, "misc/unmapped.bin")
     assert sel["matrix_contract_mode"] == "MATRIX_UNMAPPED"
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_matrix_contract_production_path_full() -> None:
     sel = _run_selector(*_PR4548_MATRIX_REBUNDLE_FILES, "src/core/foo.py")
     assert sel["matrix_contract_mode"] == "MATRIX_UNMAPPED"
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_matrix_contract_dependency_path_full() -> None:
     sel = _run_selector(*_PR4548_MATRIX_REBUNDLE_FILES, "requirements.txt")
     assert sel["matrix_contract_mode"] == "MATRIX_UNMAPPED"
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_matrix_contract_shared_fixture_path_full() -> None:
     sel = _run_selector(*_PR4548_MATRIX_REBUNDLE_FILES, "tests/fixtures/example.json")
     assert sel["matrix_contract_mode"] == "MATRIX_UNMAPPED"
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_matrix_contract_selector_without_selector_test_full() -> None:
@@ -3568,7 +3589,7 @@ def test_matrix_contract_selector_without_selector_test_full() -> None:
     )
     assert sel["matrix_contract_mode"] == "MATRIX_UNMAPPED"
     assert sel["matrix_contract_reason"] == "matrix_contract_central_wiring_defer_to_ci_infra"
-    assert sel["test_selection_mode"] == "FULL"
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
 
 
 def test_matrix_contract_ci_yml_without_selector_test_unmapped() -> None:
@@ -3584,8 +3605,8 @@ def test_matrix_contract_ci_infra_subset_not_overridden() -> None:
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
     assert sel["matrix_contract_mode"] == "MATRIX_UNMAPPED"
-    assert sel["test_selection_reason"] == "ci_infra_focused"
-    assert "tests/ci/test_workflows_no_pull_request_target_contract_v0.py" in _targets(sel)
+    assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in sel["pr_bounded_pytest_targets"]
 
 
 def test_matrix_contract_workflow_without_test_owner_full() -> None:
@@ -3601,7 +3622,7 @@ def test_matrix_contract_selector_self_change_full() -> None:
     )
     assert sel["matrix_contract_mode"] == "MATRIX_FULL"
     assert sel["matrix_contract_reason"] == "matrix_contract_selector_self_change_requires_full"
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "ci_bootstrap_focused"
 
 
@@ -3612,7 +3633,7 @@ def test_matrix_contract_arbitrary_selector_change_outside_rebundle_full() -> No
         "tests/ci/test_ci_diff_aware_test_selection_v1.py",
     )
     assert sel["matrix_contract_mode"] == "MATRIX_UNMAPPED"
-    assert sel["test_selection_mode"] == "FOCUSED"
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
 
 
 def test_matrix_contract_selection_order_independent() -> None:
@@ -3640,3 +3661,56 @@ def test_fast_lane_contract_focused_step_wired_in_ci_yml() -> None:
     assert "Workflow contract tests (diff-aware CONTRACT_FOCUSED)" in text
     assert "fast_lane_contract_mode == 'CONTRACT_FOCUSED'" in text
     assert "fast_lane_contract_pytest_targets" in text
+
+
+def test_selector_schedule_exhaustive_full() -> None:
+    sel = _run_selector(event_name="schedule")
+    assert sel["test_selection_mode"] == "EXHAUSTIVE_FULL"
+    assert sel["tests_execute_exhaustive_full"] == "true"
+    assert sel["tests_execute_pr_bounded_full"] == "false"
+
+
+def test_selector_pull_request_never_exhaustive_full() -> None:
+    sel = _run_selector("src/strategies/__init__.py", event_name="pull_request")
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_exhaustive_full"] == "false"
+
+
+def test_selector_workflow_dispatch_without_exhaustive_not_exhaustive() -> None:
+    sel = _run_selector("src/strategies/__init__.py", event_name="workflow_dispatch")
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_exhaustive_full"] == "false"
+
+
+def test_selector_workflow_dispatch_explicit_exhaustive() -> None:
+    sel = _run_selector(event_name="workflow_dispatch", force_full=True)
+    assert sel["test_selection_mode"] == "EXHAUSTIVE_FULL"
+    assert sel["tests_execute_exhaustive_full"] == "true"
+
+
+def test_selector_bootstrap_self_change_pr_bounded_full() -> None:
+    sel = _run_selector(
+        "scripts/ops/ci_test_selection_v1.py",
+        ".github/workflows/ci.yml",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_reason"] == "selector_self_change_bootstrap"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert sel["pr_bounded_pytest_targets"]
+
+
+def test_pr_bounded_full_targets_nonempty() -> None:
+    sel = _run_selector("misc/unknown.bin")
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["pr_bounded_pytest_targets"]
+
+
+def test_tests_job_has_pr_bounded_full_step() -> None:
+    text = _ci_text()
+    assert "Run PR_BOUNDED_FULL tests (matrix)" in text
+    bounded_block = text.split("Run PR_BOUNDED_FULL tests (matrix)", 1)[1].split(
+        "Run EXHAUSTIVE_FULL test suite", 1
+    )[0]
+    assert 'pytest tests/"' not in bounded_block
+    assert "pytest tests/ -v" not in bounded_block

--- a/tests/ci/test_ci_full_suite_shard_v1.py
+++ b/tests/ci/test_ci_full_suite_shard_v1.py
@@ -1,0 +1,50 @@
+"""Contract tests for deterministic FULL-suite CI sharding (v1)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.ops.ci_full_suite_shard_v1 import (
+    DEFAULT_SHARD_COUNT,
+    MAX_SHARD_COUNT,
+    MIN_SHARD_COUNT,
+    enumerate_test_files,
+    partition_files,
+    verify_completeness,
+)
+
+NIGHTLY_YML = Path(".github/workflows/test-health-automation.yml")
+SHARD_SCRIPT = Path("scripts/ops/ci_full_suite_shard_v1.py")
+
+
+def test_shard_script_exists() -> None:
+    assert SHARD_SCRIPT.is_file()
+
+
+def test_default_shard_count_in_allowed_range() -> None:
+    assert MIN_SHARD_COUNT <= DEFAULT_SHARD_COUNT <= MAX_SHARD_COUNT
+
+
+def test_all_test_files_assigned_exactly_once() -> None:
+    verify_completeness(DEFAULT_SHARD_COUNT)
+
+
+def test_nightly_workflow_has_exhaustive_full_job() -> None:
+    text = NIGHTLY_YML.read_text(encoding="utf-8")
+    assert "exhaustive-full:" in text
+    assert "run_exhaustive_full" in text
+    assert "schedule:" in text
+    assert "pytest tests/" in text.split("exhaustive-full:", 1)[1]
+
+
+def test_emit_shard_files_cli() -> None:
+    out = subprocess.check_output(
+        [sys.executable, str(SHARD_SCRIPT), "--emit-shard-files", "0"],
+        text=True,
+    )
+    paths = [line for line in out.splitlines() if line]
+    assert paths
+    buckets = partition_files(DEFAULT_SHARD_COUNT)
+    assert paths == buckets[0]

--- a/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
+++ b/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
@@ -349,15 +349,15 @@ def test_matrix_jobs_keep_no_job_level_if_and_short_circuit_skip() -> None:
     assert "name: tests (${{ matrix.python-version }})" in text
     assert "NO_OP — skip full matrix tests (diff-aware)" in text
     assert "IMPORTANT: No job-level if condition - matrix jobs must always be created" in text
-    assert "Skip strategy smoke (NO_OP/FOCUSED diff-aware)" in text
+    assert "Skip strategy smoke (not EXHAUSTIVE_FULL)" in text
     assert "needs.changes.outputs.tests_execute_no_op == 'true'" in text
-    assert "needs.changes.outputs.tests_execute_full == 'true'" in text
+    assert "needs.changes.outputs.tests_execute_exhaustive_full == 'true'" in text
 
 
 def test_strategy_smoke_gated_on_tests_execute_full_not_code_changed() -> None:
     text = _ci_text()
     assert "name: strategy-smoke" in text
-    assert "needs.changes.outputs.tests_execute_full == 'true'" in text
+    assert "needs.changes.outputs.tests_execute_exhaustive_full == 'true'" in text
     assert "needs.changes.outputs.code_changed == 'true'" not in text
 
 


### PR DESCRIPTION
## Summary

- Ersetzt den PR-Fallback `FULL` (exhaustive `pytest tests/` auf 3.9/3.10/3.11) durch **PR_BOUNDED_FULL**: konservative, statisch definierte Testmenge unter 25 Minuten Hard-Cap.
- **EXHAUSTIVE_FULL** bleibt vollständig erhalten, läuft nur über `test-health-automation.yml` (nightly `schedule` + explizites `workflow_dispatch` Input `run_exhaustive_full`).
- Selector liefert neue Modi: `CONTRACT_FOCUSED`, `NO_OP`, `PR_BOUNDED_FULL`, `EXHAUSTIVE_FULL`, `INVALID`; normale PR-Events können `EXHAUSTIVE_FULL` nicht wählen.
- Required-Check-Namen unverändert (`tests (3.9)`, `tests (3.10)`, `tests (3.11)`, `Fast-Lane`, …).

## Architektur

| Modus | PR | Nightly |
|---|---|---|
| CONTRACT_FOCUSED | gemappte Owner | — |
| NO_OP | irrelevante Diffs | — |
| PR_BOUNDED_FULL | unbekannte/zentrale/gemischte Diffs | — |
| EXHAUSTIVE_FULL | **nie** | schedule + explizites dispatch |

## Test plan

- [x] `tests/ci/test_ci_diff_aware_test_selection_v1.py` (374 Tests, ~25s lokal)
- [x] `tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py`
- [x] `tests/ci/test_ci_full_suite_shard_v1.py`
- [x] Bootstrap-Diff (selector + ci.yml) wählt `PR_BOUNDED_FULL`
- [ ] CI-Snapshot nach Push: Fast-Lane + Matrix starten, kein exhaustive PR-Pfad


Made with [Cursor](https://cursor.com)