### PR TITLE
feat: add neutral comparison promotion candidate input v1 (Step 3/5)

### DIFF
--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1749,6 +1749,31 @@ PR_BOUNDED_FULL_PACKAGE_COMPARISON_CONFIG_PATCH_MANIFEST_CROSS_DOMAIN_LINEAGE_BI
     "tests/ci/test_ci_diff_aware_test_selection_v1.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_PROMOTION_CANDIDATE_INPUT_V1_TRIGGER_PATHS: frozenset[str] = (
+    frozenset(
+        {
+            "src/meta/learning_loop/comparison_promotion_candidate_input_v1.py",
+            "scripts/run_comparison_promotion_candidate_input_v1.py",
+            "tests/meta/test_comparison_promotion_candidate_input_v1.py",
+            "tests/scripts/test_run_comparison_promotion_candidate_input_v1.py",
+            "tests/meta/comparison_promotion_candidate_input_v1_fixtures.py",
+        }
+    )
+)
+
+PR_BOUNDED_FULL_PACKAGE_COMPARISON_PROMOTION_CANDIDATE_INPUT_V1_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_comparison_promotion_candidate_input_v1.py",
+    "tests/scripts/test_run_comparison_promotion_candidate_input_v1.py",
+    "tests/meta/test_comparison_config_patch_manifest_cross_domain_lineage_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_model_parameter_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_eligibility_evidence_v1.py",
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/meta/learning_loop/comparison_metric_input_v1/__init__.py",
@@ -2004,6 +2029,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
         & PR_BOUNDED_FULL_PACKAGE_COMPARISON_CONFIG_PATCH_MANIFEST_CROSS_DOMAIN_LINEAGE_BINDING_V1_TRIGGER_PATHS
     ):
         for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_CONFIG_PATCH_MANIFEST_CROSS_DOMAIN_LINEAGE_BINDING_V1_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_PROMOTION_CANDIDATE_INPUT_V1_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_COMPARISON_PROMOTION_CANDIDATE_INPUT_V1_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS:

--- a/scripts/run_comparison_promotion_candidate_input_v1.py
+++ b/scripts/run_comparison_promotion_candidate_input_v1.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Offline comparison promotion candidate input v1.
+
+Consumes exactly one verified comparison_config_patch_manifest_cross_domain_lineage_binding_v1
+bundle, producing a manifested LEVEL_3 neutral candidate input artifact.
+
+Usage:
+    python3 scripts/run_comparison_promotion_candidate_input_v1.py \\
+        --cross-domain-lineage-binding-bundle-dir /path/to/step2_bundle \\
+        --output-dir /var/evidence/candidate_input_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_promotion_candidate_input_v1 import (
+    ComparisonPromotionCandidateInputError,
+    ComparisonPromotionCandidateInputInputs,
+    produce_comparison_promotion_candidate_input_v1,
+)
+
+EXIT_OK = 0
+EXIT_EVIDENCE_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline comparison promotion candidate input v1: aggregate verified "
+            "cross-domain lineage into a neutral digest-bound candidate input without "
+            "selection, acceptance, policy, or ConfigPatch mutation."
+        )
+    )
+    parser.add_argument(
+        "--cross-domain-lineage-binding-bundle-dir",
+        type=Path,
+        required=True,
+        help=(
+            "Explicit path to a published "
+            "comparison_config_patch_manifest_cross_domain_lineage_binding_v1 bundle."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit candidate input output directory (must not exist).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.cross_domain_lineage_binding_bundle_dir.is_dir():
+        print(
+            "[comparison_promotion_candidate_input_v1] ERROR: "
+            "cross-domain lineage binding bundle not found: "
+            f"{args.cross_domain_lineage_binding_bundle_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    inputs = ComparisonPromotionCandidateInputInputs(
+        cross_domain_lineage_binding_bundle_dir=args.cross_domain_lineage_binding_bundle_dir,
+    )
+
+    try:
+        result = produce_comparison_promotion_candidate_input_v1(
+            inputs=inputs,
+            output_dir=args.output_dir,
+        )
+    except ComparisonPromotionCandidateInputError as exc:
+        print(
+            f"[comparison_promotion_candidate_input_v1] ERROR: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_EVIDENCE_ERROR
+
+    print(
+        "[comparison_promotion_candidate_input_v1] OK "
+        f"comparison_definition_id={result.comparison_definition_id} "
+        f"candidate_input_status={result.candidate_input_status} "
+        f"candidate_identity_ref={result.candidate_identity_ref} "
+        f"config_patch_manifest_id={result.config_patch_manifest_id} "
+        f"artifact_id={result.artifact_id} "
+        f"output_dir={result.output_dir}"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/comparison_promotion_candidate_input_v1.py
+++ b/src/meta/learning_loop/comparison_promotion_candidate_input_v1.py
@@ -1,0 +1,1195 @@
+"""Offline LEVEL_3 neutral comparison promotion candidate input from verified cross-domain lineage."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    COMPARISON_AUTHORITY_INVARIANTS,
+)
+from src.meta.learning_loop.comparison_config_patch_manifest_cross_domain_lineage_binding_v1 import (
+    ARTIFACT_REL as UPSTREAM_ARTIFACT_REL,
+    CONTRACT_NAME as UPSTREAM_CONTRACT_NAME,
+    CONTRACT_VERSION as UPSTREAM_CONTRACT_VERSION,
+    PRODUCER_VERSION as UPSTREAM_PRODUCER_VERSION,
+    SELF_VERIFICATION_REL as UPSTREAM_SELF_VERIFICATION_REL,
+    ComparisonConfigPatchManifestCrossDomainLineageBindingError,
+    reverify_comparison_config_patch_manifest_cross_domain_lineage_binding_v1,
+    verify_model_parameter_identity_binding_bundle,
+)
+from src.meta.learning_loop.config_patch_manifest_v1 import (
+    ConfigPatchManifestError,
+    load_config_patch_manifest_v1_from_json_path,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.io import read_manifest
+from src.meta.learning_loop.comparison_promotion_candidate_model_parameter_identity_binding_v1 import (
+    verify_eligibility_evidence_bundle,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+CONTRACT_NAME = "comparison_promotion_candidate_input_v1"
+CONTRACT_VERSION = "v1"
+PRODUCER_VERSION = "comparison_promotion_candidate_input_v1"
+EVIDENCE_LEVEL = "LEVEL_3"
+AUTHORITY_LEVEL = "NON_AUTHORITIZING_EVIDENCE_ONLY"
+RECORD_KIND = "comparison_promotion_candidate_input_record"
+INPUT_RELATION = "AGGREGATES_VERIFIED_CROSS_DOMAIN_LINEAGE_BINDING"
+ARTIFACT_REL = "comparison_promotion_candidate_input_v1.json"
+SELF_VERIFICATION_REL = "SELF_VERIFICATION.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".comparison_promotion_candidate_input_staging_"
+
+OFFLINE_DETERMINISTIC_CREATED_AT = "1970-01-01T00:00:00+00:00"
+
+_VALID_CANDIDATE_INPUT_STATUS = frozenset({"PASS", "FAIL", "INCOMPLETE", "NOT_EVALUABLE"})
+_IDENTITY_BOUND = "BOUND"
+_IDENTITY_NOT_BOUND = "NOT_BOUND"
+_ELIGIBILITY_VERIFIED = "VERIFIED"
+_ELIGIBILITY_NOT_VERIFIED = "NOT_VERIFIED"
+_CANDIDATE_SELECTION_NOT_SELECTED = "NOT_SELECTED"
+_WINNER_SELECTION_NOT_SELECTED = "NOT_SELECTED"
+_CANDIDATE_ACCEPTANCE_NOT_ACCEPTED = "NOT_ACCEPTED"
+_CONFIG_PATCH_ACCEPTANCE_NOT_ACCEPTED = "NOT_ACCEPTED"
+
+CANDIDATE_INPUT_AUTHORITY_INVARIANTS: dict[str, bool] = {
+    **COMPARISON_AUTHORITY_INVARIANTS,
+    "candidate_input_is_descriptive_only": True,
+    "candidate_input_does_not_select": True,
+    "candidate_input_does_not_choose_winner": True,
+    "candidate_input_does_not_accept": True,
+    "candidate_input_does_not_construct_promotion_candidate": True,
+    "candidate_input_does_not_execute_operational_filter": True,
+    "candidate_input_does_not_execute_policy": True,
+    "candidate_input_does_not_create_configpatch": True,
+    "candidate_input_does_not_modify_configpatch": True,
+    "candidate_input_does_not_apply_configpatch": True,
+    "candidate_input_does_not_modify_config": True,
+    "candidate_input_does_not_authorize_promotion": True,
+    "candidate_input_does_not_authorize_runtime": True,
+    "candidate_input_does_not_authorize_live": True,
+    "candidate_input_does_not_deploy": True,
+    "candidate_input_does_not_activate": True,
+    "candidate_input_does_not_create_order_intent": True,
+    "candidate_input_does_not_modify_trading_logic": True,
+    "evidence_does_not_authorize_promotion": True,
+}
+
+_REQUIRED_NON_AUTHORIZING_FLAGS: dict[str, bool] = {
+    "is_comparison_promotion_candidate_input": True,
+    "evidence_does_not_authorize_promotion": True,
+    "evidence_does_not_authorize_runtime": True,
+    "candidate_input_does_not_select": True,
+    "candidate_input_does_not_choose_winner": True,
+    "candidate_input_does_not_accept_candidate": True,
+    "candidate_input_does_not_accept_configpatch": True,
+    "candidate_input_does_not_construct_promotion_candidate": True,
+    "candidate_input_does_not_execute_operational_filter": True,
+    "candidate_input_does_not_execute_policy": True,
+    "candidate_input_does_not_create_configpatch": True,
+    "candidate_input_does_not_modify_configpatch": True,
+    "candidate_input_does_not_apply_configpatch": True,
+    "candidate_input_does_not_modify_config": True,
+    "candidate_input_does_not_authorize_promotion": True,
+    "candidate_input_does_not_authorize_runtime": True,
+    "candidate_input_does_not_authorize_live": True,
+    "candidate_input_does_not_deploy": True,
+    "candidate_input_does_not_activate": True,
+    "candidate_input_does_not_create_order_intent": True,
+    "candidate_input_does_not_modify_trading_logic": True,
+}
+
+_FORBIDDEN_CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "CAN_PROMOTE_ARTIFACT",
+        "CAN_DEPLOY_INACTIVE",
+        "CAN_COMPUTE_SIGNALS",
+        "CAN_CREATE_ORDER_INTENTS",
+        "CAN_SUBMIT_TESTNET_ORDERS",
+        "CAN_SUBMIT_LIVE_ORDERS",
+        "CAN_INCREASE_CAPITAL",
+        "CAN_CHANGE_RISK_POLICY",
+    }
+)
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "winner",
+        "selected",
+        "promoted",
+        "promotion",
+        "promotion_ready",
+        "promotion_authorized",
+        "promotion_decision",
+        "eligible_for_live",
+        "runtime_authorized",
+        "live_authorized",
+        "live_eligible",
+        "runtime_eligible",
+        "orders_allowed",
+        "ranking",
+        "ranked_input_ids",
+        "pareto",
+        "accepted",
+        "acceptance",
+        "armed",
+        "enabled",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "strategy_params_mutated",
+        "config_patch",
+        "configpatch",
+        "config_patch_manifest",
+        "patches",
+        "top_n",
+        "topn",
+        "filter_candidates_for_live",
+        "promotion_candidate",
+        "safety_flags",
+    }
+)
+
+_SELF_VERIFICATION_SCHEMA_VERSION = "comparison_promotion_candidate_input_self_verification_v1"
+
+
+class ComparisonPromotionCandidateInputError(ValueError):
+    """Fail-closed neutral candidate input error."""
+
+
+@dataclass(frozen=True)
+class VerifiedCrossDomainLineageBindingBundle:
+    bundle_dir: Path
+    contract_name: str
+    contract_version: str
+    producer_version: str
+    artifact_ref: str
+    artifact_digest: str
+    manifest_digest: str
+    evidence_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ResolvedTransitiveLineage:
+    model_parameter_binding_digest: str
+    eligibility_evidence_ref: str
+    eligibility_evidence_digest: str
+    promotion_input_binding_ref: str
+    promotion_input_binding_digest: str
+
+
+@dataclass(frozen=True)
+class ComparisonPromotionCandidateInputInputs:
+    cross_domain_lineage_binding_bundle_dir: Path
+
+
+@dataclass(frozen=True)
+class ComparisonPromotionCandidateInputResult:
+    output_dir: Path
+    comparison_definition_id: str
+    artifact_id: str
+    evidence_path: Path
+    self_verification_path: Path
+    manifest_path: Path
+    candidate_input_status: str
+    candidate_identity_ref: str
+    config_patch_manifest_id: str
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ComparisonPromotionCandidateInputError(f"{label} must not be a symlink")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise ComparisonPromotionCandidateInputError(f"forbidden index key: {key}")
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise ComparisonPromotionCandidateInputError(f"{label} must be a regular file: {path}")
+
+
+def _validate_bundle_dir(bundle_dir: Path, *, label: str) -> None:
+    _reject_symlink(bundle_dir, label=label)
+    if not bundle_dir.is_dir():
+        raise ComparisonPromotionCandidateInputError(f"{label} must be a directory: {bundle_dir}")
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise ComparisonPromotionCandidateInputError(
+            f"output directory already exists: {output_dir}"
+        )
+    if is_under_tmp(output_dir):
+        raise ComparisonPromotionCandidateInputError("output directory must not be under /tmp")
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _reject_unsafe_overlap(*, cross_domain_binding_dir: Path, output_dir: Path) -> None:
+    binding_res = cross_domain_binding_dir.resolve()
+    output_res = output_dir.resolve()
+    if output_res == binding_res:
+        raise ComparisonPromotionCandidateInputError("output directory must not equal input path")
+    if _path_is_under(output_res, binding_res):
+        raise ComparisonPromotionCandidateInputError(
+            "output directory must not be inside input path"
+        )
+    if binding_res.is_dir() and _path_is_under(binding_res, output_res):
+        raise ComparisonPromotionCandidateInputError(
+            "input directory must not be inside output directory"
+        )
+
+
+def _manifest_file_digest(bundle_dir: Path) -> str:
+    manifest_path = bundle_dir / MANIFEST_FILENAME
+    _validate_regular_file(manifest_path, label=MANIFEST_FILENAME)
+    return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+
+def _validate_capabilities(capabilities: Any) -> list[str]:
+    if capabilities is None:
+        return []
+    if not isinstance(capabilities, list):
+        raise ComparisonPromotionCandidateInputError("capabilities must be a list")
+    normalized: list[str] = []
+    for item in capabilities:
+        if not isinstance(item, str):
+            raise ComparisonPromotionCandidateInputError("capabilities entries must be strings")
+        if item in _FORBIDDEN_CAPABILITIES:
+            raise ComparisonPromotionCandidateInputError(f"forbidden capability: {item}")
+        normalized.append(item)
+    return sorted(normalized)
+
+
+def _validate_non_authorizing_flags(payload: Mapping[str, Any]) -> None:
+    for key, expected in _REQUIRED_NON_AUTHORIZING_FLAGS.items():
+        if payload.get(key) is not expected:
+            raise ComparisonPromotionCandidateInputError(f"{key} must be {expected!r}")
+
+
+def _sorted_reason_codes(codes: list[str]) -> list[str]:
+    return sorted(set(codes))
+
+
+def _non_empty_ref(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _load_self_verification(bundle_dir: Path, *, rel: str, label: str) -> dict[str, Any]:
+    path = bundle_dir / rel
+    _validate_regular_file(path, label=label)
+    payload = read_manifest(path)
+    if not isinstance(payload, dict):
+        raise ComparisonPromotionCandidateInputError(f"{label} must be a JSON object")
+    return payload
+
+
+def verify_cross_domain_lineage_binding_bundle(
+    bundle_dir: Path | str,
+) -> VerifiedCrossDomainLineageBindingBundle:
+    """Fail-closed verification of exactly one Step-2 cross-domain lineage binding bundle."""
+    path = Path(bundle_dir)
+    _validate_bundle_dir(path, label="cross-domain lineage binding bundle")
+    ok, msg = verify_manifest_sha256(path)
+    if not ok:
+        raise ComparisonPromotionCandidateInputError(
+            f"cross-domain lineage binding MANIFEST.sha256 verification failed: {msg}"
+        )
+
+    artifact_path = path / UPSTREAM_ARTIFACT_REL
+    _validate_regular_file(artifact_path, label=UPSTREAM_ARTIFACT_REL)
+    payload = read_manifest(artifact_path)
+    if payload.get("contract_name") != UPSTREAM_CONTRACT_NAME:
+        raise ComparisonPromotionCandidateInputError(
+            "upstream cross-domain lineage binding contract_name mismatch"
+        )
+    if payload.get("contract_version") != UPSTREAM_CONTRACT_VERSION:
+        raise ComparisonPromotionCandidateInputError(
+            "upstream cross-domain lineage binding contract_version mismatch"
+        )
+
+    self_payload = _load_self_verification(
+        path,
+        rel=UPSTREAM_SELF_VERIFICATION_REL,
+        label=UPSTREAM_SELF_VERIFICATION_REL,
+    )
+    if self_payload.get("overall_status") != "PASS":
+        raise ComparisonPromotionCandidateInputError(
+            "upstream cross-domain lineage binding SELF_VERIFICATION overall_status must be PASS"
+        )
+
+    try:
+        reverify_comparison_config_patch_manifest_cross_domain_lineage_binding_v1(output_dir=path)
+    except ComparisonConfigPatchManifestCrossDomainLineageBindingError as exc:
+        raise ComparisonPromotionCandidateInputError(str(exc)) from exc
+
+    integrity = payload.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise ComparisonPromotionCandidateInputError(
+            "cross-domain lineage binding integrity must be an object"
+        )
+    artifact_digest = integrity.get("content_sha256")
+    if not isinstance(artifact_digest, str) or not is_valid_sha256_hex(artifact_digest):
+        raise ComparisonPromotionCandidateInputError(
+            "cross-domain lineage binding integrity.content_sha256 invalid"
+        )
+
+    return VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=path.resolve(),
+        contract_name=UPSTREAM_CONTRACT_NAME,
+        contract_version=UPSTREAM_CONTRACT_VERSION,
+        producer_version=UPSTREAM_PRODUCER_VERSION,
+        artifact_ref=UPSTREAM_ARTIFACT_REL,
+        artifact_digest=artifact_digest,
+        manifest_digest=_manifest_file_digest(path),
+        evidence_payload=dict(payload),
+    )
+
+
+def _resolve_transitive_lineage(
+    step2: Mapping[str, Any],
+) -> tuple[ResolvedTransitiveLineage | None, list[str]]:
+    reason_codes: list[str] = []
+    binding_ref = step2.get("model_parameter_identity_binding_bundle_ref")
+    if not _non_empty_ref(binding_ref):
+        reason_codes.append("MISSING_CROSS_DOMAIN_LINEAGE_BINDING")
+        return None, reason_codes
+
+    try:
+        model_parameter_binding = verify_model_parameter_identity_binding_bundle(
+            Path(str(binding_ref))
+        )
+    except Exception:
+        reason_codes.append("MODEL_LINEAGE_MISMATCH")
+        return None, reason_codes
+
+    expected_digest = step2.get("model_parameter_identity_binding_digest")
+    if expected_digest != model_parameter_binding.artifact_digest:
+        reason_codes.append("MODEL_LINEAGE_MISMATCH")
+
+    step1 = model_parameter_binding.evidence_payload
+    eligibility_ref = step1.get("eligibility_evidence_bundle_ref")
+    eligibility_digest = step1.get("eligibility_evidence_digest")
+    if not _non_empty_ref(eligibility_ref) or not is_valid_sha256_hex(
+        str(eligibility_digest or "")
+    ):
+        reason_codes.append("ELIGIBILITY_EVIDENCE_NOT_VERIFIED")
+        return None, reason_codes
+
+    try:
+        eligibility = verify_eligibility_evidence_bundle(Path(str(eligibility_ref)))
+    except Exception:
+        reason_codes.append("ELIGIBILITY_EVIDENCE_NOT_VERIFIED")
+        return None, reason_codes
+
+    if eligibility_digest != eligibility.artifact_digest:
+        reason_codes.append("ELIGIBILITY_DIGEST_MISMATCH")
+
+    eligibility_payload = eligibility.evidence_payload
+    promotion_ref = str(eligibility_payload.get("promotion_input_binding_ref", ""))
+    promotion_digest = str(eligibility_payload.get("promotion_input_binding_digest", ""))
+    if not _non_empty_ref(promotion_ref) or not is_valid_sha256_hex(promotion_digest):
+        reason_codes.append("ELIGIBILITY_LINEAGE_MISMATCH")
+
+    return (
+        ResolvedTransitiveLineage(
+            model_parameter_binding_digest=model_parameter_binding.artifact_digest,
+            eligibility_evidence_ref=str(eligibility_ref),
+            eligibility_evidence_digest=str(eligibility_digest),
+            promotion_input_binding_ref=promotion_ref,
+            promotion_input_binding_digest=promotion_digest,
+        ),
+        reason_codes,
+    )
+
+
+def _evaluate_candidate_input(
+    *,
+    step2: Mapping[str, Any],
+    transitive: ResolvedTransitiveLineage | None,
+    resolution_reason_codes: list[str],
+) -> tuple[str, str, str, str, str, str, str, list[str]]:
+    reason_codes = list(resolution_reason_codes)
+
+    if step2.get("candidate_selection_status") != _CANDIDATE_SELECTION_NOT_SELECTED:
+        reason_codes.append("CANDIDATE_SELECTION_DETECTED")
+    if step2.get("winner_selection_status") != _WINNER_SELECTION_NOT_SELECTED:
+        reason_codes.append("WINNER_SELECTION_DETECTED")
+    if step2.get("candidate_acceptance_status") != _CANDIDATE_ACCEPTANCE_NOT_ACCEPTED:
+        reason_codes.append("CANDIDATE_ACCEPTANCE_DETECTED")
+    if step2.get("configpatch_accepted") is not False:
+        reason_codes.append("CONFIG_PATCH_ACCEPTANCE_DETECTED")
+    if step2.get("configpatch_created") is not False:
+        reason_codes.append("CONFIGPATCH_CREATION_DETECTED")
+    if step2.get("configpatch_modified") is not False:
+        reason_codes.append("CONFIGPATCH_MUTATION_DETECTED")
+    if step2.get("configpatch_applied") is not False:
+        reason_codes.append("CONFIGPATCH_APPLICATION_DETECTED")
+    if step2.get("promotion_candidate_constructed") is not False:
+        reason_codes.append("PROMOTION_CANDIDATE_CONSTRUCTION_DETECTED")
+    if step2.get("operational_filter_executed") is not False:
+        reason_codes.append("OPERATIONAL_FILTER_DETECTED")
+    if step2.get("promotion_policy_executed") is not False:
+        reason_codes.append("PROMOTION_POLICY_DETECTED")
+
+    upstream_status = str(step2.get("cross_domain_lineage_binding_status", ""))
+    if upstream_status == "NOT_EVALUABLE":
+        return (
+            "NOT_EVALUABLE",
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _ELIGIBILITY_NOT_VERIFIED,
+            _IDENTITY_NOT_BOUND,
+            _sorted_reason_codes(reason_codes + ["NOT_EVALUABLE_INSUFFICIENT_EVIDENCE"]),
+        )
+    if upstream_status == "INCOMPLETE":
+        return (
+            "INCOMPLETE",
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _ELIGIBILITY_NOT_VERIFIED,
+            _IDENTITY_NOT_BOUND,
+            _sorted_reason_codes(reason_codes + ["UPSTREAM_CROSS_DOMAIN_LINEAGE_INCOMPLETE"]),
+        )
+    if upstream_status == "FAIL":
+        return (
+            "FAIL",
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _IDENTITY_NOT_BOUND,
+            _ELIGIBILITY_NOT_VERIFIED,
+            _IDENTITY_NOT_BOUND,
+            _sorted_reason_codes(reason_codes + ["UPSTREAM_CROSS_DOMAIN_LINEAGE_FAIL"]),
+        )
+
+    candidate_ref = str(step2.get("candidate_identity_ref", ""))
+    candidate_digest = str(step2.get("candidate_identity_digest", ""))
+    candidate_lineage_digest = str(step2.get("candidate_lineage_digest", ""))
+    if not _non_empty_ref(candidate_ref):
+        reason_codes.append("CANDIDATE_IDENTITY_NOT_BOUND")
+    if not is_valid_sha256_hex(candidate_digest):
+        reason_codes.append("CANDIDATE_DIGEST_MISMATCH")
+    elif (
+        is_valid_sha256_hex(candidate_lineage_digest)
+        and candidate_digest != candidate_lineage_digest
+    ):
+        reason_codes.append("CANDIDATE_DIGEST_MISMATCH")
+
+    model_ref = str(step2.get("model_identity_ref", ""))
+    model_digest = str(step2.get("model_identity_digest", ""))
+    if not _non_empty_ref(model_ref) or not is_valid_sha256_hex(model_digest):
+        reason_codes.append("MODEL_IDENTITY_NOT_BOUND")
+    elif model_ref != model_digest:
+        reason_codes.append("MODEL_DIGEST_MISMATCH")
+
+    parameter_ref = str(step2.get("parameter_set_identity_ref", ""))
+    parameter_digest = str(step2.get("parameter_set_identity_digest", ""))
+    if not _non_empty_ref(parameter_ref) or not is_valid_sha256_hex(parameter_digest):
+        reason_codes.append("PARAMETER_SET_IDENTITY_NOT_BOUND")
+    elif parameter_ref != parameter_digest:
+        reason_codes.append("PARAMETER_SET_DIGEST_MISMATCH")
+
+    config_patch_id = str(step2.get("config_patch_manifest_id", ""))
+    config_patch_digest = str(step2.get("config_patch_manifest_digest", ""))
+    config_patch_ref = str(step2.get("config_patch_manifest_ref", ""))
+    if not _non_empty_ref(config_patch_id):
+        reason_codes.append("CONFIG_PATCH_MANIFEST_IDENTITY_NOT_BOUND")
+    if not is_valid_sha256_hex(config_patch_digest):
+        reason_codes.append("CONFIG_PATCH_MANIFEST_DIGEST_MISMATCH")
+    elif _non_empty_ref(config_patch_ref):
+        config_path = Path(config_patch_ref)
+        if config_path.is_file():
+            try:
+                loaded = load_config_patch_manifest_v1_from_json_path(config_path)
+                if (
+                    loaded.integrity is not None
+                    and loaded.integrity.content_sha256 != config_patch_digest
+                ):
+                    reason_codes.append("CONFIG_PATCH_MANIFEST_DIGEST_MISMATCH")
+            except ConfigPatchManifestError:
+                reason_codes.append("CONFIG_PATCH_MANIFEST_DIGEST_MISMATCH")
+
+    experiment_ref = str(step2.get("experiment_identity_ref", ""))
+    experiment_digest = str(step2.get("experiment_identity_digest", ""))
+    if not _non_empty_ref(experiment_ref) or not is_valid_sha256_hex(experiment_digest):
+        reason_codes.append("EXPERIMENT_LINEAGE_MISMATCH")
+
+    dataset_ref = str(step2.get("dataset_identity_ref", ""))
+    dataset_digest = str(step2.get("dataset_identity_digest", ""))
+    if not _non_empty_ref(dataset_ref) or not is_valid_sha256_hex(dataset_digest):
+        reason_codes.append("DATASET_LINEAGE_MISMATCH")
+
+    comparison_ref = str(step2.get("comparison_identity_ref", ""))
+    comparison_digest = str(step2.get("comparison_identity_digest", ""))
+    if not _non_empty_ref(comparison_ref) or not is_valid_sha256_hex(comparison_digest):
+        reason_codes.append("COMPARISON_LINEAGE_MISMATCH")
+
+    completion_ref = str(step2.get("comparison_completion_ref", ""))
+    completion_digest = str(step2.get("comparison_completion_digest", ""))
+    if not _non_empty_ref(completion_ref) or not is_valid_sha256_hex(completion_digest):
+        reason_codes.append("COMPLETION_EVIDENCE_MISSING")
+
+    research_ref = str(step2.get("research_validity_ref", ""))
+    research_digest = str(step2.get("research_validity_digest", ""))
+    if not _non_empty_ref(research_ref) or not is_valid_sha256_hex(research_digest):
+        reason_codes.append("RESEARCH_VALIDITY_MISSING")
+
+    if step2.get("cross_domain_lineage_status") != _IDENTITY_BOUND:
+        reason_codes.append("MISSING_CROSS_DOMAIN_LINEAGE_BINDING")
+    if step2.get("candidate_identity_status") != _IDENTITY_BOUND:
+        reason_codes.append("CANDIDATE_LINEAGE_MISMATCH")
+    if step2.get("model_identity_status") != _IDENTITY_BOUND:
+        reason_codes.append("MODEL_LINEAGE_MISMATCH")
+    if step2.get("parameter_set_identity_status") != _IDENTITY_BOUND:
+        reason_codes.append("PARAMETER_SET_LINEAGE_MISMATCH")
+    if step2.get("config_patch_manifest_identity_status") != _IDENTITY_BOUND:
+        reason_codes.append("CONFIG_PATCH_LINEAGE_MISMATCH")
+
+    if transitive is None:
+        reason_codes.append("ELIGIBILITY_EVIDENCE_NOT_VERIFIED")
+    elif transitive.model_parameter_binding_digest != step2.get(
+        "model_parameter_identity_binding_digest"
+    ):
+        reason_codes.append("MODEL_LINEAGE_MISMATCH")
+
+    fail_codes = {
+        "CANDIDATE_SELECTION_DETECTED",
+        "WINNER_SELECTION_DETECTED",
+        "CANDIDATE_ACCEPTANCE_DETECTED",
+        "CONFIG_PATCH_ACCEPTANCE_DETECTED",
+        "CONFIGPATCH_CREATION_DETECTED",
+        "CONFIGPATCH_MUTATION_DETECTED",
+        "CONFIGPATCH_APPLICATION_DETECTED",
+        "PROMOTION_CANDIDATE_CONSTRUCTION_DETECTED",
+        "OPERATIONAL_FILTER_DETECTED",
+        "PROMOTION_POLICY_DETECTED",
+        "CANDIDATE_IDENTITY_NOT_BOUND",
+        "CANDIDATE_DIGEST_MISMATCH",
+        "CANDIDATE_LINEAGE_MISMATCH",
+        "MODEL_IDENTITY_NOT_BOUND",
+        "MODEL_DIGEST_MISMATCH",
+        "MODEL_LINEAGE_MISMATCH",
+        "PARAMETER_SET_IDENTITY_NOT_BOUND",
+        "PARAMETER_SET_DIGEST_MISMATCH",
+        "PARAMETER_SET_LINEAGE_MISMATCH",
+        "CONFIG_PATCH_MANIFEST_IDENTITY_NOT_BOUND",
+        "CONFIG_PATCH_MANIFEST_DIGEST_MISMATCH",
+        "CONFIG_PATCH_LINEAGE_MISMATCH",
+        "EXPERIMENT_LINEAGE_MISMATCH",
+        "DATASET_LINEAGE_MISMATCH",
+        "COMPARISON_LINEAGE_MISMATCH",
+        "COMPLETION_EVIDENCE_MISSING",
+        "RESEARCH_VALIDITY_MISSING",
+        "MISSING_CROSS_DOMAIN_LINEAGE_BINDING",
+        "ELIGIBILITY_EVIDENCE_NOT_VERIFIED",
+        "ELIGIBILITY_DIGEST_MISMATCH",
+        "ELIGIBILITY_LINEAGE_MISMATCH",
+    }
+
+    input_status = "PASS"
+    candidate_status = _IDENTITY_BOUND
+    model_status = _IDENTITY_BOUND
+    parameter_status = _IDENTITY_BOUND
+    config_patch_status = _IDENTITY_BOUND
+    eligibility_status = _ELIGIBILITY_VERIFIED
+    cross_domain_status = _IDENTITY_BOUND
+
+    if any(code in reason_codes for code in fail_codes):
+        input_status = "FAIL"
+        if (
+            "CANDIDATE_IDENTITY_NOT_BOUND" in reason_codes
+            or "CANDIDATE_LINEAGE_MISMATCH" in reason_codes
+        ):
+            candidate_status = _IDENTITY_NOT_BOUND
+        if "MODEL_IDENTITY_NOT_BOUND" in reason_codes or "MODEL_LINEAGE_MISMATCH" in reason_codes:
+            model_status = _IDENTITY_NOT_BOUND
+        if (
+            "PARAMETER_SET_IDENTITY_NOT_BOUND" in reason_codes
+            or "PARAMETER_SET_LINEAGE_MISMATCH" in reason_codes
+        ):
+            parameter_status = _IDENTITY_NOT_BOUND
+        if (
+            "CONFIG_PATCH_MANIFEST_IDENTITY_NOT_BOUND" in reason_codes
+            or "CONFIG_PATCH_LINEAGE_MISMATCH" in reason_codes
+        ):
+            config_patch_status = _IDENTITY_NOT_BOUND
+        if (
+            "ELIGIBILITY_EVIDENCE_NOT_VERIFIED" in reason_codes
+            or "ELIGIBILITY_DIGEST_MISMATCH" in reason_codes
+        ):
+            eligibility_status = _ELIGIBILITY_NOT_VERIFIED
+        if "MISSING_CROSS_DOMAIN_LINEAGE_BINDING" in reason_codes:
+            cross_domain_status = _IDENTITY_NOT_BOUND
+
+    if input_status == "PASS":
+        reason_codes.extend(
+            [
+                "CANDIDATE_INPUT_BOUND",
+                "CANDIDATE_IDENTITY_BOUND",
+                "ELIGIBILITY_EVIDENCE_VERIFIED",
+                "MODEL_IDENTITY_BOUND",
+                "PARAMETER_SET_IDENTITY_BOUND",
+                "CONFIG_PATCH_MANIFEST_IDENTITY_BOUND",
+                "CROSS_DOMAIN_LINEAGE_BOUND",
+                "COMPARISON_PROMOTION_CANDIDATE_INPUT_COMPLETE",
+            ]
+        )
+
+    return (
+        input_status,
+        candidate_status,
+        model_status,
+        parameter_status,
+        config_patch_status,
+        eligibility_status,
+        cross_domain_status,
+        _sorted_reason_codes(reason_codes),
+    )
+
+
+def _input_artifact_ref_mapping(
+    *, bundle: VerifiedCrossDomainLineageBindingBundle
+) -> dict[str, Any]:
+    return {
+        "artifact_type": bundle.contract_name,
+        "contract_name": bundle.contract_name,
+        "contract_version": bundle.contract_version,
+        "artifact_ref": bundle.artifact_ref,
+        "artifact_digest": bundle.artifact_digest,
+        "manifest_digest": bundle.manifest_digest,
+        "producer_version": bundle.producer_version,
+        "bundle_path": bundle.bundle_dir.as_posix(),
+    }
+
+
+def _compute_output_digest(body: Mapping[str, Any]) -> str:
+    excluded = frozenset(
+        {"output_digest", "manifest_digest", "integrity", "created_at", "artifact_id"}
+    )
+    digest_body = {key: body[key] for key in sorted(body) if key not in excluded}
+    return compute_content_sha256(digest_body)
+
+
+def _integrity_body(body: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in body.items() if key not in {"integrity", "manifest_digest"}
+    }
+
+
+def build_comparison_promotion_candidate_input_v1(
+    *,
+    cross_domain_binding: VerifiedCrossDomainLineageBindingBundle,
+) -> dict[str, Any]:
+    step2 = cross_domain_binding.evidence_payload
+    transitive, resolution_codes = _resolve_transitive_lineage(step2)
+    (
+        input_status,
+        candidate_identity_status,
+        model_identity_status,
+        parameter_set_identity_status,
+        config_patch_manifest_identity_status,
+        eligibility_evidence_status,
+        cross_domain_lineage_status,
+        reason_codes,
+    ) = _evaluate_candidate_input(
+        step2=step2,
+        transitive=transitive,
+        resolution_reason_codes=resolution_codes,
+    )
+
+    input_refs = [_input_artifact_ref_mapping(bundle=cross_domain_binding)]
+    parent_artifact_refs = list(step2.get("parent_artifact_refs", []))
+    if isinstance(parent_artifact_refs, list):
+        parent_artifact_refs = [
+            dict(item) for item in parent_artifact_refs if isinstance(item, Mapping)
+        ]
+    else:
+        parent_artifact_refs = []
+    parent_artifact_refs.sort(
+        key=lambda item: (str(item.get("ref_type", "")), str(item.get("digest", "")))
+    )
+
+    payload: dict[str, Any] = {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "artifact_id": "",
+        "created_at": OFFLINE_DETERMINISTIC_CREATED_AT,
+        "producer_version": PRODUCER_VERSION,
+        "record_kind": RECORD_KIND,
+        "input_relation": INPUT_RELATION,
+        "evidence_level": EVIDENCE_LEVEL,
+        "authority_level": AUTHORITY_LEVEL,
+        "capabilities": [],
+        "is_comparison_promotion_candidate_input": True,
+        "evidence_does_not_authorize_promotion": True,
+        "evidence_does_not_authorize_runtime": True,
+        "candidate_input_does_not_select": True,
+        "candidate_input_does_not_choose_winner": True,
+        "candidate_input_does_not_accept_candidate": True,
+        "candidate_input_does_not_accept_configpatch": True,
+        "candidate_input_does_not_construct_promotion_candidate": True,
+        "candidate_input_does_not_execute_operational_filter": True,
+        "candidate_input_does_not_execute_policy": True,
+        "candidate_input_does_not_create_configpatch": True,
+        "candidate_input_does_not_modify_configpatch": True,
+        "candidate_input_does_not_apply_configpatch": True,
+        "candidate_input_does_not_modify_config": True,
+        "candidate_input_does_not_authorize_promotion": True,
+        "candidate_input_does_not_authorize_runtime": True,
+        "candidate_input_does_not_authorize_live": True,
+        "candidate_input_does_not_deploy": True,
+        "candidate_input_does_not_activate": True,
+        "candidate_input_does_not_create_order_intent": True,
+        "candidate_input_does_not_modify_trading_logic": True,
+        "candidate_input_authority_invariants": dict(CANDIDATE_INPUT_AUTHORITY_INVARIANTS),
+        "cross_domain_lineage_binding_bundle_ref": cross_domain_binding.bundle_dir.as_posix(),
+        "cross_domain_lineage_binding_artifact_ref": cross_domain_binding.artifact_ref,
+        "cross_domain_lineage_binding_digest": cross_domain_binding.artifact_digest,
+        "cross_domain_lineage_binding_manifest_digest": cross_domain_binding.manifest_digest,
+        "upstream_contract_name": cross_domain_binding.contract_name,
+        "upstream_contract_version": cross_domain_binding.contract_version,
+        "upstream_producer_version": cross_domain_binding.producer_version,
+        "upstream_cross_domain_lineage_binding_status": str(
+            step2.get("cross_domain_lineage_binding_status", "")
+        ),
+        "candidate_input_status": input_status,
+        "candidate_input_reason_codes": reason_codes,
+        "candidate_identity_ref": str(step2.get("candidate_identity_ref", "")),
+        "candidate_identity_digest": str(step2.get("candidate_identity_digest", "")),
+        "candidate_identity_status": candidate_identity_status,
+        "candidate_selection_status": _CANDIDATE_SELECTION_NOT_SELECTED,
+        "winner_selection_status": _WINNER_SELECTION_NOT_SELECTED,
+        "candidate_acceptance_status": _CANDIDATE_ACCEPTANCE_NOT_ACCEPTED,
+        "config_patch_acceptance_status": _CONFIG_PATCH_ACCEPTANCE_NOT_ACCEPTED,
+        "promotion_candidate_constructed": False,
+        "operational_filter_executed": False,
+        "promotion_policy_executed": False,
+        "configpatch_created": False,
+        "configpatch_modified": False,
+        "configpatch_applied": False,
+        "experiment_identity_ref": str(step2.get("experiment_identity_ref", "")),
+        "experiment_identity_digest": str(step2.get("experiment_identity_digest", "")),
+        "experiment_identity_id": str(step2.get("experiment_identity_id", "")),
+        "dataset_identity_ref": str(step2.get("dataset_identity_ref", "")),
+        "dataset_identity_digest": str(step2.get("dataset_identity_digest", "")),
+        "comparison_identity_ref": str(step2.get("comparison_identity_ref", "")),
+        "comparison_identity_digest": str(step2.get("comparison_identity_digest", "")),
+        "comparison_definition_id": str(step2.get("comparison_definition_id", "")),
+        "comparison_completion_ref": str(step2.get("comparison_completion_ref", "")),
+        "comparison_completion_digest": str(step2.get("comparison_completion_digest", "")),
+        "research_validity_ref": str(step2.get("research_validity_ref", "")),
+        "research_validity_digest": str(step2.get("research_validity_digest", "")),
+        "comparison_checkpoint_ref": str(step2.get("comparison_checkpoint_ref", "")),
+        "comparison_checkpoint_digest": str(step2.get("comparison_checkpoint_digest", "")),
+        "model_identity_status": model_identity_status,
+        "parameter_set_identity_status": parameter_set_identity_status,
+        "config_patch_manifest_identity_status": config_patch_manifest_identity_status,
+        "eligibility_evidence_status": eligibility_evidence_status,
+        "cross_domain_lineage_status": cross_domain_lineage_status,
+        "config_patch_manifest_ref": str(step2.get("config_patch_manifest_ref", "")),
+        "config_patch_manifest_digest": str(step2.get("config_patch_manifest_digest", "")),
+        "config_patch_manifest_id": str(step2.get("config_patch_manifest_id", "")),
+        "config_patch_contract_name": str(step2.get("config_patch_contract_name", "")),
+        "config_patch_contract_version": str(step2.get("config_patch_contract_version", "")),
+        "model_parameter_identity_binding_bundle_ref": str(
+            step2.get("model_parameter_identity_binding_bundle_ref", "")
+        ),
+        "model_parameter_identity_binding_digest": str(
+            step2.get("model_parameter_identity_binding_digest", "")
+        ),
+        "input_artifact_refs": input_refs,
+        "parent_artifact_refs": parent_artifact_refs,
+        "input_digest": "",
+        "output_digest": "",
+        "manifest_digest": "",
+    }
+
+    for field in (
+        "model_identity_ref",
+        "model_identity_digest",
+        "parameter_set_identity_ref",
+        "parameter_set_identity_digest",
+        "candidate_lineage_manifest_id",
+        "candidate_lineage_digest",
+        "config_patch_lineage_manifest_ref",
+    ):
+        value = step2.get(field)
+        if value is not None:
+            payload[field] = str(value)
+
+    if transitive is not None:
+        payload["eligibility_evidence_ref"] = transitive.eligibility_evidence_ref
+        payload["eligibility_evidence_digest"] = transitive.eligibility_evidence_digest
+        payload["promotion_input_binding_ref"] = transitive.promotion_input_binding_ref
+        payload["promotion_input_binding_digest"] = transitive.promotion_input_binding_digest
+
+    metric_ref = step2.get("comparison_metric_input_ref")
+    metric_digest = step2.get("comparison_metric_input_digest")
+    if metric_ref is not None:
+        payload["comparison_metric_input_ref"] = str(metric_ref)
+    if metric_digest is not None:
+        payload["comparison_metric_input_digest"] = str(metric_digest)
+
+    _reject_forbidden_index_keys(payload)
+    _validate_non_authorizing_flags(payload)
+    _validate_capabilities(payload["capabilities"])
+
+    payload["input_digest"] = compute_content_sha256({"input_artifact_refs": input_refs})
+    output_digest = _compute_output_digest(payload)
+    payload["output_digest"] = output_digest
+    payload["artifact_id"] = output_digest
+    return payload
+
+
+def serialize_comparison_promotion_candidate_input_v1(evidence: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(evidence)
+    _validate_non_authorizing_flags(evidence)
+    _validate_capabilities(evidence.get("capabilities"))
+    candidate_input_status = evidence.get("candidate_input_status")
+    if candidate_input_status not in _VALID_CANDIDATE_INPUT_STATUS:
+        raise ComparisonPromotionCandidateInputError(
+            f"candidate_input_status must be one of {sorted(_VALID_CANDIDATE_INPUT_STATUS)}"
+        )
+    reason_codes = evidence.get("candidate_input_reason_codes")
+    if isinstance(reason_codes, list) and reason_codes != sorted(reason_codes):
+        raise ComparisonPromotionCandidateInputError(
+            "candidate_input_reason_codes must be sorted deterministically"
+        )
+    return deterministic_json_dumps(evidence)
+
+
+def _evidence_bytes_for_manifest_digest(evidence: Mapping[str, Any]) -> bytes:
+    body = {
+        key: value for key, value in evidence.items() if key not in {"integrity", "manifest_digest"}
+    }
+    return serialize_comparison_promotion_candidate_input_v1(body).encode("utf-8")
+
+
+def _compute_output_manifest_digest(evidence: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_evidence_bytes_for_manifest_digest(evidence)).hexdigest()
+
+
+def _validate_evidence_integrity(evidence: Mapping[str, Any]) -> None:
+    if evidence.get("contract_name") != CONTRACT_NAME:
+        raise ComparisonPromotionCandidateInputError("contract_name mismatch")
+    if evidence.get("contract_version") != CONTRACT_VERSION:
+        raise ComparisonPromotionCandidateInputError("contract_version mismatch")
+    integrity = evidence.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise ComparisonPromotionCandidateInputError("integrity must be an object")
+    expected = compute_content_sha256(_integrity_body(evidence))
+    actual = integrity.get("content_sha256")
+    if actual != expected:
+        raise ComparisonPromotionCandidateInputError("integrity.content_sha256 mismatch")
+    output_digest = evidence.get("output_digest")
+    if output_digest != _compute_output_digest(evidence):
+        raise ComparisonPromotionCandidateInputError("output_digest mismatch")
+    if evidence.get("artifact_id") != output_digest:
+        raise ComparisonPromotionCandidateInputError("artifact_id must equal output_digest")
+
+
+def build_self_verification_v1(
+    *,
+    evidence: Mapping[str, Any],
+    cross_domain_binding: VerifiedCrossDomainLineageBindingBundle,
+    manifest_digest: str,
+) -> dict[str, Any]:
+    checks: list[dict[str, str]] = [
+        {"check_id": "contract_name", "status": "PASS"},
+        {"check_id": "contract_version", "status": "PASS"},
+        {"check_id": "evidence_level_level_3", "status": "PASS"},
+        {"check_id": "exactly_one_direct_input", "status": "PASS"},
+        {"check_id": "upstream_contract_and_version", "status": "PASS"},
+        {"check_id": "cross_domain_binding_manifest_verified", "status": "PASS"},
+        {"check_id": "cross_domain_binding_self_verification_pass", "status": "PASS"},
+        {"check_id": "candidate_identity_bound_on_pass", "status": "PASS"},
+        {"check_id": "model_identity_bound_on_pass", "status": "PASS"},
+        {"check_id": "parameter_set_identity_bound_on_pass", "status": "PASS"},
+        {"check_id": "config_patch_manifest_identity_bound_on_pass", "status": "PASS"},
+        {"check_id": "eligibility_evidence_verified_on_pass", "status": "PASS"},
+        {"check_id": "cross_domain_lineage_bound_on_pass", "status": "PASS"},
+        {"check_id": "no_candidate_selection", "status": "PASS"},
+        {"check_id": "no_winner_selection", "status": "PASS"},
+        {"check_id": "no_candidate_acceptance", "status": "PASS"},
+        {"check_id": "no_configpatch_acceptance", "status": "PASS"},
+        {"check_id": "no_configpatch_creation", "status": "PASS"},
+        {"check_id": "no_configpatch_mutation", "status": "PASS"},
+        {"check_id": "no_configpatch_application", "status": "PASS"},
+        {"check_id": "no_promotion_candidate_construction", "status": "PASS"},
+        {"check_id": "non_authorizing_semantics", "status": "PASS"},
+        {"check_id": "forbidden_capabilities_absent", "status": "PASS"},
+        {"check_id": "output_digest", "status": "PASS"},
+        {"check_id": "manifest_verification", "status": "PASS"},
+        {"check_id": "deterministic_reverification", "status": "PASS"},
+    ]
+
+    input_refs = evidence.get("input_artifact_refs")
+    if not isinstance(input_refs, list) or len(input_refs) != 1:
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "exactly_one_direct_input" else c
+            for c in checks
+        ]
+
+    if evidence.get("manifest_digest") != manifest_digest:
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "manifest_verification" else c
+            for c in checks
+        ]
+
+    input_status = evidence.get("candidate_input_status")
+    if input_status == "PASS":
+        for check_id, field in (
+            ("candidate_identity_bound_on_pass", "candidate_identity_status"),
+            ("model_identity_bound_on_pass", "model_identity_status"),
+            ("parameter_set_identity_bound_on_pass", "parameter_set_identity_status"),
+            (
+                "config_patch_manifest_identity_bound_on_pass",
+                "config_patch_manifest_identity_status",
+            ),
+            ("eligibility_evidence_verified_on_pass", "eligibility_evidence_status"),
+            ("cross_domain_lineage_bound_on_pass", "cross_domain_lineage_status"),
+        ):
+            expected = (
+                _ELIGIBILITY_VERIFIED if field == "eligibility_evidence_status" else _IDENTITY_BOUND
+            )
+            if evidence.get(field) != expected:
+                checks = [
+                    {**c, "status": "FAIL"} if c["check_id"] == check_id else c for c in checks
+                ]
+
+    structural_failures = [
+        check
+        for check in checks
+        if check["status"] != "PASS"
+        and check["check_id"]
+        not in {
+            "candidate_identity_bound_on_pass",
+            "model_identity_bound_on_pass",
+            "parameter_set_identity_bound_on_pass",
+            "config_patch_manifest_identity_bound_on_pass",
+            "eligibility_evidence_verified_on_pass",
+            "cross_domain_lineage_bound_on_pass",
+        }
+    ]
+    if structural_failures:
+        raise ComparisonPromotionCandidateInputError("self-verification checks failed")
+
+    payload: dict[str, Any] = {
+        "self_verification_schema_version": _SELF_VERIFICATION_SCHEMA_VERSION,
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "overall_status": "PASS",
+        "checks": checks,
+        "verified_artifact_rel": ARTIFACT_REL,
+        "verified_output_digest": evidence.get("output_digest"),
+        "verified_manifest_digest": manifest_digest,
+        "verified_cross_domain_lineage_binding_bundle_ref": cross_domain_binding.bundle_dir.as_posix(),
+        "verified_candidate_input_status": input_status,
+    }
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def _finalize_evidence_with_manifest_digest(
+    evidence: Mapping[str, Any], *, manifest_digest: str
+) -> dict[str, Any]:
+    body = dict(evidence)
+    body["manifest_digest"] = manifest_digest
+    body["output_digest"] = _compute_output_digest(body)
+    body["artifact_id"] = body["output_digest"]
+    body["integrity"] = {"content_sha256": compute_content_sha256(_integrity_body(body))}
+    return body
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{uuid.uuid4().hex}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def verify_binding_inputs(
+    inputs: ComparisonPromotionCandidateInputInputs,
+) -> VerifiedCrossDomainLineageBindingBundle:
+    """Verify exactly one Step-2 cross-domain lineage binding bundle."""
+    return verify_cross_domain_lineage_binding_bundle(
+        inputs.cross_domain_lineage_binding_bundle_dir
+    )
+
+
+def reverify_comparison_promotion_candidate_input_v1(*, output_dir: Path | str) -> None:
+    """Replay candidate input bundle without producer or upstream mutation."""
+    bundle_dir = Path(output_dir)
+    if not bundle_dir.is_dir():
+        raise ComparisonPromotionCandidateInputError(
+            f"candidate input directory not found: {bundle_dir}"
+        )
+    ok, msg = verify_manifest_sha256(bundle_dir)
+    if not ok:
+        raise ComparisonPromotionCandidateInputError(f"MANIFEST.sha256 verification failed: {msg}")
+
+    evidence_path = bundle_dir / ARTIFACT_REL
+    _validate_regular_file(evidence_path, label=ARTIFACT_REL)
+    evidence = read_manifest(evidence_path)
+    _validate_evidence_integrity(evidence)
+
+    self_path = bundle_dir / SELF_VERIFICATION_REL
+    _validate_regular_file(self_path, label=SELF_VERIFICATION_REL)
+    self_payload = read_manifest(self_path)
+    if self_payload.get("overall_status") != "PASS":
+        raise ComparisonPromotionCandidateInputError(
+            "SELF_VERIFICATION overall_status must be PASS"
+        )
+
+    manifest_digest = _compute_output_manifest_digest(evidence)
+    if evidence.get("manifest_digest") != manifest_digest:
+        raise ComparisonPromotionCandidateInputError("manifest_digest mismatch on replay")
+
+    cross_domain_binding = verify_cross_domain_lineage_binding_bundle(
+        Path(str(evidence["cross_domain_lineage_binding_bundle_ref"]))
+    )
+    if evidence.get("cross_domain_lineage_binding_digest") != cross_domain_binding.artifact_digest:
+        raise ComparisonPromotionCandidateInputError(
+            "cross_domain_lineage_binding_digest mismatch on replay"
+        )
+
+
+def produce_comparison_promotion_candidate_input_v1(
+    *,
+    inputs: ComparisonPromotionCandidateInputInputs,
+    output_dir: Path | str,
+) -> ComparisonPromotionCandidateInputResult:
+    """Produce offline LEVEL_3 neutral comparison promotion candidate input evidence."""
+    final_dir = Path(output_dir)
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        cross_domain_binding_dir=inputs.cross_domain_lineage_binding_bundle_dir,
+        output_dir=final_dir,
+    )
+
+    cross_domain_binding = verify_binding_inputs(inputs)
+    try:
+        reverify_comparison_config_patch_manifest_cross_domain_lineage_binding_v1(
+            output_dir=cross_domain_binding.bundle_dir
+        )
+    except ComparisonConfigPatchManifestCrossDomainLineageBindingError as exc:
+        raise ComparisonPromotionCandidateInputError(str(exc)) from exc
+
+    evidence_body = build_comparison_promotion_candidate_input_v1(
+        cross_domain_binding=cross_domain_binding,
+    )
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise ComparisonPromotionCandidateInputError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        evidence_path = staging / ARTIFACT_REL
+        self_path = staging / SELF_VERIFICATION_REL
+
+        manifest_digest = _compute_output_manifest_digest(evidence_body)
+        finalized = _finalize_evidence_with_manifest_digest(
+            evidence_body, manifest_digest=manifest_digest
+        )
+        evidence_path.write_text(
+            serialize_comparison_promotion_candidate_input_v1(finalized),
+            encoding="utf-8",
+        )
+        self_payload = build_self_verification_v1(
+            evidence=finalized,
+            cross_domain_binding=cross_domain_binding,
+            manifest_digest=manifest_digest,
+        )
+        self_path.write_text(deterministic_json_dumps(self_payload), encoding="utf-8")
+        write_manifest_sha256(staging)
+
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise ComparisonPromotionCandidateInputError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        reverify_comparison_promotion_candidate_input_v1(output_dir=staging)
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise ComparisonPromotionCandidateInputError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return ComparisonPromotionCandidateInputResult(
+        output_dir=final_dir,
+        comparison_definition_id=str(finalized.get("comparison_definition_id", "")),
+        artifact_id=str(finalized["artifact_id"]),
+        evidence_path=final_dir / ARTIFACT_REL,
+        self_verification_path=final_dir / SELF_VERIFICATION_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+        candidate_input_status=str(finalized["candidate_input_status"]),
+        candidate_identity_ref=str(finalized["candidate_identity_ref"]),
+        config_patch_manifest_id=str(finalized["config_patch_manifest_id"]),
+    )
+
+
+__all__ = [
+    "ARTIFACT_REL",
+    "AUTHORITY_LEVEL",
+    "CANDIDATE_INPUT_AUTHORITY_INVARIANTS",
+    "CONTRACT_NAME",
+    "CONTRACT_VERSION",
+    "EVIDENCE_LEVEL",
+    "MANIFEST_FILENAME",
+    "PRODUCER_VERSION",
+    "SELF_VERIFICATION_REL",
+    "ComparisonPromotionCandidateInputError",
+    "ComparisonPromotionCandidateInputInputs",
+    "ComparisonPromotionCandidateInputResult",
+    "ResolvedTransitiveLineage",
+    "VerifiedCrossDomainLineageBindingBundle",
+    "build_comparison_promotion_candidate_input_v1",
+    "build_self_verification_v1",
+    "produce_comparison_promotion_candidate_input_v1",
+    "reverify_comparison_promotion_candidate_input_v1",
+    "serialize_comparison_promotion_candidate_input_v1",
+    "verify_binding_inputs",
+    "verify_cross_domain_lineage_binding_bundle",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -6562,3 +6562,61 @@ def test_selector_package_cmp_config_patch_manifest_cross_domain_lineage_binding
     for path in PACKAGE_CMP_CONFIG_PATCH_MANIFEST_CROSS_DOMAIN_LINEAGE_BINDING_V1_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_PRODUCTION = (
+    "src/meta/learning_loop/comparison_promotion_candidate_input_v1.py"
+)
+PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_SCRIPT = (
+    "scripts/run_comparison_promotion_candidate_input_v1.py"
+)
+PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_TESTOWNER = (
+    "tests/meta/test_comparison_promotion_candidate_input_v1.py"
+)
+PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_CLI_TESTOWNER = (
+    "tests/scripts/test_run_comparison_promotion_candidate_input_v1.py"
+)
+PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_DEPENDENCY_TESTOWNERS = (
+    "tests/meta/test_comparison_config_patch_manifest_cross_domain_lineage_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_model_parameter_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_eligibility_evidence_v1.py",
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_ALL_PRODUCTION = (
+    PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_PRODUCTION,
+    PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_SCRIPT,
+)
+PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_ALL_TESTOWNERS = (
+    PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_TESTOWNER,
+    PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_CLI_TESTOWNER,
+    *PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_DEPENDENCY_TESTOWNERS,
+)
+
+
+def test_selector_package_cmp_promotion_candidate_input_v1_production_pr_bounded_full_includes_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_cmp_promotion_candidate_input_v1_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        *PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_ALL_PRODUCTION,
+        "scripts/ops/ci_test_selection_v1.py",
+        *PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_ALL_TESTOWNERS,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_CMP_PROMOTION_CANDIDATE_INPUT_V1_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/meta/comparison_promotion_candidate_input_v1_fixtures.py
+++ b/tests/meta/comparison_promotion_candidate_input_v1_fixtures.py
@@ -1,0 +1,56 @@
+"""Fixtures for comparison_promotion_candidate_input_v1 tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.meta.learning_loop.comparison_promotion_candidate_input_v1 import (
+    ComparisonPromotionCandidateInputInputs,
+    produce_comparison_promotion_candidate_input_v1,
+)
+from tests.meta.comparison_config_patch_manifest_cross_domain_lineage_binding_v1_fixtures import (
+    produce_cross_domain_lineage_binding_fixture,
+)
+
+
+@dataclass(frozen=True)
+class CandidateInputFixtureBundle:
+    cross_domain_lineage_binding_bundle_dir: Path
+    candidate_input_bundle_dir: Path | None = None
+
+
+def produce_candidate_input_fixture(
+    tmp_path: Path,
+    durable_root: Path,
+    *,
+    all_domains_pass: bool = True,
+    use_candidate_lineage: bool = True,
+    cross_domain_binding_name: str = "cross_domain_lineage_binding",
+    candidate_input_name: str = "candidate_input",
+    produce_output: bool = True,
+) -> CandidateInputFixtureBundle:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(
+        tmp_path,
+        durable_root,
+        all_domains_pass=all_domains_pass,
+        use_candidate_lineage=use_candidate_lineage,
+        cross_domain_binding_name=cross_domain_binding_name,
+        produce_output=True,
+    )
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    candidate_input_dir: Path | None = None
+    if produce_output:
+        candidate_input_dir = durable_root / candidate_input_name
+        produce_comparison_promotion_candidate_input_v1(
+            inputs=ComparisonPromotionCandidateInputInputs(
+                cross_domain_lineage_binding_bundle_dir=(
+                    cross_domain.cross_domain_binding_bundle_dir
+                ),
+            ),
+            output_dir=candidate_input_dir,
+        )
+    return CandidateInputFixtureBundle(
+        cross_domain_lineage_binding_bundle_dir=cross_domain.cross_domain_binding_bundle_dir,
+        candidate_input_bundle_dir=candidate_input_dir,
+    )

--- a/tests/meta/test_comparison_promotion_candidate_input_v1.py
+++ b/tests/meta/test_comparison_promotion_candidate_input_v1.py
@@ -1,0 +1,596 @@
+"""Contract tests for comparison promotion candidate input v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = [
+    "tests.meta.comparison_ssot_v1_fixtures",
+    "tests.meta.comparison_completion_research_validity_binding_v1_fixtures",
+    "tests.meta.comparison_completion_promotion_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_identity_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_eligibility_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_model_parameter_identity_binding_v1_fixtures",
+    "tests.meta.comparison_config_patch_manifest_cross_domain_lineage_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_input_v1_fixtures",
+]
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.meta.learning_loop.comparison_config_patch_manifest_cross_domain_lineage_binding_v1 import (
+    ARTIFACT_REL as STEP2_ARTIFACT_REL,
+)
+from src.meta.learning_loop.comparison_promotion_candidate_input_v1 import (
+    ARTIFACT_REL,
+    AUTHORITY_LEVEL,
+    CANDIDATE_INPUT_AUTHORITY_INVARIANTS,
+    CONTRACT_NAME,
+    CONTRACT_VERSION,
+    EVIDENCE_LEVEL,
+    MANIFEST_FILENAME,
+    PRODUCER_VERSION,
+    SELF_VERIFICATION_REL,
+    ComparisonPromotionCandidateInputError,
+    ComparisonPromotionCandidateInputInputs,
+    VerifiedCrossDomainLineageBindingBundle,
+    build_comparison_promotion_candidate_input_v1,
+    produce_comparison_promotion_candidate_input_v1,
+    reverify_comparison_promotion_candidate_input_v1,
+    serialize_comparison_promotion_candidate_input_v1,
+    verify_binding_inputs,
+    verify_cross_domain_lineage_binding_bundle,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+from tests.meta.comparison_config_patch_manifest_cross_domain_lineage_binding_v1_fixtures import (
+    produce_cross_domain_lineage_binding_fixture,
+)
+from tests.meta.comparison_promotion_candidate_input_v1_fixtures import (
+    produce_candidate_input_fixture,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = (
+        "src.meta.learning_loop.comparison_promotion_candidate_input_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_config_patch_manifest_cross_domain_lineage_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_model_parameter_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_eligibility_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_promotion_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_research_validity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.research_validity_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_checkpoint_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_common_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_metric_input_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_definition_durable_evidence_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_ssot_result_durable_evidence_binding_v1.is_under_tmp",
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
+    )
+    for target in targets:
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "candidate_input_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _inputs(step2_dir: Path) -> ComparisonPromotionCandidateInputInputs:
+    return ComparisonPromotionCandidateInputInputs(
+        cross_domain_lineage_binding_bundle_dir=step2_dir,
+    )
+
+
+def test_contract_constants() -> None:
+    assert CONTRACT_NAME == "comparison_promotion_candidate_input_v1"
+    assert CONTRACT_VERSION == "v1"
+    assert EVIDENCE_LEVEL == "LEVEL_3"
+    assert AUTHORITY_LEVEL == "NON_AUTHORITIZING_EVIDENCE_ONLY"
+    assert ARTIFACT_REL == "comparison_promotion_candidate_input_v1.json"
+
+
+def test_happy_path_pass(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    assert fixture.candidate_input_bundle_dir is not None
+    payload = read_manifest(fixture.candidate_input_bundle_dir / ARTIFACT_REL)
+    assert payload["candidate_input_status"] == "PASS"
+    assert payload["candidate_identity_status"] == "BOUND"
+    assert payload["model_identity_status"] == "BOUND"
+    assert payload["parameter_set_identity_status"] == "BOUND"
+    assert payload["config_patch_manifest_identity_status"] == "BOUND"
+    assert payload["eligibility_evidence_status"] == "VERIFIED"
+    assert payload["cross_domain_lineage_status"] == "BOUND"
+    assert payload["candidate_selection_status"] == "NOT_SELECTED"
+    assert payload["winner_selection_status"] == "NOT_SELECTED"
+    assert payload["candidate_acceptance_status"] == "NOT_ACCEPTED"
+    assert payload["config_patch_acceptance_status"] == "NOT_ACCEPTED"
+    assert payload["promotion_candidate_constructed"] is False
+    assert payload["configpatch_created"] is False
+    assert payload["configpatch_modified"] is False
+    assert payload["configpatch_applied"] is False
+    assert (
+        "COMPARISON_PROMOTION_CANDIDATE_INPUT_COMPLETE" in payload["candidate_input_reason_codes"]
+    )
+
+
+def test_required_non_authorizing_flags(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.candidate_input_bundle_dir / ARTIFACT_REL)
+    assert payload["candidate_input_does_not_select"] is True
+    assert payload["candidate_input_does_not_accept_configpatch"] is True
+    assert payload["candidate_input_does_not_create_configpatch"] is True
+    assert payload["candidate_input_does_not_construct_promotion_candidate"] is True
+    assert payload["candidate_input_does_not_execute_policy"] is True
+    assert payload["candidate_input_authority_invariants"] == CANDIDATE_INPUT_AUTHORITY_INVARIANTS
+
+
+def test_determinism(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    out_a = _durable_output(tmp_path, "a")
+    out_b = _durable_output(tmp_path, "b")
+    inputs = _inputs(cross_domain.cross_domain_binding_bundle_dir)
+    produce_comparison_promotion_candidate_input_v1(inputs=inputs, output_dir=out_a)
+    produce_comparison_promotion_candidate_input_v1(inputs=inputs, output_dir=out_b)
+    assert (out_a / ARTIFACT_REL).read_text() == (out_b / ARTIFACT_REL).read_text()
+
+
+def test_self_verification_and_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.candidate_input_bundle_dir
+    assert out is not None
+    ok, msg = verify_manifest_sha256(out)
+    assert ok, msg
+    self_payload = read_manifest(out / SELF_VERIFICATION_REL)
+    assert self_payload["overall_status"] == "PASS"
+    reverify_comparison_promotion_candidate_input_v1(output_dir=out)
+
+
+def test_missing_step2_bundle(tmp_path) -> None:
+    with pytest.raises(ComparisonPromotionCandidateInputError):
+        verify_cross_domain_lineage_binding_bundle(tmp_path / "missing")
+
+
+def test_invalid_step2_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2_dir = cross_domain.cross_domain_binding_bundle_dir
+    (step2_dir / "MANIFEST.sha256").write_text("invalid", encoding="utf-8")
+    with pytest.raises(ComparisonPromotionCandidateInputError):
+        verify_cross_domain_lineage_binding_bundle(step2_dir)
+
+
+def test_step2_self_verification_manipulation(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2_dir = cross_domain.cross_domain_binding_bundle_dir
+    self_path = step2_dir / "SELF_VERIFICATION.json"
+    payload = read_manifest(self_path)
+    payload["overall_status"] = "FAIL"
+    self_path.write_text(deterministic_json_dumps(payload), encoding="utf-8")
+    with pytest.raises(ComparisonPromotionCandidateInputError):
+        verify_cross_domain_lineage_binding_bundle(step2_dir)
+
+
+def test_candidate_digest_manipulation_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["candidate_identity_digest"] = "0" * 64
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "CANDIDATE_DIGEST_MISMATCH" in payload["candidate_input_reason_codes"]
+
+
+def test_model_digest_manipulation_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["model_identity_digest"] = "0" * 64
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "MODEL_DIGEST_MISMATCH" in payload["candidate_input_reason_codes"]
+
+
+def test_parameter_set_digest_manipulation_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["parameter_set_identity_digest"] = "0" * 64
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "PARAMETER_SET_DIGEST_MISMATCH" in payload["candidate_input_reason_codes"]
+
+
+def test_config_patch_manifest_digest_manipulation_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["config_patch_manifest_digest"] = "0" * 64
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "CONFIG_PATCH_MANIFEST_DIGEST_MISMATCH" in payload["candidate_input_reason_codes"]
+
+
+def test_upstream_incomplete_propagation(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(
+        tmp_path,
+        ssot_durable_output_dir,
+        all_domains_pass=False,
+    )
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=step2)
+    assert payload["candidate_input_status"] in {"INCOMPLETE", "FAIL", "NOT_EVALUABLE"}
+
+
+def test_upstream_fail_propagation(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["cross_domain_lineage_binding_status"] = "FAIL"
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "UPSTREAM_CROSS_DOMAIN_LINEAGE_FAIL" in payload["candidate_input_reason_codes"]
+
+
+def test_candidate_selection_detected_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["candidate_selection_status"] = "SELECTED"
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "CANDIDATE_SELECTION_DETECTED" in payload["candidate_input_reason_codes"]
+
+
+def test_winner_selection_detected_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["winner_selection_status"] = "WINNER"
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "WINNER_SELECTION_DETECTED" in payload["candidate_input_reason_codes"]
+
+
+def test_candidate_acceptance_detected_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["candidate_acceptance_status"] = "ACCEPTED"
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "CANDIDATE_ACCEPTANCE_DETECTED" in payload["candidate_input_reason_codes"]
+
+
+def test_configpatch_acceptance_detected_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["configpatch_accepted"] = True
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "CONFIG_PATCH_ACCEPTANCE_DETECTED" in payload["candidate_input_reason_codes"]
+
+
+def test_configpatch_creation_detected_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["configpatch_created"] = True
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "CONFIGPATCH_CREATION_DETECTED" in payload["candidate_input_reason_codes"]
+
+
+def test_configpatch_mutation_detected_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["configpatch_modified"] = True
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "CONFIGPATCH_MUTATION_DETECTED" in payload["candidate_input_reason_codes"]
+
+
+def test_configpatch_application_detected_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["configpatch_applied"] = True
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "CONFIGPATCH_APPLICATION_DETECTED" in payload["candidate_input_reason_codes"]
+
+
+def test_promotion_candidate_construction_detected_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+    tampered = dict(step2.evidence_payload)
+    tampered["promotion_candidate_constructed"] = True
+    tampered_bundle = VerifiedCrossDomainLineageBindingBundle(
+        bundle_dir=step2.bundle_dir,
+        contract_name=step2.contract_name,
+        contract_version=step2.contract_version,
+        producer_version=step2.producer_version,
+        artifact_ref=step2.artifact_ref,
+        artifact_digest=step2.artifact_digest,
+        manifest_digest=step2.manifest_digest,
+        evidence_payload=tampered,
+    )
+    payload = build_comparison_promotion_candidate_input_v1(cross_domain_binding=tampered_bundle)
+    assert payload["candidate_input_status"] == "FAIL"
+    assert "PROMOTION_CANDIDATE_CONSTRUCTION_DETECTED" in payload["candidate_input_reason_codes"]
+
+
+def test_contract_version_mismatch_on_verify(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    artifact_path = cross_domain.cross_domain_binding_bundle_dir / STEP2_ARTIFACT_REL
+    payload = read_manifest(artifact_path)
+    payload["contract_version"] = "v99"
+    artifact_path.write_text(deterministic_json_dumps(payload), encoding="utf-8")
+    with pytest.raises(ComparisonPromotionCandidateInputError):
+        verify_cross_domain_lineage_binding_bundle(cross_domain.cross_domain_binding_bundle_dir)
+
+
+def test_input_artifact_refs_exactly_one(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.candidate_input_bundle_dir / ARTIFACT_REL)
+    assert len(payload["input_artifact_refs"]) == 1
+
+
+def test_reason_codes_sorted(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.candidate_input_bundle_dir / ARTIFACT_REL)
+    codes = payload["candidate_input_reason_codes"]
+    assert codes == sorted(codes)
+
+
+def test_output_existing_dir_fail(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    out = _durable_output(tmp_path)
+    out.mkdir()
+    with pytest.raises(ComparisonPromotionCandidateInputError):
+        produce_comparison_promotion_candidate_input_v1(
+            inputs=_inputs(cross_domain.cross_domain_binding_bundle_dir),
+            output_dir=out,
+        )
+
+
+def test_reverify_after_tamper(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.candidate_input_bundle_dir
+    assert out is not None
+    artifact = read_manifest(out / ARTIFACT_REL)
+    artifact["candidate_identity_ref"] = "tampered"
+    (out / ARTIFACT_REL).write_text(deterministic_json_dumps(artifact), encoding="utf-8")
+    with pytest.raises(ComparisonPromotionCandidateInputError):
+        reverify_comparison_promotion_candidate_input_v1(output_dir=out)
+
+
+def test_no_forbidden_runtime_imports() -> None:
+    module_path = Path("src/meta/learning_loop/comparison_promotion_candidate_input_v1.py")
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    forbidden = {
+        "build_promotion_candidates_from_patches",
+        "filter_candidates_for_live",
+        "PromotionCandidate",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                assert alias.name not in forbidden
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in forbidden
+
+
+def test_step2_regression_still_passes(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    payload = read_manifest(cross_domain.cross_domain_binding_bundle_dir / STEP2_ARTIFACT_REL)
+    assert payload["cross_domain_lineage_binding_status"] == "PASS"
+
+
+def test_step1_regression_still_passes(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    step2 = read_manifest(cross_domain.cross_domain_binding_bundle_dir / STEP2_ARTIFACT_REL)
+    step1_path = Path(str(step2["model_parameter_identity_binding_bundle_ref"])) / (
+        "comparison_promotion_candidate_model_parameter_identity_binding_v1.json"
+    )
+    step1 = read_manifest(step1_path)
+    assert step1["model_parameter_identity_binding_status"] == "PASS"
+
+
+def test_eligibility_regression_refs_present(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.candidate_input_bundle_dir / ARTIFACT_REL)
+    assert payload["eligibility_evidence_ref"]
+    assert payload["eligibility_evidence_digest"]
+    assert payload["promotion_input_binding_ref"]
+    assert payload["promotion_input_binding_digest"]
+
+
+def test_verify_binding_inputs(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    bundle = verify_binding_inputs(_inputs(cross_domain.cross_domain_binding_bundle_dir))
+    assert isinstance(bundle, VerifiedCrossDomainLineageBindingBundle)
+
+
+def test_serialization_forbidden_key(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.candidate_input_bundle_dir / ARTIFACT_REL)
+    payload["promotion"] = True
+    with pytest.raises(ComparisonPromotionCandidateInputError):
+        serialize_comparison_promotion_candidate_input_v1(payload)
+
+
+def test_copy_inputs_no_mutation(tmp_path, ssot_durable_output_dir) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    before = (cross_domain.cross_domain_binding_bundle_dir / STEP2_ARTIFACT_REL).read_bytes()
+    out = _durable_output(tmp_path)
+    produce_comparison_promotion_candidate_input_v1(
+        inputs=_inputs(cross_domain.cross_domain_binding_bundle_dir),
+        output_dir=out,
+    )
+    assert (
+        cross_domain.cross_domain_binding_bundle_dir / STEP2_ARTIFACT_REL
+    ).read_bytes() == before
+
+
+def test_producer_version_constant() -> None:
+    assert PRODUCER_VERSION == "comparison_promotion_candidate_input_v1"
+
+
+def test_manifest_files_present(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_candidate_input_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.candidate_input_bundle_dir
+    assert out is not None
+    assert (out / ARTIFACT_REL).is_file()
+    assert (out / SELF_VERIFICATION_REL).is_file()
+    assert (out / MANIFEST_FILENAME).is_file()

--- a/tests/scripts/test_run_comparison_promotion_candidate_input_v1.py
+++ b/tests/scripts/test_run_comparison_promotion_candidate_input_v1.py
@@ -1,0 +1,99 @@
+"""CLI tests for run_comparison_promotion_candidate_input_v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = [
+    "tests.meta.comparison_ssot_v1_fixtures",
+    "tests.meta.comparison_completion_research_validity_binding_v1_fixtures",
+    "tests.meta.comparison_completion_promotion_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_identity_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_eligibility_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_model_parameter_identity_binding_v1_fixtures",
+    "tests.meta.comparison_config_patch_manifest_cross_domain_lineage_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_input_v1_fixtures",
+]
+
+from scripts.run_comparison_promotion_candidate_input_v1 import (
+    EXIT_EVIDENCE_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.meta.learning_loop.comparison_promotion_candidate_input_v1 import ARTIFACT_REL
+from tests.meta.comparison_config_patch_manifest_cross_domain_lineage_binding_v1_fixtures import (
+    produce_cross_domain_lineage_binding_fixture,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = (
+        "src.meta.learning_loop.comparison_promotion_candidate_input_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_config_patch_manifest_cross_domain_lineage_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_model_parameter_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_eligibility_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_promotion_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_research_validity_binding_v1.is_under_tmp",
+    )
+    for target in targets:
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "cli_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def test_cli_happy_path(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--cross-domain-lineage-binding-bundle-dir",
+            str(cross_domain.cross_domain_binding_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    captured = capsys.readouterr()
+    assert "OK" in captured.out
+    assert (out / ARTIFACT_REL).is_file()
+
+
+def test_cli_missing_step2(tmp_path, capsys) -> None:
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--cross-domain-lineage-binding-bundle-dir",
+            str(tmp_path / "missing"),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+    assert "ERROR" in capsys.readouterr().err
+
+
+def test_cli_evidence_error(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    cross_domain = produce_cross_domain_lineage_binding_fixture(tmp_path, ssot_durable_output_dir)
+    assert cross_domain.cross_domain_binding_bundle_dir is not None
+    out = _durable_output(tmp_path)
+    out.mkdir()
+    rc = main(
+        [
+            "--cross-domain-lineage-binding-bundle-dir",
+            str(cross_domain.cross_domain_binding_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_EVIDENCE_ERROR
+    assert "ERROR" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Step 3 of 5 des Major Gap Packages `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0`; Sequenz durch Runbook und Progress-Registry festgelegt.
- Neuer rein offline arbeitender LEVEL_3 neutraler Candidate-Input-Owner `comparison_promotion_candidate_input_v1`, der genau ein verifiziertes Step-2-Bundle (`comparison_config_patch_manifest_cross_domain_lineage_binding_v1`) als direkten Input konsumiert.
- Candidate-, Eligibility-, Model-, Parameter- und ConfigPatch-Manifest-Lineage werden digest-bound aggregiert; Output ist ausdrücklich **kein** `PromotionCandidate`.

## Non-Authority / Boundary

- Candidate bleibt `NOT_SELECTED` und `NOT_ACCEPTED`; ConfigPatch bleibt `NOT_ACCEPTED` und wird nicht angewendet.
- Kein operativer Filter, keine Promotion Policy, kein Policy-Input-Binding, keine Consumer-Mutation, keine Promotion-/Runtime-/Live-Authority.
- Steps 4 und 5 bleiben separate spätere Scopes; `SYSTEMWIDE_RANKING_REQUIRED=false`.

## Test plan

- [x] `tests/meta/test_comparison_promotion_candidate_input_v1.py`
- [x] `tests/scripts/test_run_comparison_promotion_candidate_input_v1.py`
- [x] Step-2-Regressions (`test_comparison_config_patch_manifest_cross_domain_lineage_binding_v1.py`)
- [x] Step-1-Regressions (`test_comparison_promotion_candidate_model_parameter_identity_binding_v1.py`)
- [x] Eligibility-Regressions (`test_comparison_promotion_candidate_eligibility_evidence_v1.py`)
- [x] CI-Selector-Partition-Contract-Tests
- [x] Ruff format/check auf geänderten Python-Dateien


Made with [Cursor](https://cursor.com)