### PR TITLE
Comparison SSOT v1 — bounded offline Model C

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1541,6 +1541,45 @@ PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS: tuple[str, ...] = (
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_V1_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/comparison_ssot_v1/__init__.py",
+        "src/meta/learning_loop/comparison_ssot_v1/constants.py",
+        "src/meta/learning_loop/comparison_ssot_v1/models.py",
+        "src/meta/learning_loop/comparison_ssot_v1/identity.py",
+        "src/meta/learning_loop/comparison_ssot_v1/validation.py",
+        "src/meta/learning_loop/comparison_ssot_v1/comparison_definition_manifest_v1.py",
+        "src/meta/learning_loop/comparison_ssot_v1/comparison_result_manifest_v1.py",
+        "src/meta/learning_loop/comparison_ssot_v1/comparison_gates_v1.py",
+        "src/meta/learning_loop/comparison_ssot_v1/comparison_pareto_v1.py",
+        "src/meta/learning_loop/comparison_ssot_v1/comparison_ranking_v1.py",
+        "src/meta/learning_loop/comparison_ssot_v1/comparison_input_loader_v1.py",
+        "src/meta/learning_loop/comparison_ssot_v1/comparison_offline_producer_v1.py",
+        "src/meta/learning_loop/comparison_ssot_v1/io.py",
+        "src/meta/learning_loop/comparison_ssot_v1/producer.py",
+        "scripts/run_comparison_offline_v1.py",
+        "tests/meta/test_comparison_definition_manifest_v1.py",
+        "tests/meta/test_comparison_result_manifest_v1.py",
+        "tests/meta/test_comparison_gates_v1.py",
+        "tests/meta/test_comparison_offline_producer_v1.py",
+        "tests/scripts/test_run_comparison_offline_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_V1_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_comparison_definition_manifest_v1.py",
+    "tests/meta/test_comparison_result_manifest_v1.py",
+    "tests/meta/test_comparison_gates_v1.py",
+    "tests/meta/test_comparison_offline_producer_v1.py",
+    "tests/scripts/test_run_comparison_offline_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/meta/test_comparison_metric_input_identity_v1.py",
+    "tests/meta/test_comparison_metric_input_validation_v1.py",
+    "tests/meta/test_comparison_metric_input_producer_v1.py",
+    "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
+    "tests/experiments/test_equity_loader.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/experiments/experiment_identity_manifest_v1.py",
@@ -1642,6 +1681,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_V1_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_V1_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TRIGGER_PATHS:
@@ -4827,6 +4870,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                     add(candidate)
             elif path == "scripts/run_comparison_metric_input_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_comparison_offline_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_V1_TARGETS:
                     add(candidate)
             elif path == "scripts/run_experiment_identity_manifest_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_N_EXPERIMENT_IDENTITY_TARGETS:

--- a/scripts/run_comparison_offline_v1.py
+++ b/scripts/run_comparison_offline_v1.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Offline CLI for comparison_ssot.v1 manifest production."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    LEXICOGRAPHIC_RANKING_RULE_V1,
+    RANKING_RULE_NONE,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from src.meta.learning_loop.comparison_ssot_v1.producer import produce_comparison_offline_v1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Produce comparison_definition_manifest_v1.json and comparison_result_manifest_v1.json"
+    )
+    parser.add_argument(
+        "--input-manifest",
+        action="append",
+        required=True,
+        type=Path,
+        dest="input_manifests",
+        help="Path to comparison_metric_input_manifest_v1.json (repeat 2..32 times)",
+    )
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument(
+        "--ranking-rule-version",
+        default=RANKING_RULE_NONE,
+        choices=[RANKING_RULE_NONE, LEXICOGRAPHIC_RANKING_RULE_V1],
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if len(args.input_manifests) < 2:
+        print("ERROR: at least 2 --input-manifest paths required", file=sys.stderr)
+        return 1
+    if len(args.input_manifests) > 32:
+        print("ERROR: at most 32 --input-manifest paths allowed", file=sys.stderr)
+        return 1
+    try:
+        result = produce_comparison_offline_v1(
+            input_manifest_paths=list(args.input_manifests),
+            output_root=args.output_root,
+            ranking_rule_version=args.ranking_rule_version,
+        )
+    except ComparisonSsotError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(result.definition_path)
+    print(result.result_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/comparison_ssot_v1/__init__.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/__init__.py
@@ -1,0 +1,5 @@
+"""Offline comparison SSOT v1 — definition, result, and producer."""
+
+from src.meta.learning_loop.comparison_ssot_v1.producer import produce_comparison_offline_v1
+
+__all__ = ["produce_comparison_offline_v1"]

--- a/src/meta/learning_loop/comparison_ssot_v1/comparison_definition_manifest_v1.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/comparison_definition_manifest_v1.py
@@ -1,0 +1,25 @@
+"""Build comparison_definition_manifest_v1 bodies."""
+
+from __future__ import annotations
+
+from src.meta.learning_loop.comparison_ssot_v1.identity import build_definition_body
+from src.meta.learning_loop.comparison_ssot_v1.models import LoadedMetricInput
+
+
+def build_definition_manifest_body(
+    inputs: list[LoadedMetricInput],
+    *,
+    ranking_rule_version: str,
+    tie_rule_version: str,
+) -> dict[str, object]:
+    input_refs = [item.source_ref.to_mapping() for item in inputs]
+    evaluation_slice_id = inputs[0].evaluation_slice_id
+    from src.meta.learning_loop.comparison_ssot_v1.constants import CANONICAL_AUTHORITY_INVARIANTS
+
+    return build_definition_body(
+        input_refs=input_refs,
+        ranking_rule_version=ranking_rule_version,
+        tie_rule_version=tie_rule_version,
+        evaluation_slice_id=evaluation_slice_id,
+        authority_invariants=CANONICAL_AUTHORITY_INVARIANTS,
+    )

--- a/src/meta/learning_loop/comparison_ssot_v1/comparison_gates_v1.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/comparison_gates_v1.py
@@ -1,0 +1,217 @@
+"""Comparability gate evaluation for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import METRIC_KEYS
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    COMPARABILITY_GATE_VERSION,
+    MAX_INPUT_COUNT,
+    MIN_INPUT_COUNT,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import GateOutcome, LoadedMetricInput
+
+
+def _pass(gate_id: str, reason_code: str = "OK") -> GateOutcome:
+    return GateOutcome(gate_id, COMPARABILITY_GATE_VERSION, "PASS", reason_code)
+
+
+def _fail(gate_id: str, reason_code: str, evidence_refs: tuple[str, ...] = ()) -> GateOutcome:
+    return GateOutcome(gate_id, COMPARABILITY_GATE_VERSION, "FAIL", reason_code, evidence_refs)
+
+
+def _reference_value(inputs: list[LoadedMetricInput], field: str) -> Any:
+    return inputs[0].comparability_metadata.get(field)
+
+
+def _all_equal(inputs: list[LoadedMetricInput], field: str) -> bool:
+    values = [item.comparability_metadata.get(field) for item in inputs]
+    return all(value == values[0] for value in values)
+
+
+def _dicts_equal(a: Any, b: Any) -> bool:
+    return a == b
+
+
+def evaluate_comparability_gates(inputs: list[LoadedMetricInput]) -> list[GateOutcome]:
+    outcomes: list[GateOutcome] = []
+
+    count = len(inputs)
+    outcomes.append(
+        _pass("G01_INPUT_COUNT_VALID")
+        if MIN_INPUT_COUNT <= count <= MAX_INPUT_COUNT
+        else _fail("G01_INPUT_COUNT_VALID", "INPUT_COUNT_OUT_OF_RANGE")
+    )
+
+    outcomes.append(_pass("G02_INPUTS_CANONICALLY_VALIDATED"))
+
+    domains = {item.source_domain for item in inputs}
+    outcomes.append(
+        _pass("G03_SAME_ALLOWED_DOMAIN")
+        if len(domains) == 1
+        else _fail("G03_SAME_ALLOWED_DOMAIN", "CROSS_DOMAIN_MIX")
+    )
+
+    outcomes.append(
+        _pass("G04_COMPATIBLE_SOURCE_SCHEMA_VERSIONS")
+        if _all_equal(inputs, "source_schema_version")
+        else _fail("G04_COMPATIBLE_SOURCE_SCHEMA_VERSIONS", "SOURCE_SCHEMA_VERSION_MISMATCH")
+    )
+
+    for gate_id, field, reason in (
+        ("G05_COMPATIBLE_TIMEFRAME", "timeframe", "TIMEFRAME_MISMATCH"),
+        ("G06_COMPATIBLE_EVALUATION_RANGE", "evaluation_start", "EVALUATION_START_MISMATCH"),
+        ("G06_COMPATIBLE_EVALUATION_RANGE_END", "evaluation_end", "EVALUATION_END_MISMATCH"),
+        ("G07_COMPATIBLE_UNIVERSE", "universe", "UNIVERSE_MISMATCH"),
+        ("G08_COMPATIBLE_INSTRUMENT_SET", "instrument_set", "INSTRUMENT_SET_MISMATCH"),
+        (
+            "G09_COMPATIBLE_DATASET_LINEAGE_REF",
+            "dataset_lineage_ref",
+            "DATASET_LINEAGE_REF_MISMATCH",
+        ),
+        (
+            "G09_COMPATIBLE_DATASET_LINEAGE_DIGEST",
+            "dataset_lineage_digest",
+            "DATASET_LINEAGE_DIGEST_MISMATCH",
+        ),
+        ("G10_COMPATIBLE_FEE_MODEL", "fee_model", "FEE_MODEL_MISMATCH"),
+        ("G11_COMPATIBLE_SLIPPAGE_MODEL", "slippage_model", "SLIPPAGE_MODEL_MISMATCH"),
+        ("G12_COMPATIBLE_RISK_POLICY", "risk_policy_ref", "RISK_POLICY_MISMATCH"),
+        ("G13_COMPATIBLE_INITIAL_CAPITAL", "initial_capital", "INITIAL_CAPITAL_MISMATCH"),
+        ("G14_COMPATIBLE_CAPITAL_CURRENCY", "capital_currency", "CAPITAL_CURRENCY_MISMATCH"),
+        ("G15_COMPATIBLE_RESULT_CURRENCY", "result_currency", "RESULT_CURRENCY_MISMATCH"),
+        (
+            "G16_COMPATIBLE_EQUITY_SAMPLING_FREQUENCY",
+            "equity_sampling_frequency",
+            "EQUITY_SAMPLING_FREQUENCY_MISMATCH",
+        ),
+        (
+            "G17_COMPATIBLE_ANNUALIZATION_PROFILE",
+            "annualization_profile",
+            "ANNUALIZATION_PROFILE_MISMATCH",
+        ),
+        ("G18_COMPATIBLE_RETURN_BASIS", "return_basis", "RETURN_BASIS_MISMATCH"),
+    ):
+        if _all_equal(inputs, field):
+            outcomes.append(_pass(gate_id))
+        else:
+            outcomes.append(_fail(gate_id, reason))
+
+    fee_params_ok = all(
+        _dicts_equal(
+            item.comparability_metadata.get("fee_parameters"),
+            _reference_value(inputs, "fee_parameters"),
+        )
+        for item in inputs
+    )
+    outcomes.append(
+        _pass("G10_COMPATIBLE_FEE_PARAMETERS")
+        if fee_params_ok
+        else _fail("G10_COMPATIBLE_FEE_PARAMETERS", "FEE_PARAMETERS_MISMATCH")
+    )
+
+    slippage_params_ok = all(
+        _dicts_equal(
+            item.comparability_metadata.get("slippage_parameters"),
+            _reference_value(inputs, "slippage_parameters"),
+        )
+        for item in inputs
+    )
+    outcomes.append(
+        _pass("G11_COMPATIBLE_SLIPPAGE_PARAMETERS")
+        if slippage_params_ok
+        else _fail("G11_COMPATIBLE_SLIPPAGE_PARAMETERS", "SLIPPAGE_PARAMETERS_MISMATCH")
+    )
+
+    metrics_complete = all(set(item.metrics.keys()) == set(METRIC_KEYS) for item in inputs)
+    outcomes.append(
+        _pass("G19_COMPLETE_METRIC_SET")
+        if metrics_complete
+        else _fail("G19_COMPLETE_METRIC_SET", "INCOMPLETE_METRIC_SET")
+    )
+
+    nan_found = any(
+        isinstance(value, float) and math.isnan(float(value))
+        for item in inputs
+        for value in item.metrics.values()
+    )
+    outcomes.append(
+        _pass("G20_NO_NAN") if not nan_found else _fail("G20_NO_NAN", "NAN_METRIC_VALUE")
+    )
+
+    inf_found = any(
+        isinstance(value, float) and math.isinf(float(value))
+        for item in inputs
+        for value in item.metrics.values()
+    )
+    outcomes.append(
+        _pass("G21_NO_INFINITY")
+        if not inf_found
+        else _fail("G21_NO_INFINITY", "INFINITY_METRIC_VALUE")
+    )
+
+    ref_keys = [item.source_ref.sort_key() for item in inputs]
+    outcomes.append(
+        _pass("G22_NO_DUPLICATE_INPUTS")
+        if len(ref_keys) == len(set(ref_keys))
+        else _fail("G22_NO_DUPLICATE_INPUTS", "DUPLICATE_INPUT")
+    )
+
+    digest_stable = all(
+        item.source_ref.digest == str(item.manifest["source_ref"]["digest"]) for item in inputs
+    )
+    outcomes.append(
+        _pass("G23_STABLE_DIGESTS")
+        if digest_stable
+        else _fail("G23_STABLE_DIGESTS", "SOURCE_DIGEST_DRIFT")
+    )
+
+    sorted_keys = sorted(ref_keys)
+    actual_keys = [item.source_ref.sort_key() for item in inputs]
+    outcomes.append(
+        _pass("G24_CANONICAL_ORDER")
+        if actual_keys == sorted_keys
+        else _fail("G24_CANONICAL_ORDER", "INPUTS_NOT_CANONICALLY_SORTED")
+    )
+
+    outcomes.append(_pass("G25_NO_HIDDEN_DEFAULTS"))
+
+    untrusted = any(
+        str(item.comparability_metadata.get("dataset_lineage_ref", "")).startswith("untrusted:")
+        for item in inputs
+    )
+    outcomes.append(
+        _pass("G26_NO_UNTRUSTED_EXTERNAL_IDS")
+        if not untrusted
+        else _fail("G26_NO_UNTRUSTED_EXTERNAL_IDS", "UNTRUSTED_EXTERNAL_ID")
+    )
+
+    authority_ok = all(
+        item.comparability_metadata.get("authority_invariants", {}).get("runtime_authority_impact")
+        == "NONE"
+        for item in inputs
+    )
+    outcomes.append(
+        _pass("G27_NO_PROMOTION_OR_RUNTIME_AUTHORITY")
+        if authority_ok
+        else _fail("G27_NO_PROMOTION_OR_RUNTIME_AUTHORITY", "RUNTIME_AUTHORITY_PRESENT")
+    )
+
+    slice_window_ok = (
+        _all_equal(inputs, "evaluation_start")
+        and _all_equal(inputs, "evaluation_end")
+        and _all_equal(inputs, "timeframe")
+    )
+    outcomes.append(
+        _pass("G28_IDENTICAL_EVALUATION_SLICE")
+        if slice_window_ok
+        else _fail("G28_IDENTICAL_EVALUATION_SLICE", "EVALUATION_SLICE_MISMATCH")
+    )
+
+    return outcomes
+
+
+def overall_comparable(gate_outcomes: list[GateOutcome]) -> bool:
+    return all(outcome.status == "PASS" for outcome in gate_outcomes)

--- a/src/meta/learning_loop/comparison_ssot_v1/comparison_input_loader_v1.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/comparison_input_loader_v1.py
@@ -1,0 +1,116 @@
+"""Input loading for comparison_ssot.v1 from comparison_metric_input manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import METRIC_KEYS
+from src.meta.learning_loop.comparison_metric_input_v1.io import read_manifest
+from src.meta.learning_loop.comparison_metric_input_v1.validation import (
+    validate_comparison_metric_input_manifest_v1,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.identity import (
+    verify_manifest_identity_and_integrity,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    ALLOWED_SOURCE_DOMAINS,
+    MAX_INPUT_COUNT,
+    MIN_INPUT_COUNT,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import (
+    ComparisonSsotError,
+    InputRef,
+    LoadedMetricInput,
+)
+
+
+def _input_ref_from_manifest(manifest: dict[str, Any]) -> InputRef:
+    source_ref = manifest.get("source_ref")
+    if not isinstance(source_ref, dict):
+        raise ComparisonSsotError("source_ref must be object")
+    return InputRef(
+        owner_domain=str(source_ref["owner_domain"]),
+        ref_type=str(source_ref["ref_type"]).upper(),
+        ref_id=str(source_ref["ref_id"]),
+        digest=str(source_ref["digest"]),
+    )
+
+
+def canonical_sort_inputs(inputs: list[LoadedMetricInput]) -> list[LoadedMetricInput]:
+    return sorted(inputs, key=lambda item: item.source_ref.sort_key())
+
+
+def load_metric_input_manifest(path: Path) -> LoadedMetricInput:
+    manifest = read_manifest(path)
+    validate_comparison_metric_input_manifest_v1(manifest)
+    verify_manifest_identity_and_integrity(manifest)
+    source_domain = str(manifest["source_domain"]).upper()
+    if source_domain not in ALLOWED_SOURCE_DOMAINS:
+        raise ComparisonSsotError(f"unsupported source_domain: {source_domain}")
+    source_ref = _input_ref_from_manifest(manifest)
+    expected_id = str(manifest["comparison_metric_input_id"])
+    return LoadedMetricInput(
+        manifest_path=path.resolve(),
+        manifest=manifest,
+        comparison_metric_input_id=expected_id,
+        source_domain=source_domain,
+        source_ref=source_ref,
+        evaluation_slice_id=str(manifest["evaluation_slice_id"]),
+        comparability_metadata=dict(manifest["comparability_metadata"]),
+        metrics=dict(manifest["metrics"]),
+    )
+
+
+def load_and_validate_inputs(manifest_paths: list[Path]) -> list[LoadedMetricInput]:
+    if len(manifest_paths) < MIN_INPUT_COUNT:
+        raise ComparisonSsotError(
+            f"at least {MIN_INPUT_COUNT} input manifests required, got {len(manifest_paths)}"
+        )
+    if len(manifest_paths) > MAX_INPUT_COUNT:
+        raise ComparisonSsotError(
+            f"at most {MAX_INPUT_COUNT} input manifests allowed, got {len(manifest_paths)}"
+        )
+
+    loaded: list[LoadedMetricInput] = []
+    seen_paths: set[str] = set()
+    seen_full_refs: set[tuple[str, str, str, str]] = set()
+    seen_ref_ids: dict[str, str] = {}
+
+    for path in manifest_paths:
+        resolved = str(path.resolve())
+        if resolved in seen_paths:
+            raise ComparisonSsotError(f"duplicate manifest path (fail-closed): {path}")
+        seen_paths.add(resolved)
+
+        item = load_metric_input_manifest(path)
+        ref_key = item.source_ref.sort_key()
+        if ref_key in seen_full_refs:
+            raise ComparisonSsotError(
+                f"duplicate canonical input ref (fail-closed): {item.source_ref.ref_id}"
+            )
+        seen_full_refs.add(ref_key)
+
+        prior_digest = seen_ref_ids.get(item.source_ref.ref_id)
+        if prior_digest is not None and prior_digest != item.source_ref.digest:
+            raise ComparisonSsotError(
+                f"same ref_id with different digest (fail-closed): {item.source_ref.ref_id}"
+            )
+        seen_ref_ids[item.source_ref.ref_id] = item.source_ref.digest
+
+        metrics = item.metrics
+        for key in METRIC_KEYS:
+            if key not in metrics:
+                raise ComparisonSsotError(f"missing metric {key} in {path}")
+        if set(metrics.keys()) != set(METRIC_KEYS):
+            raise ComparisonSsotError(f"unexpected metric keys in {path}")
+
+        loaded.append(item)
+
+    domains = {item.source_domain for item in loaded}
+    if len(domains) != 1:
+        raise ComparisonSsotError(
+            f"cross-domain inputs not allowed (fail-closed): {sorted(domains)}"
+        )
+
+    return canonical_sort_inputs(loaded)

--- a/src/meta/learning_loop/comparison_ssot_v1/comparison_offline_producer_v1.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/comparison_offline_producer_v1.py
@@ -1,0 +1,102 @@
+"""Offline comparison producer for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import TIE_TOLERANCE_VERSION
+from src.meta.learning_loop.comparison_ssot_v1.constants import RANKING_RULE_NONE
+from src.meta.learning_loop.comparison_ssot_v1.comparison_definition_manifest_v1 import (
+    build_definition_manifest_body,
+)
+from src.meta.learning_loop.comparison_ssot_v1.comparison_gates_v1 import (
+    evaluate_comparability_gates,
+    overall_comparable,
+)
+from src.meta.learning_loop.comparison_ssot_v1.comparison_input_loader_v1 import (
+    load_and_validate_inputs,
+)
+from src.meta.learning_loop.comparison_ssot_v1.comparison_pareto_v1 import compute_pareto_front
+from src.meta.learning_loop.comparison_ssot_v1.comparison_ranking_v1 import compute_ranking
+from src.meta.learning_loop.comparison_ssot_v1.comparison_result_manifest_v1 import (
+    build_result_manifest_body,
+)
+from src.meta.learning_loop.comparison_ssot_v1.identity import (
+    attach_definition_identity_and_integrity,
+    compute_comparison_definition_id,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import publish_comparison_manifests_atomic
+from src.meta.learning_loop.comparison_ssot_v1.models import (
+    ComparisonOfflineResult,
+    ComparisonSsotError,
+)
+
+
+def produce_comparison_offline_v1(
+    *,
+    input_manifest_paths: list[Path],
+    output_root: Path,
+    ranking_rule_version: str,
+) -> ComparisonOfflineResult:
+    inputs = load_and_validate_inputs(input_manifest_paths)
+    definition_body = build_definition_manifest_body(
+        inputs,
+        ranking_rule_version=ranking_rule_version,
+        tie_rule_version=TIE_TOLERANCE_VERSION,
+    )
+    definition_with_id = attach_definition_identity_and_integrity(definition_body)
+    comparison_definition_id = str(definition_with_id["comparison_definition_id"])
+
+    gate_outcomes = evaluate_comparability_gates(inputs)
+    comparable = overall_comparable(gate_outcomes)
+    warnings: list[str] = []
+    if not comparable:
+        warnings.append("overall_comparable=false; pareto and ranking suppressed")
+
+    pareto_result = compute_pareto_front(inputs) if comparable else None
+    if not comparable and ranking_rule_version != RANKING_RULE_NONE:
+        ranking_result = compute_ranking(inputs, ranking_rule_version=RANKING_RULE_NONE)
+    else:
+        ranking_result = compute_ranking(inputs, ranking_rule_version=ranking_rule_version)
+    if not comparable and ranking_result.get("ranking_status") != "NONE":
+        raise ComparisonSsotError("ranking emitted while inputs not comparable")
+
+    result_body = build_result_manifest_body(
+        comparison_definition_id=comparison_definition_id,
+        inputs=inputs,
+        gate_outcomes=gate_outcomes,
+        overall_comparable=comparable,
+        pareto_result=pareto_result,
+        ranking_result=ranking_result
+        if comparable
+        else {
+            "ranking_status": "NONE",
+            "ranking_rule_version": ranking_rule_version,
+            "ranked_input_ids": [],
+        },
+        warnings=warnings,
+    )
+
+    replay_id = compute_comparison_definition_id(definition_body)
+    if replay_id != comparison_definition_id:
+        raise ComparisonSsotError("definition id replay mismatch")
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    definition_path, result_path = publish_comparison_manifests_atomic(
+        output_root=output_root,
+        definition_body=definition_body,
+        result_body=result_body,
+    )
+
+    from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+
+    definition_manifest = read_manifest(definition_path)
+    result_manifest = read_manifest(result_path)
+    return ComparisonOfflineResult(
+        output_dir=definition_path.parent,
+        definition_path=definition_path,
+        result_path=result_path,
+        comparison_definition_id=comparison_definition_id,
+        definition_manifest=definition_manifest,
+        result_manifest=result_manifest,
+    )

--- a/src/meta/learning_loop/comparison_ssot_v1/comparison_pareto_v1.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/comparison_pareto_v1.py
@@ -1,0 +1,94 @@
+"""Descriptive Pareto evaluation for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+import math
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    METRIC_KEYS,
+    PARETO_DIRECTIONALITY,
+    TIE_TOLERANCE_CATALOG,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import LoadedMetricInput
+
+
+def _metric_value(item: LoadedMetricInput, metric: str) -> float:
+    value = item.metrics[metric]
+    return float(value)
+
+
+def _within_tolerance(metric: str, a: float, b: float) -> bool:
+    tolerance = TIE_TOLERANCE_CATALOG.get(metric)
+    if tolerance is None:
+        return a == b
+    return abs(a - b) <= float(tolerance)
+
+
+def _better_or_equal(metric: str, candidate: float, other: float) -> bool:
+    direction = PARETO_DIRECTIONALITY[metric]
+    if direction == "ELIGIBILITY_ONLY_NOT_OBJECTIVE":
+        return True
+    if direction == "MAXIMIZE":
+        if _within_tolerance(metric, candidate, other):
+            return True
+        return candidate > other
+    if direction == "MINIMIZE":
+        if _within_tolerance(metric, candidate, other):
+            return True
+        return candidate < other
+    raise ValueError(f"unknown direction for metric {metric}")
+
+
+def _strictly_better(metric: str, candidate: float, other: float) -> bool:
+    direction = PARETO_DIRECTIONALITY[metric]
+    if direction == "ELIGIBILITY_ONLY_NOT_OBJECTIVE":
+        return False
+    if _within_tolerance(metric, candidate, other):
+        return False
+    if direction == "MAXIMIZE":
+        return candidate > other
+    return candidate < other
+
+
+def _pareto_objectives() -> tuple[str, ...]:
+    return tuple(
+        metric
+        for metric in METRIC_KEYS
+        if PARETO_DIRECTIONALITY[metric] != "ELIGIBILITY_ONLY_NOT_OBJECTIVE"
+    )
+
+
+def dominates(a: LoadedMetricInput, b: LoadedMetricInput) -> bool:
+    objectives = _pareto_objectives()
+    any_strict = False
+    for metric in objectives:
+        av = _metric_value(a, metric)
+        bv = _metric_value(b, metric)
+        if math.isnan(av) or math.isnan(bv) or math.isinf(av) or math.isinf(bv):
+            return False
+        if not _better_or_equal(metric, av, bv):
+            return False
+        if _strictly_better(metric, av, bv):
+            any_strict = True
+    return any_strict
+
+
+def compute_pareto_front(inputs: list[LoadedMetricInput]) -> dict[str, object]:
+    front: list[str] = []
+    for candidate in inputs:
+        dominated = False
+        for other in inputs:
+            if candidate is other:
+                continue
+            if dominates(other, candidate):
+                dominated = True
+                break
+        if not dominated:
+            front.append(candidate.comparison_metric_input_id)
+    front_sorted = sorted(front)
+    return {
+        "pareto_status": "COMPUTED",
+        "pareto_front_member_ids": front_sorted,
+        "pareto_objective_metrics": list(_pareto_objectives()),
+        "pareto_descriptive_only": True,
+    }

--- a/src/meta/learning_loop/comparison_ssot_v1/comparison_ranking_v1.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/comparison_ranking_v1.py
@@ -1,0 +1,73 @@
+"""Optional lexicographic ranking for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+from functools import cmp_to_key
+
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    LEXICOGRAPHIC_RANKING_RULE_V1,
+    LEXICOGRAPHIC_RANKING_SEQUENCE,
+    RANKING_RULE_NONE,
+)
+from src.meta.learning_loop.comparison_ssot_v1.comparison_pareto_v1 import (
+    _metric_value,
+    _within_tolerance,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError, LoadedMetricInput
+
+
+def _ref_sort_key(item: LoadedMetricInput) -> tuple[str, str, str, str]:
+    return item.source_ref.sort_key()
+
+
+def _compare_lex(a: LoadedMetricInput, b: LoadedMetricInput) -> int:
+    for metric, direction in LEXICOGRAPHIC_RANKING_SEQUENCE:
+        av = _metric_value(a, metric)
+        bv = _metric_value(b, metric)
+        if _within_tolerance(metric, av, bv):
+            continue
+        if direction == "MAXIMIZE":
+            if av > bv:
+                return -1
+            if av < bv:
+                return 1
+        elif direction == "MINIMIZE":
+            if av < bv:
+                return -1
+            if av > bv:
+                return 1
+        else:
+            raise ComparisonSsotError(f"metric {metric} is not a ranking objective")
+    ref_a = _ref_sort_key(a)
+    ref_b = _ref_sort_key(b)
+    if ref_a < ref_b:
+        return -1
+    if ref_a > ref_b:
+        return 1
+    return 0
+
+
+def compute_ranking(
+    inputs: list[LoadedMetricInput],
+    *,
+    ranking_rule_version: str,
+) -> dict[str, object]:
+    if ranking_rule_version == RANKING_RULE_NONE:
+        return {
+            "ranking_status": "NONE",
+            "ranking_rule_version": RANKING_RULE_NONE,
+            "ranked_input_ids": [],
+        }
+    if ranking_rule_version != LEXICOGRAPHIC_RANKING_RULE_V1:
+        raise ComparisonSsotError(f"unknown ranking_rule_version: {ranking_rule_version}")
+
+    ordered = sorted(inputs, key=cmp_to_key(_compare_lex))
+    return {
+        "ranking_status": "LEXICOGRAPHIC",
+        "ranking_rule_version": LEXICOGRAPHIC_RANKING_RULE_V1,
+        "ranked_input_ids": [item.comparison_metric_input_id for item in ordered],
+        "ranking_sequence": [
+            {"metric": metric, "direction": direction}
+            for metric, direction in LEXICOGRAPHIC_RANKING_SEQUENCE
+        ],
+    }

--- a/src/meta/learning_loop/comparison_ssot_v1/comparison_result_manifest_v1.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/comparison_result_manifest_v1.py
@@ -1,0 +1,71 @@
+"""Build comparison_result_manifest_v1 bodies."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import METRIC_KEYS
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    CANONICAL_AUTHORITY_INVARIANTS,
+    COMPARISON_CONTRACT_VERSION,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import GateOutcome, LoadedMetricInput
+
+
+def _gate_to_mapping(outcome: GateOutcome) -> dict[str, object]:
+    return {
+        "gate_id": outcome.gate_id,
+        "version": outcome.version,
+        "status": outcome.status,
+        "reason_code": outcome.reason_code,
+        "evidence_refs": list(outcome.evidence_refs),
+    }
+
+
+def build_input_snapshots(inputs: list[LoadedMetricInput]) -> list[dict[str, object]]:
+    snapshots: list[dict[str, object]] = []
+    for item in inputs:
+        source_digest = str(item.manifest["source_digest"])
+        snapshots.append(
+            {
+                "comparison_metric_input_id": item.comparison_metric_input_id,
+                "source_ref": item.source_ref.to_mapping(),
+                "source_digest": source_digest,
+                "metrics": {key: item.metrics[key] for key in METRIC_KEYS},
+            }
+        )
+    return snapshots
+
+
+def build_metric_matrix(inputs: list[LoadedMetricInput]) -> dict[str, list[float | int]]:
+    matrix: dict[str, list[float | int]] = {key: [] for key in METRIC_KEYS}
+    for item in inputs:
+        for key in METRIC_KEYS:
+            matrix[key].append(item.metrics[key])
+    return matrix
+
+
+def build_result_manifest_body(
+    *,
+    comparison_definition_id: str,
+    inputs: list[LoadedMetricInput],
+    gate_outcomes: list[GateOutcome],
+    overall_comparable: bool,
+    pareto_result: dict[str, object] | None,
+    ranking_result: dict[str, object],
+    warnings: list[str],
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "comparison_contract_version": COMPARISON_CONTRACT_VERSION,
+        "comparison_definition_id": comparison_definition_id,
+        "input_snapshots": build_input_snapshots(inputs),
+        "metric_matrix": build_metric_matrix(inputs),
+        "comparability_gate_outcomes": [_gate_to_mapping(g) for g in gate_outcomes],
+        "overall_comparable": overall_comparable,
+        "warnings": warnings,
+        "authority_invariants": dict(CANONICAL_AUTHORITY_INVARIANTS),
+    }
+    if overall_comparable and pareto_result is not None:
+        body["pareto_result"] = pareto_result
+    body["ranking_result"] = ranking_result
+    return body

--- a/src/meta/learning_loop/comparison_ssot_v1/constants.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/constants.py
@@ -1,0 +1,81 @@
+"""Ratified constants for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import (
+    METRIC_KEYS,
+    METRIC_SET_VERSION,
+    PARETO_DIRECTIONALITY,
+    TIE_TOLERANCE_CATALOG,
+    TIE_TOLERANCE_VERSION,
+)
+
+COMPARISON_CONTRACT_VERSION: Final = "comparison_ssot.v1"
+COMPARABILITY_GATE_VERSION: Final = "comparison_gates.v1"
+NORMALIZATION_POLICY_VERSION: Final = "NONE_V1"
+RANKING_RULE_NONE: Final = "NONE_V1"
+LEXICOGRAPHIC_RANKING_RULE_V1: Final = "lexicographic_ranking_v1"
+ELIGIBILITY_RULES_VERSION: Final = "comparison_eligibility_rules.v1"
+IDENTITY_DOMAIN_SEPARATOR: Final = "peak_trade.comparison_definition.v1"
+DEFINITION_ARTIFACT_FILENAME: Final = "comparison_definition_manifest_v1.json"
+RESULT_ARTIFACT_FILENAME: Final = "comparison_result_manifest_v1.json"
+STAGING_DIRNAME_PREFIX: Final = ".comparison_ssot_staging_"
+
+MIN_INPUT_COUNT: Final = 2
+MAX_INPUT_COUNT: Final = 32
+
+ALLOWED_SOURCE_DOMAINS: frozenset[str] = frozenset({"EXPERIMENT", "BACKTEST", "VAR_SUITE"})
+
+LEXICOGRAPHIC_RANKING_SEQUENCE: tuple[tuple[str, str], ...] = (
+    ("sharpe", "MAXIMIZE"),
+    ("max_drawdown", "MINIMIZE"),
+    ("profit_factor", "MAXIMIZE"),
+    ("total_return", "MAXIMIZE"),
+    ("volatility", "MINIMIZE"),
+)
+
+CANONICAL_AUTHORITY_INVARIANTS: dict[str, str | bool] = {
+    "comparison_is_descriptive_only": True,
+    "comparison_does_not_select": True,
+    "comparison_does_not_accept": True,
+    "comparison_does_not_promote": True,
+    "comparison_does_not_authorize_runtime": True,
+    "comparison_does_not_authorize_shadow": True,
+    "comparison_does_not_authorize_testnet": True,
+    "comparison_does_not_authorize_live": True,
+    "comparison_does_not_mutate_inputs": True,
+    "comparison_does_not_mutate_strategy_params": True,
+    "comparison_does_not_change_trading_logic": True,
+    "comparison_does_not_trigger_runs": True,
+    "evidence_does_not_authorize_runtime": True,
+    "promotion_authority_impact": "NONE",
+    "completion_authority_impact": "NONE",
+    "runtime_authority_impact": "NONE",
+    "trading_logic_impact": "NONE",
+    "experiment_config_impact": "NONE",
+}
+
+__all__ = [
+    "ALLOWED_SOURCE_DOMAINS",
+    "CANONICAL_AUTHORITY_INVARIANTS",
+    "COMPARABILITY_GATE_VERSION",
+    "COMPARISON_CONTRACT_VERSION",
+    "DEFINITION_ARTIFACT_FILENAME",
+    "ELIGIBILITY_RULES_VERSION",
+    "IDENTITY_DOMAIN_SEPARATOR",
+    "LEXICOGRAPHIC_RANKING_RULE_V1",
+    "LEXICOGRAPHIC_RANKING_SEQUENCE",
+    "MAX_INPUT_COUNT",
+    "METRIC_KEYS",
+    "METRIC_SET_VERSION",
+    "MIN_INPUT_COUNT",
+    "NORMALIZATION_POLICY_VERSION",
+    "PARETO_DIRECTIONALITY",
+    "RANKING_RULE_NONE",
+    "RESULT_ARTIFACT_FILENAME",
+    "STAGING_DIRNAME_PREFIX",
+    "TIE_TOLERANCE_CATALOG",
+    "TIE_TOLERANCE_VERSION",
+]

--- a/src/meta/learning_loop/comparison_ssot_v1/identity.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/identity.py
@@ -1,0 +1,128 @@
+"""Content-addressed identity for comparison_definition_manifest_v1."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    COMPARABILITY_GATE_VERSION,
+    COMPARISON_CONTRACT_VERSION,
+    ELIGIBILITY_RULES_VERSION,
+    IDENTITY_DOMAIN_SEPARATOR,
+    METRIC_SET_VERSION,
+    NORMALIZATION_POLICY_VERSION,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    validate_integrity_block,
+)
+
+DEFINITION_IDENTITY_FIELD_ORDER: tuple[str, ...] = (
+    "comparison_contract_version",
+    "identity_domain",
+    "input_refs",
+    "metric_set_version",
+    "comparability_gate_version",
+    "normalization_policy_version",
+    "ranking_rule_version",
+    "tie_rule_version",
+    "evaluation_slice_id",
+    "eligibility_rules_version",
+    "authority_invariants",
+)
+
+
+def build_definition_identity_payload(manifest_body: Mapping[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for field in DEFINITION_IDENTITY_FIELD_ORDER:
+        if field not in manifest_body:
+            raise ComparisonSsotError(f"definition identity payload missing field: {field}")
+        payload[field] = deepcopy(manifest_body[field])
+    return payload
+
+
+def compute_comparison_definition_id(manifest_body: Mapping[str, Any]) -> str:
+    payload = build_definition_identity_payload(manifest_body)
+    return compute_content_sha256(payload)
+
+
+def build_manifest_without_integrity(manifest_body: Mapping[str, Any]) -> dict[str, Any]:
+    body = deepcopy(dict(manifest_body))
+    body.pop("comparison_definition_id", None)
+    body.pop("integrity", None)
+    return body
+
+
+def attach_definition_identity_and_integrity(manifest_body: Mapping[str, Any]) -> dict[str, Any]:
+    body = build_manifest_without_integrity(manifest_body)
+    if body.get("identity_domain") != IDENTITY_DOMAIN_SEPARATOR:
+        raise ComparisonSsotError("identity_domain mismatch for comparison definition")
+    comparison_definition_id = compute_comparison_definition_id(body)
+    digest = compute_content_sha256(body)
+    body["comparison_definition_id"] = comparison_definition_id
+    body["integrity"] = {"content_sha256": digest}
+    return body
+
+
+def compute_definition_integrity_digest(manifest: Mapping[str, Any]) -> str:
+    return compute_content_sha256(build_manifest_without_integrity(manifest))
+
+
+def verify_definition_identity_and_integrity(manifest: Mapping[str, Any]) -> None:
+    expected_id = compute_comparison_definition_id(manifest)
+    actual_id = manifest.get("comparison_definition_id")
+    if actual_id != expected_id:
+        raise ComparisonSsotError("comparison_definition_id mismatch")
+    expected_digest = compute_definition_integrity_digest(manifest)
+    result = validate_integrity_block(manifest.get("integrity"), expected_digest=expected_digest)
+    if not result.valid:
+        raise ComparisonSsotError("; ".join(result.errors))
+
+
+def build_result_manifest_without_integrity(manifest_body: Mapping[str, Any]) -> dict[str, Any]:
+    body = deepcopy(dict(manifest_body))
+    body.pop("integrity", None)
+    return body
+
+
+def attach_result_integrity(manifest_body: Mapping[str, Any]) -> dict[str, Any]:
+    body = build_result_manifest_without_integrity(manifest_body)
+    digest = compute_content_sha256(body)
+    body["integrity"] = {"content_sha256": digest}
+    return body
+
+
+def compute_result_integrity_digest(manifest: Mapping[str, Any]) -> str:
+    return compute_content_sha256(build_result_manifest_without_integrity(manifest))
+
+
+def verify_result_integrity(manifest: Mapping[str, Any]) -> None:
+    expected_digest = compute_result_integrity_digest(manifest)
+    result = validate_integrity_block(manifest.get("integrity"), expected_digest=expected_digest)
+    if not result.valid:
+        raise ComparisonSsotError("; ".join(result.errors))
+
+
+def build_definition_body(
+    *,
+    input_refs: list[dict[str, str]],
+    ranking_rule_version: str,
+    tie_rule_version: str,
+    evaluation_slice_id: str,
+    authority_invariants: Mapping[str, str | bool],
+) -> dict[str, Any]:
+    return {
+        "comparison_contract_version": COMPARISON_CONTRACT_VERSION,
+        "identity_domain": IDENTITY_DOMAIN_SEPARATOR,
+        "input_refs": input_refs,
+        "metric_set_version": METRIC_SET_VERSION,
+        "comparability_gate_version": COMPARABILITY_GATE_VERSION,
+        "normalization_policy_version": NORMALIZATION_POLICY_VERSION,
+        "ranking_rule_version": ranking_rule_version,
+        "tie_rule_version": tie_rule_version,
+        "evaluation_slice_id": evaluation_slice_id,
+        "eligibility_rules_version": ELIGIBILITY_RULES_VERSION,
+        "authority_invariants": dict(authority_invariants),
+    }

--- a/src/meta/learning_loop/comparison_ssot_v1/io.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/io.py
@@ -1,0 +1,129 @@
+"""Atomic IO for comparison_ssot.v1 manifests."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    DEFINITION_ARTIFACT_FILENAME,
+    RESULT_ARTIFACT_FILENAME,
+    STAGING_DIRNAME_PREFIX,
+)
+from src.meta.learning_loop.comparison_ssot_v1.identity import (
+    attach_definition_identity_and_integrity,
+    attach_result_integrity,
+    verify_definition_identity_and_integrity,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from src.meta.learning_loop.comparison_ssot_v1.validation import (
+    validate_definition_manifest_v1,
+    validate_result_manifest_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{uuid.uuid4().hex}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if is_under_tmp(output_dir):
+        raise ComparisonSsotError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ComparisonSsotError(f"output parent directory missing: {parent}")
+    if is_under_tmp(parent):
+        raise ComparisonSsotError("output parent directory must be outside /tmp")
+
+
+def serialize_manifest(manifest: Mapping[str, Any]) -> str:
+    return deterministic_json_dumps(manifest) + "\n"
+
+
+def read_manifest(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ComparisonSsotError(f"invalid manifest JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ComparisonSsotError(f"manifest root must be object: {path}")
+    return payload
+
+
+def _self_verify_definition(path: Path) -> None:
+    manifest = read_manifest(path)
+    validate_definition_manifest_v1(manifest)
+    verify_definition_identity_and_integrity(manifest)
+
+
+def _self_verify_result(path: Path) -> None:
+    manifest = read_manifest(path)
+    validate_result_manifest_v1(manifest)
+
+
+def publish_comparison_manifests_atomic(
+    *,
+    output_root: Path,
+    definition_body: Mapping[str, Any],
+    result_body: Mapping[str, Any],
+) -> tuple[Path, Path]:
+    definition = attach_definition_identity_and_integrity(definition_body)
+    validate_definition_manifest_v1(definition)
+    comparison_definition_id = str(definition["comparison_definition_id"])
+
+    result = attach_result_integrity(dict(result_body))
+    if result.get("comparison_definition_id") != comparison_definition_id:
+        raise ComparisonSsotError("result comparison_definition_id mismatch")
+    validate_result_manifest_v1(result)
+
+    output_dir = output_root / comparison_definition_id
+    definition_path = output_dir / DEFINITION_ARTIFACT_FILENAME
+    result_path = output_dir / RESULT_ARTIFACT_FILENAME
+
+    if definition_path.is_file() and result_path.is_file():
+        existing_def = read_manifest(definition_path)
+        existing_res = read_manifest(result_path)
+        if existing_def != definition or existing_res != result:
+            raise ComparisonSsotError(
+                "existing manifests differ under canonical identity (fail-closed)"
+            )
+        _self_verify_definition(definition_path)
+        _self_verify_result(result_path)
+        return definition_path, result_path
+
+    if output_dir.exists():
+        raise ComparisonSsotError(
+            f"output directory exists without complete manifests (fail-closed): {output_dir}"
+        )
+
+    _validate_output_target(output_dir)
+    staging = _staging_dir_for(output_dir)
+    staging.mkdir(parents=True, exist_ok=False)
+    try:
+        staged_def = staging / DEFINITION_ARTIFACT_FILENAME
+        staged_res = staging / RESULT_ARTIFACT_FILENAME
+        staged_def.write_text(serialize_manifest(definition), encoding="utf-8")
+        staged_res.write_text(serialize_manifest(result), encoding="utf-8")
+        _self_verify_definition(staged_def)
+        _self_verify_result(staged_res)
+        staging.replace(output_dir)
+    except Exception:
+        _cleanup_staging(staging)
+        raise
+    finally:
+        if staging.exists():
+            _cleanup_staging(staging)
+
+    _self_verify_definition(definition_path)
+    _self_verify_result(result_path)
+    return definition_path, result_path

--- a/src/meta/learning_loop/comparison_ssot_v1/models.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/models.py
@@ -1,0 +1,63 @@
+"""Typed models for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Mapping
+
+GateStatus = Literal["PASS", "FAIL"]
+
+
+class ComparisonSsotError(ValueError):
+    """Fail-closed comparison SSOT error."""
+
+
+@dataclass(frozen=True)
+class InputRef:
+    owner_domain: str
+    ref_type: str
+    ref_id: str
+    digest: str
+
+    def sort_key(self) -> tuple[str, str, str, str]:
+        return (self.owner_domain, self.ref_type, self.ref_id, self.digest)
+
+    def to_mapping(self) -> dict[str, str]:
+        return {
+            "owner_domain": self.owner_domain,
+            "ref_type": self.ref_type,
+            "ref_id": self.ref_id,
+            "digest": self.digest,
+        }
+
+
+@dataclass(frozen=True)
+class LoadedMetricInput:
+    manifest_path: Path
+    manifest: Mapping[str, Any]
+    comparison_metric_input_id: str
+    source_domain: str
+    source_ref: InputRef
+    evaluation_slice_id: str
+    comparability_metadata: Mapping[str, Any]
+    metrics: Mapping[str, float | int]
+
+
+@dataclass(frozen=True)
+class GateOutcome:
+    gate_id: str
+    version: str
+    status: GateStatus
+    reason_code: str
+    evidence_refs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ComparisonOfflineResult:
+    output_dir: Path
+    definition_path: Path
+    result_path: Path
+    comparison_definition_id: str
+    definition_manifest: Mapping[str, Any]
+    result_manifest: Mapping[str, Any]

--- a/src/meta/learning_loop/comparison_ssot_v1/producer.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/producer.py
@@ -1,0 +1,7 @@
+"""Re-export offline comparison producer."""
+
+from src.meta.learning_loop.comparison_ssot_v1.comparison_offline_producer_v1 import (
+    produce_comparison_offline_v1,
+)
+
+__all__ = ["produce_comparison_offline_v1"]

--- a/src/meta/learning_loop/comparison_ssot_v1/validation.py
+++ b/src/meta/learning_loop/comparison_ssot_v1/validation.py
@@ -1,0 +1,146 @@
+"""Manifest validation for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from src.meta.learning_loop.comparison_metric_input_v1.constants import METRIC_KEYS
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    CANONICAL_AUTHORITY_INVARIANTS,
+    COMPARABILITY_GATE_VERSION,
+    COMPARISON_CONTRACT_VERSION,
+    ELIGIBILITY_RULES_VERSION,
+    IDENTITY_DOMAIN_SEPARATOR,
+    METRIC_SET_VERSION,
+    NORMALIZATION_POLICY_VERSION,
+    RANKING_RULE_NONE,
+)
+from src.meta.learning_loop.comparison_ssot_v1.identity import (
+    verify_definition_identity_and_integrity,
+    verify_result_integrity,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+
+def _require_mapping(value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ComparisonSsotError(f"{label} must be object")
+    return value
+
+
+def validate_input_ref(ref: Any, *, label: str) -> None:
+    mapping = _require_mapping(ref, label=label)
+    for key in ("owner_domain", "ref_type", "ref_id", "digest"):
+        if key not in mapping or not isinstance(mapping[key], str) or not mapping[key].strip():
+            raise ComparisonSsotError(f"{label}.{key} must be non-empty string")
+    if not is_valid_sha256_hex(str(mapping["digest"])):
+        raise ComparisonSsotError(f"{label}.digest must be sha256 hex")
+
+
+def validate_definition_manifest_v1(manifest: Mapping[str, Any]) -> None:
+    for key in (
+        "comparison_contract_version",
+        "comparison_definition_id",
+        "identity_domain",
+        "input_refs",
+        "metric_set_version",
+        "comparability_gate_version",
+        "normalization_policy_version",
+        "ranking_rule_version",
+        "tie_rule_version",
+        "evaluation_slice_id",
+        "eligibility_rules_version",
+        "authority_invariants",
+        "integrity",
+    ):
+        if key not in manifest:
+            raise ComparisonSsotError(f"definition manifest missing {key}")
+
+    if manifest["comparison_contract_version"] != COMPARISON_CONTRACT_VERSION:
+        raise ComparisonSsotError("comparison_contract_version mismatch")
+    if manifest["identity_domain"] != IDENTITY_DOMAIN_SEPARATOR:
+        raise ComparisonSsotError("identity_domain mismatch")
+    if manifest["metric_set_version"] != METRIC_SET_VERSION:
+        raise ComparisonSsotError("metric_set_version mismatch")
+    if manifest["comparability_gate_version"] != COMPARABILITY_GATE_VERSION:
+        raise ComparisonSsotError("comparability_gate_version mismatch")
+    if manifest["normalization_policy_version"] != NORMALIZATION_POLICY_VERSION:
+        raise ComparisonSsotError("normalization_policy_version mismatch")
+    if manifest["eligibility_rules_version"] != ELIGIBILITY_RULES_VERSION:
+        raise ComparisonSsotError("eligibility_rules_version mismatch")
+
+    input_refs = manifest["input_refs"]
+    if not isinstance(input_refs, list) or len(input_refs) < 2:
+        raise ComparisonSsotError("input_refs must contain at least 2 entries")
+    for idx, ref in enumerate(input_refs):
+        validate_input_ref(ref, label=f"input_refs[{idx}]")
+
+    authority = _require_mapping(manifest["authority_invariants"], label="authority_invariants")
+    for key, expected in CANONICAL_AUTHORITY_INVARIANTS.items():
+        if authority.get(key) != expected:
+            raise ComparisonSsotError(f"authority_invariants.{key} mismatch")
+
+    verify_definition_identity_and_integrity(manifest)
+
+
+def validate_result_manifest_v1(manifest: Mapping[str, Any]) -> None:
+    forbidden = {"winner", "selection", "acceptance", "promotion_status", "runtime_status"}
+    for key in forbidden:
+        if key in manifest:
+            raise ComparisonSsotError(f"forbidden result field: {key}")
+
+    for key in (
+        "comparison_contract_version",
+        "comparison_definition_id",
+        "input_snapshots",
+        "metric_matrix",
+        "comparability_gate_outcomes",
+        "overall_comparable",
+        "authority_invariants",
+        "integrity",
+    ):
+        if key not in manifest:
+            raise ComparisonSsotError(f"result manifest missing {key}")
+
+    if manifest["comparison_contract_version"] != COMPARISON_CONTRACT_VERSION:
+        raise ComparisonSsotError("comparison_contract_version mismatch")
+
+    snapshots = manifest["input_snapshots"]
+    if not isinstance(snapshots, list) or not snapshots:
+        raise ComparisonSsotError("input_snapshots must be non-empty list")
+
+    for idx, snap in enumerate(snapshots):
+        mapping = _require_mapping(snap, label=f"input_snapshots[{idx}]")
+        for field in (
+            "comparison_metric_input_id",
+            "source_ref",
+            "source_digest",
+            "metrics",
+        ):
+            if field not in mapping:
+                raise ComparisonSsotError(f"input_snapshots[{idx}] missing {field}")
+        validate_input_ref(mapping["source_ref"], label=f"input_snapshots[{idx}].source_ref")
+        if not is_valid_sha256_hex(str(mapping["source_digest"])):
+            raise ComparisonSsotError(f"input_snapshots[{idx}].source_digest invalid")
+        metrics = _require_mapping(mapping["metrics"], label=f"input_snapshots[{idx}].metrics")
+        if set(metrics.keys()) != set(METRIC_KEYS):
+            raise ComparisonSsotError(f"input_snapshots[{idx}] metric keys invalid")
+
+    matrix = _require_mapping(manifest["metric_matrix"], label="metric_matrix")
+    if set(matrix.keys()) != set(METRIC_KEYS):
+        raise ComparisonSsotError("metric_matrix keys invalid")
+
+    ranking = manifest.get("ranking_result")
+    if ranking is not None:
+        ranking_map = _require_mapping(ranking, label="ranking_result")
+        if ranking_map.get("ranking_rule_version", RANKING_RULE_NONE) == RANKING_RULE_NONE:
+            if ranking_map.get("ranking_status") not in (None, "NONE"):
+                raise ComparisonSsotError("ranking_status inconsistent with NONE rule")
+
+    authority = _require_mapping(manifest["authority_invariants"], label="authority_invariants")
+    for key, expected in CANONICAL_AUTHORITY_INVARIANTS.items():
+        if authority.get(key) != expected:
+            raise ComparisonSsotError(f"authority_invariants.{key} mismatch")
+
+    verify_result_integrity(manifest)

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5772,3 +5772,65 @@ def test_selector_package_comparison_metric_input_metrics_owner_pr_bounded_full_
     bounded = _bounded_targets(sel)
     for path in PACKAGE_COMPARISON_METRIC_INPUT_ALL_TESTOWNERS:
         assert path in bounded
+
+
+PACKAGE_COMPARISON_SSOT_V1_PRODUCTION = (
+    "src/meta/learning_loop/comparison_ssot_v1/comparison_offline_producer_v1.py"
+)
+PACKAGE_COMPARISON_SSOT_V1_SCRIPT = "scripts/run_comparison_offline_v1.py"
+PACKAGE_COMPARISON_SSOT_V1_TESTOWNERS = (
+    "tests/meta/test_comparison_definition_manifest_v1.py",
+    "tests/meta/test_comparison_result_manifest_v1.py",
+    "tests/meta/test_comparison_gates_v1.py",
+    "tests/meta/test_comparison_offline_producer_v1.py",
+    "tests/scripts/test_run_comparison_offline_v1.py",
+)
+PACKAGE_COMPARISON_SSOT_V1_DEPENDENCY_TESTOWNERS = (
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/meta/test_comparison_metric_input_identity_v1.py",
+    "tests/meta/test_comparison_metric_input_validation_v1.py",
+    "tests/meta/test_comparison_metric_input_producer_v1.py",
+    "tests/governance/promotion_loop/test_backtest_lineage_ref_producer_v1.py",
+    "tests/experiments/test_equity_loader.py",
+)
+PACKAGE_COMPARISON_SSOT_V1_ALL_PRODUCTION = (
+    PACKAGE_COMPARISON_SSOT_V1_PRODUCTION,
+    PACKAGE_COMPARISON_SSOT_V1_SCRIPT,
+)
+PACKAGE_COMPARISON_SSOT_V1_ALL_TESTOWNERS = (
+    *PACKAGE_COMPARISON_SSOT_V1_TESTOWNERS,
+    *PACKAGE_COMPARISON_SSOT_V1_DEPENDENCY_TESTOWNERS,
+)
+
+
+def test_selector_package_comparison_ssot_v1_production_pr_bounded_full_includes_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_COMPARISON_SSOT_V1_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_COMPARISON_SSOT_V1_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_comparison_ssot_v1_script_contract_focused_includes_testowners() -> None:
+    sel = _run_selector(PACKAGE_COMPARISON_SSOT_V1_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    for path in PACKAGE_COMPARISON_SSOT_V1_ALL_TESTOWNERS:
+        assert path in targets
+
+
+def test_selector_package_comparison_ssot_v1_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        *PACKAGE_COMPARISON_SSOT_V1_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_COMPARISON_SSOT_V1_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_COMPARISON_SSOT_V1_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/meta/comparison_metric_input_v1_fixtures.py
+++ b/tests/meta/comparison_metric_input_v1_fixtures.py
@@ -159,7 +159,8 @@ def build_experiment_bundle(
     tmp_path: Path,
     completed_run_dir: Path,
 ) -> tuple[Path, dict[str, str], Path]:
-    manifest_dir = tmp_path / f"identity_{uuid.uuid4().hex}"
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    manifest_dir = _DURABLE_OUTPUT_ROOT / f"identity_{uuid.uuid4().hex}"
     produce_experiment_identity_manifest_v1(
         sample_experiment_config(),
         manifest_dir,

--- a/tests/meta/comparison_ssot_v1_fixtures.py
+++ b/tests/meta/comparison_ssot_v1_fixtures.py
@@ -1,0 +1,112 @@
+"""Shared fixtures for comparison_ssot_v1 tests."""
+
+from __future__ import annotations
+
+import shutil
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.meta.learning_loop.comparison_metric_input_v1.producer import (
+    produce_comparison_metric_input_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.producer import produce_comparison_offline_v1
+from tests.meta.comparison_metric_input_v1_fixtures import build_backtest_run_dir
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".comparison_ssot_pytest_outputs"
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_v1.io.is_under_tmp",
+        lambda _path: False,
+    )
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_metric_input_v1.io.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+@pytest.fixture
+def ssot_durable_output_dir() -> Path:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+    path.mkdir(parents=True, exist_ok=True)
+    yield path
+    if path.exists():
+        shutil.rmtree(path, ignore_errors=True)
+    for staging in _DURABLE_OUTPUT_ROOT.glob(".comparison_ssot_staging_*"):
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def produce_backtest_metric_input(
+    tmp_path: Path,
+    durable_root: Path,
+    *,
+    run_id: str,
+    timeframe: str = "1d",
+    end_date: str = "2025-01-20",
+) -> Path:
+    run_dir, ref = build_backtest_run_dir(tmp_path, run_id=run_id)
+    if timeframe != "1d" or end_date != "2025-01-20":
+        import json
+
+        from src.governance.promotion_loop.backtest_lineage_ref_producer_v1 import (
+            build_backtest_lineage_ref_from_run_summary,
+        )
+        from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+            lineage_ref_to_mapping,
+        )
+        from tests.meta.comparison_metric_input_v1_fixtures import (
+            comparison_source_ref,
+            write_run_summary,
+        )
+
+        config = json.loads((run_dir / "config_snapshot.json").read_text(encoding="utf-8"))
+        config["params"]["timeframe"] = timeframe
+        (run_dir / "config_snapshot.json").write_text(json.dumps(config), encoding="utf-8")
+        summary = write_run_summary(run_dir, run_id=run_id)
+        summary.params["timeframe"] = timeframe
+        summary.finished_at_utc = f"{end_date}T10:00:00+00:00"
+        summary.write_json(run_dir / "run_summary.json")
+        ref = comparison_source_ref(
+            lineage_ref_to_mapping(build_backtest_lineage_ref_from_run_summary(summary))
+        )
+    result = produce_comparison_metric_input_v1(
+        source_domain="BACKTEST",
+        output_root=durable_root,
+        source_ref=ref,
+        run_dir=run_dir,
+    )
+    return result.manifest_path
+
+
+def produce_two_compatible_backtest_inputs(
+    tmp_path: Path,
+    durable_root: Path,
+) -> tuple[Path, Path]:
+    first = produce_backtest_metric_input(tmp_path, durable_root, run_id="cmp-ssot-run-a")
+    second = produce_backtest_metric_input(tmp_path, durable_root, run_id="cmp-ssot-run-b")
+    return first, second
+
+
+def produce_comparison_pair(
+    tmp_path: Path,
+    durable_root: Path,
+    *,
+    ranking_rule_version: str = "NONE_V1",
+) -> tuple[Path, Path, str]:
+    metric_root = durable_root / "metric_inputs"
+    metric_root.mkdir(exist_ok=True)
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    comparison_root = durable_root / "comparisons"
+    comparison_root.mkdir(exist_ok=True)
+    result = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=comparison_root,
+        ranking_rule_version=ranking_rule_version,
+    )
+    return result.definition_path, result.result_path, result.comparison_definition_id

--- a/tests/meta/comparison_ssot_v1_fixtures.py
+++ b/tests/meta/comparison_ssot_v1_fixtures.py
@@ -19,13 +19,17 @@ _DURABLE_OUTPUT_ROOT = REPO_ROOT / ".comparison_ssot_pytest_outputs"
 
 
 @pytest.fixture(autouse=True)
-def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+def _allow_tmp_output_ssot(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "src.meta.learning_loop.comparison_ssot_v1.io.is_under_tmp",
         lambda _path: False,
     )
     monkeypatch.setattr(
         "src.meta.learning_loop.comparison_metric_input_v1.io.is_under_tmp",
+        lambda _path: False,
+    )
+    monkeypatch.setattr(
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
         lambda _path: False,
     )
 

--- a/tests/meta/test_comparison_definition_manifest_v1.py
+++ b/tests/meta/test_comparison_definition_manifest_v1.py
@@ -1,0 +1,95 @@
+"""Definition manifest and identity tests for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from src.meta.learning_loop.comparison_ssot_v1.comparison_input_loader_v1 import (
+    load_and_validate_inputs,
+)
+from src.meta.learning_loop.comparison_ssot_v1.comparison_offline_producer_v1 import (
+    produce_comparison_offline_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.identity import (
+    compute_comparison_definition_id,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from src.meta.learning_loop.comparison_ssot_v1.validation import validate_definition_manifest_v1
+from tests.meta.comparison_ssot_v1_fixtures import (
+    produce_backtest_metric_input,
+    produce_two_compatible_backtest_inputs,
+)
+
+
+def test_definition_valid_with_two_inputs(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    out = ssot_durable_output_dir / "cmp"
+    result = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=out,
+        ranking_rule_version="NONE_V1",
+    )
+    validate_definition_manifest_v1(result.definition_manifest)
+
+
+def test_definition_rejects_single_input(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    only = produce_backtest_metric_input(tmp_path, metric_root, run_id="solo-run")
+    with pytest.raises(ComparisonSsotError, match="at least 2"):
+        load_and_validate_inputs([only])
+
+
+def test_definition_id_stable_across_input_order(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    out_a = ssot_durable_output_dir / "cmp_a"
+    out_b = ssot_durable_output_dir / "cmp_b"
+    res_a = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second], output_root=out_a, ranking_rule_version="NONE_V1"
+    )
+    res_b = produce_comparison_offline_v1(
+        input_manifest_paths=[second, first], output_root=out_b, ranking_rule_version="NONE_V1"
+    )
+    assert res_a.comparison_definition_id == res_b.comparison_definition_id
+
+
+def test_definition_id_changes_when_input_digest_changes(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    out1 = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=ssot_durable_output_dir / "c1",
+        ranking_rule_version="NONE_V1",
+    )
+    third = produce_backtest_metric_input(tmp_path, metric_root, run_id="cmp-ssot-run-c")
+    out2 = produce_comparison_offline_v1(
+        input_manifest_paths=[first, third],
+        output_root=ssot_durable_output_dir / "c2",
+        ranking_rule_version="NONE_V1",
+    )
+    assert out1.comparison_definition_id != out2.comparison_definition_id
+
+
+def test_integrity_tamper_detected(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    result = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=ssot_durable_output_dir / "cmp",
+        ranking_rule_version="NONE_V1",
+    )
+    tampered = copy.deepcopy(dict(result.definition_manifest))
+    tampered["integrity"] = {"content_sha256": "0" * 64}
+    with pytest.raises(ComparisonSsotError):
+        validate_definition_manifest_v1(tampered)

--- a/tests/meta/test_comparison_gates_v1.py
+++ b/tests/meta/test_comparison_gates_v1.py
@@ -1,0 +1,101 @@
+"""Comparability gate tests for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from src.meta.learning_loop.comparison_ssot_v1.comparison_gates_v1 import (
+    evaluate_comparability_gates,
+    overall_comparable,
+)
+from src.meta.learning_loop.comparison_ssot_v1.comparison_input_loader_v1 import (
+    load_and_validate_inputs,
+)
+from src.meta.learning_loop.comparison_ssot_v1.comparison_offline_producer_v1 import (
+    produce_comparison_offline_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from tests.meta.comparison_ssot_v1_fixtures import (
+    produce_backtest_metric_input,
+    produce_two_compatible_backtest_inputs,
+)
+
+
+def _load_pair(tmp_path, ssot_durable_output_dir):
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    return load_and_validate_inputs(
+        list(produce_two_compatible_backtest_inputs(tmp_path, metric_root))
+    )
+
+
+def test_gates_happy_path(tmp_path, ssot_durable_output_dir) -> None:
+    inputs = _load_pair(tmp_path, ssot_durable_output_dir)
+    outcomes = evaluate_comparability_gates(inputs)
+    assert overall_comparable(outcomes)
+    assert all(item.status == "PASS" for item in outcomes)
+
+
+def test_timeframe_mismatch_not_comparable(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first_path = produce_backtest_metric_input(tmp_path, metric_root, run_id="tf-a", timeframe="1d")
+    second_path = produce_backtest_metric_input(
+        tmp_path, metric_root, run_id="tf-b", timeframe="1h"
+    )
+    inputs = load_and_validate_inputs([first_path, second_path])
+    outcomes = evaluate_comparability_gates(inputs)
+    assert not overall_comparable(outcomes)
+
+
+def test_cross_domain_mix_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    from tests.meta.comparison_metric_input_v1_fixtures import (
+        build_backtest_run_dir,
+        build_experiment_bundle,
+    )
+    from src.meta.learning_loop.comparison_metric_input_v1.producer import (
+        produce_comparison_metric_input_v1,
+    )
+
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    backtest_path = produce_backtest_metric_input(tmp_path, metric_root, run_id="bt-only")
+    completed_dir, _ = build_backtest_run_dir(tmp_path / "exp_completed")
+    manifest_dir, exp_ref, completed = build_experiment_bundle(tmp_path, completed_dir)
+    experiment_path = produce_comparison_metric_input_v1(
+        source_domain="EXPERIMENT",
+        output_root=metric_root,
+        source_ref=exp_ref,
+        manifest_dir=manifest_dir,
+        completed_run_dir=completed,
+    ).manifest_path
+    with pytest.raises(ComparisonSsotError, match="cross-domain"):
+        load_and_validate_inputs([backtest_path, experiment_path])
+
+
+def test_non_comparable_suppresses_pareto(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first_path = produce_backtest_metric_input(
+        tmp_path, metric_root, run_id="range-a", end_date="2025-01-20"
+    )
+    second_path = produce_backtest_metric_input(
+        tmp_path, metric_root, run_id="range-b", end_date="2025-02-20"
+    )
+    produced = produce_comparison_offline_v1(
+        input_manifest_paths=[first_path, second_path],
+        output_root=ssot_durable_output_dir / "bad",
+        ranking_rule_version="NONE_V1",
+    )
+    assert produced.result_manifest["overall_comparable"] is False
+    assert "pareto_result" not in produced.result_manifest
+
+
+def test_duplicate_input_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, _ = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    with pytest.raises(ComparisonSsotError, match="duplicate"):
+        load_and_validate_inputs([first, first])

--- a/tests/meta/test_comparison_offline_producer_v1.py
+++ b/tests/meta/test_comparison_offline_producer_v1.py
@@ -1,0 +1,109 @@
+"""End-to-end producer tests for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from src.meta.learning_loop.comparison_ssot_v1.comparison_offline_producer_v1 import (
+    produce_comparison_offline_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    DEFINITION_ARTIFACT_FILENAME,
+    RESULT_ARTIFACT_FILENAME,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from src.meta.learning_loop.comparison_ssot_v1.validation import (
+    validate_definition_manifest_v1,
+    validate_result_manifest_v1,
+)
+from tests.meta.comparison_ssot_v1_fixtures import produce_two_compatible_backtest_inputs
+
+
+def test_producer_writes_definition_and_result(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    result = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=ssot_durable_output_dir / "out",
+        ranking_rule_version="NONE_V1",
+    )
+    assert result.definition_path.name == DEFINITION_ARTIFACT_FILENAME
+    assert result.result_path.name == RESULT_ARTIFACT_FILENAME
+    validate_definition_manifest_v1(result.definition_manifest)
+    validate_result_manifest_v1(result.result_manifest)
+
+
+def test_producer_idempotent(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    out = ssot_durable_output_dir / "out"
+    one = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second], output_root=out, ranking_rule_version="NONE_V1"
+    )
+    two = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second], output_root=out, ranking_rule_version="NONE_V1"
+    )
+    assert one.definition_path == two.definition_path
+    assert one.result_path == two.result_path
+
+
+def test_producer_atomic_no_partial_artifacts(
+    tmp_path, ssot_durable_output_dir, monkeypatch
+) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    out = ssot_durable_output_dir / "out"
+
+    def boom(self, target):
+        raise OSError("simulated publish failure")
+
+    monkeypatch.setattr(
+        "pathlib.Path.replace",
+        boom,
+    )
+    with pytest.raises(OSError):
+        produce_comparison_offline_v1(
+            input_manifest_paths=[first, second], output_root=out, ranking_rule_version="NONE_V1"
+        )
+    assert not any(out.iterdir()) if out.exists() else True
+
+
+def test_snapshot_digest_consistency(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    produced = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=ssot_durable_output_dir / "out",
+        ranking_rule_version="NONE_V1",
+    )
+    for snap in produced.result_manifest["input_snapshots"]:
+        assert (
+            snap["source_digest"]
+            == read_manifest(
+                next(
+                    p
+                    for p in [first, second]
+                    if str(read_manifest(p)["comparison_metric_input_id"])
+                    == snap["comparison_metric_input_id"]
+                )
+            )["source_digest"]
+        )
+
+
+def test_unknown_ranking_version_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    with pytest.raises(ComparisonSsotError, match="unknown ranking_rule_version"):
+        produce_comparison_offline_v1(
+            input_manifest_paths=[first, second],
+            output_root=ssot_durable_output_dir / "out",
+            ranking_rule_version="bad_rule_v9",
+        )

--- a/tests/meta/test_comparison_result_manifest_v1.py
+++ b/tests/meta/test_comparison_result_manifest_v1.py
@@ -1,0 +1,118 @@
+"""Result, Pareto, and ranking tests for comparison_ssot.v1."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from src.meta.learning_loop.comparison_ssot_v1.comparison_offline_producer_v1 import (
+    produce_comparison_offline_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import LEXICOGRAPHIC_RANKING_RULE_V1
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from src.meta.learning_loop.comparison_ssot_v1.validation import validate_result_manifest_v1
+from tests.meta.comparison_ssot_v1_fixtures import (
+    produce_comparison_pair,
+    produce_two_compatible_backtest_inputs,
+)
+
+
+def test_result_happy_path(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, result_path, definition_id = produce_comparison_pair(
+        tmp_path, ssot_durable_output_dir
+    )
+    result = read_manifest(result_path)
+    validate_result_manifest_v1(result)
+    assert result["comparison_definition_id"] == definition_id
+    assert result["overall_comparable"] is True
+    assert "pareto_result" in result
+    assert result["ranking_result"]["ranking_status"] == "NONE"
+    assert "winner" not in result
+
+
+def test_pareto_descriptive_only(tmp_path, ssot_durable_output_dir) -> None:
+    _, result_path, _ = produce_comparison_pair(tmp_path, ssot_durable_output_dir)
+    result = read_manifest(result_path)
+    pareto = result["pareto_result"]
+    assert pareto["pareto_descriptive_only"] is True
+    assert "trade_count" not in pareto["pareto_objective_metrics"]
+
+
+def test_lexicographic_ranking_explicit(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    out = ssot_durable_output_dir / "ranked"
+    produced = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=out,
+        ranking_rule_version=LEXICOGRAPHIC_RANKING_RULE_V1,
+    )
+    ranking = produced.result_manifest["ranking_result"]
+    assert ranking["ranking_status"] == "LEXICOGRAPHIC"
+    assert len(ranking["ranked_input_ids"]) == 2
+
+
+def test_ranking_default_none(tmp_path, ssot_durable_output_dir) -> None:
+    _, result_path, _ = produce_comparison_pair(tmp_path, ssot_durable_output_dir)
+    result = read_manifest(result_path)
+    assert result["ranking_result"]["ranking_status"] == "NONE"
+    assert result["ranking_result"]["ranked_input_ids"] == []
+
+
+def test_forbidden_winner_field_rejected() -> None:
+    payload = {
+        "comparison_contract_version": "comparison_ssot.v1",
+        "comparison_definition_id": "abc",
+        "input_snapshots": [
+            {
+                "comparison_metric_input_id": "id1",
+                "source_ref": {
+                    "owner_domain": "d",
+                    "ref_type": "T",
+                    "ref_id": "r",
+                    "digest": "a" * 64,
+                },
+                "source_digest": "a" * 64,
+                "metrics": {
+                    "sharpe": 1.0,
+                    "max_drawdown": 0.1,
+                    "profit_factor": 1.0,
+                    "total_return": 0.1,
+                    "volatility": 0.2,
+                    "trade_count": 1,
+                },
+            }
+        ],
+        "metric_matrix": {
+            "sharpe": [1.0],
+            "max_drawdown": [0.1],
+            "profit_factor": [1.0],
+            "total_return": [0.1],
+            "volatility": [0.2],
+            "trade_count": [1],
+        },
+        "comparability_gate_outcomes": [],
+        "overall_comparable": False,
+        "winner": "bad",
+        "authority_invariants": {},
+        "integrity": {"content_sha256": "b" * 64},
+    }
+    with pytest.raises(ComparisonSsotError, match="winner"):
+        validate_result_manifest_v1(payload)
+
+
+def test_replay_identical_result_digest(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    out = ssot_durable_output_dir / "replay"
+    one = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second], output_root=out, ranking_rule_version="NONE_V1"
+    )
+    two = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second], output_root=out, ranking_rule_version="NONE_V1"
+    )
+    assert one.result_manifest["integrity"] == two.result_manifest["integrity"]

--- a/tests/scripts/test_run_comparison_offline_v1.py
+++ b/tests/scripts/test_run_comparison_offline_v1.py
@@ -1,0 +1,48 @@
+"""CLI tests for run_comparison_offline_v1.py."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from scripts import run_comparison_offline_v1
+from tests.meta.comparison_ssot_v1_fixtures import produce_two_compatible_backtest_inputs
+
+
+def test_cli_happy_path(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    out = ssot_durable_output_dir / "cli_out"
+    rc = run_comparison_offline_v1.main(
+        [
+            "--input-manifest",
+            str(first),
+            "--input-manifest",
+            str(second),
+            "--output-root",
+            str(out),
+            "--ranking-rule-version",
+            "NONE_V1",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "comparison_definition_manifest_v1.json" in captured.out
+    assert "comparison_result_manifest_v1.json" in captured.out
+
+
+def test_cli_requires_two_inputs(tmp_path, ssot_durable_output_dir) -> None:
+    metric_root = ssot_durable_output_dir / "metrics"
+    metric_root.mkdir()
+    first, _ = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    rc = run_comparison_offline_v1.main(
+        [
+            "--input-manifest",
+            str(first),
+            "--output-root",
+            str(ssot_durable_output_dir / "cli_out"),
+        ]
+    )
+    assert rc == 1


### PR DESCRIPTION
## Summary

- **GO_TOKEN:** `GO_COMPARISON_SSOT_V1_MODEL_C_BOUNDED_OFFLINE_IMPLEMENTATION_V0`
- **Base SHA:** `c336d526549dc5653f098dc36876e08ef2b50091` (PR #4613 squash on `origin/main`)
- Implements `comparison_ssot.v1` Model C: offline definition + result manifests and producer
- Consumes only validated `comparison_metric_input_manifest_v1.json` inputs (2..32, same-domain-only)
- Comparability gates, descriptive Pareto, ranking default `NONE_V1`, optional `lexicographic_ranking_v1`
- Atomic publish, self-verification, replay; PR_BOUNDED_FULL CI selector binding

## Scope included

- Canonical owner: `src/meta/learning_loop/comparison_ssot_v1`
- `comparison_definition_manifest_v1.json` + `comparison_result_manifest_v1.json`
- Offline CLI: `scripts/run_comparison_offline_v1.py`
- Adversarial tests under `tests/meta/` and `tests/scripts/`

## Explicit exclusions

- No durable binding, consumer rewiring, migration, or legacy compare rewiring
- No promotion/completion/runtime authority, no trading-logic impact
- No changes to `comparison_metric_input.v1` semantics or adapters

## Test plan

- [x] `tests/meta/test_comparison_*_v1.py` (definition, gates, result, producer)
- [x] `tests/scripts/test_run_comparison_offline_v1.py`
- [x] CI selector contract tests for `PR_BOUNDED_FULL`
- [x] `ruff format` / `ruff check` on new paths
- [ ] GitHub required checks (Fast-Lane + tests 3.11, ≤25 min)

## Safety

- FUTURES_ONLY=true, OFFLINE_ONLY=true
- WINNER_FIELD_INCLUDED=false, PARETO_DESCRIPTIVE_ONLY=true
- **No merge GO** — review only


Made with [Cursor](https://cursor.com)