### PR TITLE
Comparison Metric Input v1 — bounded offline Model C

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1494,6 +1494,53 @@ PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TARGETS: tuple[str, ...]
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/comparison_metric_input_v1/__init__.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/constants.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/models.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/comparability.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/identity.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/validation.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/metrics.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/source_binding.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/io.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/producer.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/adapters/__init__.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/adapters/backtest.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/adapters/experiment.py",
+        "src/meta/learning_loop/comparison_metric_input_v1/adapters/var_suite.py",
+        "scripts/run_comparison_metric_input_v1.py",
+        "tests/meta/test_comparison_metric_input_identity_v1.py",
+        "tests/meta/test_comparison_metric_input_validation_v1.py",
+        "tests/meta/test_comparison_metric_input_metrics_v1.py",
+        "tests/meta/test_comparison_metric_input_source_binding_v1.py",
+        "tests/meta/test_comparison_metric_input_producer_v1.py",
+        "tests/meta/test_comparison_metric_input_replay_v1.py",
+        "tests/meta/test_comparison_metric_input_adapters_v1.py",
+        "tests/scripts/test_run_comparison_metric_input_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_comparison_metric_input_identity_v1.py",
+    "tests/meta/test_comparison_metric_input_validation_v1.py",
+    "tests/meta/test_comparison_metric_input_metrics_v1.py",
+    "tests/meta/test_comparison_metric_input_source_binding_v1.py",
+    "tests/meta/test_comparison_metric_input_producer_v1.py",
+    "tests/meta/test_comparison_metric_input_replay_v1.py",
+    "tests/meta/test_comparison_metric_input_adapters_v1.py",
+    "tests/scripts/test_run_comparison_metric_input_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
+    "tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py",
+    "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py",
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
+    "tests/experiments/test_equity_loader.py",
+    "tests/meta/test_var_suite_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/experiments/experiment_identity_manifest_v1.py",
@@ -1591,6 +1638,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TRIGGER_PATHS:
@@ -4773,6 +4824,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                     add(candidate)
             elif path == "scripts/run_experiment_durable_evidence_binding_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_E21_EXPERIMENT_DURABLE_EVIDENCE_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_comparison_metric_input_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS:
                     add(candidate)
             elif path == "scripts/run_experiment_identity_manifest_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TARGETS:

--- a/scripts/run_comparison_metric_input_v1.py
+++ b/scripts/run_comparison_metric_input_v1.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Offline CLI for comparison_metric_input.v1 manifest production."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.comparison_metric_input_v1.producer import (
+    produce_comparison_metric_input_v1,
+)
+
+
+def _load_ref(path: Path) -> dict[str, str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ComparisonMetricInputError(f"source ref must be JSON object: {path}")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Produce comparison_metric_input_manifest_v1.json")
+    parser.add_argument(
+        "--source-domain", required=True, choices=["EXPERIMENT", "BACKTEST", "VAR_SUITE"]
+    )
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument("--source-ref", required=True, type=Path)
+    parser.add_argument("--run-dir", type=Path, default=None)
+    parser.add_argument("--manifest-dir", type=Path, default=None)
+    parser.add_argument("--completed-run-dir", type=Path, default=None)
+    parser.add_argument("--suite-report-dir", type=Path, default=None)
+    parser.add_argument("--companion-run-dir", type=Path, default=None)
+    parser.add_argument("--backtest-source-ref", type=Path, default=None)
+    parser.add_argument("--evaluation-slice-id", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        source_ref = _load_ref(args.source_ref)
+        backtest_source_ref = (
+            _load_ref(args.backtest_source_ref) if args.backtest_source_ref is not None else None
+        )
+        result = produce_comparison_metric_input_v1(
+            source_domain=args.source_domain,
+            output_root=args.output_root,
+            source_ref=source_ref,
+            run_dir=args.run_dir,
+            manifest_dir=args.manifest_dir,
+            completed_run_dir=args.completed_run_dir,
+            suite_report_dir=args.suite_report_dir,
+            companion_run_dir=args.companion_run_dir,
+            backtest_source_ref=backtest_source_ref,
+            evaluation_slice_id=args.evaluation_slice_id,
+        )
+    except ComparisonMetricInputError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(result.manifest_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/comparison_metric_input_v1/__init__.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/__init__.py
@@ -1,0 +1,19 @@
+"""comparison_metric_input.v1 bounded offline package."""
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    ARTIFACT_FILENAME,
+    COMPARISON_METRIC_INPUT_CONTRACT_VERSION,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.producer import (
+    produce_comparison_metric_input_v1,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.validation import (
+    validate_comparison_metric_input_manifest_v1,
+)
+
+__all__ = [
+    "ARTIFACT_FILENAME",
+    "COMPARISON_METRIC_INPUT_CONTRACT_VERSION",
+    "produce_comparison_metric_input_v1",
+    "validate_comparison_metric_input_manifest_v1",
+]

--- a/src/meta/learning_loop/comparison_metric_input_v1/adapters/__init__.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/adapters/__init__.py
@@ -1,0 +1,17 @@
+"""Domain adapters for comparison_metric_input.v1."""
+
+from src.meta.learning_loop.comparison_metric_input_v1.adapters.backtest import (
+    adapt_backtest_domain,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.adapters.experiment import (
+    adapt_experiment_domain,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.adapters.var_suite import (
+    adapt_var_suite_domain,
+)
+
+__all__ = [
+    "adapt_backtest_domain",
+    "adapt_experiment_domain",
+    "adapt_var_suite_domain",
+]

--- a/src/meta/learning_loop/comparison_metric_input_v1/adapters/backtest.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/adapters/backtest.py
@@ -1,0 +1,139 @@
+"""BACKTEST domain adapter for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.experiments.equity_loader import load_equity_curves_from_run_dir
+from src.experiments.tracking.run_summary import RunSummary
+from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+    BACKTEST_OWNER_DOMAIN,
+    RUN_SUMMARY_REL_PATH,
+    compute_backtest_lineage_ref_digest,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.comparability import (
+    comparability_from_backtest_config_snapshot,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.constants import ANNUALIZATION_PROFILE_V1
+from src.meta.learning_loop.comparison_metric_input_v1.metrics import compute_all_metrics
+from src.meta.learning_loop.comparison_metric_input_v1.models import (
+    AdapterResult,
+    ComparisonMetricInputError,
+    SourceBindingRecord,
+    SourceRef,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.source_binding import (
+    build_binding_records,
+    compute_equity_series_digest,
+    compute_source_digest,
+    compute_trade_ledger_digest,
+    load_json_object,
+    load_trades_from_parquet,
+    sha256_file,
+    verify_source_ref,
+)
+
+CONFIG_SNAPSHOT_REL = "config_snapshot.json"
+TRADES_REL = "trades.parquet"
+
+
+def _resolve_run_dir(run_dir: Path) -> Path:
+    if not run_dir.exists() or not run_dir.is_dir() or run_dir.is_symlink():
+        raise ComparisonMetricInputError(f"run_dir invalid: {run_dir}")
+    return run_dir.resolve()
+
+
+def _equity_relative_path(run_dir: Path) -> str:
+    equity_csv = run_dir / "equity.csv"
+    if equity_csv.is_file():
+        return "equity.csv"
+    matches = sorted(run_dir.glob("*equity.csv"))
+    if not matches:
+        raise ComparisonMetricInputError("equity artifact not found in run_dir")
+    if len(matches) > 1:
+        raise ComparisonMetricInputError("ambiguous equity artifacts in run_dir")
+    return matches[0].name
+
+
+def _validate_backtest_lineage_ref(
+    *,
+    run_dir: Path,
+    source_ref: Mapping[str, Any],
+) -> SourceRef:
+    ref = verify_source_ref(source_ref, expected_domain="BACKTEST")
+    if ref.owner_domain != BACKTEST_OWNER_DOMAIN:
+        raise ComparisonMetricInputError("BACKTEST source_ref owner_domain mismatch")
+    summary_path = run_dir / RUN_SUMMARY_REL_PATH
+    if not summary_path.is_file():
+        raise ComparisonMetricInputError(f"{RUN_SUMMARY_REL_PATH} not found in run_dir")
+    summary = RunSummary.read_json(summary_path)
+    errors = summary.validate_contract(strict=True)
+    if errors:
+        raise ComparisonMetricInputError(f"RunSummary validation failed: {'; '.join(errors)}")
+    if summary.status != "FINISHED":
+        raise ComparisonMetricInputError("backtest run must be FINISHED")
+    expected_digest = compute_backtest_lineage_ref_digest(summary)
+    if ref.digest != expected_digest:
+        raise ComparisonMetricInputError("BACKTEST source_ref digest mismatch with run_summary")
+    if ref.ref_id != str(summary.run_id):
+        raise ComparisonMetricInputError(
+            "BACKTEST source_ref ref_id mismatch with run_summary.run_id"
+        )
+    return ref
+
+
+def adapt_backtest_domain(
+    *,
+    run_dir: Path,
+    source_ref: Mapping[str, Any],
+) -> AdapterResult:
+    resolved_run_dir = _resolve_run_dir(run_dir)
+    ref = _validate_backtest_lineage_ref(run_dir=resolved_run_dir, source_ref=source_ref)
+    config_path = resolved_run_dir / CONFIG_SNAPSHOT_REL
+    config_snapshot = load_json_object(config_path, label=CONFIG_SNAPSHOT_REL)
+    summary = RunSummary.read_json(resolved_run_dir / RUN_SUMMARY_REL_PATH)
+    comparability_metadata, evaluation_slice_id = comparability_from_backtest_config_snapshot(
+        config_snapshot=config_snapshot,
+        run_summary_params=summary.params,
+        source_domain="BACKTEST",
+        source_ref_id=ref.ref_id,
+        evaluation_start=summary.started_at_utc,
+        evaluation_end=summary.finished_at_utc,
+    )
+    periods_per_year = ANNUALIZATION_PROFILE_V1.get(str(comparability_metadata["timeframe"]))
+    if periods_per_year is None:
+        raise ComparisonMetricInputError(
+            f"unknown timeframe: {comparability_metadata['timeframe']}"
+        )
+    equity = load_equity_curves_from_run_dir(resolved_run_dir, max_curves=1)[0]
+    trades_path = resolved_run_dir / TRADES_REL
+    trades = load_trades_from_parquet(trades_path)
+    source_digest = compute_source_digest(
+        equity_series_digest=compute_equity_series_digest(equity),
+        trade_ledger_digest=compute_trade_ledger_digest(trades),
+    )
+    metrics = compute_all_metrics(
+        equity=equity,
+        trades=trades,
+        periods_per_year=periods_per_year,
+    )
+    equity_rel = _equity_relative_path(resolved_run_dir)
+    bindings = build_binding_records(
+        SourceBindingRecord(CONFIG_SNAPSHOT_REL, sha256_file(config_path)),
+        SourceBindingRecord(
+            RUN_SUMMARY_REL_PATH, sha256_file(resolved_run_dir / RUN_SUMMARY_REL_PATH)
+        ),
+        SourceBindingRecord(TRADES_REL, sha256_file(trades_path)),
+        SourceBindingRecord(equity_rel, sha256_file(resolved_run_dir / equity_rel)),
+    )
+    return AdapterResult(
+        source_domain="BACKTEST",
+        source_ref=ref,
+        source_digest=source_digest,
+        evaluation_slice_id=evaluation_slice_id,
+        comparability_metadata=comparability_metadata,
+        metrics=metrics,
+        source_bindings=bindings,
+        var_suite_companion=None,
+    )

--- a/src/meta/learning_loop/comparison_metric_input_v1/adapters/experiment.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/adapters/experiment.py
@@ -1,0 +1,145 @@
+"""EXPERIMENT domain adapter for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.experiments.equity_loader import load_equity_curves_from_run_dir
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME as EXPERIMENT_IDENTITY_ARTIFACT,
+    validate_experiment_identity_manifest_v1,
+)
+from src.experiments.tracking.run_summary import RunSummary
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import EXPERIMENT_OWNER_DOMAIN
+from src.meta.learning_loop.comparison_metric_input_v1.adapters.backtest import (
+    CONFIG_SNAPSHOT_REL,
+    TRADES_REL,
+    _equity_relative_path,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.comparability import (
+    comparability_from_experiment_identity,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.constants import ANNUALIZATION_PROFILE_V1
+from src.meta.learning_loop.comparison_metric_input_v1.metrics import compute_all_metrics
+from src.meta.learning_loop.comparison_metric_input_v1.models import (
+    AdapterResult,
+    ComparisonMetricInputError,
+    SourceBindingRecord,
+    SourceRef,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.source_binding import (
+    build_binding_records,
+    compute_equity_series_digest,
+    compute_source_digest,
+    compute_trade_ledger_digest,
+    load_json_object,
+    load_trades_from_parquet,
+    sha256_file,
+    verify_source_ref,
+)
+
+RUN_SUMMARY_REL_PATH = "run_summary.json"
+
+
+def _validate_experiment_lineage_ref(
+    *,
+    manifest_dir: Path,
+    source_ref: Mapping[str, Any],
+) -> tuple[SourceRef, dict[str, Any]]:
+    ref = verify_source_ref(source_ref, expected_domain="EXPERIMENT")
+    if ref.owner_domain != EXPERIMENT_OWNER_DOMAIN:
+        raise ComparisonMetricInputError("EXPERIMENT source_ref owner_domain mismatch")
+    manifest_path = manifest_dir / EXPERIMENT_IDENTITY_ARTIFACT
+    manifest = load_json_object(manifest_path, label=EXPERIMENT_IDENTITY_ARTIFACT)
+    validate_experiment_identity_manifest_v1(manifest)
+    integrity = manifest.get("integrity")
+    if not isinstance(integrity, dict):
+        raise ComparisonMetricInputError("experiment identity manifest missing integrity")
+    expected_digest = integrity.get("content_sha256")
+    if ref.digest != expected_digest:
+        raise ComparisonMetricInputError(
+            "EXPERIMENT source_ref digest mismatch with identity manifest"
+        )
+    experiment_identity_id = manifest.get("experiment_identity_id")
+    if ref.ref_id != experiment_identity_id:
+        raise ComparisonMetricInputError(
+            "EXPERIMENT source_ref ref_id mismatch with experiment_identity_id"
+        )
+    return ref, manifest
+
+
+def _validate_completed_run_dir(run_dir: Path) -> RunSummary:
+    if not run_dir.exists() or not run_dir.is_dir() or run_dir.is_symlink():
+        raise ComparisonMetricInputError(f"completed_run_dir invalid: {run_dir}")
+    summary_path = run_dir / RUN_SUMMARY_REL_PATH
+    if not summary_path.is_file():
+        raise ComparisonMetricInputError("completed run_dir missing run_summary.json")
+    summary = RunSummary.read_json(summary_path)
+    errors = summary.validate_contract(strict=True)
+    if errors:
+        raise ComparisonMetricInputError(f"completed run summary invalid: {'; '.join(errors)}")
+    if summary.status != "FINISHED":
+        raise ComparisonMetricInputError("experiment run must be FINISHED")
+    return summary
+
+
+def adapt_experiment_domain(
+    *,
+    manifest_dir: Path,
+    completed_run_dir: Path,
+    source_ref: Mapping[str, Any],
+) -> AdapterResult:
+    manifest_dir = manifest_dir.resolve()
+    completed_run_dir = completed_run_dir.resolve()
+    ref, manifest = _validate_experiment_lineage_ref(
+        manifest_dir=manifest_dir, source_ref=source_ref
+    )
+    identity_config = manifest.get("identity_config")
+    if not isinstance(identity_config, dict):
+        raise ComparisonMetricInputError("experiment identity manifest missing identity_config")
+    _validate_completed_run_dir(completed_run_dir)
+    comparability_metadata, evaluation_slice_id = comparability_from_experiment_identity(
+        identity_config=identity_config,
+        source_ref_id=ref.ref_id,
+    )
+    periods_per_year = ANNUALIZATION_PROFILE_V1.get(str(comparability_metadata["timeframe"]))
+    if periods_per_year is None:
+        raise ComparisonMetricInputError(
+            f"unknown timeframe: {comparability_metadata['timeframe']}"
+        )
+    equity = load_equity_curves_from_run_dir(completed_run_dir, max_curves=1)[0]
+    trades_path = completed_run_dir / TRADES_REL
+    trades = load_trades_from_parquet(trades_path)
+    config_path = completed_run_dir / CONFIG_SNAPSHOT_REL
+    if not config_path.is_file():
+        raise ComparisonMetricInputError("completed run_dir missing config_snapshot.json")
+    source_digest = compute_source_digest(
+        equity_series_digest=compute_equity_series_digest(equity),
+        trade_ledger_digest=compute_trade_ledger_digest(trades),
+    )
+    metrics = compute_all_metrics(
+        equity=equity,
+        trades=trades,
+        periods_per_year=periods_per_year,
+    )
+    equity_rel = _equity_relative_path(completed_run_dir)
+    bindings = build_binding_records(
+        SourceBindingRecord(
+            f"manifest/{EXPERIMENT_IDENTITY_ARTIFACT}",
+            sha256_file(manifest_dir / EXPERIMENT_IDENTITY_ARTIFACT),
+        ),
+        SourceBindingRecord(CONFIG_SNAPSHOT_REL, sha256_file(config_path)),
+        SourceBindingRecord(TRADES_REL, sha256_file(trades_path)),
+        SourceBindingRecord(equity_rel, sha256_file(completed_run_dir / equity_rel)),
+    )
+    return AdapterResult(
+        source_domain="EXPERIMENT",
+        source_ref=ref,
+        source_digest=source_digest,
+        evaluation_slice_id=evaluation_slice_id,
+        comparability_metadata=comparability_metadata,
+        metrics=metrics,
+        source_bindings=bindings,
+        var_suite_companion=None,
+    )

--- a/src/meta/learning_loop/comparison_metric_input_v1/adapters/var_suite.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/adapters/var_suite.py
@@ -1,0 +1,112 @@
+"""VAR_SUITE domain adapter for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.risk.validation.var_suite_backtest_wiring_v1 import SUITE_REPORT_JSON
+from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import VAR_SUITE_OWNER_DOMAIN
+from src.meta.learning_loop.comparison_metric_input_v1.adapters.backtest import (
+    adapt_backtest_domain,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import (
+    AdapterResult,
+    ComparisonMetricInputError,
+    SourceRef,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.source_binding import (
+    load_json_object,
+    verify_digest_matches_file,
+    verify_source_ref,
+)
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _validate_var_suite_lineage_ref(
+    *,
+    suite_report_dir: Path,
+    source_ref: Mapping[str, Any],
+) -> SourceRef:
+    ref = verify_source_ref(source_ref, expected_domain="VAR_SUITE")
+    if ref.owner_domain != VAR_SUITE_OWNER_DOMAIN:
+        raise ComparisonMetricInputError("VAR_SUITE source_ref owner_domain mismatch")
+    report_path = suite_report_dir / SUITE_REPORT_JSON
+    if not report_path.is_file():
+        raise ComparisonMetricInputError(f"{SUITE_REPORT_JSON} not found in suite_report_dir")
+    if ref.ref_id != suite_report_dir.name:
+        raise ComparisonMetricInputError(
+            "VAR_SUITE source_ref ref_id must equal suite_report_dir.name"
+        )
+    expected_digest = _sha256_file(report_path)
+    if ref.digest != expected_digest:
+        raise ComparisonMetricInputError(
+            "VAR_SUITE source_ref digest mismatch with suite_report.json bytes"
+        )
+    verify_digest_matches_file(report_path, expected_digest, label=SUITE_REPORT_JSON)
+    return ref
+
+
+def adapt_var_suite_domain(
+    *,
+    suite_report_dir: Path,
+    companion_run_dir: Path,
+    var_suite_source_ref: Mapping[str, Any],
+    backtest_source_ref: Mapping[str, Any],
+    evaluation_slice_id: str | None = None,
+) -> AdapterResult:
+    suite_report_dir = suite_report_dir.resolve()
+    if not suite_report_dir.is_dir() or suite_report_dir.is_symlink():
+        raise ComparisonMetricInputError(f"suite_report_dir invalid: {suite_report_dir}")
+    suite_ref = _validate_var_suite_lineage_ref(
+        suite_report_dir=suite_report_dir,
+        source_ref=var_suite_source_ref,
+    )
+    backtest_result = adapt_backtest_domain(
+        run_dir=companion_run_dir, source_ref=backtest_source_ref
+    )
+    if (
+        evaluation_slice_id is not None
+        and backtest_result.evaluation_slice_id != evaluation_slice_id
+    ):
+        raise ComparisonMetricInputError(
+            "VAR_SUITE evaluation_slice_id mismatch with companion backtest"
+        )
+    suite_report = load_json_object(
+        suite_report_dir / SUITE_REPORT_JSON,
+        label=SUITE_REPORT_JSON,
+    )
+    forbidden_metric_keys = {
+        "sharpe",
+        "max_drawdown",
+        "profit_factor",
+        "total_return",
+        "volatility",
+        "trade_count",
+    }
+    if forbidden_metric_keys & set(suite_report):
+        raise ComparisonMetricInputError(
+            "suite_report.json must not supply trading performance metrics"
+        )
+    var_suite_companion = {
+        "companion_required": True,
+        "wired_backtest_lineage_ref": backtest_result.source_ref.to_mapping(),
+        "suite_report_lineage_ref": suite_ref.to_mapping(),
+    }
+    return AdapterResult(
+        source_domain="VAR_SUITE",
+        source_ref=suite_ref,
+        source_digest=backtest_result.source_digest,
+        evaluation_slice_id=backtest_result.evaluation_slice_id,
+        comparability_metadata={
+            **backtest_result.comparability_metadata,
+            "source_domain": "VAR_SUITE",
+        },
+        metrics=backtest_result.metrics,
+        source_bindings=backtest_result.source_bindings,
+        var_suite_companion=var_suite_companion,
+    )

--- a/src/meta/learning_loop/comparison_metric_input_v1/comparability.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/comparability.py
@@ -1,0 +1,243 @@
+"""Shared comparability metadata extraction for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    COMPARABILITY_METADATA_VERSION,
+    COMPARISON_METRIC_INPUT_AUTHORITY_FLAGS,
+    METRIC_SEMANTICS_VERSION,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256, is_valid_sha256_hex
+
+
+def build_evaluation_slice_id(
+    *,
+    source_ref_id: str,
+    evaluation_start: str,
+    evaluation_end: str,
+) -> str:
+    payload = {
+        "evaluation_end": evaluation_end,
+        "evaluation_start": evaluation_start,
+        "source_ref_id": source_ref_id,
+    }
+    return compute_content_sha256(payload)
+
+
+def _require_str(mapping: Mapping[str, Any], key: str, *, label: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ComparisonMetricInputError(f"{label}.{key} must be non-empty string")
+    return value
+
+
+def _require_symbol_list(value: Any, *, label: str) -> list[str]:
+    if not isinstance(value, list) or not value or not all(isinstance(v, str) for v in value):
+        raise ComparisonMetricInputError(f"{label} must be non-empty string array")
+    return list(value)
+
+
+def build_comparability_metadata(
+    *,
+    source_domain: str,
+    source_schema_version: str,
+    timeframe: str,
+    evaluation_start: str,
+    evaluation_end: str,
+    universe: list[str],
+    instrument_set: list[str],
+    dataset_lineage_ref: str,
+    dataset_lineage_digest: str,
+    fee_model: str,
+    fee_parameters: dict[str, Any],
+    slippage_model: str,
+    slippage_parameters: dict[str, Any],
+    risk_policy_ref: str,
+    initial_capital: float,
+    capital_currency: str,
+    result_currency: str,
+    return_basis: str,
+    evaluation_slice_id: str,
+) -> dict[str, Any]:
+    if return_basis not in {"NET_EQUITY_CURVE", "GROSS_EQUITY_CURVE"}:
+        raise ComparisonMetricInputError(
+            "return_basis must be NET_EQUITY_CURVE or GROSS_EQUITY_CURVE"
+        )
+    if dataset_lineage_digest != "NOT_APPLICABLE" and not is_valid_sha256_hex(
+        dataset_lineage_digest
+    ):
+        raise ComparisonMetricInputError(
+            "dataset_lineage_digest must be sha256 hex or NOT_APPLICABLE"
+        )
+    if initial_capital <= 0.0:
+        raise ComparisonMetricInputError("initial_capital must be > 0")
+    return {
+        "timeframe": timeframe,
+        "evaluation_start": evaluation_start,
+        "evaluation_end": evaluation_end,
+        "universe": universe,
+        "instrument_set": instrument_set,
+        "dataset_lineage_ref": dataset_lineage_ref,
+        "dataset_lineage_digest": dataset_lineage_digest,
+        "fee_model": fee_model,
+        "fee_parameters": fee_parameters,
+        "slippage_model": slippage_model,
+        "slippage_parameters": slippage_parameters,
+        "risk_policy_ref": risk_policy_ref,
+        "initial_capital": float(initial_capital),
+        "capital_currency": capital_currency,
+        "result_currency": result_currency,
+        "equity_sampling_frequency": timeframe,
+        "annualization_profile": "annualization_profile_v1",
+        "return_basis": return_basis,
+        "risk_free_rate_annualized": 0.0,
+        "metric_semantics_version": METRIC_SEMANTICS_VERSION,
+        "source_schema_version": source_schema_version,
+        "source_domain": source_domain,
+        "evaluation_slice_id": evaluation_slice_id,
+        "authority_invariants": dict(COMPARISON_METRIC_INPUT_AUTHORITY_FLAGS),
+        "comparability_metadata_version": COMPARABILITY_METADATA_VERSION,
+    }
+
+
+def comparability_from_backtest_config_snapshot(
+    *,
+    config_snapshot: Mapping[str, Any],
+    run_summary_params: Mapping[str, Any],
+    source_domain: str,
+    source_ref_id: str,
+    evaluation_start: str,
+    evaluation_end: str,
+) -> tuple[dict[str, Any], str]:
+    meta = config_snapshot.get("meta")
+    params = config_snapshot.get("params")
+    if not isinstance(meta, dict) or not isinstance(params, dict):
+        raise ComparisonMetricInputError("config_snapshot must contain meta and params objects")
+    if "timeframe" in params:
+        timeframe = _require_str(params, "timeframe", label="config_snapshot.params")
+    elif "timeframe" in run_summary_params:
+        timeframe = _require_str(run_summary_params, "timeframe", label="run_summary.params")
+    else:
+        raise ComparisonMetricInputError("timeframe missing from config_snapshot/run_summary")
+    symbols = params.get("symbols")
+    if symbols is None:
+        symbols = run_summary_params.get("symbols")
+    universe = _require_symbol_list(symbols, label="symbols")
+    initial_capital = params.get("initial_capital", run_summary_params.get("initial_capital"))
+    if initial_capital is None:
+        raise ComparisonMetricInputError("initial_capital missing from config_snapshot/run_summary")
+    if not isinstance(initial_capital, (int, float)) or float(initial_capital) <= 0.0:
+        raise ComparisonMetricInputError("initial_capital must be > 0")
+    quote = universe[0].split("/")[-1] if "/" in universe[0] else "USD"
+    dataset_ref = str(meta.get("data_source") or meta.get("dataset_id") or "NOT_APPLICABLE")
+    if dataset_ref == "NOT_APPLICABLE":
+        dataset_digest = "NOT_APPLICABLE"
+    else:
+        dataset_digest = compute_content_sha256({"dataset_lineage_ref": dataset_ref})
+    fee_model = str(params.get("fee_model") or meta.get("fee_model") or "PROVABLY_ZERO")
+    slippage_model = str(
+        params.get("slippage_model") or meta.get("slippage_model") or "PROVABLY_ZERO"
+    )
+    fee_parameters = params.get("fee_parameters")
+    slippage_parameters = params.get("slippage_parameters")
+    if not isinstance(fee_parameters, dict):
+        fee_parameters = {}
+    if not isinstance(slippage_parameters, dict):
+        slippage_parameters = {}
+    risk_policy_ref = str(
+        params.get("risk_policy_ref") or meta.get("risk_policy_ref") or "NOT_APPLICABLE"
+    )
+    return_basis = str(params.get("return_basis") or meta.get("return_basis") or "NET_EQUITY_CURVE")
+    evaluation_slice_id = build_evaluation_slice_id(
+        source_ref_id=source_ref_id,
+        evaluation_start=evaluation_start,
+        evaluation_end=evaluation_end,
+    )
+    metadata = build_comparability_metadata(
+        source_domain=source_domain,
+        source_schema_version="backtest_run_artifacts_v1",
+        timeframe=timeframe,
+        evaluation_start=evaluation_start,
+        evaluation_end=evaluation_end,
+        universe=universe,
+        instrument_set=list(universe),
+        dataset_lineage_ref=dataset_ref,
+        dataset_lineage_digest=dataset_digest,
+        fee_model=fee_model,
+        fee_parameters=fee_parameters,
+        slippage_model=slippage_model,
+        slippage_parameters=slippage_parameters,
+        risk_policy_ref=risk_policy_ref,
+        initial_capital=float(initial_capital),
+        capital_currency=str(params.get("capital_currency") or quote),
+        result_currency=str(params.get("result_currency") or quote),
+        return_basis=return_basis,
+        evaluation_slice_id=evaluation_slice_id,
+    )
+    metadata.pop("comparability_metadata_version", None)
+    return metadata, evaluation_slice_id
+
+
+def comparability_from_experiment_identity(
+    *,
+    identity_config: Mapping[str, Any],
+    source_ref_id: str,
+) -> tuple[dict[str, Any], str]:
+    timeframe = _require_str(identity_config, "timeframe", label="identity_config")
+    evaluation_start = _require_str(identity_config, "start_date", label="identity_config")
+    evaluation_end = _require_str(identity_config, "end_date", label="identity_config")
+    universe = _require_symbol_list(identity_config.get("symbols"), label="identity_config.symbols")
+    initial_capital = identity_config.get("initial_capital")
+    if not isinstance(initial_capital, (int, float)) or float(initial_capital) <= 0.0:
+        raise ComparisonMetricInputError("identity_config.initial_capital must be > 0")
+    base_params = identity_config.get("base_params")
+    if not isinstance(base_params, dict):
+        raise ComparisonMetricInputError("identity_config.base_params must be object")
+    quote = universe[0].split("/")[-1] if "/" in universe[0] else "USD"
+    dataset_ref = str(base_params.get("data_source") or "NOT_APPLICABLE")
+    dataset_digest = (
+        "NOT_APPLICABLE"
+        if dataset_ref == "NOT_APPLICABLE"
+        else compute_content_sha256({"dataset_lineage_ref": dataset_ref})
+    )
+    fee_model = str(base_params.get("fee_model") or "PROVABLY_ZERO")
+    slippage_model = str(base_params.get("slippage_model") or "PROVABLY_ZERO")
+    fee_parameters = base_params.get("fee_parameters")
+    slippage_parameters = base_params.get("slippage_parameters")
+    if not isinstance(fee_parameters, dict):
+        fee_parameters = {}
+    if not isinstance(slippage_parameters, dict):
+        slippage_parameters = {}
+    risk_policy_ref = str(base_params.get("risk_policy_ref") or "NOT_APPLICABLE")
+    return_basis = str(base_params.get("return_basis") or "NET_EQUITY_CURVE")
+    evaluation_slice_id = build_evaluation_slice_id(
+        source_ref_id=source_ref_id,
+        evaluation_start=evaluation_start,
+        evaluation_end=evaluation_end,
+    )
+    metadata = build_comparability_metadata(
+        source_domain="EXPERIMENT",
+        source_schema_version="experiment_identity_manifest_v1",
+        timeframe=timeframe,
+        evaluation_start=evaluation_start,
+        evaluation_end=evaluation_end,
+        universe=universe,
+        instrument_set=list(universe),
+        dataset_lineage_ref=dataset_ref,
+        dataset_lineage_digest=dataset_digest,
+        fee_model=fee_model,
+        fee_parameters=fee_parameters,
+        slippage_model=slippage_model,
+        slippage_parameters=slippage_parameters,
+        risk_policy_ref=risk_policy_ref,
+        initial_capital=float(initial_capital),
+        capital_currency=str(base_params.get("capital_currency") or quote),
+        result_currency=str(base_params.get("result_currency") or quote),
+        return_basis=return_basis,
+        evaluation_slice_id=evaluation_slice_id,
+    )
+    metadata.pop("comparability_metadata_version", None)
+    return metadata, evaluation_slice_id

--- a/src/meta/learning_loop/comparison_metric_input_v1/constants.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/constants.py
@@ -1,0 +1,93 @@
+"""Ratified constants for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+COMPARISON_METRIC_INPUT_CONTRACT_VERSION: Final = "comparison_metric_input.v1"
+METRIC_SET_VERSION: Final = "comparison_metrics.v1"
+METRIC_SEMANTICS_VERSION: Final = "comparison_metric_semantics.v1"
+COMPARABILITY_METADATA_VERSION: Final = "comparison_comparability_metadata.v1"
+PARETO_DIRECTIONALITY_VERSION: Final = "comparison_metric_directionality.v1"
+TIE_TOLERANCE_VERSION: Final = "comparison_metric_tolerances.v1"
+IDENTITY_DOMAIN_SEPARATOR: Final = "peak_trade.comparison_metric_input.v1"
+ARTIFACT_FILENAME: Final = "comparison_metric_input_manifest_v1.json"
+SOURCE_DIGEST_RULE_VERSION: Final = "equity_trade_source_digest_v1"
+STAGING_DIRNAME_PREFIX: Final = ".comparison_metric_input_staging_"
+MINIMUM_RETURN_OBSERVATIONS: Final = 2
+
+ALLOWED_SOURCE_DOMAINS: frozenset[str] = frozenset({"EXPERIMENT", "BACKTEST", "VAR_SUITE"})
+
+METRIC_KEYS: tuple[str, ...] = (
+    "sharpe",
+    "max_drawdown",
+    "profit_factor",
+    "total_return",
+    "volatility",
+    "trade_count",
+)
+
+ANNUALIZATION_PROFILE_V1: dict[str, int] = {
+    "1m": 525600,
+    "5m": 105120,
+    "15m": 35040,
+    "1h": 8760,
+    "4h": 2190,
+    "1d": 252,
+    "1w": 52,
+}
+
+MetricDirection = Literal[
+    "MAXIMIZE",
+    "MINIMIZE",
+    "ELIGIBILITY_ONLY_NOT_OBJECTIVE",
+]
+
+PARETO_DIRECTIONALITY: dict[str, MetricDirection] = {
+    "sharpe": "MAXIMIZE",
+    "max_drawdown": "MINIMIZE",
+    "profit_factor": "MAXIMIZE",
+    "total_return": "MAXIMIZE",
+    "volatility": "MINIMIZE",
+    "trade_count": "ELIGIBILITY_ONLY_NOT_OBJECTIVE",
+}
+
+TIE_TOLERANCE_CATALOG: dict[str, float | None] = {
+    "sharpe": 1e-10,
+    "max_drawdown": 1e-12,
+    "profit_factor": 1e-10,
+    "total_return": 1e-12,
+    "volatility": 1e-10,
+    "trade_count": None,
+}
+
+CANONICAL_AUTHORITY_INVARIANTS: dict[str, str | bool] = {
+    "evidence_does_not_authorize_runtime": True,
+    "promotion_authority_impact": "NONE",
+    "runtime_authority_impact": "NONE",
+    "trading_logic_impact": "NONE",
+}
+
+COMPARISON_METRIC_INPUT_AUTHORITY_FLAGS: dict[str, bool | str] = {
+    "comparison_metric_input_is_offline_only": True,
+    "comparison_metric_input_does_not_compare": True,
+    "comparison_metric_input_does_not_rank": True,
+    "comparison_metric_input_does_not_select": True,
+    "comparison_metric_input_does_not_accept": True,
+    "comparison_metric_input_does_not_promote": True,
+    "comparison_metric_input_does_not_authorize_runtime": True,
+    "comparison_metric_input_does_not_authorize_shadow": True,
+    "comparison_metric_input_does_not_authorize_testnet": True,
+    "comparison_metric_input_does_not_authorize_live": True,
+    "comparison_metric_input_does_not_mutate_sources": True,
+    "evidence_does_not_authorize_runtime": True,
+    "promotion_authority_impact": "NONE",
+    "completion_authority_impact": "NONE",
+    "runtime_authority_impact": "NONE",
+    "trading_logic_impact": "NONE",
+    "experiment_config_impact": "NONE",
+}
+
+BACKTEST_OWNER_DOMAIN: Final = "experiments/tracking"
+EXPERIMENT_OWNER_DOMAIN: Final = "experiments/base"
+VAR_SUITE_OWNER_DOMAIN: Final = "risk/validation/var_suite_backtest_wiring_v1"

--- a/src/meta/learning_loop/comparison_metric_input_v1/identity.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/identity.py
@@ -1,0 +1,85 @@
+"""Content-addressed identity for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    COMPARABILITY_METADATA_VERSION,
+    COMPARISON_METRIC_INPUT_CONTRACT_VERSION,
+    IDENTITY_DOMAIN_SEPARATOR,
+    METRIC_SEMANTICS_VERSION,
+    METRIC_SET_VERSION,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    validate_integrity_block,
+)
+
+
+IDENTITY_PAYLOAD_FIELD_ORDER: tuple[str, ...] = (
+    "comparison_metric_input_contract_version",
+    "metric_set_version",
+    "metric_semantics_version",
+    "comparability_metadata_version",
+    "source_domain",
+    "source_ref",
+    "source_digest",
+    "evaluation_slice_id",
+    "comparability_metadata",
+    "metrics",
+    "var_suite_companion",
+    "authority_invariants",
+)
+
+
+def build_identity_payload(manifest_body: Mapping[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for field in IDENTITY_PAYLOAD_FIELD_ORDER:
+        if field not in manifest_body:
+            if field == "var_suite_companion":
+                payload[field] = None
+                continue
+            raise ComparisonMetricInputError(f"identity payload missing field: {field}")
+        value = manifest_body[field]
+        payload[field] = deepcopy(value)
+    return payload
+
+
+def compute_comparison_metric_input_id(manifest_body: Mapping[str, Any]) -> str:
+    identity_payload = build_identity_payload(manifest_body)
+    identity_payload["identity_domain"] = IDENTITY_DOMAIN_SEPARATOR
+    return compute_content_sha256(identity_payload)
+
+
+def build_manifest_without_integrity(manifest_body: Mapping[str, Any]) -> dict[str, Any]:
+    body = deepcopy(dict(manifest_body))
+    body.pop("comparison_metric_input_id", None)
+    body.pop("integrity", None)
+    return body
+
+
+def attach_identity_and_integrity(manifest_body: Mapping[str, Any]) -> dict[str, Any]:
+    body = build_manifest_without_integrity(manifest_body)
+    comparison_metric_input_id = compute_comparison_metric_input_id(body)
+    digest = compute_content_sha256(body)
+    body["comparison_metric_input_id"] = comparison_metric_input_id
+    body["integrity"] = {"content_sha256": digest}
+    return body
+
+
+def compute_integrity_digest(manifest: Mapping[str, Any]) -> str:
+    return compute_content_sha256(build_manifest_without_integrity(manifest))
+
+
+def verify_manifest_identity_and_integrity(manifest: Mapping[str, Any]) -> None:
+    expected_id = compute_comparison_metric_input_id(manifest)
+    actual_id = manifest.get("comparison_metric_input_id")
+    if actual_id != expected_id:
+        raise ComparisonMetricInputError("comparison_metric_input_id mismatch")
+    expected_digest = compute_integrity_digest(manifest)
+    result = validate_integrity_block(manifest.get("integrity"), expected_digest=expected_digest)
+    if not result.valid:
+        raise ComparisonMetricInputError("; ".join(result.errors))

--- a/src/meta/learning_loop/comparison_metric_input_v1/io.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/io.py
@@ -1,0 +1,103 @@
+"""Atomic IO for comparison_metric_input.v1 manifests."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    ARTIFACT_FILENAME,
+    STAGING_DIRNAME_PREFIX,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.identity import (
+    attach_identity_and_integrity,
+    verify_manifest_identity_and_integrity,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.comparison_metric_input_v1.validation import (
+    validate_comparison_metric_input_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{uuid.uuid4().hex}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if is_under_tmp(output_dir):
+        raise ComparisonMetricInputError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ComparisonMetricInputError(f"output parent directory missing: {parent}")
+    if is_under_tmp(parent):
+        raise ComparisonMetricInputError("output parent directory must be outside /tmp")
+
+
+def serialize_manifest(manifest: Mapping[str, Any]) -> str:
+    return deterministic_json_dumps(manifest) + "\n"
+
+
+def read_manifest(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ComparisonMetricInputError(f"invalid manifest JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ComparisonMetricInputError(f"manifest root must be object: {path}")
+    return payload
+
+
+def _self_verify_manifest_file(path: Path) -> None:
+    manifest = read_manifest(path)
+    validate_comparison_metric_input_manifest_v1(manifest)
+    verify_manifest_identity_and_integrity(manifest)
+
+
+def publish_manifest_atomic(*, output_root: Path, manifest_body: Mapping[str, Any]) -> Path:
+    manifest = attach_identity_and_integrity(manifest_body)
+    validate_comparison_metric_input_manifest_v1(manifest)
+    comparison_metric_input_id = str(manifest["comparison_metric_input_id"])
+    output_dir = output_root / comparison_metric_input_id
+    manifest_path = output_dir / ARTIFACT_FILENAME
+
+    if manifest_path.is_file():
+        existing = read_manifest(manifest_path)
+        if existing != manifest:
+            raise ComparisonMetricInputError(
+                "existing manifest content differs under canonical identity (fail-closed)"
+            )
+        _self_verify_manifest_file(manifest_path)
+        return manifest_path
+
+    if output_dir.exists():
+        raise ComparisonMetricInputError(
+            f"output directory exists without manifest (fail-closed): {output_dir}"
+        )
+
+    _validate_output_target(output_dir)
+    staging = _staging_dir_for(output_dir)
+    staging.mkdir(parents=True, exist_ok=False)
+    try:
+        staged_manifest = staging / ARTIFACT_FILENAME
+        staged_manifest.write_text(serialize_manifest(manifest), encoding="utf-8")
+        _self_verify_manifest_file(staged_manifest)
+        staging.replace(output_dir)
+    except Exception:
+        _cleanup_staging(staging)
+        raise
+    finally:
+        if staging.exists():
+            _cleanup_staging(staging)
+
+    _self_verify_manifest_file(manifest_path)
+    return manifest_path

--- a/src/meta/learning_loop/comparison_metric_input_v1/metrics.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/metrics.py
@@ -1,0 +1,167 @@
+"""Ratified metric semantics for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    METRIC_KEYS,
+    METRIC_SEMANTICS_VERSION,
+    MINIMUM_RETURN_OBSERVATIONS,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+
+
+def _reject_non_finite(value: float, *, metric: str) -> None:
+    if not math.isfinite(value):
+        raise ComparisonMetricInputError(f"{metric} must be finite, got {value!r}")
+
+
+def _returns_from_equity(equity: pd.Series) -> pd.Series:
+    if len(equity) < 2:
+        raise ComparisonMetricInputError("equity series too short for returns")
+    returns = equity.astype(float).pct_change().dropna()
+    if len(returns) < MINIMUM_RETURN_OBSERVATIONS:
+        raise ComparisonMetricInputError(
+            f"insufficient return observations: need >= {MINIMUM_RETURN_OBSERVATIONS}"
+        )
+    if returns.isna().any() or np.isinf(returns.to_numpy()).any():
+        raise ComparisonMetricInputError("returns contain NaN or Infinity")
+    return returns
+
+
+def compute_sharpe(equity: pd.Series, *, periods_per_year: int) -> float:
+    returns = _returns_from_equity(equity)
+    std = float(returns.std(ddof=1))
+    mean = float(returns.mean())
+    if std == 0.0:
+        if mean == 0.0:
+            value = 0.0
+        else:
+            raise ComparisonMetricInputError("zero volatility with non-zero mean is fail-closed")
+    else:
+        mean_return = mean * periods_per_year
+        std_return = std * math.sqrt(periods_per_year)
+        value = (mean_return - 0.0) / std_return
+    _reject_non_finite(value, metric="sharpe")
+    return float(value)
+
+
+def compute_volatility(equity: pd.Series, *, periods_per_year: int) -> float:
+    returns = _returns_from_equity(equity)
+    std = float(returns.std(ddof=1))
+    if std == 0.0 and float(returns.mean()) == 0.0:
+        value = 0.0
+    elif std == 0.0:
+        raise ComparisonMetricInputError("zero volatility with non-zero mean is fail-closed")
+    else:
+        value = std * math.sqrt(periods_per_year)
+    _reject_non_finite(value, metric="volatility")
+    if value < 0.0:
+        raise ComparisonMetricInputError("volatility must be non-negative")
+    return float(value)
+
+
+def compute_total_return(equity: pd.Series) -> float:
+    if len(equity) < 2:
+        raise ComparisonMetricInputError("equity series too short for total_return")
+    initial = float(equity.iloc[0])
+    final = float(equity.iloc[-1])
+    if initial <= 0.0:
+        raise ComparisonMetricInputError("initial equity must be positive")
+    value = (final - initial) / initial
+    _reject_non_finite(value, metric="total_return")
+    return float(value)
+
+
+def compute_max_drawdown(equity: pd.Series) -> float:
+    if len(equity) < 2:
+        raise ComparisonMetricInputError("equity series too short for max_drawdown")
+    equity_f = equity.astype(float)
+    running_max = equity_f.cummax()
+    dd = (equity_f - running_max) / running_max.replace(0.0, np.nan)
+    dd = dd.fillna(0.0)
+    value = abs(float(dd.min()))
+    _reject_non_finite(value, metric="max_drawdown")
+    if value < 0.0 or value > 1.0:
+        raise ComparisonMetricInputError("max_drawdown must be in [0, 1]")
+    return float(value)
+
+
+def _trade_pnls(trades: Sequence[Mapping[str, Any]]) -> list[float]:
+    if not trades:
+        raise ComparisonMetricInputError("trade ledger is empty")
+    pnls: list[float] = []
+    for index, trade in enumerate(trades):
+        if "pnl" not in trade:
+            raise ComparisonMetricInputError(f"trade {index} missing pnl")
+        pnl = float(trade["pnl"])
+        if not math.isfinite(pnl):
+            raise ComparisonMetricInputError(f"trade {index} pnl is not finite")
+        pnls.append(pnl)
+    return pnls
+
+
+def compute_profit_factor(trades: Sequence[Mapping[str, Any]]) -> float:
+    pnls = _trade_pnls(trades)
+    gross_profit = sum(p for p in pnls if p > 0.0)
+    gross_loss = abs(sum(p for p in pnls if p < 0.0))
+    if gross_loss == 0.0:
+        raise ComparisonMetricInputError("gross_loss=0 is fail-closed for profit_factor")
+    value = gross_profit / gross_loss
+    _reject_non_finite(value, metric="profit_factor")
+    if value < 0.0:
+        raise ComparisonMetricInputError("profit_factor must be non-negative")
+    return float(value)
+
+
+def compute_trade_count(trades: Sequence[Mapping[str, Any]]) -> int:
+    pnls = _trade_pnls(trades)
+    count = len(pnls)
+    if count == 0:
+        raise ComparisonMetricInputError("trade_count=0 is fail-closed")
+    return int(count)
+
+
+def compute_all_metrics(
+    *,
+    equity: pd.Series,
+    trades: Sequence[Mapping[str, Any]],
+    periods_per_year: int,
+) -> dict[str, float | int]:
+    metrics: dict[str, float | int] = {
+        "sharpe": compute_sharpe(equity, periods_per_year=periods_per_year),
+        "volatility": compute_volatility(equity, periods_per_year=periods_per_year),
+        "total_return": compute_total_return(equity),
+        "max_drawdown": compute_max_drawdown(equity),
+        "profit_factor": compute_profit_factor(trades),
+        "trade_count": compute_trade_count(trades),
+    }
+    for key in METRIC_KEYS:
+        if key not in metrics:
+            raise ComparisonMetricInputError(f"missing metric: {key}")
+    return metrics
+
+
+def metrics_within_tolerance(
+    left: Mapping[str, float | int],
+    right: Mapping[str, float | int],
+) -> bool:
+    from src.meta.learning_loop.comparison_metric_input_v1.constants import TIE_TOLERANCE_CATALOG
+
+    for key in METRIC_KEYS:
+        if key not in left or key not in right:
+            return False
+        if key == "trade_count":
+            if int(left[key]) != int(right[key]):
+                return False
+            continue
+        tolerance = TIE_TOLERANCE_CATALOG[key]
+        assert tolerance is not None
+        if abs(float(left[key]) - float(right[key])) > tolerance:
+            return False
+    return True

--- a/src/meta/learning_loop/comparison_metric_input_v1/models.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/models.py
@@ -1,0 +1,63 @@
+"""Typed models for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class ComparisonMetricInputError(ValueError):
+    """Fail-closed comparison metric input error."""
+
+
+@dataclass(frozen=True)
+class SourceRef:
+    owner_domain: str
+    ref_type: str
+    ref_id: str
+    digest: str
+
+    def to_mapping(self) -> dict[str, str]:
+        return {
+            "owner_domain": self.owner_domain,
+            "ref_type": self.ref_type,
+            "ref_id": self.ref_id,
+            "digest": self.digest,
+        }
+
+
+@dataclass(frozen=True)
+class SourceBindingRecord:
+    relative_path: str
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class AdapterArtifacts:
+    equity_path: Path
+    trades_path: Path
+    equity_digest: str
+    trades_digest: str
+    source_digest: str
+    bindings: tuple[SourceBindingRecord, ...]
+
+
+@dataclass(frozen=True)
+class AdapterResult:
+    source_domain: str
+    source_ref: SourceRef
+    source_digest: str
+    evaluation_slice_id: str
+    comparability_metadata: dict[str, Any]
+    metrics: dict[str, float | int]
+    source_bindings: tuple[SourceBindingRecord, ...]
+    var_suite_companion: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ComparisonMetricInputResult:
+    output_dir: Path
+    manifest_path: Path
+    comparison_metric_input_id: str
+    manifest: Mapping[str, Any]

--- a/src/meta/learning_loop/comparison_metric_input_v1/producer.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/producer.py
@@ -1,0 +1,102 @@
+"""Generic offline producer for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.meta.learning_loop.comparison_metric_input_v1.adapters import (
+    adapt_backtest_domain,
+    adapt_experiment_domain,
+    adapt_var_suite_domain,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    ARTIFACT_FILENAME,
+    CANONICAL_AUTHORITY_INVARIANTS,
+    COMPARABILITY_METADATA_VERSION,
+    COMPARISON_METRIC_INPUT_CONTRACT_VERSION,
+    METRIC_SEMANTICS_VERSION,
+    METRIC_SET_VERSION,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.io import (
+    publish_manifest_atomic,
+    read_manifest,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import (
+    AdapterResult,
+    ComparisonMetricInputError,
+    ComparisonMetricInputResult,
+)
+
+
+def _adapter_result_to_manifest_body(result: AdapterResult) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "comparison_metric_input_contract_version": COMPARISON_METRIC_INPUT_CONTRACT_VERSION,
+        "metric_set_version": METRIC_SET_VERSION,
+        "metric_semantics_version": METRIC_SEMANTICS_VERSION,
+        "comparability_metadata_version": COMPARABILITY_METADATA_VERSION,
+        "source_domain": result.source_domain,
+        "source_ref": result.source_ref.to_mapping(),
+        "source_digest": result.source_digest,
+        "evaluation_slice_id": result.evaluation_slice_id,
+        "comparability_metadata": result.comparability_metadata,
+        "metrics": dict(result.metrics),
+        "authority_invariants": dict(CANONICAL_AUTHORITY_INVARIANTS),
+    }
+    if result.var_suite_companion is not None:
+        body["var_suite_companion"] = result.var_suite_companion
+    return body
+
+
+def produce_comparison_metric_input_v1(
+    *,
+    source_domain: str,
+    output_root: Path,
+    source_ref: Mapping[str, Any],
+    run_dir: Path | None = None,
+    manifest_dir: Path | None = None,
+    completed_run_dir: Path | None = None,
+    suite_report_dir: Path | None = None,
+    companion_run_dir: Path | None = None,
+    backtest_source_ref: Mapping[str, Any] | None = None,
+    evaluation_slice_id: str | None = None,
+) -> ComparisonMetricInputResult:
+    domain = source_domain.upper()
+    if domain == "BACKTEST":
+        if run_dir is None:
+            raise ComparisonMetricInputError("run_dir required for BACKTEST domain")
+        adapter_result = adapt_backtest_domain(run_dir=run_dir, source_ref=source_ref)
+    elif domain == "EXPERIMENT":
+        if manifest_dir is None or completed_run_dir is None:
+            raise ComparisonMetricInputError(
+                "manifest_dir and completed_run_dir required for EXPERIMENT domain"
+            )
+        adapter_result = adapt_experiment_domain(
+            manifest_dir=manifest_dir,
+            completed_run_dir=completed_run_dir,
+            source_ref=source_ref,
+        )
+    elif domain == "VAR_SUITE":
+        if suite_report_dir is None or companion_run_dir is None or backtest_source_ref is None:
+            raise ComparisonMetricInputError(
+                "suite_report_dir, companion_run_dir, and backtest_source_ref required for VAR_SUITE"
+            )
+        adapter_result = adapt_var_suite_domain(
+            suite_report_dir=suite_report_dir,
+            companion_run_dir=companion_run_dir,
+            var_suite_source_ref=source_ref,
+            backtest_source_ref=backtest_source_ref,
+            evaluation_slice_id=evaluation_slice_id,
+        )
+    else:
+        raise ComparisonMetricInputError(f"unsupported source_domain: {source_domain}")
+
+    manifest_body = _adapter_result_to_manifest_body(adapter_result)
+    manifest_path = publish_manifest_atomic(output_root=output_root, manifest_body=manifest_body)
+    manifest = read_manifest(manifest_path)
+    return ComparisonMetricInputResult(
+        output_dir=manifest_path.parent,
+        manifest_path=manifest_path,
+        comparison_metric_input_id=str(manifest["comparison_metric_input_id"]),
+        manifest=manifest,
+    )

--- a/src/meta/learning_loop/comparison_metric_input_v1/source_binding.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/source_binding.py
@@ -1,0 +1,142 @@
+"""Source artifact binding and digest rules for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    METRIC_SEMANTICS_VERSION,
+    SOURCE_DIGEST_RULE_VERSION,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import (
+    ComparisonMetricInputError,
+    SourceBindingRecord,
+    SourceRef,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+
+def sha256_file(path: Path) -> str:
+    if not path.is_file():
+        raise ComparisonMetricInputError(f"source file not found: {path}")
+    if path.is_symlink():
+        raise ComparisonMetricInputError(f"source file must not be a symlink: {path}")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def compute_equity_series_digest(equity: pd.Series) -> str:
+    payload = {
+        "timestamps": [ts.isoformat() for ts in equity.index],
+        "values": [float(v) for v in equity.astype(float).to_numpy()],
+    }
+    return compute_content_sha256(payload)
+
+
+def compute_trade_ledger_digest(trades: Sequence[Mapping[str, Any]]) -> str:
+    payload = {
+        "trades": [{"pnl": float(trade["pnl"])} for trade in trades],
+    }
+    return compute_content_sha256(payload)
+
+
+def compute_source_digest(*, equity_series_digest: str, trade_ledger_digest: str) -> str:
+    payload = {
+        "rule_version": SOURCE_DIGEST_RULE_VERSION,
+        "equity_series_digest": equity_series_digest,
+        "trade_ledger_digest": trade_ledger_digest,
+        "metric_semantics_version": METRIC_SEMANTICS_VERSION,
+    }
+    return compute_content_sha256(payload)
+
+
+def load_trades_from_parquet(path: Path) -> list[dict[str, float]]:
+    if not path.is_file():
+        raise ComparisonMetricInputError(f"trades file not found: {path}")
+    if path.is_symlink():
+        raise ComparisonMetricInputError(f"trades file must not be a symlink: {path}")
+    try:
+        frame = pd.read_parquet(path)
+    except Exception as exc:  # noqa: BLE001 - fail-closed surface
+        raise ComparisonMetricInputError(f"failed to read trades parquet: {path}: {exc}") from exc
+    if "pnl" not in frame.columns:
+        raise ComparisonMetricInputError(f"trades parquet missing pnl column: {path}")
+    trades: list[dict[str, float]] = []
+    for index, row in frame.iterrows():
+        pnl = row["pnl"]
+        if pd.isna(pnl):
+            raise ComparisonMetricInputError(f"trade row {index} has NaN pnl")
+        trades.append({"pnl": float(pnl)})
+    if not trades:
+        raise ComparisonMetricInputError("trade ledger is empty")
+    return trades
+
+
+def verify_source_ref(ref: Mapping[str, Any], *, expected_domain: str) -> SourceRef:
+    required = ("owner_domain", "ref_type", "ref_id", "digest")
+    for key in required:
+        if key not in ref:
+            raise ComparisonMetricInputError(f"source_ref missing {key}")
+        if not isinstance(ref[key], str) or not ref[key].strip():
+            raise ComparisonMetricInputError(f"source_ref.{key} must be non-empty string")
+    digest = ref["digest"]
+    if not is_valid_sha256_hex(digest):
+        raise ComparisonMetricInputError("source_ref.digest must be lowercase sha256 hex")
+    ref_type = ref["ref_type"]
+    if ref_type != expected_domain:
+        raise ComparisonMetricInputError(
+            f"source_ref.ref_type {ref_type!r} must match domain {expected_domain!r}"
+        )
+    return SourceRef(
+        owner_domain=str(ref["owner_domain"]),
+        ref_type=str(ref_type),
+        ref_id=str(ref["ref_id"]),
+        digest=str(digest),
+    )
+
+
+def verify_digest_matches_file(path: Path, expected_digest: str, *, label: str) -> None:
+    actual = sha256_file(path)
+    if actual != expected_digest:
+        raise ComparisonMetricInputError(
+            f"{label} digest mismatch: expected {expected_digest}, got {actual}"
+        )
+
+
+def build_binding_records(*records: SourceBindingRecord) -> tuple[SourceBindingRecord, ...]:
+    return tuple(records)
+
+
+def binding_records_to_mapping(records: Sequence[SourceBindingRecord]) -> list[dict[str, str]]:
+    return [
+        {"relative_path": record.relative_path, "content_sha256": record.content_sha256}
+        for record in records
+    ]
+
+
+def load_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise ComparisonMetricInputError(f"{label} not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ComparisonMetricInputError(f"invalid JSON in {label}: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ComparisonMetricInputError(f"{label} root must be object: {path}")
+    return payload
+
+
+def canonical_lineage_ref_mapping(ref: SourceRef) -> dict[str, str]:
+    return ref.to_mapping()
+
+
+def serialize_binding_snapshot(bindings: Sequence[SourceBindingRecord]) -> str:
+    return deterministic_json_dumps(binding_records_to_mapping(bindings))

--- a/src/meta/learning_loop/comparison_metric_input_v1/validation.py
+++ b/src/meta/learning_loop/comparison_metric_input_v1/validation.py
@@ -1,0 +1,230 @@
+"""Manifest validation for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    ALLOWED_SOURCE_DOMAINS,
+    ANNUALIZATION_PROFILE_V1,
+    CANONICAL_AUTHORITY_INVARIANTS,
+    COMPARABILITY_METADATA_VERSION,
+    COMPARISON_METRIC_INPUT_CONTRACT_VERSION,
+    METRIC_KEYS,
+    METRIC_SEMANTICS_VERSION,
+    METRIC_SET_VERSION,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.identity import (
+    verify_manifest_identity_and_integrity,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.comparison_metric_input_v1.source_binding import verify_source_ref
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+_REQUIRED_TOP_LEVEL = (
+    "comparison_metric_input_contract_version",
+    "metric_set_version",
+    "metric_semantics_version",
+    "comparability_metadata_version",
+    "source_domain",
+    "source_ref",
+    "source_digest",
+    "evaluation_slice_id",
+    "comparability_metadata",
+    "metrics",
+    "authority_invariants",
+    "integrity",
+)
+
+_COMPARABILITY_REQUIRED = (
+    "timeframe",
+    "evaluation_start",
+    "evaluation_end",
+    "universe",
+    "instrument_set",
+    "dataset_lineage_ref",
+    "dataset_lineage_digest",
+    "fee_model",
+    "fee_parameters",
+    "slippage_model",
+    "slippage_parameters",
+    "risk_policy_ref",
+    "initial_capital",
+    "capital_currency",
+    "result_currency",
+    "equity_sampling_frequency",
+    "annualization_profile",
+    "return_basis",
+    "risk_free_rate_annualized",
+    "metric_semantics_version",
+    "source_schema_version",
+    "source_domain",
+    "evaluation_slice_id",
+    "authority_invariants",
+)
+
+
+def _reject_unknown_keys(
+    payload: Mapping[str, Any], *, allowed: frozenset[str], label: str
+) -> None:
+    unknown = set(payload) - allowed
+    if unknown:
+        raise ComparisonMetricInputError(f"{label} contains unknown keys: {sorted(unknown)}")
+
+
+def _validate_finite_number(value: Any, *, field: str) -> None:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ComparisonMetricInputError(f"{field} must be numeric")
+    if not math.isfinite(float(value)):
+        raise ComparisonMetricInputError(f"{field} must be finite")
+
+
+def validate_metrics_block(metrics: Any) -> None:
+    if not isinstance(metrics, dict):
+        raise ComparisonMetricInputError("metrics must be an object")
+    _reject_unknown_keys(metrics, allowed=frozenset(METRIC_KEYS), label="metrics")
+    for key in METRIC_KEYS:
+        if key not in metrics:
+            raise ComparisonMetricInputError(f"metrics missing required key: {key}")
+    for key in ("sharpe", "profit_factor", "total_return", "volatility"):
+        _validate_finite_number(metrics[key], field=f"metrics.{key}")
+    _validate_finite_number(metrics["max_drawdown"], field="metrics.max_drawdown")
+    max_dd = float(metrics["max_drawdown"])
+    if max_dd < 0.0 or max_dd > 1.0:
+        raise ComparisonMetricInputError("metrics.max_drawdown must be in [0, 1]")
+    trade_count = metrics["trade_count"]
+    if not isinstance(trade_count, int) or isinstance(trade_count, bool):
+        raise ComparisonMetricInputError("metrics.trade_count must be integer")
+    if trade_count < 0:
+        raise ComparisonMetricInputError("metrics.trade_count must be non-negative")
+    pf = float(metrics["profit_factor"])
+    if pf < 0.0:
+        raise ComparisonMetricInputError("metrics.profit_factor must be non-negative")
+    vol = float(metrics["volatility"])
+    if vol < 0.0:
+        raise ComparisonMetricInputError("metrics.volatility must be non-negative")
+
+
+def validate_comparability_metadata(metadata: Any, *, source_domain: str) -> None:
+    if not isinstance(metadata, dict):
+        raise ComparisonMetricInputError("comparability_metadata must be an object")
+    allowed = frozenset(_COMPARABILITY_REQUIRED)
+    _reject_unknown_keys(metadata, allowed=allowed, label="comparability_metadata")
+    for key in _COMPARABILITY_REQUIRED:
+        if key not in metadata:
+            raise ComparisonMetricInputError(f"comparability_metadata missing {key}")
+    timeframe = metadata["timeframe"]
+    if not isinstance(timeframe, str) or not timeframe.strip():
+        raise ComparisonMetricInputError("comparability_metadata.timeframe must be non-empty")
+    if timeframe not in ANNUALIZATION_PROFILE_V1:
+        raise ComparisonMetricInputError(f"unknown timeframe: {timeframe}")
+    if metadata["annualization_profile"] != "annualization_profile_v1":
+        raise ComparisonMetricInputError("annualization_profile must be annualization_profile_v1")
+    if metadata["metric_semantics_version"] != METRIC_SEMANTICS_VERSION:
+        raise ComparisonMetricInputError("metric_semantics_version mismatch")
+    if metadata["source_domain"] != source_domain:
+        raise ComparisonMetricInputError("comparability_metadata.source_domain mismatch")
+    if metadata["risk_free_rate_annualized"] != 0.0:
+        raise ComparisonMetricInputError("risk_free_rate_annualized must be exactly 0.0")
+    if metadata["return_basis"] not in {"NET_EQUITY_CURVE", "GROSS_EQUITY_CURVE"}:
+        raise ComparisonMetricInputError("invalid return_basis")
+    initial_capital = metadata["initial_capital"]
+    if not isinstance(initial_capital, (int, float)) or float(initial_capital) <= 0.0:
+        raise ComparisonMetricInputError("initial_capital must be > 0")
+    for key in ("universe", "instrument_set"):
+        value = metadata[key]
+        if not isinstance(value, list) or not value or not all(isinstance(v, str) for v in value):
+            raise ComparisonMetricInputError(
+                f"comparability_metadata.{key} must be non-empty string array"
+            )
+    digest = metadata["dataset_lineage_digest"]
+    if digest != "NOT_APPLICABLE" and not is_valid_sha256_hex(str(digest)):
+        raise ComparisonMetricInputError("dataset_lineage_digest must be sha256 or NOT_APPLICABLE")
+    if not isinstance(metadata["fee_parameters"], dict):
+        raise ComparisonMetricInputError("fee_parameters must be object")
+    if not isinstance(metadata["slippage_parameters"], dict):
+        raise ComparisonMetricInputError("slippage_parameters must be object")
+    if not isinstance(metadata["authority_invariants"], dict):
+        raise ComparisonMetricInputError(
+            "comparability_metadata.authority_invariants must be object"
+        )
+
+
+def validate_authority_invariants(block: Any) -> None:
+    if not isinstance(block, dict):
+        raise ComparisonMetricInputError("authority_invariants must be an object")
+    allowed = frozenset(CANONICAL_AUTHORITY_INVARIANTS)
+    _reject_unknown_keys(block, allowed=allowed, label="authority_invariants")
+    for key, expected in CANONICAL_AUTHORITY_INVARIANTS.items():
+        if block.get(key) != expected:
+            raise ComparisonMetricInputError(
+                f"authority_invariants.{key} must equal canonical value"
+            )
+
+
+def validate_var_suite_companion(block: Any | None, *, source_domain: str) -> None:
+    if source_domain != "VAR_SUITE":
+        if block is not None:
+            raise ComparisonMetricInputError("var_suite_companion only allowed for VAR_SUITE")
+        return
+    if not isinstance(block, dict):
+        raise ComparisonMetricInputError("var_suite_companion required for VAR_SUITE")
+    allowed = frozenset(
+        {"companion_required", "wired_backtest_lineage_ref", "suite_report_lineage_ref"}
+    )
+    _reject_unknown_keys(block, allowed=allowed, label="var_suite_companion")
+    if block.get("companion_required") is not True:
+        raise ComparisonMetricInputError("var_suite_companion.companion_required must be true")
+    wired = block["wired_backtest_lineage_ref"]
+    suite = block["suite_report_lineage_ref"]
+    verify_source_ref(wired, expected_domain="BACKTEST")
+    verify_source_ref(suite, expected_domain="VAR_SUITE")
+
+
+def validate_comparison_metric_input_manifest_v1(manifest: Mapping[str, Any]) -> None:
+    if not isinstance(manifest, dict):
+        raise ComparisonMetricInputError("manifest root must be object")
+    allowed_top = frozenset(
+        _REQUIRED_TOP_LEVEL + ("comparison_metric_input_id", "var_suite_companion")
+    )
+    _reject_unknown_keys(manifest, allowed=allowed_top, label="manifest")
+    for key in _REQUIRED_TOP_LEVEL:
+        if key not in manifest:
+            raise ComparisonMetricInputError(f"manifest missing required field: {key}")
+    if (
+        manifest["comparison_metric_input_contract_version"]
+        != COMPARISON_METRIC_INPUT_CONTRACT_VERSION
+    ):
+        raise ComparisonMetricInputError("comparison_metric_input_contract_version mismatch")
+    if manifest["metric_set_version"] != METRIC_SET_VERSION:
+        raise ComparisonMetricInputError("metric_set_version mismatch")
+    if manifest["metric_semantics_version"] != METRIC_SEMANTICS_VERSION:
+        raise ComparisonMetricInputError("metric_semantics_version mismatch")
+    if manifest["comparability_metadata_version"] != COMPARABILITY_METADATA_VERSION:
+        raise ComparisonMetricInputError("comparability_metadata_version mismatch")
+    source_domain = manifest["source_domain"]
+    if source_domain not in ALLOWED_SOURCE_DOMAINS:
+        raise ComparisonMetricInputError(f"unknown source_domain: {source_domain}")
+    verify_source_ref(manifest["source_ref"], expected_domain=str(source_domain))
+    source_digest = manifest["source_digest"]
+    if not is_valid_sha256_hex(str(source_digest)):
+        raise ComparisonMetricInputError("source_digest must be lowercase sha256 hex")
+    evaluation_slice_id = manifest["evaluation_slice_id"]
+    if not isinstance(evaluation_slice_id, str) or not evaluation_slice_id.strip():
+        raise ComparisonMetricInputError("evaluation_slice_id must be non-empty")
+    validate_metrics_block(manifest["metrics"])
+    validate_comparability_metadata(
+        manifest["comparability_metadata"], source_domain=str(source_domain)
+    )
+    if manifest["comparability_metadata"]["evaluation_slice_id"] != evaluation_slice_id:
+        raise ComparisonMetricInputError(
+            "evaluation_slice_id mismatch between top-level and metadata"
+        )
+    validate_authority_invariants(manifest["authority_invariants"])
+    validate_var_suite_companion(
+        manifest.get("var_suite_companion"),
+        source_domain=str(source_domain),
+    )
+    if "comparison_metric_input_id" in manifest:
+        verify_manifest_identity_and_integrity(manifest)

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5724,7 +5724,9 @@ PACKAGE_COMPARISON_METRIC_INPUT_ALL_TESTOWNERS = (
 )
 
 
-def test_selector_package_comparison_metric_input_production_pr_bounded_full_includes_testowners() -> None:
+def test_selector_package_comparison_metric_input_production_pr_bounded_full_includes_testowners() -> (
+    None
+):
     sel = _run_selector(PACKAGE_COMPARISON_METRIC_INPUT_PRODUCTION)
     assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
     bounded = _bounded_targets(sel)
@@ -5732,7 +5734,9 @@ def test_selector_package_comparison_metric_input_production_pr_bounded_full_inc
         assert path in bounded
 
 
-def test_selector_package_comparison_metric_input_script_contract_focused_includes_testowners() -> None:
+def test_selector_package_comparison_metric_input_script_contract_focused_includes_testowners() -> (
+    None
+):
     sel = _run_selector(PACKAGE_COMPARISON_METRIC_INPUT_SCRIPT)
     assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
     targets = _targets(sel)
@@ -5740,7 +5744,9 @@ def test_selector_package_comparison_metric_input_script_contract_focused_includ
         assert path in targets
 
 
-def test_selector_package_comparison_metric_input_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+def test_selector_package_comparison_metric_input_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
     sel = _run_selector(
         *PACKAGE_COMPARISON_METRIC_INPUT_ALL_PRODUCTION,
         "scripts/ops/ci_test_selection_v1.py",

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5688,3 +5688,81 @@ def test_selector_package_e21_full_six_file_diff_pr_bounded_full_not_no_op() -> 
     bounded = _bounded_targets(sel)
     for path in PACKAGE_E21_ALL_TESTOWNERS:
         assert path in bounded
+
+
+PACKAGE_COMPARISON_METRIC_INPUT_PRODUCTION = (
+    "src/meta/learning_loop/comparison_metric_input_v1/producer.py"
+)
+PACKAGE_COMPARISON_METRIC_INPUT_SCRIPT = "scripts/run_comparison_metric_input_v1.py"
+PACKAGE_COMPARISON_METRIC_INPUT_TESTOWNERS = (
+    "tests/meta/test_comparison_metric_input_identity_v1.py",
+    "tests/meta/test_comparison_metric_input_validation_v1.py",
+    "tests/meta/test_comparison_metric_input_metrics_v1.py",
+    "tests/meta/test_comparison_metric_input_source_binding_v1.py",
+    "tests/meta/test_comparison_metric_input_producer_v1.py",
+    "tests/meta/test_comparison_metric_input_replay_v1.py",
+    "tests/meta/test_comparison_metric_input_adapters_v1.py",
+    "tests/scripts/test_run_comparison_metric_input_v1.py",
+)
+PACKAGE_COMPARISON_METRIC_INPUT_DEPENDENCY_TESTOWNERS = (
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
+    "tests/governance/promotion_loop/test_experiment_lineage_ref_producer_v1.py",
+    "tests/governance/promotion_loop/test_var_suite_lineage_ref_producer_v1.py",
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
+    "tests/experiments/test_equity_loader.py",
+    "tests/meta/test_var_suite_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+PACKAGE_COMPARISON_METRIC_INPUT_ALL_PRODUCTION = (
+    PACKAGE_COMPARISON_METRIC_INPUT_PRODUCTION,
+    PACKAGE_COMPARISON_METRIC_INPUT_SCRIPT,
+)
+PACKAGE_COMPARISON_METRIC_INPUT_ALL_TESTOWNERS = (
+    *PACKAGE_COMPARISON_METRIC_INPUT_TESTOWNERS,
+    *PACKAGE_COMPARISON_METRIC_INPUT_DEPENDENCY_TESTOWNERS,
+)
+
+
+def test_selector_package_comparison_metric_input_production_pr_bounded_full_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_COMPARISON_METRIC_INPUT_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_COMPARISON_METRIC_INPUT_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_comparison_metric_input_script_contract_focused_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_COMPARISON_METRIC_INPUT_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    for path in PACKAGE_COMPARISON_METRIC_INPUT_ALL_TESTOWNERS:
+        assert path in targets
+
+
+def test_selector_package_comparison_metric_input_combined_diff_pr_bounded_full_includes_all_testowners_once() -> None:
+    sel = _run_selector(
+        *PACKAGE_COMPARISON_METRIC_INPUT_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_COMPARISON_METRIC_INPUT_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_COMPARISON_METRIC_INPUT_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+
+
+def test_selector_package_comparison_metric_input_metrics_owner_pr_bounded_full_not_no_op() -> None:
+    sel = _run_selector(
+        "src/meta/learning_loop/comparison_metric_input_v1/metrics.py",
+        PACKAGE_COMPARISON_METRIC_INPUT_TESTOWNERS[2],
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_mode"] != "NO_OP"
+    assert sel["test_selection_mode"] != "FOCUSED"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_COMPARISON_METRIC_INPUT_ALL_TESTOWNERS:
+        assert path in bounded

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,6 @@ import sys
 import warnings
 from pathlib import Path
 
-pytest_plugins = ["tests.meta.comparison_metric_input_v1_fixtures"]
-
 import pytest
 
 # ============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,8 @@ import sys
 import warnings
 from pathlib import Path
 
+pytest_plugins = ["tests.meta.comparison_metric_input_v1_fixtures"]
+
 import pytest
 
 # ============================================================================

--- a/tests/meta/comparison_metric_input_v1_fixtures.py
+++ b/tests/meta/comparison_metric_input_v1_fixtures.py
@@ -1,0 +1,182 @@
+"""Shared fixtures for comparison_metric_input_v1 tests."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.experiment_identity_manifest_v1 import produce_experiment_identity_manifest_v1
+from src.experiments.tracking.run_summary import RunSummary
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import lineage_ref_to_mapping
+from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+    RUN_SUMMARY_REL_PATH,
+    build_backtest_lineage_ref_from_run_summary,
+)
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    produce_experiment_lineage_ref_v1,
+)
+from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import (
+    produce_var_suite_lineage_ref_v1,
+)
+from src.risk.validation.var_suite_backtest_wiring_v1 import SUITE_REPORT_JSON
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".comparison_metric_input_pytest_outputs"
+
+FIXED_STARTED = "2025-01-15T10:00:00+00:00"
+FIXED_FINISHED = "2025-01-20T10:00:00+00:00"
+RUN_ID = "cmp-metric-run-001"
+SYMBOLS = ["ETH/USDT:USDT"]
+
+GOLDEN_METRICS = {
+    "sharpe": 7.463815111313766,
+    "volatility": 0.22422070129952124,
+    "total_return": 0.04,
+    "max_drawdown": 0.014563106796116505,
+    "profit_factor": 4.0,
+    "trade_count": 4,
+}
+GOLDEN_EQUITY_SERIES_DIGEST = "8369d37532c0c0984f8e692f172892c0f6cd7ffe47a85ee6ecbf012a7dc7f53a"
+GOLDEN_TRADE_LEDGER_DIGEST = "2b326c7d1f5bd78ec890458eb89cadc0633e4dbfd38d0a740d23c8dea0cd5c6b"
+GOLDEN_SOURCE_DIGEST = "ecd909cabf20131fa39d6ce1aa03d73f29bbd1a77795a2c2fe2fcb4c16c5a547"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_metric_input_v1.io.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+@pytest.fixture
+def durable_output_dir() -> Path:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+    path.mkdir(parents=True, exist_ok=True)
+    yield path
+    if path.exists():
+        shutil.rmtree(path, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".comparison_metric_input_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".experiment_identity_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def comparison_source_ref(ref_mapping: dict[str, Any]) -> dict[str, str]:
+    return {
+        "owner_domain": str(ref_mapping["owner_domain"]),
+        "ref_type": str(ref_mapping["ref_type"]).upper(),
+        "ref_id": str(ref_mapping["ref_id"]),
+        "digest": str(ref_mapping["digest"]),
+    }
+
+
+def sample_experiment_config(**overrides: Any) -> ExperimentConfig:
+    base = ExperimentConfig(
+        name="cmp metric test",
+        strategy_name="ma_crossover",
+        param_sweeps=[ParamSweep(name="fast", values=[10])],
+        symbols=SYMBOLS,
+        timeframe="1d",
+        start_date="2025-01-01",
+        end_date="2025-01-20",
+        initial_capital=10000.0,
+        base_params={"return_basis": "NET_EQUITY_CURVE"},
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def write_equity_csv(run_dir: Path, values: list[float] | None = None) -> None:
+    values = values or [10000.0, 10100.0, 10050.0, 10200.0, 10300.0, 10150.0, 10400.0]
+    rows = []
+    for idx, equity in enumerate(values):
+        rows.append({"timestamp": f"2025-01-{idx + 1:02d}T00:00:00+00:00", "equity": equity})
+    pd.DataFrame(rows).to_csv(run_dir / "equity.csv", index=False)
+
+
+def write_trades_parquet(run_dir: Path, pnls: list[float] | None = None) -> None:
+    pnls = pnls or [100.0, -50.0, 75.0, 25.0]
+    pd.DataFrame({"pnl": pnls}).to_parquet(run_dir / "trades.parquet", index=False)
+
+
+def write_config_snapshot(run_dir: Path) -> None:
+    payload = {
+        "meta": {"data_source": "synthetic_fixture_v1"},
+        "params": {
+            "symbols": SYMBOLS,
+            "timeframe": "1d",
+            "initial_capital": 10000.0,
+            "return_basis": "NET_EQUITY_CURVE",
+            "fee_model": "PROVABLY_ZERO",
+            "slippage_model": "PROVABLY_ZERO",
+        },
+    }
+    (run_dir / "config_snapshot.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def write_run_summary(run_dir: Path, *, run_id: str = RUN_ID) -> RunSummary:
+    summary = RunSummary(
+        run_id=run_id,
+        started_at_utc=FIXED_STARTED,
+        finished_at_utc=FIXED_FINISHED,
+        status="FINISHED",
+        params={
+            "symbols": SYMBOLS,
+            "timeframe": "1d",
+            "initial_capital": 10000.0,
+        },
+    )
+    summary.write_json(run_dir / RUN_SUMMARY_REL_PATH)
+    return summary
+
+
+def build_backtest_run_dir(tmp_path: Path, *, run_id: str = RUN_ID) -> tuple[Path, dict[str, str]]:
+    run_dir = tmp_path / run_id
+    run_dir.mkdir(parents=True)
+    summary = write_run_summary(run_dir, run_id=run_id)
+    write_config_snapshot(run_dir)
+    write_equity_csv(run_dir)
+    write_trades_parquet(run_dir)
+    ref = build_backtest_lineage_ref_from_run_summary(summary)
+    return run_dir, comparison_source_ref(lineage_ref_to_mapping(ref))
+
+
+def build_experiment_bundle(
+    tmp_path: Path,
+    completed_run_dir: Path,
+) -> tuple[Path, dict[str, str], Path]:
+    manifest_dir = _DURABLE_OUTPUT_ROOT / f"identity_{uuid.uuid4().hex}"
+    produce_experiment_identity_manifest_v1(
+        sample_experiment_config(),
+        manifest_dir,
+        source_experiment_id="source-exp-001",
+    )
+    lineage = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    ref = comparison_source_ref(lineage_ref_to_mapping(lineage.ref))
+    return manifest_dir, ref, completed_run_dir
+
+
+def build_var_suite_bundle(
+    tmp_path: Path,
+    *,
+    companion_run_dir: Path,
+    backtest_ref: dict[str, str],
+) -> tuple[Path, dict[str, str], dict[str, str]]:
+    suite_dir = tmp_path / "suite_run_candidate"
+    suite_dir.mkdir()
+    report = {"overall_result": "PASS", "checks": []}
+    (suite_dir / SUITE_REPORT_JSON).write_text(json.dumps(report), encoding="utf-8")
+    var_ref = comparison_source_ref(
+        lineage_ref_to_mapping(produce_var_suite_lineage_ref_v1(report_dir=suite_dir).ref)
+    )
+    return suite_dir, var_ref, backtest_ref

--- a/tests/meta/comparison_metric_input_v1_fixtures.py
+++ b/tests/meta/comparison_metric_input_v1_fixtures.py
@@ -54,6 +54,10 @@ def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
         "src.meta.learning_loop.comparison_metric_input_v1.io.is_under_tmp",
         lambda _path: False,
     )
+    monkeypatch.setattr(
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
+        lambda _path: False,
+    )
 
 
 @pytest.fixture
@@ -155,7 +159,7 @@ def build_experiment_bundle(
     tmp_path: Path,
     completed_run_dir: Path,
 ) -> tuple[Path, dict[str, str], Path]:
-    manifest_dir = _DURABLE_OUTPUT_ROOT / f"identity_{uuid.uuid4().hex}"
+    manifest_dir = tmp_path / f"identity_{uuid.uuid4().hex}"
     produce_experiment_identity_manifest_v1(
         sample_experiment_config(),
         manifest_dir,

--- a/tests/meta/conftest.py
+++ b/tests/meta/conftest.py
@@ -1,0 +1,3 @@
+"""Pytest plugins scoped to comparison_metric_input_v1 testowners only."""
+
+pytest_plugins = ["tests.meta.comparison_metric_input_v1_fixtures"]

--- a/tests/meta/test_comparison_metric_input_adapters_v1.py
+++ b/tests/meta/test_comparison_metric_input_adapters_v1.py
@@ -1,0 +1,188 @@
+"""Adapter tests for BACKTEST, EXPERIMENT, and VAR_SUITE comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.meta.learning_loop.comparison_metric_input_v1.adapters.backtest import (
+    adapt_backtest_domain,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.adapters.experiment import (
+    adapt_experiment_domain,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.adapters.var_suite import (
+    adapt_var_suite_domain,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.constants import METRIC_KEYS
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.comparison_metric_input_v1.source_binding import (
+    verify_digest_matches_file,
+)
+from src.risk.validation.var_suite_backtest_wiring_v1 import SUITE_REPORT_JSON
+from tests.meta.comparison_metric_input_v1_fixtures import (
+    GOLDEN_METRICS,
+    GOLDEN_SOURCE_DIGEST,
+    build_backtest_run_dir,
+    build_experiment_bundle,
+    build_var_suite_bundle,
+)
+
+
+def test_adapt_backtest_domain_happy_path(tmp_path) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    result = adapt_backtest_domain(run_dir=run_dir, source_ref=ref)
+    assert result.source_domain == "BACKTEST"
+    assert result.metrics == GOLDEN_METRICS
+    assert result.source_digest == GOLDEN_SOURCE_DIGEST
+    assert set(result.metrics) == set(METRIC_KEYS)
+
+
+def test_adapt_backtest_domain_rejects_bad_digest(tmp_path) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    bad = dict(ref)
+    bad["digest"] = "0" * 64
+    with pytest.raises(ComparisonMetricInputError, match="digest mismatch"):
+        adapt_backtest_domain(run_dir=run_dir, source_ref=bad)
+
+
+def test_adapt_backtest_domain_rejects_non_finished_run(tmp_path) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    summary_path = run_dir / "run_summary.json"
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    payload["status"] = "RUNNING"
+    summary_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ComparisonMetricInputError, match="must be FINISHED"):
+        adapt_backtest_domain(run_dir=run_dir, source_ref=ref)
+
+
+def test_adapt_backtest_domain_rejects_missing_equity(tmp_path) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    (run_dir / "equity.csv").unlink()
+    with pytest.raises((ComparisonMetricInputError, FileNotFoundError), match="equity"):
+        adapt_backtest_domain(run_dir=run_dir, source_ref=ref)
+
+
+def test_adapt_experiment_domain_happy_path(tmp_path) -> None:
+    completed_dir, _ = build_backtest_run_dir(tmp_path / "completed")
+    manifest_dir, exp_ref, completed = build_experiment_bundle(tmp_path, completed_dir)
+    result = adapt_experiment_domain(
+        manifest_dir=manifest_dir,
+        completed_run_dir=completed,
+        source_ref=exp_ref,
+    )
+    assert result.source_domain == "EXPERIMENT"
+    assert result.metrics["trade_count"] == GOLDEN_METRICS["trade_count"]
+
+
+def test_adapt_experiment_domain_rejects_missing_completed_run_summary(tmp_path) -> None:
+    completed_dir, _ = build_backtest_run_dir(tmp_path / "completed")
+    manifest_dir, exp_ref, completed = build_experiment_bundle(tmp_path, completed_dir)
+    (completed / "run_summary.json").unlink()
+    with pytest.raises(ComparisonMetricInputError, match="missing run_summary.json"):
+        adapt_experiment_domain(
+            manifest_dir=manifest_dir,
+            completed_run_dir=completed,
+            source_ref=exp_ref,
+        )
+
+
+def test_adapt_experiment_domain_rejects_ref_id_mismatch(tmp_path) -> None:
+    completed_dir, _ = build_backtest_run_dir(tmp_path / "completed")
+    manifest_dir, exp_ref, completed = build_experiment_bundle(tmp_path, completed_dir)
+    bad = dict(exp_ref)
+    bad["ref_id"] = "wrong-id"
+    with pytest.raises(ComparisonMetricInputError, match="ref_id mismatch"):
+        adapt_experiment_domain(
+            manifest_dir=manifest_dir,
+            completed_run_dir=completed,
+            source_ref=bad,
+        )
+
+
+def test_adapt_var_suite_domain_happy_path(tmp_path) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    result = adapt_var_suite_domain(
+        suite_report_dir=suite_dir,
+        companion_run_dir=run_dir,
+        var_suite_source_ref=var_ref,
+        backtest_source_ref=backtest_ref,
+    )
+    assert result.source_domain == "VAR_SUITE"
+    assert result.var_suite_companion is not None
+    assert result.metrics == GOLDEN_METRICS
+
+
+def test_adapt_var_suite_domain_rejects_suite_report_metrics(tmp_path) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir = tmp_path / "suite_run_candidate"
+    suite_dir.mkdir()
+    report = {"overall_result": "PASS", "checks": [], "sharpe": 1.0}
+    (suite_dir / SUITE_REPORT_JSON).write_text(json.dumps(report), encoding="utf-8")
+    from src.governance.promotion_loop.var_suite_lineage_ref_producer_v1 import (
+        produce_var_suite_lineage_ref_v1,
+    )
+    from src.governance.promotion_loop.candidate_lineage_manifest_v1 import lineage_ref_to_mapping
+    from tests.meta.comparison_metric_input_v1_fixtures import comparison_source_ref
+
+    var_ref = comparison_source_ref(
+        lineage_ref_to_mapping(produce_var_suite_lineage_ref_v1(report_dir=suite_dir).ref)
+    )
+    with pytest.raises(
+        ComparisonMetricInputError, match="must not supply trading performance metrics"
+    ):
+        adapt_var_suite_domain(
+            suite_report_dir=suite_dir,
+            companion_run_dir=run_dir,
+            var_suite_source_ref=var_ref,
+            backtest_source_ref=backtest_ref,
+        )
+
+
+def test_adapt_var_suite_domain_rejects_ref_id_not_equal_dir_name(tmp_path) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    bad = dict(var_ref)
+    bad["ref_id"] = "not-the-dir-name"
+    with pytest.raises(ComparisonMetricInputError, match="ref_id must equal suite_report_dir.name"):
+        adapt_var_suite_domain(
+            suite_report_dir=suite_dir,
+            companion_run_dir=run_dir,
+            var_suite_source_ref=bad,
+            backtest_source_ref=backtest_ref,
+        )
+
+
+def test_adapt_var_suite_domain_rejects_evaluation_slice_override_mismatch(tmp_path) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    with pytest.raises(ComparisonMetricInputError, match="evaluation_slice_id mismatch"):
+        adapt_var_suite_domain(
+            suite_report_dir=suite_dir,
+            companion_run_dir=run_dir,
+            var_suite_source_ref=var_ref,
+            backtest_source_ref=backtest_ref,
+            evaluation_slice_id="deadbeef" * 8,
+        )
+
+
+def test_adapt_backtest_verify_digest_matches_file_detects_file_tampering(tmp_path) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    adapt_backtest_domain(run_dir=run_dir, source_ref=ref)
+    summary_path = run_dir / "run_summary.json"
+    with pytest.raises(ComparisonMetricInputError, match="digest mismatch"):
+        verify_digest_matches_file(summary_path, "0" * 64, label="run_summary.json")

--- a/tests/meta/test_comparison_metric_input_identity_v1.py
+++ b/tests/meta/test_comparison_metric_input_identity_v1.py
@@ -1,0 +1,121 @@
+"""Identity and digest tests for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    COMPARISON_METRIC_INPUT_CONTRACT_VERSION,
+    IDENTITY_DOMAIN_SEPARATOR,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.identity import (
+    IDENTITY_PAYLOAD_FIELD_ORDER,
+    attach_identity_and_integrity,
+    build_identity_payload,
+    build_manifest_without_integrity,
+    compute_comparison_metric_input_id,
+    compute_integrity_digest,
+    verify_manifest_identity_and_integrity,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.comparison_metric_input_v1.producer import (
+    produce_comparison_metric_input_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256
+from tests.meta.comparison_metric_input_v1_fixtures import build_backtest_run_dir
+
+
+def _produce_backtest_manifest(tmp_path, durable_output_dir):
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    result = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    return result.manifest
+
+
+def test_identity_payload_field_order_is_stable() -> None:
+    assert IDENTITY_PAYLOAD_FIELD_ORDER[0] == "comparison_metric_input_contract_version"
+    assert IDENTITY_PAYLOAD_FIELD_ORDER[-1] == "authority_invariants"
+
+
+def test_build_identity_payload_includes_var_suite_companion_none(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _produce_backtest_manifest(tmp_path, durable_output_dir)
+    payload = build_identity_payload(manifest)
+    assert payload["var_suite_companion"] is None
+
+
+def test_compute_comparison_metric_input_id_uses_identity_domain_separator(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _produce_backtest_manifest(tmp_path, durable_output_dir)
+    body = build_manifest_without_integrity(manifest)
+    payload = build_identity_payload(body)
+    payload["identity_domain"] = IDENTITY_DOMAIN_SEPARATOR
+    expected = compute_content_sha256(payload)
+    assert manifest["comparison_metric_input_id"] == expected
+
+
+def test_attach_identity_and_integrity_is_deterministic(tmp_path, durable_output_dir) -> None:
+    manifest = _produce_backtest_manifest(tmp_path, durable_output_dir)
+    body = build_manifest_without_integrity(manifest)
+    first = attach_identity_and_integrity(body)
+    second = attach_identity_and_integrity(body)
+    assert first["comparison_metric_input_id"] == second["comparison_metric_input_id"]
+    assert first["integrity"] == second["integrity"]
+
+
+def test_compute_integrity_digest_matches_integrity_block(tmp_path, durable_output_dir) -> None:
+    manifest = _produce_backtest_manifest(tmp_path, durable_output_dir)
+    assert compute_integrity_digest(manifest) == manifest["integrity"]["content_sha256"]
+
+
+def test_verify_manifest_identity_and_integrity_accepts_valid_manifest(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _produce_backtest_manifest(tmp_path, durable_output_dir)
+    verify_manifest_identity_and_integrity(manifest)
+
+
+def test_verify_manifest_identity_and_integrity_rejects_id_mismatch(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = copy.deepcopy(_produce_backtest_manifest(tmp_path, durable_output_dir))
+    manifest["comparison_metric_input_id"] = "0" * 64
+    with pytest.raises(ComparisonMetricInputError, match="comparison_metric_input_id mismatch"):
+        verify_manifest_identity_and_integrity(manifest)
+
+
+def test_verify_manifest_identity_and_integrity_rejects_integrity_mismatch(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = copy.deepcopy(_produce_backtest_manifest(tmp_path, durable_output_dir))
+    manifest["integrity"] = {"content_sha256": "0" * 64}
+    with pytest.raises(ComparisonMetricInputError):
+        verify_manifest_identity_and_integrity(manifest)
+
+
+def test_build_manifest_without_integrity_strips_identity_fields(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _produce_backtest_manifest(tmp_path, durable_output_dir)
+    stripped = build_manifest_without_integrity(manifest)
+    assert "comparison_metric_input_id" not in stripped
+    assert "integrity" not in stripped
+    assert (
+        stripped["comparison_metric_input_contract_version"]
+        == COMPARISON_METRIC_INPUT_CONTRACT_VERSION
+    )
+
+
+def test_identity_payload_missing_required_field_fail_closed() -> None:
+    with pytest.raises(ComparisonMetricInputError, match="identity payload missing field"):
+        build_identity_payload(
+            {"comparison_metric_input_contract_version": COMPARISON_METRIC_INPUT_CONTRACT_VERSION}
+        )

--- a/tests/meta/test_comparison_metric_input_metrics_v1.py
+++ b/tests/meta/test_comparison_metric_input_metrics_v1.py
@@ -1,0 +1,131 @@
+"""Golden and fail-closed tests for comparison_metric_input.v1 metrics."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    METRIC_KEYS,
+    TIE_TOLERANCE_CATALOG,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.metrics import (
+    compute_all_metrics,
+    compute_max_drawdown,
+    compute_profit_factor,
+    compute_sharpe,
+    compute_total_return,
+    compute_trade_count,
+    compute_volatility,
+    metrics_within_tolerance,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from tests.meta.comparison_metric_input_v1_fixtures import (
+    GOLDEN_METRICS,
+    write_equity_csv,
+    write_trades_parquet,
+)
+
+
+def _equity_series(values: list[float]) -> pd.Series:
+    index = pd.date_range("2025-01-01", periods=len(values), freq="D")
+    return pd.Series(values, index=index)
+
+
+def _trades(pnls: list[float]) -> list[dict[str, float]]:
+    return [{"pnl": pnl} for pnl in pnls]
+
+
+def test_golden_compute_all_metrics_matches_fixture_catalog() -> None:
+    equity = _equity_series([10000.0, 10100.0, 10050.0, 10200.0, 10300.0, 10150.0, 10400.0])
+    metrics = compute_all_metrics(
+        equity=equity, trades=_trades([100.0, -50.0, 75.0, 25.0]), periods_per_year=252
+    )
+    assert metrics == GOLDEN_METRICS
+
+
+@pytest.mark.parametrize("metric", METRIC_KEYS)
+def test_golden_metric_keys_present(metric: str) -> None:
+    equity = _equity_series([10000.0, 10100.0, 10050.0, 10200.0, 10300.0, 10150.0, 10400.0])
+    metrics = compute_all_metrics(
+        equity=equity, trades=_trades([100.0, -50.0, 75.0, 25.0]), periods_per_year=252
+    )
+    assert metric in metrics
+
+
+def test_compute_sharpe_zero_volatility_zero_mean_returns_zero() -> None:
+    equity = _equity_series([100.0, 100.0, 100.0])
+    assert compute_sharpe(equity, periods_per_year=252) == 0.0
+
+
+def test_compute_sharpe_zero_volatility_non_zero_mean_fail_closed() -> None:
+    equity = _equity_series([100.0, 110.0, 121.0])
+    with pytest.raises(ComparisonMetricInputError, match="zero volatility with non-zero mean"):
+        compute_sharpe(equity, periods_per_year=252)
+
+
+def test_compute_total_return_requires_positive_initial_equity() -> None:
+    equity = _equity_series([0.0, 1.0, 2.0])
+    with pytest.raises(ComparisonMetricInputError, match="initial equity must be positive"):
+        compute_total_return(equity)
+
+
+def test_compute_max_drawdown_out_of_range_fail_closed() -> None:
+    equity = pd.Series([1.0, -1.0], index=pd.date_range("2025-01-01", periods=2, freq="D"))
+    with pytest.raises(ComparisonMetricInputError, match="max_drawdown must be in"):
+        compute_max_drawdown(equity)
+
+
+def test_compute_profit_factor_zero_gross_loss_fail_closed() -> None:
+    with pytest.raises(ComparisonMetricInputError, match="gross_loss=0"):
+        compute_profit_factor(_trades([10.0, 5.0]))
+
+
+def test_compute_trade_count_empty_ledger_fail_closed() -> None:
+    with pytest.raises(ComparisonMetricInputError, match="trade ledger is empty"):
+        compute_trade_count([])
+
+
+def test_returns_with_nan_fail_closed() -> None:
+    equity = _equity_series([100.0, 0.0, 100.0])
+    with pytest.raises(ComparisonMetricInputError, match="returns contain NaN or Infinity"):
+        compute_volatility(equity, periods_per_year=252)
+
+
+def test_metrics_within_tolerance_exact_match() -> None:
+    assert metrics_within_tolerance(GOLDEN_METRICS, dict(GOLDEN_METRICS)) is True
+
+
+def test_metrics_within_tolerance_respects_trade_count_exactness() -> None:
+    left = dict(GOLDEN_METRICS)
+    right = dict(GOLDEN_METRICS)
+    right["trade_count"] = int(right["trade_count"]) + 1
+    assert metrics_within_tolerance(left, right) is False
+
+
+def test_metrics_within_tolerance_respects_numeric_tolerance() -> None:
+    left = dict(GOLDEN_METRICS)
+    right = dict(GOLDEN_METRICS)
+    tol = TIE_TOLERANCE_CATALOG["sharpe"]
+    assert tol is not None
+    right["sharpe"] = float(left["sharpe"]) + tol * 2
+    assert metrics_within_tolerance(left, right) is False
+
+
+def test_fixture_artifacts_support_metric_recompute(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_equity_csv(run_dir)
+    write_trades_parquet(run_dir)
+    frame = pd.read_csv(run_dir / "equity.csv")
+    equity = pd.Series(frame["equity"].values, index=pd.to_datetime(frame["timestamp"]))
+    trades = pd.read_parquet(run_dir / "trades.parquet")
+    recomputed = compute_all_metrics(
+        equity=equity,
+        trades=[{"pnl": float(v)} for v in trades["pnl"].tolist()],
+        periods_per_year=252,
+    )
+    assert math.isfinite(float(recomputed["sharpe"]))

--- a/tests/meta/test_comparison_metric_input_producer_v1.py
+++ b/tests/meta/test_comparison_metric_input_producer_v1.py
@@ -1,0 +1,194 @@
+"""Producer, atomic publish, and self-verify tests for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import json
+import shutil
+
+import pytest
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import ARTIFACT_FILENAME
+from src.meta.learning_loop.comparison_metric_input_v1.io import (
+    publish_manifest_atomic,
+    read_manifest,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.comparison_metric_input_v1.producer import (
+    produce_comparison_metric_input_v1,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.validation import (
+    validate_comparison_metric_input_manifest_v1,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.identity import (
+    verify_manifest_identity_and_integrity,
+)
+from tests.meta.comparison_metric_input_v1_fixtures import (
+    build_backtest_run_dir,
+    build_experiment_bundle,
+    build_var_suite_bundle,
+)
+
+
+def test_produce_backtest_writes_manifest_and_self_verifies(tmp_path, durable_output_dir) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    result = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    assert result.manifest_path.is_file()
+    assert result.output_dir.name == result.comparison_metric_input_id
+    validate_comparison_metric_input_manifest_v1(result.manifest)
+    verify_manifest_identity_and_integrity(result.manifest)
+
+
+def test_produce_backtest_is_idempotent(tmp_path, durable_output_dir) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    first = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    second = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    assert first.manifest_path == second.manifest_path
+    assert first.comparison_metric_input_id == second.comparison_metric_input_id
+
+
+def test_produce_experiment_domain_happy_path(tmp_path, durable_output_dir) -> None:
+    completed_dir, _ = build_backtest_run_dir(tmp_path / "completed")
+    manifest_dir, exp_ref, completed = build_experiment_bundle(tmp_path, completed_dir)
+    result = produce_comparison_metric_input_v1(
+        source_domain="EXPERIMENT",
+        output_root=durable_output_dir,
+        source_ref=exp_ref,
+        manifest_dir=manifest_dir,
+        completed_run_dir=completed,
+    )
+    assert result.manifest["source_domain"] == "EXPERIMENT"
+
+
+def test_produce_var_suite_domain_includes_companion_block(tmp_path, durable_output_dir) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    result = produce_comparison_metric_input_v1(
+        source_domain="VAR_SUITE",
+        output_root=durable_output_dir,
+        source_ref=var_ref,
+        suite_report_dir=suite_dir,
+        companion_run_dir=run_dir,
+        backtest_source_ref=backtest_ref,
+    )
+    assert result.manifest["var_suite_companion"]["companion_required"] is True
+
+
+def test_produce_backtest_requires_run_dir(durable_output_dir) -> None:
+    with pytest.raises(ComparisonMetricInputError, match="run_dir required"):
+        produce_comparison_metric_input_v1(
+            source_domain="BACKTEST",
+            output_root=durable_output_dir,
+            source_ref={
+                "owner_domain": "x",
+                "ref_type": "BACKTEST",
+                "ref_id": "y",
+                "digest": "d" * 64,
+            },
+        )
+
+
+def test_produce_experiment_requires_manifest_and_completed_run(durable_output_dir) -> None:
+    with pytest.raises(ComparisonMetricInputError, match="manifest_dir and completed_run_dir"):
+        produce_comparison_metric_input_v1(
+            source_domain="EXPERIMENT",
+            output_root=durable_output_dir,
+            source_ref={
+                "owner_domain": "x",
+                "ref_type": "EXPERIMENT",
+                "ref_id": "y",
+                "digest": "d" * 64,
+            },
+        )
+
+
+def test_publish_manifest_atomic_rejects_existing_dir_without_manifest(
+    tmp_path, durable_output_dir, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_metric_input_v1.io.is_under_tmp",
+        lambda _path: False,
+    )
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    produced = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    orphan = produced.output_dir
+    manifest_path = orphan / ARTIFACT_FILENAME
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    shutil.rmtree(orphan)
+    orphan.mkdir()
+    with pytest.raises(ComparisonMetricInputError, match="exists without manifest"):
+        publish_manifest_atomic(output_root=durable_output_dir, manifest_body=payload)
+
+
+def test_publish_manifest_atomic_rejects_tmp_output(
+    tmp_path, durable_output_dir, monkeypatch
+) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    produced = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    body = read_manifest(produced.manifest_path)
+    body.pop("comparison_metric_input_id", None)
+    body.pop("integrity", None)
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_metric_input_v1.io.is_under_tmp",
+        lambda _path: True,
+    )
+    with pytest.raises(ComparisonMetricInputError, match="must be outside /tmp"):
+        publish_manifest_atomic(output_root=tmp_path / "tmp_root", manifest_body=body)
+
+
+def test_publish_manifest_atomic_self_verifies_written_manifest(
+    tmp_path, durable_output_dir
+) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    produced = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    on_disk = json.loads(produced.manifest_path.read_text(encoding="utf-8"))
+    validate_comparison_metric_input_manifest_v1(on_disk)
+    verify_manifest_identity_and_integrity(on_disk)
+
+
+def test_produce_unsupported_domain_fail_closed(durable_output_dir) -> None:
+    with pytest.raises(ComparisonMetricInputError, match="unsupported source_domain"):
+        produce_comparison_metric_input_v1(
+            source_domain="UNKNOWN",
+            output_root=durable_output_dir,
+            source_ref={
+                "owner_domain": "x",
+                "ref_type": "BACKTEST",
+                "ref_id": "y",
+                "digest": "d" * 64,
+            },
+            run_dir=durable_output_dir,
+        )

--- a/tests/meta/test_comparison_metric_input_replay_v1.py
+++ b/tests/meta/test_comparison_metric_input_replay_v1.py
@@ -1,0 +1,195 @@
+"""Deterministic replay tests for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import json
+
+from src.meta.learning_loop.comparison_metric_input_v1.io import read_manifest, serialize_manifest
+from src.meta.learning_loop.comparison_metric_input_v1.producer import (
+    produce_comparison_metric_input_v1,
+)
+from tests.meta.comparison_metric_input_v1_fixtures import (
+    build_backtest_run_dir,
+    build_experiment_bundle,
+    build_var_suite_bundle,
+)
+
+
+def test_backtest_replay_is_deterministic(tmp_path, durable_output_dir) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    out_a = durable_output_dir / "a"
+    out_b = durable_output_dir / "b"
+    out_a.mkdir()
+    out_b.mkdir()
+    first = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=out_a,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    second = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=out_b,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    assert first.comparison_metric_input_id == second.comparison_metric_input_id
+    assert serialize_manifest(first.manifest) == serialize_manifest(second.manifest)
+
+
+def test_experiment_replay_is_deterministic(tmp_path, durable_output_dir) -> None:
+    completed_dir, _ = build_backtest_run_dir(tmp_path / "completed")
+    manifest_dir, exp_ref, completed = build_experiment_bundle(tmp_path, completed_dir)
+    out_a = durable_output_dir / "a"
+    out_b = durable_output_dir / "b"
+    out_a.mkdir()
+    out_b.mkdir()
+    first = produce_comparison_metric_input_v1(
+        source_domain="EXPERIMENT",
+        output_root=out_a,
+        source_ref=exp_ref,
+        manifest_dir=manifest_dir,
+        completed_run_dir=completed,
+    )
+    second = produce_comparison_metric_input_v1(
+        source_domain="EXPERIMENT",
+        output_root=out_b,
+        source_ref=exp_ref,
+        manifest_dir=manifest_dir,
+        completed_run_dir=completed,
+    )
+    assert first.comparison_metric_input_id == second.comparison_metric_input_id
+
+
+def test_var_suite_replay_is_deterministic(tmp_path, durable_output_dir) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    out_a = durable_output_dir / "a"
+    out_b = durable_output_dir / "b"
+    out_a.mkdir()
+    out_b.mkdir()
+    first = produce_comparison_metric_input_v1(
+        source_domain="VAR_SUITE",
+        output_root=out_a,
+        source_ref=var_ref,
+        suite_report_dir=suite_dir,
+        companion_run_dir=run_dir,
+        backtest_source_ref=backtest_ref,
+    )
+    second = produce_comparison_metric_input_v1(
+        source_domain="VAR_SUITE",
+        output_root=out_b,
+        source_ref=var_ref,
+        suite_report_dir=suite_dir,
+        companion_run_dir=run_dir,
+        backtest_source_ref=backtest_ref,
+    )
+    assert first.comparison_metric_input_id == second.comparison_metric_input_id
+
+
+def test_replay_manifest_bytes_are_stable(tmp_path, durable_output_dir) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    result = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    first_bytes = result.manifest_path.read_bytes()
+    replay = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    assert replay.manifest_path.read_bytes() == first_bytes
+
+
+def test_read_manifest_roundtrip_matches_serialized_form(tmp_path, durable_output_dir) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    result = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    loaded = read_manifest(result.manifest_path)
+    assert json.loads(serialize_manifest(loaded)) == loaded
+
+
+def test_replay_metrics_block_is_identical_across_domains(tmp_path, durable_output_dir) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    out_backtest = durable_output_dir / "backtest"
+    out_var = durable_output_dir / "var"
+    out_backtest.mkdir()
+    out_var.mkdir()
+    backtest = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=out_backtest,
+        source_ref=backtest_ref,
+        run_dir=run_dir,
+    )
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    var_suite = produce_comparison_metric_input_v1(
+        source_domain="VAR_SUITE",
+        output_root=out_var,
+        source_ref=var_ref,
+        suite_report_dir=suite_dir,
+        companion_run_dir=run_dir,
+        backtest_source_ref=backtest_ref,
+    )
+    assert backtest.manifest["metrics"] == var_suite.manifest["metrics"]
+
+
+def test_replay_source_digest_matches_for_var_suite_companion_backtest(
+    tmp_path, durable_output_dir
+) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    out_backtest = durable_output_dir / "backtest"
+    out_var = durable_output_dir / "var"
+    out_backtest.mkdir()
+    out_var.mkdir()
+    backtest = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=out_backtest,
+        source_ref=backtest_ref,
+        run_dir=run_dir,
+    )
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    var_suite = produce_comparison_metric_input_v1(
+        source_domain="VAR_SUITE",
+        output_root=out_var,
+        source_ref=var_ref,
+        suite_report_dir=suite_dir,
+        companion_run_dir=run_dir,
+        backtest_source_ref=backtest_ref,
+    )
+    assert var_suite.manifest["source_digest"] == backtest.manifest["source_digest"]
+
+
+def test_replay_evaluation_slice_id_stable_for_backtest(tmp_path, durable_output_dir) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    ids = []
+    for suffix in ("one", "two", "three"):
+        out = durable_output_dir / suffix
+        out.mkdir()
+        result = produce_comparison_metric_input_v1(
+            source_domain="BACKTEST",
+            output_root=out,
+            source_ref=ref,
+            run_dir=run_dir,
+        )
+        ids.append(result.manifest["evaluation_slice_id"])
+    assert len(set(ids)) == 1

--- a/tests/meta/test_comparison_metric_input_source_binding_v1.py
+++ b/tests/meta/test_comparison_metric_input_source_binding_v1.py
@@ -1,0 +1,132 @@
+"""Source binding and digest tests for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.comparison_metric_input_v1.source_binding import (
+    binding_records_to_mapping,
+    compute_equity_series_digest,
+    compute_source_digest,
+    compute_trade_ledger_digest,
+    load_json_object,
+    load_trades_from_parquet,
+    serialize_binding_snapshot,
+    sha256_file,
+    verify_digest_matches_file,
+    verify_source_ref,
+)
+from tests.meta.comparison_metric_input_v1_fixtures import (
+    GOLDEN_EQUITY_SERIES_DIGEST,
+    GOLDEN_SOURCE_DIGEST,
+    GOLDEN_TRADE_LEDGER_DIGEST,
+    build_backtest_run_dir,
+    comparison_source_ref,
+    write_equity_csv,
+    write_trades_parquet,
+)
+
+
+def _equity_series() -> pd.Series:
+    values = [10000.0, 10100.0, 10050.0, 10200.0, 10300.0, 10150.0, 10400.0]
+    index = pd.date_range("2025-01-01", periods=len(values), freq="D")
+    return pd.Series(values, index=index)
+
+
+def test_compute_equity_series_digest_golden(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_equity_csv(run_dir)
+    frame = pd.read_csv(run_dir / "equity.csv")
+    equity = pd.Series(frame["equity"].values, index=pd.to_datetime(frame["timestamp"]))
+    assert compute_equity_series_digest(equity) == GOLDEN_EQUITY_SERIES_DIGEST
+
+
+def test_compute_trade_ledger_digest_golden() -> None:
+    trades = [{"pnl": 100.0}, {"pnl": -50.0}, {"pnl": 75.0}, {"pnl": 25.0}]
+    assert compute_trade_ledger_digest(trades) == GOLDEN_TRADE_LEDGER_DIGEST
+
+
+def test_compute_source_digest_golden() -> None:
+    digest = compute_source_digest(
+        equity_series_digest=GOLDEN_EQUITY_SERIES_DIGEST,
+        trade_ledger_digest=GOLDEN_TRADE_LEDGER_DIGEST,
+    )
+    assert digest == GOLDEN_SOURCE_DIGEST
+
+
+def test_verify_source_ref_accepts_backtest_mapping(tmp_path) -> None:
+    _, ref = build_backtest_run_dir(tmp_path)
+    parsed = verify_source_ref(ref, expected_domain="BACKTEST")
+    assert parsed.ref_type == "BACKTEST"
+
+
+def test_verify_source_ref_rejects_domain_mismatch(tmp_path) -> None:
+    _, ref = build_backtest_run_dir(tmp_path)
+    with pytest.raises(ComparisonMetricInputError, match="must match domain"):
+        verify_source_ref(ref, expected_domain="EXPERIMENT")
+
+
+def test_verify_source_ref_rejects_invalid_digest(tmp_path) -> None:
+    _, ref = build_backtest_run_dir(tmp_path)
+    bad = dict(ref)
+    bad["digest"] = "not-a-digest"
+    with pytest.raises(ComparisonMetricInputError, match="lowercase sha256 hex"):
+        verify_source_ref(bad, expected_domain="BACKTEST")
+
+
+def test_load_trades_from_parquet_roundtrip(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_trades_parquet(run_dir)
+    trades = load_trades_from_parquet(run_dir / "trades.parquet")
+    assert trades == [{"pnl": 100.0}, {"pnl": -50.0}, {"pnl": 75.0}, {"pnl": 25.0}]
+
+
+def test_load_trades_from_parquet_missing_column_fail_closed(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    pd.DataFrame({"x": [1.0]}).to_parquet(run_dir / "trades.parquet")
+    with pytest.raises(ComparisonMetricInputError, match="missing pnl column"):
+        load_trades_from_parquet(run_dir / "trades.parquet")
+
+
+def test_sha256_file_and_verify_digest_matches_file(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_equity_csv(run_dir)
+    path = run_dir / "equity.csv"
+    digest = sha256_file(path)
+    verify_digest_matches_file(path, digest, label="equity.csv")
+
+
+def test_verify_digest_matches_file_rejects_mismatch(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_equity_csv(run_dir)
+    with pytest.raises(ComparisonMetricInputError, match="digest mismatch"):
+        verify_digest_matches_file(run_dir / "equity.csv", "0" * 64, label="equity.csv")
+
+
+def test_load_json_object_requires_object_root(tmp_path) -> None:
+    path = tmp_path / "payload.json"
+    path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    with pytest.raises(ComparisonMetricInputError, match="root must be object"):
+        load_json_object(path, label="payload")
+
+
+def test_binding_snapshot_serialization_is_deterministic() -> None:
+    from src.meta.learning_loop.comparison_metric_input_v1.models import SourceBindingRecord
+
+    records = (
+        SourceBindingRecord("a.json", "a" * 64),
+        SourceBindingRecord("b.json", "b" * 64),
+    )
+    first = serialize_binding_snapshot(records)
+    second = serialize_binding_snapshot(records)
+    assert first == second
+    assert binding_records_to_mapping(records) == json.loads(first)

--- a/tests/meta/test_comparison_metric_input_validation_v1.py
+++ b/tests/meta/test_comparison_metric_input_validation_v1.py
@@ -1,0 +1,171 @@
+"""Schema validation adversarial tests for comparison_metric_input.v1."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import METRIC_KEYS
+from src.meta.learning_loop.comparison_metric_input_v1.models import ComparisonMetricInputError
+from src.meta.learning_loop.comparison_metric_input_v1.producer import (
+    produce_comparison_metric_input_v1,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.validation import (
+    validate_authority_invariants,
+    validate_comparison_metric_input_manifest_v1,
+    validate_comparability_metadata,
+    validate_metrics_block,
+    validate_var_suite_companion,
+)
+from tests.meta.comparison_metric_input_v1_fixtures import (
+    build_backtest_run_dir,
+    build_experiment_bundle,
+    build_var_suite_bundle,
+)
+
+
+def _valid_manifest(tmp_path, durable_output_dir) -> dict:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    result = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_output_dir,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    return copy.deepcopy(dict(result.manifest))
+
+
+def test_validate_comparison_metric_input_manifest_v1_accepts_produced_manifest(
+    tmp_path, durable_output_dir
+) -> None:
+    validate_comparison_metric_input_manifest_v1(_valid_manifest(tmp_path, durable_output_dir))
+
+
+def test_validate_metrics_block_rejects_unknown_key() -> None:
+    metrics = {key: 1 for key in METRIC_KEYS}
+    metrics["unexpected"] = 1
+    with pytest.raises(ComparisonMetricInputError, match="unknown keys"):
+        validate_metrics_block(metrics)
+
+
+def test_validate_metrics_block_rejects_missing_key() -> None:
+    metrics = {key: 1 for key in METRIC_KEYS}
+    metrics.pop("sharpe")
+    with pytest.raises(ComparisonMetricInputError, match="missing required key"):
+        validate_metrics_block(metrics)
+
+
+def test_validate_metrics_block_rejects_non_finite_sharpe() -> None:
+    metrics = {key: 1 for key in METRIC_KEYS}
+    metrics["sharpe"] = float("inf")
+    with pytest.raises(ComparisonMetricInputError, match="must be finite"):
+        validate_metrics_block(metrics)
+
+
+def test_validate_metrics_block_rejects_negative_profit_factor() -> None:
+    metrics = {key: 1 for key in METRIC_KEYS}
+    metrics["profit_factor"] = -1.0
+    with pytest.raises(ComparisonMetricInputError, match="profit_factor must be non-negative"):
+        validate_metrics_block(metrics)
+
+
+def test_validate_metrics_block_rejects_bool_trade_count() -> None:
+    metrics = {key: 1 for key in METRIC_KEYS}
+    metrics["trade_count"] = True
+    with pytest.raises(ComparisonMetricInputError, match="trade_count must be integer"):
+        validate_metrics_block(metrics)
+
+
+def test_validate_comparability_metadata_rejects_unknown_timeframe(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _valid_manifest(tmp_path, durable_output_dir)
+    metadata = copy.deepcopy(manifest["comparability_metadata"])
+    metadata["timeframe"] = "999x"
+    with pytest.raises(ComparisonMetricInputError, match="unknown timeframe"):
+        validate_comparability_metadata(metadata, source_domain="BACKTEST")
+
+
+def test_validate_comparability_metadata_rejects_non_zero_risk_free_rate(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _valid_manifest(tmp_path, durable_output_dir)
+    metadata = copy.deepcopy(manifest["comparability_metadata"])
+    metadata["risk_free_rate_annualized"] = 0.01
+    with pytest.raises(ComparisonMetricInputError, match="must be exactly 0.0"):
+        validate_comparability_metadata(metadata, source_domain="BACKTEST")
+
+
+def test_validate_authority_invariants_rejects_unknown_key() -> None:
+    block = {"evidence_does_not_authorize_runtime": True, "unexpected": True}
+    with pytest.raises(ComparisonMetricInputError, match="unknown keys"):
+        validate_authority_invariants(block)
+
+
+def test_validate_manifest_rejects_source_domain_mismatch_in_metadata(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _valid_manifest(tmp_path, durable_output_dir)
+    manifest["comparability_metadata"]["source_domain"] = "EXPERIMENT"
+    with pytest.raises(ComparisonMetricInputError, match="source_domain mismatch"):
+        validate_comparison_metric_input_manifest_v1(manifest)
+
+
+def test_validate_manifest_rejects_evaluation_slice_id_mismatch(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _valid_manifest(tmp_path, durable_output_dir)
+    manifest["evaluation_slice_id"] = "changed"
+    with pytest.raises(ComparisonMetricInputError, match="evaluation_slice_id mismatch"):
+        validate_comparison_metric_input_manifest_v1(manifest)
+
+
+def test_validate_var_suite_companion_required_for_var_suite(tmp_path, durable_output_dir) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    result = produce_comparison_metric_input_v1(
+        source_domain="VAR_SUITE",
+        output_root=durable_output_dir,
+        source_ref=var_ref,
+        suite_report_dir=suite_dir,
+        companion_run_dir=run_dir,
+        backtest_source_ref=backtest_ref,
+    )
+    manifest = copy.deepcopy(dict(result.manifest))
+    manifest.pop("var_suite_companion", None)
+    with pytest.raises(ComparisonMetricInputError, match="var_suite_companion required"):
+        validate_comparison_metric_input_manifest_v1(manifest)
+
+
+def test_validate_var_suite_companion_rejects_forbidden_on_backtest(
+    tmp_path, durable_output_dir
+) -> None:
+    manifest = _valid_manifest(tmp_path, durable_output_dir)
+    manifest["var_suite_companion"] = {"companion_required": True}
+    with pytest.raises(ComparisonMetricInputError, match="only allowed for VAR_SUITE"):
+        validate_comparison_metric_input_manifest_v1(manifest)
+
+
+def test_validate_var_suite_companion_accepts_produced_var_suite_manifest(
+    tmp_path, durable_output_dir
+) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    result = produce_comparison_metric_input_v1(
+        source_domain="VAR_SUITE",
+        output_root=durable_output_dir,
+        source_ref=var_ref,
+        suite_report_dir=suite_dir,
+        companion_run_dir=run_dir,
+        backtest_source_ref=backtest_ref,
+    )
+    validate_var_suite_companion(result.manifest["var_suite_companion"], source_domain="VAR_SUITE")

--- a/tests/scripts/test_run_comparison_metric_input_v1.py
+++ b/tests/scripts/test_run_comparison_metric_input_v1.py
@@ -1,0 +1,190 @@
+"""CLI tests for scripts/run_comparison_metric_input_v1.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.run_comparison_metric_input_v1 import build_parser, main
+from src.meta.learning_loop.comparison_metric_input_v1.constants import ARTIFACT_FILENAME
+from tests.meta.comparison_metric_input_v1_fixtures import (
+    build_backtest_run_dir,
+    build_experiment_bundle,
+    build_var_suite_bundle,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / "scripts" / "run_comparison_metric_input_v1.py"
+
+
+def _write_ref(path: Path, ref: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(ref), encoding="utf-8")
+
+
+def test_build_parser_requires_source_domain_and_output_root() -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+def test_cli_backtest_happy_path(tmp_path, durable_output_dir) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    ref_path = tmp_path / "backtest_ref.json"
+    _write_ref(ref_path, ref)
+    rc = main(
+        [
+            "--source-domain",
+            "BACKTEST",
+            "--output-root",
+            str(durable_output_dir),
+            "--source-ref",
+            str(ref_path),
+            "--run-dir",
+            str(run_dir),
+        ]
+    )
+    assert rc == 0
+
+
+def test_cli_experiment_happy_path(tmp_path, durable_output_dir) -> None:
+    completed_dir, _ = build_backtest_run_dir(tmp_path / "completed")
+    manifest_dir, exp_ref, completed = build_experiment_bundle(tmp_path, completed_dir)
+    ref_path = tmp_path / "experiment_ref.json"
+    _write_ref(ref_path, exp_ref)
+    rc = main(
+        [
+            "--source-domain",
+            "EXPERIMENT",
+            "--output-root",
+            str(durable_output_dir),
+            "--source-ref",
+            str(ref_path),
+            "--manifest-dir",
+            str(manifest_dir),
+            "--completed-run-dir",
+            str(completed),
+        ]
+    )
+    assert rc == 0
+
+
+def test_cli_var_suite_happy_path(tmp_path, durable_output_dir) -> None:
+    run_dir, backtest_ref = build_backtest_run_dir(tmp_path)
+    suite_dir, var_ref, _ = build_var_suite_bundle(
+        tmp_path,
+        companion_run_dir=run_dir,
+        backtest_ref=backtest_ref,
+    )
+    var_ref_path = tmp_path / "var_ref.json"
+    backtest_ref_path = tmp_path / "backtest_ref.json"
+    _write_ref(var_ref_path, var_ref)
+    _write_ref(backtest_ref_path, backtest_ref)
+    rc = main(
+        [
+            "--source-domain",
+            "VAR_SUITE",
+            "--output-root",
+            str(durable_output_dir),
+            "--source-ref",
+            str(var_ref_path),
+            "--suite-report-dir",
+            str(suite_dir),
+            "--companion-run-dir",
+            str(run_dir),
+            "--backtest-source-ref",
+            str(backtest_ref_path),
+        ]
+    )
+    assert rc == 0
+
+
+def test_cli_missing_run_dir_returns_error(tmp_path, durable_output_dir, capsys) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    ref_path = tmp_path / "backtest_ref.json"
+    _write_ref(ref_path, ref)
+    rc = main(
+        [
+            "--source-domain",
+            "BACKTEST",
+            "--output-root",
+            str(durable_output_dir / "missing-run"),
+            "--source-ref",
+            str(ref_path),
+        ]
+    )
+    assert rc == 1
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_cli_invalid_source_ref_json_returns_error(tmp_path, durable_output_dir, capsys) -> None:
+    bad_ref = tmp_path / "bad_ref.json"
+    bad_ref.write_text("[1, 2, 3]", encoding="utf-8")
+    rc = main(
+        [
+            "--source-domain",
+            "BACKTEST",
+            "--output-root",
+            str(durable_output_dir),
+            "--source-ref",
+            str(bad_ref),
+            "--run-dir",
+            str(tmp_path / "missing"),
+        ]
+    )
+    assert rc == 1
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_cli_module_entrypoint_runs_via_subprocess(tmp_path, durable_output_dir) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    ref_path = tmp_path / "backtest_ref.json"
+    _write_ref(ref_path, ref)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--source-domain",
+            "BACKTEST",
+            "--output-root",
+            str(durable_output_dir),
+            "--source-ref",
+            str(ref_path),
+            "--run-dir",
+            str(run_dir),
+        ],
+        cwd=str(REPO_ROOT),
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    manifest_path = Path(proc.stdout.strip())
+    assert manifest_path.name == ARTIFACT_FILENAME
+
+
+def test_cli_backtest_prints_manifest_path(tmp_path, durable_output_dir, capsys) -> None:
+    run_dir, ref = build_backtest_run_dir(tmp_path)
+    ref_path = tmp_path / "backtest_ref.json"
+    _write_ref(ref_path, ref)
+    rc = main(
+        [
+            "--source-domain",
+            "BACKTEST",
+            "--output-root",
+            str(durable_output_dir),
+            "--source-ref",
+            str(ref_path),
+            "--run-dir",
+            str(run_dir),
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out.endswith(ARTIFACT_FILENAME)


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_COMPARISON_METRIC_INPUT_V1_IMPLEMENTATION_MODEL_C_BOUNDED_OFFLINE_V0`
- **Base-SHA:** `d95e100036c62ff9d89ccd0013885e5ab852b3d1`
- **Implementation model:** MODEL_C (contract core + three fail-closed domain adapters)

Implements `comparison_metric_input.v1` as a bounded offline package under `src/meta/learning_loop/comparison_metric_input_v1/`:

- Contract core: schema/models, content-addressed identity, validation, six metric calculations, comparability metadata, source binding, atomic IO, generic offline producer, self-verification, replay
- Domain adapters: **EXPERIMENT** (Package N/M + completed run), **BACKTEST** (Package I + run artifacts), **VAR_SUITE** (Package J + mandatory Backtest companion; metrics from equity/trades only)
- Reuses `contract_safety_v1` for `deterministic_json_dumps`, `compute_content_sha256`, integrity validation
- CLI: `scripts/run_comparison_metric_input_v1.py` (explicit inputs only; no auto-discovery)

## Ratification / contract baseline

- Foundational + supplement contracts: OPERATOR_RATIFIED
- Admissibility re-review: PASS_GO_READY
- Metric semantics: `comparison_metric_semantics.v1` (Sharpe/Volatility/Total Return/Max Drawdown/Profit Factor/Trade Count)
- Comparability metadata: full ratified field set; no hidden defaults
- Pareto directionality + tie tolerances stored as contract constants (not executed in this slice)

## Safety boundaries

- Offline only; no runtime/shadow/testnet/live authority
- No comparison execution, ranking, Pareto, selection, acceptance, promotion, completion binding, durable binding
- No consumer rewiring, registry/MLflow mutation, backtest/experiment execution
- **VAR_SUITE:** `suite_report.json` VaR fields are never used as trading metrics
- **FUTURES_ONLY=true**, **BITCOIN_DIRECTION_ALLOWED=false**

## Required CI

- Selector mode: **PR_BOUNDED_FULL** (new trigger/target bundle wired in `ci_test_selection_v1.py`)
- 96 new focused test nodes across 8 testowners + CI selector contract tests

## Explicitly excluded

- `comparison_definition_manifest_v1.json`, `comparison_result_manifest_v1.json`, `comparison_ssot.v1` producer
- Legacy comparison surfaces, migration, consumer rewiring

**No merge-GO.** Operator review required after CI.

## Test plan

- [x] Local focused suite: 96 tests PASS (`tests/meta/test_comparison_metric_input_*`, CLI, CI selector contracts)
- [x] `ruff format --check` / `ruff check` PASS on changed paths
- [ ] GitHub Required Checks (awaiting CI)


Made with [Cursor](https://cursor.com)