### PR TITLE
feat(governance): Package J offline VAR_SUITE LineageRef producer v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1390,12 +1390,16 @@ PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TRIGGER_PATHS: frozenset[
     {
         "src/governance/promotion_loop/candidate_lineage_manifest_v1.py",
         "src/governance/promotion_loop/backtest_lineage_ref_producer_v1.py",
+        "src/governance/promotion_loop/var_suite_lineage_ref_producer_v1.py",
         "scripts/run_candidate_lineage_manifest_v1.py",
         "scripts/run_backtest_lineage_ref_producer_v1.py",
+        "scripts/run_var_suite_lineage_ref_producer_v1.py",
         "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py",
         "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
+        "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py",
         "tests/scripts/test_run_candidate_lineage_manifest_v1.py",
         "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py",
+        "tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py",
     }
 )
 
@@ -1403,9 +1407,12 @@ PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS: tuple[str, ...] 
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py",
     "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
+    "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py",
     "tests/scripts/test_run_candidate_lineage_manifest_v1.py",
     "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py",
+    "tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py",
     "tests/test_run_summary_contract.py",
+    *PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_TARGETS,
 )
 
 PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TRIGGER_PATHS: frozenset[str] = frozenset(
@@ -4655,6 +4662,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                 for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
                     add(candidate)
             elif path == "scripts/run_backtest_lineage_ref_producer_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_var_suite_lineage_ref_producer_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
                     add(candidate)
             elif path == "scripts/run_learning_manifest_durable_evidence_binding_v1.py":

--- a/scripts/run_var_suite_lineage_ref_producer_v1.py
+++ b/scripts/run_var_suite_lineage_ref_producer_v1.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Offline Package J — VAR_SUITE LineageRef producer from explicit existing report directory.
+
+Produces a validated, deterministic VAR_SUITE LineageRef JSON artifact only.
+No VaR suite execution, promotion, apply, runtime, registry mutation, or live authority.
+
+Usage:
+    python3 scripts/run_var_suite_lineage_ref_producer_v1.py \\
+        --report-dir reports/var_suite/run_pass_all \\
+        --output reports/lineage_refs/var_suite_run_pass_all.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import (
+    VarSuiteLineageRefProducerError,
+    produce_var_suite_lineage_ref_v1_to_path,
+)
+
+EXIT_OK = 0
+EXIT_PRODUCER_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Package J VAR_SUITE LineageRef producer: explicit existing "
+            "VaR suite report directory to validated reference-only JSON artifact."
+        )
+    )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to an existing VaR suite report directory containing suite_report.json.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination path for the validated VAR_SUITE LineageRef JSON file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        result = produce_var_suite_lineage_ref_v1_to_path(
+            report_dir=args.report_dir,
+            output_path=args.output,
+            fail_closed_if_exists=True,
+        )
+    except VarSuiteLineageRefProducerError as exc:
+        print(f"[var_suite_lineage_ref] ERROR: {exc}", file=sys.stderr)
+        return EXIT_PRODUCER_ERROR
+    except OSError as exc:
+        print(f"[var_suite_lineage_ref] ERROR: {exc}", file=sys.stderr)
+        return EXIT_PRODUCER_ERROR
+
+    print(
+        "[var_suite_lineage_ref] wrote validated VAR_SUITE LineageRef to "
+        f"{args.output} (ref_id={result.ref.ref_id}, digest={result.ref.digest})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/governance/promotion_loop/var_suite_lineage_ref_producer_v1.py
+++ b/src/governance/promotion_loop/var_suite_lineage_ref_producer_v1.py
@@ -1,0 +1,226 @@
+"""Package J — offline VAR_SUITE LineageRef producer from explicit existing report directory."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_to_mapping,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+from src.risk.validation.var_suite_backtest_wiring_v1 import SUITE_REPORT_JSON
+
+VAR_SUITE_OWNER_DOMAIN = "risk/validation/var_suite_backtest_wiring_v1"
+VAR_SUITE_LINEAGE_REF_REQUIRED = False
+_FORBIDDEN_REF_IDS = frozenset({".", ".."})
+
+
+class VarSuiteLineageRefProducerError(ValueError):
+    """Fail-closed Package J VAR_SUITE LineageRef production error."""
+
+
+@dataclass(frozen=True)
+class VarSuiteLineageRefProducerResult:
+    report_dir: Path
+    suite_report_path: Path
+    ref: LineageRef
+
+
+def _resolve_existing_directory(report_dir: Path) -> Path:
+    if not report_dir.exists():
+        raise VarSuiteLineageRefProducerError(f"report_dir not found: {report_dir}")
+    if report_dir.is_symlink():
+        raise VarSuiteLineageRefProducerError(
+            f"report_dir must not be a symlink (fail-closed): {report_dir}"
+        )
+    if not report_dir.is_dir():
+        raise VarSuiteLineageRefProducerError(f"report_dir is not a directory: {report_dir}")
+    return report_dir.resolve()
+
+
+def _assert_path_under_root(path: Path, root: Path) -> Path:
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise VarSuiteLineageRefProducerError(
+            f"path escapes report_dir root: {path} (root={root})"
+        ) from exc
+    return resolved
+
+
+def _validate_artifact_relative_path(artifact_path: str) -> None:
+    if not artifact_path or artifact_path.strip() != artifact_path:
+        raise VarSuiteLineageRefProducerError("artifact_path must be non-empty and trimmed")
+    if artifact_path.startswith("/") or artifact_path.startswith("\\"):
+        raise VarSuiteLineageRefProducerError("artifact_path must be relative")
+    if "\\" in artifact_path:
+        raise VarSuiteLineageRefProducerError("artifact_path must use forward slashes only")
+    if ".." in artifact_path.split("/"):
+        raise VarSuiteLineageRefProducerError("artifact_path must not contain '..' segments")
+
+
+def _validate_ref_id(ref_id: str, *, report_dir: Path) -> str:
+    if not ref_id or not ref_id.strip():
+        raise VarSuiteLineageRefProducerError(
+            f"ref_id missing or empty for report_dir={report_dir}"
+        )
+    if ref_id in _FORBIDDEN_REF_IDS:
+        raise VarSuiteLineageRefProducerError(
+            f"ref_id is unsafe for report_dir={report_dir}: {ref_id!r}"
+        )
+    if "/" in ref_id or "\\" in ref_id:
+        raise VarSuiteLineageRefProducerError(
+            f"ref_id must be a single directory name for report_dir={report_dir}"
+        )
+    return ref_id
+
+
+def _validate_suite_report_structure(data: object, *, report_dir: Path) -> None:
+    if not isinstance(data, dict):
+        raise VarSuiteLineageRefProducerError(
+            f"suite_report.json root must be a JSON object for report_dir={report_dir}"
+        )
+    if "overall_result" not in data:
+        raise VarSuiteLineageRefProducerError(
+            f"suite_report.json missing overall_result for report_dir={report_dir}"
+        )
+
+
+def _load_existing_suite_report(report_dir: Path) -> tuple[bytes, Path]:
+    report_path = report_dir / SUITE_REPORT_JSON
+    if report_path.is_symlink():
+        raise VarSuiteLineageRefProducerError(
+            f"{SUITE_REPORT_JSON} must not be a symlink (fail-closed): {report_path}"
+        )
+    if report_path.is_dir():
+        raise VarSuiteLineageRefProducerError(
+            f"{SUITE_REPORT_JSON} is a directory, expected regular file: {report_path}"
+        )
+    if not report_path.is_file():
+        raise VarSuiteLineageRefProducerError(
+            f"{SUITE_REPORT_JSON} not found in report_dir: {report_dir}"
+        )
+    _assert_path_under_root(report_path, report_dir)
+
+    report_bytes = report_path.read_bytes()
+    try:
+        data = json.loads(report_bytes)
+    except json.JSONDecodeError as exc:
+        raise VarSuiteLineageRefProducerError(
+            f"invalid {SUITE_REPORT_JSON} in report_dir={report_dir}: {exc}"
+        ) from exc
+
+    _validate_suite_report_structure(data, report_dir=report_dir)
+    return report_bytes, report_path
+
+
+def compute_var_suite_lineage_ref_digest(report_bytes: bytes) -> str:
+    """Deterministic digest from exact suite_report.json file bytes (payload-free reference)."""
+    digest = hashlib.sha256(report_bytes).hexdigest()
+    if not is_valid_sha256_hex(digest):
+        raise VarSuiteLineageRefProducerError("computed digest is not valid sha256 hex")
+    return digest
+
+
+def build_var_suite_lineage_ref_from_report_dir(
+    report_dir: Path,
+    *,
+    report_bytes: bytes,
+    artifact_path: str = SUITE_REPORT_JSON,
+) -> LineageRef:
+    """Build a validated VAR_SUITE LineageRef from an already validated report directory."""
+    _validate_artifact_relative_path(artifact_path)
+    ref_id = _validate_ref_id(report_dir.name, report_dir=report_dir)
+    digest = compute_var_suite_lineage_ref_digest(report_bytes)
+    return LineageRef(
+        ref_type=LineageRefType.VAR_SUITE,
+        ref_id=ref_id,
+        relation=LineageRelation.VALIDATES,
+        owner_domain=VAR_SUITE_OWNER_DOMAIN,
+        required=VAR_SUITE_LINEAGE_REF_REQUIRED,
+        digest=digest,
+        artifact_path=artifact_path,
+    )
+
+
+def produce_var_suite_lineage_ref_v1(*, report_dir: Path | str) -> VarSuiteLineageRefProducerResult:
+    """Extract a reference-only VAR_SUITE LineageRef from an explicit report directory."""
+    resolved_report_dir = _resolve_existing_directory(Path(report_dir))
+    report_bytes, report_path = _load_existing_suite_report(resolved_report_dir)
+    ref = build_var_suite_lineage_ref_from_report_dir(
+        resolved_report_dir,
+        report_bytes=report_bytes,
+    )
+    return VarSuiteLineageRefProducerResult(
+        report_dir=resolved_report_dir,
+        suite_report_path=report_path,
+        ref=ref,
+    )
+
+
+def serialize_var_suite_lineage_ref_v1(ref: LineageRef) -> str:
+    """Serialize a VAR_SUITE LineageRef to deterministic canonical JSON."""
+    if ref.ref_type != LineageRefType.VAR_SUITE:
+        raise VarSuiteLineageRefProducerError(
+            f"ref_type must be VAR_SUITE, got {ref.ref_type.value!r}"
+        )
+    return deterministic_json_dumps(lineage_ref_to_mapping(ref))
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+    except OSError:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+    try:
+        tmp.replace(path)
+    except OSError:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+
+
+def write_var_suite_lineage_ref_v1_atomic(
+    ref: LineageRef,
+    output_path: Path | str,
+    *,
+    fail_closed_if_exists: bool = True,
+) -> Path:
+    """Validate and atomically write a VAR_SUITE LineageRef JSON file."""
+    out = Path(output_path)
+    if fail_closed_if_exists and out.exists():
+        raise VarSuiteLineageRefProducerError(f"output path already exists (fail-closed): {out}")
+    serialized = serialize_var_suite_lineage_ref_v1(ref)
+    _atomic_write_text(out, serialized)
+    return out
+
+
+def produce_var_suite_lineage_ref_v1_to_path(
+    *,
+    report_dir: Path | str,
+    output_path: Path | str,
+    fail_closed_if_exists: bool = True,
+) -> VarSuiteLineageRefProducerResult:
+    """End-to-end offline producer: explicit report_dir -> validated VAR_SUITE LineageRef JSON."""
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    write_var_suite_lineage_ref_v1_atomic(
+        result.ref,
+        output_path,
+        fail_closed_if_exists=fail_closed_if_exists,
+    )
+    return result

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5222,11 +5222,28 @@ PACKAGE_I_BACKTEST_REF_PRODUCER_TESTOWNER = (
 PACKAGE_F_LINEAGE_CLI_TESTOWNER = "tests/scripts/test_run_candidate_lineage_manifest_v1.py"
 PACKAGE_I_BACKTEST_REF_CLI_TESTOWNER = "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py"
 PACKAGE_I_RUN_SUMMARY_CONTRACT = "tests/test_run_summary_contract.py"
+PACKAGE_J_VAR_SUITE_REF_PRODUCTION = (
+    "src/governance/promotion_loop/var_suite_lineage_ref_producer_v1.py"
+)
+PACKAGE_J_VAR_SUITE_REF_SCRIPT = "scripts/run_var_suite_lineage_ref_producer_v1.py"
+PACKAGE_J_VAR_SUITE_REF_PRODUCER_TESTOWNER = (
+    "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py"
+)
+PACKAGE_J_VAR_SUITE_REF_CLI_TESTOWNER = (
+    "tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py"
+)
+VAR_SUITE_ADAPTER_ALL_TESTOWNERS = (
+    VAR_SUITE_ADAPTER_TESTOWNER,
+    VAR_SUITE_BACKTEST_WIRING_TESTOWNER,
+    VAR_SUITE_BACKTEST_CLI_TESTOWNER,
+)
 PACKAGE_F_ALL_PRODUCTION = (
     PACKAGE_F_LINEAGE_PRODUCTION,
     PACKAGE_F_LINEAGE_SCRIPT,
     PACKAGE_I_BACKTEST_REF_PRODUCTION,
     PACKAGE_I_BACKTEST_REF_SCRIPT,
+    PACKAGE_J_VAR_SUITE_REF_PRODUCTION,
+    PACKAGE_J_VAR_SUITE_REF_SCRIPT,
 )
 PACKAGE_F_ALL_TESTOWNERS = (
     PACKAGE_F_LINEAGE_CONTRACT_TESTOWNER,
@@ -5235,6 +5252,9 @@ PACKAGE_F_ALL_TESTOWNERS = (
     PACKAGE_F_LINEAGE_CLI_TESTOWNER,
     PACKAGE_I_BACKTEST_REF_CLI_TESTOWNER,
     PACKAGE_I_RUN_SUMMARY_CONTRACT,
+    PACKAGE_J_VAR_SUITE_REF_PRODUCER_TESTOWNER,
+    PACKAGE_J_VAR_SUITE_REF_CLI_TESTOWNER,
+    *VAR_SUITE_ADAPTER_ALL_TESTOWNERS,
 )
 
 
@@ -5289,6 +5309,38 @@ def test_selector_package_i_backtest_ref_combined_diff_pr_bounded_full_includes_
     sel = _run_selector(
         PACKAGE_I_BACKTEST_REF_PRODUCTION,
         PACKAGE_I_BACKTEST_REF_SCRIPT,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_F_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+
+
+def test_selector_package_j_var_suite_ref_production_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_J_VAR_SUITE_REF_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_j_var_suite_ref_script_contract_focused_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_J_VAR_SUITE_REF_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    focused = sel.get("focused_pytest_targets") or ""
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in focused.split()
+
+
+def test_selector_package_j_var_suite_ref_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        PACKAGE_J_VAR_SUITE_REF_PRODUCTION,
+        PACKAGE_J_VAR_SUITE_REF_SCRIPT,
         "scripts/ops/ci_test_selection_v1.py",
         *PACKAGE_F_ALL_TESTOWNERS,
     )

--- a/tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py
+++ b/tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py
@@ -1,0 +1,383 @@
+"""Producer tests for Package J offline VAR_SUITE LineageRef production."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    CandidateType,
+    LineageRefType,
+    LineageRelation,
+    build_candidate_lineage_manifest_v1_from_producer_input,
+    lineage_ref_to_mapping,
+    serialize_candidate_lineage_manifest_v1,
+    validate_candidate_lineage_manifest_v1,
+)
+from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import (
+    SUITE_REPORT_JSON,
+    VAR_SUITE_LINEAGE_REF_REQUIRED,
+    VAR_SUITE_OWNER_DOMAIN,
+    VarSuiteLineageRefProducerError,
+    build_var_suite_lineage_ref_from_report_dir,
+    compute_var_suite_lineage_ref_digest,
+    produce_var_suite_lineage_ref_v1,
+    produce_var_suite_lineage_ref_v1_to_path,
+    serialize_var_suite_lineage_ref_v1,
+    write_var_suite_lineage_ref_v1_atomic,
+)
+from src.risk.validation.var_suite_backtest_wiring_v1 import SUITE_REPORT_JSON as WIRING_JSON
+
+LINEAGE_ID = "11111111-1111-4111-8111-111111111111"
+CONTRACT_REF = "22222222-2222-4222-8222-222222222222"
+REPORT_DIR_NAME = "suite-run-001"
+
+
+def _minimal_suite_report_data(*, overall_result: str = "PASS") -> dict:
+    return {"overall_result": overall_result}
+
+
+def _full_suite_report_data(*, overall_result: str = "PASS") -> dict:
+    return {
+        "overall_result": overall_result,
+        "observations": 250,
+        "breaches": 3,
+        "confidence_level": 0.95,
+        "kupiec_pof_result": "PASS",
+        "kupiec_pof_pvalue": 0.78,
+        "basel_traffic_light": "GREEN",
+        "christoffersen_ind_result": "PASS",
+        "christoffersen_ind_pvalue": 0.88,
+        "christoffersen_cc_result": "PASS",
+        "christoffersen_cc_pvalue": 0.92,
+    }
+
+
+def _write_report_dir(
+    tmp_path: Path,
+    data: dict,
+    *,
+    report_dir_name: str = REPORT_DIR_NAME,
+    indent: int | None = 2,
+) -> Path:
+    report_dir = tmp_path / report_dir_name
+    report_dir.mkdir()
+    report_path = report_dir / SUITE_REPORT_JSON
+    if indent is None:
+        report_path.write_bytes(json.dumps(data, separators=(",", ":")).encode("utf-8"))
+    else:
+        report_path.write_text(json.dumps(data, indent=indent), encoding="utf-8")
+    return report_dir
+
+
+def test_minimal_report_dir_produces_valid_var_suite_ref(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    ref = result.ref
+    assert ref.ref_type == LineageRefType.VAR_SUITE
+    assert ref.ref_id == REPORT_DIR_NAME
+    assert ref.relation == LineageRelation.VALIDATES
+    assert ref.owner_domain == VAR_SUITE_OWNER_DOMAIN
+    assert ref.required is VAR_SUITE_LINEAGE_REF_REQUIRED
+    assert ref.artifact_path == SUITE_REPORT_JSON
+    report_bytes = result.suite_report_path.read_bytes()
+    assert ref.digest == compute_var_suite_lineage_ref_digest(report_bytes)
+
+
+def test_full_report_dir_produces_valid_var_suite_ref(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _full_suite_report_data())
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    assert result.ref.ref_id == REPORT_DIR_NAME
+    payload = json.loads(serialize_var_suite_lineage_ref_v1(result.ref))
+    assert "observations" not in payload
+    assert "breaches" not in payload
+    assert "overall_result" not in payload
+    assert "kupiec_pof_pvalue" not in payload
+
+
+def test_ref_id_equals_report_dir_name(tmp_path: Path) -> None:
+    explicit_name = "canonical-suite-run-42"
+    report_dir = _write_report_dir(
+        tmp_path,
+        _minimal_suite_report_data(),
+        report_dir_name=explicit_name,
+    )
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    assert result.ref.ref_id == explicit_name
+
+
+def test_uses_suite_report_json_file(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    assert result.suite_report_path.name == WIRING_JSON
+    assert result.suite_report_path == report_dir / SUITE_REPORT_JSON
+
+
+def test_deterministic_digest_and_relative_artifact_path(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _full_suite_report_data())
+    first = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    second = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    assert first.ref.digest == second.ref.digest
+    assert first.ref.artifact_path == SUITE_REPORT_JSON
+    assert not first.ref.artifact_path.startswith("/")
+
+
+def test_byte_identical_canonical_json_output(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    first = serialize_var_suite_lineage_ref_v1(result.ref)
+    second = serialize_var_suite_lineage_ref_v1(result.ref)
+    assert first == second
+    assert json.loads(first) == json.loads(second)
+
+
+def test_candidate_lineage_manifest_v1_accepts_producer_output(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    ref = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref
+    fixed_now = datetime(2026, 6, 27, 18, 0, 0, tzinfo=timezone.utc)
+    manifest = build_candidate_lineage_manifest_v1_from_producer_input(
+        {
+            "lineage_manifest_id": LINEAGE_ID,
+            "candidate_id": "candidate-package-j-001",
+            "candidate_type": CandidateType.CONFIG_PATCH_BUNDLE.value,
+            "candidate_contract_ref": CONTRACT_REF,
+            "refs": [lineage_ref_to_mapping(ref)],
+            "created_at": fixed_now.isoformat(),
+        },
+        created_at=fixed_now,
+    )
+    payload = json.loads(serialize_candidate_lineage_manifest_v1(manifest))
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is True, (phase, errors)
+    assert payload["refs"][0]["ref_id"] == REPORT_DIR_NAME
+    assert payload["refs"][0]["ref_type"] == LineageRefType.VAR_SUITE.value
+
+
+def test_missing_report_dir_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(VarSuiteLineageRefProducerError, match="report_dir not found"):
+        produce_var_suite_lineage_ref_v1(report_dir=tmp_path / "missing")
+
+
+def test_report_path_is_file_not_directory(tmp_path: Path) -> None:
+    file_path = tmp_path / "not-a-dir"
+    file_path.write_text("x", encoding="utf-8")
+    with pytest.raises(VarSuiteLineageRefProducerError, match="not a directory"):
+        produce_var_suite_lineage_ref_v1(report_dir=file_path)
+
+
+def test_missing_suite_report_json_fails_closed(tmp_path: Path) -> None:
+    report_dir = tmp_path / "empty-report"
+    report_dir.mkdir()
+    with pytest.raises(VarSuiteLineageRefProducerError, match="suite_report.json not found"):
+        produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+
+
+def test_suite_report_is_directory_fails_closed(tmp_path: Path) -> None:
+    report_dir = tmp_path / "bad-report"
+    report_dir.mkdir()
+    (report_dir / SUITE_REPORT_JSON).mkdir()
+    with pytest.raises(VarSuiteLineageRefProducerError, match="is a directory"):
+        produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+
+
+def test_invalid_json_fails_closed(tmp_path: Path) -> None:
+    report_dir = tmp_path / "bad-json-report"
+    report_dir.mkdir()
+    (report_dir / SUITE_REPORT_JSON).write_text("{not-json", encoding="utf-8")
+    with pytest.raises(VarSuiteLineageRefProducerError, match="invalid suite_report.json"):
+        produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+
+
+def test_invalid_root_structure_fails_closed(tmp_path: Path) -> None:
+    report_dir = tmp_path / "array-root"
+    report_dir.mkdir()
+    (report_dir / SUITE_REPORT_JSON).write_text("[]", encoding="utf-8")
+    with pytest.raises(VarSuiteLineageRefProducerError, match="root must be a JSON object"):
+        produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+
+
+def test_missing_overall_result_fails_closed(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, {"observations": 10})
+    with pytest.raises(VarSuiteLineageRefProducerError, match="missing overall_result"):
+        produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+
+
+@pytest.mark.parametrize("overall_result", ["PASS", "FAIL", "WARN", "UNKNOWN", ""])
+def test_overall_result_values_structurally_accepted_not_interpreted(
+    tmp_path: Path, overall_result: str
+) -> None:
+    report_dir = _write_report_dir(tmp_path, {"overall_result": overall_result})
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    assert result.ref.ref_id == REPORT_DIR_NAME
+
+
+def test_unsafe_ref_id_dot_fails_closed() -> None:
+    report_dir = MagicMock(spec=Path)
+    report_dir.name = "."
+    with pytest.raises(VarSuiteLineageRefProducerError, match="ref_id is unsafe"):
+        build_var_suite_lineage_ref_from_report_dir(
+            report_dir,
+            report_bytes=b'{"overall_result":"PASS"}',
+        )
+
+
+def test_report_dir_symlink_fails_closed(tmp_path: Path) -> None:
+    real_dir = _write_report_dir(
+        tmp_path, _minimal_suite_report_data(), report_dir_name="real-report"
+    )
+    link = tmp_path / "linked-report"
+    link.symlink_to(real_dir, target_is_directory=True)
+    with pytest.raises(VarSuiteLineageRefProducerError, match="must not be a symlink"):
+        produce_var_suite_lineage_ref_v1(report_dir=link)
+
+
+def test_suite_report_symlink_fails_closed(tmp_path: Path) -> None:
+    report_dir = tmp_path / "report-with-link"
+    report_dir.mkdir()
+    external = tmp_path / "external_report.json"
+    external.write_text(json.dumps(_minimal_suite_report_data()), encoding="utf-8")
+    (report_dir / SUITE_REPORT_JSON).symlink_to(external)
+    with pytest.raises(VarSuiteLineageRefProducerError, match="must not be a symlink"):
+        produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+
+
+def test_mtime_does_not_change_digest(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    first = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref.digest
+    report_path = report_dir / SUITE_REPORT_JSON
+    old = report_path.stat().st_mtime
+    os.utime(report_path, (old + 3600, old + 3600))
+    second = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref.digest
+    assert first == second
+
+
+def test_byte_change_changes_digest(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    first = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref.digest
+    report_path = report_dir / SUITE_REPORT_JSON
+    report_path.write_text(
+        json.dumps({"overall_result": "PASS", "extra": 1}, indent=2),
+        encoding="utf-8",
+    )
+    second = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref.digest
+    assert first != second
+
+
+def test_suite_report_file_not_modified(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    report_path = report_dir / SUITE_REPORT_JSON
+    before = report_path.read_bytes()
+    produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    assert report_path.read_bytes() == before
+
+
+def test_digest_matches_sha256_of_exact_file_bytes(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _full_suite_report_data(), indent=None)
+    report_bytes = (report_dir / SUITE_REPORT_JSON).read_bytes()
+    ref = build_var_suite_lineage_ref_from_report_dir(report_dir, report_bytes=report_bytes)
+    assert ref.digest == hashlib.sha256(report_bytes).hexdigest()
+
+
+def test_atomic_writer_success_and_fail_closed_existing(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    ref = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref
+    output_path = tmp_path / "ref.json"
+    write_var_suite_lineage_ref_v1_atomic(ref, output_path)
+    assert output_path.is_file()
+    with pytest.raises(VarSuiteLineageRefProducerError, match="already exists"):
+        write_var_suite_lineage_ref_v1_atomic(ref, output_path)
+
+
+def test_end_to_end_producer_writes_output(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    output_path = tmp_path / "out" / "var_suite_ref.json"
+    produce_var_suite_lineage_ref_v1_to_path(report_dir=report_dir, output_path=output_path)
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["ref_type"] == LineageRefType.VAR_SUITE.value
+    assert payload["ref_id"] == REPORT_DIR_NAME
+
+
+def test_non_writable_output_parent_fails_without_partial_output(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    readonly_parent = tmp_path / "readonly"
+    readonly_parent.mkdir()
+    output_path = readonly_parent / "ref.json"
+    os.chmod(readonly_parent, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        with pytest.raises(OSError):
+            produce_var_suite_lineage_ref_v1_to_path(report_dir=report_dir, output_path=output_path)
+    finally:
+        os.chmod(readonly_parent, stat.S_IRWXU)
+    assert not output_path.exists()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_writer_replace_failure_cleans_tmp_and_leaves_existing_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    ref = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref
+    output_path = tmp_path / "ref.json"
+    output_path.write_text('{"existing": true}', encoding="utf-8")
+    original = Path.replace
+
+    def _fail_replace(self, target):  # type: ignore[no-untyped-def]
+        if self.name.endswith(".tmp"):
+            raise OSError("forced replace failure")
+        return original(self, target)
+
+    monkeypatch.setattr(Path, "replace", _fail_replace)
+    with pytest.raises(OSError, match="forced replace failure"):
+        write_var_suite_lineage_ref_v1_atomic(
+            ref,
+            output_path,
+            fail_closed_if_exists=False,
+        )
+    assert output_path.read_text(encoding="utf-8") == '{"existing": true}'
+    assert list(output_path.parent.glob("*.tmp")) == []
+
+
+def test_fixture_report_dir_integration(tmp_path: Path) -> None:
+    fixture_root = (
+        Path(__file__).parent.parent.parent / "fixtures" / "var_suite_reports" / "run_pass_all"
+    )
+    result = produce_var_suite_lineage_ref_v1(report_dir=fixture_root)
+    assert result.ref.ref_id == "run_pass_all"
+    assert (
+        result.ref.digest
+        == hashlib.sha256((fixture_root / SUITE_REPORT_JSON).read_bytes()).hexdigest()
+    )
+
+
+def test_no_var_suite_or_runtime_side_effects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("VaR suite or runtime invocation forbidden")
+
+    monkeypatch.setattr(
+        "src.risk.validation.var_suite_backtest_wiring_v1.run_backtest_var_suite_wiring_v1",
+        _forbidden,
+    )
+    monkeypatch.setattr(
+        "src.risk.validation.var_suite_backtest_wiring_v1.resolve_backtest_returns",
+        _forbidden,
+    )
+    produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+
+
+def test_absolute_path_not_in_serialized_ref(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, _minimal_suite_report_data())
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    serialized = serialize_var_suite_lineage_ref_v1(result.ref)
+    assert str(report_dir) not in serialized
+    assert "/Users/" not in serialized

--- a/tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py
+++ b/tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py
@@ -1,0 +1,215 @@
+"""CLI tests for Package J offline VAR_SUITE LineageRef producer."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_var_suite_lineage_ref_producer_v1 import (
+    EXIT_OK,
+    EXIT_PRODUCER_ERROR,
+    main,
+)
+from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import (
+    SUITE_REPORT_JSON,
+    VarSuiteLineageRefProducerError,
+)
+
+REPORT_DIR_NAME = "cli-suite-run-001"
+
+
+def _minimal_suite_report_data(*, overall_result: str = "PASS") -> dict:
+    return {"overall_result": overall_result}
+
+
+def _write_report_dir(tmp_path: Path, data: dict | None = None) -> Path:
+    report_dir = tmp_path / REPORT_DIR_NAME
+    report_dir.mkdir()
+    payload = data if data is not None else _minimal_suite_report_data()
+    (report_dir / SUITE_REPORT_JSON).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return report_dir
+
+
+def test_cli_successful_run(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    output_path = tmp_path / "ref.json"
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["ref_id"] == REPORT_DIR_NAME
+    assert payload["ref_type"] == "var_suite"
+
+
+def test_cli_deterministic_output(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    output_a = tmp_path / "a.json"
+    output_b = tmp_path / "b.json"
+    assert main(["--report-dir", str(report_dir), "--output", str(output_a)]) == EXIT_OK
+    assert main(["--report-dir", str(report_dir), "--output", str(output_b)]) == EXIT_OK
+    assert output_a.read_text(encoding="utf-8") == output_b.read_text(encoding="utf-8")
+
+
+def test_cli_requires_explicit_report_dir_and_output(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    with pytest.raises(SystemExit):
+        main(["--output", str(tmp_path / "out.json")])
+    with pytest.raises(SystemExit):
+        main(["--report-dir", str(report_dir)])
+
+
+def test_cli_invalid_report_is_producer_error(tmp_path: Path, capsys) -> None:
+    report_dir = tmp_path / "empty-report"
+    report_dir.mkdir()
+    output_path = tmp_path / "out.json"
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_cli_missing_overall_result_is_producer_error(tmp_path: Path, capsys) -> None:
+    report_dir = _write_report_dir(tmp_path, {"observations": 10})
+    output_path = tmp_path / "out.json"
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert "missing overall_result" in capsys.readouterr().err
+
+
+def test_cli_existing_output_fail_closed(tmp_path: Path, capsys) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+    output_path.write_text('{"stale": true}', encoding="utf-8")
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert output_path.read_text(encoding="utf-8") == '{"stale": true}'
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_cli_non_writable_output_parent(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir()
+    output_path = readonly_dir / "out.json"
+    os.chmod(readonly_dir, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    finally:
+        os.chmod(readonly_dir, stat.S_IRWXU)
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+
+
+def test_cli_no_partial_output_on_producer_error(tmp_path: Path) -> None:
+    report_dir = tmp_path / "bad-json"
+    report_dir.mkdir()
+    (report_dir / SUITE_REPORT_JSON).write_text("{bad", encoding="utf-8")
+    output_path = tmp_path / "out.json"
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_cli_atomic_writer_success(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    output_path = tmp_path / "nested" / "ref.json"
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_cli_writer_error_before_replace(tmp_path: Path, monkeypatch) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+
+    def _fail_write(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("forced write failure")
+
+    monkeypatch.setattr(Path, "write_text", _fail_write)
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+
+
+def test_cli_writer_error_on_replace(tmp_path: Path, monkeypatch) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+    original = Path.replace
+
+    def _fail_replace(self, target):  # type: ignore[no-untyped-def]
+        if self.name.endswith(".tmp"):
+            raise OSError("forced replace failure")
+        return original(self, target)
+
+    monkeypatch.setattr(Path, "replace", _fail_replace)
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert list(output_path.parent.glob("*.tmp")) == []
+
+
+def test_cli_stderr_without_secrets_or_full_report_payload(tmp_path: Path, capsys) -> None:
+    report_dir = _write_report_dir(
+        tmp_path,
+        {
+            "overall_result": "PASS",
+            "secret_token": "super-secret-value",
+            "kupiec_pof_pvalue": 0.01,
+        },
+    )
+    output_path = tmp_path / "out.json"
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    err = capsys.readouterr().err
+    assert "super-secret-value" not in err
+    assert "kupiec_pof_pvalue" not in err
+    assert "secret" not in err.lower()
+
+
+def test_cli_producer_error_reports_on_stderr(tmp_path: Path, capsys, monkeypatch) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+
+    def _raise(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise VarSuiteLineageRefProducerError("forced producer failure")
+
+    monkeypatch.setattr(
+        "scripts.run_var_suite_lineage_ref_producer_v1.produce_var_suite_lineage_ref_v1_to_path",
+        _raise,
+    )
+    rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert "forced producer failure" in capsys.readouterr().err
+
+
+def test_cli_stable_exit_codes(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    assert main(["--report-dir", str(report_dir), "--output", str(tmp_path / "ok.json")]) == EXIT_OK
+    assert (
+        main(["--report-dir", str(tmp_path / "missing"), "--output", str(tmp_path / "bad.json")])
+        == EXIT_PRODUCER_ERROR
+    )
+
+
+def test_cli_no_var_suite_registry_or_network_calls(tmp_path: Path, monkeypatch) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("forbidden side-effect invocation")
+
+    monkeypatch.setattr(
+        "src.risk.validation.var_suite_backtest_wiring_v1.run_backtest_var_suite_wiring_v1",
+        _forbidden,
+    )
+    with patch("urllib.request.urlopen", side_effect=_forbidden):
+        rc = main(["--report-dir", str(report_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK


### PR DESCRIPTION
## Summary

- Add offline Package J `VAR_SUITE` LineageRef producer: explicit existing VaR suite report directory → validated reference-only `LineageRef` JSON
- Add offline CLI `scripts/run_var_suite_lineage_ref_producer_v1.py` with atomic writer (Package I pattern)
- Extend Package F/I CI selector bundle with new producer/CLI testowners and Package H VaR wiring regression targets

## GO_TOKEN

`GO_PACKAGE_J_OFFLINE_VAR_SUITE_DOMAIN_REF_PRODUCER_V1_IMPLEMENTATION_V0`

## Scope

- Read-only extraction from existing `suite_report.json` in explicit `--report-dir`
- `ref_id = report_dir.name` (SSOT from `report_compare.py` / `report_index.py`)
- `digest = sha256(suite_report.json)` exact file bytes
- `artifact_path = suite_report.json`
- `LineageRefType.VAR_SUITE`, `LineageRelation.VALIDATES`
- `owner_domain = risk/validation/var_suite_backtest_wiring_v1`
- `required = false`
- Structural gate only: JSON object + `overall_result` present (not interpreted)
- CandidateLineageManifestV1 compatibility via existing producer input path

## Out of scope

- VaR suite execution, report generation, or mutation
- BACKTEST / EXPERIMENT refs
- Package K durable binding
- Promotion, apply, runtime, live authority
- Threshold / pass-fail / verdict interpretation
- Contract or enum changes

## Changed files (6)

1. `src/governance/promotion_loop/var_suite_lineage_ref_producer_v1.py`
2. `scripts/run_var_suite_lineage_ref_producer_v1.py`
3. `tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py`
4. `tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py`
5. `scripts/ops/ci_test_selection_v1.py`
6. `tests/ci/test_ci_diff_aware_test_selection_v1.py`

## Safety / immutability

| Field | Value |
|-------|-------|
| TRADING_LOGIC_IMMUTABILITY | PASS |
| VAR_SEMANTICS_IMMUTABLE | true |
| RISK_LIMITS_IMMUTABLE | true |
| THRESHOLD_SEMANTICS_IMMUTABLE | true |
| SUITE_VERDICT_SEMANTICS_IMMUTABLE | true |
| REFERENCE_ONLY | true |
| REPORT_PAYLOAD_NOT_EMBEDDED | true |
| PAYLOAD_DUPLICATION_ABSENT | true |
| EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME | true |
| RUNTIME_AUTHORITY_IMPACT | NONE |

## Local validation

- 177 focused tests PASS (producer, CLI, lineage contract/producer, Package I regression, Package H wiring, report compare/index, CI selector)
- `ruff format --check` PASS
- `ruff check` PASS
- `pyright` PASS (producer + CLI)

## Expected CI path

- Producer src diff: `PR_BOUNDED_FULL` via `PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_*` + `PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_TARGETS`
- CLI-only diff: `CONTRACT_FOCUSED` via `scripts/run_var_suite_lineage_ref_producer_v1.py`

## Durable evidence

Bundle path and `MANIFEST_VERIFY_RC=0` will be recorded post-PR creation in durable archive (not committed).

## Test plan

- [x] Producer contract tests (ref_id, digest, artifact_path, determinism, fail-closed gates)
- [x] CLI tests (explicit args, atomic writer, exit codes, no payload leaks)
- [x] CandidateLineageManifestV1 integration acceptance
- [x] Package I regression unchanged
- [x] Package H wiring regression bound in selector
- [x] CI selector contract tests for Package J


Made with [Cursor](https://cursor.com)