### PR TITLE
feat(meta): Package G — offline learning manifest durable evidence binding v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1395,6 +1395,24 @@ PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS: tuple[str, ...] 
     "tests/scripts/test_run_candidate_lineage_manifest_v1.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/manifest_durable_evidence_binding_v1.py",
+        "scripts/run_learning_manifest_durable_evidence_binding_v1.py",
+        "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+        "tests/scripts/test_run_learning_manifest_durable_evidence_binding_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_learning_manifest_bridge_v1.py",
+    "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/scripts/test_run_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/governance/promotion_loop/engine.py",
@@ -1461,6 +1479,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TRIGGER_PATHS:
@@ -4618,6 +4640,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                     add(candidate)
             elif path == "scripts/run_candidate_lineage_manifest_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_learning_manifest_durable_evidence_binding_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TARGETS:
                     add(candidate)
             for candidate in (
                 f"tests/scripts/test_{script_stem}_load_strategy_v1.py",

--- a/scripts/run_learning_manifest_durable_evidence_binding_v1.py
+++ b/scripts/run_learning_manifest_durable_evidence_binding_v1.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Offline Package G — bind ConfigPatchManifest v1 + CandidateLineageManifest v1 to durable evidence.
+
+Produces a validated durable evidence bundle with binding index and MANIFEST.sha256 only.
+No promotion, apply, runtime, registry mutation, or live authority.
+
+Usage:
+    python3 scripts/run_learning_manifest_durable_evidence_binding_v1.py \\
+        --config-patch-manifest reports/manifests/config_patch.json \\
+        --candidate-lineage-manifest reports/manifests/lineage.json \\
+        --output-dir /var/evidence/learning_bundle_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.config_patch_manifest_v1 import ConfigPatchManifestValidationError
+from src.meta.learning_loop.manifest_durable_evidence_binding_v1 import (
+    ManifestDurableEvidenceBindingError,
+    produce_learning_manifest_durable_evidence_bundle_v1,
+)
+
+EXIT_OK = 0
+EXIT_BINDING_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Package G: bind validated learning manifest artifacts to "
+            "durable evidence (index + MANIFEST.sha256)."
+        )
+    )
+    parser.add_argument(
+        "--config-patch-manifest",
+        type=Path,
+        required=True,
+        help="Explicit path to validated ConfigPatchManifest v1 JSON.",
+    )
+    parser.add_argument(
+        "--candidate-lineage-manifest",
+        type=Path,
+        required=True,
+        help="Explicit path to validated CandidateLineageManifest v1 JSON.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit durable evidence bundle directory (must not exist; outside /tmp).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.config_patch_manifest.is_file():
+        print(
+            "[learning_manifest_durable_evidence_binding] ERROR: "
+            f"config patch manifest not found: {args.config_patch_manifest}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if not args.candidate_lineage_manifest.is_file():
+        print(
+            "[learning_manifest_durable_evidence_binding] ERROR: "
+            f"candidate lineage manifest not found: {args.candidate_lineage_manifest}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    try:
+        result = produce_learning_manifest_durable_evidence_bundle_v1(
+            config_patch_manifest_path=args.config_patch_manifest,
+            candidate_lineage_manifest_path=args.candidate_lineage_manifest,
+            output_dir=args.output_dir,
+        )
+    except ManifestDurableEvidenceBindingError as exc:
+        print(f"[learning_manifest_durable_evidence_binding] ERROR: {exc}", file=sys.stderr)
+        return EXIT_BINDING_ERROR
+    except ConfigPatchManifestValidationError as exc:
+        print(
+            f"[learning_manifest_durable_evidence_binding] VALIDATION_ERROR: {exc}",
+            file=sys.stderr,
+        )
+        if exc.verdict:
+            print(
+                f"[learning_manifest_durable_evidence_binding] VERDICT={exc.verdict}",
+                file=sys.stderr,
+            )
+        return EXIT_BINDING_ERROR
+
+    print(
+        "[learning_manifest_durable_evidence_binding] wrote durable evidence bundle to "
+        f"{result.output_dir} "
+        f"(config_patch_manifest_id={result.config_patch_manifest_id}, "
+        f"candidate_lineage_manifest_id={result.candidate_lineage_manifest_id})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/manifest_durable_evidence_binding_v1.py
+++ b/src/meta/learning_loop/manifest_durable_evidence_binding_v1.py
@@ -1,0 +1,457 @@
+"""Offline Package G — durable evidence binding for learning manifest artifacts v1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    CandidateLineageManifestError,
+    CandidateLineageManifestValidationError,
+    CandidateLineageManifestV1,
+    deserialize_candidate_lineage_manifest_v1,
+    validate_candidate_lineage_manifest_v1,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    ConfigPatchManifestError,
+    ConfigPatchManifestValidationError,
+    load_config_patch_manifest_v1_from_json_path,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_uuid,
+)
+
+BINDING_SCHEMA_VERSION = "learning_manifest_durable_evidence_binding_v1"
+CONFIG_PATCH_ARTIFACT_REL = "config_patch_manifest_v1.json"
+LINEAGE_ARTIFACT_REL = "candidate_lineage_manifest_v1.json"
+INDEX_ARTIFACT_REL = "learning_manifest_durable_evidence_binding_index_v1.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".learning_manifest_durable_evidence_staging_"
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "patches",
+        "patch",
+        "strategy",
+        "signal",
+        "signals",
+        "entry",
+        "exit",
+        "position_sizing",
+        "leverage",
+        "stop_loss",
+        "take_profit",
+        "execution",
+        "order_routing",
+        "risk_limits",
+        "killswitch",
+        "old_value",
+        "new_value",
+        "target",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "runtime_status",
+        "live_arming",
+        "apply_authority",
+        "promotion_authority",
+    }
+)
+
+
+class ManifestDurableEvidenceBindingError(ValueError):
+    """Fail-closed Package G durable evidence binding error."""
+
+
+@dataclass(frozen=True)
+class BindingCrossReferences:
+    lineage_manifest_ref_bound: bool
+    config_patch_lineage_manifest_ref: str | None
+    candidate_lineage_manifest_id: str
+
+
+@dataclass(frozen=True)
+class BoundArtifactRecord:
+    artifact_kind: str
+    relative_path: str
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class DurableEvidenceBindingResult:
+    output_dir: Path
+    config_patch_manifest_id: str
+    candidate_lineage_manifest_id: str
+    binding_index_path: Path
+    manifest_path: Path
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_candidate_lineage_manifest_v1_from_json_path(path: Path) -> CandidateLineageManifestV1:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CandidateLineageManifestError(f"failed to read manifest file: {path}") from exc
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise CandidateLineageManifestError(f"invalid JSON in manifest file: {path}") from exc
+    if not isinstance(data, Mapping):
+        raise CandidateLineageManifestError("manifest root must be a JSON object")
+    valid, phase, errors, verdict = validate_candidate_lineage_manifest_v1(data)
+    if not valid:
+        raise CandidateLineageManifestValidationError(
+            f"CandidateLineageManifest v1 validation failed for {path}",
+            phase=phase,
+            errors=errors,
+            verdict=verdict,
+        )
+    return deserialize_candidate_lineage_manifest_v1(data)
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ManifestDurableEvidenceBindingError(f"{label} must not be a symlink: {path}")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise ManifestDurableEvidenceBindingError(
+                f"binding index must not contain forbidden key: {key}"
+            )
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise ManifestDurableEvidenceBindingError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise ManifestDurableEvidenceBindingError(f"{label} must be a regular file: {path}")
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise ManifestDurableEvidenceBindingError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise ManifestDurableEvidenceBindingError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ManifestDurableEvidenceBindingError(f"output parent directory missing: {parent}")
+    if is_under_tmp(parent):
+        raise ManifestDurableEvidenceBindingError("output parent directory must be outside /tmp")
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _reject_unsafe_overlap(
+    *,
+    config_patch_path: Path,
+    candidate_lineage_path: Path,
+    output_dir: Path,
+) -> None:
+    config_res = config_patch_path.resolve()
+    lineage_res = candidate_lineage_path.resolve()
+    output_res = output_dir.resolve()
+
+    if output_res in {config_res, lineage_res}:
+        raise ManifestDurableEvidenceBindingError(
+            "output directory must not equal a source manifest path (fail-closed)"
+        )
+
+    for src in (config_res, lineage_res):
+        if _path_is_under(src, output_res):
+            raise ManifestDurableEvidenceBindingError(
+                "source manifest must not be inside output directory (fail-closed)"
+            )
+
+    for src in (config_res, lineage_res):
+        if src.is_file() and _path_is_under(output_res, src):
+            raise ManifestDurableEvidenceBindingError(
+                "output directory must not be inside a source manifest path (fail-closed)"
+            )
+
+
+def _verify_manifest_id_matches_integrity(
+    *,
+    manifest_id: str,
+    integrity_digest: str,
+    label: str,
+) -> None:
+    if not is_valid_uuid(manifest_id):
+        raise ManifestDurableEvidenceBindingError(f"{label} manifest_id must be a UUID")
+
+
+def check_reference_consistency(
+    *,
+    config_patch_manifest_id: str,
+    config_patch_lineage_manifest_ref: str | None,
+    candidate_lineage_manifest_id: str,
+) -> BindingCrossReferences:
+    _verify_manifest_id_matches_integrity(
+        manifest_id=config_patch_manifest_id,
+        integrity_digest="",
+        label="config_patch",
+    )
+    _verify_manifest_id_matches_integrity(
+        manifest_id=candidate_lineage_manifest_id,
+        integrity_digest="",
+        label="candidate_lineage",
+    )
+    if config_patch_lineage_manifest_ref is None:
+        return BindingCrossReferences(
+            lineage_manifest_ref_bound=False,
+            config_patch_lineage_manifest_ref=None,
+            candidate_lineage_manifest_id=candidate_lineage_manifest_id,
+        )
+    if not is_valid_uuid(config_patch_lineage_manifest_ref):
+        raise ManifestDurableEvidenceBindingError(
+            "config patch lineage_manifest_ref must be a UUID when present"
+        )
+    if config_patch_lineage_manifest_ref != candidate_lineage_manifest_id:
+        raise ManifestDurableEvidenceBindingError(
+            "config patch lineage_manifest_ref does not match candidate lineage manifest_id"
+        )
+    return BindingCrossReferences(
+        lineage_manifest_ref_bound=True,
+        config_patch_lineage_manifest_ref=config_patch_lineage_manifest_ref,
+        candidate_lineage_manifest_id=candidate_lineage_manifest_id,
+    )
+
+
+def _build_cross_references_payload(cross: BindingCrossReferences) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "lineage_manifest_ref_bound": cross.lineage_manifest_ref_bound,
+        "candidate_lineage_manifest_id": cross.candidate_lineage_manifest_id,
+    }
+    if cross.config_patch_lineage_manifest_ref is not None:
+        payload["config_patch_lineage_manifest_ref"] = cross.config_patch_lineage_manifest_ref
+    return payload
+
+
+def build_binding_index_v1(
+    *,
+    config_patch_manifest_id: str,
+    candidate_lineage_manifest_id: str,
+    cross_references: BindingCrossReferences,
+    artifacts: tuple[BoundArtifactRecord, ...],
+    futures_scope_ref: Mapping[str, Any],
+    trading_logic_immutability_ref: Mapping[str, Any],
+) -> dict[str, Any]:
+    sorted_artifacts = sorted(
+        artifacts,
+        key=lambda item: (item.artifact_kind, item.relative_path),
+    )
+    payload: dict[str, Any] = {
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "config_patch_manifest_id": config_patch_manifest_id,
+        "candidate_lineage_manifest_id": candidate_lineage_manifest_id,
+        "cross_references": _build_cross_references_payload(cross_references),
+        "artifacts": [
+            {
+                "artifact_kind": item.artifact_kind,
+                "relative_path": item.relative_path,
+                "content_sha256": item.content_sha256,
+            }
+            for item in sorted_artifacts
+        ],
+        "futures_scope_ref": dict(futures_scope_ref),
+        "trading_logic_immutability_ref": dict(trading_logic_immutability_ref),
+        "evidence_does_not_authorize_runtime": True,
+    }
+    _reject_forbidden_index_keys(payload)
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def serialize_binding_index_v1(index: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(index)
+    return deterministic_json_dumps(dict(index))
+
+
+def _copy_byte_identical(source: Path, dest: Path) -> str:
+    _validate_regular_file(source, label="source artifact")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, dest)
+    source_digest = _sha256_file(source)
+    dest_digest = _sha256_file(dest)
+    if source_digest != dest_digest:
+        raise ManifestDurableEvidenceBindingError(f"byte-identical copy failed for {source.name}")
+    return source_digest
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    token = uuid.uuid4().hex
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{token}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def _validate_bundle_relative_path(rel: str) -> None:
+    candidate = Path(rel)
+    if candidate.is_absolute():
+        raise ManifestDurableEvidenceBindingError(
+            f"bundle relative path must not be absolute: {rel!r}"
+        )
+    if ".." in candidate.parts:
+        raise ManifestDurableEvidenceBindingError(
+            f"bundle relative path must not traverse upward: {rel!r}"
+        )
+
+
+def produce_learning_manifest_durable_evidence_bundle_v1(
+    *,
+    config_patch_manifest_path: Path | str,
+    candidate_lineage_manifest_path: Path | str,
+    output_dir: Path | str,
+) -> DurableEvidenceBindingResult:
+    """Bind validated manifest artifacts into an offline durable evidence bundle."""
+    config_path = Path(config_patch_manifest_path)
+    lineage_path = Path(candidate_lineage_manifest_path)
+    final_dir = Path(output_dir)
+
+    _validate_regular_file(config_path, label="config patch manifest")
+    _validate_regular_file(lineage_path, label="candidate lineage manifest")
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        config_patch_path=config_path,
+        candidate_lineage_path=lineage_path,
+        output_dir=final_dir,
+    )
+
+    try:
+        config_manifest = load_config_patch_manifest_v1_from_json_path(config_path)
+    except ConfigPatchManifestValidationError as exc:
+        raise ManifestDurableEvidenceBindingError(str(exc)) from exc
+    except ConfigPatchManifestError as exc:
+        raise ManifestDurableEvidenceBindingError(str(exc)) from exc
+
+    try:
+        lineage_manifest = _load_candidate_lineage_manifest_v1_from_json_path(lineage_path)
+    except CandidateLineageManifestValidationError as exc:
+        raise ManifestDurableEvidenceBindingError(str(exc)) from exc
+    except CandidateLineageManifestError as exc:
+        raise ManifestDurableEvidenceBindingError(str(exc)) from exc
+
+    if config_manifest.integrity is None:
+        raise ManifestDurableEvidenceBindingError("config patch manifest integrity missing")
+    if lineage_manifest.integrity is None:
+        raise ManifestDurableEvidenceBindingError("candidate lineage manifest integrity missing")
+
+    cross = check_reference_consistency(
+        config_patch_manifest_id=config_manifest.manifest_id,
+        config_patch_lineage_manifest_ref=config_manifest.lineage_manifest_ref,
+        candidate_lineage_manifest_id=lineage_manifest.lineage_manifest_id,
+    )
+
+    for rel in (CONFIG_PATCH_ARTIFACT_REL, LINEAGE_ARTIFACT_REL, INDEX_ARTIFACT_REL):
+        _validate_bundle_relative_path(rel)
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise ManifestDurableEvidenceBindingError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+
+        config_dest = staging / CONFIG_PATCH_ARTIFACT_REL
+        lineage_dest = staging / LINEAGE_ARTIFACT_REL
+        config_digest = _copy_byte_identical(config_path, config_dest)
+        lineage_digest = _copy_byte_identical(lineage_path, lineage_dest)
+
+        artifacts = (
+            BoundArtifactRecord(
+                artifact_kind="config_patch_manifest_v1",
+                relative_path=CONFIG_PATCH_ARTIFACT_REL,
+                content_sha256=config_digest,
+            ),
+            BoundArtifactRecord(
+                artifact_kind="candidate_lineage_manifest_v1",
+                relative_path=LINEAGE_ARTIFACT_REL,
+                content_sha256=lineage_digest,
+            ),
+        )
+        index_payload = build_binding_index_v1(
+            config_patch_manifest_id=config_manifest.manifest_id,
+            candidate_lineage_manifest_id=lineage_manifest.lineage_manifest_id,
+            cross_references=cross,
+            artifacts=artifacts,
+            futures_scope_ref=config_manifest.source_scope,
+            trading_logic_immutability_ref=config_manifest.trading_logic_immutability_ref,
+        )
+        index_path = staging / INDEX_ARTIFACT_REL
+        index_path.write_text(serialize_binding_index_v1(index_payload), encoding="utf-8")
+
+        write_manifest_sha256(staging)
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise ManifestDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        staging.replace(final_dir)
+
+        final_index = final_dir / INDEX_ARTIFACT_REL
+        final_manifest = final_dir / MANIFEST_FILENAME
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise ManifestDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return DurableEvidenceBindingResult(
+        output_dir=final_dir,
+        config_patch_manifest_id=config_manifest.manifest_id,
+        candidate_lineage_manifest_id=lineage_manifest.lineage_manifest_id,
+        binding_index_path=final_dir / INDEX_ARTIFACT_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+    )
+
+
+__all__ = [
+    "BINDING_SCHEMA_VERSION",
+    "CONFIG_PATCH_ARTIFACT_REL",
+    "INDEX_ARTIFACT_REL",
+    "LINEAGE_ARTIFACT_REL",
+    "BoundArtifactRecord",
+    "BindingCrossReferences",
+    "DurableEvidenceBindingResult",
+    "ManifestDurableEvidenceBindingError",
+    "build_binding_index_v1",
+    "check_reference_consistency",
+    "produce_learning_manifest_durable_evidence_bundle_v1",
+    "serialize_binding_index_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5203,3 +5203,68 @@ def test_selector_package_f_combined_diff_pr_bounded_full_includes_all_testowner
     for path in PACKAGE_F_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_G_BINDING_PRODUCTION = "src/meta/learning_loop/manifest_durable_evidence_binding_v1.py"
+PACKAGE_G_BINDING_SCRIPT = "scripts/run_learning_manifest_durable_evidence_binding_v1.py"
+PACKAGE_G_BINDING_TESTOWNER = "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py"
+PACKAGE_G_BINDING_CLI_TESTOWNER = (
+    "tests/scripts/test_run_learning_manifest_durable_evidence_binding_v1.py"
+)
+PACKAGE_G_CONFIG_PATCH_CONTRACT = "tests/meta/test_config_patch_manifest_v1_contract.py"
+PACKAGE_G_BRIDGE_REGRESSION = "tests/meta/test_learning_manifest_bridge_v1.py"
+PACKAGE_G_LINEAGE_CONTRACT = (
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py"
+)
+PACKAGE_G_LINEAGE_PRODUCER = (
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py"
+)
+PACKAGE_G_ALL_PRODUCTION = (
+    PACKAGE_G_BINDING_PRODUCTION,
+    PACKAGE_G_BINDING_SCRIPT,
+)
+PACKAGE_G_ALL_TESTOWNERS = (
+    PACKAGE_G_CONFIG_PATCH_CONTRACT,
+    PACKAGE_G_BRIDGE_REGRESSION,
+    PACKAGE_G_BINDING_TESTOWNER,
+    PACKAGE_G_BINDING_CLI_TESTOWNER,
+    PACKAGE_G_LINEAGE_CONTRACT,
+    PACKAGE_G_LINEAGE_PRODUCER,
+)
+
+
+def test_selector_package_g_binding_production_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_G_BINDING_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_G_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_g_script_contract_focused_includes_binding_testowners() -> None:
+    sel = _run_selector(PACKAGE_G_BINDING_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    for path in PACKAGE_G_ALL_TESTOWNERS:
+        assert path in targets
+
+
+def test_selector_package_g_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+    sel = _run_selector(
+        *PACKAGE_G_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_G_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_G_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+
+
+def test_selector_package_g_foreign_central_src_mixed_diff_pr_bounded_full() -> None:
+    sel = _run_selector(
+        PACKAGE_G_BINDING_PRODUCTION,
+        "src/governance/promotion_loop/engine.py",
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"

--- a/tests/meta/test_learning_manifest_durable_evidence_binding_v1.py
+++ b/tests/meta/test_learning_manifest_durable_evidence_binding_v1.py
@@ -418,7 +418,9 @@ def test_invalid_config_json_fail_closed(tmp_path: Path, sources: Path) -> None:
         )
 
 
-def test_output_under_tmp_rejected(tmp_path: Path, sources: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_output_under_tmp_rejected(
+    tmp_path: Path, sources: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from scripts.ops.primary_evidence_retention_v0 import is_under_tmp as real_is_under_tmp
 
     monkeypatch.setattr(

--- a/tests/meta/test_learning_manifest_durable_evidence_binding_v1.py
+++ b/tests/meta/test_learning_manifest_durable_evidence_binding_v1.py
@@ -1,0 +1,486 @@
+"""Contract tests for Package G offline learning manifest durable evidence binding v1."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRefType,
+    LineageRelation,
+    build_candidate_lineage_manifest_v1_from_producer_input,
+    serialize_candidate_lineage_manifest_v1,
+    write_candidate_lineage_manifest_v1_atomic,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    build_empty_config_patch_manifest_v1,
+    validate_config_patch_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256
+from src.meta.learning_loop.manifest_bridge_v1 import (
+    build_config_patch_manifest_v1_from_learning_input,
+    write_config_patch_manifest_v1_atomic,
+)
+from src.meta.learning_loop.manifest_durable_evidence_binding_v1 import (
+    CONFIG_PATCH_ARTIFACT_REL,
+    INDEX_ARTIFACT_REL,
+    LINEAGE_ARTIFACT_REL,
+    ManifestDurableEvidenceBindingError,
+    build_binding_index_v1,
+    check_reference_consistency,
+    produce_learning_manifest_durable_evidence_bundle_v1,
+    serialize_binding_index_v1,
+)
+from src.meta.learning_loop.models import PatchStatus
+
+FIXED_NOW = datetime(2026, 6, 27, 18, 0, 0, tzinfo=timezone.utc)
+CONFIG_ID = "11111111-1111-4111-8111-111111111111"
+LINEAGE_ID = "22222222-2222-4222-8222-222222222222"
+CONTRACT_REF = "33333333-3333-4333-8333-333333333333"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.manifest_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def _minimal_lineage_input() -> dict:
+    return {
+        "lineage_manifest_id": LINEAGE_ID,
+        "candidate_id": "candidate-g-test",
+        "candidate_type": "config_patch_bundle",
+        "candidate_contract_ref": CONTRACT_REF,
+        "refs": [
+            {
+                "ref_type": LineageRefType.EXPERIMENT.value,
+                "ref_id": "exp-g-1",
+                "relation": LineageRelation.SOURCES.value,
+                "owner_domain": "experiments/base",
+                "required": True,
+            }
+        ],
+        "created_at": FIXED_NOW.isoformat(),
+        "created_by": "package_g_binding_tests",
+    }
+
+
+def _full_lineage_input() -> dict:
+    payload = _minimal_lineage_input()
+    payload["refs"] = [
+        *_minimal_lineage_input()["refs"],
+        {
+            "ref_type": LineageRefType.EVIDENCE_OPS.value,
+            "ref_id": "evidence-ref-g",
+            "relation": LineageRelation.RETAINS.value,
+            "owner_domain": "primary_evidence_retention",
+            "required": True,
+            "digest": "b" * 64,
+        },
+    ]
+    return payload
+
+
+def _write_minimal_config_patch(path: Path, *, empty: bool = True) -> None:
+    if empty:
+        manifest = build_empty_config_patch_manifest_v1(
+            manifest_id=CONFIG_ID,
+            lineage_manifest_ref=LINEAGE_ID,
+            generated_at=FIXED_NOW,
+        )
+    else:
+        manifest = build_config_patch_manifest_v1_from_learning_input(
+            {
+                "patches": [
+                    {
+                        "id": "patch-g-1",
+                        "target": "research.offline.window_days",
+                        "old_value": 30,
+                        "new_value": 45,
+                        "status": PatchStatus.APPLIED_OFFLINE.value,
+                        "reason": "package g binding test",
+                    }
+                ]
+            },
+            manifest_id=CONFIG_ID,
+            lineage_manifest_ref=LINEAGE_ID,
+            generated_at=FIXED_NOW,
+        )
+    write_config_patch_manifest_v1_atomic(manifest, path)
+
+
+def _write_lineage(path: Path, *, full: bool = False) -> None:
+    raw = _full_lineage_input() if full else _minimal_lineage_input()
+    manifest = build_candidate_lineage_manifest_v1_from_producer_input(raw, created_at=FIXED_NOW)
+    write_candidate_lineage_manifest_v1_atomic(manifest, path)
+
+
+def _sources_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "sources"
+    path.mkdir(exist_ok=True)
+    return path
+
+
+def _durable_output(tmp_path: Path, name: str = "bundle") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+@pytest.fixture
+def sources(tmp_path: Path) -> Path:
+    return _sources_dir(tmp_path)
+
+
+def test_minimal_manifest_pair_binds_successfully(tmp_path: Path, sources: Path) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path)
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+
+    result = produce_learning_manifest_durable_evidence_bundle_v1(
+        config_patch_manifest_path=config_path,
+        candidate_lineage_manifest_path=lineage_path,
+        output_dir=out,
+    )
+
+    assert result.config_patch_manifest_id == CONFIG_ID
+    assert result.candidate_lineage_manifest_id == LINEAGE_ID
+    assert (out / CONFIG_PATCH_ARTIFACT_REL).is_file()
+    assert (out / LINEAGE_ARTIFACT_REL).is_file()
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is True
+
+
+def test_full_manifest_pair_passes_contract_validation(tmp_path: Path, sources: Path) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path, "full")
+    _write_minimal_config_patch(config_path, empty=False)
+    _write_lineage(lineage_path, full=True)
+
+    produce_learning_manifest_durable_evidence_bundle_v1(
+        config_patch_manifest_path=config_path,
+        candidate_lineage_manifest_path=lineage_path,
+        output_dir=out,
+    )
+    config_payload = json.loads((out / CONFIG_PATCH_ARTIFACT_REL).read_text(encoding="utf-8"))
+    valid, phase, errors, _ = validate_config_patch_manifest_v1(config_payload)
+    assert valid is True, (phase, errors)
+
+
+def test_reference_consistency_pass_and_fail() -> None:
+    cross = check_reference_consistency(
+        config_patch_manifest_id=CONFIG_ID,
+        config_patch_lineage_manifest_ref=LINEAGE_ID,
+        candidate_lineage_manifest_id=LINEAGE_ID,
+    )
+    assert cross.lineage_manifest_ref_bound is True
+
+    with pytest.raises(ManifestDurableEvidenceBindingError, match="does not match"):
+        check_reference_consistency(
+            config_patch_manifest_id=CONFIG_ID,
+            config_patch_lineage_manifest_ref="99999999-9999-4999-8999-999999999999",
+            candidate_lineage_manifest_id=LINEAGE_ID,
+        )
+
+
+def test_binding_index_has_no_payload_duplication(tmp_path: Path, sources: Path) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path, "index")
+    _write_minimal_config_patch(config_path, empty=False)
+    _write_lineage(lineage_path)
+
+    produce_learning_manifest_durable_evidence_bundle_v1(
+        config_patch_manifest_path=config_path,
+        candidate_lineage_manifest_path=lineage_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert index["evidence_does_not_authorize_runtime"] is True
+    assert "patches" not in index
+    assert "strategy" not in index
+    assert "old_value" not in json.dumps(index)
+    assert all(not Path(item["relative_path"]).is_absolute() for item in index["artifacts"])
+
+
+def test_build_binding_index_rejects_forbidden_payload_key() -> None:
+    from src.meta.learning_loop.manifest_durable_evidence_binding_v1 import BoundArtifactRecord
+
+    cross = check_reference_consistency(
+        config_patch_manifest_id=CONFIG_ID,
+        config_patch_lineage_manifest_ref=LINEAGE_ID,
+        candidate_lineage_manifest_id=LINEAGE_ID,
+    )
+    artifacts = (
+        BoundArtifactRecord("config_patch_manifest_v1", CONFIG_PATCH_ARTIFACT_REL, "a" * 64),
+    )
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=CONFIG_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+    index = build_binding_index_v1(
+        config_patch_manifest_id=CONFIG_ID,
+        candidate_lineage_manifest_id=LINEAGE_ID,
+        cross_references=cross,
+        artifacts=artifacts,
+        futures_scope_ref=manifest.source_scope,
+        trading_logic_immutability_ref=manifest.trading_logic_immutability_ref,
+    )
+    index["patches"] = []
+    with pytest.raises(ManifestDurableEvidenceBindingError, match="forbidden key"):
+        serialize_binding_index_v1(index)
+
+
+def test_deterministic_index_and_manifest(tmp_path: Path, sources: Path) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+
+    out1 = _durable_output(tmp_path, "det1")
+    out2 = _durable_output(tmp_path, "det2")
+    produce_learning_manifest_durable_evidence_bundle_v1(
+        config_patch_manifest_path=config_path,
+        candidate_lineage_manifest_path=lineage_path,
+        output_dir=out1,
+    )
+    produce_learning_manifest_durable_evidence_bundle_v1(
+        config_patch_manifest_path=config_path,
+        candidate_lineage_manifest_path=lineage_path,
+        output_dir=out2,
+    )
+
+    index1 = (out1 / INDEX_ARTIFACT_REL).read_bytes()
+    index2 = (out2 / INDEX_ARTIFACT_REL).read_bytes()
+    manifest1 = (out1 / "MANIFEST.sha256").read_bytes()
+    manifest2 = (out2 / "MANIFEST.sha256").read_bytes()
+    assert index1 == index2
+    assert manifest1 == manifest2
+
+
+def test_byte_identical_artifact_copies(tmp_path: Path, sources: Path) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path, "bytes")
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+
+    produce_learning_manifest_durable_evidence_bundle_v1(
+        config_patch_manifest_path=config_path,
+        candidate_lineage_manifest_path=lineage_path,
+        output_dir=out,
+    )
+    assert (out / CONFIG_PATCH_ARTIFACT_REL).read_bytes() == config_path.read_bytes()
+    assert (out / LINEAGE_ARTIFACT_REL).read_bytes() == lineage_path.read_bytes()
+
+
+def test_existing_output_dir_fail_closed(tmp_path: Path, sources: Path) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path, "exists")
+    out.mkdir(parents=True)
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+
+    with pytest.raises(ManifestDurableEvidenceBindingError, match="already exists"):
+        produce_learning_manifest_durable_evidence_bundle_v1(
+            config_patch_manifest_path=config_path,
+            candidate_lineage_manifest_path=lineage_path,
+            output_dir=out,
+        )
+
+
+def test_missing_source_fail_closed(tmp_path: Path) -> None:
+    out = _durable_output(tmp_path, "missing")
+    with pytest.raises(ManifestDurableEvidenceBindingError, match="not found"):
+        produce_learning_manifest_durable_evidence_bundle_v1(
+            config_patch_manifest_path=tmp_path / "missing.json",
+            candidate_lineage_manifest_path=tmp_path / "missing2.json",
+            output_dir=out,
+        )
+
+
+def test_symlink_source_rejected(tmp_path: Path, sources: Path) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+    link = tmp_path / "config_link.json"
+    link.symlink_to(config_path)
+    out = _durable_output(tmp_path, "symlink")
+
+    with pytest.raises(ManifestDurableEvidenceBindingError, match="symlink"):
+        produce_learning_manifest_durable_evidence_bundle_v1(
+            config_patch_manifest_path=link,
+            candidate_lineage_manifest_path=lineage_path,
+            output_dir=out,
+        )
+
+
+def test_copy_failure_leaves_no_final_bundle(
+    tmp_path: Path, sources: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path, "copy_fail")
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+
+    def _boom(src: Path, dst: Path) -> str:
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.manifest_durable_evidence_binding_v1._copy_byte_identical",
+        _boom,
+    )
+    with pytest.raises(OSError, match="copy failed"):
+        produce_learning_manifest_durable_evidence_bundle_v1(
+            config_patch_manifest_path=config_path,
+            candidate_lineage_manifest_path=lineage_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_manifest_write_failure_cleans_up(
+    tmp_path: Path, sources: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path, "manifest_fail")
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+
+    def _fail_write(_root: Path) -> None:
+        raise OSError("manifest write failed")
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.manifest_durable_evidence_binding_v1.write_manifest_sha256",
+        _fail_write,
+    )
+    with pytest.raises(OSError, match="manifest write failed"):
+        produce_learning_manifest_durable_evidence_bundle_v1(
+            config_patch_manifest_path=config_path,
+            candidate_lineage_manifest_path=lineage_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_verify_failure_before_publish_cleans_up(
+    tmp_path: Path, sources: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path, "verify_fail")
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.manifest_durable_evidence_binding_v1.verify_manifest_sha256",
+        lambda _root: (False, "checksum mismatch"),
+    )
+    with pytest.raises(ManifestDurableEvidenceBindingError, match="verification failed"):
+        produce_learning_manifest_durable_evidence_bundle_v1(
+            config_patch_manifest_path=config_path,
+            candidate_lineage_manifest_path=lineage_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_invalid_config_json_fail_closed(tmp_path: Path, sources: Path) -> None:
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    out = _durable_output(tmp_path, "bad_config")
+    config_path.write_text("{not json", encoding="utf-8")
+    _write_lineage(lineage_path)
+
+    with pytest.raises(ManifestDurableEvidenceBindingError):
+        produce_learning_manifest_durable_evidence_bundle_v1(
+            config_patch_manifest_path=config_path,
+            candidate_lineage_manifest_path=lineage_path,
+            output_dir=out,
+        )
+
+
+def test_output_under_tmp_rejected(tmp_path: Path, sources: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts.ops.primary_evidence_retention_v0 import is_under_tmp as real_is_under_tmp
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.manifest_durable_evidence_binding_v1.is_under_tmp",
+        real_is_under_tmp,
+    )
+    config_path = sources / "config.json"
+    lineage_path = sources / "lineage.json"
+    _write_minimal_config_patch(config_path)
+    _write_lineage(lineage_path)
+    out = Path("/tmp/peak_trade_pkg_g_binding_reject_test")
+
+    try:
+        with pytest.raises(ManifestDurableEvidenceBindingError, match="outside /tmp"):
+            produce_learning_manifest_durable_evidence_bundle_v1(
+                config_patch_manifest_path=config_path,
+                candidate_lineage_manifest_path=lineage_path,
+                output_dir=out,
+            )
+    finally:
+        if out.exists():
+            shutil.rmtree(out)
+
+
+def test_no_runtime_imports_in_binding_module() -> None:
+    import ast
+    from pathlib import Path
+
+    path = Path("src/meta/learning_loop/manifest_durable_evidence_binding_v1.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = ("promotion_loop.engine", "governance.promotion_loop.engine")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for token in forbidden:
+                assert token not in node.module
+
+
+def test_integrity_id_stable_for_index_payload() -> None:
+    cross = check_reference_consistency(
+        config_patch_manifest_id=CONFIG_ID,
+        config_patch_lineage_manifest_ref=LINEAGE_ID,
+        candidate_lineage_manifest_id=LINEAGE_ID,
+    )
+    manifest = build_empty_config_patch_manifest_v1(
+        manifest_id=CONFIG_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+    from src.meta.learning_loop.manifest_durable_evidence_binding_v1 import BoundArtifactRecord
+
+    artifacts = (
+        BoundArtifactRecord("config_patch_manifest_v1", CONFIG_PATCH_ARTIFACT_REL, "c" * 64),
+        BoundArtifactRecord("candidate_lineage_manifest_v1", LINEAGE_ARTIFACT_REL, "d" * 64),
+    )
+    index = build_binding_index_v1(
+        config_patch_manifest_id=CONFIG_ID,
+        candidate_lineage_manifest_id=LINEAGE_ID,
+        cross_references=cross,
+        artifacts=artifacts,
+        futures_scope_ref=manifest.source_scope,
+        trading_logic_immutability_ref=manifest.trading_logic_immutability_ref,
+    )
+    payload = dict(index)
+    digest = payload.pop("integrity")
+    assert digest["content_sha256"] == compute_content_sha256(payload)

--- a/tests/scripts/test_run_learning_manifest_durable_evidence_binding_v1.py
+++ b/tests/scripts/test_run_learning_manifest_durable_evidence_binding_v1.py
@@ -1,0 +1,251 @@
+"""CLI tests for Package G offline learning manifest durable evidence binding v1."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_learning_manifest_durable_evidence_binding_v1 import (
+    EXIT_BINDING_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    build_candidate_lineage_manifest_v1_from_producer_input,
+    write_candidate_lineage_manifest_v1_atomic,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import build_empty_config_patch_manifest_v1
+from src.meta.learning_loop.manifest_bridge_v1 import write_config_patch_manifest_v1_atomic
+from src.meta.learning_loop.manifest_durable_evidence_binding_v1 import INDEX_ARTIFACT_REL
+
+FIXED_NOW = datetime(2026, 6, 27, 19, 0, 0, tzinfo=timezone.utc)
+CONFIG_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+LINEAGE_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+CONTRACT_REF = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.manifest_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def _write_manifest_pair(tmp_path: Path) -> tuple[Path, Path, Path]:
+    sources = tmp_path / "sources"
+    sources.mkdir(exist_ok=True)
+    config_path = sources / "config_patch.json"
+    lineage_path = sources / "lineage.json"
+    config = build_empty_config_patch_manifest_v1(
+        manifest_id=CONFIG_ID,
+        lineage_manifest_ref=LINEAGE_ID,
+        generated_at=FIXED_NOW,
+    )
+    write_config_patch_manifest_v1_atomic(config, config_path)
+    lineage = build_candidate_lineage_manifest_v1_from_producer_input(
+        {
+            "lineage_manifest_id": LINEAGE_ID,
+            "candidate_id": "cli-candidate",
+            "candidate_type": "config_patch_bundle",
+            "candidate_contract_ref": CONTRACT_REF,
+            "refs": [
+                {
+                    "ref_type": "experiment",
+                    "ref_id": "exp-cli",
+                    "relation": "sources",
+                    "owner_domain": "experiments/base",
+                    "required": True,
+                }
+            ],
+            "created_at": FIXED_NOW.isoformat(),
+        },
+        created_at=FIXED_NOW,
+    )
+    write_candidate_lineage_manifest_v1_atomic(lineage, lineage_path)
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir(exist_ok=True)
+    return config_path, lineage_path, out_root
+
+
+def test_cli_successful_run(tmp_path: Path) -> None:
+    config_path, lineage_path, out_root = _write_manifest_pair(tmp_path)
+    out = out_root / "bundle_out"
+    rc = main(
+        [
+            "--config-patch-manifest",
+            str(config_path),
+            "--candidate-lineage-manifest",
+            str(lineage_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+
+
+def test_cli_requires_all_three_paths() -> None:
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_cli_missing_config_manifest_usage_error(tmp_path: Path) -> None:
+    _, lineage_path, out_root = _write_manifest_pair(tmp_path)
+    rc = main(
+        [
+            "--config-patch-manifest",
+            str(tmp_path / "missing.json"),
+            "--candidate-lineage-manifest",
+            str(lineage_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_missing_lineage_manifest_usage_error(tmp_path: Path) -> None:
+    config_path, _, out_root = _write_manifest_pair(tmp_path)
+    rc = main(
+        [
+            "--config-patch-manifest",
+            str(config_path),
+            "--candidate-lineage-manifest",
+            str(tmp_path / "missing.json"),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_invalid_json_binding_error(tmp_path: Path) -> None:
+    config_path = tmp_path / "bad.json"
+    config_path.write_text("{broken", encoding="utf-8")
+    _, lineage_path, out_root = _write_manifest_pair(tmp_path)
+    rc = main(
+        [
+            "--config-patch-manifest",
+            str(config_path),
+            "--candidate-lineage-manifest",
+            str(lineage_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_ref_inconsistency_binding_error(tmp_path: Path) -> None:
+    config_path, lineage_path, out_root = _write_manifest_pair(tmp_path)
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    payload["lineage_manifest_ref"] = "99999999-9999-4999-8999-999999999999"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--config-patch-manifest",
+            str(config_path),
+            "--candidate-lineage-manifest",
+            str(lineage_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_existing_output_binding_error(tmp_path: Path) -> None:
+    config_path, lineage_path, out_root = _write_manifest_pair(tmp_path)
+    out = out_root / "exists"
+    out.mkdir()
+    rc = main(
+        [
+            "--config-patch-manifest",
+            str(config_path),
+            "--candidate-lineage-manifest",
+            str(lineage_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_stderr_has_no_full_payload_dump(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path, lineage_path, out_root = _write_manifest_pair(tmp_path)
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    payload["lineage_manifest_ref"] = "99999999-9999-4999-8999-999999999999"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--config-patch-manifest",
+            str(config_path),
+            "--candidate-lineage-manifest",
+            str(lineage_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+    err = capsys.readouterr().err
+    assert "patches" not in err
+    assert len(err) < 500
+
+
+def test_cli_no_network_or_promotion_side_effects(tmp_path: Path) -> None:
+    config_path, lineage_path, out_root = _write_manifest_pair(tmp_path)
+    out = out_root / "bundle"
+    with patch("urllib.request.urlopen", side_effect=AssertionError("network forbidden")):
+        rc = main(
+            [
+                "--config-patch-manifest",
+                str(config_path),
+                "--candidate-lineage-manifest",
+                str(lineage_path),
+                "--output-dir",
+                str(out),
+            ]
+        )
+    assert rc == EXIT_OK
+
+
+def test_cli_deterministic_output(tmp_path: Path) -> None:
+    config_path, lineage_path, out_root = _write_manifest_pair(tmp_path)
+    out1 = out_root / "bundle1"
+    out2 = out_root / "bundle2"
+    assert (
+        main(
+            [
+                "--config-patch-manifest",
+                str(config_path),
+                "--candidate-lineage-manifest",
+                str(lineage_path),
+                "--output-dir",
+                str(out1),
+            ]
+        )
+        == EXIT_OK
+    )
+    assert (
+        main(
+            [
+                "--config-patch-manifest",
+                str(config_path),
+                "--candidate-lineage-manifest",
+                str(lineage_path),
+                "--output-dir",
+                str(out2),
+            ]
+        )
+        == EXIT_OK
+    )
+    assert (out1 / INDEX_ARTIFACT_REL).read_bytes() == (out2 / INDEX_ARTIFACT_REL).read_bytes()


### PR DESCRIPTION
## Summary

- Adds Package G offline durable evidence binding for validated `ConfigPatchManifestV1` and `CandidateLineageManifestV1` artifacts
- Produces schema-versioned binding index (ID/ref/hash/relative paths only), byte-identical manifest copies, and `MANIFEST.sha256` via atomic publish
- Adds CLI, contract testowners, and `PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_*` CI selector bundle

## GO_TOKEN

`GO_PACKAGE_G_OFFLINE_LEARNING_MANIFEST_DURABLE_EVIDENCE_BINDING_V1_IMPLEMENTATION_V0`

## Scope

- `src/meta/learning_loop/manifest_durable_evidence_binding_v1.py`
- `scripts/run_learning_manifest_durable_evidence_binding_v1.py`
- `tests/meta/test_learning_manifest_durable_evidence_binding_v1.py`
- `tests/scripts/test_run_learning_manifest_durable_evidence_binding_v1.py`
- `scripts/ops/ci_test_selection_v1.py`
- `tests/ci/test_ci_diff_aware_test_selection_v1.py`

## Out of scope

- No Package A–F producer/schema changes
- No promotion/apply/runtime/AWS/S3/scheduler integration
- No Package H or later work

## Test results

- Package G binding + CLI + selector: **31 passed**
- Regression (config patch contract, learning bridge, lineage contract/producer, offline E2E): **99 passed**
- **Total local: 130 passed**
- Ruff format/check: **PASS**

## Binding index contract

- Schema: `learning_manifest_durable_evidence_binding_v1`
- Metadata only: manifest IDs, cross-refs, artifact SHA256 + relative paths, canonical safety refs
- `evidence_does_not_authorize_runtime=true`
- No patch/strategy/signal/risk payload duplication

## Determinism & atomic publication

- Identical inputs → identical index + `MANIFEST.sha256`
- Staging sibling → verify → atomic rename; fail-closed on existing target; cleanup on error

## Required CI path

**PR_BOUNDED_FULL** via `PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_*`

## Safety

- `TRADING_LOGIC_IMMUTABILITY=PASS`
- `EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true`
- `RUNTIME_AUTHORITY_IMPACT=NONE`

## Durable evidence

Bundle path and `MANIFEST_VERIFY_RC=0` documented in implementation evidence (outside repo).


Made with [Cursor](https://cursor.com)