### PR TITLE
feat(risk): Package H — offline backtest returns→VaR suite wiring v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1313,12 +1313,18 @@ PR_BOUNDED_FULL_CI_CHANGE_EXTRA_TARGETS: tuple[str, ...] = (
 PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/risk/validation/var_suite_adapter.py",
+        "src/risk/validation/var_suite_backtest_wiring_v1.py",
+        "scripts/run_var_suite_from_backtest_run_v1.py",
         "tests/risk/validation/test_var_suite_adapter_v0.py",
+        "tests/risk/validation/test_var_suite_backtest_wiring_v1.py",
+        "tests/scripts/test_backtest_returns_var_suite_offline_v1.py",
     }
 )
 
 PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_TARGETS: tuple[str, ...] = (
     "tests/risk/validation/test_var_suite_adapter_v0.py",
+    "tests/risk/validation/test_var_suite_backtest_wiring_v1.py",
+    "tests/scripts/test_backtest_returns_var_suite_offline_v1.py",
 )
 
 PR_BOUNDED_FULL_PACKAGE_A_META_TRIGGER_PATHS: frozenset[str] = frozenset(

--- a/scripts/run_var_suite_from_backtest_run_v1.py
+++ b/scripts/run_var_suite_from_backtest_run_v1.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Package H — offline backtest returns to VaR suite evidence wiring CLI v1.
+
+Wires explicit backtest run artifacts through the existing var_suite_adapter to
+canonical suite_report.json and suite_report.md.  Evidence-only; no promotion,
+apply, runtime, or registry mutation.
+
+Usage:
+    python3 scripts/run_var_suite_from_backtest_run_v1.py \\
+        --run-dir results/backtest/run_001 \\
+        --output-dir reports/var_suite/run_001
+
+    python3 scripts/run_var_suite_from_backtest_run_v1.py \\
+        --strategy-returns-manifest configs/strategy_returns.toml \\
+        --strategy-id demo_strategy \\
+        --output-dir reports/var_suite/demo_strategy
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.risk.validation.var_suite_backtest_wiring_v1 import (
+    DEFAULT_ROLLING_WINDOW,
+    VarSuiteBacktestWiringError,
+    run_backtest_var_suite_wiring_v1,
+)
+
+EXIT_OK = 0
+EXIT_WIRING_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Package H: wire explicit backtest returns to VaR suite evidence reports."
+        )
+    )
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        default=None,
+        help="Explicit backtest run directory containing equity artifacts.",
+    )
+    parser.add_argument(
+        "--strategy-returns-manifest",
+        type=Path,
+        default=None,
+        help="Explicit strategy_returns manifest TOML path.",
+    )
+    parser.add_argument(
+        "--strategy-id",
+        type=str,
+        default=None,
+        help="Strategy id key inside [strategy_returns] (required with --strategy-returns-manifest).",
+    )
+    parser.add_argument(
+        "--manifest-base-dir",
+        type=Path,
+        default=None,
+        help="Optional base directory for relative run_dir paths in the manifest.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit output directory for suite reports (must not exist).",
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=DEFAULT_ROLLING_WINDOW,
+        help=f"Rolling historical VaR window (default: {DEFAULT_ROLLING_WINDOW}).",
+    )
+    parser.add_argument(
+        "--confidence",
+        type=float,
+        default=0.95,
+        help="VaR confidence level (default: 0.95).",
+    )
+    parser.add_argument(
+        "--significance",
+        type=float,
+        default=0.05,
+        help="Statistical test significance level (default: 0.05).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.strategy_returns_manifest is not None and not args.strategy_id:
+        print(
+            "ERROR: --strategy-id is required with --strategy-returns-manifest",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if args.run_dir is None and args.strategy_returns_manifest is None:
+        print("ERROR: --run-dir or --strategy-returns-manifest is required", file=sys.stderr)
+        return EXIT_USAGE_ERROR
+
+    try:
+        result = run_backtest_var_suite_wiring_v1(
+            run_dir=args.run_dir,
+            strategy_returns_manifest=args.strategy_returns_manifest,
+            strategy_id=args.strategy_id,
+            manifest_base_dir=args.manifest_base_dir,
+            output_dir=args.output_dir,
+            window=args.window,
+            confidence_level=args.confidence,
+            significance=args.significance,
+        )
+    except VarSuiteBacktestWiringError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return EXIT_WIRING_ERROR
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return EXIT_WIRING_ERROR
+
+    print(f"overall_result={result.suite_result.overall_result}")
+    print(f"observations={result.suite_result.observations}")
+    print(f"output_dir={result.output_dir.name}")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/risk/validation/var_suite_backtest_wiring_v1.py
+++ b/src/risk/validation/var_suite_backtest_wiring_v1.py
@@ -1,0 +1,238 @@
+"""
+Package H — offline backtest returns to VaR suite report wiring v1.
+
+Deterministic, fail-closed bridge from explicit backtest run artifacts to canonical
+VaR suite evidence reports.  No trading, runtime, promotion, or VaR semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from src.experiments.equity_loader import equity_to_returns, load_equity_curves_from_run_dir
+from src.experiments.strategy_returns_manifest_loader import (
+    StrategyReturnsManifestError,
+    load_returns_for_strategy_from_manifest,
+)
+from src.risk.validation.report_formatter import (
+    format_suite_result_json,
+    format_suite_result_markdown,
+)
+from src.risk.validation.suite_runner import VaRBacktestSuiteResult
+from src.risk.validation.var_suite_adapter import run_rolling_historical_var_backtest_suite
+
+SUITE_REPORT_JSON = "suite_report.json"
+SUITE_REPORT_MD = "suite_report.md"
+STAGING_DIRNAME_PREFIX = ".var_suite_backtest_wiring_staging_"
+DEFAULT_ROLLING_WINDOW = 5
+
+
+class VarSuiteBacktestWiringError(ValueError):
+    """Fail-closed Package H backtest→VaR suite wiring error."""
+
+
+@dataclass(frozen=True)
+class BacktestVarSuiteWiringResult:
+    """Published offline VaR suite evidence bundle."""
+
+    output_dir: Path
+    suite_result: VaRBacktestSuiteResult
+
+
+def load_returns_from_run_dir(run_dir: Path | str) -> pd.Series:
+    """Load canonical returns from an explicit backtest run directory."""
+    path = Path(run_dir)
+    if not path.exists():
+        raise VarSuiteBacktestWiringError(f"run_dir not found: {path}")
+    if not path.is_dir():
+        raise VarSuiteBacktestWiringError(f"run_dir is not a directory: {path}")
+    try:
+        curves = load_equity_curves_from_run_dir(path, max_curves=1)
+    except (FileNotFoundError, ValueError) as exc:
+        raise VarSuiteBacktestWiringError(f"equity load failed for run_dir={path}: {exc}") from exc
+    try:
+        return equity_to_returns(curves[0])
+    except ValueError as exc:
+        raise VarSuiteBacktestWiringError(
+            f"returns derivation failed for run_dir={path}: {exc}"
+        ) from exc
+
+
+def resolve_backtest_returns(
+    *,
+    run_dir: Path | str | None,
+    strategy_returns_manifest: Path | str | None,
+    strategy_id: str | None,
+    manifest_base_dir: Path | str | None = None,
+) -> pd.Series:
+    """Resolve returns from exactly one explicit offline input source."""
+    has_run_dir = run_dir is not None
+    has_manifest_path = strategy_returns_manifest is not None
+    has_strategy_id = strategy_id is not None
+
+    if has_manifest_path and not has_strategy_id:
+        raise VarSuiteBacktestWiringError("strategy_id required with strategy_returns_manifest")
+    if has_strategy_id and not has_manifest_path:
+        raise VarSuiteBacktestWiringError("strategy_returns_manifest required with strategy_id")
+    if has_run_dir and (has_manifest_path or has_strategy_id):
+        raise VarSuiteBacktestWiringError(
+            "run_dir and strategy_returns_manifest inputs are mutually exclusive"
+        )
+    if not has_run_dir and not (has_manifest_path and has_strategy_id):
+        raise VarSuiteBacktestWiringError(
+            "exactly one input required: run_dir or (strategy_returns_manifest, strategy_id)"
+        )
+
+    if has_run_dir:
+        return load_returns_from_run_dir(run_dir)
+
+    try:
+        return load_returns_for_strategy_from_manifest(
+            strategy_id=str(strategy_id),
+            manifest_path=Path(strategy_returns_manifest),
+            base_dir=Path(manifest_base_dir) if manifest_base_dir is not None else None,
+        )
+    except StrategyReturnsManifestError as exc:
+        raise VarSuiteBacktestWiringError(str(exc)) from exc
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise VarSuiteBacktestWiringError(f"output_dir already exists (fail-closed): {output_dir}")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise VarSuiteBacktestWiringError(f"output_dir parent missing: {parent}")
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    token = uuid.uuid4().hex
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{token}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def _validate_report_payloads(*, json_text: str, markdown_text: str) -> None:
+    try:
+        data = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise VarSuiteBacktestWiringError(f"suite_report.json is invalid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise VarSuiteBacktestWiringError("suite_report.json root must be a JSON object")
+    if "overall_result" not in data:
+        raise VarSuiteBacktestWiringError("suite_report.json missing overall_result")
+    if not markdown_text.strip():
+        raise VarSuiteBacktestWiringError("suite_report.md is empty")
+
+
+def _assert_no_absolute_paths_in_reports(*, json_text: str, markdown_text: str) -> None:
+    for label, text in (("suite_report.json", json_text), ("suite_report.md", markdown_text)):
+        if "://" in text:
+            raise VarSuiteBacktestWiringError(f"{label} must not contain URL-like absolute paths")
+        if "/Users/" in text or "C:\\" in text or "\\\\" in text:
+            raise VarSuiteBacktestWiringError(f"{label} must not contain host absolute paths")
+
+
+def _atomic_publish_suite_reports(
+    *,
+    staging: Path,
+    final_dir: Path,
+    json_text: str,
+    markdown_text: str,
+) -> None:
+    _validate_report_payloads(json_text=json_text, markdown_text=markdown_text)
+    _assert_no_absolute_paths_in_reports(json_text=json_text, markdown_text=markdown_text)
+
+    json_path = staging / SUITE_REPORT_JSON
+    md_path = staging / SUITE_REPORT_MD
+    json_path.write_text(json_text, encoding="utf-8")
+    md_path.write_text(markdown_text, encoding="utf-8")
+
+    reread_json = json_path.read_text(encoding="utf-8")
+    reread_md = md_path.read_text(encoding="utf-8")
+    if reread_json != json_text or reread_md != markdown_text:
+        raise VarSuiteBacktestWiringError("report read-back verification failed before publish")
+
+    staging.replace(final_dir)
+
+    final_json = final_dir / SUITE_REPORT_JSON
+    final_md = final_dir / SUITE_REPORT_MD
+    if not final_json.is_file() or not final_md.is_file():
+        raise VarSuiteBacktestWiringError("published suite reports missing after atomic rename")
+
+
+def run_backtest_var_suite_wiring_v1(
+    *,
+    run_dir: Path | str | None = None,
+    strategy_returns_manifest: Path | str | None = None,
+    strategy_id: str | None = None,
+    manifest_base_dir: Path | str | None = None,
+    output_dir: Path | str,
+    window: int = DEFAULT_ROLLING_WINDOW,
+    confidence_level: float = 0.95,
+    significance: float = 0.05,
+) -> BacktestVarSuiteWiringResult:
+    """
+      Wire explicit offline backtest returns to canonical VaR suite evidence reports.
+
+    Pure orchestration: loader → existing adapter → existing formatter → atomic publish.
+    """
+    final_dir = Path(output_dir)
+    _validate_output_target(final_dir)
+
+    returns = resolve_backtest_returns(
+        run_dir=run_dir,
+        strategy_returns_manifest=strategy_returns_manifest,
+        strategy_id=strategy_id,
+        manifest_base_dir=manifest_base_dir,
+    )
+
+    suite_result = run_rolling_historical_var_backtest_suite(
+        returns,
+        window=window,
+        confidence_level=confidence_level,
+        significance=significance,
+    )
+
+    json_text = format_suite_result_json(suite_result)
+    markdown_text = format_suite_result_markdown(suite_result)
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise VarSuiteBacktestWiringError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        _atomic_publish_suite_reports(
+            staging=staging,
+            final_dir=final_dir,
+            json_text=json_text,
+            markdown_text=markdown_text,
+        )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return BacktestVarSuiteWiringResult(output_dir=final_dir, suite_result=suite_result)
+
+
+__all__ = [
+    "DEFAULT_ROLLING_WINDOW",
+    "BacktestVarSuiteWiringResult",
+    "SUITE_REPORT_JSON",
+    "SUITE_REPORT_MD",
+    "VarSuiteBacktestWiringError",
+    "load_returns_from_run_dir",
+    "resolve_backtest_returns",
+    "run_backtest_var_suite_wiring_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -4860,6 +4860,10 @@ def test_tests_job_has_pr_bounded_full_step() -> None:
 
 VAR_SUITE_ADAPTER_PRODUCTION = "src/risk/validation/var_suite_adapter.py"
 VAR_SUITE_ADAPTER_TESTOWNER = "tests/risk/validation/test_var_suite_adapter_v0.py"
+VAR_SUITE_BACKTEST_WIRING_PRODUCTION = "src/risk/validation/var_suite_backtest_wiring_v1.py"
+VAR_SUITE_BACKTEST_WIRING_TESTOWNER = "tests/risk/validation/test_var_suite_backtest_wiring_v1.py"
+VAR_SUITE_BACKTEST_CLI = "scripts/run_var_suite_from_backtest_run_v1.py"
+VAR_SUITE_BACKTEST_CLI_TESTOWNER = "tests/scripts/test_backtest_returns_var_suite_offline_v1.py"
 
 
 def _bounded_targets(sel: dict[str, str]) -> list[str]:
@@ -4882,7 +4886,11 @@ def _resolve_finalized_with_adapter_testowner_present(monkeypatch: pytest.Monkey
     original_exists = sel_mod._repo_path_exists
 
     def fake_exists(path: str) -> bool:
-        if path == VAR_SUITE_ADAPTER_TESTOWNER:
+        if path in (
+            VAR_SUITE_ADAPTER_TESTOWNER,
+            VAR_SUITE_BACKTEST_WIRING_TESTOWNER,
+            VAR_SUITE_BACKTEST_CLI_TESTOWNER,
+        ):
             return True
         return original_exists(path)
 
@@ -4955,6 +4963,46 @@ def test_selector_var_suite_adapter_empty_diff_does_not_add_adapter_testowner() 
     sel = _run_selector()
     assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     assert VAR_SUITE_ADAPTER_TESTOWNER not in _bounded_targets(sel)
+
+
+def test_selector_var_suite_backtest_wiring_production_path_includes_package_h_testowners(
+    monkeypatch,
+) -> None:
+    result = _resolve_finalized_with_adapter_testowner_present(
+        monkeypatch, VAR_SUITE_BACKTEST_WIRING_PRODUCTION
+    )
+    assert result.mode == "PR_BOUNDED_FULL"
+    assert VAR_SUITE_BACKTEST_WIRING_TESTOWNER in result.pr_bounded_pytest_targets
+    assert VAR_SUITE_BACKTEST_CLI_TESTOWNER in result.pr_bounded_pytest_targets
+    assert VAR_SUITE_ADAPTER_TESTOWNER in result.pr_bounded_pytest_targets
+
+
+def test_selector_var_suite_backtest_cli_trigger_adds_targets_when_combined_with_wiring(
+    monkeypatch,
+) -> None:
+    result = _resolve_finalized_with_adapter_testowner_present(
+        monkeypatch,
+        VAR_SUITE_BACKTEST_CLI,
+        VAR_SUITE_BACKTEST_WIRING_PRODUCTION,
+    )
+    assert result.mode == "PR_BOUNDED_FULL"
+    assert VAR_SUITE_BACKTEST_CLI_TESTOWNER in result.pr_bounded_pytest_targets
+    assert VAR_SUITE_BACKTEST_WIRING_TESTOWNER in result.pr_bounded_pytest_targets
+
+
+def test_selector_var_suite_backtest_wiring_combined_diff_includes_testowners_once(
+    monkeypatch,
+) -> None:
+    result = _resolve_finalized_with_adapter_testowner_present(
+        monkeypatch,
+        VAR_SUITE_BACKTEST_WIRING_PRODUCTION,
+        VAR_SUITE_BACKTEST_CLI,
+        VAR_SUITE_BACKTEST_WIRING_TESTOWNER,
+        VAR_SUITE_BACKTEST_CLI_TESTOWNER,
+    )
+    assert result.pr_bounded_pytest_targets.count(VAR_SUITE_BACKTEST_WIRING_TESTOWNER) == 1
+    assert result.pr_bounded_pytest_targets.count(VAR_SUITE_BACKTEST_CLI_TESTOWNER) == 1
+    assert result.pr_bounded_pytest_targets.count(VAR_SUITE_ADAPTER_TESTOWNER) == 1
 
 
 PACKAGE_A_META_PRODUCTION = "src/meta/learning_loop/contract_safety_v1.py"

--- a/tests/risk/validation/test_var_suite_backtest_wiring_v1.py
+++ b/tests/risk/validation/test_var_suite_backtest_wiring_v1.py
@@ -1,0 +1,289 @@
+"""Contract tests for Package H offline backtest→VaR suite wiring v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.risk.validation.suite_runner import VaRBacktestSuiteResult
+from src.risk.validation.var_suite_backtest_wiring_v1 import (
+    SUITE_REPORT_JSON,
+    SUITE_REPORT_MD,
+    VarSuiteBacktestWiringError,
+    load_returns_from_run_dir,
+    resolve_backtest_returns,
+    run_backtest_var_suite_wiring_v1,
+)
+from src.risk.validation.var_suite_adapter import run_rolling_historical_var_backtest_suite
+
+
+def _write_equity_csv(run_dir: Path, *, periods: int = 20) -> None:
+    rng = np.random.default_rng(42)
+    equity = 100.0 + np.cumsum(rng.normal(0.0, 0.5, size=periods))
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=periods, freq="D", tz="UTC"),
+            "equity": equity,
+        }
+    )
+    df.to_csv(run_dir / "run_equity.csv", index=False)
+
+
+def _write_strategy_manifest(manifest_path: Path, strategy_id: str, rel_run_dir: str) -> None:
+    manifest_path.write_text(
+        f'[strategy_returns]\n{strategy_id} = "{rel_run_dir}"\n',
+        encoding="utf-8",
+    )
+
+
+def _sample_suite_result() -> VaRBacktestSuiteResult:
+    return VaRBacktestSuiteResult(
+        observations=12,
+        breaches=1,
+        confidence_level=0.95,
+        kupiec_pof_result="PASS",
+        kupiec_pof_pvalue=0.5,
+        basel_traffic_light="GREEN",
+        christoffersen_ind_result="PASS",
+        christoffersen_ind_pvalue=0.5,
+        christoffersen_cc_result="PASS",
+        christoffersen_cc_pvalue=0.5,
+    )
+
+
+class TestReturnsLoaderReuse:
+    def test_load_returns_from_run_dir_uses_equity_loader(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir)
+        returns = load_returns_from_run_dir(run_dir)
+        assert isinstance(returns, pd.Series)
+        assert len(returns) >= 2
+        assert np.isfinite(returns.to_numpy(dtype=float)).all()
+
+    def test_missing_run_dir_fail_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(VarSuiteBacktestWiringError, match="run_dir not found"):
+            load_returns_from_run_dir(tmp_path / "missing")
+
+    def test_empty_run_dir_fail_closed(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "empty"
+        run_dir.mkdir()
+        with pytest.raises(VarSuiteBacktestWiringError, match="equity load failed"):
+            load_returns_from_run_dir(run_dir)
+
+
+class TestInputContract:
+    def test_mutually_exclusive_inputs_fail_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(VarSuiteBacktestWiringError, match="mutually exclusive"):
+            resolve_backtest_returns(
+                run_dir=tmp_path,
+                strategy_returns_manifest=tmp_path / "m.toml",
+                strategy_id="s1",
+            )
+
+    def test_missing_input_fail_closed(self) -> None:
+        with pytest.raises(VarSuiteBacktestWiringError, match="exactly one input"):
+            resolve_backtest_returns(run_dir=None, strategy_returns_manifest=None, strategy_id=None)
+
+    def test_manifest_requires_strategy_id(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "m.toml"
+        manifest.write_text("[strategy_returns]\n", encoding="utf-8")
+        with pytest.raises(VarSuiteBacktestWiringError, match="strategy_id required"):
+            resolve_backtest_returns(
+                run_dir=None,
+                strategy_returns_manifest=manifest,
+                strategy_id=None,
+            )
+
+    def test_manifest_loader_path(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "runs" / "r1"
+        run_dir.mkdir(parents=True)
+        _write_equity_csv(run_dir)
+        manifest = tmp_path / "strategy_returns.toml"
+        manifest.write_text('[strategy_returns]\ndemo = "runs/r1"\n', encoding="utf-8")
+        returns = resolve_backtest_returns(
+            run_dir=None,
+            strategy_returns_manifest=manifest,
+            strategy_id="demo",
+            manifest_base_dir=tmp_path,
+        )
+        assert len(returns) >= 2
+
+
+class TestAdapterDelegation:
+    def test_wiring_calls_existing_adapter(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir)
+        out = tmp_path / "out"
+        expected = _sample_suite_result()
+
+        with patch(
+            "src.risk.validation.var_suite_backtest_wiring_v1.run_rolling_historical_var_backtest_suite",
+            return_value=expected,
+        ) as mocked:
+            result = run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out, window=5)
+
+        mocked.assert_called_once()
+        call_kwargs = mocked.call_args.kwargs
+        assert call_kwargs["window"] == 5
+        assert call_kwargs["confidence_level"] == 0.95
+        assert isinstance(mocked.call_args.args[0], pd.Series)
+        assert result.suite_result is expected
+
+    def test_end_to_end_uses_real_adapter(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir, periods=30)
+        out = tmp_path / "out"
+        result = run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out, window=5)
+        assert result.suite_result.observations >= 2
+        assert result.suite_result.overall_result in {"PASS", "FAIL"}
+
+
+class TestDeterminism:
+    def test_identical_inputs_identical_report_bytes(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir, periods=30)
+
+        out1 = tmp_path / "out1"
+        out2 = tmp_path / "out2"
+        run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out1, window=5)
+        run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out2, window=5)
+
+        json1 = (out1 / SUITE_REPORT_JSON).read_text(encoding="utf-8")
+        json2 = (out2 / SUITE_REPORT_JSON).read_text(encoding="utf-8")
+        md1 = (out1 / SUITE_REPORT_MD).read_text(encoding="utf-8")
+        md2 = (out2 / SUITE_REPORT_MD).read_text(encoding="utf-8")
+        assert json1 == json2
+        assert md1 == md2
+
+
+class TestAtomicPublication:
+    def test_publishes_both_reports(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir, periods=30)
+        out = tmp_path / "out"
+        run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out, window=5)
+        assert (out / SUITE_REPORT_JSON).is_file()
+        assert (out / SUITE_REPORT_MD).is_file()
+        data = json.loads((out / SUITE_REPORT_JSON).read_text(encoding="utf-8"))
+        assert "overall_result" in data
+
+    def test_existing_output_dir_fail_closed(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir)
+        out = tmp_path / "out"
+        out.mkdir()
+        with pytest.raises(VarSuiteBacktestWiringError, match="already exists"):
+            run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out, window=5)
+
+    def test_adapter_failure_leaves_no_final_output(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir)
+        out = tmp_path / "out"
+        with patch(
+            "src.risk.validation.var_suite_backtest_wiring_v1.run_rolling_historical_var_backtest_suite",
+            side_effect=ValueError("adapter failed"),
+        ):
+            with pytest.raises(ValueError, match="adapter failed"):
+                run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out, window=5)
+        assert not out.exists()
+
+    def test_publish_failure_cleans_staging(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir)
+        out = tmp_path / "out"
+
+        with patch(
+            "src.risk.validation.var_suite_backtest_wiring_v1._atomic_publish_suite_reports",
+            side_effect=VarSuiteBacktestWiringError("publish failed"),
+        ):
+            with pytest.raises(VarSuiteBacktestWiringError, match="publish failed"):
+                run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out, window=5)
+        assert not out.exists()
+        assert not any(
+            p.name.startswith(".var_suite_backtest_wiring_staging_") for p in tmp_path.iterdir()
+        )
+
+
+class TestInvalidReturns:
+    def test_nan_returns_fail_at_adapter(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir, periods=30)
+        out = tmp_path / "out"
+        nan_returns = load_returns_from_run_dir(run_dir)
+        nan_returns.iloc[0] = np.nan
+        with patch(
+            "src.risk.validation.var_suite_backtest_wiring_v1.resolve_backtest_returns",
+            return_value=nan_returns,
+        ):
+            with pytest.raises(ValueError, match="NaN"):
+                run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out, window=5)
+
+
+class TestAuthorityNeutrality:
+    _FORBIDDEN_IMPORTS = (
+        "src.execution",
+        "src.governance",
+        "requests",
+        "urllib",
+        "httpx",
+        "aiohttp",
+        "ccxt",
+    )
+
+    def test_wiring_module_has_no_trading_or_network_imports(self) -> None:
+        module_path = Path("src/risk/validation/var_suite_backtest_wiring_v1.py")
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported.add(alias.name)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        for forbidden in self._FORBIDDEN_IMPORTS:
+            assert not any(mod == forbidden or mod.startswith(f"{forbidden}.") for mod in imported)
+
+
+class TestNoDuplicatedVarCalculation:
+    def test_wiring_does_not_import_var_calculation_modules(self) -> None:
+        source = Path("src/risk/validation/var_suite_backtest_wiring_v1.py").read_text(
+            encoding="utf-8"
+        )
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported.add(alias.name)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        assert "src.risk.portfolio_var" not in imported
+
+    def test_real_path_matches_direct_adapter(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        _write_equity_csv(run_dir, periods=30)
+        returns = load_returns_from_run_dir(run_dir)
+        direct = run_rolling_historical_var_backtest_suite(returns, window=5)
+        out = tmp_path / "out"
+        wired = run_backtest_var_suite_wiring_v1(run_dir=run_dir, output_dir=out, window=5)
+        assert wired.suite_result.observations == direct.observations
+        assert wired.suite_result.breaches == direct.breaches
+        assert wired.suite_result.overall_result == direct.overall_result

--- a/tests/scripts/test_backtest_returns_var_suite_offline_v1.py
+++ b/tests/scripts/test_backtest_returns_var_suite_offline_v1.py
@@ -1,0 +1,151 @@
+"""CLI tests for Package H offline backtest→VaR suite wiring v1."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.run_var_suite_from_backtest_run_v1 import (
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    EXIT_WIRING_ERROR,
+    main,
+)
+from src.risk.validation.var_suite_backtest_wiring_v1 import SUITE_REPORT_JSON, SUITE_REPORT_MD
+
+
+def _write_equity_csv(run_dir: Path, *, periods: int = 30) -> None:
+    rng = np.random.default_rng(7)
+    equity = 100.0 + np.cumsum(rng.normal(0.0, 0.4, size=periods))
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-02-01", periods=periods, freq="D", tz="UTC"),
+            "equity": equity,
+        }
+    )
+    df.to_csv(run_dir / "cli_equity.csv", index=False)
+
+
+def test_cli_successful_run_dir_path(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_equity_csv(run_dir)
+    out = tmp_path / "suite_out"
+    rc = main(["--run-dir", str(run_dir), "--output-dir", str(out)])
+    assert rc == EXIT_OK
+    assert (out / SUITE_REPORT_JSON).is_file()
+    assert (out / SUITE_REPORT_MD).is_file()
+    data = json.loads((out / SUITE_REPORT_JSON).read_text(encoding="utf-8"))
+    assert data["overall_result"] in {"PASS", "FAIL"}
+
+
+def test_cli_requires_output_dir(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_equity_csv(run_dir)
+    rc = main(["--run-dir", str(run_dir)])
+    assert rc == EXIT_USAGE_ERROR
+    assert "required" in capsys.readouterr().err.lower()
+
+
+def test_cli_missing_run_dir_fail_closed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    out = tmp_path / "out"
+    rc = main(["--run-dir", str(tmp_path / "missing"), "--output-dir", str(out)])
+    assert rc == EXIT_WIRING_ERROR
+    assert not out.exists()
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_cli_existing_output_dir_fail_closed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_equity_csv(run_dir)
+    out = tmp_path / "out"
+    out.mkdir()
+    rc = main(["--run-dir", str(run_dir), "--output-dir", str(out)])
+    assert rc == EXIT_WIRING_ERROR
+    assert not (out / SUITE_REPORT_JSON).exists()
+
+
+def test_cli_manifest_requires_strategy_id(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    manifest = tmp_path / "returns.toml"
+    manifest.write_text("[strategy_returns]\ndemo = 'run'\n", encoding="utf-8")
+    out = tmp_path / "out"
+    rc = main(
+        [
+            "--strategy-returns-manifest",
+            str(manifest),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+    assert "strategy-id" in capsys.readouterr().err.lower()
+
+
+def test_cli_manifest_success(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+    _write_equity_csv(run_dir)
+    manifest = tmp_path / "returns.toml"
+    manifest.write_text('[strategy_returns]\ndemo = "runs/r1"\n', encoding="utf-8")
+    out = tmp_path / "out"
+    rc = main(
+        [
+            "--strategy-returns-manifest",
+            str(manifest),
+            "--strategy-id",
+            "demo",
+            "--manifest-base-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert (out / SUITE_REPORT_JSON).is_file()
+
+
+def test_cli_deterministic_output(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_equity_csv(run_dir)
+    out1 = tmp_path / "out1"
+    out2 = tmp_path / "out2"
+    assert main(["--run-dir", str(run_dir), "--output-dir", str(out1)]) == EXIT_OK
+    assert main(["--run-dir", str(run_dir), "--output-dir", str(out2)]) == EXIT_OK
+    assert (out1 / SUITE_REPORT_JSON).read_bytes() == (out2 / SUITE_REPORT_JSON).read_bytes()
+
+
+def test_cli_no_backtest_or_network_side_effects(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_equity_csv(run_dir)
+    out = tmp_path / "out"
+    with patch("subprocess.run") as subprocess_run:
+        rc = main(["--run-dir", str(run_dir), "--output-dir", str(out)])
+    assert rc == EXIT_OK
+    subprocess_run.assert_not_called()
+
+
+def test_cli_stderr_has_no_secrets(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_equity_csv(run_dir)
+    out = tmp_path / "out"
+    main(["--run-dir", str(run_dir), "--output-dir", str(out)])
+    err = capsys.readouterr().err
+    for token in ("api_key", "secret", "password", "token="):
+        assert token not in err.lower()

--- a/tests/scripts/test_backtest_returns_var_suite_offline_v1.py
+++ b/tests/scripts/test_backtest_returns_var_suite_offline_v1.py
@@ -49,8 +49,9 @@ def test_cli_requires_output_dir(tmp_path: Path, capsys: pytest.CaptureFixture[s
     run_dir = tmp_path / "run"
     run_dir.mkdir()
     _write_equity_csv(run_dir)
-    rc = main(["--run-dir", str(run_dir)])
-    assert rc == EXIT_USAGE_ERROR
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--run-dir", str(run_dir)])
+    assert exc_info.value.code == EXIT_USAGE_ERROR
     assert "required" in capsys.readouterr().err.lower()
 
 


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_PACKAGE_H_OFFLINE_BACKTEST_RETURNS_VAR_SUITE_WIRING_V1_IMPLEMENTATION_V0`
- Implements Package H: deterministic offline wiring from explicit backtest run/manifest artifacts → existing `var_suite_adapter` → `run_var_backtest_suite` → canonical `suite_report.json` / `suite_report.md` with atomic publication
- Adds `var_suite_backtest_wiring_v1.py`, CLI `run_var_suite_from_backtest_run_v1.py`, contract/E2E testowners, and extends `PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_*` CI bundle

## Scope

- Reuses `equity_loader`, `strategy_returns_manifest_loader`, `var_suite_adapter`, `suite_runner`, `report_formatter`
- Fail-closed input contract (explicit `--run-dir` or manifest pair + `--output-dir`)
- Evidence-only; no promotion, apply, runtime, or registry mutation

## Out of scope

- VaR→Promotion, compare decisions, domain producers, Package G durable binding, Ops GAP4, Package I
- No changes to VaR formulas, suite thresholds, risk limits, KillSwitch, strategy/signal/sizing/execution

## Changed files

- `src/risk/validation/var_suite_backtest_wiring_v1.py` (new)
- `scripts/run_var_suite_from_backtest_run_v1.py` (new)
- `tests/risk/validation/test_var_suite_backtest_wiring_v1.py` (new)
- `tests/scripts/test_backtest_returns_var_suite_offline_v1.py` (new)
- `scripts/ops/ci_test_selection_v1.py`
- `tests/ci/test_ci_diff_aware_test_selection_v1.py`

## VaR semantics / risk limits

- `VAR_SEMANTICS_IMMUTABLE=true` — adapter and suite runner called unchanged; no duplicated VaR calculation in wiring
- `RISK_LIMITS_IMMUTABLE=true` — no enforcement/KillSwitch/sizing touches

## Determinism & atomic publication

- Identical inputs → identical report bytes (tested)
- Staging sibling dir → validate → atomic `replace` to final output; failures leave no partial final output

## JSON drift decision

- `NESTED_CANONICAL_NO_FLAT_PROJECTION` — `format_suite_result_json` unchanged; no `report_formatter.py` change; `report_compare.load_run` not in Package H consumer scope

## Local tests

- 83 tests PASS (Package H wiring/CLI/adapter/CI selector + equity loader + strategy returns manifest + suite runner + report formatter)

## Required CI testowner matrix

| Changed owner | Selector | Required node | Executed testowner |
|---|---|---|---|
| var_suite_backtest_wiring_v1 | PR_BOUNDED_FULL_VAR_SUITE_ADAPTER | tests (3.11) | test_var_suite_backtest_wiring_v1.py |
| run_var_suite_from_backtest_run_v1 | PR_BOUNDED_FULL_VAR_SUITE_ADAPTER | tests (3.11) | test_backtest_returns_var_suite_offline_v1.py |
| var_suite_adapter (regression) | PR_BOUNDED_FULL_VAR_SUITE_ADAPTER | tests (3.11) | test_var_suite_adapter_v0.py |
| ci_test_selection_v1 | PR_BOUNDED_FULL | tests (3.11) | test_ci_diff_aware_test_selection_v1.py |

**Expected CI path:** `PR_BOUNDED_FULL` via `PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_*` bundle extension

## Safety

- `TRADING_LOGIC_IMMUTABILITY=PASS`
- `EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true`
- `RUNTIME_AUTHORITY_IMPACT=NONE`

## Durable evidence

- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/package_h_offline_backtest_returns_var_suite_wiring_v1_20260627T070901Z`
- `MANIFEST_VERIFY_RC=0` (post-PR finalize)


Made with [Cursor](https://cursor.com)