### PR TITLE
feat(governance): Package I offline BACKTEST LineageRef producer v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1389,16 +1389,23 @@ PR_BOUNDED_FULL_PACKAGE_A_GOVERNANCE_TARGETS: tuple[str, ...] = (
 PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/governance/promotion_loop/candidate_lineage_manifest_v1.py",
+        "src/governance/promotion_loop/backtest_lineage_ref_producer_v1.py",
         "scripts/run_candidate_lineage_manifest_v1.py",
+        "scripts/run_backtest_lineage_ref_producer_v1.py",
         "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py",
+        "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
         "tests/scripts/test_run_candidate_lineage_manifest_v1.py",
+        "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py",
     }
 )
 
 PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS: tuple[str, ...] = (
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py",
+    "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
     "tests/scripts/test_run_candidate_lineage_manifest_v1.py",
+    "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py",
+    "tests/test_run_summary_contract.py",
 )
 
 PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TRIGGER_PATHS: frozenset[str] = frozenset(
@@ -4645,6 +4652,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                 for candidate in PR_BOUNDED_FULL_PACKAGE_D_LEARNING_BRIDGE_TARGETS:
                     add(candidate)
             elif path == "scripts/run_candidate_lineage_manifest_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_backtest_lineage_ref_producer_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
                     add(candidate)
             elif path == "scripts/run_learning_manifest_durable_evidence_binding_v1.py":

--- a/scripts/run_backtest_lineage_ref_producer_v1.py
+++ b/scripts/run_backtest_lineage_ref_producer_v1.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Offline Package I — BACKTEST LineageRef producer from explicit completed run directory.
+
+Produces a validated, deterministic BACKTEST LineageRef JSON artifact only.
+No backtest start, promotion, apply, runtime, registry mutation, or live authority.
+
+Usage:
+    python3 scripts/run_backtest_lineage_ref_producer_v1.py \\
+        --run-dir reports/backtests/run-001 \\
+        --output reports/lineage_refs/backtest_run-001.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+    BacktestLineageRefProducerError,
+    produce_backtest_lineage_ref_v1_to_path,
+)
+
+EXIT_OK = 0
+EXIT_PRODUCER_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Package I BACKTEST LineageRef producer: explicit completed "
+            "backtest run directory to validated reference-only JSON artifact."
+        )
+    )
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to a completed backtest run directory containing run_summary.json.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination path for the validated BACKTEST LineageRef JSON file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        result = produce_backtest_lineage_ref_v1_to_path(
+            run_dir=args.run_dir,
+            output_path=args.output,
+            fail_closed_if_exists=True,
+        )
+    except BacktestLineageRefProducerError as exc:
+        print(f"[backtest_lineage_ref] ERROR: {exc}", file=sys.stderr)
+        return EXIT_PRODUCER_ERROR
+    except OSError as exc:
+        print(f"[backtest_lineage_ref] ERROR: {exc}", file=sys.stderr)
+        return EXIT_PRODUCER_ERROR
+
+    print(
+        "[backtest_lineage_ref] wrote validated BACKTEST LineageRef to "
+        f"{args.output} (ref_id={result.ref.ref_id}, digest={result.ref.digest})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/governance/promotion_loop/backtest_lineage_ref_producer_v1.py
+++ b/src/governance/promotion_loop/backtest_lineage_ref_producer_v1.py
@@ -1,0 +1,217 @@
+"""Package I — offline BACKTEST LineageRef producer from explicit completed run directory."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.experiments.tracking.run_summary import RunSummary
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_to_mapping,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+RUN_SUMMARY_REL_PATH = "run_summary.json"
+BACKTEST_OWNER_DOMAIN = "experiments/tracking"
+BACKTEST_LINEAGE_REF_REQUIRED = False
+COMPLETED_RUN_STATUS = "FINISHED"
+
+
+class BacktestLineageRefProducerError(ValueError):
+    """Fail-closed Package I BACKTEST LineageRef production error."""
+
+
+@dataclass(frozen=True)
+class BacktestLineageRefProducerResult:
+    run_dir: Path
+    run_summary_path: Path
+    ref: LineageRef
+
+
+def _resolve_existing_directory(run_dir: Path) -> Path:
+    if not run_dir.exists():
+        raise BacktestLineageRefProducerError(f"run_dir not found: {run_dir}")
+    if run_dir.is_symlink():
+        raise BacktestLineageRefProducerError(
+            f"run_dir must not be a symlink (fail-closed): {run_dir}"
+        )
+    if not run_dir.is_dir():
+        raise BacktestLineageRefProducerError(f"run_dir is not a directory: {run_dir}")
+    return run_dir.resolve()
+
+
+def _assert_path_under_root(path: Path, root: Path) -> Path:
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise BacktestLineageRefProducerError(
+            f"path escapes run_dir root: {path} (root={root})"
+        ) from exc
+    return resolved
+
+
+def _validate_run_summary_relative_path(artifact_path: str) -> None:
+    if not artifact_path or artifact_path.strip() != artifact_path:
+        raise BacktestLineageRefProducerError("artifact_path must be non-empty and trimmed")
+    if artifact_path.startswith("/") or artifact_path.startswith("\\"):
+        raise BacktestLineageRefProducerError("artifact_path must be relative")
+    if "\\" in artifact_path:
+        raise BacktestLineageRefProducerError("artifact_path must use forward slashes only")
+    if ".." in artifact_path.split("/"):
+        raise BacktestLineageRefProducerError("artifact_path must not contain '..' segments")
+
+
+def _load_completed_run_summary(run_dir: Path) -> tuple[RunSummary, Path]:
+    summary_path = run_dir / RUN_SUMMARY_REL_PATH
+    if summary_path.is_symlink():
+        raise BacktestLineageRefProducerError(
+            f"{RUN_SUMMARY_REL_PATH} must not be a symlink (fail-closed): {summary_path}"
+        )
+    if not summary_path.is_file():
+        raise BacktestLineageRefProducerError(
+            f"{RUN_SUMMARY_REL_PATH} not found in run_dir: {run_dir}"
+        )
+    _assert_path_under_root(summary_path, run_dir)
+
+    try:
+        summary = RunSummary.read_json(summary_path)
+    except FileNotFoundError as exc:
+        raise BacktestLineageRefProducerError(
+            f"{RUN_SUMMARY_REL_PATH} not found in run_dir: {run_dir}"
+        ) from exc
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise BacktestLineageRefProducerError(
+            f"invalid {RUN_SUMMARY_REL_PATH} in run_dir={run_dir}: {exc}"
+        ) from exc
+
+    errors = summary.validate_contract(strict=True)
+    if errors:
+        raise BacktestLineageRefProducerError(
+            f"RunSummary contract validation failed for run_dir={run_dir}: " + "; ".join(errors)
+        )
+
+    if not summary.run_id or not str(summary.run_id).strip():
+        raise BacktestLineageRefProducerError(
+            f"run_id missing or empty in {RUN_SUMMARY_REL_PATH} for run_dir={run_dir}"
+        )
+
+    if summary.status != COMPLETED_RUN_STATUS:
+        raise BacktestLineageRefProducerError(
+            f"run is not completed (status={summary.status!r}); "
+            f"expected {COMPLETED_RUN_STATUS!r} for run_dir={run_dir}"
+        )
+
+    return summary, summary_path
+
+
+def compute_backtest_lineage_ref_digest(summary: RunSummary) -> str:
+    """Deterministic digest from stable RunSummary identity fields (payload-free reference)."""
+    payload = {
+        "run_id": summary.run_id,
+        "started_at_utc": summary.started_at_utc,
+        "finished_at_utc": summary.finished_at_utc,
+        "status": summary.status,
+        "tracking_backend": summary.tracking_backend,
+    }
+    digest = compute_content_sha256(payload)
+    if not is_valid_sha256_hex(digest):
+        raise BacktestLineageRefProducerError("computed digest is not valid sha256 hex")
+    return digest
+
+
+def build_backtest_lineage_ref_from_run_summary(
+    summary: RunSummary,
+    *,
+    artifact_path: str = RUN_SUMMARY_REL_PATH,
+) -> LineageRef:
+    """Build a validated BACKTEST LineageRef from an already validated RunSummary."""
+    _validate_run_summary_relative_path(artifact_path)
+    digest = compute_backtest_lineage_ref_digest(summary)
+    return LineageRef(
+        ref_type=LineageRefType.BACKTEST,
+        ref_id=str(summary.run_id),
+        relation=LineageRelation.EVALUATES,
+        owner_domain=BACKTEST_OWNER_DOMAIN,
+        required=BACKTEST_LINEAGE_REF_REQUIRED,
+        digest=digest,
+        artifact_path=artifact_path,
+    )
+
+
+def produce_backtest_lineage_ref_v1(*, run_dir: Path | str) -> BacktestLineageRefProducerResult:
+    """Extract a reference-only BACKTEST LineageRef from an explicit completed run directory."""
+    resolved_run_dir = _resolve_existing_directory(Path(run_dir))
+    summary, summary_path = _load_completed_run_summary(resolved_run_dir)
+    ref = build_backtest_lineage_ref_from_run_summary(summary)
+    return BacktestLineageRefProducerResult(
+        run_dir=resolved_run_dir,
+        run_summary_path=summary_path,
+        ref=ref,
+    )
+
+
+def serialize_backtest_lineage_ref_v1(ref: LineageRef) -> str:
+    """Serialize a BACKTEST LineageRef to deterministic canonical JSON."""
+    if ref.ref_type != LineageRefType.BACKTEST:
+        raise BacktestLineageRefProducerError(
+            f"ref_type must be BACKTEST, got {ref.ref_type.value!r}"
+        )
+    return deterministic_json_dumps(lineage_ref_to_mapping(ref))
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+    except OSError:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+    try:
+        tmp.replace(path)
+    except OSError:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+
+
+def write_backtest_lineage_ref_v1_atomic(
+    ref: LineageRef,
+    output_path: Path | str,
+    *,
+    fail_closed_if_exists: bool = True,
+) -> Path:
+    """Validate and atomically write a BACKTEST LineageRef JSON file."""
+    out = Path(output_path)
+    if fail_closed_if_exists and out.exists():
+        raise BacktestLineageRefProducerError(f"output path already exists (fail-closed): {out}")
+    serialized = serialize_backtest_lineage_ref_v1(ref)
+    _atomic_write_text(out, serialized)
+    return out
+
+
+def produce_backtest_lineage_ref_v1_to_path(
+    *,
+    run_dir: Path | str,
+    output_path: Path | str,
+    fail_closed_if_exists: bool = True,
+) -> BacktestLineageRefProducerResult:
+    """End-to-end offline producer: explicit run_dir -> validated BACKTEST LineageRef JSON."""
+    result = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    write_backtest_lineage_ref_v1_atomic(
+        result.ref,
+        output_path,
+        fail_closed_if_exists=fail_closed_if_exists,
+    )
+    return result

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5206,21 +5206,35 @@ def test_selector_package_e_combined_diff_pr_bounded_full_includes_all_testowner
 
 PACKAGE_F_LINEAGE_PRODUCTION = "src/governance/promotion_loop/candidate_lineage_manifest_v1.py"
 PACKAGE_F_LINEAGE_SCRIPT = "scripts/run_candidate_lineage_manifest_v1.py"
+PACKAGE_I_BACKTEST_REF_PRODUCTION = (
+    "src/governance/promotion_loop/backtest_lineage_ref_producer_v1.py"
+)
+PACKAGE_I_BACKTEST_REF_SCRIPT = "scripts/run_backtest_lineage_ref_producer_v1.py"
 PACKAGE_F_LINEAGE_CONTRACT_TESTOWNER = (
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py"
 )
 PACKAGE_F_LINEAGE_PRODUCER_TESTOWNER = (
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py"
 )
+PACKAGE_I_BACKTEST_REF_PRODUCER_TESTOWNER = (
+    "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py"
+)
 PACKAGE_F_LINEAGE_CLI_TESTOWNER = "tests/scripts/test_run_candidate_lineage_manifest_v1.py"
+PACKAGE_I_BACKTEST_REF_CLI_TESTOWNER = "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py"
+PACKAGE_I_RUN_SUMMARY_CONTRACT = "tests/test_run_summary_contract.py"
 PACKAGE_F_ALL_PRODUCTION = (
     PACKAGE_F_LINEAGE_PRODUCTION,
     PACKAGE_F_LINEAGE_SCRIPT,
+    PACKAGE_I_BACKTEST_REF_PRODUCTION,
+    PACKAGE_I_BACKTEST_REF_SCRIPT,
 )
 PACKAGE_F_ALL_TESTOWNERS = (
     PACKAGE_F_LINEAGE_CONTRACT_TESTOWNER,
     PACKAGE_F_LINEAGE_PRODUCER_TESTOWNER,
+    PACKAGE_I_BACKTEST_REF_PRODUCER_TESTOWNER,
     PACKAGE_F_LINEAGE_CLI_TESTOWNER,
+    PACKAGE_I_BACKTEST_REF_CLI_TESTOWNER,
+    PACKAGE_I_RUN_SUMMARY_CONTRACT,
 )
 
 
@@ -5243,6 +5257,38 @@ def test_selector_package_f_script_contract_focused_includes_lineage_testowners(
 def test_selector_package_f_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
     sel = _run_selector(
         *PACKAGE_F_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_F_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+
+
+def test_selector_package_i_backtest_ref_production_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_I_BACKTEST_REF_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_i_backtest_ref_script_contract_focused_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_I_BACKTEST_REF_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    focused = sel.get("focused_pytest_targets") or ""
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in focused.split()
+
+
+def test_selector_package_i_backtest_ref_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        PACKAGE_I_BACKTEST_REF_PRODUCTION,
+        PACKAGE_I_BACKTEST_REF_SCRIPT,
         "scripts/ops/ci_test_selection_v1.py",
         *PACKAGE_F_ALL_TESTOWNERS,
     )

--- a/tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py
+++ b/tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py
@@ -1,0 +1,359 @@
+"""Producer tests for Package I offline BACKTEST LineageRef production."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.experiments.tracking.run_summary import RunSummary
+from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+    BACKTEST_LINEAGE_REF_REQUIRED,
+    BACKTEST_OWNER_DOMAIN,
+    RUN_SUMMARY_REL_PATH,
+    BacktestLineageRefProducerError,
+    build_backtest_lineage_ref_from_run_summary,
+    compute_backtest_lineage_ref_digest,
+    produce_backtest_lineage_ref_v1,
+    produce_backtest_lineage_ref_v1_to_path,
+    serialize_backtest_lineage_ref_v1,
+    write_backtest_lineage_ref_v1_atomic,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    CandidateType,
+    LineageRefType,
+    LineageRelation,
+    build_candidate_lineage_manifest_v1_from_producer_input,
+    lineage_ref_to_mapping,
+    serialize_candidate_lineage_manifest_v1,
+    validate_candidate_lineage_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256
+
+FIXED_STARTED = "2025-01-15T10:00:00+00:00"
+FIXED_FINISHED = "2025-01-15T10:05:00+00:00"
+RUN_ID = "test-run-123"
+LINEAGE_ID = "11111111-1111-4111-8111-111111111111"
+CONTRACT_REF = "22222222-2222-4222-8222-222222222222"
+
+
+def _minimal_run_summary_data(*, run_id: str = RUN_ID, status: str = "FINISHED") -> dict:
+    return {
+        "run_id": run_id,
+        "started_at_utc": FIXED_STARTED,
+        "finished_at_utc": FIXED_FINISHED,
+        "status": status,
+        "tracking_backend": "null",
+    }
+
+
+def _full_run_summary_data(*, run_id: str = RUN_ID, status: str = "FINISHED") -> dict:
+    return {
+        **_minimal_run_summary_data(run_id=run_id, status=status),
+        "tags": {"experiment": "test", "version": "v1"},
+        "params": {"fast_period": 10, "slow_period": 20, "enabled": True},
+        "metrics": {"sharpe": 1.5, "total_return": 0.25},
+        "artifacts": ["results/equity_curve.png", "results/trades.csv"],
+        "git_sha": "abc123def456",
+        "worktree": "clever-varahamihira",
+        "hostname": "test-machine",
+    }
+
+
+def _write_run_dir(
+    tmp_path: Path,
+    data: dict,
+    *,
+    run_dir_name: str = "completed-run",
+) -> Path:
+    run_dir = tmp_path / run_dir_name
+    run_dir.mkdir()
+    summary_path = run_dir / RUN_SUMMARY_REL_PATH
+    summary_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return run_dir
+
+
+def test_minimal_completed_run_produces_valid_backtest_ref(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    result = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    ref = result.ref
+    assert ref.ref_type == LineageRefType.BACKTEST
+    assert ref.ref_id == RUN_ID
+    assert ref.relation == LineageRelation.EVALUATES
+    assert ref.owner_domain == BACKTEST_OWNER_DOMAIN
+    assert ref.required is BACKTEST_LINEAGE_REF_REQUIRED
+    assert ref.artifact_path == RUN_SUMMARY_REL_PATH
+    assert ref.digest == compute_backtest_lineage_ref_digest(
+        RunSummary.read_json(result.run_summary_path)
+    )
+
+
+def test_full_completed_run_produces_valid_backtest_ref(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _full_run_summary_data())
+    result = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    assert result.ref.ref_id == RUN_ID
+    payload = json.loads(serialize_backtest_lineage_ref_v1(result.ref))
+    assert "params" not in payload
+    assert "metrics" not in payload
+    assert "returns" not in payload
+    assert "equity" not in payload
+    assert "trades" not in payload
+
+
+def test_uses_existing_run_summary_loader(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    calls: list[Path] = []
+
+    original = RunSummary.read_json
+
+    def _tracked_read(path):  # type: ignore[no-untyped-def]
+        calls.append(Path(path))
+        return original(path)
+
+    monkeypatch.setattr(RunSummary, "read_json", _tracked_read)
+    produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    assert calls == [run_dir / RUN_SUMMARY_REL_PATH]
+
+
+def test_run_id_exactly_adopted_from_run_summary(tmp_path: Path) -> None:
+    explicit_id = "canonical-run-id-42"
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data(run_id=explicit_id))
+    result = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    assert result.ref.ref_id == explicit_id
+
+
+def test_deterministic_digest_and_relative_artifact_path(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _full_run_summary_data())
+    first = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    second = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    assert first.ref.digest == second.ref.digest
+    assert first.ref.artifact_path == RUN_SUMMARY_REL_PATH
+    assert not first.ref.artifact_path.startswith("/")
+
+
+def test_byte_identical_canonical_json_output(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    result = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    first = serialize_backtest_lineage_ref_v1(result.ref)
+    second = serialize_backtest_lineage_ref_v1(result.ref)
+    assert first == second
+    assert json.loads(first) == json.loads(second)
+
+
+def test_candidate_lineage_manifest_v1_accepts_producer_output(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    ref = produce_backtest_lineage_ref_v1(run_dir=run_dir).ref
+    fixed_now = datetime(2026, 6, 27, 18, 0, 0, tzinfo=timezone.utc)
+    manifest = build_candidate_lineage_manifest_v1_from_producer_input(
+        {
+            "lineage_manifest_id": LINEAGE_ID,
+            "candidate_id": "candidate-package-i-001",
+            "candidate_type": CandidateType.CONFIG_PATCH_BUNDLE.value,
+            "candidate_contract_ref": CONTRACT_REF,
+            "refs": [lineage_ref_to_mapping(ref)],
+            "created_at": fixed_now.isoformat(),
+        },
+        created_at=fixed_now,
+    )
+    payload = json.loads(serialize_candidate_lineage_manifest_v1(manifest))
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is True, (phase, errors)
+    assert payload["refs"][0]["ref_id"] == RUN_ID
+    assert payload["refs"][0]["ref_type"] == LineageRefType.BACKTEST.value
+
+
+def test_missing_run_dir_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(BacktestLineageRefProducerError, match="run_dir not found"):
+        produce_backtest_lineage_ref_v1(run_dir=tmp_path / "missing")
+
+
+def test_run_path_is_file_not_directory(tmp_path: Path) -> None:
+    file_path = tmp_path / "not-a-dir"
+    file_path.write_text("x", encoding="utf-8")
+    with pytest.raises(BacktestLineageRefProducerError, match="not a directory"):
+        produce_backtest_lineage_ref_v1(run_dir=file_path)
+
+
+def test_missing_run_summary_json_fails_closed(tmp_path: Path) -> None:
+    run_dir = tmp_path / "empty-run"
+    run_dir.mkdir()
+    with pytest.raises(BacktestLineageRefProducerError, match="run_summary.json not found"):
+        produce_backtest_lineage_ref_v1(run_dir=run_dir)
+
+
+def test_invalid_json_fails_closed(tmp_path: Path) -> None:
+    run_dir = tmp_path / "bad-json-run"
+    run_dir.mkdir()
+    (run_dir / RUN_SUMMARY_REL_PATH).write_text("{not-json", encoding="utf-8")
+    with pytest.raises(BacktestLineageRefProducerError, match="invalid run_summary.json"):
+        produce_backtest_lineage_ref_v1(run_dir=run_dir)
+
+
+def test_unknown_fields_fail_closed(tmp_path: Path) -> None:
+    data = _minimal_run_summary_data()
+    data["unknown_field"] = "forbidden"
+    run_dir = _write_run_dir(tmp_path, data)
+    with pytest.raises(BacktestLineageRefProducerError, match="invalid run_summary.json"):
+        produce_backtest_lineage_ref_v1(run_dir=run_dir)
+
+
+def test_missing_run_id_fails_closed(tmp_path: Path) -> None:
+    data = _minimal_run_summary_data()
+    del data["run_id"]
+    run_dir = _write_run_dir(tmp_path, data)
+    with pytest.raises(BacktestLineageRefProducerError, match="invalid run_summary.json"):
+        produce_backtest_lineage_ref_v1(run_dir=run_dir)
+
+
+@pytest.mark.parametrize("run_id", ["", "   "])
+def test_empty_or_invalid_run_id_fails_closed(tmp_path: Path, run_id: str) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data(run_id=run_id))
+    with pytest.raises(BacktestLineageRefProducerError, match="run_id"):
+        produce_backtest_lineage_ref_v1(run_dir=run_dir)
+
+
+@pytest.mark.parametrize("status", ["RUNNING", "FAILED", "KILLED"])
+def test_non_completed_run_fails_closed(tmp_path: Path, status: str) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data(status=status))
+    with pytest.raises(BacktestLineageRefProducerError, match="not completed"):
+        produce_backtest_lineage_ref_v1(run_dir=run_dir)
+
+
+def test_run_dir_symlink_fails_closed(tmp_path: Path) -> None:
+    real_dir = _write_run_dir(tmp_path, _minimal_run_summary_data(), run_dir_name="real-run")
+    link = tmp_path / "linked-run"
+    link.symlink_to(real_dir, target_is_directory=True)
+    with pytest.raises(BacktestLineageRefProducerError, match="must not be a symlink"):
+        produce_backtest_lineage_ref_v1(run_dir=link)
+
+
+def test_run_summary_symlink_fails_closed(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run-with-link"
+    run_dir.mkdir()
+    external = tmp_path / "external_summary.json"
+    external.write_text(json.dumps(_minimal_run_summary_data()), encoding="utf-8")
+    (run_dir / RUN_SUMMARY_REL_PATH).symlink_to(external)
+    with pytest.raises(BacktestLineageRefProducerError, match="must not be a symlink"):
+        produce_backtest_lineage_ref_v1(run_dir=run_dir)
+
+
+def test_mtime_does_not_change_digest(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    first = produce_backtest_lineage_ref_v1(run_dir=run_dir).ref.digest
+    summary_path = run_dir / RUN_SUMMARY_REL_PATH
+    old = summary_path.stat().st_mtime
+    os.utime(summary_path, (old + 3600, old + 3600))
+    second = produce_backtest_lineage_ref_v1(run_dir=run_dir).ref.digest
+    assert first == second
+
+
+def test_hostname_in_summary_does_not_change_ref_id_or_digest(tmp_path: Path) -> None:
+    base = _minimal_run_summary_data()
+    run_dir_a = _write_run_dir(tmp_path, base, run_dir_name="run-a")
+    mutated = dict(base)
+    mutated["hostname"] = "other-host"
+    run_dir_b = _write_run_dir(tmp_path, mutated, run_dir_name="run-b")
+    ref_a = produce_backtest_lineage_ref_v1(run_dir=run_dir_a).ref
+    ref_b = produce_backtest_lineage_ref_v1(run_dir=run_dir_b).ref
+    assert ref_a.ref_id == ref_b.ref_id
+    assert ref_a.digest == ref_b.digest
+
+
+def test_run_summary_file_not_modified(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    summary_path = run_dir / RUN_SUMMARY_REL_PATH
+    before = summary_path.read_bytes()
+    produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    assert summary_path.read_bytes() == before
+
+
+def test_atomic_writer_success_and_fail_closed_existing(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    ref = produce_backtest_lineage_ref_v1(run_dir=run_dir).ref
+    output_path = tmp_path / "ref.json"
+    write_backtest_lineage_ref_v1_atomic(ref, output_path)
+    assert output_path.is_file()
+    with pytest.raises(BacktestLineageRefProducerError, match="already exists"):
+        write_backtest_lineage_ref_v1_atomic(ref, output_path)
+
+
+def test_end_to_end_producer_writes_output(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    output_path = tmp_path / "out" / "backtest_ref.json"
+    produce_backtest_lineage_ref_v1_to_path(run_dir=run_dir, output_path=output_path)
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["ref_type"] == LineageRefType.BACKTEST.value
+    assert payload["ref_id"] == RUN_ID
+
+
+def test_digest_matches_compute_content_sha256_of_stable_summary_fields() -> None:
+    summary = RunSummary(**_full_run_summary_data())
+    ref = build_backtest_lineage_ref_from_run_summary(summary)
+    stable_payload = {
+        "run_id": summary.run_id,
+        "started_at_utc": summary.started_at_utc,
+        "finished_at_utc": summary.finished_at_utc,
+        "status": summary.status,
+        "tracking_backend": summary.tracking_backend,
+    }
+    assert ref.digest == compute_content_sha256(stable_payload)
+
+
+def test_non_writable_output_parent_fails_without_partial_output(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    readonly_parent = tmp_path / "readonly"
+    readonly_parent.mkdir()
+    output_path = readonly_parent / "ref.json"
+    os.chmod(readonly_parent, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        with pytest.raises(OSError):
+            produce_backtest_lineage_ref_v1_to_path(run_dir=run_dir, output_path=output_path)
+    finally:
+        os.chmod(readonly_parent, stat.S_IRWXU)
+    assert not output_path.exists()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_writer_replace_failure_cleans_tmp_and_leaves_existing_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+    ref = produce_backtest_lineage_ref_v1(run_dir=run_dir).ref
+    output_path = tmp_path / "ref.json"
+    output_path.write_text('{"existing": true}', encoding="utf-8")
+    original = Path.replace
+
+    def _fail_replace(self, target):  # type: ignore[no-untyped-def]
+        if self.name.endswith(".tmp"):
+            raise OSError("forced replace failure")
+        return original(self, target)
+
+    monkeypatch.setattr(Path, "replace", _fail_replace)
+    with pytest.raises(OSError, match="forced replace failure"):
+        write_backtest_lineage_ref_v1_atomic(
+            ref,
+            output_path,
+            fail_closed_if_exists=False,
+        )
+    assert output_path.read_text(encoding="utf-8") == '{"existing": true}'
+    assert list(output_path.parent.glob("*.tmp")) == []
+
+
+def test_no_backtest_or_runtime_side_effects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data())
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("backtest or runtime invocation forbidden")
+
+    monkeypatch.setattr(
+        "src.risk.validation.var_suite_backtest_wiring_v1.resolve_backtest_returns",
+        _forbidden,
+    )
+    produce_backtest_lineage_ref_v1(run_dir=run_dir)

--- a/tests/scripts/test_run_backtest_lineage_ref_producer_v1.py
+++ b/tests/scripts/test_run_backtest_lineage_ref_producer_v1.py
@@ -1,0 +1,219 @@
+"""CLI tests for Package I offline BACKTEST LineageRef producer."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_backtest_lineage_ref_producer_v1 import (
+    EXIT_OK,
+    EXIT_PRODUCER_ERROR,
+    main,
+)
+from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+    RUN_SUMMARY_REL_PATH,
+    BacktestLineageRefProducerError,
+)
+
+RUN_ID = "cli-run-001"
+
+
+def _minimal_run_summary_data(*, run_id: str = RUN_ID, status: str = "FINISHED") -> dict:
+    return {
+        "run_id": run_id,
+        "started_at_utc": "2025-01-15T10:00:00+00:00",
+        "finished_at_utc": "2025-01-15T10:05:00+00:00",
+        "status": status,
+        "tracking_backend": "null",
+    }
+
+
+def _write_run_dir(tmp_path: Path, data: dict | None = None) -> Path:
+    run_dir = tmp_path / "completed-run"
+    run_dir.mkdir()
+    payload = data if data is not None else _minimal_run_summary_data()
+    (run_dir / RUN_SUMMARY_REL_PATH).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return run_dir
+
+
+def test_cli_successful_run(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    output_path = tmp_path / "ref.json"
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["ref_id"] == RUN_ID
+    assert payload["ref_type"] == "backtest"
+
+
+def test_cli_deterministic_output(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    output_a = tmp_path / "a.json"
+    output_b = tmp_path / "b.json"
+    assert main(["--run-dir", str(run_dir), "--output", str(output_a)]) == EXIT_OK
+    assert main(["--run-dir", str(run_dir), "--output", str(output_b)]) == EXIT_OK
+    assert output_a.read_text(encoding="utf-8") == output_b.read_text(encoding="utf-8")
+
+
+def test_cli_requires_explicit_run_dir_and_output(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    with pytest.raises(SystemExit):
+        main(["--output", str(tmp_path / "out.json")])
+    with pytest.raises(SystemExit):
+        main(["--run-dir", str(run_dir)])
+
+
+def test_cli_invalid_run_is_producer_error(tmp_path: Path, capsys) -> None:
+    run_dir = tmp_path / "empty-run"
+    run_dir.mkdir()
+    output_path = tmp_path / "out.json"
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_cli_non_completed_run_is_producer_error(tmp_path: Path, capsys) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data(status="RUNNING"))
+    output_path = tmp_path / "out.json"
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert "not completed" in capsys.readouterr().err
+
+
+def test_cli_existing_output_fail_closed(tmp_path: Path, capsys) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+    output_path.write_text('{"stale": true}', encoding="utf-8")
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert output_path.read_text(encoding="utf-8") == '{"stale": true}'
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_cli_non_writable_output_parent(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir()
+    output_path = readonly_dir / "out.json"
+    os.chmod(readonly_dir, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    finally:
+        os.chmod(readonly_dir, stat.S_IRWXU)
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+
+
+def test_cli_no_partial_output_on_producer_error(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data(status="FAILED"))
+    output_path = tmp_path / "out.json"
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_cli_atomic_writer_success(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    output_path = tmp_path / "nested" / "ref.json"
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_cli_writer_error_before_replace(tmp_path: Path, monkeypatch) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+
+    def _fail_write(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("forced write failure")
+
+    monkeypatch.setattr(Path, "write_text", _fail_write)
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+
+
+def test_cli_writer_error_on_replace(tmp_path: Path, monkeypatch) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+    original = Path.replace
+
+    def _fail_replace(self, target):  # type: ignore[no-untyped-def]
+        if self.name.endswith(".tmp"):
+            raise OSError("forced replace failure")
+        return original(self, target)
+
+    monkeypatch.setattr(Path, "replace", _fail_replace)
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert list(output_path.parent.glob("*.tmp")) == []
+
+
+def test_cli_stderr_without_secrets_or_full_run_summary_payload(tmp_path: Path, capsys) -> None:
+    run_dir = _write_run_dir(
+        tmp_path,
+        {
+            **_minimal_run_summary_data(),
+            "params": {"secret_token": "super-secret-value"},
+            "metrics": {"sharpe": 9.9},
+        },
+    )
+    output_path = tmp_path / "out.json"
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    err = capsys.readouterr().err
+    assert "super-secret-value" not in err
+    assert "sharpe" not in err
+    assert "secret" not in err.lower()
+
+
+def test_cli_producer_error_reports_on_stderr(tmp_path: Path, capsys, monkeypatch) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+
+    def _raise(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise BacktestLineageRefProducerError("forced producer failure")
+
+    monkeypatch.setattr(
+        "scripts.run_backtest_lineage_ref_producer_v1.produce_backtest_lineage_ref_v1_to_path",
+        _raise,
+    )
+    rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert "forced producer failure" in capsys.readouterr().err
+
+
+def test_cli_stable_exit_codes(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    assert main(["--run-dir", str(run_dir), "--output", str(tmp_path / "ok.json")]) == EXIT_OK
+    assert (
+        main(["--run-dir", str(tmp_path / "missing"), "--output", str(tmp_path / "bad.json")])
+        == EXIT_PRODUCER_ERROR
+    )
+
+
+def test_cli_no_backtest_registry_or_network_calls(tmp_path: Path, monkeypatch) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("forbidden side-effect invocation")
+
+    monkeypatch.setattr(
+        "src.risk.validation.var_suite_backtest_wiring_v1.resolve_backtest_returns",
+        _forbidden,
+    )
+    with patch("urllib.request.urlopen", side_effect=_forbidden):
+        rc = main(["--run-dir", str(run_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_PACKAGE_I_OFFLINE_BACKTEST_DOMAIN_REF_PRODUCER_V1_IMPLEMENTATION_V0`
- Implements read-only offline extraction of a validated `LineageRef` (`BACKTEST`) from an explicit completed backtest run directory (`--run-dir`) with deterministic JSON output (`--output`).
- Extends existing Package-F CI bundle (`PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_*`) to bind new producer/CLI testowners and RunSummary contract regression.

## Scope

- `src/governance/promotion_loop/backtest_lineage_ref_producer_v1.py`
- `scripts/run_backtest_lineage_ref_producer_v1.py`
- Contract + CLI testowners
- CI selector + selector contract tests

## Out of scope

- No backtest execution, VAR_SUITE/EXPERIMENT refs, CandidateLineageManifest production, promotion/apply/runtime/registry mutation, Package J+.

## Changed files

- `src/governance/promotion_loop/backtest_lineage_ref_producer_v1.py`
- `scripts/run_backtest_lineage_ref_producer_v1.py`
- `tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py`
- `tests/scripts/test_run_backtest_lineage_ref_producer_v1.py`
- `scripts/ops/ci_test_selection_v1.py`
- `tests/ci/test_ci_diff_aware_test_selection_v1.py`

## Canonical Backtest ID

- **SSOT:** `RunSummary.run_id` from validated `run_summary.json` (byte/case-exact adoption; fail-closed if missing/empty).

## Completion proof

- Existing RunSummary contract: `status == FINISHED` only (`RUNNING`/`FAILED`/`KILLED` fail closed).

## Digest basis

- Deterministic SHA-256 via `compute_content_sha256` over stable identity fields: `run_id`, `started_at_utc`, `finished_at_utc`, `status`, `tracking_backend` (payload-free; excludes params/metrics/hostname/worktree).

## Relative artifact path

- `run_summary.json` (relative under explicit run root; no `..`; symlink escape fail-closed).

## LineageRef contract

- `ref_type=BACKTEST`, `relation=EVALUATES`, `owner_domain=experiments/tracking`, `required=false`, plus `digest` + `artifact_path`.

## CandidateLineageManifest compatibility

- Producer output is an existing `LineageRef` and is accepted by `build_candidate_lineage_manifest_v1_from_producer_input` without schema changes (integration test included).

## Safety / immutability

- `PAYLOAD_DUPLICATION_ABSENT=true`
- `TRADING_LOGIC_IMMUTABILITY=PASS`
- `VAR_SEMANTICS_IMMUTABLE=true`
- `RISK_LIMITS_IMMUTABLE=true`
- `EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true`
- `RUNTIME_AUTHORITY_IMPACT=NONE`
- `FUTURES_ONLY=true`

## Determinism / atomic writer

- Deterministic `ref_id`/`digest`/`artifact_path`/canonical JSON; hostname/mtime do not affect digest.
- Atomic tmp+replace writer; existing output fail-closed; no partial output on failure.

## Local tests

- 67 focused tests PASS (producer, CLI, CandidateLineageManifest contract/producer regressions, RunSummary contract, Package-I selector bindings).

## Required CI testowner matrix

| Changed owner | Selector | Executed testowner |
|---|---|---|
| backtest_lineage_ref_producer_v1 | PR_BOUNDED_FULL | `tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py` |
| run_backtest_lineage_ref_producer_v1 | PR_BOUNDED_FULL / CONTRACT_FOCUSED | `tests/scripts/test_run_backtest_lineage_ref_producer_v1.py` |
| candidate_lineage_manifest_v1_contract | PR_BOUNDED_FULL | `tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py` |
| run_summary_contract | PR_BOUNDED_FULL | `tests/test_run_summary_contract.py` |
| ci selector contract | PR_BOUNDED_FULL | `tests/ci/test_ci_diff_aware_test_selection_v1.py` |

## Expected CI path

- `PR_BOUNDED_FULL` via Package-F candidate-lineage production bundle extension (`category_central_src_requires_full` for governance producer path).

## Durable evidence

- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/package_i_offline_backtest_domain_ref_producer_v1_20260627T074609Z`
- `MANIFEST_VERIFY_RC=0` (post-PR finalize)

## Test plan

- [x] Producer contract tests
- [x] CLI tests (fail-closed, atomic writer, determinism)
- [x] CandidateLineageManifest compatibility regression
- [x] RunSummary contract regression
- [x] CI selector binding tests
- [ ] GitHub required checks snapshot (post-push)

Made with [Cursor](https://cursor.com)