### PR TITLE
feat(meta): add offline VAR_SUITE durable evidence binding v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1433,6 +1433,24 @@ PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/var_suite_durable_evidence_binding_v1.py",
+        "scripts/run_var_suite_durable_evidence_binding_v1.py",
+        "tests/meta/test_var_suite_durable_evidence_binding_v1.py",
+        "tests/scripts/test_run_var_suite_durable_evidence_binding_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_var_suite_durable_evidence_binding_v1.py",
+    "tests/scripts/test_run_var_suite_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py",
+    "tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py",
+    "tests/risk/validation/test_var_suite_backtest_wiring_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/governance/promotion_loop/engine.py",
@@ -1503,6 +1521,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TRIGGER_PATHS:
@@ -4669,6 +4691,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                     add(candidate)
             elif path == "scripts/run_learning_manifest_durable_evidence_binding_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_G_LEARNING_DURABLE_EVIDENCE_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_var_suite_durable_evidence_binding_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TARGETS:
                     add(candidate)
             for candidate in (
                 f"tests/scripts/test_{script_stem}_load_strategy_v1.py",

--- a/scripts/run_var_suite_durable_evidence_binding_v1.py
+++ b/scripts/run_var_suite_durable_evidence_binding_v1.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Offline Package K — bind VAR_SUITE report directory + LineageRef to durable evidence.
+
+Produces a validated durable evidence bundle with binding index and MANIFEST.sha256 only.
+No VaR execution, promotion, apply, runtime, registry mutation, or live authority.
+
+Usage:
+    python3 scripts/run_var_suite_durable_evidence_binding_v1.py \\
+        --report-dir reports/var_suite/run_pass_all \\
+        --var-suite-lineage-ref reports/lineage_refs/var_suite_run_pass_all.json \\
+        --output-dir /var/evidence/var_suite_bundle_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.var_suite_durable_evidence_binding_v1 import (
+    VarSuiteDurableEvidenceBindingError,
+    produce_var_suite_durable_evidence_bundle_v1,
+)
+
+EXIT_OK = 0
+EXIT_BINDING_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Package K: bind validated VAR_SUITE report directory and "
+            "LineageRef to durable evidence (index + MANIFEST.sha256)."
+        )
+    )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to an existing VaR suite report directory containing suite_report.json.",
+    )
+    parser.add_argument(
+        "--var-suite-lineage-ref",
+        type=Path,
+        required=True,
+        help="Explicit path to a validated Package J VAR_SUITE LineageRef JSON file.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit durable evidence bundle directory (must not exist; outside /tmp).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.report_dir.is_dir():
+        print(
+            "[var_suite_durable_evidence_binding] ERROR: "
+            f"report directory not found: {args.report_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if not args.var_suite_lineage_ref.is_file():
+        print(
+            "[var_suite_durable_evidence_binding] ERROR: "
+            f"var suite lineage ref not found: {args.var_suite_lineage_ref}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    try:
+        result = produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=args.report_dir,
+            var_suite_lineage_ref_path=args.var_suite_lineage_ref,
+            output_dir=args.output_dir,
+        )
+    except VarSuiteDurableEvidenceBindingError as exc:
+        print(f"[var_suite_durable_evidence_binding] ERROR: {exc}", file=sys.stderr)
+        return EXIT_BINDING_ERROR
+
+    print(
+        "[var_suite_durable_evidence_binding] wrote durable evidence bundle to "
+        f"{result.output_dir} (report_ref_id={result.report_ref_id})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/var_suite_durable_evidence_binding_v1.py
+++ b/src/meta/learning_loop/var_suite_durable_evidence_binding_v1.py
@@ -1,0 +1,479 @@
+"""Offline Package K — durable evidence binding for VAR_SUITE report + LineageRef v1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    CandidateLineageManifestError,
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_from_mapping,
+    lineage_ref_to_mapping,
+)
+from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import (
+    VAR_SUITE_OWNER_DOMAIN,
+    compute_var_suite_lineage_ref_digest,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+from src.risk.validation.var_suite_backtest_wiring_v1 import SUITE_REPORT_JSON
+
+BINDING_SCHEMA_VERSION = "var_suite_durable_evidence_binding_v1"
+SUITE_REPORT_ARTIFACT_REL = SUITE_REPORT_JSON
+LINEAGE_REF_ARTIFACT_REL = "var_suite_lineage_ref_v1.json"
+INDEX_ARTIFACT_REL = "var_suite_durable_evidence_binding_index_v1.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".var_suite_durable_evidence_staging_"
+
+FUTURES_SCOPE_REF: dict[str, bool] = {
+    "futures_only": True,
+    "bitcoin_direction_allowed": False,
+}
+TRADING_LOGIC_IMMUTABILITY_REF: dict[str, bool] = {
+    "trading_logic_immutability": True,
+}
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "patches",
+        "patch",
+        "strategy",
+        "signal",
+        "signals",
+        "entry",
+        "exit",
+        "position_sizing",
+        "leverage",
+        "stop_loss",
+        "take_profit",
+        "execution",
+        "order_routing",
+        "risk_limits",
+        "killswitch",
+        "old_value",
+        "new_value",
+        "target",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "runtime_status",
+        "live_arming",
+        "apply_authority",
+        "promotion_authority",
+        "overall_result",
+        "observations",
+        "breaches",
+        "basel_traffic_light",
+    }
+)
+
+
+class VarSuiteDurableEvidenceBindingError(ValueError):
+    """Fail-closed Package K VAR_SUITE durable evidence binding error."""
+
+
+@dataclass(frozen=True)
+class BoundArtifactRecord:
+    artifact_kind: str
+    relative_path: str
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class VarSuiteBindingCrossReferences:
+    report_ref_id: str
+    lineage_ref_digest: str
+    lineage_ref_artifact_path: str
+
+
+@dataclass(frozen=True)
+class VarSuiteDurableEvidenceBindingResult:
+    output_dir: Path
+    report_ref_id: str
+    binding_index_path: Path
+    manifest_path: Path
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise VarSuiteDurableEvidenceBindingError(f"{label} must not be a symlink: {path}")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise VarSuiteDurableEvidenceBindingError(
+                f"binding index must not contain forbidden key: {key}"
+            )
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise VarSuiteDurableEvidenceBindingError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise VarSuiteDurableEvidenceBindingError(f"{label} must be a regular file: {path}")
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise VarSuiteDurableEvidenceBindingError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise VarSuiteDurableEvidenceBindingError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise VarSuiteDurableEvidenceBindingError(f"output parent directory missing: {parent}")
+    if is_under_tmp(parent):
+        raise VarSuiteDurableEvidenceBindingError("output parent directory must be outside /tmp")
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_existing_report_dir(report_dir: Path) -> Path:
+    if not report_dir.exists():
+        raise VarSuiteDurableEvidenceBindingError(f"report_dir not found: {report_dir}")
+    _reject_symlink(report_dir, label="report_dir")
+    if not report_dir.is_dir():
+        raise VarSuiteDurableEvidenceBindingError(f"report_dir is not a directory: {report_dir}")
+    return report_dir.resolve()
+
+
+def _validate_suite_report_structure(data: object, *, report_dir: Path) -> None:
+    if not isinstance(data, dict):
+        raise VarSuiteDurableEvidenceBindingError(
+            f"suite_report.json root must be a JSON object for report_dir={report_dir}"
+        )
+    if "overall_result" not in data:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"suite_report.json missing overall_result for report_dir={report_dir}"
+        )
+
+
+def _load_suite_report_bytes(report_dir: Path) -> tuple[bytes, Path]:
+    report_path = report_dir / SUITE_REPORT_JSON
+    _validate_regular_file(report_path, label=SUITE_REPORT_JSON)
+    resolved = report_path.resolve()
+    if not _path_is_under(resolved, report_dir.resolve()):
+        raise VarSuiteDurableEvidenceBindingError(
+            f"{SUITE_REPORT_JSON} escapes report_dir root: {report_path}"
+        )
+    report_bytes = report_path.read_bytes()
+    try:
+        data = json.loads(report_bytes)
+    except json.JSONDecodeError as exc:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"invalid {SUITE_REPORT_JSON} in report_dir={report_dir}: {exc}"
+        ) from exc
+    _validate_suite_report_structure(data, report_dir=report_dir)
+    return report_bytes, report_path
+
+
+def _load_lineage_ref_from_json_path(path: Path) -> LineageRef:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"failed to read lineage ref file: {path}"
+        ) from exc
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"invalid JSON in lineage ref file: {path}"
+        ) from exc
+    if not isinstance(data, Mapping):
+        raise VarSuiteDurableEvidenceBindingError("lineage ref root must be a JSON object")
+    try:
+        return lineage_ref_from_mapping(data)
+    except CandidateLineageManifestError as exc:
+        raise VarSuiteDurableEvidenceBindingError(str(exc)) from exc
+
+
+def _reject_unsafe_overlap(
+    *,
+    report_dir: Path,
+    lineage_ref_path: Path,
+    output_dir: Path,
+) -> None:
+    report_res = report_dir.resolve()
+    lineage_res = lineage_ref_path.resolve()
+    output_res = output_dir.resolve()
+
+    if output_res == report_res or output_res == lineage_res:
+        raise VarSuiteDurableEvidenceBindingError(
+            "output directory must not equal a source path (fail-closed)"
+        )
+
+    if _path_is_under(report_res, output_res) or _path_is_under(lineage_res, output_res):
+        raise VarSuiteDurableEvidenceBindingError(
+            "source path must not be inside output directory (fail-closed)"
+        )
+
+    if _path_is_under(output_res, report_res) or _path_is_under(output_res, lineage_res):
+        raise VarSuiteDurableEvidenceBindingError(
+            "output directory must not be inside a source path (fail-closed)"
+        )
+
+
+def _validate_bundle_relative_path(rel: str) -> None:
+    candidate = Path(rel)
+    if candidate.is_absolute():
+        raise VarSuiteDurableEvidenceBindingError(
+            f"bundle relative path must not be absolute: {rel!r}"
+        )
+    if ".." in candidate.parts:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"bundle relative path must not traverse upward: {rel!r}"
+        )
+
+
+def check_reference_consistency(
+    *,
+    report_dir: Path,
+    report_bytes: bytes,
+    ref: LineageRef,
+) -> VarSuiteBindingCrossReferences:
+    if ref.ref_type != LineageRefType.VAR_SUITE:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"ref_type must be VAR_SUITE, got {ref.ref_type.value!r}"
+        )
+    if ref.relation != LineageRelation.VALIDATES:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"relation must be VALIDATES, got {ref.relation.value!r}"
+        )
+    if ref.artifact_path != SUITE_REPORT_JSON:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"artifact_path must be {SUITE_REPORT_JSON!r}, got {ref.artifact_path!r}"
+        )
+    if ref.owner_domain != VAR_SUITE_OWNER_DOMAIN:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"owner_domain must be {VAR_SUITE_OWNER_DOMAIN!r}, got {ref.owner_domain!r}"
+        )
+    if ref.ref_id != report_dir.name:
+        raise VarSuiteDurableEvidenceBindingError(
+            f"ref_id must match report_dir.name: {ref.ref_id!r} != {report_dir.name!r}"
+        )
+    if ref.digest is None:
+        raise VarSuiteDurableEvidenceBindingError("lineage ref digest is required")
+    if not is_valid_sha256_hex(ref.digest):
+        raise VarSuiteDurableEvidenceBindingError("lineage ref digest must be valid sha256 hex")
+    expected_digest = compute_var_suite_lineage_ref_digest(report_bytes)
+    if ref.digest != expected_digest:
+        raise VarSuiteDurableEvidenceBindingError(
+            "lineage ref digest does not match suite_report.json file bytes"
+        )
+    return VarSuiteBindingCrossReferences(
+        report_ref_id=report_dir.name,
+        lineage_ref_digest=ref.digest,
+        lineage_ref_artifact_path=ref.artifact_path,
+    )
+
+
+def _build_var_suite_lineage_ref_payload(ref: LineageRef) -> dict[str, Any]:
+    payload = lineage_ref_to_mapping(ref)
+    for forbidden in ("overall_result", "observations", "breaches"):
+        if forbidden in payload:
+            raise VarSuiteDurableEvidenceBindingError(
+                f"lineage ref must not contain report payload key: {forbidden}"
+            )
+    return payload
+
+
+def build_binding_index_v1(
+    *,
+    report_ref_id: str,
+    cross_references: VarSuiteBindingCrossReferences,
+    ref: LineageRef,
+    artifacts: tuple[BoundArtifactRecord, ...],
+) -> dict[str, Any]:
+    sorted_artifacts = sorted(
+        artifacts,
+        key=lambda item: (item.artifact_kind, item.relative_path),
+    )
+    payload: dict[str, Any] = {
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "report_ref_id": report_ref_id,
+        "var_suite_lineage_ref": _build_var_suite_lineage_ref_payload(ref),
+        "cross_references": {
+            "report_ref_id": cross_references.report_ref_id,
+            "lineage_ref_digest": cross_references.lineage_ref_digest,
+            "lineage_ref_artifact_path": cross_references.lineage_ref_artifact_path,
+        },
+        "artifacts": [
+            {
+                "artifact_kind": item.artifact_kind,
+                "relative_path": item.relative_path,
+                "content_sha256": item.content_sha256,
+            }
+            for item in sorted_artifacts
+        ],
+        "futures_scope_ref": dict(FUTURES_SCOPE_REF),
+        "trading_logic_immutability_ref": dict(TRADING_LOGIC_IMMUTABILITY_REF),
+        "evidence_does_not_authorize_runtime": True,
+    }
+    _reject_forbidden_index_keys(payload)
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def serialize_binding_index_v1(index: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(index)
+    return deterministic_json_dumps(dict(index))
+
+
+def _copy_byte_identical(source: Path, dest: Path) -> str:
+    _validate_regular_file(source, label="source artifact")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, dest)
+    source_digest = _sha256_file(source)
+    dest_digest = _sha256_file(dest)
+    if source_digest != dest_digest:
+        raise VarSuiteDurableEvidenceBindingError(f"byte-identical copy failed for {source.name}")
+    return source_digest
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    token = uuid.uuid4().hex
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{token}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def produce_var_suite_durable_evidence_bundle_v1(
+    *,
+    report_dir: Path | str,
+    var_suite_lineage_ref_path: Path | str,
+    output_dir: Path | str,
+) -> VarSuiteDurableEvidenceBindingResult:
+    """Bind validated VAR_SUITE report + LineageRef artifacts into offline durable evidence."""
+    resolved_report_dir = _resolve_existing_report_dir(Path(report_dir))
+    lineage_ref_file = Path(var_suite_lineage_ref_path)
+    final_dir = Path(output_dir)
+
+    _validate_regular_file(lineage_ref_file, label="var suite lineage ref")
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        report_dir=resolved_report_dir,
+        lineage_ref_path=lineage_ref_file,
+        output_dir=final_dir,
+    )
+
+    report_bytes, report_path = _load_suite_report_bytes(resolved_report_dir)
+    ref = _load_lineage_ref_from_json_path(lineage_ref_file)
+    cross = check_reference_consistency(
+        report_dir=resolved_report_dir,
+        report_bytes=report_bytes,
+        ref=ref,
+    )
+
+    for rel in (SUITE_REPORT_ARTIFACT_REL, LINEAGE_REF_ARTIFACT_REL, INDEX_ARTIFACT_REL):
+        _validate_bundle_relative_path(rel)
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise VarSuiteDurableEvidenceBindingError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+
+        report_dest = staging / SUITE_REPORT_ARTIFACT_REL
+        ref_dest = staging / LINEAGE_REF_ARTIFACT_REL
+        report_digest = _copy_byte_identical(report_path, report_dest)
+        ref_digest = _copy_byte_identical(lineage_ref_file, ref_dest)
+
+        artifacts = (
+            BoundArtifactRecord(
+                artifact_kind="var_suite_report",
+                relative_path=SUITE_REPORT_ARTIFACT_REL,
+                content_sha256=report_digest,
+            ),
+            BoundArtifactRecord(
+                artifact_kind="var_suite_lineage_ref_v1",
+                relative_path=LINEAGE_REF_ARTIFACT_REL,
+                content_sha256=ref_digest,
+            ),
+        )
+        index_payload = build_binding_index_v1(
+            report_ref_id=resolved_report_dir.name,
+            cross_references=cross,
+            ref=ref,
+            artifacts=artifacts,
+        )
+        index_path = staging / INDEX_ARTIFACT_REL
+        index_path.write_text(serialize_binding_index_v1(index_payload), encoding="utf-8")
+
+        write_manifest_sha256(staging)
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise VarSuiteDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise VarSuiteDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return VarSuiteDurableEvidenceBindingResult(
+        output_dir=final_dir,
+        report_ref_id=resolved_report_dir.name,
+        binding_index_path=final_dir / INDEX_ARTIFACT_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+    )
+
+
+__all__ = [
+    "BINDING_SCHEMA_VERSION",
+    "INDEX_ARTIFACT_REL",
+    "LINEAGE_REF_ARTIFACT_REL",
+    "SUITE_REPORT_ARTIFACT_REL",
+    "BoundArtifactRecord",
+    "VarSuiteBindingCrossReferences",
+    "VarSuiteDurableEvidenceBindingError",
+    "VarSuiteDurableEvidenceBindingResult",
+    "build_binding_index_v1",
+    "check_reference_consistency",
+    "produce_var_suite_durable_evidence_bundle_v1",
+    "serialize_binding_index_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5419,9 +5419,7 @@ def test_selector_package_g_foreign_central_src_mixed_diff_pr_bounded_full() -> 
 PACKAGE_K_BINDING_PRODUCTION = "src/meta/learning_loop/var_suite_durable_evidence_binding_v1.py"
 PACKAGE_K_BINDING_SCRIPT = "scripts/run_var_suite_durable_evidence_binding_v1.py"
 PACKAGE_K_BINDING_TESTOWNER = "tests/meta/test_var_suite_durable_evidence_binding_v1.py"
-PACKAGE_K_BINDING_CLI_TESTOWNER = (
-    "tests/scripts/test_run_var_suite_durable_evidence_binding_v1.py"
-)
+PACKAGE_K_BINDING_CLI_TESTOWNER = "tests/scripts/test_run_var_suite_durable_evidence_binding_v1.py"
 PACKAGE_K_J_PRODUCER_TESTOWNER = (
     "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py"
 )

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5414,3 +5414,60 @@ def test_selector_package_g_foreign_central_src_mixed_diff_pr_bounded_full() -> 
         "src/governance/promotion_loop/engine.py",
     )
     assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+
+
+PACKAGE_K_BINDING_PRODUCTION = "src/meta/learning_loop/var_suite_durable_evidence_binding_v1.py"
+PACKAGE_K_BINDING_SCRIPT = "scripts/run_var_suite_durable_evidence_binding_v1.py"
+PACKAGE_K_BINDING_TESTOWNER = "tests/meta/test_var_suite_durable_evidence_binding_v1.py"
+PACKAGE_K_BINDING_CLI_TESTOWNER = (
+    "tests/scripts/test_run_var_suite_durable_evidence_binding_v1.py"
+)
+PACKAGE_K_J_PRODUCER_TESTOWNER = (
+    "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py"
+)
+PACKAGE_K_J_CLI_TESTOWNER = "tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py"
+PACKAGE_K_H_WIRING_TESTOWNER = "tests/risk/validation/test_var_suite_backtest_wiring_v1.py"
+PACKAGE_K_LINEAGE_CONTRACT = (
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py"
+)
+PACKAGE_K_ALL_PRODUCTION = (
+    PACKAGE_K_BINDING_PRODUCTION,
+    PACKAGE_K_BINDING_SCRIPT,
+)
+PACKAGE_K_ALL_TESTOWNERS = (
+    PACKAGE_K_BINDING_TESTOWNER,
+    PACKAGE_K_BINDING_CLI_TESTOWNER,
+    PACKAGE_K_J_PRODUCER_TESTOWNER,
+    PACKAGE_K_J_CLI_TESTOWNER,
+    PACKAGE_K_H_WIRING_TESTOWNER,
+    PACKAGE_K_LINEAGE_CONTRACT,
+)
+
+
+def test_selector_package_k_binding_production_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_K_BINDING_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_K_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_k_script_contract_focused_includes_binding_testowners() -> None:
+    sel = _run_selector(PACKAGE_K_BINDING_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    for path in PACKAGE_K_ALL_TESTOWNERS:
+        assert path in targets
+
+
+def test_selector_package_k_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+    sel = _run_selector(
+        *PACKAGE_K_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_K_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_K_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/meta/test_var_suite_durable_evidence_binding_v1.py
+++ b/tests/meta/test_var_suite_durable_evidence_binding_v1.py
@@ -1,0 +1,442 @@
+"""Contract tests for Package K offline VAR_SUITE durable evidence binding v1."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_to_mapping,
+)
+from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import (
+    SUITE_REPORT_JSON,
+    VAR_SUITE_OWNER_DOMAIN,
+    produce_var_suite_lineage_ref_v1,
+    serialize_var_suite_lineage_ref_v1,
+    write_var_suite_lineage_ref_v1_atomic,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256
+from src.meta.learning_loop.var_suite_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL,
+    LINEAGE_REF_ARTIFACT_REL,
+    SUITE_REPORT_ARTIFACT_REL,
+    BoundArtifactRecord,
+    VarSuiteBindingCrossReferences,
+    VarSuiteDurableEvidenceBindingError,
+    build_binding_index_v1,
+    check_reference_consistency,
+    produce_var_suite_durable_evidence_bundle_v1,
+    serialize_binding_index_v1,
+)
+
+REPORT_DIR_NAME = "suite-run-k-001"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.var_suite_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def _minimal_suite_report_data(*, overall_result: str = "PASS") -> dict:
+    return {"overall_result": overall_result}
+
+
+def _write_report_dir(
+    tmp_path: Path,
+    data: dict | None = None,
+    *,
+    report_dir_name: str = REPORT_DIR_NAME,
+) -> Path:
+    report_dir = tmp_path / "sources" / report_dir_name
+    report_dir.mkdir(parents=True)
+    payload = _minimal_suite_report_data() if data is None else data
+    (report_dir / SUITE_REPORT_JSON).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return report_dir
+
+
+def _write_lineage_ref(report_dir: Path, ref_path: Path) -> None:
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    write_var_suite_lineage_ref_v1_atomic(result.ref, ref_path, fail_closed_if_exists=True)
+
+
+def _durable_output(tmp_path: Path, name: str = "bundle") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _bind_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    report_dir = _write_report_dir(tmp_path)
+    ref_path = tmp_path / "sources" / "var_suite_ref.json"
+    _write_lineage_ref(report_dir, ref_path)
+    return report_dir, ref_path, _durable_output(tmp_path)
+
+
+def test_happy_path_binds_successfully(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    result = produce_var_suite_durable_evidence_bundle_v1(
+        report_dir=report_dir,
+        var_suite_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    assert result.report_ref_id == REPORT_DIR_NAME
+    assert (out / SUITE_REPORT_ARTIFACT_REL).is_file()
+    assert (out / LINEAGE_REF_ARTIFACT_REL).is_file()
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is True
+
+
+def test_byte_identical_copies(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    report_bytes = (report_dir / SUITE_REPORT_JSON).read_bytes()
+    ref_bytes = ref_path.read_bytes()
+    produce_var_suite_durable_evidence_bundle_v1(
+        report_dir=report_dir,
+        var_suite_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    assert (out / SUITE_REPORT_ARTIFACT_REL).read_bytes() == report_bytes
+    assert (out / LINEAGE_REF_ARTIFACT_REL).read_bytes() == ref_bytes
+
+
+def test_binding_index_metadata_only(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    produce_var_suite_durable_evidence_bundle_v1(
+        report_dir=report_dir,
+        var_suite_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert index["evidence_does_not_authorize_runtime"] is True
+    assert index["report_ref_id"] == REPORT_DIR_NAME
+    assert "overall_result" not in index
+    assert "observations" not in json.dumps(index["var_suite_lineage_ref"])
+    assert all(not Path(item["relative_path"]).is_absolute() for item in index["artifacts"])
+
+
+def test_overall_result_present_but_not_interpreted(tmp_path: Path) -> None:
+    for value in ("PASS", "FAIL", "UNKNOWN", "REJECT"):
+        report_dir = _write_report_dir(
+            tmp_path, {"overall_result": value}, report_dir_name=f"r-{value}"
+        )
+        ref_path = tmp_path / "sources" / f"ref-{value}.json"
+        _write_lineage_ref(report_dir, ref_path)
+        out = _durable_output(tmp_path, f"out-{value}")
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+        assert (out / SUITE_REPORT_ARTIFACT_REL).exists()
+
+
+def test_check_reference_consistency_digest_mismatch(tmp_path: Path) -> None:
+    report_dir, ref_path, _ = _bind_inputs(tmp_path)
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    ref = result.ref
+    report_bytes = (report_dir / SUITE_REPORT_JSON).read_bytes()
+    bad_ref = type(ref)(
+        ref_type=ref.ref_type,
+        ref_id=ref.ref_id,
+        relation=ref.relation,
+        owner_domain=ref.owner_domain,
+        required=ref.required,
+        digest="0" * 64,
+        artifact_path=ref.artifact_path,
+        schema_version=ref.schema_version,
+    )
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="digest does not match"):
+        check_reference_consistency(report_dir=report_dir, report_bytes=report_bytes, ref=bad_ref)
+
+
+def test_wrong_ref_type_fail_closed(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["ref_type"] = LineageRefType.BACKTEST.value
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="ref_type must be VAR_SUITE"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_wrong_relation_fail_closed(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["relation"] = LineageRelation.EVALUATES.value
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="relation must be VALIDATES"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_wrong_artifact_path_fail_closed(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["artifact_path"] = "other_report.json"
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="artifact_path must be"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_inconsistent_ref_id_fail_closed(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["ref_id"] = "wrong-id"
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="ref_id must match"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_inconsistent_owner_domain_fail_closed(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["owner_domain"] = "other/domain"
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="owner_domain must be"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_missing_suite_report_fail_closed(tmp_path: Path) -> None:
+    report_dir = tmp_path / "sources" / "empty-dir"
+    report_dir.mkdir(parents=True)
+    ref_path = tmp_path / "sources" / "orphan_ref.json"
+    result = produce_var_suite_lineage_ref_v1(report_dir=_write_report_dir(tmp_path))
+    write_var_suite_lineage_ref_v1_atomic(result.ref, ref_path)
+    out = _durable_output(tmp_path, "missing_report")
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="not found"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_missing_overall_result_fail_closed(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path, {"observations": 1})
+    ref_path = tmp_path / "sources" / "ref-no-overall.json"
+    with pytest.raises(Exception):
+        _write_lineage_ref(report_dir, ref_path)
+
+
+def test_invalid_report_json_fail_closed(tmp_path: Path) -> None:
+    report_dir = tmp_path / "sources" / "bad-json"
+    report_dir.mkdir(parents=True)
+    (report_dir / SUITE_REPORT_JSON).write_text("{broken", encoding="utf-8")
+    ref_path = tmp_path / "sources" / "ref.json"
+    good_dir = _write_report_dir(tmp_path, report_dir_name="good")
+    _write_lineage_ref(good_dir, ref_path)
+    out = _durable_output(tmp_path, "bad-json")
+    with pytest.raises(VarSuiteDurableEvidenceBindingError):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_missing_lineage_ref_fail_closed(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    out = _durable_output(tmp_path, "missing_ref")
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="not found"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=tmp_path / "missing_ref.json",
+            output_dir=out,
+        )
+
+
+def test_symlink_report_rejected(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    link = tmp_path / "sources" / "report_link"
+    link.symlink_to(report_dir, target_is_directory=True)
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="symlink"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=link,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_existing_output_dir_fail_closed(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    out.mkdir(parents=True)
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="already exists"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_deterministic_index_and_manifest(tmp_path: Path) -> None:
+    report_dir, ref_path, _ = _bind_inputs(tmp_path)
+    out1 = _durable_output(tmp_path, "det1")
+    out2 = _durable_output(tmp_path, "det2")
+    produce_var_suite_durable_evidence_bundle_v1(
+        report_dir=report_dir,
+        var_suite_lineage_ref_path=ref_path,
+        output_dir=out1,
+    )
+    produce_var_suite_durable_evidence_bundle_v1(
+        report_dir=report_dir,
+        var_suite_lineage_ref_path=ref_path,
+        output_dir=out2,
+    )
+    assert (out1 / INDEX_ARTIFACT_REL).read_bytes() == (out2 / INDEX_ARTIFACT_REL).read_bytes()
+    assert (out1 / "MANIFEST.sha256").read_bytes() == (out2 / "MANIFEST.sha256").read_bytes()
+
+
+def test_copy_failure_cleans_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+
+    def _boom(_src: Path, _dst: Path) -> str:
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.var_suite_durable_evidence_binding_v1._copy_byte_identical",
+        _boom,
+    )
+    with pytest.raises(OSError, match="copy failed"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_manifest_verify_failure_cleans_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    monkeypatch.setattr(
+        "src.meta.learning_loop.var_suite_durable_evidence_binding_v1.verify_manifest_sha256",
+        lambda _root: (False, "checksum mismatch"),
+    )
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="verification failed"):
+        produce_var_suite_durable_evidence_bundle_v1(
+            report_dir=report_dir,
+            var_suite_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_build_binding_index_rejects_forbidden_key(tmp_path: Path) -> None:
+    report_dir = _write_report_dir(tmp_path)
+    ref = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref
+    cross = VarSuiteBindingCrossReferences(
+        report_ref_id=ref.ref_id,
+        lineage_ref_digest=ref.digest or "a" * 64,
+        lineage_ref_artifact_path=ref.artifact_path or SUITE_REPORT_JSON,
+    )
+    artifacts = (
+        BoundArtifactRecord("var_suite_report", SUITE_REPORT_ARTIFACT_REL, "b" * 64),
+        BoundArtifactRecord("var_suite_lineage_ref_v1", LINEAGE_REF_ARTIFACT_REL, "c" * 64),
+    )
+    index = build_binding_index_v1(
+        report_ref_id=ref.ref_id,
+        cross_references=cross,
+        ref=ref,
+        artifacts=artifacts,
+    )
+    index["overall_result"] = "PASS"
+    with pytest.raises(VarSuiteDurableEvidenceBindingError, match="forbidden key"):
+        serialize_binding_index_v1(index)
+
+
+def test_integrity_hash_stable_for_index_payload(tmp_path: Path) -> None:
+    report_dir, ref_path, _ = _bind_inputs(tmp_path)
+    ref = produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref
+    report_bytes = (report_dir / SUITE_REPORT_JSON).read_bytes()
+    cross = check_reference_consistency(report_dir=report_dir, report_bytes=report_bytes, ref=ref)
+    artifacts = (
+        BoundArtifactRecord("var_suite_report", SUITE_REPORT_ARTIFACT_REL, ref.digest or ""),
+        BoundArtifactRecord("var_suite_lineage_ref_v1", LINEAGE_REF_ARTIFACT_REL, ref.digest or ""),
+    )
+    index = build_binding_index_v1(
+        report_ref_id=report_dir.name,
+        cross_references=cross,
+        ref=ref,
+        artifacts=artifacts,
+    )
+    payload = dict(index)
+    digest = payload.pop("integrity")
+    assert digest["content_sha256"] == compute_content_sha256(payload)
+
+
+def test_output_under_tmp_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts.ops.primary_evidence_retention_v0 import is_under_tmp as real_is_under_tmp
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.var_suite_durable_evidence_binding_v1.is_under_tmp",
+        real_is_under_tmp,
+    )
+    report_dir, ref_path, _ = _bind_inputs(tmp_path)
+    out = Path("/tmp/peak_trade_pkg_k_binding_reject_test")
+    try:
+        with pytest.raises(VarSuiteDurableEvidenceBindingError, match="outside /tmp"):
+            produce_var_suite_durable_evidence_bundle_v1(
+                report_dir=report_dir,
+                var_suite_lineage_ref_path=ref_path,
+                output_dir=out,
+            )
+    finally:
+        if out.exists():
+            shutil.rmtree(out)
+
+
+def test_no_runtime_imports_in_binding_module() -> None:
+    import ast
+
+    path = Path("src/meta/learning_loop/var_suite_durable_evidence_binding_v1.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = ("promotion_loop.engine", "governance.promotion_loop.engine")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for token in forbidden:
+                assert token not in node.module
+
+
+def test_package_j_ref_serialization_compatible(tmp_path: Path) -> None:
+    report_dir, ref_path, out = _bind_inputs(tmp_path)
+    produce_var_suite_durable_evidence_bundle_v1(
+        report_dir=report_dir,
+        var_suite_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    original = json.loads(ref_path.read_text(encoding="utf-8"))
+    copied = json.loads((out / LINEAGE_REF_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert copied == original
+    assert copied == json.loads(
+        serialize_var_suite_lineage_ref_v1(
+            produce_var_suite_lineage_ref_v1(report_dir=report_dir).ref
+        )
+    )

--- a/tests/scripts/test_run_var_suite_durable_evidence_binding_v1.py
+++ b/tests/scripts/test_run_var_suite_durable_evidence_binding_v1.py
@@ -1,0 +1,210 @@
+"""CLI tests for Package K offline VAR_SUITE durable evidence binding v1."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_var_suite_durable_evidence_binding_v1 import (
+    EXIT_BINDING_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import (
+    produce_var_suite_lineage_ref_v1,
+    write_var_suite_lineage_ref_v1_atomic,
+)
+from src.meta.learning_loop.var_suite_durable_evidence_binding_v1 import INDEX_ARTIFACT_REL
+
+REPORT_DIR_NAME = "suite-cli-k-001"
+SUITE_REPORT_JSON = "suite_report.json"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.var_suite_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    report_dir = sources / REPORT_DIR_NAME
+    report_dir.mkdir()
+    (report_dir / SUITE_REPORT_JSON).write_text(
+        json.dumps({"overall_result": "PASS"}, indent=2),
+        encoding="utf-8",
+    )
+    ref_path = sources / "var_suite_ref.json"
+    result = produce_var_suite_lineage_ref_v1(report_dir=report_dir)
+    write_var_suite_lineage_ref_v1_atomic(result.ref, ref_path)
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    return report_dir, ref_path, out_root
+
+
+def test_cli_successful_run(tmp_path: Path) -> None:
+    report_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out = out_root / "bundle_out"
+    rc = main(
+        [
+            "--report-dir",
+            str(report_dir),
+            "--var-suite-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+
+
+def test_cli_requires_all_paths() -> None:
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_cli_missing_report_dir_usage_error(tmp_path: Path) -> None:
+    _, ref_path, out_root = _write_inputs(tmp_path)
+    rc = main(
+        [
+            "--report-dir",
+            str(tmp_path / "missing"),
+            "--var-suite-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_missing_lineage_ref_usage_error(tmp_path: Path) -> None:
+    report_dir, _, out_root = _write_inputs(tmp_path)
+    rc = main(
+        [
+            "--report-dir",
+            str(report_dir),
+            "--var-suite-lineage-ref",
+            str(tmp_path / "missing.json"),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_digest_mismatch_binding_error(tmp_path: Path) -> None:
+    report_dir, ref_path, out_root = _write_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["digest"] = "0" * 64
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--report-dir",
+            str(report_dir),
+            "--var-suite-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_existing_output_binding_error(tmp_path: Path) -> None:
+    report_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out = out_root / "exists"
+    out.mkdir()
+    rc = main(
+        [
+            "--report-dir",
+            str(report_dir),
+            "--var-suite-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_stderr_has_no_report_payload_dump(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    report_dir, ref_path, out_root = _write_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["digest"] = "0" * 64
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--report-dir",
+            str(report_dir),
+            "--var-suite-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+    err = capsys.readouterr().err
+    assert "overall_result" not in err
+    assert len(err) < 500
+
+
+def test_cli_no_network_side_effects(tmp_path: Path) -> None:
+    report_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out = out_root / "bundle"
+    with patch("urllib.request.urlopen", side_effect=AssertionError("network forbidden")):
+        rc = main(
+            [
+                "--report-dir",
+                str(report_dir),
+                "--var-suite-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out),
+            ]
+        )
+    assert rc == EXIT_OK
+
+
+def test_cli_deterministic_output(tmp_path: Path) -> None:
+    report_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out1 = out_root / "bundle1"
+    out2 = out_root / "bundle2"
+    assert (
+        main(
+            [
+                "--report-dir",
+                str(report_dir),
+                "--var-suite-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out1),
+            ]
+        )
+        == EXIT_OK
+    )
+    assert (
+        main(
+            [
+                "--report-dir",
+                str(report_dir),
+                "--var-suite-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out2),
+            ]
+        )
+        == EXIT_OK
+    )
+    assert (out1 / INDEX_ARTIFACT_REL).read_bytes() == (out2 / INDEX_ARTIFACT_REL).read_bytes()


### PR DESCRIPTION
## Summary

- Package K: offline durable evidence binding for explicit VaR suite report directories + separate Package J `VAR_SUITE` LineageRef JSON files
- Additive sibling to Package G under `src/meta/learning_loop/` — byte-identical artifact copies, metadata-only binding index, atomic publish, `MANIFEST.sha256`
- Extends CI selector with `PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_*` cluster (Package G pattern) including Package H/J regression testowners

## Scope

**Inputs (explicit, separate):**
- `--report-dir` containing `suite_report.json` (structural `overall_result` check only; no interpretation)
- `--var-suite-lineage-ref` Package J output (`ref_type=VAR_SUITE`, `relation=VALIDATES`, digest = sha256 of exact report bytes)

**Outputs:**
- `suite_report.json`, `var_suite_lineage_ref_v1.json`, `var_suite_durable_evidence_binding_index_v1.json`, `MANIFEST.sha256`

**Not in scope:** `suite_report.md`, VaR execution, promotion, runtime authority, registry mutation, Package L

## Changed files (6)

1. `src/meta/learning_loop/var_suite_durable_evidence_binding_v1.py`
2. `scripts/run_var_suite_durable_evidence_binding_v1.py`
3. `tests/meta/test_var_suite_durable_evidence_binding_v1.py`
4. `tests/scripts/test_run_var_suite_durable_evidence_binding_v1.py`
5. `scripts/ops/ci_test_selection_v1.py`
6. `tests/ci/test_ci_diff_aware_test_selection_v1.py`

## Safety

| Field | Value |
|-------|-------|
| OFFLINE_ONLY | true |
| EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME | true |
| RUNTIME_AUTHORITY_IMPACT | NONE |
| TRADING_LOGIC_IMMUTABILITY | true |
| PACKAGE_L_STARTED | false |

## Test plan

- [x] Package K producer tests (24) + CLI tests (9)
- [x] Package G regression (27)
- [x] Package H regression (`test_var_suite_backtest_wiring_v1`, 18)
- [x] Package J regression (44)
- [x] LineageRef contract regression (16)
- [x] CI selector Package K contracts (3)
- [x] Focused selector path: **866 tests passed** in 46s
- [x] Ruff format/check PASS
- [x] Pyright producer+CLI: 0 errors

**Required check:** `tests (3.11)` via `PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_*`


Made with [Cursor](https://cursor.com)