### PR TITLE
feat(meta): add comparison definition durable binding v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1514,6 +1514,25 @@ PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_DURABLE_EVIDENCE_TARGETS: tuple[
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_DEFINITION_DURABLE_EVIDENCE_TRIGGER_PATHS: frozenset[
+    str
+] = frozenset(
+    {
+        "src/meta/learning_loop/comparison_ssot_definition_durable_evidence_binding_v1.py",
+        "scripts/run_comparison_ssot_definition_durable_evidence_binding_v1.py",
+        "tests/meta/test_comparison_ssot_definition_durable_evidence_binding_v1.py",
+        "tests/scripts/test_run_comparison_ssot_definition_durable_evidence_binding_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_DEFINITION_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_comparison_ssot_definition_durable_evidence_binding_v1.py",
+    "tests/scripts/test_run_comparison_ssot_definition_durable_evidence_binding_v1.py",
+    "tests/meta/test_comparison_definition_manifest_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/meta/learning_loop/comparison_metric_input_v1/__init__.py",
@@ -1701,6 +1720,13 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_DURABLE_EVIDENCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_DURABLE_EVIDENCE_TARGETS:
+            add(path)
+
+    if (
+        normalized
+        & PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_DEFINITION_DURABLE_EVIDENCE_TRIGGER_PATHS
+    ):
+        for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_DEFINITION_DURABLE_EVIDENCE_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS:
@@ -4896,6 +4922,11 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                 for (
                     candidate
                 ) in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_DURABLE_EVIDENCE_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_comparison_ssot_definition_durable_evidence_binding_v1.py":
+                for (
+                    candidate
+                ) in PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_DEFINITION_DURABLE_EVIDENCE_TARGETS:
                     add(candidate)
             elif path == "scripts/run_comparison_metric_input_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS:

--- a/scripts/run_comparison_ssot_definition_durable_evidence_binding_v1.py
+++ b/scripts/run_comparison_ssot_definition_durable_evidence_binding_v1.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Offline durable evidence binding for comparison_ssot.v1 definition manifest.
+
+Produces a validated durable evidence bundle with binding index and MANIFEST.sha256 only.
+No comparison evaluation, definition production, result binding, promotion, or runtime.
+
+Usage:
+    python3 scripts/run_comparison_ssot_definition_durable_evidence_binding_v1.py \\
+        --manifest-path /path/to/comparison_definition_manifest_v1.json \\
+        --output-dir /var/evidence/comparison_definition_bundle_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1 import (
+    ComparisonSsotDefinitionDurableEvidenceBindingError,
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1,
+)
+
+EXIT_OK = 0
+EXIT_BINDING_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline durable evidence binding: bind validated "
+            "comparison_definition_manifest_v1.json to durable evidence "
+            "(index + MANIFEST.sha256)."
+        )
+    )
+    parser.add_argument(
+        "--manifest-path",
+        type=Path,
+        required=True,
+        help="Explicit path to comparison_definition_manifest_v1.json.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit durable evidence bundle directory (must not exist; outside /tmp).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.manifest_path.is_file():
+        print(
+            "[comparison_ssot_definition_durable_evidence_binding] ERROR: "
+            f"manifest not found: {args.manifest_path}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    try:
+        result = produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=args.manifest_path,
+            output_dir=args.output_dir,
+        )
+    except ComparisonSsotDefinitionDurableEvidenceBindingError as exc:
+        print(
+            f"[comparison_ssot_definition_durable_evidence_binding] ERROR: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_BINDING_ERROR
+
+    print(
+        "[comparison_ssot_definition_durable_evidence_binding] wrote durable evidence bundle to "
+        f"{result.output_dir} (comparison_definition_id={result.comparison_definition_id})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/comparison_ssot_definition_durable_evidence_binding_v1.py
+++ b/src/meta/learning_loop/comparison_ssot_definition_durable_evidence_binding_v1.py
@@ -1,0 +1,479 @@
+"""Offline durable evidence binding for comparison_ssot.v1 definition manifest."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import (
+    COMPARISON_CONTRACT_VERSION,
+    DEFINITION_ARTIFACT_FILENAME,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.comparison_ssot_v1.validation import validate_definition_manifest_v1
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+BINDING_SCHEMA_VERSION = "comparison_ssot_definition_durable_evidence_binding_v1"
+BINDING_RELATION = "PRESERVES_DEFINITION_IDENTITY_AND_INPUT_REFS"
+MANIFEST_ARTIFACT_REL = DEFINITION_ARTIFACT_FILENAME
+INDEX_ARTIFACT_REL = "comparison_ssot_definition_durable_evidence_binding_index_v1.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".comparison_ssot_definition_durable_evidence_staging_"
+
+FUTURES_SCOPE_REF: dict[str, bool] = {
+    "futures_only": True,
+    "bitcoin_direction_allowed": False,
+}
+TRADING_LOGIC_IMMUTABILITY_REF: dict[str, bool] = {
+    "trading_logic_immutability": True,
+}
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "patches",
+        "patch",
+        "strategy",
+        "signal",
+        "signals",
+        "entry",
+        "exit",
+        "position_sizing",
+        "leverage",
+        "stop_loss",
+        "take_profit",
+        "execution",
+        "order_routing",
+        "risk_limits",
+        "killswitch",
+        "old_value",
+        "new_value",
+        "target",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "runtime_status",
+        "live_arming",
+        "apply_authority",
+        "promotion_authority",
+        "completion",
+        "checkpoint",
+        "params",
+        "metrics",
+        "tags",
+        "winner",
+        "selection",
+        "acceptance",
+        "ranking",
+        "pareto",
+        "selected",
+        "accepted",
+        "promoted",
+        "completed",
+        "runtime_authorized",
+        "shadow_authorized",
+        "testnet_authorized",
+        "live_authorized",
+    }
+)
+
+
+class ComparisonSsotDefinitionDurableEvidenceBindingError(ValueError):
+    """Fail-closed comparison definition durable evidence binding error."""
+
+
+@dataclass(frozen=True)
+class BoundArtifactRecord:
+    artifact_kind: str
+    relative_path: str
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class ComparisonDefinitionBindingCrossReferences:
+    comparison_definition_id: str
+    manifest_content_sha256: str
+
+
+@dataclass(frozen=True)
+class ComparisonSsotDefinitionDurableEvidenceBindingResult:
+    output_dir: Path
+    comparison_definition_id: str
+    binding_index_path: Path
+    manifest_path: Path
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"{label} must not be a symlink: {path}"
+        )
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+                f"binding index must not contain forbidden key: {key}"
+            )
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"{label} must be a regular file: {path}"
+        )
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "output directory must be outside /tmp"
+        )
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"output parent directory missing: {parent}"
+        )
+    if is_under_tmp(parent):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "output parent directory must be outside /tmp"
+        )
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_bundle_relative_path(rel: str) -> None:
+    candidate = Path(rel)
+    if candidate.is_absolute():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"bundle relative path must not be absolute: {rel!r}"
+        )
+    if ".." in candidate.parts:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"bundle relative path must not traverse upward: {rel!r}"
+        )
+
+
+def _reject_unsafe_overlap(*, manifest_path: Path, output_dir: Path) -> None:
+    manifest_res = manifest_path.resolve()
+    output_res = output_dir.resolve()
+    if output_res == manifest_res:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "output directory must not equal manifest path (fail-closed)"
+        )
+    if _path_is_under(manifest_res, output_res):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "manifest path must not be inside output directory (fail-closed)"
+        )
+
+
+def _load_validated_manifest(manifest_path: Path) -> tuple[dict[str, Any], bytes]:
+    _validate_regular_file(manifest_path, label="comparison definition manifest")
+    if manifest_path.name != MANIFEST_ARTIFACT_REL:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"manifest filename must be {MANIFEST_ARTIFACT_REL!r}, got {manifest_path.name!r}"
+        )
+    manifest_bytes = manifest_path.read_bytes()
+    manifest = read_manifest(manifest_path)
+    validate_definition_manifest_v1(manifest)
+    return manifest, manifest_bytes
+
+
+def _verbatim_input_refs(manifest: Mapping[str, Any]) -> list[dict[str, str]]:
+    input_refs = manifest.get("input_refs")
+    if not isinstance(input_refs, list):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError("input_refs must be a list")
+    preserved: list[dict[str, str]] = []
+    for idx, ref in enumerate(input_refs):
+        if not isinstance(ref, Mapping):
+            raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+                f"input_refs[{idx}] must be an object"
+            )
+        preserved.append(
+            {
+                "owner_domain": str(ref["owner_domain"]),
+                "ref_type": str(ref["ref_type"]),
+                "ref_id": str(ref["ref_id"]),
+                "digest": str(ref["digest"]),
+            }
+        )
+    return preserved
+
+
+def _verbatim_policy_config_ref(manifest: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        "ranking_rule_version": str(manifest["ranking_rule_version"]),
+        "tie_rule_version": str(manifest["tie_rule_version"]),
+        "evaluation_slice_id": str(manifest["evaluation_slice_id"]),
+        "metric_set_version": str(manifest["metric_set_version"]),
+        "comparability_gate_version": str(manifest["comparability_gate_version"]),
+        "normalization_policy_version": str(manifest["normalization_policy_version"]),
+        "eligibility_rules_version": str(manifest["eligibility_rules_version"]),
+    }
+
+
+def check_reference_consistency(
+    manifest: Mapping[str, Any],
+) -> ComparisonDefinitionBindingCrossReferences:
+    comparison_definition_id = manifest.get("comparison_definition_id")
+    if not isinstance(comparison_definition_id, str) or not comparison_definition_id.strip():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "comparison_definition_id missing or invalid"
+        )
+    integrity = manifest.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError("integrity must be an object")
+    manifest_content_sha256 = integrity.get("content_sha256")
+    if not isinstance(manifest_content_sha256, str) or not manifest_content_sha256.strip():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "integrity.content_sha256 missing or invalid"
+        )
+    if not is_valid_sha256_hex(manifest_content_sha256):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "integrity.content_sha256 must be valid sha256 hex"
+        )
+    return ComparisonDefinitionBindingCrossReferences(
+        comparison_definition_id=comparison_definition_id,
+        manifest_content_sha256=manifest_content_sha256,
+    )
+
+
+def build_binding_index_v1(
+    *,
+    manifest: Mapping[str, Any],
+    cross_references: ComparisonDefinitionBindingCrossReferences,
+    artifacts: tuple[BoundArtifactRecord, ...],
+) -> dict[str, Any]:
+    sorted_artifacts = sorted(
+        artifacts,
+        key=lambda item: (item.artifact_kind, item.relative_path),
+    )
+    input_refs = _verbatim_input_refs(manifest)
+    payload: dict[str, Any] = {
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "bound_contract": COMPARISON_CONTRACT_VERSION,
+        "comparison_definition_id": cross_references.comparison_definition_id,
+        "identity_domain": str(manifest["identity_domain"]),
+        "binding_relation": BINDING_RELATION,
+        "definition_input_refs": input_refs,
+        "policy_config_ref": _verbatim_policy_config_ref(manifest),
+        "cross_references": {
+            "comparison_definition_id": cross_references.comparison_definition_id,
+            "manifest_content_sha256": cross_references.manifest_content_sha256,
+        },
+        "artifacts": [
+            {
+                "artifact_kind": item.artifact_kind,
+                "relative_path": item.relative_path,
+                "content_sha256": item.content_sha256,
+            }
+            for item in sorted_artifacts
+        ],
+        "futures_scope_ref": dict(FUTURES_SCOPE_REF),
+        "trading_logic_immutability_ref": dict(TRADING_LOGIC_IMMUTABILITY_REF),
+        "evidence_does_not_authorize_runtime": True,
+    }
+    _reject_forbidden_index_keys(payload)
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def serialize_binding_index_v1(index: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(index)
+    return deterministic_json_dumps(dict(index))
+
+
+def _copy_byte_identical(source: Path, dest: Path) -> str:
+    _validate_regular_file(source, label="source artifact")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, dest)
+    source_digest = _sha256_file(source)
+    dest_digest = _sha256_file(dest)
+    if source_digest != dest_digest:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"byte-identical copy failed for {source.name}"
+        )
+    return source_digest
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    token = uuid.uuid4().hex
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{token}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def reverify_comparison_ssot_definition_durable_evidence_bundle_v1(
+    *,
+    output_dir: Path | str,
+) -> None:
+    """Replay durable evidence bundle without raw source access."""
+    bundle_dir = Path(output_dir)
+    if not bundle_dir.is_dir():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"bundle directory not found: {bundle_dir}"
+        )
+    ok, msg = verify_manifest_sha256(bundle_dir)
+    if not ok:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"MANIFEST.sha256 verification failed: {msg}"
+        )
+    manifest_path = bundle_dir / MANIFEST_ARTIFACT_REL
+    index_path = bundle_dir / INDEX_ARTIFACT_REL
+    _validate_regular_file(manifest_path, label=MANIFEST_ARTIFACT_REL)
+    _validate_regular_file(index_path, label=INDEX_ARTIFACT_REL)
+    manifest = _load_validated_manifest(manifest_path)[0]
+    cross = check_reference_consistency(manifest)
+    index = read_manifest(index_path)
+    if index.get("binding_relation") != BINDING_RELATION:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError("binding_relation mismatch")
+    if index.get("comparison_definition_id") != cross.comparison_definition_id:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "binding index comparison_definition_id mismatch"
+        )
+    index_cross = index.get("cross_references")
+    if not isinstance(index_cross, Mapping):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError("cross_references must be object")
+    if index_cross.get("comparison_definition_id") != cross.comparison_definition_id:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "cross_references comparison_definition_id mismatch"
+        )
+    if index_cross.get("manifest_content_sha256") != cross.manifest_content_sha256:
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "manifest_content_sha256 mismatch"
+        )
+    if index.get("definition_input_refs") != _verbatim_input_refs(manifest):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "definition_input_refs not preserved verbatim"
+        )
+    if index.get("policy_config_ref") != _verbatim_policy_config_ref(manifest):
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            "policy_config_ref not preserved verbatim"
+        )
+    validate_definition_manifest_v1(manifest)
+
+
+def produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+    *,
+    manifest_path: Path | str,
+    output_dir: Path | str,
+) -> ComparisonSsotDefinitionDurableEvidenceBindingResult:
+    """Bind validated comparison definition manifest into offline durable evidence."""
+    manifest_file = Path(manifest_path)
+    final_dir = Path(output_dir)
+
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(manifest_path=manifest_file, output_dir=final_dir)
+
+    manifest, _manifest_bytes = _load_validated_manifest(manifest_file)
+    cross = check_reference_consistency(manifest)
+    comparison_definition_id = cross.comparison_definition_id
+
+    for rel in (MANIFEST_ARTIFACT_REL, INDEX_ARTIFACT_REL):
+        _validate_bundle_relative_path(rel)
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+            f"staging directory collision: {staging}"
+        )
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+
+        manifest_dest = staging / MANIFEST_ARTIFACT_REL
+        manifest_file_digest = _copy_byte_identical(manifest_file, manifest_dest)
+
+        artifacts = (
+            BoundArtifactRecord(
+                artifact_kind="comparison_definition_manifest_v1",
+                relative_path=MANIFEST_ARTIFACT_REL,
+                content_sha256=manifest_file_digest,
+            ),
+        )
+        index_payload = build_binding_index_v1(
+            manifest=manifest,
+            cross_references=cross,
+            artifacts=artifacts,
+        )
+        index_path = staging / INDEX_ARTIFACT_REL
+        index_path.write_text(serialize_binding_index_v1(index_payload), encoding="utf-8")
+
+        write_manifest_sha256(staging)
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise ComparisonSsotDefinitionDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return ComparisonSsotDefinitionDurableEvidenceBindingResult(
+        output_dir=final_dir,
+        comparison_definition_id=comparison_definition_id,
+        binding_index_path=final_dir / INDEX_ARTIFACT_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+    )
+
+
+__all__ = [
+    "BINDING_RELATION",
+    "BINDING_SCHEMA_VERSION",
+    "INDEX_ARTIFACT_REL",
+    "MANIFEST_ARTIFACT_REL",
+    "BoundArtifactRecord",
+    "ComparisonDefinitionBindingCrossReferences",
+    "ComparisonSsotDefinitionDurableEvidenceBindingError",
+    "ComparisonSsotDefinitionDurableEvidenceBindingResult",
+    "build_binding_index_v1",
+    "check_reference_consistency",
+    "produce_comparison_ssot_definition_durable_evidence_bundle_v1",
+    "reverify_comparison_ssot_definition_durable_evidence_bundle_v1",
+    "serialize_binding_index_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -5773,6 +5773,88 @@ def test_selector_package_cmp_metric_input_durable_binding_full_six_file_diff_pr
         assert path in bounded
 
 
+PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_PRODUCTION = (
+    "src/meta/learning_loop/comparison_ssot_definition_durable_evidence_binding_v1.py"
+)
+PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_SCRIPT = (
+    "scripts/run_comparison_ssot_definition_durable_evidence_binding_v1.py"
+)
+PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_TESTOWNER = (
+    "tests/meta/test_comparison_ssot_definition_durable_evidence_binding_v1.py"
+)
+PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_CLI_TESTOWNER = (
+    "tests/scripts/test_run_comparison_ssot_definition_durable_evidence_binding_v1.py"
+)
+PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_DEPENDENCY_TESTOWNERS = (
+    "tests/meta/test_comparison_definition_manifest_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_ALL_PRODUCTION = (
+    PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_PRODUCTION,
+    PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_SCRIPT,
+)
+PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_ALL_TESTOWNERS = (
+    PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_TESTOWNER,
+    PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_CLI_TESTOWNER,
+    *PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_DEPENDENCY_TESTOWNERS,
+)
+
+
+def test_selector_package_cmp_ssot_definition_durable_binding_production_pr_bounded_full_includes_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_cmp_ssot_definition_durable_binding_script_contract_focused_includes_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_SCRIPT)
+    assert sel["test_selection_mode"] == "CONTRACT_FOCUSED"
+    targets = _targets(sel)
+    for path in PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_ALL_TESTOWNERS:
+        assert path in targets
+
+
+def test_selector_package_cmp_ssot_definition_durable_binding_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        *PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1
+
+
+def test_selector_package_cmp_ssot_definition_durable_binding_full_six_file_diff_pr_bounded_full_not_no_op() -> (
+    None
+):
+    sel = _run_selector(
+        PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_PRODUCTION,
+        PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_SCRIPT,
+        PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_TESTOWNER,
+        PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_CLI_TESTOWNER,
+        "scripts/ops/ci_test_selection_v1.py",
+        "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    assert sel["test_selection_mode"] != "NO_OP"
+    assert sel["test_selection_mode"] != "FOCUSED"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_SSOT_DEFINITION_DURABLE_BINDING_ALL_TESTOWNERS:
+        assert path in bounded
+
+
 PACKAGE_COMPARISON_METRIC_INPUT_PRODUCTION = (
     "src/meta/learning_loop/comparison_metric_input_v1/producer.py"
 )

--- a/tests/meta/test_comparison_ssot_definition_durable_evidence_binding_v1.py
+++ b/tests/meta/test_comparison_ssot_definition_durable_evidence_binding_v1.py
@@ -1,0 +1,473 @@
+"""Contract tests for comparison_ssot.v1 definition durable evidence binding."""
+
+from __future__ import annotations
+
+import ast
+import json
+import shutil
+from copy import deepcopy
+from pathlib import Path
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.meta.learning_loop.comparison_ssot_v1.constants import DEFINITION_ARTIFACT_FILENAME
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1 import (
+    BINDING_RELATION,
+    INDEX_ARTIFACT_REL,
+    MANIFEST_ARTIFACT_REL,
+    BoundArtifactRecord,
+    ComparisonDefinitionBindingCrossReferences,
+    ComparisonSsotDefinitionDurableEvidenceBindingError,
+    build_binding_index_v1,
+    check_reference_consistency,
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1,
+    reverify_comparison_ssot_definition_durable_evidence_bundle_v1,
+    serialize_binding_index_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256
+from tests.meta.comparison_ssot_v1_fixtures import produce_comparison_pair
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def _durable_output(tmp_path: Path, name: str = "bundle") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _produce_definition_manifest(tmp_path, durable_root) -> tuple[Path, dict, str]:
+    definition_path, _, comparison_definition_id = produce_comparison_pair(
+        tmp_path,
+        durable_root,
+        ranking_rule_version="NONE_V1",
+    )
+    manifest = read_manifest(definition_path)
+    return definition_path, manifest, comparison_definition_id
+
+
+def test_happy_path_definition_binding(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, manifest, comparison_definition_id = _produce_definition_manifest(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path)
+    result = produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    assert result.comparison_definition_id == comparison_definition_id
+    assert (out / MANIFEST_ARTIFACT_REL).is_file()
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is True
+
+
+def test_byte_identical_manifest_copy(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    source_bytes = definition_path.read_bytes()
+    out = _durable_output(tmp_path, "copy")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    assert (out / MANIFEST_ARTIFACT_REL).read_bytes() == source_bytes
+
+
+def test_input_refs_preserved_verbatim(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "refs")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert index["definition_input_refs"] == manifest["input_refs"]
+
+
+def test_input_ref_ordering_preserved(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "order")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert [ref["ref_id"] for ref in index["definition_input_refs"]] == [
+        ref["ref_id"] for ref in manifest["input_refs"]
+    ]
+
+
+def test_policy_config_preserved_verbatim(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "policy")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert index["policy_config_ref"]["ranking_rule_version"] == manifest["ranking_rule_version"]
+    assert index["policy_config_ref"]["tie_rule_version"] == manifest["tie_rule_version"]
+
+
+def test_binding_index_metadata_only(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "meta")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert index["evidence_does_not_authorize_runtime"] is True
+    assert index["binding_relation"] == BINDING_RELATION
+    assert "winner" not in index
+    assert "selection" not in index
+    assert all(not Path(item["relative_path"]).is_absolute() for item in index["artifacts"])
+
+
+def test_reverify_without_raw_data(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "replay")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    reverify_comparison_ssot_definition_durable_evidence_bundle_v1(output_dir=out)
+
+
+def test_deterministic_index_and_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out1 = _durable_output(tmp_path, "det1")
+    out2 = _durable_output(tmp_path, "det2")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out1,
+    )
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out2,
+    )
+    assert (out1 / INDEX_ARTIFACT_REL).read_bytes() == (out2 / INDEX_ARTIFACT_REL).read_bytes()
+    assert (out1 / "MANIFEST.sha256").read_bytes() == (out2 / "MANIFEST.sha256").read_bytes()
+
+
+def test_missing_manifest_fail_closed(tmp_path) -> None:
+    out = _durable_output(tmp_path, "missing")
+    with pytest.raises(ComparisonSsotDefinitionDurableEvidenceBindingError, match="not found"):
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=tmp_path / "missing.json",
+            output_dir=out,
+        )
+
+
+def test_wrong_manifest_filename_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    bad_path = definition_path.parent / "wrong_name.json"
+    bad_path.write_text(definition_path.read_text(encoding="utf-8"), encoding="utf-8")
+    out = _durable_output(tmp_path, "badname")
+    with pytest.raises(ComparisonSsotDefinitionDurableEvidenceBindingError, match="filename"):
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=bad_path,
+            output_dir=out,
+        )
+
+
+def test_existing_output_dir_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "exists")
+    out.mkdir(parents=True)
+    with pytest.raises(ComparisonSsotDefinitionDurableEvidenceBindingError, match="already exists"):
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=definition_path,
+            output_dir=out,
+        )
+
+
+def test_symlink_manifest_rejected(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    link = tmp_path / "manifest_link.json"
+    link.symlink_to(definition_path)
+    out = _durable_output(tmp_path, "symlink")
+    with pytest.raises(ComparisonSsotDefinitionDurableEvidenceBindingError, match="symlink"):
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=link,
+            output_dir=out,
+        )
+
+
+def test_id_mismatch_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    payload = deepcopy(dict(manifest))
+    payload["comparison_definition_id"] = "0" * 64
+    tampered = definition_path.parent / "tampered.json"
+    tampered.write_text(json.dumps(payload), encoding="utf-8")
+    out = _durable_output(tmp_path, "idmismatch")
+    with pytest.raises(ComparisonSsotDefinitionDurableEvidenceBindingError):
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=tampered,
+            output_dir=out,
+        )
+
+
+def test_digest_mismatch_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    payload = deepcopy(dict(manifest))
+    payload["integrity"]["content_sha256"] = "0" * 64
+    tampered = definition_path.parent / "digest_tampered.json"
+    tampered.write_text(json.dumps(payload), encoding="utf-8")
+    out = _durable_output(tmp_path, "digest")
+    with pytest.raises(ComparisonSsotDefinitionDurableEvidenceBindingError):
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=tampered,
+            output_dir=out,
+        )
+
+
+def test_copy_failure_cleans_up(
+    tmp_path, ssot_durable_output_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "copyfail")
+
+    def _boom(_src: Path, _dst: Path) -> str:
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1._copy_byte_identical",
+        _boom,
+    )
+    with pytest.raises(OSError, match="copy failed"):
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=definition_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_manifest_verify_failure_cleans_up(
+    tmp_path, ssot_durable_output_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "manifestfail")
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.verify_manifest_sha256",
+        lambda _root: (False, "checksum mismatch"),
+    )
+    with pytest.raises(
+        ComparisonSsotDefinitionDurableEvidenceBindingError, match="verification failed"
+    ):
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+            manifest_path=definition_path,
+            output_dir=out,
+        )
+    assert not out.exists()
+
+
+def test_build_binding_index_rejects_forbidden_key(tmp_path, ssot_durable_output_dir) -> None:
+    _, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    cross = check_reference_consistency(manifest)
+    artifacts = (
+        BoundArtifactRecord(
+            artifact_kind="comparison_definition_manifest_v1",
+            relative_path=MANIFEST_ARTIFACT_REL,
+            content_sha256="a" * 64,
+        ),
+    )
+    index = build_binding_index_v1(
+        manifest=manifest,
+        cross_references=cross,
+        artifacts=artifacts,
+    )
+    index["winner"] = "candidate-a"
+    with pytest.raises(ComparisonSsotDefinitionDurableEvidenceBindingError, match="forbidden key"):
+        serialize_binding_index_v1(index)
+
+
+def test_integrity_hash_stable_for_index_payload(tmp_path, ssot_durable_output_dir) -> None:
+    _, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    cross = check_reference_consistency(manifest)
+    artifacts = (
+        BoundArtifactRecord(
+            artifact_kind="comparison_definition_manifest_v1",
+            relative_path=MANIFEST_ARTIFACT_REL,
+            content_sha256=cross.manifest_content_sha256,
+        ),
+    )
+    index = build_binding_index_v1(
+        manifest=manifest,
+        cross_references=cross,
+        artifacts=artifacts,
+    )
+    payload = dict(index)
+    digest = payload.pop("integrity")
+    assert digest["content_sha256"] == compute_content_sha256(payload)
+
+
+def test_output_under_tmp_rejected(
+    tmp_path, ssot_durable_output_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts.ops.primary_evidence_retention_v0 import is_under_tmp as real_is_under_tmp
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        real_is_under_tmp,
+    )
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = Path("/tmp/peak_trade_cmp_definition_binding_reject_test")
+    try:
+        with pytest.raises(
+            ComparisonSsotDefinitionDurableEvidenceBindingError, match="outside /tmp"
+        ):
+            produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+                manifest_path=definition_path,
+                output_dir=out,
+            )
+    finally:
+        if out.exists():
+            shutil.rmtree(out)
+
+
+def test_no_runtime_imports_in_binding_module() -> None:
+    path = Path("src/meta/learning_loop/comparison_ssot_definition_durable_evidence_binding_v1.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = ("promotion_loop.engine", "governance.promotion_loop.engine")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for token in forbidden:
+                assert token not in node.module
+
+
+def test_reverify_detects_tampered_index(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "tamper")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    index_path = out / INDEX_ARTIFACT_REL
+    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    payload["definition_input_refs"][0]["ref_id"] = "tampered"
+    index_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(
+        ComparisonSsotDefinitionDurableEvidenceBindingError, match="MANIFEST.sha256"
+    ):
+        reverify_comparison_ssot_definition_durable_evidence_bundle_v1(output_dir=out)
+
+
+def test_check_reference_consistency_requires_valid_id(tmp_path, ssot_durable_output_dir) -> None:
+    _, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    bad = dict(manifest)
+    bad.pop("comparison_definition_id")
+    with pytest.raises(
+        ComparisonSsotDefinitionDurableEvidenceBindingError, match="comparison_definition_id"
+    ):
+        check_reference_consistency(bad)
+
+
+def test_binding_preserves_id_and_digest_verbatim(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, manifest, comparison_definition_id = _produce_definition_manifest(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path, "verbatim")
+    result = produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    assert result.comparison_definition_id == comparison_definition_id
+    bound_manifest = json.loads((out / MANIFEST_ARTIFACT_REL).read_text(encoding="utf-8"))
+    assert bound_manifest["comparison_definition_id"] == comparison_definition_id
+    assert bound_manifest["integrity"]["content_sha256"] == manifest["integrity"]["content_sha256"]
+
+
+def test_binding_does_not_read_metric_inputs_or_raw_sources(
+    tmp_path, ssot_durable_output_dir, monkeypatch
+) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "noraw")
+
+    original_read_bytes = Path.read_bytes
+
+    def _tracked_read_bytes(self: Path) -> bytes:
+        if self.name == "comparison_metric_input_manifest_v1.json":
+            raise AssertionError("metric input read forbidden during definition binding")
+        if self.suffix in {".csv", ".parquet"} or self.name == "run_summary.json":
+            raise AssertionError("raw source read forbidden during definition binding")
+        return original_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _tracked_read_bytes)
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+
+
+def test_index_cross_references_match_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, manifest, comparison_definition_id = _produce_definition_manifest(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path, "cross")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    index = json.loads((out / INDEX_ARTIFACT_REL).read_text(encoding="utf-8"))
+    cross = index["cross_references"]
+    assert cross["comparison_definition_id"] == comparison_definition_id
+    assert cross["manifest_content_sha256"] == manifest["integrity"]["content_sha256"]
+
+
+def test_definition_manifest_filename_constant() -> None:
+    assert MANIFEST_ARTIFACT_REL == DEFINITION_ARTIFACT_FILENAME
+
+
+def test_check_reference_consistency_cross_fields(tmp_path, ssot_durable_output_dir) -> None:
+    _, manifest, comparison_definition_id = _produce_definition_manifest(
+        tmp_path, ssot_durable_output_dir
+    )
+    cross = check_reference_consistency(manifest)
+    assert cross.comparison_definition_id == comparison_definition_id
+    assert cross.manifest_content_sha256 == manifest["integrity"]["content_sha256"]
+
+
+def test_reverify_binding_relation_mismatch(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "rel")
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=definition_path,
+        output_dir=out,
+    )
+    index_path = out / INDEX_ARTIFACT_REL
+    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    payload["binding_relation"] = "WRONG_RELATION"
+    index_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ComparisonSsotDefinitionDurableEvidenceBindingError):
+        reverify_comparison_ssot_definition_durable_evidence_bundle_v1(output_dir=out)
+
+
+def test_build_binding_index_type(tmp_path, ssot_durable_output_dir) -> None:
+    _, manifest, _ = _produce_definition_manifest(tmp_path, ssot_durable_output_dir)
+    cross = ComparisonDefinitionBindingCrossReferences(
+        comparison_definition_id=str(manifest["comparison_definition_id"]),
+        manifest_content_sha256=str(manifest["integrity"]["content_sha256"]),
+    )
+    index = build_binding_index_v1(
+        manifest=manifest,
+        cross_references=cross,
+        artifacts=(
+            BoundArtifactRecord(
+                artifact_kind="comparison_definition_manifest_v1",
+                relative_path=MANIFEST_ARTIFACT_REL,
+                content_sha256=cross.manifest_content_sha256,
+            ),
+        ),
+    )
+    assert index["schema_version"] == "comparison_ssot_definition_durable_evidence_binding_v1"
+    assert index["bound_contract"] == "comparison_ssot.v1"

--- a/tests/scripts/test_run_comparison_ssot_definition_durable_evidence_binding_v1.py
+++ b/tests/scripts/test_run_comparison_ssot_definition_durable_evidence_binding_v1.py
@@ -1,0 +1,103 @@
+"""CLI tests for comparison_ssot.v1 definition durable evidence binding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from scripts.run_comparison_ssot_definition_durable_evidence_binding_v1 import (
+    EXIT_BINDING_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL,
+)
+from tests.meta.comparison_ssot_v1_fixtures import produce_comparison_pair
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def test_cli_successful_run(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = produce_comparison_pair(
+        tmp_path, ssot_durable_output_dir, ranking_rule_version="NONE_V1"
+    )
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    out = out_root / "bundle_out"
+    rc = main(
+        [
+            "--manifest-path",
+            str(definition_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+
+
+def test_cli_requires_all_paths() -> None:
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_cli_missing_manifest_usage_error(tmp_path) -> None:
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    rc = main(
+        [
+            "--manifest-path",
+            str(tmp_path / "missing.json"),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_binding_error(tmp_path, ssot_durable_output_dir) -> None:
+    definition_path, _, _ = produce_comparison_pair(
+        tmp_path, ssot_durable_output_dir, ranking_rule_version="NONE_V1"
+    )
+    out = tmp_path / "evidence_root" / "exists"
+    out.mkdir(parents=True)
+    rc = main(
+        [
+            "--manifest-path",
+            str(definition_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_prints_success_message(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    definition_path, _, comparison_definition_id = produce_comparison_pair(
+        tmp_path, ssot_durable_output_dir, ranking_rule_version="NONE_V1"
+    )
+    out_root = tmp_path / "evidence_root2"
+    out_root.mkdir()
+    out = out_root / "bundle_out"
+    rc = main(
+        [
+            "--manifest-path",
+            str(definition_path),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    captured = capsys.readouterr()
+    assert comparison_definition_id in captured.out


### PR DESCRIPTION
## Summary

- Implements offline `comparison_ssot.v1` **Definition Durable Binding v1** as a bounded additive slice (PR #4615 analog).
- Binds only pre-validated `comparison_definition_manifest_v1.json` with verbatim `comparison_definition_id`, `integrity.content_sha256`, and `input_refs` preservation.
- Adds canonical owner, CLI, contract tests, and CI selector partition for PR_BOUNDED_FULL coverage.

## GO / Safety

| Field | Value |
|-------|-------|
| GO_TOKEN | `GO_COMPARISON_SSOT_V1_DEFINITION_DURABLE_BINDING_V1_IMPLEMENTATION_V0` |
| Base SHA | `da9b257bf1630758e204db16cb15c97fcfef3ad6` |
| Admissibility bundle | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/comparison_ssot_v1_definition_durable_binding_bounded_read_only_admissibility_review_v0_20260627T180200Z` |
| Admissibility MANIFEST RC | 0 |
| Canonical owner | `src/meta/learning_loop/comparison_ssot_definition_durable_evidence_binding_v1.py` |
| Target contract | `comparison_ssot_definition_durable_evidence_binding.v1` |
| Bound artifact | `comparison_definition_manifest_v1.json` |
| Relation | `PRESERVES_DEFINITION_IDENTITY_AND_INPUT_REFS` |
| Ref-ID source | `manifest.comparison_definition_id` verbatim |
| Digest source | `manifest.integrity.content_sha256` verbatim |
| Input-ref model | `PRESERVE_ORIGINAL_INPUT_REFS_ONLY` |
| ID/digest recompute at bind | **false** |
| Raw source re-read | **false** |
| Staging/publish | staging prefix → MANIFEST.sha256 → self-verify → atomic replace |
| Self-verification | `validate_definition_manifest_v1` + `verify_manifest_sha256` before/after publish |
| Replay | bundle-only re-verification; no bind-time ID/digest assignment |
| PRIMARY_WORKTREE_TOUCHED | false |
| IMPLEMENTATION_GO_GRANTED | true |
| MERGE_GO_GRANTED | false |

## Explicit exclusions

- No Result Binding
- No Common Bundle
- No Completion / Promotion / Runtime authority
- No Consumer rewiring / Migration / Registry / MLflow mutation
- No Trading logic / OKX / Kraken work

## Test plan

- [x] `tests/meta/test_comparison_ssot_definition_durable_evidence_binding_v1.py` (29 tests)
- [x] `tests/scripts/test_run_comparison_ssot_definition_durable_evidence_binding_v1.py` (5 tests)
- [x] CI selector contract tests for definition durable binding package (4 tests)
- [x] Dependency regression: definition manifest + contract_safety + candidate_lineage contract tests
- [x] `ruff format --check` / `ruff check` on changed files

## CI

| Field | Value |
|-------|-------|
| Expected required CI mode | PR_BOUNDED_FULL (6-file package; PR #4615-class) |
| Core package wallclock (local) | ~2s for 77 selected tests |
| 25-minute compatible | yes |

Made with [Cursor](https://cursor.com)