### PR TITLE
feat(learning): Package B — ConfigPatch-Manifest v1 promotion input loader (GAP-001)

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1327,12 +1327,26 @@ PR_BOUNDED_FULL_PACKAGE_A_META_TRIGGER_PATHS: frozenset[str] = frozenset(
         "src/meta/learning_loop/config_patch_manifest_v1.py",
         "tests/meta/test_contract_safety_v1.py",
         "tests/meta/test_config_patch_manifest_v1_contract.py",
+        "tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py",
     }
 )
 
 PR_BOUNDED_FULL_PACKAGE_A_META_TARGETS: tuple[str, ...] = (
     "tests/meta/test_contract_safety_v1.py",
     "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py",
+)
+
+PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "scripts/run_promotion_proposal_cycle.py",
+        "tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py",
+    "tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py",
 )
 
 PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TRIGGER_PATHS: frozenset[str] = frozenset(
@@ -1386,6 +1400,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TARGETS:
             add(path)
 
     if not targets:
@@ -4523,6 +4541,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
             add(path)
         elif path.startswith("scripts/") and path.endswith(".py"):
             script_stem = PurePosixPath(path).stem
+            if path == "scripts/run_promotion_proposal_cycle.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TARGETS:
+                    add(candidate)
             for candidate in (
                 f"tests/scripts/test_{script_stem}_load_strategy_v1.py",
                 f"tests/scripts/test_{script_stem}.py",

--- a/scripts/run_promotion_proposal_cycle.py
+++ b/scripts/run_promotion_proposal_cycle.py
@@ -5,18 +5,26 @@ apply governance filters, and materialize live promotion proposals.
 
 Usage:
     # Manual-only mode (only generate proposals, no auto-apply)
-    python scripts/run_promotion_proposal_cycle.py --auto-apply-mode manual_only
+    python scripts/run_promotion_proposal_cycle.py \
+        --promotion-input-manifest reports/learning_snippets/promotion_input_manifest.json \
+        --auto-apply-mode manual_only
 
     # Bounded auto-apply mode (proposals + live overrides within bounds)
-    python scripts/run_promotion_proposal_cycle.py --auto-apply-mode bounded_auto
+    python scripts/run_promotion_proposal_cycle.py \
+        --promotion-input-manifest reports/learning_snippets/promotion_input_manifest.json \
+        --auto-apply-mode bounded_auto
 
     # Disabled mode (no proposals, no auto-apply)
-    python scripts/run_promotion_proposal_cycle.py --auto-apply-mode disabled
+    python scripts/run_promotion_proposal_cycle.py \
+        --promotion-input-manifest reports/learning_snippets/promotion_input_manifest.json \
+        --auto-apply-mode disabled
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -31,7 +39,12 @@ from src.governance.promotion_loop import (
 from src.governance.promotion_loop.engine import apply_proposals_to_live_overrides
 from src.governance.promotion_loop.models import DecisionStatus
 from src.governance.promotion_loop.policy import AutoApplyBounds, AutoApplyPolicy
-from src.meta.learning_loop.models import ConfigPatch
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    ConfigPatchManifestError,
+    ConfigPatchManifestValidationError,
+    load_config_patches_for_promotion_from_manifest_path,
+)
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
 
 
 def parse_args() -> argparse.Namespace:
@@ -41,6 +54,20 @@ def parse_args() -> argparse.Namespace:
             "Run the Promotion Loop v0: build promotion candidates from config patches, "
             "apply governance filters, and materialize live promotion proposals."
         )
+    )
+    parser.add_argument(
+        "--promotion-input-manifest",
+        type=Path,
+        default=None,
+        help=("Path to ConfigPatch-Manifest v1 JSON (canonical offline promotion input; AD-01)."),
+    )
+    parser.add_argument(
+        "--non-canonical-demo-legacy-patches",
+        action="store_true",
+        help=(
+            "NON_CANONICAL test-only: load legacy raw demo patch list JSON. "
+            "Not a valid ConfigPatch-Manifest v1 input and must never be used as default."
+        ),
     )
     parser.add_argument(
         "--output-dir",
@@ -64,58 +91,100 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _load_patches_for_promotion() -> List[ConfigPatch]:
+def _load_non_canonical_demo_legacy_patches() -> List[ConfigPatch]:
+    """
+    NON_CANONICAL test-only loader for legacy raw demo patch JSON.
+
+    This path exists solely for explicit regression coverage. It is not a valid
+    ConfigPatch-Manifest v1 promotion input and must never be used as default SSOT.
+    """
+    demo_path = Path("reports/learning_snippets/demo_patches_for_promotion.json")
+
+    if not demo_path.is_file():
+        print(f"[promotion_loop] NON_CANONICAL demo legacy path: no patches found at {demo_path}")
+        return []
+
+    with demo_path.open("r", encoding="utf-8") as handle:
+        patches_data = json.load(handle)
+
+    if not isinstance(patches_data, list):
+        print("[promotion_loop] NON_CANONICAL demo legacy path: expected JSON array of patches")
+        return []
+
+    patches: List[ConfigPatch] = []
+    for patch_dict in patches_data:
+        if not isinstance(patch_dict, dict):
+            continue
+        patch_payload = dict(patch_dict)
+        if patch_payload.get("generated_at"):
+            patch_payload["generated_at"] = datetime.fromisoformat(patch_payload["generated_at"])
+        if patch_payload.get("applied_at"):
+            patch_payload["applied_at"] = (
+                datetime.fromisoformat(patch_payload["applied_at"])
+                if patch_payload["applied_at"]
+                else None
+            )
+        if patch_payload.get("promoted_at"):
+            patch_payload["promoted_at"] = (
+                datetime.fromisoformat(patch_payload["promoted_at"])
+                if patch_payload["promoted_at"]
+                else None
+            )
+        if isinstance(patch_payload.get("status"), str):
+            patch_payload["status"] = PatchStatus(patch_payload["status"])
+        patch_payload.setdefault("old_value", None)
+        patches.append(ConfigPatch(**patch_payload))
+
+    print(
+        "[promotion_loop] NON_CANONICAL demo legacy path loaded "
+        f"{len(patches)} patch(es) from {demo_path}"
+    )
+    return patches
+
+
+def _load_patches_for_promotion(
+    *,
+    promotion_input_manifest: Path | None,
+    non_canonical_demo_legacy_patches: bool = False,
+) -> List[ConfigPatch]:
     """
     Load ConfigPatch objects that are candidates for live promotion.
 
-    v1 implementation: Load from JSON file generated by Learning Loop or demo script.
-
-    Returns:
-        List of ConfigPatch objects with APPLIED_OFFLINE or PROMOTED status
+    Canonical path (AD-01): ConfigPatch-Manifest v1 JSON via Package-A validation.
     """
-    import json
-    from datetime import datetime
-    from pathlib import Path as P
-    from src.meta.learning_loop.models import PatchStatus
+    if non_canonical_demo_legacy_patches:
+        return _load_non_canonical_demo_legacy_patches()
 
-    # Try to load from demo patches (for testing)
-    demo_path = P("reports/learning_snippets/demo_patches_for_promotion.json")
-
-    if not demo_path.exists():
-        print(f"[promotion_loop] Warning: No patches found at {demo_path}")
+    if promotion_input_manifest is None:
         print(
-            "[promotion_loop] Generate demo patches with: python scripts/generate_demo_patches_for_promotion.py"
+            "[promotion_loop] Error: --promotion-input-manifest is required for the "
+            "canonical ConfigPatch-Manifest v1 promotion input."
+        )
+        print(
+            "[promotion_loop] demo_patches_for_promotion.json is a NON-SSOT test fixture "
+            "only; use --non-canonical-demo-legacy-patches explicitly for legacy tests."
         )
         return []
 
-    with demo_path.open("r", encoding="utf-8") as f:
-        patches_data = json.load(f)
+    try:
+        patches = load_config_patches_for_promotion_from_manifest_path(promotion_input_manifest)
+    except ConfigPatchManifestValidationError as exc:
+        print(
+            f"[promotion_loop] ConfigPatch-Manifest v1 validation failed ({exc.phase.value}): {exc}"
+        )
+        for error in exc.errors:
+            print(f"[promotion_loop]   - {error}")
+        if exc.verdict:
+            print(f"[promotion_loop] Verdict: {exc.verdict}")
+        return []
+    except ConfigPatchManifestError as exc:
+        print(f"[promotion_loop] Failed to load promotion input manifest: {exc}")
+        return []
 
-    patches = []
-    for patch_dict in patches_data:
-        # Convert ISO strings back to datetime
-        if patch_dict.get("generated_at"):
-            patch_dict["generated_at"] = datetime.fromisoformat(patch_dict["generated_at"])
-        if patch_dict.get("applied_at"):
-            patch_dict["applied_at"] = (
-                datetime.fromisoformat(patch_dict["applied_at"])
-                if patch_dict["applied_at"]
-                else None
-            )
-        if patch_dict.get("promoted_at"):
-            patch_dict["promoted_at"] = (
-                datetime.fromisoformat(patch_dict["promoted_at"])
-                if patch_dict["promoted_at"]
-                else None
-            )
-
-        # Convert status string back to PatchStatus enum
-        if isinstance(patch_dict.get("status"), str):
-            patch_dict["status"] = PatchStatus(patch_dict["status"])
-
-        patches.append(ConfigPatch(**patch_dict))
-
-    print(f"[promotion_loop] Loaded {len(patches)} patches from {demo_path}")
+    print(
+        "[promotion_loop] Loaded "
+        f"{len(patches)} patch(es) from ConfigPatch-Manifest v1 {promotion_input_manifest}"
+    )
     return patches
 
 
@@ -137,7 +206,10 @@ def main() -> None:
             args.auto_apply_mode = "manual_only"
 
     print("[promotion_loop] Loading patches for promotion...")
-    patches = _load_patches_for_promotion()
+    patches = _load_patches_for_promotion(
+        promotion_input_manifest=args.promotion_input_manifest,
+        non_canonical_demo_legacy_patches=args.non_canonical_demo_legacy_patches,
+    )
     print(f"[promotion_loop] Loaded {len(patches)} patch(es).")
 
     candidates = build_promotion_candidates_from_patches(patches)

--- a/src/meta/learning_loop/config_patch_manifest_v1.py
+++ b/src/meta/learning_loop/config_patch_manifest_v1.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import Any, Mapping
 
 from src.meta.learning_loop.contract_safety_v1 import (
@@ -27,6 +29,23 @@ from src.meta.learning_loop.models import ConfigPatch, PatchStatus
 
 class ConfigPatchManifestError(ValueError):
     """Fail-closed ConfigPatch-Manifest v1 error."""
+
+
+class ConfigPatchManifestValidationError(ConfigPatchManifestError):
+    """Raised when Package-A manifest validation fails fail-closed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        phase: ValidationPhase,
+        errors: tuple[str, ...],
+        verdict: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.phase = phase
+        self.errors = errors
+        self.verdict = verdict
 
 
 @dataclass(frozen=True)
@@ -351,3 +370,42 @@ def build_empty_config_patch_manifest_v1(
     )
     manifest.integrity = compute_manifest_integrity(manifest)
     return manifest
+
+
+def load_config_patch_manifest_v1_from_json_path(path: Path | str) -> ConfigPatchManifestV1:
+    """Load, validate, and deserialize a ConfigPatch-Manifest v1 JSON file."""
+    manifest_path = Path(path)
+    if not manifest_path.is_file():
+        raise ConfigPatchManifestError(f"manifest file not found: {manifest_path}")
+
+    try:
+        raw_text = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConfigPatchManifestError(f"failed to read manifest file: {manifest_path}") from exc
+
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise ConfigPatchManifestError(f"invalid JSON in manifest file: {manifest_path}") from exc
+
+    if not isinstance(data, Mapping):
+        raise ConfigPatchManifestError("manifest root must be a JSON object")
+
+    valid, phase, errors, verdict = validate_config_patch_manifest_v1(data)
+    if not valid:
+        raise ConfigPatchManifestValidationError(
+            f"ConfigPatch-Manifest v1 validation failed for {manifest_path}",
+            phase=phase,
+            errors=errors,
+            verdict=verdict,
+        )
+
+    return deserialize_config_patch_manifest_v1(data)
+
+
+def load_config_patches_for_promotion_from_manifest_path(
+    path: Path | str,
+) -> list[ConfigPatch]:
+    """Return validated ConfigPatch entries from a canonical manifest file."""
+    manifest = load_config_patch_manifest_v1_from_json_path(path)
+    return list(manifest.patches)

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -4975,6 +4975,23 @@ PACKAGE_A_ALL_TESTOWNERS = (
     PACKAGE_A_CONFIG_PATCH_MANIFEST_TESTOWNER,
     PACKAGE_A_CANDIDATE_LINEAGE_TESTOWNER,
 )
+PACKAGE_B_PROMOTION_INPUT_SCRIPT = "scripts/run_promotion_proposal_cycle.py"
+PACKAGE_B_PROMOTION_INPUT_LOADER_TESTOWNER = (
+    "tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py"
+)
+PACKAGE_B_PROMOTION_INPUT_REWIRE_TESTOWNER = (
+    "tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py"
+)
+PACKAGE_B_ALL_PRODUCTION = (
+    PACKAGE_A_META_PRODUCTION_CONFIG,
+    PACKAGE_B_PROMOTION_INPUT_SCRIPT,
+)
+PACKAGE_B_ALL_TESTOWNERS = (
+    PACKAGE_A_CONTRACT_SAFETY_TESTOWNER,
+    PACKAGE_A_CONFIG_PATCH_MANIFEST_TESTOWNER,
+    PACKAGE_B_PROMOTION_INPUT_LOADER_TESTOWNER,
+    PACKAGE_B_PROMOTION_INPUT_REWIRE_TESTOWNER,
+)
 
 
 def test_selector_package_a_meta_production_pr_bounded_full_includes_meta_testowners() -> None:
@@ -5012,3 +5029,29 @@ def test_selector_central_src_without_package_a_path_excludes_package_a_testowne
     bounded = _bounded_targets(sel)
     for path in PACKAGE_A_ALL_TESTOWNERS:
         assert path not in bounded
+
+
+def test_selector_package_b_promotion_script_contract_focused_includes_loader_and_rewire_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_B_PROMOTION_INPUT_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    assert PACKAGE_B_PROMOTION_INPUT_LOADER_TESTOWNER in targets
+    assert PACKAGE_B_PROMOTION_INPUT_REWIRE_TESTOWNER in targets
+
+
+def test_selector_package_b_combined_diff_pr_bounded_full_includes_required_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        *PACKAGE_B_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_B_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_B_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+    assert PACKAGE_A_CANDIDATE_LINEAGE_TESTOWNER not in bounded

--- a/tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py
+++ b/tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py
@@ -1,0 +1,282 @@
+"""Tests for ConfigPatch-Manifest v1 promotion input file loader (Package B)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    ConfigPatchManifestError,
+    ConfigPatchManifestValidationError,
+    build_empty_config_patch_manifest_v1,
+    compute_manifest_integrity,
+    deserialize_config_patch_manifest_v1,
+    load_config_patch_manifest_v1_from_json_path,
+    load_config_patches_for_promotion_from_manifest_path,
+    manifest_to_canonical_dict,
+    patch_to_mapping,
+    serialize_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+    VERDICT_FUTURES_SCOPE_VIOLATION,
+)
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "11111111-1111-4111-8111-111111111111"
+LINEAGE_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _build_manifest(*, patches: list[ConfigPatch] | None = None) -> object:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    if patches is not None:
+        manifest.patches = patches
+    manifest.integrity = compute_manifest_integrity(manifest)
+    return manifest
+
+
+def _write_manifest(path: Path, *, patches: list[ConfigPatch] | None = None) -> None:
+    manifest = _build_manifest(patches=patches)
+    path.write_text(serialize_config_patch_manifest_v1(manifest), encoding="utf-8")
+
+
+def _allowed_patch() -> ConfigPatch:
+    return ConfigPatch(
+        id="patch-research-window",
+        target="research.offline.window_days",
+        old_value=30,
+        new_value=45,
+        status=PatchStatus.APPLIED_OFFLINE,
+        generated_at=FIXED_NOW,
+        confidence_score=0.91,
+    )
+
+
+def test_loader_reads_valid_manifest_with_allowed_patch(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "promotion_input.json"
+    _write_manifest(manifest_path, patches=[_allowed_patch()])
+
+    patches = load_config_patches_for_promotion_from_manifest_path(manifest_path)
+
+    assert len(patches) == 1
+    assert patches[0].target == "research.offline.window_days"
+    assert patches[0].status is PatchStatus.APPLIED_OFFLINE
+
+
+def test_loader_supports_patch_empty_manifest(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "empty.json"
+    _write_manifest(manifest_path, patches=[])
+
+    patches = load_config_patches_for_promotion_from_manifest_path(manifest_path)
+
+    assert patches == []
+
+
+def test_loader_returns_deterministic_config_patch_objects(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "deterministic.json"
+    _write_manifest(manifest_path, patches=[_allowed_patch()])
+
+    first = load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    second = load_config_patches_for_promotion_from_manifest_path(manifest_path)
+
+    assert first[0].id == second[0].id
+    assert first[0].target == second[0].target
+    assert first[0].status == second[0].status
+
+
+def test_loader_returns_full_manifest_object(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    _write_manifest(manifest_path, patches=[_allowed_patch()])
+
+    manifest = load_config_patch_manifest_v1_from_json_path(manifest_path)
+
+    assert manifest.manifest_id == MANIFEST_ID
+    assert manifest.lineage_manifest_ref == LINEAGE_ID
+    assert len(manifest.patches) == 1
+
+
+def test_loader_missing_file_fail_closed(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    with pytest.raises(ConfigPatchManifestError, match="manifest file not found"):
+        load_config_patches_for_promotion_from_manifest_path(missing)
+
+
+def test_loader_invalid_json_fail_closed(tmp_path: Path) -> None:
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(ConfigPatchManifestError, match="invalid JSON"):
+        load_config_patches_for_promotion_from_manifest_path(bad_json)
+
+
+def test_loader_rejects_raw_patch_list_as_canonical_input(tmp_path: Path) -> None:
+    raw_list = tmp_path / "raw_list.json"
+    raw_list.write_text(
+        json.dumps([patch_to_mapping(_allowed_patch())]),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigPatchManifestError, match="JSON object"):
+        load_config_patches_for_promotion_from_manifest_path(raw_list)
+
+
+def test_loader_rejects_toml_fail_closed(tmp_path: Path) -> None:
+    toml_path = tmp_path / "legacy.toml"
+    toml_path.write_text("[patch]\ntarget = 'research.offline.window_days'\n", encoding="utf-8")
+    with pytest.raises(ConfigPatchManifestError, match="invalid JSON"):
+        load_config_patches_for_promotion_from_manifest_path(toml_path)
+
+
+def test_loader_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "bad_schema.json"
+    manifest = _build_manifest(patches=[_allowed_patch()])
+    payload = json.loads(serialize_config_patch_manifest_v1(manifest))
+    payload["schema_version"] = "9.9"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.phase.value == "schema_version"
+
+
+def test_loader_rejects_duplicate_patch_ids(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "dup.json"
+    manifest = _build_manifest(
+        patches=[
+            _allowed_patch(),
+            ConfigPatch(
+                id="patch-research-window",
+                target="research.offline.window_days",
+                old_value=20,
+                new_value=25,
+                status=PatchStatus.APPLIED_OFFLINE,
+            ),
+        ]
+    )
+    manifest_path.write_text(serialize_config_patch_manifest_v1(manifest), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.phase.value == "cardinality"
+
+
+def test_loader_rejects_unknown_patch_status(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "bad_status.json"
+    manifest = _build_manifest(patches=[_allowed_patch()])
+    payload = json.loads(serialize_config_patch_manifest_v1(manifest))
+    payload["patches"][0]["status"] = "UNKNOWN_STATUS"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.phase.value == "schema"
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "portfolio.leverage",
+        "strategy.trigger_delay",
+        "master_v2.config",
+        "double_play.slot",
+        "signal.threshold",
+        "sizing.fraction",
+        "execution.routing",
+        "risk.stop_loss",
+        "killswitch.enabled",
+    ],
+)
+def test_loader_rejects_forbidden_targets(tmp_path: Path, target: str) -> None:
+    manifest_path = tmp_path / f"forbidden_{uuid.uuid4().hex}.json"
+    patch = ConfigPatch(
+        id=str(uuid.uuid4()),
+        target=target,
+        old_value=None,
+        new_value=1,
+        status=PatchStatus.APPLIED_OFFLINE,
+    )
+    manifest = _build_manifest(patches=[patch])
+    manifest_path.write_text(serialize_config_patch_manifest_v1(manifest), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.verdict in {
+        VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+        "TARGET_NOT_ALLOWED",
+    }
+
+
+def test_loader_rejects_empty_target_fail_closed(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "empty_target.json"
+    patch = ConfigPatch(
+        id=str(uuid.uuid4()),
+        target="",
+        old_value=None,
+        new_value=1,
+        status=PatchStatus.APPLIED_OFFLINE,
+    )
+    manifest = _build_manifest(patches=[patch])
+    manifest_path.write_text(serialize_config_patch_manifest_v1(manifest), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.phase.value == "target_policy"
+
+    manifest_path = tmp_path / "btc_scope.json"
+    manifest = _build_manifest(patches=[_allowed_patch()])
+    payload = json.loads(serialize_config_patch_manifest_v1(manifest))
+    payload["source_scope"] = {
+        "scope": "BTC_PERP",
+        "bitcoin_direction_allowed": False,
+        "autonomous_live_promotion": False,
+        "autonomous_order_authority": False,
+    }
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.verdict == VERDICT_FUTURES_SCOPE_VIOLATION
+
+
+def test_loader_rejects_invalid_lineage_reference(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "bad_lineage.json"
+    manifest = _build_manifest(patches=[_allowed_patch()])
+    payload = json.loads(serialize_config_patch_manifest_v1(manifest))
+    payload["lineage_manifest_ref"] = "not-a-uuid"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.phase.value == "lineage_references"
+
+
+def test_loader_rejects_integrity_mismatch(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "bad_integrity.json"
+    manifest = _build_manifest(patches=[_allowed_patch()])
+    payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+    payload["integrity"] = {"content_sha256": "0" * 64}
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.phase.value == "integrity"
+
+
+def test_loader_rejects_missing_required_top_level_field(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "missing_field.json"
+    manifest = _build_manifest(patches=[_allowed_patch()])
+    payload = json.loads(serialize_config_patch_manifest_v1(manifest))
+    payload.pop("integrity")
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ConfigPatchManifestValidationError) as exc_info:
+        load_config_patches_for_promotion_from_manifest_path(manifest_path)
+    assert exc_info.value.phase.value == "schema"

--- a/tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py
+++ b/tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py
@@ -1,0 +1,176 @@
+"""Tests for bounded GAP-001 rewire in run_promotion_proposal_cycle."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    build_empty_config_patch_manifest_v1,
+    compute_manifest_integrity,
+    serialize_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "33333333-3333-4333-8333-333333333333"
+LINEAGE_ID = "44444444-4444-4444-8444-444444444444"
+
+
+def _load_promotion_cycle_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "run_promotion_proposal_cycle.py"
+    module_name = "run_promotion_proposal_cycle_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def promotion_cycle():
+    return _load_promotion_cycle_module()
+
+
+def _write_manifest(path: Path, *, patches: list[ConfigPatch]) -> None:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    manifest.patches = patches
+    manifest.integrity = compute_manifest_integrity(manifest)
+    path.write_text(serialize_config_patch_manifest_v1(manifest), encoding="utf-8")
+
+
+def test_load_patches_requires_manifest_by_default(promotion_cycle, tmp_path: Path) -> None:
+    patches = promotion_cycle._load_patches_for_promotion(
+        promotion_input_manifest=None,
+        non_canonical_demo_legacy_patches=False,
+    )
+    assert patches == []
+
+
+def test_load_patches_uses_manifest_loader(promotion_cycle, tmp_path: Path) -> None:
+    manifest_path = tmp_path / "promotion_input.json"
+    _write_manifest(
+        manifest_path,
+        patches=[
+            ConfigPatch(
+                id="patch-1",
+                target="research.offline.window_days",
+                old_value=30,
+                new_value=45,
+                status=PatchStatus.APPLIED_OFFLINE,
+                confidence_score=0.9,
+            )
+        ],
+    )
+
+    patches = promotion_cycle._load_patches_for_promotion(
+        promotion_input_manifest=manifest_path,
+        non_canonical_demo_legacy_patches=False,
+    )
+
+    assert len(patches) == 1
+    assert patches[0].target == "research.offline.window_days"
+    assert isinstance(patches[0], ConfigPatch)
+
+
+def test_load_patches_empty_manifest_returns_empty_list(
+    promotion_cycle,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "empty.json"
+    _write_manifest(manifest_path, patches=[])
+
+    patches = promotion_cycle._load_patches_for_promotion(
+        promotion_input_manifest=manifest_path,
+        non_canonical_demo_legacy_patches=False,
+    )
+
+    assert patches == []
+
+
+def test_demo_json_not_default_without_explicit_legacy_flag(
+    promotion_cycle,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    demo_path = tmp_path / "demo_patches_for_promotion.json"
+    demo_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "demo-1",
+                    "target": "portfolio.leverage",
+                    "new_value": 1.5,
+                    "status": PatchStatus.APPLIED_OFFLINE.value,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    patches = promotion_cycle._load_patches_for_promotion(
+        promotion_input_manifest=None,
+        non_canonical_demo_legacy_patches=False,
+    )
+
+    assert patches == []
+
+
+def test_non_canonical_demo_legacy_flag_is_explicit_only(
+    promotion_cycle,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    demo_dir = tmp_path / "reports" / "learning_snippets"
+    demo_dir.mkdir(parents=True)
+    demo_path = demo_dir / "demo_patches_for_promotion.json"
+    demo_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "demo-legacy-1",
+                    "target": "research.offline.window_days",
+                    "new_value": 45,
+                    "status": PatchStatus.APPLIED_OFFLINE.value,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    patches = promotion_cycle._load_patches_for_promotion(
+        promotion_input_manifest=None,
+        non_canonical_demo_legacy_patches=True,
+    )
+
+    assert len(patches) == 1
+    assert patches[0].id == "demo-legacy-1"
+
+
+def test_invalid_manifest_returns_empty_without_demo_fallback(
+    promotion_cycle,
+    tmp_path: Path,
+) -> None:
+    bad_manifest = tmp_path / "bad.json"
+    bad_manifest.write_text("{not-json", encoding="utf-8")
+
+    patches = promotion_cycle._load_patches_for_promotion(
+        promotion_input_manifest=bad_manifest,
+        non_canonical_demo_legacy_patches=False,
+    )
+
+    assert patches == []


### PR DESCRIPTION
## GO_TOKEN
`GO_PACKAGE_B_CONFIGPATCH_MANIFEST_V1_PROMOTION_INPUT_LOADER_AND_BOUNDED_GAP001_REWIRE_V0`

## Summary
- Add fail-closed ConfigPatch-Manifest v1 file loader reusing Package-A validate/deserialize APIs
- Rewire `_load_patches_for_promotion` to canonical `--promotion-input-manifest` input (GAP-001)
- Remove implicit demo JSON default; legacy demo list only via explicit `--non-canonical-demo-legacy-patches`
- Bind new loader/rewire testowners in CI selector (Package-A bindings extended)

## Non-Goals (verified absent)
- Reference-only proposal path
- Backtest / VaR integration
- CandidateLineage orchestration
- Promotion policy / engine semantic changes
- Runtime / live execution

## AD-01 / AD-04
- AD-01: ConfigPatch-Manifest v1 is canonical offline promotion input
- AD-04: lineage refs validated at manifest layer; no lineage orchestration in this slice

## GAP-001
Closes bounded promotion-input edge: manifest file → validated patches → existing promotion engine consumer.

## Demo NON-SSOT
`demo_patches_for_promotion.json` is no longer implicit default. Explicit legacy flag only for tests.

## Apply vs Promotion separation
No changes to `run_learning_apply_cycle` or `learning.override.toml`.

## Trading-Logic-Immutability
Package-A validation enforced before patches reach promotion engine. No strategy/signal/sizing/execution/risk/killswitch files changed.

## Changed files
- `src/meta/learning_loop/config_patch_manifest_v1.py`
- `scripts/run_promotion_proposal_cycle.py`
- `scripts/ops/ci_test_selection_v1.py`
- `tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py`
- `tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py`
- `tests/ci/test_ci_diff_aware_test_selection_v1.py`

## Tests
- 98 focused tests PASS locally (loader, rewire, Package-A contracts, selector bindings)
- `ruff format --check` / `ruff check` PASS on changed files

## CI selection
Combined diff → `PR_BOUNDED_FULL` (includes all Package-B required testowners)
Script-only diff → `CONTRACT_FOCUSED` with loader + rewire testowners

## Durable evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/package_b_configpatch_manifest_v1_promotion_input_loader_gap001_v0_20260627T044357Z`
`MANIFEST_VERIFY_RC=0`

## Runtime / order safety
`RUNTIME_ATTEMPT_COUNT=0` · `ORDER_ATTEMPT_COUNT=0` · `CANCEL_ATTEMPT_COUNT=0`

## Test plan
- [x] Loader positive/negative contract tests
- [x] Patch-empty manifest returns `[]`
- [x] Promotion rewire requires manifest path
- [x] Package-A regression tests
- [x] CI selector binding contract tests
- [ ] GitHub required checks (tests 3.11)

Made with [Cursor](https://cursor.com)