### PR TITLE
feat(learning): Package D — offline learning bridge to ConfigPatch-Manifest v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1354,6 +1354,21 @@ PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TARGETS: tuple[str, ...] = (
     "tests/governance/promotion_loop/test_proposal_input_refs_v1.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/manifest_bridge_v1.py",
+        "src/meta/learning_loop/bridge.py",
+        "scripts/run_learning_manifest_bridge_v1.py",
+        "tests/meta/test_learning_manifest_bridge_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_learning_loop_bridge.py",
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_learning_manifest_bridge_v1.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/governance/promotion_loop/candidate_lineage_manifest_v1.py",
@@ -1409,6 +1424,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_TARGETS:
             add(path)
 
     if not targets:
@@ -4548,6 +4567,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
             script_stem = PurePosixPath(path).stem
             if path == "scripts/run_promotion_proposal_cycle.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_learning_manifest_bridge_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_TARGETS:
                     add(candidate)
             for candidate in (
                 f"tests/scripts/test_{script_stem}_load_strategy_v1.py",

--- a/scripts/run_learning_manifest_bridge_v1.py
+++ b/scripts/run_learning_manifest_bridge_v1.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Offline Learning Bridge v1 — explicit snippet input to ConfigPatch-Manifest v1.
+
+Produces a validated, deterministic ConfigPatch-Manifest v1 JSON artifact only.
+No promotion, apply, runtime, or live authority.
+
+Usage:
+    python3 scripts/run_learning_manifest_bridge_v1.py \\
+        --input-path reports/learning_snippets/example.json \\
+        --output-path reports/learning_manifests/example_manifest.json \\
+        --manifest-id 11111111-1111-4111-8111-111111111111 \\
+        --lineage-manifest-ref 22222222-2222-4222-8222-222222222222
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.meta.learning_loop.config_patch_manifest_v1 import ConfigPatchManifestValidationError
+from src.meta.learning_loop.manifest_bridge_v1 import (
+    LearningManifestBridgeError,
+    produce_config_patch_manifest_v1_from_paths,
+)
+
+EXIT_OK = 0
+EXIT_BRIDGE_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def _parse_generated_at(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("generated-at must be an ISO8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Learning Bridge v1: explicit snippet/patch input to "
+            "validated ConfigPatch-Manifest v1 JSON."
+        )
+    )
+    parser.add_argument(
+        "--input-path",
+        type=Path,
+        required=True,
+        help="Explicit offline learning snippet input (.json or .jsonl).",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        required=True,
+        help="Destination path for the validated ConfigPatch-Manifest v1 JSON file.",
+    )
+    parser.add_argument(
+        "--manifest-id",
+        required=True,
+        help="Explicit UUID for the produced ConfigPatch-Manifest v1 manifest_id.",
+    )
+    parser.add_argument(
+        "--lineage-manifest-ref",
+        required=True,
+        help="Explicit UUID lineage_manifest_ref (never invented by the bridge).",
+    )
+    parser.add_argument(
+        "--generated-at",
+        type=_parse_generated_at,
+        default=None,
+        help="Optional ISO8601 timestamp for manifest generated_at (default: UTC now).",
+    )
+    parser.add_argument(
+        "--generated-by",
+        default="package_d_learning_manifest_bridge_v1",
+        help="Optional generated_by label stored in the manifest envelope.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.input_path.is_file():
+        print(
+            f"[learning_manifest_bridge] ERROR: input file not found: {args.input_path}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    try:
+        manifest = produce_config_patch_manifest_v1_from_paths(
+            input_path=args.input_path,
+            output_path=args.output_path,
+            manifest_id=args.manifest_id,
+            lineage_manifest_ref=args.lineage_manifest_ref,
+            generated_at=args.generated_at,
+            generated_by=args.generated_by,
+        )
+    except LearningManifestBridgeError as exc:
+        print(f"[learning_manifest_bridge] ERROR: {exc}", file=sys.stderr)
+        return EXIT_BRIDGE_ERROR
+    except ConfigPatchManifestValidationError as exc:
+        print(f"[learning_manifest_bridge] VALIDATION_ERROR: {exc}", file=sys.stderr)
+        if exc.verdict:
+            print(f"[learning_manifest_bridge] VERDICT={exc.verdict}", file=sys.stderr)
+        return EXIT_BRIDGE_ERROR
+
+    print(
+        "[learning_manifest_bridge] wrote validated ConfigPatch-Manifest v1 to "
+        f"{args.output_path} (manifest_id={manifest.manifest_id}, "
+        f"patches={len(manifest.patches)})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/manifest_bridge_v1.py
+++ b/src/meta/learning_loop/manifest_bridge_v1.py
@@ -1,0 +1,299 @@
+"""Offline Learning Bridge v1 — explicit input to ConfigPatch-Manifest v1 (Package D)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.meta.learning_loop.bridge import RawInput, normalize_patches
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    ConfigPatchManifestError,
+    ConfigPatchManifestV1,
+    ConfigPatchManifestValidationError,
+    build_empty_config_patch_manifest_v1,
+    compute_manifest_integrity,
+    deserialize_config_patch_manifest_v1,
+    patch_from_mapping,
+    serialize_config_patch_manifest_v1,
+    validate_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    SCHEMA_VERSION_V1,
+    canonical_futures_scope_ref,
+    canonical_trading_logic_immutability_ref,
+    is_valid_uuid,
+)
+from src.meta.learning_loop.models import ConfigPatch
+
+
+class LearningManifestBridgeError(ValueError):
+    """Fail-closed Package-D learning manifest bridge error."""
+
+
+def load_learning_input_from_path(path: Path | str) -> RawInput:
+    """Load explicit offline learning input from a JSON or JSONL snippet file."""
+    input_path = Path(path)
+    if not input_path.is_file():
+        raise LearningManifestBridgeError(f"input file not found: {input_path}")
+
+    try:
+        text = input_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise LearningManifestBridgeError(f"failed to read input file: {input_path}") from exc
+
+    suffix = input_path.suffix.lower()
+    if suffix == ".jsonl":
+        rows: list[dict[str, Any]] = []
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise LearningManifestBridgeError(
+                    f"invalid JSONL at {input_path}:{line_number}: {exc.msg}"
+                ) from exc
+            if not isinstance(obj, dict):
+                raise LearningManifestBridgeError(
+                    f"JSONL row must be an object at {input_path}:{line_number}"
+                )
+            rows.append(obj)
+        return rows
+
+    if suffix == ".json":
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise LearningManifestBridgeError(f"invalid JSON in {input_path}: {exc.msg}") from exc
+        if isinstance(payload, dict):
+            return payload
+        if isinstance(payload, list):
+            if not all(isinstance(item, dict) for item in payload):
+                raise LearningManifestBridgeError("JSON array input must contain only objects")
+            return payload
+        raise LearningManifestBridgeError("JSON root must be an object or array of patch objects")
+
+    raise LearningManifestBridgeError(
+        f"unsupported input format {suffix!r}; expected .json or .jsonl"
+    )
+
+
+def _raw_patch_dicts_by_target(
+    raw: RawInput,
+    *,
+    normalized_targets: set[str],
+) -> dict[str, dict[str, Any]]:
+    if not normalized_targets:
+        return {}
+
+    if isinstance(raw, Mapping):
+        if "patches" in raw and isinstance(raw["patches"], list):
+            candidates = [item for item in raw["patches"] if isinstance(item, dict)]
+            if raw["patches"] and not candidates:
+                raise LearningManifestBridgeError("patch entries must be JSON objects")
+        elif "target" in raw:
+            candidates = [dict(raw)]
+        else:
+            candidates = []
+    elif isinstance(raw, list):
+        candidates = [item for item in raw if isinstance(item, dict)]
+        if raw and not candidates:
+            raise LearningManifestBridgeError("patch entries must be JSON objects")
+    else:
+        raise LearningManifestBridgeError("raw input must be a mapping or list of mappings")
+
+    by_target: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        target = candidate.get("target")
+        if not isinstance(target, str):
+            continue
+        key = target.strip()
+        if key not in normalized_targets:
+            continue
+        if key in by_target:
+            raise LearningManifestBridgeError(f"duplicate patch targets in explicit input: [{key}]")
+        by_target[key] = candidate
+
+    missing = sorted(normalized_targets - set(by_target))
+    if missing:
+        raise LearningManifestBridgeError(
+            "explicit input missing required patch envelope fields for normalized targets: "
+            f"{missing}"
+        )
+
+    return by_target
+
+
+def build_config_patches_from_learning_input(raw: RawInput) -> list[ConfigPatch]:
+    """Convert explicit offline input to ConfigPatch objects via normalize_patches."""
+    try:
+        normalized = normalize_patches(raw)
+    except TypeError as exc:
+        raise LearningManifestBridgeError(str(exc)) from exc
+
+    if not normalized:
+        return []
+
+    raw_by_target = _raw_patch_dicts_by_target(
+        raw,
+        normalized_targets={item["target"] for item in normalized},
+    )
+    patches: list[ConfigPatch] = []
+    for norm in sorted(normalized, key=lambda item: item["target"]):
+        raw_patch = raw_by_target[norm["target"]]
+        patch_id = raw_patch.get("id")
+        status = raw_patch.get("status")
+        if not isinstance(patch_id, str) or not patch_id.strip():
+            raise LearningManifestBridgeError(f"patch id is required for target {norm['target']!r}")
+        if status is None:
+            raise LearningManifestBridgeError(
+                f"patch status is required for target {norm['target']!r}"
+            )
+
+        mapping: dict[str, Any] = {
+            "id": patch_id.strip(),
+            "target": norm["target"],
+            "new_value": norm["new_value"],
+            "status": status,
+        }
+        if "old_value" in norm:
+            mapping["old_value"] = norm["old_value"]
+        if "reason" in norm:
+            mapping["reason"] = norm["reason"]
+        if "source_experiment_id" in norm:
+            mapping["source_experiment_id"] = norm["source_experiment_id"]
+        for optional_field in (
+            "generated_at",
+            "applied_at",
+            "promoted_at",
+            "confidence_score",
+            "meta",
+        ):
+            if optional_field in raw_patch:
+                mapping[optional_field] = raw_patch[optional_field]
+
+        try:
+            patches.append(patch_from_mapping(mapping))
+        except ConfigPatchManifestError as exc:
+            raise LearningManifestBridgeError(str(exc)) from exc
+
+    patch_ids = [patch.id for patch in patches]
+    if len(set(patch_ids)) != len(patch_ids):
+        raise LearningManifestBridgeError("duplicate patch id in explicit input")
+
+    return patches
+
+
+def build_config_patch_manifest_v1_from_learning_input(
+    raw: RawInput,
+    *,
+    manifest_id: str,
+    lineage_manifest_ref: str,
+    generated_at: datetime,
+    generated_by: str | None = "package_d_learning_manifest_bridge_v1",
+    metadata: Mapping[str, Any] | None = None,
+) -> ConfigPatchManifestV1:
+    """Build a validated ConfigPatch-Manifest v1 envelope from explicit offline input."""
+    if not isinstance(manifest_id, str) or not is_valid_uuid(manifest_id):
+        raise LearningManifestBridgeError("manifest_id must be a UUID")
+    if not isinstance(lineage_manifest_ref, str) or not is_valid_uuid(lineage_manifest_ref):
+        raise LearningManifestBridgeError("lineage_manifest_ref must be a UUID")
+
+    patches = build_config_patches_from_learning_input(raw)
+    if not patches:
+        manifest = build_empty_config_patch_manifest_v1(
+            manifest_id=manifest_id,
+            generated_at=generated_at,
+            lineage_manifest_ref=lineage_manifest_ref,
+            generated_by=generated_by,
+        )
+    else:
+        manifest = ConfigPatchManifestV1(
+            schema_version=SCHEMA_VERSION_V1,
+            manifest_id=manifest_id,
+            generated_at=generated_at,
+            generated_by=generated_by,
+            lineage_manifest_ref=lineage_manifest_ref,
+            source_scope=canonical_futures_scope_ref(),
+            trading_logic_immutability_ref=canonical_trading_logic_immutability_ref(),
+            patches=patches,
+            metadata=dict(metadata) if metadata is not None else {},
+        )
+        manifest.integrity = compute_manifest_integrity(manifest)
+
+    serialized = serialize_config_patch_manifest_v1(manifest)
+    payload = json.loads(serialized)
+    valid, phase, errors, verdict = validate_config_patch_manifest_v1(payload)
+    if not valid:
+        raise ConfigPatchManifestValidationError(
+            "ConfigPatch-Manifest v1 validation failed during bridge production",
+            phase=phase,
+            errors=errors,
+            verdict=verdict,
+        )
+
+    return deserialize_config_patch_manifest_v1(payload)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(path)
+
+
+def write_config_patch_manifest_v1_atomic(
+    manifest: ConfigPatchManifestV1,
+    output_path: Path | str,
+) -> Path:
+    """Validate, serialize, and atomically write a ConfigPatch-Manifest v1 JSON file."""
+    out = Path(output_path)
+    serialized = serialize_config_patch_manifest_v1(manifest)
+    payload = json.loads(serialized)
+    valid, phase, errors, verdict = validate_config_patch_manifest_v1(payload)
+    if not valid:
+        raise ConfigPatchManifestValidationError(
+            f"refusing to write invalid manifest to {out}",
+            phase=phase,
+            errors=errors,
+            verdict=verdict,
+        )
+
+    _atomic_write_text(out, serialized)
+    return out
+
+
+def produce_config_patch_manifest_v1_from_paths(
+    *,
+    input_path: Path | str,
+    output_path: Path | str,
+    manifest_id: str,
+    lineage_manifest_ref: str,
+    generated_at: datetime | None = None,
+    generated_by: str | None = "package_d_learning_manifest_bridge_v1",
+) -> ConfigPatchManifestV1:
+    """End-to-end offline bridge: explicit snippet file -> validated manifest file."""
+    raw = load_learning_input_from_path(input_path)
+    when = generated_at if generated_at is not None else datetime.now(timezone.utc)
+    manifest = build_config_patch_manifest_v1_from_learning_input(
+        raw,
+        manifest_id=manifest_id,
+        lineage_manifest_ref=lineage_manifest_ref,
+        generated_at=when,
+        generated_by=generated_by,
+    )
+    write_config_patch_manifest_v1_atomic(manifest, output_path)
+    return manifest
+
+
+__all__ = [
+    "LearningManifestBridgeError",
+    "build_config_patch_manifest_v1_from_learning_input",
+    "build_config_patches_from_learning_input",
+    "load_learning_input_from_path",
+    "produce_config_patch_manifest_v1_from_paths",
+    "write_config_patch_manifest_v1_atomic",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5066,3 +5066,49 @@ def test_selector_package_b_combined_diff_pr_bounded_full_includes_required_test
         assert path in bounded
         assert bounded.count(path) == 1
     assert PACKAGE_A_CANDIDATE_LINEAGE_TESTOWNER not in bounded
+
+
+PACKAGE_D_LEARNING_BRIDGE_PRODUCTION = "src/meta/learning_loop/manifest_bridge_v1.py"
+PACKAGE_D_LEARNING_BRIDGE_SCRIPT = "scripts/run_learning_manifest_bridge_v1.py"
+PACKAGE_D_LEARNING_BRIDGE_TESTOWNER = "tests/meta/test_learning_manifest_bridge_v1.py"
+PACKAGE_D_BRIDGE_NORMALIZE_TESTOWNER = "tests/meta/test_learning_loop_bridge.py"
+PACKAGE_D_CONFIG_PATCH_MANIFEST_TESTOWNER = "tests/meta/test_config_patch_manifest_v1_contract.py"
+PACKAGE_D_ALL_PRODUCTION = (
+    PACKAGE_D_LEARNING_BRIDGE_PRODUCTION,
+    PACKAGE_D_LEARNING_BRIDGE_SCRIPT,
+    "src/meta/learning_loop/bridge.py",
+)
+PACKAGE_D_ALL_TESTOWNERS = (
+    PACKAGE_D_BRIDGE_NORMALIZE_TESTOWNER,
+    PACKAGE_D_CONFIG_PATCH_MANIFEST_TESTOWNER,
+    PACKAGE_D_LEARNING_BRIDGE_TESTOWNER,
+)
+
+
+def test_selector_package_d_learning_bridge_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_D_LEARNING_BRIDGE_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_D_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_d_script_contract_focused_includes_bridge_testowners() -> None:
+    sel = _run_selector(PACKAGE_D_LEARNING_BRIDGE_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    for path in PACKAGE_D_ALL_TESTOWNERS:
+        assert path in targets
+
+
+def test_selector_package_d_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+    sel = _run_selector(
+        *PACKAGE_D_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_D_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_D_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/meta/test_learning_manifest_bridge_v1.py
+++ b/tests/meta/test_learning_manifest_bridge_v1.py
@@ -1,0 +1,371 @@
+"""Tests for Package D offline learning manifest bridge v1."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.generate_demo_patches_for_promotion import build_demo_patches
+from scripts.run_learning_manifest_bridge_v1 import (
+    EXIT_BRIDGE_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    ConfigPatchManifestValidationError,
+    load_config_patch_manifest_v1_from_json_path,
+    validate_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+)
+from src.meta.learning_loop.manifest_bridge_v1 import (
+    LearningManifestBridgeError,
+    build_config_patch_manifest_v1_from_learning_input,
+    build_config_patches_from_learning_input,
+    load_learning_input_from_path,
+    produce_config_patch_manifest_v1_from_paths,
+    write_config_patch_manifest_v1_atomic,
+)
+from src.meta.learning_loop.models import PatchStatus
+
+
+FIXED_NOW = datetime(2026, 6, 27, 14, 0, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "11111111-1111-4111-8111-111111111111"
+LINEAGE_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _valid_patch_payload() -> dict:
+    return {
+        "patches": [
+            {
+                "id": "patch-1",
+                "target": "research.offline.window_days",
+                "old_value": 30,
+                "new_value": 45,
+                "status": PatchStatus.APPLIED_OFFLINE.value,
+                "reason": "offline bridge test",
+                "source_experiment_id": "exp-bridge-1",
+            }
+        ]
+    }
+
+
+def test_build_manifest_from_explicit_input_uses_normalize_patches() -> None:
+    raw = _valid_patch_payload()
+    with patch(
+        "src.meta.learning_loop.manifest_bridge_v1.normalize_patches",
+        wraps=__import__(
+            "src.meta.learning_loop.bridge", fromlist=["normalize_patches"]
+        ).normalize_patches,
+    ) as normalize_mock:
+        manifest = build_config_patch_manifest_v1_from_learning_input(
+            raw,
+            manifest_id=MANIFEST_ID,
+            lineage_manifest_ref=LINEAGE_ID,
+            generated_at=FIXED_NOW,
+        )
+        assert normalize_mock.call_count >= 1
+        assert normalize_mock.call_args_list[0].args[0] == raw
+
+    assert manifest.manifest_id == MANIFEST_ID
+    assert manifest.lineage_manifest_ref == LINEAGE_ID
+    assert len(manifest.patches) == 1
+    assert manifest.patches[0].target == "research.offline.window_days"
+
+
+def test_deterministic_json_roundtrip_and_package_a_validation(tmp_path: Path) -> None:
+    raw = _valid_patch_payload()
+    manifest = build_config_patch_manifest_v1_from_learning_input(
+        raw,
+        manifest_id=MANIFEST_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+    out = tmp_path / "manifest.json"
+    write_config_patch_manifest_v1_atomic(manifest, out)
+    loaded = load_config_patch_manifest_v1_from_json_path(out)
+    assert loaded.manifest_id == MANIFEST_ID
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    valid, phase, errors, _ = validate_config_patch_manifest_v1(payload)
+    assert valid is True, (phase, errors)
+
+
+def test_empty_input_produces_valid_patch_empty_manifest() -> None:
+    manifest = build_config_patch_manifest_v1_from_learning_input(
+        {"patches": []},
+        manifest_id=MANIFEST_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+    assert manifest.patches == []
+    payload = json.loads(
+        __import__(
+            "src.meta.learning_loop.config_patch_manifest_v1",
+            fromlist=["serialize_config_patch_manifest_v1"],
+        ).serialize_config_patch_manifest_v1(manifest)
+    )
+    valid, _, errors, _ = validate_config_patch_manifest_v1(payload)
+    assert valid is True, errors
+
+
+def test_lineage_manifest_ref_preserved_unchanged() -> None:
+    manifest = build_config_patch_manifest_v1_from_learning_input(
+        _valid_patch_payload(),
+        manifest_id=MANIFEST_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+    assert manifest.lineage_manifest_ref == LINEAGE_ID
+
+
+def test_cli_produces_validated_manifest_file(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.json"
+    output_path = tmp_path / "output.json"
+    input_path.write_text(json.dumps(_valid_patch_payload()) + "\n", encoding="utf-8")
+
+    rc = main(
+        [
+            "--input-path",
+            str(input_path),
+            "--output-path",
+            str(output_path),
+            "--manifest-id",
+            MANIFEST_ID,
+            "--lineage-manifest-ref",
+            LINEAGE_ID,
+            "--generated-at",
+            FIXED_NOW.isoformat(),
+        ]
+    )
+    assert rc == EXIT_OK
+    loaded = load_config_patch_manifest_v1_from_json_path(output_path)
+    assert loaded.manifest_id == MANIFEST_ID
+    assert loaded.lineage_manifest_ref == LINEAGE_ID
+
+
+def test_jsonl_input_supported(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.jsonl"
+    patch = _valid_patch_payload()["patches"][0]
+    input_path.write_text(json.dumps(patch) + "\n", encoding="utf-8")
+    raw = load_learning_input_from_path(input_path)
+    patches = build_config_patches_from_learning_input(raw)
+    assert len(patches) == 1
+
+
+def test_invalid_json_rejected(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(LearningManifestBridgeError, match="invalid JSON"):
+        load_learning_input_from_path(bad)
+
+
+def test_missing_patch_id_rejected() -> None:
+    raw = {
+        "patches": [
+            {
+                "target": "research.offline.window_days",
+                "new_value": 45,
+                "status": PatchStatus.APPLIED_OFFLINE.value,
+            }
+        ]
+    }
+    with pytest.raises(LearningManifestBridgeError, match="patch id is required"):
+        build_config_patches_from_learning_input(raw)
+
+
+def test_missing_patch_status_rejected() -> None:
+    raw = {
+        "patches": [
+            {
+                "id": "patch-1",
+                "target": "research.offline.window_days",
+                "new_value": 45,
+            }
+        ]
+    }
+    with pytest.raises(LearningManifestBridgeError, match="patch status is required"):
+        build_config_patches_from_learning_input(raw)
+
+
+def test_duplicate_patch_id_rejected() -> None:
+    raw = {
+        "patches": [
+            {
+                "id": "dup",
+                "target": "research.offline.window_days",
+                "new_value": 45,
+                "status": PatchStatus.APPLIED_OFFLINE.value,
+            },
+            {
+                "id": "dup",
+                "target": "research.offline.other_field",
+                "new_value": 1,
+                "status": PatchStatus.APPLIED_OFFLINE.value,
+            },
+        ]
+    }
+    with pytest.raises(LearningManifestBridgeError, match="duplicate patch id"):
+        build_config_patches_from_learning_input(raw)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "master_v2.config",
+        "double_play.lane",
+        "strategy.trigger_delay",
+        "portfolio.leverage",
+        "risk.stop_loss",
+        "execution.routing.mode",
+        "killswitch.enabled",
+    ],
+)
+def test_forbidden_trading_logic_targets_rejected(target: str) -> None:
+    raw = {
+        "patches": [
+            {
+                "id": "patch-forbidden",
+                "target": target,
+                "new_value": 1,
+                "status": PatchStatus.APPLIED_OFFLINE.value,
+            }
+        ]
+    }
+    with pytest.raises(ConfigPatchManifestValidationError) as exc:
+        build_config_patch_manifest_v1_from_learning_input(
+            raw,
+            manifest_id=MANIFEST_ID,
+            lineage_manifest_ref=LINEAGE_ID,
+            generated_at=FIXED_NOW,
+        )
+    assert exc.value.verdict == VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION
+
+
+def test_demo_patches_remain_fail_closed_regression() -> None:
+    from src.meta.learning_loop.config_patch_manifest_v1 import patch_to_mapping
+
+    demo_patches = build_demo_patches(variant="diverse", base_confidence=0.85)
+    raw = {"patches": [patch_to_mapping(demo_patches[0])]}
+    with pytest.raises(ConfigPatchManifestValidationError) as exc:
+        build_config_patch_manifest_v1_from_learning_input(
+            raw,
+            manifest_id=MANIFEST_ID,
+            lineage_manifest_ref=LINEAGE_ID,
+            generated_at=FIXED_NOW,
+        )
+    assert exc.value.verdict == VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION
+
+
+def test_invalid_lineage_reference_rejected() -> None:
+    with pytest.raises(LearningManifestBridgeError, match="lineage_manifest_ref must be a UUID"):
+        build_config_patch_manifest_v1_from_learning_input(
+            _valid_patch_payload(),
+            manifest_id=MANIFEST_ID,
+            lineage_manifest_ref="not-a-uuid",
+            generated_at=FIXED_NOW,
+        )
+
+
+def test_invalid_manifest_id_rejected() -> None:
+    with pytest.raises(LearningManifestBridgeError, match="manifest_id must be a UUID"):
+        build_config_patch_manifest_v1_from_learning_input(
+            _valid_patch_payload(),
+            manifest_id="bad-id",
+            lineage_manifest_ref=LINEAGE_ID,
+            generated_at=FIXED_NOW,
+        )
+
+
+def test_no_partial_output_on_validation_failure(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.json"
+    output_path = tmp_path / "output.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "patches": [
+                    {
+                        "id": "patch-1",
+                        "target": "strategy.trigger_delay",
+                        "new_value": 1,
+                        "status": PatchStatus.APPLIED_OFFLINE.value,
+                    }
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigPatchManifestValidationError):
+        produce_config_patch_manifest_v1_from_paths(
+            input_path=input_path,
+            output_path=output_path,
+            manifest_id=MANIFEST_ID,
+            lineage_manifest_ref=LINEAGE_ID,
+            generated_at=FIXED_NOW,
+        )
+    assert not output_path.exists()
+
+
+def test_cli_missing_input_path_is_usage_error(tmp_path: Path) -> None:
+    rc = main(
+        [
+            "--input-path",
+            str(tmp_path / "missing.json"),
+            "--output-path",
+            str(tmp_path / "out.json"),
+            "--manifest-id",
+            MANIFEST_ID,
+            "--lineage-manifest-ref",
+            LINEAGE_ID,
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_unknown_patch_status_rejected() -> None:
+    raw = {
+        "patches": [
+            {
+                "id": "patch-1",
+                "target": "research.offline.window_days",
+                "new_value": 45,
+                "status": "NOT_A_STATUS",
+            }
+        ]
+    }
+    with pytest.raises(LearningManifestBridgeError, match="unknown PatchStatus"):
+        build_config_patches_from_learning_input(raw)
+
+
+def test_emit_learning_snippet_optional_adapter_only(tmp_path: Path) -> None:
+    """emit_learning_snippet is optional; bridge reads explicit files directly."""
+    from src.meta.learning_loop.emitter import emit_learning_snippet
+
+    snippet_path = tmp_path / "snippet.json"
+    emit_learning_snippet(_valid_patch_payload(), out_path=snippet_path)
+    manifest = produce_config_patch_manifest_v1_from_paths(
+        input_path=snippet_path,
+        output_path=tmp_path / "manifest.json",
+        manifest_id=MANIFEST_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+    assert manifest.patches[0].id == "patch-1"
+
+
+def test_manifest_ids_must_be_unique_per_call() -> None:
+    manifest = build_config_patch_manifest_v1_from_learning_input(
+        _valid_patch_payload(),
+        manifest_id=str(uuid.uuid4()),
+        lineage_manifest_ref=str(uuid.uuid4()),
+        generated_at=FIXED_NOW,
+    )
+    assert manifest.manifest_id != manifest.lineage_manifest_ref


### PR DESCRIPTION
## Summary

- Adds an explicit-input offline learning bridge (`manifest_bridge_v1` + CLI) that converts learning snippet / patch JSON into validated **ConfigPatch-Manifest v1** artifacts via existing `normalize_patches` and Package-A validators.
- Closes the upstream GAP-002 edge (Schicht 3→4) without domain producers, promotion execution, apply cycle, runtime, or trading-logic changes.
- Binds Package-D testowners in the CI selector (`PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_*`).

**GO_TOKEN:** `GO_PACKAGE_D_OFFLINE_LEARNING_BRIDGE_TO_CONFIGPATCH_MANIFEST_V1_V0`

## Scope

- `src/meta/learning_loop/manifest_bridge_v1.py` — library: explicit input → `normalize_patches` → `ConfigPatch[]` → manifest production + atomic write
- `scripts/run_learning_manifest_bridge_v1.py` — CLI with required `--input-path`, `--output-path`, `--manifest-id`, `--lineage-manifest-ref`
- `tests/meta/test_learning_manifest_bridge_v1.py` — positive/negative contract tests
- Minimal CI selector bindings + contract tests

## Non-Goals

- No domain producers (TestHealth/Trigger/Macro/Backtest)
- No promotion loader/engine/proposal changes
- No apply cycle / `learning.override.toml` output
- No Backtest/VaR/runtime integration
- No reference-only proposal semantics
- No trading-logic, strategy, signal, sizing, execution, risk, or killswitch changes

## Reuse

- `normalize_patches` (direct call)
- Package-A `patch_from_mapping`, `validate_config_patch_manifest_v1`, `serialize_config_patch_manifest_v1`
- `emit_learning_snippet` optional only (pre-write adapter; not required in canonical path)

## Upstream call graph

```text
explicit .json/.jsonl input
  -> load_learning_input_from_path
  -> normalize_patches
  -> patch_from_mapping (explicit id/status required)
  -> build_config_patch_manifest_v1_from_learning_input
  -> validate_config_patch_manifest_v1
  -> write_config_patch_manifest_v1_atomic
```

Downstream unchanged: Package B loader → Package C FK propagation → promotion (manual_only default).

## Apply / Promotion separation

- No imports from promotion engine/loader
- No calls to `run_promotion_proposal_cycle.py` or `run_learning_apply_cycle.py`
- Only output: validated ConfigPatch-Manifest v1 JSON

## Trading-Logic-Immutability proof

- All patches pass Package-A target policy; forbidden targets fail-closed
- Negative tests: master_v2, double_play, strategy, portfolio.leverage, risk.stop_loss, execution, killswitch
- Demo patch regression rejects trading-logic targets
- Protected trading-logic files untouched

## Tests

- 33 focused tests passed locally (Package D + A/B/C regressions + selector contracts)
- `ruff format --check` / `ruff check` PASS

## CI selection

- `PR_BOUNDED_FULL` with Package-D testowners:
  - `tests/meta/test_learning_manifest_bridge_v1.py`
  - `tests/meta/test_learning_loop_bridge.py`
  - `tests/meta/test_config_patch_manifest_v1_contract.py`

## Durable bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/package_d_offline_learning_bridge_configpatch_manifest_v1_20260627T051916Z`

`MANIFEST_VERIFY_RC=0`

## Safety counts

- `RUNTIME_ATTEMPT_COUNT=0`
- `ORDER_ATTEMPT_COUNT=0`
- `CANCEL_ATTEMPT_COUNT=0`
- `DOMAIN_PRODUCERS_IMPLEMENTED=false`


Made with [Cursor](https://cursor.com)