### PR TITLE
feat(ops): bind Master V2 state events into primary evidence

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1186,6 +1186,17 @@ DURABLE_COMPLETION_FAST_LANE_SELECTOR_ANCHOR_NODE_IDS: tuple[str, ...] = (
     "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_pr4550_cross_slice_coherence_bounded_node_ids",
 )
 
+DURABLE_COMPLETION_FAST_LANE_MASTER_V2_EVENT_STREAM_SCOPED_PATHS = frozenset(
+    {
+        "src/ops/durable_completion_validation/validators/event_stream.py",
+    }
+)
+
+DURABLE_COMPLETION_FAST_LANE_MASTER_V2_EVENT_STREAM_HAPPY_PATH_NODE_IDS: tuple[str, ...] = (
+    f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_master_v2_kill_all_event_stream_happy_path",
+    f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_master_v2_state_switch_event_stream_happy_path_non_authorizing",
+)
+
 
 def _durable_completion_pe33_pr_smoke_pytest_targets() -> tuple[str, ...]:
     try:
@@ -1206,8 +1217,21 @@ def _partition_selection_uses_pe33_pr_smoke(partition_selection: frozenset[str])
     return "pe33_pr_smoke" in partition_selection
 
 
+def _durable_completion_fast_lane_master_v2_event_stream_happy_path_targets(
+    files: list[str],
+) -> tuple[str, ...]:
+    if not any(
+        path in DURABLE_COMPLETION_FAST_LANE_MASTER_V2_EVENT_STREAM_SCOPED_PATHS for path in files
+    ):
+        return ()
+    for target in DURABLE_COMPLETION_FAST_LANE_MASTER_V2_EVENT_STREAM_HAPPY_PATH_NODE_IDS:
+        if not _repo_pytest_target_exists(target):
+            return ()
+    return DURABLE_COMPLETION_FAST_LANE_MASTER_V2_EVENT_STREAM_HAPPY_PATH_NODE_IDS
+
+
 def _durable_completion_fast_lane_bounded_targets(files: list[str]) -> tuple[str, ...]:
-    """Fast-Lane: PE-33 PR smoke nodes + 3 graph structure tests + selector anchors only."""
+    """Fast-Lane: PE-33 PR smoke + Master-V2 event-stream happy-path + graph + selector anchors only."""
     graph_owner = DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER
     selector_owner = "tests/ci/test_ci_diff_aware_test_selection_v1.py"
     if not _repo_path_exists(graph_owner) or not _repo_path_exists(selector_owner):
@@ -1229,14 +1253,11 @@ def _durable_completion_fast_lane_bounded_targets(files: list[str]) -> tuple[str
             return ()
         targets.update(smoke_targets)
         return tuple(sorted(targets))
-    if not partition_selection:
-        return tuple(sorted(targets))
-    try:
-        if partition_union_node_count(partition_selection) >= integration_owner_node_count():
-            return ()
-        targets.update(expand_partitions_to_pytest_targets(partition_selection))
-    except (KeyError, RuntimeError, OSError, ValueError):
-        return ()
+    master_v2_targets = _durable_completion_fast_lane_master_v2_event_stream_happy_path_targets(
+        files
+    )
+    if master_v2_targets:
+        targets.update(master_v2_targets)
     return tuple(sorted(targets))
 
 

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1197,6 +1197,51 @@ DURABLE_COMPLETION_FAST_LANE_MASTER_V2_EVENT_STREAM_HAPPY_PATH_NODE_IDS: tuple[s
     f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_master_v2_state_switch_event_stream_happy_path_non_authorizing",
 )
 
+DURABLE_COMPLETION_MATRIX_MASTER_V2_EVENT_STREAM_BOUNDED_SCOPED_PATHS = frozenset(
+    {
+        DURABLE_COMPLETION_FACADE_PATH,
+        "src/ops/durable_completion_validation/validators/event_stream.py",
+        DURABLE_COMPLETION_INTEGRATION_TEST_OWNER,
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    }
+)
+
+DURABLE_COMPLETION_MATRIX_MASTER_V2_EVENT_STREAM_BOUNDED_NODE_IDS: tuple[str, ...] = (
+    f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_master_v2_state_switch_event_stream_happy_path_non_authorizing",
+    f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_master_v2_kill_all_event_stream_happy_path",
+    f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_master_v2_missing_required_event_fail_closed",
+    f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_master_v2_kill_all_terminal_break_fail_closed",
+    f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_completion_proof_chain_pe38_digest_bound_positive",
+    f"{DURABLE_COMPLETION_INTEGRATION_TEST_OWNER}::test_glb019_missing_proof_fail_closed",
+    f"{DURABLE_COMPLETION_VALIDATION_GRAPH_TEST_OWNER}::test_graph_explicit_order_matches_dependencies",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_pr4554_fast_lane_durable_completion_bounded_master_v2_event_stream",
+)
+
+
+def _is_durable_completion_matrix_master_v2_event_stream_bounded_scope(files: list[str]) -> bool:
+    if not any(
+        path in DURABLE_COMPLETION_FAST_LANE_MASTER_V2_EVENT_STREAM_SCOPED_PATHS for path in files
+    ):
+        return False
+    for path in files:
+        if path in DURABLE_COMPLETION_CI_POLICY_PATHS:
+            continue
+        if path in DURABLE_COMPLETION_CI_WORKFLOW_REBUNDLE_PATHS:
+            continue
+        if path in DURABLE_COMPLETION_MATRIX_MASTER_V2_EVENT_STREAM_BOUNDED_SCOPED_PATHS:
+            continue
+        return False
+    return True
+
+
+def _durable_completion_matrix_master_v2_event_stream_bounded_targets() -> tuple[str, ...]:
+    targets: list[str] = []
+    for target in DURABLE_COMPLETION_MATRIX_MASTER_V2_EVENT_STREAM_BOUNDED_NODE_IDS:
+        if not _repo_pytest_target_exists(target):
+            return ()
+        targets.append(target)
+    return tuple(sorted(set(targets)))
+
 
 def _durable_completion_pe33_pr_smoke_pytest_targets() -> tuple[str, ...]:
     try:
@@ -1665,6 +1710,10 @@ def _durable_completion_focused_targets(
             return tuple(sorted(set(targets)))
     if files and _is_durable_completion_wallclock_binding_rebinding_scope(files):
         return _durable_completion_wallclock_binding_focused_targets(files)
+    if files and _is_durable_completion_matrix_master_v2_event_stream_bounded_scope(files):
+        bounded = _durable_completion_matrix_master_v2_event_stream_bounded_targets()
+        if bounded:
+            return bounded
     if files and not _requires_durable_completion_integration_test_owner(files):
         validation_targets: list[str] = []
         for path in CANONICAL_DURABLE_COMPLETION_VALIDATION_GRAPH_FOCUSED_TESTS:

--- a/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -178,11 +178,18 @@ from src.ops.testnet_wallclock_duration_evidence_contract_v0 import (
 from src.ops.durable_completion_validation.validators.event_stream import (
     Glb019EventStreamProofBinding,
     Glb019EventStreamValidationInput,
+    MasterV2StateEventStreamProofBinding,
+    MasterV2StateEventStreamValidationInput,
+    compute_master_v2_state_event_validation_input_digest,
     compute_validation_input_digest as compute_glb019_event_stream_validation_input_digest,
     default_minimal_glb019_proof_binding,
     default_minimal_glb019_validation_input,
+    default_minimal_master_v2_state_event_proof_binding,
+    default_minimal_master_v2_state_event_validation_input,
     evaluate_glb019_event_stream_validation,
+    evaluate_master_v2_state_event_stream_validation,
     validate_glb019_event_stream_validation_input,
+    validate_master_v2_state_event_stream_validation_input,
 )
 from src.ops.wallclock_session_evidence_v0 import (
     WALLCLOCK_EVIDENCE_FILENAME,
@@ -776,6 +783,8 @@ class DurableRunPrimaryEvidenceCompletionIntegrationInput:
     contract_versions: ContractVersionsInput
     glb019_event_stream_validation_input: Glb019EventStreamValidationInput
     glb019_event_stream_proof: Glb019EventStreamProofBinding
+    master_v2_state_event_stream_validation_input: MasterV2StateEventStreamValidationInput
+    master_v2_state_event_stream_proof: MasterV2StateEventStreamProofBinding
     futures_only: bool = True
     environment: str = ENVIRONMENT_TESTNET
     non_authorizing: bool = True
@@ -1167,6 +1176,83 @@ def _validate_wallclock_evidence_proof(
         fail_reasons.append(
             "wallclock_evidence_proof.duration_proven drift from canonical evaluation"
         )
+    return _sorted_unique(fail_reasons)
+
+
+def _validate_master_v2_state_event_stream_binding(
+    integration_input: DurableRunPrimaryEvidenceCompletionIntegrationInput,
+    *,
+    completion_identity_digest: str,
+    manifest_identity_digest: str,
+    run_identity_digest: str,
+) -> list[str]:
+    fail_reasons: list[str] = []
+    validation_input = getattr(
+        integration_input, "master_v2_state_event_stream_validation_input", None
+    )
+    proof = getattr(integration_input, "master_v2_state_event_stream_proof", None)
+    if validation_input is None:
+        fail_reasons.append("master_v2_state_event_stream_validation_input required")
+        return fail_reasons
+    if proof is None:
+        fail_reasons.append("master_v2_state_event_stream_proof required")
+        return fail_reasons
+
+    fail_reasons.extend(validate_master_v2_state_event_stream_validation_input(validation_input))
+    if validation_input.source_revision != integration_input.source_revision:
+        fail_reasons.append(
+            "master_v2_state_event_stream_validation_input: source_revision mismatch with "
+            "completion input"
+        )
+    if validation_input.run_identity_digest != run_identity_digest:
+        fail_reasons.append(
+            "master_v2_state_event_stream_validation_input: run_identity_digest drift"
+        )
+    if validation_input.manifest_identity_digest != manifest_identity_digest:
+        fail_reasons.append(
+            "master_v2_state_event_stream_validation_input: manifest_identity_digest drift"
+        )
+    if validation_input.completion_identity_digest != completion_identity_digest:
+        fail_reasons.append(
+            "master_v2_state_event_stream_validation_input: completion_identity_digest drift"
+        )
+
+    master_v2_binding = integration_input.master_v2_decision_state_digest_binding
+    if master_v2_binding is not None:
+        if validation_input.bound_dynamic_scope_state_digest is None:
+            fail_reasons.append(
+                "master_v2_state_event_stream_validation_input: bound_dynamic_scope_state_digest "
+                "required when master_v2_decision_state_digest_binding present"
+            )
+        elif (
+            validation_input.bound_dynamic_scope_state_digest
+            != master_v2_binding.dynamic_scope_state_digest
+        ):
+            fail_reasons.append(
+                "master_v2_state_event_stream_validation_input: dynamic_scope_state_digest drift "
+                "from master_v2_decision_state_digest_binding"
+            )
+
+    master_v2_result = evaluate_master_v2_state_event_stream_validation(validation_input)
+    prefix = "master_v2_state_event_stream_proof"
+    if proof.source_revision != integration_input.source_revision:
+        fail_reasons.append(f"{prefix}: source_revision mismatch")
+    if proof.validation_input_digest != master_v2_result["validation_input_digest"]:
+        fail_reasons.append(f"{prefix}: validation_input_digest mismatch")
+    if proof.validation_result_digest != master_v2_result["validation_result_digest"]:
+        fail_reasons.append(f"{prefix}: validation_result_digest mismatch")
+    if proof.state_event_stream_identity != master_v2_result["state_event_stream_identity"]:
+        fail_reasons.append(f"{prefix}: state_event_stream_identity mismatch")
+    if proof.evidence_chain_profile != validation_input.evidence_chain_profile:
+        fail_reasons.append(f"{prefix}: evidence_chain_profile mismatch")
+    if not master_v2_result["validation_pass"]:
+        fail_reasons.append("master_v2_state_event_stream_validation: canonical evaluation failed")
+        fail_reasons.extend(
+            f"master_v2_state_event_stream_validation: {reason}"
+            for reason in master_v2_result.get("fail_reasons", [])
+        )
+    if proof.event_stream_non_authorizing is not True:
+        fail_reasons.append(f"{prefix}: event_stream_non_authorizing must be true")
     return _sorted_unique(fail_reasons)
 
 
@@ -2316,6 +2402,14 @@ def validate_durable_run_primary_evidence_completion_integration_input(
             run_identity_digest=run_identity.run_identity_digest,
         )
     )
+    fail_reasons.extend(
+        _validate_master_v2_state_event_stream_binding(
+            integration_input,
+            completion_identity_digest=expected_completion_identity_digest,
+            manifest_identity_digest=integration_input.manifest_proof.manifest_digest,
+            run_identity_digest=run_identity.run_identity_digest,
+        )
+    )
 
     post_write = integration_input.post_write_verification
     if post_write.post_write_verification_pass is not True:
@@ -2486,6 +2580,14 @@ def _integration_input_dict(
         "glb019_event_stream_validation_input_digest": (
             compute_glb019_event_stream_validation_input_digest(
                 integration_input.glb019_event_stream_validation_input
+            )
+        ),
+        "master_v2_state_event_stream_proof": asdict(
+            integration_input.master_v2_state_event_stream_proof
+        ),
+        "master_v2_state_event_stream_validation_input_digest": (
+            compute_master_v2_state_event_validation_input_digest(
+                integration_input.master_v2_state_event_stream_validation_input
             )
         ),
         "gap2a1_enforcement": asdict(integration_input.gap2a1_enforcement),
@@ -2754,6 +2856,9 @@ def evaluate_durable_run_primary_evidence_completion_integration(
     glb019_result = evaluate_glb019_event_stream_validation(
         integration_input.glb019_event_stream_validation_input
     )
+    master_v2_state_event_result = evaluate_master_v2_state_event_stream_validation(
+        integration_input.master_v2_state_event_stream_validation_input
+    )
     from src.ops.durable_completion_validation.graph import execute_proof_binding_validation_graph
     from src.ops.durable_completion_validation.models import ValidationContext
 
@@ -2826,6 +2931,9 @@ def evaluate_durable_run_primary_evidence_completion_integration(
         "pe36_admission_presentation_bound": bool(pe37_result.get("owner_identities_coherent")),
         "pe33_cross_slice_proof_coherence_bound": bool(
             pe33_result.get("cross_slice_proof_coherence_for_separate_operator_review")
+        ),
+        "master_v2_state_event_stream_bound": bool(
+            master_v2_state_event_result.get("validation_pass")
         ),
         "pe25_operator_closure_lifecycle_bound": bool(
             pe25_result.get("operator_closure_static_complete")
@@ -3509,6 +3617,20 @@ def default_minimal_completion_integration_input(
     )
     glb019_result = evaluate_glb019_event_stream_validation(glb019_validation_input)
     glb019_proof = default_minimal_glb019_proof_binding(glb019_validation_input, glb019_result)
+    master_v2_state_event_validation_input = default_minimal_master_v2_state_event_validation_input(
+        source_revision=source_revision,
+        completion_identity_digest=completion_identity_digest,
+        manifest_identity_digest=manifest_digest,
+        run_identity_digest=run_identity_digest,
+        correlation_id=run_id,
+    )
+    master_v2_state_event_result = evaluate_master_v2_state_event_stream_validation(
+        master_v2_state_event_validation_input
+    )
+    master_v2_state_event_proof = default_minimal_master_v2_state_event_proof_binding(
+        master_v2_state_event_validation_input,
+        master_v2_state_event_result,
+    )
     pe23_proof = default_minimal_pe23_integration_proof(
         pe23_integration_input,
         traceability_identity=run_root_digest,
@@ -3753,6 +3875,8 @@ def default_minimal_completion_integration_input(
         safety_snapshot=default_minimal_safety_snapshot(),
         glb019_event_stream_validation_input=glb019_validation_input,
         glb019_event_stream_proof=glb019_proof,
+        master_v2_state_event_stream_validation_input=master_v2_state_event_validation_input,
+        master_v2_state_event_stream_proof=master_v2_state_event_proof,
         contract_versions=ContractVersionsInput(
             pe12_lifecycle=PE12_CONTRACT_VERSION,
             pe16_archive=ARCHIVE_CONTRACT_VERSION,

--- a/src/ops/durable_completion_validation/validators/event_stream.py
+++ b/src/ops/durable_completion_validation/validators/event_stream.py
@@ -1,4 +1,4 @@
-"""GLB-019 event stream static boundary validator for durable completion proof binding."""
+"""GLB-019 and Master-V2 state event stream validators for durable completion proof binding."""
 
 from __future__ import annotations
 
@@ -404,4 +404,585 @@ def default_minimal_glb019_proof_binding(
         run_identity_digest=validation_input.run_identity_digest,
         correlation_id=validation_input.correlation_id,
         event_stream_identity=glb019_result["event_stream_identity"],
+    )
+
+
+MASTER_V2_STATE_EVENT_BOUNDARY_OWNER = (
+    "master_v2_kill_all_state_switch_event_stream_static_boundary_v0"
+)
+MASTER_V2_STATE_EVENT_CONTRACT_VERSION = "v0"
+
+MASTER_V2_SEMANTIC_EVENT_CLASSES: tuple[str, ...] = (
+    "dynamic_scope",
+    "state_switch",
+    "chop_guard",
+    "kill_all_terminal",
+)
+
+MASTER_V2_EVIDENCE_CHAIN_PROFILE_STATE_SWITCH = "state_switch_coherent_v0"
+MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL = "kill_all_terminal_v0"
+
+_SUPPORTED_EVIDENCE_CHAIN_PROFILES: frozenset[str] = frozenset(
+    {
+        MASTER_V2_EVIDENCE_CHAIN_PROFILE_STATE_SWITCH,
+        MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL,
+    }
+)
+
+_OFFLINE_SOURCE = "bounded_futures_testnet_durable_completion_offline_v0"
+_DEFAULT_TIMESTAMP_UTC = "2026-06-25T12:00:00Z"
+
+
+@dataclass(frozen=True)
+class MasterV2StateEventRecord:
+    semantic_event_class: str
+    event_id: str
+    sequence: int
+    timestamp_utc: str
+    source: str
+    correlation_id: str
+    schema_version: str
+    scope_event: str
+    side_state_before: str
+    side_state_after: str
+    scope_state_digest: str
+    transition_allowed: bool
+    present: bool
+    claims_live_authority: bool = False
+    claims_execution_authority: bool = False
+
+
+@dataclass(frozen=True)
+class MasterV2StateEventStreamValidationInput:
+    boundary_owner: str
+    source_revision: str
+    completion_identity_digest: str
+    manifest_identity_digest: str
+    run_identity_digest: str
+    correlation_id: str
+    evidence_chain_profile: str
+    bound_dynamic_scope_state_digest: str | None
+    events: tuple[MasterV2StateEventRecord, ...]
+
+
+@dataclass(frozen=True)
+class MasterV2StateEventStreamProofBinding:
+    boundary_owner: str
+    source_revision: str
+    validation_input_digest: str
+    validation_result_digest: str
+    master_v2_state_event_validation_pass: bool
+    event_stream_boundary_satisfied: bool
+    durable_completion_master_v2_state_event_bound: bool
+    incomplete_event_stream_fail_closed: bool
+    event_stream_non_authorizing: bool
+    completion_identity_digest: str
+    manifest_identity_digest: str
+    run_identity_digest: str
+    correlation_id: str
+    state_event_stream_identity: str
+    evidence_chain_profile: str
+
+
+def _master_v2_state_event_record_dict(record: MasterV2StateEventRecord) -> dict[str, Any]:
+    return asdict(record)
+
+
+def _master_v2_validation_input_dict(
+    validation_input: MasterV2StateEventStreamValidationInput,
+) -> dict[str, Any]:
+    return {
+        "boundary_owner": validation_input.boundary_owner,
+        "bound_dynamic_scope_state_digest": validation_input.bound_dynamic_scope_state_digest,
+        "completion_identity_digest": validation_input.completion_identity_digest,
+        "contract_version": MASTER_V2_STATE_EVENT_CONTRACT_VERSION,
+        "correlation_id": validation_input.correlation_id,
+        "evidence_chain_profile": validation_input.evidence_chain_profile,
+        "events": [
+            _master_v2_state_event_record_dict(record) for record in validation_input.events
+        ],
+        "hash_algorithm": HASH_ALGORITHM,
+        "manifest_identity_digest": validation_input.manifest_identity_digest,
+        "run_identity_digest": validation_input.run_identity_digest,
+        "source_revision": validation_input.source_revision,
+    }
+
+
+def compute_master_v2_scope_state_evidence_digest(*, scope_state: dict[str, Any]) -> str:
+    payload = {
+        "component": "dynamic_scope",
+        "hash_algorithm": HASH_ALGORITHM,
+        "state": dict(scope_state),
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def compute_master_v2_state_event_validation_input_digest(
+    validation_input: MasterV2StateEventStreamValidationInput,
+) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            _master_v2_validation_input_dict(validation_input),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def compute_master_v2_state_event_stream_identity(
+    validation_input: MasterV2StateEventStreamValidationInput,
+    *,
+    validation_pass: bool,
+) -> str:
+    payload = {
+        "correlation_id": validation_input.correlation_id,
+        "evidence_chain_profile": validation_input.evidence_chain_profile,
+        "hash_algorithm": HASH_ALGORITHM,
+        "required_semantic_event_classes": list(MASTER_V2_SEMANTIC_EVENT_CLASSES),
+        "validation_input_digest": compute_master_v2_state_event_validation_input_digest(
+            validation_input
+        ),
+        "validation_pass": validation_pass,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def compute_master_v2_state_event_validation_result_digest(
+    validation_input: MasterV2StateEventStreamValidationInput,
+    *,
+    validation_pass: bool,
+    fail_reasons: tuple[str, ...],
+) -> str:
+    payload = {
+        "boundary_owner": MASTER_V2_STATE_EVENT_BOUNDARY_OWNER,
+        "fail_reasons": list(fail_reasons),
+        "hash_algorithm": HASH_ALGORITHM,
+        "state_event_stream_identity": compute_master_v2_state_event_stream_identity(
+            validation_input,
+            validation_pass=validation_pass,
+        ),
+        "validation_input_digest": compute_master_v2_state_event_validation_input_digest(
+            validation_input
+        ),
+        "validation_pass": validation_pass,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _default_offline_scope_state() -> dict[str, Any]:
+    return {
+        "anchor_price": 100.0,
+        "chop_latched": False,
+        "current_downscope_boundary": 95.0,
+        "current_hysteresis_band": 2.0,
+        "current_upscope_boundary": 105.0,
+        "last_completed_side_switch_tick": -1_000_000,
+        "last_switch_tick": -1_000_000,
+        "now_tick": 0,
+        "scope_stability_ticks": 0,
+        "switches_in_window": 0,
+        "window_start_tick": 0,
+    }
+
+
+def _master_v2_state_event_record(
+    *,
+    semantic_event_class: str,
+    event_id: str,
+    sequence: int,
+    correlation_id: str,
+    scope_event: str,
+    side_state_before: str,
+    side_state_after: str,
+    scope_state_digest: str,
+    transition_allowed: bool,
+    present: bool = True,
+) -> MasterV2StateEventRecord:
+    return MasterV2StateEventRecord(
+        semantic_event_class=semantic_event_class,
+        event_id=event_id,
+        sequence=sequence,
+        timestamp_utc=_DEFAULT_TIMESTAMP_UTC,
+        source=_OFFLINE_SOURCE,
+        correlation_id=correlation_id,
+        schema_version=MASTER_V2_STATE_EVENT_CONTRACT_VERSION,
+        scope_event=scope_event,
+        side_state_before=side_state_before,
+        side_state_after=side_state_after,
+        scope_state_digest=scope_state_digest,
+        transition_allowed=transition_allowed,
+        present=present,
+        claims_live_authority=False,
+        claims_execution_authority=False,
+    )
+
+
+def default_minimal_master_v2_state_switch_event_records(
+    *,
+    correlation_id: str,
+    scope_state_digest: str,
+) -> tuple[MasterV2StateEventRecord, ...]:
+    from src.trading.master_v2.double_play_state import ScopeEvent, SideState
+
+    return (
+        _master_v2_state_event_record(
+            semantic_event_class="dynamic_scope",
+            event_id="mv2-dynamic-scope-001",
+            sequence=0,
+            correlation_id=correlation_id,
+            scope_event=ScopeEvent.UPSCOPE_CANDIDATE.value,
+            side_state_before=SideState.LONG_ACTIVE.value,
+            side_state_after=SideState.LONG_ACTIVE.value,
+            scope_state_digest=scope_state_digest,
+            transition_allowed=True,
+        ),
+        _master_v2_state_event_record(
+            semantic_event_class="state_switch",
+            event_id="mv2-state-switch-001",
+            sequence=1,
+            correlation_id=correlation_id,
+            scope_event=ScopeEvent.DOWNSCOPE_CONFIRMED.value,
+            side_state_before=SideState.LONG_ACTIVE.value,
+            side_state_after=SideState.SWITCH_LONG_TO_SHORT_PENDING.value,
+            scope_state_digest=scope_state_digest,
+            transition_allowed=True,
+        ),
+        _master_v2_state_event_record(
+            semantic_event_class="chop_guard",
+            event_id="mv2-chop-guard-001",
+            sequence=2,
+            correlation_id=correlation_id,
+            scope_event=ScopeEvent.CHOP_DETECTED.value,
+            side_state_before=SideState.LONG_ACTIVE.value,
+            side_state_after=SideState.LONG_ACTIVE.value,
+            scope_state_digest=scope_state_digest,
+            transition_allowed=False,
+        ),
+    )
+
+
+def default_minimal_master_v2_kill_all_event_records(
+    *,
+    correlation_id: str,
+    scope_state_digest: str,
+) -> tuple[MasterV2StateEventRecord, ...]:
+    from src.trading.master_v2.double_play_state import ScopeEvent, SideState
+
+    return (
+        _master_v2_state_event_record(
+            semantic_event_class="kill_all_terminal",
+            event_id="mv2-kill-all-001",
+            sequence=0,
+            correlation_id=correlation_id,
+            scope_event=ScopeEvent.KILL_ALL_REQUIRED.value,
+            side_state_before=SideState.LONG_ACTIVE.value,
+            side_state_after=SideState.KILL_ALL.value,
+            scope_state_digest=scope_state_digest,
+            transition_allowed=True,
+        ),
+    )
+
+
+def validate_master_v2_state_event_stream_validation_input(
+    validation_input: MasterV2StateEventStreamValidationInput,
+) -> list[str]:
+    fail_reasons: list[str] = []
+    prefix = "master_v2_state_event_stream_input"
+
+    if validation_input.boundary_owner != MASTER_V2_STATE_EVENT_BOUNDARY_OWNER:
+        fail_reasons.append(
+            f"{prefix}: boundary_owner must be {MASTER_V2_STATE_EVENT_BOUNDARY_OWNER!r}"
+        )
+    if not validation_input.source_revision:
+        fail_reasons.append(f"{prefix}: source_revision required")
+    if validation_input.evidence_chain_profile not in _SUPPORTED_EVIDENCE_CHAIN_PROFILES:
+        fail_reasons.append(f"{prefix}: unsupported evidence_chain_profile")
+
+    for field_name in (
+        "completion_identity_digest",
+        "manifest_identity_digest",
+        "run_identity_digest",
+    ):
+        value = getattr(validation_input, field_name)
+        if not value:
+            fail_reasons.append(f"{prefix}: {field_name} required")
+        elif not valid_sha256_digest(value):
+            fail_reasons.append(f"{prefix}: {field_name} must be 64-char lowercase sha256 hex")
+
+    if validation_input.bound_dynamic_scope_state_digest is not None and not valid_sha256_digest(
+        validation_input.bound_dynamic_scope_state_digest
+    ):
+        fail_reasons.append(
+            f"{prefix}: bound_dynamic_scope_state_digest must be 64-char lowercase sha256 hex"
+        )
+
+    if not validation_input.correlation_id:
+        fail_reasons.append(f"{prefix}: correlation_id required")
+    if not validation_input.events:
+        fail_reasons.append(f"{prefix}: events required")
+
+    seen_ids: set[str] = set()
+    seen_sequences: set[int] = set()
+    for index, record in enumerate(validation_input.events):
+        rec_prefix = f"{prefix}: events[{index}]"
+        if record.semantic_event_class not in MASTER_V2_SEMANTIC_EVENT_CLASSES:
+            fail_reasons.append(f"{rec_prefix}: unknown semantic_event_class")
+        if not record.event_id:
+            fail_reasons.append(f"{rec_prefix}: event_id required")
+        elif record.event_id in seen_ids:
+            fail_reasons.append(f"{rec_prefix}: duplicate event_id")
+        else:
+            seen_ids.add(record.event_id)
+        if record.sequence in seen_sequences:
+            fail_reasons.append(f"{rec_prefix}: duplicate sequence")
+        else:
+            seen_sequences.add(record.sequence)
+        if not record.timestamp_utc:
+            fail_reasons.append(f"{rec_prefix}: timestamp_utc required")
+        if not record.source:
+            fail_reasons.append(f"{rec_prefix}: source required")
+        if not record.schema_version:
+            fail_reasons.append(f"{rec_prefix}: schema_version required")
+        if record.correlation_id != validation_input.correlation_id:
+            fail_reasons.append(f"{rec_prefix}: correlation_id mismatch with validation input")
+        if record.present and not valid_sha256_digest(record.scope_state_digest):
+            fail_reasons.append(
+                f"{rec_prefix}: scope_state_digest must be 64-char lowercase sha256 hex"
+            )
+        if record.claims_live_authority or record.claims_execution_authority:
+            fail_reasons.append(f"{rec_prefix}: authority claims forbidden in evidence-only stream")
+
+    return sorted_unique(fail_reasons)
+
+
+def _validate_master_v2_transition_semantics(
+    validation_input: MasterV2StateEventStreamValidationInput,
+) -> list[str]:
+    from src.trading.master_v2.double_play_state import (
+        DynamicScopeRules,
+        RuntimeEnvelope,
+        RuntimeScopeState,
+        ScopeEvent,
+        SideState,
+        StaticHardLimits,
+        transition_state,
+    )
+
+    fail_reasons: list[str] = []
+    prefix = "master_v2_state_event_stream"
+    envelope = RuntimeEnvelope(static=StaticHardLimits(), live_authorization=False)
+    rules = DynamicScopeRules(
+        downscope_band_multiplier=1.0,
+        upscope_band_multiplier=1.0,
+        min_band_width=0.5,
+        max_band_width=100.0,
+        min_switch_cooldown_ticks=0,
+        max_switches_per_window=10,
+    )
+    scope_state = RuntimeScopeState(**_default_offline_scope_state())
+    transition_keys: set[tuple[str, str, int]] = set()
+    kill_all_terminal_seen = False
+
+    present_records = sorted(
+        (record for record in validation_input.events if record.present),
+        key=lambda record: record.sequence,
+    )
+
+    for index, record in enumerate(present_records):
+        rec_prefix = f"{prefix}: events[{index}]"
+        try:
+            side_before = SideState(record.side_state_before)
+            scope_event = ScopeEvent(record.scope_event)
+        except ValueError:
+            fail_reasons.append(f"{rec_prefix}: invalid canonical scope_event or side_state_before")
+            continue
+
+        transition_key = (record.scope_event, record.side_state_before)
+        if transition_key in transition_keys:
+            fail_reasons.append(f"{rec_prefix}: duplicate transition event")
+        else:
+            transition_keys.add(transition_key)
+
+        if kill_all_terminal_seen:
+            fail_reasons.append(f"{rec_prefix}: transition after kill_all_terminal forbidden")
+            continue
+
+        if (
+            validation_input.bound_dynamic_scope_state_digest is not None
+            and record.scope_state_digest != validation_input.bound_dynamic_scope_state_digest
+        ):
+            fail_reasons.append(f"{rec_prefix}: scope_state_digest drift from bound dynamic scope")
+
+        side_after, _, decision = transition_state(
+            side_state=side_before,
+            event=scope_event,
+            scope_state=scope_state,
+            rules=rules,
+            envelope=envelope,
+            now_tick=record.sequence + 1,
+        )
+        expected_after = side_after.value
+        if record.side_state_after != expected_after:
+            fail_reasons.append(
+                f"{rec_prefix}: side_state_after mismatch with canonical transition semantics"
+            )
+        if record.transition_allowed != decision.allowed:
+            fail_reasons.append(
+                f"{rec_prefix}: transition_allowed mismatch with canonical semantics"
+            )
+
+        if (
+            record.semantic_event_class == "chop_guard"
+            and expected_after == SideState.KILL_ALL.value
+        ):
+            fail_reasons.append(f"{rec_prefix}: chop_guard must not escalate to kill_all")
+
+        if record.semantic_event_class == "kill_all_terminal":
+            if scope_event != ScopeEvent.KILL_ALL_REQUIRED:
+                fail_reasons.append(f"{rec_prefix}: kill_all_terminal requires KILL_ALL_REQUIRED")
+            if expected_after != SideState.KILL_ALL.value:
+                fail_reasons.append(
+                    f"{rec_prefix}: kill_all_terminal must end in kill_all side state"
+                )
+            kill_all_terminal_seen = True
+
+    return fail_reasons
+
+
+def _validate_master_v2_profile_requirements(
+    validation_input: MasterV2StateEventStreamValidationInput,
+) -> list[str]:
+    fail_reasons: list[str] = []
+    prefix = "master_v2_state_event_stream"
+    present_by_class: dict[str, list[MasterV2StateEventRecord]] = {}
+    for record in validation_input.events:
+        if record.present:
+            present_by_class.setdefault(record.semantic_event_class, []).append(record)
+
+    profile = validation_input.evidence_chain_profile
+    if profile == MASTER_V2_EVIDENCE_CHAIN_PROFILE_STATE_SWITCH:
+        for event_class in ("dynamic_scope", "state_switch"):
+            if event_class not in present_by_class:
+                fail_reasons.append(f"{prefix}: missing required event class {event_class!r}")
+        if "kill_all_terminal" in present_by_class:
+            fail_reasons.append(f"{prefix}: kill_all_terminal forbidden in state_switch profile")
+        if "chop_guard" in present_by_class:
+            for record in present_by_class["chop_guard"]:
+                if record.side_state_after == "kill_all":
+                    fail_reasons.append(f"{prefix}: chop_guard escalated to kill_all")
+    elif profile == MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL:
+        if "kill_all_terminal" not in present_by_class:
+            fail_reasons.append(f"{prefix}: missing required event class 'kill_all_terminal'")
+        if "state_switch" in present_by_class:
+            fail_reasons.append(f"{prefix}: state_switch forbidden after kill_all profile binding")
+
+    sequences = sorted(record.sequence for record in validation_input.events if record.present)
+    if sequences and sequences != list(range(sequences[0], sequences[0] + len(sequences))):
+        fail_reasons.append(f"{prefix}: contradictory or non-contiguous sequence ordering")
+
+    return fail_reasons
+
+
+def evaluate_master_v2_state_event_stream_validation(
+    validation_input: MasterV2StateEventStreamValidationInput,
+) -> dict[str, Any]:
+    """Canonical offline Master-V2 Kill-All/State-Switch event stream validation."""
+    fail_reasons = validate_master_v2_state_event_stream_validation_input(validation_input)
+    if not fail_reasons:
+        fail_reasons.extend(_validate_master_v2_profile_requirements(validation_input))
+    if not fail_reasons:
+        fail_reasons.extend(_validate_master_v2_transition_semantics(validation_input))
+
+    fail_reasons = sorted_unique(fail_reasons)
+    validation_pass = not fail_reasons
+    state_event_stream_identity = compute_master_v2_state_event_stream_identity(
+        validation_input,
+        validation_pass=validation_pass,
+    )
+    validation_result_digest = compute_master_v2_state_event_validation_result_digest(
+        validation_input,
+        validation_pass=validation_pass,
+        fail_reasons=tuple(fail_reasons),
+    )
+    return {
+        "boundary_owner": MASTER_V2_STATE_EVENT_BOUNDARY_OWNER,
+        "validation_pass": validation_pass,
+        "event_stream_boundary_satisfied": validation_pass,
+        "incomplete_event_stream_fail_closed": not validation_pass,
+        "event_stream_non_authorizing": True,
+        "validation_input_digest": compute_master_v2_state_event_validation_input_digest(
+            validation_input
+        ),
+        "validation_result_digest": validation_result_digest,
+        "state_event_stream_identity": state_event_stream_identity,
+        "evidence_chain_profile": validation_input.evidence_chain_profile,
+        "fail_reasons": fail_reasons,
+    }
+
+
+def default_minimal_master_v2_state_event_validation_input(
+    *,
+    source_revision: str,
+    completion_identity_digest: str,
+    manifest_identity_digest: str,
+    run_identity_digest: str,
+    correlation_id: str,
+    evidence_chain_profile: str = MASTER_V2_EVIDENCE_CHAIN_PROFILE_STATE_SWITCH,
+    bound_dynamic_scope_state_digest: str | None = None,
+) -> MasterV2StateEventStreamValidationInput:
+    scope_state_digest = (
+        bound_dynamic_scope_state_digest
+        or compute_master_v2_scope_state_evidence_digest(scope_state=_default_offline_scope_state())
+    )
+    if evidence_chain_profile == MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL:
+        events = default_minimal_master_v2_kill_all_event_records(
+            correlation_id=correlation_id,
+            scope_state_digest=scope_state_digest,
+        )
+    else:
+        events = default_minimal_master_v2_state_switch_event_records(
+            correlation_id=correlation_id,
+            scope_state_digest=scope_state_digest,
+        )
+    return MasterV2StateEventStreamValidationInput(
+        boundary_owner=MASTER_V2_STATE_EVENT_BOUNDARY_OWNER,
+        source_revision=source_revision,
+        completion_identity_digest=completion_identity_digest,
+        manifest_identity_digest=manifest_identity_digest,
+        run_identity_digest=run_identity_digest,
+        correlation_id=correlation_id,
+        evidence_chain_profile=evidence_chain_profile,
+        bound_dynamic_scope_state_digest=bound_dynamic_scope_state_digest,
+        events=events,
+    )
+
+
+def default_minimal_master_v2_state_event_proof_binding(
+    validation_input: MasterV2StateEventStreamValidationInput,
+    master_v2_result: dict[str, Any],
+) -> MasterV2StateEventStreamProofBinding:
+    if not master_v2_result.get("validation_pass"):
+        raise ValueError("Master-V2 state event validation must pass for default minimal proof")
+    return MasterV2StateEventStreamProofBinding(
+        boundary_owner=MASTER_V2_STATE_EVENT_BOUNDARY_OWNER,
+        source_revision=validation_input.source_revision,
+        validation_input_digest=master_v2_result["validation_input_digest"],
+        validation_result_digest=master_v2_result["validation_result_digest"],
+        master_v2_state_event_validation_pass=True,
+        event_stream_boundary_satisfied=True,
+        durable_completion_master_v2_state_event_bound=True,
+        incomplete_event_stream_fail_closed=False,
+        event_stream_non_authorizing=True,
+        completion_identity_digest=validation_input.completion_identity_digest,
+        manifest_identity_digest=validation_input.manifest_identity_digest,
+        run_identity_digest=validation_input.run_identity_digest,
+        correlation_id=validation_input.correlation_id,
+        state_event_stream_identity=master_v2_result["state_event_stream_identity"],
+        evidence_chain_profile=validation_input.evidence_chain_profile,
     )

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -1462,6 +1462,35 @@ def test_selector_pr4550_fast_lane_durable_completion_bounded() -> None:
     assert len(fast_lane_targets) <= 10
 
 
+PR4554_MASTER_V2_EVENT_STREAM_BINDING_FILES = (
+    "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "src/ops/durable_completion_validation/validators/event_stream.py",
+    "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+)
+
+
+def test_selector_pr4554_fast_lane_durable_completion_bounded_master_v2_event_stream() -> None:
+    sel = _run_selector(*PR4554_MASTER_V2_EVENT_STREAM_BINDING_FILES)
+    assert sel["fast_lane_contract_mode"] == "DURABLE_COMPLETION_BOUNDED"
+    assert sel["fast_lane_contract_reason"] == "durable_completion_bounded_partition"
+    fast_lane_targets = _fast_lane_targets(sel)
+    graph_targets = [t for t in fast_lane_targets if t.startswith(_GRAPH_OWNER + "::")]
+    master_v2_targets = [
+        t
+        for t in fast_lane_targets
+        if "::test_master_v2_kill_all_event_stream_happy_path" in t
+        or "::test_master_v2_state_switch_event_stream_happy_path_non_authorizing" in t
+    ]
+    assert len(graph_targets) == 3
+    assert len(master_v2_targets) == 2
+    assert not any(
+        "::test_coherent_static_completion_happy_path_passes" in t for t in fast_lane_targets
+    )
+    assert _INTEGRATION_OWNER not in fast_lane_targets
+    assert _GRAPH_OWNER not in fast_lane_targets
+    assert len(fast_lane_targets) == 7
+
+
 def test_selector_pr4550_matrix_contract_focused_not_exhaustive() -> None:
     sel = _run_selector(*PR4550_CROSS_SLICE_DIFF)
     assert sel["tests_execute_exhaustive_full"] == "false"

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -682,7 +682,7 @@ def test_selector_glb019_a2b_full_nine_file_pr_explicit_git_diff_focused() -> No
     assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" in targets
     assert _GRAPH_OWNER in targets
     integration_nodes = [t for t in targets if t.startswith(f"{_INTEGRATION_OWNER}::test_")]
-    assert len(integration_nodes) == 45
+    assert len(integration_nodes) == 47
 
 
 def test_selector_glb019_a2b_live_collect_patch_contract_focused() -> None:
@@ -1409,7 +1409,7 @@ def test_integration_partition_inventory_covers_all_nodes() -> None:
     )
 
     nodes = collect_integration_owner_node_ids()
-    assert len(nodes) == 257
+    assert len(nodes) == 271
     inventory = integration_partition_inventory()
     assert set(inventory) <= set(ALL_PARTITIONS)
     covered = [node for part in inventory.values() for node in part]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -1491,6 +1491,41 @@ def test_selector_pr4554_fast_lane_durable_completion_bounded_master_v2_event_st
     assert len(fast_lane_targets) == 7
 
 
+DURABLE_COMPLETION_EVENT_STREAM_VALIDATOR_BINDING_FILES = (
+    "src/ops/bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "src/ops/durable_completion_validation/validators/event_stream.py",
+    "tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
+DURABLE_COMPLETION_MATRIX_MASTER_V2_EVENT_STREAM_BOUNDED_TARGETS = (
+    f"{_INTEGRATION_OWNER}::test_master_v2_state_switch_event_stream_happy_path_non_authorizing",
+    f"{_INTEGRATION_OWNER}::test_master_v2_kill_all_event_stream_happy_path",
+    f"{_INTEGRATION_OWNER}::test_master_v2_missing_required_event_fail_closed",
+    f"{_INTEGRATION_OWNER}::test_master_v2_kill_all_terminal_break_fail_closed",
+    f"{_INTEGRATION_OWNER}::test_completion_proof_chain_pe38_digest_bound_positive",
+    f"{_INTEGRATION_OWNER}::test_glb019_missing_proof_fail_closed",
+    f"{_GRAPH_OWNER}::test_graph_explicit_order_matches_dependencies",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_pr4554_fast_lane_durable_completion_bounded_master_v2_event_stream",
+)
+
+
+def test_selector_durable_completion_event_stream_validator_focused_matrix_eight_node_bounded() -> (
+    None
+):
+    sel = _run_selector(*DURABLE_COMPLETION_EVENT_STREAM_VALIDATOR_BINDING_FILES)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    assert sel["test_selection_reason"] == "durable_completion_focused"
+    targets = _targets(sel)
+    assert targets == sorted(DURABLE_COMPLETION_MATRIX_MASTER_V2_EVENT_STREAM_BOUNDED_TARGETS)
+    assert _INTEGRATION_OWNER not in targets
+    assert _GRAPH_OWNER not in targets
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" not in targets
+    assert not any("::test_coherent_static_completion_happy_path_passes" in t for t in targets)
+    assert not any("::test_global_safety_flags_remain_blocked" in t for t in targets)
+    assert not any("::test_master_v2_dynamic_scope_digest_drift_fail_closed" in t for t in targets)
+
+
 def test_selector_pr4550_matrix_contract_focused_not_exhaustive() -> None:
     sel = _run_selector(*PR4550_CROSS_SLICE_DIFF)
     assert sel["tests_execute_exhaustive_full"] == "false"

--- a/tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_durable_run_primary_evidence_completion_integration_contract_v0.py
@@ -3997,6 +3997,288 @@ def test_glb019_deterministic_repeat() -> None:
     assert first["integration_input_digest"] == second["integration_input_digest"]
 
 
+def test_master_v2_state_switch_event_stream_happy_path_non_authorizing() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    result = evaluate_durable_run_primary_evidence_completion_integration(integration_input)
+    assert result["integration_pass"] is True
+    assert result["master_v2_state_event_stream_bound"] is True
+    assert integration_input.master_v2_state_event_stream_proof.event_stream_non_authorizing is True
+    assert result["authority_lift"] is False
+
+
+def test_master_v2_kill_all_event_stream_happy_path() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL,
+        default_minimal_master_v2_kill_all_event_records,
+        default_minimal_master_v2_state_event_proof_binding,
+        default_minimal_master_v2_state_event_validation_input,
+        evaluate_master_v2_state_event_stream_validation,
+    )
+
+    integration_input = default_minimal_completion_integration_input()
+    validation_input = default_minimal_master_v2_state_event_validation_input(
+        source_revision=integration_input.source_revision,
+        completion_identity_digest=integration_input.master_v2_state_event_stream_validation_input.completion_identity_digest,
+        manifest_identity_digest=integration_input.master_v2_state_event_stream_validation_input.manifest_identity_digest,
+        run_identity_digest=integration_input.run_identity.run_identity_digest,
+        correlation_id=integration_input.run_identity.run_id,
+        evidence_chain_profile=MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL,
+    )
+    master_v2_result = evaluate_master_v2_state_event_stream_validation(validation_input)
+    assert master_v2_result["validation_pass"] is True
+    proof = default_minimal_master_v2_state_event_proof_binding(validation_input, master_v2_result)
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=validation_input,
+        master_v2_state_event_stream_proof=proof,
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is True
+    assert result["master_v2_state_event_stream_bound"] is True
+    assert validation_input.events == default_minimal_master_v2_kill_all_event_records(
+        correlation_id=integration_input.run_identity.run_id,
+        scope_state_digest=validation_input.events[0].scope_state_digest,
+    )
+
+
+def test_master_v2_missing_validation_input_fail_closed() -> None:
+    from types import SimpleNamespace
+
+    integration_input = default_minimal_completion_integration_input()
+    legacy = SimpleNamespace(
+        **{
+            field.name: getattr(integration_input, field.name)
+            for field in integration_input.__dataclass_fields__.values()
+            if field.name != "master_v2_state_event_stream_validation_input"
+        }
+    )
+    fail_reasons = validate_durable_run_primary_evidence_completion_integration_input(legacy)  # type: ignore[arg-type]
+    assert any(
+        "master_v2_state_event_stream_validation_input required" in reason
+        for reason in fail_reasons
+    )
+
+
+def test_master_v2_missing_proof_fail_closed() -> None:
+    from types import SimpleNamespace
+
+    integration_input = default_minimal_completion_integration_input()
+    legacy = SimpleNamespace(
+        **{
+            field.name: getattr(integration_input, field.name)
+            for field in integration_input.__dataclass_fields__.values()
+            if field.name != "master_v2_state_event_stream_proof"
+        }
+    )
+    fail_reasons = validate_durable_run_primary_evidence_completion_integration_input(legacy)  # type: ignore[arg-type]
+    assert any("master_v2_state_event_stream_proof required" in reason for reason in fail_reasons)
+
+
+def test_master_v2_missing_required_event_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    kept = tuple(
+        record
+        for record in validation_input.events
+        if record.semantic_event_class != "state_switch"
+    )
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=replace(
+            validation_input,
+            events=kept,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any(
+        "missing required event class 'state_switch'" in reason for reason in result["fail_reasons"]
+    )
+
+
+def test_master_v2_wrong_event_order_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    reordered = (
+        replace(validation_input.events[0], sequence=0),
+        replace(validation_input.events[1], sequence=2),
+    )
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=replace(
+            validation_input,
+            events=reordered,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("non-contiguous sequence ordering" in reason for reason in result["fail_reasons"])
+
+
+def test_master_v2_duplicate_transition_event_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    duplicate = validation_input.events[1]
+    bad_events = validation_input.events + (
+        replace(duplicate, event_id="mv2-state-switch-dup", sequence=len(validation_input.events)),
+    )
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=replace(
+            validation_input,
+            events=bad_events,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("duplicate transition event" in reason for reason in result["fail_reasons"])
+
+
+def test_master_v2_digest_drift_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_proof=replace(
+            integration_input.master_v2_state_event_stream_proof,
+            validation_result_digest="0" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("validation_result_digest mismatch" in reason for reason in result["fail_reasons"])
+
+
+def test_master_v2_identity_drift_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=replace(
+            integration_input.master_v2_state_event_stream_validation_input,
+            run_identity_digest="0" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("run_identity_digest drift" in reason for reason in result["fail_reasons"])
+
+
+def test_master_v2_proof_reference_drift_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_proof=replace(
+            integration_input.master_v2_state_event_stream_proof,
+            state_event_stream_identity="0" * 64,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any(
+        "state_event_stream_identity mismatch" in reason for reason in result["fail_reasons"]
+    )
+
+
+def test_master_v2_state_switch_coherence_break_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    broken_events = tuple(
+        replace(
+            record,
+            side_state_after="short_active",
+        )
+        if record.semantic_event_class == "state_switch"
+        else record
+        for record in validation_input.events
+    )
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=replace(
+            validation_input,
+            events=broken_events,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any(
+        "side_state_after mismatch with canonical transition semantics" in reason
+        for reason in result["fail_reasons"]
+    )
+
+
+def test_master_v2_kill_all_terminal_break_fail_closed() -> None:
+    from src.ops.durable_completion_validation.validators.event_stream import (
+        MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL,
+        default_minimal_master_v2_kill_all_event_records,
+    )
+    from src.trading.master_v2.double_play_state import SideState
+
+    integration_input = default_minimal_completion_integration_input()
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    scope_digest = validation_input.events[0].scope_state_digest
+    broken_kill_all = replace(
+        default_minimal_master_v2_kill_all_event_records(
+            correlation_id=validation_input.correlation_id,
+            scope_state_digest=scope_digest,
+        )[0],
+        side_state_after=SideState.LONG_BLOCKED.value,
+    )
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=replace(
+            validation_input,
+            evidence_chain_profile=MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL,
+            events=(broken_kill_all,),
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any(
+        "kill_all_terminal must end in kill_all side state" in reason
+        or "side_state_after mismatch with canonical transition semantics" in reason
+        for reason in result["fail_reasons"]
+    )
+
+
+def test_master_v2_dynamic_scope_digest_drift_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    drifted_events = tuple(
+        replace(record, scope_state_digest="f" * 64) for record in validation_input.events
+    )
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=replace(
+            validation_input,
+            bound_dynamic_scope_state_digest="a" * 64,
+            events=drifted_events,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any(
+        "scope_state_digest drift from bound dynamic scope" in reason
+        for reason in result["fail_reasons"]
+    )
+
+
+def test_master_v2_authority_claim_fail_closed() -> None:
+    integration_input = default_minimal_completion_integration_input()
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    authority_events = tuple(
+        replace(record, claims_live_authority=True) for record in validation_input.events
+    )
+    bad = replace(
+        integration_input,
+        master_v2_state_event_stream_validation_input=replace(
+            validation_input,
+            events=authority_events,
+        ),
+    )
+    result = evaluate_durable_run_primary_evidence_completion_integration(bad)
+    assert result["integration_pass"] is False
+    assert any("authority claims forbidden" in reason for reason in result["fail_reasons"])
+
+
 def test_pe33_cross_slice_coherence_bound_in_completion_happy_path() -> None:
     integration_input = default_minimal_completion_integration_input(
         source_revision=VALID_COMMIT_SHA


### PR DESCRIPTION
## Summary
- Bind offline Master-V2 Kill-All, State-Switch, Chop and Dynamic-Scope event-stream semantics into the canonical durable-completion primary evidence integration owner.
- Extend the existing GLB-019 `event_stream` validator with explicit Master-V2 state event records, proof bindings, and fail-closed transition semantics reuse from `double_play_state`.
- Add bounded contract tests for happy-path state-switch and kill-all chains plus fail-closed drift, ordering, duplicate-transition, coherence, and non-authorizing posture.

## Safety boundary
- Offline contract only
- Evidence validation only — no trading decision
- No execution, runtime, testnet, live, credentials, orders, arming, or authority lift

## Test plan
- [x] `ruff format --check` on changed Python files
- [x] `ruff check` on changed Python files
- [x] Focused master_v2 tests in primary evidence testowner
- [x] `tests/ops/test_durable_completion_validation_graph_v1.py`
- [x] CI selector: `CONTRACT_FOCUSED` / `FULL_CI_TRIGGER_FOUND=false`


Made with [Cursor](https://cursor.com)