### PR TITLE
feat(meta): add learning loop comparison checkpoint v1

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1574,6 +1574,23 @@ PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TARGETS: tuple[str, .
     "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_CHECKPOINT_V1_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/comparison_checkpoint_v1.py",
+        "scripts/run_comparison_checkpoint_v1.py",
+        "tests/meta/test_comparison_checkpoint_v1.py",
+        "tests/scripts/test_run_comparison_checkpoint_v1.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_CHECKPOINT_V1_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_comparison_checkpoint_v1.py",
+    "tests/scripts/test_run_comparison_checkpoint_v1.py",
+    "tests/meta/test_comparison_common_durable_evidence_binding_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/meta/learning_loop/comparison_metric_input_v1/__init__.py",
@@ -1776,6 +1793,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_CHECKPOINT_V1_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_CHECKPOINT_V1_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS:
@@ -4984,6 +5005,9 @@ def _focused_targets(files: list[str]) -> tuple[str, ...]:
                     add(candidate)
             elif path == "scripts/run_comparison_common_durable_evidence_binding_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_COMMON_DURABLE_EVIDENCE_TARGETS:
+                    add(candidate)
+            elif path == "scripts/run_comparison_checkpoint_v1.py":
+                for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_CHECKPOINT_V1_TARGETS:
                     add(candidate)
             elif path == "scripts/run_comparison_metric_input_v1.py":
                 for candidate in PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TARGETS:

--- a/scripts/run_comparison_checkpoint_v1.py
+++ b/scripts/run_comparison_checkpoint_v1.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Offline learning loop comparison checkpoint v1.
+
+Records a non-authoritative, durable checkpoint over an already-published and
+self-verified Common Comparison Durable Evidence Bundle v1. Optional soft
+cross-check against a pre-published Comparison Lineage Ref v1.
+
+Usage:
+    python3 scripts/run_comparison_checkpoint_v1.py \\
+        --common-bundle-dir /path/to/common_bundle \\
+        --output-dir /var/evidence/comparison_checkpoint_001 \\
+        [--lineage-ref-path /path/to/comparison_ref.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_checkpoint_v1 import (
+    ComparisonCheckpointError,
+    produce_comparison_checkpoint_v1,
+)
+
+EXIT_OK = 0
+EXIT_CHECKPOINT_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline learning loop comparison checkpoint v1: record a "
+            "non-authoritative durable mark over a verified common comparison bundle."
+        )
+    )
+    parser.add_argument(
+        "--common-bundle-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to a published common comparison durable evidence bundle.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit checkpoint output directory (must not exist; outside /tmp).",
+    )
+    parser.add_argument(
+        "--lineage-ref-path",
+        type=Path,
+        default=None,
+        help="Optional explicit path to a pre-published Comparison Lineage Ref JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.common_bundle_dir.is_dir():
+        print(
+            f"[comparison_checkpoint_v1] ERROR: common bundle not found: {args.common_bundle_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if args.lineage_ref_path is not None and not args.lineage_ref_path.is_file():
+        print(
+            f"[comparison_checkpoint_v1] ERROR: lineage ref not found: {args.lineage_ref_path}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    try:
+        result = produce_comparison_checkpoint_v1(
+            common_bundle_dir=args.common_bundle_dir,
+            output_dir=args.output_dir,
+            lineage_ref_path=args.lineage_ref_path,
+        )
+    except ComparisonCheckpointError as exc:
+        print(f"[comparison_checkpoint_v1] ERROR: {exc}", file=sys.stderr)
+        return EXIT_CHECKPOINT_ERROR
+
+    print(
+        "[comparison_checkpoint_v1] wrote checkpoint to "
+        f"{result.output_dir} (comparison_definition_id={result.comparison_definition_id}, "
+        f"checkpoint_id={result.checkpoint_id})"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/comparison_checkpoint_v1.py
+++ b/src/meta/learning_loop/comparison_checkpoint_v1.py
@@ -1,0 +1,488 @@
+"""Offline learning loop comparison checkpoint v1 — non-authoritative durable mark."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRefType,
+    lineage_ref_from_mapping,
+    lineage_ref_to_mapping,
+)
+from src.governance.promotion_loop.comparison_lineage_ref_producer_v1 import (
+    COMPARISON_OWNER_DOMAIN,
+)
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    COMPARISON_AUTHORITY_INVARIANTS,
+    ComparisonCommonDurableEvidenceBindingError,
+    INDEX_ARTIFACT_REL as COMMON_INDEX_ARTIFACT_REL,
+    reverify_comparison_common_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.constants import COMPARISON_CONTRACT_VERSION
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+CHECKPOINT_SCHEMA_VERSION = "comparison_checkpoint_v1"
+CHECKPOINT_RELATION = "REFERENCES_VERIFIED_COMMON_BUNDLE"
+RECORD_KIND = "comparison_durable_evidence_completeness"
+INDEX_ARTIFACT_REL = "comparison_checkpoint_index_v1.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".comparison_checkpoint_staging_"
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "patches",
+        "patch",
+        "strategy",
+        "signal",
+        "signals",
+        "entry",
+        "exit",
+        "position_sizing",
+        "leverage",
+        "stop_loss",
+        "take_profit",
+        "execution",
+        "order_routing",
+        "risk_limits",
+        "killswitch",
+        "old_value",
+        "new_value",
+        "target",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "runtime_status",
+        "live_arming",
+        "apply_authority",
+        "promotion_authority",
+        "completion",
+        "completed",
+        "completion_claimed",
+        "completion_ready",
+        "completion_authorized",
+        "checkpoint",
+        "params",
+        "metrics",
+        "tags",
+        "winner",
+        "selection",
+        "acceptance",
+        "accepted",
+        "ranking",
+        "pareto",
+        "selected",
+        "promoted",
+        "promotion",
+        "promotion_ready",
+        "promotion_authorized",
+        "runtime_authorized",
+        "shadow_authorized",
+        "paper_authorized",
+        "testnet_authorized",
+        "live_authorized",
+        "orders_allowed",
+        "ready_for_operator_arming",
+        "armed",
+        "enabled",
+        "capital_allocated",
+        "strategy_params_mutated",
+        "stage_transition_authorized",
+    }
+)
+
+
+class ComparisonCheckpointError(ValueError):
+    """Fail-closed comparison checkpoint error."""
+
+
+@dataclass(frozen=True)
+class ComparisonCheckpointResult:
+    output_dir: Path
+    comparison_definition_id: str
+    checkpoint_id: str
+    checkpoint_index_path: Path
+    manifest_path: Path
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ComparisonCheckpointError(f"{label} must not be a symlink: {path}")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise ComparisonCheckpointError(
+                f"checkpoint index must not contain forbidden key: {key}"
+            )
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise ComparisonCheckpointError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise ComparisonCheckpointError(f"{label} must be a regular file: {path}")
+
+
+def _validate_bundle_dir(bundle_dir: Path, *, label: str) -> None:
+    if not bundle_dir.is_dir():
+        raise ComparisonCheckpointError(f"{label} must be a directory: {bundle_dir}")
+    _reject_symlink(bundle_dir, label=label)
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise ComparisonCheckpointError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise ComparisonCheckpointError("output directory must be outside /tmp")
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ComparisonCheckpointError(f"output parent directory missing: {parent}")
+    if is_under_tmp(parent):
+        raise ComparisonCheckpointError("output parent directory must be outside /tmp")
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _reject_unsafe_overlap(*, common_bundle_dir: Path, output_dir: Path) -> None:
+    common_res = common_bundle_dir.resolve()
+    output_res = output_dir.resolve()
+    if output_res == common_res:
+        raise ComparisonCheckpointError(
+            "output directory must not equal common bundle path (fail-closed)"
+        )
+    if _path_is_under(common_res, output_res):
+        raise ComparisonCheckpointError(
+            "common bundle must not be inside output directory (fail-closed)"
+        )
+    if _path_is_under(output_res, common_res):
+        raise ComparisonCheckpointError(
+            "output directory must not be inside common bundle path (fail-closed)"
+        )
+
+
+def _binding_index_integrity_sha256(index: Mapping[str, Any], *, label: str) -> str:
+    integrity = index.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise ComparisonCheckpointError(f"{label} integrity must be an object")
+    digest = integrity.get("content_sha256")
+    if not isinstance(digest, str) or not digest.strip():
+        raise ComparisonCheckpointError(f"{label} integrity.content_sha256 missing or invalid")
+    if not is_valid_sha256_hex(digest):
+        raise ComparisonCheckpointError(
+            f"{label} integrity.content_sha256 must be valid sha256 hex"
+        )
+    return digest
+
+
+def _verbatim_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): value[key] for key in value}
+
+
+def _verbatim_ref_list(value: Any, *, label: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ComparisonCheckpointError(f"{label} must be a list")
+    out: list[dict[str, Any]] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise ComparisonCheckpointError(f"{label}[{idx}] must be an object")
+        out.append(_verbatim_mapping(item))
+    return out
+
+
+def _load_verified_common_bundle_index(common_bundle_dir: Path) -> dict[str, Any]:
+    _validate_bundle_dir(common_bundle_dir, label="common bundle")
+    try:
+        reverify_comparison_common_durable_evidence_bundle_v1(output_dir=common_bundle_dir)
+    except ComparisonCommonDurableEvidenceBindingError as exc:
+        raise ComparisonCheckpointError(str(exc)) from exc
+    index_path = common_bundle_dir / COMMON_INDEX_ARTIFACT_REL
+    return read_manifest(index_path)
+
+
+def _load_optional_lineage_ref(lineage_ref_path: Path) -> dict[str, Any]:
+    _validate_regular_file(lineage_ref_path, label="lineage ref")
+    try:
+        payload = json.loads(lineage_ref_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ComparisonCheckpointError(
+            f"lineage ref is not valid JSON: {lineage_ref_path}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ComparisonCheckpointError("lineage ref root must be a JSON object")
+    try:
+        ref = lineage_ref_from_mapping(payload)
+    except Exception as exc:
+        raise ComparisonCheckpointError(f"lineage ref validation failed: {exc}") from exc
+    if ref.ref_type != LineageRefType.COMPARISON:
+        raise ComparisonCheckpointError("lineage ref ref_type must be comparison")
+    if ref.owner_domain != COMPARISON_OWNER_DOMAIN:
+        raise ComparisonCheckpointError(
+            f"lineage ref owner_domain must be {COMPARISON_OWNER_DOMAIN!r}"
+        )
+    return lineage_ref_to_mapping(ref)
+
+
+def _cross_check_lineage_ref(
+    *,
+    lineage_ref_record: Mapping[str, Any],
+    comparison_definition_id: str,
+    result_binding_ref: Mapping[str, Any],
+) -> None:
+    ref_id = lineage_ref_record.get("ref_id")
+    if ref_id != comparison_definition_id:
+        raise ComparisonCheckpointError(
+            "lineage ref ref_id must equal comparison_definition_id (fail-closed)"
+        )
+    digest = lineage_ref_record.get("digest")
+    result_manifest_digest = result_binding_ref.get("manifest_content_sha256")
+    if digest != result_manifest_digest:
+        raise ComparisonCheckpointError(
+            "lineage ref digest must match result_binding_ref.manifest_content_sha256"
+        )
+
+
+def build_checkpoint_index_v1(
+    *,
+    common_bundle_dir: Path,
+    common_bundle_index: Mapping[str, Any],
+    lineage_ref_record: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    comparison_definition_id = common_bundle_index.get("comparison_definition_id")
+    if not isinstance(comparison_definition_id, str) or not comparison_definition_id.strip():
+        raise ComparisonCheckpointError("comparison_definition_id missing or invalid")
+
+    metric_input_binding_refs = _verbatim_ref_list(
+        common_bundle_index.get("metric_input_binding_refs"),
+        label="metric_input_binding_refs",
+    )
+    definition_binding_ref = common_bundle_index.get("definition_binding_ref")
+    result_binding_ref = common_bundle_index.get("result_binding_ref")
+    chain_cross_references = common_bundle_index.get("chain_cross_references")
+    if not isinstance(definition_binding_ref, Mapping):
+        raise ComparisonCheckpointError("definition_binding_ref must be an object")
+    if not isinstance(result_binding_ref, Mapping):
+        raise ComparisonCheckpointError("result_binding_ref must be an object")
+    if not isinstance(chain_cross_references, Mapping):
+        raise ComparisonCheckpointError("chain_cross_references must be an object")
+
+    authority_invariants = common_bundle_index.get("comparison_authority_invariants")
+    if authority_invariants != COMPARISON_AUTHORITY_INVARIANTS:
+        raise ComparisonCheckpointError("comparison_authority_invariants mismatch")
+
+    common_integrity = _binding_index_integrity_sha256(
+        common_bundle_index, label="common bundle index"
+    )
+
+    if lineage_ref_record is not None:
+        _cross_check_lineage_ref(
+            lineage_ref_record=lineage_ref_record,
+            comparison_definition_id=comparison_definition_id,
+            result_binding_ref=result_binding_ref,
+        )
+
+    payload: dict[str, Any] = {
+        "record_schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "record_kind": RECORD_KIND,
+        "bound_contract": COMPARISON_CONTRACT_VERSION,
+        "comparison_definition_id": comparison_definition_id,
+        "checkpoint_relation": CHECKPOINT_RELATION,
+        "common_bundle_ref": {
+            "source_path": common_bundle_dir.resolve().as_posix(),
+            "binding_index_integrity_sha256": common_integrity,
+        },
+        "metric_input_binding_refs": metric_input_binding_refs,
+        "definition_binding_ref": _verbatim_mapping(definition_binding_ref),
+        "result_binding_ref": _verbatim_mapping(result_binding_ref),
+        "chain_cross_references": _verbatim_mapping(chain_cross_references),
+        "comparison_authority_invariants": dict(COMPARISON_AUTHORITY_INVARIANTS),
+        "evidence_does_not_authorize_runtime": True,
+        "is_completion_evidence": False,
+    }
+    if lineage_ref_record is not None:
+        payload["lineage_ref_record"] = _verbatim_mapping(lineage_ref_record)
+
+    _reject_forbidden_index_keys(payload)
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def serialize_checkpoint_index_v1(index: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(index)
+    return deterministic_json_dumps(dict(index))
+
+
+def _validate_checkpoint_index(index: Mapping[str, Any]) -> None:
+    if index.get("record_schema_version") != CHECKPOINT_SCHEMA_VERSION:
+        raise ComparisonCheckpointError("record_schema_version mismatch")
+    if index.get("record_kind") != RECORD_KIND:
+        raise ComparisonCheckpointError("record_kind mismatch")
+    if index.get("checkpoint_relation") != CHECKPOINT_RELATION:
+        raise ComparisonCheckpointError("checkpoint_relation mismatch")
+    if index.get("evidence_does_not_authorize_runtime") is not True:
+        raise ComparisonCheckpointError("evidence_does_not_authorize_runtime must be true")
+    if index.get("is_completion_evidence") is not False:
+        raise ComparisonCheckpointError("is_completion_evidence must be false")
+    invariants = index.get("comparison_authority_invariants")
+    if invariants != COMPARISON_AUTHORITY_INVARIANTS:
+        raise ComparisonCheckpointError("comparison_authority_invariants mismatch")
+    _reject_forbidden_index_keys(index)
+
+    stored = index.get("integrity")
+    if not isinstance(stored, Mapping):
+        raise ComparisonCheckpointError("integrity must be an object")
+    body = {key: value for key, value in index.items() if key != "integrity"}
+    expected = compute_content_sha256(body)
+    actual = stored.get("content_sha256")
+    if actual != expected:
+        raise ComparisonCheckpointError("checkpoint index integrity mismatch")
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{uuid.uuid4().hex}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def reverify_comparison_checkpoint_v1(*, output_dir: Path | str) -> None:
+    """Replay comparison checkpoint bundle without producer or upstream mutation."""
+    bundle_dir = Path(output_dir)
+    if not bundle_dir.is_dir():
+        raise ComparisonCheckpointError(f"checkpoint directory not found: {bundle_dir}")
+    ok, msg = verify_manifest_sha256(bundle_dir)
+    if not ok:
+        raise ComparisonCheckpointError(f"MANIFEST.sha256 verification failed: {msg}")
+    index_path = bundle_dir / INDEX_ARTIFACT_REL
+    _validate_regular_file(index_path, label=INDEX_ARTIFACT_REL)
+    index = read_manifest(index_path)
+    _validate_checkpoint_index(index)
+
+    lineage_ref_record = index.get("lineage_ref_record")
+    if lineage_ref_record is not None:
+        if not isinstance(lineage_ref_record, Mapping):
+            raise ComparisonCheckpointError("lineage_ref_record must be an object")
+        try:
+            ref = lineage_ref_from_mapping(dict(lineage_ref_record))
+        except Exception as exc:
+            raise ComparisonCheckpointError(f"lineage_ref_record invalid on replay: {exc}") from exc
+        if ref.ref_type != LineageRefType.COMPARISON:
+            raise ComparisonCheckpointError("lineage_ref_record ref_type must be comparison")
+        _cross_check_lineage_ref(
+            lineage_ref_record=lineage_ref_record,
+            comparison_definition_id=str(index["comparison_definition_id"]),
+            result_binding_ref=index["result_binding_ref"],
+        )
+
+
+def produce_comparison_checkpoint_v1(
+    *,
+    common_bundle_dir: Path | str,
+    output_dir: Path | str,
+    lineage_ref_path: Path | str | None = None,
+) -> ComparisonCheckpointResult:
+    """Record a non-authoritative checkpoint over a verified common comparison bundle."""
+    common_dir = Path(common_bundle_dir)
+    final_dir = Path(output_dir)
+    lineage_path = Path(lineage_ref_path) if lineage_ref_path is not None else None
+
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(common_bundle_dir=common_dir, output_dir=final_dir)
+
+    common_index = _load_verified_common_bundle_index(common_dir)
+
+    lineage_ref_record: dict[str, Any] | None = None
+    if lineage_path is not None:
+        _reject_symlink(lineage_path, label="lineage ref path")
+        if ".." in lineage_path.parts:
+            raise ComparisonCheckpointError("lineage ref path must not traverse upward")
+        lineage_ref_record = _load_optional_lineage_ref(lineage_path)
+
+    index_payload = build_checkpoint_index_v1(
+        common_bundle_dir=common_dir,
+        common_bundle_index=common_index,
+        lineage_ref_record=lineage_ref_record,
+    )
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise ComparisonCheckpointError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        index_path = staging / INDEX_ARTIFACT_REL
+        index_path.write_text(serialize_checkpoint_index_v1(index_payload), encoding="utf-8")
+
+        write_manifest_sha256(staging)
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise ComparisonCheckpointError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        reverify_comparison_checkpoint_v1(output_dir=staging)
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise ComparisonCheckpointError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    checkpoint_id = str(index_payload["integrity"]["content_sha256"])
+    return ComparisonCheckpointResult(
+        output_dir=final_dir,
+        comparison_definition_id=str(common_index["comparison_definition_id"]),
+        checkpoint_id=checkpoint_id,
+        checkpoint_index_path=final_dir / INDEX_ARTIFACT_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+    )
+
+
+__all__ = [
+    "CHECKPOINT_RELATION",
+    "CHECKPOINT_SCHEMA_VERSION",
+    "COMPARISON_AUTHORITY_INVARIANTS",
+    "INDEX_ARTIFACT_REL",
+    "MANIFEST_FILENAME",
+    "RECORD_KIND",
+    "ComparisonCheckpointError",
+    "ComparisonCheckpointResult",
+    "build_checkpoint_index_v1",
+    "produce_comparison_checkpoint_v1",
+    "reverify_comparison_checkpoint_v1",
+    "serialize_checkpoint_index_v1",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -6137,3 +6137,48 @@ def test_selector_package_cmp_common_durable_binding_combined_diff_pr_bounded_fu
     for path in PACKAGE_CMP_COMMON_DURABLE_BINDING_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_CMP_CHECKPOINT_V1_PRODUCTION = "src/meta/learning_loop/comparison_checkpoint_v1.py"
+PACKAGE_CMP_CHECKPOINT_V1_SCRIPT = "scripts/run_comparison_checkpoint_v1.py"
+PACKAGE_CMP_CHECKPOINT_V1_TESTOWNER = "tests/meta/test_comparison_checkpoint_v1.py"
+PACKAGE_CMP_CHECKPOINT_V1_CLI_TESTOWNER = "tests/scripts/test_run_comparison_checkpoint_v1.py"
+PACKAGE_CMP_CHECKPOINT_V1_DEPENDENCY_TESTOWNERS = (
+    "tests/meta/test_comparison_common_durable_evidence_binding_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+PACKAGE_CMP_CHECKPOINT_V1_ALL_PRODUCTION = (
+    PACKAGE_CMP_CHECKPOINT_V1_PRODUCTION,
+    PACKAGE_CMP_CHECKPOINT_V1_SCRIPT,
+)
+PACKAGE_CMP_CHECKPOINT_V1_ALL_TESTOWNERS = (
+    PACKAGE_CMP_CHECKPOINT_V1_TESTOWNER,
+    PACKAGE_CMP_CHECKPOINT_V1_CLI_TESTOWNER,
+    *PACKAGE_CMP_CHECKPOINT_V1_DEPENDENCY_TESTOWNERS,
+)
+
+
+def test_selector_package_cmp_checkpoint_v1_production_pr_bounded_full_includes_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_CMP_CHECKPOINT_V1_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_CHECKPOINT_V1_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_cmp_checkpoint_v1_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        *PACKAGE_CMP_CHECKPOINT_V1_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_CMP_CHECKPOINT_V1_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_CHECKPOINT_V1_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/meta/test_comparison_checkpoint_v1.py
+++ b/tests/meta/test_comparison_checkpoint_v1.py
@@ -1,0 +1,517 @@
+"""Contract tests for learning loop comparison checkpoint v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.governance.promotion_loop.comparison_lineage_ref_producer_v1 import (
+    produce_comparison_lineage_ref_v1_to_path,
+)
+from src.meta.learning_loop.comparison_checkpoint_v1 import (
+    CHECKPOINT_RELATION,
+    COMPARISON_AUTHORITY_INVARIANTS,
+    INDEX_ARTIFACT_REL,
+    ComparisonCheckpointError,
+    build_checkpoint_index_v1,
+    produce_comparison_checkpoint_v1,
+    reverify_comparison_checkpoint_v1,
+    serialize_checkpoint_index_v1,
+)
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    INDEX_ARTIFACT_REL as COMMON_INDEX_ARTIFACT_REL,
+    produce_comparison_common_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1 import (
+    produce_comparison_metric_input_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1 import (
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1 import (
+    produce_comparison_ssot_result_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.comparison_ssot_v1.producer import produce_comparison_offline_v1
+from tests.meta.comparison_ssot_v1_fixtures import produce_two_compatible_backtest_inputs
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    for target in (
+        "src.meta.learning_loop.comparison_checkpoint_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_common_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1.is_under_tmp",
+    ):
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "checkpoint_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _produce_common_bundle(
+    tmp_path: Path,
+    durable_root: Path,
+) -> tuple[Path, str, Path, Path]:
+    metric_root = durable_root / "metric_inputs"
+    metric_root.mkdir(exist_ok=True)
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    comparison_root = durable_root / "comparisons"
+    comparison_root.mkdir(exist_ok=True)
+    offline = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=comparison_root,
+        ranking_rule_version="NONE_V1",
+    )
+    metric_bindings: list[Path] = []
+    for idx, manifest_path in enumerate([first, second]):
+        out = durable_root / f"metric_input_binding_{idx}"
+        produce_comparison_metric_input_durable_evidence_bundle_v1(
+            manifest_path=manifest_path,
+            output_dir=out,
+        )
+        metric_bindings.append(out)
+    definition_binding = durable_root / "definition_binding"
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=offline.definition_path,
+        output_dir=definition_binding,
+    )
+    result_binding = durable_root / "result_binding"
+    produce_comparison_ssot_result_durable_evidence_bundle_v1(
+        manifest_path=offline.result_path,
+        output_dir=result_binding,
+    )
+    common_out = durable_root / "common_bundle"
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=common_out,
+    )
+    return common_out, offline.comparison_definition_id, result_binding, offline.result_path
+
+
+def _produce_lineage_ref(result_path: Path, durable_root: Path) -> Path:
+    ref_path = durable_root / "lineage_ref.json"
+    produce_comparison_lineage_ref_v1_to_path(
+        manifest_dir=result_path.parent,
+        output_path=ref_path,
+    )
+    return ref_path
+
+
+def test_happy_path_checkpoint_from_verified_common_bundle(
+    tmp_path, ssot_durable_output_dir
+) -> None:
+    common_out, comparison_definition_id, _, _ = _produce_common_bundle(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path)
+    result = produce_comparison_checkpoint_v1(
+        common_bundle_dir=common_out,
+        output_dir=out,
+    )
+    assert result.comparison_definition_id == comparison_definition_id
+    assert result.checkpoint_id
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is True
+
+
+def test_deterministic_index_and_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out_a = _durable_output(tmp_path, "det_a")
+    out_b = _durable_output(tmp_path, "det_b")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out_a)
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out_b)
+    assert (out_a / INDEX_ARTIFACT_REL).read_text(encoding="utf-8") == (
+        out_b / INDEX_ARTIFACT_REL
+    ).read_text(encoding="utf-8")
+    assert (out_a / "MANIFEST.sha256").read_text(encoding="utf-8") == (
+        out_b / "MANIFEST.sha256"
+    ).read_text(encoding="utf-8")
+
+
+def test_reverify_without_producers(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "replay")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    reverify_comparison_checkpoint_v1(output_dir=out)
+
+
+def test_common_bundle_integrity_digest_verbatim(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    common_index = read_manifest(common_out / COMMON_INDEX_ARTIFACT_REL)
+    out = _durable_output(tmp_path, "digest")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert (
+        index["common_bundle_ref"]["binding_index_integrity_sha256"]
+        == common_index["integrity"]["content_sha256"]
+    )
+
+
+def test_comparison_definition_id_verbatim(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, comparison_definition_id, _, _ = _produce_common_bundle(
+        tmp_path, ssot_durable_output_dir
+    )
+    out = _durable_output(tmp_path, "def_id")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert index["comparison_definition_id"] == comparison_definition_id
+
+
+def test_metric_input_binding_refs_order_preserved(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    common_index = read_manifest(common_out / COMMON_INDEX_ARTIFACT_REL)
+    out = _durable_output(tmp_path, "order")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert index["metric_input_binding_refs"] == common_index["metric_input_binding_refs"]
+
+
+def test_definition_and_result_binding_refs_verbatim(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    common_index = read_manifest(common_out / COMMON_INDEX_ARTIFACT_REL)
+    out = _durable_output(tmp_path, "refs")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert index["definition_binding_ref"] == common_index["definition_binding_ref"]
+    assert index["result_binding_ref"] == common_index["result_binding_ref"]
+
+
+def test_optional_lineage_ref_cross_check_pass(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, result_path = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    ref_path = _produce_lineage_ref(result_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "with_lineage")
+    produce_comparison_checkpoint_v1(
+        common_bundle_dir=common_out,
+        output_dir=out,
+        lineage_ref_path=ref_path,
+    )
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert "lineage_ref_record" in index
+
+
+def test_lineage_ref_id_mismatch_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, result_path = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    ref_path = _produce_lineage_ref(result_path, ssot_durable_output_dir)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["ref_id"] = "00000000-0000-4000-8000-000000000001"
+    bad_ref = ssot_durable_output_dir / "bad_lineage_ref.json"
+    bad_ref.write_text(json.dumps(payload), encoding="utf-8")
+    out = _durable_output(tmp_path, "lineage_id_mismatch")
+    with pytest.raises(ComparisonCheckpointError, match="ref_id"):
+        produce_comparison_checkpoint_v1(
+            common_bundle_dir=common_out,
+            output_dir=out,
+            lineage_ref_path=bad_ref,
+        )
+
+
+def test_lineage_ref_digest_mismatch_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, result_path = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    ref_path = _produce_lineage_ref(result_path, ssot_durable_output_dir)
+    payload = json.loads(ref_path.read_text(encoding="utf-8"))
+    payload["digest"] = "0" * 64
+    bad_ref = ssot_durable_output_dir / "bad_digest_ref.json"
+    bad_ref.write_text(json.dumps(payload), encoding="utf-8")
+    out = _durable_output(tmp_path, "lineage_digest_mismatch")
+    with pytest.raises(ComparisonCheckpointError, match="digest"):
+        produce_comparison_checkpoint_v1(
+            common_bundle_dir=common_out,
+            output_dir=out,
+            lineage_ref_path=bad_ref,
+        )
+
+
+def test_missing_common_bundle_dir(tmp_path) -> None:
+    out = _durable_output(tmp_path, "missing")
+    with pytest.raises(ComparisonCheckpointError, match="must be a directory"):
+        produce_comparison_checkpoint_v1(
+            common_bundle_dir=tmp_path / "missing_common",
+            output_dir=out,
+        )
+
+
+def test_common_bundle_manifest_verify_fails(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    (common_out / "MANIFEST.sha256").write_text("broken", encoding="utf-8")
+    out = _durable_output(tmp_path, "bad_manifest")
+    with pytest.raises(ComparisonCheckpointError, match="MANIFEST.sha256"):
+        produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+
+
+def test_unverified_common_bundle_rejected(tmp_path) -> None:
+    fake = tmp_path / "fake_common"
+    fake.mkdir()
+    (fake / COMMON_INDEX_ARTIFACT_REL).write_text("{}", encoding="utf-8")
+    out = _durable_output(tmp_path, "unverified")
+    with pytest.raises(ComparisonCheckpointError, match="MANIFEST.sha256"):
+        produce_comparison_checkpoint_v1(common_bundle_dir=fake, output_dir=out)
+
+
+def test_symlink_input_rejected(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    link = tmp_path / "common_link"
+    link.symlink_to(common_out)
+    out = _durable_output(tmp_path, "symlink")
+    with pytest.raises(ComparisonCheckpointError, match="symlink"):
+        produce_comparison_checkpoint_v1(common_bundle_dir=link, output_dir=out)
+
+
+def test_path_traversal_rejected(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "traversal")
+    bad_ref = tmp_path / ".." / "escape.json"
+    with pytest.raises(ComparisonCheckpointError, match="traverse upward"):
+        produce_comparison_checkpoint_v1(
+            common_bundle_dir=common_out,
+            output_dir=out,
+            lineage_ref_path=bad_ref,
+        )
+
+
+def test_output_overlap_with_common_bundle_rejected(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    nested = common_out / "nested_checkpoint"
+    with pytest.raises(ComparisonCheckpointError, match="inside common bundle"):
+        produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=nested)
+
+
+def test_output_under_tmp_rejected(tmp_path, ssot_durable_output_dir, monkeypatch) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    monkeypatch.setattr(
+        "src.meta.learning_loop.comparison_checkpoint_v1.is_under_tmp",
+        lambda path: str(path).startswith("/tmp") or "/tmp/" in str(path),
+    )
+    out = Path("/tmp/checkpoint_out")
+    with pytest.raises(ComparisonCheckpointError, match="/tmp"):
+        produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+
+
+def test_existing_output_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "exists")
+    out.mkdir()
+    with pytest.raises(ComparisonCheckpointError, match="already exists"):
+        produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+
+
+def test_partial_staging_no_output_on_failure(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "partial")
+    with patch(
+        "src.meta.learning_loop.comparison_checkpoint_v1.write_manifest_sha256",
+        side_effect=RuntimeError("staging failure"),
+    ):
+        with pytest.raises(RuntimeError, match="staging failure"):
+            produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    assert not out.exists()
+
+
+def test_manifest_sha256_present_and_valid(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "manifest")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    ok, msg = verify_manifest_sha256(out)
+    assert ok is True, msg
+
+
+def test_evidence_does_not_authorize_runtime(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "auth")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert index["evidence_does_not_authorize_runtime"] is True
+
+
+def test_comparison_authority_invariants_present(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "invariants")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert index["comparison_authority_invariants"] == COMPARISON_AUTHORITY_INVARIANTS
+
+
+def _valid_common_index() -> dict[str, object]:
+    return {
+        "comparison_definition_id": "00000000-0000-4000-8000-000000000099",
+        "metric_input_binding_refs": [],
+        "definition_binding_ref": {"manifest_content_sha256": "a" * 64},
+        "result_binding_ref": {"manifest_content_sha256": "b" * 64},
+        "chain_cross_references": {},
+        "comparison_authority_invariants": COMPARISON_AUTHORITY_INVARIANTS,
+        "integrity": {"content_sha256": "c" * 64},
+    }
+
+
+def test_forbidden_completion_field_rejected() -> None:
+    index = build_checkpoint_index_v1(
+        common_bundle_dir=Path("/var/evidence/common"),
+        common_bundle_index=_valid_common_index(),
+    )
+    index["completion"] = True
+    with pytest.raises(ComparisonCheckpointError, match="forbidden key: completion"):
+        serialize_checkpoint_index_v1(index)
+
+
+def test_forbidden_promotion_field_rejected() -> None:
+    index = build_checkpoint_index_v1(
+        common_bundle_dir=Path("/var/evidence/common"),
+        common_bundle_index=_valid_common_index(),
+    )
+    index["promotion"] = True
+    with pytest.raises(ComparisonCheckpointError, match="forbidden key: promotion"):
+        serialize_checkpoint_index_v1(index)
+
+
+def test_forbidden_winner_selection_acceptance_rejected() -> None:
+    for forbidden in ("winner", "selected", "accepted"):
+        index = build_checkpoint_index_v1(
+            common_bundle_dir=Path("/var/evidence/common"),
+            common_bundle_index=_valid_common_index(),
+        )
+        index[forbidden] = True
+        with pytest.raises(ComparisonCheckpointError, match=f"forbidden key: {forbidden}"):
+            serialize_checkpoint_index_v1(index)
+
+
+def test_forbidden_runtime_field_rejected() -> None:
+    index = build_checkpoint_index_v1(
+        common_bundle_dir=Path("/var/evidence/common"),
+        common_bundle_index=_valid_common_index(),
+    )
+    index["live_authorized"] = True
+    with pytest.raises(ComparisonCheckpointError, match="forbidden key: live_authorized"):
+        serialize_checkpoint_index_v1(index)
+
+
+def test_is_completion_evidence_false(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "not_completion")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert index["is_completion_evidence"] is False
+
+
+def test_ast_no_forbidden_runtime_imports() -> None:
+    module_path = Path(__file__).resolve().parents[2] / (
+        "src/meta/learning_loop/comparison_checkpoint_v1.py"
+    )
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    forbidden = {"src.execution", "src.risk", "mlflow", "src.ops.durable_completion_validation"}
+    assert not modules & forbidden
+
+
+def test_no_common_bundle_producer_re_run(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "no_producer")
+    with patch(
+        "src.meta.learning_loop.comparison_common_durable_evidence_binding_v1.produce_comparison_common_durable_evidence_bundle_v1"
+    ) as mocked:
+        produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+        mocked.assert_not_called()
+
+
+def test_no_comparison_offline_reexecution(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "no_offline")
+    with patch(
+        "src.meta.learning_loop.comparison_ssot_v1.producer.produce_comparison_offline_v1"
+    ) as mocked:
+        produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+        mocked.assert_not_called()
+
+
+def test_no_registry_or_mlflow_resolution() -> None:
+    module_path = Path(__file__).resolve().parents[2] / (
+        "src/meta/learning_loop/comparison_checkpoint_v1.py"
+    )
+    source = module_path.read_text(encoding="utf-8")
+    assert "mlflow" not in source.lower()
+    assert "registry" not in source.lower()
+
+
+def test_common_bundle_dir_not_mutated(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    before = {
+        rel.as_posix(): rel.read_bytes()
+        for rel in common_out.rglob("*")
+        if rel.is_file() and not rel.is_symlink()
+    }
+    out = _durable_output(tmp_path, "nomut")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    after = {
+        rel.as_posix(): rel.read_bytes()
+        for rel in common_out.rglob("*")
+        if rel.is_file() and not rel.is_symlink()
+    }
+    assert before == after
+
+
+def test_duplicate_metric_input_ref_order_stable(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    common_index = read_manifest(common_out / COMMON_INDEX_ARTIFACT_REL)
+    out = _durable_output(tmp_path, "dup_order")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    refs = index["metric_input_binding_refs"]
+    assert refs == common_index["metric_input_binding_refs"]
+
+
+def test_checkpoint_relation_constant(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "relation")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    index = read_manifest(out / INDEX_ARTIFACT_REL)
+    assert index["checkpoint_relation"] == CHECKPOINT_RELATION
+
+
+def test_replay_mutates_nothing(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "replay_nomut")
+    produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)
+    before = {
+        rel.as_posix(): rel.read_bytes()
+        for rel in out.rglob("*")
+        if rel.is_file() and not rel.is_symlink()
+    }
+    reverify_comparison_checkpoint_v1(output_dir=out)
+    after = {
+        rel.as_posix(): rel.read_bytes()
+        for rel in out.rglob("*")
+        if rel.is_file() and not rel.is_symlink()
+    }
+    assert before == after
+
+
+def test_common_bundle_ref_mismatch_on_tampered_index(tmp_path, ssot_durable_output_dir) -> None:
+    common_out, _, _, _ = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    index_path = common_out / COMMON_INDEX_ARTIFACT_REL
+    index = read_manifest(index_path)
+    mutated = deepcopy(index)
+    mutated["comparison_definition_id"] = "00000000-0000-4000-8000-000000000001"
+    index_path.write_text(json.dumps(mutated), encoding="utf-8")
+    out = _durable_output(tmp_path, "tampered")
+    with pytest.raises(ComparisonCheckpointError, match="MANIFEST.sha256"):
+        produce_comparison_checkpoint_v1(common_bundle_dir=common_out, output_dir=out)

--- a/tests/scripts/test_run_comparison_checkpoint_v1.py
+++ b/tests/scripts/test_run_comparison_checkpoint_v1.py
@@ -1,0 +1,159 @@
+"""CLI tests for learning loop comparison checkpoint v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["tests.meta.comparison_ssot_v1_fixtures"]
+
+from scripts.run_comparison_checkpoint_v1 import (
+    EXIT_CHECKPOINT_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.meta.learning_loop.comparison_checkpoint_v1 import INDEX_ARTIFACT_REL
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    produce_comparison_common_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1 import (
+    produce_comparison_metric_input_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1 import (
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1 import (
+    produce_comparison_ssot_result_durable_evidence_bundle_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.producer import produce_comparison_offline_v1
+from tests.meta.comparison_ssot_v1_fixtures import produce_two_compatible_backtest_inputs
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    for target in (
+        "src.meta.learning_loop.comparison_checkpoint_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_common_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1.is_under_tmp",
+    ):
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _produce_common_bundle(tmp_path: Path, durable_root: Path) -> Path:
+    metric_root = durable_root / "metric_inputs"
+    metric_root.mkdir(exist_ok=True)
+    first, second = produce_two_compatible_backtest_inputs(tmp_path, metric_root)
+    comparison_root = durable_root / "comparisons"
+    comparison_root.mkdir(exist_ok=True)
+    offline = produce_comparison_offline_v1(
+        input_manifest_paths=[first, second],
+        output_root=comparison_root,
+        ranking_rule_version="NONE_V1",
+    )
+    metric_bindings = []
+    for idx, manifest_path in enumerate([first, second]):
+        out = durable_root / f"metric_input_binding_{idx}"
+        produce_comparison_metric_input_durable_evidence_bundle_v1(
+            manifest_path=manifest_path,
+            output_dir=out,
+        )
+        metric_bindings.append(out)
+    definition_binding = durable_root / "definition_binding"
+    produce_comparison_ssot_definition_durable_evidence_bundle_v1(
+        manifest_path=offline.definition_path,
+        output_dir=definition_binding,
+    )
+    result_binding = durable_root / "result_binding"
+    produce_comparison_ssot_result_durable_evidence_bundle_v1(
+        manifest_path=offline.result_path,
+        output_dir=result_binding,
+    )
+    common_out = durable_root / "common_bundle"
+    produce_comparison_common_durable_evidence_bundle_v1(
+        definition_bound_bundle_dir=definition_binding,
+        result_bound_bundle_dir=result_binding,
+        metric_input_bound_bundle_dirs=metric_bindings,
+        output_dir=common_out,
+    )
+    return common_out
+
+
+def test_cli_successful_run(tmp_path, ssot_durable_output_dir) -> None:
+    common_out = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    out = out_root / "checkpoint"
+    rc = main(
+        [
+            "--common-bundle-dir",
+            str(common_out),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert (out / INDEX_ARTIFACT_REL).is_file()
+
+
+def test_cli_deterministic_output(tmp_path, ssot_durable_output_dir) -> None:
+    common_out = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    out_a = out_root / "checkpoint_a"
+    out_b = out_root / "checkpoint_b"
+    assert main(["--common-bundle-dir", str(common_out), "--output-dir", str(out_a)]) == EXIT_OK
+    assert main(["--common-bundle-dir", str(common_out), "--output-dir", str(out_b)]) == EXIT_OK
+    assert (out_a / INDEX_ARTIFACT_REL).read_text(encoding="utf-8") == (
+        out_b / INDEX_ARTIFACT_REL
+    ).read_text(encoding="utf-8")
+
+
+def test_cli_missing_common_bundle(tmp_path) -> None:
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    rc = main(
+        [
+            "--common-bundle-dir",
+            str(tmp_path / "missing"),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_invalid_common_bundle(tmp_path) -> None:
+    fake = tmp_path / "fake_common"
+    fake.mkdir()
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    rc = main(
+        [
+            "--common-bundle-dir",
+            str(fake),
+            "--output-dir",
+            str(out_root / "out"),
+        ]
+    )
+    assert rc == EXIT_CHECKPOINT_ERROR
+
+
+def test_cli_existing_output_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    common_out = _produce_common_bundle(tmp_path, ssot_durable_output_dir)
+    out_root = tmp_path / "evidence_root"
+    out_root.mkdir()
+    out = out_root / "exists"
+    out.mkdir()
+    rc = main(
+        [
+            "--common-bundle-dir",
+            str(common_out),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_CHECKPOINT_ERROR


### PR DESCRIPTION
## Summary

- Adds **Learning Loop Comparison Checkpoint v1** — a LEVEL_2 non-authoritative durable mark over verified Common Comparison Durable Evidence Bundle v1
- Optional soft cross-check against pre-published Comparison Lineage Ref v1
- Staging/MANIFEST/replay pattern reuses `primary_evidence_retention_v0` and `contract_safety_v1`

## Governance

| Field | Value |
|-------|-------|
| GO_TOKEN | `GO_LEARNING_LOOP_COMPARISON_CHECKPOINT_V1_IMPLEMENTATION_V0` |
| Operator ratification | `LEARNING_LOOP_COMPARISON_CHECKPOINT_V1_SPECIFICATION_RATIFIED=true` |
| Base SHA | `88360c09c20c1db64c8f3f4b5f3c59fc4c01b223` |
| Admissibility bundle | `planning/learning_loop_comparison_checkpoint_v1_bounded_read_only_admissibility_review_v0_20260627T204900Z` |
| Admissibility MANIFEST RC | 0 |
| IMPLEMENTATION_GO_GRANTED | true |
| MERGE_GO_GRANTED | false |
| PRIMARY_WORKTREE_TOUCHED | false |

## Canonical owner / contract

- **Owner:** `src/meta/learning_loop/comparison_checkpoint_v1.py`
- **Contract:** `comparison_checkpoint_v1`
- **Relation:** `REFERENCES_VERIFIED_COMMON_BUNDLE`

## Input model

- **Required:** published Common Comparison Durable Evidence Bundle v1 (explicit path, `reverify_comparison_common_durable_evidence_bundle_v1` gate)
- **Optional:** Comparison Lineage Ref v1 JSON (explicit path, cross-check ref_id/digest/relation)

## Authority invariants

- `is_completion_evidence=false`
- `evidence_does_not_authorize_runtime=true`
- No completion/promotion/runtime authority fields
- No consumer rewiring, registry, MLflow, or producer re-execution

## Tests

- `tests/meta/test_comparison_checkpoint_v1.py`
- `tests/scripts/test_run_comparison_checkpoint_v1.py`
- Upstream regression: `tests/meta/test_comparison_common_durable_evidence_binding_v1.py`
- CI partition: `tests/ci/test_ci_diff_aware_test_selection_v1.py`

## Expected CI

- **Mode:** PR_BOUNDED_FULL
- **25-minute compatible:** yes (local focused suite ~2s)


Made with [Cursor](https://cursor.com)