### PR TITLE
feat: add handoff trust policy v1 offline slice

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -16,10 +16,10 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 | Feld | Wert |
 |---|---|
-| `LAST_VERIFIED_ORIGIN_MAIN` | `6712dd75e1771e6e4e0a3f086f1b3f223453b77c` |
-| `LAST_VERIFIED_AT` | `2026-06-29T20:00:00Z` |
+| `LAST_VERIFIED_ORIGIN_MAIN` | `e30f5a3797e50f9fabe2f81b587539bb57a5d5a3` |
+| `LAST_VERIFIED_AT` | `2026-06-29T22:00:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
-| `NEXT_CANONICAL_STEP` | `versioned_strategy_model_parameter_artifact` |
+| `NEXT_CANONICAL_STEP` | `handoff_trust_policy` |
 | `SYSTEMWIDE_RANKING_REQUIRED` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |
 
@@ -196,9 +196,12 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 |---|---|
 | `RUNBOOK_PHASE` | 5 |
 | `RUNBOOK_STEP_ID` | `versioned_strategy_model_parameter_artifact` |
-| `STATUS` | `IN_PROGRESS` |
+| `STATUS` | `COMPLETED` |
 | `CANONICAL_OWNER` | `src/meta/learning_loop/versioned_strategy_model_parameter_artifact_v1.py` |
+| `MERGED_PRS` | `#4637` |
+| `MERGE_COMMITS` | `e30f5a3797e50f9fabe2f81b587539bb57a5d5a3` |
 | `DEPENDENCIES` | RUNBOOK_STEP_06, `ai_promotion_assessment_v1` |
+| `NEXT_REQUIRED_CONTRACT` | `handoff_trust_policy` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |
@@ -207,10 +210,12 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 
 | Feld | Wert |
 |---|---|
-| `RUNBOOK_PHASE` | 6 |
+| `RUNBOOK_PHASE` | 5 |
 | `RUNBOOK_STEP_ID` | `handoff_trust_policy` |
-| `STATUS` | `NOT_STARTED` |
-| `DEPENDENCIES` | RUNBOOK_STEP_07 |
+| `STATUS` | `IN_PROGRESS` |
+| `CANONICAL_OWNER` | `src/meta/learning_loop/handoff_trust_policy_v1.py` |
+| `DEPENDENCIES` | RUNBOOK_STEP_07, `versioned_strategy_model_parameter_artifact_v1` |
+| `NEXT_REQUIRED_CONTRACT` | `authority_lease_and_revocation` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1915,6 +1915,34 @@ PR_BOUNDED_FULL_PACKAGE_VERSIONED_STRATEGY_MODEL_PARAMETER_ARTIFACT_V1_TARGETS: 
     "tests/ci/test_ci_diff_aware_test_selection_v1.py",
 )
 
+PR_BOUNDED_FULL_PACKAGE_HANDOFF_TRUST_POLICY_V1_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/handoff_trust_policy_v1.py",
+        "scripts/run_handoff_trust_policy_v1.py",
+        "tests/meta/test_handoff_trust_policy_v1.py",
+        "tests/scripts/test_run_handoff_trust_policy_v1.py",
+        "tests/meta/handoff_trust_policy_v1_fixtures.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_HANDOFF_TRUST_POLICY_V1_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_handoff_trust_policy_v1.py",
+    "tests/scripts/test_run_handoff_trust_policy_v1.py",
+    "tests/meta/test_versioned_strategy_model_parameter_artifact_v1.py",
+    "tests/scripts/test_run_versioned_strategy_model_parameter_artifact_v1.py",
+    "tests/meta/test_ai_promotion_assessment_v1.py",
+    "tests/meta/test_comparison_promotion_policy_decision_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_model_parameter_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_eligibility_evidence_v1.py",
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS: frozenset[str] = frozenset(
     {
         "src/meta/learning_loop/comparison_metric_input_v1/__init__.py",
@@ -2205,6 +2233,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
         & PR_BOUNDED_FULL_PACKAGE_VERSIONED_STRATEGY_MODEL_PARAMETER_ARTIFACT_V1_TRIGGER_PATHS
     ):
         for path in PR_BOUNDED_FULL_PACKAGE_VERSIONED_STRATEGY_MODEL_PARAMETER_ARTIFACT_V1_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_HANDOFF_TRUST_POLICY_V1_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_HANDOFF_TRUST_POLICY_V1_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS:

--- a/scripts/run_handoff_trust_policy_v1.py
+++ b/scripts/run_handoff_trust_policy_v1.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Offline handoff trust policy v1.
+
+Consumes exactly one verified versioned_strategy_model_parameter_artifact_v1 bundle,
+producing a manifested LEVEL_3 non-authorizing trust/admissibility evaluation.
+
+Usage:
+    python3 scripts/run_handoff_trust_policy_v1.py \\
+        --versioned-artifact-bundle-dir /path/to/versioned_artifact \\
+        [--consumer-contract-ref /path/to/consumer_contract.json] \\
+        --output-dir /var/evidence/handoff_trust_policy_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.handoff_trust_policy_v1 import (
+    HandoffTrustPolicyError,
+    HandoffTrustPolicyInputs,
+    produce_handoff_trust_policy_v1,
+)
+
+EXIT_OK = 0
+EXIT_TRUST_POLICY_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline handoff trust policy v1: deterministically evaluate whether a "
+            "verified versioned strategy/model/parameter artifact could be handed off "
+            "offline without executing handoff, invoking consumers, promotion authority, "
+            "ConfigPatch mutation, or runtime authority."
+        )
+    )
+    parser.add_argument(
+        "--versioned-artifact-bundle-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to a published versioned_strategy_model_parameter_artifact_v1 bundle.",
+    )
+    parser.add_argument(
+        "--consumer-contract-ref",
+        type=Path,
+        default=None,
+        help=(
+            "Optional offline consumer capability contract file or directory. "
+            "When omitted, the embedded default consumer contract is used."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit handoff trust policy output directory (must not exist).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.versioned_artifact_bundle_dir.is_dir():
+        print(
+            "[handoff_trust_policy_v1] ERROR: versioned artifact bundle not found: "
+            f"{args.versioned_artifact_bundle_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+    if args.consumer_contract_ref is not None and not args.consumer_contract_ref.exists():
+        print(
+            "[handoff_trust_policy_v1] ERROR: consumer contract ref not found: "
+            f"{args.consumer_contract_ref}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    inputs = HandoffTrustPolicyInputs(
+        versioned_artifact_bundle_dir=args.versioned_artifact_bundle_dir,
+        consumer_contract_ref=args.consumer_contract_ref,
+    )
+
+    try:
+        result = produce_handoff_trust_policy_v1(
+            inputs=inputs,
+            output_dir=args.output_dir,
+        )
+    except HandoffTrustPolicyError as exc:
+        print(f"[handoff_trust_policy_v1] ERROR: {exc}", file=sys.stderr)
+        return EXIT_TRUST_POLICY_ERROR
+
+    print(
+        "[handoff_trust_policy_v1] OK "
+        f"comparison_definition_id={result.comparison_definition_id} "
+        f"trust_result={result.trust_result} "
+        f"compatibility_result={result.compatibility_result} "
+        f"versioned_artifact_ref={result.versioned_artifact_ref} "
+        f"artifact_id={result.artifact_id} "
+        f"output_dir={result.output_dir}"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/handoff_trust_policy_v1.py
+++ b/src/meta/learning_loop/handoff_trust_policy_v1.py
@@ -1,0 +1,1368 @@
+"""Offline LEVEL_3 handoff trust policy owner v1."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    COMPARISON_AUTHORITY_INVARIANTS,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+from src.meta.learning_loop.versioned_strategy_model_parameter_artifact_v1 import (
+    ARTIFACT_REL as UPSTREAM_ARTIFACT_REL,
+    ARTIFACT_SCHEMA_VERSION as UPSTREAM_ARTIFACT_SCHEMA_VERSION,
+    CONTRACT_NAME as UPSTREAM_CONTRACT_NAME,
+    CONTRACT_VERSION as UPSTREAM_CONTRACT_VERSION,
+    CREATION_CONTRACT_VERSION as UPSTREAM_CREATION_CONTRACT_VERSION,
+    PRODUCER_VERSION as UPSTREAM_PRODUCER_VERSION,
+    SELF_VERIFICATION_REL as UPSTREAM_SELF_VERIFICATION_REL,
+    VersionedStrategyModelParameterArtifactError,
+    reverify_versioned_strategy_model_parameter_artifact_v1,
+)
+
+CONTRACT_NAME = "handoff_trust_policy_v1"
+CONTRACT_VERSION = "v1"
+PRODUCER_VERSION = "handoff_trust_policy_v1"
+EVIDENCE_LEVEL = "LEVEL_3"
+AUTHORITY_LEVEL = "NON_AUTHORITIZING"
+RECORD_KIND = "handoff_trust_policy_record"
+INPUT_RELATION = "EVALUATES_VERIFIED_VERSIONED_STRATEGY_MODEL_PARAMETER_ARTIFACT_V1"
+ARTIFACT_REL = "handoff_trust_policy_v1.json"
+SELF_VERIFICATION_REL = "SELF_VERIFICATION.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".handoff_trust_policy_staging_"
+
+HANDOFF_TYPE = "versioned_strategy_model_parameter_artifact_v1_offline_handoff"
+DETERMINISTIC_RULE_SET_VERSION = "handoff_trust_policy_rules_v1"
+OFFLINE_DETERMINISTIC_CREATED_AT = "1970-01-01T00:00:00+00:00"
+
+CONSUMER_CONTRACT_NAME = "offline_strategy_model_parameter_consumer_capability_v1"
+CONSUMER_CONTRACT_VERSION = "v1"
+CONSUMER_CONTRACT_ID = "offline_strategy_model_parameter_consumer_capability_v1@v1"
+
+_VALID_TRUST_RESULTS = frozenset({"ALLOW_OFFLINE_HANDOFF", "DENY_HANDOFF", "ABSTAIN"})
+_VALID_COMPATIBILITY_RESULTS = frozenset({"COMPATIBLE", "INCOMPATIBLE", "UNKNOWN"})
+_VALID_REVOCATION_STATES = frozenset({"NOT_REVOKED", "REVOKED", "UNKNOWN"})
+_EVIDENCE_BOUND = "BOUND"
+_IDENTITY_BOUND = "BOUND"
+
+HANDOFF_TRUST_POLICY_AUTHORITY_INVARIANTS: dict[str, bool] = {
+    **COMPARISON_AUTHORITY_INVARIANTS,
+    "trust_policy_is_descriptive_only": True,
+    "trust_policy_does_not_execute_handoff": True,
+    "trust_policy_does_not_invoke_consumer": True,
+    "trust_policy_does_not_mutate_consumer": True,
+    "trust_policy_does_not_authorize_promotion": True,
+    "trust_policy_does_not_construct_promotion_candidate": True,
+    "trust_policy_does_not_create_configpatch": True,
+    "trust_policy_does_not_modify_config": True,
+    "trust_policy_does_not_authorize_runtime": True,
+    "trust_policy_does_not_authorize_live": True,
+    "trust_policy_does_not_create_order_intent": True,
+    "trust_policy_is_offline_only": True,
+    "evidence_does_not_authorize_promotion": True,
+}
+
+_REQUIRED_NON_AUTHORIZING_FLAGS: dict[str, bool] = {
+    "is_handoff_trust_policy": True,
+    "handoff_trust_policy_offline_only": True,
+    "evidence_does_not_authorize_promotion": True,
+    "evidence_does_not_authorize_runtime": True,
+    "handoff_executed": False,
+    "consumer_invoked": False,
+    "consumer_mutated": False,
+    "files_transferred": False,
+    "network_side_effect_created": False,
+    "strategy_executed": False,
+    "model_inference_executed": False,
+    "parameters_modified": False,
+    "promotion_policy_executed": False,
+    "promotion_authorized": False,
+    "promotion_candidate_constructed": False,
+    "configpatch_created": False,
+    "configpatch_modified": False,
+    "configpatch_applied": False,
+    "configpatch_accepted": False,
+    "runtime_configuration_created": False,
+    "runtime_authorized": False,
+    "live_authorized": False,
+    "orders_allowed": False,
+    "scheduler_runtime_allowed": False,
+}
+
+_FORBIDDEN_CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "CAN_PROMOTE_ARTIFACT",
+        "CAN_DEPLOY_INACTIVE",
+        "CAN_COMPUTE_SIGNALS",
+        "CAN_CREATE_ORDER_INTENTS",
+        "CAN_SUBMIT_TESTNET_ORDERS",
+        "CAN_SUBMIT_LIVE_ORDERS",
+        "CAN_INCREASE_CAPITAL",
+        "CAN_CHANGE_RISK_POLICY",
+    }
+)
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "winner",
+        "selected",
+        "promoted",
+        "promotion",
+        "promotion_ready",
+        "eligible_for_live",
+        "live_eligible",
+        "runtime_eligible",
+        "ranking",
+        "ranked_input_ids",
+        "pareto",
+        "accepted",
+        "acceptance",
+        "armed",
+        "enabled",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "strategy_params_mutated",
+        "config_patch",
+        "configpatch",
+        "config_patch_manifest",
+        "patches",
+        "top_n",
+        "topn",
+        "filter_candidates_for_live",
+        "promotion_candidate",
+        "safety_flags",
+    }
+)
+
+_SELF_VERIFICATION_SCHEMA_VERSION = "handoff_trust_policy_self_verification_v1"
+
+_TRANSITIVE_LINEAGE_FIELDS: tuple[str, ...] = (
+    "experiment_identity_ref",
+    "experiment_identity_digest",
+    "experiment_identity_id",
+    "dataset_identity_ref",
+    "dataset_identity_digest",
+    "comparison_identity_ref",
+    "comparison_identity_digest",
+    "comparison_definition_id",
+    "comparison_completion_ref",
+    "comparison_completion_digest",
+    "research_validity_ref",
+    "research_validity_digest",
+    "promotion_input_binding_ref",
+    "promotion_input_binding_digest",
+    "policy_input_evidence_bundle_ref",
+    "policy_input_evidence_artifact_ref",
+    "policy_input_evidence_digest",
+    "policy_input_evidence_manifest_digest",
+    "promotion_policy_input_evidence_status",
+    "policy_input_binding_bundle_ref",
+    "policy_input_binding_digest",
+    "policy_input_binding_manifest_digest",
+    "policy_decision_ref",
+    "policy_decision_digest",
+    "policy_decision_manifest_digest",
+    "config_patch_manifest_ref",
+    "config_patch_manifest_digest",
+    "config_patch_manifest_id",
+    "config_patch_contract_name",
+    "config_patch_contract_version",
+    "cross_domain_lineage_binding_bundle_ref",
+    "cross_domain_lineage_binding_digest",
+    "candidate_lineage_manifest_id",
+    "candidate_lineage_digest",
+    "config_patch_lineage_manifest_ref",
+    "comparison_checkpoint_ref",
+    "comparison_checkpoint_digest",
+    "comparison_metric_input_ref",
+    "comparison_metric_input_digest",
+    "eligibility_evidence_ref",
+    "eligibility_evidence_digest",
+    "strategy_identity_ref",
+    "strategy_identity_digest",
+    "model_identity_ref",
+    "model_identity_digest",
+    "parameter_set_identity_ref",
+    "parameter_set_identity_digest",
+    "ai_promotion_assessment_ref",
+    "ai_promotion_assessment_digest",
+)
+
+_REQUIRED_LINEAGE_FIELDS_FOR_ALLOW: tuple[str, ...] = (
+    "strategy_identity_ref",
+    "strategy_identity_digest",
+    "model_identity_ref",
+    "model_identity_digest",
+    "parameter_set_identity_ref",
+    "parameter_set_identity_digest",
+    "experiment_identity_ref",
+    "experiment_identity_digest",
+    "comparison_definition_id",
+)
+
+_OPTIONAL_LINEAGE_FIELDS_FOR_ABSTAIN: tuple[str, ...] = (
+    "ai_promotion_assessment_ref",
+    "policy_decision_ref",
+    "research_validity_ref",
+    "cross_domain_lineage_binding_digest",
+)
+
+_EMBEDDED_CONSUMER_CONTRACT: dict[str, Any] = {
+    "consumer_contract_id": CONSUMER_CONTRACT_ID,
+    "contract_name": CONSUMER_CONTRACT_NAME,
+    "contract_version": CONSUMER_CONTRACT_VERSION,
+    "handoff_type": HANDOFF_TYPE,
+    "accepted_producer_contract_name": UPSTREAM_CONTRACT_NAME,
+    "accepted_producer_contract_version": UPSTREAM_CONTRACT_VERSION,
+    "accepted_artifact_schema_version": UPSTREAM_ARTIFACT_SCHEMA_VERSION,
+    "accepted_creation_contract_version": UPSTREAM_CREATION_CONTRACT_VERSION,
+    "minimum_artifact_version": UPSTREAM_CONTRACT_VERSION,
+    "required_binding_status": "PASS",
+    "required_completion_flags": [
+        "versioned_strategy_model_parameter_artifact_complete",
+        "strategy_identity_bound",
+        "model_identity_bound",
+        "parameter_set_identity_bound",
+        "cross_domain_lineage_bound",
+    ],
+    "forbidden_upstream_capabilities": sorted(_FORBIDDEN_CAPABILITIES),
+    "offline_only_required": True,
+}
+
+
+class HandoffTrustPolicyError(ValueError):
+    """Fail-closed handoff trust policy error."""
+
+
+@dataclass(frozen=True)
+class VerifiedVersionedArtifactBundle:
+    bundle_dir: Path
+    contract_name: str
+    contract_version: str
+    producer_version: str
+    artifact_ref: str
+    artifact_digest: str
+    manifest_digest: str
+    artifact_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ConsumerCapabilityContract:
+    contract_id: str
+    contract_name: str
+    contract_version: str
+    handoff_type: str
+    payload: dict[str, Any]
+    source_ref: str
+
+
+@dataclass(frozen=True)
+class HandoffTrustPolicyInputs:
+    versioned_artifact_bundle_dir: Path
+    consumer_contract_ref: Path | None = None
+
+
+@dataclass(frozen=True)
+class HandoffTrustPolicyResult:
+    output_dir: Path
+    comparison_definition_id: str
+    artifact_id: str
+    trust_policy_path: Path
+    self_verification_path: Path
+    manifest_path: Path
+    trust_result: str
+    compatibility_result: str
+    versioned_artifact_ref: str
+    versioned_artifact_digest: str
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise HandoffTrustPolicyError(f"{label} must not be a symlink")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise HandoffTrustPolicyError(f"forbidden index key: {key}")
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise HandoffTrustPolicyError(f"{label} must be a regular file: {path}")
+
+
+def _validate_bundle_dir(bundle_dir: Path, *, label: str) -> None:
+    _reject_symlink(bundle_dir, label=label)
+    if not bundle_dir.is_dir():
+        raise HandoffTrustPolicyError(f"{label} must be a directory: {bundle_dir}")
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise HandoffTrustPolicyError(f"output directory already exists: {output_dir}")
+    if is_under_tmp(output_dir):
+        raise HandoffTrustPolicyError("output directory must not be under /tmp")
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _reject_unsafe_overlap(*, versioned_artifact_dir: Path, output_dir: Path) -> None:
+    input_res = versioned_artifact_dir.resolve()
+    output_res = output_dir.resolve()
+    if output_res == input_res:
+        raise HandoffTrustPolicyError("output directory must not equal input path")
+    if _path_is_under(output_res, input_res):
+        raise HandoffTrustPolicyError("output directory must not be inside input path")
+    if _path_is_under(input_res, output_res):
+        raise HandoffTrustPolicyError("input directory must not be inside output directory")
+
+
+def _manifest_file_digest(bundle_dir: Path) -> str:
+    manifest_path = bundle_dir / MANIFEST_FILENAME
+    _validate_regular_file(manifest_path, label=MANIFEST_FILENAME)
+    return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+
+def _validate_capabilities(capabilities: Any) -> list[str]:
+    if capabilities is None:
+        return []
+    if not isinstance(capabilities, list):
+        raise HandoffTrustPolicyError("capabilities must be a list")
+    normalized: list[str] = []
+    for item in capabilities:
+        if not isinstance(item, str):
+            raise HandoffTrustPolicyError("capabilities entries must be strings")
+        if item in _FORBIDDEN_CAPABILITIES:
+            raise HandoffTrustPolicyError(f"forbidden capability: {item}")
+        normalized.append(item)
+    return sorted(normalized)
+
+
+def _validate_non_authorizing_flags(payload: Mapping[str, Any]) -> None:
+    for key, expected in _REQUIRED_NON_AUTHORIZING_FLAGS.items():
+        if payload.get(key) is not expected:
+            raise HandoffTrustPolicyError(f"{key} must be {expected!r}")
+
+
+def _validate_completion_flags(payload: Mapping[str, Any]) -> None:
+    complete = payload.get("handoff_trust_policy_complete")
+    if complete is True and payload.get("versioned_artifact_bound") is not True:
+        raise HandoffTrustPolicyError(
+            "versioned_artifact_bound must be True when handoff trust policy complete"
+        )
+    if complete is True and payload.get("producer_contract_bound") is not True:
+        raise HandoffTrustPolicyError(
+            "producer_contract_bound must be True when handoff trust policy complete"
+        )
+    if (
+        complete is True
+        and payload.get("trust_result") == "ALLOW_OFFLINE_HANDOFF"
+        and payload.get("cross_domain_lineage_bound") is not True
+    ):
+        raise HandoffTrustPolicyError(
+            "cross_domain_lineage_bound must be True for complete ALLOW_OFFLINE_HANDOFF"
+        )
+
+
+def _sorted_strings(values: list[str]) -> list[str]:
+    return sorted(set(values))
+
+
+def _factor(
+    *,
+    factor_id: str,
+    factor_type: str,
+    source_field: str,
+    observation: str,
+) -> dict[str, str]:
+    return {
+        "factor_id": factor_id,
+        "factor_type": factor_type,
+        "source_field": source_field,
+        "observation": observation,
+    }
+
+
+def _load_self_verification(bundle_dir: Path, *, rel: str, label: str) -> dict[str, Any]:
+    path = bundle_dir / rel
+    _validate_regular_file(path, label=label)
+    payload = read_manifest(path)
+    if not isinstance(payload, dict):
+        raise HandoffTrustPolicyError(f"{label} must be a JSON object")
+    return payload
+
+
+def _artifact_digest_from_payload(payload: Mapping[str, Any]) -> str:
+    integrity = payload.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise HandoffTrustPolicyError("integrity must be an object")
+    digest = integrity.get("content_sha256")
+    if not isinstance(digest, str) or not is_valid_sha256_hex(digest):
+        raise HandoffTrustPolicyError("integrity.content_sha256 invalid")
+    return digest
+
+
+def _validate_consumer_contract_payload(payload: Mapping[str, Any]) -> None:
+    if payload.get("contract_name") != CONSUMER_CONTRACT_NAME:
+        raise HandoffTrustPolicyError("consumer contract_name mismatch")
+    if payload.get("contract_version") != CONSUMER_CONTRACT_VERSION:
+        raise HandoffTrustPolicyError("consumer contract_version mismatch")
+    if payload.get("handoff_type") != HANDOFF_TYPE:
+        raise HandoffTrustPolicyError("consumer handoff_type mismatch")
+    if payload.get("accepted_producer_contract_name") != UPSTREAM_CONTRACT_NAME:
+        raise HandoffTrustPolicyError("consumer accepted_producer_contract_name mismatch")
+
+
+def _resolve_consumer_contract(
+    consumer_contract_ref: Path | None,
+) -> ConsumerCapabilityContract:
+    if consumer_contract_ref is None:
+        return ConsumerCapabilityContract(
+            contract_id=CONSUMER_CONTRACT_ID,
+            contract_name=CONSUMER_CONTRACT_NAME,
+            contract_version=CONSUMER_CONTRACT_VERSION,
+            handoff_type=HANDOFF_TYPE,
+            payload=dict(_EMBEDDED_CONSUMER_CONTRACT),
+            source_ref="embedded_default",
+        )
+
+    path = consumer_contract_ref.resolve()
+    _reject_symlink(path, label="consumer contract ref")
+    if path.is_dir():
+        contract_path = path / f"{CONSUMER_CONTRACT_NAME}.json"
+        source_ref = path.as_posix()
+    else:
+        contract_path = path
+        source_ref = path.parent.as_posix()
+    _validate_regular_file(contract_path, label="consumer contract")
+    payload = read_manifest(contract_path)
+    if not isinstance(payload, dict):
+        raise HandoffTrustPolicyError("consumer contract must be a JSON object")
+    _validate_consumer_contract_payload(payload)
+    contract_id = str(payload.get("consumer_contract_id", ""))
+    if not contract_id:
+        raise HandoffTrustPolicyError("consumer consumer_contract_id missing")
+    return ConsumerCapabilityContract(
+        contract_id=contract_id,
+        contract_name=str(payload["contract_name"]),
+        contract_version=str(payload["contract_version"]),
+        handoff_type=str(payload["handoff_type"]),
+        payload=dict(payload),
+        source_ref=source_ref,
+    )
+
+
+def verify_versioned_artifact_bundle(
+    bundle_dir: Path | str,
+) -> VerifiedVersionedArtifactBundle:
+    """Fail-closed verification of exactly one versioned strategy/model/parameter artifact."""
+    path = Path(bundle_dir)
+    _validate_bundle_dir(path, label="versioned artifact bundle")
+    ok, msg = verify_manifest_sha256(path)
+    if not ok:
+        raise HandoffTrustPolicyError(
+            f"versioned artifact MANIFEST.sha256 verification failed: {msg}"
+        )
+
+    artifact_path = path / UPSTREAM_ARTIFACT_REL
+    _validate_regular_file(artifact_path, label=UPSTREAM_ARTIFACT_REL)
+    payload = read_manifest(artifact_path)
+    if payload.get("contract_name") != UPSTREAM_CONTRACT_NAME:
+        raise HandoffTrustPolicyError("upstream versioned artifact contract_name mismatch")
+    if payload.get("contract_version") != UPSTREAM_CONTRACT_VERSION:
+        raise HandoffTrustPolicyError("upstream versioned artifact contract_version mismatch")
+
+    self_payload = _load_self_verification(
+        path,
+        rel=UPSTREAM_SELF_VERIFICATION_REL,
+        label=UPSTREAM_SELF_VERIFICATION_REL,
+    )
+    if self_payload.get("overall_status") != "PASS":
+        raise HandoffTrustPolicyError(
+            "upstream versioned artifact SELF_VERIFICATION overall_status must be PASS"
+        )
+
+    try:
+        reverify_versioned_strategy_model_parameter_artifact_v1(output_dir=path)
+    except VersionedStrategyModelParameterArtifactError as exc:
+        raise HandoffTrustPolicyError(str(exc)) from exc
+
+    return VerifiedVersionedArtifactBundle(
+        bundle_dir=path.resolve(),
+        contract_name=UPSTREAM_CONTRACT_NAME,
+        contract_version=UPSTREAM_CONTRACT_VERSION,
+        producer_version=UPSTREAM_PRODUCER_VERSION,
+        artifact_ref=UPSTREAM_ARTIFACT_REL,
+        artifact_digest=_artifact_digest_from_payload(payload),
+        manifest_digest=_manifest_file_digest(path),
+        artifact_payload=dict(payload),
+    )
+
+
+def _detect_forbidden_artifact_flags(artifact: Mapping[str, Any]) -> list[dict[str, str]]:
+    blocking: list[dict[str, str]] = []
+    flag_checks = (
+        ("handoff_executed", "HANDOFF_EXECUTED_IN_ARTIFACT"),
+        ("consumer_invoked", "CONSUMER_INVOKED_IN_ARTIFACT"),
+        ("consumer_mutated", "CONSUMER_MUTATED_IN_ARTIFACT"),
+        ("files_transferred", "FILES_TRANSFERRED_IN_ARTIFACT"),
+        ("network_side_effect_created", "NETWORK_SIDE_EFFECT_IN_ARTIFACT"),
+        ("promotion_authorized", "PROMOTION_AUTHORIZED_IN_ARTIFACT"),
+        ("promotion_candidate_constructed", "PROMOTION_CANDIDATE_CONSTRUCTED_IN_ARTIFACT"),
+        ("configpatch_created", "CONFIGPATCH_CREATED_IN_ARTIFACT"),
+        ("configpatch_modified", "CONFIGPATCH_MODIFIED_IN_ARTIFACT"),
+        ("configpatch_applied", "CONFIGPATCH_APPLIED_IN_ARTIFACT"),
+        ("configpatch_accepted", "CONFIGPATCH_ACCEPTED_IN_ARTIFACT"),
+        ("runtime_configuration_created", "RUNTIME_CONFIGURATION_CREATED_IN_ARTIFACT"),
+        ("runtime_authorized", "RUNTIME_AUTHORIZED_IN_ARTIFACT"),
+        ("live_authorized", "LIVE_AUTHORIZED_IN_ARTIFACT"),
+        ("orders_allowed", "ORDERS_ALLOWED_IN_ARTIFACT"),
+        ("scheduler_runtime_allowed", "SCHEDULER_RUNTIME_ALLOWED_IN_ARTIFACT"),
+        ("strategy_executed", "STRATEGY_EXECUTED_IN_ARTIFACT"),
+        ("model_inference_executed", "MODEL_INFERENCE_EXECUTED_IN_ARTIFACT"),
+        ("parameters_modified", "PARAMETERS_MODIFIED_IN_ARTIFACT"),
+    )
+    for field, factor_id in flag_checks:
+        if artifact.get(field) is True:
+            blocking.append(
+                _factor(
+                    factor_id=factor_id,
+                    factor_type="BLOCKING_FACT",
+                    source_field=field,
+                    observation=f"artifact carries forbidden flag {field}=true",
+                )
+            )
+    return blocking
+
+
+def _detect_lineage_contradictions(artifact: Mapping[str, Any]) -> list[dict[str, str]]:
+    contradictions: list[dict[str, str]] = []
+    strategy_ref = str(artifact.get("strategy_identity_ref", ""))
+    strategy_digest = str(artifact.get("strategy_identity_digest", ""))
+    experiment_digest = str(artifact.get("experiment_identity_digest", ""))
+    experiment_id = str(artifact.get("experiment_identity_id", ""))
+    if strategy_ref and experiment_id and strategy_ref != experiment_id:
+        contradictions.append(
+            _factor(
+                factor_id="STRATEGY_EXPERIMENT_IDENTITY_MISMATCH",
+                factor_type="CONTRADICTION",
+                source_field="experiment_identity_id",
+                observation="strategy_identity_ref differs from experiment_identity_id",
+            )
+        )
+    if (
+        strategy_digest
+        and experiment_digest
+        and is_valid_sha256_hex(strategy_digest)
+        and is_valid_sha256_hex(experiment_digest)
+        and strategy_digest != experiment_digest
+    ):
+        contradictions.append(
+            _factor(
+                factor_id="STRATEGY_EXPERIMENT_DIGEST_MISMATCH",
+                factor_type="CONTRADICTION",
+                source_field="strategy_identity_digest",
+                observation="strategy_identity_digest differs from experiment_identity_digest",
+            )
+        )
+    binding_status = str(artifact.get("versioned_artifact_binding_status", ""))
+    if binding_status == "PASS":
+        if artifact.get("strategy_identity_bound") is not True:
+            contradictions.append(
+                _factor(
+                    factor_id="PASS_WITHOUT_STRATEGY_BOUND",
+                    factor_type="CONTRADICTION",
+                    source_field="strategy_identity_bound",
+                    observation="PASS binding without strategy_identity_bound",
+                )
+            )
+        if artifact.get("versioned_strategy_model_parameter_artifact_complete") is not True:
+            contradictions.append(
+                _factor(
+                    factor_id="PASS_WITHOUT_COMPLETE_ARTIFACT",
+                    factor_type="CONTRADICTION",
+                    source_field="versioned_strategy_model_parameter_artifact_complete",
+                    observation="PASS binding without artifact_complete",
+                )
+            )
+    return contradictions
+
+
+def _detect_missing_required_lineage(artifact: Mapping[str, Any]) -> list[dict[str, str]]:
+    missing: list[dict[str, str]] = []
+    for field in _REQUIRED_LINEAGE_FIELDS_FOR_ALLOW:
+        value = artifact.get(field)
+        if not value or (field.endswith("_digest") and not is_valid_sha256_hex(str(value))):
+            missing.append(
+                _factor(
+                    factor_id=f"MISSING_{field.upper()}",
+                    factor_type="MISSING_PRECONDITION",
+                    source_field=field,
+                    observation=f"required lineage field {field!r} absent or invalid",
+                )
+            )
+    return missing
+
+
+def _detect_missing_optional_lineage(artifact: Mapping[str, Any]) -> list[dict[str, str]]:
+    missing: list[dict[str, str]] = []
+    for field in _OPTIONAL_LINEAGE_FIELDS_FOR_ABSTAIN:
+        value = artifact.get(field)
+        if not value:
+            missing.append(
+                _factor(
+                    factor_id=f"OPTIONAL_{field.upper()}_ABSENT",
+                    factor_type="MISSING_INPUT",
+                    source_field=field,
+                    observation=f"optional provenance field {field!r} absent",
+                )
+            )
+    return missing
+
+
+def _evaluate_producer_compatibility(
+    *,
+    artifact: Mapping[str, Any],
+    consumer: ConsumerCapabilityContract,
+) -> tuple[str, list[dict[str, str]], list[dict[str, str]]]:
+    supporting: list[dict[str, str]] = []
+    blocking: list[dict[str, str]] = []
+    contract = consumer.payload
+
+    if artifact.get("contract_name") != contract.get("accepted_producer_contract_name"):
+        blocking.append(
+            _factor(
+                factor_id="PRODUCER_CONTRACT_NAME_MISMATCH",
+                factor_type="BLOCKING_FACT",
+                source_field="contract_name",
+                observation="artifact producer contract_name incompatible with consumer",
+            )
+        )
+    else:
+        supporting.append(
+            _factor(
+                factor_id="PRODUCER_CONTRACT_NAME_MATCH",
+                factor_type="SUPPORTING_FACT",
+                source_field="contract_name",
+                observation="producer contract_name matches consumer acceptance",
+            )
+        )
+
+    if artifact.get("contract_version") != contract.get("accepted_producer_contract_version"):
+        blocking.append(
+            _factor(
+                factor_id="PRODUCER_CONTRACT_VERSION_MISMATCH",
+                factor_type="BLOCKING_FACT",
+                source_field="contract_version",
+                observation="artifact producer contract_version incompatible with consumer",
+            )
+        )
+    else:
+        supporting.append(
+            _factor(
+                factor_id="PRODUCER_CONTRACT_VERSION_MATCH",
+                factor_type="SUPPORTING_FACT",
+                source_field="contract_version",
+                observation="producer contract_version matches consumer acceptance",
+            )
+        )
+
+    if artifact.get("artifact_schema_version") != contract.get("accepted_artifact_schema_version"):
+        blocking.append(
+            _factor(
+                factor_id="ARTIFACT_SCHEMA_VERSION_MISMATCH",
+                factor_type="BLOCKING_FACT",
+                source_field="artifact_schema_version",
+                observation="artifact schema version incompatible with consumer",
+            )
+        )
+
+    if artifact.get("creation_contract_version") != contract.get(
+        "accepted_creation_contract_version"
+    ):
+        blocking.append(
+            _factor(
+                factor_id="CREATION_CONTRACT_VERSION_MISMATCH",
+                factor_type="BLOCKING_FACT",
+                source_field="creation_contract_version",
+                observation="creation contract version incompatible with consumer",
+            )
+        )
+
+    required_binding = str(contract.get("required_binding_status", "PASS"))
+    actual_binding = str(artifact.get("versioned_artifact_binding_status", ""))
+    if actual_binding != required_binding:
+        blocking.append(
+            _factor(
+                factor_id="BINDING_STATUS_INCOMPATIBLE",
+                factor_type="BLOCKING_FACT",
+                source_field="versioned_artifact_binding_status",
+                observation=f"binding status {actual_binding!r} != required {required_binding!r}",
+            )
+        )
+    elif actual_binding == "PASS":
+        supporting.append(
+            _factor(
+                factor_id="BINDING_STATUS_PASS",
+                factor_type="SUPPORTING_FACT",
+                source_field="versioned_artifact_binding_status",
+                observation="artifact binding status PASS",
+            )
+        )
+
+    required_flags = contract.get("required_completion_flags", [])
+    if isinstance(required_flags, list):
+        for flag in required_flags:
+            if artifact.get(flag) is not True:
+                blocking.append(
+                    _factor(
+                        factor_id=f"REQUIRED_FLAG_{str(flag).upper()}_FALSE",
+                        factor_type="BLOCKING_FACT",
+                        source_field=str(flag),
+                        observation=f"required completion flag {flag!r} is not true",
+                    )
+                )
+
+    capabilities = artifact.get("capabilities", [])
+    forbidden = set(contract.get("forbidden_upstream_capabilities", []))
+    if isinstance(capabilities, list):
+        for capability in capabilities:
+            if capability in forbidden:
+                blocking.append(
+                    _factor(
+                        factor_id=f"FORBIDDEN_CAPABILITY_{capability}",
+                        factor_type="BLOCKING_FACT",
+                        source_field="capabilities",
+                        observation=f"artifact carries forbidden capability {capability!r}",
+                    )
+                )
+
+    if blocking:
+        return "INCOMPATIBLE", supporting, blocking
+    return "COMPATIBLE", supporting, blocking
+
+
+def _resolve_revocation_state(artifact: Mapping[str, Any]) -> str:
+    state = str(artifact.get("revocation_state", "NOT_REVOKED"))
+    if state not in _VALID_REVOCATION_STATES:
+        return "UNKNOWN"
+    return state
+
+
+def _evaluate_trust(
+    *,
+    artifact: Mapping[str, Any],
+    consumer: ConsumerCapabilityContract,
+) -> tuple[
+    str,
+    str,
+    list[dict[str, str]],
+    list[dict[str, str]],
+    list[dict[str, str]],
+    list[dict[str, str]],
+    list[str],
+    dict[str, bool],
+]:
+    supporting: list[dict[str, str]] = []
+    blocking = _detect_forbidden_artifact_flags(artifact)
+    contradictions = _detect_lineage_contradictions(artifact)
+    missing_required = _detect_missing_required_lineage(artifact)
+    missing_optional = _detect_missing_optional_lineage(artifact)
+    reason_codes: list[str] = []
+    completion_flags = {
+        "handoff_trust_policy_complete": False,
+        "versioned_artifact_bound": False,
+        "producer_contract_bound": False,
+        "cross_domain_lineage_bound": False,
+    }
+
+    compatibility_result, compat_supporting, compat_blocking = _evaluate_producer_compatibility(
+        artifact=artifact,
+        consumer=consumer,
+    )
+    supporting.extend(compat_supporting)
+    blocking.extend(compat_blocking)
+
+    revocation_state = _resolve_revocation_state(artifact)
+    if revocation_state == "REVOKED":
+        blocking.append(
+            _factor(
+                factor_id="ARTIFACT_REVOKED",
+                factor_type="BLOCKING_FACT",
+                source_field="revocation_state",
+                observation="artifact revocation_state is REVOKED",
+            )
+        )
+        reason_codes.append("REVOCATION_STATE_REVOKED")
+    elif revocation_state == "UNKNOWN":
+        reason_codes.append("REVOCATION_STATE_UNKNOWN")
+
+    completion_flags["versioned_artifact_bound"] = True
+    completion_flags["producer_contract_bound"] = (
+        compatibility_result == "COMPATIBLE" and not compat_blocking
+    )
+
+    if blocking or contradictions or missing_required or compatibility_result == "INCOMPATIBLE":
+        reason_codes.extend(
+            [
+                "TRUST_DENY_BLOCKING_OR_INCOMPATIBLE",
+                "ARTIFACT_FAILS_HANDOFF_TRUST_PRECONDITIONS",
+            ]
+        )
+        return (
+            "DENY_HANDOFF",
+            compatibility_result,
+            supporting,
+            blocking,
+            contradictions,
+            missing_required + missing_optional,
+            _sorted_strings(reason_codes),
+            completion_flags,
+        )
+
+    if revocation_state == "UNKNOWN":
+        reason_codes.append("REVOCATION_STATE_UNKNOWN_ABSTAIN")
+        return (
+            "ABSTAIN",
+            compatibility_result,
+            supporting,
+            blocking,
+            contradictions,
+            missing_required + missing_optional,
+            _sorted_strings(reason_codes),
+            completion_flags,
+        )
+
+    binding_status = str(artifact.get("versioned_artifact_binding_status", ""))
+    if binding_status != "PASS":
+        reason_codes.append("BINDING_STATUS_NOT_PASS_DENY")
+        return (
+            "DENY_HANDOFF",
+            compatibility_result,
+            supporting,
+            blocking,
+            contradictions,
+            missing_required + missing_optional,
+            _sorted_strings(reason_codes),
+            completion_flags,
+        )
+
+    if artifact.get("cross_domain_lineage_bound") is True:
+        completion_flags["cross_domain_lineage_bound"] = True
+
+    reason_codes.extend(
+        [
+            "PRODUCER_CONSUMER_COMPATIBLE",
+            "REQUIRED_LINEAGE_PRESENT",
+            "NON_AUTHORIZING_ARTIFACT_VERIFIED",
+            "ALLOW_OFFLINE_HANDOFF",
+        ]
+    )
+    completion_flags["handoff_trust_policy_complete"] = True
+    return (
+        "ALLOW_OFFLINE_HANDOFF",
+        compatibility_result,
+        supporting,
+        blocking,
+        contradictions,
+        missing_optional,
+        _sorted_strings(reason_codes),
+        completion_flags,
+    )
+
+
+def _input_artifact_ref_mapping(*, bundle: VerifiedVersionedArtifactBundle) -> dict[str, Any]:
+    return {
+        "artifact_type": bundle.contract_name,
+        "contract_name": bundle.contract_name,
+        "contract_version": bundle.contract_version,
+        "artifact_ref": bundle.artifact_ref,
+        "artifact_digest": bundle.artifact_digest,
+        "manifest_digest": bundle.manifest_digest,
+        "producer_version": bundle.producer_version,
+        "bundle_path": bundle.bundle_dir.as_posix(),
+    }
+
+
+def _compute_output_digest(body: Mapping[str, Any]) -> str:
+    excluded = frozenset(
+        {
+            "output_digest",
+            "manifest_digest",
+            "integrity",
+            "created_at",
+            "artifact_id",
+            "trust_policy_id",
+        }
+    )
+    digest_body = {key: body[key] for key in sorted(body) if key not in excluded}
+    return compute_content_sha256(digest_body)
+
+
+def _integrity_body(body: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in body.items() if key not in {"integrity", "manifest_digest"}
+    }
+
+
+def _sort_factors(factors: list[dict[str, str]]) -> list[dict[str, str]]:
+    return sorted(factors, key=lambda item: (item["factor_id"], item["source_field"]))
+
+
+def build_handoff_trust_policy_v1(
+    *,
+    versioned_artifact: VerifiedVersionedArtifactBundle,
+    consumer: ConsumerCapabilityContract,
+) -> dict[str, Any]:
+    artifact = versioned_artifact.artifact_payload
+    (
+        trust_result,
+        compatibility_result,
+        supporting_facts,
+        blocking_facts,
+        contradictions,
+        missing_preconditions,
+        trust_reason_codes,
+        completion_flags,
+    ) = _evaluate_trust(artifact=artifact, consumer=consumer)
+
+    input_refs = [_input_artifact_ref_mapping(bundle=versioned_artifact)]
+    parent_artifact_refs = list(artifact.get("parent_artifact_refs", []))
+    if isinstance(parent_artifact_refs, list):
+        parent_artifact_refs = [
+            dict(item) for item in parent_artifact_refs if isinstance(item, Mapping)
+        ]
+    else:
+        parent_artifact_refs = []
+    parent_artifact_refs.sort(
+        key=lambda item: (str(item.get("ref_type", "")), str(item.get("digest", "")))
+    )
+
+    payload: dict[str, Any] = {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "trust_policy_id": "",
+        "artifact_id": "",
+        "created_at": OFFLINE_DETERMINISTIC_CREATED_AT,
+        "producer_version": PRODUCER_VERSION,
+        "record_kind": RECORD_KIND,
+        "input_relation": INPUT_RELATION,
+        "evidence_level": EVIDENCE_LEVEL,
+        "authority_level": AUTHORITY_LEVEL,
+        "capabilities": [],
+        "deterministic_rule_set_version": DETERMINISTIC_RULE_SET_VERSION,
+        "trust_policy_version": CONTRACT_VERSION,
+        "handoff_type": HANDOFF_TYPE,
+        "is_handoff_trust_policy": True,
+        "handoff_trust_policy_offline_only": True,
+        "handoff_trust_policy_authority_invariants": dict(
+            HANDOFF_TRUST_POLICY_AUTHORITY_INVARIANTS
+        ),
+        "trust_result": trust_result,
+        "compatibility_result": compatibility_result,
+        "trust_reason_codes": trust_reason_codes,
+        "supporting_facts": _sort_factors(supporting_facts),
+        "blocking_facts": _sort_factors(blocking_facts),
+        "contradictions": _sort_factors(contradictions),
+        "missing_preconditions": _sort_factors(missing_preconditions),
+        "revocation_state": _resolve_revocation_state(artifact),
+        "versioned_artifact_bundle_ref": versioned_artifact.bundle_dir.as_posix(),
+        "versioned_artifact_artifact_ref": versioned_artifact.artifact_ref,
+        "artifact_ref": versioned_artifact.artifact_ref,
+        "artifact_digest": versioned_artifact.artifact_digest,
+        "versioned_artifact_digest": versioned_artifact.artifact_digest,
+        "versioned_artifact_manifest_digest": versioned_artifact.manifest_digest,
+        "producer_contract_ref": UPSTREAM_CONTRACT_NAME,
+        "producer_contract_name": UPSTREAM_CONTRACT_NAME,
+        "producer_contract_version": UPSTREAM_CONTRACT_VERSION,
+        "upstream_producer_contract_version": UPSTREAM_PRODUCER_VERSION,
+        "upstream_contract_name": versioned_artifact.contract_name,
+        "upstream_contract_version": versioned_artifact.contract_version,
+        "upstream_producer_version": versioned_artifact.producer_version,
+        "upstream_binding_status": str(artifact.get("versioned_artifact_binding_status", "")),
+        "consumer_contract_ref": consumer.source_ref,
+        "consumer_contract_id": consumer.contract_id,
+        "consumer_contract_name": consumer.contract_name,
+        "consumer_contract_version": consumer.contract_version,
+        "consumer_handoff_type": consumer.handoff_type,
+        "input_artifact_refs": input_refs,
+        "parent_artifact_refs": parent_artifact_refs,
+        "transitive_lineage": {
+            field: str(artifact[field])
+            for field in _TRANSITIVE_LINEAGE_FIELDS
+            if artifact.get(field) is not None and str(artifact.get(field))
+        },
+        "input_digest": "",
+        "output_digest": "",
+        "manifest_digest": "",
+        **completion_flags,
+    }
+
+    for key, value in _REQUIRED_NON_AUTHORIZING_FLAGS.items():
+        payload[key] = value
+    payload.update(completion_flags)
+
+    for field in _TRANSITIVE_LINEAGE_FIELDS:
+        value = artifact.get(field)
+        if value is not None and str(value):
+            payload[field] = str(value)
+
+    _reject_forbidden_index_keys(payload)
+    _validate_non_authorizing_flags(payload)
+    if completion_flags["handoff_trust_policy_complete"]:
+        _validate_completion_flags(payload)
+    _validate_capabilities(payload["capabilities"])
+    if trust_result not in _VALID_TRUST_RESULTS:
+        raise HandoffTrustPolicyError("trust_result invalid")
+    if compatibility_result not in _VALID_COMPATIBILITY_RESULTS:
+        raise HandoffTrustPolicyError("compatibility_result invalid")
+
+    payload["input_digest"] = compute_content_sha256({"input_artifact_refs": input_refs})
+    output_digest = _compute_output_digest(payload)
+    payload["output_digest"] = output_digest
+    payload["artifact_id"] = output_digest
+    payload["trust_policy_id"] = output_digest
+    return payload
+
+
+def serialize_handoff_trust_policy_v1(
+    trust_policy: Mapping[str, Any],
+) -> str:
+    _reject_forbidden_index_keys(trust_policy)
+    _validate_non_authorizing_flags(trust_policy)
+    _validate_capabilities(trust_policy.get("capabilities"))
+    if trust_policy.get("trust_result") not in _VALID_TRUST_RESULTS:
+        raise HandoffTrustPolicyError("trust_result invalid")
+    if trust_policy.get("compatibility_result") not in _VALID_COMPATIBILITY_RESULTS:
+        raise HandoffTrustPolicyError("compatibility_result invalid")
+    for list_field in (
+        "trust_reason_codes",
+        "supporting_facts",
+        "blocking_facts",
+        "contradictions",
+        "missing_preconditions",
+    ):
+        values = trust_policy.get(list_field)
+        if isinstance(values, list) and values != sorted(
+            values,
+            key=lambda item: (
+                item.get("factor_id", item) if isinstance(item, dict) else item,
+                item.get("source_field", "") if isinstance(item, dict) else "",
+            ),
+        ):
+            raise HandoffTrustPolicyError(f"{list_field} must be sorted deterministically")
+    return deterministic_json_dumps(trust_policy)
+
+
+def _artifact_bytes_for_manifest_digest(artifact: Mapping[str, Any]) -> bytes:
+    body = {
+        key: value for key, value in artifact.items() if key not in {"integrity", "manifest_digest"}
+    }
+    return serialize_handoff_trust_policy_v1(body).encode("utf-8")
+
+
+def _compute_output_manifest_digest(artifact: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_artifact_bytes_for_manifest_digest(artifact)).hexdigest()
+
+
+def _validate_trust_policy_integrity(artifact: Mapping[str, Any]) -> None:
+    if artifact.get("contract_name") != CONTRACT_NAME:
+        raise HandoffTrustPolicyError("contract_name mismatch")
+    if artifact.get("contract_version") != CONTRACT_VERSION:
+        raise HandoffTrustPolicyError("contract_version mismatch")
+    integrity = artifact.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise HandoffTrustPolicyError("integrity must be an object")
+    expected = compute_content_sha256(_integrity_body(artifact))
+    actual = integrity.get("content_sha256")
+    if actual != expected:
+        raise HandoffTrustPolicyError("integrity.content_sha256 mismatch")
+    output_digest = artifact.get("output_digest")
+    if output_digest != _compute_output_digest(artifact):
+        raise HandoffTrustPolicyError("output_digest mismatch")
+    if artifact.get("artifact_id") != output_digest:
+        raise HandoffTrustPolicyError("artifact_id must equal output_digest")
+
+
+def build_self_verification_v1(
+    *,
+    trust_policy: Mapping[str, Any],
+    versioned_artifact: VerifiedVersionedArtifactBundle,
+    consumer: ConsumerCapabilityContract,
+    manifest_digest: str,
+) -> dict[str, Any]:
+    checks: list[dict[str, str]] = [
+        {"check_id": "contract_name", "status": "PASS"},
+        {"check_id": "contract_version", "status": "PASS"},
+        {"check_id": "evidence_level_level_3", "status": "PASS"},
+        {"check_id": "exactly_one_versioned_artifact_input", "status": "PASS"},
+        {"check_id": "versioned_artifact_verified", "status": "PASS"},
+        {"check_id": "producer_contract_bound", "status": "PASS"},
+        {"check_id": "consumer_contract_resolved", "status": "PASS"},
+        {"check_id": "offline_only_no_handoff_execution", "status": "PASS"},
+        {"check_id": "no_consumer_invocation", "status": "PASS"},
+        {"check_id": "no_promotion_authority", "status": "PASS"},
+        {"check_id": "no_configpatch_mutation", "status": "PASS"},
+        {"check_id": "non_authorizing_semantics", "status": "PASS"},
+        {"check_id": "forbidden_capabilities_absent", "status": "PASS"},
+        {"check_id": "output_digest", "status": "PASS"},
+        {"check_id": "manifest_verification", "status": "PASS"},
+        {"check_id": "deterministic_reverification", "status": "PASS"},
+    ]
+
+    input_refs = trust_policy.get("input_artifact_refs")
+    if not isinstance(input_refs, list) or len(input_refs) != 1:
+        checks = [
+            {**c, "status": "FAIL"}
+            if c["check_id"] == "exactly_one_versioned_artifact_input"
+            else c
+            for c in checks
+        ]
+
+    if trust_policy.get("manifest_digest") != manifest_digest:
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "manifest_verification" else c
+            for c in checks
+        ]
+
+    if trust_policy.get("artifact_digest") != versioned_artifact.artifact_digest:
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "versioned_artifact_verified" else c
+            for c in checks
+        ]
+
+    if trust_policy.get("trust_result") == "ALLOW_OFFLINE_HANDOFF":
+        for check_id, field in (("producer_contract_bound", "producer_contract_bound"),):
+            if trust_policy.get(field) is not True:
+                checks = [
+                    {**c, "status": "FAIL"} if c["check_id"] == check_id else c for c in checks
+                ]
+
+    structural_failures = [check for check in checks if check["status"] != "PASS"]
+    if structural_failures:
+        raise HandoffTrustPolicyError("self-verification checks failed")
+
+    payload: dict[str, Any] = {
+        "self_verification_schema_version": _SELF_VERIFICATION_SCHEMA_VERSION,
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "overall_status": "PASS",
+        "checks": checks,
+        "verified_artifact_rel": ARTIFACT_REL,
+        "verified_output_digest": trust_policy.get("output_digest"),
+        "verified_manifest_digest": manifest_digest,
+        "verified_versioned_artifact_bundle_ref": versioned_artifact.bundle_dir.as_posix(),
+        "verified_consumer_contract_id": consumer.contract_id,
+        "verified_trust_result": trust_policy.get("trust_result"),
+        "verified_compatibility_result": trust_policy.get("compatibility_result"),
+        "verified_deterministic_rule_set_version": DETERMINISTIC_RULE_SET_VERSION,
+    }
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def _finalize_trust_policy_with_manifest_digest(
+    artifact: Mapping[str, Any], *, manifest_digest: str
+) -> dict[str, Any]:
+    body = dict(artifact)
+    body["manifest_digest"] = manifest_digest
+    body["output_digest"] = _compute_output_digest(body)
+    body["artifact_id"] = body["output_digest"]
+    body["trust_policy_id"] = body["output_digest"]
+    body["integrity"] = {"content_sha256": compute_content_sha256(_integrity_body(body))}
+    return body
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{uuid.uuid4().hex}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def verify_trust_policy_inputs(
+    inputs: HandoffTrustPolicyInputs,
+) -> tuple[VerifiedVersionedArtifactBundle, ConsumerCapabilityContract]:
+    """Verify exactly one versioned artifact bundle and resolve consumer contract."""
+    versioned_artifact = verify_versioned_artifact_bundle(inputs.versioned_artifact_bundle_dir)
+    consumer = _resolve_consumer_contract(inputs.consumer_contract_ref)
+    return versioned_artifact, consumer
+
+
+def reverify_handoff_trust_policy_v1(*, output_dir: Path | str) -> None:
+    """Replay handoff trust policy bundle without upstream mutation."""
+    bundle_dir = Path(output_dir)
+    if not bundle_dir.is_dir():
+        raise HandoffTrustPolicyError(f"handoff trust policy directory not found: {bundle_dir}")
+    ok, msg = verify_manifest_sha256(bundle_dir)
+    if not ok:
+        raise HandoffTrustPolicyError(f"MANIFEST.sha256 verification failed: {msg}")
+
+    artifact_path = bundle_dir / ARTIFACT_REL
+    _validate_regular_file(artifact_path, label=ARTIFACT_REL)
+    trust_policy = read_manifest(artifact_path)
+    _validate_trust_policy_integrity(trust_policy)
+
+    self_path = bundle_dir / SELF_VERIFICATION_REL
+    _validate_regular_file(self_path, label=SELF_VERIFICATION_REL)
+    self_payload = read_manifest(self_path)
+    if self_payload.get("overall_status") != "PASS":
+        raise HandoffTrustPolicyError("SELF_VERIFICATION overall_status must be PASS")
+
+    manifest_digest = _compute_output_manifest_digest(trust_policy)
+    if trust_policy.get("manifest_digest") != manifest_digest:
+        raise HandoffTrustPolicyError("manifest_digest mismatch on replay")
+
+    versioned_artifact = verify_versioned_artifact_bundle(
+        Path(str(trust_policy["versioned_artifact_bundle_ref"]))
+    )
+    if trust_policy.get("artifact_digest") != versioned_artifact.artifact_digest:
+        raise HandoffTrustPolicyError("artifact_digest mismatch on replay")
+
+    consumer_ref = trust_policy.get("consumer_contract_ref")
+    consumer_path = None if consumer_ref == "embedded_default" else Path(str(consumer_ref))
+    consumer = _resolve_consumer_contract(consumer_path)
+    rebuilt = build_handoff_trust_policy_v1(
+        versioned_artifact=versioned_artifact,
+        consumer=consumer,
+    )
+    if trust_policy.get("trust_result") != rebuilt.get("trust_result"):
+        raise HandoffTrustPolicyError("trust_result mismatch on replay")
+    if trust_policy.get("compatibility_result") != rebuilt.get("compatibility_result"):
+        raise HandoffTrustPolicyError("compatibility_result mismatch on replay")
+
+
+def produce_handoff_trust_policy_v1(
+    *,
+    inputs: HandoffTrustPolicyInputs,
+    output_dir: Path | str,
+) -> HandoffTrustPolicyResult:
+    """Produce offline LEVEL_3 handoff trust policy evidence."""
+    final_dir = Path(output_dir)
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        versioned_artifact_dir=inputs.versioned_artifact_bundle_dir,
+        output_dir=final_dir,
+    )
+
+    versioned_artifact, consumer = verify_trust_policy_inputs(inputs)
+    trust_policy_body = build_handoff_trust_policy_v1(
+        versioned_artifact=versioned_artifact,
+        consumer=consumer,
+    )
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise HandoffTrustPolicyError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        artifact_path = staging / ARTIFACT_REL
+        self_path = staging / SELF_VERIFICATION_REL
+
+        manifest_digest = _compute_output_manifest_digest(trust_policy_body)
+        finalized = _finalize_trust_policy_with_manifest_digest(
+            trust_policy_body, manifest_digest=manifest_digest
+        )
+        artifact_path.write_text(
+            serialize_handoff_trust_policy_v1(finalized),
+            encoding="utf-8",
+        )
+        self_payload = build_self_verification_v1(
+            trust_policy=finalized,
+            versioned_artifact=versioned_artifact,
+            consumer=consumer,
+            manifest_digest=manifest_digest,
+        )
+        self_path.write_text(deterministic_json_dumps(self_payload), encoding="utf-8")
+        write_manifest_sha256(staging)
+
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise HandoffTrustPolicyError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        reverify_handoff_trust_policy_v1(output_dir=staging)
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise HandoffTrustPolicyError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return HandoffTrustPolicyResult(
+        output_dir=final_dir,
+        comparison_definition_id=str(finalized.get("comparison_definition_id", "")),
+        artifact_id=str(finalized["artifact_id"]),
+        trust_policy_path=final_dir / ARTIFACT_REL,
+        self_verification_path=final_dir / SELF_VERIFICATION_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+        trust_result=str(finalized["trust_result"]),
+        compatibility_result=str(finalized["compatibility_result"]),
+        versioned_artifact_ref=str(finalized["versioned_artifact_bundle_ref"]),
+        versioned_artifact_digest=str(finalized["artifact_digest"]),
+    )
+
+
+__all__ = [
+    "ARTIFACT_REL",
+    "AUTHORITY_LEVEL",
+    "CONTRACT_NAME",
+    "CONTRACT_VERSION",
+    "CONSUMER_CONTRACT_ID",
+    "CONSUMER_CONTRACT_NAME",
+    "CONSUMER_CONTRACT_VERSION",
+    "DETERMINISTIC_RULE_SET_VERSION",
+    "EVIDENCE_LEVEL",
+    "HANDOFF_TRUST_POLICY_AUTHORITY_INVARIANTS",
+    "HANDOFF_TYPE",
+    "HandoffTrustPolicyError",
+    "HandoffTrustPolicyInputs",
+    "HandoffTrustPolicyResult",
+    "MANIFEST_FILENAME",
+    "PRODUCER_VERSION",
+    "SELF_VERIFICATION_REL",
+    "VerifiedVersionedArtifactBundle",
+    "build_handoff_trust_policy_v1",
+    "produce_handoff_trust_policy_v1",
+    "reverify_handoff_trust_policy_v1",
+    "serialize_handoff_trust_policy_v1",
+    "verify_trust_policy_inputs",
+    "verify_versioned_artifact_bundle",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -6859,3 +6859,59 @@ def test_selector_package_ai_promotion_assessment_v1_combined_diff_pr_bounded_fu
     for path in PACKAGE_AI_PROMOTION_ASSESSMENT_V1_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_HANDOFF_TRUST_POLICY_V1_PRODUCTION = (
+    "src/meta/learning_loop/handoff_trust_policy_v1.py"
+)
+PACKAGE_HANDOFF_TRUST_POLICY_V1_SCRIPT = "scripts/run_handoff_trust_policy_v1.py"
+PACKAGE_HANDOFF_TRUST_POLICY_V1_TESTOWNER = "tests/meta/test_handoff_trust_policy_v1.py"
+PACKAGE_HANDOFF_TRUST_POLICY_V1_CLI_TESTOWNER = (
+    "tests/scripts/test_run_handoff_trust_policy_v1.py"
+)
+PACKAGE_HANDOFF_TRUST_POLICY_V1_DEPENDENCY_TESTOWNERS = (
+    "tests/meta/test_versioned_strategy_model_parameter_artifact_v1.py",
+    "tests/meta/test_ai_promotion_assessment_v1.py",
+    "tests/meta/test_comparison_promotion_policy_decision_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_model_parameter_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_eligibility_evidence_v1.py",
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+PACKAGE_HANDOFF_TRUST_POLICY_V1_ALL_PRODUCTION = (
+    PACKAGE_HANDOFF_TRUST_POLICY_V1_PRODUCTION,
+    PACKAGE_HANDOFF_TRUST_POLICY_V1_SCRIPT,
+)
+PACKAGE_HANDOFF_TRUST_POLICY_V1_ALL_TESTOWNERS = (
+    PACKAGE_HANDOFF_TRUST_POLICY_V1_TESTOWNER,
+    PACKAGE_HANDOFF_TRUST_POLICY_V1_CLI_TESTOWNER,
+    *PACKAGE_HANDOFF_TRUST_POLICY_V1_DEPENDENCY_TESTOWNERS,
+)
+
+
+def test_selector_package_handoff_trust_policy_v1_production_pr_bounded_full_includes_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_HANDOFF_TRUST_POLICY_V1_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_HANDOFF_TRUST_POLICY_V1_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_handoff_trust_policy_v1_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        *PACKAGE_HANDOFF_TRUST_POLICY_V1_ALL_PRODUCTION,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_HANDOFF_TRUST_POLICY_V1_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -6861,14 +6861,10 @@ def test_selector_package_ai_promotion_assessment_v1_combined_diff_pr_bounded_fu
         assert bounded.count(path) == 1
 
 
-PACKAGE_HANDOFF_TRUST_POLICY_V1_PRODUCTION = (
-    "src/meta/learning_loop/handoff_trust_policy_v1.py"
-)
+PACKAGE_HANDOFF_TRUST_POLICY_V1_PRODUCTION = "src/meta/learning_loop/handoff_trust_policy_v1.py"
 PACKAGE_HANDOFF_TRUST_POLICY_V1_SCRIPT = "scripts/run_handoff_trust_policy_v1.py"
 PACKAGE_HANDOFF_TRUST_POLICY_V1_TESTOWNER = "tests/meta/test_handoff_trust_policy_v1.py"
-PACKAGE_HANDOFF_TRUST_POLICY_V1_CLI_TESTOWNER = (
-    "tests/scripts/test_run_handoff_trust_policy_v1.py"
-)
+PACKAGE_HANDOFF_TRUST_POLICY_V1_CLI_TESTOWNER = "tests/scripts/test_run_handoff_trust_policy_v1.py"
 PACKAGE_HANDOFF_TRUST_POLICY_V1_DEPENDENCY_TESTOWNERS = (
     "tests/meta/test_versioned_strategy_model_parameter_artifact_v1.py",
     "tests/meta/test_ai_promotion_assessment_v1.py",

--- a/tests/meta/handoff_trust_policy_v1_fixtures.py
+++ b/tests/meta/handoff_trust_policy_v1_fixtures.py
@@ -1,0 +1,115 @@
+"""Fixtures for handoff_trust_policy_v1 tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+from src.meta.learning_loop.handoff_trust_policy_v1 import (
+    CONSUMER_CONTRACT_ID,
+    CONSUMER_CONTRACT_NAME,
+    CONSUMER_CONTRACT_VERSION,
+    HANDOFF_TYPE,
+    HandoffTrustPolicyInputs,
+    produce_handoff_trust_policy_v1,
+)
+from src.meta.learning_loop.versioned_strategy_model_parameter_artifact_v1 import (
+    ARTIFACT_SCHEMA_VERSION as UPSTREAM_ARTIFACT_SCHEMA_VERSION,
+    CONTRACT_NAME as UPSTREAM_CONTRACT_NAME,
+    CONTRACT_VERSION as UPSTREAM_CONTRACT_VERSION,
+    CREATION_CONTRACT_VERSION as UPSTREAM_CREATION_CONTRACT_VERSION,
+)
+from tests.meta.versioned_strategy_model_parameter_artifact_v1_fixtures import (
+    produce_versioned_artifact_fixture,
+)
+
+
+@dataclass(frozen=True)
+class HandoffTrustPolicyFixtureBundle:
+    versioned_artifact_bundle_dir: Path
+    consumer_contract_path: Path | None = None
+    handoff_trust_policy_bundle_dir: Path | None = None
+
+
+def embedded_consumer_contract_payload() -> dict[str, object]:
+    return {
+        "consumer_contract_id": CONSUMER_CONTRACT_ID,
+        "contract_name": CONSUMER_CONTRACT_NAME,
+        "contract_version": CONSUMER_CONTRACT_VERSION,
+        "handoff_type": HANDOFF_TYPE,
+        "accepted_producer_contract_name": UPSTREAM_CONTRACT_NAME,
+        "accepted_producer_contract_version": UPSTREAM_CONTRACT_VERSION,
+        "accepted_artifact_schema_version": UPSTREAM_ARTIFACT_SCHEMA_VERSION,
+        "accepted_creation_contract_version": UPSTREAM_CREATION_CONTRACT_VERSION,
+        "minimum_artifact_version": UPSTREAM_CONTRACT_VERSION,
+        "required_binding_status": "PASS",
+        "required_completion_flags": [
+            "versioned_strategy_model_parameter_artifact_complete",
+            "strategy_identity_bound",
+            "model_identity_bound",
+            "parameter_set_identity_bound",
+            "cross_domain_lineage_bound",
+        ],
+        "forbidden_upstream_capabilities": [
+            "CAN_CHANGE_RISK_POLICY",
+            "CAN_COMPUTE_SIGNALS",
+            "CAN_CREATE_ORDER_INTENTS",
+            "CAN_DEPLOY_INACTIVE",
+            "CAN_INCREASE_CAPITAL",
+            "CAN_PROMOTE_ARTIFACT",
+            "CAN_SUBMIT_LIVE_ORDERS",
+            "CAN_SUBMIT_TESTNET_ORDERS",
+        ],
+        "offline_only_required": True,
+    }
+
+
+def write_consumer_contract_file(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        deterministic_json_dumps(embedded_consumer_contract_payload()),
+        encoding="utf-8",
+    )
+    return path
+
+
+def produce_handoff_trust_policy_fixture(
+    tmp_path: Path,
+    durable_root: Path,
+    *,
+    all_domains_pass: bool = True,
+    use_candidate_lineage: bool = True,
+    include_ai_assessment: bool = False,
+    include_consumer_contract_file: bool = False,
+    handoff_trust_policy_name: str = "handoff_trust_policy",
+    produce_output: bool = True,
+) -> HandoffTrustPolicyFixtureBundle:
+    versioned = produce_versioned_artifact_fixture(
+        tmp_path,
+        durable_root,
+        all_domains_pass=all_domains_pass,
+        use_candidate_lineage=use_candidate_lineage,
+        include_ai_assessment=include_ai_assessment,
+    )
+    assert versioned.versioned_artifact_bundle_dir is not None
+    consumer_path: Path | None = None
+    if include_consumer_contract_file:
+        consumer_path = write_consumer_contract_file(
+            durable_root / "offline_strategy_model_parameter_consumer_capability_v1.json"
+        )
+    trust_dir: Path | None = None
+    if produce_output:
+        trust_dir = durable_root / handoff_trust_policy_name
+        produce_handoff_trust_policy_v1(
+            inputs=HandoffTrustPolicyInputs(
+                versioned_artifact_bundle_dir=versioned.versioned_artifact_bundle_dir,
+                consumer_contract_ref=consumer_path,
+            ),
+            output_dir=trust_dir,
+        )
+    return HandoffTrustPolicyFixtureBundle(
+        versioned_artifact_bundle_dir=versioned.versioned_artifact_bundle_dir,
+        consumer_contract_path=consumer_path,
+        handoff_trust_policy_bundle_dir=trust_dir,
+    )

--- a/tests/meta/test_handoff_trust_policy_v1.py
+++ b/tests/meta/test_handoff_trust_policy_v1.py
@@ -1,0 +1,444 @@
+"""Contract tests for handoff_trust_policy_v1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = [
+    "tests.meta.comparison_ssot_v1_fixtures",
+    "tests.meta.comparison_completion_research_validity_binding_v1_fixtures",
+    "tests.meta.comparison_completion_promotion_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_identity_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_eligibility_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_model_parameter_identity_binding_v1_fixtures",
+    "tests.meta.comparison_config_patch_manifest_cross_domain_lineage_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_input_v1_fixtures",
+    "tests.meta.comparison_eligibility_promotion_policy_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_policy_input_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_policy_decision_v1_fixtures",
+    "tests.meta.ai_promotion_assessment_v1_fixtures",
+    "tests.meta.versioned_strategy_model_parameter_artifact_v1_fixtures",
+    "tests.meta.handoff_trust_policy_v1_fixtures",
+]
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+from src.meta.learning_loop.handoff_trust_policy_v1 import (
+    ARTIFACT_REL,
+    AUTHORITY_LEVEL,
+    CONTRACT_NAME,
+    CONTRACT_VERSION,
+    DETERMINISTIC_RULE_SET_VERSION,
+    EVIDENCE_LEVEL,
+    HANDOFF_TRUST_POLICY_AUTHORITY_INVARIANTS,
+    MANIFEST_FILENAME,
+    PRODUCER_VERSION,
+    SELF_VERIFICATION_REL,
+    HandoffTrustPolicyError,
+    HandoffTrustPolicyInputs,
+    VerifiedVersionedArtifactBundle,
+    build_handoff_trust_policy_v1,
+    produce_handoff_trust_policy_v1,
+    reverify_handoff_trust_policy_v1,
+    serialize_handoff_trust_policy_v1,
+    verify_trust_policy_inputs,
+    verify_versioned_artifact_bundle,
+    _resolve_consumer_contract,
+)
+from src.meta.learning_loop.versioned_strategy_model_parameter_artifact_v1 import (
+    ARTIFACT_REL as VERSIONED_ARTIFACT_REL,
+)
+from tests.meta.handoff_trust_policy_v1_fixtures import (
+    embedded_consumer_contract_payload,
+    produce_handoff_trust_policy_fixture,
+    write_consumer_contract_file,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = (
+        "src.meta.learning_loop.handoff_trust_policy_v1.is_under_tmp",
+        "src.meta.learning_loop.versioned_strategy_model_parameter_artifact_v1.is_under_tmp",
+        "src.meta.learning_loop.ai_promotion_assessment_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_policy_decision_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_policy_input_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_eligibility_promotion_policy_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_input_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_config_patch_manifest_cross_domain_lineage_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_model_parameter_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_eligibility_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_promotion_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_research_validity_binding_v1.is_under_tmp",
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
+    )
+    for target in targets:
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "handoff_trust_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _inputs(versioned_dir: Path, consumer: Path | None = None) -> HandoffTrustPolicyInputs:
+    return HandoffTrustPolicyInputs(
+        versioned_artifact_bundle_dir=versioned_dir,
+        consumer_contract_ref=consumer,
+    )
+
+
+def test_contract_constants() -> None:
+    assert CONTRACT_NAME == "handoff_trust_policy_v1"
+    assert CONTRACT_VERSION == "v1"
+    assert EVIDENCE_LEVEL == "LEVEL_3"
+    assert AUTHORITY_LEVEL == "NON_AUTHORITIZING"
+    assert ARTIFACT_REL == "handoff_trust_policy_v1.json"
+    assert DETERMINISTIC_RULE_SET_VERSION == "handoff_trust_policy_rules_v1"
+
+
+def test_happy_path_allow_offline_handoff(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    assert fixture.handoff_trust_policy_bundle_dir is not None
+    payload = read_manifest(fixture.handoff_trust_policy_bundle_dir / ARTIFACT_REL)
+    assert payload["trust_result"] == "ALLOW_OFFLINE_HANDOFF"
+    assert payload["compatibility_result"] == "COMPATIBLE"
+    assert payload["handoff_trust_policy_complete"] is True
+    assert payload["versioned_artifact_bound"] is True
+    assert payload["producer_contract_bound"] is True
+    assert payload["cross_domain_lineage_bound"] is True
+    assert payload["handoff_executed"] is False
+    assert payload["consumer_invoked"] is False
+    assert payload["consumer_mutated"] is False
+
+
+def test_required_non_authorizing_flags(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_trust_policy_bundle_dir / ARTIFACT_REL)
+    assert payload["promotion_authorized"] is False
+    assert payload["promotion_candidate_constructed"] is False
+    assert payload["configpatch_created"] is False
+    assert payload["configpatch_modified"] is False
+    assert payload["configpatch_applied"] is False
+    assert payload["configpatch_accepted"] is False
+    assert payload["runtime_configuration_created"] is False
+    assert payload["runtime_authorized"] is False
+    assert payload["live_authorized"] is False
+    assert payload["orders_allowed"] is False
+    assert payload["scheduler_runtime_allowed"] is False
+    assert payload["files_transferred"] is False
+    assert payload["network_side_effect_created"] is False
+    assert (
+        payload["handoff_trust_policy_authority_invariants"]
+        == HANDOFF_TRUST_POLICY_AUTHORITY_INVARIANTS
+    )
+
+
+def test_determinism(tmp_path, ssot_durable_output_dir) -> None:
+    versioned = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    out_a = _durable_output(tmp_path, "a")
+    out_b = _durable_output(tmp_path, "b")
+    inputs = _inputs(versioned.versioned_artifact_bundle_dir)
+    produce_handoff_trust_policy_v1(inputs=inputs, output_dir=out_a)
+    produce_handoff_trust_policy_v1(inputs=inputs, output_dir=out_b)
+    assert (out_a / ARTIFACT_REL).read_text() == (out_b / ARTIFACT_REL).read_text()
+
+
+def test_self_verification_and_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.handoff_trust_policy_bundle_dir
+    assert out is not None
+    ok, msg = verify_manifest_sha256(out)
+    assert ok, msg
+    self_payload = read_manifest(out / SELF_VERIFICATION_REL)
+    assert self_payload["overall_status"] == "PASS"
+    reverify_handoff_trust_policy_v1(output_dir=out)
+
+
+def test_explicit_consumer_contract_file(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path,
+        ssot_durable_output_dir,
+        include_consumer_contract_file=True,
+    )
+    payload = read_manifest(fixture.handoff_trust_policy_bundle_dir / ARTIFACT_REL)
+    assert payload["trust_result"] == "ALLOW_OFFLINE_HANDOFF"
+    assert payload["consumer_contract_ref"] == fixture.consumer_contract_path.parent.as_posix()
+
+
+def test_missing_versioned_artifact_bundle(tmp_path) -> None:
+    with pytest.raises(HandoffTrustPolicyError):
+        verify_versioned_artifact_bundle(tmp_path / "missing")
+
+
+def test_invalid_versioned_artifact_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned_dir = fixture.versioned_artifact_bundle_dir
+    (versioned_dir / "MANIFEST.sha256").write_text("invalid", encoding="utf-8")
+    with pytest.raises(HandoffTrustPolicyError):
+        verify_versioned_artifact_bundle(versioned_dir)
+
+
+def test_versioned_artifact_self_verification_manipulation(
+    tmp_path, ssot_durable_output_dir
+) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned_dir = fixture.versioned_artifact_bundle_dir
+    self_path = versioned_dir / "SELF_VERIFICATION.json"
+    payload = read_manifest(self_path)
+    payload["overall_status"] = "FAIL"
+    self_path.write_text(deterministic_json_dumps(payload), encoding="utf-8")
+    with pytest.raises(HandoffTrustPolicyError):
+        verify_versioned_artifact_bundle(versioned_dir)
+
+
+def test_versioned_artifact_contract_version_mismatch(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    artifact_path = fixture.versioned_artifact_bundle_dir / VERSIONED_ARTIFACT_REL
+    payload = read_manifest(artifact_path)
+    payload["contract_version"] = "v99"
+    artifact_path.write_text(deterministic_json_dumps(payload), encoding="utf-8")
+    with pytest.raises(HandoffTrustPolicyError):
+        verify_versioned_artifact_bundle(fixture.versioned_artifact_bundle_dir)
+
+
+def test_versioned_artifact_digest_mismatch_on_reverify(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.handoff_trust_policy_bundle_dir
+    artifact = read_manifest(out / ARTIFACT_REL)
+    artifact["artifact_digest"] = "0" * 64
+    (out / ARTIFACT_REL).write_text(deterministic_json_dumps(artifact), encoding="utf-8")
+    with pytest.raises(HandoffTrustPolicyError):
+        reverify_handoff_trust_policy_v1(output_dir=out)
+
+
+def test_strategy_lineage_mismatch_denies(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned = verify_versioned_artifact_bundle(fixture.versioned_artifact_bundle_dir)
+    tampered = dict(versioned.artifact_payload)
+    tampered["strategy_identity_digest"] = "1" * 64
+    versioned = VerifiedVersionedArtifactBundle(
+        **{**versioned.__dict__, "artifact_payload": tampered}
+    )
+    consumer = _resolve_consumer_contract(None)
+    policy = build_handoff_trust_policy_v1(versioned_artifact=versioned, consumer=consumer)
+    assert policy["trust_result"] == "DENY_HANDOFF"
+
+
+def test_producer_contract_mismatch_denies(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned = verify_versioned_artifact_bundle(fixture.versioned_artifact_bundle_dir)
+    tampered = dict(versioned.artifact_payload)
+    tampered["contract_name"] = "wrong_producer"
+    versioned = VerifiedVersionedArtifactBundle(
+        **{**versioned.__dict__, "artifact_payload": tampered}
+    )
+    consumer = _resolve_consumer_contract(None)
+    policy = build_handoff_trust_policy_v1(versioned_artifact=versioned, consumer=consumer)
+    assert policy["trust_result"] == "DENY_HANDOFF"
+    assert policy["compatibility_result"] == "INCOMPATIBLE"
+
+
+def test_consumer_contract_mismatch_rejected(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    bad_consumer = write_consumer_contract_file(
+        _durable_output(tmp_path, "consumer") / "bad_consumer.json"
+    )
+    payload = embedded_consumer_contract_payload()
+    payload["contract_version"] = "v99"
+    bad_consumer.write_text(deterministic_json_dumps(payload), encoding="utf-8")
+    with pytest.raises(HandoffTrustPolicyError):
+        verify_trust_policy_inputs(
+            HandoffTrustPolicyInputs(
+                versioned_artifact_bundle_dir=fixture.versioned_artifact_bundle_dir,
+                consumer_contract_ref=bad_consumer,
+            )
+        )
+
+
+def test_incompatible_schema_version_denies(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned = verify_versioned_artifact_bundle(fixture.versioned_artifact_bundle_dir)
+    tampered = dict(versioned.artifact_payload)
+    tampered["artifact_schema_version"] = "v99"
+    versioned = VerifiedVersionedArtifactBundle(
+        **{**versioned.__dict__, "artifact_payload": tampered}
+    )
+    consumer = _resolve_consumer_contract(None)
+    policy = build_handoff_trust_policy_v1(versioned_artifact=versioned, consumer=consumer)
+    assert policy["trust_result"] == "DENY_HANDOFF"
+
+
+def test_revoked_trust_denies(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned = verify_versioned_artifact_bundle(fixture.versioned_artifact_bundle_dir)
+    tampered = dict(versioned.artifact_payload)
+    tampered["revocation_state"] = "REVOKED"
+    versioned = VerifiedVersionedArtifactBundle(
+        **{**versioned.__dict__, "artifact_payload": tampered}
+    )
+    consumer = _resolve_consumer_contract(None)
+    policy = build_handoff_trust_policy_v1(versioned_artifact=versioned, consumer=consumer)
+    assert policy["trust_result"] == "DENY_HANDOFF"
+
+
+def test_unknown_revocation_abstains(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned = verify_versioned_artifact_bundle(fixture.versioned_artifact_bundle_dir)
+    tampered = dict(versioned.artifact_payload)
+    tampered["revocation_state"] = "UNKNOWN"
+    versioned = VerifiedVersionedArtifactBundle(
+        **{**versioned.__dict__, "artifact_payload": tampered}
+    )
+    consumer = _resolve_consumer_contract(None)
+    policy = build_handoff_trust_policy_v1(versioned_artifact=versioned, consumer=consumer)
+    assert policy["trust_result"] == "ABSTAIN"
+
+
+def test_promotion_authorized_in_artifact_denies(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned = verify_versioned_artifact_bundle(fixture.versioned_artifact_bundle_dir)
+    tampered = dict(versioned.artifact_payload)
+    tampered["promotion_authorized"] = True
+    versioned = VerifiedVersionedArtifactBundle(
+        **{**versioned.__dict__, "artifact_payload": tampered}
+    )
+    consumer = _resolve_consumer_contract(None)
+    policy = build_handoff_trust_policy_v1(versioned_artifact=versioned, consumer=consumer)
+    assert policy["trust_result"] == "DENY_HANDOFF"
+
+
+def test_handoff_executed_flag_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_trust_policy_bundle_dir / ARTIFACT_REL)
+    payload["handoff_executed"] = True
+    with pytest.raises(HandoffTrustPolicyError):
+        serialize_handoff_trust_policy_v1(payload)
+
+
+def test_consumer_invoked_flag_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_trust_policy_bundle_dir / ARTIFACT_REL)
+    payload["consumer_invoked"] = True
+    with pytest.raises(HandoffTrustPolicyError):
+        serialize_handoff_trust_policy_v1(payload)
+
+
+def test_runtime_authorized_flag_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_trust_policy_bundle_dir / ARTIFACT_REL)
+    payload["runtime_authorized"] = True
+    with pytest.raises(HandoffTrustPolicyError):
+        serialize_handoff_trust_policy_v1(payload)
+
+
+def test_forbidden_key_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_trust_policy_bundle_dir / ARTIFACT_REL)
+    payload["promotion"] = True
+    with pytest.raises(HandoffTrustPolicyError):
+        serialize_handoff_trust_policy_v1(payload)
+
+
+def test_output_existing_dir_fail(tmp_path, ssot_durable_output_dir) -> None:
+    versioned = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    out = _durable_output(tmp_path)
+    out.mkdir()
+    with pytest.raises(HandoffTrustPolicyError):
+        produce_handoff_trust_policy_v1(
+            inputs=_inputs(versioned.versioned_artifact_bundle_dir),
+            output_dir=out,
+        )
+
+
+def test_reverify_after_tamper(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.handoff_trust_policy_bundle_dir
+    artifact = read_manifest(out / ARTIFACT_REL)
+    artifact["trust_result"] = "DENY_HANDOFF"
+    (out / ARTIFACT_REL).write_text(deterministic_json_dumps(artifact), encoding="utf-8")
+    with pytest.raises(HandoffTrustPolicyError):
+        reverify_handoff_trust_policy_v1(output_dir=out)
+
+
+def test_manifest_self_hashing_not_allowed(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_trust_policy_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.handoff_trust_policy_bundle_dir
+    manifest_path = out / MANIFEST_FILENAME
+    lines = manifest_path.read_text(encoding="utf-8").splitlines()
+    manifest_path.write_text(
+        "\n".join(lines + [f"{manifest_path.name}  deadbeef"]), encoding="utf-8"
+    )
+    ok, _ = verify_manifest_sha256(out)
+    assert ok is False
+
+
+def test_verify_trust_policy_inputs(tmp_path, ssot_durable_output_dir) -> None:
+    versioned = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    artifact_bundle, consumer = verify_trust_policy_inputs(
+        _inputs(versioned.versioned_artifact_bundle_dir)
+    )
+    assert artifact_bundle.bundle_dir.is_dir()
+    assert consumer.contract_id
+
+
+def test_copy_inputs_no_mutation(tmp_path, ssot_durable_output_dir) -> None:
+    versioned = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    before = (versioned.versioned_artifact_bundle_dir / VERSIONED_ARTIFACT_REL).read_bytes()
+    out = _durable_output(tmp_path)
+    produce_handoff_trust_policy_v1(
+        inputs=_inputs(versioned.versioned_artifact_bundle_dir),
+        output_dir=out,
+    )
+    assert (versioned.versioned_artifact_bundle_dir / VERSIONED_ARTIFACT_REL).read_bytes() == before
+
+
+def test_no_forbidden_runtime_imports() -> None:
+    module_path = Path("src/meta/learning_loop/handoff_trust_policy_v1.py")
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    forbidden = {
+        "src.governance.promotion_loop.engine",
+        "src.governance.promotion_loop.policy",
+        "src.governance.promotion_loop.safety",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in forbidden:
+            pytest.fail(f"forbidden import: {node.module}")
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in forbidden:
+                    pytest.fail(f"forbidden import: {alias.name}")

--- a/tests/scripts/test_run_handoff_trust_policy_v1.py
+++ b/tests/scripts/test_run_handoff_trust_policy_v1.py
@@ -1,0 +1,125 @@
+"""CLI tests for run_handoff_trust_policy_v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = [
+    "tests.meta.comparison_ssot_v1_fixtures",
+    "tests.meta.comparison_completion_research_validity_binding_v1_fixtures",
+    "tests.meta.comparison_completion_promotion_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_identity_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_eligibility_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_model_parameter_identity_binding_v1_fixtures",
+    "tests.meta.versioned_strategy_model_parameter_artifact_v1_fixtures",
+    "tests.meta.handoff_trust_policy_v1_fixtures",
+]
+
+from scripts.run_handoff_trust_policy_v1 import (
+    EXIT_OK,
+    EXIT_TRUST_POLICY_ERROR,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+from src.meta.learning_loop.handoff_trust_policy_v1 import ARTIFACT_REL
+from src.meta.learning_loop.versioned_strategy_model_parameter_artifact_v1 import (
+    ARTIFACT_REL as VERSIONED_ARTIFACT_REL,
+)
+from tests.meta.handoff_trust_policy_v1_fixtures import produce_handoff_trust_policy_fixture
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = (
+        "src.meta.learning_loop.handoff_trust_policy_v1.is_under_tmp",
+        "src.meta.learning_loop.versioned_strategy_model_parameter_artifact_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_model_parameter_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_eligibility_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_promotion_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_research_validity_binding_v1.is_under_tmp",
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
+    )
+    for target in targets:
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "cli_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def test_cli_happy_path(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    versioned = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--versioned-artifact-bundle-dir",
+            str(versioned.versioned_artifact_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    captured = capsys.readouterr()
+    assert "OK" in captured.out
+    assert "trust_result=ALLOW_OFFLINE_HANDOFF" in captured.out
+    assert (out / ARTIFACT_REL).is_file()
+
+
+def test_cli_missing_versioned_bundle(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--versioned-artifact-bundle-dir",
+            "/nonexistent/versioned",
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+
+
+def test_cli_invalid_manifest(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    versioned = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    versioned_dir = versioned.versioned_artifact_bundle_dir
+    (versioned_dir / "MANIFEST.sha256").write_text("invalid", encoding="utf-8")
+    out = _durable_output(tmp_path, "cli_invalid")
+    rc = main(
+        [
+            "--versioned-artifact-bundle-dir",
+            str(versioned_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_TRUST_POLICY_ERROR
+
+
+def test_cli_tampered_versioned_artifact(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    versioned = produce_handoff_trust_policy_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    artifact_path = versioned.versioned_artifact_bundle_dir / VERSIONED_ARTIFACT_REL
+    payload = read_manifest(artifact_path)
+    payload["model_identity_ref"] = "tampered"
+    artifact_path.write_text(deterministic_json_dumps(payload), encoding="utf-8")
+    out = _durable_output(tmp_path, "cli_tamper")
+    rc = main(
+        [
+            "--versioned-artifact-bundle-dir",
+            str(versioned.versioned_artifact_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_TRUST_POLICY_ERROR


### PR DESCRIPTION
## Summary

- **Runbook:** Phase 5 / `RUNBOOK_STEP_08` (`handoff_trust_policy`)
- **Owner:** `src/meta/learning_loop/handoff_trust_policy_v1.py`
- Offline, deterministic, fail-closed trust/admissibility evaluation for exactly one verified `versioned_strategy_model_parameter_artifact_v1` bundle
- Producer contract digest/version bound; embedded default consumer capability contract (`offline_strategy_model_parameter_consumer_capability_v1@v1`) with optional `--consumer-contract-ref` override
- Outputs `handoff_trust_policy_v1.json`, `SELF_VERIFICATION.json`, `MANIFEST.sha256`
- Trust results: `ALLOW_OFFLINE_HANDOFF`, `DENY_HANDOFF`, `ABSTAIN` (descriptive only)

## Safety boundaries (explicit)

- No actual handoff execution (`HANDOFF_EXECUTED=false`)
- No consumer invocation or mutation
- No promotion authority, no `PromotionCandidate`, no ConfigPatch create/modify/apply/accept
- No runtime/live/order/scheduler authority
- Forbidden promotion_loop owners unchanged

## Tests & CI

- Focused unit/contract/negative/tamper/determinism tests (34 passed locally on Python 3.11)
- diff-aware CI selector package: `PR_BOUNDED_FULL` for handoff trust policy paths
- Progress registry updated: RUNBOOK_STEP_07 complete, RUNBOOK_STEP_08 in progress

## Evidence

- Implementation bundle: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/handoff_trust_policy_v1_offline_slice_implementation_v0_20260629T020250Z`
- `MANIFEST_VERIFY_RC=0`

## Next canonical step

`PR_REQUIRED_CHECKS_AND_REVIEW` → after merge: `authority_lease_and_revocation` (RUNBOOK_STEP_09)

## Test plan

- [x] `tests/meta/test_handoff_trust_policy_v1.py`
- [x] `tests/scripts/test_run_handoff_trust_policy_v1.py`
- [x] CI selector contract tests for handoff trust policy package
- [x] `ruff format --check` / `ruff check`
- [ ] GitHub required checks green


Made with [Cursor](https://cursor.com)