### PR TITLE
feat(meta): add common comparison durable evidence bundle v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1552,6 +1552,28 @@ PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_RESULT_DURABLE_EVIDENCE_TARGETS: tuple[s
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TRIGGER_PATHS: frozenset[str] = (
+    frozenset(
+        {
+            "src/meta/learning_loop/comparison_common_durable_evidence_binding_v1.py",
+            "scripts/run_comparison_common_durable_evidence_binding_v1.py",
+            "tests/meta/test_comparison_common_durable_evidence_binding_v1.py",
+            "tests/scripts/test_run_comparison_common_durable_evidence_binding_v1.py",
+        }
+    )
+)
+
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_comparison_common_durable_evidence_binding_v1.py",
+    "tests/scripts/test_run_comparison_common_durable_evidence_binding_v1.py",
+    "tests/meta/test_comparison_metric_input_durable_evidence_binding_v1.py",
+    "tests/meta/test_comparison_ssot_definition_durable_evidence_binding_v1.py",
+    "tests/meta/test_comparison_ssot_result_durable_evidence_binding_v1.py",
+    "tests/meta/test_comparison_result_manifest_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/meta/learning_loop/comparison_metric_input_v1/__init__.py",
@@ -1750,6 +1772,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_RESULT_DURABLE_EVIDENCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_RESULT_DURABLE_EVIDENCE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS:
@@ -4955,6 +4981,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                 for (
                     candidate
                 ) in PR_BOUNDED_FULL_PACKAGE_COMPARISON_SSOT_RESULT_DURABLE_EVIDENCE_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_comparison_common_durable_evidence_binding_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TARGETS:
                     add(candidate)
             elif path == "scripts/run_comparison_metric_input_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS:

--- a/scripts/run_comparison_common_durable_evidence_binding_v1.py
+++ b/scripts/run_comparison_common_durable_evidence_binding_v1.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Offline durable evidence binding for common comparison chain bundles.
+
+Aggregates already-bound metric-input, definition, and result durable evidence
+bundles into one common bundle with cross-reference index and MANIFEST.sha256 only.
+No comparison execution, producer re-run, promotion, or runtime.
+
+Usage:
+    python3 scripts/run_comparison_common_durable_evidence_binding_v1.py \\
+        --definition-bound-bundle-dir /path/to/definition_bound_bundle \\
+        --result-bound-bundle-dir /path/to/result_bound_bundle \\
+        --metric-input-bound-bundle-dir /path/to/mi_bound_a \\
+        --metric-input-bound-bundle-dir /path/to/mi_bound_b \\
+        --output-dir /var/evidence/comparison_common_bundle_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    ComparisonCommonDurableEvidenceBindingError,
+    produce_comparison_common_durable_evidence_bundle_v1,
+)
+
+EXIT_OK = 0
+EXIT_BINDING_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline durable evidence binding: aggregate verified comparison "
+            "metric-input, definition, and result bound bundles into a common bundle."
+        )
+    )
+    parser.add_argument(
+        "--definition-bound-bundle-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to comparison definition durable evidence bound bundle.",
+    )
+    parser.add_argument(
+        "--result-bound-bundle-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to comparison result durable evidence bound bundle.",
+    )
+    parser.add_argument(
+        "--metric-input-bound-bundle-dir",
+        type=Path,
+        action="append",
+        required=True,
+        dest="metric_input_bound_bundle_dirs",
+        help=(
+            "Explicit path to one comparison metric-input durable evidence bound bundle. "
+            "Repeat for each definition input ref (2..32)."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit common durable evidence bundle directory (must not exist; outside /tmp).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.definition_bound_bundle_dir.is_dir():
+        print(
+            "[comparison_common_durable_evidence_binding] ERROR: "
+            f"definition bound bundle not found: {args.definition_bound_bundle_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if not args.result_bound_bundle_dir.is_dir():
+        print(
+            "[comparison_common_durable_evidence_binding] ERROR: "
+            f"result bound bundle not found: {args.result_bound_bundle_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    for path in args.metric_input_bound_bundle_dirs:
+        if not path.is_dir():
+            print(
+                "[comparison_common_durable_evidence_binding] ERROR: "
+                f"metric input bound bundle not found: {path}",
+                file=sys.stderr,
+            )
+            return EXIT_USAGE_ERROR
+
+    try:
+        result = produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=args.definition_bound_bundle_dir,
+            result_bound_bundle_dir=args.result_bound_bundle_dir,
+            metric_input_bound_bundle_dirs=args.metric_input_bound_bundle_dirs,
+            output_dir=args.output_dir,
+        )
+    except ComparisonCommonDurableEvidenceBindingError as exc:
+        print(
+            f"[comparison_common_durable_evidence_binding] ERROR: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_BINDING_ERROR
+
+    print(
+        "[comparison_common_durable_evidence_binding] wrote common durable evidence bundle to "
+        f"{result.output_dir} (comparison_definition_id={result.comparison_definition_id}, "
+        f"metric_input_binding_count={result.metric_input_binding_count})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/comparison_common_durable_evidence_binding_v1.py
+++ b/src/meta/learning_loop/comparison_common_durable_evidence_binding_v1.py
@@ -1,0 +1,920 @@
+"""Offline durable evidence binding aggregating comparison chain sub-bundles v1."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL as METRIC_INPUT_INDEX_ARTIFACT_REL,
+    reverify_comparison_metric_input_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL as DEFINITION_INDEX_ARTIFACT_REL,
+    reverify_comparison_ssot_definition_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL as RESULT_INDEX_ARTIFACT_REL,
+    reverify_comparison_ssot_result_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import COMPARISON_CONTRACT_VERSION
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+BINDING_SCHEMA_VERSION = "comparison_common_durable_evidence_binding_v1"
+BINDING_RELATION = "PRESERVES_COMPARISON_CHAIN_REFERENCES"
+INDEX_ARTIFACT_REL = "comparison_common_durable_evidence_binding_index_v1.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".comparison_common_durable_evidence_staging_"
+
+MIN_METRIC_INPUT_BINDINGS = 2
+MAX_METRIC_INPUT_BINDINGS = 32
+
+METRIC_INPUT_EMBED_PREFIX = "embedded/metric_input_bindings"
+DEFINITION_EMBED_PREFIX = "embedded/definition_binding"
+RESULT_EMBED_PREFIX = "embedded/result_binding"
+
+FUTURES_SCOPE_REF: dict[str, bool] = {
+    "futures_only": True,
+    "bitcoin_direction_allowed": False,
+}
+TRADING_LOGIC_IMMUTABILITY_REF: dict[str, bool] = {
+    "trading_logic_immutability": True,
+}
+COMPARISON_AUTHORITY_INVARIANTS: dict[str, bool] = {
+    "comparison_is_descriptive_only": True,
+    "comparison_does_not_select": True,
+    "comparison_does_not_accept": True,
+    "comparison_does_not_promote": True,
+    "comparison_does_not_authorize_runtime": True,
+}
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "patches",
+        "patch",
+        "strategy",
+        "signal",
+        "signals",
+        "entry",
+        "exit",
+        "position_sizing",
+        "leverage",
+        "stop_loss",
+        "take_profit",
+        "execution",
+        "order_routing",
+        "risk_limits",
+        "killswitch",
+        "old_value",
+        "new_value",
+        "target",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "runtime_status",
+        "live_arming",
+        "apply_authority",
+        "promotion_authority",
+        "completion",
+        "completed",
+        "checkpoint",
+        "params",
+        "metrics",
+        "tags",
+        "winner",
+        "selection",
+        "acceptance",
+        "ranking",
+        "pareto",
+        "selected",
+        "accepted",
+        "promoted",
+        "promotion",
+        "runtime_authorized",
+        "shadow_authorized",
+        "paper_authorized",
+        "testnet_authorized",
+        "live_authorized",
+        "orders_allowed",
+        "armed",
+        "enabled",
+    }
+)
+
+
+class ComparisonCommonDurableEvidenceBindingError(ValueError):
+    """Fail-closed common comparison durable evidence binding error."""
+
+
+@dataclass(frozen=True)
+class BoundArtifactRecord:
+    artifact_kind: str
+    relative_path: str
+    content_sha256: str
+
+
+@dataclass(frozen=True)
+class MetricInputBindingRef:
+    comparison_metric_input_id: str
+    binding_index_integrity_sha256: str
+    relative_path: str
+    definition_input_ref: dict[str, str]
+    source_domain: str
+
+
+@dataclass(frozen=True)
+class UpstreamBindingRef:
+    binding_index_integrity_sha256: str
+    relative_path: str
+    manifest_content_sha256: str
+
+
+@dataclass(frozen=True)
+class ComparisonChainCrossReferences:
+    comparison_definition_id: str
+    definition_input_refs: tuple[dict[str, str], ...]
+    result_input_snapshot_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ComparisonCommonDurableEvidenceBindingResult:
+    output_dir: Path
+    comparison_definition_id: str
+    binding_index_path: Path
+    manifest_path: Path
+    metric_input_binding_count: int
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ComparisonCommonDurableEvidenceBindingError(f"{label} must not be a symlink: {path}")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"binding index must not contain forbidden key: {key}"
+            )
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise ComparisonCommonDurableEvidenceBindingError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise ComparisonCommonDurableEvidenceBindingError(f"{label} must be a regular file: {path}")
+
+
+def _validate_bundle_dir(bundle_dir: Path, *, label: str) -> None:
+    if not bundle_dir.is_dir():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"{label} must be a directory: {bundle_dir}"
+        )
+    _reject_symlink(bundle_dir, label=label)
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise ComparisonCommonDurableEvidenceBindingError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"output parent directory missing: {parent}"
+        )
+    if is_under_tmp(parent):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "output parent directory must be outside /tmp"
+        )
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_bundle_relative_path(rel: str) -> None:
+    candidate = Path(rel)
+    if candidate.is_absolute():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"bundle relative path must not be absolute: {rel!r}"
+        )
+    if ".." in candidate.parts:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"bundle relative path must not traverse upward: {rel!r}"
+        )
+
+
+def _reject_unsafe_overlap(
+    *,
+    definition_bound_bundle_dir: Path,
+    result_bound_bundle_dir: Path,
+    metric_input_bound_bundle_dirs: Sequence[Path],
+    output_dir: Path,
+) -> None:
+    output_res = output_dir.resolve()
+    for label, bundle_dir in (
+        ("definition bound bundle", definition_bound_bundle_dir),
+        ("result bound bundle", result_bound_bundle_dir),
+        *(
+            (f"metric input bound bundle[{idx}]", path)
+            for idx, path in enumerate(metric_input_bound_bundle_dirs)
+        ),
+    ):
+        bundle_res = bundle_dir.resolve()
+        if output_res == bundle_res:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"output directory must not equal {label} path (fail-closed)"
+            )
+        if _path_is_under(bundle_res, output_res):
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"{label} must not be inside output directory (fail-closed)"
+            )
+        if _path_is_under(output_res, bundle_res):
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"output directory must not be inside {label} path (fail-closed)"
+            )
+
+
+def _binding_index_integrity_sha256(index: Mapping[str, Any], *, label: str) -> str:
+    integrity = index.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise ComparisonCommonDurableEvidenceBindingError(f"{label} integrity must be an object")
+    digest = integrity.get("content_sha256")
+    if not isinstance(digest, str) or not digest.strip():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"{label} integrity.content_sha256 missing or invalid"
+        )
+    if not is_valid_sha256_hex(digest):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"{label} integrity.content_sha256 must be valid sha256 hex"
+        )
+    return digest
+
+
+def _manifest_content_sha256(index: Mapping[str, Any], *, label: str) -> str:
+    cross = index.get("cross_references")
+    if not isinstance(cross, Mapping):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"{label} cross_references must be an object"
+        )
+    digest = cross.get("manifest_content_sha256")
+    if not isinstance(digest, str) or not digest.strip():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"{label} cross_references.manifest_content_sha256 missing or invalid"
+        )
+    if not is_valid_sha256_hex(digest):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"{label} cross_references.manifest_content_sha256 must be valid sha256 hex"
+        )
+    return digest
+
+
+def _source_ref_key(ref: Mapping[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(ref["owner_domain"]),
+        str(ref["ref_type"]),
+        str(ref["ref_id"]),
+        str(ref["digest"]),
+    )
+
+
+def _verbatim_definition_input_ref(ref: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        "owner_domain": str(ref["owner_domain"]),
+        "ref_type": str(ref["ref_type"]),
+        "ref_id": str(ref["ref_id"]),
+        "digest": str(ref["digest"]),
+    }
+
+
+def _load_definition_binding_index(bundle_dir: Path) -> dict[str, Any]:
+    _validate_bundle_dir(bundle_dir, label="definition bound bundle")
+    reverify_comparison_ssot_definition_durable_evidence_bundle_v1(output_dir=bundle_dir)
+    index_path = bundle_dir / DEFINITION_INDEX_ARTIFACT_REL
+    return read_manifest(index_path)
+
+
+def _load_result_binding_index(bundle_dir: Path) -> dict[str, Any]:
+    _validate_bundle_dir(bundle_dir, label="result bound bundle")
+    reverify_comparison_ssot_result_durable_evidence_bundle_v1(output_dir=bundle_dir)
+    index_path = bundle_dir / RESULT_INDEX_ARTIFACT_REL
+    return read_manifest(index_path)
+
+
+def _load_metric_input_binding_index(bundle_dir: Path, *, label: str) -> dict[str, Any]:
+    _validate_bundle_dir(bundle_dir, label=label)
+    reverify_comparison_metric_input_durable_evidence_bundle_v1(output_dir=bundle_dir)
+    index_path = bundle_dir / METRIC_INPUT_INDEX_ARTIFACT_REL
+    return read_manifest(index_path)
+
+
+def check_reference_consistency(
+    *,
+    definition_bound_bundle_dir: Path | str,
+    result_bound_bundle_dir: Path | str,
+    metric_input_bound_bundle_dirs: Sequence[Path | str],
+) -> ComparisonChainCrossReferences:
+    """Fail-closed cross-reference chain lock across upstream bound bundles."""
+    definition_dir = Path(definition_bound_bundle_dir)
+    result_dir = Path(result_bound_bundle_dir)
+    metric_dirs = tuple(Path(item) for item in metric_input_bound_bundle_dirs)
+
+    if len(metric_dirs) != len(set(item.resolve() for item in metric_dirs)):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "duplicate metric input bound bundle paths (fail-closed)"
+        )
+
+    definition_index = _load_definition_binding_index(definition_dir)
+    result_index = _load_result_binding_index(result_dir)
+
+    definition_id = definition_index.get("comparison_definition_id")
+    result_id = result_index.get("comparison_definition_id")
+    if not isinstance(definition_id, str) or not definition_id.strip():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "definition binding comparison_definition_id missing or invalid"
+        )
+    if not isinstance(result_id, str) or not result_id.strip():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "result binding comparison_definition_id missing or invalid"
+        )
+    if definition_id != result_id:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "definition and result comparison_definition_id mismatch (fail-closed)"
+        )
+
+    raw_definition_input_refs = definition_index.get("definition_input_refs")
+    if not isinstance(raw_definition_input_refs, list):
+        raise ComparisonCommonDurableEvidenceBindingError("definition_input_refs must be a list")
+    definition_input_refs = tuple(
+        _verbatim_definition_input_ref(ref)
+        for ref in raw_definition_input_refs
+        if isinstance(ref, Mapping)
+    )
+    if len(definition_input_refs) != len(raw_definition_input_refs):
+        raise ComparisonCommonDurableEvidenceBindingError("definition_input_refs must be objects")
+
+    cardinality = len(definition_input_refs)
+    if cardinality < MIN_METRIC_INPUT_BINDINGS or cardinality > MAX_METRIC_INPUT_BINDINGS:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"metric input cardinality must be {MIN_METRIC_INPUT_BINDINGS}.."
+            f"{MAX_METRIC_INPUT_BINDINGS}, got {cardinality}"
+        )
+    if len(metric_dirs) != cardinality:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "metric input bound bundle count must match definition_input_refs cardinality"
+        )
+
+    lookup: dict[tuple[str, str, str, str], tuple[Path, dict[str, Any]]] = {}
+    for idx, bundle_dir in enumerate(metric_dirs):
+        label = f"metric input bound bundle[{idx}]"
+        index = _load_metric_input_binding_index(bundle_dir, label=label)
+        source_ref = index.get("comparison_metric_input_source_ref")
+        if not isinstance(source_ref, Mapping):
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"{label} comparison_metric_input_source_ref must be an object"
+            )
+        key = _source_ref_key(source_ref)
+        if key in lookup:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                "ambiguous metric input binding mapping (duplicate source ref)"
+            )
+        lookup[key] = (bundle_dir, index)
+
+    ordered_metric_refs: list[MetricInputBindingRef] = []
+    used_dirs: set[Path] = set()
+    for def_ref in definition_input_refs:
+        key = (
+            def_ref["owner_domain"],
+            def_ref["ref_type"],
+            def_ref["ref_id"],
+            def_ref["digest"],
+        )
+        match = lookup.get(key)
+        if match is None:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                "missing metric input bound bundle for definition input ref"
+            )
+        bundle_dir, index = match
+        bundle_res = bundle_dir.resolve()
+        if bundle_res in used_dirs:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                "duplicate metric input bound bundle assignment (fail-closed)"
+            )
+        used_dirs.add(bundle_res)
+        comparison_metric_input_id = index.get("comparison_metric_input_id")
+        if (
+            not isinstance(comparison_metric_input_id, str)
+            or not comparison_metric_input_id.strip()
+        ):
+            raise ComparisonCommonDurableEvidenceBindingError(
+                "metric input binding comparison_metric_input_id missing or invalid"
+            )
+        ordered_metric_refs.append(
+            MetricInputBindingRef(
+                comparison_metric_input_id=comparison_metric_input_id,
+                binding_index_integrity_sha256=_binding_index_integrity_sha256(
+                    index, label="metric input binding index"
+                ),
+                relative_path="",
+                definition_input_ref=def_ref,
+                source_domain=str(index.get("source_domain", "")),
+            )
+        )
+
+    raw_result_snapshots = result_index.get("result_input_snapshots")
+    if not isinstance(raw_result_snapshots, list):
+        raise ComparisonCommonDurableEvidenceBindingError("result_input_snapshots must be a list")
+    result_ids: list[str] = []
+    for idx, snap in enumerate(raw_result_snapshots):
+        if not isinstance(snap, Mapping):
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"result_input_snapshots[{idx}] must be an object"
+            )
+        metric_id = snap.get("comparison_metric_input_id")
+        if not isinstance(metric_id, str) or not metric_id.strip():
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"result_input_snapshots[{idx}].comparison_metric_input_id missing or invalid"
+            )
+        source_ref = snap.get("source_ref")
+        if not isinstance(source_ref, Mapping):
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"result_input_snapshots[{idx}].source_ref must be an object"
+            )
+        result_ids.append(metric_id)
+        expected_ref = _verbatim_definition_input_ref(source_ref)
+        matched = next(
+            (item for item in ordered_metric_refs if item.comparison_metric_input_id == metric_id),
+            None,
+        )
+        if matched is None:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                "result input snapshot comparison_metric_input_id not mapped"
+            )
+        if matched.definition_input_ref != expected_ref:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                "result input snapshot source_ref mismatch against definition input ref"
+            )
+
+    ordered_ids = tuple(item.comparison_metric_input_id for item in ordered_metric_refs)
+    if tuple(result_ids) != ordered_ids:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "result_input_snapshots ordering or ids mismatch against definition order"
+        )
+
+    return ComparisonChainCrossReferences(
+        comparison_definition_id=definition_id,
+        definition_input_refs=tuple(definition_input_refs),
+        result_input_snapshot_ids=tuple(result_ids),
+    )
+
+
+def _resolve_ordered_metric_refs(
+    *,
+    definition_bound_bundle_dir: Path,
+    result_bound_bundle_dir: Path,
+    metric_input_bound_bundle_dirs: Sequence[Path],
+) -> tuple[
+    ComparisonChainCrossReferences,
+    dict[str, Any],
+    dict[str, Any],
+    list[tuple[Path, dict[str, Any]]],
+]:
+    chain = check_reference_consistency(
+        definition_bound_bundle_dir=definition_bound_bundle_dir,
+        result_bound_bundle_dir=result_bound_bundle_dir,
+        metric_input_bound_bundle_dirs=metric_input_bound_bundle_dirs,
+    )
+    definition_index = read_manifest(definition_bound_bundle_dir / DEFINITION_INDEX_ARTIFACT_REL)
+    result_index = read_manifest(result_bound_bundle_dir / RESULT_INDEX_ARTIFACT_REL)
+
+    lookup: dict[tuple[str, str, str, str], tuple[Path, dict[str, Any]]] = {}
+    for idx, bundle_dir in enumerate(metric_input_bound_bundle_dirs):
+        index = read_manifest(bundle_dir / METRIC_INPUT_INDEX_ARTIFACT_REL)
+        source_ref = index["comparison_metric_input_source_ref"]
+        lookup[_source_ref_key(source_ref)] = (bundle_dir, index)
+
+    ordered_pairs: list[tuple[Path, dict[str, Any]]] = []
+    for def_ref in chain.definition_input_refs:
+        key = (
+            def_ref["owner_domain"],
+            def_ref["ref_type"],
+            def_ref["ref_id"],
+            def_ref["digest"],
+        )
+        ordered_pairs.append(lookup[key])
+
+    return chain, definition_index, result_index, ordered_pairs
+
+
+def build_binding_index_v1(
+    *,
+    chain_cross_references: ComparisonChainCrossReferences,
+    metric_input_binding_refs: Sequence[MetricInputBindingRef],
+    definition_binding_ref: UpstreamBindingRef,
+    result_binding_ref: UpstreamBindingRef,
+    artifacts: tuple[BoundArtifactRecord, ...],
+) -> dict[str, Any]:
+    sorted_artifacts = sorted(
+        artifacts,
+        key=lambda item: (item.artifact_kind, item.relative_path),
+    )
+    payload: dict[str, Any] = {
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "bound_contract": COMPARISON_CONTRACT_VERSION,
+        "comparison_definition_id": chain_cross_references.comparison_definition_id,
+        "binding_relation": BINDING_RELATION,
+        "metric_input_binding_refs": [
+            {
+                "comparison_metric_input_id": item.comparison_metric_input_id,
+                "binding_index_integrity_sha256": item.binding_index_integrity_sha256,
+                "relative_path": item.relative_path,
+                "definition_input_ref": dict(item.definition_input_ref),
+                "source_domain": item.source_domain,
+            }
+            for item in metric_input_binding_refs
+        ],
+        "definition_binding_ref": {
+            "binding_index_integrity_sha256": definition_binding_ref.binding_index_integrity_sha256,
+            "relative_path": definition_binding_ref.relative_path,
+            "manifest_content_sha256": definition_binding_ref.manifest_content_sha256,
+        },
+        "result_binding_ref": {
+            "binding_index_integrity_sha256": result_binding_ref.binding_index_integrity_sha256,
+            "relative_path": result_binding_ref.relative_path,
+            "manifest_content_sha256": result_binding_ref.manifest_content_sha256,
+        },
+        "chain_cross_references": {
+            "comparison_definition_id": chain_cross_references.comparison_definition_id,
+            "definition_input_refs": [
+                dict(item) for item in chain_cross_references.definition_input_refs
+            ],
+            "result_input_snapshot_ids": list(chain_cross_references.result_input_snapshot_ids),
+        },
+        "artifacts": [
+            {
+                "artifact_kind": item.artifact_kind,
+                "relative_path": item.relative_path,
+                "content_sha256": item.content_sha256,
+            }
+            for item in sorted_artifacts
+        ],
+        "futures_scope_ref": dict(FUTURES_SCOPE_REF),
+        "trading_logic_immutability_ref": dict(TRADING_LOGIC_IMMUTABILITY_REF),
+        "comparison_authority_invariants": dict(COMPARISON_AUTHORITY_INVARIANTS),
+        "evidence_does_not_authorize_runtime": True,
+    }
+    _reject_forbidden_index_keys(payload)
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def serialize_binding_index_v1(index: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(index)
+    return deterministic_json_dumps(dict(index))
+
+
+def _copy_byte_identical(source: Path, dest: Path) -> str:
+    _validate_regular_file(source, label="source artifact")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, dest)
+    source_digest = _sha256_file(source)
+    dest_digest = _sha256_file(dest)
+    if source_digest != dest_digest:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"byte-identical copy failed for {source.name}"
+        )
+    return source_digest
+
+
+def _embed_bound_bundle(
+    *,
+    source_dir: Path,
+    staging_root: Path,
+    embed_relative_prefix: str,
+    artifact_kind_prefix: str,
+) -> tuple[str, list[BoundArtifactRecord]]:
+    _validate_bundle_dir(source_dir, label="bound bundle source")
+    embed_root = staging_root / embed_relative_prefix
+    artifacts: list[BoundArtifactRecord] = []
+    for src_file in sorted(source_dir.rglob("*")):
+        if not src_file.is_file():
+            continue
+        _reject_symlink(src_file, label="embedded artifact source")
+        rel_inside = src_file.relative_to(source_dir).as_posix()
+        rel_path = f"{embed_relative_prefix}/{rel_inside}"
+        _validate_bundle_relative_path(rel_path)
+        dest_file = staging_root / rel_path
+        digest = _copy_byte_identical(src_file, dest_file)
+        artifacts.append(
+            BoundArtifactRecord(
+                artifact_kind=f"{artifact_kind_prefix}_{Path(rel_inside).name}",
+                relative_path=rel_path,
+                content_sha256=digest,
+            )
+        )
+    return embed_relative_prefix, artifacts
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    token = uuid.uuid4().hex
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{token}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def _validate_chain_from_index(index: Mapping[str, Any]) -> None:
+    if index.get("binding_relation") != BINDING_RELATION:
+        raise ComparisonCommonDurableEvidenceBindingError("binding_relation mismatch")
+    if index.get("evidence_does_not_authorize_runtime") is not True:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "evidence_does_not_authorize_runtime must be true"
+        )
+    invariants = index.get("comparison_authority_invariants")
+    if invariants != COMPARISON_AUTHORITY_INVARIANTS:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "comparison_authority_invariants mismatch"
+        )
+
+
+def reverify_comparison_common_durable_evidence_bundle_v1(
+    *,
+    output_dir: Path | str,
+) -> None:
+    """Replay common durable evidence bundle without producer or raw source access."""
+    bundle_dir = Path(output_dir)
+    if not bundle_dir.is_dir():
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"bundle directory not found: {bundle_dir}"
+        )
+    ok, msg = verify_manifest_sha256(bundle_dir)
+    if not ok:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            f"MANIFEST.sha256 verification failed: {msg}"
+        )
+    index_path = bundle_dir / INDEX_ARTIFACT_REL
+    _validate_regular_file(index_path, label=INDEX_ARTIFACT_REL)
+    index = read_manifest(index_path)
+    _validate_chain_from_index(index)
+
+    metric_refs = index.get("metric_input_binding_refs")
+    if not isinstance(metric_refs, list):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "metric_input_binding_refs must be a list"
+        )
+    definition_ref = index.get("definition_binding_ref")
+    result_ref = index.get("result_binding_ref")
+    if not isinstance(definition_ref, Mapping) or not isinstance(result_ref, Mapping):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "definition_binding_ref and result_binding_ref must be objects"
+        )
+
+    metric_dirs: list[Path] = []
+    for idx, ref in enumerate(metric_refs):
+        if not isinstance(ref, Mapping):
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"metric_input_binding_refs[{idx}] must be an object"
+            )
+        rel = str(ref.get("relative_path", ""))
+        _validate_bundle_relative_path(rel)
+        embedded = bundle_dir / rel
+        metric_dirs.append(embedded)
+        reverify_comparison_metric_input_durable_evidence_bundle_v1(output_dir=embedded)
+        sub_index = read_manifest(embedded / METRIC_INPUT_INDEX_ARTIFACT_REL)
+        if sub_index["integrity"]["content_sha256"] != ref.get("binding_index_integrity_sha256"):
+            raise ComparisonCommonDurableEvidenceBindingError(
+                "metric input binding index integrity mismatch on replay"
+            )
+
+    def_rel = str(definition_ref["relative_path"])
+    res_rel = str(result_ref["relative_path"])
+    _validate_bundle_relative_path(def_rel)
+    _validate_bundle_relative_path(res_rel)
+    definition_embedded = bundle_dir / def_rel
+    result_embedded = bundle_dir / res_rel
+    reverify_comparison_ssot_definition_durable_evidence_bundle_v1(output_dir=definition_embedded)
+    reverify_comparison_ssot_result_durable_evidence_bundle_v1(output_dir=result_embedded)
+
+    def_index = read_manifest(definition_embedded / DEFINITION_INDEX_ARTIFACT_REL)
+    res_index = read_manifest(result_embedded / RESULT_INDEX_ARTIFACT_REL)
+    if def_index["integrity"]["content_sha256"] != definition_ref.get(
+        "binding_index_integrity_sha256"
+    ):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "definition binding index integrity mismatch on replay"
+        )
+    if res_index["integrity"]["content_sha256"] != result_ref.get("binding_index_integrity_sha256"):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "result binding index integrity mismatch on replay"
+        )
+
+    chain = check_reference_consistency(
+        definition_bound_bundle_dir=definition_embedded,
+        result_bound_bundle_dir=result_embedded,
+        metric_input_bound_bundle_dirs=metric_dirs,
+    )
+    chain_block = index.get("chain_cross_references")
+    if not isinstance(chain_block, Mapping):
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "chain_cross_references must be an object"
+        )
+    if chain_block.get("comparison_definition_id") != chain.comparison_definition_id:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "chain_cross_references comparison_definition_id mismatch on replay"
+        )
+    if tuple(chain_block.get("definition_input_refs", [])) != chain.definition_input_refs:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "chain_cross_references definition_input_refs mismatch on replay"
+        )
+    if tuple(chain_block.get("result_input_snapshot_ids", [])) != chain.result_input_snapshot_ids:
+        raise ComparisonCommonDurableEvidenceBindingError(
+            "chain_cross_references result_input_snapshot_ids mismatch on replay"
+        )
+
+
+def produce_comparison_common_durable_evidence_bundle_v1(
+    *,
+    definition_bound_bundle_dir: Path | str,
+    result_bound_bundle_dir: Path | str,
+    metric_input_bound_bundle_dirs: Sequence[Path | str],
+    output_dir: Path | str,
+) -> ComparisonCommonDurableEvidenceBindingResult:
+    """Aggregate verified comparison durable evidence sub-bundles into one common bundle."""
+    definition_dir = Path(definition_bound_bundle_dir)
+    result_dir = Path(result_bound_bundle_dir)
+    metric_dirs = tuple(Path(item) for item in metric_input_bound_bundle_dirs)
+    final_dir = Path(output_dir)
+
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        definition_bound_bundle_dir=definition_dir,
+        result_bound_bundle_dir=result_dir,
+        metric_input_bound_bundle_dirs=metric_dirs,
+        output_dir=final_dir,
+    )
+
+    chain, definition_index, result_index, ordered_pairs = _resolve_ordered_metric_refs(
+        definition_bound_bundle_dir=definition_dir,
+        result_bound_bundle_dir=result_dir,
+        metric_input_bound_bundle_dirs=metric_dirs,
+    )
+
+    _validate_bundle_relative_path(INDEX_ARTIFACT_REL)
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise ComparisonCommonDurableEvidenceBindingError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        artifacts: list[BoundArtifactRecord] = []
+
+        metric_binding_refs: list[MetricInputBindingRef] = []
+        for ordinal, ((bundle_dir, index), def_ref) in enumerate(
+            zip(ordered_pairs, chain.definition_input_refs, strict=True)
+        ):
+            embed_prefix = f"{METRIC_INPUT_EMBED_PREFIX}/{ordinal:02d}"
+            _, embedded_artifacts = _embed_bound_bundle(
+                source_dir=bundle_dir,
+                staging_root=staging,
+                embed_relative_prefix=embed_prefix,
+                artifact_kind_prefix="comparison_metric_input_bound_bundle",
+            )
+            artifacts.extend(embedded_artifacts)
+            metric_binding_refs.append(
+                MetricInputBindingRef(
+                    comparison_metric_input_id=str(index["comparison_metric_input_id"]),
+                    binding_index_integrity_sha256=_binding_index_integrity_sha256(
+                        index, label="metric input binding index"
+                    ),
+                    relative_path=embed_prefix,
+                    definition_input_ref=def_ref,
+                    source_domain=str(index.get("source_domain", "")),
+                )
+            )
+
+        _, definition_artifacts = _embed_bound_bundle(
+            source_dir=definition_dir,
+            staging_root=staging,
+            embed_relative_prefix=DEFINITION_EMBED_PREFIX,
+            artifact_kind_prefix="comparison_definition_bound_bundle",
+        )
+        artifacts.extend(definition_artifacts)
+
+        _, result_artifacts = _embed_bound_bundle(
+            source_dir=result_dir,
+            staging_root=staging,
+            embed_relative_prefix=RESULT_EMBED_PREFIX,
+            artifact_kind_prefix="comparison_result_bound_bundle",
+        )
+        artifacts.extend(result_artifacts)
+
+        definition_binding_ref = UpstreamBindingRef(
+            binding_index_integrity_sha256=_binding_index_integrity_sha256(
+                definition_index, label="definition binding index"
+            ),
+            relative_path=DEFINITION_EMBED_PREFIX,
+            manifest_content_sha256=_manifest_content_sha256(
+                definition_index, label="definition binding index"
+            ),
+        )
+        result_binding_ref = UpstreamBindingRef(
+            binding_index_integrity_sha256=_binding_index_integrity_sha256(
+                result_index, label="result binding index"
+            ),
+            relative_path=RESULT_EMBED_PREFIX,
+            manifest_content_sha256=_manifest_content_sha256(
+                result_index, label="result binding index"
+            ),
+        )
+
+        index_payload = build_binding_index_v1(
+            chain_cross_references=chain,
+            metric_input_binding_refs=metric_binding_refs,
+            definition_binding_ref=definition_binding_ref,
+            result_binding_ref=result_binding_ref,
+            artifacts=tuple(artifacts),
+        )
+        index_path = staging / INDEX_ARTIFACT_REL
+        index_path.write_text(serialize_binding_index_v1(index_payload), encoding="utf-8")
+
+        write_manifest_sha256(staging)
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        reverify_comparison_common_durable_evidence_bundle_v1(output_dir=staging)
+
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise ComparisonCommonDurableEvidenceBindingError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return ComparisonCommonDurableEvidenceBindingResult(
+        output_dir=final_dir,
+        comparison_definition_id=chain.comparison_definition_id,
+        binding_index_path=final_dir / INDEX_ARTIFACT_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+        metric_input_binding_count=len(metric_binding_refs),
+    )
+
+
+__all__ = [
+    "BINDING_RELATION",
+    "BINDING_SCHEMA_VERSION",
+    "COMPARISON_AUTHORITY_INVARIANTS",
+    "INDEX_ARTIFACT_REL",
+    "MANIFEST_FILENAME",
+    "MAX_METRIC_INPUT_BINDINGS",
+    "MIN_METRIC_INPUT_BINDINGS",
+    "BoundArtifactRecord",
+    "ComparisonChainCrossReferences",
+    "ComparisonCommonDurableEvidenceBindingError",
+    "ComparisonCommonDurableEvidenceBindingResult",
+    "MetricInputBindingRef",
+    "UpstreamBindingRef",
+    "build_binding_index_v1",
+    "check_reference_consistency",
+    "produce_comparison_common_durable_evidence_bundle_v1",
+    "reverify_comparison_common_durable_evidence_bundle_v1",
+    "serialize_binding_index_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -6081,3 +6081,59 @@ def test_selector_package_comparison_ssot_v1_combined_diff_pr_bounded_full_inclu
     for path in PACKAGE_COMPARISON_SSOT_V1_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_CMP_COMMON_DURABLE_BINDING_PRODUCTION = (
+    "src/meta/learning_loop/comparison_common_durable_evidence_binding_v1.py"
+)
+PACKAGE_CMP_COMMON_DURABLE_BINDING_SCRIPT = (
+    "scripts/run_comparison_common_durable_evidence_binding_v1.py"
+)
+PACKAGE_CMP_COMMON_DURABLE_BINDING_TESTOWNER = (
+    "tests/meta/test_comparison_common_durable_evidence_binding_v1.py"
+)
+PACKAGE_CMP_COMMON_DURABLE_BINDING_CLI_TESTOWNER = (
+    "tests/scripts/test_run_comparison_common_durable_evidence_binding_v1.py"
+)
+PACKAGE_CMP_COMMON_DURABLE_BINDING_DEPENDENCY_TESTOWNERS = (
+    "tests/meta/test_comparison_metric_input_durable_evidence_binding_v1.py",
+    "tests/meta/test_comparison_ssot_definition_durable_evidence_binding_v1.py",
+    "tests/meta/test_comparison_ssot_result_durable_evidence_binding_v1.py",
+    "tests/meta/test_comparison_result_manifest_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+)
+PACKAGE_CMP_COMMON_DURABLE_BINDING_ALL_PRODUCTION = (
+    PACKAGE_CMP_COMMON_DURABLE_BINDING_PRODUCTION,
+    PACKAGE_CMP_COMMON_DURABLE_BINDING_SCRIPT,
+)
+PACKAGE_CMP_COMMON_DURABLE_BINDING_ALL_TESTOWNERS = (
+    PACKAGE_CMP_COMMON_DURABLE_BINDING_TESTOWNER,
+    PACKAGE_CMP_COMMON_DURABLE_BINDING_CLI_TESTOWNER,
+    *PACKAGE_CMP_COMMON_DURABLE_BINDING_DEPENDENCY_TESTOWNERS,
+)
+
+
+def test_selector_package_cmp_common_durable_binding_production_pr_bounded_full_includes_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_CMP_COMMON_DURABLE_BINDING_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_COMMON_DURABLE_BINDING_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_cmp_common_durable_binding_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        *PACKAGE_CMP_COMMON_DURABLE_BINDING_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_CMP_COMMON_DURABLE_BINDING_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_COMMON_DURABLE_BINDING_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/meta/test_comparison_common_durable_evidence_binding_v1.py
+++ b/tests/meta/test_comparison_common_durable_evidence_binding_v1.py
@@ -1,0 +1,388 @@
+"""Contract tests for comparison common durable evidence binding v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+import shutil
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    BINDING_RELATION,
+    COMPARISON_AUTHORITY_INVARIANTS,
+    INDEX_ARTIFACT_REL,
+    MAX_METRIC_INPUT_BINDINGS,
+    MIN_METRIC_INPUT_BINDINGS,
+    ComparisonCommonDurableEvidenceBindingError,
+    check_reference_consistency,
+    produce_comparison_common_durable_evidence_bundle_v1,
+    reverify_comparison_common_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1 import (
+    produce_comparison_metric_input_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL as DEFINITION_INDEX_ARTIFACT_REL,
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL as RESULT_INDEX_ARTIFACT_REL,
+    produce_comparison_ssot_result_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.comparison_ssot_v1.producer import produce_comparison_offline_v1
+from tests.meta.comparison_ssot_v1_fixtures import produce_two_compatible_backtest_inputs
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_common_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1.is_under_tmp",
+        lambda _path: False,
+    )
+
+
+def _durable_output(tmp_path: Path, name: str = "common_bundle") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _produce_bound_chain(
+    tmp_path: Path,
+    durable_root: Path,
+) -> tuple[list[Path], Path, Path, str]:
+    metric_root = durable_root / "metric_inputs"
+    metric_root.mkdir(exist_ok=True)
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    comparison_root = durable_root / "comparisons"
+    comparison_root.mkdir(exist_ok=True)
+    offline = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=comparison_root,
+        ranking_rule_version="NONE_V1",
+    )
+
+    metric_bindings: list[Path] = []
+    for idx, manifest_path in enumerate([first, second]):
+        out = durable_root / f"metric_input_binding_{idx}"
+        produce_comparison_metric_input_durable_evidence_bundle_v1(
+            manifest_path=manifest_path,
+            output_dir=out,
+        )
+        metric_bindings.append(out)
+
+    definition_binding = durable_root / "definition_binding"
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=offline.definition_path,
+        output_dir=definition_binding,
+    )
+    result_binding = durable_root / "result_binding"
+    produce_comparison_ssot_result_durable_evidence_bundle_v1(
+        manifest_path=offline.result_path,
+        output_dir=result_binding,
+    )
+    return metric_bindings, definition_binding, result_binding, offline.comparison_definition_id
+
+
+def test_happy_path_common_bundle(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, comparison_definition_id = (
+        _produce_bound_chain(tmp_path, ssot_durable_output_dir)
+    )
+    out = _durable_output(tmp_path)
+    result = produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=out,
+    )
+    assert result.comparison_definition_id == comparison_definition_id
+    assert result.metric_input_binding_count == MIN_METRIC_INPUT_BINDINGS
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is True
+
+
+def test_definition_input_ordering_preserved(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    definition_index = read_manifest(definition_binding / DEFINITION_INDEX_ARTIFACT_REL)
+    out = _durable_output(tmp_path, "order")
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=out,
+    )
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert [
+        item["definition_input_ref"] for item in index["metric_input_binding_refs"]
+    ] == definition_index["definition_input_refs"]
+
+
+def test_metric_input_list_not_mutated(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    original = list(metric_bindings)
+    out = _durable_output(tmp_path, "nomut")
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=out,
+    )
+    assert metric_bindings == original
+
+
+def test_reverify_without_producers(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path, "replay")
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=out,
+    )
+    reverify_comparison_common_durable_evidence_bundle_v1(output_dir=out)
+
+
+def test_deterministic_index_and_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    out_a = _durable_output(tmp_path, "det_a")
+    out_b = _durable_output(tmp_path, "det_b")
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=out_a,
+    )
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=out_b,
+    )
+    index_a = (out_a / INDEX_ARTIFACT_REL).read_text(encoding="utf-8")
+    index_b = (out_b / INDEX_ARTIFACT_REL).read_text(encoding="utf-8")
+    assert index_a == index_b
+    assert (out_a / "MANIFEST.sha256").read_text(encoding="utf-8") == (
+        out_b / "MANIFEST.sha256"
+    ).read_text(encoding="utf-8")
+
+
+def test_authority_invariants_and_forbidden_keys(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path, "auth")
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=out,
+    )
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert index["evidence_does_not_authorize_runtime"] is True
+    assert index["comparison_authority_invariants"] == COMPARISON_AUTHORITY_INVARIANTS
+    assert index["binding_relation"] == BINDING_RELATION
+    for forbidden in ("winner", "promotion", "completion", "runtime_authorized"):
+        assert forbidden not in index
+
+
+def test_missing_metric_input_binding(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path, "missing_mi")
+    with pytest.raises(ComparisonCommonDurableEvidenceBindingError, match="cardinality"):
+        produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=definition_binding,
+            result_bound_bundle_dir=result_binding,
+            metric_input_bound_bundle_dirs=[metric_bindings[0]],
+            output_dir=out,
+        )
+
+
+def test_extra_metric_input_binding(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    extra_copy = ssot_durable_output_dir / "metric_input_binding_extra"
+    shutil.copytree(metric_bindings[0], extra_copy)
+    out = _durable_output(tmp_path, "extra_mi")
+    with pytest.raises(ComparisonCommonDurableEvidenceBindingError, match="cardinality"):
+        produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=definition_binding,
+            result_bound_bundle_dir=result_binding,
+            metric_input_bound_bundle_dirs=[*metric_bindings, extra_copy],
+            output_dir=out,
+        )
+
+
+def test_duplicate_metric_input_binding_path(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path, "dup_path")
+    with pytest.raises(ComparisonCommonDurableEvidenceBindingError, match="duplicate metric input"):
+        produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=definition_binding,
+            result_bound_bundle_dir=result_binding,
+            metric_input_bound_bundle_dirs=[metric_bindings[0], metric_bindings[0]],
+            output_dir=out,
+        )
+
+
+def test_definition_result_definition_id_mismatch(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    result_index_path = result_binding / RESULT_INDEX_ARTIFACT_REL
+    result_index = read_manifest(result_index_path)
+    mutated = deepcopy(result_index)
+    mutated["comparison_definition_id"] = "00000000-0000-4000-8000-000000000001"
+    result_index_path.write_text(json.dumps(mutated), encoding="utf-8")
+    out = _durable_output(tmp_path, "id_mismatch")
+    with pytest.raises(Exception, match="MANIFEST.sha256 verification failed"):
+        produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=definition_binding,
+            result_bound_bundle_dir=result_binding,
+            metric_input_bound_bundle_dirs=metric_bindings,
+            output_dir=out,
+        )
+
+
+def test_input_path_order_does_not_change_published_order(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    definition_index = read_manifest(definition_binding / DEFINITION_INDEX_ARTIFACT_REL)
+    out = _durable_output(tmp_path, "path_order")
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=[metric_bindings[1], metric_bindings[0]],
+        output_dir=out,
+    )
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert [
+        item["definition_input_ref"] for item in index["metric_input_binding_refs"]
+    ] == definition_index["definition_input_refs"]
+
+
+def test_unverified_metric_input_bundle(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    fake = tmp_path / "fake_metric_bundle"
+    fake.mkdir()
+    (fake / "comparison_metric_input_durable_evidence_binding_index_v1.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    out = _durable_output(tmp_path, "unverified")
+    with pytest.raises(Exception, match="MANIFEST.sha256"):
+        produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=definition_binding,
+            result_bound_bundle_dir=result_binding,
+            metric_input_bound_bundle_dirs=[fake, metric_bindings[1]],
+            output_dir=out,
+        )
+
+
+def test_corrupted_sub_bundle_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    (metric_bindings[0] / "MANIFEST.sha256").write_text("broken", encoding="utf-8")
+    out = _durable_output(tmp_path, "broken_manifest")
+    with pytest.raises(Exception, match="MANIFEST.sha256"):
+        produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=definition_binding,
+            result_bound_bundle_dir=result_binding,
+            metric_input_bound_bundle_dirs=metric_bindings,
+            output_dir=out,
+        )
+
+
+def test_output_collision(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path, "exists")
+    out.mkdir()
+    with pytest.raises(ComparisonCommonDurableEvidenceBindingError, match="already exists"):
+        produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=definition_binding,
+            result_bound_bundle_dir=result_binding,
+            metric_input_bound_bundle_dirs=metric_bindings,
+            output_dir=out,
+        )
+
+
+def test_path_traversal_relative_path_rejected() -> None:
+    with pytest.raises(ComparisonCommonDurableEvidenceBindingError, match="traverse upward"):
+        from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+            _validate_bundle_relative_path,
+        )
+
+        _validate_bundle_relative_path("../escape")
+
+
+def test_symlink_escape_rejected(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    link = tmp_path / "symlink_bundle"
+    link.symlink_to(metric_bindings[0])
+    out = _durable_output(tmp_path, "symlink")
+    with pytest.raises(ComparisonCommonDurableEvidenceBindingError, match="symlink"):
+        produce_comparison_common_durable_evidence_bundle_v1(
+            definition_bound_bundle_dir=definition_binding,
+            result_bound_bundle_dir=result_binding,
+            metric_input_bound_bundle_dirs=[link, metric_bindings[1]],
+            output_dir=out,
+        )
+
+
+def test_max_cardinality_constant_enforced() -> None:
+    assert MIN_METRIC_INPUT_BINDINGS == 2
+    assert MAX_METRIC_INPUT_BINDINGS == 32
+
+
+def test_no_forbidden_runtime_imports() -> None:
+    module_path = Path(__file__).resolve().parents[2] / (
+        "src/meta/learning_loop/comparison_common_durable_evidence_binding_v1.py"
+    )
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    forbidden = {"src.execution", "src.risk", "mlflow"}
+    assert not modules & forbidden

--- a/tests/meta/test_comparison_common_durable_evidence_binding_v1.py
+++ b/tests/meta/test_comparison_common_durable_evidence_binding_v1.py
@@ -276,7 +276,9 @@ def test_definition_result_definition_id_mismatch(tmp_path, ssot_durable_output_
         )
 
 
-def test_input_path_order_does_not_change_published_order(tmp_path, ssot_durable_output_dir) -> None:
+def test_input_path_order_does_not_change_published_order(
+    tmp_path, ssot_durable_output_dir
+) -> None:
     metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
         tmp_path, ssot_durable_output_dir
     )

--- a/tests/scripts/test_run_comparison_common_durable_evidence_binding_v1.py
+++ b/tests/scripts/test_run_comparison_common_durable_evidence_binding_v1.py
@@ -1,0 +1,160 @@
+"""CLI tests for comparison common durable evidence binding v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from scripts.run_comparison_common_durable_evidence_binding_v1 import (
+    EXIT_BINDING_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import INDEX_ARTIFACT_REL
+from tests.meta.comparison_ssot_v1_fixtures import produce_two_compatible_backtest_inputs
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    for target in (
+        "src.meta.learning_loop.comparison_common_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1.is_under_tmp",
+    ):
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _produce_bound_chain(tmp_path: Path, durable_root: Path):
+    from src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1 import (
+        produce_comparison_metric_input_durable_evidence_bundle_v1,
+    )
+    from src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1 import (
+        produce_comparison_ssot_definition_durable_evidence_bundle_v1,
+    )
+    from src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1 import (
+        produce_comparison_ssot_result_durable_evidence_bundle_v1,
+    )
+    from src.meta.learning_loop.comparison_ssot_v1.producer import produce_comparison_offline_v1
+
+    metric_root = durable_root / "metric_inputs"
+    metric_root.mkdir(exist_ok=True)
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    comparison_root = durable_root / "comparisons"
+    comparison_root.mkdir(exist_ok=True)
+    offline = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=comparison_root,
+        ranking_rule_version="NONE_V1",
+    )
+    metric_bindings = []
+    for idx, manifest_path in enumerate([first, second]):
+        out = durable_root / f"metric_input_binding_{idx}"
+        produce_comparison_metric_input_durable_evidence_bundle_v1(
+            manifest_path=manifest_path,
+            output_dir=out,
+        )
+        metric_bindings.append(out)
+    definition_binding = durable_root / "definition_binding"
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=offline.definition_path,
+        output_dir=definition_binding,
+    )
+    result_binding = durable_root / "result_binding"
+    produce_comparison_ssot_result_durable_evidence_bundle_v1(
+        manifest_path=offline.result_path,
+        output_dir=result_binding,
+    )
+    return metric_bindings, definition_binding, result_binding, offline.comparison_definition_id
+
+
+def test_cli_successful_run(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, comparison_definition_id = (
+        _produce_bound_chain(tmp_path, ssot_durable_output_dir)
+    )
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    out = out_root / "common_out"
+    args = [
+        "--definition-bound-bundle-dir",
+        str(definition_binding),
+        "--result-bound-bundle-dir",
+        str(result_binding),
+        "--output-dir",
+        str(out),
+    ]
+    for path in metric_bindings:
+        args.extend(["--metric-input-bound-bundle-dir", str(path)])
+    rc = main(args)
+    assert rc == EXIT_OK
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+
+
+def test_cli_requires_all_paths() -> None:
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_cli_missing_definition_usage_error(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, _, result_binding, _ = _produce_bound_chain(tmp_path, ssot_durable_output_dir)
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    args = [
+        "--definition-bound-bundle-dir",
+        str(tmp_path / "missing"),
+        "--result-bound-bundle-dir",
+        str(result_binding),
+        "--output-dir",
+        str(out_root / "out"),
+    ]
+    for path in metric_bindings:
+        args.extend(["--metric-input-bound-bundle-dir", str(path)])
+    rc = main(args)
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_binding_error(tmp_path, ssot_durable_output_dir) -> None:
+    metric_bindings, definition_binding, result_binding, _ = _produce_bound_chain(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = tmp_path / "evidence_root" / "exists"
+    out.mkdir(parents=True)
+    args = [
+        "--definition-bound-bundle-dir",
+        str(definition_binding),
+        "--result-bound-bundle-dir",
+        str(result_binding),
+        "--output-dir",
+        str(out),
+    ]
+    for path in metric_bindings:
+        args.extend(["--metric-input-bound-bundle-dir", str(path)])
+    rc = main(args)
+    assert rc == EXIT_BINDING_ERROR
+
+
+def test_cli_prints_success_message(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    metric_bindings, definition_binding, result_binding, comparison_definition_id = (
+        _produce_bound_chain(tmp_path, ssot_durable_output_dir)
+    )
+    out_root = tmp_path / "evidence_root2"
+    out_root.mkdir()
+    out = out_root / "common_out"
+    args = [
+        "--definition-bound-bundle-dir",
+        str(definition_binding),
+        "--result-bound-bundle-dir",
+        str(result_binding),
+        "--output-dir",
+        str(out),
+    ]
+    for path in metric_bindings:
+        args.extend(["--metric-input-bound-bundle-dir", str(path)])
+    rc = main(args)
+    assert rc == EXIT_OK
+    captured = capsys.readouterr()
+    assert comparison_definition_id in captured.out


### PR DESCRIPTION
## Summary

- Add offline `comparison_common_durable_evidence_binding_v1` to aggregate already-bound metric-input, definition, and result durable evidence sub-bundles into one common bundle.
- Enforce fail-closed cross-ref chain validation (definition/result `comparison_definition_id` lock, metric-input cardinality 2..32, injective source-ref mapping, definition-order preservation).
- Add CLI runner, contract tests, and CI selector partition for PR_BOUNDED_FULL coverage.

## Governance

- **GO_TOKEN:** `GO_COMMON_COMPARISON_DURABLE_EVIDENCE_BUNDLE_V1_IMPLEMENTATION_V0`
- **Operator ratification:** `COMMON_COMPARISON_DURABLE_EVIDENCE_BUNDLE_V1_SPECIFICATION_RATIFIED=true`
- **Base SHA:** `e24a1741b111730bb0eba1c5af537765ea9e2213`
- **Admissibility bundle:** `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/common_comparison_durable_evidence_bundle_v1_admissibility_review_v0_20260627T190907Z`
- **MANIFEST_VERIFY_RC:** 0 (planning, admissibility, PR4618 closeout verified pre-implementation)
- **MERGE_GO_GRANTED:** false
- **PRIMARY_WORKTREE_TOUCHED:** false

## Canonical owner / contract

- **Owner:** `src/meta/learning_loop/comparison_common_durable_evidence_binding_v1.py`
- **Target contract:** `comparison_common_durable_evidence_binding_v1`
- **Relation model:** `PRESERVES_COMPARISON_CHAIN_REFERENCES`

## Sub-bundles / cross-ref chain

- Inputs: explicit paths only (definition bound bundle, result bound bundle, 2..32 metric-input bound bundles)
- No raw manifests, no producer re-execution, no registry/MLflow lookup
- Upstream sub-bundles reverified before publish; embedded under `embedded/metric_input_bindings/{ordinal}`, `embedded/definition_binding`, `embedded/result_binding`
- IDs/digests verbatim from upstream binding indexes only (no recomputation)

## Authority invariants

- `evidence_does_not_authorize_runtime=true`
- `comparison_authority_invariants` block selection/acceptance/promotion/runtime semantics
- Forbidden completion/promotion/winner/runtime keys fail-closed

## Tests / CI

- **Testowners:** common meta + script tests; cross-ref against existing comparison binding testowners
- **Expected CI mode:** PR_BOUNDED_FULL
- **Local timing proof (bounded targets):** 150 tests in ~2.75s wallclock
- **25-minute compatible:** true (`EXPECTED_MAX_CI_DURATION_SECONDS=840`)

## Test plan

- [x] Happy-path common bundle production + MANIFEST.sha256 self-verify
- [x] Bundle-only replay (`reverify_*`) without producers
- [x] Cardinality/injectivity/ordering negative cases
- [x] Authority forbidden-key guards
- [x] CI selector partition contracts


Made with [Cursor](https://cursor.com)