### PR TITLE
feat(learning): Package A — Self-Learning contract manifests v1 (offline)

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1321,6 +1321,31 @@ PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_TARGETS: tuple[str, ...] = (
     "tests/risk/validation/test_var_suite_adapter_v0.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_A_META_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/contract_safety_v1.py",
+        "src/meta/learning_loop/config_patch_manifest_v1.py",
+        "tests/meta/test_contract_safety_v1.py",
+        "tests/meta/test_config_patch_manifest_v1_contract.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_A_META_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+)
+
+PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/governance/promotion_loop/candidate_lineage_manifest_v1.py",
+        "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TARGETS: tuple[str, ...] = (
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+
 
 def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
     """Conservative, deterministic PR_BOUNDED_FULL pytest targets (3.11 main lane)."""
@@ -1353,6 +1378,14 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_A_META_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_A_META_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TARGETS:
             add(path)
 
     if not targets:

--- a/src/governance/promotion_loop/candidate_lineage_manifest_v1.py
+++ b/src/governance/promotion_loop/candidate_lineage_manifest_v1.py
@@ -1,0 +1,455 @@
+"""CandidateLineageManifest v1 — offline reference-only cross-domain FK graph."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Mapping
+
+from src.meta.learning_loop.contract_safety_v1 import (
+    SCHEMA_VERSION_V1,
+    ValidationPhase,
+    canonical_futures_scope_ref,
+    canonical_trading_logic_immutability_ref,
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+    is_valid_uuid,
+    validate_futures_scope_ref,
+    validate_integrity_block,
+    validate_schema_version,
+    validate_trading_logic_immutability_ref,
+)
+
+
+class CandidateLineageManifestError(ValueError):
+    """Fail-closed CandidateLineageManifest v1 error."""
+
+
+class CandidateType(str, Enum):
+    CONFIG_PATCH_BUNDLE = "config_patch_bundle"
+    SWEEP_CONFIG = "sweep_config"
+    WALKFORWARD_CONFIG = "walkforward_config"
+
+
+class LineageRefType(str, Enum):
+    FEATURE_SNAPSHOT = "feature_snapshot"
+    EXPERIMENT = "experiment"
+    BACKTEST = "backtest"
+    REPLAY = "replay"
+    VAR_SUITE = "var_suite"
+    PERFORMANCE_EVIDENCE = "performance_evidence"
+    ROBUSTNESS_EVIDENCE = "robustness_evidence"
+    EVIDENCE_OPS = "evidence_ops"
+    EVIDENCE_AI = "evidence_ai"
+    COMPARISON = "comparison"
+    PROMOTION_PROPOSAL = "promotion_proposal"
+    PARENT_LINEAGE = "parent_lineage"
+
+
+class LineageRelation(str, Enum):
+    SOURCES = "sources"
+    EVALUATES = "evaluates"
+    VALIDATES = "validates"
+    COMPARES = "compares"
+    PROPOSES = "proposes"
+    RETAINS = "retains"
+    REPRODUCES = "reproduces"
+    EXTENDS = "extends"
+
+
+_REF_TYPE_CARDINALITY: dict[LineageRefType, tuple[int, int | None]] = {
+    LineageRefType.FEATURE_SNAPSHOT: (0, None),
+    LineageRefType.EXPERIMENT: (0, 1),
+    LineageRefType.BACKTEST: (0, None),
+    LineageRefType.REPLAY: (0, None),
+    LineageRefType.VAR_SUITE: (0, None),
+    LineageRefType.PERFORMANCE_EVIDENCE: (0, None),
+    LineageRefType.ROBUSTNESS_EVIDENCE: (0, None),
+    LineageRefType.EVIDENCE_OPS: (0, None),
+    LineageRefType.EVIDENCE_AI: (0, None),
+    LineageRefType.COMPARISON: (0, None),
+    LineageRefType.PROMOTION_PROPOSAL: (0, 1),
+    LineageRefType.PARENT_LINEAGE: (0, None),
+}
+
+
+@dataclass(frozen=True)
+class LineageIntegrity:
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class LineageRef:
+    ref_type: LineageRefType
+    ref_id: str
+    relation: LineageRelation
+    owner_domain: str
+    required: bool
+    digest: str | None = None
+    artifact_path: str | None = None
+    schema_version: str | None = None
+
+
+@dataclass
+class CandidateLineageManifestV1:
+    schema_version: str
+    lineage_manifest_id: str
+    candidate_id: str
+    candidate_type: CandidateType
+    candidate_contract_ref: str
+    refs: list[LineageRef]
+    created_at: datetime
+    futures_scope_ref: dict[str, Any]
+    trading_logic_immutability_ref: dict[str, Any]
+    integrity: LineageIntegrity | None = None
+    parent_lineage_manifest_ids: list[str] = field(default_factory=list)
+    created_by: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _parse_datetime(value: Any, *, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        raise CandidateLineageManifestError(f"{field_name} must be an ISO8601 string")
+    normalized = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise CandidateLineageManifestError(f"{field_name} must be an ISO8601 string") from exc
+
+
+def lineage_ref_from_mapping(raw: Mapping[str, Any]) -> LineageRef:
+    required = ("ref_type", "ref_id", "relation", "owner_domain", "required")
+    for key in required:
+        if key not in raw:
+            raise CandidateLineageManifestError(f"ref missing required field: {key}")
+
+    try:
+        ref_type = LineageRefType(str(raw["ref_type"]))
+    except ValueError as exc:
+        raise CandidateLineageManifestError(f"unknown ref_type: {raw['ref_type']!r}") from exc
+    try:
+        relation = LineageRelation(str(raw["relation"]))
+    except ValueError as exc:
+        raise CandidateLineageManifestError(f"unknown relation: {raw['relation']!r}") from exc
+
+    digest = raw.get("digest")
+    schema_version = raw.get("schema_version")
+    artifact_path = raw.get("artifact_path")
+
+    return LineageRef(
+        ref_type=ref_type,
+        ref_id=str(raw["ref_id"]),
+        relation=relation,
+        owner_domain=str(raw["owner_domain"]),
+        required=bool(raw["required"]),
+        digest=str(digest) if digest is not None else None,
+        artifact_path=str(artifact_path) if artifact_path is not None else None,
+        schema_version=str(schema_version) if schema_version is not None else None,
+    )
+
+
+def lineage_ref_to_mapping(ref: LineageRef) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "ref_type": ref.ref_type.value,
+        "ref_id": ref.ref_id,
+        "relation": ref.relation.value,
+        "owner_domain": ref.owner_domain,
+        "required": ref.required,
+    }
+    if ref.digest is not None:
+        payload["digest"] = ref.digest
+    if ref.artifact_path is not None:
+        payload["artifact_path"] = ref.artifact_path
+    if ref.schema_version is not None:
+        payload["schema_version"] = ref.schema_version
+    return payload
+
+
+def manifest_to_canonical_dict(
+    manifest: CandidateLineageManifestV1,
+    *,
+    include_integrity: bool = True,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": manifest.schema_version,
+        "lineage_manifest_id": manifest.lineage_manifest_id,
+        "candidate_id": manifest.candidate_id,
+        "candidate_type": manifest.candidate_type.value,
+        "candidate_contract_ref": manifest.candidate_contract_ref,
+        "refs": [lineage_ref_to_mapping(ref) for ref in manifest.refs],
+        "created_at": manifest.created_at.isoformat(),
+        "futures_scope_ref": dict(manifest.futures_scope_ref),
+        "trading_logic_immutability_ref": dict(manifest.trading_logic_immutability_ref),
+    }
+    if manifest.parent_lineage_manifest_ids:
+        payload["parent_lineage_manifest_ids"] = list(manifest.parent_lineage_manifest_ids)
+    if manifest.created_by is not None:
+        payload["created_by"] = manifest.created_by
+    if manifest.metadata:
+        payload["metadata"] = dict(manifest.metadata)
+    if include_integrity and manifest.integrity is not None:
+        payload["integrity"] = {"content_sha256": manifest.integrity.content_sha256}
+    return payload
+
+
+def compute_lineage_manifest_integrity(manifest: CandidateLineageManifestV1) -> LineageIntegrity:
+    payload = manifest_to_canonical_dict(manifest, include_integrity=False)
+    return LineageIntegrity(content_sha256=compute_content_sha256(payload))
+
+
+def serialize_candidate_lineage_manifest_v1(manifest: CandidateLineageManifestV1) -> str:
+    if manifest.integrity is None:
+        manifest.integrity = compute_lineage_manifest_integrity(manifest)
+    return deterministic_json_dumps(manifest_to_canonical_dict(manifest, include_integrity=True))
+
+
+def deserialize_candidate_lineage_manifest_v1(
+    data: Mapping[str, Any],
+) -> CandidateLineageManifestV1:
+    if not isinstance(data, Mapping):
+        raise CandidateLineageManifestError("manifest payload must be a mapping")
+
+    required_fields = (
+        "schema_version",
+        "lineage_manifest_id",
+        "candidate_id",
+        "candidate_type",
+        "candidate_contract_ref",
+        "refs",
+        "created_at",
+        "futures_scope_ref",
+        "trading_logic_immutability_ref",
+        "integrity",
+    )
+    for key in required_fields:
+        if key not in data:
+            raise CandidateLineageManifestError(f"missing required field: {key}")
+
+    refs_raw = data["refs"]
+    if not isinstance(refs_raw, list):
+        raise CandidateLineageManifestError("refs must be an array")
+
+    integrity_raw = data["integrity"]
+    if not isinstance(integrity_raw, Mapping):
+        raise CandidateLineageManifestError("integrity must be an object")
+    digest = integrity_raw.get("content_sha256")
+    if not isinstance(digest, str):
+        raise CandidateLineageManifestError("integrity.content_sha256 must be a string")
+
+    try:
+        candidate_type = CandidateType(str(data["candidate_type"]))
+    except ValueError as exc:
+        raise CandidateLineageManifestError(
+            f"unknown candidate_type: {data['candidate_type']!r}"
+        ) from exc
+
+    parent_ids_raw = data.get("parent_lineage_manifest_ids", [])
+    if parent_ids_raw is None:
+        parent_ids: list[str] = []
+    elif not isinstance(parent_ids_raw, list):
+        raise CandidateLineageManifestError("parent_lineage_manifest_ids must be an array")
+    else:
+        parent_ids = [str(item) for item in parent_ids_raw]
+
+    manifest = CandidateLineageManifestV1(
+        schema_version=str(data["schema_version"]),
+        lineage_manifest_id=str(data["lineage_manifest_id"]),
+        candidate_id=str(data["candidate_id"]),
+        candidate_type=candidate_type,
+        candidate_contract_ref=str(data["candidate_contract_ref"]),
+        refs=[lineage_ref_from_mapping(item) for item in refs_raw if isinstance(item, Mapping)],
+        created_at=_parse_datetime(data["created_at"], field_name="created_at"),
+        created_by=str(data["created_by"]) if data.get("created_by") is not None else None,
+        futures_scope_ref=dict(data["futures_scope_ref"]),
+        trading_logic_immutability_ref=dict(data["trading_logic_immutability_ref"]),
+        integrity=LineageIntegrity(content_sha256=digest),
+        parent_lineage_manifest_ids=parent_ids,
+        metadata=dict(data["metadata"]) if isinstance(data.get("metadata"), dict) else {},
+    )
+    if len(manifest.refs) != len(refs_raw):
+        raise CandidateLineageManifestError("each ref must be an object")
+    return manifest
+
+
+def _is_fixture_mode(metadata: Mapping[str, Any]) -> bool:
+    return metadata.get("fixture_kind") == "lineage_fixture"
+
+
+def _validate_ref_cardinalities(refs: list[LineageRef]) -> tuple[bool, tuple[str, ...]]:
+    counts: dict[LineageRefType, int] = {ref_type: 0 for ref_type in LineageRefType}
+    for ref in refs:
+        counts[ref.ref_type] += 1
+
+    errors: list[str] = []
+    for ref_type, (minimum, maximum) in _REF_TYPE_CARDINALITY.items():
+        count = counts[ref_type]
+        if count < minimum:
+            errors.append(f"ref_type {ref_type.value} count {count} below minimum {minimum}")
+        if maximum is not None and count > maximum:
+            errors.append(f"ref_type {ref_type.value} count {count} exceeds maximum {maximum}")
+    return (not errors, tuple(errors))
+
+
+def validate_candidate_lineage_manifest_v1(
+    data: Mapping[str, Any],
+) -> tuple[bool, ValidationPhase, tuple[str, ...], str | None]:
+    if not isinstance(data, Mapping):
+        return False, ValidationPhase.SCHEMA, ("manifest payload must be a mapping",), None
+
+    required_top_level = (
+        "schema_version",
+        "lineage_manifest_id",
+        "candidate_id",
+        "candidate_type",
+        "candidate_contract_ref",
+        "refs",
+        "created_at",
+        "futures_scope_ref",
+        "trading_logic_immutability_ref",
+        "integrity",
+    )
+    for key in required_top_level:
+        if key not in data:
+            return False, ValidationPhase.SCHEMA, (f"missing required field: {key}",), None
+
+    if not isinstance(data["refs"], list):
+        return False, ValidationPhase.SCHEMA, ("refs must be an array",), None
+    if not isinstance(data["integrity"], Mapping):
+        return False, ValidationPhase.SCHEMA, ("integrity must be an object",), None
+
+    metadata = data.get("metadata") if isinstance(data.get("metadata"), Mapping) else {}
+
+    schema_version_result = validate_schema_version(data["schema_version"])
+    if not schema_version_result.valid:
+        return (
+            False,
+            schema_version_result.phase,
+            schema_version_result.errors,
+            schema_version_result.verdict,
+        )
+
+    futures_result = validate_futures_scope_ref(data["futures_scope_ref"])
+    if not futures_result.valid:
+        return False, futures_result.phase, futures_result.errors, futures_result.verdict
+
+    immutability_result = validate_trading_logic_immutability_ref(
+        data["trading_logic_immutability_ref"]
+    )
+    if not immutability_result.valid:
+        return (
+            False,
+            immutability_result.phase,
+            immutability_result.errors,
+            immutability_result.verdict,
+        )
+
+    if not data["refs"] and not _is_fixture_mode(metadata):
+        return (
+            False,
+            ValidationPhase.LINEAGE_REFERENCES,
+            ("refs may be empty only in fixture mode",),
+            None,
+        )
+
+    seen_ref_keys: set[tuple[str, str, str]] = set()
+    for ref in data["refs"]:
+        if not isinstance(ref, Mapping):
+            return False, ValidationPhase.SCHEMA, ("each ref must be an object",), None
+        ref_type = ref.get("ref_type")
+        ref_id = ref.get("ref_id")
+        relation = ref.get("relation")
+        if ref_type not in {item.value for item in LineageRefType}:
+            return (
+                False,
+                ValidationPhase.LINEAGE_REFERENCES,
+                (f"unknown ref_type: {ref_type!r}",),
+                None,
+            )
+        if relation not in {item.value for item in LineageRelation}:
+            return (
+                False,
+                ValidationPhase.LINEAGE_REFERENCES,
+                (f"unknown relation: {relation!r}",),
+                None,
+            )
+        if not isinstance(ref_id, str) or not ref_id.strip():
+            return (
+                False,
+                ValidationPhase.LINEAGE_REFERENCES,
+                ("ref_id must be a non-empty string",),
+                None,
+            )
+
+        key = (str(ref_type), str(ref_id), str(relation))
+        if key in seen_ref_keys:
+            return (
+                False,
+                ValidationPhase.CARDINALITY,
+                (f"duplicate ref entry: {ref_type}/{ref_id}/{relation}",),
+                None,
+            )
+        seen_ref_keys.add(key)
+
+        digest = ref.get("digest")
+        if digest is not None and not is_valid_sha256_hex(str(digest)):
+            return (
+                False,
+                ValidationPhase.INTEGRITY,
+                ("ref digest must be 64-char lowercase sha256 hex",),
+                None,
+            )
+        if ref_type == LineageRefType.EVIDENCE_OPS.value and ref.get("required") and not digest:
+            return (
+                False,
+                ValidationPhase.LINEAGE_REFERENCES,
+                ("evidence_ops ref requires digest when required=true",),
+                None,
+            )
+
+    if not is_valid_uuid(str(data["lineage_manifest_id"])):
+        return False, ValidationPhase.SCHEMA, ("lineage_manifest_id must be a UUID",), None
+    if not is_valid_uuid(str(data["candidate_contract_ref"])):
+        return (
+            False,
+            ValidationPhase.LINEAGE_REFERENCES,
+            ("candidate_contract_ref must be a UUID",),
+            None,
+        )
+
+    parent_ids = data.get("parent_lineage_manifest_ids", [])
+    if parent_ids is not None:
+        if not isinstance(parent_ids, list):
+            return (
+                False,
+                ValidationPhase.LINEAGE_REFERENCES,
+                ("parent_lineage_manifest_ids must be an array",),
+                None,
+            )
+        for parent_id in parent_ids:
+            if not is_valid_uuid(str(parent_id)):
+                return (
+                    False,
+                    ValidationPhase.LINEAGE_REFERENCES,
+                    ("parent_lineage_manifest_ids entries must be UUIDs",),
+                    None,
+                )
+
+    try:
+        manifest = deserialize_candidate_lineage_manifest_v1(data)
+    except CandidateLineageManifestError as exc:
+        return False, ValidationPhase.SCHEMA, (str(exc),), None
+
+    cardinality_ok, cardinality_errors = _validate_ref_cardinalities(manifest.refs)
+    if not cardinality_ok:
+        return False, ValidationPhase.CARDINALITY, cardinality_errors, None
+
+    expected_digest = compute_lineage_manifest_integrity(manifest).content_sha256
+    integrity_result = validate_integrity_block(data["integrity"], expected_digest=expected_digest)
+    if not integrity_result.valid:
+        return False, integrity_result.phase, integrity_result.errors, integrity_result.verdict
+
+    return True, ValidationPhase.RESULT, (), None

--- a/src/meta/learning_loop/config_patch_manifest_v1.py
+++ b/src/meta/learning_loop/config_patch_manifest_v1.py
@@ -1,0 +1,353 @@
+"""ConfigPatch-Manifest v1 — offline canonical promotion-input contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Mapping
+
+from src.meta.learning_loop.contract_safety_v1 import (
+    SCHEMA_VERSION_V1,
+    ValidationPhase,
+    canonical_futures_scope_ref,
+    canonical_trading_logic_immutability_ref,
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+    is_valid_uuid,
+    validate_futures_scope_ref,
+    validate_integrity_block,
+    validate_patch_target,
+    validate_schema_version,
+    validate_trading_logic_immutability_ref,
+)
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+class ConfigPatchManifestError(ValueError):
+    """Fail-closed ConfigPatch-Manifest v1 error."""
+
+
+@dataclass(frozen=True)
+class ManifestIntegrity:
+    content_sha256: str
+
+
+@dataclass
+class ConfigPatchManifestV1:
+    schema_version: str
+    manifest_id: str
+    generated_at: datetime
+    source_scope: dict[str, Any]
+    trading_logic_immutability_ref: dict[str, Any]
+    patches: list[ConfigPatch] = field(default_factory=list)
+    generated_by: str | None = None
+    lineage_manifest_ref: str | None = None
+    integrity: ManifestIntegrity | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _parse_datetime(value: Any, *, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigPatchManifestError(f"{field_name} must be an ISO8601 string")
+    normalized = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ConfigPatchManifestError(f"{field_name} must be an ISO8601 string") from exc
+
+
+def _parse_patch_status(value: Any) -> PatchStatus:
+    if isinstance(value, PatchStatus):
+        return value
+    if not isinstance(value, str):
+        raise ConfigPatchManifestError("patch status must be a string enum value")
+    try:
+        return PatchStatus(value)
+    except ValueError as exc:
+        raise ConfigPatchManifestError(f"unknown PatchStatus: {value!r}") from exc
+
+
+def patch_from_mapping(raw: Mapping[str, Any]) -> ConfigPatch:
+    required = ("id", "target", "new_value", "status")
+    for key in required:
+        if key not in raw:
+            raise ConfigPatchManifestError(f"patch missing required field: {key}")
+
+    generated_at = raw.get("generated_at")
+    applied_at = raw.get("applied_at")
+    promoted_at = raw.get("promoted_at")
+    meta = raw.get("meta")
+
+    return ConfigPatch(
+        id=str(raw["id"]),
+        target=str(raw["target"]),
+        old_value=raw.get("old_value"),
+        new_value=raw["new_value"],
+        status=_parse_patch_status(raw["status"]),
+        generated_at=_parse_datetime(generated_at, field_name="generated_at")
+        if generated_at is not None
+        else None,
+        applied_at=_parse_datetime(applied_at, field_name="applied_at")
+        if applied_at is not None
+        else None,
+        promoted_at=_parse_datetime(promoted_at, field_name="promoted_at")
+        if promoted_at is not None
+        else None,
+        reason=str(raw["reason"]) if raw.get("reason") is not None else None,
+        source_experiment_id=str(raw["source_experiment_id"])
+        if raw.get("source_experiment_id") is not None
+        else None,
+        confidence_score=float(raw["confidence_score"])
+        if raw.get("confidence_score") is not None
+        else None,
+        meta=dict(meta) if isinstance(meta, dict) else {},
+    )
+
+
+def patch_to_mapping(patch: ConfigPatch) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": patch.id,
+        "target": patch.target,
+        "new_value": patch.new_value,
+        "status": patch.status.value,
+    }
+    if patch.old_value is not None:
+        payload["old_value"] = patch.old_value
+    if patch.generated_at is not None:
+        payload["generated_at"] = patch.generated_at.isoformat()
+    if patch.applied_at is not None:
+        payload["applied_at"] = patch.applied_at.isoformat()
+    if patch.promoted_at is not None:
+        payload["promoted_at"] = patch.promoted_at.isoformat()
+    if patch.reason is not None:
+        payload["reason"] = patch.reason
+    if patch.source_experiment_id is not None:
+        payload["source_experiment_id"] = patch.source_experiment_id
+    if patch.confidence_score is not None:
+        payload["confidence_score"] = patch.confidence_score
+    if patch.meta:
+        payload["meta"] = dict(patch.meta)
+    return payload
+
+
+def manifest_to_canonical_dict(
+    manifest: ConfigPatchManifestV1,
+    *,
+    include_integrity: bool = True,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": manifest.schema_version,
+        "manifest_id": manifest.manifest_id,
+        "generated_at": manifest.generated_at.isoformat(),
+        "source_scope": dict(manifest.source_scope),
+        "trading_logic_immutability_ref": dict(manifest.trading_logic_immutability_ref),
+        "patches": [patch_to_mapping(patch) for patch in manifest.patches],
+    }
+    if manifest.generated_by is not None:
+        payload["generated_by"] = manifest.generated_by
+    if manifest.lineage_manifest_ref is not None:
+        payload["lineage_manifest_ref"] = manifest.lineage_manifest_ref
+    if manifest.metadata:
+        payload["metadata"] = dict(manifest.metadata)
+    if include_integrity and manifest.integrity is not None:
+        payload["integrity"] = {"content_sha256": manifest.integrity.content_sha256}
+    return payload
+
+
+def compute_manifest_integrity(manifest: ConfigPatchManifestV1) -> ManifestIntegrity:
+    payload = manifest_to_canonical_dict(manifest, include_integrity=False)
+    return ManifestIntegrity(content_sha256=compute_content_sha256(payload))
+
+
+def serialize_config_patch_manifest_v1(manifest: ConfigPatchManifestV1) -> str:
+    if manifest.integrity is None:
+        manifest.integrity = compute_manifest_integrity(manifest)
+    return deterministic_json_dumps(manifest_to_canonical_dict(manifest, include_integrity=True))
+
+
+def deserialize_config_patch_manifest_v1(data: Mapping[str, Any]) -> ConfigPatchManifestV1:
+    if not isinstance(data, Mapping):
+        raise ConfigPatchManifestError("manifest payload must be a mapping")
+
+    required_fields = (
+        "schema_version",
+        "manifest_id",
+        "generated_at",
+        "source_scope",
+        "trading_logic_immutability_ref",
+        "patches",
+        "integrity",
+    )
+    for key in required_fields:
+        if key not in data:
+            raise ConfigPatchManifestError(f"missing required field: {key}")
+
+    patches_raw = data["patches"]
+    if not isinstance(patches_raw, list):
+        raise ConfigPatchManifestError("patches must be an array")
+
+    integrity_raw = data["integrity"]
+    if not isinstance(integrity_raw, Mapping):
+        raise ConfigPatchManifestError("integrity must be an object")
+    digest = integrity_raw.get("content_sha256")
+    if not isinstance(digest, str):
+        raise ConfigPatchManifestError("integrity.content_sha256 must be a string")
+
+    manifest = ConfigPatchManifestV1(
+        schema_version=str(data["schema_version"]),
+        manifest_id=str(data["manifest_id"]),
+        generated_at=_parse_datetime(data["generated_at"], field_name="generated_at"),
+        generated_by=str(data["generated_by"]) if data.get("generated_by") is not None else None,
+        lineage_manifest_ref=str(data["lineage_manifest_ref"])
+        if data.get("lineage_manifest_ref") is not None
+        else None,
+        source_scope=dict(data["source_scope"]),
+        trading_logic_immutability_ref=dict(data["trading_logic_immutability_ref"]),
+        patches=[patch_from_mapping(item) for item in patches_raw if isinstance(item, Mapping)],
+        integrity=ManifestIntegrity(content_sha256=digest),
+        metadata=dict(data["metadata"]) if isinstance(data.get("metadata"), dict) else {},
+    )
+    if len(manifest.patches) != len(patches_raw):
+        raise ConfigPatchManifestError("each patch must be an object")
+    return manifest
+
+
+def _is_fixture_mode(metadata: Mapping[str, Any]) -> bool:
+    return metadata.get("fixture_kind") == "demo_patches_for_promotion"
+
+
+def validate_config_patch_manifest_v1(
+    data: Mapping[str, Any],
+) -> tuple[bool, ValidationPhase, tuple[str, ...], str | None]:
+    if not isinstance(data, Mapping):
+        return False, ValidationPhase.SCHEMA, ("manifest payload must be a mapping",), None
+
+    required_top_level = (
+        "schema_version",
+        "manifest_id",
+        "generated_at",
+        "source_scope",
+        "trading_logic_immutability_ref",
+        "patches",
+        "integrity",
+    )
+    for key in required_top_level:
+        if key not in data:
+            return False, ValidationPhase.SCHEMA, (f"missing required field: {key}",), None
+
+    if not isinstance(data["patches"], list):
+        return False, ValidationPhase.SCHEMA, ("patches must be an array",), None
+    if not isinstance(data["integrity"], Mapping):
+        return False, ValidationPhase.SCHEMA, ("integrity must be an object",), None
+    metadata = data.get("metadata") if isinstance(data.get("metadata"), Mapping) else {}
+
+    schema_version_result = validate_schema_version(data["schema_version"])
+    if not schema_version_result.valid:
+        return (
+            False,
+            schema_version_result.phase,
+            schema_version_result.errors,
+            schema_version_result.verdict,
+        )
+
+    futures_result = validate_futures_scope_ref(data["source_scope"])
+    if not futures_result.valid:
+        return False, futures_result.phase, futures_result.errors, futures_result.verdict
+
+    immutability_result = validate_trading_logic_immutability_ref(
+        data["trading_logic_immutability_ref"]
+    )
+    if not immutability_result.valid:
+        return (
+            False,
+            immutability_result.phase,
+            immutability_result.errors,
+            immutability_result.verdict,
+        )
+
+    for patch in data["patches"]:
+        if not isinstance(patch, Mapping):
+            return False, ValidationPhase.SCHEMA, ("each patch must be an object",), None
+        target = patch.get("target")
+        if not isinstance(target, str):
+            return False, ValidationPhase.TARGET_POLICY, ("patch target must be a string",), None
+        target_result = validate_patch_target(target)
+        if not target_result.valid:
+            return False, target_result.phase, target_result.errors, target_result.verdict
+        status = patch.get("status")
+        if status is not None:
+            try:
+                PatchStatus(str(status))
+            except ValueError:
+                return False, ValidationPhase.SCHEMA, (f"unknown PatchStatus: {status!r}",), None
+
+    manifest_id = data["manifest_id"]
+    if not isinstance(manifest_id, str) or not is_valid_uuid(manifest_id):
+        return False, ValidationPhase.SCHEMA, ("manifest_id must be a UUID",), None
+
+    lineage_ref = data.get("lineage_manifest_ref")
+    if lineage_ref is None and not _is_fixture_mode(metadata):
+        return (
+            False,
+            ValidationPhase.LINEAGE_REFERENCES,
+            ("lineage_manifest_ref is required unless metadata.fixture_kind is set",),
+            None,
+        )
+    if lineage_ref is not None and not is_valid_uuid(str(lineage_ref)):
+        return (
+            False,
+            ValidationPhase.LINEAGE_REFERENCES,
+            ("lineage_manifest_ref must be a UUID",),
+            None,
+        )
+
+    patch_ids: list[str] = []
+    for patch in data["patches"]:
+        patch_id = patch.get("id")
+        if not isinstance(patch_id, str) or not patch_id.strip():
+            return (
+                False,
+                ValidationPhase.CARDINALITY,
+                ("patch id must be a non-empty string",),
+                None,
+            )
+        patch_ids.append(patch_id)
+    if len(set(patch_ids)) != len(patch_ids):
+        return False, ValidationPhase.CARDINALITY, ("duplicate patch id",), None
+
+    try:
+        manifest = deserialize_config_patch_manifest_v1(data)
+    except ConfigPatchManifestError as exc:
+        return False, ValidationPhase.SCHEMA, (str(exc),), None
+
+    expected_digest = compute_manifest_integrity(manifest).content_sha256
+    integrity_result = validate_integrity_block(data["integrity"], expected_digest=expected_digest)
+    if not integrity_result.valid:
+        return False, integrity_result.phase, integrity_result.errors, integrity_result.verdict
+
+    return True, ValidationPhase.RESULT, (), None
+
+
+def build_empty_config_patch_manifest_v1(
+    *,
+    manifest_id: str,
+    generated_at: datetime,
+    lineage_manifest_ref: str,
+    generated_by: str | None = "package_a_contract_tests",
+) -> ConfigPatchManifestV1:
+    manifest = ConfigPatchManifestV1(
+        schema_version=SCHEMA_VERSION_V1,
+        manifest_id=manifest_id,
+        generated_at=generated_at,
+        generated_by=generated_by,
+        lineage_manifest_ref=lineage_manifest_ref,
+        source_scope=canonical_futures_scope_ref(),
+        trading_logic_immutability_ref=canonical_trading_logic_immutability_ref(),
+        patches=[],
+    )
+    manifest.integrity = compute_manifest_integrity(manifest)
+    return manifest

--- a/src/meta/learning_loop/contract_safety_v1.py
+++ b/src/meta/learning_loop/contract_safety_v1.py
@@ -1,0 +1,361 @@
+"""Shared offline safety validators for Self-Learning contract manifests v1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+SCHEMA_VERSION_V1 = "1.0"
+
+VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION = (
+    "FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION"
+)
+VERDICT_TARGET_NOT_ALLOWED = "TARGET_NOT_ALLOWED"
+VERDICT_FUTURES_SCOPE_VIOLATION = "FUTURES_SCOPE_VIOLATION"
+
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+_FORBIDDEN_TARGET_SEGMENTS = frozenset(
+    {
+        "master_v2",
+        "double_play",
+        "bull",
+        "bear",
+        "strategy",
+        "signal",
+        "entry",
+        "exit",
+        "sizing",
+        "leverage",
+        "stop",
+        "stop_loss",
+        "take_profit",
+        "execution",
+        "routing",
+        "order",
+        "risk_limit",
+        "killswitch",
+        "kill_switch",
+        "capital_slot",
+        "dynamic_scope",
+        "state_switch",
+        "runtime",
+        "live",
+        "arming",
+    }
+)
+
+_FORBIDDEN_TARGET_EXACT = frozenset(
+    {
+        "portfolio.leverage",
+        "macro.regime_weight",
+        "risk.stop_loss",
+    }
+)
+
+_FORBIDDEN_SCOPE_TOKENS = frozenset(
+    {
+        "btc",
+        "xbt",
+        "bitcoin",
+        "spot",
+        "synthetic_spot",
+        "synthetic spot",
+        "synthetic-spot",
+    }
+)
+
+_CANONICAL_FORBIDDEN_SURFACES = (
+    "master_v2",
+    "double_play",
+    "bull_bear_logic",
+    "strategy_selection",
+    "signal_generation",
+    "entry_exit_logic",
+    "position_sizing",
+    "leverage",
+    "stop_loss",
+    "take_profit",
+    "execution_semantics",
+    "order_routing",
+    "risk_limits",
+    "killswitch",
+    "capital_slot",
+    "dynamic_scope",
+    "state_switch",
+)
+
+
+class ValidationPhase(str, Enum):
+    SCHEMA = "schema"
+    SCHEMA_VERSION = "schema_version"
+    FUTURES_SCOPE = "futures_scope"
+    TARGET_POLICY = "target_policy"
+    TRADING_LOGIC_IMMUTABILITY = "trading_logic_immutability"
+    LINEAGE_REFERENCES = "lineage_references"
+    CARDINALITY = "cardinality"
+    INTEGRITY = "integrity"
+    RESULT = "result"
+
+
+@dataclass(frozen=True)
+class ContractValidationResult:
+    valid: bool
+    phase: ValidationPhase
+    errors: tuple[str, ...] = ()
+    verdict: str | None = None
+
+
+@dataclass(frozen=True)
+class ContractSafetyError(ValueError):
+    phase: ValidationPhase
+    message: str
+    verdict: str | None = None
+
+    def __str__(self) -> str:
+        if self.verdict:
+            return f"{self.verdict}: {self.message}"
+        return self.message
+
+
+def canonical_futures_scope_ref() -> dict[str, Any]:
+    return {
+        "scope": "FUTURES_ONLY",
+        "bitcoin_direction_allowed": False,
+        "autonomous_live_promotion": False,
+        "autonomous_order_authority": False,
+    }
+
+
+def canonical_trading_logic_immutability_ref() -> dict[str, Any]:
+    return {
+        "trading_logic_immutability": True,
+        "forbidden_surfaces": list(_CANONICAL_FORBIDDEN_SURFACES),
+        "reference_only": True,
+        "mutable_trading_payloads_forbidden": True,
+    }
+
+
+def normalize_path_token(value: str) -> str:
+    lowered = value.strip().lower()
+    normalized = lowered.replace("/", ".").replace("\\", ".").replace("-", "_")
+    while ".." in normalized:
+        normalized = normalized.replace("..", ".")
+    return normalized.strip(".")
+
+
+def normalize_target_path(target: str) -> str:
+    return normalize_path_token(target)
+
+
+def is_valid_sha256_hex(value: str) -> bool:
+    return bool(_SHA256_HEX_RE.match(value))
+
+
+def is_valid_uuid(value: str) -> bool:
+    return bool(_UUID_RE.match(value))
+
+
+def deterministic_json_dumps(payload: Mapping[str, Any] | Sequence[Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_content_sha256(payload: Mapping[str, Any]) -> str:
+    body = deterministic_json_dumps(payload)
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _scope_value_contains_forbidden_token(value: str) -> str | None:
+    normalized = normalize_path_token(value)
+    for token in _FORBIDDEN_SCOPE_TOKENS:
+        token_norm = normalize_path_token(token)
+        if token_norm in normalized.split(".") or token_norm in normalized:
+            return token
+    if re.search(r"\bbtc\b", normalized):
+        return "btc"
+    if re.search(r"\bxbt\b", normalized):
+        return "xbt"
+    if "bitcoin" in normalized:
+        return "bitcoin"
+    if "spot" in normalized.split(".") or normalized.endswith(".spot") or normalized == "spot":
+        return "spot"
+    if "synthetic" in normalized and "spot" in normalized:
+        return "synthetic_spot"
+    return None
+
+
+def _collect_scope_strings(ref: Mapping[str, Any]) -> list[str]:
+    values: list[str] = []
+    for key in ("scope", "market", "symbol", "instrument", "venue", "product_class"):
+        raw = ref.get(key)
+        if isinstance(raw, str) and raw.strip():
+            values.append(raw)
+    metadata = ref.get("metadata")
+    if isinstance(metadata, Mapping):
+        for key in ("scope", "market", "symbol", "instrument", "venue", "product_class"):
+            raw = metadata.get(key)
+            if isinstance(raw, str) and raw.strip():
+                values.append(raw)
+    return values
+
+
+def validate_futures_scope_ref(ref: Any) -> ContractValidationResult:
+    if not isinstance(ref, dict):
+        return ContractValidationResult(
+            valid=False,
+            phase=ValidationPhase.FUTURES_SCOPE,
+            errors=("futures_scope_ref must be an object",),
+            verdict=VERDICT_FUTURES_SCOPE_VIOLATION,
+        )
+
+    expected = canonical_futures_scope_ref()
+    for key, expected_value in expected.items():
+        if ref.get(key) != expected_value:
+            return ContractValidationResult(
+                valid=False,
+                phase=ValidationPhase.FUTURES_SCOPE,
+                errors=(f"futures_scope_ref.{key} must equal canonical futures-only value",),
+                verdict=VERDICT_FUTURES_SCOPE_VIOLATION,
+            )
+
+    for scope_value in _collect_scope_strings(ref):
+        forbidden = _scope_value_contains_forbidden_token(scope_value)
+        if forbidden is not None:
+            return ContractValidationResult(
+                valid=False,
+                phase=ValidationPhase.FUTURES_SCOPE,
+                errors=(f"futures_scope_ref contains forbidden scope token: {forbidden}",),
+                verdict=VERDICT_FUTURES_SCOPE_VIOLATION,
+            )
+
+    return ContractValidationResult(valid=True, phase=ValidationPhase.FUTURES_SCOPE)
+
+
+def validate_trading_logic_immutability_ref(ref: Any) -> ContractValidationResult:
+    if not isinstance(ref, dict):
+        return ContractValidationResult(
+            valid=False,
+            phase=ValidationPhase.TRADING_LOGIC_IMMUTABILITY,
+            errors=("trading_logic_immutability_ref must be an object",),
+            verdict=VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+        )
+
+    expected = canonical_trading_logic_immutability_ref()
+    for key in (
+        "trading_logic_immutability",
+        "reference_only",
+        "mutable_trading_payloads_forbidden",
+    ):
+        if ref.get(key) is not True:
+            return ContractValidationResult(
+                valid=False,
+                phase=ValidationPhase.TRADING_LOGIC_IMMUTABILITY,
+                errors=(f"trading_logic_immutability_ref.{key} must be true",),
+                verdict=VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+            )
+
+    forbidden_surfaces = ref.get("forbidden_surfaces")
+    if forbidden_surfaces != expected["forbidden_surfaces"]:
+        return ContractValidationResult(
+            valid=False,
+            phase=ValidationPhase.TRADING_LOGIC_IMMUTABILITY,
+            errors=("trading_logic_immutability_ref.forbidden_surfaces must match canonical list",),
+            verdict=VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+        )
+
+    return ContractValidationResult(
+        valid=True,
+        phase=ValidationPhase.TRADING_LOGIC_IMMUTABILITY,
+    )
+
+
+def classify_patch_target(target: str) -> tuple[bool, str | None]:
+    if not isinstance(target, str) or not target.strip():
+        return False, "patch target must be a non-empty string"
+
+    normalized = normalize_target_path(target)
+    if normalized in _FORBIDDEN_TARGET_EXACT:
+        return False, normalized
+
+    segments = [segment for segment in normalized.split(".") if segment]
+    if not segments:
+        return False, "patch target must contain at least one segment"
+
+    for index, segment in enumerate(segments):
+        if segment in _FORBIDDEN_TARGET_SEGMENTS:
+            return False, segment
+        if segment == "risk" and index + 1 < len(segments):
+            return False, f"risk.{segments[index + 1]}"
+        if (
+            segment == "portfolio"
+            and index + 1 < len(segments)
+            and segments[index + 1] == "leverage"
+        ):
+            return False, "portfolio.leverage"
+
+    if normalized.startswith("master_v2") or normalized.startswith("double_play"):
+        return False, normalized.split(".")[0]
+
+    return True, None
+
+
+def validate_patch_target(target: str) -> ContractValidationResult:
+    allowed, reason = classify_patch_target(target)
+    if allowed:
+        return ContractValidationResult(valid=True, phase=ValidationPhase.TARGET_POLICY)
+
+    if reason in _FORBIDDEN_TARGET_SEGMENTS or reason in _FORBIDDEN_TARGET_EXACT:
+        return ContractValidationResult(
+            valid=False,
+            phase=ValidationPhase.TRADING_LOGIC_IMMUTABILITY,
+            errors=(f"forbidden trading-logic patch target: {target}",),
+            verdict=VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+        )
+
+    return ContractValidationResult(
+        valid=False,
+        phase=ValidationPhase.TARGET_POLICY,
+        errors=(f"target not allowed: {target}",),
+        verdict=VERDICT_TARGET_NOT_ALLOWED,
+    )
+
+
+def validate_schema_version(value: Any) -> ContractValidationResult:
+    if value != SCHEMA_VERSION_V1:
+        return ContractValidationResult(
+            valid=False,
+            phase=ValidationPhase.SCHEMA_VERSION,
+            errors=(f"unsupported schema_version: {value!r}",),
+        )
+    return ContractValidationResult(valid=True, phase=ValidationPhase.SCHEMA_VERSION)
+
+
+def validate_integrity_block(integrity: Any, *, expected_digest: str) -> ContractValidationResult:
+    if not isinstance(integrity, dict):
+        return ContractValidationResult(
+            valid=False,
+            phase=ValidationPhase.INTEGRITY,
+            errors=("integrity must be an object",),
+        )
+    digest = integrity.get("content_sha256")
+    if not isinstance(digest, str) or not is_valid_sha256_hex(digest):
+        return ContractValidationResult(
+            valid=False,
+            phase=ValidationPhase.INTEGRITY,
+            errors=("integrity.content_sha256 must be 64-char lowercase sha256 hex",),
+        )
+    if digest != expected_digest:
+        return ContractValidationResult(
+            valid=False,
+            phase=ValidationPhase.INTEGRITY,
+            errors=("integrity.content_sha256 mismatch",),
+        )
+    return ContractValidationResult(valid=True, phase=ValidationPhase.INTEGRITY)

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -4955,3 +4955,60 @@ def test_selector_var_suite_adapter_empty_diff_does_not_add_adapter_testowner() 
     sel = _run_selector()
     assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert VAR_SUITE_ADAPTER_TESTOWNER not in _bounded_targets(sel)
+
+
+PACKAGE_A_META_PRODUCTION = "src/meta/learning_loop/contract_safety_v1.py"
+PACKAGE_A_META_PRODUCTION_CONFIG = "src/meta/learning_loop/config_patch_manifest_v1.py"
+PACKAGE_A_GOVERNANCE_PRODUCTION = "src/governance/promotion_loop/candidate_lineage_manifest_v1.py"
+PACKAGE_A_CONTRACT_SAFETY_TESTOWNER = "tests/meta/test_contract_safety_v1.py"
+PACKAGE_A_CONFIG_PATCH_MANIFEST_TESTOWNER = "tests/meta/test_config_patch_manifest_v1_contract.py"
+PACKAGE_A_CANDIDATE_LINEAGE_TESTOWNER = (
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py"
+)
+PACKAGE_A_ALL_PRODUCTION = (
+    PACKAGE_A_META_PRODUCTION,
+    PACKAGE_A_META_PRODUCTION_CONFIG,
+    PACKAGE_A_GOVERNANCE_PRODUCTION,
+)
+PACKAGE_A_ALL_TESTOWNERS = (
+    PACKAGE_A_CONTRACT_SAFETY_TESTOWNER,
+    PACKAGE_A_CONFIG_PATCH_MANIFEST_TESTOWNER,
+    PACKAGE_A_CANDIDATE_LINEAGE_TESTOWNER,
+)
+
+
+def test_selector_package_a_meta_production_pr_bounded_full_includes_meta_testowners() -> None:
+    sel = _run_selector(PACKAGE_A_META_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    assert PACKAGE_A_CONTRACT_SAFETY_TESTOWNER in bounded
+    assert PACKAGE_A_CONFIG_PATCH_MANIFEST_TESTOWNER in bounded
+    assert PACKAGE_A_CANDIDATE_LINEAGE_TESTOWNER not in bounded
+
+
+def test_selector_package_a_governance_production_pr_bounded_full_includes_lineage_testowner() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_A_GOVERNANCE_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    assert PACKAGE_A_CANDIDATE_LINEAGE_TESTOWNER in bounded
+    assert PACKAGE_A_CONTRACT_SAFETY_TESTOWNER not in bounded
+    assert PACKAGE_A_CONFIG_PATCH_MANIFEST_TESTOWNER not in bounded
+
+
+def test_selector_package_a_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+    sel = _run_selector(*PACKAGE_A_ALL_PRODUCTION, *PACKAGE_A_ALL_TESTOWNERS)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_A_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+
+
+def test_selector_central_src_without_package_a_path_excludes_package_a_testowners() -> None:
+    sel = _run_selector("src/core/foo.py")
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_A_ALL_TESTOWNERS:
+        assert path not in bounded

--- a/tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py
+++ b/tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py
@@ -1,0 +1,231 @@
+"""Contract tests for CandidateLineageManifest v1."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    CandidateLineageManifestV1,
+    CandidateType,
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+    compute_lineage_manifest_integrity,
+    deserialize_candidate_lineage_manifest_v1,
+    manifest_to_canonical_dict,
+    serialize_candidate_lineage_manifest_v1,
+    validate_candidate_lineage_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    VERDICT_FUTURES_SCOPE_VIOLATION,
+    canonical_futures_scope_ref,
+    canonical_trading_logic_immutability_ref,
+)
+
+
+FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+LINEAGE_ID = "33333333-3333-4333-8333-333333333333"
+MANIFEST_ID = "44444444-4444-4444-8444-444444444444"
+PARENT_LINEAGE_ID = "55555555-5555-4555-8555-555555555555"
+
+
+def _sample_refs() -> list[LineageRef]:
+    return [
+        LineageRef(
+            ref_type=LineageRefType.EXPERIMENT,
+            ref_id="exp-md5-12-abc",
+            relation=LineageRelation.SOURCES,
+            owner_domain="experiments/base",
+            required=True,
+        ),
+        LineageRef(
+            ref_type=LineageRefType.BACKTEST,
+            ref_id="run-001",
+            relation=LineageRelation.EVALUATES,
+            owner_domain="experiments/tracking",
+            required=False,
+        ),
+        LineageRef(
+            ref_type=LineageRefType.EVIDENCE_OPS,
+            ref_id="manifest-digest-ref",
+            relation=LineageRelation.RETAINS,
+            owner_domain="primary_evidence_retention",
+            required=True,
+            digest="a" * 64,
+        ),
+    ]
+
+
+def _valid_manifest(*, refs: list[LineageRef] | None = None) -> CandidateLineageManifestV1:
+    manifest = CandidateLineageManifestV1(
+        schema_version="1.0",
+        lineage_manifest_id=LINEAGE_ID,
+        candidate_id="candidate-bundle-001",
+        candidate_type=CandidateType.CONFIG_PATCH_BUNDLE,
+        candidate_contract_ref=MANIFEST_ID,
+        refs=refs if refs is not None else _sample_refs(),
+        created_at=FIXED_NOW,
+        created_by="package_a_contract_tests",
+        parent_lineage_manifest_ids=[PARENT_LINEAGE_ID],
+        futures_scope_ref=canonical_futures_scope_ref(),
+        trading_logic_immutability_ref=canonical_trading_logic_immutability_ref(),
+        metadata={"proposal_type": "OFFLINE_PROMOTE"},
+    )
+    manifest.integrity = compute_lineage_manifest_integrity(manifest)
+    return manifest
+
+
+def test_valid_candidate_lineage_manifest_with_typed_refs() -> None:
+    payload = manifest_to_canonical_dict(_valid_manifest(), include_integrity=True)
+    valid, phase, errors, verdict = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is True, errors
+    assert phase.value == "result"
+    assert verdict is None
+
+
+def test_deterministic_json_roundtrip() -> None:
+    manifest = _valid_manifest()
+    first = serialize_candidate_lineage_manifest_v1(manifest)
+    second = serialize_candidate_lineage_manifest_v1(manifest)
+    assert first == second
+    roundtrip = deserialize_candidate_lineage_manifest_v1(json.loads(first))
+    assert roundtrip.lineage_manifest_id == LINEAGE_ID
+    assert len(roundtrip.refs) == 3
+
+
+def test_parent_lineage_reference_supported() -> None:
+    payload = manifest_to_canonical_dict(_valid_manifest(), include_integrity=True)
+    assert payload["parent_lineage_manifest_ids"] == [PARENT_LINEAGE_ID]
+
+
+def test_unknown_schema_version_rejected() -> None:
+    payload = manifest_to_canonical_dict(_valid_manifest(), include_integrity=True)
+    payload["schema_version"] = "2.0"
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "schema_version"
+    assert "unsupported schema_version" in errors[0]
+
+
+def test_unknown_ref_type_rejected() -> None:
+    payload = manifest_to_canonical_dict(_valid_manifest(), include_integrity=True)
+    payload["refs"][0]["ref_type"] = "unknown_ref"
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "lineage_references"
+    assert "unknown ref_type" in errors[0]
+
+
+def test_unknown_relation_rejected() -> None:
+    payload = manifest_to_canonical_dict(_valid_manifest(), include_integrity=True)
+    payload["refs"][0]["relation"] = "unknown_relation"
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "lineage_references"
+    assert "unknown relation" in errors[0]
+
+
+def test_duplicate_ref_entry_rejected() -> None:
+    refs = _sample_refs()
+    refs.append(
+        LineageRef(
+            ref_type=LineageRefType.EXPERIMENT,
+            ref_id=refs[0].ref_id,
+            relation=refs[0].relation,
+            owner_domain=refs[0].owner_domain,
+            required=False,
+        )
+    )
+    payload = manifest_to_canonical_dict(_valid_manifest(refs=refs), include_integrity=True)
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "cardinality"
+    assert "duplicate ref entry" in errors[0]
+
+
+def test_experiment_cardinality_exceeded_rejected() -> None:
+    refs = _sample_refs()
+    refs.append(
+        LineageRef(
+            ref_type=LineageRefType.EXPERIMENT,
+            ref_id="exp-second",
+            relation=LineageRelation.EXTENDS,
+            owner_domain="experiments/base",
+            required=False,
+        )
+    )
+    payload = manifest_to_canonical_dict(_valid_manifest(refs=refs), include_integrity=True)
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "cardinality"
+    assert "experiment" in errors[0]
+
+
+def test_evidence_ops_required_digest_missing_rejected() -> None:
+    refs = [
+        LineageRef(
+            ref_type=LineageRefType.EVIDENCE_OPS,
+            ref_id="missing-digest",
+            relation=LineageRelation.RETAINS,
+            owner_domain="primary_evidence_retention",
+            required=True,
+        )
+    ]
+    payload = manifest_to_canonical_dict(_valid_manifest(refs=refs), include_integrity=True)
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "lineage_references"
+    assert "evidence_ops ref requires digest" in errors[0]
+
+
+def test_invalid_digest_rejected() -> None:
+    payload = manifest_to_canonical_dict(_valid_manifest(), include_integrity=True)
+    payload["refs"][2]["digest"] = "not-a-digest"
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "integrity"
+
+
+@pytest.mark.parametrize(
+    "scope_value",
+    [
+        {"scope": "BTC_ONLY"},
+        {"scope": "XBT_PERP"},
+        {"scope": "BITCOIN_FUTURES"},
+        {"scope": "SPOT_ONLY"},
+        {"scope": "SYNTHETIC_SPOT"},
+    ],
+)
+def test_invalid_futures_scope_rejected(scope_value: dict[str, str]) -> None:
+    payload = manifest_to_canonical_dict(_valid_manifest(), include_integrity=True)
+    payload["futures_scope_ref"] = {
+        **canonical_futures_scope_ref(),
+        **scope_value,
+    }
+    valid, phase, _, verdict = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "futures_scope"
+    assert verdict == VERDICT_FUTURES_SCOPE_VIOLATION
+
+
+def test_empty_refs_only_allowed_in_fixture_mode() -> None:
+    manifest = _valid_manifest(refs=[])
+    payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "lineage_references"
+    assert "fixture mode" in errors[0]
+
+    payload["metadata"] = {"fixture_kind": "lineage_fixture"}
+    manifest = deserialize_candidate_lineage_manifest_v1(
+        {**payload, "integrity": {"content_sha256": "0" * 64}}
+    )
+    payload["integrity"] = {
+        "content_sha256": compute_lineage_manifest_integrity(manifest).content_sha256
+    }
+    valid, phase, _, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is True, phase

--- a/tests/meta/test_config_patch_manifest_v1_contract.py
+++ b/tests/meta/test_config_patch_manifest_v1_contract.py
@@ -1,0 +1,240 @@
+"""Contract tests for ConfigPatch-Manifest v1."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from scripts.generate_demo_patches_for_promotion import build_demo_patches
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    ConfigPatchManifestV1,
+    build_empty_config_patch_manifest_v1,
+    compute_manifest_integrity,
+    deserialize_config_patch_manifest_v1,
+    manifest_to_canonical_dict,
+    patch_to_mapping,
+    serialize_config_patch_manifest_v1,
+    validate_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+    VERDICT_FUTURES_SCOPE_VIOLATION,
+    canonical_futures_scope_ref,
+    canonical_trading_logic_immutability_ref,
+)
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "11111111-1111-4111-8111-111111111111"
+LINEAGE_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _empty_manifest_dict(*, include_bad_integrity: bool = False) -> dict:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+    if include_bad_integrity:
+        payload["integrity"] = {"content_sha256": "0" * 64}
+    return payload
+
+
+def test_empty_patch_manifest_is_valid() -> None:
+    payload = _empty_manifest_dict()
+    valid, phase, errors, verdict = validate_config_patch_manifest_v1(payload)
+    assert valid is True
+    assert phase.value == "result"
+    assert errors == ()
+    assert verdict is None
+
+
+def test_deterministic_json_roundtrip() -> None:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    first = serialize_config_patch_manifest_v1(manifest)
+    second = serialize_config_patch_manifest_v1(manifest)
+    assert first == second
+    roundtrip = deserialize_config_patch_manifest_v1(json.loads(first))
+    assert roundtrip.manifest_id == MANIFEST_ID
+    assert roundtrip.patches == []
+
+
+def test_optional_fields_and_config_patch_compatibility() -> None:
+    patch = ConfigPatch(
+        id="patch-1",
+        target="research.offline.window_days",
+        old_value=30,
+        new_value=45,
+        status=PatchStatus.APPLIED_OFFLINE,
+        generated_at=FIXED_NOW,
+        reason="offline only",
+        source_experiment_id="exp-abc123",
+        confidence_score=0.91,
+        meta={"operator_hint": "review"},
+    )
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    manifest.patches = [patch]
+    manifest.metadata = {"proposal_type": "OFFLINE_PROMOTE"}
+    manifest.integrity = compute_manifest_integrity(manifest)
+
+    payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+    valid, _, errors, _ = validate_config_patch_manifest_v1(payload)
+    assert valid is True, errors
+    assert payload["patches"][0]["status"] == PatchStatus.APPLIED_OFFLINE.value
+    assert patch_to_mapping(patch)["source_experiment_id"] == "exp-abc123"
+
+
+def test_unknown_schema_version_rejected() -> None:
+    payload = _empty_manifest_dict()
+    payload["schema_version"] = "9.9"
+    valid, phase, errors, _ = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "schema_version"
+    assert "unsupported schema_version" in errors[0]
+
+
+def test_duplicate_patch_id_rejected() -> None:
+    payload = _empty_manifest_dict()
+    payload["patches"] = [
+        {
+            "id": "dup",
+            "target": "research.offline.window_days",
+            "new_value": 1,
+            "status": PatchStatus.APPLIED_OFFLINE.value,
+        },
+        {
+            "id": "dup",
+            "target": "research.offline.window_days",
+            "new_value": 2,
+            "status": PatchStatus.APPLIED_OFFLINE.value,
+        },
+    ]
+    payload["integrity"] = {
+        "content_sha256": compute_manifest_integrity(
+            deserialize_config_patch_manifest_v1(
+                {**payload, "integrity": {"content_sha256": "0" * 64}}
+            )
+        ).content_sha256
+    }
+    valid, phase, errors, _ = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "cardinality"
+    assert errors[0] == "duplicate patch id"
+
+
+def test_missing_lineage_ref_rejected_outside_fixture_mode() -> None:
+    payload = _empty_manifest_dict()
+    payload.pop("lineage_manifest_ref")
+    valid, phase, errors, _ = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "lineage_references"
+
+
+def test_invalid_futures_scope_rejected() -> None:
+    payload = _empty_manifest_dict()
+    payload["source_scope"] = {"scope": "BTC_PERP", "bitcoin_direction_allowed": False}
+    valid, phase, _, verdict = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "futures_scope"
+    assert verdict == VERDICT_FUTURES_SCOPE_VIOLATION
+
+
+def test_integrity_mismatch_rejected() -> None:
+    payload = _empty_manifest_dict(include_bad_integrity=True)
+    valid, phase, errors, _ = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert phase.value == "integrity"
+    assert "integrity.content_sha256 mismatch" in errors[0]
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "portfolio.leverage",
+        "strategy.trigger_delay",
+        "risk.stop_loss",
+        "macro.regime_weight",
+        "master_v2.config",
+        "double_play.slot",
+        "signal.threshold",
+        "entry.rule",
+        "exit.rule",
+        "sizing.fraction",
+        "leverage.max",
+        "stop_loss.pct",
+        "take_profit.pct",
+        "execution.routing",
+        "order.route",
+        "risk_limit.max",
+        "killswitch.enabled",
+        "capital_slot.id",
+        "dynamic_scope.mode",
+        "state_switch.enabled",
+        "runtime.mode",
+        "live.arming",
+    ],
+)
+def test_forbidden_trading_logic_targets_rejected(target: str) -> None:
+    payload = _empty_manifest_dict()
+    payload["patches"] = [
+        {
+            "id": str(uuid.uuid4()),
+            "target": target,
+            "new_value": 1,
+            "status": PatchStatus.APPLIED_OFFLINE.value,
+        }
+    ]
+    manifest = deserialize_config_patch_manifest_v1(
+        {**payload, "integrity": {"content_sha256": "0" * 64}}
+    )
+    payload["integrity"] = {"content_sha256": compute_manifest_integrity(manifest).content_sha256}
+    valid, _, _, verdict = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert verdict == VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION
+
+
+def test_demo_patch_targets_remain_fail_closed_regression() -> None:
+    demo_patches = build_demo_patches(variant="diverse", base_confidence=0.85)
+    for demo_patch in demo_patches:
+        payload = _empty_manifest_dict()
+        payload["metadata"] = {"fixture_kind": "demo_patches_for_promotion"}
+        payload["patches"] = [patch_to_mapping(demo_patch)]
+        manifest = deserialize_config_patch_manifest_v1(
+            {**payload, "integrity": {"content_sha256": "0" * 64}}
+        )
+        payload["integrity"] = {
+            "content_sha256": compute_manifest_integrity(manifest).content_sha256
+        }
+        valid, _, _, verdict = validate_config_patch_manifest_v1(payload)
+        assert valid is False, demo_patch.target
+        assert verdict == VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION
+
+
+def test_fixture_mode_allows_missing_lineage_with_forbidden_targets_still_rejected() -> None:
+    payload = _empty_manifest_dict()
+    payload.pop("lineage_manifest_ref")
+    payload["metadata"] = {"fixture_kind": "demo_patches_for_promotion"}
+    payload["patches"] = [
+        {
+            "id": "demo_patch_leverage_175",
+            "target": "portfolio.leverage",
+            "new_value": 1.75,
+            "status": PatchStatus.APPLIED_OFFLINE.value,
+        }
+    ]
+    valid, _, _, verdict = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert verdict == VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION

--- a/tests/meta/test_contract_safety_v1.py
+++ b/tests/meta/test_contract_safety_v1.py
@@ -1,0 +1,98 @@
+"""Contract tests for shared Self-Learning safety validators v1."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.meta.learning_loop.contract_safety_v1 import (
+    VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+    VERDICT_FUTURES_SCOPE_VIOLATION,
+    VERDICT_TARGET_NOT_ALLOWED,
+    canonical_futures_scope_ref,
+    canonical_trading_logic_immutability_ref,
+    classify_patch_target,
+    compute_content_sha256,
+    deterministic_json_dumps,
+    validate_futures_scope_ref,
+    validate_patch_target,
+    validate_trading_logic_immutability_ref,
+)
+
+
+def test_canonical_futures_scope_ref_is_futures_only() -> None:
+    ref = canonical_futures_scope_ref()
+    assert ref["scope"] == "FUTURES_ONLY"
+    assert ref["bitcoin_direction_allowed"] is False
+
+
+def test_canonical_trading_logic_immutability_ref_is_fail_closed() -> None:
+    ref = canonical_trading_logic_immutability_ref()
+    assert ref["trading_logic_immutability"] is True
+    assert ref["mutable_trading_payloads_forbidden"] is True
+
+
+def test_deterministic_json_dumps_is_stable() -> None:
+    payload = {"b": 2, "a": {"d": 4, "c": 3}}
+    assert deterministic_json_dumps(payload) == '{"a":{"c":3,"d":4},"b":2}'
+
+
+def test_compute_content_sha256_is_deterministic() -> None:
+    payload = {"schema_version": "1.0", "manifest_id": "abc"}
+    first = compute_content_sha256(payload)
+    second = compute_content_sha256(payload)
+    assert first == second
+    assert len(first) == 64
+
+
+@pytest.mark.parametrize(
+    ("target", "allowed"),
+    [
+        ("research.offline.feature_flag", True),
+        ("portfolio.leverage", False),
+        ("strategy.trigger_delay", False),
+        ("risk.stop_loss", False),
+        ("macro.regime_weight", False),
+        ("master_v2.config", False),
+        ("double_play.slot", False),
+        ("execution.routing.default", False),
+        ("live.arming.enabled", False),
+    ],
+)
+def test_classify_patch_target_cases(target: str, allowed: bool) -> None:
+    is_allowed, _ = classify_patch_target(target)
+    assert is_allowed is allowed
+
+
+def test_validate_futures_scope_rejects_btc_scope() -> None:
+    bad = dict(canonical_futures_scope_ref())
+    bad["scope"] = "BTC_FUTURES"
+    result = validate_futures_scope_ref(bad)
+    assert result.valid is False
+    assert result.verdict == VERDICT_FUTURES_SCOPE_VIOLATION
+
+
+def test_validate_futures_scope_rejects_spot_scope() -> None:
+    bad = dict(canonical_futures_scope_ref())
+    bad["scope"] = "SPOT_ONLY"
+    result = validate_futures_scope_ref(bad)
+    assert result.valid is False
+
+
+def test_validate_patch_target_trading_logic_verdict() -> None:
+    result = validate_patch_target("strategy.trigger_delay")
+    assert result.valid is False
+    assert result.verdict == VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION
+
+
+def test_validate_patch_target_unknown_target_verdict() -> None:
+    result = validate_patch_target("")
+    assert result.valid is False
+    assert result.verdict == VERDICT_TARGET_NOT_ALLOWED
+
+
+def test_validate_trading_logic_immutability_ref_rejects_mutation() -> None:
+    bad = dict(canonical_trading_logic_immutability_ref())
+    bad["reference_only"] = False
+    result = validate_trading_logic_immutability_ref(bad)
+    assert result.valid is False
+    assert result.verdict == VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION


### PR DESCRIPTION
## GO_TOKEN
`GO_PACKAGE_A_SELF_LEARNING_CONTRACT_MODELS_VALIDATION_AND_TRADING_LOGIC_IMMUTABILITY_V0`

## Scope
Offline-only Package A implementation:
- `CandidateLineageManifest v1` (reference-only FK graph)
- `ConfigPatch-Manifest v1` (canonical offline promotion-input contract)
- Deterministic JSON serialization/deserialization
- Schema versioning + fail-closed validation (futures-only, trading-logic immutability, integrity)
- Focused unit/contract tests including demo-patch negative regressions

## Non-Goals
- No promotion input rewire / no `promotion_loop` loader changes
- No BacktestEngine, VaR, runtime, live, or order paths
- No changes to demo_patches_for_promotion.json or learning.override.toml
- No trading-logic file mutations

## Trading-Logic-Immutability Proof
All protected surfaces untouched (Master V2, Double Play, strategy/signal/entry/exit/sizing/leverage/stop/execution/routing/risk/killswitch/capital_slot/dynamic_scope/state_switch). Contract validators reject forbidden patch targets with `FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION`. Historical demo patch targets remain fail-closed.

## Futures-only Proof
Canonical `futures_scope_ref` enforces `FUTURES_ONLY` + `bitcoin_direction_allowed=false`; BTC/XBT/Bitcoin/Spot/Synthetic-Spot scope values rejected.

## Changed files
- `src/meta/learning_loop/contract_safety_v1.py`
- `src/meta/learning_loop/config_patch_manifest_v1.py`
- `src/governance/promotion_loop/candidate_lineage_manifest_v1.py`
- `tests/meta/test_contract_safety_v1.py`
- `tests/meta/test_config_patch_manifest_v1_contract.py`
- `tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py`

## Tests
66 focused contract tests — all passed locally.

## CI selection
`PR_BOUNDED_FULL` (`category_central_src_requires_full` — src/meta + src/governance paths)

## Durable bundle
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/package_a_self_learning_contract_models_validation_trading_logic_immutability_v0_20260627T120000Z`

## MANIFEST_VERIFY_RC
0

## Runtime / Order counts
Runtime attempts = 0 · Order attempts = 0 · Cancel attempts = 0


Made with [Cursor](https://cursor.com)