### PR TITLE
fix(ops): fail zero-order on unreachable venue

### DIFF
--- a/scripts/ops/archive_futures_testnet_harness_v0.py
+++ b/scripts/ops/archive_futures_testnet_harness_v0.py
@@ -369,8 +369,15 @@ def classify_pf_xbtusd_symbol_visibility(
     body: bytes,
     *,
     endpoint: str,
+    instrument: str | None = None,
 ) -> SymbolVisibility:
-    if endpoint != "/derivatives/api/v3/tickers":
+    """Classify bound-instrument visibility for tickers or instruments responses."""
+    bound_instrument = instrument or DEFAULT_FUTURES_SYMBOL
+    if endpoint == "/derivatives/api/v3/tickers":
+        collection_key = "tickers"
+    elif endpoint == "/derivatives/api/v3/instruments":
+        collection_key = "instruments"
+    else:
         return "not_checked"
     if not body:
         return "response_unparseable"
@@ -378,13 +385,13 @@ def classify_pf_xbtusd_symbol_visibility(
         payload = json.loads(body.decode("utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError):
         return "response_unparseable"
-    tickers: Any = payload.get("tickers") if isinstance(payload, dict) else None
-    if tickers is None and isinstance(payload, list):
-        tickers = payload
-    if not isinstance(tickers, list):
+    entries: Any = payload.get(collection_key) if isinstance(payload, dict) else None
+    if entries is None and isinstance(payload, list):
+        entries = payload
+    if not isinstance(entries, list) or not entries:
         return "response_unparseable"
-    for entry in tickers:
-        if isinstance(entry, dict) and entry.get("symbol") == DEFAULT_FUTURES_SYMBOL:
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("symbol") == bound_instrument:
             return "visible"
     return "not_visible"
 
@@ -556,12 +563,30 @@ def run_zero_order_public_reachability(
         suffix = ep.split("/derivatives/api/v3", 1)[-1]
         url = f"{rest_base_url.rstrip('/')}{suffix}"
         _assert_network_url_allowed(url, rest_base_url)
-        status, body = fetcher.fetch(
-            url,
-            timeout_seconds=min(DEFAULT_PUBLIC_GET_TIMEOUT_SECONDS, duration_cap_seconds),
+        try:
+            status, body = fetcher.fetch(
+                url,
+                timeout_seconds=min(DEFAULT_PUBLIC_GET_TIMEOUT_SECONDS, duration_cap_seconds),
+            )
+        except (TimeoutError, error.URLError, OSError):
+            network_calls.append(
+                NetworkCallRecord(
+                    endpoint=ep,
+                    http_status=0,
+                    http_status_class="other",
+                    response_size_bytes=0,
+                    response_sha256=_sha256_hex(b""),
+                )
+            )
+            endpoints_called.append(ep)
+            symbol_visibility = "response_unparseable"
+            break
+        visibility = classify_pf_xbtusd_symbol_visibility(
+            body,
+            endpoint=ep,
+            instrument=DEFAULT_FUTURES_SYMBOL,
         )
-        visibility = classify_pf_xbtusd_symbol_visibility(body, endpoint=ep)
-        if visibility != "not_checked":
+        if ep == "/derivatives/api/v3/instruments" and visibility != "not_checked":
             symbol_visibility = visibility
         network_calls.append(
             NetworkCallRecord(
@@ -832,9 +857,7 @@ def main(
         )
     evaluation = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
     evidence["bounded_futures_testnet_pass"] = evaluation["bounded_futures_testnet_pass"]
-    persist_runtime_bundle = evaluation["bounded_futures_testnet_pass"] or (
-        args.execute_network and args.mode == PRIVATE_READONLY_MODE
-    )
+    persist_runtime_bundle = evaluation["bounded_futures_testnet_pass"] or args.execute_network
     out: Path | None = None
     if persist_runtime_bundle:
         out = write_durable_evidence_bundle(

--- a/src/ops/bounded_futures_testnet_contract_v0.py
+++ b/src/ops/bounded_futures_testnet_contract_v0.py
@@ -44,6 +44,11 @@ SPOT_SESSION_CLASSES: frozenset[str] = frozenset(
 )
 SPOT_INSTRUMENTS: frozenset[str] = frozenset({"BTC/EUR", "ETH/EUR"})
 
+ZERO_ORDER_REQUIRED_PUBLIC_ENDPOINTS: tuple[str, ...] = (
+    "/derivatives/api/v3/tickers",
+    "/derivatives/api/v3/instruments",
+)
+
 REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES: tuple[str, ...] = (
     "session_class",
     "order_policy",
@@ -180,6 +185,106 @@ def spot_evidence_misclassified_as_futures(evidence: dict[str, Any]) -> list[str
     return reasons
 
 
+def _is_zero_order_reachability_spec(spec: BoundedFuturesTestnetSpec) -> bool:
+    return (
+        spec.max_real_orders == 0
+        and spec.max_order_attempts == 0
+        and spec.max_cancel_attempts == 0
+        and spec.session_class == DEFAULT_SESSION_CLASS
+    )
+
+
+def _zero_order_network_execution_attempted(evidence: dict[str, Any]) -> bool:
+    request_count = evidence.get("request_count")
+    if request_count is not None and int(request_count) > 0:
+        return True
+    network_calls = evidence.get("network_calls")
+    if isinstance(network_calls, list) and network_calls:
+        return True
+    endpoints_called = evidence.get("endpoints_called")
+    return isinstance(endpoints_called, list) and bool(endpoints_called)
+
+
+def _evaluate_zero_order_reachability_gate(
+    evidence: dict[str, Any],
+    spec: BoundedFuturesTestnetSpec,
+) -> tuple[list[str], dict[str, bool]]:
+    """Fail-closed reachability gate for zero-order execute-network evidence."""
+    flags = {
+        "network_reachability_pass": False,
+        "required_public_endpoints_2xx_pass": False,
+        "bound_instrument_present_pass": False,
+    }
+    if not _is_zero_order_reachability_spec(spec):
+        return [], flags
+    if not _zero_order_network_execution_attempted(evidence):
+        return [], flags
+
+    fail_reasons: list[str] = []
+    if evidence.get("network_reachability_proven") is not True:
+        fail_reasons.append("network_reachability_proven must be true")
+
+    endpoints_called = evidence.get("endpoints_called") or []
+    if not isinstance(endpoints_called, list):
+        fail_reasons.append("endpoints_called must be a list")
+        endpoints_called = []
+    missing_endpoints = [
+        ep for ep in ZERO_ORDER_REQUIRED_PUBLIC_ENDPOINTS if ep not in endpoints_called
+    ]
+    if missing_endpoints:
+        fail_reasons.append(
+            "required zero-order public endpoints missing: " + ", ".join(sorted(missing_endpoints))
+        )
+
+    network_calls = evidence.get("network_calls") or []
+    if not isinstance(network_calls, list):
+        fail_reasons.append("network_calls must be a list")
+        network_calls = []
+
+    endpoint_statuses: dict[str, int] = {}
+    for call in network_calls:
+        if not isinstance(call, dict):
+            fail_reasons.append("network_calls entries must be objects")
+            continue
+        endpoint = call.get("endpoint")
+        status = call.get("http_status")
+        if not isinstance(endpoint, str) or not isinstance(status, int):
+            fail_reasons.append("network_calls entry missing endpoint or http_status")
+            continue
+        endpoint_statuses[endpoint] = status
+        if not (200 <= status < 300):
+            fail_reasons.append(f"required endpoint {endpoint!r} returned non-2xx HTTP {status}")
+        if int(call.get("response_size_bytes") or 0) <= 0:
+            fail_reasons.append(f"required endpoint {endpoint!r} returned empty body")
+
+    for required_ep in ZERO_ORDER_REQUIRED_PUBLIC_ENDPOINTS:
+        if required_ep not in endpoint_statuses:
+            fail_reasons.append(f"required endpoint {required_ep!r} missing from network_calls")
+
+    flags["required_public_endpoints_2xx_pass"] = not missing_endpoints and all(
+        200 <= endpoint_statuses.get(ep, 0) < 300 for ep in ZERO_ORDER_REQUIRED_PUBLIC_ENDPOINTS
+    )
+
+    visibility = evidence.get("pf_xbtusd_symbol_visibility")
+    if visibility != "visible":
+        fail_reasons.append(
+            f"bound instrument {spec.instrument!r} must be visible in instruments evidence "
+            f"(got {visibility!r})"
+        )
+    flags["bound_instrument_present_pass"] = visibility == "visible"
+
+    flags["network_reachability_pass"] = (
+        evidence.get("network_reachability_proven") is True
+        and flags["required_public_endpoints_2xx_pass"]
+        and flags["bound_instrument_present_pass"]
+        and not any(
+            reason.startswith("required endpoint") or reason.startswith("network_calls")
+            for reason in fail_reasons
+        )
+    )
+    return fail_reasons, flags
+
+
 def evaluate_bounded_futures_testnet_evidence(
     evidence: dict[str, Any],
     spec: BoundedFuturesTestnetSpec | None = None,
@@ -196,6 +301,13 @@ def evaluate_bounded_futures_testnet_evidence(
         "cancel_flatten_pass": False,
         "risk_killswitch_scope_pass": False,
         "master_v2_boundary_pass": False,
+        "safety_execution_pass": False,
+        "harness_contract_pass": False,
+        "network_reachability_pass": False,
+        "required_public_endpoints_2xx_pass": False,
+        "bound_instrument_present_pass": False,
+        "zero_order_objective_complete": False,
+        "next_phase_ready": False,
         "fail_reasons": [],
     }
 
@@ -318,6 +430,25 @@ def evaluate_bounded_futures_testnet_evidence(
     result["cancel_flatten_pass"] = evidence.get("position_flattened_by_end") is True
     result["risk_killswitch_scope_pass"] = evidence.get("risk_killswitch_scope_pass") is True
     result["master_v2_boundary_pass"] = not evidence.get("master_v2_double_play_authority_used")
+
+    safety_fail_reasons = list(result["fail_reasons"])
+    result["safety_execution_pass"] = not safety_fail_reasons
+    result["harness_contract_pass"] = result["safety_execution_pass"]
+
+    reachability_fail_reasons, reachability_flags = _evaluate_zero_order_reachability_gate(
+        evidence,
+        spec,
+    )
+    result.update(reachability_flags)
+    result["fail_reasons"].extend(reachability_fail_reasons)
+
+    zero_order_objective_complete = (
+        _is_zero_order_reachability_spec(spec)
+        and _zero_order_network_execution_attempted(evidence)
+        and not reachability_fail_reasons
+    )
+    result["zero_order_objective_complete"] = zero_order_objective_complete
+    result["next_phase_ready"] = zero_order_objective_complete
 
     result["bounded_futures_testnet_pass"] = not result["fail_reasons"]
     return result

--- a/tests/ops/test_archive_futures_testnet_harness_v0.py
+++ b/tests/ops/test_archive_futures_testnet_harness_v0.py
@@ -51,13 +51,40 @@ def _durable_test_archive_root(tmp_path: Path) -> Path:
 
 
 class _FakeFetcher:
-    def __init__(self, *, body: bytes | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        tickers_body: bytes | None = None,
+        instruments_body: bytes | None = None,
+        body: bytes | None = None,
+        status_by_path: dict[str, int] | None = None,
+    ) -> None:
         self.urls: list[str] = []
-        self._body = body if body is not None else b'{"tickers":[{"symbol":"PF_ETHUSD"}]}'
+        default_tickers = b'{"tickers":[{"symbol":"PF_ETHUSD"}]}'
+        default_instruments = b'{"instruments":[{"symbol":"PF_ETHUSD"}]}'
+        if body is not None:
+            self._tickers_body = body
+            self._instruments_body = body
+        else:
+            self._tickers_body = tickers_body if tickers_body is not None else default_tickers
+            self._instruments_body = (
+                instruments_body if instruments_body is not None else default_instruments
+            )
+        self._status_by_path = status_by_path or {}
 
     def fetch(self, url: str, *, timeout_seconds: float) -> tuple[int, bytes]:
         self.urls.append(url)
-        return 200, self._body
+        if "tickers" in url:
+            path = "/derivatives/api/v3/tickers"
+            body = self._tickers_body
+        elif "instruments" in url:
+            path = "/derivatives/api/v3/instruments"
+            body = self._instruments_body
+        else:
+            path = url
+            body = b""
+        status = self._status_by_path.get(path, 200)
+        return status, body
 
 
 class _PrivateTimeoutFetcher:
@@ -272,7 +299,10 @@ def test_assert_network_url_rejects_non_allowlisted_path() -> None:
 
 
 def test_tickers_path_increments_request_count_and_endpoints() -> None:
-    fetcher = _FakeFetcher(body=b'{"tickers":[{"symbol":"PF_ETHUSD"}]}')
+    fetcher = _FakeFetcher(
+        tickers_body=b'{"tickers":[{"symbol":"PF_ETHUSD"}]}',
+        instruments_body=b'{"instruments":[{"symbol":"PF_ETHUSD"}]}',
+    )
     result = harness.run_zero_order_public_reachability(
         rest_base_url=harness.DEFAULT_REST_BASE_URL,
         duration_cap_seconds=60,
@@ -285,7 +315,10 @@ def test_tickers_path_increments_request_count_and_endpoints() -> None:
 
 
 def test_pf_ethusd_not_visible_when_response_lacks_default_symbol() -> None:
-    fetcher = _FakeFetcher(body=b'{"tickers":[{"symbol":"PF_XBTUSD"}]}')
+    fetcher = _FakeFetcher(
+        tickers_body=b'{"tickers":[{"symbol":"PF_XBTUSD"}]}',
+        instruments_body=b'{"instruments":[{"symbol":"PF_XBTUSD"}]}',
+    )
     result = harness.run_zero_order_public_reachability(
         rest_base_url=harness.DEFAULT_REST_BASE_URL,
         duration_cap_seconds=60,
@@ -324,6 +357,22 @@ def test_pe8_zero_order_spec_accepts_harness_evidence() -> None:
         wall_clock_start_utc="2026-06-04T00:00:00Z",
         wall_clock_end_utc="2026-06-04T00:00:01Z",
     )
+    network_calls = [
+        {
+            "endpoint": "/derivatives/api/v3/tickers",
+            "http_status": 200,
+            "http_status_class": "2xx",
+            "response_size_bytes": 32,
+            "response_sha256": "a" * 64,
+        },
+        {
+            "endpoint": "/derivatives/api/v3/instruments",
+            "http_status": 200,
+            "http_status_class": "2xx",
+            "response_size_bytes": 36,
+            "response_sha256": "b" * 64,
+        },
+    ]
     evidence = harness.build_zero_order_evidence_payload(
         timing=timing,
         endpoints_called=list(harness.ZERO_ORDER_PUBLIC_ENDPOINT_ORDER),
@@ -332,11 +381,23 @@ def test_pe8_zero_order_spec_accepts_harness_evidence() -> None:
         run_id="offline",
         pe8_pass=False,
         network_reachability_proven=True,
+        network_calls=[
+            harness.NetworkCallRecord(
+                endpoint=call["endpoint"],
+                http_status=call["http_status"],
+                http_status_class=call["http_status_class"],
+                response_size_bytes=call["response_size_bytes"],
+                response_sha256=call["response_sha256"],
+            )
+            for call in network_calls
+        ],
         pf_xbtusd_symbol_visibility="visible",
     )
     spec = default_bounded_futures_zero_order_reachability_v0_spec()
     result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
     assert result["bounded_futures_testnet_pass"] is True
+    assert result["zero_order_objective_complete"] is True
+    assert result["next_phase_ready"] is True
 
 
 def test_rejected_placeholder_set_unchanged() -> None:
@@ -514,3 +575,196 @@ def test_credentials_in_environ_alone_do_not_authorize_execute(tmp_path: Path) -
     assert evidence["request_count"] == 0
     assert evidence["private_readonly_reachability_proven"] is False
     assert evidence["futures_private_api_authorized"] is False
+
+
+def test_execute_network_both_endpoints_503_fail_closed(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    fetcher = _FakeFetcher(
+        status_by_path={
+            "/derivatives/api/v3/tickers": 503,
+            "/derivatives/api/v3/instruments": 503,
+        },
+    )
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "http503",
+            "--execute-network",
+            "--confirm-futures-zero-order-reachability",
+            harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+        ],
+        fetcher=fetcher,
+    )
+    assert rc == harness.USAGE_EXIT
+    bundle = list((archive / "runtime").iterdir())[0]
+    evidence = json.loads((bundle / "FUTURES_EVIDENCE.json").read_text(encoding="utf-8"))
+    evaluation = json.loads((bundle / "PE8_EVALUATION.json").read_text(encoding="utf-8"))
+    assert evidence["network_reachability_proven"] is False
+    assert evidence["bounded_futures_testnet_pass"] is False
+    assert evaluation["bounded_futures_testnet_pass"] is False
+    assert evaluation["zero_order_objective_complete"] is False
+    assert evaluation["next_phase_ready"] is False
+    assert evidence["order_attempt_count"] == 0
+    assert evidence["real_orders_created_count"] == 0
+
+
+def test_execute_network_mixed_200_and_503_fail_closed(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    fetcher = _FakeFetcher(
+        status_by_path={
+            "/derivatives/api/v3/tickers": 200,
+            "/derivatives/api/v3/instruments": 503,
+        },
+    )
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "mixed503",
+            "--execute-network",
+            "--confirm-futures-zero-order-reachability",
+            harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+        ],
+        fetcher=fetcher,
+    )
+    assert rc == harness.USAGE_EXIT
+    evaluation = json.loads(
+        list((archive / "runtime").iterdir())[0]
+        .joinpath("PE8_EVALUATION.json")
+        .read_text(encoding="utf-8")
+    )
+    assert evaluation["bounded_futures_testnet_pass"] is False
+    assert evaluation["zero_order_objective_complete"] is False
+
+
+def test_execute_network_http_429_fail_closed(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    fetcher = _FakeFetcher(
+        status_by_path={
+            "/derivatives/api/v3/tickers": 429,
+            "/derivatives/api/v3/instruments": 429,
+        },
+    )
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "http429",
+            "--execute-network",
+            "--confirm-futures-zero-order-reachability",
+            harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+        ],
+        fetcher=fetcher,
+    )
+    assert rc == harness.USAGE_EXIT
+    evaluation = json.loads(
+        list((archive / "runtime").iterdir())[0]
+        .joinpath("PE8_EVALUATION.json")
+        .read_text(encoding="utf-8")
+    )
+    assert evaluation["bounded_futures_testnet_pass"] is False
+
+
+def test_execute_network_invalid_json_fail_closed(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    fetcher = _FakeFetcher(
+        tickers_body=b"not-json",
+        instruments_body=b"not-json",
+    )
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "badjson",
+            "--execute-network",
+            "--confirm-futures-zero-order-reachability",
+            harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+        ],
+        fetcher=fetcher,
+    )
+    assert rc == harness.USAGE_EXIT
+    evaluation = json.loads(
+        list((archive / "runtime").iterdir())[0]
+        .joinpath("PE8_EVALUATION.json")
+        .read_text(encoding="utf-8")
+    )
+    assert evaluation["bounded_futures_testnet_pass"] is False
+    assert evaluation["bound_instrument_present_pass"] is False
+
+
+def test_execute_network_missing_pf_ethusd_fail_closed(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    fetcher = _FakeFetcher(
+        tickers_body=b'{"tickers":[{"symbol":"PF_XBTUSD"}]}',
+        instruments_body=b'{"instruments":[{"symbol":"PF_XBTUSD"}]}',
+    )
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "missingeth",
+            "--execute-network",
+            "--confirm-futures-zero-order-reachability",
+            harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+        ],
+        fetcher=fetcher,
+    )
+    assert rc == harness.USAGE_EXIT
+    evaluation = json.loads(
+        list((archive / "runtime").iterdir())[0]
+        .joinpath("PE8_EVALUATION.json")
+        .read_text(encoding="utf-8")
+    )
+    assert evaluation["bounded_futures_testnet_pass"] is False
+    assert evaluation["bound_instrument_present_pass"] is False
+
+
+class _TimeoutFetcher:
+    def fetch(self, url: str, *, timeout_seconds: float) -> tuple[int, bytes]:
+        raise TimeoutError("timed out")
+
+
+def test_execute_network_transport_timeout_fail_closed(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    rc = harness.main(
+        [
+            "--archive-root",
+            str(archive),
+            "--run-id",
+            "timeout",
+            "--execute-network",
+            "--confirm-futures-zero-order-reachability",
+            harness.CONFIRM_TOKEN_ZERO_ORDER_REACHABILITY,
+        ],
+        fetcher=_TimeoutFetcher(),
+    )
+    assert rc == harness.USAGE_EXIT
+    evaluation = json.loads(
+        list((archive / "runtime").iterdir())[0]
+        .joinpath("PE8_EVALUATION.json")
+        .read_text(encoding="utf-8")
+    )
+    assert evaluation["bounded_futures_testnet_pass"] is False
+    assert evaluation["zero_order_objective_complete"] is False
+
+
+def test_plan_only_keeps_safety_pass_without_objective_complete(tmp_path: Path) -> None:
+    archive = _durable_test_archive_root(tmp_path)
+    rc = harness.main(["--archive-root", str(archive), "--run-id", "planonly3"])
+    assert rc == 0
+    evaluation = json.loads(
+        list((archive / "runtime").iterdir())[0]
+        .joinpath("PE8_EVALUATION.json")
+        .read_text(encoding="utf-8")
+    )
+    assert evaluation["safety_execution_pass"] is True
+    assert evaluation["harness_contract_pass"] is True
+    assert evaluation["bounded_futures_testnet_pass"] is True
+    assert evaluation["zero_order_objective_complete"] is False
+    assert evaluation["next_phase_ready"] is False

--- a/tests/ops/test_bounded_futures_testnet_contract_v0.py
+++ b/tests/ops/test_bounded_futures_testnet_contract_v0.py
@@ -18,7 +18,9 @@ from src.ops.bounded_futures_testnet_contract_v0 import (
     REJECTED_FUTURES_INSTRUMENT_PLACEHOLDERS,
     REQUIRED_FUTURES_EVIDENCE_FIELD_NAMES,
     SPOT_KRAKEN_ENDPOINT_PREFIXES,
+    ZERO_ORDER_REQUIRED_PUBLIC_ENDPOINTS,
     default_bounded_futures_normal_v0_spec,
+    default_bounded_futures_zero_order_reachability_v0_spec,
     evaluate_bounded_futures_testnet_evidence,
     spot_evidence_misclassified_as_futures,
 )
@@ -179,3 +181,167 @@ def test_btcusdt_placeholder_rejected_in_futures_evidence() -> None:
 
 def test_closeout_review_bundle_suffix_documented_in_test() -> None:
     assert REVIEW_BUNDLE_SUFFIX in Path(__file__).read_text(encoding="utf-8")
+
+
+def _zero_order_network_evidence(**overrides: object) -> dict:
+    evidence = _valid_futures_evidence()
+    evidence.update(
+        {
+            "order_attempt_count": 0,
+            "real_orders_created_count": 0,
+            "cancel_or_close_attempt_count": 0,
+            "request_count": 2,
+            "network_reachability_proven": True,
+            "endpoints_called": list(ZERO_ORDER_REQUIRED_PUBLIC_ENDPOINTS),
+            "network_calls": [
+                {
+                    "endpoint": "/derivatives/api/v3/tickers",
+                    "http_status": 200,
+                    "http_status_class": "2xx",
+                    "response_size_bytes": 32,
+                    "response_sha256": "a" * 64,
+                },
+                {
+                    "endpoint": "/derivatives/api/v3/instruments",
+                    "http_status": 200,
+                    "http_status_class": "2xx",
+                    "response_size_bytes": 36,
+                    "response_sha256": "b" * 64,
+                },
+            ],
+            "pf_xbtusd_symbol_visibility": "visible",
+            "network_host": "https://demo-futures.kraken.com",
+        }
+    )
+    evidence.update(overrides)
+    return evidence
+
+
+def test_zero_order_reachability_success_passes_objective_complete() -> None:
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    result = evaluate_bounded_futures_testnet_evidence(_zero_order_network_evidence(), spec=spec)
+    assert result["bounded_futures_testnet_pass"] is True
+    assert result["zero_order_objective_complete"] is True
+    assert result["next_phase_ready"] is True
+    assert result["network_reachability_pass"] is True
+    assert result["required_public_endpoints_2xx_pass"] is True
+    assert result["bound_instrument_present_pass"] is True
+
+
+def test_zero_order_both_endpoints_503_fail_closed() -> None:
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    evidence = _zero_order_network_evidence(
+        network_reachability_proven=False,
+        network_calls=[
+            {
+                "endpoint": "/derivatives/api/v3/tickers",
+                "http_status": 503,
+                "http_status_class": "5xx",
+                "response_size_bytes": 19,
+                "response_sha256": "c" * 64,
+            },
+            {
+                "endpoint": "/derivatives/api/v3/instruments",
+                "http_status": 503,
+                "http_status_class": "5xx",
+                "response_size_bytes": 19,
+                "response_sha256": "c" * 64,
+            },
+        ],
+        pf_xbtusd_symbol_visibility="response_unparseable",
+    )
+    result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    assert result["bounded_futures_testnet_pass"] is False
+    assert result["zero_order_objective_complete"] is False
+    assert result["next_phase_ready"] is False
+    assert result["safety_execution_pass"] is True
+
+
+def test_zero_order_mixed_endpoint_results_fail_closed() -> None:
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    evidence = _zero_order_network_evidence(
+        network_reachability_proven=False,
+        network_calls=[
+            {
+                "endpoint": "/derivatives/api/v3/tickers",
+                "http_status": 200,
+                "http_status_class": "2xx",
+                "response_size_bytes": 32,
+                "response_sha256": "a" * 64,
+            },
+            {
+                "endpoint": "/derivatives/api/v3/instruments",
+                "http_status": 503,
+                "http_status_class": "5xx",
+                "response_size_bytes": 19,
+                "response_sha256": "c" * 64,
+            },
+        ],
+        pf_xbtusd_symbol_visibility="response_unparseable",
+    )
+    result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    assert result["bounded_futures_testnet_pass"] is False
+    assert result["zero_order_objective_complete"] is False
+
+
+def test_zero_order_http_429_fail_closed() -> None:
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    evidence = _zero_order_network_evidence(
+        network_reachability_proven=False,
+        network_calls=[
+            {
+                "endpoint": "/derivatives/api/v3/tickers",
+                "http_status": 429,
+                "http_status_class": "4xx",
+                "response_size_bytes": 12,
+                "response_sha256": "d" * 64,
+            },
+            {
+                "endpoint": "/derivatives/api/v3/instruments",
+                "http_status": 429,
+                "http_status_class": "4xx",
+                "response_size_bytes": 12,
+                "response_sha256": "d" * 64,
+            },
+        ],
+        pf_xbtusd_symbol_visibility="response_unparseable",
+    )
+    result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    assert result["bounded_futures_testnet_pass"] is False
+
+
+def test_zero_order_invalid_json_fail_closed() -> None:
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    evidence = _zero_order_network_evidence(pf_xbtusd_symbol_visibility="response_unparseable")
+    result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    assert result["bounded_futures_testnet_pass"] is False
+    assert result["bound_instrument_present_pass"] is False
+
+
+def test_zero_order_missing_pf_ethusd_fail_closed() -> None:
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    evidence = _zero_order_network_evidence(pf_xbtusd_symbol_visibility="not_visible")
+    result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    assert result["bounded_futures_testnet_pass"] is False
+    assert result["bound_instrument_present_pass"] is False
+
+
+def test_zero_order_plan_only_does_not_require_reachability_pass() -> None:
+    spec = default_bounded_futures_zero_order_reachability_v0_spec()
+    evidence = _valid_futures_evidence()
+    evidence.update(
+        {
+            "order_attempt_count": 0,
+            "real_orders_created_count": 0,
+            "cancel_or_close_attempt_count": 0,
+            "request_count": 0,
+            "network_reachability_proven": False,
+            "endpoints_called": [],
+            "pf_xbtusd_symbol_visibility": "not_checked",
+        }
+    )
+    result = evaluate_bounded_futures_testnet_evidence(evidence, spec=spec)
+    assert result["bounded_futures_testnet_pass"] is True
+    assert result["zero_order_objective_complete"] is False
+    assert result["next_phase_ready"] is False
+    assert result["safety_execution_pass"] is True


### PR DESCRIPTION
## Summary
- Gate zero-order `bounded_futures_testnet_pass` on reachability when execute-network evidence is present: HTTP 2xx on both demo public endpoints, non-empty JSON, and PF_ETHUSD visible in instruments.
- Keep safety/plan-only pass separate via `safety_execution_pass` / `harness_contract_pass`; set `zero_order_objective_complete` and `next_phase_ready` only on proven reachability.
- Harness now persists failure bundles on execute-network runs and fail-closed on transport errors; non-2xx paths return `USAGE_EXIT`.

## Test plan
- [x] `pytest tests/ops/test_bounded_futures_testnet_contract_v0.py tests/ops/test_archive_futures_testnet_harness_v0.py` (54 offline tests)
- [x] ruff format/check on changed files
- [ ] CI required checks (bounded full path)


Made with [Cursor](https://cursor.com)