### PR TITLE
feat(experiments): add experiment domain ref producer v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1391,15 +1391,19 @@ PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TRIGGER_PATHS: frozenset[
         "src/governance/promotion_loop/candidate_lineage_manifest_v1.py",
         "src/governance/promotion_loop/backtest_lineage_ref_producer_v1.py",
         "src/governance/promotion_loop/var_suite_lineage_ref_producer_v1.py",
+        "src/governance/promotion_loop/experiment_lineage_ref_producer_v1.py",
         "scripts/run_candidate_lineage_manifest_v1.py",
         "scripts/run_backtest_lineage_ref_producer_v1.py",
         "scripts/run_var_suite_lineage_ref_producer_v1.py",
+        "scripts/run_experiment_lineage_ref_producer_v1.py",
         "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py",
         "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
         "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py",
+        "tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py",
         "tests/scripts/test_run_candidate_lineage_manifest_v1.py",
         "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py",
         "tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py",
+        "tests/scripts/test_run_experiment_lineage_ref_producer_v1.py",
     }
 )
 
@@ -1408,9 +1412,12 @@ PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS: tuple[str, ...] 
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_producer_v1.py",
     "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
     "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py",
+    "tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py",
     "tests/scripts/test_run_candidate_lineage_manifest_v1.py",
     "tests/scripts/test_run_backtest_lineage_ref_producer_v1.py",
     "tests/scripts/test_run_var_suite_lineage_ref_producer_v1.py",
+    "tests/scripts/test_run_experiment_lineage_ref_producer_v1.py",
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
     "tests/test_run_summary_contract.py",
     *PR_BOUNDED_FULL_VAR_SUITE_ADAPTER_TARGETS,
 )
@@ -4728,6 +4735,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                 for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
                     add(candidate)
             elif path == "scripts/run_var_suite_lineage_ref_producer_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_experiment_lineage_ref_producer_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_F_CANDIDATE_LINEAGE_PRODUCTION_TARGETS:
                     add(candidate)
             elif path == "scripts/run_learning_manifest_durable_evidence_binding_v1.py":

--- a/scripts/run_experiment_lineage_ref_producer_v1.py
+++ b/scripts/run_experiment_lineage_ref_producer_v1.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Offline Package M — EXPERIMENT LineageRef producer from explicit manifest directory.
+
+Produces a validated, deterministic EXPERIMENT LineageRef JSON artifact only.
+No experiment start, backtest start, promotion, apply, runtime, registry mutation, or live authority.
+
+Usage:
+    python3 scripts/run_experiment_lineage_ref_producer_v1.py \\
+        --manifest-dir reports/experiments/identity-run-001 \\
+        --output reports/lineage_refs/experiment_run-001.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    ExperimentLineageRefProducerError,
+    produce_experiment_lineage_ref_v1_to_path,
+)
+
+EXIT_OK = 0
+EXIT_PRODUCER_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Package M EXPERIMENT LineageRef producer: explicit manifest "
+            "directory to validated reference-only JSON artifact."
+        )
+    )
+    parser.add_argument(
+        "--manifest-dir",
+        type=Path,
+        required=True,
+        help=("Explicit path to a directory containing experiment_identity_manifest_v1.json."),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination path for the validated EXPERIMENT LineageRef JSON file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        result = produce_experiment_lineage_ref_v1_to_path(
+            manifest_dir=args.manifest_dir,
+            output_path=args.output,
+            fail_closed_if_exists=True,
+        )
+    except ExperimentLineageRefProducerError as exc:
+        print(f"[experiment_lineage_ref] ERROR: {exc}", file=sys.stderr)
+        return EXIT_PRODUCER_ERROR
+    except OSError as exc:
+        print(f"[experiment_lineage_ref] ERROR: {exc}", file=sys.stderr)
+        return EXIT_PRODUCER_ERROR
+
+    print(
+        "[experiment_lineage_ref] wrote validated EXPERIMENT LineageRef to "
+        f"{args.output} (ref_id={result.ref.ref_id}, digest={result.ref.digest})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/governance/promotion_loop/experiment_lineage_ref_producer_v1.py
+++ b/src/governance/promotion_loop/experiment_lineage_ref_producer_v1.py
@@ -1,0 +1,235 @@
+"""Package M — offline EXPERIMENT LineageRef producer from explicit manifest directory."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    ExperimentIdentityManifestError,
+    validate_experiment_identity_manifest_v1,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_from_mapping,
+    lineage_ref_to_mapping,
+)
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+EXPERIMENT_OWNER_DOMAIN = "experiments/base"
+EXPERIMENT_LINEAGE_REF_REQUIRED = False
+
+
+class ExperimentLineageRefProducerError(ValueError):
+    """Fail-closed Package M EXPERIMENT LineageRef production error."""
+
+
+@dataclass(frozen=True)
+class ExperimentLineageRefProducerResult:
+    manifest_dir: Path
+    manifest_path: Path
+    ref: LineageRef
+
+
+def _resolve_existing_directory(manifest_dir: Path) -> Path:
+    if not manifest_dir.exists():
+        raise ExperimentLineageRefProducerError(f"manifest_dir not found: {manifest_dir}")
+    if manifest_dir.is_symlink():
+        raise ExperimentLineageRefProducerError(
+            f"manifest_dir must not be a symlink (fail-closed): {manifest_dir}"
+        )
+    if not manifest_dir.is_dir():
+        raise ExperimentLineageRefProducerError(f"manifest_dir is not a directory: {manifest_dir}")
+    return manifest_dir.resolve()
+
+
+def _assert_path_under_root(path: Path, root: Path) -> Path:
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ExperimentLineageRefProducerError(
+            f"path escapes manifest_dir root: {path} (root={root})"
+        ) from exc
+    return resolved
+
+
+def _validate_artifact_relative_path(artifact_path: str) -> None:
+    if not artifact_path or artifact_path.strip() != artifact_path:
+        raise ExperimentLineageRefProducerError("artifact_path must be non-empty and trimmed")
+    if artifact_path.startswith("/") or artifact_path.startswith("\\"):
+        raise ExperimentLineageRefProducerError("artifact_path must be relative")
+    if "\\" in artifact_path:
+        raise ExperimentLineageRefProducerError("artifact_path must use forward slashes only")
+    if ".." in artifact_path.split("/"):
+        raise ExperimentLineageRefProducerError("artifact_path must not contain '..' segments")
+
+
+def _load_validated_manifest(manifest_dir: Path) -> tuple[dict[str, Any], Path]:
+    manifest_path = manifest_dir / ARTIFACT_FILENAME
+    if manifest_path.is_symlink():
+        raise ExperimentLineageRefProducerError(
+            f"{ARTIFACT_FILENAME} must not be a symlink (fail-closed): {manifest_path}"
+        )
+    if manifest_path.is_dir():
+        raise ExperimentLineageRefProducerError(
+            f"{ARTIFACT_FILENAME} is a directory, expected regular file: {manifest_path}"
+        )
+    if not manifest_path.is_file():
+        raise ExperimentLineageRefProducerError(
+            f"{ARTIFACT_FILENAME} not found in manifest_dir: {manifest_dir}"
+        )
+    _assert_path_under_root(manifest_path, manifest_dir)
+
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExperimentLineageRefProducerError(
+            f"invalid {ARTIFACT_FILENAME} in manifest_dir={manifest_dir}: {exc}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise ExperimentLineageRefProducerError(
+            f"{ARTIFACT_FILENAME} root must be a JSON object for manifest_dir={manifest_dir}"
+        )
+
+    try:
+        validate_experiment_identity_manifest_v1(raw)
+    except ExperimentIdentityManifestError as exc:
+        raise ExperimentLineageRefProducerError(
+            f"experiment identity manifest validation failed for manifest_dir={manifest_dir}: {exc}"
+        ) from exc
+
+    return raw, manifest_path
+
+
+def build_experiment_lineage_ref_from_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    artifact_path: str = ARTIFACT_FILENAME,
+) -> LineageRef:
+    """Build a validated EXPERIMENT LineageRef from an already validated Package N manifest."""
+    _validate_artifact_relative_path(artifact_path)
+
+    experiment_identity_id = manifest.get("experiment_identity_id")
+    if not isinstance(experiment_identity_id, str) or not experiment_identity_id.strip():
+        raise ExperimentLineageRefProducerError("experiment_identity_id missing or invalid")
+
+    integrity = manifest.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise ExperimentLineageRefProducerError("integrity must be an object")
+    content_sha256 = integrity.get("content_sha256")
+    if not isinstance(content_sha256, str) or not content_sha256.strip():
+        raise ExperimentLineageRefProducerError("integrity.content_sha256 missing or invalid")
+
+    return LineageRef(
+        ref_type=LineageRefType.EXPERIMENT,
+        ref_id=experiment_identity_id,
+        relation=LineageRelation.SOURCES,
+        owner_domain=EXPERIMENT_OWNER_DOMAIN,
+        required=EXPERIMENT_LINEAGE_REF_REQUIRED,
+        digest=content_sha256,
+        artifact_path=artifact_path,
+    )
+
+
+def produce_experiment_lineage_ref_v1(
+    *,
+    manifest_dir: Path | str,
+) -> ExperimentLineageRefProducerResult:
+    """Extract a reference-only EXPERIMENT LineageRef from an explicit manifest directory."""
+    resolved_manifest_dir = _resolve_existing_directory(Path(manifest_dir))
+    manifest, manifest_path = _load_validated_manifest(resolved_manifest_dir)
+    ref = build_experiment_lineage_ref_from_manifest(manifest)
+    return ExperimentLineageRefProducerResult(
+        manifest_dir=resolved_manifest_dir,
+        manifest_path=manifest_path,
+        ref=ref,
+    )
+
+
+def serialize_experiment_lineage_ref_v1(ref: LineageRef) -> str:
+    """Serialize an EXPERIMENT LineageRef to deterministic canonical JSON."""
+    if ref.ref_type != LineageRefType.EXPERIMENT:
+        raise ExperimentLineageRefProducerError(
+            f"ref_type must be EXPERIMENT, got {ref.ref_type.value!r}"
+        )
+    return deterministic_json_dumps(lineage_ref_to_mapping(ref))
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+    except OSError:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+    try:
+        tmp.replace(path)
+    except OSError:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+
+
+def _self_verify_written_ref(ref: LineageRef, output_path: Path) -> None:
+    try:
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExperimentLineageRefProducerError(
+            f"self-verification failed: output is not valid JSON: {output_path}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ExperimentLineageRefProducerError(
+            f"self-verification failed: output root must be object: {output_path}"
+        )
+    try:
+        roundtrip = lineage_ref_from_mapping(payload)
+    except Exception as exc:
+        raise ExperimentLineageRefProducerError(
+            f"self-verification failed: output LineageRef invalid: {output_path}: {exc}"
+        ) from exc
+    if roundtrip != ref:
+        raise ExperimentLineageRefProducerError(
+            f"self-verification failed: output LineageRef mismatch for {output_path}"
+        )
+
+
+def write_experiment_lineage_ref_v1_atomic(
+    ref: LineageRef,
+    output_path: Path | str,
+    *,
+    fail_closed_if_exists: bool = True,
+) -> Path:
+    """Validate, atomically write, and self-verify an EXPERIMENT LineageRef JSON file."""
+    out = Path(output_path)
+    if fail_closed_if_exists and out.exists():
+        raise ExperimentLineageRefProducerError(f"output path already exists (fail-closed): {out}")
+    serialized = serialize_experiment_lineage_ref_v1(ref)
+    _atomic_write_text(out, serialized)
+    _self_verify_written_ref(ref, out)
+    return out
+
+
+def produce_experiment_lineage_ref_v1_to_path(
+    *,
+    manifest_dir: Path | str,
+    output_path: Path | str,
+    fail_closed_if_exists: bool = True,
+) -> ExperimentLineageRefProducerResult:
+    """End-to-end offline producer: explicit manifest_dir -> validated EXPERIMENT LineageRef JSON."""
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    write_experiment_lineage_ref_v1_atomic(
+        result.ref,
+        output_path,
+        fail_closed_if_exists=fail_closed_if_exists,
+    )
+    return result

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5367,6 +5367,80 @@ def test_selector_package_j_var_suite_ref_combined_diff_pr_bounded_full_includes
         assert bounded.count(path) == 1
 
 
+PACKAGE_M_EXPERIMENT_REF_PRODUCTION = (
+    "src/governance/promotion_loop/experiment_lineage_ref_producer_v1.py"
+)
+PACKAGE_M_EXPERIMENT_REF_SCRIPT = "scripts/run_experiment_lineage_ref_producer_v1.py"
+PACKAGE_M_EXPERIMENT_REF_PRODUCER_TESTOWNER = (
+    "tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py"
+)
+PACKAGE_M_EXPERIMENT_REF_CLI_TESTOWNER = (
+    "tests/scripts/test_run_experiment_lineage_ref_producer_v1.py"
+)
+PACKAGE_M_PACKAGE_N_REGRESSION = "tests/experiments/test_experiment_identity_manifest_v1.py"
+PACKAGE_M_ALL_PRODUCTION = (
+    PACKAGE_M_EXPERIMENT_REF_PRODUCTION,
+    PACKAGE_M_EXPERIMENT_REF_SCRIPT,
+)
+PACKAGE_M_ALL_TESTOWNERS = (
+    PACKAGE_M_EXPERIMENT_REF_PRODUCER_TESTOWNER,
+    PACKAGE_M_EXPERIMENT_REF_CLI_TESTOWNER,
+    PACKAGE_M_PACKAGE_N_REGRESSION,
+)
+PACKAGE_M_FULL_DIFF = (
+    PACKAGE_M_EXPERIMENT_REF_PRODUCTION,
+    PACKAGE_M_EXPERIMENT_REF_SCRIPT,
+    PACKAGE_M_EXPERIMENT_REF_PRODUCER_TESTOWNER,
+    PACKAGE_M_EXPERIMENT_REF_CLI_TESTOWNER,
+    "scripts/ops/ci_test_selection_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
+
+def test_selector_package_m_experiment_ref_production_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_M_EXPERIMENT_REF_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_M_ALL_TESTOWNERS:
+        assert path in bounded
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_m_experiment_ref_script_contract_focused_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_M_EXPERIMENT_REF_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    focused = sel.get("focused_pytest_targets") or ""
+    for path in PACKAGE_M_ALL_TESTOWNERS:
+        assert path in focused.split()
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in focused.split()
+
+
+def test_selector_package_m_experiment_ref_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(*PACKAGE_M_FULL_DIFF)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_M_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+    for path in PACKAGE_F_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_m_full_six_file_diff_pr_bounded_full() -> None:
+    sel = _run_selector(*PACKAGE_M_FULL_DIFF)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["tests_execute_pr_bounded_full"] == "true"
+    assert sel["tests_execute_full"] == "false"
+    bounded = _bounded_targets(sel)
+    assert PACKAGE_M_EXPERIMENT_REF_PRODUCER_TESTOWNER in bounded
+    assert PACKAGE_M_EXPERIMENT_REF_CLI_TESTOWNER in bounded
+    assert PACKAGE_M_PACKAGE_N_REGRESSION in bounded
+
+
 PACKAGE_G_BINDING_PRODUCTION = "src/meta/learning_loop/manifest_durable_evidence_binding_v1.py"
 PACKAGE_G_BINDING_SCRIPT = "scripts/run_learning_manifest_durable_evidence_binding_v1.py"
 PACKAGE_G_BINDING_TESTOWNER = "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py"

--- a/tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py
+++ b/tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import shutil
 import stat
 import uuid
 from datetime import datetime, timezone
@@ -17,7 +18,6 @@ import pytest
 from src.experiments.base import ExperimentConfig, ParamSweep
 from src.experiments.experiment_identity_manifest_v1 import (
     ARTIFACT_FILENAME,
-    ExperimentIdentityManifestError,
     build_manifest,
     produce_experiment_identity_manifest_v1,
     validate_experiment_identity_manifest_v1,
@@ -65,9 +65,9 @@ def durable_output_dir() -> Callable[[], Path]:
 
     for path in created:
         if path.exists():
-            import shutil
-
             shutil.rmtree(path, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".experiment_identity_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
 
 
 def _sample_config(**overrides: Any) -> ExperimentConfig:
@@ -91,13 +91,12 @@ def _sample_config(**overrides: Any) -> ExperimentConfig:
 
 
 def _write_manifest_dir(
-    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
     *,
     config: ExperimentConfig | None = None,
     source_experiment_id: str | None = None,
-    dir_name: str = "manifest-dir",
 ) -> tuple[Path, dict[str, Any]]:
-    manifest_dir = tmp_path / dir_name
+    manifest_dir = durable_output_dir()
     produce_experiment_identity_manifest_v1(
         config or _sample_config(),
         manifest_dir,
@@ -107,8 +106,10 @@ def _write_manifest_dir(
     return manifest_dir, manifest
 
 
-def test_happy_path_produces_valid_experiment_ref(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_happy_path_produces_valid_experiment_ref(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
     ref = result.ref
     assert ref.ref_type == LineageRefType.EXPERIMENT
@@ -120,30 +121,38 @@ def test_happy_path_produces_valid_experiment_ref(tmp_path: Path) -> None:
     assert ref.digest == manifest["integrity"]["content_sha256"]
 
 
-def test_ref_id_exactly_adopted_from_experiment_identity_id(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_ref_id_exactly_adopted_from_experiment_identity_id(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
     assert result.ref.ref_id == manifest["experiment_identity_id"]
     assert is_valid_sha256_hex(result.ref.ref_id)
 
 
-def test_digest_exactly_adopted_from_integrity_content_sha256(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_digest_exactly_adopted_from_integrity_content_sha256(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
     assert result.ref.digest == manifest["integrity"]["content_sha256"]
     assert is_valid_sha256_hex(result.ref.digest)
 
 
-def test_no_recomputation_of_ref_id_or_digest(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_no_recomputation_of_ref_id_or_digest(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
     assert result.ref.ref_id == manifest["experiment_identity_id"]
     assert result.ref.digest == manifest["integrity"]["content_sha256"]
     assert result.ref.ref_id != manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
 
 
-def test_deterministic_canonical_json_output(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_deterministic_canonical_json_output(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
     first = serialize_experiment_lineage_ref_v1(result.ref)
     second = serialize_experiment_lineage_ref_v1(result.ref)
@@ -151,8 +160,10 @@ def test_deterministic_canonical_json_output(tmp_path: Path) -> None:
     assert json.loads(first) == json.loads(second)
 
 
-def test_candidate_lineage_manifest_v1_accepts_producer_output(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_candidate_lineage_manifest_v1_accepts_producer_output(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
     fixed_now = datetime(2026, 6, 27, 18, 0, 0, tzinfo=timezone.utc)
     candidate_manifest = build_candidate_lineage_manifest_v1_from_producer_input(
@@ -192,8 +203,10 @@ def test_missing_manifest_artifact_fails_closed(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_wrong_manifest_filename_fails_closed(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_wrong_manifest_filename_fails_closed(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     artifact = manifest_dir / ARTIFACT_FILENAME
     artifact.rename(manifest_dir / "wrong_manifest_name.json")
     with pytest.raises(ExperimentLineageRefProducerError, match=f"{ARTIFACT_FILENAME} not found"):
@@ -217,8 +230,10 @@ def test_package_n_validator_rejects_invalid_manifest(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_identity_id_mismatch_fails_closed(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_identity_id_mismatch_fails_closed(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     tampered = copy.deepcopy(manifest)
     tampered["experiment_identity_id"] = "a" * 64
     (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
@@ -226,8 +241,10 @@ def test_identity_id_mismatch_fails_closed(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_digest_mismatch_fails_closed(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_digest_mismatch_fails_closed(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     tampered = copy.deepcopy(manifest)
     tampered["integrity"] = dict(tampered["integrity"])
     tampered["integrity"]["content_sha256"] = "b" * 64
@@ -236,17 +253,21 @@ def test_digest_mismatch_fails_closed(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_legacy_md5_must_not_become_ref_id(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_legacy_md5_must_not_become_ref_id(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
     legacy_id = manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
     assert result.ref.ref_id != legacy_id
     assert result.ref.ref_id == manifest["experiment_identity_id"]
 
 
-def test_source_experiment_id_must_not_become_ref_id(tmp_path: Path) -> None:
+def test_source_experiment_id_must_not_become_ref_id(
+    durable_output_dir: Callable[[], Path],
+) -> None:
     manifest_dir, manifest = _write_manifest_dir(
-        tmp_path,
+        durable_output_dir,
         source_experiment_id="legacy-src-123",
     )
     result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
@@ -255,8 +276,10 @@ def test_source_experiment_id_must_not_become_ref_id(tmp_path: Path) -> None:
     assert result.ref.ref_id == manifest["experiment_identity_id"]
 
 
-def test_registry_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_registry_run_id_forbidden_in_manifest(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     tampered = copy.deepcopy(manifest)
     tampered["registry_run_id"] = "registry-abc"
     (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
@@ -264,8 +287,10 @@ def test_registry_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_mlflow_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_mlflow_run_id_forbidden_in_manifest(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     tampered = copy.deepcopy(manifest)
     tampered["mlflow_run_id"] = "mlflow-abc"
     (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
@@ -273,8 +298,10 @@ def test_mlflow_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_backtest_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_backtest_run_id_forbidden_in_manifest(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     tampered = copy.deepcopy(manifest)
     tampered["run_id"] = "backtest-run-001"
     (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
@@ -282,16 +309,22 @@ def test_backtest_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_manifest_dir_symlink_fails_closed(tmp_path: Path) -> None:
-    real_dir, _manifest = _write_manifest_dir(tmp_path, dir_name="real-manifest")
+def test_manifest_dir_symlink_fails_closed(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    real_dir, _manifest = _write_manifest_dir(durable_output_dir)
     link = tmp_path / "linked-manifest"
     link.symlink_to(real_dir, target_is_directory=True)
     with pytest.raises(ExperimentLineageRefProducerError, match="must not be a symlink"):
         produce_experiment_lineage_ref_v1(manifest_dir=link)
 
 
-def test_manifest_artifact_symlink_fails_closed(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path, dir_name="manifest-with-link")
+def test_manifest_artifact_symlink_fails_closed(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     artifact = manifest_dir / ARTIFACT_FILENAME
     external = tmp_path / "external_manifest.json"
     external.write_text(json.dumps(manifest), encoding="utf-8")
@@ -301,16 +334,21 @@ def test_manifest_artifact_symlink_fails_closed(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_manifest_file_not_modified(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_manifest_file_not_modified(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     manifest_path = manifest_dir / ARTIFACT_FILENAME
     before = manifest_path.read_bytes()
     produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
     assert manifest_path.read_bytes() == before
 
 
-def test_atomic_writer_success_and_fail_closed_existing(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_atomic_writer_success_and_fail_closed_existing(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
     output_path = tmp_path / "ref.json"
     write_experiment_lineage_ref_v1_atomic(ref, output_path)
@@ -319,8 +357,11 @@ def test_atomic_writer_success_and_fail_closed_existing(tmp_path: Path) -> None:
         write_experiment_lineage_ref_v1_atomic(ref, output_path)
 
 
-def test_end_to_end_producer_writes_output(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_end_to_end_producer_writes_output(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     output_path = tmp_path / "out" / "experiment_ref.json"
     produce_experiment_lineage_ref_v1_to_path(
         manifest_dir=manifest_dir,
@@ -332,8 +373,11 @@ def test_end_to_end_producer_writes_output(tmp_path: Path) -> None:
     assert payload["digest"] == manifest["integrity"]["content_sha256"]
 
 
-def test_self_verification_roundtrip(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_self_verification_roundtrip(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
     output_path = tmp_path / "ref.json"
     write_experiment_lineage_ref_v1_atomic(ref, output_path)
@@ -357,14 +401,19 @@ def test_build_from_manifest_rejects_missing_digest() -> None:
         build_experiment_lineage_ref_from_manifest(tampered)
 
 
-def test_no_experiment_execution(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_no_experiment_execution(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
     assert result.ref.ref_type == LineageRefType.EXPERIMENT
 
 
-def test_no_backtest_execution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_no_backtest_execution(
+    durable_output_dir: Callable[[], Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
 
     def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise AssertionError("backtest execution forbidden")
@@ -376,8 +425,10 @@ def test_no_backtest_execution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_no_registry_or_mlflow_resolution(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_no_registry_or_mlflow_resolution(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
 
     def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise AssertionError("registry or mlflow resolution forbidden")
@@ -386,8 +437,8 @@ def test_no_registry_or_mlflow_resolution(tmp_path: Path) -> None:
         produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
 
 
-def test_atomic_write_outside_tmp(durable_output_dir: Callable[[], Path], tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_atomic_write_outside_tmp(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     output_path = durable_output_dir() / "experiment_ref.json"
     produce_experiment_lineage_ref_v1_to_path(
         manifest_dir=manifest_dir,
@@ -396,8 +447,11 @@ def test_atomic_write_outside_tmp(durable_output_dir: Callable[[], Path], tmp_pa
     assert output_path.is_file()
 
 
-def test_non_writable_output_parent(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_non_writable_output_parent(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
     readonly_dir = tmp_path / "readonly"
     readonly_dir.mkdir()
@@ -411,8 +465,10 @@ def test_non_writable_output_parent(tmp_path: Path) -> None:
     assert not output_path.exists()
 
 
-def test_validate_experiment_identity_manifest_v1_is_mandatory(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_validate_experiment_identity_manifest_v1_is_mandatory(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     calls: list[dict[str, Any]] = []
     original = validate_experiment_identity_manifest_v1
 

--- a/tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py
+++ b/tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py
@@ -1,0 +1,429 @@
+"""Producer tests for Package M offline EXPERIMENT LineageRef production."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import stat
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import patch
+
+import pytest
+
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    ExperimentIdentityManifestError,
+    build_manifest,
+    produce_experiment_identity_manifest_v1,
+    validate_experiment_identity_manifest_v1,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    CandidateType,
+    LineageRefType,
+    LineageRelation,
+    build_candidate_lineage_manifest_v1_from_producer_input,
+    lineage_ref_from_mapping,
+    lineage_ref_to_mapping,
+    serialize_candidate_lineage_manifest_v1,
+    validate_candidate_lineage_manifest_v1,
+)
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    EXPERIMENT_LINEAGE_REF_REQUIRED,
+    EXPERIMENT_OWNER_DOMAIN,
+    ExperimentLineageRefProducerError,
+    build_experiment_lineage_ref_from_manifest,
+    produce_experiment_lineage_ref_v1,
+    produce_experiment_lineage_ref_v1_to_path,
+    serialize_experiment_lineage_ref_v1,
+    write_experiment_lineage_ref_v1_atomic,
+)
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".package_m_pytest_outputs"
+LINEAGE_ID = "11111111-1111-4111-8111-111111111111"
+CONTRACT_REF = "22222222-2222-4222-8222-222222222222"
+
+
+@pytest.fixture
+def durable_output_dir() -> Callable[[], Path]:
+    """Output paths outside /tmp for producer atomic-write contract tests."""
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    created: list[Path] = []
+
+    def _make() -> Path:
+        path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+        created.append(path)
+        return path
+
+    yield _make
+
+    for path in created:
+        if path.exists():
+            import shutil
+
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _sample_config(**overrides: Any) -> ExperimentConfig:
+    base = ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[
+            ParamSweep("slow", [50, 100], description="ignored in identity"),
+            ParamSweep("fast", [5, 10]),
+        ],
+        symbols=["ETH/EUR", "BTC/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def _write_manifest_dir(
+    tmp_path: Path,
+    *,
+    config: ExperimentConfig | None = None,
+    source_experiment_id: str | None = None,
+    dir_name: str = "manifest-dir",
+) -> tuple[Path, dict[str, Any]]:
+    manifest_dir = tmp_path / dir_name
+    produce_experiment_identity_manifest_v1(
+        config or _sample_config(),
+        manifest_dir,
+        source_experiment_id=source_experiment_id,
+    )
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    return manifest_dir, manifest
+
+
+def test_happy_path_produces_valid_experiment_ref(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    ref = result.ref
+    assert ref.ref_type == LineageRefType.EXPERIMENT
+    assert ref.relation == LineageRelation.SOURCES
+    assert ref.owner_domain == EXPERIMENT_OWNER_DOMAIN
+    assert ref.required is EXPERIMENT_LINEAGE_REF_REQUIRED
+    assert ref.artifact_path == ARTIFACT_FILENAME
+    assert ref.ref_id == manifest["experiment_identity_id"]
+    assert ref.digest == manifest["integrity"]["content_sha256"]
+
+
+def test_ref_id_exactly_adopted_from_experiment_identity_id(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert result.ref.ref_id == manifest["experiment_identity_id"]
+    assert is_valid_sha256_hex(result.ref.ref_id)
+
+
+def test_digest_exactly_adopted_from_integrity_content_sha256(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert result.ref.digest == manifest["integrity"]["content_sha256"]
+    assert is_valid_sha256_hex(result.ref.digest)
+
+
+def test_no_recomputation_of_ref_id_or_digest(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert result.ref.ref_id == manifest["experiment_identity_id"]
+    assert result.ref.digest == manifest["integrity"]["content_sha256"]
+    assert result.ref.ref_id != manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
+
+
+def test_deterministic_canonical_json_output(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    first = serialize_experiment_lineage_ref_v1(result.ref)
+    second = serialize_experiment_lineage_ref_v1(result.ref)
+    assert first == second
+    assert json.loads(first) == json.loads(second)
+
+
+def test_candidate_lineage_manifest_v1_accepts_producer_output(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    fixed_now = datetime(2026, 6, 27, 18, 0, 0, tzinfo=timezone.utc)
+    candidate_manifest = build_candidate_lineage_manifest_v1_from_producer_input(
+        {
+            "lineage_manifest_id": LINEAGE_ID,
+            "candidate_id": "candidate-package-m-001",
+            "candidate_type": CandidateType.CONFIG_PATCH_BUNDLE.value,
+            "candidate_contract_ref": CONTRACT_REF,
+            "refs": [lineage_ref_to_mapping(ref)],
+            "created_at": fixed_now.isoformat(),
+        },
+        created_at=fixed_now,
+    )
+    payload = json.loads(serialize_candidate_lineage_manifest_v1(candidate_manifest))
+    valid, phase, errors, _ = validate_candidate_lineage_manifest_v1(payload)
+    assert valid is True, (phase, errors)
+    assert payload["refs"][0]["ref_id"] == manifest["experiment_identity_id"]
+    assert payload["refs"][0]["ref_type"] == LineageRefType.EXPERIMENT.value
+
+
+def test_missing_manifest_dir_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(ExperimentLineageRefProducerError, match="manifest_dir not found"):
+        produce_experiment_lineage_ref_v1(manifest_dir=tmp_path / "missing")
+
+
+def test_manifest_path_is_file_not_directory(tmp_path: Path) -> None:
+    file_path = tmp_path / "not-a-dir"
+    file_path.write_text("x", encoding="utf-8")
+    with pytest.raises(ExperimentLineageRefProducerError, match="not a directory"):
+        produce_experiment_lineage_ref_v1(manifest_dir=file_path)
+
+
+def test_missing_manifest_artifact_fails_closed(tmp_path: Path) -> None:
+    manifest_dir = tmp_path / "empty-dir"
+    manifest_dir.mkdir()
+    with pytest.raises(ExperimentLineageRefProducerError, match=f"{ARTIFACT_FILENAME} not found"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_wrong_manifest_filename_fails_closed(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    artifact = manifest_dir / ARTIFACT_FILENAME
+    artifact.rename(manifest_dir / "wrong_manifest_name.json")
+    with pytest.raises(ExperimentLineageRefProducerError, match=f"{ARTIFACT_FILENAME} not found"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_invalid_json_fails_closed(tmp_path: Path) -> None:
+    manifest_dir = tmp_path / "bad-json-dir"
+    manifest_dir.mkdir()
+    (manifest_dir / ARTIFACT_FILENAME).write_text("{not-json", encoding="utf-8")
+    with pytest.raises(ExperimentLineageRefProducerError, match="invalid"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_package_n_validator_rejects_invalid_manifest(tmp_path: Path) -> None:
+    manifest_dir = tmp_path / "invalid-manifest-dir"
+    manifest_dir.mkdir()
+    invalid = {"schema_version": "9.9", "experiment_identity_id": "x" * 64}
+    (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(invalid), encoding="utf-8")
+    with pytest.raises(ExperimentLineageRefProducerError, match="validation failed"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_identity_id_mismatch_fails_closed(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    tampered = copy.deepcopy(manifest)
+    tampered["experiment_identity_id"] = "a" * 64
+    (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(ExperimentLineageRefProducerError, match="experiment_identity_id mismatch"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_digest_mismatch_fails_closed(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    tampered = copy.deepcopy(manifest)
+    tampered["integrity"] = dict(tampered["integrity"])
+    tampered["integrity"]["content_sha256"] = "b" * 64
+    (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(ExperimentLineageRefProducerError, match="integrity"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_legacy_md5_must_not_become_ref_id(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    legacy_id = manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
+    assert result.ref.ref_id != legacy_id
+    assert result.ref.ref_id == manifest["experiment_identity_id"]
+
+
+def test_source_experiment_id_must_not_become_ref_id(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(
+        tmp_path,
+        source_experiment_id="legacy-src-123",
+    )
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert manifest["provenance"]["source_experiment_id"] == "legacy-src-123"
+    assert result.ref.ref_id != "legacy-src-123"
+    assert result.ref.ref_id == manifest["experiment_identity_id"]
+
+
+def test_registry_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    tampered = copy.deepcopy(manifest)
+    tampered["registry_run_id"] = "registry-abc"
+    (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(ExperimentLineageRefProducerError, match="registry_run_id"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_mlflow_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    tampered = copy.deepcopy(manifest)
+    tampered["mlflow_run_id"] = "mlflow-abc"
+    (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(ExperimentLineageRefProducerError, match="mlflow_run_id"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_backtest_run_id_forbidden_in_manifest(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    tampered = copy.deepcopy(manifest)
+    tampered["run_id"] = "backtest-run-001"
+    (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(ExperimentLineageRefProducerError, match="run_id"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_manifest_dir_symlink_fails_closed(tmp_path: Path) -> None:
+    real_dir, _manifest = _write_manifest_dir(tmp_path, dir_name="real-manifest")
+    link = tmp_path / "linked-manifest"
+    link.symlink_to(real_dir, target_is_directory=True)
+    with pytest.raises(ExperimentLineageRefProducerError, match="must not be a symlink"):
+        produce_experiment_lineage_ref_v1(manifest_dir=link)
+
+
+def test_manifest_artifact_symlink_fails_closed(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path, dir_name="manifest-with-link")
+    artifact = manifest_dir / ARTIFACT_FILENAME
+    external = tmp_path / "external_manifest.json"
+    external.write_text(json.dumps(manifest), encoding="utf-8")
+    artifact.unlink()
+    artifact.symlink_to(external)
+    with pytest.raises(ExperimentLineageRefProducerError, match="must not be a symlink"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_manifest_file_not_modified(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    manifest_path = manifest_dir / ARTIFACT_FILENAME
+    before = manifest_path.read_bytes()
+    produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert manifest_path.read_bytes() == before
+
+
+def test_atomic_writer_success_and_fail_closed_existing(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    output_path = tmp_path / "ref.json"
+    write_experiment_lineage_ref_v1_atomic(ref, output_path)
+    assert output_path.is_file()
+    with pytest.raises(ExperimentLineageRefProducerError, match="already exists"):
+        write_experiment_lineage_ref_v1_atomic(ref, output_path)
+
+
+def test_end_to_end_producer_writes_output(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    output_path = tmp_path / "out" / "experiment_ref.json"
+    produce_experiment_lineage_ref_v1_to_path(
+        manifest_dir=manifest_dir,
+        output_path=output_path,
+    )
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["ref_type"] == LineageRefType.EXPERIMENT.value
+    assert payload["ref_id"] == manifest["experiment_identity_id"]
+    assert payload["digest"] == manifest["integrity"]["content_sha256"]
+
+
+def test_self_verification_roundtrip(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    output_path = tmp_path / "ref.json"
+    write_experiment_lineage_ref_v1_atomic(ref, output_path)
+    roundtrip = lineage_ref_from_mapping(json.loads(output_path.read_text(encoding="utf-8")))
+    assert roundtrip == ref
+
+
+def test_build_from_manifest_rejects_missing_ref_id() -> None:
+    manifest = build_manifest(_sample_config())
+    tampered = copy.deepcopy(manifest)
+    del tampered["experiment_identity_id"]
+    with pytest.raises(ExperimentLineageRefProducerError, match="experiment_identity_id"):
+        build_experiment_lineage_ref_from_manifest(tampered)
+
+
+def test_build_from_manifest_rejects_missing_digest() -> None:
+    manifest = build_manifest(_sample_config())
+    tampered = copy.deepcopy(manifest)
+    tampered["integrity"] = {}
+    with pytest.raises(ExperimentLineageRefProducerError, match="content_sha256"):
+        build_experiment_lineage_ref_from_manifest(tampered)
+
+
+def test_no_experiment_execution(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert result.ref.ref_type == LineageRefType.EXPERIMENT
+
+
+def test_no_backtest_execution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("backtest execution forbidden")
+
+    monkeypatch.setattr(
+        "src.risk.validation.var_suite_backtest_wiring_v1.resolve_backtest_returns",
+        _forbidden,
+    )
+    produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_no_registry_or_mlflow_resolution(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("registry or mlflow resolution forbidden")
+
+    with patch("urllib.request.urlopen", side_effect=_forbidden):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_atomic_write_outside_tmp(durable_output_dir: Callable[[], Path], tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    output_path = durable_output_dir() / "experiment_ref.json"
+    produce_experiment_lineage_ref_v1_to_path(
+        manifest_dir=manifest_dir,
+        output_path=output_path,
+    )
+    assert output_path.is_file()
+
+
+def test_non_writable_output_parent(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir()
+    output_path = readonly_dir / "out.json"
+    os.chmod(readonly_dir, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        with pytest.raises(OSError):
+            write_experiment_lineage_ref_v1_atomic(ref, output_path)
+    finally:
+        os.chmod(readonly_dir, stat.S_IRWXU)
+    assert not output_path.exists()
+
+
+def test_validate_experiment_identity_manifest_v1_is_mandatory(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    calls: list[dict[str, Any]] = []
+    original = validate_experiment_identity_manifest_v1
+
+    def _tracked_validate(payload):  # type: ignore[no-untyped-def]
+        calls.append(dict(payload))
+        return original(payload)
+
+    with patch(
+        "src.governance.promotion_loop.experiment_lineage_ref_producer_v1.validate_experiment_identity_manifest_v1",
+        side_effect=_tracked_validate,
+    ):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert calls
+    assert calls[0]["experiment_identity_id"] == manifest["experiment_identity_id"]

--- a/tests/scripts/test_run_experiment_lineage_ref_producer_v1.py
+++ b/tests/scripts/test_run_experiment_lineage_ref_producer_v1.py
@@ -1,0 +1,238 @@
+"""CLI tests for Package M offline EXPERIMENT LineageRef producer."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_experiment_lineage_ref_producer_v1 import (
+    EXIT_OK,
+    EXIT_PRODUCER_ERROR,
+    main,
+)
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    produce_experiment_identity_manifest_v1,
+)
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    ExperimentLineageRefProducerError,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".package_m_cli_pytest_outputs"
+
+
+@pytest.fixture
+def durable_output_dir() -> Callable[[], Path]:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    created: list[Path] = []
+
+    def _make() -> Path:
+        path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+        created.append(path)
+        return path
+
+    yield _make
+
+    for path in created:
+        if path.exists():
+            import shutil
+
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _sample_config(**overrides: Any) -> ExperimentConfig:
+    base = ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[ParamSweep("fast", [5, 10])],
+        symbols=["ETH/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def _write_manifest_dir(tmp_path: Path) -> tuple[Path, dict[str, Any]]:
+    manifest_dir = tmp_path / "manifest-dir"
+    produce_experiment_identity_manifest_v1(_sample_config(), manifest_dir)
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    return manifest_dir, manifest
+
+
+def test_cli_successful_run(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    output_path = tmp_path / "ref.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["ref_id"] == manifest["experiment_identity_id"]
+    assert payload["ref_type"] == "experiment"
+    assert payload["relation"] == "sources"
+    assert payload["owner_domain"] == "experiments/base"
+
+
+def test_cli_deterministic_output(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    output_a = tmp_path / "a.json"
+    output_b = tmp_path / "b.json"
+    assert main(["--manifest-dir", str(manifest_dir), "--output", str(output_a)]) == EXIT_OK
+    assert main(["--manifest-dir", str(manifest_dir), "--output", str(output_b)]) == EXIT_OK
+    assert output_a.read_text(encoding="utf-8") == output_b.read_text(encoding="utf-8")
+
+
+def test_cli_requires_explicit_manifest_dir_and_output(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    with pytest.raises(SystemExit):
+        main(["--output", str(tmp_path / "out.json")])
+    with pytest.raises(SystemExit):
+        main(["--manifest-dir", str(manifest_dir)])
+
+
+def test_cli_invalid_input_is_producer_error(tmp_path: Path, capsys) -> None:
+    manifest_dir = tmp_path / "empty-dir"
+    manifest_dir.mkdir()
+    output_path = tmp_path / "out.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_cli_missing_input_manifest_fail_closed(tmp_path: Path, capsys) -> None:
+    manifest_dir = tmp_path / "missing-manifest"
+    manifest_dir.mkdir()
+    output_path = tmp_path / "out.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert ARTIFACT_FILENAME in capsys.readouterr().err
+
+
+def test_cli_existing_output_fail_closed(tmp_path: Path, capsys) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+    output_path.write_text('{"stale": true}', encoding="utf-8")
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert output_path.read_text(encoding="utf-8") == '{"stale": true}'
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_cli_non_writable_output_parent(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir()
+    output_path = readonly_dir / "out.json"
+    os.chmod(readonly_dir, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    finally:
+        os.chmod(readonly_dir, stat.S_IRWXU)
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+
+
+def test_cli_no_partial_output_on_producer_error(tmp_path: Path) -> None:
+    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+    tampered = dict(manifest)
+    tampered["run_id"] = "forbidden-backtest-run"
+    (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
+    output_path = tmp_path / "out.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_cli_atomic_writer_success(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    output_path = tmp_path / "nested" / "ref.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_cli_producer_error_reports_on_stderr(tmp_path: Path, capsys, monkeypatch) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+
+    def _raise(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise ExperimentLineageRefProducerError("forced producer failure")
+
+    monkeypatch.setattr(
+        "scripts.run_experiment_lineage_ref_producer_v1.produce_experiment_lineage_ref_v1_to_path",
+        _raise,
+    )
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert "forced producer failure" in capsys.readouterr().err
+
+
+def test_cli_stable_exit_codes(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    assert (
+        main(["--manifest-dir", str(manifest_dir), "--output", str(tmp_path / "ok.json")])
+        == EXIT_OK
+    )
+    assert (
+        main(
+            [
+                "--manifest-dir",
+                str(tmp_path / "missing"),
+                "--output",
+                str(tmp_path / "bad.json"),
+            ]
+        )
+        == EXIT_PRODUCER_ERROR
+    )
+
+
+def test_cli_no_experiment_backtest_registry_or_mlflow_calls(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    output_path = tmp_path / "out.json"
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("forbidden side-effect invocation")
+
+    monkeypatch.setattr(
+        "src.risk.validation.var_suite_backtest_wiring_v1.resolve_backtest_returns",
+        _forbidden,
+    )
+    with patch("urllib.request.urlopen", side_effect=_forbidden):
+        rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+
+
+def test_cli_explicit_paths_only_no_defaults(tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    output_path = tmp_path / "explicit.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()
+
+
+def test_cli_durable_output_path(durable_output_dir: Callable[[], Path], tmp_path: Path) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    output_path = durable_output_dir() / "ref.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()

--- a/tests/scripts/test_run_experiment_lineage_ref_producer_v1.py
+++ b/tests/scripts/test_run_experiment_lineage_ref_producer_v1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import uuid
 from pathlib import Path
@@ -44,9 +45,9 @@ def durable_output_dir() -> Callable[[], Path]:
 
     for path in created:
         if path.exists():
-            import shutil
-
             shutil.rmtree(path, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".experiment_identity_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
 
 
 def _sample_config(**overrides: Any) -> ExperimentConfig:
@@ -66,15 +67,18 @@ def _sample_config(**overrides: Any) -> ExperimentConfig:
     return base
 
 
-def _write_manifest_dir(tmp_path: Path) -> tuple[Path, dict[str, Any]]:
-    manifest_dir = tmp_path / "manifest-dir"
+def _write_manifest_dir(durable_output_dir: Callable[[], Path]) -> tuple[Path, dict[str, Any]]:
+    manifest_dir = durable_output_dir()
     produce_experiment_identity_manifest_v1(_sample_config(), manifest_dir)
     manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
     return manifest_dir, manifest
 
 
-def test_cli_successful_run(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_cli_successful_run(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     output_path = tmp_path / "ref.json"
     rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
     assert rc == EXIT_OK
@@ -86,8 +90,11 @@ def test_cli_successful_run(tmp_path: Path) -> None:
     assert payload["owner_domain"] == "experiments/base"
 
 
-def test_cli_deterministic_output(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_deterministic_output(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     output_a = tmp_path / "a.json"
     output_b = tmp_path / "b.json"
     assert main(["--manifest-dir", str(manifest_dir), "--output", str(output_a)]) == EXIT_OK
@@ -95,8 +102,11 @@ def test_cli_deterministic_output(tmp_path: Path) -> None:
     assert output_a.read_text(encoding="utf-8") == output_b.read_text(encoding="utf-8")
 
 
-def test_cli_requires_explicit_manifest_dir_and_output(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_requires_explicit_manifest_dir_and_output(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     with pytest.raises(SystemExit):
         main(["--output", str(tmp_path / "out.json")])
     with pytest.raises(SystemExit):
@@ -123,8 +133,12 @@ def test_cli_missing_input_manifest_fail_closed(tmp_path: Path, capsys) -> None:
     assert ARTIFACT_FILENAME in capsys.readouterr().err
 
 
-def test_cli_existing_output_fail_closed(tmp_path: Path, capsys) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_existing_output_fail_closed(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+    capsys,
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     output_path = tmp_path / "out.json"
     output_path.write_text('{"stale": true}', encoding="utf-8")
     rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
@@ -133,8 +147,11 @@ def test_cli_existing_output_fail_closed(tmp_path: Path, capsys) -> None:
     assert "already exists" in capsys.readouterr().err
 
 
-def test_cli_non_writable_output_parent(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_non_writable_output_parent(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     readonly_dir = tmp_path / "readonly"
     readonly_dir.mkdir()
     output_path = readonly_dir / "out.json"
@@ -147,8 +164,11 @@ def test_cli_non_writable_output_parent(tmp_path: Path) -> None:
     assert not output_path.exists()
 
 
-def test_cli_no_partial_output_on_producer_error(tmp_path: Path) -> None:
-    manifest_dir, manifest = _write_manifest_dir(tmp_path)
+def test_cli_no_partial_output_on_producer_error(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
     tampered = dict(manifest)
     tampered["run_id"] = "forbidden-backtest-run"
     (manifest_dir / ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
@@ -159,8 +179,11 @@ def test_cli_no_partial_output_on_producer_error(tmp_path: Path) -> None:
     assert not output_path.with_name(output_path.name + ".tmp").exists()
 
 
-def test_cli_atomic_writer_success(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_atomic_writer_success(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     output_path = tmp_path / "nested" / "ref.json"
     rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
     assert rc == EXIT_OK
@@ -168,8 +191,13 @@ def test_cli_atomic_writer_success(tmp_path: Path) -> None:
     assert not output_path.with_name(output_path.name + ".tmp").exists()
 
 
-def test_cli_producer_error_reports_on_stderr(tmp_path: Path, capsys, monkeypatch) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_producer_error_reports_on_stderr(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+    capsys,
+    monkeypatch,
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     output_path = tmp_path / "out.json"
 
     def _raise(*args, **kwargs):  # type: ignore[no-untyped-def]
@@ -184,8 +212,11 @@ def test_cli_producer_error_reports_on_stderr(tmp_path: Path, capsys, monkeypatc
     assert "forced producer failure" in capsys.readouterr().err
 
 
-def test_cli_stable_exit_codes(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_stable_exit_codes(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     assert (
         main(["--manifest-dir", str(manifest_dir), "--output", str(tmp_path / "ok.json")])
         == EXIT_OK
@@ -205,9 +236,10 @@ def test_cli_stable_exit_codes(tmp_path: Path) -> None:
 
 def test_cli_no_experiment_backtest_registry_or_mlflow_calls(
     tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
     monkeypatch,
 ) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     output_path = tmp_path / "out.json"
 
     def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
@@ -222,16 +254,19 @@ def test_cli_no_experiment_backtest_registry_or_mlflow_calls(
     assert rc == EXIT_OK
 
 
-def test_cli_explicit_paths_only_no_defaults(tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_explicit_paths_only_no_defaults(
+    tmp_path: Path,
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     output_path = tmp_path / "explicit.json"
     rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
     assert rc == EXIT_OK
     assert output_path.is_file()
 
 
-def test_cli_durable_output_path(durable_output_dir: Callable[[], Path], tmp_path: Path) -> None:
-    manifest_dir, _manifest = _write_manifest_dir(tmp_path)
+def test_cli_durable_output_path(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
     output_path = durable_output_dir() / "ref.json"
     rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
     assert rc == EXIT_OK


### PR DESCRIPTION
## Summary

- Adds a purely additive offline EXPERIMENT domain LineageRef producer (Package M) that reads an explicit `manifest_dir`, validates `experiment_identity_manifest_v1.json` via the Package N validator, and writes a deterministic LineageRef JSON artifact.
- `ref_id` is taken verbatim from `experiment_identity_id`; `digest` is taken verbatim from `integrity.content_sha256` — no recomputation.
- Produces `domain=EXPERIMENT`, `relation=SOURCES`, `owner_domain=experiments/base`; BACKTEST and EXPERIMENT domains remain strictly separated.
- Exactly six files changed; no Package E21 durable binding, no migration, no consumer rewiring, no runtime impact.
- CI selector rebundle extends Package F candidate-lineage production triggers/targets; expected Required CI mode is `PR_BOUNDED_FULL` on `tests (3.11)`.

## Contract notes

- Reuses Package N `validate_experiment_identity_manifest_v1` and existing LineageRef model/serialization helpers.
- CLI is offline-only with explicit `--manifest-dir` and `--output` arguments; no registry/MLflow/default path resolution.
- `EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true`.

## Local validation

- Producer tests: 33 passed
- CLI tests: 14 passed
- Package M CI selector contract tests: 4 passed
- Package I/J/N regressions: 100 passed
- PR_BOUNDED selector scope: 1039 passed in 46.30s
- Ruff format/check: PASS
- Pyright (producer + CLI): PASS
- git diff --check: PASS

## Test plan

- [ ] Required CI `tests (3.11)` completes green in `PR_BOUNDED_FULL` mode
- [ ] Review confirms no seventh file and no trading/experiment-config semantics drift

Made with [Cursor](https://cursor.com)