### PR TITLE
feat: bind completion and research validity evidence

### DIFF
--- a/scripts/run_comparison_completion_research_validity_binding_v1.py
+++ b/scripts/run_comparison_completion_research_validity_binding_v1.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Offline comparison completion + research validity binding v1.
+
+Consumes exactly one verified comparison_completion_evidence_v1 bundle and one
+verified research_validity_evidence_v1 bundle, producing a manifested LEVEL_3
+non-authorizing sibling binding artifact.
+
+Usage:
+    python3 scripts/run_comparison_completion_research_validity_binding_v1.py \\
+        --completion-evidence-bundle-dir /path/to/completion_bundle \\
+        --research-validity-evidence-bundle-dir /path/to/validity_bundle \\
+        --output-dir /var/evidence/completion_validity_binding_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_completion_research_validity_binding_v1 import (
+    ComparisonCompletionResearchValidityBindingError,
+    ComparisonCompletionResearchValidityBindingInputs,
+    produce_comparison_completion_research_validity_binding_v1,
+)
+
+EXIT_OK = 0
+EXIT_BINDING_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline comparison completion research validity binding v1: bind "
+            "LEVEL_3 non-authorizing completion and research validity evidence."
+        )
+    )
+    parser.add_argument(
+        "--completion-evidence-bundle-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to a published comparison_completion_evidence_v1 bundle.",
+    )
+    parser.add_argument(
+        "--research-validity-evidence-bundle-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to a published research_validity_evidence_v1 bundle.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit binding output directory (must not exist; outside /tmp).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.completion_evidence_bundle_dir.is_dir():
+        print(
+            "[comparison_completion_research_validity_binding_v1] ERROR: "
+            f"completion bundle not found: {args.completion_evidence_bundle_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if not args.research_validity_evidence_bundle_dir.is_dir():
+        print(
+            "[comparison_completion_research_validity_binding_v1] ERROR: "
+            f"research validity bundle not found: "
+            f"{args.research_validity_evidence_bundle_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    inputs = ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=args.completion_evidence_bundle_dir,
+        research_validity_evidence_bundle_dir=args.research_validity_evidence_bundle_dir,
+    )
+
+    try:
+        result = produce_comparison_completion_research_validity_binding_v1(
+            inputs=inputs,
+            output_dir=args.output_dir,
+        )
+    except ComparisonCompletionResearchValidityBindingError as exc:
+        print(
+            f"[comparison_completion_research_validity_binding_v1] ERROR: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_BINDING_ERROR
+
+    print(
+        "[comparison_completion_research_validity_binding_v1] OK "
+        f"comparison_definition_id={result.comparison_definition_id} "
+        f"binding_status={result.binding_status} "
+        f"shared_lineage_status={result.shared_lineage_status} "
+        f"artifact_id={result.artifact_id} "
+        f"output_dir={result.output_dir}"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/comparison_completion_research_validity_binding_v1.py
+++ b/src/meta/learning_loop/comparison_completion_research_validity_binding_v1.py
@@ -1,0 +1,1072 @@
+"""Offline LEVEL_3 sibling binding joining completion and research validity evidence v1."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    COMPARISON_AUTHORITY_INVARIANTS,
+)
+from src.meta.learning_loop.comparison_completion_evidence_v1 import (
+    ARTIFACT_REL as COMPLETION_ARTIFACT_REL,
+    CONTRACT_NAME as COMPLETION_CONTRACT_NAME,
+    CONTRACT_VERSION as COMPLETION_CONTRACT_VERSION,
+    PRODUCER_VERSION as COMPLETION_PRODUCER_VERSION,
+    SELF_VERIFICATION_REL as COMPLETION_SELF_VERIFICATION_REL,
+    ComparisonCompletionEvidenceError,
+    reverify_comparison_completion_evidence_v1,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+from src.meta.learning_loop.research_validity_evidence_v1 import (
+    ARTIFACT_REL as VALIDITY_ARTIFACT_REL,
+    CONTRACT_NAME as VALIDITY_CONTRACT_NAME,
+    CONTRACT_VERSION as VALIDITY_CONTRACT_VERSION,
+    PRODUCER_VERSION as VALIDITY_PRODUCER_VERSION,
+    SELF_VERIFICATION_REL as VALIDITY_SELF_VERIFICATION_REL,
+    ResearchValidityEvidenceError,
+    reverify_research_validity_evidence_v1,
+)
+
+CONTRACT_NAME = "comparison_completion_research_validity_binding_v1"
+CONTRACT_VERSION = "v1"
+PRODUCER_VERSION = "comparison_completion_research_validity_binding_v1"
+EVIDENCE_LEVEL = "LEVEL_3"
+AUTHORITY_LEVEL = "NON_AUTHORITIZING_EVIDENCE_ONLY"
+RECORD_KIND = "comparison_completion_research_validity_binding_record"
+INPUT_RELATION = "BINDS_VERIFIED_COMPLETION_AND_RESEARCH_VALIDITY_V1"
+ARTIFACT_REL = "comparison_completion_research_validity_binding_v1.json"
+SELF_VERIFICATION_REL = "SELF_VERIFICATION.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".comparison_completion_research_validity_binding_staging_"
+
+OFFLINE_DETERMINISTIC_CREATED_AT = "1970-01-01T00:00:00+00:00"
+
+_VALID_BINDING_STATUS = frozenset({"PASS", "FAIL", "INCOMPLETE", "NOT_EVALUABLE"})
+_VALID_COMPLETION_STATUS = frozenset({"COMPLETE", "FAIL", "INCOMPLETE", "NOT_EVALUABLE"})
+
+BINDING_AUTHORITY_INVARIANTS: dict[str, bool] = {
+    **COMPARISON_AUTHORITY_INVARIANTS,
+    "binding_is_descriptive_only": True,
+    "binding_does_not_select": True,
+    "binding_does_not_accept": True,
+    "binding_does_not_promote": True,
+    "binding_does_not_deploy": True,
+    "binding_does_not_activate": True,
+    "binding_does_not_create_order_intent": True,
+    "binding_does_not_modify_trading_logic": True,
+    "binding_does_not_authorize_runtime": True,
+    "evidence_does_not_authorize_promotion": True,
+}
+
+_REQUIRED_NON_AUTHORIZING_FLAGS: dict[str, bool] = {
+    "is_completion_research_validity_binding": True,
+    "evidence_does_not_authorize_promotion": True,
+    "evidence_does_not_authorize_runtime": True,
+    "binding_does_not_select": True,
+    "binding_does_not_accept": True,
+    "binding_does_not_promote": True,
+    "binding_does_not_deploy": True,
+    "binding_does_not_activate": True,
+    "binding_does_not_create_order_intent": True,
+    "binding_does_not_modify_trading_logic": True,
+    "binding_does_not_authorize_runtime": True,
+}
+
+_FORBIDDEN_CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "CAN_PROMOTE_ARTIFACT",
+        "CAN_DEPLOY_INACTIVE",
+        "CAN_COMPUTE_SIGNALS",
+        "CAN_CREATE_ORDER_INTENTS",
+        "CAN_SUBMIT_TESTNET_ORDERS",
+        "CAN_SUBMIT_LIVE_ORDERS",
+        "CAN_INCREASE_CAPITAL",
+        "CAN_CHANGE_RISK_POLICY",
+    }
+)
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "winner",
+        "selected",
+        "promoted",
+        "promotion",
+        "promotion_ready",
+        "promotion_authorized",
+        "promotion_input",
+        "is_promotion_input",
+        "runtime_authorized",
+        "live_authorized",
+        "orders_allowed",
+        "ranking",
+        "pareto",
+        "accepted",
+        "acceptance",
+        "armed",
+        "enabled",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "strategy_params_mutated",
+    }
+)
+
+_SELF_VERIFICATION_SCHEMA_VERSION = (
+    "comparison_completion_research_validity_binding_self_verification_v1"
+)
+
+
+class ComparisonCompletionResearchValidityBindingError(ValueError):
+    """Fail-closed completion/research validity binding error."""
+
+
+@dataclass(frozen=True)
+class VerifiedEvidenceBundle:
+    bundle_dir: Path
+    contract_name: str
+    contract_version: str
+    producer_version: str
+    artifact_ref: str
+    artifact_digest: str
+    manifest_digest: str
+    evidence_level: str
+    parent_artifact_refs: tuple[dict[str, Any], ...]
+    evidence_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SharedLineageResult:
+    status: str
+    reason_codes: tuple[str, ...]
+    comparison_checkpoint_ref: str
+    comparison_checkpoint_digest: str
+    experiment_identity_ref: str
+    experiment_identity_digest: str
+    dataset_identity_ref: str
+    dataset_identity_digest: str
+    comparison_definition_id: str
+
+
+@dataclass(frozen=True)
+class ComparisonCompletionResearchValidityBindingInputs:
+    completion_evidence_bundle_dir: Path
+    research_validity_evidence_bundle_dir: Path
+
+
+@dataclass(frozen=True)
+class ComparisonCompletionResearchValidityBindingResult:
+    output_dir: Path
+    comparison_definition_id: str
+    artifact_id: str
+    evidence_path: Path
+    self_verification_path: Path
+    manifest_path: Path
+    binding_status: str
+    shared_lineage_status: str
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"{label} must not be a symlink: {path}"
+        )
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"binding artifact must not contain forbidden key: {key}"
+            )
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    if not path.exists():
+        raise ComparisonCompletionResearchValidityBindingError(f"{label} not found: {path}")
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"{label} must be a regular file: {path}"
+        )
+
+
+def _validate_bundle_dir(bundle_dir: Path, *, label: str) -> None:
+    if not bundle_dir.is_dir():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"{label} must be a directory: {bundle_dir}"
+        )
+    _reject_symlink(bundle_dir, label=label)
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise ComparisonCompletionResearchValidityBindingError(
+            "output directory must be outside /tmp"
+        )
+    parent = output_dir.parent
+    if not parent.is_dir():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"output parent directory missing: {parent}"
+        )
+    if is_under_tmp(parent):
+        raise ComparisonCompletionResearchValidityBindingError(
+            "output parent directory must be outside /tmp"
+        )
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _reject_unsafe_overlap(
+    *,
+    completion_bundle_dir: Path,
+    validity_bundle_dir: Path,
+    output_dir: Path,
+) -> None:
+    output_res = output_dir.resolve()
+    for label, bundle_dir in (
+        ("completion evidence bundle", completion_bundle_dir),
+        ("research validity evidence bundle", validity_bundle_dir),
+    ):
+        bundle_res = bundle_dir.resolve()
+        if output_res == bundle_res:
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"output directory must not equal {label} path (fail-closed)"
+            )
+        if _path_is_under(bundle_res, output_res):
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"{label} must not be inside output directory (fail-closed)"
+            )
+        if _path_is_under(output_res, bundle_res):
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"output directory must not be inside {label} path (fail-closed)"
+            )
+
+
+def _manifest_file_digest(bundle_dir: Path) -> str:
+    manifest_path = bundle_dir / MANIFEST_FILENAME
+    _validate_regular_file(manifest_path, label=MANIFEST_FILENAME)
+    return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+
+def _artifact_digest_from_evidence(evidence: Mapping[str, Any]) -> str:
+    stored = evidence.get("output_digest")
+    if isinstance(stored, str) and is_valid_sha256_hex(stored):
+        return stored
+    integrity = evidence.get("integrity")
+    if isinstance(integrity, Mapping):
+        digest = integrity.get("content_sha256")
+        if isinstance(digest, str) and is_valid_sha256_hex(digest):
+            return digest
+    raise ComparisonCompletionResearchValidityBindingError("evidence digest missing or invalid")
+
+
+def _validate_capabilities(capabilities: Any) -> list[str]:
+    if not isinstance(capabilities, list):
+        raise ComparisonCompletionResearchValidityBindingError("capabilities must be a list")
+    normalized: list[str] = []
+    for idx, item in enumerate(capabilities):
+        if not isinstance(item, str) or not item.strip():
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"capabilities[{idx}] must be a non-empty string"
+            )
+        if item in _FORBIDDEN_CAPABILITIES:
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"forbidden capability present: {item}"
+            )
+        normalized.append(item)
+    return normalized
+
+
+def _validate_non_authorizing_flags(payload: Mapping[str, Any]) -> None:
+    for key, expected in _REQUIRED_NON_AUTHORIZING_FLAGS.items():
+        if payload.get(key) is not expected:
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"{key} must be {expected!r} (fail-closed)"
+            )
+    if payload.get("evidence_level") != EVIDENCE_LEVEL:
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"evidence_level must be {EVIDENCE_LEVEL!r} (fail-closed)"
+        )
+
+
+def _validate_completion_evidence_payload(payload: Mapping[str, Any]) -> None:
+    if payload.get("contract_name") != COMPLETION_CONTRACT_NAME:
+        raise ComparisonCompletionResearchValidityBindingError("completion contract_name mismatch")
+    if payload.get("contract_version") != COMPLETION_CONTRACT_VERSION:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "completion contract_version not supported"
+        )
+    if payload.get("producer_version") != COMPLETION_PRODUCER_VERSION:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "completion producer_version mismatch"
+        )
+    if payload.get("evidence_level") != EVIDENCE_LEVEL:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "completion evidence_level must be LEVEL_3"
+        )
+    if payload.get("is_completion_evidence") is not True:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "is_completion_evidence must be true"
+        )
+    for flag in (
+        "evidence_does_not_authorize_promotion",
+        "evidence_does_not_authorize_runtime",
+        "completion_does_not_select",
+        "completion_does_not_accept",
+        "completion_does_not_deploy",
+        "completion_does_not_activate",
+        "completion_does_not_create_order_intent",
+    ):
+        if payload.get(flag) is not True:
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"completion {flag} must be true"
+            )
+    _validate_capabilities(payload.get("capabilities"))
+
+
+def _validate_research_validity_evidence_payload(payload: Mapping[str, Any]) -> None:
+    if payload.get("contract_name") != VALIDITY_CONTRACT_NAME:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "research validity contract_name mismatch"
+        )
+    if payload.get("contract_version") != VALIDITY_CONTRACT_VERSION:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "research validity contract_version not supported"
+        )
+    if payload.get("producer_version") != VALIDITY_PRODUCER_VERSION:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "research validity producer_version mismatch"
+        )
+    if payload.get("evidence_level") != EVIDENCE_LEVEL:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "research validity evidence_level must be LEVEL_3"
+        )
+    if payload.get("is_research_validity_evidence") is not True:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "is_research_validity_evidence must be true"
+        )
+    for flag in (
+        "evidence_does_not_authorize_promotion",
+        "evidence_does_not_authorize_runtime",
+        "research_validity_does_not_select",
+        "research_validity_does_not_accept",
+        "research_validity_does_not_deploy",
+        "research_validity_does_not_activate",
+        "research_validity_does_not_create_order_intent",
+        "research_validity_does_not_modify_trading_logic",
+    ):
+        if payload.get(flag) is not True:
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"research validity {flag} must be true"
+            )
+    _validate_capabilities(payload.get("capabilities"))
+
+
+def _load_self_verification(bundle_dir: Path, *, rel: str, label: str) -> dict[str, Any]:
+    path = bundle_dir / rel
+    _validate_regular_file(path, label=label)
+    payload = read_manifest(path)
+    if payload.get("overall_status") != "PASS":
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"{label} overall_status must be PASS"
+        )
+    return payload
+
+
+def _normalize_parent_refs(value: Any, *, label: str) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, list):
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"{label} parent_artifact_refs must be a list"
+        )
+    refs: list[dict[str, Any]] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"{label} parent_artifact_refs[{idx}] must be an object"
+            )
+        refs.append(dict(item))
+    return tuple(refs)
+
+
+def verify_completion_evidence_bundle(bundle_dir: Path | str) -> VerifiedEvidenceBundle:
+    """Fail-closed verification of exactly one completion evidence bundle."""
+    path = Path(bundle_dir)
+    _validate_bundle_dir(path, label="completion evidence bundle")
+    try:
+        reverify_comparison_completion_evidence_v1(output_dir=path)
+    except ComparisonCompletionEvidenceError as exc:
+        raise ComparisonCompletionResearchValidityBindingError(str(exc)) from exc
+
+    evidence_path = path / COMPLETION_ARTIFACT_REL
+    if not evidence_path.is_file():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"completion artifact not found: {COMPLETION_ARTIFACT_REL}"
+        )
+    evidence = read_manifest(evidence_path)
+    _validate_completion_evidence_payload(evidence)
+    _load_self_verification(
+        path, rel=COMPLETION_SELF_VERIFICATION_REL, label="completion SELF_VERIFICATION"
+    )
+    manifest_digest = _manifest_file_digest(path)
+    return VerifiedEvidenceBundle(
+        bundle_dir=path.resolve(),
+        contract_name=str(evidence["contract_name"]),
+        contract_version=str(evidence["contract_version"]),
+        producer_version=str(evidence["producer_version"]),
+        artifact_ref=COMPLETION_ARTIFACT_REL,
+        artifact_digest=_artifact_digest_from_evidence(evidence),
+        manifest_digest=manifest_digest,
+        evidence_level=str(evidence["evidence_level"]),
+        parent_artifact_refs=_normalize_parent_refs(
+            evidence.get("parent_artifact_refs"), label="completion"
+        ),
+        evidence_payload=dict(evidence),
+    )
+
+
+def verify_research_validity_evidence_bundle(bundle_dir: Path | str) -> VerifiedEvidenceBundle:
+    """Fail-closed verification of exactly one research validity evidence bundle."""
+    path = Path(bundle_dir)
+    _validate_bundle_dir(path, label="research validity evidence bundle")
+    try:
+        reverify_research_validity_evidence_v1(output_dir=path)
+    except ResearchValidityEvidenceError as exc:
+        raise ComparisonCompletionResearchValidityBindingError(str(exc)) from exc
+
+    evidence_path = path / VALIDITY_ARTIFACT_REL
+    if not evidence_path.is_file():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"research validity artifact not found: {VALIDITY_ARTIFACT_REL}"
+        )
+    evidence = read_manifest(evidence_path)
+    _validate_research_validity_evidence_payload(evidence)
+    _load_self_verification(
+        path, rel=VALIDITY_SELF_VERIFICATION_REL, label="research validity SELF_VERIFICATION"
+    )
+    manifest_digest = _manifest_file_digest(path)
+    return VerifiedEvidenceBundle(
+        bundle_dir=path.resolve(),
+        contract_name=str(evidence["contract_name"]),
+        contract_version=str(evidence["contract_version"]),
+        producer_version=str(evidence["producer_version"]),
+        artifact_ref=VALIDITY_ARTIFACT_REL,
+        artifact_digest=_artifact_digest_from_evidence(evidence),
+        manifest_digest=manifest_digest,
+        evidence_level=str(evidence["evidence_level"]),
+        parent_artifact_refs=_normalize_parent_refs(
+            evidence.get("parent_artifact_refs"), label="research validity"
+        ),
+        evidence_payload=dict(evidence),
+    )
+
+
+def check_shared_lineage(
+    *,
+    completion: VerifiedEvidenceBundle,
+    validity: VerifiedEvidenceBundle,
+) -> SharedLineageResult:
+    """Fail-closed shared lineage lock across completion and research validity evidence."""
+    completion_payload = completion.evidence_payload
+    validity_payload = validity.evidence_payload
+
+    reason_codes: list[str] = []
+
+    completion_checkpoint_ref = str(completion_payload.get("input_checkpoint_bundle_ref", ""))
+    completion_checkpoint_digest = str(completion_payload.get("input_checkpoint_digest", ""))
+    validity_checkpoint_ref = str(validity_payload.get("comparison_checkpoint_ref", ""))
+    validity_checkpoint_digest = str(validity_payload.get("comparison_checkpoint_digest", ""))
+
+    experiment_ref = str(validity_payload.get("experiment_identity_ref", ""))
+    experiment_digest = str(validity_payload.get("experiment_identity_digest", ""))
+    dataset_ref = str(validity_payload.get("dataset_identity_ref", ""))
+    dataset_digest = str(validity_payload.get("dataset_identity_digest", ""))
+
+    completion_definition_id = str(completion_payload.get("comparison_definition_id", ""))
+    validity_definition_id = str(validity_payload.get("comparison_definition_id", ""))
+
+    if not completion_checkpoint_ref or not validity_checkpoint_ref:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "comparison checkpoint ref missing on input evidence"
+        )
+    if completion_checkpoint_ref != validity_checkpoint_ref:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "completion and research validity comparison_checkpoint_ref mismatch (fail-closed)"
+        )
+    if completion_checkpoint_digest != validity_checkpoint_digest:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "completion and research validity comparison_checkpoint_digest mismatch (fail-closed)"
+        )
+    if completion_definition_id != validity_definition_id:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "comparison_definition_id mismatch between completion and research validity"
+        )
+    if not experiment_ref or not is_valid_sha256_hex(experiment_digest):
+        raise ComparisonCompletionResearchValidityBindingError(
+            "experiment identity ref/digest missing or invalid on research validity evidence"
+        )
+    if not dataset_ref or not is_valid_sha256_hex(dataset_digest):
+        raise ComparisonCompletionResearchValidityBindingError(
+            "dataset identity ref/digest missing or invalid on research validity evidence"
+        )
+
+    if len(completion.parent_artifact_refs) != 1 or len(validity.parent_artifact_refs) != 1:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "parent_artifact_refs must contain exactly one checkpoint ref on each input"
+        )
+
+    completion_parent = completion.parent_artifact_refs[0]
+    validity_parent = validity.parent_artifact_refs[0]
+    if completion_parent.get("ref_type") != validity_parent.get("ref_type"):
+        raise ComparisonCompletionResearchValidityBindingError(
+            "parent checkpoint ref_type mismatch"
+        )
+    if str(completion_parent.get("digest", "")) != str(validity_parent.get("digest", "")):
+        raise ComparisonCompletionResearchValidityBindingError(
+            "parent checkpoint digest mismatch (fail-closed)"
+        )
+    if str(completion_parent.get("bundle_path", "")) != str(validity_parent.get("bundle_path", "")):
+        raise ComparisonCompletionResearchValidityBindingError(
+            "parent checkpoint bundle_path mismatch (fail-closed)"
+        )
+    if str(completion_parent.get("digest", "")) != completion_checkpoint_digest:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "completion parent checkpoint digest inconsistent with input_checkpoint_digest"
+        )
+    if str(validity_parent.get("digest", "")) != validity_checkpoint_digest:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "validity parent checkpoint digest inconsistent with comparison_checkpoint_digest"
+        )
+
+    reason_codes.extend(
+        [
+            "CHECKPOINT_REF_MATCH",
+            "CHECKPOINT_DIGEST_MATCH",
+            "EXPERIMENT_IDENTITY_BOUND",
+            "DATASET_IDENTITY_BOUND",
+            "COMPARISON_DEFINITION_ID_MATCH",
+            "PARENT_REFS_CONSISTENT",
+        ]
+    )
+
+    return SharedLineageResult(
+        status="PASS",
+        reason_codes=tuple(reason_codes),
+        comparison_checkpoint_ref=completion_checkpoint_ref,
+        comparison_checkpoint_digest=completion_checkpoint_digest,
+        experiment_identity_ref=experiment_ref,
+        experiment_identity_digest=experiment_digest,
+        dataset_identity_ref=dataset_ref,
+        dataset_identity_digest=dataset_digest,
+        comparison_definition_id=completion_definition_id,
+    )
+
+
+def _derive_binding_status(
+    *,
+    shared_lineage_status: str,
+    completion_status: str,
+    research_validity_status: str,
+) -> tuple[str, list[str]]:
+    reason_codes: list[str] = []
+    if shared_lineage_status != "PASS":
+        return "FAIL", ["SHARED_LINEAGE_FAIL"]
+
+    if completion_status not in _VALID_COMPLETION_STATUS:
+        return "FAIL", ["COMPLETION_STATUS_UNKNOWN"]
+    if research_validity_status not in _VALID_BINDING_STATUS:
+        return "FAIL", ["RESEARCH_VALIDITY_STATUS_UNKNOWN"]
+
+    if completion_status != "COMPLETE":
+        reason_codes.append("COMPLETION_STATUS_NOT_COMPLETE")
+        return "FAIL", reason_codes
+
+    if research_validity_status == "FAIL":
+        reason_codes.append("UPSTREAM_RESEARCH_VALIDITY_FAIL")
+        return "FAIL", reason_codes
+    if research_validity_status == "INCOMPLETE":
+        reason_codes.append("UPSTREAM_RESEARCH_VALIDITY_INCOMPLETE")
+        return "INCOMPLETE", reason_codes
+    if research_validity_status == "NOT_EVALUABLE":
+        reason_codes.append("UPSTREAM_RESEARCH_VALIDITY_NOT_EVALUABLE")
+        return "NOT_EVALUABLE", reason_codes
+
+    reason_codes.extend(["COMPLETION_COMPLETE", "RESEARCH_VALIDITY_PASS"])
+    return "PASS", reason_codes
+
+
+def _input_artifact_ref_mapping(bundle: VerifiedEvidenceBundle) -> dict[str, Any]:
+    return {
+        "artifact_type": bundle.contract_name,
+        "contract_name": bundle.contract_name,
+        "contract_version": bundle.contract_version,
+        "artifact_ref": bundle.artifact_ref,
+        "artifact_digest": bundle.artifact_digest,
+        "manifest_digest": bundle.manifest_digest,
+        "producer_version": bundle.producer_version,
+        "bundle_path": bundle.bundle_dir.as_posix(),
+    }
+
+
+def _compute_output_digest(body: Mapping[str, Any]) -> str:
+    excluded = frozenset(
+        {"output_digest", "manifest_digest", "integrity", "created_at", "artifact_id"}
+    )
+    digest_body = {key: body[key] for key in sorted(body) if key not in excluded}
+    return compute_content_sha256(digest_body)
+
+
+def _integrity_body(body: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in body.items() if key not in {"integrity", "manifest_digest"}
+    }
+
+
+def build_comparison_completion_research_validity_binding_v1(
+    *,
+    completion: VerifiedEvidenceBundle,
+    validity: VerifiedEvidenceBundle,
+    shared_lineage: SharedLineageResult,
+) -> dict[str, Any]:
+    completion_payload = completion.evidence_payload
+    validity_payload = validity.evidence_payload
+
+    completion_status = str(completion_payload.get("completion_status", ""))
+    research_validity_status = str(validity_payload.get("research_validity_status", ""))
+    binding_status, binding_reason_codes = _derive_binding_status(
+        shared_lineage_status=shared_lineage.status,
+        completion_status=completion_status,
+        research_validity_status=research_validity_status,
+    )
+
+    input_refs = [
+        _input_artifact_ref_mapping(completion),
+        _input_artifact_ref_mapping(validity),
+    ]
+    input_refs.sort(key=lambda item: (item["artifact_type"], item["artifact_digest"]))
+
+    parent_artifact_refs = list(validity.parent_artifact_refs)
+    parent_artifact_refs.sort(
+        key=lambda item: (str(item.get("ref_type", "")), str(item.get("digest", "")))
+    )
+
+    payload: dict[str, Any] = {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "artifact_id": "",
+        "created_at": OFFLINE_DETERMINISTIC_CREATED_AT,
+        "producer_version": PRODUCER_VERSION,
+        "record_kind": RECORD_KIND,
+        "input_relation": INPUT_RELATION,
+        "evidence_level": EVIDENCE_LEVEL,
+        "authority_level": AUTHORITY_LEVEL,
+        "capabilities": [],
+        "is_completion_research_validity_binding": True,
+        "evidence_does_not_authorize_promotion": True,
+        "evidence_does_not_authorize_runtime": True,
+        "binding_does_not_select": True,
+        "binding_does_not_accept": True,
+        "binding_does_not_promote": True,
+        "binding_does_not_deploy": True,
+        "binding_does_not_activate": True,
+        "binding_does_not_create_order_intent": True,
+        "binding_does_not_modify_trading_logic": True,
+        "binding_does_not_authorize_runtime": True,
+        "binding_authority_invariants": dict(BINDING_AUTHORITY_INVARIANTS),
+        "completion_evidence_bundle_ref": completion.bundle_dir.as_posix(),
+        "completion_evidence_artifact_ref": completion.artifact_ref,
+        "completion_evidence_digest": completion.artifact_digest,
+        "completion_manifest_digest": completion.manifest_digest,
+        "research_validity_bundle_ref": validity.bundle_dir.as_posix(),
+        "research_validity_artifact_ref": validity.artifact_ref,
+        "research_validity_digest": validity.artifact_digest,
+        "research_validity_manifest_digest": validity.manifest_digest,
+        "comparison_checkpoint_ref": shared_lineage.comparison_checkpoint_ref,
+        "comparison_checkpoint_digest": shared_lineage.comparison_checkpoint_digest,
+        "experiment_identity_ref": shared_lineage.experiment_identity_ref,
+        "experiment_identity_digest": shared_lineage.experiment_identity_digest,
+        "dataset_identity_ref": shared_lineage.dataset_identity_ref,
+        "dataset_identity_digest": shared_lineage.dataset_identity_digest,
+        "comparison_definition_id": shared_lineage.comparison_definition_id,
+        "completion_status": completion_status,
+        "research_validity_status": research_validity_status,
+        "shared_lineage_status": shared_lineage.status,
+        "shared_lineage_reason_codes": list(shared_lineage.reason_codes),
+        "binding_status": binding_status,
+        "binding_reason_codes": binding_reason_codes,
+        "completion_contract_name": completion.contract_name,
+        "completion_contract_version": completion.contract_version,
+        "completion_producer_version": completion.producer_version,
+        "research_validity_contract_name": validity.contract_name,
+        "research_validity_contract_version": validity.contract_version,
+        "research_validity_producer_version": validity.producer_version,
+        "input_artifact_refs": input_refs,
+        "parent_artifact_refs": parent_artifact_refs,
+        "input_digest": "",
+        "output_digest": "",
+        "manifest_digest": "",
+    }
+
+    _reject_forbidden_index_keys(payload)
+    _validate_non_authorizing_flags(payload)
+    _validate_capabilities(payload["capabilities"])
+
+    payload["input_digest"] = compute_content_sha256({"input_artifact_refs": input_refs})
+    output_digest = _compute_output_digest(payload)
+    payload["output_digest"] = output_digest
+    payload["artifact_id"] = output_digest
+    return payload
+
+
+def serialize_comparison_completion_research_validity_binding_v1(
+    evidence: Mapping[str, Any],
+) -> str:
+    _reject_forbidden_index_keys(evidence)
+    _validate_non_authorizing_flags(evidence)
+    _validate_capabilities(evidence.get("capabilities"))
+    binding_status = evidence.get("binding_status")
+    if binding_status not in _VALID_BINDING_STATUS:
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"binding_status must be one of {sorted(_VALID_BINDING_STATUS)}"
+        )
+    return deterministic_json_dumps(dict(evidence))
+
+
+def _evidence_bytes_for_manifest_digest(evidence: Mapping[str, Any]) -> bytes:
+    canonical = {
+        key: value for key, value in evidence.items() if key not in {"integrity", "manifest_digest"}
+    }
+    return serialize_comparison_completion_research_validity_binding_v1(canonical).encode("utf-8")
+
+
+def _compute_output_manifest_digest(evidence: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_evidence_bytes_for_manifest_digest(evidence)).hexdigest()
+
+
+def _validate_evidence_integrity(evidence: Mapping[str, Any]) -> None:
+    if evidence.get("contract_name") != CONTRACT_NAME:
+        raise ComparisonCompletionResearchValidityBindingError("contract_name mismatch")
+    if evidence.get("contract_version") != CONTRACT_VERSION:
+        raise ComparisonCompletionResearchValidityBindingError("contract_version mismatch")
+    if evidence.get("producer_version") != PRODUCER_VERSION:
+        raise ComparisonCompletionResearchValidityBindingError("producer_version mismatch")
+    _validate_non_authorizing_flags(evidence)
+    _validate_capabilities(evidence.get("capabilities"))
+    invariants = evidence.get("binding_authority_invariants")
+    if invariants != BINDING_AUTHORITY_INVARIANTS:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "binding_authority_invariants mismatch"
+        )
+
+    stored = evidence.get("integrity")
+    if not isinstance(stored, Mapping):
+        raise ComparisonCompletionResearchValidityBindingError("integrity must be an object")
+    expected = compute_content_sha256(_integrity_body(evidence))
+    actual = stored.get("content_sha256")
+    if actual != expected:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "binding evidence integrity mismatch"
+        )
+
+    output_digest = evidence.get("output_digest")
+    if output_digest != _compute_output_digest(evidence):
+        raise ComparisonCompletionResearchValidityBindingError("output_digest mismatch")
+    if evidence.get("artifact_id") != output_digest:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "artifact_id must equal output_digest"
+        )
+
+
+def build_self_verification_v1(
+    *,
+    evidence: Mapping[str, Any],
+    completion: VerifiedEvidenceBundle,
+    validity: VerifiedEvidenceBundle,
+    shared_lineage: SharedLineageResult,
+    manifest_digest: str,
+) -> dict[str, Any]:
+    checks: list[dict[str, str]] = [
+        {"check_id": "contract_name", "status": "PASS"},
+        {"check_id": "contract_version", "status": "PASS"},
+        {"check_id": "evidence_level_level_3", "status": "PASS"},
+        {"check_id": "exactly_two_direct_inputs", "status": "PASS"},
+        {"check_id": "completion_contract_and_version", "status": "PASS"},
+        {"check_id": "research_validity_contract_and_version", "status": "PASS"},
+        {"check_id": "input_manifests_verified", "status": "PASS"},
+        {"check_id": "input_self_verifications_pass", "status": "PASS"},
+        {"check_id": "shared_checkpoint_lineage", "status": "PASS"},
+        {"check_id": "shared_experiment_lineage", "status": "PASS"},
+        {"check_id": "shared_dataset_lineage", "status": "PASS"},
+        {"check_id": "parent_and_input_refs", "status": "PASS"},
+        {"check_id": "required_fields", "status": "PASS"},
+        {"check_id": "binding_status_present", "status": "PASS"},
+        {"check_id": "non_authorizing_semantics", "status": "PASS"},
+        {"check_id": "forbidden_capabilities_absent", "status": "PASS"},
+        {"check_id": "canonical_serialization", "status": "PASS"},
+        {"check_id": "output_digest", "status": "PASS"},
+        {"check_id": "manifest_verification", "status": "PASS"},
+        {"check_id": "deterministic_reverification", "status": "PASS"},
+    ]
+
+    input_refs = evidence.get("input_artifact_refs")
+    if not isinstance(input_refs, list) or len(input_refs) != 2:
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "exactly_two_direct_inputs" else c
+            for c in checks
+        ]
+
+    if evidence.get("manifest_digest") != manifest_digest:
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "manifest_verification" else c
+            for c in checks
+        ]
+
+    if shared_lineage.status != "PASS":
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "shared_checkpoint_lineage" else c
+            for c in checks
+        ]
+
+    if evidence.get("completion_evidence_bundle_ref") != completion.bundle_dir.as_posix():
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "input_manifests_verified" else c
+            for c in checks
+        ]
+    if evidence.get("research_validity_bundle_ref") != validity.bundle_dir.as_posix():
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "input_manifests_verified" else c
+            for c in checks
+        ]
+
+    if any(check["status"] != "PASS" for check in checks):
+        raise ComparisonCompletionResearchValidityBindingError("self-verification checks failed")
+
+    payload: dict[str, Any] = {
+        "self_verification_schema_version": _SELF_VERIFICATION_SCHEMA_VERSION,
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "overall_status": "PASS",
+        "checks": checks,
+        "verified_artifact_rel": ARTIFACT_REL,
+        "verified_output_digest": evidence.get("output_digest"),
+        "verified_manifest_digest": manifest_digest,
+    }
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def _finalize_evidence_with_manifest_digest(
+    evidence: Mapping[str, Any], *, manifest_digest: str
+) -> dict[str, Any]:
+    body = dict(evidence)
+    body["manifest_digest"] = manifest_digest
+    body["output_digest"] = _compute_output_digest(body)
+    body["artifact_id"] = body["output_digest"]
+    body["integrity"] = {"content_sha256": compute_content_sha256(_integrity_body(body))}
+    return body
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{uuid.uuid4().hex}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def verify_binding_inputs(
+    inputs: ComparisonCompletionResearchValidityBindingInputs,
+) -> tuple[VerifiedEvidenceBundle, VerifiedEvidenceBundle, SharedLineageResult]:
+    """Verify exactly one completion and one research validity bundle with shared lineage."""
+    completion = verify_completion_evidence_bundle(inputs.completion_evidence_bundle_dir)
+    validity = verify_research_validity_evidence_bundle(
+        inputs.research_validity_evidence_bundle_dir
+    )
+    shared_lineage = check_shared_lineage(completion=completion, validity=validity)
+    return completion, validity, shared_lineage
+
+
+def reverify_comparison_completion_research_validity_binding_v1(
+    *,
+    output_dir: Path | str,
+) -> None:
+    """Replay binding bundle without producer or upstream mutation."""
+    bundle_dir = Path(output_dir)
+    if not bundle_dir.is_dir():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"binding directory not found: {bundle_dir}"
+        )
+    ok, msg = verify_manifest_sha256(bundle_dir)
+    if not ok:
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"MANIFEST.sha256 verification failed: {msg}"
+        )
+
+    evidence_path = bundle_dir / ARTIFACT_REL
+    _validate_regular_file(evidence_path, label=ARTIFACT_REL)
+    evidence = read_manifest(evidence_path)
+    _validate_evidence_integrity(evidence)
+
+    self_path = bundle_dir / SELF_VERIFICATION_REL
+    _validate_regular_file(self_path, label=SELF_VERIFICATION_REL)
+    self_payload = read_manifest(self_path)
+    if self_payload.get("overall_status") != "PASS":
+        raise ComparisonCompletionResearchValidityBindingError(
+            "SELF_VERIFICATION overall_status must be PASS"
+        )
+
+    manifest_digest = _compute_output_manifest_digest(evidence)
+    if evidence.get("manifest_digest") != manifest_digest:
+        raise ComparisonCompletionResearchValidityBindingError("manifest_digest mismatch on replay")
+
+    completion_dir = Path(str(evidence["completion_evidence_bundle_ref"]))
+    validity_dir = Path(str(evidence["research_validity_bundle_ref"]))
+    completion = verify_completion_evidence_bundle(completion_dir)
+    validity = verify_research_validity_evidence_bundle(validity_dir)
+    shared_lineage = check_shared_lineage(completion=completion, validity=validity)
+
+    if evidence.get("shared_lineage_status") != shared_lineage.status:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "shared_lineage_status mismatch on replay"
+        )
+    if evidence.get("comparison_checkpoint_digest") != shared_lineage.comparison_checkpoint_digest:
+        raise ComparisonCompletionResearchValidityBindingError(
+            "comparison_checkpoint_digest mismatch on replay"
+        )
+
+
+def produce_comparison_completion_research_validity_binding_v1(
+    *,
+    inputs: ComparisonCompletionResearchValidityBindingInputs,
+    output_dir: Path | str,
+) -> ComparisonCompletionResearchValidityBindingResult:
+    """Bind exactly one verified completion bundle and one verified research validity bundle."""
+    final_dir = Path(output_dir)
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        completion_bundle_dir=inputs.completion_evidence_bundle_dir,
+        validity_bundle_dir=inputs.research_validity_evidence_bundle_dir,
+        output_dir=final_dir,
+    )
+
+    completion, validity, shared_lineage = verify_binding_inputs(inputs)
+    evidence_body = build_comparison_completion_research_validity_binding_v1(
+        completion=completion,
+        validity=validity,
+        shared_lineage=shared_lineage,
+    )
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise ComparisonCompletionResearchValidityBindingError(
+            f"staging directory collision: {staging}"
+        )
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        evidence_path = staging / ARTIFACT_REL
+        self_path = staging / SELF_VERIFICATION_REL
+
+        manifest_digest = _compute_output_manifest_digest(evidence_body)
+        finalized = _finalize_evidence_with_manifest_digest(
+            evidence_body, manifest_digest=manifest_digest
+        )
+        evidence_path.write_text(
+            serialize_comparison_completion_research_validity_binding_v1(finalized),
+            encoding="utf-8",
+        )
+        self_payload = build_self_verification_v1(
+            evidence=finalized,
+            completion=completion,
+            validity=validity,
+            shared_lineage=shared_lineage,
+            manifest_digest=manifest_digest,
+        )
+        self_path.write_text(deterministic_json_dumps(self_payload), encoding="utf-8")
+        write_manifest_sha256(staging)
+
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        reverify_comparison_completion_research_validity_binding_v1(output_dir=staging)
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise ComparisonCompletionResearchValidityBindingError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    artifact_id = str(finalized["artifact_id"])
+    return ComparisonCompletionResearchValidityBindingResult(
+        output_dir=final_dir,
+        comparison_definition_id=str(finalized["comparison_definition_id"]),
+        artifact_id=artifact_id,
+        evidence_path=final_dir / ARTIFACT_REL,
+        self_verification_path=final_dir / SELF_VERIFICATION_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+        binding_status=str(finalized["binding_status"]),
+        shared_lineage_status=str(finalized["shared_lineage_status"]),
+    )
+
+
+__all__ = [
+    "ARTIFACT_REL",
+    "AUTHORITY_LEVEL",
+    "BINDING_AUTHORITY_INVARIANTS",
+    "CONTRACT_NAME",
+    "CONTRACT_VERSION",
+    "EVIDENCE_LEVEL",
+    "MANIFEST_FILENAME",
+    "PRODUCER_VERSION",
+    "SELF_VERIFICATION_REL",
+    "ComparisonCompletionResearchValidityBindingError",
+    "ComparisonCompletionResearchValidityBindingInputs",
+    "ComparisonCompletionResearchValidityBindingResult",
+    "SharedLineageResult",
+    "VerifiedEvidenceBundle",
+    "build_comparison_completion_research_validity_binding_v1",
+    "build_self_verification_v1",
+    "check_shared_lineage",
+    "produce_comparison_completion_research_validity_binding_v1",
+    "reverify_comparison_completion_research_validity_binding_v1",
+    "serialize_comparison_completion_research_validity_binding_v1",
+    "verify_binding_inputs",
+    "verify_completion_evidence_bundle",
+    "verify_research_validity_evidence_bundle",
+]

--- a/tests/meta/comparison_completion_research_validity_binding_v1_fixtures.py
+++ b/tests/meta/comparison_completion_research_validity_binding_v1_fixtures.py
@@ -1,0 +1,52 @@
+"""Fixtures for comparison_completion_research_validity_binding_v1 contract tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_completion_evidence_v1 import (
+    produce_comparison_completion_evidence_v1,
+)
+from src.meta.learning_loop.research_validity_evidence_v1 import (
+    produce_research_validity_evidence_v1,
+)
+from tests.meta.research_validity_evidence_v1_fixtures import produce_full_research_validity_inputs
+
+
+@dataclass(frozen=True)
+class MatchedEvidenceBundles:
+    completion_bundle_dir: Path
+    research_validity_bundle_dir: Path
+    checkpoint_bundle_dir: Path
+    comparison_definition_id: str
+
+
+def produce_matched_completion_and_validity_bundles(
+    tmp_path: Path,
+    durable_root: Path,
+    *,
+    all_domains_pass: bool = True,
+    completion_name: str = "completion_evidence",
+    validity_name: str = "research_validity_evidence",
+) -> MatchedEvidenceBundles:
+    """Produce completion and research validity bundles sharing one checkpoint lineage."""
+    inputs = produce_full_research_validity_inputs(
+        tmp_path, durable_root, all_domains_pass=all_domains_pass
+    )
+    validity_out = durable_root / validity_name
+    validity_result = produce_research_validity_evidence_v1(
+        inputs=inputs,
+        output_dir=validity_out,
+    )
+    completion_out = durable_root / completion_name
+    produce_comparison_completion_evidence_v1(
+        checkpoint_bundle_dir=inputs.checkpoint_bundle_dir,
+        output_dir=completion_out,
+    )
+    return MatchedEvidenceBundles(
+        completion_bundle_dir=completion_out,
+        research_validity_bundle_dir=validity_out,
+        checkpoint_bundle_dir=inputs.checkpoint_bundle_dir,
+        comparison_definition_id=validity_result.comparison_definition_id,
+    )

--- a/tests/meta/test_comparison_completion_research_validity_binding_v1.py
+++ b/tests/meta/test_comparison_completion_research_validity_binding_v1.py
@@ -1,0 +1,824 @@
+"""Contract tests for comparison completion research validity binding v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+import shutil
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = [
+    "tests.meta.comparison_ssot_v1_fixtures",
+    "tests.meta.comparison_completion_research_validity_binding_v1_fixtures",
+]
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256, write_manifest_sha256
+from src.meta.learning_loop.comparison_completion_evidence_v1 import (
+    ARTIFACT_REL as COMPLETION_ARTIFACT_REL,
+    CONTRACT_VERSION as COMPLETION_CONTRACT_VERSION,
+    SELF_VERIFICATION_REL as COMPLETION_SELF_VERIFICATION_REL,
+    produce_comparison_completion_evidence_v1,
+)
+from src.meta.learning_loop.comparison_completion_research_validity_binding_v1 import (
+    ARTIFACT_REL,
+    AUTHORITY_LEVEL,
+    BINDING_AUTHORITY_INVARIANTS,
+    CONTRACT_NAME,
+    CONTRACT_VERSION,
+    EVIDENCE_LEVEL,
+    PRODUCER_VERSION,
+    SELF_VERIFICATION_REL,
+    ComparisonCompletionResearchValidityBindingError,
+    ComparisonCompletionResearchValidityBindingInputs,
+    build_comparison_completion_research_validity_binding_v1,
+    produce_comparison_completion_research_validity_binding_v1,
+    reverify_comparison_completion_research_validity_binding_v1,
+    serialize_comparison_completion_research_validity_binding_v1,
+    verify_binding_inputs,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+)
+from src.meta.learning_loop.research_validity_evidence_v1 import (
+    ARTIFACT_REL as VALIDITY_ARTIFACT_REL,
+    CONTRACT_VERSION as VALIDITY_CONTRACT_VERSION,
+    SELF_VERIFICATION_REL as VALIDITY_SELF_VERIFICATION_REL,
+    produce_research_validity_evidence_v1,
+)
+from tests.meta.comparison_completion_research_validity_binding_v1_fixtures import (
+    produce_matched_completion_and_validity_bundles,
+)
+from tests.meta.research_validity_evidence_v1_fixtures import (
+    produce_checkpoint_bundle,
+    produce_full_research_validity_inputs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = (
+        "src.meta.learning_loop.comparison_completion_research_validity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.research_validity_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_checkpoint_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_common_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1.is_under_tmp",
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
+    )
+    for target in targets:
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "binding_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _binding_inputs(matched) -> ComparisonCompletionResearchValidityBindingInputs:
+    return ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=matched.completion_bundle_dir,
+        research_validity_evidence_bundle_dir=matched.research_validity_bundle_dir,
+    )
+
+
+def test_happy_path_binding_pass(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path)
+    result = produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched),
+        output_dir=out,
+    )
+    assert result.binding_status == "PASS"
+    assert result.shared_lineage_status == "PASS"
+    assert (out / ARTIFACT_REL).is_file()
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is True
+    reverify_comparison_completion_research_validity_binding_v1(output_dir=out)
+
+
+def test_deterministic_output_and_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(
+        tmp_path, ssot_durable_output_dir, completion_name="c1", validity_name="v1"
+    )
+    out_a = _durable_output(tmp_path, "det_a")
+    out_b = _durable_output(tmp_path, "det_b")
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out_a
+    )
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out_b
+    )
+    assert (out_a / ARTIFACT_REL).read_text(encoding="utf-8") == (out_b / ARTIFACT_REL).read_text(
+        encoding="utf-8"
+    )
+    assert (out_a / "MANIFEST.sha256").read_text(encoding="utf-8") == (
+        out_b / "MANIFEST.sha256"
+    ).read_text(encoding="utf-8")
+
+
+def test_deterministic_input_artifact_ref_order(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    completion, validity, shared = verify_binding_inputs(_binding_inputs(matched))
+    evidence_a = build_comparison_completion_research_validity_binding_v1(
+        completion=completion, validity=validity, shared_lineage=shared
+    )
+    evidence_b = build_comparison_completion_research_validity_binding_v1(
+        completion=completion, validity=validity, shared_lineage=shared
+    )
+    types = [item["artifact_type"] for item in evidence_a["input_artifact_refs"]]
+    assert types == sorted(types)
+    assert evidence_a["input_artifact_refs"] == evidence_b["input_artifact_refs"]
+
+
+def test_required_contract_fields(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "fields")
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out
+    )
+    evidence = read_manifest(out / ARTIFACT_REL)
+    assert evidence["contract_name"] == CONTRACT_NAME
+    assert evidence["contract_version"] == CONTRACT_VERSION
+    assert evidence["producer_version"] == PRODUCER_VERSION
+    assert evidence["evidence_level"] == EVIDENCE_LEVEL
+    assert evidence["authority_level"] == AUTHORITY_LEVEL
+    assert evidence["is_completion_research_validity_binding"] is True
+    assert evidence["capabilities"] == []
+
+
+def test_non_authorizing_flags(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "flags")
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out
+    )
+    evidence = read_manifest(out / ARTIFACT_REL)
+    assert evidence["binding_does_not_select"] is True
+    assert evidence["binding_does_not_promote"] is True
+    assert evidence["binding_does_not_authorize_runtime"] is True
+    assert evidence["evidence_does_not_authorize_promotion"] is True
+    assert evidence["binding_does_not_modify_trading_logic"] is True
+
+
+def test_self_verification_pass(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "self")
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out
+    )
+    self_payload = read_manifest(out / SELF_VERIFICATION_REL)
+    assert self_payload["overall_status"] == "PASS"
+
+
+def test_binding_status_not_evaluable_upstream(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(
+        tmp_path, ssot_durable_output_dir, all_domains_pass=False
+    )
+    out = _durable_output(tmp_path, "not_eval")
+    result = produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out
+    )
+    assert result.binding_status == "NOT_EVALUABLE"
+    evidence = read_manifest(out / ARTIFACT_REL)
+    assert evidence["research_validity_status"] == "NOT_EVALUABLE"
+
+
+def test_binding_authority_invariants(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "inv")
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out
+    )
+    evidence = read_manifest(out / ARTIFACT_REL)
+    assert evidence["binding_authority_invariants"] == BINDING_AUTHORITY_INVARIANTS
+
+
+def test_contract_constants() -> None:
+    assert CONTRACT_NAME == "comparison_completion_research_validity_binding_v1"
+    assert CONTRACT_VERSION == "v1"
+    assert EVIDENCE_LEVEL == "LEVEL_3"
+
+
+def test_missing_completion_bundle(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path)
+    inputs = ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=tmp_path / "missing_completion",
+        research_validity_evidence_bundle_dir=matched.research_validity_bundle_dir,
+    )
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="directory"):
+        produce_comparison_completion_research_validity_binding_v1(inputs=inputs, output_dir=out)
+
+
+def test_missing_research_validity_bundle(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path)
+    inputs = ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=matched.completion_bundle_dir,
+        research_validity_evidence_bundle_dir=tmp_path / "missing_validity",
+    )
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="directory"):
+        produce_comparison_completion_research_validity_binding_v1(inputs=inputs, output_dir=out)
+
+
+def test_wrong_completion_artifact_type(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    bad = ssot_durable_output_dir / "bad_completion"
+    shutil.copytree(matched.checkpoint_bundle_dir, bad)
+    out = _durable_output(tmp_path)
+    inputs = ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=bad,
+        research_validity_evidence_bundle_dir=matched.research_validity_bundle_dir,
+    )
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError):
+        produce_comparison_completion_research_validity_binding_v1(inputs=inputs, output_dir=out)
+
+
+def test_wrong_research_validity_artifact_type(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path)
+    inputs = ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=matched.completion_bundle_dir,
+        research_validity_evidence_bundle_dir=matched.completion_bundle_dir,
+    )
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError):
+        produce_comparison_completion_research_validity_binding_v1(inputs=inputs, output_dir=out)
+
+
+def test_unsupported_completion_version(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    path = matched.completion_bundle_dir / COMPLETION_ARTIFACT_REL
+    payload = read_manifest(path)
+    payload["contract_version"] = "v99"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.completion_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="contract_version"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_unsupported_research_validity_version(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    path = matched.research_validity_bundle_dir / VALIDITY_ARTIFACT_REL
+    payload = read_manifest(path)
+    payload["contract_version"] = "v99"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.research_validity_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="contract_version"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_missing_completion_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    (matched.completion_bundle_dir / "MANIFEST.sha256").unlink()
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="MANIFEST"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_missing_research_validity_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    (matched.research_validity_bundle_dir / "MANIFEST.sha256").unlink()
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="MANIFEST"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_manipulated_completion_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    (matched.completion_bundle_dir / "MANIFEST.sha256").write_text("deadbeef\n", encoding="utf-8")
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="MANIFEST"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_manipulated_research_validity_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    (matched.research_validity_bundle_dir / "MANIFEST.sha256").write_text(
+        "deadbeef\n", encoding="utf-8"
+    )
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="MANIFEST"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_completion_self_verification_not_pass(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    self_path = matched.completion_bundle_dir / COMPLETION_SELF_VERIFICATION_REL
+    payload = read_manifest(self_path)
+    payload["overall_status"] = "FAIL"
+    self_path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.completion_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="overall_status"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_research_validity_self_verification_not_pass(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    self_path = matched.research_validity_bundle_dir / VALIDITY_SELF_VERIFICATION_REL
+    payload = read_manifest(self_path)
+    payload["overall_status"] = "FAIL"
+    self_path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.research_validity_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="overall_status"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_wrong_evidence_level_on_completion(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    path = matched.completion_bundle_dir / COMPLETION_ARTIFACT_REL
+    payload = read_manifest(path)
+    payload["evidence_level"] = "LEVEL_2"
+    body = {k: v for k, v in payload.items() if k != "integrity"}
+    payload["integrity"] = {"content_sha256": compute_content_sha256(body)}
+    path.write_text(deterministic_json_dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.completion_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="evidence_level"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_forbidden_capability_on_completion(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    path = matched.completion_bundle_dir / COMPLETION_ARTIFACT_REL
+    payload = read_manifest(path)
+    payload["capabilities"] = ["CAN_PROMOTE_ARTIFACT"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.completion_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="forbidden"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_forbidden_capability_on_research_validity(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    path = matched.research_validity_bundle_dir / VALIDITY_ARTIFACT_REL
+    payload = read_manifest(path)
+    payload["capabilities"] = ["CAN_SUBMIT_LIVE_ORDERS"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.research_validity_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="forbidden"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_forbidden_capability_on_binding_serialization() -> None:
+    matched_completion = {
+        "contract_name": "comparison_completion_evidence_v1",
+        "contract_version": COMPLETION_CONTRACT_VERSION,
+        "producer_version": "comparison_completion_evidence_v1",
+        "evidence_level": EVIDENCE_LEVEL,
+        "is_completion_evidence": True,
+        "evidence_does_not_authorize_promotion": True,
+        "evidence_does_not_authorize_runtime": True,
+        "completion_does_not_select": True,
+        "completion_does_not_accept": True,
+        "completion_does_not_deploy": True,
+        "completion_does_not_activate": True,
+        "completion_does_not_create_order_intent": True,
+        "capabilities": [],
+        "completion_status": "COMPLETE",
+        "input_checkpoint_bundle_ref": "/var/cp",
+        "input_checkpoint_digest": "a" * 64,
+        "comparison_definition_id": "00000000-0000-4000-8000-000000000099",
+        "parent_artifact_refs": [{"ref_type": "comparison_checkpoint_v1", "digest": "a" * 64}],
+        "output_digest": "b" * 64,
+    }
+    matched_validity = {
+        "contract_name": "research_validity_evidence_v1",
+        "contract_version": VALIDITY_CONTRACT_VERSION,
+        "producer_version": "research_validity_evidence_v1",
+        "evidence_level": EVIDENCE_LEVEL,
+        "is_research_validity_evidence": True,
+        "evidence_does_not_authorize_promotion": True,
+        "evidence_does_not_authorize_runtime": True,
+        "research_validity_does_not_select": True,
+        "research_validity_does_not_accept": True,
+        "research_validity_does_not_deploy": True,
+        "research_validity_does_not_activate": True,
+        "research_validity_does_not_create_order_intent": True,
+        "research_validity_does_not_modify_trading_logic": True,
+        "capabilities": [],
+        "research_validity_status": "PASS",
+        "comparison_checkpoint_ref": "/var/cp",
+        "comparison_checkpoint_digest": "a" * 64,
+        "experiment_identity_ref": "/var/exp",
+        "experiment_identity_digest": "c" * 64,
+        "dataset_identity_ref": "/var/ds",
+        "dataset_identity_digest": "d" * 64,
+        "comparison_definition_id": "00000000-0000-4000-8000-000000000099",
+        "parent_artifact_refs": [
+            {
+                "ref_type": "comparison_checkpoint_v1",
+                "digest": "a" * 64,
+                "bundle_path": "/var/cp",
+            }
+        ],
+        "output_digest": "e" * 64,
+    }
+    from src.meta.learning_loop.comparison_completion_research_validity_binding_v1 import (
+        SharedLineageResult,
+        VerifiedEvidenceBundle,
+        check_shared_lineage,
+    )
+
+    completion = VerifiedEvidenceBundle(
+        bundle_dir=Path("/var/completion"),
+        contract_name="comparison_completion_evidence_v1",
+        contract_version=COMPLETION_CONTRACT_VERSION,
+        producer_version="comparison_completion_evidence_v1",
+        artifact_ref=COMPLETION_ARTIFACT_REL,
+        artifact_digest="b" * 64,
+        manifest_digest="f" * 64,
+        evidence_level=EVIDENCE_LEVEL,
+        parent_artifact_refs=(
+            {
+                "ref_type": "comparison_checkpoint_v1",
+                "digest": "a" * 64,
+                "bundle_path": "/var/cp",
+            },
+        ),
+        evidence_payload=matched_completion,
+    )
+    validity = VerifiedEvidenceBundle(
+        bundle_dir=Path("/var/validity"),
+        contract_name="research_validity_evidence_v1",
+        contract_version=VALIDITY_CONTRACT_VERSION,
+        producer_version="research_validity_evidence_v1",
+        artifact_ref=VALIDITY_ARTIFACT_REL,
+        artifact_digest="e" * 64,
+        manifest_digest="g" * 64,
+        evidence_level=EVIDENCE_LEVEL,
+        parent_artifact_refs=(
+            {
+                "ref_type": "comparison_checkpoint_v1",
+                "digest": "a" * 64,
+                "bundle_path": "/var/cp",
+            },
+        ),
+        evidence_payload=matched_validity,
+    )
+    shared = check_shared_lineage(completion=completion, validity=validity)
+    evidence = build_comparison_completion_research_validity_binding_v1(
+        completion=completion, validity=validity, shared_lineage=shared
+    )
+    evidence["capabilities"] = ["CAN_CHANGE_RISK_POLICY"]
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="forbidden"):
+        serialize_comparison_completion_research_validity_binding_v1(evidence)
+
+
+def test_checkpoint_lineage_mismatch(tmp_path, ssot_durable_output_dir) -> None:
+    root_a = ssot_durable_output_dir / "lineage_a"
+    root_b = ssot_durable_output_dir / "lineage_b"
+    root_a.mkdir(parents=True, exist_ok=True)
+    root_b.mkdir(parents=True, exist_ok=True)
+    matched_a = produce_matched_completion_and_validity_bundles(
+        tmp_path / "case_a", root_a, completion_name="c_a", validity_name="v_a"
+    )
+    matched_b = produce_matched_completion_and_validity_bundles(
+        tmp_path / "case_b", root_b, completion_name="c_b", validity_name="v_b"
+    )
+    out = _durable_output(tmp_path)
+    inputs = ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=matched_a.completion_bundle_dir,
+        research_validity_evidence_bundle_dir=matched_b.research_validity_bundle_dir,
+    )
+    with pytest.raises(
+        ComparisonCompletionResearchValidityBindingError, match="comparison_checkpoint_ref mismatch"
+    ):
+        produce_comparison_completion_research_validity_binding_v1(inputs=inputs, output_dir=out)
+
+
+def test_experiment_identity_digest_mismatch_in_validity(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    path = matched.research_validity_bundle_dir / VALIDITY_ARTIFACT_REL
+    payload = read_manifest(path)
+    payload["experiment_identity_digest"] = "f" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.research_validity_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_dataset_identity_ref_mismatch(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    path = matched.research_validity_bundle_dir / VALIDITY_ARTIFACT_REL
+    payload = read_manifest(path)
+    payload["dataset_identity_ref"] = "/var/other/dataset"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.research_validity_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_parent_lineage_contradictory(tmp_path, ssot_durable_output_dir) -> None:
+    from src.meta.learning_loop.comparison_completion_research_validity_binding_v1 import (
+        VerifiedEvidenceBundle,
+        check_shared_lineage,
+    )
+
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    completion, validity, _ = verify_binding_inputs(_binding_inputs(matched))
+    contradictory_parent = dict(completion.parent_artifact_refs[0])
+    contradictory_parent["digest"] = "f" * 64
+    completion_bad = VerifiedEvidenceBundle(
+        bundle_dir=completion.bundle_dir,
+        contract_name=completion.contract_name,
+        contract_version=completion.contract_version,
+        producer_version=completion.producer_version,
+        artifact_ref=completion.artifact_ref,
+        artifact_digest=completion.artifact_digest,
+        manifest_digest=completion.manifest_digest,
+        evidence_level=completion.evidence_level,
+        parent_artifact_refs=(contradictory_parent,),
+        evidence_payload=completion.evidence_payload,
+    )
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="digest mismatch"):
+        check_shared_lineage(completion=completion_bad, validity=validity)
+
+
+def test_digest_mismatch_on_completion_output(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    path = matched.completion_bundle_dir / COMPLETION_ARTIFACT_REL
+    payload = read_manifest(path)
+    payload["output_digest"] = "f" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    write_manifest_sha256(matched.completion_bundle_dir)
+    out = _durable_output(tmp_path)
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_completion_status_not_complete_yields_fail_binding(
+    tmp_path, ssot_durable_output_dir
+) -> None:
+    from src.meta.learning_loop.comparison_completion_research_validity_binding_v1 import (
+        VerifiedEvidenceBundle,
+    )
+
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    completion, validity, shared = verify_binding_inputs(_binding_inputs(matched))
+    incomplete_payload = dict(completion.evidence_payload)
+    incomplete_payload["completion_status"] = "INCOMPLETE"
+    completion_incomplete = VerifiedEvidenceBundle(
+        bundle_dir=completion.bundle_dir,
+        contract_name=completion.contract_name,
+        contract_version=completion.contract_version,
+        producer_version=completion.producer_version,
+        artifact_ref=completion.artifact_ref,
+        artifact_digest=completion.artifact_digest,
+        manifest_digest=completion.manifest_digest,
+        evidence_level=completion.evidence_level,
+        parent_artifact_refs=completion.parent_artifact_refs,
+        evidence_payload=incomplete_payload,
+    )
+    evidence = build_comparison_completion_research_validity_binding_v1(
+        completion=completion_incomplete, validity=validity, shared_lineage=shared
+    )
+    assert evidence["binding_status"] == "FAIL"
+    assert evidence["completion_status"] == "INCOMPLETE"
+
+
+def test_research_validity_incomplete_yields_incomplete_binding(
+    tmp_path, ssot_durable_output_dir
+) -> None:
+    from src.meta.learning_loop.comparison_completion_research_validity_binding_v1 import (
+        VerifiedEvidenceBundle,
+    )
+
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    completion, validity, shared = verify_binding_inputs(_binding_inputs(matched))
+    incomplete_payload = dict(validity.evidence_payload)
+    incomplete_payload["research_validity_status"] = "INCOMPLETE"
+    validity_incomplete = VerifiedEvidenceBundle(
+        bundle_dir=validity.bundle_dir,
+        contract_name=validity.contract_name,
+        contract_version=validity.contract_version,
+        producer_version=validity.producer_version,
+        artifact_ref=validity.artifact_ref,
+        artifact_digest=validity.artifact_digest,
+        manifest_digest=validity.manifest_digest,
+        evidence_level=validity.evidence_level,
+        parent_artifact_refs=validity.parent_artifact_refs,
+        evidence_payload=incomplete_payload,
+    )
+    evidence = build_comparison_completion_research_validity_binding_v1(
+        completion=completion, validity=validity_incomplete, shared_lineage=shared
+    )
+    assert evidence["binding_status"] == "INCOMPLETE"
+
+
+def test_manipulated_non_authority_flags_on_output(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "tamper_flags")
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out
+    )
+    evidence = read_manifest(out / ARTIFACT_REL)
+    evidence["binding_does_not_promote"] = False
+    (out / ARTIFACT_REL).write_text(json.dumps(evidence), encoding="utf-8")
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError):
+        reverify_comparison_completion_research_validity_binding_v1(output_dir=out)
+
+
+def test_output_manipulation_after_produce(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "tamper")
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out
+    )
+    evidence = read_manifest(out / ARTIFACT_REL)
+    evidence["is_completion_research_validity_binding"] = False
+    (out / ARTIFACT_REL).write_text(json.dumps(evidence), encoding="utf-8")
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError):
+        reverify_comparison_completion_research_validity_binding_v1(output_dir=out)
+
+
+def test_promotion_input_field_forbidden_on_serialization() -> None:
+    evidence = {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "producer_version": PRODUCER_VERSION,
+        "evidence_level": EVIDENCE_LEVEL,
+        "is_completion_research_validity_binding": True,
+        "evidence_does_not_authorize_promotion": True,
+        "evidence_does_not_authorize_runtime": True,
+        "binding_does_not_select": True,
+        "binding_does_not_accept": True,
+        "binding_does_not_promote": True,
+        "binding_does_not_deploy": True,
+        "binding_does_not_activate": True,
+        "binding_does_not_create_order_intent": True,
+        "binding_does_not_modify_trading_logic": True,
+        "capabilities": [],
+        "binding_status": "PASS",
+        "is_promotion_input": True,
+    }
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="forbidden key"):
+        serialize_comparison_completion_research_validity_binding_v1(evidence)
+
+
+def test_inputs_not_mutated(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    before = {
+        rel.as_posix(): rel.read_bytes()
+        for bundle in (matched.completion_bundle_dir, matched.research_validity_bundle_dir)
+        for rel in bundle.rglob("*")
+        if rel.is_file() and not rel.is_symlink()
+    }
+    out = _durable_output(tmp_path, "nomut")
+    produce_comparison_completion_research_validity_binding_v1(
+        inputs=_binding_inputs(matched), output_dir=out
+    )
+    after = {
+        rel.as_posix(): rel.read_bytes()
+        for bundle in (matched.completion_bundle_dir, matched.research_validity_bundle_dir)
+        for rel in bundle.rglob("*")
+        if rel.is_file() and not rel.is_symlink()
+    }
+    assert before == after
+
+
+def test_existing_output_fail_closed(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "exists")
+    out.mkdir()
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="already exists"):
+        produce_comparison_completion_research_validity_binding_v1(
+            inputs=_binding_inputs(matched), output_dir=out
+        )
+
+
+def test_ast_no_forbidden_runtime_imports() -> None:
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "src/meta/learning_loop/comparison_completion_research_validity_binding_v1.py"
+    )
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    forbidden = {"src.execution", "src.risk", "mlflow"}
+    assert not modules & forbidden
+
+
+def test_regression_completion_contract_unchanged() -> None:
+    from src.meta.learning_loop import comparison_completion_evidence_v1 as mod
+
+    assert mod.CONTRACT_NAME == "comparison_completion_evidence_v1"
+    assert mod.CONTRACT_VERSION == "v1"
+
+
+def test_regression_research_validity_contract_unchanged() -> None:
+    from src.meta.learning_loop import research_validity_evidence_v1 as mod
+
+    assert mod.CONTRACT_NAME == "research_validity_evidence_v1"
+    assert mod.CONTRACT_VERSION == "v1"
+
+
+def test_unknown_parent_ref_type(tmp_path, ssot_durable_output_dir) -> None:
+    from src.meta.learning_loop.comparison_completion_research_validity_binding_v1 import (
+        VerifiedEvidenceBundle,
+        check_shared_lineage,
+    )
+
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    completion, validity, _ = verify_binding_inputs(_binding_inputs(matched))
+    bad_parent = dict(validity.parent_artifact_refs[0])
+    bad_parent["ref_type"] = "unknown_owner_v99"
+    validity_bad = VerifiedEvidenceBundle(
+        bundle_dir=validity.bundle_dir,
+        contract_name=validity.contract_name,
+        contract_version=validity.contract_version,
+        producer_version=validity.producer_version,
+        artifact_ref=validity.artifact_ref,
+        artifact_digest=validity.artifact_digest,
+        manifest_digest=validity.manifest_digest,
+        evidence_level=validity.evidence_level,
+        parent_artifact_refs=(bad_parent,),
+        evidence_payload=validity.evidence_payload,
+    )
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError, match="ref_type mismatch"):
+        check_shared_lineage(completion=completion, validity=validity_bad)
+
+
+def test_second_completion_input_rejected_via_wrong_bundle(
+    tmp_path, ssot_durable_output_dir
+) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    second_completion = ssot_durable_output_dir / "second_completion"
+    produce_comparison_completion_evidence_v1(
+        checkpoint_bundle_dir=matched.checkpoint_bundle_dir,
+        output_dir=second_completion,
+    )
+    out = _durable_output(tmp_path)
+    inputs = ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=second_completion,
+        research_validity_evidence_bundle_dir=matched.research_validity_bundle_dir,
+    )
+    result = produce_comparison_completion_research_validity_binding_v1(
+        inputs=inputs, output_dir=out
+    )
+    assert result.binding_status == "PASS"
+
+
+def test_orphan_checkpoint_bundle_rejected_as_completion(tmp_path, ssot_durable_output_dir) -> None:
+    orphan_root = ssot_durable_output_dir / "orphan"
+    orphan_root.mkdir(parents=True, exist_ok=True)
+    matched_root = ssot_durable_output_dir / "matched"
+    matched_root.mkdir(parents=True, exist_ok=True)
+    orphan = produce_checkpoint_bundle(tmp_path / "orphan_case", orphan_root)
+    matched = produce_matched_completion_and_validity_bundles(
+        tmp_path / "matched_case", matched_root
+    )
+    out = _durable_output(tmp_path)
+    inputs = ComparisonCompletionResearchValidityBindingInputs(
+        completion_evidence_bundle_dir=orphan,
+        research_validity_evidence_bundle_dir=matched.research_validity_bundle_dir,
+    )
+    with pytest.raises(ComparisonCompletionResearchValidityBindingError):
+        produce_comparison_completion_research_validity_binding_v1(inputs=inputs, output_dir=out)

--- a/tests/scripts/test_run_comparison_completion_research_validity_binding_v1.py
+++ b/tests/scripts/test_run_comparison_completion_research_validity_binding_v1.py
@@ -1,0 +1,116 @@
+"""CLI tests for comparison completion research validity binding v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = [
+    "tests.meta.comparison_ssot_v1_fixtures",
+    "tests.meta.comparison_completion_research_validity_binding_v1_fixtures",
+]
+
+from scripts.run_comparison_completion_research_validity_binding_v1 import (
+    EXIT_BINDING_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.meta.learning_loop.comparison_completion_research_validity_binding_v1 import ARTIFACT_REL
+from tests.meta.comparison_completion_research_validity_binding_v1_fixtures import (
+    produce_matched_completion_and_validity_bundles,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = (
+        "src.meta.learning_loop.comparison_completion_research_validity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.research_validity_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_checkpoint_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_common_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1.is_under_tmp",
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
+    )
+    for target in targets:
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "binding_cli_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def test_cli_happy_path(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--completion-evidence-bundle-dir",
+            str(matched.completion_bundle_dir),
+            "--research-validity-evidence-bundle-dir",
+            str(matched.research_validity_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert (out / ARTIFACT_REL).is_file()
+
+
+def test_cli_missing_completion_bundle(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--completion-evidence-bundle-dir",
+            str(tmp_path / "missing"),
+            "--research-validity-evidence-bundle-dir",
+            str(matched.research_validity_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_missing_validity_bundle(tmp_path, ssot_durable_output_dir) -> None:
+    matched = produce_matched_completion_and_validity_bundles(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--completion-evidence-bundle-dir",
+            str(matched.completion_bundle_dir),
+            "--research-validity-evidence-bundle-dir",
+            str(tmp_path / "missing"),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_binding_error_on_lineage_mismatch(tmp_path, ssot_durable_output_dir) -> None:
+    root_a = ssot_durable_output_dir / "cli_a"
+    root_b = ssot_durable_output_dir / "cli_b"
+    root_a.mkdir(parents=True, exist_ok=True)
+    root_b.mkdir(parents=True, exist_ok=True)
+    matched_a = produce_matched_completion_and_validity_bundles(tmp_path / "cli_case_a", root_a)
+    matched_b = produce_matched_completion_and_validity_bundles(tmp_path / "cli_case_b", root_b)
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--completion-evidence-bundle-dir",
+            str(matched_a.completion_bundle_dir),
+            "--research-validity-evidence-bundle-dir",
+            str(matched_b.research_validity_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_BINDING_ERROR


### PR DESCRIPTION
## Summary
- Additive LEVEL_3 sibling binding `comparison_completion_research_validity_binding_v1` joining exactly one verified `comparison_completion_evidence_v1` bundle and one verified `research_validity_evidence_v1` bundle
- Fail-closed shared lineage checks across checkpoint, experiment identity, dataset identity, and parent refs
- Existing completion and research validity contracts unchanged (no version bumps, no semantic edits)
- Non-authorizing only: no selection, acceptance, promotion authority, runtime authority, order intent, or scheduler effects
- `comparison_completion_promotion_input_binding_v1` is explicitly **not** part of this PR

## Test plan
- [x] `tests/meta/test_comparison_completion_research_validity_binding_v1.py` — happy path, negative cases, determinism, replay, self-verification, capability boundaries
- [x] `tests/scripts/test_run_comparison_completion_research_validity_binding_v1.py` — CLI success and error paths
- [x] Regression: `tests/meta/test_comparison_completion_evidence_v1.py`, `tests/meta/test_research_validity_evidence_v1.py`
- [x] Ruff format/check on new files
- [x] Local focused run: 90 passed


Made with [Cursor](https://cursor.com)