### PR TITLE
feat(ops): bind cross-slice coherence into durable completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,8 +315,18 @@ jobs:
         run: |
           pytest tests/test_stability_smoke.py tests/test_data_contracts.py tests/test_error_taxonomy.py tests/test_resilience.py -m smoke -v --tb=short
 
+      - name: Durable completion bounded Fast-Lane (diff-aware CONTRACT_FOCUSED)
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.fast_lane_contract_mode == 'DURABLE_COMPLETION_BOUNDED' }}
+        run: |
+          set -euo pipefail
+          PYTEST_ARGS=(-q --tb=short -m "not network and not external_tools")
+          TARGETS="${{ needs.changes.outputs.fast_lane_contract_pytest_targets }}"
+          mapfile -t VALIDATED_TARGETS < <(python3 scripts/ops/ci_test_selection_v1.py --emit-validated-pytest-targets "$TARGETS")
+          (( ${#VALIDATED_TARGETS[@]} )) || { echo "DURABLE_COMPLETION_BOUNDED targets empty — fail closed"; exit 1; }
+          pytest "${VALIDATED_TARGETS[@]}" "${PYTEST_ARGS[@]}"
+
       - name: Focused Fast-Lane contract check (diff-aware FOCUSED PRs)
-        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' && needs.changes.outputs.static_contract_changed == 'true' && needs.changes.outputs.workflow_only != 'true' }}
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.tests_execute_focused == 'true' && needs.changes.outputs.static_contract_changed == 'true' && needs.changes.outputs.workflow_only != 'true' && needs.changes.outputs.fast_lane_contract_mode != 'DURABLE_COMPLETION_BOUNDED' }}
         run: |
           set -euo pipefail
           PYTEST_ARGS=(-q --tb=short -m "not network and not external_tools")

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -96,7 +96,10 @@ if str(_REPO_ROOT) not in sys.path:
 
 from scripts.ops.durable_completion_integration_partitions_v0 import (  # noqa: E402
     CI_GLB019_SYNTHETIC_PATCH_BUILDER,
+    CORE_ALWAYS_PARTITIONS,
     GLB019_A2B_ALLOWED_FILES,
+    PE33_EXHAUSTIVE_OWNER,
+    PE33_PR_SMOKE_NODE_IDS,
     INTEGRATION_TEST_OWNER,
     Glb019A2bChangeContractOutcome,
     Glb019A2bChangeContractResult,
@@ -104,6 +107,7 @@ from scripts.ops.durable_completion_integration_partitions_v0 import (  # noqa: 
     collect_glb019_a2b_patch_text,
     evaluate_glb019_a2b_change_contract,
     expand_partitions_to_pytest_targets,
+    expand_pe33_pr_smoke_pytest_targets,
     integration_owner_node_count,
     integration_partition_inventory,
     is_glb019_a2b_structural_contract_candidate,
@@ -193,6 +197,7 @@ DURABLE_COMPLETION_INTEGRATION_PE_PROD_PATHS = frozenset(
         "src/ops/bounded_futures_testnet_operator_review_admission_presentation_lifecycle_integration_contract_v0.py",
         "src/ops/bounded_futures_testnet_operator_review_chain_durable_evidence_traceability_boundary_contract_v0.py",
         "src/ops/bounded_futures_testnet_preflight_execution_readiness_review_lifecycle_integration_contract_v0.py",
+        "src/ops/bounded_futures_testnet_cross_slice_proof_coherence_integration_contract_v0.py",
         "src/ops/testnet_wallclock_duration_evidence_contract_v0.py",
         "src/ops/wallclock_session_evidence_v0.py",
     }
@@ -1170,12 +1175,89 @@ def _fast_lane_requires_full_static(path: str) -> bool:
     return False
 
 
+DURABLE_COMPLETION_FAST_LANE_GRAPH_STRUCTURE_NODE_IDS: tuple[str, ...] = (
+    f"{DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER}::test_graph_is_cycle_free",
+    f"{DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER}::test_graph_explicit_order_matches_dependencies",
+    f"{DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER}::test_graph_aggregates_fail_reasons_from_executed_validators",
+)
+
+DURABLE_COMPLETION_FAST_LANE_SELECTOR_ANCHOR_NODE_IDS: tuple[str, ...] = (
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_integration_partition_inventory_covers_all_nodes",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_pr4550_cross_slice_coherence_bounded_node_ids",
+)
+
+
+def _durable_completion_pe33_pr_smoke_pytest_targets() -> tuple[str, ...]:
+    try:
+        return expand_pe33_pr_smoke_pytest_targets()
+    except (KeyError, RuntimeError, OSError, ValueError):
+        return ()
+
+
+def _durable_completion_normal_pr_graph_structure_targets() -> tuple[str, ...]:
+    return DURABLE_COMPLETION_FAST_LANE_GRAPH_STRUCTURE_NODE_IDS
+
+
+def _durable_completion_normal_pr_selector_anchor_targets() -> tuple[str, ...]:
+    return DURABLE_COMPLETION_FAST_LANE_SELECTOR_ANCHOR_NODE_IDS
+
+
+def _partition_selection_uses_pe33_pr_smoke(partition_selection: frozenset[str]) -> bool:
+    return "pe33_pr_smoke" in partition_selection
+
+
+def _durable_completion_fast_lane_bounded_targets(files: list[str]) -> tuple[str, ...]:
+    """Fast-Lane: PE-33 PR smoke nodes + 3 graph structure tests + selector anchors only."""
+    graph_owner = DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER
+    selector_owner = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
+    if not _repo_path_exists(graph_owner) or not _repo_path_exists(selector_owner):
+        return ()
+    for target in (
+        *_durable_completion_normal_pr_graph_structure_targets(),
+        *_durable_completion_normal_pr_selector_anchor_targets(),
+    ):
+        if not _repo_pytest_target_exists(target):
+            return ()
+    targets: set[str] = set(_durable_completion_normal_pr_graph_structure_targets())
+    targets.update(_durable_completion_normal_pr_selector_anchor_targets())
+    partition_selection = partitions_for_changed_files(files)
+    if partition_selection is None:
+        return ()
+    if _partition_selection_uses_pe33_pr_smoke(partition_selection):
+        smoke_targets = _durable_completion_pe33_pr_smoke_pytest_targets()
+        if not smoke_targets:
+            return ()
+        targets.update(smoke_targets)
+        return tuple(sorted(targets))
+    if not partition_selection:
+        return tuple(sorted(targets))
+    try:
+        if partition_union_node_count(partition_selection) >= integration_owner_node_count():
+            return ()
+        targets.update(expand_partitions_to_pytest_targets(partition_selection))
+    except (KeyError, RuntimeError, OSError, ValueError):
+        return ()
+    return tuple(sorted(targets))
+
+
 def resolve_fast_lane_contract_selection(files: list[str]) -> FastLaneContractSelection:
     normalized = sorted({f.strip() for f in files if f and f.strip()})
     substantive = [f for f in normalized if not _is_fast_lane_docs_noise(f)]
 
     if not substantive:
         return FastLaneContractSelection("NO_OP", "no_substantive_fast_lane_paths", ())
+
+    if _has_durable_completion_integration_partition_scope(substantive) and all(
+        _is_durable_completion_integration_partition_rebundle_path(f, files=substantive)
+        for f in substantive
+    ):
+        bounded_targets = _durable_completion_fast_lane_bounded_targets(substantive)
+        if bounded_targets:
+            return FastLaneContractSelection(
+                "DURABLE_COMPLETION_BOUNDED",
+                "durable_completion_bounded_partition",
+                bounded_targets,
+            )
 
     rebundle_only = all(f in FAST_LANE_CONTRACT_REBUNDLE_PATHS for f in substantive)
     if not rebundle_only and any(_fast_lane_requires_full_static(f) for f in substantive):
@@ -1574,29 +1656,54 @@ def _durable_completion_focused_targets(
         if not _repo_path_exists(path):
             return ()
     contract_test = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
-    targets: list[str] = [graph_owner]
+    targets: list[str] = []
     if _repo_path_exists(contract_test):
         targets.append(contract_test)
     if not files:
         targets.append(DURABLE_COMPLETION_INTEGRATION_TEST_OWNER)
+        if _repo_path_exists(graph_owner):
+            targets.insert(0, graph_owner)
         return tuple(sorted(set(targets)))
     if any(
         path in files
         for path in (DURABLE_COMPLETION_GRAPH_WIRING_PATH, DURABLE_COMPLETION_PUBLIC_API_PATH)
     ):
+        partition_selection = partitions_for_changed_files(files)
+        if partition_selection is not None and partition_selection:
+            try:
+                if _partition_selection_uses_pe33_pr_smoke(partition_selection):
+                    targets.extend(_durable_completion_normal_pr_graph_structure_targets())
+                    targets.extend(_durable_completion_pe33_pr_smoke_pytest_targets())
+                    return tuple(sorted(set(targets)))
+                if partition_union_node_count(partition_selection) < integration_owner_node_count():
+                    targets.extend(_durable_completion_normal_pr_graph_structure_targets())
+                    targets.extend(expand_partitions_to_pytest_targets(partition_selection))
+                    return tuple(sorted(set(targets)))
+            except (KeyError, RuntimeError, OSError, ValueError):
+                return ()
         targets.append(DURABLE_COMPLETION_INTEGRATION_TEST_OWNER)
+        if _repo_path_exists(graph_owner):
+            targets.insert(0, graph_owner)
         return tuple(sorted(set(targets)))
     partition_selection = partitions_for_changed_files(files)
     if partition_selection is None:
         targets.append(DURABLE_COMPLETION_INTEGRATION_TEST_OWNER)
+        if _repo_path_exists(graph_owner):
+            targets.insert(0, graph_owner)
         return tuple(sorted(set(targets)))
     if not partition_selection:
+        targets.extend(_durable_completion_normal_pr_graph_structure_targets())
         return tuple(sorted(set(targets)))
     try:
+        if _partition_selection_uses_pe33_pr_smoke(partition_selection):
+            targets.extend(_durable_completion_normal_pr_graph_structure_targets())
+            targets.extend(_durable_completion_pe33_pr_smoke_pytest_targets())
+            return tuple(sorted(set(targets)))
         selected_nodes = partition_union_node_count(partition_selection)
         if selected_nodes >= integration_owner_node_count():
             targets.append(DURABLE_COMPLETION_INTEGRATION_TEST_OWNER)
         else:
+            targets.extend(_durable_completion_normal_pr_graph_structure_targets())
             targets.extend(expand_partitions_to_pytest_targets(partition_selection))
     except (KeyError, RuntimeError, OSError, ValueError):
         return ()

--- a/scripts/ops/durable_completion_integration_partitions_v0.py
+++ b/scripts/ops/durable_completion_integration_partitions_v0.py
@@ -33,6 +33,8 @@ ALL_PARTITIONS: Final[tuple[str, ...]] = (
     "core_cross_chain",
     "pe21_reconciliation",
     "pe31_review",
+    "pe33_pr_smoke",
+    "pe33_cross_slice_exhaustive",
     "pe22_risk_killswitch",
     "pe23_capital",
     "pe24_pilot",
@@ -42,6 +44,19 @@ ALL_PARTITIONS: Final[tuple[str, ...]] = (
     "pe38_readiness",
     "wallclock",
 )
+
+# Bounded normal-PR smoke for PE-33 cross-slice coherence (exhaustive remainder stays nightly/manual).
+PE33_PR_SMOKE_NODE_IDS: Final[tuple[str, ...]] = (
+    "test_pe33_cross_slice_coherence_bound_in_completion_happy_path",
+    "test_pe33_missing_integration_proof_digest_fails",
+    "test_pe33_proof_digest_chain_drift_fails",
+    "test_pe33_source_revision_mismatch_fails",
+    "test_pe33_invalid_proof_lifecycle_states_fail[revoked]",
+)
+
+PE33_EXHAUSTIVE_OWNER: Final = INTEGRATION_TEST_OWNER
+
+_PE33_PR_SMOKE_NODE_ID_SET: Final[frozenset[str]] = frozenset(PE33_PR_SMOKE_NODE_IDS)
 
 _NODE_ID_RE = re.compile(r"<Function (test_[^>]+)>")
 
@@ -119,6 +134,11 @@ def classify_integration_node_id(node_id: str) -> str:
     ):
         return "pe37_traceability"
 
+    if "pe33" in base or "cross_slice" in base:
+        if node_id in _PE33_PR_SMOKE_NODE_ID_SET:
+            return "pe33_pr_smoke"
+        return "pe33_cross_slice_exhaustive"
+
     if "pe25" in base:
         return "pe25_closure"
 
@@ -140,6 +160,7 @@ def classify_integration_node_id(node_id: str) -> str:
     if base.startswith("test_completion_proof_chain_"):
         for tag, partition in (
             ("pe31", "pe31_review"),
+            ("pe33", "pe33_pr_smoke"),
             ("pe22", "pe22_risk_killswitch"),
             ("pe23", "pe23_capital"),
             ("pe24", "pe24_pilot"),
@@ -220,6 +241,16 @@ def partition_union_node_count(partitions: frozenset[str]) -> int:
     return len(seen)
 
 
+def expand_pe33_pr_smoke_pytest_targets() -> tuple[str, ...]:
+    collected = frozenset(collect_integration_owner_node_ids())
+    missing = [node_id for node_id in PE33_PR_SMOKE_NODE_IDS if node_id not in collected]
+    if missing:
+        raise KeyError(f"missing PE-33 PR smoke node ids: {missing[:3]}")
+    return tuple(
+        sorted(f"{INTEGRATION_TEST_OWNER}::{node_id}" for node_id in PE33_PR_SMOKE_NODE_IDS)
+    )
+
+
 def expand_partitions_to_pytest_targets(partitions: frozenset[str]) -> tuple[str, ...]:
     inventory = integration_partition_inventory()
     node_ids: set[str] = set()
@@ -243,14 +274,13 @@ def partitions_for_changed_files(changed_files: list[str]) -> frozenset[str] | N
     files = frozenset(changed_files)
     partitions: set[str] = set(CORE_ALWAYS_PARTITIONS)
 
-    if INTEGRATION_TEST_OWNER in files:
-        return None
-
-    if COMPLETION_FACADE_PATH in files:
+    prod_files = {f for f in files if f.startswith("src/")}
+    if INTEGRATION_TEST_OWNER in files and not prod_files:
         return None
 
     integration_scoped = False
     graph_only = True
+    facade_in_files = COMPLETION_FACADE_PATH in files
 
     path_rules: tuple[tuple[str, str], ...] = (
         (
@@ -302,6 +332,10 @@ def partitions_for_changed_files(changed_files: list[str]) -> frozenset[str] | N
             "pe38_readiness",
         ),
         (
+            "src/ops/bounded_futures_testnet_cross_slice_proof_coherence_integration_contract_v0.py",
+            "pe33_pr_smoke",
+        ),
+        (
             "src/ops/testnet_wallclock_duration_evidence_contract_v0.py",
             "wallclock",
         ),
@@ -320,7 +354,17 @@ def partitions_for_changed_files(changed_files: list[str]) -> frozenset[str] | N
         ("src/ops/durable_completion_validation/validators/traceability.py", "pe37_traceability"),
         ("src/ops/durable_completion_validation/validators/operator_closure.py", "pe25_closure"),
         ("src/ops/durable_completion_validation/validators/event_stream.py", "pe38_readiness"),
+        (
+            "src/ops/durable_completion_validation/validators/cross_slice_coherence.py",
+            "pe33_pr_smoke",
+        ),
     )
+
+    completion_chain_validator = (
+        "src/ops/durable_completion_validation/validators/completion_chain.py"
+    )
+
+    pe33_pr_scoped = False
 
     for path, partition in path_rules:
         if path in files:
@@ -331,9 +375,18 @@ def partitions_for_changed_files(changed_files: list[str]) -> frozenset[str] | N
     for path, partition in validator_rules:
         if path in files:
             partitions.add(partition)
-            partitions.add("core_cross_chain")
+            if partition == "pe33_pr_smoke":
+                pe33_pr_scoped = True
+            elif partition != "pe33_pr_smoke":
+                partitions.add("core_cross_chain")
             integration_scoped = True
             graph_only = False
+
+    if completion_chain_validator in files:
+        integration_scoped = True
+        graph_only = False
+        if not pe33_pr_scoped:
+            partitions.add("core_cross_chain")
 
     dc_prefix = "src/ops/durable_completion_validation/"
     for path in files:
@@ -344,6 +397,10 @@ def partitions_for_changed_files(changed_files: list[str]) -> frozenset[str] | N
             continue
         if name in {"models.py", "identity.py", "__init__.py"}:
             if name == "__init__.py":
+                if path.endswith("validators/__init__.py"):
+                    integration_scoped = True
+                    graph_only = False
+                    continue
                 return None
             integration_scoped = True
             graph_only = False
@@ -352,10 +409,16 @@ def partitions_for_changed_files(changed_files: list[str]) -> frozenset[str] | N
         if name.startswith("validators/") or path.endswith(".py") and "/validators/" in path:
             continue
 
+    if facade_in_files and not integration_scoped:
+        return None
+
+    if pe33_pr_scoped:
+        return frozenset({"pe33_pr_smoke"})
+
     if not integration_scoped:
         return frozenset()
 
-    if len(partitions - set(CORE_ALWAYS_PARTITIONS)) > 3:
+    if len(partitions - set(CORE_ALWAYS_PARTITIONS)) > 3 and "pe33_pr_smoke" not in partitions:
         partitions.update({"core_baseline_input", "core_kwargs", "core_cross_chain"})
 
     return frozenset(partitions)

--- a/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -130,7 +130,17 @@ from src.ops.bounded_futures_testnet_operator_closure_lifecycle_integration_cont
 from src.ops.bounded_futures_testnet_operator_review_handoff_boundary_contract_v0 import (
     CONTRACT_VERSION as PE34_CONTRACT_VERSION,
     HANDOFF_OWNER as PE34_HANDOFF_OWNER,
+    Pe33CoherenceProofBinding,
     compute_boundary_input_digest as compute_pe34_boundary_input_digest,
+)
+from src.ops.bounded_futures_testnet_cross_slice_proof_coherence_integration_contract_v0 import (
+    CONTRACT_VERSION as PE33_CONTRACT_VERSION,
+    COHERENCE_OWNER as PE33_COHERENCE_OWNER,
+    CrossSliceProofCoherenceIntegrationInput,
+    UpstreamDigestBinding,
+    compute_integration_input_digest as compute_pe33_integration_input_digest,
+    default_minimal_integration_input as default_minimal_pe33_integration_input,
+    evaluate_cross_slice_proof_coherence_integration,
 )
 from src.ops.bounded_futures_testnet_preflight_execution_readiness_review_lifecycle_integration_contract_v0 import (
     CONTRACT_VERSION as PE38_CONTRACT_VERSION,
@@ -201,6 +211,7 @@ PE34_INTEGRATION_OWNER = PE34_CONTRACT_VERSION
 PE36_INTEGRATION_OWNER = PE36_CONTRACT_VERSION
 PE37_INTEGRATION_OWNER = PE37_CONTRACT_VERSION
 PE25_INTEGRATION_OWNER = PE25_CONTRACT_VERSION
+PE33_INTEGRATION_OWNER = PE33_CONTRACT_VERSION
 PE38_INTEGRATION_OWNER = PE38_CONTRACT_VERSION
 GAP4_COMPLETION_OWNER = "tests/ops/test_gap4_output_evidence_paths_contract_v0.py"
 GAP2A1_ENFORCEMENT_OWNER = "tests/ops/test_gap2a1_primary_evidence_enforcement_contract_v0.py"
@@ -324,6 +335,7 @@ _EXPECTED_CONTRACT_VERSIONS: dict[str, str] = {
     "pe36_admission_presentation": PE36_CONTRACT_VERSION,
     "pe37_traceability": PE37_CONTRACT_VERSION,
     "pe38_readiness_review": PE38_CONTRACT_VERSION,
+    "pe33_cross_slice_proof_coherence": PE33_CONTRACT_VERSION,
     "pe25_operator_closure": PE25_CONTRACT_VERSION,
     "integration": CONTRACT_VERSION,
 }
@@ -344,6 +356,7 @@ class ContractVersionsInput:
     pe36_admission_presentation: str
     pe37_traceability: str
     pe38_readiness_review: str
+    pe33_cross_slice_proof_coherence: str
     pe25_operator_closure: str
     integration: str
 
@@ -615,6 +628,9 @@ class CompletionProofChainBinding:
     shared_traceability_identity: str
     completion_referenced_wallclock_evidence_digest: str
     completion_referenced_pe38_readiness_review_proof_digest: str
+    completion_referenced_pe33_integration_proof_digest: str
+    completion_referenced_pe33_integration_input_digest: str
+    completion_referenced_pe33_pe25_slot_digest: str
     completion_referenced_master_v2_decision_id: str | None = None
     completion_referenced_master_v2_decision_digest: str | None = None
     completion_referenced_selected_future_id: str | None = None
@@ -742,6 +758,9 @@ class DurableRunPrimaryEvidenceCompletionIntegrationInput:
     pe25_closure_integration_input: OperatorClosureLifecycleIntegrationInput
     pe25_operator_closure_proof: Pe25OperatorClosureLifecycleProofBinding
     pe25_proof_lifecycle: ProofLifecycleMetadata
+    pe33_cross_slice_proof_coherence_integration_input: CrossSliceProofCoherenceIntegrationInput
+    pe33_cross_slice_proof_coherence_proof: Pe33CoherenceProofBinding
+    pe33_proof_lifecycle: ProofLifecycleMetadata
     completion_proof_chain: CompletionProofChainBinding
     pe16_archive: Pe16ArchiveProofBinding
     manifest_proof: ManifestProofBinding
@@ -2380,6 +2399,16 @@ def validate_durable_run_primary_evidence_completion_integration_input(
         )
     fail_reasons.extend(validate_operator_closure_lifecycle_integration_input(pe25_input))
 
+    pe33_input = integration_input.pe33_cross_slice_proof_coherence_integration_input
+    if pe33_input.source_revision != integration_input.source_revision:
+        fail_reasons.append(
+            "pe33_cross_slice_proof_coherence_integration_input: source_revision mismatch with "
+            "completion input"
+        )
+    pe33_proof = integration_input.pe33_cross_slice_proof_coherence_proof
+    if pe33_proof.source_revision != integration_input.source_revision:
+        fail_reasons.append("pe33_cross_slice_proof_coherence_proof: source_revision mismatch")
+
     fail_reasons.extend(_validate_completion_proof_chain(integration_input))
 
     master_v2_binding = integration_input.master_v2_decision_state_digest_binding
@@ -2514,6 +2543,13 @@ def _integration_input_dict(
         ),
         "pe25_operator_closure_proof": asdict(integration_input.pe25_operator_closure_proof),
         "pe25_proof_lifecycle": asdict(integration_input.pe25_proof_lifecycle),
+        "pe33_integration_input_digest": compute_pe33_integration_input_digest(
+            integration_input.pe33_cross_slice_proof_coherence_integration_input
+        ),
+        "pe33_cross_slice_proof_coherence_proof": asdict(
+            integration_input.pe33_cross_slice_proof_coherence_proof
+        ),
+        "pe33_proof_lifecycle": asdict(integration_input.pe33_proof_lifecycle),
         "completion_proof_chain": asdict(integration_input.completion_proof_chain),
         "master_v2_decision_state_digest_binding": (
             asdict(integration_input.master_v2_decision_state_digest_binding)
@@ -2572,6 +2608,7 @@ def _integration_proof_dict(
         "pe34_handoff_bound": integration_pass,
         "pe35_staleness_revocation_recovery_bound": integration_pass,
         "pe36_admission_presentation_bound": integration_pass,
+        "pe33_cross_slice_proof_coherence_bound": integration_pass,
         "pe25_operator_closure_lifecycle_bound": integration_pass,
         "global_run_completion_readiness": GLOBAL_RUN_COMPLETION_READINESS,
         "integration_contract_version": CONTRACT_VERSION,
@@ -2711,6 +2748,9 @@ def evaluate_durable_run_primary_evidence_completion_integration(
     pe25_result = evaluate_operator_closure_lifecycle_integration(
         integration_input.pe25_closure_integration_input
     )
+    pe33_result = evaluate_cross_slice_proof_coherence_integration(
+        integration_input.pe33_cross_slice_proof_coherence_integration_input
+    )
     glb019_result = evaluate_glb019_event_stream_validation(
         integration_input.glb019_event_stream_validation_input
     )
@@ -2784,6 +2824,9 @@ def evaluate_durable_run_primary_evidence_completion_integration(
         "pe34_handoff_bound": bool(pe37_result.get("boundary_pass")),
         "pe35_staleness_revocation_recovery_bound": bool(pe37_result.get("proof_digests_coherent")),
         "pe36_admission_presentation_bound": bool(pe37_result.get("owner_identities_coherent")),
+        "pe33_cross_slice_proof_coherence_bound": bool(
+            pe33_result.get("cross_slice_proof_coherence_for_separate_operator_review")
+        ),
         "pe25_operator_closure_lifecycle_bound": bool(
             pe25_result.get("operator_closure_static_complete")
         ),
@@ -3150,6 +3193,93 @@ def _master_v2_completion_chain_references(
     }
 
 
+def _rebind_pe33_proof_slots_to_completion_digests(
+    slots: tuple[Any, ...],
+    *,
+    completion_digests: dict[str, str],
+) -> tuple[Any, ...]:
+    from src.ops.bounded_futures_testnet_cross_slice_proof_coherence_integration_contract_v0 import (
+        ProofSlotBinding,
+    )
+
+    slot_map: dict[str, ProofSlotBinding] = {slot.slot_id: slot for slot in slots}
+    for slot_id, digest in completion_digests.items():
+        if slot_id in slot_map:
+            slot_map[slot_id] = replace(slot_map[slot_id], proof_digest=digest)
+    rebound: list[ProofSlotBinding] = []
+    for slot_id in sorted(slot_map):
+        slot = slot_map[slot_id]
+        rebound.append(
+            replace(
+                slot,
+                upstream_bindings=tuple(
+                    UpstreamDigestBinding(
+                        upstream_slot_id=binding.upstream_slot_id,
+                        upstream_proof_digest=slot_map[binding.upstream_slot_id].proof_digest,
+                    )
+                    for binding in slot.upstream_bindings
+                ),
+            )
+        )
+    return tuple(rebound)
+
+
+def _build_pe33_integration_input_from_completion(
+    integration_input: DurableRunPrimaryEvidenceCompletionIntegrationInput,
+) -> CrossSliceProofCoherenceIntegrationInput:
+    """Build canonical PE-33 input with completion-bound PE-21..PE-32 slot digests."""
+    pe24_input = integration_input.pe24_pilot_envelope_lifecycle_integration_input
+    pe33_base = default_minimal_pe33_integration_input(
+        source_revision=integration_input.source_revision,
+        adapter_id=pe24_input.adapter_id,
+        instrument=pe24_input.instrument,
+        lifecycle_state_digest=integration_input.durable_run_root.run_root_digest,
+    )
+    completion_digests = {
+        "pe21": integration_input.pe21_proof.integration_proof_digest,
+        "pe22": integration_input.pe22_risk_killswitch_flatten_proof.integration_proof_digest,
+        "pe23": integration_input.pe23_capital_slot_ratchet_release_proof.integration_proof_digest,
+        "pe24": integration_input.pe24_pilot_envelope_lifecycle_proof.integration_proof_digest,
+        "pe25": integration_input.pe25_operator_closure_proof.closure_result_digest,
+        "pe31": integration_input.pe31_reconciliation_review_integration_proof.integration_proof_digest,
+    }
+    return replace(
+        pe33_base,
+        proof_slots=_rebind_pe33_proof_slots_to_completion_digests(
+            pe33_base.proof_slots,
+            completion_digests=completion_digests,
+        ),
+    )
+
+
+def _pe33_coherence_proof_from_result(
+    integration_input: DurableRunPrimaryEvidenceCompletionIntegrationInput,
+    *,
+    pe33_input: CrossSliceProofCoherenceIntegrationInput,
+    pe33_result: dict[str, Any],
+) -> Pe33CoherenceProofBinding:
+    return Pe33CoherenceProofBinding(
+        coherence_owner=PE33_COHERENCE_OWNER,
+        source_revision=integration_input.source_revision,
+        integration_input_digest=pe33_result["integration_input_digest"],
+        integration_proof_digest=pe33_result["integration_proof_digest"],
+        cross_slice_proof_coherence_for_separate_operator_review=pe33_result[
+            "cross_slice_proof_coherence_for_separate_operator_review"
+        ],
+        static_pe12_lifecycle_chain_complete=pe33_result["static_pe12_lifecycle_chain_complete"],
+        integration_pass=pe33_result["integration_pass"],
+    )
+
+
+def _pe33_pe25_slot_digest(
+    pe33_input: CrossSliceProofCoherenceIntegrationInput,
+) -> str:
+    for slot in pe33_input.proof_slots:
+        if slot.slot_id == "pe25":
+            return slot.proof_digest
+    raise ValueError("PE-33 pe25 slot digest required for completion binding")
+
+
 def default_minimal_completion_proof_chain(
     integration_input: DurableRunPrimaryEvidenceCompletionIntegrationInput,
 ) -> CompletionProofChainBinding:
@@ -3162,6 +3292,8 @@ def default_minimal_completion_proof_chain(
     pe37_proof = integration_input.pe37_traceability_proof
     pe25_proof = integration_input.pe25_operator_closure_proof
     pe21_proof = integration_input.pe21_proof
+    pe33_proof = integration_input.pe33_cross_slice_proof_coherence_proof
+    pe33_input = integration_input.pe33_cross_slice_proof_coherence_integration_input
     pe31_pe21_proof = integration_input.pe31_reconciliation_review_integration_input.pe21_reconciliation_primary_evidence_integration_proof
     master_v2_refs: dict[str, str] = {}
     if integration_input.master_v2_decision_state_digest_binding is not None:
@@ -3190,6 +3322,9 @@ def default_minimal_completion_proof_chain(
             artifact_checksums=integration_input.artifact_checksums,
         ),
         completion_referenced_pe38_readiness_review_proof_digest=pe38_proof.integration_proof_digest,
+        completion_referenced_pe33_integration_proof_digest=pe33_proof.integration_proof_digest,
+        completion_referenced_pe33_integration_input_digest=pe33_proof.integration_input_digest,
+        completion_referenced_pe33_pe25_slot_digest=_pe33_pe25_slot_digest(pe33_input),
         **master_v2_refs,
     )
 
@@ -3411,6 +3546,11 @@ def default_minimal_completion_integration_input(
         source_revision=source_revision,
         manifest_digest=manifest_digest,
     )
+    pe34_handoff = pe35_boundary_input.pe34_handoff
+    pe33_input = pe34_handoff.pe33_integration_input
+    pe33_proof = pe34_handoff.pe33_coherence_proof
+    if pe33_input is None:
+        raise ValueError("PE-34 handoff PE-33 integration input required for completion binding")
     pe35_proof = default_minimal_pe35_integration_proof(
         pe35_boundary_input,
         traceability_identity=run_root_digest,
@@ -3534,6 +3674,9 @@ def default_minimal_completion_integration_input(
             closure_coherence_proven=True,
         ),
         pe25_proof_lifecycle=ProofLifecycleMetadata(lifecycle_state=PROOF_LIFECYCLE_CURRENT),
+        pe33_cross_slice_proof_coherence_integration_input=pe33_input,
+        pe33_cross_slice_proof_coherence_proof=pe33_proof,
+        pe33_proof_lifecycle=ProofLifecycleMetadata(lifecycle_state=PROOF_LIFECYCLE_CURRENT),
         completion_proof_chain=CompletionProofChainBinding(
             completion_referenced_pe31_proof_digest=pe31_proof.integration_proof_digest,
             completion_referenced_pe22_proof_digest=pe22_result["integration_proof_digest"],
@@ -3559,6 +3702,9 @@ def default_minimal_completion_integration_input(
                 artifact_checksums=artifact_checksums,
             ),
             completion_referenced_pe38_readiness_review_proof_digest=pe38_proof.integration_proof_digest,
+            completion_referenced_pe33_integration_proof_digest=pe33_proof.integration_proof_digest,
+            completion_referenced_pe33_integration_input_digest=pe33_proof.integration_input_digest,
+            completion_referenced_pe33_pe25_slot_digest=_pe33_pe25_slot_digest(pe33_input),
         ),
         pe16_archive=Pe16ArchiveProofBinding(
             archive_owner=PE16_ARCHIVE_OWNER,
@@ -3621,6 +3767,7 @@ def default_minimal_completion_integration_input(
             pe36_admission_presentation=PE36_CONTRACT_VERSION,
             pe37_traceability=PE37_CONTRACT_VERSION,
             pe38_readiness_review=PE38_CONTRACT_VERSION,
+            pe33_cross_slice_proof_coherence=PE33_CONTRACT_VERSION,
             pe25_operator_closure=PE25_CONTRACT_VERSION,
             integration=CONTRACT_VERSION,
         ),
@@ -3649,7 +3796,19 @@ def default_minimal_completion_integration_input(
         draft,
         pe25_operator_closure_proof=pe25_proof,
     )
-    return replace(
+    pe33_input = _build_pe33_integration_input_from_completion(completed)
+    pe33_result = evaluate_cross_slice_proof_coherence_integration(pe33_input)
+    pe33_proof = _pe33_coherence_proof_from_result(
         completed,
-        completion_proof_chain=default_minimal_completion_proof_chain(completed),
+        pe33_input=pe33_input,
+        pe33_result=pe33_result,
+    )
+    fully_completed = replace(
+        completed,
+        pe33_cross_slice_proof_coherence_integration_input=pe33_input,
+        pe33_cross_slice_proof_coherence_proof=pe33_proof,
+    )
+    return replace(
+        fully_completed,
+        completion_proof_chain=default_minimal_completion_proof_chain(fully_completed),
     )

--- a/src/ops/durable_completion_validation/graph.py
+++ b/src/ops/durable_completion_validation/graph.py
@@ -10,6 +10,7 @@ from src.ops.durable_completion_validation.models import ValidationContext, Vali
 
 VALIDATOR_RECONCILIATION = "reconciliation"
 VALIDATOR_RECOVERY = "recovery"
+VALIDATOR_CROSS_SLICE_COHERENCE = "cross_slice_coherence"
 VALIDATOR_TRACEABILITY = "traceability"
 VALIDATOR_OPERATOR_CLOSURE = "operator_closure"
 VALIDATOR_WALLCLOCK = "wallclock"
@@ -19,14 +20,20 @@ VALIDATOR_COMPLETION_CHAIN = "completion_chain"
 PROOF_BINDING_VALIDATION_GRAPH: dict[str, tuple[str, ...]] = {
     VALIDATOR_RECONCILIATION: (),
     VALIDATOR_RECOVERY: (),
+    VALIDATOR_CROSS_SLICE_COHERENCE: (VALIDATOR_RECONCILIATION,),
     VALIDATOR_TRACEABILITY: (VALIDATOR_RECOVERY,),
-    VALIDATOR_OPERATOR_CLOSURE: (VALIDATOR_TRACEABILITY, VALIDATOR_RECOVERY),
+    VALIDATOR_OPERATOR_CLOSURE: (
+        VALIDATOR_TRACEABILITY,
+        VALIDATOR_RECOVERY,
+        VALIDATOR_CROSS_SLICE_COHERENCE,
+    ),
     VALIDATOR_WALLCLOCK: (),
     VALIDATOR_EVENT_STREAM: (),
     VALIDATOR_COMPLETION_CHAIN: (
         VALIDATOR_OPERATOR_CLOSURE,
         VALIDATOR_TRACEABILITY,
         VALIDATOR_RECOVERY,
+        VALIDATOR_CROSS_SLICE_COHERENCE,
         VALIDATOR_WALLCLOCK,
         VALIDATOR_EVENT_STREAM,
     ),
@@ -35,6 +42,7 @@ PROOF_BINDING_VALIDATION_GRAPH: dict[str, tuple[str, ...]] = {
 PROOF_BINDING_VALIDATION_ORDER: tuple[str, ...] = (
     VALIDATOR_RECONCILIATION,
     VALIDATOR_RECOVERY,
+    VALIDATOR_CROSS_SLICE_COHERENCE,
     VALIDATOR_TRACEABILITY,
     VALIDATOR_OPERATOR_CLOSURE,
     VALIDATOR_WALLCLOCK,
@@ -68,6 +76,7 @@ def proof_binding_validation_graph_is_cycle_free() -> bool:
 def _load_validators() -> dict[str, ValidatorFn]:
     from src.ops.durable_completion_validation.validators import (
         completion_chain,
+        cross_slice_coherence,
         event_stream,
         operator_closure,
         reconciliation,
@@ -79,6 +88,9 @@ def _load_validators() -> dict[str, ValidatorFn]:
     return {
         VALIDATOR_RECONCILIATION: reconciliation.validate_reconciliation_proof_binding,
         VALIDATOR_RECOVERY: recovery.validate_recovery_proof_binding,
+        VALIDATOR_CROSS_SLICE_COHERENCE: (
+            cross_slice_coherence.validate_pe33_cross_slice_proof_coherence
+        ),
         VALIDATOR_TRACEABILITY: traceability.validate_traceability_proof_binding,
         VALIDATOR_OPERATOR_CLOSURE: operator_closure.validate_operator_closure_proof_binding,
         VALIDATOR_WALLCLOCK: wallclock.validate_wallclock_proof_binding,

--- a/src/ops/durable_completion_validation/validators/__init__.py
+++ b/src/ops/durable_completion_validation/validators/__init__.py
@@ -1,8 +1,16 @@
 """Durable completion validator modules."""
 
-from . import event_stream, operator_closure, reconciliation, recovery, traceability
+from . import (
+    cross_slice_coherence,
+    event_stream,
+    operator_closure,
+    reconciliation,
+    recovery,
+    traceability,
+)
 
 __all__ = [
+    "cross_slice_coherence",
     "event_stream",
     "operator_closure",
     "reconciliation",

--- a/src/ops/durable_completion_validation/validators/completion_chain.py
+++ b/src/ops/durable_completion_validation/validators/completion_chain.py
@@ -92,6 +92,8 @@ def validate_completion_proof_chain_binding(context: ValidationContext) -> Valid
     pe21_proof = integration_input.pe21_proof
     pe31_pe21_proof = integration_input.pe31_reconciliation_review_integration_input.pe21_reconciliation_primary_evidence_integration_proof
     pe38_proof = integration_input.pe38_readiness_review_integration_proof
+    pe33_proof = integration_input.pe33_cross_slice_proof_coherence_proof
+    pe33_input = integration_input.pe33_cross_slice_proof_coherence_integration_input
     wallclock_proof = integration_input.wallclock_evidence_proof
     checksum_by_path = {
         entry.relative_path: entry.digest for entry in integration_input.artifact_checksums
@@ -141,6 +143,18 @@ def validate_completion_proof_chain_binding(context: ValidationContext) -> Valid
         (
             "completion_referenced_pe38_readiness_review_proof_digest",
             chain.completion_referenced_pe38_readiness_review_proof_digest,
+        ),
+        (
+            "completion_referenced_pe33_integration_proof_digest",
+            chain.completion_referenced_pe33_integration_proof_digest,
+        ),
+        (
+            "completion_referenced_pe33_integration_input_digest",
+            chain.completion_referenced_pe33_integration_input_digest,
+        ),
+        (
+            "completion_referenced_pe33_pe25_slot_digest",
+            chain.completion_referenced_pe33_pe25_slot_digest,
         ),
     )
     for field_name, value in digest_fields:
@@ -224,6 +238,30 @@ def validate_completion_proof_chain_binding(context: ValidationContext) -> Valid
     ):
         fail_reasons.append(
             "completion_proof_chain: completion_referenced_pe38_readiness_review_proof_digest mismatch"
+        )
+    if (
+        chain.completion_referenced_pe33_integration_proof_digest
+        != pe33_proof.integration_proof_digest
+    ):
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe33_integration_proof_digest mismatch"
+        )
+    if (
+        chain.completion_referenced_pe33_integration_input_digest
+        != pe33_proof.integration_input_digest
+    ):
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe33_integration_input_digest mismatch"
+        )
+    pe25_slot_digest = next(
+        (slot.proof_digest for slot in pe33_input.proof_slots if slot.slot_id == "pe25"),
+        None,
+    )
+    if pe25_slot_digest is None:
+        fail_reasons.append("completion_proof_chain: PE-33 pe25 slot digest unavailable")
+    elif chain.completion_referenced_pe33_pe25_slot_digest != pe25_slot_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe33_pe25_slot_digest mismatch"
         )
 
     fail_reasons.extend(_validate_master_v2_completion_chain_digest_binding(context))

--- a/src/ops/durable_completion_validation/validators/cross_slice_coherence.py
+++ b/src/ops/durable_completion_validation/validators/cross_slice_coherence.py
@@ -1,0 +1,148 @@
+"""PE-33 cross-slice proof coherence validator for durable completion binding."""
+
+from __future__ import annotations
+
+from src.ops.bounded_futures_testnet_cross_slice_proof_coherence_integration_contract_v0 import (
+    COHERENCE_OWNER as PE33_COHERENCE_OWNER,
+    CONTRACT_VERSION as PE33_INTEGRATION_OWNER,
+    compute_integration_input_digest as compute_pe33_integration_input_digest,
+    compute_integration_proof_digest as compute_pe33_integration_proof_digest,
+    evaluate_cross_slice_proof_coherence_integration,
+)
+from src.ops.durable_completion_validation.identity import sorted_unique, valid_sha256_digest
+from src.ops.durable_completion_validation.models import ValidationContext, ValidationResult
+
+
+def _pe33_slot_digest_by_id(integration_input) -> dict[str, str]:
+    return {slot.slot_id: slot.proof_digest for slot in integration_input.proof_slots}
+
+
+def validate_pe33_cross_slice_proof_coherence(context: ValidationContext) -> ValidationResult:
+    """Fail-closed PE-33 cross-slice coherence binding against completion proof chain."""
+    from src.ops.bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0 import (
+        INVALID_PROOF_LIFECYCLE_STATES,
+    )
+
+    integration_input = context.integration_input
+    fail_reasons: list[str] = []
+
+    pe33_lifecycle = integration_input.pe33_proof_lifecycle
+    if pe33_lifecycle.lifecycle_state in INVALID_PROOF_LIFECYCLE_STATES:
+        fail_reasons.append(
+            f"pe33_proof_lifecycle: invalid lifecycle state {pe33_lifecycle.lifecycle_state!r}"
+        )
+
+    pe33_input = integration_input.pe33_cross_slice_proof_coherence_integration_input
+    pe33_proof = integration_input.pe33_cross_slice_proof_coherence_proof
+    chain = integration_input.completion_proof_chain
+
+    if pe33_proof.coherence_owner != PE33_COHERENCE_OWNER:
+        fail_reasons.append(f"pe33_proof: coherence_owner must be {PE33_COHERENCE_OWNER!r}")
+    if pe33_proof.source_revision != integration_input.source_revision:
+        fail_reasons.append("pe33_proof: source_revision mismatch with completion input")
+    if pe33_input.source_revision != integration_input.source_revision:
+        fail_reasons.append(
+            "pe33_cross_slice_proof_coherence_integration_input: source_revision mismatch "
+            "with completion input"
+        )
+
+    for field_name in (
+        "integration_input_digest",
+        "integration_proof_digest",
+    ):
+        value = getattr(pe33_proof, field_name)
+        if not value:
+            fail_reasons.append(f"pe33_proof: {field_name} required")
+        elif not valid_sha256_digest(value):
+            fail_reasons.append(f"pe33_proof: {field_name} must be 64-char lowercase sha256 hex")
+
+    pe33_result = evaluate_cross_slice_proof_coherence_integration(pe33_input)
+    if not pe33_result["integration_pass"]:
+        fail_reasons.append(
+            "pe33_cross_slice_proof_coherence_integration_input: PE-33 evaluation failed"
+        )
+        fail_reasons.extend(
+            f"pe33_cross_slice_proof_coherence_integration_input: {reason}"
+            for reason in pe33_result.get("fail_reasons", [])
+        )
+    elif not pe33_result["cross_slice_proof_coherence_for_separate_operator_review"]:
+        fail_reasons.append(
+            "pe33_cross_slice_proof_coherence_integration_input: "
+            "cross_slice_proof_coherence_for_separate_operator_review required"
+        )
+    elif not pe33_result["static_pe12_lifecycle_chain_complete"]:
+        fail_reasons.append(
+            "pe33_cross_slice_proof_coherence_integration_input: "
+            "static_pe12_lifecycle_chain_complete required"
+        )
+
+    computed_input_digest = compute_pe33_integration_input_digest(pe33_input)
+    if pe33_proof.integration_input_digest != computed_input_digest:
+        fail_reasons.append("pe33_proof: integration_input_digest mismatch")
+    if chain.completion_referenced_pe33_integration_input_digest != computed_input_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe33_integration_input_digest mismatch"
+        )
+
+    if pe33_result["integration_pass"]:
+        computed_proof_digest = compute_pe33_integration_proof_digest(
+            pe33_input,
+            cross_slice_proof_coherence_for_separate_operator_review=True,
+        )
+        if pe33_proof.integration_proof_digest != computed_proof_digest:
+            fail_reasons.append("pe33_proof: integration_proof_digest mismatch")
+        if chain.completion_referenced_pe33_integration_proof_digest != computed_proof_digest:
+            fail_reasons.append(
+                "completion_proof_chain: completion_referenced_pe33_integration_proof_digest mismatch"
+            )
+
+    if pe33_proof.integration_pass is not True:
+        fail_reasons.append("pe33_proof: integration_pass must be true")
+    if pe33_proof.cross_slice_proof_coherence_for_separate_operator_review is not True:
+        fail_reasons.append(
+            "pe33_proof: cross_slice_proof_coherence_for_separate_operator_review must be true"
+        )
+    if pe33_proof.static_pe12_lifecycle_chain_complete is not True:
+        fail_reasons.append("pe33_proof: static_pe12_lifecycle_chain_complete must be true")
+
+    slot_by_id = _pe33_slot_digest_by_id(pe33_input)
+    completion_slot_checks = (
+        ("pe21", integration_input.pe21_proof.integration_proof_digest),
+        ("pe22", integration_input.pe22_risk_killswitch_flatten_proof.integration_proof_digest),
+        (
+            "pe23",
+            integration_input.pe23_capital_slot_ratchet_release_proof.integration_proof_digest,
+        ),
+        ("pe24", integration_input.pe24_pilot_envelope_lifecycle_proof.integration_proof_digest),
+        (
+            "pe31",
+            integration_input.pe31_reconciliation_review_integration_proof.integration_proof_digest,
+        ),
+        ("pe25", integration_input.pe25_operator_closure_proof.closure_result_digest),
+    )
+    for slot_id, completion_digest in completion_slot_checks:
+        pe33_digest = slot_by_id.get(slot_id)
+        if pe33_digest is None:
+            fail_reasons.append(f"pe33_proof: missing PE-33 slot {slot_id!r}")
+        elif pe33_digest != completion_digest:
+            fail_reasons.append(
+                f"pe33_proof: PE-33 slot {slot_id} proof_digest mismatch with completion chain"
+            )
+
+    pe25_slot_digest = slot_by_id.get("pe25")
+    if pe25_slot_digest is None:
+        fail_reasons.append("pe33_proof: PE-33 pe25 slot digest required")
+    elif chain.completion_referenced_pe33_pe25_slot_digest != pe25_slot_digest:
+        fail_reasons.append(
+            "completion_proof_chain: completion_referenced_pe33_pe25_slot_digest mismatch"
+        )
+
+    if (
+        integration_input.contract_versions.pe33_cross_slice_proof_coherence
+        != PE33_INTEGRATION_OWNER
+    ):
+        fail_reasons.append(
+            f"contract_versions: pe33_cross_slice_proof_coherence must be {PE33_INTEGRATION_OWNER!r}"
+        )
+
+    return ValidationResult(fail_reasons=tuple(sorted_unique(fail_reasons)))

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -1239,11 +1239,10 @@ def test_selector_pe55_fill_rebinding_bounded_focused_targets() -> None:
     assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
-    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
-    assert (
-        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
-        in targets
-    )
+    assert any(t.startswith(f"{_GRAPH_OWNER}::") for t in targets)
+    assert any(t.startswith(f"{_INTEGRATION_OWNER}::") for t in targets)
+    assert _GRAPH_OWNER not in targets
+    assert _INTEGRATION_OWNER not in targets
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_no_op"] == "false"
 
@@ -1293,11 +1292,10 @@ def test_selector_pe56_graph_wiring_rebinding_bounded_focused_targets() -> None:
     assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
-    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
-    assert (
-        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
-        in targets
-    )
+    assert any(t.startswith(f"{_GRAPH_OWNER}::") for t in targets)
+    assert any(t.startswith(f"{_INTEGRATION_OWNER}::") for t in targets)
+    assert _GRAPH_OWNER not in targets
+    assert _INTEGRATION_OWNER not in targets
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
 
 
@@ -1379,7 +1377,9 @@ def test_selector_glb019_graph_wiring_still_selects_integration_owner() -> None:
         _GRAPH_OWNER,
     )
     assert sel["test_selection_reason"] == "durable_completion_focused"
-    assert _INTEGRATION_OWNER in _targets(sel)
+    targets = _targets(sel)
+    assert any(t.startswith(f"{_INTEGRATION_OWNER}::") for t in targets)
+    assert _INTEGRATION_OWNER not in targets
 
 
 def test_integration_partition_inventory_covers_all_nodes() -> None:
@@ -1479,7 +1479,8 @@ def test_selector_pe21_prod_owner_partitioned_integration_nodes() -> None:
     assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
-    assert _GRAPH_OWNER in targets
+    assert any(t.startswith(f"{_GRAPH_OWNER}::") for t in targets)
+    assert _GRAPH_OWNER not in targets
     assert _INTEGRATION_OWNER not in targets
     assert any(t.startswith(f"{_INTEGRATION_OWNER}::test_pe21") for t in targets)
     assert any("test_reconciliation_result_" in t for t in targets)
@@ -1532,7 +1533,9 @@ def test_selector_glb019_mixed_validation_and_facade_selects_integration_owner()
         _GRAPH_OWNER,
     )
     assert sel["test_selection_reason"] == "durable_completion_focused"
-    assert _INTEGRATION_OWNER in _targets(sel)
+    targets = _targets(sel)
+    assert any(t.startswith(f"{_INTEGRATION_OWNER}::") for t in targets)
+    assert _INTEGRATION_OWNER not in targets
 
 
 from scripts.ops.durable_completion_integration_partitions_v0 import (
@@ -2380,8 +2383,10 @@ def test_selector_durable_completion_foreign_production_change_stays_broad() -> 
     )
     assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     targets = _targets(sel)
-    assert _COMPLETION_OWNER in targets
-    assert _GRAPH_OWNER in targets
+    assert any(t.startswith(f"{_COMPLETION_OWNER}::") for t in targets)
+    assert any(t.startswith(f"{_GRAPH_OWNER}::") for t in targets)
+    assert _COMPLETION_OWNER not in targets
+    assert _GRAPH_OWNER not in targets
 
 
 def test_selector_pr4504_wallclock_binding_plus_foreign_file_full() -> None:
@@ -2419,8 +2424,10 @@ def test_selector_durable_completion_validator_rebinding_rules_unchanged() -> No
     sel = _run_selector(*PE55_DURABLE_COMPLETION_FILL_REBINDING_FILES)
     assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     targets = _targets(sel)
-    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
-    assert _INTEGRATION_OWNER in targets
+    assert any(t.startswith(f"{_GRAPH_OWNER}::") for t in targets)
+    assert any(t.startswith(f"{_INTEGRATION_OWNER}::") for t in targets)
+    assert _GRAPH_OWNER not in targets
+    assert _INTEGRATION_OWNER not in targets
 
 
 def test_fast_lane_skips_full_static_sweep_when_focused() -> None:

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -1314,11 +1314,8 @@ def test_selector_pe60_completion_chain_delegation_rebinding_bounded_focused_tar
     assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     assert sel["test_selection_reason"] == "durable_completion_focused"
     targets = _targets(sel)
-    assert "tests/ops/test_durable_completion_validation_graph_v1.py" in targets
-    assert (
-        "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py"
-        in targets
-    )
+    assert _INTEGRATION_OWNER not in targets
+    assert any(t.startswith(f"{_INTEGRATION_OWNER}::") for t in targets)
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
     assert sel["tests_execute_full"] == "false"
     assert sel["tests_execute_no_op"] == "false"
@@ -1394,7 +1391,7 @@ def test_integration_partition_inventory_covers_all_nodes() -> None:
     )
 
     nodes = collect_integration_owner_node_ids()
-    assert len(nodes) == 246
+    assert len(nodes) == 257
     inventory = integration_partition_inventory()
     assert set(inventory) <= set(ALL_PARTITIONS)
     covered = [node for part in inventory.values() for node in part]
@@ -1402,6 +1399,76 @@ def test_integration_partition_inventory_covers_all_nodes() -> None:
     assert len(set(covered)) == len(nodes)
     for node in nodes:
         assert classify_integration_node_id(node) in inventory
+
+
+PR4550_CROSS_SLICE_DIFF = (
+    "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "src/ops/durable_completion_validation/graph.py",
+    "src/ops/durable_completion_validation/validators/__init__.py",
+    "src/ops/durable_completion_validation/validators/completion_chain.py",
+    "src/ops/durable_completion_validation/validators/cross_slice_coherence.py",
+    "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "tests/ops/test_durable_completion_validation_graph_v1.py",
+)
+
+
+def test_selector_pr4550_cross_slice_coherence_bounded_node_ids() -> None:
+    sel = _run_selector(*PR4550_CROSS_SLICE_DIFF)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    assert sel["test_selection_reason"] == "durable_completion_focused"
+    assert sel["tests_execute_exhaustive_full"] == "false"
+    targets = _targets(sel)
+    assert _GRAPH_OWNER not in targets
+    assert _CI_OWNER in targets
+    assert _INTEGRATION_OWNER not in targets
+    assert any(
+        "::test_pe33_cross_slice_coherence_bound_in_completion_happy_path" in t for t in targets
+    )
+    assert any("::test_pe33_proof_digest_chain_drift_fails" in t for t in targets)
+    pe33_targets = [t for t in targets if t.startswith(_INTEGRATION_OWNER + "::")]
+    assert len(pe33_targets) == 5
+    assert all("::test_pe33_" in t for t in pe33_targets)
+
+
+def test_selector_pr4550_fast_lane_durable_completion_bounded() -> None:
+    sel = _run_selector(*PR4550_CROSS_SLICE_DIFF)
+    assert sel["fast_lane_contract_mode"] == "DURABLE_COMPLETION_BOUNDED"
+    assert sel["fast_lane_contract_reason"] == "durable_completion_bounded_partition"
+    fast_lane_targets = _fast_lane_targets(sel)
+    pe33_targets = [t for t in fast_lane_targets if "::test_pe33_" in t]
+    graph_targets = [t for t in fast_lane_targets if t.startswith(_GRAPH_OWNER + "::")]
+    assert len(pe33_targets) == 5
+    assert len(graph_targets) == 3
+    assert _INTEGRATION_OWNER not in fast_lane_targets
+    assert _GRAPH_OWNER not in fast_lane_targets
+    assert len(fast_lane_targets) <= 10
+
+
+def test_selector_pr4550_matrix_contract_focused_not_exhaustive() -> None:
+    sel = _run_selector(*PR4550_CROSS_SLICE_DIFF)
+    assert sel["tests_execute_exhaustive_full"] == "false"
+    assert sel["tests_execute_pr_bounded_full"] == "false"
+    assert sel["tests_execute_contract_focused"] == "true"
+    targets = _targets(sel)
+    assert _INTEGRATION_OWNER not in targets
+    assert sum(1 for t in targets if "::test_pe33_" in t) == 5
+
+
+def test_selector_pe33_nodes_classified_in_inventory() -> None:
+    from scripts.ops.durable_completion_integration_partitions_v0 import (
+        PE33_PR_SMOKE_NODE_IDS,
+        classify_integration_node_id,
+        integration_partition_inventory,
+    )
+
+    inventory = integration_partition_inventory()
+    for node in PE33_PR_SMOKE_NODE_IDS:
+        assert classify_integration_node_id(node) == "pe33_pr_smoke"
+        assert node in inventory["pe33_pr_smoke"]
+    assert (
+        classify_integration_node_id("test_pe33_invalid_proof_lifecycle_states_fail[stale]")
+        == "pe33_cross_slice_exhaustive"
+    )
 
 
 def test_selector_pe21_prod_owner_partitioned_integration_nodes() -> None:

--- a/tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -503,6 +503,7 @@ def test_coherent_static_completion_happy_path_passes() -> None:
     assert result["pe34_handoff_bound"] is True
     assert result["pe35_staleness_revocation_recovery_bound"] is True
     assert result["pe36_admission_presentation_bound"] is True
+    assert result["pe33_cross_slice_proof_coherence_bound"] is True
     assert result["pe25_operator_closure_lifecycle_bound"] is True
     assert result["fail_reasons"] == []
 
@@ -3994,3 +3995,152 @@ def test_glb019_deterministic_repeat() -> None:
     second = evaluate_durable_run_primary_evidence_completion_integration(integration_input)
     assert first == second
     assert first["integration_input_digest"] == second["integration_input_digest"]
+
+
+def test_pe33_cross_slice_coherence_bound_in_completion_happy_path() -> None:
+    integration_input = default_minimal_completion_integration_input(
+        source_revision=VALID_COMMIT_SHA
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(integration_input)
+    assert result["integration_pass"] is True
+    assert result["pe33_cross_slice_proof_coherence_bound"] is True
+    chain = integration_input.completion_proof_chain
+    pe33_proof = integration_input.pe33_cross_slice_proof_coherence_proof
+    assert chain.completion_referenced_pe33_integration_proof_digest == pe33_proof.integration_proof_digest
+    assert chain.completion_referenced_pe33_integration_input_digest == pe33_proof.integration_input_digest
+
+
+def test_pe33_missing_integration_proof_digest_fails() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        pe33_cross_slice_proof_coherence_proof=replace(
+            integration_input.pe33_cross_slice_proof_coherence_proof,
+            integration_proof_digest="",
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("pe33_proof: integration_proof_digest required" in r for r in result["fail_reasons"])
+
+
+def test_pe33_proof_digest_chain_drift_fails() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        completion_proof_chain=replace(
+            integration_input.completion_proof_chain,
+            completion_referenced_pe33_integration_proof_digest="f" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any(
+        "completion_referenced_pe33_integration_proof_digest mismatch" in r
+        for r in result["fail_reasons"]
+    )
+
+
+def test_pe33_input_digest_chain_drift_fails() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        completion_proof_chain=replace(
+            integration_input.completion_proof_chain,
+            completion_referenced_pe33_integration_input_digest="a" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any(
+        "completion_referenced_pe33_integration_input_digest mismatch" in r
+        for r in result["fail_reasons"]
+    )
+
+
+def test_pe33_pe25_slot_digest_drift_fails() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        completion_proof_chain=replace(
+            integration_input.completion_proof_chain,
+            completion_referenced_pe33_pe25_slot_digest="b" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any(
+        "completion_referenced_pe33_pe25_slot_digest mismatch" in r for r in result["fail_reasons"]
+    )
+
+
+@pytest.mark.parametrize(
+    "lifecycle_state",
+    [
+        PROOF_LIFECYCLE_STALE,
+        PROOF_LIFECYCLE_REVOKED,
+        PROOF_LIFECYCLE_SUPERSEDED,
+    ],
+)
+def test_pe33_invalid_proof_lifecycle_states_fail(lifecycle_state: str) -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        pe33_proof_lifecycle=replace(
+            integration_input.pe33_proof_lifecycle,
+            lifecycle_state=lifecycle_state,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("pe33_proof_lifecycle: invalid lifecycle state" in r for r in result["fail_reasons"])
+
+
+def test_pe33_source_revision_mismatch_fails() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        pe33_cross_slice_proof_coherence_proof=replace(
+            integration_input.pe33_cross_slice_proof_coherence_proof,
+            source_revision=ALT_COMMIT_SHA,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("pe33_proof: source_revision mismatch" in r for r in result["fail_reasons"])
+
+
+def test_pe33_integration_proof_digest_drift_fails() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        pe33_cross_slice_proof_coherence_proof=replace(
+            integration_input.pe33_cross_slice_proof_coherence_proof,
+            integration_proof_digest="c" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("pe33_proof: integration_proof_digest mismatch" in r for r in result["fail_reasons"])
+
+
+def test_pe33_completion_slot_pe21_digest_drift_fails() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    slots = integration_input.pe33_cross_slice_proof_coherence_integration_input.proof_slots
+    pe21_slot = next(slot for slot in slots if slot.slot_id == "pe21")
+    bad_slot = replace(pe21_slot, proof_digest="d" * 64)
+    from src.ops.bounded_futures_testnet_cross_slice_proof_coherence_integration_contract_v0 import (
+        replace_proof_slot,
+    )
+
+    bad_pe33_input = replace(
+        integration_input.pe33_cross_slice_proof_coherence_integration_input,
+        proof_slots=replace_proof_slot(slots, bad_slot),
+    )
+    bad = replace(
+        integration_input,
+        pe33_cross_slice_proof_coherence_integration_input=bad_pe33_input,
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("PE-33 slot pe21 proof_digest mismatch" in r for r in result["fail_reasons"])

--- a/tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -4006,8 +4006,14 @@ def test_pe33_cross_slice_coherence_bound_in_completion_happy_path() -> None:
     assert result["pe33_cross_slice_proof_coherence_bound"] is True
     chain = integration_input.completion_proof_chain
     pe33_proof = integration_input.pe33_cross_slice_proof_coherence_proof
-    assert chain.completion_referenced_pe33_integration_proof_digest == pe33_proof.integration_proof_digest
-    assert chain.completion_referenced_pe33_integration_input_digest == pe33_proof.integration_input_digest
+    assert (
+        chain.completion_referenced_pe33_integration_proof_digest
+        == pe33_proof.integration_proof_digest
+    )
+    assert (
+        chain.completion_referenced_pe33_integration_input_digest
+        == pe33_proof.integration_input_digest
+    )
 
 
 def test_pe33_missing_integration_proof_digest_fails() -> None:

--- a/tests/ops/test_durable_completion_validation_graph_v1.py
+++ b/tests/ops/test_durable_completion_validation_graph_v1.py
@@ -180,7 +180,9 @@ def test_graph_missing_dependency_is_fail_closed() -> None:
     validators = {
         VALIDATOR_RECONCILIATION: lambda _ctx: ValidationResult(),
         VALIDATOR_RECOVERY: failing_recovery,
-        VALIDATOR_CROSS_SLICE_COHERENCE: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
+        VALIDATOR_CROSS_SLICE_COHERENCE: lambda _ctx: ValidationResult(
+            fail_reasons=("should not run",)
+        ),
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
         VALIDATOR_OPERATOR_CLOSURE: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
         VALIDATOR_WALLCLOCK: lambda _ctx: ValidationResult(),
@@ -227,7 +229,9 @@ def test_graph_aggregates_fail_reasons_from_executed_validators() -> None:
     validators = {
         VALIDATOR_RECONCILIATION: lambda _ctx: ValidationResult(fail_reasons=("alpha",)),
         VALIDATOR_RECOVERY: lambda _ctx: ValidationResult(fail_reasons=("beta",)),
-        VALIDATOR_CROSS_SLICE_COHERENCE: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
+        VALIDATOR_CROSS_SLICE_COHERENCE: lambda _ctx: ValidationResult(
+            fail_reasons=("should not run",)
+        ),
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(fail_reasons=("gamma",)),
         VALIDATOR_OPERATOR_CLOSURE: lambda _ctx: ValidationResult(fail_reasons=("delta",)),
         VALIDATOR_WALLCLOCK: lambda _ctx: ValidationResult(),

--- a/tests/ops/test_durable_completion_validation_graph_v1.py
+++ b/tests/ops/test_durable_completion_validation_graph_v1.py
@@ -21,6 +21,7 @@ from src.ops.durable_completion_validation.graph import (
     PROOF_BINDING_VALIDATION_GRAPH,
     PROOF_BINDING_VALIDATION_ORDER,
     VALIDATOR_COMPLETION_CHAIN,
+    VALIDATOR_CROSS_SLICE_COHERENCE,
     VALIDATOR_EVENT_STREAM,
     VALIDATOR_OPERATOR_CLOSURE,
     VALIDATOR_RECONCILIATION,
@@ -179,6 +180,7 @@ def test_graph_missing_dependency_is_fail_closed() -> None:
     validators = {
         VALIDATOR_RECONCILIATION: lambda _ctx: ValidationResult(),
         VALIDATOR_RECOVERY: failing_recovery,
+        VALIDATOR_CROSS_SLICE_COHERENCE: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
         VALIDATOR_OPERATOR_CLOSURE: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
         VALIDATOR_WALLCLOCK: lambda _ctx: ValidationResult(),
@@ -206,6 +208,7 @@ def test_graph_exception_is_fail_closed() -> None:
     validators = {
         VALIDATOR_RECONCILIATION: exploding,
         VALIDATOR_RECOVERY: lambda _ctx: ValidationResult(),
+        VALIDATOR_CROSS_SLICE_COHERENCE: lambda _ctx: ValidationResult(),
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(),
         VALIDATOR_OPERATOR_CLOSURE: lambda _ctx: ValidationResult(),
         VALIDATOR_WALLCLOCK: lambda _ctx: ValidationResult(),
@@ -224,6 +227,7 @@ def test_graph_aggregates_fail_reasons_from_executed_validators() -> None:
     validators = {
         VALIDATOR_RECONCILIATION: lambda _ctx: ValidationResult(fail_reasons=("alpha",)),
         VALIDATOR_RECOVERY: lambda _ctx: ValidationResult(fail_reasons=("beta",)),
+        VALIDATOR_CROSS_SLICE_COHERENCE: lambda _ctx: ValidationResult(fail_reasons=("should not run",)),
         VALIDATOR_TRACEABILITY: lambda _ctx: ValidationResult(fail_reasons=("gamma",)),
         VALIDATOR_OPERATOR_CLOSURE: lambda _ctx: ValidationResult(fail_reasons=("delta",)),
         VALIDATOR_WALLCLOCK: lambda _ctx: ValidationResult(),
@@ -234,9 +238,10 @@ def test_graph_aggregates_fail_reasons_from_executed_validators() -> None:
     assert set(result.fail_reasons) == {
         "alpha",
         "beta",
+        "validation_graph: dependency failed for 'cross_slice_coherence': ['reconciliation']",
         "validation_graph: dependency failed for 'traceability': ['recovery']",
-        "validation_graph: dependency failed for 'operator_closure': ['traceability', 'recovery']",
-        "validation_graph: dependency failed for 'completion_chain': ['operator_closure', 'traceability', 'recovery']",
+        "validation_graph: dependency failed for 'operator_closure': ['traceability', 'recovery', 'cross_slice_coherence']",
+        "validation_graph: dependency failed for 'completion_chain': ['operator_closure', 'traceability', 'recovery', 'cross_slice_coherence']",
     }
 
 


### PR DESCRIPTION
## Summary

- Bind PE-33 cross-slice proof coherence into the durable completion integration input, proof chain binding, and validation graph.
- Build PE-33 after finalized PE-25 from canonical completion proofs (`_build_pe33_integration_input_from_completion`) with deterministic slot rebind — not from the PE-34 handoff copy.
- Register `VALIDATOR_CROSS_SLICE_COHERENCE` in the durable completion validation graph; extend completion-chain digest checks and fail-closed PE-33 tests.

## Root cause

PE-33 was initially taken from the PE-34 handoff embedded evidence, which used separate default lifecycle digests. That caused digest mismatch on PE-22..PE-25 vs. the finalized completion chain.

## Bounded local validation

- `ruff format --check` / `ruff check` on changed files: PASS
- `test_pe33_cross_slice_coherence_bound_in_completion_happy_path`: PASS (~40s)
- Graph structure tests (cycle-free, dependency order, fail-reason aggregation with `VALIDATOR_CROSS_SLICE_COHERENCE`): 3/3 PASS
- **4 bounded tests in 73.66s** — no full completion/graph file runs (each `default_minimal_completion_integration_input()` + evaluate costs ~35–40s offline replay)

## CI

- Selector: `CONTRACT_FOCUSED` / `FOCUSED` (`durable_completion_focused`)
- `EXHAUSTIVE_FULL_SELECTED_FOR_PR=false`

## Safety

- Futures-only, offline/static integration — no runtime, orders, authority lift, or trading logic changes
- GLB019 / Master V2 bindings unchanged
- Existing proof slices preserved

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/durable_run_completion_cross_slice_proof_coherence_integration_v0_20260625T060724Z`

## Test plan

- [x] Bounded local happy path + graph structure tests
- [ ] CI FOCUSED path (completion + graph testowners)
- [ ] Fast-Lane / Matrix / Liveness Guard snapshot


Made with [Cursor](https://cursor.com)