### PR TITLE
feat(master-v2): add fail-closed arithmetic conversion boundary

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -626,6 +626,65 @@ MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_BOUNDARY_CONTRACT_CI_SELECTOR_TARG
     "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_arithmetic_decimal_float_conversion_boundary_contract_foreign_path_escalates_full",
 )
 
+MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_PRODUCTION_PATH = (
+    "src/trading/master_v2/arithmetic_decimal_float_conversion_v0.py"
+)
+
+MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER = (
+    "tests/ops/test_master_v2_arithmetic_decimal_float_conversion_implementation_v0.py"
+)
+
+MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_CI_POLICY_PATHS = frozenset(
+    {
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    }
+)
+
+MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_SCOPED_PATHS = frozenset(
+    {
+        MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_PRODUCTION_PATH,
+        MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER,
+        *MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_CI_POLICY_PATHS,
+    }
+)
+
+MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_FOCUSED_NODES: tuple[str, ...] = (
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[price]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[mark_price]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[entry_price]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[qty]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[contract_size]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[tick_size]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[min_qty]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[realized_pnl]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[unrealized_pnl]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[notional]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[fee_bps]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[funding_rate]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[equity]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[initial_margin_rate]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[maintenance_margin_rate]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[quote_currency_notional]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[fee_rate]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[maintenance_margin]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_all_19_field_policies_convert_successfully[adverse_slippage_bps]",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_rejects_bool_missing_and_invalid_type",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_rejects_non_finite_values",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_negative_zero_and_overflow_boundaries",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_deterministic_decimal_no_float_leakage",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_conversion_quantization_tick_lot_separation",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_batch_partial_and_complete_semantics",
+    f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_immutable_non_authorizing_no_wiring",
+)
+
+MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_CI_SELECTOR_TARGETS: tuple[
+    str, ...
+] = (
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_arithmetic_decimal_float_conversion_implementation_test_only_focused",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_arithmetic_decimal_float_conversion_implementation_foreign_path_escalates_full",
+)
+
 _PYTEST_NODE_ID = re.compile(r"^[A-Za-z0-9_\-]+(?:\[[^\]]+\])?$")
 
 DURABLE_COMPLETION_WALLCLOCK_BINDING_FOCUSED_TARGETS: tuple[str, ...] = (
@@ -2739,6 +2798,73 @@ def _try_master_v2_arithmetic_decimal_float_conversion_boundary_contract_focused
     )
 
 
+def _is_master_v2_arithmetic_decimal_float_conversion_implementation_scoped_path(path: str) -> bool:
+    return path in MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_SCOPED_PATHS
+
+
+def _is_master_v2_arithmetic_decimal_float_conversion_implementation_rebundle_path(
+    path: str,
+) -> bool:
+    return _is_master_v2_arithmetic_decimal_float_conversion_implementation_scoped_path(path)
+
+
+def _is_master_v2_arithmetic_decimal_float_conversion_implementation_scope(
+    files: list[str],
+) -> bool:
+    if not files:
+        return False
+    files_set = set(files)
+    if MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER not in files_set:
+        return False
+    return all(
+        path in MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_SCOPED_PATHS
+        for path in files
+    )
+
+
+def _master_v2_arithmetic_decimal_float_conversion_implementation_focused_targets(
+    files: list[str] | None = None,
+) -> tuple[str, ...]:
+    if not _repo_path_exists(
+        MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER
+    ):
+        return ()
+    targets: list[str] = []
+    for node in MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_FOCUSED_NODES:
+        if _repo_pytest_target_exists(node):
+            targets.append(node)
+    if len(targets) != len(
+        MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_FOCUSED_NODES
+    ):
+        return ()
+    if files and any(
+        path in MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_CI_POLICY_PATHS
+        for path in files
+    ):
+        for (
+            ci_target
+        ) in MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_CI_SELECTOR_TARGETS:
+            if _repo_pytest_target_exists(ci_target):
+                targets.append(ci_target)
+    return tuple(sorted(set(targets)))
+
+
+def _try_master_v2_arithmetic_decimal_float_conversion_implementation_focused(
+    files: list[str],
+) -> SelectionResult | None:
+    if not _is_master_v2_arithmetic_decimal_float_conversion_implementation_scope(files):
+        return None
+    targets = _master_v2_arithmetic_decimal_float_conversion_implementation_focused_targets(files)
+    if not targets:
+        return None
+    return SelectionResult(
+        "FOCUSED",
+        "master_v2_arithmetic_decimal_float_conversion_implementation_focused",
+        targets,
+        ("src.trading.master_v2.arithmetic_decimal_float_conversion_v0",),
+    )
+
+
 def _is_master_v2_replay_display_projection_digest_completion_evidence_scope(
     files: list[str],
 ) -> bool:
@@ -3666,6 +3792,12 @@ def resolve_selection(
     if master_v2_arithmetic_decimal_float_conversion_boundary is not None:
         return master_v2_arithmetic_decimal_float_conversion_boundary
 
+    master_v2_arithmetic_decimal_float_conversion_implementation = (
+        _try_master_v2_arithmetic_decimal_float_conversion_implementation_focused(normalized)
+    )
+    if master_v2_arithmetic_decimal_float_conversion_implementation is not None:
+        return master_v2_arithmetic_decimal_float_conversion_implementation
+
     master_v2_replay_display_projection = (
         _try_master_v2_replay_display_projection_digest_completion_evidence_focused(normalized)
     )
@@ -3890,6 +4022,25 @@ def resolve_selection(
         return SelectionResult(
             "FULL",
             "master_v2_arithmetic_decimal_float_conversion_boundary_contract_incomplete_or_missing_test_owner",
+            (),
+        )
+
+    if any(
+        _is_master_v2_arithmetic_decimal_float_conversion_implementation_scoped_path(f)
+        for f in normalized
+    ):
+        if not all(
+            _is_master_v2_arithmetic_decimal_float_conversion_implementation_rebundle_path(f)
+            for f in normalized
+        ):
+            return SelectionResult(
+                "FULL",
+                "master_v2_arithmetic_decimal_float_conversion_implementation_foreign_path_requires_full",
+                (),
+            )
+        return SelectionResult(
+            "FULL",
+            "master_v2_arithmetic_decimal_float_conversion_implementation_incomplete_or_missing_test_owner",
             (),
         )
 

--- a/src/trading/master_v2/arithmetic_decimal_float_conversion_v0.py
+++ b/src/trading/master_v2/arithmetic_decimal_float_conversion_v0.py
@@ -1,0 +1,828 @@
+"""Master V2 arithmetic Decimal/float conversion boundary v0.
+
+Fail-closed conversion for Master-V2-to-futures-kernel boundary fields.
+Pure module: no wiring, no PnL/fee/funding formulas, no authority lift.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from enum import Enum
+from typing import Callable, Final, Mapping
+
+from src.execution.ledger import quantization as ledger_quantization
+from src.execution.ledger.models import QuantizationPolicy
+
+QUANTIZATION_OWNER_PATH: Final[str] = "src/execution/ledger/quantization.py"
+
+
+class MasterV2BoundaryField(str, Enum):
+    PRICE = "price"
+    MARK_PRICE = "mark_price"
+    ENTRY_PRICE = "entry_price"
+    QTY = "qty"
+    CONTRACT_SIZE = "contract_size"
+    TICK_SIZE = "tick_size"
+    MIN_QTY = "min_qty"
+    REALIZED_PNL = "realized_pnl"
+    UNREALIZED_PNL = "unrealized_pnl"
+    NOTIONAL = "notional"
+    FEE_BPS = "fee_bps"
+    FUNDING_RATE = "funding_rate"
+    EQUITY = "equity"
+    INITIAL_MARGIN_RATE = "initial_margin_rate"
+    MAINTENANCE_MARGIN_RATE = "maintenance_margin_rate"
+    QUOTE_CURRENCY_NOTIONAL = "quote_currency_notional"
+    FEE_RATE = "fee_rate"
+    MAINTENANCE_MARGIN = "maintenance_margin"
+    ADVERSE_SLIPPAGE_BPS = "adverse_slippage_bps"
+
+
+class MasterV2BoundaryConversionErrorCode(str, Enum):
+    MISSING_VALUE = "missing_value"
+    WRONG_TYPE = "wrong_type"
+    BOOL_AS_NUMBER = "bool_as_number"
+    NAN = "nan"
+    POSITIVE_INFINITY = "positive_infinity"
+    NEGATIVE_INFINITY = "negative_infinity"
+    OVERFLOW = "overflow"
+    UNDERFLOW = "underflow"
+    INVALID_NUMERIC_STRING = "invalid_numeric_string"
+    NEGATIVE_DISALLOWED = "negative_disallowed"
+    ZERO_DISALLOWED = "zero_disallowed"
+    UNIT_MISMATCH = "unit_mismatch"
+    SIGN_MISMATCH = "sign_mismatch"
+    MISSING_PRECISION_METADATA = "missing_precision_metadata"
+    MISSING_TICK_SIZE = "missing_tick_size"
+    MISSING_LOT_SIZE = "missing_lot_size"
+    QUANTIZATION_FAILURE = "quantization_failure"
+    UNSUPPORTED_FIELD = "unsupported_field"
+    DUPLICATE_FIELD = "duplicate_field"
+    PARTIAL_CONVERSION_RESULT = "partial_conversion_result"
+    INCOMPLETE_REQUIRED_FIELDS = "incomplete_required_fields"
+
+
+@dataclass(frozen=True)
+class _FieldConversionPolicy:
+    unit: str
+    target_unit: str
+    sign_convention: str
+    nullable: bool
+    zero_allowed: bool
+    negative_allowed: bool
+    accepts_float: bool
+    strict_positive: bool
+    nonnegative_only: bool
+    open_interval_01: bool
+    tick_size_required: bool
+    lot_size_required: bool
+    quantization_owner_suffix: str | None
+
+
+@dataclass(frozen=True)
+class MasterV2BoundaryFieldInput:
+    field: MasterV2BoundaryField
+    value: float | Decimal | None
+    tick_size: Decimal | None = None
+    lot_size: Decimal | None = None
+    quantization_policy: QuantizationPolicy | None = None
+    apply_quantization: bool = False
+
+
+@dataclass(frozen=True)
+class MasterV2BoundaryConversionSuccess:
+    field: MasterV2BoundaryField
+    decimal_value: Decimal
+    source_number_type: str
+    target_number_type: str
+    unit: str
+    sign_convention: str
+    quantization_applied: bool
+    quantization_owner: str | None
+
+
+@dataclass(frozen=True)
+class MasterV2BoundaryConversionError:
+    field: MasterV2BoundaryField | None
+    error_code: MasterV2BoundaryConversionErrorCode
+    message: str
+
+
+@dataclass(frozen=True)
+class MasterV2BoundaryConversionResult:
+    success: MasterV2BoundaryConversionSuccess | None
+    error: MasterV2BoundaryConversionError | None
+
+
+@dataclass(frozen=True)
+class MasterV2BoundaryBatchConversionResult:
+    results: tuple[MasterV2BoundaryConversionResult, ...]
+    all_fields_converted: bool
+    errors: tuple[MasterV2BoundaryConversionError, ...]
+
+
+_FIELD_POLICIES: Final[Mapping[MasterV2BoundaryField, _FieldConversionPolicy]] = {
+    MasterV2BoundaryField.PRICE: _FieldConversionPolicy(
+        unit="price",
+        target_unit="price",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=True,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=True,
+        lot_size_required=False,
+        quantization_owner_suffix="q_price",
+    ),
+    MasterV2BoundaryField.MARK_PRICE: _FieldConversionPolicy(
+        unit="price",
+        target_unit="price",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=True,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=True,
+        lot_size_required=False,
+        quantization_owner_suffix="q_price",
+    ),
+    MasterV2BoundaryField.ENTRY_PRICE: _FieldConversionPolicy(
+        unit="price",
+        target_unit="price",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=True,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=True,
+        lot_size_required=False,
+        quantization_owner_suffix="q_price",
+    ),
+    MasterV2BoundaryField.QTY: _FieldConversionPolicy(
+        unit="quantity",
+        target_unit="contracts",
+        sign_convention="long_short_quantity",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=True,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=True,
+        quantization_owner_suffix="q_qty",
+    ),
+    MasterV2BoundaryField.CONTRACT_SIZE: _FieldConversionPolicy(
+        unit="base_asset",
+        target_unit="base_asset",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=False,
+        strict_positive=True,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix=None,
+    ),
+    MasterV2BoundaryField.TICK_SIZE: _FieldConversionPolicy(
+        unit="price",
+        target_unit="price",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=False,
+        strict_positive=True,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=True,
+        lot_size_required=False,
+        quantization_owner_suffix=None,
+    ),
+    MasterV2BoundaryField.MIN_QTY: _FieldConversionPolicy(
+        unit="quantity",
+        target_unit="contracts",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=False,
+        strict_positive=True,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=True,
+        quantization_owner_suffix="q_qty",
+    ),
+    MasterV2BoundaryField.REALIZED_PNL: _FieldConversionPolicy(
+        unit="pnl",
+        target_unit="quote_notional",
+        sign_convention="realized_pnl",
+        nullable=False,
+        zero_allowed=True,
+        negative_allowed=True,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix="q_money",
+    ),
+    MasterV2BoundaryField.UNREALIZED_PNL: _FieldConversionPolicy(
+        unit="pnl",
+        target_unit="quote_notional",
+        sign_convention="unrealized_pnl",
+        nullable=False,
+        zero_allowed=True,
+        negative_allowed=True,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix="q_money",
+    ),
+    MasterV2BoundaryField.NOTIONAL: _FieldConversionPolicy(
+        unit="quote_notional",
+        target_unit="quote_notional",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=True,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=True,
+        lot_size_required=True,
+        quantization_owner_suffix=None,
+    ),
+    MasterV2BoundaryField.FEE_BPS: _FieldConversionPolicy(
+        unit="basis_points",
+        target_unit="basis_points",
+        sign_convention="fee_as_charge",
+        nullable=False,
+        zero_allowed=True,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=True,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix=None,
+    ),
+    MasterV2BoundaryField.FUNDING_RATE: _FieldConversionPolicy(
+        unit="funding_rate",
+        target_unit="funding_rate",
+        sign_convention="funding_payment_or_receipt",
+        nullable=True,
+        zero_allowed=True,
+        negative_allowed=True,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=False,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix=None,
+    ),
+    MasterV2BoundaryField.EQUITY: _FieldConversionPolicy(
+        unit="equity",
+        target_unit="quote_notional",
+        sign_convention="drawdown_loss",
+        nullable=False,
+        zero_allowed=True,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=True,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix="q_money",
+    ),
+    MasterV2BoundaryField.INITIAL_MARGIN_RATE: _FieldConversionPolicy(
+        unit="percent",
+        target_unit="percent",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=False,
+        strict_positive=False,
+        nonnegative_only=False,
+        open_interval_01=True,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix=None,
+    ),
+    MasterV2BoundaryField.MAINTENANCE_MARGIN_RATE: _FieldConversionPolicy(
+        unit="percent",
+        target_unit="percent",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=False,
+        negative_allowed=False,
+        accepts_float=False,
+        strict_positive=False,
+        nonnegative_only=False,
+        open_interval_01=True,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix=None,
+    ),
+    MasterV2BoundaryField.QUOTE_CURRENCY_NOTIONAL: _FieldConversionPolicy(
+        unit="quote_asset",
+        target_unit="quote_asset",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=True,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=True,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix="q_money",
+    ),
+    MasterV2BoundaryField.FEE_RATE: _FieldConversionPolicy(
+        unit="fee_rate",
+        target_unit="fee_rate",
+        sign_convention="fee_as_charge",
+        nullable=False,
+        zero_allowed=True,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=True,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix=None,
+    ),
+    MasterV2BoundaryField.MAINTENANCE_MARGIN: _FieldConversionPolicy(
+        unit="margin",
+        target_unit="margin",
+        sign_convention="nonnegative_magnitude",
+        nullable=False,
+        zero_allowed=True,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=True,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix="q_money",
+    ),
+    MasterV2BoundaryField.ADVERSE_SLIPPAGE_BPS: _FieldConversionPolicy(
+        unit="basis_points",
+        target_unit="basis_points",
+        sign_convention="adverse_slippage",
+        nullable=False,
+        zero_allowed=True,
+        negative_allowed=False,
+        accepts_float=True,
+        strict_positive=False,
+        nonnegative_only=True,
+        open_interval_01=False,
+        tick_size_required=False,
+        lot_size_required=False,
+        quantization_owner_suffix=None,
+    ),
+}
+
+_ALL_FIELDS: Final[tuple[MasterV2BoundaryField, ...]] = tuple(MasterV2BoundaryField)
+_DECIMAL_MAX_MAGNITUDE: Final[Decimal] = Decimal("1e308")
+
+
+def _error(
+    field: MasterV2BoundaryField | None,
+    code: MasterV2BoundaryConversionErrorCode,
+    message: str,
+) -> MasterV2BoundaryConversionError:
+    return MasterV2BoundaryConversionError(field=field, error_code=code, message=message)
+
+
+def _failure(
+    field: MasterV2BoundaryField | None,
+    code: MasterV2BoundaryConversionErrorCode,
+    message: str,
+) -> MasterV2BoundaryConversionResult:
+    return MasterV2BoundaryConversionResult(success=None, error=_error(field, code, message))
+
+
+def _is_finite_number(
+    value: float | Decimal,
+) -> tuple[bool, MasterV2BoundaryConversionErrorCode | None]:
+    if isinstance(value, float):
+        if math.isnan(value):
+            return False, MasterV2BoundaryConversionErrorCode.NAN
+        if math.isinf(value):
+            if value > 0:
+                return False, MasterV2BoundaryConversionErrorCode.POSITIVE_INFINITY
+            return False, MasterV2BoundaryConversionErrorCode.NEGATIVE_INFINITY
+        return True, None
+    if not value.is_finite():
+        if value.is_nan():
+            return False, MasterV2BoundaryConversionErrorCode.NAN
+        if value < 0:
+            return False, MasterV2BoundaryConversionErrorCode.NEGATIVE_INFINITY
+        return False, MasterV2BoundaryConversionErrorCode.POSITIVE_INFINITY
+    return True, None
+
+
+def _to_decimal_text(value: float) -> Decimal | MasterV2BoundaryConversionErrorCode:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, OverflowError):
+        return MasterV2BoundaryConversionErrorCode.OVERFLOW
+
+
+def _validate_range(
+    field: MasterV2BoundaryField,
+    policy: _FieldConversionPolicy,
+    decimal_value: Decimal,
+) -> MasterV2BoundaryConversionError | None:
+    if abs(decimal_value) > _DECIMAL_MAX_MAGNITUDE:
+        return _error(
+            field, MasterV2BoundaryConversionErrorCode.OVERFLOW, f"{field.value} overflow"
+        )
+
+    if policy.open_interval_01:
+        if decimal_value <= 0 or decimal_value >= 1:
+            if decimal_value == 0:
+                return _error(
+                    field,
+                    MasterV2BoundaryConversionErrorCode.ZERO_DISALLOWED,
+                    f"{field.value} must be in (0, 1)",
+                )
+            if decimal_value < 0:
+                return _error(
+                    field,
+                    MasterV2BoundaryConversionErrorCode.NEGATIVE_DISALLOWED,
+                    f"{field.value} must be in (0, 1)",
+                )
+            return _error(
+                field,
+                MasterV2BoundaryConversionErrorCode.OVERFLOW,
+                f"{field.value} must be in (0, 1)",
+            )
+        return None
+
+    if decimal_value == 0:
+        if not policy.zero_allowed:
+            return _error(
+                field,
+                MasterV2BoundaryConversionErrorCode.ZERO_DISALLOWED,
+                f"{field.value} zero disallowed",
+            )
+        return None
+
+    if decimal_value < 0:
+        if not policy.negative_allowed:
+            return _error(
+                field,
+                MasterV2BoundaryConversionErrorCode.NEGATIVE_DISALLOWED,
+                f"{field.value} negative disallowed",
+            )
+        return None
+
+    if policy.strict_positive and decimal_value <= 0:
+        if decimal_value == 0:
+            return _error(
+                field,
+                MasterV2BoundaryConversionErrorCode.ZERO_DISALLOWED,
+                f"{field.value} must be > 0",
+            )
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.NEGATIVE_DISALLOWED,
+            f"{field.value} must be > 0",
+        )
+
+    if policy.nonnegative_only and decimal_value < 0:
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.NEGATIVE_DISALLOWED,
+            f"{field.value} must be >= 0",
+        )
+
+    if policy.strict_positive and 0 < decimal_value < Decimal("1e-300"):
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.UNDERFLOW,
+            f"{field.value} underflow",
+        )
+
+    return None
+
+
+def _validate_precision_metadata(
+    field: MasterV2BoundaryField,
+    policy: _FieldConversionPolicy,
+    input_data: MasterV2BoundaryFieldInput,
+) -> MasterV2BoundaryConversionError | None:
+    if not input_data.apply_quantization:
+        return None
+    if policy.tick_size_required and input_data.tick_size is None:
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.MISSING_TICK_SIZE,
+            f"{field.value} requires tick_size metadata",
+        )
+    if policy.lot_size_required and input_data.lot_size is None:
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.MISSING_LOT_SIZE,
+            f"{field.value} requires lot_size metadata",
+        )
+    if input_data.quantization_policy is None:
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.MISSING_PRECISION_METADATA,
+            f"{field.value} requires quantization_policy when apply_quantization=True",
+        )
+    if input_data.tick_size is not None:
+        if not isinstance(input_data.tick_size, Decimal) or input_data.tick_size <= 0:
+            return _error(
+                field,
+                MasterV2BoundaryConversionErrorCode.UNIT_MISMATCH,
+                "tick_size must be positive Decimal",
+            )
+    if input_data.lot_size is not None:
+        if not isinstance(input_data.lot_size, Decimal) or input_data.lot_size <= 0:
+            return _error(
+                field,
+                MasterV2BoundaryConversionErrorCode.UNIT_MISMATCH,
+                "lot_size must be positive Decimal",
+            )
+    return None
+
+
+def _delegate_quantize(
+    field: MasterV2BoundaryField,
+    policy: _FieldConversionPolicy,
+    decimal_value: Decimal,
+    quantization_policy: QuantizationPolicy,
+) -> tuple[Decimal, str] | MasterV2BoundaryConversionError:
+    suffix = policy.quantization_owner_suffix
+    if suffix is None:
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.QUANTIZATION_FAILURE,
+            f"{field.value} has no quantization delegate",
+        )
+    fn_map: Mapping[str, Callable[..., Decimal]] = {
+        "q_price": ledger_quantization.q_price,
+        "q_qty": ledger_quantization.q_qty,
+        "q_money": ledger_quantization.q_money,
+    }
+    quant_fn = fn_map.get(suffix)
+    if quant_fn is None:
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.QUANTIZATION_FAILURE,
+            f"unknown quantization delegate for {field.value}",
+        )
+    try:
+        quantized = quant_fn(decimal_value, policy=quantization_policy)
+    except Exception as exc:  # noqa: BLE001 — fail-closed boundary
+        return _error(
+            field,
+            MasterV2BoundaryConversionErrorCode.QUANTIZATION_FAILURE,
+            f"quantization failed for {field.value}: {type(exc).__name__}",
+        )
+    owner = f"{QUANTIZATION_OWNER_PATH}::{suffix}"
+    return quantized, owner
+
+
+def _convert_field_with_policy(
+    input_data: MasterV2BoundaryFieldInput,
+    policy: _FieldConversionPolicy,
+) -> MasterV2BoundaryConversionResult:
+    field = input_data.field
+
+    if input_data.value is None:
+        if policy.nullable:
+            return _failure(
+                field,
+                MasterV2BoundaryConversionErrorCode.MISSING_VALUE,
+                f"{field.value} missing value",
+            )
+        return _failure(
+            field,
+            MasterV2BoundaryConversionErrorCode.MISSING_VALUE,
+            f"{field.value} missing value",
+        )
+
+    value = input_data.value
+    if isinstance(value, bool):
+        return _failure(
+            field,
+            MasterV2BoundaryConversionErrorCode.BOOL_AS_NUMBER,
+            f"{field.value} rejects bool",
+        )
+
+    if isinstance(value, str):
+        return _failure(
+            field,
+            MasterV2BoundaryConversionErrorCode.WRONG_TYPE,
+            f"{field.value} rejects string ingress in v0",
+        )
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        return _failure(
+            field,
+            MasterV2BoundaryConversionErrorCode.WRONG_TYPE,
+            f"{field.value} rejects int ingress in v0",
+        )
+
+    source_type: str
+    decimal_value: Decimal
+
+    if isinstance(value, Decimal):
+        finite_ok, finite_code = _is_finite_number(value)
+        if not finite_ok:
+            assert finite_code is not None
+            return _failure(field, finite_code, f"{field.value} non-finite")
+        decimal_value = value
+        source_type = "Decimal"
+    elif isinstance(value, float):
+        if not policy.accepts_float:
+            return _failure(
+                field,
+                MasterV2BoundaryConversionErrorCode.WRONG_TYPE,
+                f"{field.value} requires Decimal identity path",
+            )
+        finite_ok, finite_code = _is_finite_number(value)
+        if not finite_ok:
+            assert finite_code is not None
+            return _failure(field, finite_code, f"{field.value} non-finite")
+        converted = _to_decimal_text(value)
+        if isinstance(converted, MasterV2BoundaryConversionErrorCode):
+            return _failure(field, converted, f"{field.value} conversion failed")
+        decimal_value = converted
+        source_type = "float"
+    else:
+        return _failure(
+            field,
+            MasterV2BoundaryConversionErrorCode.WRONG_TYPE,
+            f"{field.value} unsupported input type",
+        )
+
+    range_error = _validate_range(field, policy, decimal_value)
+    if range_error is not None:
+        return MasterV2BoundaryConversionResult(success=None, error=range_error)
+
+    metadata_error = _validate_precision_metadata(field, policy, input_data)
+    if metadata_error is not None:
+        return MasterV2BoundaryConversionResult(success=None, error=metadata_error)
+
+    quantization_applied = False
+    quantization_owner: str | None = None
+    final_decimal = decimal_value
+
+    if input_data.apply_quantization:
+        if policy.quantization_owner_suffix is None:
+            return _failure(
+                field,
+                MasterV2BoundaryConversionErrorCode.QUANTIZATION_FAILURE,
+                f"{field.value} cannot be quantized",
+            )
+        assert input_data.quantization_policy is not None
+        quant_result = _delegate_quantize(
+            field,
+            policy,
+            decimal_value,
+            input_data.quantization_policy,
+        )
+        if isinstance(quant_result, MasterV2BoundaryConversionError):
+            return MasterV2BoundaryConversionResult(success=None, error=quant_result)
+        final_decimal, quantization_owner = quant_result
+        quantization_applied = True
+
+    success = MasterV2BoundaryConversionSuccess(
+        field=field,
+        decimal_value=final_decimal,
+        source_number_type=source_type,
+        target_number_type="Decimal",
+        unit=policy.target_unit,
+        sign_convention=policy.sign_convention,
+        quantization_applied=quantization_applied,
+        quantization_owner=quantization_owner,
+    )
+    return MasterV2BoundaryConversionResult(success=success, error=None)
+
+
+def convert_master_v2_boundary_field(
+    input: MasterV2BoundaryFieldInput,
+) -> MasterV2BoundaryConversionResult:
+    policy = _FIELD_POLICIES.get(input.field)
+    if policy is None:
+        return _failure(
+            input.field,
+            MasterV2BoundaryConversionErrorCode.UNSUPPORTED_FIELD,
+            "unsupported field",
+        )
+    return _convert_field_with_policy(input, policy)
+
+
+def convert_master_v2_boundary_fields_batch(
+    inputs: tuple[MasterV2BoundaryFieldInput, ...],
+    *,
+    require_all_fields: bool = False,
+) -> MasterV2BoundaryBatchConversionResult:
+    seen: set[MasterV2BoundaryField] = set()
+    errors: list[MasterV2BoundaryConversionError] = []
+
+    for input_data in inputs:
+        if input_data.field in seen:
+            errors.append(
+                _error(
+                    input_data.field,
+                    MasterV2BoundaryConversionErrorCode.DUPLICATE_FIELD,
+                    f"duplicate field {input_data.field.value}",
+                )
+            )
+        seen.add(input_data.field)
+
+    if errors:
+        return MasterV2BoundaryBatchConversionResult(
+            results=(),
+            all_fields_converted=False,
+            errors=tuple(errors),
+        )
+
+    if require_all_fields:
+        present = {item.field for item in inputs}
+        if present != set(_ALL_FIELDS):
+            missing = sorted(
+                (field.value for field in _ALL_FIELDS if field not in present),
+                key=str,
+            )
+            batch_error = _error(
+                None,
+                MasterV2BoundaryConversionErrorCode.INCOMPLETE_REQUIRED_FIELDS,
+                f"missing required fields: {', '.join(missing)}",
+            )
+            return MasterV2BoundaryBatchConversionResult(
+                results=(),
+                all_fields_converted=False,
+                errors=(batch_error,),
+            )
+
+    sorted_inputs = sorted(inputs, key=lambda item: item.field.value)
+    results: list[MasterV2BoundaryConversionResult] = []
+    field_errors: list[MasterV2BoundaryConversionError] = []
+
+    for input_data in sorted_inputs:
+        result = convert_master_v2_boundary_field(input_data)
+        results.append(result)
+        if result.error is not None:
+            field_errors.append(result.error)
+
+    if field_errors:
+        return MasterV2BoundaryBatchConversionResult(
+            results=tuple(results),
+            all_fields_converted=False,
+            errors=tuple(field_errors),
+        )
+
+    all_ok = len(results) > 0 and all(r.success is not None for r in results)
+    if not all_ok:
+        partial_error = _error(
+            None,
+            MasterV2BoundaryConversionErrorCode.PARTIAL_CONVERSION_RESULT,
+            "partial conversion result",
+        )
+        return MasterV2BoundaryBatchConversionResult(
+            results=tuple(results),
+            all_fields_converted=False,
+            errors=(partial_error,),
+        )
+
+    return MasterV2BoundaryBatchConversionResult(
+        results=tuple(results),
+        all_fields_converted=True,
+        errors=(),
+    )

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -3671,6 +3671,75 @@ def test_selector_master_v2_arithmetic_decimal_float_conversion_boundary_contrac
     )
 
 
+MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_PRODUCTION_PATH = (
+    "src/trading/master_v2/arithmetic_decimal_float_conversion_v0.py"
+)
+MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER = (
+    "tests/ops/test_master_v2_arithmetic_decimal_float_conversion_implementation_v0.py"
+)
+
+
+def test_selector_master_v2_arithmetic_decimal_float_conversion_implementation_test_only_focused() -> (
+    None
+):
+    sel = _run_selector(MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    assert (
+        sel["test_selection_reason"]
+        == "master_v2_arithmetic_decimal_float_conversion_implementation_focused"
+    )
+    assert sel["tests_execute_full"] == "false"
+    assert sel["tests_execute_focused"] == "true"
+    assert sel["tests_execute_no_op"] == "false"
+    targets = _targets(sel)
+    assert len([t for t in targets if "::test_" in t]) == 26
+    assert (
+        f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_deterministic_decimal_no_float_leakage"
+        in targets
+    )
+    assert (
+        f"{MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER}::test_immutable_non_authorizing_no_wiring"
+        in targets
+    )
+    assert "tests/ci/test_ci_diff_aware_test_selection_v1.py" not in targets
+
+
+def test_selector_master_v2_arithmetic_decimal_float_conversion_implementation_selector_rebundle_focused() -> (
+    None
+):
+    sel = _run_selector(
+        MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_PRODUCTION_PATH,
+        MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_TEST_OWNER,
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    assert (
+        sel["test_selection_reason"]
+        == "master_v2_arithmetic_decimal_float_conversion_implementation_focused"
+    )
+    targets = _targets(sel)
+    assert len([t for t in targets if "::test_" in t]) == 28
+    assert (
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py::test_selector_master_v2_arithmetic_decimal_float_conversion_implementation_test_only_focused"
+        in targets
+    )
+
+
+def test_selector_master_v2_arithmetic_decimal_float_conversion_implementation_foreign_path_escalates_full() -> (
+    None
+):
+    sel = _run_selector(
+        MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_PRODUCTION_PATH,
+        "src/execution/paper/futures_accounting.py",
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert (
+        sel["test_selection_reason"]
+        == "master_v2_arithmetic_decimal_float_conversion_implementation_foreign_path_requires_full"
+    )
+
+
 def test_selector_testnet_wallclock_duration_evidence_owner_pair_focused() -> None:
     sel = _run_selector(*TESTNET_WALLCLOCK_DURATION_EVIDENCE_FILES)
     assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"

--- a/tests/ops/test_master_v2_arithmetic_decimal_float_conversion_implementation_v0.py
+++ b/tests/ops/test_master_v2_arithmetic_decimal_float_conversion_implementation_v0.py
@@ -1,0 +1,360 @@
+"""Bounded tests for Master V2 arithmetic Decimal/float conversion implementation v0.
+
+26 collected nodes (19 parametrize expansions + 7 fixed). Non-authorizing. No runtime/network.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+from decimal import Decimal
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from src.execution.ledger.models import QuantizationPolicy
+from src.trading.master_v2 import arithmetic_decimal_float_conversion_v0 as conv
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRODUCTION_MODULE = (
+    REPO_ROOT / "src" / "trading" / "master_v2" / "arithmetic_decimal_float_conversion_v0.py"
+)
+MODULE_IMPORT = "src.trading.master_v2.arithmetic_decimal_float_conversion_v0"
+
+_PACKAGE_MARKER = "MASTER_V2_ARITHMETIC_DECIMAL_FLOAT_CONVERSION_IMPLEMENTATION_V0=true"
+_AUTHORITY_LIFT = False
+
+_HAPPY_VALUES: Final[dict[conv.MasterV2BoundaryField, float | Decimal]] = {
+    conv.MasterV2BoundaryField.PRICE: 100.5,
+    conv.MasterV2BoundaryField.MARK_PRICE: 101.25,
+    conv.MasterV2BoundaryField.ENTRY_PRICE: 99.0,
+    conv.MasterV2BoundaryField.QTY: 2.0,
+    conv.MasterV2BoundaryField.CONTRACT_SIZE: Decimal("0.001"),
+    conv.MasterV2BoundaryField.TICK_SIZE: Decimal("0.01"),
+    conv.MasterV2BoundaryField.MIN_QTY: Decimal("0.001"),
+    conv.MasterV2BoundaryField.REALIZED_PNL: -12.5,
+    conv.MasterV2BoundaryField.UNREALIZED_PNL: 3.75,
+    conv.MasterV2BoundaryField.NOTIONAL: 5000.0,
+    conv.MasterV2BoundaryField.FEE_BPS: 7.5,
+    conv.MasterV2BoundaryField.FUNDING_RATE: 0.0001,
+    conv.MasterV2BoundaryField.EQUITY: 10000.0,
+    conv.MasterV2BoundaryField.INITIAL_MARGIN_RATE: Decimal("0.1"),
+    conv.MasterV2BoundaryField.MAINTENANCE_MARGIN_RATE: Decimal("0.05"),
+    conv.MasterV2BoundaryField.QUOTE_CURRENCY_NOTIONAL: 2500.0,
+    conv.MasterV2BoundaryField.FEE_RATE: 0.0005,
+    conv.MasterV2BoundaryField.MAINTENANCE_MARGIN: 150.0,
+    conv.MasterV2BoundaryField.ADVERSE_SLIPPAGE_BPS: 2.0,
+}
+
+_ALL_FIELDS: Final[tuple[conv.MasterV2BoundaryField, ...]] = tuple(conv.MasterV2BoundaryField)
+
+
+def _input_for(field: conv.MasterV2BoundaryField) -> conv.MasterV2BoundaryFieldInput:
+    return conv.MasterV2BoundaryFieldInput(field=field, value=_HAPPY_VALUES[field])
+
+
+def _imports_module(tree: ast.AST, module_suffix: str) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if module_suffix in (alias.name or ""):
+                    return True
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if module_suffix in mod:
+                return True
+    return False
+
+
+@pytest.mark.parametrize("field", _ALL_FIELDS, ids=[f.value for f in _ALL_FIELDS])
+def test_all_19_field_policies_convert_successfully(field: conv.MasterV2BoundaryField) -> None:
+    result = conv.convert_master_v2_boundary_field(_input_for(field))
+    assert result.error is None, result.error
+    assert result.success is not None
+    success = result.success
+    assert success.field == field
+    assert isinstance(success.decimal_value, Decimal)
+    assert success.target_number_type == "Decimal"
+    assert success.unit
+    assert success.sign_convention
+    assert success.quantization_applied is False
+    assert success.quantization_owner is None
+
+
+def test_rejects_bool_missing_and_invalid_type() -> None:
+    bool_result = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=True)
+    )
+    assert bool_result.success is None
+    assert bool_result.error is not None
+    assert bool_result.error.error_code == conv.MasterV2BoundaryConversionErrorCode.BOOL_AS_NUMBER
+
+    missing = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=None)
+    )
+    assert missing.error is not None
+    assert missing.error.error_code == conv.MasterV2BoundaryConversionErrorCode.MISSING_VALUE
+
+    wrong_type = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value="100.5")
+    )
+    assert wrong_type.error is not None
+    assert wrong_type.error.error_code == conv.MasterV2BoundaryConversionErrorCode.WRONG_TYPE
+
+    decimal_only = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(
+            field=conv.MasterV2BoundaryField.CONTRACT_SIZE,
+            value=1.5,
+        )
+    )
+    assert decimal_only.error is not None
+    assert decimal_only.error.error_code == conv.MasterV2BoundaryConversionErrorCode.WRONG_TYPE
+
+
+def test_rejects_non_finite_values() -> None:
+    for raw, code in (
+        (float("nan"), conv.MasterV2BoundaryConversionErrorCode.NAN),
+        (float("inf"), conv.MasterV2BoundaryConversionErrorCode.POSITIVE_INFINITY),
+        (float("-inf"), conv.MasterV2BoundaryConversionErrorCode.NEGATIVE_INFINITY),
+    ):
+        result = conv.convert_master_v2_boundary_field(
+            conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=raw)
+        )
+        assert result.success is None
+        assert result.error is not None
+        assert result.error.error_code == code
+
+
+def test_negative_zero_and_overflow_boundaries() -> None:
+    negative_price = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=-1.0)
+    )
+    assert negative_price.error is not None
+    assert (
+        negative_price.error.error_code
+        == conv.MasterV2BoundaryConversionErrorCode.NEGATIVE_DISALLOWED
+    )
+
+    zero_price = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=0.0)
+    )
+    assert zero_price.error is not None
+    assert zero_price.error.error_code == conv.MasterV2BoundaryConversionErrorCode.ZERO_DISALLOWED
+
+    overflow = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(
+            field=conv.MasterV2BoundaryField.CONTRACT_SIZE,
+            value=Decimal("9e999"),
+        )
+    )
+    assert overflow.error is not None
+    assert overflow.error.error_code == conv.MasterV2BoundaryConversionErrorCode.OVERFLOW
+
+    underflow = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=5e-324)
+    )
+    assert underflow.error is not None
+    assert underflow.error.error_code == conv.MasterV2BoundaryConversionErrorCode.UNDERFLOW
+
+    signed_ok = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.REALIZED_PNL, value=-1.0)
+    )
+    assert signed_ok.success is not None
+
+    margin_rate = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(
+            field=conv.MasterV2BoundaryField.INITIAL_MARGIN_RATE,
+            value=Decimal("1.5"),
+        )
+    )
+    assert margin_rate.error is not None
+    assert margin_rate.error.error_code == conv.MasterV2BoundaryConversionErrorCode.OVERFLOW
+
+
+def test_deterministic_decimal_no_float_leakage() -> None:
+    value = 0.1 + 0.2
+    result_a = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.FEE_BPS, value=value)
+    )
+    result_b = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.FEE_BPS, value=value)
+    )
+    assert result_a.success is not None and result_b.success is not None
+    assert result_a.success.decimal_value == result_b.success.decimal_value
+    assert result_a.success.decimal_value == Decimal(str(value))
+    assert isinstance(result_a.success.decimal_value, Decimal)
+    assert not isinstance(result_a.success.decimal_value, float)
+
+
+def test_conversion_quantization_tick_lot_separation() -> None:
+    policy = QuantizationPolicy(
+        price_quant=Decimal("0.01"),
+        qty_quant=Decimal("0.001"),
+        money_quant=Decimal("0.01"),
+    )
+    without_quant = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(
+            field=conv.MasterV2BoundaryField.PRICE,
+            value=100.555,
+            tick_size=Decimal("0.01"),
+        )
+    )
+    assert without_quant.success is not None
+    assert without_quant.success.quantization_applied is False
+    assert without_quant.success.decimal_value == Decimal("100.555")
+
+    missing_tick = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(
+            field=conv.MasterV2BoundaryField.PRICE,
+            value=100.5,
+            apply_quantization=True,
+            quantization_policy=policy,
+        )
+    )
+    assert missing_tick.error is not None
+    assert (
+        missing_tick.error.error_code == conv.MasterV2BoundaryConversionErrorCode.MISSING_TICK_SIZE
+    )
+
+    with_quant = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(
+            field=conv.MasterV2BoundaryField.PRICE,
+            value=100.555,
+            tick_size=Decimal("0.01"),
+            apply_quantization=True,
+            quantization_policy=policy,
+        )
+    )
+    assert with_quant.success is not None
+    assert with_quant.success.quantization_applied is True
+    assert with_quant.success.quantization_owner == f"{conv.QUANTIZATION_OWNER_PATH}::q_price"
+    assert with_quant.success.decimal_value == Decimal("100.56")
+
+    missing_lot = conv.convert_master_v2_boundary_field(
+        conv.MasterV2BoundaryFieldInput(
+            field=conv.MasterV2BoundaryField.QTY,
+            value=1.5,
+            apply_quantization=True,
+            quantization_policy=policy,
+        )
+    )
+    assert missing_lot.error is not None
+    assert missing_lot.error.error_code == conv.MasterV2BoundaryConversionErrorCode.MISSING_LOT_SIZE
+
+    src = PRODUCTION_MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    assert "round(" not in src
+    assert "ledger_quantization" in src
+    assert '"q_price"' in src or "'q_price'" in src
+    assert conv.QUANTIZATION_OWNER_PATH.endswith("quantization.py")
+
+
+def test_batch_partial_and_complete_semantics() -> None:
+    duplicate_batch = conv.convert_master_v2_boundary_fields_batch(
+        (
+            conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=1.0),
+            conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=2.0),
+        )
+    )
+    assert duplicate_batch.all_fields_converted is False
+    assert duplicate_batch.results == ()
+    assert any(
+        err.error_code == conv.MasterV2BoundaryConversionErrorCode.DUPLICATE_FIELD
+        for err in duplicate_batch.errors
+    )
+
+    partial_batch = conv.convert_master_v2_boundary_fields_batch(
+        (
+            conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=100.0),
+            conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.QTY, value=-1.0),
+        )
+    )
+    assert partial_batch.all_fields_converted is False
+    assert partial_batch.errors
+    assert any(r.error is not None for r in partial_batch.results)
+
+    complete_inputs = tuple(_input_for(field) for field in _ALL_FIELDS)
+    complete_batch = conv.convert_master_v2_boundary_fields_batch(
+        complete_inputs,
+        require_all_fields=True,
+    )
+    assert complete_batch.all_fields_converted is True
+    assert complete_batch.errors == ()
+    assert len(complete_batch.results) == 19
+
+    incomplete = conv.convert_master_v2_boundary_fields_batch(
+        (conv.MasterV2BoundaryFieldInput(field=conv.MasterV2BoundaryField.PRICE, value=1.0),),
+        require_all_fields=True,
+    )
+    assert incomplete.all_fields_converted is False
+    assert incomplete.results == ()
+    assert (
+        incomplete.errors[0].error_code
+        == conv.MasterV2BoundaryConversionErrorCode.INCOMPLETE_REQUIRED_FIELDS
+    )
+
+
+def test_immutable_non_authorizing_no_wiring() -> None:
+    assert _PACKAGE_MARKER
+    assert _AUTHORITY_LIFT is False
+
+    for cls in (
+        conv.MasterV2BoundaryFieldInput,
+        conv.MasterV2BoundaryConversionSuccess,
+        conv.MasterV2BoundaryConversionError,
+        conv.MasterV2BoundaryConversionResult,
+        conv.MasterV2BoundaryBatchConversionResult,
+    ):
+        assert getattr(cls, "__dataclass_params__").frozen
+
+    public_functions = {
+        name
+        for name, obj in inspect.getmembers(conv, inspect.isfunction)
+        if obj.__module__ == conv.__name__ and not name.startswith("_")
+    }
+    assert public_functions == {
+        "convert_master_v2_boundary_field",
+        "convert_master_v2_boundary_fields_batch",
+    }
+
+    production_paths = [
+        REPO_ROOT / "src" / "trading" / "master_v2",
+        REPO_ROOT / "src" / "execution" / "paper",
+        REPO_ROOT / "src" / "ops",
+    ]
+    importers: list[str] = []
+    for base in production_paths:
+        if not base.exists():
+            continue
+        for path in base.rglob("*.py"):
+            if path.name == "arithmetic_decimal_float_conversion_v0.py":
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            if _imports_module(tree, "arithmetic_decimal_float_conversion_v0"):
+                importers.append(str(path.relative_to(REPO_ROOT)))
+
+    assert importers == [], f"unexpected production importers: {importers}"
+
+    forbidden_runtime = ("requests", "socket", "urllib", "httpx", "aiohttp")
+    src = PRODUCTION_MODULE.read_text(encoding="utf-8")
+    for token in forbidden_runtime:
+        assert token not in src
+
+    formula_names = {
+        "unrealized_pnl",
+        "notional_value",
+        "funding_payment_quote",
+        "apply_fee_on_notional",
+        "_to_decimal",
+    }
+    tree = ast.parse(src)
+    defined = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and not node.name.startswith("_")
+    }
+    assert defined.isdisjoint(formula_names)
+
+    assert math.isfinite(1.0)


### PR DESCRIPTION
## Summary
- Erster produktiver Arithmetic-Conversion-Slice: `convert_master_v2_boundary_field` und `convert_master_v2_boundary_fields_batch` mit 19 geschlossenen `MasterV2BoundaryField`-Policies und immutable Result-/Error-Modellen
- Keine Master-V2-/Kernel-/Completion-/Adapter-Verdrahtung; keine Arithmetic-Formeln; keine Quantisierungsimplementierung im Modul (Delegation an `src/execution/ledger/quantization.py`)
- Fail-closed für bool, NaN, ±Infinity, Overflow/Underflow, fehlende Werte, unbekannte/doppelte Felder; kein Partial Result
- Exakt vier Diff-Dateien; 26 bounded Implementation-Testnodes; `CONTRACT_FOCUSED` mit `master_v2_arithmetic_decimal_float_conversion_implementation_focused`
- Required Check `tests (3.11)` führt alle 26 Implementation-Nodes aus; CI-Hard-Timeout 25 Minuten; keine Runtime-/Netzwerk-/Testnet-Ausführung

## Durable Evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/master_v2_arithmetic_decimal_float_conversion_implementation_v0_<UTC_TIMESTAMP>`

## Test plan
- [x] 26 Implementation-Nodes lokal grün
- [x] Selector-Contract-Tests (focused + rebundle + foreign-path escalation) grün
- [x] `ruff format --check` und `ruff check` auf allen vier Dateien
- [x] Statischer No-Wiring-Nachweis (keine Produktions-Importer)
- [ ] GitHub Required Checks (Initial-Snapshot)


Made with [Cursor](https://cursor.com)