### PR TITLE
test(governance): Package E — GAP-007 promotion-loop testowner closeout

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1380,6 +1380,28 @@ PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TARGETS: tuple[str, ...] = (
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/governance/promotion_loop/engine.py",
+        "src/governance/promotion_loop/safety.py",
+        "src/governance/promotion_loop/policy.py",
+        "tests/governance/promotion_loop/test_engine_manifest_era_v1.py",
+        "tests/governance/promotion_loop/test_safety_manifest_era_v1.py",
+        "tests/governance/promotion_loop/test_policy_manifest_era_v1.py",
+        "tests/scripts/test_offline_learning_promotion_e2e_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_TARGETS: tuple[str, ...] = (
+    "tests/governance/promotion_loop/test_engine_manifest_era_v1.py",
+    "tests/governance/promotion_loop/test_safety_manifest_era_v1.py",
+    "tests/governance/promotion_loop/test_policy_manifest_era_v1.py",
+    "tests/scripts/test_offline_learning_promotion_e2e_v1.py",
+    "tests/meta/test_config_patch_manifest_v1_promotion_input_loader_v1.py",
+    "tests/governance/promotion_loop/test_proposal_input_refs_v1.py",
+    "tests/meta/test_learning_manifest_bridge_v1.py",
+)
+
 
 def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
     """Conservative, deterministic PR_BOUNDED_FULL pytest targets (3.11 main lane)."""
@@ -1428,6 +1450,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_TARGETS:
             add(path)
 
     if not targets:

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5112,3 +5112,45 @@ def test_selector_package_d_combined_diff_pr_bounded_full_includes_all_testowner
     for path in PACKAGE_D_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_E_ENGINE_PRODUCTION = "src/governance/promotion_loop/engine.py"
+PACKAGE_E_SAFETY_PRODUCTION = "src/governance/promotion_loop/safety.py"
+PACKAGE_E_POLICY_PRODUCTION = "src/governance/promotion_loop/policy.py"
+PACKAGE_E_ENGINE_TESTOWNER = "tests/governance/promotion_loop/test_engine_manifest_era_v1.py"
+PACKAGE_E_SAFETY_TESTOWNER = "tests/governance/promotion_loop/test_safety_manifest_era_v1.py"
+PACKAGE_E_POLICY_TESTOWNER = "tests/governance/promotion_loop/test_policy_manifest_era_v1.py"
+PACKAGE_E_E2E_TESTOWNER = "tests/scripts/test_offline_learning_promotion_e2e_v1.py"
+PACKAGE_E_ALL_PRODUCTION = (
+    PACKAGE_E_ENGINE_PRODUCTION,
+    PACKAGE_E_SAFETY_PRODUCTION,
+    PACKAGE_E_POLICY_PRODUCTION,
+)
+PACKAGE_E_ALL_TESTOWNERS = (
+    PACKAGE_E_ENGINE_TESTOWNER,
+    PACKAGE_E_SAFETY_TESTOWNER,
+    PACKAGE_E_POLICY_TESTOWNER,
+    PACKAGE_E_E2E_TESTOWNER,
+)
+
+
+def test_selector_package_e_engine_pr_bounded_full_includes_governance_testowners() -> None:
+    sel = _run_selector(PACKAGE_E_ENGINE_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_E_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_e_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+    sel = _run_selector(
+        *PACKAGE_E_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_E_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_E_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+    assert PACKAGE_E_E2E_TESTOWNER in bounded

--- a/tests/governance/promotion_loop/test_engine_manifest_era_v1.py
+++ b/tests/governance/promotion_loop/test_engine_manifest_era_v1.py
@@ -1,0 +1,167 @@
+"""Dedicated engine characterization tests for manifest-era offline promotion (GAP-007)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.governance.promotion_loop import (
+    build_promotion_candidates_from_patches,
+    build_promotion_proposals,
+    materialize_promotion_proposals,
+)
+from src.governance.promotion_loop.models import (
+    DecisionStatus,
+    PromotionCandidate,
+    PromotionDecision,
+)
+from src.governance.promotion_loop.proposal_input_refs_v1 import (
+    apply_promotion_input_references_to_proposal,
+    promotion_input_references_from_manifest,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    build_empty_config_patch_manifest_v1,
+    compute_manifest_integrity,
+    load_promotion_input_from_manifest_path,
+    serialize_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+FIXED_NOW = datetime(2026, 6, 27, 15, 0, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+LINEAGE_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+
+def _immutability_compliant_patch(*, patch_id: str = "patch-engine-1") -> ConfigPatch:
+    return ConfigPatch(
+        id=patch_id,
+        target="research.offline.window_days",
+        old_value=30,
+        new_value=45,
+        status=PatchStatus.APPLIED_OFFLINE,
+        generated_at=FIXED_NOW,
+        confidence_score=0.92,
+        source_experiment_id="exp-engine-1",
+    )
+
+
+def _write_manifest(path: Path, *, patches: list[ConfigPatch]) -> None:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    manifest.patches = patches
+    manifest.integrity = compute_manifest_integrity(manifest)
+    path.write_text(serialize_config_patch_manifest_v1(manifest), encoding="utf-8")
+
+
+def test_build_candidates_only_includes_applied_offline_or_promoted() -> None:
+    patches = [
+        _immutability_compliant_patch(patch_id="applied"),
+        ConfigPatch(
+            id="proposed",
+            target="research.offline.feature_flag",
+            old_value=False,
+            new_value=True,
+            status=PatchStatus.PROPOSED,
+        ),
+        ConfigPatch(
+            id="rejected",
+            target="research.offline.other_flag",
+            old_value=True,
+            new_value=False,
+            status=PatchStatus.REJECTED,
+        ),
+    ]
+    candidates = build_promotion_candidates_from_patches(patches)
+    assert [c.patch.id for c in candidates] == ["applied"]
+
+
+def test_build_candidates_default_ineligible_and_tag_heuristics_unchanged() -> None:
+    patch = _immutability_compliant_patch()
+    candidates = build_promotion_candidates_from_patches([patch])
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.eligible_for_live is False
+    assert candidate.patch.target == patch.target
+    assert candidate.patch.new_value == patch.new_value
+    assert "trigger" not in candidate.tags
+
+
+def test_manifest_fk_refs_do_not_change_candidate_count(tmp_path: Path) -> None:
+    patch = _immutability_compliant_patch()
+    manifest_path = tmp_path / "input.json"
+    _write_manifest(manifest_path, patches=[patch])
+
+    direct_candidates = build_promotion_candidates_from_patches([patch])
+    loaded = load_promotion_input_from_manifest_path(manifest_path)
+    manifest_candidates = build_promotion_candidates_from_patches(loaded.patches)
+    refs = promotion_input_references_from_manifest(loaded.manifest)
+
+    assert len(manifest_candidates) == len(direct_candidates)
+    assert refs.config_patch_manifest_id == MANIFEST_ID
+    assert refs.candidate_lineage_manifest_ref == LINEAGE_ID
+
+
+def test_build_proposals_returns_empty_without_accepted_decisions() -> None:
+    patch = _immutability_compliant_patch()
+    candidate = PromotionCandidate(patch=patch, eligible_for_live=False)
+    decision = PromotionDecision(
+        candidate=candidate,
+        status=DecisionStatus.REJECTED_BY_POLICY,
+        reasons=["candidate not marked as eligible_for_live"],
+    )
+    assert build_promotion_proposals([decision]) == []
+
+
+def test_materialize_proposal_meta_carries_fk_refs_without_payload_duplication(
+    tmp_path: Path,
+) -> None:
+    patch = _immutability_compliant_patch()
+    manifest_path = tmp_path / "input.json"
+    _write_manifest(manifest_path, patches=[patch])
+    loaded = load_promotion_input_from_manifest_path(manifest_path)
+    refs = promotion_input_references_from_manifest(loaded.manifest)
+
+    candidate = PromotionCandidate(patch=patch, eligible_for_live=True, tags=["research"])
+    decision = PromotionDecision(
+        candidate=candidate,
+        status=DecisionStatus.ACCEPTED_FOR_PROPOSAL,
+        reasons=[],
+    )
+    proposals = build_promotion_proposals([decision], proposal_id_prefix="offline_promotion_test")
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    apply_promotion_input_references_to_proposal(proposal, refs)
+
+    output_dir = tmp_path / "proposals"
+    materialize_promotion_proposals(proposals, output_dir)
+
+    meta_path = output_dir / proposal.proposal_id / "proposal_meta.json"
+    meta_payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta_fields = meta_payload["meta"]
+    assert meta_fields["config_patch_manifest_id"] == MANIFEST_ID
+    assert meta_fields["candidate_lineage_manifest_ref"] == LINEAGE_ID
+    forbidden = {
+        "patches",
+        "manifest",
+        "lineage_manifest",
+        "config_patch_manifest",
+        "candidate_lineage_manifest",
+        "integrity",
+    }
+    assert forbidden.isdisjoint(meta_fields.keys())
+
+
+def test_patch_empty_manifest_yields_zero_candidates_and_zero_proposals(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "empty.json"
+    _write_manifest(manifest_path, patches=[])
+    loaded = load_promotion_input_from_manifest_path(manifest_path)
+    candidates = build_promotion_candidates_from_patches(loaded.patches)
+    assert candidates == []
+    assert build_promotion_proposals([]) == []

--- a/tests/governance/promotion_loop/test_policy_manifest_era_v1.py
+++ b/tests/governance/promotion_loop/test_policy_manifest_era_v1.py
@@ -1,0 +1,85 @@
+"""Dedicated policy characterization tests for manifest-era offline promotion (GAP-007)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.governance.promotion_loop.engine import apply_proposals_to_live_overrides
+from src.governance.promotion_loop.models import (
+    DecisionStatus,
+    PromotionCandidate,
+    PromotionDecision,
+    PromotionProposal,
+)
+from src.governance.promotion_loop.policy import AutoApplyBounds, AutoApplyPolicy
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+def _accepted_proposal(*, target: str = "research.offline.window_days") -> PromotionProposal:
+    patch = ConfigPatch(
+        id="patch-policy-1",
+        target=target,
+        old_value=30,
+        new_value=45,
+        status=PatchStatus.APPLIED_OFFLINE,
+    )
+    candidate = PromotionCandidate(patch=patch, eligible_for_live=True, tags=["research"])
+    decision = PromotionDecision(
+        candidate=candidate,
+        status=DecisionStatus.ACCEPTED_FOR_PROPOSAL,
+        reasons=[],
+    )
+    return PromotionProposal(
+        proposal_id="offline_policy_test_001",
+        title="test",
+        description="test",
+        decisions=[decision],
+        meta={},
+    )
+
+
+def test_auto_apply_policy_default_is_manual_only() -> None:
+    policy = AutoApplyPolicy()
+    assert policy.mode == "manual_only"
+    assert policy.is_bounded_auto() is False
+
+
+def test_is_bounded_auto_only_for_bounded_auto_mode() -> None:
+    assert AutoApplyPolicy(mode="disabled").is_bounded_auto() is False
+    assert AutoApplyPolicy(mode="manual_only").is_bounded_auto() is False
+    assert AutoApplyPolicy(mode="bounded_auto").is_bounded_auto() is True
+
+
+def test_apply_proposals_returns_none_for_manual_only(tmp_path: Path) -> None:
+    proposal = _accepted_proposal()
+    live_path = tmp_path / "config" / "live_overrides" / "auto.toml"
+    result = apply_proposals_to_live_overrides(
+        [proposal],
+        policy=AutoApplyPolicy(mode="manual_only"),
+        live_override_path=live_path,
+    )
+    assert result is None
+    assert not live_path.exists()
+
+
+def test_apply_proposals_returns_none_for_disabled_mode(tmp_path: Path) -> None:
+    proposal = _accepted_proposal()
+    live_path = tmp_path / "auto.toml"
+    result = apply_proposals_to_live_overrides(
+        [proposal],
+        policy=AutoApplyPolicy(mode="disabled"),
+        live_override_path=live_path,
+    )
+    assert result is None
+    assert not live_path.exists()
+
+
+def test_bounded_auto_policy_retains_existing_bounds_fields() -> None:
+    policy = AutoApplyPolicy(
+        mode="bounded_auto",
+        leverage_bounds=AutoApplyBounds(min_value=1.0, max_value=2.0, max_step=0.25),
+        trigger_delay_bounds=AutoApplyBounds(min_value=3.0, max_value=15.0, max_step=2.0),
+        macro_weight_bounds=AutoApplyBounds(min_value=0.0, max_value=0.8, max_step=0.1),
+    )
+    assert policy.leverage_bounds is not None
+    assert policy.leverage_bounds.max_value == 2.0

--- a/tests/governance/promotion_loop/test_safety_manifest_era_v1.py
+++ b/tests/governance/promotion_loop/test_safety_manifest_era_v1.py
@@ -1,0 +1,259 @@
+"""Dedicated safety characterization tests for manifest-era offline promotion (GAP-007)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.governance.promotion_loop import filter_candidates_for_live
+from src.governance.promotion_loop.models import DecisionStatus, PromotionCandidate
+from src.governance.promotion_loop.policy import AutoApplyBounds
+from src.governance.promotion_loop.safety import (
+    SafetyConfig,
+    apply_safety_filters,
+    check_blacklist,
+    check_bounded_auto_guardrails,
+    check_global_promotion_lock,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    build_empty_config_patch_manifest_v1,
+    compute_manifest_integrity,
+    load_promotion_input_from_manifest_path,
+    manifest_to_canonical_dict,
+    serialize_config_patch_manifest_v1,
+    validate_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+    VERDICT_TARGET_NOT_ALLOWED,
+    canonical_futures_scope_ref,
+    canonical_trading_logic_immutability_ref,
+)
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+
+FIXED_NOW = datetime(2026, 6, 27, 15, 30, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+LINEAGE_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+
+
+def _candidate(
+    *,
+    target: str = "research.offline.window_days",
+    new_value: object = 45,
+    eligible: bool = True,
+    confidence: float | None = 0.9,
+    tags: list[str] | None = None,
+) -> PromotionCandidate:
+    patch = ConfigPatch(
+        id="patch-safety-1",
+        target=target,
+        old_value=30,
+        new_value=new_value,
+        status=PatchStatus.APPLIED_OFFLINE,
+        confidence_score=confidence,
+    )
+    return PromotionCandidate(
+        patch=patch,
+        eligible_for_live=eligible,
+        tags=tags or ["research"],
+    )
+
+
+def test_filter_rejects_candidates_not_eligible_for_live() -> None:
+    candidate = _candidate(eligible=False)
+    decisions = filter_candidates_for_live([candidate], safety_config=None, mode="manual_only")
+    assert len(decisions) == 1
+    assert decisions[0].status is DecisionStatus.REJECTED_BY_POLICY
+
+
+def test_blacklist_target_adds_p0_flag() -> None:
+    config = SafetyConfig(blacklist_targets=["live.api_keys"])
+    candidate = _candidate(target="live.api_keys.binance")
+    violations = check_blacklist(candidate, config)
+    assert violations
+    apply_safety_filters(candidate, config, mode="manual_only")
+    assert any(flag.startswith("P0_BLACKLIST") for flag in candidate.safety_flags)
+
+
+def test_bounded_auto_guardrails_only_apply_in_bounded_auto_mode() -> None:
+    config = SafetyConfig(global_promotion_lock=True, min_confidence_for_auto_apply=0.95)
+    candidate = _candidate(confidence=0.5)
+    manual_violations = check_bounded_auto_guardrails(candidate, config, mode="manual_only")
+    bounded_violations = check_bounded_auto_guardrails(candidate, config, mode="bounded_auto")
+    assert manual_violations == []
+    assert bounded_violations
+
+
+def test_global_promotion_lock_warning_is_non_blocking_for_manual_only() -> None:
+    config = SafetyConfig(global_promotion_lock=True)
+    warning = check_global_promotion_lock(config)
+    assert warning is not None
+    candidate = _candidate(eligible=True)
+    decisions = filter_candidates_for_live([candidate], safety_config=config, mode="manual_only")
+    assert decisions[0].status is DecisionStatus.ACCEPTED_FOR_PROPOSAL
+
+
+def test_bounds_violation_characterization() -> None:
+    config = SafetyConfig(
+        bounds={
+            "research": AutoApplyBounds(min_value=10.0, max_value=40.0, max_step=5.0),
+        }
+    )
+    candidate = _candidate(new_value=50.0, tags=["research"])
+    apply_safety_filters(candidate, config, mode="bounded_auto")
+    assert any(flag.startswith("P0_BOUNDS") for flag in candidate.safety_flags)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "master_v2.config",
+        "double_play.slot",
+        "strategy.selection.mode",
+        "signal.generation.threshold",
+        "entry.logic.window",
+        "exit.logic.window",
+        "sizing.position.max",
+        "portfolio.leverage",
+        "stop_loss.default",
+        "take_profit.default",
+        "execution.routing.default",
+        "orders.routing.primary",
+        "risk.limits.max_drawdown",
+        "killswitch.enabled",
+        "live.arming.enabled",
+    ],
+)
+def test_forbidden_targets_fail_manifest_validation(target: str) -> None:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    manifest.patches = [
+        ConfigPatch(
+            id="patch-negative",
+            target=target,
+            old_value=0,
+            new_value=1,
+            status=PatchStatus.APPLIED_OFFLINE,
+        )
+    ]
+    manifest.integrity = compute_manifest_integrity(manifest)
+    payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+    valid, _, errors, verdict = validate_config_patch_manifest_v1(payload)
+    assert valid is False, (target, errors, verdict)
+    assert verdict in {
+        VERDICT_FAIL_CLOSED_TRADING_LOGIC_BOUNDARY_VIOLATION,
+        VERDICT_TARGET_NOT_ALLOWED,
+    }
+
+
+def test_btc_and_spot_patch_targets_not_individually_blocked_at_target_policy() -> None:
+    """Characterization: BTC/spot prohibition is enforced via source_scope, not patch target."""
+    for target in (
+        "btc.futures.direction",
+        "xbt.spot.enabled",
+        "bitcoin.direction.allowed",
+        "spot.market.enabled",
+    ):
+        manifest = build_empty_config_patch_manifest_v1(
+            manifest_id=MANIFEST_ID,
+            generated_at=FIXED_NOW,
+            lineage_manifest_ref=LINEAGE_ID,
+        )
+        manifest.patches = [
+            ConfigPatch(
+                id=f"patch-{target}",
+                target=target,
+                old_value=False,
+                new_value=True,
+                status=PatchStatus.APPLIED_OFFLINE,
+            )
+        ]
+        manifest.integrity = compute_manifest_integrity(manifest)
+        payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+        valid, _, _, _ = validate_config_patch_manifest_v1(payload)
+        assert valid is True, target
+
+
+def test_non_forbidden_unknown_target_currently_allowed_by_contract() -> None:
+    """Characterization: only forbidden-prefix targets are fail-closed today."""
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    manifest.patches = [
+        ConfigPatch(
+            id="patch-unknown-allowed",
+            target="experimental.config.flag",
+            old_value=False,
+            new_value=True,
+            status=PatchStatus.APPLIED_OFFLINE,
+        )
+    ]
+    manifest.integrity = compute_manifest_integrity(manifest)
+    payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+    valid, _, errors, verdict = validate_config_patch_manifest_v1(payload)
+    assert valid is True, (errors, verdict)
+
+
+def test_invalid_manifest_rejected_by_loader(tmp_path: Path) -> None:
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(Exception):
+        load_promotion_input_from_manifest_path(bad_path)
+
+
+def test_invalid_lineage_uuid_rejected_at_manifest_build() -> None:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref="not-a-uuid",
+    )
+    manifest.integrity = compute_manifest_integrity(manifest)
+    payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+    valid, _, errors, _ = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert errors
+
+
+def test_learning_override_toml_is_not_valid_promotion_manifest(tmp_path: Path) -> None:
+    toml_path = tmp_path / "learning.override.toml"
+    toml_path.write_text("[auto]\nflag = true\n", encoding="utf-8")
+    with pytest.raises(Exception):
+        load_promotion_input_from_manifest_path(toml_path)
+
+
+def test_btc_scope_in_source_scope_rejected() -> None:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    bad_scope = dict(canonical_futures_scope_ref())
+    bad_scope["scope"] = "BTC_FUTURES"
+    manifest.source_scope = bad_scope
+    manifest.trading_logic_immutability_ref = canonical_trading_logic_immutability_ref()
+    manifest.integrity = compute_manifest_integrity(manifest)
+    payload = manifest_to_canonical_dict(manifest, include_integrity=True)
+    valid, _, _, verdict = validate_config_patch_manifest_v1(payload)
+    assert valid is False
+    assert verdict is not None
+
+
+def test_patch_empty_manifest_loads_with_zero_patches(tmp_path: Path) -> None:
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=MANIFEST_ID,
+        generated_at=FIXED_NOW,
+        lineage_manifest_ref=LINEAGE_ID,
+    )
+    manifest.integrity = compute_manifest_integrity(manifest)
+    path = tmp_path / "empty.json"
+    path.write_text(serialize_config_patch_manifest_v1(manifest), encoding="utf-8")
+    loaded = load_promotion_input_from_manifest_path(path)
+    assert list(loaded.patches) == []

--- a/tests/scripts/test_offline_learning_promotion_e2e_v1.py
+++ b/tests/scripts/test_offline_learning_promotion_e2e_v1.py
@@ -1,0 +1,152 @@
+"""Offline E2E contract test: Learning-Bridge → ConfigPatchManifest → Promotion artifacts (GAP-007)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.governance.promotion_loop import (
+    build_promotion_candidates_from_patches,
+    build_promotion_proposals,
+    filter_candidates_for_live,
+    materialize_promotion_proposals,
+)
+from src.governance.promotion_loop.models import DecisionStatus
+from src.governance.promotion_loop.policy import AutoApplyPolicy
+from src.governance.promotion_loop.proposal_input_refs_v1 import (
+    apply_promotion_input_references_to_proposal,
+    promotion_input_references_from_manifest,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import load_promotion_input_from_manifest_path
+from src.meta.learning_loop.manifest_bridge_v1 import (
+    LearningManifestBridgeError,
+    produce_config_patch_manifest_v1_from_paths,
+)
+from src.meta.learning_loop.models import PatchStatus
+
+
+FIXED_NOW = datetime(2026, 6, 27, 16, 0, 0, tzinfo=timezone.utc)
+MANIFEST_ID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+LINEAGE_ID = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+
+
+def _write_learning_input(path: Path) -> None:
+    payload = {
+        "patches": [
+            {
+                "id": "e2e-patch-1",
+                "target": "research.offline.window_days",
+                "old_value": 30,
+                "new_value": 45,
+                "status": PatchStatus.APPLIED_OFFLINE.value,
+                "reason": "offline e2e contract",
+                "source_experiment_id": "exp-e2e-1",
+                "confidence_score": 0.91,
+            }
+        ]
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_offline_learning_to_promotion_e2e_contract(tmp_path: Path) -> None:
+    input_path = tmp_path / "learning_input.json"
+    manifest_path = tmp_path / "promotion_input_manifest.json"
+    proposal_root = tmp_path / "live_promotion"
+    live_override_path = tmp_path / "config" / "live_overrides" / "auto.toml"
+
+    _write_learning_input(input_path)
+    produce_config_patch_manifest_v1_from_paths(
+        input_path=input_path,
+        output_path=manifest_path,
+        manifest_id=MANIFEST_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+
+    promotion_input = load_promotion_input_from_manifest_path(manifest_path)
+    refs = promotion_input_references_from_manifest(promotion_input.manifest)
+    patches = promotion_input.patches
+    assert len(patches) == 1
+
+    candidates = build_promotion_candidates_from_patches(patches)
+    assert len(candidates) == 1
+    candidates[0].eligible_for_live = True
+
+    decisions = filter_candidates_for_live(candidates, safety_config=None, mode="manual_only")
+    accepted = [d for d in decisions if d.status is DecisionStatus.ACCEPTED_FOR_PROPOSAL]
+    assert len(accepted) == 1
+
+    proposals = build_promotion_proposals(accepted, proposal_id_prefix="offline_e2e")
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    apply_promotion_input_references_to_proposal(proposal, refs)
+
+    materialize_promotion_proposals(proposals, proposal_root)
+
+    meta_path = proposal_root / proposal.proposal_id / "proposal_meta.json"
+    meta_payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta_fields = meta_payload["meta"]
+    assert meta_fields["config_patch_manifest_id"] == MANIFEST_ID
+    assert meta_fields["candidate_lineage_manifest_ref"] == LINEAGE_ID
+    assert "patches" not in meta_fields
+    assert "config_patch_manifest" not in meta_fields
+
+    from src.governance.promotion_loop.engine import apply_proposals_to_live_overrides
+
+    applied = apply_proposals_to_live_overrides(
+        proposals,
+        policy=AutoApplyPolicy(mode="manual_only"),
+        live_override_path=live_override_path,
+    )
+    assert applied is None
+    assert not live_override_path.exists()
+
+
+def test_offline_e2e_patch_empty_manifest_produces_zero_proposals(tmp_path: Path) -> None:
+    input_path = tmp_path / "empty_input.json"
+    manifest_path = tmp_path / "empty_manifest.json"
+    input_path.write_text(json.dumps({"patches": []}), encoding="utf-8")
+
+    produce_config_patch_manifest_v1_from_paths(
+        input_path=input_path,
+        output_path=manifest_path,
+        manifest_id=MANIFEST_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+
+    promotion_input = load_promotion_input_from_manifest_path(manifest_path)
+    candidates = build_promotion_candidates_from_patches(promotion_input.patches)
+    assert candidates == []
+
+    decisions = filter_candidates_for_live(candidates, safety_config=None, mode="manual_only")
+    proposals = build_promotion_proposals(decisions)
+    assert proposals == []
+
+
+def test_offline_e2e_rejects_forbidden_strategy_target_at_bridge(tmp_path: Path) -> None:
+    input_path = tmp_path / "forbidden_input.json"
+    manifest_path = tmp_path / "forbidden_manifest.json"
+    payload = {
+        "patches": [
+            {
+                "id": "bad-patch",
+                "target": "strategy.selection.mode",
+                "new_value": "bull",
+                "status": PatchStatus.APPLIED_OFFLINE.value,
+            }
+        ]
+    }
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises((LearningManifestBridgeError, Exception)):
+        produce_config_patch_manifest_v1_from_paths(
+            input_path=input_path,
+            output_path=manifest_path,
+            manifest_id=MANIFEST_ID,
+            lineage_manifest_ref=LINEAGE_ID,
+            generated_at=FIXED_NOW,
+        )


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_PACKAGE_E_GAP007_PROMOTION_LOOP_TESTOWNER_AND_GOVERNANCE_CLOSEOUT_V0`
- Adds dedicated manifest-era testowners for `promotion_loop` **engine**, **safety**, and **policy** (characterization only; no semantic changes)
- Adds offline E2E contract test: explicit learning input → Learning-Bridge → ConfigPatchManifest v1 → promotion loader → candidates/filter → proposal artifacts with manifest/lineage FK refs
- Binds new testowners to Required Check `tests (3.11)` via `PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_*`

## Scope / Non-Goals

**In scope:** GAP-007 testowner + governance closeout, CI selector binding, negative safety regressions (Package A rules reused)

**Out of scope:** Engine/safety/policy semantic changes, reference-only proposals, patch-empty proposals, CandidateLineageManifest production, durable-evidence integration, backtest/VaR, domain producers, runtime/live authority

## Owner coverage

| Area | New testowner |
|---|---|
| Engine | `tests/governance/promotion_loop/test_engine_manifest_era_v1.py` |
| Safety | `tests/governance/promotion_loop/test_safety_manifest_era_v1.py` |
| Policy | `tests/governance/promotion_loop/test_policy_manifest_era_v1.py` |
| Offline E2E | `tests/scripts/test_offline_learning_promotion_e2e_v1.py` |

## E2E contract proof

- Manifest ID + lineage ref verified in proposal meta
- No payload duplication in proposal meta
- `manual_only`: no live override write
- Patch-empty manifest → 0 candidates, 0 proposals

## Trading-Logic-Immutability

- **Production code unchanged** (`engine.py`, `safety.py`, `policy.py` untouched)
- Fixtures use immutability-compliant targets; forbidden targets fail-closed via existing Package A validators

## Tests

- 41 new Package E tests
- 183 passed in local validation batch (Packages A–E regression + selector contracts)
- `ruff format --check` / `ruff check` PASS on changed files

## CI selection

- Expected: **PR_BOUNDED_FULL** on `tests (3.11)` via Package E governance closeout bindings

## Durable bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/package_e_gap007_promotion_loop_testowner_governance_closeout_v1_20260627T160000Z`

- `MANIFEST_VERIFY_RC=0`
- `RUNTIME_ATTEMPT_COUNT=0`, `ORDER_ATTEMPT_COUNT=0`, `CANCEL_ATTEMPT_COUNT=0`


Made with [Cursor](https://cursor.com)