### PR TITLE
feat(experiments): add experiment identity manifest producer v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1469,6 +1469,21 @@ PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/experiments/experiment_identity_manifest_v1.py",
+        "scripts/run_experiment_identity_manifest_v1.py",
+        "tests/experiments/test_experiment_identity_manifest_v1.py",
+        "tests/scripts/test_run_experiment_identity_manifest_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TARGETS: tuple[str, ...] = (
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
+    "tests/scripts/test_run_experiment_identity_manifest_v1.py",
+    "tests/test_experiments_base.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_E_GOVERNANCE_CLOSEOUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/governance/promotion_loop/engine.py",
@@ -1547,6 +1562,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_B_PROMOTION_INPUT_TRIGGER_PATHS:
@@ -4719,6 +4738,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                     add(candidate)
             elif path == "scripts/run_backtest_durable_evidence_binding_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_experiment_identity_manifest_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TARGETS:
                     add(candidate)
             for candidate in (
                 f"tests/scripts/test_{script_stem}_load_strategy_v1.py",

--- a/scripts/run_experiment_identity_manifest_v1.py
+++ b/scripts/run_experiment_identity_manifest_v1.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Offline CLI for Package N experiment identity manifest producer v1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.experiments.experiment_identity_manifest_v1 import (  # noqa: E402
+    ExperimentIdentityManifestError,
+    experiment_config_from_mapping,
+    produce_experiment_identity_manifest_v1,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Produce offline experiment_identity_manifest_v1.json from ExperimentConfig JSON."
+    )
+    parser.add_argument(
+        "--config-json",
+        required=True,
+        help="Path to ExperimentConfig JSON input (no runner invocation).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Output directory that must not exist and must be outside /tmp.",
+    )
+    parser.add_argument(
+        "--source-experiment-id",
+        default=None,
+        help="Optional external provenance alias (metadata only; not identity SSOT).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    config_path = Path(args.config_json)
+    output_dir = Path(args.output_dir)
+
+    if not config_path.is_file():
+        print(f"config-json not found: {config_path}", file=sys.stderr)
+        return 2
+
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+        config = experiment_config_from_mapping(raw)
+        artifact_path = produce_experiment_identity_manifest_v1(
+            config,
+            output_dir,
+            source_experiment_id=args.source_experiment_id,
+        )
+    except ExperimentIdentityManifestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except (json.JSONDecodeError, TypeError, ValueError, KeyError) as exc:
+        print(f"invalid config-json: {exc}", file=sys.stderr)
+        return 1
+
+    print(artifact_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/experiments/experiment_identity_manifest_v1.py
+++ b/src/experiments/experiment_identity_manifest_v1.py
@@ -1,0 +1,580 @@
+"""Offline Package N — Experiment Identity Manifest Producer v1."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import shutil
+import uuid
+from dataclasses import fields
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.meta.learning_loop.contract_safety_v1 import (
+    SCHEMA_VERSION_V1,
+    canonical_futures_scope_ref,
+    canonical_trading_logic_immutability_ref,
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+    normalize_path_token,
+    validate_futures_scope_ref,
+    validate_integrity_block,
+    validate_schema_version,
+    validate_trading_logic_immutability_ref,
+)
+
+CONTRACT_VERSION = SCHEMA_VERSION_V1
+IDENTITY_SCHEMA_VERSION = SCHEMA_VERSION_V1
+IDENTITY_DOMAIN = "peak_trade.experiment_identity.v1"
+ARTIFACT_FILENAME = "experiment_identity_manifest_v1.json"
+STAGING_DIRNAME_PREFIX = ".experiment_identity_staging_"
+RUNTIME_AUTHORITY_IMPACT = "NONE"
+
+_REQUIRED_IDENTITY_FIELDS = (
+    "name",
+    "strategy_name",
+    "param_sweeps",
+    "symbols",
+    "timeframe",
+    "start_date",
+    "end_date",
+    "initial_capital",
+    "base_params",
+    "identity_schema_version",
+    "identity_domain",
+)
+
+_FORBIDDEN_MANIFEST_KEYS = frozenset(
+    {
+        "run_id",
+        "run_index",
+        "metrics",
+        "equity",
+        "trades",
+        "returns",
+        "registry_run_id",
+        "mlflow_run_id",
+        "promotion",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "runtime_status",
+        "orders",
+        "positions",
+        "credentials",
+        "summary_stats",
+        "result_payload",
+    }
+)
+
+_ACTIVE_INPUT_FIELD_CLASSIFICATION: dict[str, str] = {
+    "name": "IDENTITY_REQUIRED",
+    "strategy_name": "IDENTITY_REQUIRED",
+    "param_sweeps": "IDENTITY_REQUIRED",
+    "symbols": "IDENTITY_REQUIRED",
+    "timeframe": "IDENTITY_REQUIRED",
+    "start_date": "IDENTITY_REQUIRED",
+    "end_date": "IDENTITY_REQUIRED",
+    "initial_capital": "IDENTITY_REQUIRED",
+    "base_params": "IDENTITY_REQUIRED",
+    "regime_config": "PROVABLY_INACTIVE",
+    "switching_config": "PROVABLY_INACTIVE",
+    "metrics_to_collect": "RUNTIME_ONLY",
+    "parallel": "PROVABLY_INACTIVE",
+    "max_workers": "RUNTIME_ONLY",
+    "save_results": "RUNTIME_ONLY",
+    "output_dir": "RUNTIME_ONLY",
+    "tags": "RUNTIME_ONLY",
+}
+
+_IMPLICIT_ACTIVE_INPUT_CLASSIFICATION: dict[str, str] = {
+    "fee_bps_implicit": "PROVABLY_INACTIVE",
+    "slippage_bps_implicit": "PROVABLY_INACTIVE",
+    "random_seed_implicit": "PROVABLY_INACTIVE",
+    "data_limit_720": "PROVABLY_INACTIVE",
+    "StrategySweepConfig.constraints": "PROVABLY_INACTIVE",
+    "StrategySweepConfig.portfolio_config": "PROVABLY_INACTIVE",
+    "get_experiment_id": "EXTERNAL_ALIAS",
+    "source_experiment_id": "EXTERNAL_ALIAS",
+    "identity_schema_version": "IDENTITY_REQUIRED",
+    "identity_domain": "IDENTITY_REQUIRED",
+}
+
+
+class ExperimentIdentityManifestError(ValueError):
+    """Fail-closed Package N experiment identity manifest error."""
+
+
+def _is_regime_config_behaviorally_active(config: ExperimentConfig) -> bool:
+    return False
+
+
+def _is_switching_config_behaviorally_active(config: ExperimentConfig) -> bool:
+    return False
+
+
+def _is_phase41_constraint_bridge_active(config: ExperimentConfig) -> bool:
+    return False
+
+
+def _coerce_numpy_scalar(value: Any) -> tuple[Any, bool]:
+    module_name = type(value).__module__
+    if module_name == "numpy" and hasattr(value, "item"):
+        return value.item(), True
+    return value, False
+
+
+def _canonicalize_scalar(value: Any, *, from_numpy: bool = False) -> Any:
+    value, coerced_from_numpy = _coerce_numpy_scalar(value)
+    from_numpy = from_numpy or coerced_from_numpy
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, float):
+        if from_numpy:
+            return float(f"{value:.8g}")
+        return json.loads(json.dumps(value))
+    if isinstance(value, int) and not isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise ExperimentIdentityManifestError(
+        f"unsupported scalar type for identity canonicalization: {type(value)!r}"
+    )
+
+
+def _canonicalize_value(
+    value: Any, *, path_key: str | None = None, from_numpy: bool = False
+) -> Any:
+    coerced, was_numpy = _coerce_numpy_scalar(value)
+    from_numpy = from_numpy or was_numpy
+    value = coerced
+    if isinstance(value, Mapping):
+        return _canonicalize_mapping(value)
+    if isinstance(value, list):
+        return [_canonicalize_value(item, from_numpy=from_numpy) for item in value]
+    if isinstance(value, tuple):
+        return [_canonicalize_value(item, from_numpy=from_numpy) for item in value]
+    if isinstance(value, set):
+        return sorted(_canonicalize_value(item, from_numpy=from_numpy) for item in value)
+    if path_key in {"path", "file", "filepath", "config_path"} and isinstance(value, str):
+        return normalize_path_token(value)
+    return _canonicalize_scalar(value, from_numpy=from_numpy)
+
+
+def _canonicalize_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(key): _canonicalize_value(item, path_key=str(key))
+        for key, item in sorted(payload.items(), key=lambda pair: str(pair[0]))
+    }
+
+
+def _canonicalize_param_sweeps(param_sweeps: list[ParamSweep]) -> list[dict[str, Any]]:
+    if not param_sweeps:
+        return []
+    names = [sweep.name for sweep in param_sweeps]
+    if len(names) != len(set(names)):
+        raise ExperimentIdentityManifestError("duplicate param_sweep names are forbidden")
+    sorted_sweeps = sorted(param_sweeps, key=lambda sweep: sweep.name)
+    canonical: list[dict[str, Any]] = []
+    for sweep in sorted_sweeps:
+        canonical.append(
+            {
+                "name": sweep.name,
+                "values": [_canonicalize_value(value) for value in sweep.values],
+            }
+        )
+    return canonical
+
+
+def _canonicalize_symbols(symbols: list[str]) -> list[str]:
+    return sorted(symbols)
+
+
+def build_identity_config(config: ExperimentConfig) -> dict[str, Any]:
+    """Build ratified canonical identity projection from ExperimentConfig."""
+    return {
+        "name": config.name,
+        "strategy_name": config.strategy_name,
+        "param_sweeps": _canonicalize_param_sweeps(config.param_sweeps),
+        "symbols": _canonicalize_symbols(config.symbols),
+        "timeframe": config.timeframe,
+        "start_date": config.start_date,
+        "end_date": config.end_date,
+        "initial_capital": _canonicalize_scalar(config.initial_capital),
+        "base_params": _canonicalize_mapping(config.base_params),
+        "identity_schema_version": IDENTITY_SCHEMA_VERSION,
+        "identity_domain": IDENTITY_DOMAIN,
+    }
+
+
+def compute_experiment_identity_id(identity_config: Mapping[str, Any]) -> str:
+    return compute_content_sha256(dict(identity_config))
+
+
+def compute_legacy_experiment_id_md5_12(config: ExperimentConfig) -> str:
+    config_str = json.dumps(
+        {
+            "name": config.name,
+            "strategy": config.strategy_name,
+            "sweeps": [sweep.to_dict() for sweep in config.param_sweeps],
+            "symbols": config.symbols,
+            "timeframe": config.timeframe,
+        },
+        sort_keys=True,
+    )
+    return hashlib.md5(config_str.encode()).hexdigest()[:12]
+
+
+def _config_field_snapshot(config: ExperimentConfig) -> dict[str, Any]:
+    return {
+        field.name: copy.deepcopy(getattr(config, field.name)) for field in fields(ExperimentConfig)
+    }
+
+
+def _assert_config_unchanged(
+    config: ExperimentConfig,
+    snapshot: Mapping[str, Any],
+) -> None:
+    current = _config_field_snapshot(config)
+    if current != dict(snapshot):
+        raise ExperimentIdentityManifestError(
+            "ExperimentConfig mutated during manifest production (fail-closed)"
+        )
+
+
+def validate_active_input_completeness(
+    config: ExperimentConfig,
+    *,
+    extra_keys: tuple[str, ...] = (),
+    regime_active_hook: Callable[[ExperimentConfig], bool] | None = None,
+    switching_active_hook: Callable[[ExperimentConfig], bool] | None = None,
+    phase41_active_hook: Callable[[ExperimentConfig], bool] | None = None,
+) -> None:
+    """Fail-closed active-input completeness and classification guard."""
+    for key in extra_keys:
+        if key not in _ACTIVE_INPUT_FIELD_CLASSIFICATION:
+            raise ExperimentIdentityManifestError(
+                f"unknown active input field in config payload: {key}"
+            )
+
+    for field in fields(ExperimentConfig):
+        classification = _ACTIVE_INPUT_FIELD_CLASSIFICATION.get(field.name)
+        if classification is None:
+            raise ExperimentIdentityManifestError(
+                f"unclassified active ExperimentConfig field: {field.name}"
+            )
+
+    if (regime_active_hook or _is_regime_config_behaviorally_active)(config):
+        raise ExperimentIdentityManifestError(
+            "regime_config is behaviorally active; identity production blocked (fail-closed)"
+        )
+    if (switching_active_hook or _is_switching_config_behaviorally_active)(config):
+        raise ExperimentIdentityManifestError(
+            "switching_config is behaviorally active; identity production blocked (fail-closed)"
+        )
+    if (phase41_active_hook or _is_phase41_constraint_bridge_active)(config):
+        raise ExperimentIdentityManifestError(
+            "Phase-41 constraints are not materialized in param_sweeps (fail-closed)"
+        )
+
+
+def active_input_matrix_classifications() -> dict[str, str]:
+    merged = dict(_IMPLICIT_ACTIVE_INPUT_CLASSIFICATION)
+    merged.update(_ACTIVE_INPUT_FIELD_CLASSIFICATION)
+    return merged
+
+
+def unclassified_active_input_count() -> int:
+    known = set(active_input_matrix_classifications())
+    config_fields = {field.name for field in fields(ExperimentConfig)}
+    unclassified = config_fields - set(_ACTIVE_INPUT_FIELD_CLASSIFICATION)
+    return len(unclassified)
+
+
+def _reject_forbidden_manifest_keys(payload: Mapping[str, Any], *, prefix: str = "") -> None:
+    for key, value in payload.items():
+        full_key = f"{prefix}.{key}" if prefix else str(key)
+        if key in _FORBIDDEN_MANIFEST_KEYS:
+            raise ExperimentIdentityManifestError(
+                f"manifest must not contain forbidden key: {full_key}"
+            )
+        if isinstance(value, Mapping):
+            _reject_forbidden_manifest_keys(value, prefix=full_key)
+
+
+def _manifest_without_integrity(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(manifest)
+    payload.pop("integrity", None)
+    return payload
+
+
+def build_manifest(
+    config: ExperimentConfig,
+    *,
+    source_experiment_id: str | None = None,
+) -> dict[str, Any]:
+    validate_active_input_completeness(config)
+    identity_config = build_identity_config(config)
+    experiment_identity_id = compute_experiment_identity_id(identity_config)
+    manifest: dict[str, Any] = {
+        "schema_version": CONTRACT_VERSION,
+        "contract_version": CONTRACT_VERSION,
+        "identity_domain": IDENTITY_DOMAIN,
+        "experiment_identity_id": experiment_identity_id,
+        "identity_config": identity_config,
+        "legacy_aliases": {
+            "legacy_experiment_id_md5_12": compute_legacy_experiment_id_md5_12(config),
+        },
+        "provenance": {
+            "source_experiment_id": source_experiment_id,
+        },
+        "safety": {
+            "evidence_does_not_authorize_runtime": True,
+            "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+            "futures_scope_ref": canonical_futures_scope_ref(),
+            "trading_logic_immutability_ref": canonical_trading_logic_immutability_ref(),
+        },
+    }
+    _reject_forbidden_manifest_keys(manifest)
+    digest = compute_content_sha256(_manifest_without_integrity(manifest))
+    manifest["integrity"] = {"content_sha256": digest}
+    return manifest
+
+
+def validate_experiment_identity_manifest_v1(manifest: Mapping[str, Any]) -> None:
+    if not isinstance(manifest, Mapping):
+        raise ExperimentIdentityManifestError("manifest root must be an object")
+
+    schema_result = validate_schema_version(manifest.get("schema_version"))
+    if not schema_result.valid:
+        raise ExperimentIdentityManifestError(schema_result.errors[0])
+    if manifest.get("contract_version") != CONTRACT_VERSION:
+        raise ExperimentIdentityManifestError("contract_version must equal 1.0")
+
+    identity_config = manifest.get("identity_config")
+    if not isinstance(identity_config, Mapping):
+        raise ExperimentIdentityManifestError("identity_config must be an object")
+    for key in _REQUIRED_IDENTITY_FIELDS:
+        if key not in identity_config:
+            raise ExperimentIdentityManifestError(f"identity_config missing required field: {key}")
+
+    experiment_identity_id = manifest.get("experiment_identity_id")
+    if not isinstance(experiment_identity_id, str) or not is_valid_sha256_hex(
+        experiment_identity_id
+    ):
+        raise ExperimentIdentityManifestError(
+            "experiment_identity_id must be 64-char lowercase sha256 hex"
+        )
+    expected_identity_id = compute_experiment_identity_id(identity_config)
+    if experiment_identity_id != expected_identity_id:
+        raise ExperimentIdentityManifestError("experiment_identity_id mismatch")
+
+    legacy_aliases = manifest.get("legacy_aliases")
+    if not isinstance(legacy_aliases, Mapping):
+        raise ExperimentIdentityManifestError("legacy_aliases must be an object")
+    legacy_id = legacy_aliases.get("legacy_experiment_id_md5_12")
+    if not isinstance(legacy_id, str) or len(legacy_id) != 12:
+        raise ExperimentIdentityManifestError(
+            "legacy_aliases.legacy_experiment_id_md5_12 must be 12 hex chars"
+        )
+
+    provenance = manifest.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise ExperimentIdentityManifestError("provenance must be an object")
+    source_id = provenance.get("source_experiment_id")
+    if source_id is not None and not isinstance(source_id, str):
+        raise ExperimentIdentityManifestError(
+            "provenance.source_experiment_id must be string or null"
+        )
+
+    safety = manifest.get("safety")
+    if not isinstance(safety, Mapping):
+        raise ExperimentIdentityManifestError("safety must be an object")
+    if safety.get("evidence_does_not_authorize_runtime") is not True:
+        raise ExperimentIdentityManifestError(
+            "safety.evidence_does_not_authorize_runtime must be true"
+        )
+    if safety.get("runtime_authority_impact") != RUNTIME_AUTHORITY_IMPACT:
+        raise ExperimentIdentityManifestError("safety.runtime_authority_impact must be NONE")
+
+    futures_result = validate_futures_scope_ref(safety.get("futures_scope_ref"))
+    if not futures_result.valid:
+        raise ExperimentIdentityManifestError(futures_result.errors[0])
+    immutability_result = validate_trading_logic_immutability_ref(
+        safety.get("trading_logic_immutability_ref")
+    )
+    if not immutability_result.valid:
+        raise ExperimentIdentityManifestError(immutability_result.errors[0])
+
+    _reject_forbidden_manifest_keys(manifest)
+
+    expected_digest = compute_content_sha256(_manifest_without_integrity(manifest))
+    integrity_result = validate_integrity_block(
+        manifest.get("integrity"), expected_digest=expected_digest
+    )
+    if not integrity_result.valid:
+        raise ExperimentIdentityManifestError(integrity_result.errors[0])
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise ExperimentIdentityManifestError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise ExperimentIdentityManifestError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ExperimentIdentityManifestError(f"output parent directory missing: {parent}")
+    if is_under_tmp(parent):
+        raise ExperimentIdentityManifestError("output parent directory must be outside /tmp")
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{uuid.uuid4().hex}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def produce_experiment_identity_manifest_v1(
+    config: ExperimentConfig,
+    output_dir: Path | str,
+    *,
+    source_experiment_id: str | None = None,
+) -> Path:
+    """Atomically produce experiment_identity_manifest_v1.json under output_dir."""
+    final_dir = Path(output_dir)
+    _validate_output_target(final_dir)
+
+    snapshot = _config_field_snapshot(config)
+    manifest = build_manifest(config, source_experiment_id=source_experiment_id)
+    validate_experiment_identity_manifest_v1(manifest)
+    _assert_config_unchanged(config, snapshot)
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise ExperimentIdentityManifestError(f"staging directory collision: {staging}")
+
+    artifact_path = staging / ARTIFACT_FILENAME
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        artifact_path.write_text(
+            deterministic_json_dumps(manifest) + "\n",
+            encoding="utf-8",
+        )
+
+        written = json.loads(artifact_path.read_text(encoding="utf-8"))
+        validate_experiment_identity_manifest_v1(written)
+        _assert_config_unchanged(config, snapshot)
+
+        staging.replace(final_dir)
+
+        final_artifact = final_dir / ARTIFACT_FILENAME
+        final_payload = json.loads(final_artifact.read_text(encoding="utf-8"))
+        validate_experiment_identity_manifest_v1(final_payload)
+        _assert_config_unchanged(config, snapshot)
+        return final_artifact
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+
+def experiment_config_from_mapping(data: Mapping[str, Any]) -> ExperimentConfig:
+    if not isinstance(data, Mapping):
+        raise ExperimentIdentityManifestError("config payload must be a JSON object")
+
+    extra_keys = tuple(
+        key for key in data if key not in {field.name for field in fields(ExperimentConfig)}
+    )
+    if extra_keys:
+        raise ExperimentIdentityManifestError(
+            f"unknown active input field in config payload: {extra_keys[0]}"
+        )
+
+    required = ("name", "strategy_name")
+    for key in required:
+        if key not in data:
+            raise ExperimentIdentityManifestError(f"config missing required field: {key}")
+
+    raw_sweeps = data.get("param_sweeps", [])
+    if not isinstance(raw_sweeps, list):
+        raise ExperimentIdentityManifestError("param_sweeps must be a list")
+    param_sweeps: list[ParamSweep] = []
+    for item in raw_sweeps:
+        if not isinstance(item, Mapping):
+            raise ExperimentIdentityManifestError("param_sweeps entries must be objects")
+        param_sweeps.append(
+            ParamSweep(
+                name=str(item["name"]),
+                values=list(item["values"]),
+                description=item.get("description"),
+            )
+        )
+
+    return ExperimentConfig(
+        name=str(data["name"]),
+        strategy_name=str(data["strategy_name"]),
+        param_sweeps=param_sweeps,
+        symbols=list(data.get("symbols", ["BTC/EUR"])),
+        timeframe=str(data.get("timeframe", "1h")),
+        start_date=data.get("start_date"),
+        end_date=data.get("end_date"),
+        initial_capital=float(data.get("initial_capital", 10000.0)),
+        regime_config=data.get("regime_config"),
+        switching_config=data.get("switching_config"),
+        base_params=dict(data.get("base_params", {})),
+        metrics_to_collect=list(
+            data.get(
+                "metrics_to_collect",
+                [
+                    "total_return",
+                    "sharpe_ratio",
+                    "max_drawdown",
+                    "win_rate",
+                    "num_trades",
+                    "profit_factor",
+                    "ulcer_index",
+                    "recovery_factor",
+                ],
+            )
+        ),
+        parallel=bool(data.get("parallel", False)),
+        max_workers=int(data.get("max_workers", 4)),
+        save_results=bool(data.get("save_results", True)),
+        output_dir=str(data.get("output_dir", "reports/experiments")),
+        tags=list(data.get("tags", [])),
+    )
+
+
+__all__ = [
+    "ARTIFACT_FILENAME",
+    "CONTRACT_VERSION",
+    "ExperimentIdentityManifestError",
+    "IDENTITY_DOMAIN",
+    "IDENTITY_SCHEMA_VERSION",
+    "RUNTIME_AUTHORITY_IMPACT",
+    "active_input_matrix_classifications",
+    "build_identity_config",
+    "build_manifest",
+    "compute_experiment_identity_id",
+    "compute_legacy_experiment_id_md5_12",
+    "experiment_config_from_mapping",
+    "produce_experiment_identity_manifest_v1",
+    "unclassified_active_input_count",
+    "validate_active_input_completeness",
+    "validate_experiment_identity_manifest_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -308,6 +308,22 @@ def test_selector_central_src_full() -> None:
     assert sel["tests_execute_full"] == "false"
 
 
+def test_ci_central_src_full_package_n() -> None:
+    sel = _run_selector(
+        "src/experiments/experiment_identity_manifest_v1.py",
+        "scripts/run_experiment_identity_manifest_v1.py",
+        "tests/experiments/test_experiment_identity_manifest_v1.py",
+        "tests/scripts/test_run_experiment_identity_manifest_v1.py",
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_reason"] == "category_central_src_requires_full"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    targets = sel.get("pr_bounded_pytest_targets", "").split()
+    assert "tests/experiments/test_experiment_identity_manifest_v1.py" in targets
+    assert "tests/scripts/test_run_experiment_identity_manifest_v1.py" in targets
+    assert "tests/test_experiments_base.py" in targets
+
+
 def test_selector_registry_init_full() -> None:
     sel = _run_selector(
         "src/strategies/__init__.py",

--- a/tests/experiments/test_experiment_identity_manifest_v1.py
+++ b/tests/experiments/test_experiment_identity_manifest_v1.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import copy
 import json
+import shutil
 import subprocess
 import sys
+import uuid
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from unittest.mock import patch
 
 import numpy as np
@@ -21,9 +23,6 @@ from src.experiments.experiment_identity_manifest_v1 import (
     IDENTITY_SCHEMA_VERSION,
     ExperimentIdentityManifestError,
     _FORBIDDEN_MANIFEST_KEYS,
-    _is_phase41_constraint_bridge_active,
-    _is_regime_config_behaviorally_active,
-    _is_switching_config_behaviorally_active,
     active_input_matrix_classifications,
     build_identity_config,
     build_manifest,
@@ -35,6 +34,29 @@ from src.experiments.experiment_identity_manifest_v1 import (
     validate_active_input_completeness,
     validate_experiment_identity_manifest_v1,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".package_n_pytest_outputs"
+
+
+@pytest.fixture
+def durable_output_dir() -> Callable[[], Path]:
+    """Output paths outside /tmp for producer atomic-write contract tests."""
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    created: list[Path] = []
+
+    def _make() -> Path:
+        path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+        created.append(path)
+        return path
+
+    yield _make
+
+    for path in created:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".experiment_identity_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
 
 
 def _sample_config(**overrides: Any) -> ExperimentConfig:
@@ -57,10 +79,10 @@ def _sample_config(**overrides: Any) -> ExperimentConfig:
     return base
 
 
-def test_identity_happy_path_deterministic(tmp_path: Path) -> None:
+def test_identity_happy_path_deterministic(durable_output_dir: Callable[[], Path]) -> None:
     config = _sample_config()
-    out_a = tmp_path / "a"
-    out_b = tmp_path / "b"
+    out_a = durable_output_dir()
+    out_b = durable_output_dir()
     produce_experiment_identity_manifest_v1(config, out_a)
     produce_experiment_identity_manifest_v1(config, out_b)
     assert (out_a / ARTIFACT_FILENAME).read_text() == (out_b / ARTIFACT_FILENAME).read_text()
@@ -267,27 +289,29 @@ def test_unknown_active_field_fail_closed() -> None:
         )
 
 
-def test_input_mutation_fail_closed(tmp_path: Path) -> None:
+def test_input_mutation_fail_closed(durable_output_dir: Callable[[], Path]) -> None:
     config = _sample_config()
     with patch(
         "src.experiments.experiment_identity_manifest_v1._assert_config_unchanged",
         side_effect=ExperimentIdentityManifestError("mutated"),
     ):
         with pytest.raises(ExperimentIdentityManifestError, match="mutated"):
-            produce_experiment_identity_manifest_v1(config, tmp_path / "out")
+            produce_experiment_identity_manifest_v1(config, durable_output_dir())
 
 
-def test_atomic_write_and_cleanup(tmp_path: Path) -> None:
+def test_atomic_write_and_cleanup(durable_output_dir: Callable[[], Path]) -> None:
     config = _sample_config()
-    out = tmp_path / "bundle"
+    out = durable_output_dir()
     artifact = produce_experiment_identity_manifest_v1(config, out)
     assert artifact.exists()
-    assert not any(p.name.startswith(".experiment_identity_staging_") for p in tmp_path.iterdir())
+    assert not any(
+        p.name.startswith(".experiment_identity_staging_") for p in _DURABLE_OUTPUT_ROOT.iterdir()
+    )
 
 
-def test_existing_target_unchanged_on_error(tmp_path: Path) -> None:
+def test_existing_target_unchanged_on_error(durable_output_dir: Callable[[], Path]) -> None:
     config = _sample_config()
-    out = tmp_path / "bundle"
+    out = durable_output_dir()
     produce_experiment_identity_manifest_v1(config, out)
     original = (out / ARTIFACT_FILENAME).read_text()
     with patch(
@@ -295,7 +319,7 @@ def test_existing_target_unchanged_on_error(tmp_path: Path) -> None:
         side_effect=[None, ExperimentIdentityManifestError("verify failed")],
     ):
         with pytest.raises(ExperimentIdentityManifestError):
-            produce_experiment_identity_manifest_v1(config, tmp_path / "bundle2")
+            produce_experiment_identity_manifest_v1(config, durable_output_dir())
     assert (out / ARTIFACT_FILENAME).read_text() == original
 
 
@@ -330,10 +354,10 @@ def test_no_config_mutation() -> None:
     assert config.to_dict() == before
 
 
-def test_no_experiment_execution(tmp_path: Path) -> None:
+def test_no_experiment_execution(durable_output_dir: Callable[[], Path]) -> None:
     with patch("src.experiments.base.ExperimentRunner.run") as run_mock:
         build_manifest(_sample_config())
-        produce_experiment_identity_manifest_v1(_sample_config(), tmp_path / "out")
+        produce_experiment_identity_manifest_v1(_sample_config(), durable_output_dir())
     run_mock.assert_not_called()
 
 

--- a/tests/experiments/test_experiment_identity_manifest_v1.py
+++ b/tests/experiments/test_experiment_identity_manifest_v1.py
@@ -1,0 +1,370 @@
+"""Tests for Package N experiment identity manifest producer v1."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    IDENTITY_DOMAIN,
+    IDENTITY_SCHEMA_VERSION,
+    ExperimentIdentityManifestError,
+    _FORBIDDEN_MANIFEST_KEYS,
+    _is_phase41_constraint_bridge_active,
+    _is_regime_config_behaviorally_active,
+    _is_switching_config_behaviorally_active,
+    active_input_matrix_classifications,
+    build_identity_config,
+    build_manifest,
+    compute_experiment_identity_id,
+    compute_legacy_experiment_id_md5_12,
+    experiment_config_from_mapping,
+    produce_experiment_identity_manifest_v1,
+    unclassified_active_input_count,
+    validate_active_input_completeness,
+    validate_experiment_identity_manifest_v1,
+)
+
+
+def _sample_config(**overrides: Any) -> ExperimentConfig:
+    base = ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[
+            ParamSweep("slow", [50, 100], description="ignored in identity"),
+            ParamSweep("fast", [5, 10]),
+        ],
+        symbols=["ETH/EUR", "BTC/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def test_identity_happy_path_deterministic(tmp_path: Path) -> None:
+    config = _sample_config()
+    out_a = tmp_path / "a"
+    out_b = tmp_path / "b"
+    produce_experiment_identity_manifest_v1(config, out_a)
+    produce_experiment_identity_manifest_v1(config, out_b)
+    assert (out_a / ARTIFACT_FILENAME).read_text() == (out_b / ARTIFACT_FILENAME).read_text()
+
+
+def test_experiment_identity_id_sha256_64hex() -> None:
+    manifest = build_manifest(_sample_config())
+    identity_id = manifest["experiment_identity_id"]
+    assert len(identity_id) == 64
+    assert identity_id.islower()
+    assert all(ch in "0123456789abcdef" for ch in identity_id)
+
+
+def test_domain_separator_and_schema_version() -> None:
+    identity = build_identity_config(_sample_config())
+    assert identity["identity_schema_version"] == IDENTITY_SCHEMA_VERSION
+    assert identity["identity_domain"] == IDENTITY_DOMAIN
+
+
+def test_required_fields_present() -> None:
+    manifest = build_manifest(_sample_config())
+    for key in (
+        "schema_version",
+        "contract_version",
+        "identity_domain",
+        "experiment_identity_id",
+        "identity_config",
+        "legacy_aliases",
+        "provenance",
+        "integrity",
+        "safety",
+    ):
+        assert key in manifest
+
+
+def test_base_params_recursive_canonicalization() -> None:
+    identity = build_identity_config(
+        _sample_config(base_params={"z": 1, "nested": {"b": 2, "a": 1}})
+    )
+    assert list(identity["base_params"].keys()) == ["nested", "z"]
+    assert list(identity["base_params"]["nested"].keys()) == ["a", "b"]
+
+
+def test_param_sweeps_sorted_by_name() -> None:
+    identity = build_identity_config(_sample_config())
+    assert [item["name"] for item in identity["param_sweeps"]] == ["fast", "slow"]
+
+
+def test_symbols_lex_sort_default() -> None:
+    identity = build_identity_config(_sample_config())
+    assert identity["symbols"] == ["BTC/EUR", "ETH/EUR"]
+
+
+def test_float_numpy_normalization() -> None:
+    config = _sample_config(
+        param_sweeps=[ParamSweep("threshold", [np.float64(0.1), np.float32(0.2)])]
+    )
+    identity = build_identity_config(config)
+    assert identity["param_sweeps"][0]["values"] == [0.1, 0.2]
+
+
+def test_none_vs_missing_dates() -> None:
+    with_dates = build_identity_config(_sample_config())
+    without_dates = build_identity_config(_sample_config(start_date=None, end_date=None))
+    assert with_dates["start_date"] == "2024-01-01"
+    assert without_dates["start_date"] is None
+    assert without_dates["end_date"] is None
+    assert compute_experiment_identity_id(with_dates) != compute_experiment_identity_id(
+        without_dates
+    )
+
+
+class _Mode(Enum):
+    FAST = "fast"
+    SLOW = "slow"
+
+
+def test_enum_serialization_in_base_params() -> None:
+    identity = build_identity_config(_sample_config(base_params={"mode": _Mode.FAST}))
+    assert identity["base_params"]["mode"] == "fast"
+
+
+def test_path_normalization_in_base_params() -> None:
+    identity = build_identity_config(
+        _sample_config(base_params={"path": "/tmp/Foo/Bar-Config.JSON"})
+    )
+    assert identity["base_params"]["path"] == "tmp.foo.bar_config.json"
+
+
+def test_legacy_md5_alias_parity() -> None:
+    config = _sample_config()
+    manifest = build_manifest(config)
+    assert manifest["legacy_aliases"]["legacy_experiment_id_md5_12"] == config.get_experiment_id()
+
+
+def test_forbidden_run_fields_rejected() -> None:
+    manifest = build_manifest(_sample_config())
+    for key in ("run_id", "run_index"):
+        polluted = copy.deepcopy(manifest)
+        polluted[key] = "forbidden"
+        with pytest.raises(ExperimentIdentityManifestError, match="forbidden key"):
+            validate_experiment_identity_manifest_v1(polluted)
+
+
+def test_forbidden_result_fields_rejected() -> None:
+    manifest = build_manifest(_sample_config())
+    polluted = copy.deepcopy(manifest)
+    polluted["metrics"] = {"sharpe": 1.0}
+    with pytest.raises(ExperimentIdentityManifestError, match="forbidden key"):
+        validate_experiment_identity_manifest_v1(polluted)
+
+
+def test_forbidden_runtime_authority_fields() -> None:
+    manifest = build_manifest(_sample_config())
+    polluted = copy.deepcopy(manifest)
+    polluted["promotion_authority"] = True
+    with pytest.raises(ExperimentIdentityManifestError, match="forbidden key"):
+        validate_experiment_identity_manifest_v1(polluted)
+
+
+def test_regime_config_inactive_regression() -> None:
+    config = _sample_config(regime_config={"detector": "volatility"})
+    validate_active_input_completeness(config)
+    manifest = build_manifest(config)
+    assert "regime_config" not in manifest["identity_config"]
+
+
+def test_switching_config_inactive_regression() -> None:
+    config = _sample_config(switching_config={"mode": "auto"})
+    validate_active_input_completeness(config)
+    manifest = build_manifest(config)
+    assert "switching_config" not in manifest["identity_config"]
+
+
+def test_regime_active_simulation_fail_closed_hook() -> None:
+    config = _sample_config(regime_config={"detector": "volatility"})
+    with patch(
+        "src.experiments.experiment_identity_manifest_v1._is_regime_config_behaviorally_active",
+        return_value=True,
+    ):
+        with pytest.raises(ExperimentIdentityManifestError, match="regime_config"):
+            validate_active_input_completeness(config)
+
+
+def test_switching_active_simulation_fail_closed_hook() -> None:
+    config = _sample_config(switching_config={"mode": "auto"})
+    with patch(
+        "src.experiments.experiment_identity_manifest_v1._is_switching_config_behaviorally_active",
+        return_value=True,
+    ):
+        with pytest.raises(ExperimentIdentityManifestError, match="switching_config"):
+            validate_active_input_completeness(config)
+
+
+def test_phase41_unmaterialized_fail_closed() -> None:
+    config = _sample_config()
+    with patch(
+        "src.experiments.experiment_identity_manifest_v1._is_phase41_constraint_bridge_active",
+        return_value=True,
+    ):
+        with pytest.raises(ExperimentIdentityManifestError, match="Phase-41"):
+            validate_active_input_completeness(config)
+
+
+def test_phase41_materialized_passes() -> None:
+    config = _sample_config(
+        param_sweeps=[ParamSweep("window", [10, 20]), ParamSweep("threshold", [0.1, 0.2])]
+    )
+    validate_active_input_completeness(config)
+    manifest = build_manifest(config)
+    assert manifest["identity_config"]["param_sweeps"]
+
+
+def test_active_input_completeness_validator() -> None:
+    validate_active_input_completeness(_sample_config())
+    assert unclassified_active_input_count() == 0
+
+
+def test_all_active_input_matrix_entries_classified() -> None:
+    classifications = active_input_matrix_classifications()
+    assert len(classifications) >= 27
+    assert all(
+        classification
+        in {
+            "IDENTITY_REQUIRED",
+            "DERIVED_FROM_IDENTITY_FIELD",
+            "PROVABLY_INACTIVE",
+            "RUNTIME_ONLY",
+            "RESULT_ONLY",
+            "EXTERNAL_ALIAS",
+        }
+        for classification in classifications.values()
+    )
+
+
+def test_unknown_active_field_fail_closed() -> None:
+    with pytest.raises(ExperimentIdentityManifestError, match="unknown active input field"):
+        experiment_config_from_mapping(
+            {
+                "name": "x",
+                "strategy_name": "ma_crossover",
+                "unexpected_field": True,
+            }
+        )
+
+
+def test_input_mutation_fail_closed(tmp_path: Path) -> None:
+    config = _sample_config()
+    with patch(
+        "src.experiments.experiment_identity_manifest_v1._assert_config_unchanged",
+        side_effect=ExperimentIdentityManifestError("mutated"),
+    ):
+        with pytest.raises(ExperimentIdentityManifestError, match="mutated"):
+            produce_experiment_identity_manifest_v1(config, tmp_path / "out")
+
+
+def test_atomic_write_and_cleanup(tmp_path: Path) -> None:
+    config = _sample_config()
+    out = tmp_path / "bundle"
+    artifact = produce_experiment_identity_manifest_v1(config, out)
+    assert artifact.exists()
+    assert not any(p.name.startswith(".experiment_identity_staging_") for p in tmp_path.iterdir())
+
+
+def test_existing_target_unchanged_on_error(tmp_path: Path) -> None:
+    config = _sample_config()
+    out = tmp_path / "bundle"
+    produce_experiment_identity_manifest_v1(config, out)
+    original = (out / ARTIFACT_FILENAME).read_text()
+    with patch(
+        "src.experiments.experiment_identity_manifest_v1.validate_experiment_identity_manifest_v1",
+        side_effect=[None, ExperimentIdentityManifestError("verify failed")],
+    ):
+        with pytest.raises(ExperimentIdentityManifestError):
+            produce_experiment_identity_manifest_v1(config, tmp_path / "bundle2")
+    assert (out / ARTIFACT_FILENAME).read_text() == original
+
+
+def test_completion_gate_self_verification() -> None:
+    manifest = build_manifest(_sample_config())
+    validate_experiment_identity_manifest_v1(manifest)
+
+
+def test_integrity_block_recompute() -> None:
+    manifest = build_manifest(_sample_config())
+    integrity = manifest["integrity"]["content_sha256"]
+    tampered = copy.deepcopy(manifest)
+    tampered["integrity"] = {"content_sha256": "0" * 64}
+    with pytest.raises(ExperimentIdentityManifestError, match="mismatch"):
+        validate_experiment_identity_manifest_v1(tampered)
+    assert len(integrity) == 64
+
+
+def test_safety_block_canonical_refs() -> None:
+    manifest = build_manifest(_sample_config())
+    safety = manifest["safety"]
+    assert safety["evidence_does_not_authorize_runtime"] is True
+    assert safety["runtime_authority_impact"] == "NONE"
+    assert safety["futures_scope_ref"]["scope"] == "FUTURES_ONLY"
+    assert safety["trading_logic_immutability_ref"]["trading_logic_immutability"] is True
+
+
+def test_no_config_mutation() -> None:
+    config = _sample_config()
+    before = config.to_dict()
+    build_manifest(config)
+    assert config.to_dict() == before
+
+
+def test_no_experiment_execution(tmp_path: Path) -> None:
+    with patch("src.experiments.base.ExperimentRunner.run") as run_mock:
+        build_manifest(_sample_config())
+        produce_experiment_identity_manifest_v1(_sample_config(), tmp_path / "out")
+    run_mock.assert_not_called()
+
+
+def test_fee_slippage_provably_inactive_classification() -> None:
+    classifications = active_input_matrix_classifications()
+    assert classifications["fee_bps_implicit"] == "PROVABLY_INACTIVE"
+    assert classifications["slippage_bps_implicit"] == "PROVABLY_INACTIVE"
+
+
+def test_duplicate_param_sweep_names_fail_closed() -> None:
+    config = _sample_config(param_sweeps=[ParamSweep("fast", [1]), ParamSweep("fast", [2])])
+    with pytest.raises(ExperimentIdentityManifestError, match="duplicate param_sweep"):
+        build_identity_config(config)
+
+
+def test_source_experiment_id_external_alias_only() -> None:
+    manifest = build_manifest(_sample_config(), source_experiment_id="legacy-src-123")
+    assert manifest["provenance"]["source_experiment_id"] == "legacy-src-123"
+    assert manifest["experiment_identity_id"] != "legacy-src-123"
+
+
+def test_provenance_null_by_default() -> None:
+    manifest = build_manifest(_sample_config())
+    assert manifest["provenance"]["source_experiment_id"] is None
+
+
+def test_manifest_forbidden_keys_at_build_time() -> None:
+    assert "run_id" in _FORBIDDEN_MANIFEST_KEYS
+    assert "metrics" in _FORBIDDEN_MANIFEST_KEYS
+
+
+def test_compute_legacy_experiment_id_md5_12_matches_get_experiment_id() -> None:
+    config = _sample_config()
+    assert compute_legacy_experiment_id_md5_12(config) == config.get_experiment_id()

--- a/tests/scripts/test_run_experiment_identity_manifest_v1.py
+++ b/tests/scripts/test_run_experiment_identity_manifest_v1.py
@@ -3,14 +3,35 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
+import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI = REPO_ROOT / "scripts" / "run_experiment_identity_manifest_v1.py"
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".package_n_pytest_outputs"
+
+
+@pytest.fixture
+def durable_output_dir() -> Callable[[], Path]:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    created: list[Path] = []
+
+    def _make() -> Path:
+        path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+        created.append(path)
+        return path
+
+    yield _make
+
+    for path in created:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
 
 
 def _write_config(path: Path) -> None:
@@ -28,9 +49,12 @@ def _write_config(path: Path) -> None:
     )
 
 
-def test_cli_success_exit_code(tmp_path: Path) -> None:
+def test_cli_success_exit_code(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
     config = tmp_path / "config.json"
-    out = tmp_path / "output"
+    out = durable_output_dir()
     _write_config(config)
     proc = subprocess.run(
         [sys.executable, str(CLI), "--config-json", str(config), "--output-dir", str(out)],

--- a/tests/scripts/test_run_experiment_identity_manifest_v1.py
+++ b/tests/scripts/test_run_experiment_identity_manifest_v1.py
@@ -1,0 +1,89 @@
+"""CLI tests for Package N experiment identity manifest producer v1."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / "scripts" / "run_experiment_identity_manifest_v1.py"
+
+
+def _write_config(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "name": "CLI Test",
+                "strategy_name": "ma_crossover",
+                "param_sweeps": [{"name": "fast", "values": [5, 10]}],
+                "symbols": ["BTC/EUR"],
+                "timeframe": "1h",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_cli_success_exit_code(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    out = tmp_path / "output"
+    _write_config(config)
+    proc = subprocess.run(
+        [sys.executable, str(CLI), "--config-json", str(config), "--output-dir", str(out)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert (out / "experiment_identity_manifest_v1.json").is_file()
+
+
+def test_cli_usage_error_exit_code() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(CLI)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+
+
+def test_cli_binding_error_exit_code(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    out = tmp_path / "output"
+    config.write_text(json.dumps({"name": "missing strategy"}), encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(CLI), "--config-json", str(config), "--output-dir", str(out)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 1
+
+
+def test_cli_output_dir_outside_tmp(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    _write_config(config)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--config-json",
+            str(config),
+            "--output-dir",
+            "/tmp/pkg_n_forbidden",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 1
+    assert "outside /tmp" in proc.stderr


### PR DESCRIPTION
## Summary
- Package N: offline, additive Experiment Identity Manifest Producer v1
- Produces `experiment_identity_manifest_v1.json` with SHA-256 `experiment_identity_id` SSOT from ratified `ExperimentConfig` identity projection
- 27-field active-input matrix fully classified (`UNCLASSIFIED_ACTIVE_INPUT_COUNT=0`); trading-semantics completeness fail-closed
- Legacy `get_experiment_id()` surfaced only as `legacy_experiment_id_md5_12` metadata alias; `source_experiment_id` optional provenance alias only
- No migration, no consumer rewiring, no `ExperimentConfig` mutation, no experiment/backtest execution, no Package M

## Changed Files (6)
- `src/experiments/experiment_identity_manifest_v1.py` (NEW)
- `scripts/run_experiment_identity_manifest_v1.py` (NEW)
- `tests/experiments/test_experiment_identity_manifest_v1.py` (NEW)
- `tests/scripts/test_run_experiment_identity_manifest_v1.py` (NEW)
- `scripts/ops/ci_test_selection_v1.py` (Package N PR_BOUNDED_FULL targets)
- `tests/ci/test_ci_diff_aware_test_selection_v1.py` (central_src Package N contract)

## Local Validation
- 43 new Package N test nodes PASS (38 producer + 4 CLI + 1 CI contract)
- `tests/test_experiments_base.py` regression PASS
- `ruff format --check` PASS
- `ruff check` PASS
- `pyright` PASS (0 errors)
- `git diff --check` RC=0
- PR-bounded selector targets include all new testowners + `tests/test_experiments_base.py`
- Required CI: `tests (3.11)` via `PR_BOUNDED_FULL` / `category_central_src_requires_full`
- CI hard-timeout contract: max 25 minutes (`tests` job `timeout-minutes: 25`)

## Safety
- `EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true`
- `RUNTIME_AUTHORITY_IMPACT=NONE`
- `FUTURES_ONLY=true`, `TRADING_LOGIC_IMMUTABILITY=true`, offline-only producer

## Evidence
- Durable implementation bundle prepared outside repo with `MANIFEST_VERIFY_RC=0`

## Test plan
- [x] Deterministic manifest production + SHA-256 identity
- [x] Active-input matrix / regime / switching / Phase-41 fail-closed gates
- [x] Atomic output + integrity/safety self-verification
- [x] CLI success/error exit codes
- [x] CI selector Package N contract regression

Made with [Cursor](https://cursor.com)