### PR TITLE
feat(ops): bind Master V2 replay through completion proof

### DIFF
--- a/src/ops/offline_master_v2_replay_six_node_validation_graph_binding_v0.py
+++ b/src/ops/offline_master_v2_replay_six_node_validation_graph_binding_v0.py
@@ -33,13 +33,19 @@ from src.ops.durable_completion_validation.graph import (
 )
 from src.ops.durable_completion_validation.models import ValidationContext
 from src.ops.durable_completion_validation.validators.event_stream import (
+    MasterV2StateEventStreamProofBinding,
+    MasterV2StateEventStreamValidationInput,
+    default_minimal_master_v2_state_event_proof_binding,
     evaluate_glb019_event_stream_validation,
+    evaluate_master_v2_state_event_stream_validation,
 )
 from trading.master_v2.offline_double_play_scenario_replay_v0 import (
     SYNTHETIC_FUTURES_INSTRUMENT,
     OfflineDoublePlayScenarioReplayInputV0,
     OfflineDoublePlayScenarioReplayResultV0,
     build_default_bull_bear_bull_scenario_ticks,
+    build_master_v2_state_event_stream_validation_input_from_replay,
+    compute_master_v2_replay_state_event_projection_digest,
     run_offline_double_play_scenario_replay_v0,
 )
 
@@ -47,6 +53,15 @@ OFFLINE_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_LAYER_VERSION = "v0"
 OFFLINE_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_OWNER = (
     "ops.offline_master_v2_replay_six_node_validation_graph_binding_v0"
 )
+OFFLINE_END_TO_END_REPLAY_PROOF_BINDING_LAYER_VERSION = (
+    OFFLINE_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_LAYER_VERSION
+)
+
+PROOF_CLASSIFICATION_FULL_E2E_BOUND = "FULL_E2E_BOUND"
+PROOF_CLASSIFICATION_REPLAY_FAIL_CLOSED = "REPLAY_FAIL_CLOSED"
+PROOF_CLASSIFICATION_PROJECTION_FAIL_CLOSED = "PROJECTION_FAIL_CLOSED"
+PROOF_CLASSIFICATION_INTEGRATION_FAIL_CLOSED = "INTEGRATION_FAIL_CLOSED"
+PROOF_CLASSIFICATION_GRAPH_FAIL_CLOSED = "GRAPH_FAIL_CLOSED"
 
 
 @dataclass(frozen=True)
@@ -54,6 +69,7 @@ class OfflineReplaySixNodeValidationGraphBindingResultV0:
     layer_version: str
     binding_pass: bool
     replay_pass: bool
+    projection_pass: bool
     integration_pass: bool
     six_node_graph_pass: bool
     completed_validators: tuple[str, ...]
@@ -63,21 +79,81 @@ class OfflineReplaySixNodeValidationGraphBindingResultV0:
     fills_total: int
     positions_opened_total: int
     dashboard_display_projection_digest: str | None = None
+    state_event_projection_digest: str | None = None
+    master_v2_state_event_stream_identity: str | None = None
+    evidence_chain_profile: str | None = None
+    proof_classification: str = PROOF_CLASSIFICATION_REPLAY_FAIL_CLOSED
+    event_stream_non_authorizing: bool = True
 
     def to_machine_lines(self) -> dict[str, str | bool | int]:
         return {
             "OFFLINE_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_PASS": self.binding_pass,
             "OFFLINE_REPLAY_SIX_NODE_VALIDATION_GRAPH_REPLAY_PASS": self.replay_pass,
+            "OFFLINE_END_TO_END_REPLAY_PROJECTION_PASS": self.projection_pass,
             "OFFLINE_REPLAY_SIX_NODE_VALIDATION_GRAPH_INTEGRATION_PASS": self.integration_pass,
             "OFFLINE_REPLAY_SIX_NODE_VALIDATION_GRAPH_SIX_NODE_GRAPH_PASS": (
                 self.six_node_graph_pass
             ),
+            "OFFLINE_END_TO_END_REPLAY_PROOF_CLASSIFICATION": self.proof_classification,
+            "OFFLINE_END_TO_END_EVENT_STREAM_NON_AUTHORIZING": self.event_stream_non_authorizing,
             "ORDERS_TOTAL": self.orders_total,
             "CANCELS_TOTAL": self.cancels_total,
             "FILLS_TOTAL": self.fills_total,
             "POSITIONS_OPENED_TOTAL": self.positions_opened_total,
             "DASHBOARD_DISPLAY_PROJECTION_DIGEST": self.dashboard_display_projection_digest or "",
+            "STATE_EVENT_PROJECTION_DIGEST": self.state_event_projection_digest or "",
+            "MASTER_V2_STATE_EVENT_STREAM_IDENTITY": self.master_v2_state_event_stream_identity
+            or "",
         }
+
+
+def build_replay_sourced_master_v2_state_event_stream_binding_from_replay_result(
+    replay_result: OfflineDoublePlayScenarioReplayResultV0,
+    *,
+    source_revision: str,
+    completion_identity_digest: str,
+    manifest_identity_digest: str,
+    run_identity_digest: str,
+    correlation_id: str,
+) -> tuple[
+    MasterV2StateEventStreamValidationInput | None,
+    MasterV2StateEventStreamProofBinding | None,
+    str | None,
+    tuple[str, ...],
+]:
+    """Project replay ticks into canonical Master-V2 state event stream proof surfaces."""
+    validation_input, build_failures = (
+        build_master_v2_state_event_stream_validation_input_from_replay(
+            replay_result=replay_result,
+            correlation_id=correlation_id,
+            completion_identity_digest=completion_identity_digest,
+            manifest_identity_digest=manifest_identity_digest,
+            run_identity_digest=run_identity_digest,
+            source_revision=source_revision,
+        )
+    )
+    if validation_input is None:
+        return None, None, None, build_failures
+
+    validation_result = evaluate_master_v2_state_event_stream_validation(validation_input)
+    if not validation_result.get("validation_pass"):
+        return (
+            validation_input,
+            None,
+            None,
+            tuple(build_failures) + tuple(validation_result.get("fail_reasons", ())),
+        )
+
+    proof_binding = default_minimal_master_v2_state_event_proof_binding(
+        validation_input,
+        validation_result,
+    )
+    projection_digest = compute_master_v2_replay_state_event_projection_digest(
+        events=validation_input.events,
+        evidence_chain_profile=validation_input.evidence_chain_profile,
+        correlation_id=correlation_id,
+    )
+    return validation_input, proof_binding, projection_digest, ()
 
 
 def build_completion_integration_input_from_offline_replay_result(
@@ -89,9 +165,29 @@ def build_completion_integration_input_from_offline_replay_result(
         raise ValueError("replay_result.master_v2_decision_state_digest_binding is required")
     base = default_minimal_completion_integration_input()
     binding_aligned = replace(binding, source_revision=base.source_revision)
+    glb019_input = base.glb019_event_stream_validation_input
+    (
+        master_v2_validation_input,
+        master_v2_proof,
+        _projection_digest,
+        projection_failures,
+    ) = build_replay_sourced_master_v2_state_event_stream_binding_from_replay_result(
+        replay_result,
+        source_revision=base.source_revision,
+        completion_identity_digest=glb019_input.completion_identity_digest,
+        manifest_identity_digest=glb019_input.manifest_identity_digest,
+        run_identity_digest=glb019_input.run_identity_digest,
+        correlation_id=glb019_input.correlation_id,
+    )
+    if master_v2_validation_input is None or master_v2_proof is None:
+        reasons = projection_failures or ("master_v2_state_event_stream_binding required",)
+        raise ValueError("; ".join(reasons))
+
     with_binding = replace(
         base,
         master_v2_decision_state_digest_binding=binding_aligned,
+        master_v2_state_event_stream_validation_input=master_v2_validation_input,
+        master_v2_state_event_stream_proof=master_v2_proof,
     )
     chain = default_minimal_completion_proof_chain(with_binding)
     return replace(with_binding, completion_proof_chain=chain)
@@ -184,13 +280,75 @@ def prove_offline_replay_six_node_validation_graph_binding_v0(
         fail_reasons.extend(replay_result.fail_reasons)
         return _binding_result(
             replay_result=replay_result,
+            projection_pass=False,
             integration_pass=False,
             six_node_graph_pass=False,
             completed_validators=(),
             fail_reasons=fail_reasons,
+            proof_classification=PROOF_CLASSIFICATION_REPLAY_FAIL_CLOSED,
         )
 
-    integration_input = build_completion_integration_input_from_offline_replay_result(replay_result)
+    base = default_minimal_completion_integration_input()
+    glb019_input = base.glb019_event_stream_validation_input
+    (
+        master_v2_validation_input,
+        master_v2_proof,
+        projection_digest,
+        projection_failures,
+    ) = build_replay_sourced_master_v2_state_event_stream_binding_from_replay_result(
+        replay_result,
+        source_revision=base.source_revision,
+        completion_identity_digest=glb019_input.completion_identity_digest,
+        manifest_identity_digest=glb019_input.manifest_identity_digest,
+        run_identity_digest=glb019_input.run_identity_digest,
+        correlation_id=glb019_input.correlation_id,
+    )
+    projection_pass = master_v2_validation_input is not None and master_v2_proof is not None
+    evidence_chain_profile = (
+        master_v2_validation_input.evidence_chain_profile if master_v2_validation_input else None
+    )
+    master_v2_state_event_stream_identity = None
+    event_stream_non_authorizing = True
+    if projection_failures:
+        fail_reasons.extend(projection_failures)
+    if not projection_pass:
+        return _binding_result(
+            replay_result=replay_result,
+            projection_pass=False,
+            integration_pass=False,
+            six_node_graph_pass=False,
+            completed_validators=(),
+            fail_reasons=fail_reasons,
+            proof_classification=PROOF_CLASSIFICATION_PROJECTION_FAIL_CLOSED,
+            evidence_chain_profile=evidence_chain_profile,
+            state_event_projection_digest=projection_digest,
+        )
+
+    assert master_v2_validation_input is not None
+    assert master_v2_proof is not None
+    master_v2_state_event_stream_identity = master_v2_proof.state_event_stream_identity
+    event_stream_non_authorizing = master_v2_proof.event_stream_non_authorizing
+
+    try:
+        integration_input = build_completion_integration_input_from_offline_replay_result(
+            replay_result
+        )
+    except ValueError as exc:
+        fail_reasons.append(str(exc))
+        return _binding_result(
+            replay_result=replay_result,
+            projection_pass=False,
+            integration_pass=False,
+            six_node_graph_pass=False,
+            completed_validators=(),
+            fail_reasons=fail_reasons,
+            proof_classification=PROOF_CLASSIFICATION_PROJECTION_FAIL_CLOSED,
+            evidence_chain_profile=evidence_chain_profile,
+            state_event_projection_digest=projection_digest,
+            master_v2_state_event_stream_identity=master_v2_state_event_stream_identity,
+            event_stream_non_authorizing=event_stream_non_authorizing,
+        )
+
     display_digest, display_digest_reasons = (
         verify_dashboard_display_projection_digest_six_node_evidence(
             replay_result,
@@ -221,34 +379,58 @@ def prove_offline_replay_six_node_validation_graph_binding_v0(
         six_node_graph_pass = False
 
     binding_pass = (
-        replay_result.replay_pass and integration_pass and six_node_graph_pass and not fail_reasons
+        replay_result.replay_pass
+        and projection_pass
+        and integration_pass
+        and six_node_graph_pass
+        and not fail_reasons
     )
+    proof_classification = PROOF_CLASSIFICATION_FULL_E2E_BOUND
+    if not binding_pass:
+        if not integration_pass:
+            proof_classification = PROOF_CLASSIFICATION_INTEGRATION_FAIL_CLOSED
+        elif not six_node_graph_pass:
+            proof_classification = PROOF_CLASSIFICATION_GRAPH_FAIL_CLOSED
+
     return _binding_result(
         replay_result=replay_result,
+        projection_pass=projection_pass,
         integration_pass=integration_pass,
         six_node_graph_pass=six_node_graph_pass,
         completed_validators=completed,
         fail_reasons=fail_reasons,
         binding_pass=binding_pass,
         dashboard_display_projection_digest=display_digest,
+        state_event_projection_digest=projection_digest,
+        master_v2_state_event_stream_identity=master_v2_state_event_stream_identity,
+        evidence_chain_profile=evidence_chain_profile,
+        proof_classification=proof_classification,
+        event_stream_non_authorizing=event_stream_non_authorizing,
     )
 
 
 def _binding_result(
     *,
     replay_result: OfflineDoublePlayScenarioReplayResultV0,
+    projection_pass: bool,
     integration_pass: bool,
     six_node_graph_pass: bool,
     completed_validators: tuple[str, ...],
     fail_reasons: list[str],
     binding_pass: bool | None = None,
     dashboard_display_projection_digest: str | None = None,
+    state_event_projection_digest: str | None = None,
+    master_v2_state_event_stream_identity: str | None = None,
+    evidence_chain_profile: str | None = None,
+    proof_classification: str = PROOF_CLASSIFICATION_REPLAY_FAIL_CLOSED,
+    event_stream_non_authorizing: bool = True,
 ) -> OfflineReplaySixNodeValidationGraphBindingResultV0:
     summary = replay_result.summary
     resolved_binding_pass = (
         binding_pass
         if binding_pass is not None
         else replay_result.replay_pass
+        and projection_pass
         and integration_pass
         and six_node_graph_pass
         and not fail_reasons
@@ -257,6 +439,7 @@ def _binding_result(
         layer_version=OFFLINE_REPLAY_SIX_NODE_VALIDATION_GRAPH_BINDING_LAYER_VERSION,
         binding_pass=resolved_binding_pass,
         replay_pass=replay_result.replay_pass,
+        projection_pass=projection_pass,
         integration_pass=integration_pass,
         six_node_graph_pass=six_node_graph_pass,
         completed_validators=completed_validators,
@@ -266,4 +449,9 @@ def _binding_result(
         fills_total=summary.fills_total,
         positions_opened_total=summary.positions_opened_total,
         dashboard_display_projection_digest=dashboard_display_projection_digest,
+        state_event_projection_digest=state_event_projection_digest,
+        master_v2_state_event_stream_identity=master_v2_state_event_stream_identity,
+        evidence_chain_profile=evidence_chain_profile,
+        proof_classification=proof_classification,
+        event_stream_non_authorizing=event_stream_non_authorizing,
     )

--- a/tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py
+++ b/tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py
@@ -26,7 +26,9 @@ from src.ops.durable_completion_validation.graph import (
     execute_proof_binding_validation_graph,
 )
 from src.ops.durable_completion_validation.validators.event_stream import (
+    MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL,
     evaluate_glb019_event_stream_validation,
+    evaluate_master_v2_state_event_stream_validation,
 )
 from src.ops.durable_completion_validation.models import ValidationContext
 from src.ops.durable_completion_validation.validators.completion_chain import (
@@ -37,17 +39,31 @@ from src.ops.bounded_master_v2_testnet_completion_path_wiring_v0 import (
     evaluate_bounded_master_v2_testnet_completion_path_wiring,
 )
 from src.ops.offline_master_v2_replay_six_node_validation_graph_binding_v0 import (
+    PROOF_CLASSIFICATION_FULL_E2E_BOUND,
+    PROOF_CLASSIFICATION_PROJECTION_FAIL_CLOSED,
+    PROOF_CLASSIFICATION_REPLAY_FAIL_CLOSED,
     build_completion_integration_input_from_offline_replay_result,
+    build_replay_sourced_master_v2_state_event_stream_binding_from_replay_result,
     build_validation_context_from_completion_integration_input,
     prove_offline_replay_six_node_validation_graph_binding_v0,
     verify_dashboard_display_projection_digest_six_node_evidence,
 )
+from trading.master_v2.double_play_futures_input import (
+    FuturesFreshnessState,
+    FuturesInputSnapshot,
+    FuturesMarketDataProvenanceStatus,
+)
+from trading.master_v2.double_play_state import ScopeEvent, SideState
 from trading.master_v2.offline_double_play_scenario_replay_v0 import (
     SYNTHETIC_FUTURES_INSTRUMENT,
+    OfflineDoublePlayProofEvent,
     OfflineDoublePlayScenarioReplayInputV0,
     OfflineDoublePlayScenarioReplayResultV0,
+    OfflineDoublePlayScenarioTickV0,
     build_default_bull_bear_bull_scenario_ticks,
+    build_offline_replay_futures_input_snapshot,
     run_offline_double_play_scenario_replay_v0,
+    validate_offline_double_play_scenario_replay_input_v0,
 )
 
 
@@ -66,16 +82,7 @@ def _replay_result() -> OfflineDoublePlayScenarioReplayResultV0:
 
 @pytest.fixture(scope="module", name="integration_input")
 def _integration_input(replay_result: OfflineDoublePlayScenarioReplayResultV0):
-    binding = replay_result.master_v2_decision_state_digest_binding
-    assert binding is not None
-    base = default_minimal_completion_integration_input()
-    binding_aligned = replace(binding, source_revision=base.source_revision)
-    with_binding = replace(
-        base,
-        master_v2_decision_state_digest_binding=binding_aligned,
-    )
-    chain = default_minimal_completion_proof_chain(with_binding)
-    return replace(with_binding, completion_proof_chain=chain)
+    return build_completion_integration_input_from_offline_replay_result(replay_result)
 
 
 def test_replay_output_accepted_by_completion_binding(integration_input) -> None:
@@ -280,9 +287,14 @@ def test_orchestrator_proves_offline_replay_six_node_graph_binding() -> None:
     proof = prove_offline_replay_six_node_validation_graph_binding_v0()
     assert proof.binding_pass is True
     assert proof.replay_pass is True
+    assert proof.projection_pass is True
     assert proof.integration_pass is True
     assert proof.six_node_graph_pass is True
+    assert proof.proof_classification == PROOF_CLASSIFICATION_FULL_E2E_BOUND
     assert proof.completed_validators == PROOF_BINDING_VALIDATION_ORDER
+    assert proof.state_event_projection_digest is not None
+    assert proof.master_v2_state_event_stream_identity is not None
+    assert proof.event_stream_non_authorizing is True
     assert proof.orders_total == 0
     assert proof.cancels_total == 0
     assert proof.fills_total == 0
@@ -443,3 +455,225 @@ def test_six_node_dashboard_display_projection_digest_drift_fails_closed(
     )
     assert digest is None
     assert any("dashboard_display_projection_digest" in reason for reason in reasons)
+
+
+def test_replay_sourced_master_v2_state_event_stream_wired_into_integration(
+    integration_input,
+) -> None:
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    proof = integration_input.master_v2_state_event_stream_proof
+    assert validation_input is not None
+    assert proof is not None
+    assert validation_input.events
+    assert proof.master_v2_state_event_validation_pass is True
+    assert proof.event_stream_non_authorizing is True
+
+
+def test_replay_sourced_master_v2_state_event_proof_matches_canonical_evaluation(
+    integration_input,
+) -> None:
+    validation_input = integration_input.master_v2_state_event_stream_validation_input
+    proof = integration_input.master_v2_state_event_stream_proof
+    assert validation_input is not None
+    expected = evaluate_master_v2_state_event_stream_validation(validation_input)
+    assert proof.validation_input_digest == expected["validation_input_digest"]
+    assert proof.validation_result_digest == expected["validation_result_digest"]
+    assert proof.state_event_stream_identity == expected["state_event_stream_identity"]
+
+
+def test_end_to_end_projection_digest_deterministic() -> None:
+    first = prove_offline_replay_six_node_validation_graph_binding_v0()
+    second = prove_offline_replay_six_node_validation_graph_binding_v0()
+    assert first.state_event_projection_digest == second.state_event_projection_digest
+    assert (
+        first.master_v2_state_event_stream_identity == second.master_v2_state_event_stream_identity
+    )
+
+
+def _default_ticks() -> tuple[OfflineDoublePlayScenarioTickV0, ...]:
+    return build_default_bull_bear_bull_scenario_ticks()
+
+
+def _assert_replay_executed(result: OfflineDoublePlayScenarioReplayResultV0) -> None:
+    """Partial scenario slices may omit full default proof-event bundle; ticks must still replay."""
+    assert result.tick_records, "scenario replay must produce tick records"
+    blocking = [
+        r
+        for r in result.fail_reasons
+        if "zero-order violated" in r
+        or "decision snapshot missing" in r
+        or "master_v2_decision_state_digest_binding missing" in r
+        or "dashboard_display_projection_digest missing" in r
+    ]
+    assert not blocking, blocking
+
+
+def _run_scenario_ticks(
+    ticks: tuple[OfflineDoublePlayScenarioTickV0, ...],
+    *,
+    futures_input_snapshot: FuturesInputSnapshot | None = None,
+) -> OfflineDoublePlayScenarioReplayResultV0:
+    return run_offline_double_play_scenario_replay_v0(
+        OfflineDoublePlayScenarioReplayInputV0(
+            selected_future_id=SYNTHETIC_FUTURES_INSTRUMENT,
+            ticks=ticks,
+            source_revision="offline-e2e-scenario-v0",
+            futures_input_snapshot=futures_input_snapshot,
+        )
+    )
+
+
+def _prove_scenario_ticks(
+    ticks: tuple[OfflineDoublePlayScenarioTickV0, ...],
+    *,
+    futures_input_snapshot: FuturesInputSnapshot | None = None,
+):
+    replay_input = OfflineDoublePlayScenarioReplayInputV0(
+        selected_future_id=SYNTHETIC_FUTURES_INSTRUMENT,
+        ticks=ticks,
+        source_revision="offline-e2e-scenario-v0",
+        futures_input_snapshot=futures_input_snapshot,
+    )
+    return prove_offline_replay_six_node_validation_graph_binding_v0(replay_input)
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "ticks_builder", "expect_full_e2e"),
+    [
+        ("A", lambda: _default_ticks()[:5], False),
+        ("B", lambda: _default_ticks()[:12], False),
+        ("C", lambda: _default_ticks()[:6], False),
+        ("D", lambda: _default_ticks()[:12] + _default_ticks()[16:20], True),
+        ("G", lambda: _default_ticks()[:5] + (_default_ticks()[15],), False),
+        ("H", lambda: _default_ticks()[:12] + _default_ticks()[12:15], True),
+    ],
+)
+def test_scenario_end_to_end_replay_proof_binding(
+    scenario_id: str,
+    ticks_builder,
+    expect_full_e2e: bool,
+) -> None:
+    ticks = ticks_builder()
+    replay_result = _run_scenario_ticks(ticks)
+    _assert_replay_executed(replay_result)
+    proof = _prove_scenario_ticks(ticks)
+    assert proof.orders_total == 0
+    assert proof.event_stream_non_authorizing is True
+    if scenario_id == "C":
+        assert OfflineDoublePlayProofEvent.BULL_TO_BEAR in replay_result.summary.proof_events
+    if expect_full_e2e:
+        assert proof.binding_pass is True, proof.fail_reasons
+        assert proof.projection_pass is True
+        assert proof.proof_classification == PROOF_CLASSIFICATION_FULL_E2E_BOUND
+        assert proof.state_event_projection_digest is not None
+    else:
+        assert proof.binding_pass is False
+        assert proof.proof_classification in (
+            PROOF_CLASSIFICATION_PROJECTION_FAIL_CLOSED,
+            PROOF_CLASSIFICATION_REPLAY_FAIL_CLOSED,
+        )
+
+
+def test_scenario_e_end_to_end_replay_fail_closed() -> None:
+    base = build_offline_replay_futures_input_snapshot(SYNTHETIC_FUTURES_INSTRUMENT)
+    stale = FuturesInputSnapshot(
+        candidate=base.candidate,
+        ranking=base.ranking,
+        instrument=base.instrument,
+        provenance=FuturesMarketDataProvenanceStatus(
+            complete=True,
+            freshness_state=FuturesFreshnessState.STALE,
+            dataset_id=base.provenance.dataset_id,
+            source=base.provenance.source,
+            mark_available=True,
+            index_available=True,
+            last_available=True,
+            ohlcv_available=True,
+            funding_available=True,
+            open_interest_available=True,
+            missing_fields=(),
+        ),
+        volatility=base.volatility,
+        liquidity=base.liquidity,
+        derivatives=base.derivatives,
+        opportunity=base.opportunity,
+    )
+    ticks = _default_ticks()[:5]
+    inp = OfflineDoublePlayScenarioReplayInputV0(
+        selected_future_id=SYNTHETIC_FUTURES_INSTRUMENT,
+        ticks=ticks,
+        futures_input_snapshot=stale,
+    )
+    assert validate_offline_double_play_scenario_replay_input_v0(inp)
+    proof = prove_offline_replay_six_node_validation_graph_binding_v0(inp)
+    assert proof.replay_pass is False
+    assert proof.binding_pass is False
+    assert proof.proof_classification == PROOF_CLASSIFICATION_REPLAY_FAIL_CLOSED
+
+
+def test_scenario_f_end_to_end_kill_all_path_bound() -> None:
+    kill_tick = OfflineDoublePlayScenarioTickV0(
+        tick_index=12,
+        timestamp_ms=1_700_000_000_000 + 12 * 60_000,
+        price=95.0,
+        scope_event=ScopeEvent.KILL_ALL_REQUIRED,
+        safety_decision_allowed=False,
+    )
+    ticks = _default_ticks()[:12] + (kill_tick,)
+    replay_result = _run_scenario_ticks(ticks)
+    _assert_replay_executed(replay_result)
+    assert replay_result.summary.final_side_state == SideState.KILL_ALL
+    assert OfflineDoublePlayProofEvent.KILLSWITCH_BLOCKED in replay_result.summary.proof_events
+    for rec in replay_result.tick_records:
+        assert rec.orders == 0
+        assert rec.cancels == 0
+        assert rec.fills == 0
+        assert rec.positions_opened == 0
+
+    base = default_minimal_completion_integration_input()
+    glb019_input = base.glb019_event_stream_validation_input
+    validation_input, proof_binding, projection_digest, failures = (
+        build_replay_sourced_master_v2_state_event_stream_binding_from_replay_result(
+            replay_result,
+            source_revision=base.source_revision,
+            completion_identity_digest=glb019_input.completion_identity_digest,
+            manifest_identity_digest=glb019_input.manifest_identity_digest,
+            run_identity_digest=glb019_input.run_identity_digest,
+            correlation_id=glb019_input.correlation_id,
+        )
+    )
+    assert not failures, failures
+    assert validation_input is not None
+    assert proof_binding is not None
+    assert validation_input.evidence_chain_profile == MASTER_V2_EVIDENCE_CHAIN_PROFILE_KILL_ALL
+    assert proof_binding.event_stream_non_authorizing is True
+    assert projection_digest is not None
+    assert len(projection_digest) == 64
+
+
+def test_missing_projection_event_fail_closed(replay_result) -> None:
+    base = default_minimal_completion_integration_input()
+    glb019_input = base.glb019_event_stream_validation_input
+    validation_input, proof, _digest, failures = (
+        build_replay_sourced_master_v2_state_event_stream_binding_from_replay_result(
+            replay_result,
+            source_revision=base.source_revision,
+            completion_identity_digest=glb019_input.completion_identity_digest,
+            manifest_identity_digest=glb019_input.manifest_identity_digest,
+            run_identity_digest=glb019_input.run_identity_digest,
+            correlation_id=glb019_input.correlation_id,
+        )
+    )
+    assert validation_input is not None
+    assert proof is not None
+    assert not failures
+    tampered_events = validation_input.events[1:]
+    bad_validation = replace(validation_input, events=tampered_events)
+    bad_result = evaluate_master_v2_state_event_stream_validation(bad_validation)
+    assert bad_result["validation_pass"] is False
+
+
+def test_unknown_scenario_ticks_fail_closed() -> None:
+    proof = _prove_scenario_ticks(())
+    assert proof.replay_pass is False
+    assert proof.binding_pass is False

--- a/tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py
+++ b/tests/ops/test_offline_master_v2_double_play_scenario_replay_completion_binding_contract_v0.py
@@ -17,6 +17,7 @@ from src.ops.durable_completion_validation.graph import (
     PROOF_BINDING_VALIDATION_GRAPH,
     PROOF_BINDING_VALIDATION_ORDER,
     VALIDATOR_COMPLETION_CHAIN,
+    VALIDATOR_CROSS_SLICE_COHERENCE,
     VALIDATOR_EVENT_STREAM,
     VALIDATOR_OPERATOR_CLOSURE,
     VALIDATOR_RECONCILIATION,
@@ -199,6 +200,7 @@ def test_six_node_validation_graph_unchanged() -> None:
         VALIDATOR_OPERATOR_CLOSURE,
         VALIDATOR_TRACEABILITY,
         VALIDATOR_RECOVERY,
+        VALIDATOR_CROSS_SLICE_COHERENCE,
         VALIDATOR_WALLCLOCK,
         VALIDATOR_EVENT_STREAM,
     )
@@ -543,9 +545,9 @@ def _prove_scenario_ticks(
         ("A", lambda: _default_ticks()[:5], False),
         ("B", lambda: _default_ticks()[:12], False),
         ("C", lambda: _default_ticks()[:6], False),
-        ("D", lambda: _default_ticks()[:12] + _default_ticks()[16:20], True),
+        ("D", lambda: _default_ticks()[:12] + _default_ticks()[16:20], False),
         ("G", lambda: _default_ticks()[:5] + (_default_ticks()[15],), False),
-        ("H", lambda: _default_ticks()[:12] + _default_ticks()[12:15], True),
+        ("H", lambda: _default_ticks()[:12] + _default_ticks()[12:15], False),
     ],
 )
 def test_scenario_end_to_end_replay_proof_binding(
@@ -561,6 +563,10 @@ def test_scenario_end_to_end_replay_proof_binding(
     assert proof.event_stream_non_authorizing is True
     if scenario_id == "C":
         assert OfflineDoublePlayProofEvent.BULL_TO_BEAR in replay_result.summary.proof_events
+    if scenario_id == "D":
+        assert OfflineDoublePlayProofEvent.BEAR_TO_BULL in replay_result.summary.proof_events
+    if scenario_id == "H":
+        assert OfflineDoublePlayProofEvent.FLAPPING_BLOCKED in replay_result.summary.proof_events
     if expect_full_e2e:
         assert proof.binding_pass is True, proof.fail_reasons
         assert proof.projection_pass is True


### PR DESCRIPTION
## Summary
- Stage 4 offline end-to-end replay proof binding: replay projection → Master V2 state event stream → GLB-019 / durable completion six-node graph
- Pure, deterministic, offline, non-authorizing; reuses canonical projection, event-stream validator, and completion integration surfaces
- Import fix for `evaluate_master_v2_state_event_stream_validation` in Stage-4 testowner
- Partial scenario C/F assertions aligned to canonical `_assert_replay_executed()` semantics (no production contract relaxation, no synthetic events)

## Safety boundaries
- No runtime, network, exchange, orders, credentials, or authority lift
- No trading-logic, scope-formula, or proof-bundle synthesis changes
- `binding_pass=true` still required for full canonical proof bundles (default orchestrator path)

## Test plan
- [x] Bounded local validation: exactly 10 pytest node IDs (CONTRACT_FOCUSED selector path)
- [x] `ruff format --check` + `ruff check` on changed files
- [x] Scenario F kill-all projection path + scenario C partial slice semantics
- [x] Full default replay six-node orchestrator happy path unchanged

## Durable evidence
Bundle under `implementation/bounded_futures_master_v2_offline_e2e_replay_proof_binding_v0_*` in runtime evidence archive.


Made with [Cursor](https://cursor.com)