### PR TITLE
chore(config): deactivate Kraken and stage disabled OKX target

### DIFF
--- a/.github/workflows/prbj-testnet-exec-events.yml
+++ b/.github/workflows/prbj-testnet-exec-events.yml
@@ -1,5 +1,8 @@
 name: PR-BJ / Testnet Exec Events Artifact
 
+# Kraken testnet venue decommissioned (2026-06). Workflow retained for manual-only
+# placeholder artifact shape until OKX EEA rewire under separate operator GO.
+
 on:
   workflow_dispatch:
     inputs:
@@ -27,7 +30,7 @@ jobs:
   run-testnet:
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    if: ${{ github.event_name != 'schedule' || vars.KRAKEN_TESTNET_CRON_ENABLED == 'true' }}
+    if: ${{ false }}
     steps:
       - uses: actions/checkout@v5
 
@@ -40,33 +43,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run testnet orchestrator (exec events enabled)
+      - name: Placeholder exec events (Kraken decommissioned; OKX EEA pending)
         env:
           PT_EXEC_EVENTS_ENABLED: "true"
           PT_EXEC_MODE: "testnet"
           PT_EXEC_EVENTS_JSONL_PATH: "out/ops/execution_events/execution_events.jsonl"
-          KRAKEN_TESTNET_API_KEY: ${{ secrets.KRAKEN_TESTNET_API_KEY }}
-          KRAKEN_TESTNET_API_SECRET: ${{ secrets.KRAKEN_TESTNET_API_SECRET }}
         run: |
           mkdir -p out/ops/execution_events
-          PROFILE="${{ github.event.inputs.profile || 'ma_crossover_small' }}"
-          DURATION="${{ github.event.inputs.duration_min || '2' }}"
-          CONFIG_PATH="${{ github.event.inputs.config_path || '' }}"
-          if [ -n "${KRAKEN_TESTNET_API_KEY:-}" ] && [ -n "${KRAKEN_TESTNET_API_SECRET:-}" ]; then
-            if [ -n "${CONFIG_PATH}" ] && [ -f "${CONFIG_PATH}" ]; then
-              python3 scripts/orchestrate_testnet_runs.py --config "${CONFIG_PATH}" --profile "${PROFILE}" --override-duration "${DURATION}"
-            else
-              python3 scripts/ops/create_testnet_config.py /tmp/config_testnet.toml
-              python3 scripts/orchestrate_testnet_runs.py --config /tmp/config_testnet.toml --profile "${PROFILE}" --override-duration "${DURATION}"
-            fi
-          else
-            echo "WARN: testnet secrets not available (expected on PRs). Writing placeholder exec events."
-            python3 -c "
+          python3 -c "
           from src.observability.execution_events import emit
-          emit(event_type='session_start', level='info', msg='placeholder (no secrets in PR)')
-          emit(event_type='session_end', level='info', msg='placeholder (no secrets in PR)')
+          emit(event_type='session_start', level='info', msg='placeholder (kraken decommissioned; okx eea pending)')
+          emit(event_type='session_end', level='info', msg='placeholder (kraken decommissioned; okx eea pending)')
           "
-          fi
           test -f out/ops/execution_events/execution_events.jsonl
           wc -l out/ops/execution_events/execution_events.jsonl
 

--- a/config/config.test.toml
+++ b/config/config.test.toml
@@ -320,7 +320,7 @@ slippage_bps = 5.0
 # ============================================================================
 
 [exchange.kraken_testnet]
-enabled = true
+enabled = false
 base_url = "https://api.kraken.com"
 api_key_env_var = "KRAKEN_TESTNET_API_KEY"
 api_secret_env_var = "KRAKEN_TESTNET_API_SECRET"
@@ -329,10 +329,18 @@ timeout_seconds = 30.0
 max_retries = 3
 rate_limit_ms = 1000
 
+[exchange.okx_europe_eea]
+enabled = false
+rest_host = "https://eea.okx.com"
+readonly_api_key_env_var = "OKX_EEA_READONLY_API_KEY"
+readonly_api_secret_env_var = "OKX_EEA_READONLY_API_SECRET"
+readonly_api_passphrase_env_var = "OKX_EEA_READONLY_API_PASSPHRASE"
+validate_only = true
+
 [testnet_session]
-enabled = true
-default_exchange = "kraken_testnet"
-symbol = "BTC/EUR"
+enabled = false
+default_exchange = "okx_europe_eea"
+symbol = "ETH-USD_UM_XPERP-310328"
 timeframe = "1m"
 poll_interval_seconds = 60.0
 warmup_candles = 200

--- a/config/config.toml
+++ b/config/config.toml
@@ -416,10 +416,10 @@ auto_switch_enabled = false
 # Manuelle Switch-Bestätigung erforderlich
 require_confirmation = true
 
-# Kraken API (Keys NICHT hier speichern!)
-# Verwende Umgebungsvariablen: KRAKEN_API_KEY, KRAKEN_API_SECRET
-exchange = "kraken"
-default_pair = "BTC/USD"
+# Target venue: OKX Europe EEA (credentials via OKX_EEA_* env vars — separate operator setup).
+# Kraken live profile decommissioned 2026-06; adapter code retained as DORMANT/HISTORICAL only.
+exchange = "okx_europe_eea"
+default_pair = "ETH/USD"
 
 [validation]
 # Mindestanforderungen für Live-Trading-Freigabe
@@ -672,13 +672,14 @@ slippage_bps = 5.0
 [live_exchange]
 # Exchange-Konfiguration für Live-Marktdaten
 # WICHTIG: Nur public market data! Keine Order-APIs!
-name = "kraken"
+# Kraken public OHLCV path DORMANT — OKX EEA is the active venue target.
+name = "okx_europe_eea"
 
 # Sandbox/Public-Only Modus (MUSS true sein für Phase 31)
 use_sandbox = true
 
-# Basis-URL für Kraken Public API
-base_url = "https://api.kraken.com"
+# OKX Europe EEA REST host (public market data probes)
+base_url = "https://eea.okx.com"
 
 # Rate-Limit-Einstellungen
 rate_limit_ms = 1000
@@ -986,8 +987,8 @@ slippage_bps = 5.0
 # ============================================================================
 
 [exchange.kraken_testnet]
-# Testnet-Integration aktivieren
-enabled = true
+# Kraken venue decommissioned — retained for historical adapter/tests only.
+enabled = false
 
 # Kraken API Base-URL
 # Hinweis: Kraken hat kein echtes Testnet, daher nutzen wir validate_only=true
@@ -1027,9 +1028,39 @@ rate_limit_ms = 1000
 # ============================================================================
 
 [exchange.kraken_live]
+enabled = false
 base_url = "https://api.kraken.com"
 api_key_env_var = "KRAKEN_API_KEY"
 api_secret_env_var = "KRAKEN_API_SECRET"
+timeout_seconds = 30.0
+max_retries = 3
+rate_limit_ms = 1000
+
+# ============================================================================
+# OKX EUROPE EEA (Package E / INV-033) — target venue (credentials external)
+# ============================================================================
+# Keys/passphrases ONLY via environment variables or local bounded secret files.
+# Demo/simulation REST uses header x-simulated-trading: 1 on https://eea.okx.com
+# Runtime remains fail-closed until operator credentials + explicit GO.
+
+[exchange.okx_europe_eea]
+enabled = false
+rest_host = "https://eea.okx.com"
+public_ws_host = "wss://wseeapap.okx.com:8443/ws/v5/public"
+private_ws_host = "wss://wseeapap.okx.com:8443/ws/v5/private"
+websocket_port = 8443
+simulation_header_name = "x-simulated-trading"
+simulation_header_value = "1"
+demo_instrument_id = "ETH-USD_UM_XPERP-310328"
+production_instrument_id = "ETH-USD_UM_XPERP-310404"
+public_api_key_env_var = "OKX_EEA_PUBLIC_API_KEY"
+readonly_api_key_env_var = "OKX_EEA_READONLY_API_KEY"
+readonly_api_secret_env_var = "OKX_EEA_READONLY_API_SECRET"
+readonly_api_passphrase_env_var = "OKX_EEA_READONLY_API_PASSPHRASE"
+trade_api_key_env_var = "OKX_EEA_TRADE_API_KEY"
+trade_api_secret_env_var = "OKX_EEA_TRADE_API_SECRET"
+trade_api_passphrase_env_var = "OKX_EEA_TRADE_API_PASSPHRASE"
+validate_only = true
 timeout_seconds = 30.0
 max_retries = 3
 rate_limit_ms = 1000
@@ -1042,14 +1073,14 @@ rate_limit_ms = 1000
 # ============================================================================
 
 [testnet_session]
-# Testnet-Sessions aktivieren
-enabled = true
+# Fail-closed until OKX EEA credentials + bounded runtime GO (Kraken testnet decommissioned).
+enabled = false
 
-# Default-Exchange fuer Testnet
-default_exchange = "kraken_testnet"
+# Default-Exchange fuer Testnet (target venue)
+default_exchange = "okx_europe_eea"
 
-# Trading-Symbol (muss vom Exchange unterstuetzt werden)
-symbol = "BTC/EUR"
+# Trading-Symbol (OKX EEA X-Perp demo reference instrument)
+symbol = "ETH-USD_UM_XPERP-310328"
 
 # Timeframe fuer Candles
 timeframe = "1m"

--- a/tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py
+++ b/tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py
@@ -1,4 +1,4 @@
-"""Static contract for PR-BJ Kraken testnet exec-events workflow (manual-only dispatch).
+"""Static contract for PR-BJ testnet exec-events workflow (manual-only dispatch).
 
 Parses workflow YAML as UTF-8 text only. Never dispatches workflows, never
 reads secret values, and never touches runtime/testnet execution paths.
@@ -52,30 +52,26 @@ def test_workflow_has_workflow_dispatch_only_no_schedule() -> None:
     assert "schedule:" not in _workflow_text()
 
 
-def test_workflow_schedule_requires_kraken_testnet_cron_enabled_var() -> None:
-    text = _workflow_text()
-
-    assert "KRAKEN_TESTNET_CRON_ENABLED" in text
-    assert "vars.KRAKEN_TESTNET_CRON_ENABLED == 'true'" in text
-    assert "github.event_name != 'schedule'" in text
-
-
-def test_workflow_job_gate_preserves_manual_dispatch() -> None:
+def test_workflow_job_fail_closed_after_kraken_decommission() -> None:
     job_if = _run_testnet_job().get("if")
-    assert isinstance(job_if, str)
-
-    assert "github.event_name != 'schedule'" in job_if
-    assert "workflow_dispatch" not in job_if.lower()
-    assert "KRAKEN_TESTNET_CRON_ENABLED" in job_if
+    assert job_if == "${{ false }}"
 
 
-def test_workflow_references_kraken_testnet_secrets_without_exposing_values() -> None:
+def test_workflow_does_not_reference_kraken_testnet_secrets() -> None:
     text = _workflow_text()
 
-    assert "${{ secrets.KRAKEN_TESTNET_API_KEY }}" in text
-    assert "${{ secrets.KRAKEN_TESTNET_API_SECRET }}" in text
+    assert "KRAKEN_TESTNET_API_KEY" not in text
+    assert "KRAKEN_TESTNET_API_SECRET" not in text
+    assert "secrets.KRAKEN" not in text
     assert "sk-" not in text
     assert "AKIA" not in text
+
+
+def test_workflow_documents_kraken_decommission_placeholder() -> None:
+    text = _workflow_text()
+
+    assert "kraken decommissioned" in text.lower()
+    assert "okx eea pending" in text.lower()
 
 
 def test_workflow_does_not_introduce_live_authority_or_aws_paths() -> None:

--- a/tests/ci/test_workflow_secrets_reference_visibility_contract_v0.py
+++ b/tests/ci/test_workflow_secrets_reference_visibility_contract_v0.py
@@ -65,7 +65,6 @@ KNOWN_WORKFLOWS_WITH_SECRETS_REFERENCES = frozenset(
         "paper_session_audit_evidence.yml",
         "paper_tests_audit_evidence.yml",
         "pr-head-sha-required-checks-liveness-guard.yml",
-        "prbj-testnet-exec-events.yml",
         "prcc-aws-export-smoke.yml",
         "prcd-aws-export-write-smoke.yml",
     }
@@ -75,8 +74,6 @@ KNOWN_SECRET_REFERENCE_NAMES = frozenset(
     {
         "ADD_TO_PROJECT_PAT",
         "GITHUB_TOKEN",
-        "KRAKEN_TESTNET_API_KEY",
-        "KRAKEN_TESTNET_API_SECRET",
         "OPENAI_API_KEY",
         "PT_EXPORT_ID",
         "PT_EXPORT_PREFIX",
@@ -278,8 +275,8 @@ def test_workflow_secrets_reference_visibility_contract_classifies_current_secre
 
 def test_workflow_secrets_reference_visibility_contract_known_sets_stay_documentary() -> None:
     """Known sets are owner-review surfaces, not workflow-change mandates."""
-    assert len(KNOWN_WORKFLOWS_WITH_SECRETS_REFERENCES) == 16
-    assert len(KNOWN_SECRET_REFERENCE_NAMES) == 9
+    assert len(KNOWN_WORKFLOWS_WITH_SECRETS_REFERENCES) == 15
+    assert len(KNOWN_SECRET_REFERENCE_NAMES) == 7
 
 
 def test_workflow_secrets_reference_visibility_contract_requires_names_for_known_set() -> None:


### PR DESCRIPTION
## Summary

GO_TOKEN: `GO_KRAKEN_CONFIG_DEACTIVATION_OKX_DISABLED_TARGET_COMMIT_PUSH_PR_V0`

Base SHA: `f45e7b871c385f9a4a29e147ed6ba0a28fd75668`

Bounded config/workflow decommission PR:
- Kraken Testnet disabled (`enabled=false`)
- Kraken Live disabled (`enabled=false`)
- Testnet Session disabled (`enabled=false`), target venue staged as `okx_europe_eea`
- OKX Europe/EEA target profile added with `enabled=false` and externalized env var names only
- PRBJ workflow fail-closed (`if: false`) with Kraken GitHub secret references removed
- Contract tests updated (31 targeted tests PASS locally)

## Changed Files

- `config/config.toml`
- `config/config.test.toml`
- `.github/workflows/prbj-testnet-exec-events.yml`
- `tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py`
- `tests/ci/test_workflow_secrets_reference_visibility_contract_v0.py`

## CI / Safety

- Expected Required CI Mode: `PR_BOUNDED_FULL` (selector reason: `category_config_paths_requires_full`)
- 25-Minute Compatibility: yes (local PR_BOUNDED_FULL bundle 674 tests ~50s)
- PRIMARY_WORKTREE_TOUCHED: false

## Explicit Exclusions

- No adapter deletion
- No OKX credential setup
- No OKX activation
- No connectivity test
- No shadow/paper/testnet/live execution
- No portal key revocation in this PR
- No AWS secret cleanup
- No trading logic changes

## Test Plan

- [x] `pytest tests/ci/test_prbj_testnet_exec_events_workflow_contract_v0.py tests/ci/test_workflow_secrets_reference_visibility_contract_v0.py` (31 PASS)
- [x] PR_BOUNDED_FULL selector targets (674 PASS local)
- [ ] GitHub required checks green

Made with [Cursor](https://cursor.com)