### PR TITLE
feat(learning-loop): add experiment durable evidence binding v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1476,6 +1476,24 @@ PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/experiment_durable_evidence_binding_v1.py",
+        "scripts/run_experiment_durable_evidence_binding_v1.py",
+        "tests/meta/test_experiment_durable_evidence_binding_v1.py",
+        "tests/scripts/test_run_experiment_durable_evidence_binding_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_experiment_durable_evidence_binding_v1.py",
+    "tests/scripts/test_run_experiment_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py",
+    "tests/scripts/test_run_experiment_lineage_ref_producer_v1.py",
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/experiments/experiment_identity_manifest_v1.py",
@@ -1569,6 +1587,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TRIGGER_PATHS:
@@ -4748,6 +4770,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                     add(candidate)
             elif path == "scripts/run_backtest_durable_evidence_binding_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_L_BACKTEST_DURABLE_EVIDENCE_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_experiment_durable_evidence_binding_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TARGETS:
                     add(candidate)
             elif path == "scripts/run_experiment_identity_manifest_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TARGETS:

--- a/scripts/run_experiment_durable_evidence_binding_v1.py
+++ b/scripts/run_experiment_durable_evidence_binding_v1.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Offline Package E21 — bind EXPERIMENT identity manifest + LineageRef to durable evidence.
+
+Produces a validated durable evidence bundle with binding index and MANIFEST.sha256 only.
+No experiment execution, promotion, apply, runtime, registry mutation, or live authority.
+
+Usage:
+    python3 scripts/run_experiment_durable_evidence_binding_v1.py \\
+        --manifest-dir reports/experiments/identity_manifest_dir \\
+        --experiment-lineage-ref reports/lineage_refs/experiment_ref.json \\
+        --output-dir /var/evidence/experiment_bundle_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.experiment_durable_evidence_binding_v1 import (
+    ExperimentDurableEvidenceBindingError,
+    produce_experiment_durable_evidence_bundle_v1,
+)
+
+EXIT_OK = 0
+EXIT_BINDING_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline Package E21: bind validated EXPERIMENT identity manifest and "
+            "LineageRef to durable evidence (index + MANIFEST.sha256)."
+        )
+    )
+    parser.add_argument(
+        "--manifest-dir",
+        type=Path,
+        required=True,
+        help="Explicit directory containing experiment_identity_manifest_v1.json.",
+    )
+    parser.add_argument(
+        "--experiment-lineage-ref",
+        type=Path,
+        required=True,
+        help="Explicit path to a validated Package M EXPERIMENT LineageRef JSON file.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit durable evidence bundle directory (must not exist; outside /tmp).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.manifest_dir.is_dir():
+        print(
+            f"[experiment_durable_evidence_binding] ERROR: manifest directory not found: "
+            f"{args.manifest_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if not args.experiment_lineage_ref.is_file():
+        print(
+            "[experiment_durable_evidence_binding] ERROR: "
+            f"experiment lineage ref not found: {args.experiment_lineage_ref}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    try:
+        result = produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=args.manifest_dir,
+            experiment_lineage_ref_path=args.experiment_lineage_ref,
+            output_dir=args.output_dir,
+        )
+    except ExperimentDurableEvidenceBindingError as exc:
+        print(f"[experiment_durable_evidence_binding] ERROR: {exc}", file=sys.stderr)
+        return EXIT_BINDING_ERROR
+
+    print(
+        "[experiment_durable_evidence_binding] wrote durable evidence bundle to "
+        f"{result.output_dir} (experiment_identity_id={result.experiment_identity_id})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/experiment_durable_evidence_binding_v1.py
+++ b/src/meta/learning_loop/experiment_durable_evidence_binding_v1.py
@@ -1,0 +1,498 @@
+"""Offline Package E21 — durable evidence binding for EXPERIMENT identity + LineageRef v1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    ExperimentIdentityManifestError,
+    validate_experiment_identity_manifest_v1,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    CandidateLineageManifestError,
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_from_mapping,
+    lineage_ref_to_mapping,
+)
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    EXPERIMENT_OWNER_DOMAIN,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+BINDING_SCHEMA_VERSION = "experiment_durable_evidence_binding_v1"
+MANIFEST_ARTIFACT_REL = ARTIFACT_FILENAME
+LINEAGE_REF_ARTIFACT_REL = "experiment_lineage_ref_v1.json"
+INDEX_ARTIFACT_REL = "experiment_durable_evidence_binding_index_v1.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".experiment_durable_evidence_staging_"
+
+FUTURES_SCOPE_REF: dict[str, bool] = {
+    "futures_only": True,
+    "bitcoin_direction_allowed": False,
+}
+TRADING_LOGIC_IMMUTABILITY_REF: dict[str, bool] = {
+    "trading_logic_immutability": True,
+}
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "patches",
+        "patch",
+        "strategy",
+        "signal",
+        "signals",
+        "entry",
+        "exit",
+        "position_sizing",
+        "leverage",
+        "stop_loss",
+        "take_profit",
+        "execution",
+        "order_routing",
+        "risk_limits",
+        "killswitch",
+        "old_value",
+        "new_value",
+        "target",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "runtime_status",
+        "live_arming",
+        "apply_authority",
+        "promotion_authority",
+        "completion",
+        "checkpoint",
+        "params",
+        "metrics",
+        "tags",
+    }
+)
+
+
+class ExperimentDurableEvidenceBindingError(ValueError):
+    """Fail-closed Package E21 EXPERIMENT durable evidence binding error."""
+
+
+@dataclass(frozen=True)
+class BoundArtifactRecord:
+    artifact_kind: str
+    relative_path: str
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class ExperimentBindingCrossReferences:
+    experiment_identity_id: str
+    lineage_ref_digest: str
+    lineage_ref_artifact_path: str
+
+
+@dataclass(frozen=True)
+class ExperimentDurableEvidenceBindingResult:
+    output_dir: Path
+    experiment_identity_id: str
+    binding_index_path: Path
+    manifest_path: Path
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ExperimentDurableEvidenceBindingError(f"{label} must not be a symlink: {path}")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise ExperimentDurableEvidenceBindingError(
+                f"binding index must not contain forbidden key: {key}"
+            )
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise ExperimentDurableEvidenceBindingError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise ExperimentDurableEvidenceBindingError(f"{label} must be a regular file: {path}")
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise ExperimentDurableEvidenceBindingError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise ExperimentDurableEvidenceBindingError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ExperimentDurableEvidenceBindingError(f"output parent directory missing: {parent}")
+    if is_under_tmp(parent):
+        raise ExperimentDurableEvidenceBindingError("output parent directory must be outside /tmp")
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_existing_directory(path: Path, *, label: str) -> Path:
+    if not path.exists():
+        raise ExperimentDurableEvidenceBindingError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_dir():
+        raise ExperimentDurableEvidenceBindingError(f"{label} is not a directory: {path}")
+    return path.resolve()
+
+
+def _load_validated_identity_manifest(
+    manifest_dir: Path,
+) -> tuple[dict[str, Any], Path, bytes]:
+    manifest_path = manifest_dir / ARTIFACT_FILENAME
+    _validate_regular_file(manifest_path, label=ARTIFACT_FILENAME)
+    resolved = manifest_path.resolve()
+    if not _path_is_under(resolved, manifest_dir.resolve()):
+        raise ExperimentDurableEvidenceBindingError(
+            f"{ARTIFACT_FILENAME} escapes manifest_dir root: {manifest_path}"
+        )
+
+    manifest_bytes = manifest_path.read_bytes()
+    try:
+        data = json.loads(manifest_bytes.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExperimentDurableEvidenceBindingError(
+            f"invalid {ARTIFACT_FILENAME} in manifest_dir={manifest_dir}: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ExperimentDurableEvidenceBindingError(
+            f"{ARTIFACT_FILENAME} root must be a JSON object for manifest_dir={manifest_dir}"
+        )
+    try:
+        validate_experiment_identity_manifest_v1(data)
+    except ExperimentIdentityManifestError as exc:
+        raise ExperimentDurableEvidenceBindingError(
+            f"experiment identity manifest validation failed for manifest_dir={manifest_dir}: {exc}"
+        ) from exc
+    return data, manifest_path, manifest_bytes
+
+
+def _load_lineage_ref_from_json_path(path: Path) -> LineageRef:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ExperimentDurableEvidenceBindingError(
+            f"failed to read lineage ref file: {path}"
+        ) from exc
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise ExperimentDurableEvidenceBindingError(
+            f"invalid JSON in lineage ref file: {path}"
+        ) from exc
+    if not isinstance(data, Mapping):
+        raise ExperimentDurableEvidenceBindingError("lineage ref root must be a JSON object")
+    try:
+        return lineage_ref_from_mapping(data)
+    except CandidateLineageManifestError as exc:
+        raise ExperimentDurableEvidenceBindingError(str(exc)) from exc
+
+
+def _reject_unsafe_overlap(
+    *,
+    manifest_dir: Path,
+    lineage_ref_path: Path,
+    output_dir: Path,
+) -> None:
+    manifest_res = manifest_dir.resolve()
+    lineage_res = lineage_ref_path.resolve()
+    output_res = output_dir.resolve()
+
+    if output_res in {manifest_res, lineage_res}:
+        raise ExperimentDurableEvidenceBindingError(
+            "output directory must not equal a source path (fail-closed)"
+        )
+
+    if _path_is_under(manifest_res, output_res) or _path_is_under(lineage_res, output_res):
+        raise ExperimentDurableEvidenceBindingError(
+            "source path must not be inside output directory (fail-closed)"
+        )
+
+    if _path_is_under(output_res, manifest_res) or _path_is_under(output_res, lineage_res):
+        raise ExperimentDurableEvidenceBindingError(
+            "output directory must not be inside a source path (fail-closed)"
+        )
+
+
+def _validate_bundle_relative_path(rel: str) -> None:
+    candidate = Path(rel)
+    if candidate.is_absolute():
+        raise ExperimentDurableEvidenceBindingError(
+            f"bundle relative path must not be absolute: {rel!r}"
+        )
+    if ".." in candidate.parts:
+        raise ExperimentDurableEvidenceBindingError(
+            f"bundle relative path must not traverse upward: {rel!r}"
+        )
+
+
+def check_reference_consistency(
+    *,
+    manifest: Mapping[str, Any],
+    ref: LineageRef,
+) -> ExperimentBindingCrossReferences:
+    if ref.ref_type != LineageRefType.EXPERIMENT:
+        raise ExperimentDurableEvidenceBindingError(
+            f"ref_type must be EXPERIMENT, got {ref.ref_type.value!r}"
+        )
+    if ref.relation != LineageRelation.SOURCES:
+        raise ExperimentDurableEvidenceBindingError(
+            f"relation must be SOURCES, got {ref.relation.value!r}"
+        )
+    if ref.artifact_path != ARTIFACT_FILENAME:
+        raise ExperimentDurableEvidenceBindingError(
+            f"artifact_path must be {ARTIFACT_FILENAME!r}, got {ref.artifact_path!r}"
+        )
+    if ref.owner_domain != EXPERIMENT_OWNER_DOMAIN:
+        raise ExperimentDurableEvidenceBindingError(
+            f"owner_domain must be {EXPERIMENT_OWNER_DOMAIN!r}, got {ref.owner_domain!r}"
+        )
+
+    experiment_identity_id = manifest.get("experiment_identity_id")
+    if not isinstance(experiment_identity_id, str) or not experiment_identity_id.strip():
+        raise ExperimentDurableEvidenceBindingError("experiment_identity_id missing or invalid")
+
+    integrity = manifest.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise ExperimentDurableEvidenceBindingError("integrity must be an object")
+    content_sha256 = integrity.get("content_sha256")
+    if not isinstance(content_sha256, str) or not content_sha256.strip():
+        raise ExperimentDurableEvidenceBindingError("integrity.content_sha256 missing or invalid")
+    if not is_valid_sha256_hex(content_sha256):
+        raise ExperimentDurableEvidenceBindingError(
+            "integrity.content_sha256 must be valid sha256 hex"
+        )
+
+    if ref.ref_id != experiment_identity_id:
+        raise ExperimentDurableEvidenceBindingError(
+            f"ref_id must match experiment_identity_id: {ref.ref_id!r} != {experiment_identity_id!r}"
+        )
+    if ref.digest is None:
+        raise ExperimentDurableEvidenceBindingError("lineage ref digest is required")
+    if not is_valid_sha256_hex(ref.digest):
+        raise ExperimentDurableEvidenceBindingError("lineage ref digest must be valid sha256 hex")
+    if ref.digest != content_sha256:
+        raise ExperimentDurableEvidenceBindingError(
+            "lineage ref digest must match integrity.content_sha256 verbatim"
+        )
+
+    return ExperimentBindingCrossReferences(
+        experiment_identity_id=experiment_identity_id,
+        lineage_ref_digest=ref.digest,
+        lineage_ref_artifact_path=ref.artifact_path,
+    )
+
+
+def _build_experiment_lineage_ref_payload(ref: LineageRef) -> dict[str, Any]:
+    payload = lineage_ref_to_mapping(ref)
+    for forbidden in ("params", "metrics", "returns", "trades", "equity", "tags"):
+        if forbidden in payload:
+            raise ExperimentDurableEvidenceBindingError(
+                f"lineage ref must not contain run payload key: {forbidden}"
+            )
+    return payload
+
+
+def build_binding_index_v1(
+    *,
+    experiment_identity_id: str,
+    cross_references: ExperimentBindingCrossReferences,
+    ref: LineageRef,
+    artifacts: tuple[BoundArtifactRecord, ...],
+) -> dict[str, Any]:
+    sorted_artifacts = sorted(
+        artifacts,
+        key=lambda item: (item.artifact_kind, item.relative_path),
+    )
+    payload: dict[str, Any] = {
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "experiment_identity_id": experiment_identity_id,
+        "experiment_lineage_ref": _build_experiment_lineage_ref_payload(ref),
+        "cross_references": {
+            "experiment_identity_id": cross_references.experiment_identity_id,
+            "lineage_ref_digest": cross_references.lineage_ref_digest,
+            "lineage_ref_artifact_path": cross_references.lineage_ref_artifact_path,
+        },
+        "artifacts": [
+            {
+                "artifact_kind": item.artifact_kind,
+                "relative_path": item.relative_path,
+                "content_sha256": item.content_sha256,
+            }
+            for item in sorted_artifacts
+        ],
+        "futures_scope_ref": dict(FUTURES_SCOPE_REF),
+        "trading_logic_immutability_ref": dict(TRADING_LOGIC_IMMUTABILITY_REF),
+        "evidence_does_not_authorize_runtime": True,
+    }
+    _reject_forbidden_index_keys(payload)
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def serialize_binding_index_v1(index: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(index)
+    return deterministic_json_dumps(dict(index))
+
+
+def _copy_byte_identical(source: Path, dest: Path) -> str:
+    _validate_regular_file(source, label="source artifact")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, dest)
+    source_digest = _sha256_file(source)
+    dest_digest = _sha256_file(dest)
+    if source_digest != dest_digest:
+        raise ExperimentDurableEvidenceBindingError(f"byte-identical copy failed for {source.name}")
+    return source_digest
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    token = uuid.uuid4().hex
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{token}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def produce_experiment_durable_evidence_bundle_v1(
+    *,
+    manifest_dir: Path | str,
+    experiment_lineage_ref_path: Path | str,
+    output_dir: Path | str,
+) -> ExperimentDurableEvidenceBindingResult:
+    """Bind validated EXPERIMENT identity manifest + LineageRef into offline durable evidence."""
+    resolved_manifest_dir = _resolve_existing_directory(Path(manifest_dir), label="manifest_dir")
+    lineage_ref_file = Path(experiment_lineage_ref_path)
+    final_dir = Path(output_dir)
+
+    _validate_regular_file(lineage_ref_file, label="experiment lineage ref")
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        manifest_dir=resolved_manifest_dir,
+        lineage_ref_path=lineage_ref_file,
+        output_dir=final_dir,
+    )
+
+    manifest, manifest_path, _manifest_bytes = _load_validated_identity_manifest(
+        resolved_manifest_dir
+    )
+    ref = _load_lineage_ref_from_json_path(lineage_ref_file)
+    cross = check_reference_consistency(manifest=manifest, ref=ref)
+    experiment_identity_id = cross.experiment_identity_id
+
+    for rel in (MANIFEST_ARTIFACT_REL, LINEAGE_REF_ARTIFACT_REL, INDEX_ARTIFACT_REL):
+        _validate_bundle_relative_path(rel)
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise ExperimentDurableEvidenceBindingError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+
+        manifest_dest = staging / MANIFEST_ARTIFACT_REL
+        ref_dest = staging / LINEAGE_REF_ARTIFACT_REL
+        manifest_digest = _copy_byte_identical(manifest_path, manifest_dest)
+        ref_digest = _copy_byte_identical(lineage_ref_file, ref_dest)
+
+        artifacts = (
+            BoundArtifactRecord(
+                artifact_kind="experiment_identity_manifest_v1",
+                relative_path=MANIFEST_ARTIFACT_REL,
+                content_sha256=manifest_digest,
+            ),
+            BoundArtifactRecord(
+                artifact_kind="experiment_lineage_ref_v1",
+                relative_path=LINEAGE_REF_ARTIFACT_REL,
+                content_sha256=ref_digest,
+            ),
+        )
+        index_payload = build_binding_index_v1(
+            experiment_identity_id=experiment_identity_id,
+            cross_references=cross,
+            ref=ref,
+            artifacts=artifacts,
+        )
+        index_path = staging / INDEX_ARTIFACT_REL
+        index_path.write_text(serialize_binding_index_v1(index_payload), encoding="utf-8")
+
+        write_manifest_sha256(staging)
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise ExperimentDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise ExperimentDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return ExperimentDurableEvidenceBindingResult(
+        output_dir=final_dir,
+        experiment_identity_id=experiment_identity_id,
+        binding_index_path=final_dir / INDEX_ARTIFACT_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+    )
+
+
+__all__ = [
+    "BINDING_SCHEMA_VERSION",
+    "INDEX_ARTIFACT_REL",
+    "LINEAGE_REF_ARTIFACT_REL",
+    "MANIFEST_ARTIFACT_REL",
+    "ExperimentBindingCrossReferences",
+    "ExperimentDurableEvidenceBindingError",
+    "ExperimentDurableEvidenceBindingResult",
+    "BoundArtifactRecord",
+    "build_binding_index_v1",
+    "check_reference_consistency",
+    "produce_experiment_durable_evidence_bundle_v1",
+    "serialize_binding_index_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5614,3 +5614,77 @@ def test_selector_package_l_combined_diff_pr_bounded_full_includes_all_testowner
     for path in PACKAGE_L_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_E21_BINDING_PRODUCTION = "src/meta/learning_loop/experiment_durable_evidence_binding_v1.py"
+PACKAGE_E21_BINDING_SCRIPT = "scripts/run_experiment_durable_evidence_binding_v1.py"
+PACKAGE_E21_BINDING_TESTOWNER = "tests/meta/test_experiment_durable_evidence_binding_v1.py"
+PACKAGE_E21_BINDING_CLI_TESTOWNER = (
+    "tests/scripts/test_run_experiment_durable_evidence_binding_v1.py"
+)
+PACKAGE_E21_M_PRODUCER_TESTOWNER = (
+    "tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py"
+)
+PACKAGE_E21_M_CLI_TESTOWNER = "tests/scripts/test_run_experiment_lineage_ref_producer_v1.py"
+PACKAGE_E21_N_IDENTITY_TESTOWNER = "tests/experiments/test_experiment_identity_manifest_v1.py"
+PACKAGE_E21_LINEAGE_CONTRACT = (
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py"
+)
+PACKAGE_E21_ALL_PRODUCTION = (
+    PACKAGE_E21_BINDING_PRODUCTION,
+    PACKAGE_E21_BINDING_SCRIPT,
+)
+PACKAGE_E21_ALL_TESTOWNERS = (
+    PACKAGE_E21_BINDING_TESTOWNER,
+    PACKAGE_E21_BINDING_CLI_TESTOWNER,
+    PACKAGE_E21_M_PRODUCER_TESTOWNER,
+    PACKAGE_E21_M_CLI_TESTOWNER,
+    PACKAGE_E21_N_IDENTITY_TESTOWNER,
+    PACKAGE_E21_LINEAGE_CONTRACT,
+)
+
+
+def test_selector_package_e21_binding_production_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_E21_BINDING_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_E21_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_e21_script_contract_focused_includes_binding_testowners() -> None:
+    sel = _run_selector(PACKAGE_E21_BINDING_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    for path in PACKAGE_E21_ALL_TESTOWNERS:
+        assert path in targets
+
+
+def test_selector_package_e21_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+    sel = _run_selector(
+        *PACKAGE_E21_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_E21_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_E21_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+
+
+def test_selector_package_e21_full_six_file_diff_pr_bounded_full_not_no_op() -> None:
+    sel = _run_selector(
+        PACKAGE_E21_BINDING_PRODUCTION,
+        PACKAGE_E21_BINDING_SCRIPT,
+        PACKAGE_E21_BINDING_TESTOWNER,
+        PACKAGE_E21_BINDING_CLI_TESTOWNER,
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_mode"] != "NO_OP"
+    assert sel["test_selection_mode"] != "FOCUSED"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_E21_ALL_TESTOWNERS:
+        assert path in bounded

--- a/tests/meta/test_experiment_durable_evidence_binding_v1.py
+++ b/tests/meta/test_experiment_durable_evidence_binding_v1.py
@@ -1,0 +1,572 @@
+"""Contract tests for Package E21 offline EXPERIMENT durable evidence binding v1."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    produce_experiment_identity_manifest_v1,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRefType,
+    LineageRelation,
+)
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    EXPERIMENT_OWNER_DOMAIN,
+    produce_experiment_lineage_ref_v1,
+    serialize_experiment_lineage_ref_v1,
+    write_experiment_lineage_ref_v1_atomic,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256
+from src.meta.learning_loop.experiment_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL,
+    LINEAGE_REF_ARTIFACT_REL,
+    MANIFEST_ARTIFACT_REL,
+    BoundArtifactRecord,
+    ExperimentBindingCrossReferences,
+    ExperimentDurableEvidenceBindingError,
+    build_binding_index_v1,
+    check_reference_consistency,
+    produce_experiment_durable_evidence_bundle_v1,
+    serialize_binding_index_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".package_e21_pytest_outputs"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.experiment_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+@pytest.fixture
+def durable_output_dir() -> Callable[[], Path]:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    created: list[Path] = []
+
+    def _make() -> Path:
+        path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+        created.append(path)
+        return path
+
+    yield _make
+
+    for path in created:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".experiment_durable_evidence_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".experiment_identity_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+_durable_paths: list[Path] = []
+
+
+def _next_durable_output() -> Path:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+    _durable_paths.append(path)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_module_durable_paths() -> None:
+    yield
+    for path in _durable_paths:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+    _durable_paths.clear()
+
+
+def _sample_config(**overrides: Any) -> ExperimentConfig:
+    base = ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[
+            ParamSweep("slow", [50, 100], description="ignored in identity"),
+            ParamSweep("fast", [5, 10]),
+        ],
+        symbols=["ETH/EUR", "BTC/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def _write_manifest_dir() -> tuple[Path, dict[str, Any]]:
+    manifest_dir = _next_durable_output()
+    produce_experiment_identity_manifest_v1(_sample_config(), manifest_dir)
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    return manifest_dir, manifest
+
+
+def _write_lineage_ref(manifest_dir: Path, ref_path: Path) -> None:
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    write_experiment_lineage_ref_v1_atomic(result.ref, ref_path, fail_closed_if_exists=True)
+
+
+def _bind_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    manifest_dir, _manifest = _write_manifest_dir()
+    ref_path = tmp_path / "experiment_ref.json"
+    ref_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_lineage_ref(manifest_dir, ref_path)
+    return manifest_dir, ref_path, _next_durable_output()
+
+
+def test_happy_path_binds_successfully(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    result = produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    assert result.experiment_identity_id == manifest["experiment_identity_id"]
+    assert (out / MANIFEST_ARTIFACT_REL).is_file()
+    assert (out / LINEAGE_REF_ARTIFACT_REL).is_file()
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is True
+
+
+def test_byte_identical_copies(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    manifest_bytes = (manifest_dir / ARTIFACT_FILENAME).read_bytes()
+    ref_bytes = ref_path.read_bytes()
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    assert (out / MANIFEST_ARTIFACT_REL).read_bytes() == manifest_bytes
+    assert (out / LINEAGE_REF_ARTIFACT_REL).read_bytes() == ref_bytes
+
+
+def test_binding_index_metadata_only(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert index["evidence_does_not_authorize_runtime"] is True
+    assert index["experiment_identity_id"] == manifest["experiment_identity_id"]
+    assert "params" not in index
+    assert "metrics" not in index
+    assert "promotion_authority" not in index
+    assert "completion" not in index
+    assert all(not Path(item["relative_path"]).is_absolute() for item in index["artifacts"])
+
+
+def test_domain_relation_owner_domain_bound(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    ref_payload = index["experiment_lineage_ref"]
+    assert ref_payload["ref_type"] == LineageRefType.EXPERIMENT.value
+    assert ref_payload["relation"] == LineageRelation.SOURCES.value
+    assert ref_payload["owner_domain"] == EXPERIMENT_OWNER_DOMAIN
+
+
+def test_ref_id_and_digest_verbatim_no_recomputation(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert index["experiment_identity_id"] == manifest["experiment_identity_id"]
+    assert index["cross_references"]["experiment_identity_id"] == manifest["experiment_identity_id"]
+    assert (
+        index["cross_references"]["lineage_ref_digest"] == manifest["integrity"]["content_sha256"]
+    )
+    assert index["experiment_lineage_ref"]["ref_id"] == manifest["experiment_identity_id"]
+    assert index["experiment_lineage_ref"]["digest"] == manifest["integrity"]["content_sha256"]
+
+
+def test_check_reference_consistency_digest_mismatch(tmp_path: Path) -> None:
+    manifest_dir, ref_path, _ = _bind_inputs(tmp_path)
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    ref = result.ref
+    bad_ref = type(ref)(
+        ref_type=ref.ref_type,
+        ref_id=ref.ref_id,
+        relation=ref.relation,
+        owner_domain=ref.owner_domain,
+        required=ref.required,
+        digest="0" * 64,
+        artifact_path=ref.artifact_path,
+        schema_version=ref.schema_version,
+    )
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="digest"):
+        check_reference_consistency(manifest=manifest, ref=bad_ref)
+
+
+def test_wrong_ref_id_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["ref_id"] = "0" * 64
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="ref_id"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_wrong_ref_type_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["ref_type"] = LineageRefType.BACKTEST.value
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="EXPERIMENT"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_wrong_relation_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["relation"] = LineageRelation.EVALUATES.value
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="SOURCES"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_wrong_owner_domain_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["owner_domain"] = "backtests/base"
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="owner_domain"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_missing_identity_manifest_fail_closed(tmp_path: Path) -> None:
+    manifest_dir = tmp_path / "sources" / "empty_manifest_dir"
+    manifest_dir.mkdir(parents=True)
+    good_dir, _ = _write_manifest_dir()
+    ref_path = tmp_path / "sources" / "orphan_ref.json"
+    _write_lineage_ref(good_dir, ref_path)
+    out = _next_durable_output()
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="not found"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_invalid_manifest_json_fail_closed(tmp_path: Path) -> None:
+    manifest_dir = tmp_path / "sources" / "bad-json"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / ARTIFACT_FILENAME).write_text("{broken", encoding="utf-8")
+    good_dir, _ = _write_manifest_dir()
+    ref_path = tmp_path / "sources" / "ref.json"
+    _write_lineage_ref(good_dir, ref_path)
+    out = _next_durable_output()
+    with pytest.raises(ExperimentDurableEvidenceBindingError):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_invalid_package_n_manifest_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    manifest_path = manifest_dir / ARTIFACT_FILENAME
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["experiment_identity_id"] = "0" * 64
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="validation failed"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_missing_lineage_ref_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, _ = _write_manifest_dir()
+    out = _next_durable_output()
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="not found"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=tmp_path / "missing_ref.json",
+            output_dir=out,
+        )
+
+
+def test_invalid_lineage_ref_json_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, _ = _write_manifest_dir()
+    ref_path = tmp_path / "sources" / "bad_ref.json"
+    ref_path.parent.mkdir(parents=True)
+    ref_path.write_text("{broken", encoding="utf-8")
+    out = _next_durable_output()
+    with pytest.raises(ExperimentDurableEvidenceBindingError):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_symlink_manifest_dir_rejected(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    link = tmp_path / "manifest_link"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(manifest_dir, target_is_directory=True)
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="symlink"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=link,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_existing_output_dir_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    out.mkdir(parents=True)
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="already exists"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_deterministic_index_and_manifest(tmp_path: Path) -> None:
+    manifest_dir, ref_path, _ = _bind_inputs(tmp_path)
+    out1 = _next_durable_output()
+    out2 = _next_durable_output()
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out1,
+    )
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out2,
+    )
+    assert (out1 / INDEX_ARTIFACT_REL).read_bytes() == (out2 / INDEX_ARTIFACT_REL).read_bytes()
+    assert (out1 / "MANIFEST.sha256").read_bytes() == (out2 / "MANIFEST.sha256").read_bytes()
+
+
+def test_copy_failure_cleans_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+
+    def _boom(_src: Path, _dst: Path) -> str:
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.experiment_durable_evidence_binding_v1._copy_byte_identical",
+        _boom,
+    )
+    with pytest.raises(OSError, match="copy failed"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_manifest_verify_failure_cleans_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    monkeypatch.setattr(
+        "src.meta.learning_loop.experiment_durable_evidence_binding_v1.verify_manifest_sha256",
+        lambda _root: (False, "checksum mismatch"),
+    )
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="verification failed"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_build_binding_index_rejects_forbidden_key(tmp_path: Path) -> None:
+    manifest_dir, _ = _write_manifest_dir()
+    ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    cross = ExperimentBindingCrossReferences(
+        experiment_identity_id=ref.ref_id,
+        lineage_ref_digest=ref.digest or "a" * 64,
+        lineage_ref_artifact_path=ref.artifact_path or ARTIFACT_FILENAME,
+    )
+    artifacts = (
+        BoundArtifactRecord("experiment_identity_manifest_v1", MANIFEST_ARTIFACT_REL, "b" * 64),
+        BoundArtifactRecord("experiment_lineage_ref_v1", LINEAGE_REF_ARTIFACT_REL, "c" * 64),
+    )
+    index = build_binding_index_v1(
+        experiment_identity_id=ref.ref_id,
+        cross_references=cross,
+        ref=ref,
+        artifacts=artifacts,
+    )
+    index["promotion_authority"] = True
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="forbidden key"):
+        serialize_binding_index_v1(index)
+
+
+def test_integrity_hash_stable_for_index_payload(tmp_path: Path) -> None:
+    manifest_dir, ref_path, _ = _bind_inputs(tmp_path)
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    ref = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    cross = check_reference_consistency(manifest=manifest, ref=ref)
+    artifacts = (
+        BoundArtifactRecord("experiment_identity_manifest_v1", MANIFEST_ARTIFACT_REL, "a" * 64),
+        BoundArtifactRecord("experiment_lineage_ref_v1", LINEAGE_REF_ARTIFACT_REL, "b" * 64),
+    )
+    index = build_binding_index_v1(
+        experiment_identity_id=manifest["experiment_identity_id"],
+        cross_references=cross,
+        ref=ref,
+        artifacts=artifacts,
+    )
+    payload = dict(index)
+    digest = payload.pop("integrity")
+    assert digest["content_sha256"] == compute_content_sha256(payload)
+
+
+def test_output_under_tmp_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts.ops.primary_evidence_retention_v0 import is_under_tmp as real_is_under_tmp
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.experiment_durable_evidence_binding_v1.is_under_tmp",
+        real_is_under_tmp,
+    )
+    manifest_dir, ref_path, _ = _bind_inputs(tmp_path)
+    out = Path("/tmp/peak_trade_pkg_e21_binding_reject_test")
+    try:
+        with pytest.raises(ExperimentDurableEvidenceBindingError, match="outside /tmp"):
+            produce_experiment_durable_evidence_bundle_v1(
+                manifest_dir=manifest_dir,
+                experiment_lineage_ref_path=ref_path,
+                output_dir=out,
+            )
+    finally:
+        if out.exists():
+            shutil.rmtree(out)
+
+
+def test_no_runtime_imports_in_binding_module() -> None:
+    import ast
+
+    path = Path("src/meta/learning_loop/experiment_durable_evidence_binding_v1.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = ("promotion_loop.engine", "governance.promotion_loop.engine")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for token in forbidden:
+                assert token not in node.module
+
+
+def test_package_m_ref_serialization_compatible(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    original = json.loads(ref_path.read_text(encoding="utf-8"))
+    copied = json.loads((out / LINEAGE_REF_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert copied == original
+    assert copied == json.loads(
+        serialize_experiment_lineage_ref_v1(
+            produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir).ref
+        )
+    )
+
+
+def test_input_mutation_between_validation_and_copy_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    original_copy = shutil.copyfile
+
+    def _mutating_copy(src: Path, dst: Path) -> None:
+        original_copy(src, dst)
+        if src.name == ARTIFACT_FILENAME:
+            src.write_text('{"experiment_identity_id":"mutated"}', encoding="utf-8")
+
+    monkeypatch.setattr(shutil, "copyfile", _mutating_copy)
+    with pytest.raises(ExperimentDurableEvidenceBindingError):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_wrong_manifest_filename_fail_closed(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    wrong_name = manifest_dir / "wrong_manifest.json"
+    wrong_name.write_bytes((manifest_dir / ARTIFACT_FILENAME).read_bytes())
+    (manifest_dir / ARTIFACT_FILENAME).unlink()
+    with pytest.raises(ExperimentDurableEvidenceBindingError, match="not found"):
+        produce_experiment_durable_evidence_bundle_v1(
+            manifest_dir=manifest_dir,
+            experiment_lineage_ref_path=ref_path,
+            output_dir=out,
+        )
+
+
+def test_existing_target_replay_contract(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out = _bind_inputs(tmp_path)
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=out,
+    )
+    replay_out = _next_durable_output()
+    produce_experiment_durable_evidence_bundle_v1(
+        manifest_dir=manifest_dir,
+        experiment_lineage_ref_path=ref_path,
+        output_dir=replay_out,
+    )
+    assert (out / INDEX_ARTIFACT_REL).read_bytes() == (replay_out / INDEX_ARTIFACT_REL).read_bytes()

--- a/tests/scripts/test_run_experiment_durable_evidence_binding_v1.py
+++ b/tests/scripts/test_run_experiment_durable_evidence_binding_v1.py
@@ -1,0 +1,270 @@
+"""CLI tests for Package E21 offline EXPERIMENT durable evidence binding v1."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_experiment_durable_evidence_binding_v1 import (
+    EXIT_BINDING_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.experiment_identity_manifest_v1 import ARTIFACT_FILENAME
+from src.experiments.experiment_identity_manifest_v1 import produce_experiment_identity_manifest_v1
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    produce_experiment_lineage_ref_v1,
+    write_experiment_lineage_ref_v1_atomic,
+)
+from src.meta.learning_loop.experiment_durable_evidence_binding_v1 import INDEX_ARTIFACT_REL
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".package_e21_cli_pytest_outputs"
+_durable_paths: list[Path] = []
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.experiment_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_durable_paths() -> None:
+    yield
+    for path in _durable_paths:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+    _durable_paths.clear()
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".experiment_durable_evidence_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".experiment_identity_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _next_durable_output() -> Path:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+    _durable_paths.append(path)
+    return path
+
+
+def _sample_config(**overrides: Any) -> ExperimentConfig:
+    base = ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[
+            ParamSweep("slow", [50, 100], description="ignored in identity"),
+            ParamSweep("fast", [5, 10]),
+        ],
+        symbols=["ETH/EUR", "BTC/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    manifest_dir = _next_durable_output()
+    produce_experiment_identity_manifest_v1(_sample_config(), manifest_dir)
+    ref_path = tmp_path / "experiment_ref.json"
+    ref_path.parent.mkdir(parents=True, exist_ok=True)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    write_experiment_lineage_ref_v1_atomic(result.ref, ref_path)
+    out_root = _DURABLE_OUTPUT_ROOT
+    return manifest_dir, ref_path, out_root
+
+
+def test_cli_successful_run(tmp_path: Path) -> None:
+    manifest_dir, ref_path, _out_root = _write_inputs(tmp_path)
+    out = _next_durable_output()
+    rc = main(
+        [
+            "--manifest-dir",
+            str(manifest_dir),
+            "--experiment-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+    assert (out / ARTIFACT_FILENAME).is_file()
+
+
+def test_cli_requires_all_paths() -> None:
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_cli_missing_manifest_dir_usage_error(tmp_path: Path) -> None:
+    _, ref_path, out_root = _write_inputs(tmp_path)
+    rc = main(
+        [
+            "--manifest-dir",
+            str(tmp_path / "missing"),
+            "--experiment-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(_next_durable_output()),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_missing_lineage_ref_usage_error(tmp_path: Path) -> None:
+    manifest_dir, _, out_root = _write_inputs(tmp_path)
+    rc = main(
+        [
+            "--manifest-dir",
+            str(manifest_dir),
+            "--experiment-lineage-ref",
+            str(tmp_path / "missing.json"),
+            "--output-dir",
+            str(_next_durable_output()),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_ref_id_mismatch_binding_error(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out_root = _write_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["ref_id"] = "0" * 64
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--manifest-dir",
+            str(manifest_dir),
+            "--experiment-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(_next_durable_output()),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_digest_mismatch_binding_error(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out_root = _write_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["digest"] = "0" * 64
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--manifest-dir",
+            str(manifest_dir),
+            "--experiment-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(_next_durable_output()),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_existing_output_binding_error(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out = _next_durable_output()
+    out.mkdir()
+    rc = main(
+        [
+            "--manifest-dir",
+            str(manifest_dir),
+            "--experiment-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_stderr_has_no_manifest_payload_dump(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    manifest_dir, ref_path, out_root = _write_inputs(tmp_path)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["digest"] = "0" * 64
+    ref_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(
+        [
+            "--manifest-dir",
+            str(manifest_dir),
+            "--experiment-lineage-ref",
+            str(ref_path),
+            "--output-dir",
+            str(_next_durable_output()),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+    err = capsys.readouterr().err
+    assert "ma_crossover" not in err
+    assert "param_sweeps" not in err
+    assert len(err) < 500
+
+
+def test_cli_no_network_side_effects(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out = _next_durable_output()
+    with patch("urllib.request.urlopen", side_effect=AssertionError("network forbidden")):
+        rc = main(
+            [
+                "--manifest-dir",
+                str(manifest_dir),
+                "--experiment-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out),
+            ]
+        )
+    assert rc == EXIT_OK
+
+
+def test_cli_deterministic_output(tmp_path: Path) -> None:
+    manifest_dir, ref_path, out_root = _write_inputs(tmp_path)
+    out1 = _next_durable_output()
+    out2 = _next_durable_output()
+    assert (
+        main(
+            [
+                "--manifest-dir",
+                str(manifest_dir),
+                "--experiment-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out1),
+            ]
+        )
+        == EXIT_OK
+    )
+    assert (
+        main(
+            [
+                "--manifest-dir",
+                str(manifest_dir),
+                "--experiment-lineage-ref",
+                str(ref_path),
+                "--output-dir",
+                str(out2),
+            ]
+        )
+        == EXIT_OK
+    )
+    assert (out1 / INDEX_ARTIFACT_REL).read_bytes() == (out2 / INDEX_ARTIFACT_REL).read_bytes()


### PR DESCRIPTION
## Summary

- Adds offline Package E21 durable evidence binding for canonical EXPERIMENT artifacts: Package N `experiment_identity_manifest_v1.json` plus Package M EXPERIMENT LineageRef (`domain=EXPERIMENT`, `relation=SOURCES`, `owner_domain=experiments/base`).
- Cross-checks `experiment_identity_id` and `integrity.content_sha256` verbatim against LineageRef `ref_id`/`digest` with no recomputation; reuses Package G/K/L staging, atomic publish, and `MANIFEST.sha256` self-verification.
- Adds CLI (`--manifest-dir`, `--experiment-lineage-ref`, `--output-dir`), binder/CLI testowners, and CI selector rebundle for `PR_BOUNDED_FULL`.

## Scope

- Exactly **6 files** (binder module, CLI, 2 testowners, CI selector + contract tests).
- **No** completion/checkpoint binding, promotion integration, consumer rewiring, migration, workflow edits, or runtime authority.

## Safety

- `OFFLINE_ONLY=true`, `EVIDENCE_DOES_NOT_AUTHORIZE_RUNTIME=true`, `EXPERIMENT_CONFIG_UNCHANGED=true`, `TRADING_LOGIC_IMMUTABILITY=true`.
- Inputs resolved only via explicit directories/paths — no registry/MLflow resolution, no experiment/backtest execution.

## CI

- Expected required mode: **`PR_BOUNDED_FULL`** on `CI / tests (3.11)`.
- Local validation: E21 binder/CLI tests, CI selector contract tests, G/K/L/N/M regressions, ruff, pyright — all PASS.

## Test plan

- [x] Binder happy path + fail-closed mismatch cases
- [x] CLI explicit args + fail-closed paths
- [x] Selector: production diff → PR_BOUNDED_FULL includes E21 targets
- [ ] Required CI terminal green (no merge in this PR)

Made with [Cursor](https://cursor.com)