### PR TITLE
feat(risk): add offline VaR suite adapter

### DIFF
--- a/src/risk/validation/var_suite_adapter.py
+++ b/src/risk/validation/var_suite_adapter.py
@@ -1,0 +1,206 @@
+"""
+Offline adapter for VaR backtest suite integration.
+
+Deterministic, look-ahead-free bridge between portfolio return series and the
+existing Christoffersen/Kupiec suite runner.  No trading, runtime, or data
+loading authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from src.risk.portfolio_var import historical_var
+from src.risk.validation.suite_runner import (
+    VaRBacktestSuiteResult,
+    run_var_backtest_suite,
+)
+
+_SINGLE_ASSET_COL = "RET"
+_SINGLE_ASSET_WEIGHT = {_SINGLE_ASSET_COL: 1.0}
+
+
+@dataclass(frozen=True)
+class AlignedVaRBacktestInputs:
+    """Strictly aligned returns and VaR forecasts ready for suite evaluation."""
+
+    returns: pd.Series
+    var_series: pd.Series
+
+
+def _validate_returns_series(returns: pd.Series) -> None:
+    if not isinstance(returns, pd.Series):
+        raise ValueError(f"returns must be a pd.Series, got {type(returns).__name__}")
+    if returns.index.duplicated().any():
+        raise ValueError("returns index must be unique")
+    if len(returns) == 0:
+        raise ValueError("returns must not be empty")
+    values = returns.to_numpy(dtype=float, copy=False)
+    if not np.isfinite(values).all():
+        raise ValueError("returns must not contain NaN or Inf values")
+
+
+def _validate_var_series_strict(var_series: pd.Series) -> None:
+    if not isinstance(var_series, pd.Series):
+        raise ValueError(f"var_series must be a pd.Series, got {type(var_series).__name__}")
+    if var_series.index.duplicated().any():
+        raise ValueError("var_series index must be unique")
+    if len(var_series) == 0:
+        raise ValueError("var_series must not be empty")
+    values = var_series.to_numpy(dtype=float, copy=False)
+    if not np.isfinite(values).all():
+        raise ValueError("var_series must not contain NaN or Inf values")
+
+
+def _validate_var_series_for_alignment(var_series: pd.Series) -> None:
+    if not isinstance(var_series, pd.Series):
+        raise ValueError(f"var_series must be a pd.Series, got {type(var_series).__name__}")
+    if var_series.index.duplicated().any():
+        raise ValueError("var_series index must be unique")
+    if len(var_series) == 0:
+        raise ValueError("var_series must not be empty")
+    finite_mask = np.isfinite(var_series.to_numpy(dtype=float, copy=False))
+    if not finite_mask.any():
+        raise ValueError("var_series has no finite values")
+
+
+def _validate_confidence_level(confidence_level: float) -> None:
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError(
+            f"confidence_level must be strictly between 0 and 1, got {confidence_level}"
+        )
+
+
+def _validate_window(window: int) -> None:
+    if not isinstance(window, int) or isinstance(window, bool):
+        raise ValueError(f"window must be an integer, got {window!r}")
+    if window <= 1:
+        raise ValueError(f"window must be > 1, got {window}")
+
+
+def build_rolling_historical_var_forecast(
+    returns: pd.Series,
+    window: int,
+    confidence_level: float = 0.95,
+) -> pd.Series:
+    """
+    Build look-ahead-free rolling historical VaR forecasts.
+
+    Forecast at integer position ``t`` uses only ``returns.iloc[t - window : t]``.
+    The first ``window`` positions receive no forecast (NaN).
+
+    Reuses ``historical_var`` from ``src.risk.portfolio_var``; no alternative
+    quantile implementation.
+    """
+    _validate_returns_series(returns)
+    _validate_window(window)
+    _validate_confidence_level(confidence_level)
+
+    if len(returns) <= window:
+        raise ValueError(f"returns length ({len(returns)}) must exceed window ({window})")
+
+    forecasts = pd.Series(np.nan, index=returns.index, dtype=float)
+
+    for pos in range(window, len(returns)):
+        training = returns.iloc[pos - window : pos]
+        training_df = training.to_frame(name=_SINGLE_ASSET_COL)
+        var_val = historical_var(
+            training_df,
+            weights=_SINGLE_ASSET_WEIGHT,
+            confidence=confidence_level,
+            horizon_days=1,
+        )
+        forecasts.iloc[pos] = var_val
+
+    return forecasts
+
+
+def normalize_var_sign_to_positive_loss(var_series: pd.Series) -> pd.Series:
+    """
+    Normalize VaR sign convention to positive loss magnitude.
+
+    Negative values are converted via absolute value; positive values are
+    unchanged.  This function adjusts sign only — not unit, horizon, or
+    confidence level.
+    """
+    _validate_var_series_strict(var_series)
+    return var_series.abs()
+
+
+def align_var_backtest_inputs(
+    returns: pd.Series,
+    var_series: pd.Series,
+    *,
+    min_observations: int = 2,
+) -> AlignedVaRBacktestInputs:
+    """
+    Strict label-based alignment of returns and VaR forecasts.
+
+    Only common index labels are retained.  No forward-fill, backfill, or
+    interpolation.  Pairs with NaN or Inf in either series are dropped.
+    """
+    _validate_returns_series(returns)
+    _validate_var_series_for_alignment(var_series)
+
+    common_labels = returns.index.intersection(var_series.index)
+    if len(common_labels) == 0:
+        raise ValueError("no overlapping index labels between returns and var_series")
+
+    common_labels = common_labels.sort_values()
+
+    aligned_returns = returns.loc[common_labels]
+    aligned_var = var_series.loc[common_labels].abs()
+
+    valid_mask = (
+        aligned_returns.notna()
+        & aligned_var.notna()
+        & np.isfinite(aligned_returns.to_numpy(dtype=float, copy=False))
+        & np.isfinite(aligned_var.to_numpy(dtype=float, copy=False))
+    )
+    aligned_returns = aligned_returns[valid_mask]
+    aligned_var = aligned_var[valid_mask]
+
+    if len(aligned_returns) == 0:
+        raise ValueError("alignment produced empty series")
+
+    if len(aligned_returns) < min_observations:
+        raise ValueError(
+            f"aligned series length ({len(aligned_returns)}) is below minimum ({min_observations})"
+        )
+
+    if not aligned_returns.index.equals(aligned_var.index):
+        raise ValueError("aligned returns and var_series indices must be identical")
+
+    return AlignedVaRBacktestInputs(
+        returns=aligned_returns,
+        var_series=aligned_var,
+    )
+
+
+def run_rolling_historical_var_backtest_suite(
+    returns: pd.Series,
+    window: int,
+    confidence_level: float = 0.95,
+    significance: float = 0.05,
+) -> VaRBacktestSuiteResult:
+    """
+    Convenience entry: rolling forecast, sign normalize, align, delegate to suite.
+
+    Pure delegation — no new statistics, no file I/O, no network.
+    """
+    var_forecast = build_rolling_historical_var_forecast(
+        returns,
+        window=window,
+        confidence_level=confidence_level,
+    )
+    var_normalized = var_forecast.abs()
+    aligned = align_var_backtest_inputs(returns, var_normalized)
+    return run_var_backtest_suite(
+        aligned.returns,
+        aligned.var_series,
+        confidence_level=confidence_level,
+        significance=significance,
+    )

--- a/tests/risk/validation/test_var_suite_adapter_v0.py
+++ b/tests/risk/validation/test_var_suite_adapter_v0.py
@@ -1,0 +1,193 @@
+"""Contract tests for offline VaR suite adapter (v0)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.risk.validation.suite_runner import VaRBacktestSuiteResult, run_var_backtest_suite
+from src.risk.validation.var_suite_adapter import (
+    AlignedVaRBacktestInputs,
+    align_var_backtest_inputs,
+    build_rolling_historical_var_forecast,
+    normalize_var_sign_to_positive_loss,
+    run_rolling_historical_var_backtest_suite,
+)
+
+
+class TestLookAheadFreedom:
+    def test_forecast_at_t_unchanged_when_return_at_t_changes(self):
+        dates = pd.date_range("2024-01-01", periods=12, freq="D")
+        returns = pd.Series(
+            [0.01, 0.01, 0.01, -0.02, 0.01, 0.01, 0.01, -0.01, 0.02, 0.01, -0.015, 0.005],
+            index=dates,
+            dtype=float,
+        )
+        window = 3
+        t = 3
+
+        forecast_before = build_rolling_historical_var_forecast(
+            returns, window=window, confidence_level=0.95
+        )
+
+        returns_modified = returns.copy()
+        returns_modified.iloc[t] = -0.50
+
+        forecast_after = build_rolling_historical_var_forecast(
+            returns_modified, window=window, confidence_level=0.95
+        )
+
+        assert forecast_before.iloc[t] == forecast_after.iloc[t]
+        assert forecast_before.iloc[t + 1] != forecast_after.iloc[t + 1]
+
+
+class TestRollingWindowSemantics:
+    def test_first_valid_forecast_after_required_window(self):
+        dates = pd.date_range("2024-01-01", periods=15, freq="D")
+        returns = pd.Series([0.01, -0.02, 0.015, -0.01, 0.005] * 3, index=dates)
+        window = 5
+
+        forecast = build_rolling_historical_var_forecast(
+            returns, window=window, confidence_level=0.95
+        )
+
+        assert forecast.iloc[:window].isna().all()
+        assert forecast.iloc[window:].notna().all()
+
+
+class TestSignNormalization:
+    def test_negative_var_normalized_to_positive(self):
+        idx = pd.date_range("2024-01-01", periods=4, freq="D")
+        var_series = pd.Series([-0.03, -0.02, 0.01, -0.005], index=idx)
+
+        normalized = normalize_var_sign_to_positive_loss(var_series)
+
+        pd.testing.assert_series_equal(
+            normalized,
+            pd.Series([0.03, 0.02, 0.01, 0.005], index=idx),
+        )
+
+    def test_positive_var_unchanged(self):
+        idx = pd.date_range("2024-01-01", periods=3, freq="D")
+        var_series = pd.Series([0.03, 0.02, 0.01], index=idx)
+
+        normalized = normalize_var_sign_to_positive_loss(var_series)
+
+        pd.testing.assert_series_equal(normalized, var_series)
+
+
+class TestStrictAlignment:
+    def test_label_based_intersection_no_position_mismatch(self):
+        returns = pd.Series([0.01, -0.03, 0.02, 0.01], index=["a", "b", "c", "d"])
+        var_series = pd.Series([0.02, 0.02, 0.02, 0.02], index=["b", "c", "d", "e"])
+
+        aligned = align_var_backtest_inputs(returns, var_series)
+
+        assert isinstance(aligned, AlignedVaRBacktestInputs)
+        assert list(aligned.returns.index) == ["b", "c", "d"]
+        assert aligned.returns.index.equals(aligned.var_series.index)
+        assert len(aligned.returns) == len(aligned.var_series) == 3
+        assert aligned.returns.loc["b"] == -0.03
+        assert aligned.var_series.loc["b"] == 0.02
+
+
+class TestFailClosedInputs:
+    @pytest.mark.parametrize(
+        "returns,var_series,match",
+        [
+            (
+                pd.Series([0.01, np.nan], index=[0, 1]),
+                pd.Series([0.02, 0.02], index=[0, 1]),
+                "NaN or Inf",
+            ),
+            (
+                pd.Series([0.01, 0.02], index=[0, 0]),
+                pd.Series([0.02, 0.02], index=[0, 1]),
+                "unique",
+            ),
+        ],
+    )
+    def test_invalid_alignment_inputs_rejected(self, returns, var_series, match):
+        with pytest.raises(ValueError, match=match):
+            align_var_backtest_inputs(returns, var_series)
+
+    def test_inf_var_rejected_by_sign_normalizer(self):
+        var_series = pd.Series([0.02, np.inf], index=[0, 1])
+        with pytest.raises(ValueError, match="NaN or Inf"):
+            normalize_var_sign_to_positive_loss(var_series)
+
+    def test_empty_intersection_rejected(self):
+        returns = pd.Series([0.01], index=["a"])
+        var_series = pd.Series([0.02], index=["b"])
+
+        with pytest.raises(ValueError, match="no overlapping"):
+            align_var_backtest_inputs(returns, var_series)
+
+
+class TestSuiteIntegration:
+    def test_adapter_delegates_to_existing_suite_runner(self):
+        dates = pd.date_range("2024-01-01", periods=30, freq="D")
+        rng = np.random.default_rng(42)
+        returns = pd.Series(rng.normal(0.001, 0.015, size=30), index=dates)
+
+        result = run_rolling_historical_var_backtest_suite(
+            returns,
+            window=10,
+            confidence_level=0.95,
+            significance=0.05,
+        )
+
+        assert isinstance(result, VaRBacktestSuiteResult)
+        assert result.observations > 0
+        assert result.kupiec_pof_result in {"PASS", "FAIL"}
+        assert result.christoffersen_ind_result in {"PASS", "FAIL"}
+        assert result.christoffersen_cc_result in {"PASS", "FAIL"}
+        assert 0.0 <= result.kupiec_pof_pvalue <= 1.0
+        assert 0.0 <= result.christoffersen_ind_pvalue <= 1.0
+        assert 0.0 <= result.christoffersen_cc_pvalue <= 1.0
+
+
+class TestViolationSemantics:
+    def test_negative_return_below_negative_var_is_breach(self):
+        idx = pd.date_range("2024-01-01", periods=1, freq="D")
+        returns = pd.Series([-0.05], index=idx)
+        var_series = pd.Series([0.03], index=idx)
+
+        result = run_var_backtest_suite(returns, var_series, confidence_level=0.95)
+
+        assert result.breaches == 1
+        assert returns.iloc[0] < -var_series.iloc[0]
+
+
+class TestAuthorityNeutrality:
+    _FORBIDDEN_IMPORTS = (
+        "src.execution",
+        "src.governance",
+        "requests",
+        "urllib",
+        "httpx",
+        "aiohttp",
+        "ccxt",
+    )
+
+    def test_adapter_module_has_no_trading_or_network_imports(self):
+        module_path = Path("src/risk/validation/var_suite_adapter.py")
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        imported_modules: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported_modules.add(alias.name)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported_modules.add(node.module)
+
+        for forbidden in self._FORBIDDEN_IMPORTS:
+            assert not any(
+                mod == forbidden or mod.startswith(f"{forbidden}.") for mod in imported_modules
+            ), f"forbidden import: {forbidden}"


### PR DESCRIPTION
## Summary

- fügt einen reinen Offline-Adapter für die bestehende VaR-Backtest-Suite hinzu
- baut look-ahead-freie rolling historical VaR forecasts
- normalisiert VaR auf positive Loss-Magnitude
- richtet Returns und VaR strikt über gemeinsame Labels aus
- delegiert anschließend an den bestehenden Suite-Runner

## Scope

- exakt zwei neue Dateien
- ein Produktions-Adapter
- ein Testowner
- keine Änderung an bestehender Statistik
- keine Änderung am Default Runner
- keine Runtime-, Trading-, Execution-, Risk-Policy- oder KillSwitch-Änderung

## Reuse

- `src/risk/portfolio_var.py::historical_var`
- `src/risk/validation/suite_runner.py::run_var_backtest_suite`

## Safety and semantics

- Forecast für Position t verwendet ausschließlich Beobachtungen vor t
- kein Forward-Fill
- kein Backfill
- keine Interpolation
- strikte Index- und Label-Ausrichtung
- keine neue Kupiec-/Christoffersen-Implementierung

## Required CI

- Selector-Modus `PR_BOUNDED_FULL`
- Reason `category_central_src_requires_full`
- neuer Testowner wird genau einmal ausgewählt
- Required Check `tests (3.11)` führt den Testowner aus
- Required-CI-Coverage-Gap wurde durch PR #4596 geschlossen

## Validation

- Adaptertests: 12/12 PASS
- Suite-/Regressionstests: 25/25 PASS
- gezielte Selector-Tests: 5/5 PASS
- Ruff Format: PASS
- Ruff Check: PASS
- keine semantische Drift nach Rebase
- beide Adapterdateien byte-identisch zum ursprünglichen Implementierungscommit

## Non-goals

- kein Training
- kein autonomes Retraining
- keine Promotion
- keine Runtime-Aktivierung
- keine Orders oder Marktdaten
- keine Änderung an Handelslogik oder Risk Limits

## Evidence

Post-Rebase Implementation Bundle:

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/futures_var_suite_offline_adapter_rebased_on_pr4596_main_required_ci_reverified_v0_20260627T030529Z`

MANIFEST_VERIFY_RC=0

Post-Rebase PR-Admissibility Review Bundle:

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/reviews/futures_var_suite_offline_adapter_post_rebase_diff_test_required_ci_pr_admissibility_review_no_pr_v0_20260627T030809Z`

MANIFEST_VERIFY_RC=0

Made with [Cursor](https://cursor.com)