### PR TITLE
feat(governance): add comparison lineage ref producer v1

### DIFF
--- a/scripts/run_comparison_lineage_ref_producer_v1.py
+++ b/scripts/run_comparison_lineage_ref_producer_v1.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Offline COMPARISON LineageRef producer from explicit result manifest directory.
+
+Produces a validated, deterministic COMPARISON LineageRef JSON artifact only.
+No comparison execution, promotion, apply, runtime, registry mutation, or live authority.
+
+Usage:
+    python3 scripts/run_comparison_lineage_ref_producer_v1.py \\
+        --manifest-dir reports/comparisons/def-id-abc \\
+        --output reports/lineage_refs/comparison_def-id-abc.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.governance.promotion_loop.comparison_lineage_ref_producer_v1 import (
+    ComparisonLineageRefProducerError,
+    produce_comparison_lineage_ref_v1_to_path,
+)
+
+EXIT_OK = 0
+EXIT_PRODUCER_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline COMPARISON LineageRef producer: explicit result manifest "
+            "directory to validated reference-only JSON artifact."
+        )
+    )
+    parser.add_argument(
+        "--manifest-dir",
+        type=Path,
+        required=True,
+        help=("Explicit path to a directory containing comparison_result_manifest_v1.json."),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination path for the validated COMPARISON LineageRef JSON file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        result = produce_comparison_lineage_ref_v1_to_path(
+            manifest_dir=args.manifest_dir,
+            output_path=args.output,
+            fail_closed_if_exists=True,
+        )
+    except ComparisonLineageRefProducerError as exc:
+        print(f"[comparison_lineage_ref] ERROR: {exc}", file=sys.stderr)
+        return EXIT_PRODUCER_ERROR
+    except OSError as exc:
+        print(f"[comparison_lineage_ref] ERROR: {exc}", file=sys.stderr)
+        return EXIT_PRODUCER_ERROR
+
+    print(
+        "[comparison_lineage_ref] wrote validated COMPARISON LineageRef to "
+        f"{args.output} (ref_id={result.ref.ref_id}, digest={result.ref.digest})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/governance/promotion_loop/candidate_lineage_manifest_v1.py
+++ b/src/governance/promotion_loop/candidate_lineage_manifest_v1.py
@@ -76,6 +76,7 @@ class LineageRelation(str, Enum):
     RETAINS = "retains"
     REPRODUCES = "reproduces"
     EXTENDS = "extends"
+    DERIVES_FROM_RESULT_MANIFEST = "derives_from_result_manifest"
 
 
 _REF_TYPE_CARDINALITY: dict[LineageRefType, tuple[int, int | None]] = {

--- a/src/governance/promotion_loop/comparison_lineage_ref_producer_v1.py
+++ b/src/governance/promotion_loop/comparison_lineage_ref_producer_v1.py
@@ -1,0 +1,233 @@
+"""Offline COMPARISON LineageRef producer from explicit result manifest directory."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_from_mapping,
+    lineage_ref_to_mapping,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import RESULT_ARTIFACT_FILENAME
+from src.meta.learning_loop.comparison_ssot_v1.models import ComparisonSsotError
+from src.meta.learning_loop.comparison_ssot_v1.validation import validate_result_manifest_v1
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+COMPARISON_OWNER_DOMAIN = "meta/learning_loop/comparison_ssot_v1"
+COMPARISON_LINEAGE_REF_REQUIRED = False
+
+
+class ComparisonLineageRefProducerError(ValueError):
+    """Fail-closed COMPARISON LineageRef production error."""
+
+
+@dataclass(frozen=True)
+class ComparisonLineageRefProducerResult:
+    manifest_dir: Path
+    manifest_path: Path
+    ref: LineageRef
+
+
+def _resolve_existing_directory(manifest_dir: Path) -> Path:
+    if not manifest_dir.exists():
+        raise ComparisonLineageRefProducerError(f"manifest_dir not found: {manifest_dir}")
+    if manifest_dir.is_symlink():
+        raise ComparisonLineageRefProducerError(
+            f"manifest_dir must not be a symlink (fail-closed): {manifest_dir}"
+        )
+    if not manifest_dir.is_dir():
+        raise ComparisonLineageRefProducerError(f"manifest_dir is not a directory: {manifest_dir}")
+    return manifest_dir.resolve()
+
+
+def _assert_path_under_root(path: Path, root: Path) -> Path:
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ComparisonLineageRefProducerError(
+            f"path escapes manifest_dir root: {path} (root={root})"
+        ) from exc
+    return resolved
+
+
+def _validate_artifact_relative_path(artifact_path: str) -> None:
+    if not artifact_path or artifact_path.strip() != artifact_path:
+        raise ComparisonLineageRefProducerError("artifact_path must be non-empty and trimmed")
+    if artifact_path.startswith("/") or artifact_path.startswith("\\"):
+        raise ComparisonLineageRefProducerError("artifact_path must be relative")
+    if "\\" in artifact_path:
+        raise ComparisonLineageRefProducerError("artifact_path must use forward slashes only")
+    if ".." in artifact_path.split("/"):
+        raise ComparisonLineageRefProducerError("artifact_path must not contain '..' segments")
+
+
+def _load_validated_result_manifest(manifest_dir: Path) -> tuple[dict[str, Any], Path]:
+    manifest_path = manifest_dir / RESULT_ARTIFACT_FILENAME
+    if manifest_path.is_symlink():
+        raise ComparisonLineageRefProducerError(
+            f"{RESULT_ARTIFACT_FILENAME} must not be a symlink (fail-closed): {manifest_path}"
+        )
+    if manifest_path.is_dir():
+        raise ComparisonLineageRefProducerError(
+            f"{RESULT_ARTIFACT_FILENAME} is a directory, expected regular file: {manifest_path}"
+        )
+    if not manifest_path.is_file():
+        raise ComparisonLineageRefProducerError(
+            f"{RESULT_ARTIFACT_FILENAME} not found in manifest_dir: {manifest_dir}"
+        )
+    _assert_path_under_root(manifest_path, manifest_dir)
+
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ComparisonLineageRefProducerError(
+            f"invalid {RESULT_ARTIFACT_FILENAME} in manifest_dir={manifest_dir}: {exc}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise ComparisonLineageRefProducerError(
+            f"{RESULT_ARTIFACT_FILENAME} root must be a JSON object for manifest_dir={manifest_dir}"
+        )
+
+    try:
+        validate_result_manifest_v1(raw)
+    except ComparisonSsotError as exc:
+        raise ComparisonLineageRefProducerError(
+            f"comparison result manifest validation failed for manifest_dir={manifest_dir}: {exc}"
+        ) from exc
+
+    return raw, manifest_path
+
+
+def build_comparison_lineage_ref_from_result_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    artifact_path: str = RESULT_ARTIFACT_FILENAME,
+) -> LineageRef:
+    """Build a validated COMPARISON LineageRef from an already validated result manifest."""
+    _validate_artifact_relative_path(artifact_path)
+
+    comparison_definition_id = manifest.get("comparison_definition_id")
+    if not isinstance(comparison_definition_id, str) or not comparison_definition_id.strip():
+        raise ComparisonLineageRefProducerError("comparison_definition_id missing or invalid")
+
+    integrity = manifest.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise ComparisonLineageRefProducerError("integrity must be an object")
+    content_sha256 = integrity.get("content_sha256")
+    if not isinstance(content_sha256, str) or not content_sha256.strip():
+        raise ComparisonLineageRefProducerError("integrity.content_sha256 missing or invalid")
+
+    return LineageRef(
+        ref_type=LineageRefType.COMPARISON,
+        ref_id=comparison_definition_id,
+        relation=LineageRelation.DERIVES_FROM_RESULT_MANIFEST,
+        owner_domain=COMPARISON_OWNER_DOMAIN,
+        required=COMPARISON_LINEAGE_REF_REQUIRED,
+        digest=content_sha256,
+        artifact_path=artifact_path,
+    )
+
+
+def produce_comparison_lineage_ref_v1(
+    *,
+    manifest_dir: Path | str,
+) -> ComparisonLineageRefProducerResult:
+    """Extract a reference-only COMPARISON LineageRef from an explicit result manifest directory."""
+    resolved_manifest_dir = _resolve_existing_directory(Path(manifest_dir))
+    manifest, manifest_path = _load_validated_result_manifest(resolved_manifest_dir)
+    ref = build_comparison_lineage_ref_from_result_manifest(manifest)
+    return ComparisonLineageRefProducerResult(
+        manifest_dir=resolved_manifest_dir,
+        manifest_path=manifest_path,
+        ref=ref,
+    )
+
+
+def serialize_comparison_lineage_ref_v1(ref: LineageRef) -> str:
+    """Serialize a COMPARISON LineageRef to deterministic canonical JSON."""
+    if ref.ref_type != LineageRefType.COMPARISON:
+        raise ComparisonLineageRefProducerError(
+            f"ref_type must be COMPARISON, got {ref.ref_type.value!r}"
+        )
+    return deterministic_json_dumps(lineage_ref_to_mapping(ref))
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+    except OSError:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+    try:
+        tmp.replace(path)
+    except OSError:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
+
+
+def _self_verify_written_ref(ref: LineageRef, output_path: Path) -> None:
+    try:
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ComparisonLineageRefProducerError(
+            f"self-verification failed: output is not valid JSON: {output_path}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ComparisonLineageRefProducerError(
+            f"self-verification failed: output root must be object: {output_path}"
+        )
+    try:
+        roundtrip = lineage_ref_from_mapping(payload)
+    except Exception as exc:
+        raise ComparisonLineageRefProducerError(
+            f"self-verification failed: output LineageRef invalid: {output_path}: {exc}"
+        ) from exc
+    if roundtrip != ref:
+        raise ComparisonLineageRefProducerError(
+            f"self-verification failed: output LineageRef mismatch for {output_path}"
+        )
+
+
+def write_comparison_lineage_ref_v1_atomic(
+    ref: LineageRef,
+    output_path: Path | str,
+    *,
+    fail_closed_if_exists: bool = True,
+) -> Path:
+    """Validate, atomically write, and self-verify a COMPARISON LineageRef JSON file."""
+    out = Path(output_path)
+    if fail_closed_if_exists and out.exists():
+        raise ComparisonLineageRefProducerError(f"output path already exists (fail-closed): {out}")
+    serialized = serialize_comparison_lineage_ref_v1(ref)
+    _atomic_write_text(out, serialized)
+    _self_verify_written_ref(ref, out)
+    return out
+
+
+def produce_comparison_lineage_ref_v1_to_path(
+    *,
+    manifest_dir: Path | str,
+    output_path: Path | str,
+    fail_closed_if_exists: bool = True,
+) -> ComparisonLineageRefProducerResult:
+    """End-to-end offline producer: explicit manifest_dir -> validated COMPARISON LineageRef JSON."""
+    result = produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir)
+    write_comparison_lineage_ref_v1_atomic(
+        result.ref,
+        output_path,
+        fail_closed_if_exists=fail_closed_if_exists,
+    )
+    return result

--- a/tests/governance/promotion_loop/test_comparison_lineage_ref_producer_v1_contract.py
+++ b/tests/governance/promotion_loop/test_comparison_lineage_ref_producer_v1_contract.py
@@ -1,0 +1,309 @@
+"""Contract tests for offline COMPARISON LineageRef production."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import shutil
+import stat
+import uuid
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRefType,
+    LineageRelation,
+    lineage_ref_from_mapping,
+    lineage_ref_to_mapping,
+)
+from src.governance.promotion_loop.comparison_lineage_ref_producer_v1 import (
+    COMPARISON_LINEAGE_REF_REQUIRED,
+    COMPARISON_OWNER_DOMAIN,
+    ComparisonLineageRefProducerError,
+    build_comparison_lineage_ref_from_result_manifest,
+    produce_comparison_lineage_ref_v1,
+    produce_comparison_lineage_ref_v1_to_path,
+    serialize_comparison_lineage_ref_v1,
+    write_comparison_lineage_ref_v1_atomic,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import RESULT_ARTIFACT_FILENAME
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.comparison_ssot_v1.validation import validate_result_manifest_v1
+from tests.meta.comparison_ssot_v1_fixtures import produce_comparison_pair
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".comparison_lineage_ref_pytest_outputs"
+
+
+@pytest.fixture
+def lineage_ref_durable_output_dir() -> Callable[[], Path]:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    created: list[Path] = []
+
+    def _make() -> Path:
+        path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+        created.append(path)
+        return path
+
+    yield _make
+
+    for path in created:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _result_manifest_dir(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> tuple[Path, dict[str, object]]:
+    _, result_path, definition_id = produce_comparison_pair(tmp_path, ssot_durable_output_dir)
+    manifest = read_manifest(result_path)
+    return result_path.parent, manifest
+
+
+def test_happy_path_produces_valid_comparison_ref(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    result = produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir)
+    ref = result.ref
+    assert ref.ref_type == LineageRefType.COMPARISON
+    assert ref.relation == LineageRelation.DERIVES_FROM_RESULT_MANIFEST
+    assert ref.owner_domain == COMPARISON_OWNER_DOMAIN
+    assert ref.required is COMPARISON_LINEAGE_REF_REQUIRED
+    assert ref.artifact_path == RESULT_ARTIFACT_FILENAME
+    assert ref.ref_id == manifest["comparison_definition_id"]
+    assert ref.digest == manifest["integrity"]["content_sha256"]
+
+
+def test_digest_matches_result_manifest_integrity(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    ref = produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    assert ref.digest == manifest["integrity"]["content_sha256"]
+
+
+def test_serialization_deterministic(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    ref = produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    first = serialize_comparison_lineage_ref_v1(ref)
+    second = serialize_comparison_lineage_ref_v1(ref)
+    assert first == second
+    payload = json.loads(first)
+    assert payload["ref_type"] == LineageRefType.COMPARISON.value
+    assert payload["relation"] == LineageRelation.DERIVES_FROM_RESULT_MANIFEST.value
+
+
+def test_no_promotion_authority_fields_in_output(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    ref = produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    payload = json.loads(serialize_comparison_lineage_ref_v1(ref))
+    forbidden = {
+        "promotion",
+        "promotion_status",
+        "winner",
+        "selection",
+        "acceptance",
+        "completion",
+        "runtime_status",
+    }
+    assert forbidden.isdisjoint(payload.keys())
+
+
+def test_manifest_dir_symlink_rejected(tmp_path: Path) -> None:
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    symlink = tmp_path / "link"
+    symlink.symlink_to(real_dir, target_is_directory=True)
+    with pytest.raises(ComparisonLineageRefProducerError, match="symlink"):
+        produce_comparison_lineage_ref_v1(manifest_dir=symlink)
+
+
+def test_result_manifest_symlink_rejected(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    manifest_path = manifest_dir / RESULT_ARTIFACT_FILENAME
+    manifest_path.unlink()
+    symlink = manifest_dir / RESULT_ARTIFACT_FILENAME
+    symlink.symlink_to(tmp_path / "external.json")
+    (tmp_path / "external.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(ComparisonLineageRefProducerError, match="symlink"):
+        produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_missing_result_manifest_fail_closed(tmp_path: Path) -> None:
+    manifest_dir = tmp_path / "empty"
+    manifest_dir.mkdir()
+    with pytest.raises(ComparisonLineageRefProducerError, match=RESULT_ARTIFACT_FILENAME):
+        produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_invalid_result_manifest_fail_closed(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    manifest_path = manifest_dir / RESULT_ARTIFACT_FILENAME
+    manifest_path.write_text('{"winner": "forbidden"}', encoding="utf-8")
+    with pytest.raises(ComparisonLineageRefProducerError, match="validation failed"):
+        produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_existing_output_fail_closed(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    output_path = tmp_path / "out.json"
+    output_path.write_text('{"stale": true}', encoding="utf-8")
+    with pytest.raises(ComparisonLineageRefProducerError, match="already exists"):
+        produce_comparison_lineage_ref_v1_to_path(
+            manifest_dir=manifest_dir,
+            output_path=output_path,
+        )
+    assert output_path.read_text(encoding="utf-8") == '{"stale": true}'
+
+
+def test_self_verification_roundtrip(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    ref = produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    output_path = tmp_path / "ref.json"
+    write_comparison_lineage_ref_v1_atomic(ref, output_path)
+    roundtrip = lineage_ref_from_mapping(json.loads(output_path.read_text(encoding="utf-8")))
+    assert roundtrip == ref
+
+
+def test_build_from_manifest_rejects_missing_definition_id(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    _, manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    tampered = copy.deepcopy(manifest)
+    del tampered["comparison_definition_id"]
+    with pytest.raises(ComparisonLineageRefProducerError, match="comparison_definition_id"):
+        build_comparison_lineage_ref_from_result_manifest(tampered)
+
+
+def test_build_from_manifest_rejects_missing_digest(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    _, manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    tampered = copy.deepcopy(manifest)
+    tampered["integrity"] = {}
+    with pytest.raises(ComparisonLineageRefProducerError, match="content_sha256"):
+        build_comparison_lineage_ref_from_result_manifest(tampered)
+
+
+def test_validate_result_manifest_v1_is_mandatory(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    calls: list[dict[str, object]] = []
+    original = validate_result_manifest_v1
+
+    def _tracked_validate(payload):  # type: ignore[no-untyped-def]
+        calls.append(dict(payload))
+        return original(payload)
+
+    with patch(
+        "src.governance.promotion_loop.comparison_lineage_ref_producer_v1.validate_result_manifest_v1",
+        side_effect=_tracked_validate,
+    ):
+        produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert calls
+    assert calls[0]["comparison_definition_id"] == manifest["comparison_definition_id"]
+
+
+def test_atomic_write_outside_tmp(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+    lineage_ref_durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    output_path = lineage_ref_durable_output_dir() / "comparison_ref.json"
+    produce_comparison_lineage_ref_v1_to_path(
+        manifest_dir=manifest_dir,
+        output_path=output_path,
+    )
+    assert output_path.is_file()
+
+
+def test_non_writable_output_parent(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    ref = produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir()
+    output_path = readonly_dir / "out.json"
+    os.chmod(readonly_dir, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        with pytest.raises(OSError):
+            write_comparison_lineage_ref_v1_atomic(ref, output_path)
+    finally:
+        os.chmod(readonly_dir, stat.S_IRWXU)
+    assert not output_path.exists()
+
+
+def test_no_comparison_offline_reexecution(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("comparison offline producer forbidden")
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_v1.producer.produce_comparison_offline_v1",
+        _forbidden,
+    )
+    produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_no_registry_or_mlflow_resolution(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("registry or mlflow resolution forbidden")
+
+    with patch("urllib.request.urlopen", side_effect=_forbidden):
+        produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir)
+
+
+def test_lineage_ref_mapping_roundtrip(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    ref = produce_comparison_lineage_ref_v1(manifest_dir=manifest_dir).ref
+    mapping = lineage_ref_to_mapping(ref)
+    roundtrip = lineage_ref_from_mapping(mapping)
+    assert roundtrip == ref

--- a/tests/scripts/test_run_comparison_lineage_ref_producer_v1.py
+++ b/tests/scripts/test_run_comparison_lineage_ref_producer_v1.py
@@ -1,0 +1,215 @@
+"""CLI tests for offline COMPARISON LineageRef producer."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import uuid
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from scripts.run_comparison_lineage_ref_producer_v1 import (
+    EXIT_OK,
+    EXIT_PRODUCER_ERROR,
+    main,
+)
+from src.governance.promotion_loop.comparison_lineage_ref_producer_v1 import (
+    ComparisonLineageRefProducerError,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import RESULT_ARTIFACT_FILENAME
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from tests.meta.comparison_ssot_v1_fixtures import produce_comparison_pair
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".comparison_lineage_ref_cli_pytest_outputs"
+
+
+@pytest.fixture
+def lineage_ref_cli_durable_output_dir() -> Callable[[], Path]:
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    created: list[Path] = []
+
+    def _make() -> Path:
+        path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+        created.append(path)
+        return path
+
+    yield _make
+
+    for path in created:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _result_manifest_dir(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> tuple[Path, dict[str, object]]:
+    _, result_path, _definition_id = produce_comparison_pair(tmp_path, ssot_durable_output_dir)
+    manifest = read_manifest(result_path)
+    return result_path.parent, manifest
+
+
+def test_cli_successful_run(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    output_path = tmp_path / "ref.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["ref_id"] == manifest["comparison_definition_id"]
+    assert payload["ref_type"] == "comparison"
+    assert payload["relation"] == "derives_from_result_manifest"
+    assert payload["owner_domain"] == "meta/learning_loop/comparison_ssot_v1"
+
+
+def test_cli_deterministic_output(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    output_a = tmp_path / "a.json"
+    output_b = tmp_path / "b.json"
+    assert main(["--manifest-dir", str(manifest_dir), "--output", str(output_a)]) == EXIT_OK
+    assert main(["--manifest-dir", str(manifest_dir), "--output", str(output_b)]) == EXIT_OK
+    assert output_a.read_text(encoding="utf-8") == output_b.read_text(encoding="utf-8")
+
+
+def test_cli_requires_explicit_manifest_dir_and_output(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    with pytest.raises(SystemExit):
+        main(["--output", str(tmp_path / "out.json")])
+    with pytest.raises(SystemExit):
+        main(["--manifest-dir", str(manifest_dir)])
+
+
+def test_cli_invalid_input_is_producer_error(tmp_path: Path, capsys) -> None:
+    manifest_dir = tmp_path / "empty-dir"
+    manifest_dir.mkdir()
+    output_path = tmp_path / "out.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_cli_missing_result_manifest_fail_closed(tmp_path: Path, capsys) -> None:
+    manifest_dir = tmp_path / "missing-manifest"
+    manifest_dir.mkdir()
+    output_path = tmp_path / "out.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert RESULT_ARTIFACT_FILENAME in capsys.readouterr().err
+
+
+def test_cli_existing_output_fail_closed(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+    capsys,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    output_path = tmp_path / "out.json"
+    output_path.write_text('{"stale": true}', encoding="utf-8")
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert output_path.read_text(encoding="utf-8") == '{"stale": true}'
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_cli_non_writable_output_parent(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir()
+    output_path = readonly_dir / "out.json"
+    os.chmod(readonly_dir, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    finally:
+        os.chmod(readonly_dir, stat.S_IRWXU)
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+
+
+def test_cli_no_partial_output_on_producer_error(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+) -> None:
+    manifest_dir, manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    tampered = dict(manifest)
+    tampered["winner"] = "forbidden"
+    (manifest_dir / RESULT_ARTIFACT_FILENAME).write_text(json.dumps(tampered), encoding="utf-8")
+    output_path = tmp_path / "out.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert not output_path.exists()
+    assert not output_path.with_name(output_path.name + ".tmp").exists()
+
+
+def test_cli_producer_error_reports_on_stderr(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    output_path = tmp_path / "out.json"
+
+    def _raise(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise ComparisonLineageRefProducerError("forced producer failure")
+
+    monkeypatch.setattr(
+        "scripts.run_comparison_lineage_ref_producer_v1.produce_comparison_lineage_ref_v1_to_path",
+        _raise,
+    )
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_PRODUCER_ERROR
+    assert "forced producer failure" in capsys.readouterr().err
+
+
+def test_cli_no_comparison_offline_or_registry_calls(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+    monkeypatch,
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    output_path = tmp_path / "out.json"
+
+    def _forbidden(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("forbidden side-effect invocation")
+
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_ssot_v1.producer.produce_comparison_offline_v1",
+        _forbidden,
+    )
+    with patch("urllib.request.urlopen", side_effect=_forbidden):
+        rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+
+
+def test_cli_durable_output_path(
+    tmp_path: Path,
+    ssot_durable_output_dir: Path,
+    lineage_ref_cli_durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _result_manifest_dir(tmp_path, ssot_durable_output_dir)
+    output_path = lineage_ref_cli_durable_output_dir() / "ref.json"
+    rc = main(["--manifest-dir", str(manifest_dir), "--output", str(output_path)])
+    assert rc == EXIT_OK
+    assert output_path.is_file()


### PR DESCRIPTION
## Summary
- Add offline `comparison_lineage_ref_producer_v1` that derives a reference-only `LineageRef` from an existing `comparison_result_manifest_v1.json` directory.
- Reuse `LineageRefType.COMPARISON`, new `LineageRelation.DERIVES_FROM_RESULT_MANIFEST`, digest from `integrity.content_sha256`, and fail-closed path/symlink/manifest validation.
- Add contract tests, CLI runner, and self-verification on atomic publish; no comparison re-execution, promotion, completion, or runtime authority.

## Test plan
- [x] `pytest tests/governance/promotion_loop/test_comparison_lineage_ref_producer_v1_contract.py`
- [x] `pytest tests/scripts/test_run_comparison_lineage_ref_producer_v1.py`
- [x] PR_BOUNDED_FULL regression slice (964 tests, ~49s local)
- [x] `ruff format --check` and `ruff check` on changed files


Made with [Cursor](https://cursor.com)