### PR TITLE
feat(learning): Package C — ConfigPatch-Manifest lineage FK propagation to proposal artifacts

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1340,13 +1340,18 @@ PR_BOUNDED_FULL_PACKAGE_A_META_TARGETS: tuple[str, ...] = (
 PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "scripts/run_promotion_proposal_cycle.py",
+        "src/governance/promotion_loop/proposal_input_refs_v1.py",
         "tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py",
+        "tests/scripts/test_run_promotion_proposal_cycle_manifest_lineage_fk_v1.py",
+        "tests/governance/promotion_loop/test_proposal_input_refs_v1.py",
     }
 )
 
 PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TARGETS: tuple[str, ...] = (
     "tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py",
     "tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py",
+    "tests/scripts/test_run_promotion_proposal_cycle_manifest_lineage_fk_v1.py",
+    "tests/governance/promotion_loop/test_proposal_input_refs_v1.py",
 )
 
 PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TRIGGER_PATHS: frozenset[str] = frozenset(

--- a/scripts/run_promotion_proposal_cycle.py
+++ b/scripts/run_promotion_proposal_cycle.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import json
 from datetime import datetime
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 
@@ -39,12 +40,25 @@ from src.governance.promotion_loop import (
 from src.governance.promotion_loop.engine import apply_proposals_to_live_overrides
 from src.governance.promotion_loop.models import DecisionStatus
 from src.governance.promotion_loop.policy import AutoApplyBounds, AutoApplyPolicy
+from src.governance.promotion_loop.proposal_input_refs_v1 import (
+    PromotionInputReferencesV1,
+    apply_promotion_input_references_to_proposal,
+    promotion_input_references_from_manifest,
+)
 from src.meta.learning_loop.config_patch_manifest_v1 import (
     ConfigPatchManifestError,
     ConfigPatchManifestValidationError,
-    load_config_patches_for_promotion_from_manifest_path,
+    load_promotion_input_from_manifest_path,
 )
 from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+@dataclass(frozen=True)
+class PromotionPatchLoadResult:
+    """Result of loading promotion input patches and optional manifest reference FKs."""
+
+    patches: List[ConfigPatch]
+    input_references: PromotionInputReferencesV1 | None = None
 
 
 def parse_args() -> argparse.Namespace:
@@ -91,7 +105,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _load_non_canonical_demo_legacy_patches() -> List[ConfigPatch]:
+def _load_non_canonical_demo_legacy_patches() -> PromotionPatchLoadResult:
     """
     NON_CANONICAL test-only loader for legacy raw demo patch JSON.
 
@@ -102,14 +116,14 @@ def _load_non_canonical_demo_legacy_patches() -> List[ConfigPatch]:
 
     if not demo_path.is_file():
         print(f"[promotion_loop] NON_CANONICAL demo legacy path: no patches found at {demo_path}")
-        return []
+        return PromotionPatchLoadResult(patches=[])
 
     with demo_path.open("r", encoding="utf-8") as handle:
         patches_data = json.load(handle)
 
     if not isinstance(patches_data, list):
         print("[promotion_loop] NON_CANONICAL demo legacy path: expected JSON array of patches")
-        return []
+        return PromotionPatchLoadResult(patches=[])
 
     patches: List[ConfigPatch] = []
     for patch_dict in patches_data:
@@ -139,14 +153,14 @@ def _load_non_canonical_demo_legacy_patches() -> List[ConfigPatch]:
         "[promotion_loop] NON_CANONICAL demo legacy path loaded "
         f"{len(patches)} patch(es) from {demo_path}"
     )
-    return patches
+    return PromotionPatchLoadResult(patches=patches)
 
 
 def _load_patches_for_promotion(
     *,
     promotion_input_manifest: Path | None,
     non_canonical_demo_legacy_patches: bool = False,
-) -> List[ConfigPatch]:
+) -> PromotionPatchLoadResult:
     """
     Load ConfigPatch objects that are candidates for live promotion.
 
@@ -164,10 +178,12 @@ def _load_patches_for_promotion(
             "[promotion_loop] demo_patches_for_promotion.json is a NON-SSOT test fixture "
             "only; use --non-canonical-demo-legacy-patches explicitly for legacy tests."
         )
-        return []
+        return PromotionPatchLoadResult(patches=[])
 
     try:
-        patches = load_config_patches_for_promotion_from_manifest_path(promotion_input_manifest)
+        promotion_input = load_promotion_input_from_manifest_path(promotion_input_manifest)
+        input_references = promotion_input_references_from_manifest(promotion_input.manifest)
+        patches = list(promotion_input.patches)
     except ConfigPatchManifestValidationError as exc:
         print(
             f"[promotion_loop] ConfigPatch-Manifest v1 validation failed ({exc.phase.value}): {exc}"
@@ -176,16 +192,16 @@ def _load_patches_for_promotion(
             print(f"[promotion_loop]   - {error}")
         if exc.verdict:
             print(f"[promotion_loop] Verdict: {exc.verdict}")
-        return []
+        return PromotionPatchLoadResult(patches=[])
     except ConfigPatchManifestError as exc:
         print(f"[promotion_loop] Failed to load promotion input manifest: {exc}")
-        return []
+        return PromotionPatchLoadResult(patches=[])
 
     print(
         "[promotion_loop] Loaded "
         f"{len(patches)} patch(es) from ConfigPatch-Manifest v1 {promotion_input_manifest}"
     )
-    return patches
+    return PromotionPatchLoadResult(patches=patches, input_references=input_references)
 
 
 def main() -> None:
@@ -206,10 +222,11 @@ def main() -> None:
             args.auto_apply_mode = "manual_only"
 
     print("[promotion_loop] Loading patches for promotion...")
-    patches = _load_patches_for_promotion(
+    load_result = _load_patches_for_promotion(
         promotion_input_manifest=args.promotion_input_manifest,
         non_canonical_demo_legacy_patches=args.non_canonical_demo_legacy_patches,
     )
+    patches = load_result.patches
     print(f"[promotion_loop] Loaded {len(patches)} patch(es).")
 
     candidates = build_promotion_candidates_from_patches(patches)
@@ -254,6 +271,10 @@ def main() -> None:
     if not proposals:
         print("[promotion_loop] No proposals generated.")
         return
+
+    if load_result.input_references is not None:
+        for proposal in proposals:
+            apply_promotion_input_references_to_proposal(proposal, load_result.input_references)
 
     written = materialize_promotion_proposals(proposals, args.output_dir)
     print(

--- a/src/governance/promotion_loop/proposal_input_refs_v1.py
+++ b/src/governance/promotion_loop/proposal_input_refs_v1.py
@@ -1,0 +1,200 @@
+"""Promotion proposal input reference propagation (Package C, offline, fail-closed)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from src.meta.learning_loop.config_patch_manifest_v1 import ConfigPatchManifestV1
+from src.meta.learning_loop.contract_safety_v1 import (
+    SCHEMA_VERSION_V1,
+    is_valid_uuid,
+    validate_schema_version,
+)
+
+from .models import PromotionProposal
+
+
+class PromotionInputReferencesError(ValueError):
+    """Fail-closed error for promotion input reference propagation."""
+
+
+_FORBIDDEN_META_KEYS = frozenset(
+    {
+        "patches",
+        "refs",
+        "integrity",
+        "source_scope",
+        "trading_logic_immutability_ref",
+        "futures_scope_ref",
+        "manifest",
+        "lineage_manifest",
+        "config_patch_manifest",
+        "candidate_lineage_manifest",
+    }
+)
+
+_FORBIDDEN_META_TOKENS = frozenset(
+    {
+        "master_v2",
+        "double_play",
+        "strategy",
+        "signal",
+        "execution",
+        "killswitch",
+        "leverage",
+        "stop_loss",
+        "take_profit",
+        "order_routing",
+        "live_arming",
+    }
+)
+
+_ALLOWED_REFERENCE_KEYS = frozenset(
+    {
+        "config_patch_manifest_id",
+        "candidate_lineage_manifest_ref",
+        "config_patch_manifest_schema_version",
+        "candidate_lineage_manifest_schema_version",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PromotionInputReferencesV1:
+    """Reference-only FKs from a validated ConfigPatch-Manifest v1 input."""
+
+    config_patch_manifest_id: str
+    candidate_lineage_manifest_ref: str | None
+    config_patch_manifest_schema_version: str
+    candidate_lineage_manifest_schema_version: str | None = None
+
+    def to_proposal_meta_fields(self) -> dict[str, str]:
+        fields: dict[str, str] = {
+            "config_patch_manifest_id": self.config_patch_manifest_id,
+            "config_patch_manifest_schema_version": self.config_patch_manifest_schema_version,
+        }
+        if self.candidate_lineage_manifest_ref is not None:
+            fields["candidate_lineage_manifest_ref"] = self.candidate_lineage_manifest_ref
+        if self.candidate_lineage_manifest_schema_version is not None:
+            fields["candidate_lineage_manifest_schema_version"] = (
+                self.candidate_lineage_manifest_schema_version
+            )
+        return fields
+
+
+def promotion_input_references_from_manifest(
+    manifest: ConfigPatchManifestV1,
+) -> PromotionInputReferencesV1:
+    """Extract fail-closed reference FKs from an already validated manifest."""
+    manifest_id = manifest.manifest_id
+    if not isinstance(manifest_id, str) or not manifest_id.strip():
+        raise PromotionInputReferencesError("config_patch_manifest_id is required")
+    if not is_valid_uuid(manifest_id):
+        raise PromotionInputReferencesError("config_patch_manifest_id must be a UUID")
+
+    schema_result = validate_schema_version(manifest.schema_version)
+    if not schema_result.valid:
+        raise PromotionInputReferencesError(
+            f"unsupported config_patch_manifest_schema_version: {manifest.schema_version!r}"
+        )
+
+    lineage_ref = manifest.lineage_manifest_ref
+    lineage_schema_version: str | None = None
+    if lineage_ref is not None:
+        if not isinstance(lineage_ref, str) or not lineage_ref.strip():
+            raise PromotionInputReferencesError("candidate_lineage_manifest_ref must be non-empty")
+        if not is_valid_uuid(lineage_ref):
+            raise PromotionInputReferencesError("candidate_lineage_manifest_ref must be a UUID")
+        lineage_schema_version = SCHEMA_VERSION_V1
+
+    return PromotionInputReferencesV1(
+        config_patch_manifest_id=manifest_id,
+        candidate_lineage_manifest_ref=lineage_ref,
+        config_patch_manifest_schema_version=SCHEMA_VERSION_V1,
+        candidate_lineage_manifest_schema_version=lineage_schema_version,
+    )
+
+
+def validate_proposal_reference_meta_fields(meta_fields: Mapping[str, Any]) -> None:
+    """Reject embedded payloads, unknown keys, or trading-logic smuggling attempts."""
+    for key in meta_fields:
+        if key in _FORBIDDEN_META_KEYS:
+            raise PromotionInputReferencesError(
+                f"embedded manifest payload key not allowed in proposal references: {key!r}"
+            )
+
+    unknown = set(meta_fields) - _ALLOWED_REFERENCE_KEYS
+    if unknown:
+        raise PromotionInputReferencesError(
+            f"unsupported promotion input reference keys: {sorted(unknown)!r}"
+        )
+
+    for key, value in meta_fields.items():
+        if not isinstance(value, str) or not value.strip():
+            raise PromotionInputReferencesError(f"{key} must be a non-empty string")
+        lowered = value.lower()
+        for token in _FORBIDDEN_META_TOKENS:
+            if token in lowered:
+                raise PromotionInputReferencesError(
+                    f"{key} contains forbidden trading-logic token: {token!r}"
+                )
+
+    manifest_id = meta_fields.get("config_patch_manifest_id")
+    if manifest_id is None:
+        raise PromotionInputReferencesError("config_patch_manifest_id is required")
+    if not is_valid_uuid(str(manifest_id)):
+        raise PromotionInputReferencesError("config_patch_manifest_id must be a UUID")
+
+    manifest_schema = meta_fields.get("config_patch_manifest_schema_version")
+    if manifest_schema is None:
+        raise PromotionInputReferencesError("config_patch_manifest_schema_version is required")
+    schema_result = validate_schema_version(str(manifest_schema))
+    if not schema_result.valid:
+        raise PromotionInputReferencesError(
+            f"unsupported config_patch_manifest_schema_version: {manifest_schema!r}"
+        )
+
+    lineage_ref = meta_fields.get("candidate_lineage_manifest_ref")
+    lineage_schema = meta_fields.get("candidate_lineage_manifest_schema_version")
+    if lineage_ref is not None:
+        if not is_valid_uuid(str(lineage_ref)):
+            raise PromotionInputReferencesError("candidate_lineage_manifest_ref must be a UUID")
+        if lineage_schema is None:
+            raise PromotionInputReferencesError(
+                "candidate_lineage_manifest_schema_version required when lineage ref present"
+            )
+        lineage_schema_result = validate_schema_version(str(lineage_schema))
+        if not lineage_schema_result.valid:
+            raise PromotionInputReferencesError(
+                f"unsupported candidate_lineage_manifest_schema_version: {lineage_schema!r}"
+            )
+    elif lineage_schema is not None:
+        raise PromotionInputReferencesError(
+            "candidate_lineage_manifest_schema_version without candidate_lineage_manifest_ref"
+        )
+
+
+def apply_promotion_input_references_to_proposal(
+    proposal: PromotionProposal,
+    references: PromotionInputReferencesV1,
+) -> None:
+    """Add validated reference-only FK fields to an existing proposal meta dict."""
+    meta_fields = references.to_proposal_meta_fields()
+    validate_proposal_reference_meta_fields(meta_fields)
+
+    for key, value in meta_fields.items():
+        if key in proposal.meta and proposal.meta[key] != value:
+            raise PromotionInputReferencesError(
+                f"conflicting promotion input reference for {key!r}"
+            )
+        proposal.meta[key] = value
+
+
+__all__ = [
+    "PromotionInputReferencesError",
+    "PromotionInputReferencesV1",
+    "apply_promotion_input_references_to_proposal",
+    "promotion_input_references_from_manifest",
+    "validate_proposal_reference_meta_fields",
+]

--- a/src/meta/learning_loop/config_patch_manifest_v1.py
+++ b/src/meta/learning_loop/config_patch_manifest_v1.py
@@ -407,7 +407,7 @@ def load_config_patches_for_promotion_from_manifest_path(
     path: Path | str,
 ) -> list[ConfigPatch]:
     """Return validated ConfigPatch entries from a canonical manifest file."""
-    return load_promotion_input_from_manifest_path(path).patches
+    return list(load_promotion_input_from_manifest_path(path).patches)
 
 
 @dataclass(frozen=True)

--- a/src/meta/learning_loop/config_patch_manifest_v1.py
+++ b/src/meta/learning_loop/config_patch_manifest_v1.py
@@ -407,5 +407,18 @@ def load_config_patches_for_promotion_from_manifest_path(
     path: Path | str,
 ) -> list[ConfigPatch]:
     """Return validated ConfigPatch entries from a canonical manifest file."""
+    return load_promotion_input_from_manifest_path(path).patches
+
+
+@dataclass(frozen=True)
+class PromotionManifestInputV1:
+    """Validated ConfigPatch-Manifest v1 promotion input (patches + reference FKs)."""
+
+    patches: tuple[ConfigPatch, ...]
+    manifest: ConfigPatchManifestV1
+
+
+def load_promotion_input_from_manifest_path(path: Path | str) -> PromotionManifestInputV1:
+    """Load manifest envelope and patches without discarding reference FKs."""
     manifest = load_config_patch_manifest_v1_from_json_path(path)
-    return list(manifest.patches)
+    return PromotionManifestInputV1(patches=tuple(manifest.patches), manifest=manifest)

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -4982,15 +4982,24 @@ PACKAGE_B_PROMOTION_INPUT_LOADER_TESTOWNER = (
 PACKAGE_B_PROMOTION_INPUT_REWIRE_TESTOWNER = (
     "tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py"
 )
+PACKAGE_B_PROMOTION_INPUT_LINEAGE_FK_TESTOWNER = (
+    "tests/scripts/test_run_promotion_proposal_cycle_manifest_lineage_fk_v1.py"
+)
+PACKAGE_B_PROPOSAL_INPUT_REFS_TESTOWNER = (
+    "tests/governance/promotion_loop/test_proposal_input_refs_v1.py"
+)
 PACKAGE_B_ALL_PRODUCTION = (
     PACKAGE_A_META_PRODUCTION_CONFIG,
     PACKAGE_B_PROMOTION_INPUT_SCRIPT,
+    "src/governance/promotion_loop/proposal_input_refs_v1.py",
 )
 PACKAGE_B_ALL_TESTOWNERS = (
     PACKAGE_A_CONTRACT_SAFETY_TESTOWNER,
     PACKAGE_A_CONFIG_PATCH_MANIFEST_TESTOWNER,
     PACKAGE_B_PROMOTION_INPUT_LOADER_TESTOWNER,
     PACKAGE_B_PROMOTION_INPUT_REWIRE_TESTOWNER,
+    PACKAGE_B_PROMOTION_INPUT_LINEAGE_FK_TESTOWNER,
+    PACKAGE_B_PROPOSAL_INPUT_REFS_TESTOWNER,
 )
 
 
@@ -5039,6 +5048,8 @@ def test_selector_package_b_promotion_script_contract_focused_includes_loader_an
     targets = _targets(sel)
     assert PACKAGE_B_PROMOTION_INPUT_LOADER_TESTOWNER in targets
     assert PACKAGE_B_PROMOTION_INPUT_REWIRE_TESTOWNER in targets
+    assert PACKAGE_B_PROMOTION_INPUT_LINEAGE_FK_TESTOWNER in targets
+    assert PACKAGE_B_PROPOSAL_INPUT_REFS_TESTOWNER in targets
 
 
 def test_selector_package_b_combined_diff_pr_bounded_full_includes_required_testowners_once() -> (

--- a/tests/governance/promotion_loop/test_proposal_input_refs_v1.py
+++ b/tests/governance/promotion_loop/test_proposal_input_refs_v1.py
@@ -1,0 +1,153 @@
+"""Contract tests for promotion input reference propagation (Package C)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.governance.promotion_loop.models import PromotionProposal
+from src.governance.promotion_loop.proposal_input_refs_v1 import (
+    PromotionInputReferencesError,
+    PromotionInputReferencesV1,
+    apply_promotion_input_references_to_proposal,
+    promotion_input_references_from_manifest,
+    validate_proposal_reference_meta_fields,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import build_empty_config_patch_manifest_v1
+from src.meta.learning_loop.contract_safety_v1 import SCHEMA_VERSION_V1
+
+
+FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+LINEAGE_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+
+def _manifest(*, lineage_ref: str | None = LINEAGE_ID):
+    return build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=lineage_ref or LINEAGE_ID,
+    )
+
+
+def test_references_from_manifest_extracts_ids() -> None:
+    refs = promotion_input_references_from_manifest(_manifest())
+
+    assert refs.config_patch_manifest_id == MANIFEST_ID
+    assert refs.candidate_lineage_manifest_ref == LINEAGE_ID
+    assert refs.config_patch_manifest_schema_version == SCHEMA_VERSION_V1
+    assert refs.candidate_lineage_manifest_schema_version == SCHEMA_VERSION_V1
+
+
+def test_references_to_proposal_meta_fields_are_reference_only() -> None:
+    refs = promotion_input_references_from_manifest(_manifest())
+    fields = refs.to_proposal_meta_fields()
+
+    assert set(fields) == {
+        "config_patch_manifest_id",
+        "candidate_lineage_manifest_ref",
+        "config_patch_manifest_schema_version",
+        "candidate_lineage_manifest_schema_version",
+    }
+    assert "patches" not in fields
+    assert "integrity" not in fields
+
+
+def test_apply_references_to_proposal_is_deterministic() -> None:
+    refs = promotion_input_references_from_manifest(_manifest())
+    proposal = PromotionProposal(
+        proposal_id="live_promotion_test",
+        title="t",
+        description="d",
+        meta={"generated_at": "20260627T120000Z", "num_candidates": 1},
+    )
+
+    apply_promotion_input_references_to_proposal(proposal, refs)
+    apply_promotion_input_references_to_proposal(proposal, refs)
+
+    assert proposal.meta["config_patch_manifest_id"] == MANIFEST_ID
+    assert proposal.meta["candidate_lineage_manifest_ref"] == LINEAGE_ID
+
+
+def test_apply_references_rejects_conflicting_manifest_id() -> None:
+    refs = promotion_input_references_from_manifest(_manifest())
+    proposal = PromotionProposal(
+        proposal_id="live_promotion_test",
+        title="t",
+        description="d",
+        meta={"config_patch_manifest_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc"},
+    )
+
+    with pytest.raises(PromotionInputReferencesError, match="conflicting"):
+        apply_promotion_input_references_to_proposal(proposal, refs)
+
+
+def test_validate_rejects_embedded_manifest_payload_key() -> None:
+    with pytest.raises(PromotionInputReferencesError, match="embedded manifest payload"):
+        validate_proposal_reference_meta_fields(
+            {
+                "config_patch_manifest_id": MANIFEST_ID,
+                "config_patch_manifest_schema_version": SCHEMA_VERSION_V1,
+                "patches": "[]",
+            }
+        )
+
+
+def test_validate_rejects_trading_logic_token_in_reference() -> None:
+    with pytest.raises(PromotionInputReferencesError, match="forbidden trading-logic token"):
+        validate_proposal_reference_meta_fields(
+            {
+                "config_patch_manifest_id": MANIFEST_ID,
+                "config_patch_manifest_schema_version": SCHEMA_VERSION_V1,
+                "candidate_lineage_manifest_ref": "strategy-injection-attempt",
+            }
+        )
+
+
+def test_validate_rejects_invalid_manifest_uuid() -> None:
+    with pytest.raises(PromotionInputReferencesError, match="must be a UUID"):
+        validate_proposal_reference_meta_fields(
+            {
+                "config_patch_manifest_id": "not-a-uuid",
+                "config_patch_manifest_schema_version": SCHEMA_VERSION_V1,
+            }
+        )
+
+
+def test_validate_rejects_unknown_schema_version() -> None:
+    with pytest.raises(PromotionInputReferencesError, match="unsupported"):
+        validate_proposal_reference_meta_fields(
+            {
+                "config_patch_manifest_id": MANIFEST_ID,
+                "config_patch_manifest_schema_version": "9.9",
+            }
+        )
+
+
+def test_validate_rejects_lineage_schema_without_lineage_ref() -> None:
+    with pytest.raises(
+        PromotionInputReferencesError, match="without candidate_lineage_manifest_ref"
+    ):
+        validate_proposal_reference_meta_fields(
+            {
+                "config_patch_manifest_id": MANIFEST_ID,
+                "config_patch_manifest_schema_version": SCHEMA_VERSION_V1,
+                "candidate_lineage_manifest_schema_version": SCHEMA_VERSION_V1,
+            }
+        )
+
+
+def test_references_from_manifest_rejects_invalid_manifest_id() -> None:
+    manifest = _manifest()
+    manifest.manifest_id = "invalid"
+
+    with pytest.raises(PromotionInputReferencesError, match="must be a UUID"):
+        promotion_input_references_from_manifest(manifest)
+
+
+def test_direct_reference_model_rejects_missing_manifest_id() -> None:
+    with pytest.raises(PromotionInputReferencesError, match="config_patch_manifest_id is required"):
+        validate_proposal_reference_meta_fields(
+            {"config_patch_manifest_schema_version": SCHEMA_VERSION_V1}
+        )

--- a/tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py
+++ b/tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py
@@ -52,11 +52,12 @@ def _write_manifest(path: Path, *, patches: list[ConfigPatch]) -> None:
 
 
 def test_load_patches_requires_manifest_by_default(promotion_cycle, tmp_path: Path) -> None:
-    patches = promotion_cycle._load_patches_for_promotion(
+    result = promotion_cycle._load_patches_for_promotion(
         promotion_input_manifest=None,
         non_canonical_demo_legacy_patches=False,
     )
-    assert patches == []
+    assert result.patches == []
+    assert result.input_references is None
 
 
 def test_load_patches_uses_manifest_loader(promotion_cycle, tmp_path: Path) -> None:
@@ -75,14 +76,17 @@ def test_load_patches_uses_manifest_loader(promotion_cycle, tmp_path: Path) -> N
         ],
     )
 
-    patches = promotion_cycle._load_patches_for_promotion(
+    result = promotion_cycle._load_patches_for_promotion(
         promotion_input_manifest=manifest_path,
         non_canonical_demo_legacy_patches=False,
     )
 
-    assert len(patches) == 1
-    assert patches[0].target == "research.offline.window_days"
-    assert isinstance(patches[0], ConfigPatch)
+    assert len(result.patches) == 1
+    assert result.patches[0].target == "research.offline.window_days"
+    assert isinstance(result.patches[0], ConfigPatch)
+    assert result.input_references is not None
+    assert result.input_references.config_patch_manifest_id == MANIFEST_ID
+    assert result.input_references.candidate_lineage_manifest_ref == LINEAGE_ID
 
 
 def test_load_patches_empty_manifest_returns_empty_list(
@@ -92,12 +96,14 @@ def test_load_patches_empty_manifest_returns_empty_list(
     manifest_path = tmp_path / "empty.json"
     _write_manifest(manifest_path, patches=[])
 
-    patches = promotion_cycle._load_patches_for_promotion(
+    result = promotion_cycle._load_patches_for_promotion(
         promotion_input_manifest=manifest_path,
         non_canonical_demo_legacy_patches=False,
     )
 
-    assert patches == []
+    assert result.patches == []
+    assert result.input_references is not None
+    assert result.input_references.config_patch_manifest_id == MANIFEST_ID
 
 
 def test_demo_json_not_default_without_explicit_legacy_flag(
@@ -121,12 +127,13 @@ def test_demo_json_not_default_without_explicit_legacy_flag(
     )
     monkeypatch.chdir(tmp_path)
 
-    patches = promotion_cycle._load_patches_for_promotion(
+    result = promotion_cycle._load_patches_for_promotion(
         promotion_input_manifest=None,
         non_canonical_demo_legacy_patches=False,
     )
 
-    assert patches == []
+    assert result.patches == []
+    assert result.input_references is None
 
 
 def test_non_canonical_demo_legacy_flag_is_explicit_only(
@@ -152,13 +159,14 @@ def test_non_canonical_demo_legacy_flag_is_explicit_only(
     )
     monkeypatch.chdir(tmp_path)
 
-    patches = promotion_cycle._load_patches_for_promotion(
+    result = promotion_cycle._load_patches_for_promotion(
         promotion_input_manifest=None,
         non_canonical_demo_legacy_patches=True,
     )
 
-    assert len(patches) == 1
-    assert patches[0].id == "demo-legacy-1"
+    assert len(result.patches) == 1
+    assert result.patches[0].id == "demo-legacy-1"
+    assert result.input_references is None
 
 
 def test_invalid_manifest_returns_empty_without_demo_fallback(
@@ -168,9 +176,10 @@ def test_invalid_manifest_returns_empty_without_demo_fallback(
     bad_manifest = tmp_path / "bad.json"
     bad_manifest.write_text("{not-json", encoding="utf-8")
 
-    patches = promotion_cycle._load_patches_for_promotion(
+    result = promotion_cycle._load_patches_for_promotion(
         promotion_input_manifest=bad_manifest,
         non_canonical_demo_legacy_patches=False,
     )
 
-    assert patches == []
+    assert result.patches == []
+    assert result.input_references is None

--- a/tests/scripts/test_run_promotion_proposal_cycle_manifest_lineage_fk_v1.py
+++ b/tests/scripts/test_run_promotion_proposal_cycle_manifest_lineage_fk_v1.py
@@ -1,0 +1,192 @@
+"""Integration tests for Package C manifest lineage FK propagation to proposal artifacts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.governance.promotion_loop import (
+    build_promotion_candidates_from_patches,
+    build_promotion_proposals,
+    materialize_promotion_proposals,
+)
+from src.governance.promotion_loop.models import (
+    DecisionStatus,
+    PromotionCandidate,
+    PromotionDecision,
+)
+from src.governance.promotion_loop.proposal_input_refs_v1 import (
+    apply_promotion_input_references_to_proposal,
+    promotion_input_references_from_manifest,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    build_empty_config_patch_manifest_v1,
+    compute_manifest_integrity,
+    load_promotion_input_from_manifest_path,
+    serialize_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+LINEAGE_ID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+
+
+def _load_promotion_cycle_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "run_promotion_proposal_cycle.py"
+    module_name = "run_promotion_proposal_cycle_lineage_fk_test"
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def promotion_cycle():
+    return _load_promotion_cycle_module()
+
+
+def _write_manifest(path: Path, *, patches: list[ConfigPatch]) -> None:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    manifest.patches = patches
+    manifest.integrity = compute_manifest_integrity(manifest)
+    path.write_text(serialize_config_patch_manifest_v1(manifest), encoding="utf-8")
+
+
+def _accepted_decision(patch: ConfigPatch) -> PromotionDecision:
+    candidate = PromotionCandidate(patch=patch, eligible_for_live=True, tags=["research"])
+    return PromotionDecision(
+        candidate=candidate,
+        status=DecisionStatus.ACCEPTED_FOR_PROPOSAL,
+        reasons=[],
+    )
+
+
+def test_manifest_fk_reaches_proposal_meta_json(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "input.json"
+    patch = ConfigPatch(
+        id="patch-a",
+        target="research.offline.window_days",
+        old_value=30,
+        new_value=45,
+        status=PatchStatus.APPLIED_OFFLINE,
+        confidence_score=0.9,
+    )
+    _write_manifest(manifest_path, patches=[patch])
+
+    promotion_input = load_promotion_input_from_manifest_path(manifest_path)
+    refs = promotion_input_references_from_manifest(promotion_input.manifest)
+    decisions = [_accepted_decision(patch)]
+    proposals = build_promotion_proposals(decisions)
+    assert len(proposals) == 1
+
+    apply_promotion_input_references_to_proposal(proposals[0], refs)
+    written = materialize_promotion_proposals(proposals, tmp_path / "out")
+    meta_path = next(path for path in written if path.name == "proposal_meta.json")
+    payload = json.loads(meta_path.read_text(encoding="utf-8"))
+
+    assert payload["meta"]["config_patch_manifest_id"] == MANIFEST_ID
+    assert payload["meta"]["candidate_lineage_manifest_ref"] == LINEAGE_ID
+    assert "patches" not in payload["meta"]
+    assert "integrity" not in payload["meta"]
+
+
+def test_multiple_patches_share_single_manifest_reference(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "input.json"
+    patches = [
+        ConfigPatch(
+            id="patch-1",
+            target="research.offline.window_days",
+            old_value=30,
+            new_value=45,
+            status=PatchStatus.APPLIED_OFFLINE,
+        ),
+        ConfigPatch(
+            id="patch-2",
+            target="research.offline.holdout_days",
+            old_value=7,
+            new_value=10,
+            status=PatchStatus.APPLIED_OFFLINE,
+        ),
+    ]
+    _write_manifest(manifest_path, patches=patches)
+
+    promotion_input = load_promotion_input_from_manifest_path(manifest_path)
+    refs = promotion_input_references_from_manifest(promotion_input.manifest)
+    decisions = [_accepted_decision(patch) for patch in patches]
+    proposals = build_promotion_proposals(decisions)
+    apply_promotion_input_references_to_proposal(proposals[0], refs)
+
+    written = materialize_promotion_proposals(proposals, tmp_path / "out")
+    meta_path = next(path for path in written if path.name == "proposal_meta.json")
+    patches_path = next(path for path in written if path.name == "config_patches.json")
+    meta_payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    patches_payload = json.loads(patches_path.read_text(encoding="utf-8"))
+
+    assert meta_payload["meta"]["config_patch_manifest_id"] == MANIFEST_ID
+    assert len(patches_payload) == 2
+    assert "manifest_id" not in patches_payload[0]["patch"]
+
+
+def test_empty_manifest_does_not_create_reference_only_proposal(
+    promotion_cycle,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "empty.json"
+    _write_manifest(manifest_path, patches=[])
+
+    load_result = promotion_cycle._load_patches_for_promotion(
+        promotion_input_manifest=manifest_path,
+        non_canonical_demo_legacy_patches=False,
+    )
+    candidates = build_promotion_candidates_from_patches(load_result.patches)
+    proposals = build_promotion_proposals([])
+
+    assert load_result.patches == []
+    assert load_result.input_references is not None
+    assert candidates == []
+    assert proposals == []
+
+
+def test_legacy_demo_path_has_no_manifest_references(
+    promotion_cycle,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    demo_dir = tmp_path / "reports" / "learning_snippets"
+    demo_dir.mkdir(parents=True)
+    demo_path = demo_dir / "demo_patches_for_promotion.json"
+    demo_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "demo-legacy-1",
+                    "target": "research.offline.window_days",
+                    "new_value": 45,
+                    "status": PatchStatus.APPLIED_OFFLINE.value,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    load_result = promotion_cycle._load_patches_for_promotion(
+        promotion_input_manifest=None,
+        non_canonical_demo_legacy_patches=True,
+    )
+
+    assert load_result.input_references is None


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_PACKAGE_C_CONFIGPATCH_MANIFEST_LINEAGE_FK_PROPAGATION_TO_PROMOTION_PROPOSALS_V0`
- Propagate validated `config_patch_manifest_id` and `candidate_lineage_manifest_ref` from ConfigPatch-Manifest v1 into existing `PromotionProposal.meta` / `proposal_meta.json` as reference-only FK fields
- Reuses Package A validators and Package B canonical manifest loader; no promotion engine policy/filter/auto-apply changes

## FK edge closed

`ConfigPatchManifest.manifest_id` + `lineage_manifest_ref` → `PromotionProposal.meta` (reference-only, no payload duplication)

## Non-goals (confirmed)

- `REFERENCE_ONLY_PROPOSAL_PATH_IMPLEMENTED=false` — patch-empty manifests still produce zero proposals
- No Backtest/VaR integration
- No runtime/live/order execution
- Demo JSON not default SSOT; `learning.override.toml` not consumed

## Package A/B reuse

- `ConfigPatchManifestV1`, `load_config_patch_manifest_v1_from_json_path`, `contract_safety_v1`
- `_load_patches_for_promotion` canonical path (extended to retain envelope)
- Existing CI Package B bindings (extended for new testowners)

## Trading-logic immutability

No changes to strategy/signal/sizing/execution/risk/killswitch surfaces. Reference meta validation rejects embedded manifest payloads and forbidden trading-logic tokens.

## Tests

- `tests/governance/promotion_loop/test_proposal_input_refs_v1.py` (11 tests)
- `tests/scripts/test_run_promotion_proposal_cycle_manifest_lineage_fk_v1.py` (4 tests)
- Package B loader/rewire tests updated (6 tests)
- CI selector contract tests updated

**Local focused result:** 23 passed

## CI selection

Expected: `PR_BOUNDED_FULL` with Package B/C testowners:
- `tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py`
- `tests/scripts/test_run_promotion_proposal_cycle_manifest_input_v1.py`
- `tests/scripts/test_run_promotion_proposal_cycle_manifest_lineage_fk_v1.py`
- `tests/governance/promotion_loop/test_proposal_input_refs_v1.py`

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/package_c_configpatch_manifest_lineage_fk_propagation_v0_20260627T120000Z`

`MANIFEST_VERIFY_RC=0`

## Safety counts

- `RUNTIME_ATTEMPT_COUNT=0`
- `ORDER_ATTEMPT_COUNT=0`
- `CANCEL_ATTEMPT_COUNT=0`


Made with [Cursor](https://cursor.com)