### PR TITLE
feat(meta): add offline BACKTEST durable evidence binding v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1451,6 +1451,24 @@ PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = 
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/backtest_durable_evidence_binding_v1.py",
+        "scripts/run_backtest_durable_evidence_binding_v1.py",
+        "tests/meta/test_backtest_durable_evidence_binding_v1.py",
+        "tests/scripts/test_run_backtest_durable_evidence_binding_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_backtest_durable_evidence_binding_v1.py",
+    "tests/scripts/test_run_backtest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
+    "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py",
+    "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/governance/promotion_loop/engine.py",
@@ -1525,6 +1543,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TRIGGER_PATHS:
@@ -4694,6 +4716,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                     add(candidate)
             elif path == "scripts/run_var_suite_durable_evidence_binding_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_K_VAR_SUITE_DURABLE_EVIDENCE_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_backtest_durable_evidence_binding_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS:
                     add(candidate)
             for candidate in (
                 f"tests/scripts/test_{script_stem}_load_strategy_v1.py",

--- a/scripts/run_backtest_durable_evidence_binding_v1.py
+++ b/scripts/run_backtest_durable_evidence_binding_v1.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Offline Package L — bind BACKTEST run directory + LineageRef to durable evidence.
+
+Produces a validated durable evidence bundle with binding index and MANIFEST.sha256 only.
+No backtest execution, promotion, apply, runtime, registry mutation, or live authority.
+
+Usage:
+    python3 scripts/run_backtest_durable_evidence_binding_v1.py \\
+        --run-dir reports/backtests/completed-run-001 \\
+        --backtest-lineage-ref reports/lineage_refs/backtest_completed-run-001.json \\
+        --output-dir /var/evidence/backtest_bundle_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.backtest_durable_evidence_binding_v1 import (
+    BacktestDurableEvidenceBindingError,
+    produce_backtest_durable_evidence_bundle_v1,
+)
+
+EXIT_OK = 0
+EXIT_BINDING_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Package L: bind validated BACKTEST run directory and "
+            "LineageRef to durable evidence (index + MANIFEST.sha256)."
+        )
+    )
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to a completed backtest run directory containing run_summary.json.",
+    )
+    parser.add_argument(
+        "--backtest-lineage-ref",
+        type=Path,
+        required=True,
+        help="Explicit path to a validated Package I BACKTEST LineageRef JSON file.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit durable evidence bundle directory (must not exist; outside /tmp).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.run_dir.is_dir():
+        print(
+            f"[backtest_durable_evidence_binding] ERROR: run directory not found: {args.run_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if not args.backtest_lineage_ref.is_file():
+        print(
+            "[backtest_durable_evidence_binding] ERROR: "
+            f"backtest lineage ref not found: {args.backtest_lineage_ref}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    try:
+        result = produce_backtest_durable_evidence_bundle_v1(
+            run_dir=args.run_dir,
+            backtest_lineage_ref_path=args.backtest_lineage_ref,
+            output_dir=args.output_dir,
+        )
+    except BacktestDurableEvidenceBindingError as exc:
+        print(f"[backtest_durable_evidence_binding] ERROR: {exc}", file=sys.stderr)
+        return EXIT_BINDING_ERROR
+
+    print(
+        "[backtest_durable_evidence_binding] wrote durable evidence bundle to "
+        f"{result.output_dir} (run_ref_id={result.run_ref_id})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/backtest_durable_evidence_binding_v1.py
+++ b/src/meta/learning_loop/backtest_durable_evidence_binding_v1.py
@@ -1,0 +1,479 @@
+"""Offline Package L — durable evidence binding for BACKTEST run + LineageRef v1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.experiments.tracking.run_summary import RunSummary
+from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+    BACKTEST_OWNER_DOMAIN,
+    RUN_SUMMARY_REL_PATH,
+    compute_backtest_lineage_ref_digest,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    CandidateLineageManifestError,
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_from_mapping,
+    lineage_ref_to_mapping,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+BINDING_SCHEMA_VERSION = "backtest_durable_evidence_binding_v1"
+RUN_SUMMARY_ARTIFACT_REL = RUN_SUMMARY_REL_PATH
+LINEAGE_REF_ARTIFACT_REL = "backtest_lineage_ref_v1.json"
+INDEX_ARTIFACT_REL = "backtest_durable_evidence_binding_index_v1.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".backtest_durable_evidence_staging_"
+COMPLETED_RUN_STATUS = "FINISHED"
+
+FUTURES_SCOPE_REF: dict[str, bool] = {
+    "futures_only": True,
+    "bitcoin_direction_allowed": False,
+}
+TRADING_LOGIC_IMMUTABILITY_REF: dict[str, bool] = {
+    "trading_logic_immutability": True,
+}
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "patches",
+        "patch",
+        "strategy",
+        "signal",
+        "signals",
+        "entry",
+        "exit",
+        "position_sizing",
+        "leverage",
+        "stop_loss",
+        "take_profit",
+        "execution",
+        "order_routing",
+        "risk_limits",
+        "killswitch",
+        "old_value",
+        "new_value",
+        "target",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "runtime_status",
+        "live_arming",
+        "apply_authority",
+        "promotion_authority",
+        "params",
+        "metrics",
+        "tags",
+    }
+)
+
+
+class BacktestDurableEvidenceBindingError(ValueError):
+    """Fail-closed Package L BACKTEST durable evidence binding error."""
+
+
+@dataclass(frozen=True)
+class BoundArtifactRecord:
+    artifact_kind: str
+    relative_path: str
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class BacktestBindingCrossReferences:
+    run_ref_id: str
+    lineage_ref_digest: str
+    lineage_ref_artifact_path: str
+
+
+@dataclass(frozen=True)
+class BacktestDurableEvidenceBindingResult:
+    output_dir: Path
+    run_ref_id: str
+    binding_index_path: Path
+    manifest_path: Path
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise BacktestDurableEvidenceBindingError(f"{label} must not be a symlink: {path}")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise BacktestDurableEvidenceBindingError(
+                f"binding index must not contain forbidden key: {key}"
+            )
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise BacktestDurableEvidenceBindingError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise BacktestDurableEvidenceBindingError(f"{label} must be a regular file: {path}")
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise BacktestDurableEvidenceBindingError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise BacktestDurableEvidenceBindingError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise BacktestDurableEvidenceBindingError(f"output parent directory missing: {parent}")
+    if is_under_tmp(parent):
+        raise BacktestDurableEvidenceBindingError("output parent directory must be outside /tmp")
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_existing_directory(run_dir: Path) -> Path:
+    if not run_dir.exists():
+        raise BacktestDurableEvidenceBindingError(f"run_dir not found: {run_dir}")
+    _reject_symlink(run_dir, label="run_dir")
+    if not run_dir.is_dir():
+        raise BacktestDurableEvidenceBindingError(f"run_dir is not a directory: {run_dir}")
+    return run_dir.resolve()
+
+
+def _load_completed_run_summary(run_dir: Path) -> tuple[RunSummary, Path, bytes]:
+    summary_path = run_dir / RUN_SUMMARY_REL_PATH
+    _validate_regular_file(summary_path, label=RUN_SUMMARY_REL_PATH)
+    resolved = summary_path.resolve()
+    if not _path_is_under(resolved, run_dir.resolve()):
+        raise BacktestDurableEvidenceBindingError(
+            f"{RUN_SUMMARY_REL_PATH} escapes run_dir root: {summary_path}"
+        )
+
+    summary_bytes = summary_path.read_bytes()
+    try:
+        summary = RunSummary.read_json(summary_path)
+    except (json.JSONDecodeError, TypeError, ValueError, FileNotFoundError) as exc:
+        raise BacktestDurableEvidenceBindingError(
+            f"invalid {RUN_SUMMARY_REL_PATH} in run_dir={run_dir}: {exc}"
+        ) from exc
+
+    errors = summary.validate_contract(strict=True)
+    if errors:
+        raise BacktestDurableEvidenceBindingError(
+            f"RunSummary contract validation failed for run_dir={run_dir}: " + "; ".join(errors)
+        )
+    if not summary.run_id or not str(summary.run_id).strip():
+        raise BacktestDurableEvidenceBindingError(
+            f"run_id missing or empty in {RUN_SUMMARY_REL_PATH} for run_dir={run_dir}"
+        )
+    if summary.status != COMPLETED_RUN_STATUS:
+        raise BacktestDurableEvidenceBindingError(
+            f"run is not completed (status={summary.status!r}); "
+            f"expected {COMPLETED_RUN_STATUS!r} for run_dir={run_dir}"
+        )
+    return summary, summary_path, summary_bytes
+
+
+def _load_lineage_ref_from_json_path(path: Path) -> LineageRef:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise BacktestDurableEvidenceBindingError(
+            f"failed to read lineage ref file: {path}"
+        ) from exc
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise BacktestDurableEvidenceBindingError(
+            f"invalid JSON in lineage ref file: {path}"
+        ) from exc
+    if not isinstance(data, Mapping):
+        raise BacktestDurableEvidenceBindingError("lineage ref root must be a JSON object")
+    try:
+        return lineage_ref_from_mapping(data)
+    except CandidateLineageManifestError as exc:
+        raise BacktestDurableEvidenceBindingError(str(exc)) from exc
+
+
+def _reject_unsafe_overlap(
+    *,
+    run_dir: Path,
+    lineage_ref_path: Path,
+    output_dir: Path,
+) -> None:
+    run_res = run_dir.resolve()
+    lineage_res = lineage_ref_path.resolve()
+    output_res = output_dir.resolve()
+
+    if output_res == run_res or output_res == lineage_res:
+        raise BacktestDurableEvidenceBindingError(
+            "output directory must not equal a source path (fail-closed)"
+        )
+
+    if _path_is_under(run_res, output_res) or _path_is_under(lineage_res, output_res):
+        raise BacktestDurableEvidenceBindingError(
+            "source path must not be inside output directory (fail-closed)"
+        )
+
+    if _path_is_under(output_res, run_res) or _path_is_under(output_res, lineage_res):
+        raise BacktestDurableEvidenceBindingError(
+            "output directory must not be inside a source path (fail-closed)"
+        )
+
+
+def _validate_bundle_relative_path(rel: str) -> None:
+    candidate = Path(rel)
+    if candidate.is_absolute():
+        raise BacktestDurableEvidenceBindingError(
+            f"bundle relative path must not be absolute: {rel!r}"
+        )
+    if ".." in candidate.parts:
+        raise BacktestDurableEvidenceBindingError(
+            f"bundle relative path must not traverse upward: {rel!r}"
+        )
+
+
+def check_reference_consistency(
+    *,
+    summary: RunSummary,
+    ref: LineageRef,
+) -> BacktestBindingCrossReferences:
+    if ref.ref_type != LineageRefType.BACKTEST:
+        raise BacktestDurableEvidenceBindingError(
+            f"ref_type must be BACKTEST, got {ref.ref_type.value!r}"
+        )
+    if ref.relation != LineageRelation.EVALUATES:
+        raise BacktestDurableEvidenceBindingError(
+            f"relation must be EVALUATES, got {ref.relation.value!r}"
+        )
+    if ref.artifact_path != RUN_SUMMARY_REL_PATH:
+        raise BacktestDurableEvidenceBindingError(
+            f"artifact_path must be {RUN_SUMMARY_REL_PATH!r}, got {ref.artifact_path!r}"
+        )
+    if ref.owner_domain != BACKTEST_OWNER_DOMAIN:
+        raise BacktestDurableEvidenceBindingError(
+            f"owner_domain must be {BACKTEST_OWNER_DOMAIN!r}, got {ref.owner_domain!r}"
+        )
+    if ref.ref_id != summary.run_id:
+        raise BacktestDurableEvidenceBindingError(
+            f"ref_id must match RunSummary.run_id: {ref.ref_id!r} != {summary.run_id!r}"
+        )
+    if ref.digest is None:
+        raise BacktestDurableEvidenceBindingError("lineage ref digest is required")
+    if not is_valid_sha256_hex(ref.digest):
+        raise BacktestDurableEvidenceBindingError("lineage ref digest must be valid sha256 hex")
+    expected_digest = compute_backtest_lineage_ref_digest(summary)
+    if ref.digest != expected_digest:
+        raise BacktestDurableEvidenceBindingError(
+            "lineage ref digest does not match RunSummary identity digest contract"
+        )
+    return BacktestBindingCrossReferences(
+        run_ref_id=summary.run_id,
+        lineage_ref_digest=ref.digest,
+        lineage_ref_artifact_path=ref.artifact_path,
+    )
+
+
+def _build_backtest_lineage_ref_payload(ref: LineageRef) -> dict[str, Any]:
+    payload = lineage_ref_to_mapping(ref)
+    for forbidden in ("params", "metrics", "returns", "trades", "equity", "tags"):
+        if forbidden in payload:
+            raise BacktestDurableEvidenceBindingError(
+                f"lineage ref must not contain run payload key: {forbidden}"
+            )
+    return payload
+
+
+def build_binding_index_v1(
+    *,
+    run_ref_id: str,
+    cross_references: BacktestBindingCrossReferences,
+    ref: LineageRef,
+    artifacts: tuple[BoundArtifactRecord, ...],
+) -> dict[str, Any]:
+    sorted_artifacts = sorted(
+        artifacts,
+        key=lambda item: (item.artifact_kind, item.relative_path),
+    )
+    payload: dict[str, Any] = {
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "run_ref_id": run_ref_id,
+        "backtest_lineage_ref": _build_backtest_lineage_ref_payload(ref),
+        "cross_references": {
+            "run_ref_id": cross_references.run_ref_id,
+            "lineage_ref_digest": cross_references.lineage_ref_digest,
+            "lineage_ref_artifact_path": cross_references.lineage_ref_artifact_path,
+        },
+        "artifacts": [
+            {
+                "artifact_kind": item.artifact_kind,
+                "relative_path": item.relative_path,
+                "content_sha256": item.content_sha256,
+            }
+            for item in sorted_artifacts
+        ],
+        "futures_scope_ref": dict(FUTURES_SCOPE_REF),
+        "trading_logic_immutability_ref": dict(TRADING_LOGIC_IMMUTABILITY_REF),
+        "evidence_does_not_authorize_runtime": True,
+    }
+    _reject_forbidden_index_keys(payload)
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def serialize_binding_index_v1(index: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(index)
+    return deterministic_json_dumps(dict(index))
+
+
+def _copy_byte_identical(source: Path, dest: Path) -> str:
+    _validate_regular_file(source, label="source artifact")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, dest)
+    source_digest = _sha256_file(source)
+    dest_digest = _sha256_file(dest)
+    if source_digest != dest_digest:
+        raise BacktestDurableEvidenceBindingError(f"byte-identical copy failed for {source.name}")
+    return source_digest
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    token = uuid.uuid4().hex
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{token}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def produce_backtest_durable_evidence_bundle_v1(
+    *,
+    run_dir: Path | str,
+    backtest_lineage_ref_path: Path | str,
+    output_dir: Path | str,
+) -> BacktestDurableEvidenceBindingResult:
+    """Bind validated BACKTEST run summary + LineageRef artifacts into offline durable evidence."""
+    resolved_run_dir = _resolve_existing_directory(Path(run_dir))
+    lineage_ref_file = Path(backtest_lineage_ref_path)
+    final_dir = Path(output_dir)
+
+    _validate_regular_file(lineage_ref_file, label="backtest lineage ref")
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        run_dir=resolved_run_dir,
+        lineage_ref_path=lineage_ref_file,
+        output_dir=final_dir,
+    )
+
+    summary, summary_path, _summary_bytes = _load_completed_run_summary(resolved_run_dir)
+    ref = _load_lineage_ref_from_json_path(lineage_ref_file)
+    cross = check_reference_consistency(summary=summary, ref=ref)
+
+    for rel in (RUN_SUMMARY_ARTIFACT_REL, LINEAGE_REF_ARTIFACT_REL, INDEX_ARTIFACT_REL):
+        _validate_bundle_relative_path(rel)
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise BacktestDurableEvidenceBindingError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+
+        summary_dest = staging / RUN_SUMMARY_ARTIFACT_REL
+        ref_dest = staging / LINEAGE_REF_ARTIFACT_REL
+        summary_digest = _copy_byte_identical(summary_path, summary_dest)
+        ref_digest = _copy_byte_identical(lineage_ref_file, ref_dest)
+
+        artifacts = (
+            BoundArtifactRecord(
+                artifact_kind="backtest_run_summary",
+                relative_path=RUN_SUMMARY_ARTIFACT_REL,
+                content_sha256=summary_digest,
+            ),
+            BoundArtifactRecord(
+                artifact_kind="backtest_lineage_ref_v1",
+                relative_path=LINEAGE_REF_ARTIFACT_REL,
+                content_sha256=ref_digest,
+            ),
+        )
+        index_payload = build_binding_index_v1(
+            run_ref_id=summary.run_id,
+            cross_references=cross,
+            ref=ref,
+            artifacts=artifacts,
+        )
+        index_path = staging / INDEX_ARTIFACT_REL
+        index_path.write_text(serialize_binding_index_v1(index_payload), encoding="utf-8")
+
+        write_manifest_sha256(staging)
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise BacktestDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise BacktestDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return BacktestDurableEvidenceBindingResult(
+        output_dir=final_dir,
+        run_ref_id=summary.run_id,
+        binding_index_path=final_dir / INDEX_ARTIFACT_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+    )
+
+
+__all__ = [
+    "BINDING_SCHEMA_VERSION",
+    "INDEX_ARTIFACT_REL",
+    "LINEAGE_REF_ARTIFACT_REL",
+    "RUN_SUMMARY_ARTIFACT_REL",
+    "BacktestBindingCrossReferences",
+    "BacktestDurableEvidenceBindingError",
+    "BacktestDurableEvidenceBindingResult",
+    "BoundArtifactRecord",
+    "build_binding_index_v1",
+    "check_reference_consistency",
+    "produce_backtest_durable_evidence_bundle_v1",
+    "serialize_binding_index_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5469,3 +5469,58 @@ def test_selector_package_k_combined_diff_pr_bounded_full_includes_all_testowner
     for path in PACKAGE_K_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_L_BINDING_PRODUCTION = "src/meta/learning_loop/backtest_durable_evidence_binding_v1.py"
+PACKAGE_L_BINDING_SCRIPT = "scripts/run_backtest_durable_evidence_binding_v1.py"
+PACKAGE_L_BINDING_TESTOWNER = "tests/meta/test_backtest_durable_evidence_binding_v1.py"
+PACKAGE_L_BINDING_CLI_TESTOWNER = "tests/scripts/test_run_backtest_durable_evidence_binding_v1.py"
+PACKAGE_L_I_PRODUCER_TESTOWNER = (
+    "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py"
+)
+PACKAGE_L_I_CLI_TESTOWNER = "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py"
+PACKAGE_L_G_BINDING_TESTOWNER = "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py"
+PACKAGE_L_LINEAGE_CONTRACT = (
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py"
+)
+PACKAGE_L_ALL_PRODUCTION = (
+    PACKAGE_L_BINDING_PRODUCTION,
+    PACKAGE_L_BINDING_SCRIPT,
+)
+PACKAGE_L_ALL_TESTOWNERS = (
+    PACKAGE_L_BINDING_TESTOWNER,
+    PACKAGE_L_BINDING_CLI_TESTOWNER,
+    PACKAGE_L_I_PRODUCER_TESTOWNER,
+    PACKAGE_L_I_CLI_TESTOWNER,
+    PACKAGE_L_G_BINDING_TESTOWNER,
+    PACKAGE_L_LINEAGE_CONTRACT,
+)
+
+
+def test_selector_package_l_binding_production_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_L_BINDING_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_L_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_l_script_contract_focused_includes_binding_testowners() -> None:
+    sel = _run_selector(PACKAGE_L_BINDING_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    for path in PACKAGE_L_ALL_TESTOWNERS:
+        assert path in targets
+
+
+def test_selector_package_l_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+    sel = _run_selector(
+        *PACKAGE_L_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_L_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_L_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/meta/test_backtest_durable_evidence_binding_v1.py
+++ b/tests/meta/test_backtest_durable_evidence_binding_v1.py
@@ -1,0 +1,457 @@
+"""Contract tests for Package L offline BACKTEST durable evidence binding v1."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+    RUN_SUMMARY_REL_PATH,
+    produce_backtest_lineage_ref_v1,
+    serialize_backtest_lineage_ref_v1,
+    write_backtest_lineage_ref_v1_atomic,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRefType,
+    LineageRelation,
+)
+from src.meta.learning_loop.backtest_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL,
+    LINEAGE_REF_ARTIFACT_REL,
+    RUN_SUMMARY_ARTIFACT_REL,
+    BacktestBindingCrossReferences,
+    BacktestDurableEvidenceBindingError,
+    BoundArtifactRecord,
+    build_binding_index_v1,
+    check_reference_consistency,
+    produce_backtest_durable_evidence_bundle_v1,
+    serialize_binding_index_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256
+
+RUN_ID = "test-run-l-001"
+FIXED_STARTED = "2025-01-15T10:00:00+00:00"
+FIXED_FINISHED = "2025-01-15T10:05:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.backtest_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def _minimal_run_summary_data(*, run_id: str = RUN_ID, status: str = "FINISHED") -> dict:
+    return {
+        "run_id": run_id,
+        "started_at_utc": FIXED_STARTED,
+        "finished_at_utc": FIXED_FINISHED,
+        "status": status,
+        "tracking_backend": "null",
+    }
+
+
+def _write_run_dir(
+    tmp_path: Path,
+    data: dict | None = None,
+    *,
+    run_dir_name: str = "completed-run-l",
+) -> Path:
+    run_dir = tmp_path / "sources" / run_dir_name
+    run_dir.mkdir(parents=True)
+    payload = _minimal_run_summary_data() if data is None else data
+    (run_dir / RUN_SUMMARY_REL_PATH).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return run_dir
+
+
+def _write_lineage_ref(run_dir: Path, ref_path: Path) -> None:
+    result = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    write_backtest_lineage_ref_v1_atomic(result.ref, ref_path, fail_closed_if_exists=True)
+
+
+def _durable_output(tmp_path: Path, name: str = "bundle") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _bind_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    run_dir = _write_run_dir(tmp_path)
+    ref_path = tmp_path / "sources" / "backtest_ref.json"
+    _write_lineage_ref(run_dir, ref_path)
+    return run_dir, ref_path, _durable_output(tmp_path)
+
+
+def test_happy_path_binds_successfully(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    result = produce_backtest_durable_evidence_bundle_v1(
+        run_dir=run_dir,
+        backtest_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    assert result.run_ref_id == RUN_ID
+    assert (out / RUN_SUMMARY_ARTIFACT_REL).is_file()
+    assert (out / LINEAGE_REF_ARTIFACT_REL).is_file()
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is True
+
+
+def test_byte_identical_copies(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    summary_bytes = (run_dir / RUN_SUMMARY_REL_PATH).read_bytes()
+    ref_bytes = ref_path.read_bytes()
+    produce_backtest_durable_evidence_bundle_v1(
+        run_dir=run_dir,
+        backtest_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    assert (out / RUN_SUMMARY_ARTIFACT_REL).read_bytes() == summary_bytes
+    assert (out / LINEAGE_REF_ARTIFACT_REL).read_bytes() == ref_bytes
+
+
+def test_binding_index_metadata_only(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    produce_backtest_durable_evidence_bundle_v1(
+        run_dir=run_dir,
+        backtest_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert index["evidence_does_not_authorize_runtime"] is True
+    assert index["run_ref_id"] == RUN_ID
+    assert "params" not in index
+    assert "metrics" not in index
+    assert "params" not in json.dumps(index["backtest_lineage_ref"])
+    assert all(not Path(item["relative_path"]).is_absolute() for item in index["artifacts"])
+
+
+def test_metrics_present_in_run_summary_but_not_in_index(tmp_path: Path) -> None:
+    data = {
+        **_minimal_run_summary_data(),
+        "metrics": {"sharpe": 1.5, "total_return": 0.25},
+        "params": {"fast_period": 10},
+    }
+    run_dir = _write_run_dir(tmp_path, data, run_dir_name="metrics-run")
+    ref_path = tmp_path / "sources" / "metrics_ref.json"
+    _write_lineage_ref(run_dir, ref_path)
+    out = _durable_output(tmp_path, "metrics-out")
+    produce_backtest_durable_evidence_bundle_v1(
+        run_dir=run_dir,
+        backtest_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert "metrics" not in index
+    assert (out / RUN_SUMMARY_ARTIFACT_REL).exists()
+
+
+def test_check_reference_consistency_digest_mismatch(tmp_path: Path) -> None:
+    run_dir, ref_path, _ = _bind_inputs(tmp_path)
+    result = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    ref = result.ref
+    from src.experiments.tracking.run_summary import RunSummary
+
+    summary = RunSummary.read_json(result.run_summary_path)
+    bad_ref = type(ref)(
+        ref_type=ref.ref_type,
+        ref_id=ref.ref_id,
+        relation=ref.relation,
+        owner_domain=ref.owner_domain,
+        required=ref.required,
+        digest="0" * 64,
+        artifact_path=ref.artifact_path,
+        schema_version=ref.schema_version,
+    )
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="digest"):
+        check_reference_consistency(summary=summary, ref=bad_ref)
+
+
+def test_wrong_ref_id_fail_closed(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["ref_id"] = "wrong-run-id"
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="ref_id"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_wrong_ref_type_fail_closed(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["ref_type"] = LineageRefType.VAR_SUITE.value
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="BACKTEST"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_wrong_relation_fail_closed(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["relation"] = LineageRelation.VALIDATES.value
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="EVALUATES"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_missing_run_summary_fail_closed(tmp_path: Path) -> None:
+    run_dir = tmp_path / "sources" / "empty-run"
+    run_dir.mkdir(parents=True)
+    ref_path = tmp_path / "sources" / "orphan_ref.json"
+    good_dir = _write_run_dir(tmp_path)
+    _write_lineage_ref(good_dir, ref_path)
+    out = _durable_output(tmp_path, "missing-summary")
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="not found"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_non_finished_status_fail_closed(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path, _minimal_run_summary_data(status="RUNNING"))
+    good_dir = _write_run_dir(tmp_path, run_dir_name="good-for-ref")
+    ref_path = tmp_path / "sources" / "running_ref.json"
+    _write_lineage_ref(good_dir, ref_path)
+    out = _durable_output(tmp_path, "running-out")
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="not completed"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_invalid_run_summary_json_fail_closed(tmp_path: Path) -> None:
+    run_dir = tmp_path / "sources" / "bad-json"
+    run_dir.mkdir(parents=True)
+    (run_dir / RUN_SUMMARY_REL_PATH).write_text("{broken", encoding="utf-8")
+    ref_path = tmp_path / "sources" / "ref.json"
+    good_dir = _write_run_dir(tmp_path, run_dir_name="good-for-ref")
+    _write_lineage_ref(good_dir, ref_path)
+    out = _durable_output(tmp_path, "bad-json")
+    with pytest.raises(BacktestDurableEvidenceBindingError):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_missing_lineage_ref_fail_closed(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    out = _durable_output(tmp_path, "missing_ref")
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="not found"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=tmp_path / "missing_ref.json",
+            output_dir=out,
+        )
+
+
+def test_symlink_run_dir_rejected(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    link = tmp_path / "sources" / "run_link"
+    link.symlink_to(run_dir, target_is_directory=True)
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="symlink"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=link,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_existing_output_dir_fail_closed(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    out.mkdir(parents=True)
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="already exists"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_deterministic_index_and_manifest(tmp_path: Path) -> None:
+    run_dir, ref_path, _ = _bind_inputs(tmp_path)
+    out1 = _durable_output(tmp_path, "det1")
+    out2 = _durable_output(tmp_path, "det2")
+    produce_backtest_durable_evidence_bundle_v1(
+        run_dir=run_dir,
+        backtest_lineage_ref_path=ref_path,
+        output_dir=out1,
+    )
+    produce_backtest_durable_evidence_bundle_v1(
+        run_dir=run_dir,
+        backtest_lineage_ref_path=ref_path,
+        output_dir=out2,
+    )
+    assert (out1 / INDEX_ARTIFACT_REL).read_bytes() == (out2 / INDEX_ARTIFACT_REL).read_bytes()
+    assert (out1 / "MANIFEST.sha256").read_bytes() == (out2 / "MANIFEST.sha256").read_bytes()
+
+
+def test_copy_failure_cleans_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+
+    def _boom(_src: Path, _dst: Path) -> str:
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.backtest_durable_evidence_binding_v1._copy_byte_identical",
+        _boom,
+    )
+    with pytest.raises(OSError, match="copy failed"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_manifest_verify_failure_cleans_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    monkeypatch.setattr(
+        "src.meta.learning_loop.backtest_durable_evidence_binding_v1.verify_manifest_sha256",
+        lambda _root: (False, "checksum mismatch"),
+    )
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="verification failed"):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_build_binding_index_rejects_forbidden_key(tmp_path: Path) -> None:
+    run_dir = _write_run_dir(tmp_path)
+    ref = produce_backtest_lineage_ref_v1(run_dir=run_dir).ref
+    cross = BacktestBindingCrossReferences(
+        run_ref_id=ref.ref_id,
+        lineage_ref_digest=ref.digest or "a" * 64,
+        lineage_ref_artifact_path=ref.artifact_path or RUN_SUMMARY_REL_PATH,
+    )
+    artifacts = (
+        BoundArtifactRecord("backtest_run_summary", RUN_SUMMARY_ARTIFACT_REL, "b" * 64),
+        BoundArtifactRecord("backtest_lineage_ref_v1", LINEAGE_REF_ARTIFACT_REL, "c" * 64),
+    )
+    index = build_binding_index_v1(
+        run_ref_id=ref.ref_id,
+        cross_references=cross,
+        ref=ref,
+        artifacts=artifacts,
+    )
+    index["params"] = {"fast_period": 10}
+    with pytest.raises(BacktestDurableEvidenceBindingError, match="forbidden key"):
+        serialize_binding_index_v1(index)
+
+
+def test_integrity_hash_stable_for_index_payload(tmp_path: Path) -> None:
+    run_dir, ref_path, _ = _bind_inputs(tmp_path)
+    ref = produce_backtest_lineage_ref_v1(run_dir=run_dir).ref
+    from src.experiments.tracking.run_summary import RunSummary
+
+    summary = RunSummary.read_json(run_dir / RUN_SUMMARY_REL_PATH)
+    cross = check_reference_consistency(summary=summary, ref=ref)
+    artifacts = (
+        BoundArtifactRecord("backtest_run_summary", RUN_SUMMARY_ARTIFACT_REL, "a" * 64),
+        BoundArtifactRecord("backtest_lineage_ref_v1", LINEAGE_REF_ARTIFACT_REL, "b" * 64),
+    )
+    index = build_binding_index_v1(
+        run_ref_id=summary.run_id,
+        cross_references=cross,
+        ref=ref,
+        artifacts=artifacts,
+    )
+    payload = dict(index)
+    digest = payload.pop("integrity")
+    assert digest["content_sha256"] == compute_content_sha256(payload)
+
+
+def test_output_under_tmp_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts.ops.primary_evidence_retention_v0 import is_under_tmp as real_is_under_tmp
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.backtest_durable_evidence_binding_v1.is_under_tmp",
+        real_is_under_tmp,
+    )
+    run_dir, ref_path, _ = _bind_inputs(tmp_path)
+    out = Path("/tmp/peak_trade_pkg_l_binding_reject_test")
+    try:
+        with pytest.raises(BacktestDurableEvidenceBindingError, match="outside /tmp"):
+            produce_backtest_durable_evidence_bundle_v1(
+                run_dir=run_dir,
+                backtest_lineage_ref_path=ref_path,
+                output_dir=out,
+            )
+    finally:
+        if out.exists():
+            shutil.rmtree(out)
+
+
+def test_no_runtime_imports_in_binding_module() -> None:
+    import ast
+
+    path = Path("src/meta/learning_loop/backtest_durable_evidence_binding_v1.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = ("promotion_loop.engine", "governance.promotion_loop.engine")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for token in forbidden:
+                assert token not in node.module
+
+
+def test_package_i_ref_serialization_compatible(tmp_path: Path) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    produce_backtest_durable_evidence_bundle_v1(
+        run_dir=run_dir,
+        backtest_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    original = json.loads(ref_path.read_text(encoding="utf-8"))
+    copied = json.loads((out / LINEAGE_REF_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert copied == original
+    assert copied == json.loads(
+        serialize_backtest_lineage_ref_v1(produce_backtest_lineage_ref_v1(run_dir=run_dir).ref)
+    )
+
+
+def test_input_mutation_between_validation_and_copy_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir, ref_path, out = _bind_inputs(tmp_path)
+    original_copy = shutil.copyfile
+
+    def _mutating_copy(src: Path, dst: Path) -> None:
+        original_copy(src, dst)
+        if src.name == RUN_SUMMARY_REL_PATH:
+            src.write_text('{"run_id":"mutated"}', encoding="utf-8")
+
+    monkeypatch.setattr(shutil, "copyfile", _mutating_copy)
+    with pytest.raises(BacktestDurableEvidenceBindingError):
+        produce_backtest_durable_evidence_bundle_v1(
+            run_dir=run_dir,
+            backtest_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+    assert not out.exists()

--- a/tests/scripts/test_run_backtest_durable_evidence_binding_v1.py
+++ b/tests/scripts/test_run_backtest_durable_evidence_binding_v1.py
@@ -1,0 +1,221 @@
+"""CLI tests for Package L offline BACKTEST durable evidence binding v1."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_backtest_durable_evidence_binding_v1 import (
+    EXIT_BINDING_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+    RUN_SUMMARY_REL_PATH,
+    produce_backtest_lineage_ref_v1,
+    write_backtest_lineage_ref_v1_atomic,
+)
+from src.meta.learning_loop.backtest_durable_evidence_binding_v1 import INDEX_ARTIFACT_REL
+
+RUN_ID = "test-run-cli-l-001"
+FIXED_STARTED = "2025-01-15T10:00:00+00:00"
+FIXED_FINISHED = "2025-01-15T10:05:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.backtest_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    run_dir = sources / "completed-run"
+    run_dir.mkdir()
+    (run_dir / RUN_SUMMARY_REL_PATH).write_text(
+        json.dumps(
+            {
+                "run_id": RUN_ID,
+                "started_at_utc": FIXED_STARTED,
+                "finished_at_utc": FIXED_FINISHED,
+                "status": "FINISHED",
+                "tracking_backend": "null",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    ref_path = sources / "backtest_ref.json"
+    result = produce_backtest_lineage_ref_v1(run_dir=run_dir)
+    write_backtest_lineage_ref_v1_atomic(result.ref, ref_path)
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    return run_dir, ref_path, out_root
+
+
+def test_cli_successful_run(tmp_path: Path) -> None:
+    run_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out = out_root / "bundle_out"
+    rc = main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--backtest-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+
+
+def test_cli_requires_all_paths() -> None:
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_cli_missing_run_dir_usage_error(tmp_path: Path) -> None:
+    _, ref_path, out_root = _write_inputs(tmp_path)
+    rc = main(
+        [
+            "--run-dir",
+            str(tmp_path / "missing"),
+            "--backtest-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_missing_lineage_ref_usage_error(tmp_path: Path) -> None:
+    run_dir, _, out_root = _write_inputs(tmp_path)
+    rc = main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--backtest-lineage-ref",
+            str(tmp_path / "missing.json"),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_digest_mismatch_binding_error(tmp_path: Path) -> None:
+    run_dir, ref_path, out_root = _write_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["digest"] = "0" * 64
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--backtest-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_existing_output_binding_error(tmp_path: Path) -> None:
+    run_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out = out_root / "exists"
+    out.mkdir()
+    rc = main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--backtest-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_stderr_has_no_run_payload_dump(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    run_dir, ref_path, out_root = _write_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["digest"] = "0" * 64
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--run-dir",
+            str(run_dir),
+            "--backtest-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+    err = capsys.readouterr().err
+    assert "sharpe" not in err
+    assert "params" not in err
+    assert len(err) < 500
+
+
+def test_cli_no_network_side_effects(tmp_path: Path) -> None:
+    run_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out = out_root / "bundle"
+    with patch("urllib.request.urlopen", side_effect=AssertionError("network forbidden")):
+        rc = main(
+            [
+                "--run-dir",
+                str(run_dir),
+                "--backtest-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out),
+            ]
+        )
+    assert rc == EXIT_OK
+
+
+def test_cli_deterministic_output(tmp_path: Path) -> None:
+    run_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out1 = out_root / "bundle1"
+    out2 = out_root / "bundle2"
+    assert (
+        main(
+            [
+                "--run-dir",
+                str(run_dir),
+                "--backtest-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out1),
+            ]
+        )
+        == EXIT_OK
+    )
+    assert (
+        main(
+            [
+                "--run-dir",
+                str(run_dir),
+                "--backtest-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out2),
+            ]
+        )
+        == EXIT_OK
+    )
+    assert (out1 / INDEX_ARTIFACT_REL).read_bytes() == (out2 / INDEX_ARTIFACT_REL).read_bytes()


### PR DESCRIPTION
## Summary

- **Package L** closes the symmetric BACKTEST durable evidence edge: explicit completed `--run-dir` + validated Package I `--backtest-lineage-ref` → offline durable bundle (byte-identical artifacts + metadata-only index + `MANIFEST.sha256`).
- Additive sibling to Package K (`var_suite_durable_evidence_binding_v1.py`); reuses Package I digest contract (`compute_backtest_lineage_ref_digest`) and Package G/K staging/atomic/MANIFEST patterns.
- **6 changed files** only; FOCUSED CI via `PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_*`.

## Scope

| In scope | Out of scope |
|----------|--------------|
| Offline bind `run_summary.json` + BACKTEST LineageRef | Backtest execution |
| Structural RunSummary + LineageRef validation | Metric interpretation / promotion |
| `backtest_durable_evidence_binding_index_v1.json` + MANIFEST | VaR, EXPERIMENT, compare_runs, runtime |

## Inputs / outputs

**Inputs:** `--run-dir` (FINISHED + `run_summary.json`), `--backtest-lineage-ref` (Package I JSON), `--output-dir` (new, outside `/tmp`).

**Outputs:** `run_summary.json`, `backtest_lineage_ref_v1.json`, `backtest_durable_evidence_binding_index_v1.json`, `MANIFEST.sha256`.

## Local validation

- **Tests:** 112 passed in ~0.5s (Package L meta/CLI + Package I/F/G regressions + 3 CI selector contracts)
- **Ruff:** format + check PASS
- **Pyright:** 0 errors on production + CLI
- **git diff --check:** RC=0

## CI

- **Selector path:** FOCUSED `PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_*`
- **Required check:** `tests (3.11)`
- **Estimated unique nodes:** ~112 in bounded run

## Status fields

```
BACKTEST_DURABLE_EVIDENCE_STATUS=CLOSED_OFFLINE_DURABLE_BINDING_V1
EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true
RUNTIME_AUTHORITY_IMPACT=NONE
PACKAGE_M_STARTED=false
```

## Safety

- Offline-only; no backtest execution, registry mutation, promotion, or runtime authority.
- `TRADING_LOGIC_IMMUTABILITY=true`; futures-only posture preserved in binding index.

## Test plan

- [x] `tests/meta/test_backtest_durable_evidence_binding_v1.py`
- [x] `tests/scripts/test_run_backtest_durable_evidence_binding_v1.py`
- [x] Package I producer/CLI regressions
- [x] Package G durable binding regression
- [x] CandidateLineageManifest contract regression
- [x] CI selector Package L contract tests
- [ ] GitHub `tests (3.11)` required check (awaiting CI)


Made with [Cursor](https://cursor.com)