### PR TITLE
feat: add handoff atomic claim consume v1 offline slice

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -16,10 +16,10 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 | Feld | Wert |
 |---|---|
-| `LAST_VERIFIED_ORIGIN_MAIN` | `74e384e9b83ad2d9f59aa18361b200ed5b50ad63` |
-| `LAST_VERIFIED_AT` | `2026-06-29T02:40:00Z` |
+| `LAST_VERIFIED_ORIGIN_MAIN` | `841be8b4e8460fcd68814c21feeba1f8e28e8052` |
+| `LAST_VERIFIED_AT` | `2026-06-29T12:00:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
-| `NEXT_CANONICAL_STEP` | `secure_handoff_envelope` |
+| `NEXT_CANONICAL_STEP` | `handoff_atomic_claim_consume` |
 | `SYSTEMWIDE_RANKING_REQUIRED` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |
 
@@ -244,8 +244,10 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 |---|---|
 | `RUNBOOK_PHASE` | 6 |
 | `RUNBOOK_STEP_ID` | `secure_handoff_envelope` |
-| `STATUS` | `IN_PROGRESS` |
+| `STATUS` | `COMPLETE` |
 | `CANONICAL_OWNER` | `src/meta/learning_loop/secure_handoff_envelope_v1.py` |
+| `MERGED_PRS` | `#4640` |
+| `MERGE_COMMITS` | `841be8b4e8460fcd68814c21feeba1f8e28e8052` |
 | `DEPENDENCIES` | RUNBOOK_STEP_09, `authority_lease_and_revocation_v1` |
 | `NEXT_REQUIRED_CONTRACT` | `handoff_atomic_claim_consume` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
@@ -258,8 +260,10 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 |---|---|
 | `RUNBOOK_PHASE` | 6 |
 | `RUNBOOK_STEP_ID` | `atomic_claim_consume` |
-| `STATUS` | `NOT_STARTED` |
-| `DEPENDENCIES` | RUNBOOK_STEP_10 |
+| `STATUS` | `IN_PROGRESS` |
+| `CANONICAL_OWNER` | `src/meta/learning_loop/handoff_atomic_claim_consume_v1.py` |
+| `DEPENDENCIES` | RUNBOOK_STEP_10, `secure_handoff_envelope_v1` |
+| `NEXT_REQUIRED_CONTRACT` | `clock_trust_and_expiry` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |

--- a/scripts/ops/ci_test_selection_v1.py
+++ b/scripts/ops/ci_test_selection_v1.py
@@ -1983,6 +1983,40 @@ PR_BOUNDED_FULL_PACKAGE_SECURE_HANDOFF_ENVELOPE_V1_TRIGGER_PATHS: frozenset[str]
     }
 )
 
+PR_BOUNDED_FULL_PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_TRIGGER_PATHS: frozenset[str] = frozenset(
+    {
+        "src/meta/learning_loop/handoff_atomic_claim_consume_v1.py",
+        "scripts/run_handoff_atomic_claim_consume_v1.py",
+        "tests/meta/test_handoff_atomic_claim_consume_v1.py",
+        "tests/scripts/test_run_handoff_atomic_claim_consume_v1.py",
+        "tests/meta/handoff_atomic_claim_consume_v1_fixtures.py",
+    }
+)
+
+PR_BOUNDED_FULL_PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_TARGETS: tuple[str, ...] = (
+    "tests/meta/test_handoff_atomic_claim_consume_v1.py",
+    "tests/scripts/test_run_handoff_atomic_claim_consume_v1.py",
+    "tests/meta/test_secure_handoff_envelope_v1.py",
+    "tests/scripts/test_run_secure_handoff_envelope_v1.py",
+    "tests/meta/test_authority_lease_and_revocation_v1.py",
+    "tests/scripts/test_run_authority_lease_and_revocation_v1.py",
+    "tests/meta/test_handoff_trust_policy_v1.py",
+    "tests/scripts/test_run_handoff_trust_policy_v1.py",
+    "tests/meta/test_versioned_strategy_model_parameter_artifact_v1.py",
+    "tests/scripts/test_run_versioned_strategy_model_parameter_artifact_v1.py",
+    "tests/meta/test_ai_promotion_assessment_v1.py",
+    "tests/meta/test_comparison_promotion_policy_decision_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_model_parameter_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_eligibility_evidence_v1.py",
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+
 PR_BOUNDED_FULL_PACKAGE_SECURE_HANDOFF_ENVELOPE_V1_TARGETS: tuple[str, ...] = (
     "tests/meta/test_secure_handoff_envelope_v1.py",
     "tests/scripts/test_run_secure_handoff_envelope_v1.py",
@@ -2307,6 +2341,10 @@ def resolve_pr_bounded_full_targets(files: list[str]) -> tuple[str, ...]:
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_SECURE_HANDOFF_ENVELOPE_V1_TRIGGER_PATHS:
         for path in PR_BOUNDED_FULL_PACKAGE_SECURE_HANDOFF_ENVELOPE_V1_TARGETS:
+            add(path)
+
+    if normalized & PR_BOUNDED_FULL_PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_TRIGGER_PATHS:
+        for path in PR_BOUNDED_FULL_PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_TARGETS:
             add(path)
 
     if normalized & PR_BOUNDED_FULL_PACKAGE_COMPARISON_METRIC_INPUT_TRIGGER_PATHS:

--- a/scripts/run_handoff_atomic_claim_consume_v1.py
+++ b/scripts/run_handoff_atomic_claim_consume_v1.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Offline handoff atomic claim/consume contract v1.
+
+Consumes exactly one verified secure_handoff_envelope_v1 bundle, producing a
+manifested LEVEL_3 non-authorizing atomic claim/consume contract for offline
+evidence only.
+
+Usage:
+    python3 scripts/run_handoff_atomic_claim_consume_v1.py \\
+        --secure-handoff-envelope-bundle-dir /path/to/envelope \\
+        --evaluation-time 2026-06-29T12:00:00+00:00 \\
+        --output-dir /var/evidence/handoff_atomic_claim_consume_001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.meta.learning_loop.handoff_atomic_claim_consume_v1 import (
+    ClaimStateContext,
+    HandoffAtomicClaimConsumeError,
+    HandoffAtomicClaimConsumeInputs,
+    HandoffAtomicClaimConsumeRequest,
+    default_claim_consume_request,
+    produce_handoff_atomic_claim_consume_v1,
+    verify_secure_handoff_envelope_bundle,
+)
+
+EXIT_OK = 0
+EXIT_CONTRACT_ERROR = 1
+EXIT_USAGE_ERROR = 2
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline handoff atomic claim/consume v1: deterministically describe "
+            "atomic claim and consume transitions for a verified secure handoff "
+            "envelope without executing claim, consume, state mutation, lock, "
+            "reservation, or consumer invocation."
+        )
+    )
+    parser.add_argument(
+        "--secure-handoff-envelope-bundle-dir",
+        type=Path,
+        required=True,
+        help="Explicit path to a published secure_handoff_envelope_v1 bundle.",
+    )
+    parser.add_argument(
+        "--evaluation-time",
+        default=None,
+        help="Explicit evaluation time UTC instant (+00:00 or Z).",
+    )
+    parser.add_argument(
+        "--consumer-identity-ref",
+        default=None,
+        help="Consumer identity ref (defaults from secure handoff envelope).",
+    )
+    parser.add_argument(
+        "--consumer-identity-version",
+        default=None,
+        help="Consumer identity version (defaults from secure handoff envelope).",
+    )
+    parser.add_argument(
+        "--transition-evaluate",
+        default="FULL_CONTRACT",
+        choices=("FULL_CONTRACT", "CLAIM", "CONSUME"),
+        help="Transition evaluation mode (default FULL_CONTRACT).",
+    )
+    parser.add_argument(
+        "--claim-state",
+        default=None,
+        help="Current claim state for transition evaluation (e.g. UNCLAIMED, CLAIMED).",
+    )
+    parser.add_argument(
+        "--claim-revision",
+        type=int,
+        default=None,
+        help="Current CAS revision for transition evaluation.",
+    )
+    parser.add_argument(
+        "--claim-identity",
+        default=None,
+        help="Existing claim identity for consume evaluation.",
+    )
+    parser.add_argument(
+        "--consume-identity",
+        default=None,
+        help="Existing consume identity for duplicate consume evaluation.",
+    )
+    parser.add_argument(
+        "--allowed-offline-capability",
+        action="append",
+        default=None,
+        dest="allowed_offline_capabilities",
+        help="Allowed offline capability (repeatable).",
+    )
+    parser.add_argument(
+        "--source-revision",
+        default=None,
+        help="Source revision for provenance metadata.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Explicit handoff atomic claim/consume output directory (must not exist).",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_request(args: argparse.Namespace) -> HandoffAtomicClaimConsumeRequest:
+    envelope = verify_secure_handoff_envelope_bundle(args.secure_handoff_envelope_bundle_dir)
+    defaults = default_claim_consume_request(envelope=envelope)
+
+    claim_state_context = None
+    if any(
+        field is not None
+        for field in (
+            args.claim_state,
+            args.claim_revision,
+            args.claim_identity,
+            args.consume_identity,
+        )
+    ):
+        claim_state_context = ClaimStateContext(
+            current_state=args.claim_state or "UNCLAIMED",
+            current_revision=args.claim_revision if args.claim_revision is not None else 0,
+            claim_identity=args.claim_identity or "",
+            consume_identity=args.consume_identity or "",
+        )
+
+    explicit_fields = (
+        args.evaluation_time,
+        args.consumer_identity_ref,
+        args.consumer_identity_version,
+        args.allowed_offline_capabilities,
+        args.source_revision,
+        claim_state_context,
+    )
+    if (
+        all(field is None for field in explicit_fields)
+        and args.transition_evaluate == "FULL_CONTRACT"
+    ):
+        return defaults
+
+    return HandoffAtomicClaimConsumeRequest(
+        evaluation_time=args.evaluation_time or defaults.evaluation_time,
+        consumer_identity_ref=args.consumer_identity_ref or defaults.consumer_identity_ref,
+        consumer_identity_version=(
+            args.consumer_identity_version or defaults.consumer_identity_version
+        ),
+        transition_evaluate=args.transition_evaluate,
+        claim_state_context=claim_state_context,
+        allowed_offline_capabilities=tuple(
+            args.allowed_offline_capabilities or defaults.allowed_offline_capabilities
+        ),
+        source_revision=args.source_revision or defaults.source_revision,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.secure_handoff_envelope_bundle_dir.is_dir():
+        print(
+            "[handoff_atomic_claim_consume_v1] ERROR: secure handoff envelope bundle not found: "
+            f"{args.secure_handoff_envelope_bundle_dir}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE_ERROR
+
+    try:
+        claim_consume_request = _resolve_request(args)
+    except HandoffAtomicClaimConsumeError as exc:
+        print(f"[handoff_atomic_claim_consume_v1] ERROR: {exc}", file=sys.stderr)
+        return EXIT_CONTRACT_ERROR
+
+    inputs = HandoffAtomicClaimConsumeInputs(
+        secure_handoff_envelope_bundle_dir=args.secure_handoff_envelope_bundle_dir,
+        claim_consume_request=claim_consume_request,
+    )
+
+    try:
+        result = produce_handoff_atomic_claim_consume_v1(
+            inputs=inputs,
+            output_dir=args.output_dir,
+        )
+    except HandoffAtomicClaimConsumeError as exc:
+        print(f"[handoff_atomic_claim_consume_v1] ERROR: {exc}", file=sys.stderr)
+        return EXIT_CONTRACT_ERROR
+
+    print(
+        "[handoff_atomic_claim_consume_v1] OK "
+        f"contract_id={result.contract_id} "
+        f"contract_status={result.contract_status} "
+        f"claim_identity={result.claim_identity} "
+        f"consume_identity={result.consume_identity} "
+        f"output_dir={result.output_dir}"
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meta/learning_loop/handoff_atomic_claim_consume_v1.py
+++ b/src/meta/learning_loop/handoff_atomic_claim_consume_v1.py
@@ -1,0 +1,1671 @@
+"""Offline LEVEL_3 handoff atomic claim/consume contract owner v1."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    is_under_tmp,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.meta.learning_loop.comparison_common_durable_evidence_binding_v1 import (
+    COMPARISON_AUTHORITY_INVARIANTS,
+)
+from src.meta.learning_loop.comparison_metric_input_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+from src.meta.learning_loop.handoff_trust_policy_v1 import (
+    CONSUMER_CONTRACT_ID,
+    CONSUMER_CONTRACT_VERSION,
+)
+from src.meta.learning_loop.secure_handoff_envelope_v1 import (
+    ARTIFACT_REL as SECURE_HANDOFF_ENVELOPE_ARTIFACT_REL,
+    CONTRACT_NAME as SECURE_HANDOFF_ENVELOPE_CONTRACT_NAME,
+    CONTRACT_VERSION as SECURE_HANDOFF_ENVELOPE_CONTRACT_VERSION,
+    PRODUCER_VERSION as SECURE_HANDOFF_ENVELOPE_PRODUCER_VERSION,
+    SELF_VERIFICATION_REL as SECURE_HANDOFF_ENVELOPE_SELF_VERIFICATION_REL,
+    SecureHandoffEnvelopeError,
+    reverify_secure_handoff_envelope_v1,
+)
+
+CONTRACT_NAME = "handoff_atomic_claim_consume_v1"
+CONTRACT_VERSION = "v1"
+PRODUCER_VERSION = "handoff_atomic_claim_consume_v1"
+EVIDENCE_LEVEL = "LEVEL_3"
+AUTHORITY_LEVEL = "NON_AUTHORITIZING"
+RECORD_KIND = "handoff_atomic_claim_consume_record"
+INPUT_RELATION = "PACKAGES_VERIFIED_SECURE_HANDOFF_ENVELOPE_V1_FOR_OFFLINE_ATOMIC_CLAIM_CONSUME"
+ARTIFACT_REL = "handoff_atomic_claim_consume_v1.json"
+SELF_VERIFICATION_REL = "SELF_VERIFICATION.json"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+STAGING_DIRNAME_PREFIX = ".handoff_atomic_claim_consume_staging_"
+
+CLAIM_CONTRACT_VERSION = "handoff_atomic_claim_v1"
+CONSUME_CONTRACT_VERSION = "handoff_atomic_consume_v1"
+SCHEMA_VERSION = "handoff_atomic_claim_consume_schema_v1"
+CREATION_CONTRACT_VERSION = "handoff_atomic_claim_consume_creation_v1"
+DETERMINISTIC_RULE_SET_VERSION = "handoff_atomic_claim_consume_rules_v1"
+OFFLINE_DETERMINISTIC_CREATED_AT = "1970-01-01T00:00:00+00:00"
+DEFAULT_PRODUCER_IDENTITY_REF = "peak_trade_offline_handoff_atomic_claim_consume_producer_v1"
+DEFAULT_SOURCE_REVISION = "OFFLINE_DETERMINISTIC_EVIDENCE"
+INITIAL_REVISION = 0
+
+_VALID_CONTRACT_STATUSES = frozenset(
+    {
+        "CONTRACT_VALID_FOR_OFFLINE_ATOMIC_CLAIM_CONSUME",
+        "CONTRACT_CLAIMABLE",
+        "CONTRACT_CONSUMABLE",
+        "CONTRACT_INVALID",
+        "CONTRACT_REVOKED",
+        "CONTRACT_EXPIRED",
+        "CONTRACT_CONFLICT",
+        "CONTRACT_REPLAY_REJECTED",
+        "ABSTAIN",
+    }
+)
+_VALID_STATES = frozenset(
+    {
+        "UNCLAIMED",
+        "CLAIMABLE",
+        "CLAIMED",
+        "CONSUMABLE",
+        "CONSUMED",
+        "REVOKED",
+        "EXPIRED",
+        "CONFLICT",
+        "REPLAY_REJECTED",
+        "ABSTAIN",
+    }
+)
+_VALID_TRANSITION_EVALUATE = frozenset({"FULL_CONTRACT", "CLAIM", "CONSUME"})
+_VALID_REVOCATION_STATES = frozenset({"NOT_REVOKED", "REVOKED", "UNKNOWN"})
+_UTC_INSTANT_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(\+00:00|Z)$")
+_SELF_VERIFICATION_SCHEMA_VERSION = "handoff_atomic_claim_consume_self_verification_v1"
+
+_ALLOWED_TRANSITIONS: tuple[tuple[str, str], ...] = (
+    ("UNCLAIMED", "CLAIMABLE"),
+    ("CLAIMABLE", "CLAIMED"),
+    ("CLAIMED", "CONSUMABLE"),
+    ("CONSUMABLE", "CONSUMED"),
+)
+
+_FORBIDDEN_TRANSITIONS: tuple[tuple[str, str], ...] = (
+    ("UNCLAIMED", "CLAIMED"),
+    ("UNCLAIMED", "CONSUMED"),
+    ("CLAIMABLE", "CONSUMED"),
+    ("CLAIMED", "CONSUMED"),
+    ("CONSUMED", "CLAIMED"),
+    ("CONSUMED", "CLAIMABLE"),
+    ("REVOKED", "CLAIMABLE"),
+    ("REVOKED", "CLAIMED"),
+    ("EXPIRED", "CLAIMABLE"),
+    ("EXPIRED", "CLAIMED"),
+)
+
+_DEFAULT_ALLOWED_OFFLINE_CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "CAN_DESCRIBE_OFFLINE_ATOMIC_CLAIM",
+        "CAN_DESCRIBE_OFFLINE_ATOMIC_CONSUME",
+        "CAN_BIND_SECURE_HANDOFF_ENVELOPE_REF",
+        "CAN_BIND_CONSUMER_IDENTITY_REF",
+    }
+)
+
+_FORBIDDEN_CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "CAN_EXECUTE_CLAIM",
+        "CAN_EXECUTE_CONSUME",
+        "CAN_MUTATE_STATE",
+        "CAN_ACQUIRE_LOCK",
+        "CAN_CREATE_RESERVATION",
+        "CAN_INVOKE_CONSUMER",
+        "CAN_MUTATE_CONSUMER",
+        "CAN_TRANSFER_FILES",
+        "CAN_TRANSFER_PAYLOAD",
+        "CAN_GRANT_AUTHORITY",
+        "CAN_ACTIVATE_LEASE",
+        "CAN_ACTIVATE_AUTHORITY",
+        "CAN_EXECUTE_REVOCATION",
+        "CAN_ARM_RUNTIME",
+        "CAN_CREATE_EXECUTION_PERMISSION",
+        "CAN_CREATE_ORDER_INTENTS",
+        "CAN_SUBMIT_TESTNET_ORDERS",
+        "CAN_SUBMIT_LIVE_ORDERS",
+        "CAN_PROMOTE_ARTIFACT",
+        "CAN_*",
+        "*",
+    }
+)
+
+_FORBIDDEN_INDEX_KEYS: frozenset[str] = frozenset(
+    {
+        "winner",
+        "selected",
+        "promoted",
+        "promotion",
+        "promotion_ready",
+        "eligible_for_live",
+        "live_eligible",
+        "runtime_eligible",
+        "ranking",
+        "ranked_input_ids",
+        "pareto",
+        "accepted",
+        "acceptance",
+        "armed",
+        "enabled",
+        "returns",
+        "positions",
+        "orders",
+        "credentials",
+        "strategy_params_mutated",
+        "config_patch",
+        "configpatch",
+        "config_patch_manifest",
+        "patches",
+        "top_n",
+        "topn",
+        "filter_candidates_for_live",
+        "promotion_candidate",
+        "safety_flags",
+    }
+)
+
+HANDOFF_ATOMIC_CLAIM_CONSUME_AUTHORITY_INVARIANTS: dict[str, bool] = {
+    **COMPARISON_AUTHORITY_INVARIANTS,
+    "handoff_atomic_claim_consume_is_descriptive_only": True,
+    "handoff_atomic_claim_consume_does_not_execute_claim": True,
+    "handoff_atomic_claim_consume_does_not_execute_consume": True,
+    "handoff_atomic_claim_consume_does_not_mutate_state": True,
+    "handoff_atomic_claim_consume_does_not_acquire_lock": True,
+    "handoff_atomic_claim_consume_does_not_create_reservation": True,
+    "handoff_atomic_claim_consume_does_not_invoke_consumer": True,
+    "handoff_atomic_claim_consume_does_not_transfer_files": True,
+    "handoff_atomic_claim_consume_does_not_grant_authority": True,
+    "handoff_atomic_claim_consume_does_not_activate_lease": True,
+    "handoff_atomic_claim_consume_does_not_execute_revocation": True,
+    "handoff_atomic_claim_consume_does_not_authorize_promotion": True,
+    "handoff_atomic_claim_consume_does_not_create_configpatch": True,
+    "handoff_atomic_claim_consume_does_not_authorize_runtime": True,
+    "handoff_atomic_claim_consume_does_not_authorize_live": True,
+    "handoff_atomic_claim_consume_is_offline_only": True,
+    "deny_by_default": True,
+    "replay_protection_bound": True,
+    "atomic_transition_contract_bound": True,
+}
+
+_REQUIRED_NON_AUTHORIZING_FLAGS: dict[str, bool] = {
+    "is_handoff_atomic_claim_consume": True,
+    "handoff_atomic_claim_consume_offline_only": True,
+    "handoff_atomic_claim_consume_complete": False,
+    "secure_handoff_envelope_bound": False,
+    "consumer_identity_bound": False,
+    "cross_domain_lineage_bound": False,
+    "deny_by_default": True,
+    "replay_protection_bound": False,
+    "atomic_transition_contract_bound": False,
+    "claim_executed": False,
+    "consume_executed": False,
+    "state_mutated": False,
+    "lock_acquired": False,
+    "reservation_created": False,
+    "ack_emitted": False,
+    "payload_transferred": False,
+    "files_transferred": False,
+    "consumer_invoked": False,
+    "consumer_mutated": False,
+    "network_side_effect_created": False,
+    "authority_granted": False,
+    "authority_activated": False,
+    "lease_activated": False,
+    "lease_renewed": False,
+    "revocation_executed": False,
+    "killswitch_executed": False,
+    "promotion_policy_executed": False,
+    "promotion_authorized": False,
+    "promotion_candidate_constructed": False,
+    "configpatch_created": False,
+    "configpatch_modified": False,
+    "configpatch_applied": False,
+    "configpatch_accepted": False,
+    "runtime_configuration_created": False,
+    "runtime_permission_created": False,
+    "execution_permission_created": False,
+    "arming_token_created": False,
+    "runtime_authorized": False,
+    "live_authorized": False,
+    "orders_allowed": False,
+    "scheduler_runtime_allowed": False,
+    "signature_created": False,
+    "private_key_used": False,
+    "credentials_accessed": False,
+}
+
+_TRANSITIVE_LINEAGE_FIELDS = (
+    "comparison_run_id",
+    "experiment_id",
+    "experiment_identity_manifest_id",
+    "learning_manifest_id",
+    "promotion_candidate_id",
+    "config_patch_manifest_id",
+    "versioned_artifact_id",
+)
+
+
+class HandoffAtomicClaimConsumeError(ValueError):
+    """Fail-closed handoff atomic claim/consume error."""
+
+
+@dataclass(frozen=True)
+class VerifiedSecureHandoffEnvelopeBundle:
+    bundle_dir: Path
+    contract_name: str
+    contract_version: str
+    producer_version: str
+    artifact_ref: str
+    artifact_digest: str
+    manifest_digest: str
+    artifact_payload: dict[str, Any]
+    envelope_id: str
+    envelope_status: str
+    payload_digest: str
+    intended_consumer_identity_ref: str
+    intended_consumer_identity_version: str
+    revocation_state: str
+    validity_metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ClaimStateContext:
+    current_state: str
+    current_revision: int
+    claim_identity: str = ""
+    consume_identity: str = ""
+    prior_claim_content_digest: str = ""
+
+
+@dataclass(frozen=True)
+class HandoffAtomicClaimConsumeRequest:
+    evaluation_time: str
+    consumer_identity_ref: str
+    consumer_identity_version: str
+    transition_evaluate: str = "FULL_CONTRACT"
+    claim_state_context: ClaimStateContext | None = None
+    allowed_offline_capabilities: tuple[str, ...] = ()
+    denied_capabilities: tuple[str, ...] = ()
+    source_revision: str = DEFAULT_SOURCE_REVISION
+    proposed_claim_content_digest: str = ""
+
+
+@dataclass(frozen=True)
+class HandoffAtomicClaimConsumeInputs:
+    secure_handoff_envelope_bundle_dir: Path
+    claim_consume_request: HandoffAtomicClaimConsumeRequest
+
+
+@dataclass(frozen=True)
+class HandoffAtomicClaimConsumeResult:
+    output_dir: Path
+    contract_id: str
+    contract_status: str
+    claim_identity: str
+    consume_identity: str
+    contract_path: Path
+    self_verification_path: Path
+    manifest_path: Path
+    envelope_ref: str
+    envelope_digest: str
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise HandoffAtomicClaimConsumeError(f"{label} must not be a symlink")
+
+
+def _reject_forbidden_index_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        if key in _FORBIDDEN_INDEX_KEYS:
+            raise HandoffAtomicClaimConsumeError(f"forbidden index key: {key}")
+
+
+def _validate_regular_file(path: Path, *, label: str) -> None:
+    _reject_symlink(path, label=label)
+    if not path.is_file():
+        raise HandoffAtomicClaimConsumeError(f"{label} must be a regular file: {path}")
+
+
+def _validate_bundle_dir(bundle_dir: Path, *, label: str) -> None:
+    _reject_symlink(bundle_dir, label=label)
+    if not bundle_dir.is_dir():
+        raise HandoffAtomicClaimConsumeError(f"{label} must be a directory: {bundle_dir}")
+
+
+def _validate_output_target(output_dir: Path) -> None:
+    if output_dir.exists():
+        raise HandoffAtomicClaimConsumeError(f"output directory already exists: {output_dir}")
+    if is_under_tmp(output_dir):
+        raise HandoffAtomicClaimConsumeError("output directory must not be under /tmp")
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _reject_unsafe_overlap(*, envelope_dir: Path, output_dir: Path) -> None:
+    if envelope_dir.resolve() == output_dir.resolve():
+        raise HandoffAtomicClaimConsumeError(
+            "output directory must not equal secure handoff envelope bundle directory"
+        )
+    if _path_is_under(output_dir, envelope_dir) or _path_is_under(envelope_dir, output_dir):
+        raise HandoffAtomicClaimConsumeError(
+            "output directory must not overlap secure handoff envelope bundle directory"
+        )
+
+
+def _manifest_file_digest(bundle_dir: Path) -> str:
+    manifest_path = bundle_dir / MANIFEST_FILENAME
+    _validate_regular_file(manifest_path, label=MANIFEST_FILENAME)
+    return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+
+def _factor(
+    *,
+    factor_id: str,
+    factor_type: str,
+    source_field: str,
+    detail: str,
+) -> dict[str, str]:
+    return {
+        "factor_id": factor_id,
+        "factor_type": factor_type,
+        "source_field": source_field,
+        "detail": detail,
+    }
+
+
+def _sort_factors(factors: list[dict[str, str]]) -> list[dict[str, str]]:
+    return sorted(factors, key=lambda item: (item["factor_id"], item["source_field"]))
+
+
+def _sorted_strings(values: list[str]) -> list[str]:
+    return sorted(values)
+
+
+def _load_self_verification(bundle_dir: Path, *, rel: str, label: str) -> dict[str, Any]:
+    path = bundle_dir / rel
+    _validate_regular_file(path, label=label)
+    payload = read_manifest(path)
+    if not isinstance(payload, dict):
+        raise HandoffAtomicClaimConsumeError(f"{label} must be an object")
+    return payload
+
+
+def _artifact_digest_from_payload(payload: Mapping[str, Any]) -> str:
+    output_digest = payload.get("output_digest")
+    if isinstance(output_digest, str) and is_valid_sha256_hex(output_digest):
+        return output_digest
+    raise HandoffAtomicClaimConsumeError("artifact output_digest missing or invalid")
+
+
+def _parse_utc_instant(value: str, *, field: str) -> datetime:
+    if not _UTC_INSTANT_PATTERN.match(value):
+        raise HandoffAtomicClaimConsumeError(f"{field} must be UTC instant with +00:00 or Z")
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        raise HandoffAtomicClaimConsumeError(f"{field} must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _validate_capability_name(capability: str) -> None:
+    if capability in _FORBIDDEN_CAPABILITIES:
+        raise HandoffAtomicClaimConsumeError(f"forbidden capability: {capability}")
+    if not capability.startswith("CAN_"):
+        raise HandoffAtomicClaimConsumeError(f"capability must start with CAN_: {capability}")
+
+
+def _normalize_capabilities(values: tuple[str, ...] | list[str], *, label: str) -> list[str]:
+    normalized: list[str] = []
+    for capability in values:
+        if not isinstance(capability, str) or not capability:
+            raise HandoffAtomicClaimConsumeError(f"{label} entries must be non-empty strings")
+        _validate_capability_name(capability)
+        normalized.append(capability)
+    return sorted(set(normalized))
+
+
+def _validate_non_authorizing_flags(payload: Mapping[str, Any]) -> None:
+    for key, expected in _REQUIRED_NON_AUTHORIZING_FLAGS.items():
+        actual = payload.get(key)
+        if key in {
+            "handoff_atomic_claim_consume_complete",
+            "secure_handoff_envelope_bound",
+            "consumer_identity_bound",
+            "cross_domain_lineage_bound",
+            "replay_protection_bound",
+            "atomic_transition_contract_bound",
+        }:
+            continue
+        if actual is not expected:
+            raise HandoffAtomicClaimConsumeError(f"{key} must be {expected!r}, got {actual!r}")
+
+
+def verify_secure_handoff_envelope_bundle(
+    bundle_dir: Path | str,
+) -> VerifiedSecureHandoffEnvelopeBundle:
+    """Fail-closed verification of exactly one secure handoff envelope bundle."""
+    path = Path(bundle_dir)
+    _validate_bundle_dir(path, label="secure handoff envelope bundle")
+    ok, msg = verify_manifest_sha256(path)
+    if not ok:
+        raise HandoffAtomicClaimConsumeError(
+            f"secure handoff envelope MANIFEST.sha256 verification failed: {msg}"
+        )
+
+    artifact_path = path / SECURE_HANDOFF_ENVELOPE_ARTIFACT_REL
+    _validate_regular_file(artifact_path, label=SECURE_HANDOFF_ENVELOPE_ARTIFACT_REL)
+    payload = read_manifest(artifact_path)
+    if payload.get("contract_name") != SECURE_HANDOFF_ENVELOPE_CONTRACT_NAME:
+        raise HandoffAtomicClaimConsumeError("secure handoff envelope contract_name mismatch")
+    if payload.get("contract_version") != SECURE_HANDOFF_ENVELOPE_CONTRACT_VERSION:
+        raise HandoffAtomicClaimConsumeError("secure handoff envelope contract_version mismatch")
+
+    self_payload = _load_self_verification(
+        path,
+        rel=SECURE_HANDOFF_ENVELOPE_SELF_VERIFICATION_REL,
+        label=SECURE_HANDOFF_ENVELOPE_SELF_VERIFICATION_REL,
+    )
+    if self_payload.get("overall_status") != "PASS":
+        raise HandoffAtomicClaimConsumeError(
+            "secure handoff envelope SELF_VERIFICATION overall_status must be PASS"
+        )
+
+    try:
+        reverify_secure_handoff_envelope_v1(output_dir=path)
+    except SecureHandoffEnvelopeError as exc:
+        raise HandoffAtomicClaimConsumeError(str(exc)) from exc
+
+    validity_metadata = payload.get("validity_metadata")
+    if not isinstance(validity_metadata, dict):
+        raise HandoffAtomicClaimConsumeError("secure handoff envelope validity_metadata invalid")
+
+    return VerifiedSecureHandoffEnvelopeBundle(
+        bundle_dir=path.resolve(),
+        contract_name=SECURE_HANDOFF_ENVELOPE_CONTRACT_NAME,
+        contract_version=SECURE_HANDOFF_ENVELOPE_CONTRACT_VERSION,
+        producer_version=SECURE_HANDOFF_ENVELOPE_PRODUCER_VERSION,
+        artifact_ref=SECURE_HANDOFF_ENVELOPE_ARTIFACT_REL,
+        artifact_digest=_artifact_digest_from_payload(payload),
+        manifest_digest=_manifest_file_digest(path),
+        artifact_payload=dict(payload),
+        envelope_id=str(payload.get("envelope_id", "")),
+        envelope_status=str(payload.get("envelope_status", "")),
+        payload_digest=str(payload.get("payload_digest", "")),
+        intended_consumer_identity_ref=str(
+            payload.get("intended_consumer_identity_ref", CONSUMER_CONTRACT_ID)
+        ),
+        intended_consumer_identity_version=str(
+            payload.get("intended_consumer_identity_version", CONSUMER_CONTRACT_VERSION)
+        ),
+        revocation_state=str(payload.get("revocation_state", "")),
+        validity_metadata=dict(validity_metadata),
+    )
+
+
+def _default_claim_state_context() -> ClaimStateContext:
+    return ClaimStateContext(current_state="UNCLAIMED", current_revision=INITIAL_REVISION)
+
+
+def _compute_claim_identity(
+    *,
+    envelope_id: str,
+    envelope_digest: str,
+    consumer_identity_ref: str,
+    consumer_identity_version: str,
+    expected_revision: int,
+) -> str:
+    return compute_content_sha256(
+        {
+            "claim_domain": CONTRACT_NAME,
+            "claim_contract_version": CLAIM_CONTRACT_VERSION,
+            "envelope_id": envelope_id,
+            "envelope_digest": envelope_digest,
+            "consumer_identity_ref": consumer_identity_ref,
+            "consumer_identity_version": consumer_identity_version,
+            "expected_revision": expected_revision,
+            "deterministic_rule_set_version": DETERMINISTIC_RULE_SET_VERSION,
+        }
+    )
+
+
+def _compute_consume_identity(
+    *,
+    claim_identity: str,
+    envelope_id: str,
+    consumer_identity_ref: str,
+    consumer_identity_version: str,
+) -> str:
+    return compute_content_sha256(
+        {
+            "consume_domain": CONTRACT_NAME,
+            "consume_contract_version": CONSUME_CONTRACT_VERSION,
+            "claim_identity": claim_identity,
+            "envelope_id": envelope_id,
+            "consumer_identity_ref": consumer_identity_ref,
+            "consumer_identity_version": consumer_identity_version,
+            "deterministic_rule_set_version": DETERMINISTIC_RULE_SET_VERSION,
+        }
+    )
+
+
+def _compute_contract_id(
+    *,
+    envelope_id: str,
+    claim_identity: str,
+    consume_identity: str,
+    transition_evaluate: str,
+    expected_revision: int,
+) -> str:
+    return compute_content_sha256(
+        {
+            "contract_domain": CONTRACT_NAME,
+            "envelope_id": envelope_id,
+            "claim_identity": claim_identity,
+            "consume_identity": consume_identity,
+            "transition_evaluate": transition_evaluate,
+            "expected_revision": expected_revision,
+            "deterministic_rule_set_version": DETERMINISTIC_RULE_SET_VERSION,
+        }
+    )
+
+
+def _validate_request(
+    request: HandoffAtomicClaimConsumeRequest,
+    *,
+    envelope: VerifiedSecureHandoffEnvelopeBundle,
+) -> list[dict[str, str]]:
+    blocking: list[dict[str, str]] = []
+
+    if request.transition_evaluate not in _VALID_TRANSITION_EVALUATE:
+        blocking.append(
+            _factor(
+                factor_id="UNKNOWN_TRANSITION_EVALUATE",
+                factor_type="CONTRADICTION",
+                source_field="transition_evaluate",
+                detail=request.transition_evaluate,
+            )
+        )
+
+    try:
+        eval_time = _parse_utc_instant(request.evaluation_time, field="evaluation_time")
+    except HandoffAtomicClaimConsumeError as exc:
+        blocking.append(
+            _factor(
+                factor_id="INVALID_EVALUATION_TIME",
+                factor_type="BLOCKING",
+                source_field="evaluation_time",
+                detail=str(exc),
+            )
+        )
+        eval_time = None
+
+    if request.consumer_identity_ref != envelope.intended_consumer_identity_ref:
+        blocking.append(
+            _factor(
+                factor_id="CONSUMER_IDENTITY_REF_MISMATCH",
+                factor_type="CONTRADICTION",
+                source_field="consumer_identity_ref",
+                detail=request.consumer_identity_ref,
+            )
+        )
+
+    if request.consumer_identity_version != envelope.intended_consumer_identity_version:
+        blocking.append(
+            _factor(
+                factor_id="CONSUMER_IDENTITY_VERSION_MISMATCH",
+                factor_type="CONTRADICTION",
+                source_field="consumer_identity_version",
+                detail=request.consumer_identity_version,
+            )
+        )
+
+    if eval_time is not None:
+        valid_from_raw = envelope.validity_metadata.get("valid_from")
+        valid_until_raw = envelope.validity_metadata.get("valid_until")
+        if valid_from_raw and valid_until_raw:
+            valid_from = _parse_utc_instant(str(valid_from_raw), field="valid_from")
+            valid_until = _parse_utc_instant(str(valid_until_raw), field="valid_until")
+            if eval_time < valid_from:
+                blocking.append(
+                    _factor(
+                        factor_id="EVALUATION_BEFORE_VALID_FROM",
+                        factor_type="BLOCKING",
+                        source_field="evaluation_time",
+                        detail=request.evaluation_time,
+                    )
+                )
+            if eval_time >= valid_until:
+                blocking.append(
+                    _factor(
+                        factor_id="EVALUATION_AT_OR_AFTER_VALID_UNTIL",
+                        factor_type="BLOCKING",
+                        source_field="evaluation_time",
+                        detail=request.evaluation_time,
+                    )
+                )
+
+    allowed_capabilities = (
+        _normalize_capabilities(
+            request.allowed_offline_capabilities, label="allowed_offline_capabilities"
+        )
+        if request.allowed_offline_capabilities
+        else []
+    )
+    if not allowed_capabilities and request.transition_evaluate == "FULL_CONTRACT":
+        blocking.append(
+            _factor(
+                factor_id="EMPTY_CAPABILITY_ALLOWLIST",
+                factor_type="MISSING_PRECONDITION",
+                source_field="allowed_offline_capabilities",
+                detail="empty",
+            )
+        )
+
+    for capability in allowed_capabilities:
+        if capability not in _DEFAULT_ALLOWED_OFFLINE_CAPABILITIES:
+            blocking.append(
+                _factor(
+                    factor_id="UNKNOWN_OFFLINE_CAPABILITY",
+                    factor_type="BLOCKING",
+                    source_field="allowed_offline_capabilities",
+                    detail=capability,
+                )
+            )
+
+    denied_capabilities = _normalize_capabilities(
+        request.denied_capabilities, label="denied_capabilities"
+    )
+    overlap = sorted(set(allowed_capabilities) & set(denied_capabilities))
+    for capability in overlap:
+        blocking.append(
+            _factor(
+                factor_id="CAPABILITY_ALLOW_DENY_CONFLICT",
+                factor_type="CONTRADICTION",
+                source_field="allowed_offline_capabilities",
+                detail=capability,
+            )
+        )
+
+    context = request.claim_state_context or _default_claim_state_context()
+    if context.current_state not in _VALID_STATES:
+        blocking.append(
+            _factor(
+                factor_id="UNKNOWN_CLAIM_STATE",
+                factor_type="CONTRADICTION",
+                source_field="claim_state_context.current_state",
+                detail=context.current_state,
+            )
+        )
+    if context.current_revision < 0:
+        blocking.append(
+            _factor(
+                factor_id="NEGATIVE_REVISION",
+                factor_type="CONTRADICTION",
+                source_field="claim_state_context.current_revision",
+                detail=str(context.current_revision),
+            )
+        )
+
+    return blocking
+
+
+def _evaluate_transition(
+    *,
+    envelope: VerifiedSecureHandoffEnvelopeBundle,
+    request: HandoffAtomicClaimConsumeRequest,
+    blocking_facts: list[dict[str, str]],
+    claim_identity: str,
+    consume_identity: str,
+) -> tuple[str, list[str], dict[str, Any]]:
+    reason_codes: list[str] = []
+    transition_metadata: dict[str, Any] = {
+        "expected_state": "UNCLAIMED",
+        "claim_target_state": "CLAIMED",
+        "consume_target_state": "CONSUMED",
+        "claim_precondition_state": "CLAIMABLE",
+        "consume_precondition_state": "CONSUMABLE",
+        "expected_revision": INITIAL_REVISION,
+        "claim_transition_allowed": False,
+        "consume_transition_allowed": False,
+        "exactly_once_semantics": "AT_MOST_ONCE_PER_ENVELOPE_AND_CONSUMER",
+        "duplicate_claim_policy": "FAIL_CLOSED",
+        "duplicate_consume_policy": "FAIL_CLOSED",
+    }
+    completion = {
+        "handoff_atomic_claim_consume_complete": False,
+        "secure_handoff_envelope_bound": False,
+        "consumer_identity_bound": False,
+        "cross_domain_lineage_bound": False,
+        "replay_protection_bound": False,
+        "atomic_transition_contract_bound": False,
+    }
+
+    envelope_payload = envelope.artifact_payload
+    envelope_status = envelope.envelope_status
+
+    if envelope_status == "ABSTAIN" or envelope.revocation_state == "UNKNOWN":
+        reason_codes.append("REVOCATION_STATE_UNKNOWN")
+        transition_metadata["expected_state"] = "ABSTAIN"
+        return (
+            "ABSTAIN",
+            _sorted_strings(reason_codes),
+            {
+                **transition_metadata,
+                **completion,
+            },
+        )
+
+    if envelope_status == "ENVELOPE_REVOKED" or envelope.revocation_state == "REVOKED":
+        reason_codes.append("REVOCATION_PRECEDENCE")
+        transition_metadata["expected_state"] = "REVOKED"
+        completion["secure_handoff_envelope_bound"] = True
+        return (
+            "CONTRACT_REVOKED",
+            _sorted_strings(reason_codes),
+            {
+                **transition_metadata,
+                **completion,
+            },
+        )
+
+    if envelope_status == "ENVELOPE_EXPIRED":
+        reason_codes.append("ENVELOPE_EXPIRED")
+        transition_metadata["expected_state"] = "EXPIRED"
+        completion["secure_handoff_envelope_bound"] = True
+        return (
+            "CONTRACT_EXPIRED",
+            _sorted_strings(reason_codes),
+            {
+                **transition_metadata,
+                **completion,
+            },
+        )
+
+    if envelope_status != "ENVELOPE_VALID_FOR_OFFLINE_HANDOFF":
+        reason_codes.append("ENVELOPE_NOT_VALID")
+        return (
+            "CONTRACT_INVALID",
+            _sorted_strings(reason_codes),
+            {
+                **transition_metadata,
+                **completion,
+            },
+        )
+
+    completion["secure_handoff_envelope_bound"] = True
+    completion["consumer_identity_bound"] = True
+    if envelope_payload.get("cross_domain_lineage_bound") is True:
+        completion["cross_domain_lineage_bound"] = True
+
+    contradictions = [item for item in blocking_facts if item.get("factor_type") == "CONTRADICTION"]
+    if contradictions or any(
+        item.get("factor_id") == "EVALUATION_AT_OR_AFTER_VALID_UNTIL" for item in blocking_facts
+    ):
+        reason_codes.append("CONTRACT_FAIL_CLOSED")
+        if any(
+            item.get("factor_id") == "EVALUATION_AT_OR_AFTER_VALID_UNTIL" for item in blocking_facts
+        ):
+            transition_metadata["expected_state"] = "EXPIRED"
+            return (
+                "CONTRACT_EXPIRED",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+        return (
+            "CONTRACT_INVALID",
+            _sorted_strings(reason_codes),
+            {
+                **transition_metadata,
+                **completion,
+            },
+        )
+
+    if blocking_facts:
+        reason_codes.append("CONTRACT_FAIL_CLOSED")
+        return (
+            "CONTRACT_INVALID",
+            _sorted_strings(reason_codes),
+            {
+                **transition_metadata,
+                **completion,
+            },
+        )
+
+    context = request.claim_state_context or _default_claim_state_context()
+    transition_metadata["expected_state"] = context.current_state
+    transition_metadata["expected_revision"] = context.current_revision
+
+    expected_claim_identity = _compute_claim_identity(
+        envelope_id=envelope.envelope_id,
+        envelope_digest=envelope.artifact_digest,
+        consumer_identity_ref=request.consumer_identity_ref,
+        consumer_identity_version=request.consumer_identity_version,
+        expected_revision=context.current_revision,
+    )
+    expected_consume_identity = _compute_consume_identity(
+        claim_identity=expected_claim_identity,
+        envelope_id=envelope.envelope_id,
+        consumer_identity_ref=request.consumer_identity_ref,
+        consumer_identity_version=request.consumer_identity_version,
+    )
+
+    if request.transition_evaluate == "CLAIM":
+        if context.current_state in {"CLAIMED", "CONSUMABLE", "CONSUMED"}:
+            if context.claim_identity and context.claim_identity == expected_claim_identity:
+                reason_codes.append("DUPLICATE_CLAIM_REPLAY")
+                transition_metadata["expected_state"] = "REPLAY_REJECTED"
+                completion["replay_protection_bound"] = True
+                return (
+                    "CONTRACT_REPLAY_REJECTED",
+                    _sorted_strings(reason_codes),
+                    {
+                        **transition_metadata,
+                        **completion,
+                    },
+                )
+            reason_codes.append("DUPLICATE_CLAIM_CONFLICT")
+            transition_metadata["expected_state"] = "CONFLICT"
+            completion["replay_protection_bound"] = True
+            return (
+                "CONTRACT_CONFLICT",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+
+        if context.current_state not in {"UNCLAIMED", "CLAIMABLE"}:
+            reason_codes.append("CLAIM_INVALID_PRECONDITION_STATE")
+            return (
+                "CONTRACT_INVALID",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+
+        if context.current_revision != INITIAL_REVISION:
+            reason_codes.append("STALE_REVISION")
+            transition_metadata["expected_state"] = "CONFLICT"
+            completion["replay_protection_bound"] = True
+            return (
+                "CONTRACT_CONFLICT",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+
+        if (
+            request.proposed_claim_content_digest
+            and context.prior_claim_content_digest
+            and request.proposed_claim_content_digest != context.prior_claim_content_digest
+        ):
+            reason_codes.append("CLAIM_REPLAY_CONTENT_MISMATCH")
+            transition_metadata["expected_state"] = "REPLAY_REJECTED"
+            completion["replay_protection_bound"] = True
+            return (
+                "CONTRACT_REPLAY_REJECTED",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+
+        transition_metadata["claim_transition_allowed"] = True
+        transition_metadata["expected_state"] = "CLAIMABLE"
+        reason_codes.extend(["ENVELOPE_BOUND", "CLAIM_PRECONDITIONS_MET", "CLAIM_CLAIMABLE"])
+        completion["atomic_transition_contract_bound"] = True
+        completion["replay_protection_bound"] = True
+        return (
+            "CONTRACT_CLAIMABLE",
+            _sorted_strings(reason_codes),
+            {
+                **transition_metadata,
+                **completion,
+            },
+        )
+
+    if request.transition_evaluate == "CONSUME":
+        if context.current_state == "CONSUMED":
+            if context.consume_identity and context.consume_identity == expected_consume_identity:
+                reason_codes.append("DUPLICATE_CONSUME_REPLAY")
+                transition_metadata["expected_state"] = "REPLAY_REJECTED"
+                completion["replay_protection_bound"] = True
+                return (
+                    "CONTRACT_REPLAY_REJECTED",
+                    _sorted_strings(reason_codes),
+                    {
+                        **transition_metadata,
+                        **completion,
+                    },
+                )
+            reason_codes.append("DUPLICATE_CONSUME_CONFLICT")
+            transition_metadata["expected_state"] = "CONFLICT"
+            completion["replay_protection_bound"] = True
+            return (
+                "CONTRACT_CONFLICT",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+
+        if context.current_state not in {"CLAIMED", "CONSUMABLE"}:
+            reason_codes.append("CONSUME_WITHOUT_CLAIM")
+            return (
+                "CONTRACT_INVALID",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+
+        if not context.claim_identity:
+            reason_codes.append("MISSING_CLAIM_IDENTITY")
+            return (
+                "CONTRACT_INVALID",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+
+        if context.claim_identity != expected_claim_identity:
+            reason_codes.append("FOREIGN_CLAIM_IDENTITY")
+            return (
+                "CONTRACT_INVALID",
+                _sorted_strings(reason_codes),
+                {
+                    **transition_metadata,
+                    **completion,
+                },
+            )
+
+        transition_metadata["consume_transition_allowed"] = True
+        transition_metadata["expected_state"] = "CONSUMABLE"
+        reason_codes.extend(
+            ["ENVELOPE_BOUND", "CLAIM_BOUND", "CONSUME_PRECONDITIONS_MET", "CONSUME_CONSUMABLE"]
+        )
+        completion["atomic_transition_contract_bound"] = True
+        completion["replay_protection_bound"] = True
+        return (
+            "CONTRACT_CONSUMABLE",
+            _sorted_strings(reason_codes),
+            {
+                **transition_metadata,
+                **completion,
+            },
+        )
+
+    transition_metadata["claim_transition_allowed"] = True
+    transition_metadata["consume_transition_allowed"] = True
+    reason_codes.extend(
+        [
+            "ENVELOPE_BOUND",
+            "CONSUMER_IDENTITY_BOUND",
+            "ATOMIC_TRANSITION_CONTRACT_BOUND",
+            "REPLAY_PROTECTION_BOUND",
+            "CONTRACT_VALID_FOR_OFFLINE_ATOMIC_CLAIM_CONSUME",
+        ]
+    )
+    completion["handoff_atomic_claim_consume_complete"] = True
+    completion["atomic_transition_contract_bound"] = True
+    completion["replay_protection_bound"] = True
+    return (
+        "CONTRACT_VALID_FOR_OFFLINE_ATOMIC_CLAIM_CONSUME",
+        _sorted_strings(reason_codes),
+        {**transition_metadata, **completion},
+    )
+
+
+def _input_artifact_ref_mapping(*, bundle: VerifiedSecureHandoffEnvelopeBundle) -> dict[str, Any]:
+    return {
+        "artifact_type": bundle.contract_name,
+        "contract_name": bundle.contract_name,
+        "contract_version": bundle.contract_version,
+        "artifact_ref": bundle.artifact_ref,
+        "artifact_digest": bundle.artifact_digest,
+        "manifest_digest": bundle.manifest_digest,
+        "producer_version": bundle.producer_version,
+        "bundle_path": bundle.bundle_dir.as_posix(),
+    }
+
+
+def _compute_output_digest(body: Mapping[str, Any]) -> str:
+    excluded = frozenset(
+        {
+            "output_digest",
+            "manifest_digest",
+            "integrity",
+            "created_at",
+            "artifact_id",
+            "contract_id",
+        }
+    )
+    digest_body = {key: body[key] for key in sorted(body) if key not in excluded}
+    return compute_content_sha256(digest_body)
+
+
+def _integrity_body(body: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in body.items() if key not in {"integrity", "manifest_digest"}
+    }
+
+
+def build_handoff_atomic_claim_consume_v1(
+    *,
+    envelope: VerifiedSecureHandoffEnvelopeBundle,
+    request: HandoffAtomicClaimConsumeRequest,
+) -> dict[str, Any]:
+    blocking_facts = _validate_request(request, envelope=envelope)
+    contradictions = [item for item in blocking_facts if item.get("factor_type") == "CONTRADICTION"]
+    non_contradiction_blocking = [
+        item for item in blocking_facts if item.get("factor_type") != "CONTRADICTION"
+    ]
+
+    context = request.claim_state_context or _default_claim_state_context()
+    claim_identity = _compute_claim_identity(
+        envelope_id=envelope.envelope_id,
+        envelope_digest=envelope.artifact_digest,
+        consumer_identity_ref=request.consumer_identity_ref,
+        consumer_identity_version=request.consumer_identity_version,
+        expected_revision=context.current_revision,
+    )
+    consume_identity = _compute_consume_identity(
+        claim_identity=claim_identity,
+        envelope_id=envelope.envelope_id,
+        consumer_identity_ref=request.consumer_identity_ref,
+        consumer_identity_version=request.consumer_identity_version,
+    )
+
+    contract_status, reason_codes, transition_metadata = _evaluate_transition(
+        envelope=envelope,
+        request=request,
+        blocking_facts=blocking_facts,
+        claim_identity=claim_identity,
+        consume_identity=consume_identity,
+    )
+    completion_flags = {
+        key: transition_metadata[key]
+        for key in (
+            "handoff_atomic_claim_consume_complete",
+            "secure_handoff_envelope_bound",
+            "consumer_identity_bound",
+            "cross_domain_lineage_bound",
+            "replay_protection_bound",
+            "atomic_transition_contract_bound",
+        )
+        if key in transition_metadata
+    }
+
+    allowed_capabilities = (
+        _normalize_capabilities(
+            request.allowed_offline_capabilities, label="allowed_offline_capabilities"
+        )
+        if request.allowed_offline_capabilities
+        else sorted(_DEFAULT_ALLOWED_OFFLINE_CAPABILITIES)
+    )
+    denied_capabilities = _normalize_capabilities(
+        request.denied_capabilities, label="denied_capabilities"
+    )
+    for forbidden in sorted(_FORBIDDEN_CAPABILITIES - {"*", "CAN_*"}):
+        if forbidden not in denied_capabilities:
+            denied_capabilities.append(forbidden)
+    denied_capabilities = sorted(set(denied_capabilities))
+
+    envelope_payload = envelope.artifact_payload
+    input_refs = [_input_artifact_ref_mapping(bundle=envelope)]
+    input_digest = compute_content_sha256({"input_artifact_refs": input_refs})
+
+    contract_id = _compute_contract_id(
+        envelope_id=envelope.envelope_id,
+        claim_identity=claim_identity,
+        consume_identity=consume_identity,
+        transition_evaluate=request.transition_evaluate,
+        expected_revision=context.current_revision,
+    )
+
+    idempotency_key = compute_content_sha256(
+        {
+            "envelope_id": envelope.envelope_id,
+            "claim_identity": claim_identity,
+            "consume_identity": consume_identity,
+            "transition_evaluate": request.transition_evaluate,
+            "evaluation_time": request.evaluation_time,
+        }
+    )
+
+    replay_protection_metadata = {
+        "idempotency_key": idempotency_key,
+        "input_digest": input_digest,
+        "duplicate_claim_policy": "FAIL_CLOSED",
+        "duplicate_consume_policy": "FAIL_CLOSED",
+        "replay_with_changed_payload_digest_policy": "FAIL_CLOSED",
+        "deterministic_rule_set_version": DETERMINISTIC_RULE_SET_VERSION,
+        "cas_revision_field": "expected_revision",
+        "generation_field": "expected_revision",
+    }
+
+    duplicate_detection_metadata = {
+        "claim_identity_domain": CLAIM_CONTRACT_VERSION,
+        "consume_identity_domain": CONSUME_CONTRACT_VERSION,
+        "same_identity_same_content_policy": "IDEMPOTENT_REPLAY_ALLOWED_OFFLINE_ONLY",
+        "same_identity_different_content_policy": "FAIL_CLOSED",
+    }
+
+    retry_semantics = {
+        "crash_before_commit": "NO_EFFECT",
+        "crash_after_commit": "REPLAY_DETECTED_BY_IDENTITY_AND_REVISION",
+        "retry_without_double_effect": True,
+        "offline_only": True,
+    }
+
+    crash_consistency_semantics = {
+        "atomicity_model": "COMPARE_AND_SWAP_ON_REVISION",
+        "partial_success_forbidden": True,
+        "failure_before_commit_no_effect": True,
+        "failure_after_commit_replay_visible": True,
+    }
+
+    allowed_transitions = [
+        {"from_state": source, "to_state": target} for source, target in _ALLOWED_TRANSITIONS
+    ]
+    forbidden_transitions = [
+        {"from_state": source, "to_state": target} for source, target in _FORBIDDEN_TRANSITIONS
+    ]
+
+    transition_preconditions = {
+        "claim": [
+            "verified_secure_handoff_envelope_v1_bundle",
+            "envelope_status_valid_for_offline_handoff",
+            "consumer_identity_matches_envelope",
+            "expected_state_unclaimed_or_claimable",
+            "expected_revision_matches_cas",
+            "revocation_not_active",
+            "expiry_not_reached",
+            "deny_by_default",
+        ],
+        "consume": [
+            "verified_secure_handoff_envelope_v1_bundle",
+            "valid_claim_identity_present",
+            "claim_identity_matches_envelope_and_consumer",
+            "expected_state_claimed_or_consumable",
+            "no_duplicate_consume",
+            "revocation_not_active",
+            "expiry_not_reached",
+            "deny_by_default",
+        ],
+    }
+
+    payload: dict[str, Any] = {
+        "contract_id": "",
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "claim_contract_version": CLAIM_CONTRACT_VERSION,
+        "consume_contract_version": CONSUME_CONTRACT_VERSION,
+        "schema_version": SCHEMA_VERSION,
+        "creation_contract_version": CREATION_CONTRACT_VERSION,
+        "artifact_id": "",
+        "created_at": OFFLINE_DETERMINISTIC_CREATED_AT,
+        "contract_creation_time": OFFLINE_DETERMINISTIC_CREATED_AT,
+        "producer_version": PRODUCER_VERSION,
+        "producer_identity_ref": DEFAULT_PRODUCER_IDENTITY_REF,
+        "producer_identity_version": PRODUCER_VERSION,
+        "record_kind": RECORD_KIND,
+        "input_relation": INPUT_RELATION,
+        "evidence_level": EVIDENCE_LEVEL,
+        "authority_level": AUTHORITY_LEVEL,
+        "deterministic_rule_set_version": DETERMINISTIC_RULE_SET_VERSION,
+        "contract_status": contract_status,
+        "contract_reason_codes": reason_codes,
+        "transition_evaluate": request.transition_evaluate,
+        "envelope_ref": envelope.artifact_ref,
+        "envelope_digest": envelope.artifact_digest,
+        "envelope_id": envelope.envelope_id,
+        "envelope_status": envelope.envelope_status,
+        "secure_handoff_envelope_bundle_ref": envelope.bundle_dir.as_posix(),
+        "secure_handoff_envelope_manifest_digest": envelope.manifest_digest,
+        "secure_handoff_envelope_contract_name": envelope.contract_name,
+        "secure_handoff_envelope_contract_version": envelope.contract_version,
+        "secure_handoff_envelope_producer_version": envelope.producer_version,
+        "consumer_identity_ref": request.consumer_identity_ref,
+        "consumer_identity_version": request.consumer_identity_version,
+        "claim_identity": claim_identity,
+        "consume_identity": consume_identity,
+        "expected_state": transition_metadata.get("expected_state", context.current_state),
+        "claim_target_state": transition_metadata.get("claim_target_state", "CLAIMED"),
+        "consume_target_state": transition_metadata.get("consume_target_state", "CONSUMED"),
+        "claim_precondition_state": transition_metadata.get(
+            "claim_precondition_state", "CLAIMABLE"
+        ),
+        "consume_precondition_state": transition_metadata.get(
+            "consume_precondition_state", "CONSUMABLE"
+        ),
+        "expected_revision": transition_metadata.get("expected_revision", context.current_revision),
+        "claim_transition_allowed": transition_metadata.get("claim_transition_allowed", False),
+        "consume_transition_allowed": transition_metadata.get("consume_transition_allowed", False),
+        "exactly_once_semantics": transition_metadata.get(
+            "exactly_once_semantics", "AT_MOST_ONCE_PER_ENVELOPE_AND_CONSUMER"
+        ),
+        "allowed_transitions": allowed_transitions,
+        "forbidden_transitions": forbidden_transitions,
+        "transition_preconditions": transition_preconditions,
+        "allowed_offline_capabilities": allowed_capabilities,
+        "denied_capabilities": denied_capabilities,
+        "revocation_state": envelope.revocation_state,
+        "expiry_state": envelope.envelope_status
+        if envelope.envelope_status == "ENVELOPE_EXPIRED"
+        else "NOT_EXPIRED",
+        "replay_protection_metadata": replay_protection_metadata,
+        "duplicate_detection_metadata": duplicate_detection_metadata,
+        "retry_semantics": retry_semantics,
+        "crash_consistency_semantics": crash_consistency_semantics,
+        "blocking_facts": _sort_factors(non_contradiction_blocking),
+        "missing_preconditions": _sort_factors(
+            [item for item in blocking_facts if item.get("factor_type") == "MISSING_PRECONDITION"]
+        ),
+        "contradictions": _sort_factors(contradictions),
+        "handoff_atomic_claim_consume_authority_invariants": dict(
+            HANDOFF_ATOMIC_CLAIM_CONSUME_AUTHORITY_INVARIANTS
+        ),
+        "input_artifact_refs": input_refs,
+        "cross_domain_lineage": (
+            dict(envelope_payload["cross_domain_lineage"])
+            if isinstance(envelope_payload.get("cross_domain_lineage"), dict)
+            and envelope_payload.get("cross_domain_lineage")
+            else {
+                field: str(envelope_payload[field])
+                for field in _TRANSITIVE_LINEAGE_FIELDS
+                if envelope_payload.get(field) is not None and str(envelope_payload.get(field))
+            }
+        ),
+        "provenance": {
+            "producer_contract_name": CONTRACT_NAME,
+            "producer_contract_version": CONTRACT_VERSION,
+            "creation_contract_version": CREATION_CONTRACT_VERSION,
+            "evidence_level": EVIDENCE_LEVEL,
+            "offline_only": True,
+            "contract_created_for_offline_evidence_only": True,
+        },
+        "source_revision": request.source_revision,
+        "validity_metadata": {
+            **envelope.validity_metadata,
+            "evaluation_time": request.evaluation_time,
+        },
+        "integrity_metadata": {
+            "digest_algorithm": "sha256",
+            "canonical_serialization": "deterministic_json_dumps",
+            "contract_id_domain": CONTRACT_NAME,
+            "signature_created": False,
+        },
+        "input_digest": input_digest,
+        "output_digest": "",
+        "manifest_digest": "",
+    }
+
+    for key, value in _REQUIRED_NON_AUTHORIZING_FLAGS.items():
+        payload[key] = value
+    payload.update(completion_flags)
+
+    for field in _TRANSITIVE_LINEAGE_FIELDS:
+        value = envelope_payload.get(field)
+        if value is not None and str(value):
+            payload[field] = str(value)
+
+    _reject_forbidden_index_keys(payload)
+    _validate_non_authorizing_flags(payload)
+    if contract_status not in _VALID_CONTRACT_STATUSES:
+        raise HandoffAtomicClaimConsumeError("contract_status invalid")
+
+    payload["input_digest"] = input_digest
+    output_digest = _compute_output_digest(payload)
+    payload["output_digest"] = output_digest
+    payload["artifact_id"] = output_digest
+    payload["contract_id"] = contract_id
+    return payload
+
+
+def serialize_handoff_atomic_claim_consume_v1(contract: Mapping[str, Any]) -> str:
+    _reject_forbidden_index_keys(contract)
+    _validate_non_authorizing_flags(contract)
+    if contract.get("contract_status") not in _VALID_CONTRACT_STATUSES:
+        raise HandoffAtomicClaimConsumeError("contract_status invalid")
+    for list_field in (
+        "contract_reason_codes",
+        "blocking_facts",
+        "missing_preconditions",
+        "contradictions",
+        "allowed_offline_capabilities",
+        "denied_capabilities",
+    ):
+        values = contract.get(list_field)
+        if isinstance(values, list) and values != sorted(
+            values,
+            key=lambda item: (
+                item.get("factor_id", item) if isinstance(item, dict) else item,
+                item.get("source_field", "") if isinstance(item, dict) else "",
+            ),
+        ):
+            raise HandoffAtomicClaimConsumeError(f"{list_field} must be sorted deterministically")
+    return deterministic_json_dumps(contract)
+
+
+def _artifact_bytes_for_manifest_digest(artifact: Mapping[str, Any]) -> bytes:
+    body = {
+        key: value for key, value in artifact.items() if key not in {"integrity", "manifest_digest"}
+    }
+    return serialize_handoff_atomic_claim_consume_v1(body).encode("utf-8")
+
+
+def _compute_output_manifest_digest(artifact: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_artifact_bytes_for_manifest_digest(artifact)).hexdigest()
+
+
+def _validate_contract_integrity(artifact: Mapping[str, Any]) -> None:
+    if artifact.get("contract_name") != CONTRACT_NAME:
+        raise HandoffAtomicClaimConsumeError("contract_name mismatch")
+    if artifact.get("contract_version") != CONTRACT_VERSION:
+        raise HandoffAtomicClaimConsumeError("contract_version mismatch")
+    integrity = artifact.get("integrity")
+    if not isinstance(integrity, Mapping):
+        raise HandoffAtomicClaimConsumeError("integrity must be an object")
+    expected = compute_content_sha256(_integrity_body(artifact))
+    actual = integrity.get("content_sha256")
+    if actual != expected:
+        raise HandoffAtomicClaimConsumeError("integrity.content_sha256 mismatch")
+    output_digest = artifact.get("output_digest")
+    if output_digest != _compute_output_digest(artifact):
+        raise HandoffAtomicClaimConsumeError("output_digest mismatch")
+    if artifact.get("artifact_id") != output_digest:
+        raise HandoffAtomicClaimConsumeError("artifact_id must equal output_digest")
+
+
+def build_self_verification_v1(
+    *,
+    contract: Mapping[str, Any],
+    envelope: VerifiedSecureHandoffEnvelopeBundle,
+    manifest_digest: str,
+) -> dict[str, Any]:
+    checks: list[dict[str, str]] = [
+        {"check_id": "contract_name", "status": "PASS"},
+        {"check_id": "contract_version", "status": "PASS"},
+        {"check_id": "evidence_level_level_3", "status": "PASS"},
+        {"check_id": "exactly_one_secure_handoff_envelope_input", "status": "PASS"},
+        {"check_id": "secure_handoff_envelope_verified", "status": "PASS"},
+        {"check_id": "consumer_identity_bound", "status": "PASS"},
+        {"check_id": "offline_only_no_claim_execution", "status": "PASS"},
+        {"check_id": "offline_only_no_consume_execution", "status": "PASS"},
+        {"check_id": "no_state_mutation", "status": "PASS"},
+        {"check_id": "no_lock_acquired", "status": "PASS"},
+        {"check_id": "no_reservation_created", "status": "PASS"},
+        {"check_id": "no_consumer_invocation", "status": "PASS"},
+        {"check_id": "no_authority_grant", "status": "PASS"},
+        {"check_id": "no_lease_activation", "status": "PASS"},
+        {"check_id": "no_revocation_execution", "status": "PASS"},
+        {"check_id": "deny_by_default", "status": "PASS"},
+        {"check_id": "replay_protection_bound", "status": "PASS"},
+        {"check_id": "atomic_transition_contract_bound", "status": "PASS"},
+        {"check_id": "output_digest", "status": "PASS"},
+        {"check_id": "manifest_verification", "status": "PASS"},
+        {"check_id": "deterministic_reverification", "status": "PASS"},
+    ]
+
+    input_refs = contract.get("input_artifact_refs")
+    if not isinstance(input_refs, list) or len(input_refs) != 1:
+        checks = [
+            {**c, "status": "FAIL"}
+            if c["check_id"] == "exactly_one_secure_handoff_envelope_input"
+            else c
+            for c in checks
+        ]
+
+    if contract.get("manifest_digest") != manifest_digest:
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "manifest_verification" else c
+            for c in checks
+        ]
+
+    if contract.get("envelope_digest") != envelope.artifact_digest:
+        checks = [
+            {**c, "status": "FAIL"} if c["check_id"] == "secure_handoff_envelope_verified" else c
+            for c in checks
+        ]
+
+    structural_failures = [check for check in checks if check["status"] != "PASS"]
+    if structural_failures:
+        raise HandoffAtomicClaimConsumeError("self-verification checks failed")
+
+    payload: dict[str, Any] = {
+        "self_verification_schema_version": _SELF_VERIFICATION_SCHEMA_VERSION,
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "overall_status": "PASS",
+        "checks": checks,
+        "verified_artifact_rel": ARTIFACT_REL,
+        "verified_output_digest": contract.get("output_digest"),
+        "verified_manifest_digest": manifest_digest,
+        "verified_secure_handoff_envelope_bundle_ref": envelope.bundle_dir.as_posix(),
+        "verified_contract_status": contract.get("contract_status"),
+        "verified_deterministic_rule_set_version": DETERMINISTIC_RULE_SET_VERSION,
+    }
+    digest = compute_content_sha256(payload)
+    payload["integrity"] = {"content_sha256": digest}
+    return payload
+
+
+def _finalize_contract_with_manifest_digest(
+    artifact: Mapping[str, Any], *, manifest_digest: str
+) -> dict[str, Any]:
+    body = dict(artifact)
+    body["manifest_digest"] = manifest_digest
+    body["output_digest"] = _compute_output_digest(body)
+    body["artifact_id"] = body["output_digest"]
+    body["integrity"] = {"content_sha256": compute_content_sha256(_integrity_body(body))}
+    return body
+
+
+def _staging_dir_for(output_dir: Path) -> Path:
+    return output_dir.parent / f"{STAGING_DIRNAME_PREFIX}{uuid.uuid4().hex}"
+
+
+def _cleanup_staging(staging: Path) -> None:
+    if staging.exists():
+        shutil.rmtree(staging)
+
+
+def default_claim_consume_request(
+    *, envelope: VerifiedSecureHandoffEnvelopeBundle
+) -> HandoffAtomicClaimConsumeRequest:
+    """Build a deterministic offline claim/consume request from verified envelope."""
+    return HandoffAtomicClaimConsumeRequest(
+        evaluation_time=str(envelope.validity_metadata.get("evaluation_time", "")),
+        consumer_identity_ref=envelope.intended_consumer_identity_ref,
+        consumer_identity_version=envelope.intended_consumer_identity_version,
+        allowed_offline_capabilities=tuple(sorted(_DEFAULT_ALLOWED_OFFLINE_CAPABILITIES)),
+    )
+
+
+def verify_handoff_atomic_claim_consume_inputs(
+    inputs: HandoffAtomicClaimConsumeInputs,
+) -> VerifiedSecureHandoffEnvelopeBundle:
+    """Verify exactly one secure handoff envelope bundle."""
+    return verify_secure_handoff_envelope_bundle(inputs.secure_handoff_envelope_bundle_dir)
+
+
+def reverify_handoff_atomic_claim_consume_v1(*, output_dir: Path | str) -> None:
+    """Replay handoff atomic claim/consume bundle without upstream mutation."""
+    bundle_dir = Path(output_dir)
+    if not bundle_dir.is_dir():
+        raise HandoffAtomicClaimConsumeError(
+            f"handoff atomic claim/consume directory not found: {bundle_dir}"
+        )
+    ok, msg = verify_manifest_sha256(bundle_dir)
+    if not ok:
+        raise HandoffAtomicClaimConsumeError(f"MANIFEST.sha256 verification failed: {msg}")
+
+    artifact_path = bundle_dir / ARTIFACT_REL
+    _validate_regular_file(artifact_path, label=ARTIFACT_REL)
+    contract = read_manifest(artifact_path)
+    _validate_contract_integrity(contract)
+
+    self_path = bundle_dir / SELF_VERIFICATION_REL
+    _validate_regular_file(self_path, label=SELF_VERIFICATION_REL)
+    self_payload = read_manifest(self_path)
+    if self_payload.get("overall_status") != "PASS":
+        raise HandoffAtomicClaimConsumeError("SELF_VERIFICATION overall_status must be PASS")
+
+    manifest_digest = _compute_output_manifest_digest(contract)
+    if contract.get("manifest_digest") != manifest_digest:
+        raise HandoffAtomicClaimConsumeError("manifest_digest mismatch on replay")
+
+    envelope = verify_secure_handoff_envelope_bundle(
+        Path(str(contract["secure_handoff_envelope_bundle_ref"]))
+    )
+    if contract.get("envelope_digest") != envelope.artifact_digest:
+        raise HandoffAtomicClaimConsumeError("envelope digest mismatch on replay")
+
+
+def produce_handoff_atomic_claim_consume_v1(
+    *,
+    inputs: HandoffAtomicClaimConsumeInputs,
+    output_dir: Path | str,
+) -> HandoffAtomicClaimConsumeResult:
+    """Produce offline LEVEL_3 handoff atomic claim/consume evidence."""
+    final_dir = Path(output_dir)
+    _validate_output_target(final_dir)
+    _reject_unsafe_overlap(
+        envelope_dir=inputs.secure_handoff_envelope_bundle_dir,
+        output_dir=final_dir,
+    )
+
+    envelope = verify_handoff_atomic_claim_consume_inputs(inputs)
+    contract_body = build_handoff_atomic_claim_consume_v1(
+        envelope=envelope,
+        request=inputs.claim_consume_request,
+    )
+
+    staging = _staging_dir_for(final_dir)
+    if staging.exists():
+        raise HandoffAtomicClaimConsumeError(f"staging directory collision: {staging}")
+
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        artifact_path = staging / ARTIFACT_REL
+        self_path = staging / SELF_VERIFICATION_REL
+
+        manifest_digest = _compute_output_manifest_digest(contract_body)
+        finalized = _finalize_contract_with_manifest_digest(
+            contract_body, manifest_digest=manifest_digest
+        )
+        artifact_path.write_text(
+            serialize_handoff_atomic_claim_consume_v1(finalized),
+            encoding="utf-8",
+        )
+        self_payload = build_self_verification_v1(
+            contract=finalized,
+            envelope=envelope,
+            manifest_digest=manifest_digest,
+        )
+        self_path.write_text(deterministic_json_dumps(self_payload), encoding="utf-8")
+        write_manifest_sha256(staging)
+
+        ok, msg = verify_manifest_sha256(staging)
+        if not ok:
+            raise HandoffAtomicClaimConsumeError(
+                f"MANIFEST.sha256 verification failed before publish: {msg}"
+            )
+
+        reverify_handoff_atomic_claim_consume_v1(output_dir=staging)
+        staging.replace(final_dir)
+
+        ok, msg = verify_manifest_sha256(final_dir)
+        if not ok:
+            raise HandoffAtomicClaimConsumeError(
+                f"MANIFEST.sha256 verification failed after publish: {msg}"
+            )
+    except Exception:
+        _cleanup_staging(staging)
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        raise
+
+    return HandoffAtomicClaimConsumeResult(
+        output_dir=final_dir,
+        contract_id=str(finalized["contract_id"]),
+        contract_status=str(finalized["contract_status"]),
+        claim_identity=str(finalized["claim_identity"]),
+        consume_identity=str(finalized["consume_identity"]),
+        contract_path=final_dir / ARTIFACT_REL,
+        self_verification_path=final_dir / SELF_VERIFICATION_REL,
+        manifest_path=final_dir / MANIFEST_FILENAME,
+        envelope_ref=str(finalized["envelope_ref"]),
+        envelope_digest=str(finalized["envelope_digest"]),
+    )
+
+
+__all__ = [
+    "ARTIFACT_REL",
+    "CLAIM_CONTRACT_VERSION",
+    "CONSUME_CONTRACT_VERSION",
+    "CONTRACT_NAME",
+    "CONTRACT_VERSION",
+    "CREATION_CONTRACT_VERSION",
+    "DEFAULT_PRODUCER_IDENTITY_REF",
+    "DEFAULT_SOURCE_REVISION",
+    "DETERMINISTIC_RULE_SET_VERSION",
+    "EVIDENCE_LEVEL",
+    "HANDOFF_ATOMIC_CLAIM_CONSUME_AUTHORITY_INVARIANTS",
+    "MANIFEST_FILENAME",
+    "PRODUCER_VERSION",
+    "SCHEMA_VERSION",
+    "SELF_VERIFICATION_REL",
+    "ClaimStateContext",
+    "HandoffAtomicClaimConsumeError",
+    "HandoffAtomicClaimConsumeInputs",
+    "HandoffAtomicClaimConsumeRequest",
+    "HandoffAtomicClaimConsumeResult",
+    "VerifiedSecureHandoffEnvelopeBundle",
+    "build_handoff_atomic_claim_consume_v1",
+    "default_claim_consume_request",
+    "produce_handoff_atomic_claim_consume_v1",
+    "reverify_handoff_atomic_claim_consume_v1",
+    "serialize_handoff_atomic_claim_consume_v1",
+    "verify_handoff_atomic_claim_consume_inputs",
+    "verify_secure_handoff_envelope_bundle",
+]

--- a/tests/ci/test_ci_diff_aware_test_selection_v1.py
+++ b/tests/ci/test_ci_diff_aware_test_selection_v1.py
@@ -7033,3 +7033,67 @@ def test_selector_package_secure_handoff_envelope_v1_combined_diff_pr_bounded_fu
     for path in PACKAGE_SECURE_HANDOFF_ENVELOPE_V1_ALL_TESTOWNERS:
         assert path in bounded
         assert bounded.count(path) == 1
+
+
+PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_PRODUCTION = (
+    "src/meta/learning_loop/handoff_atomic_claim_consume_v1.py"
+)
+PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_SCRIPT = "scripts/run_handoff_atomic_claim_consume_v1.py"
+PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_TESTOWNER = (
+    "tests/meta/test_handoff_atomic_claim_consume_v1.py"
+)
+PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_CLI_TESTOWNER = (
+    "tests/scripts/test_run_handoff_atomic_claim_consume_v1.py"
+)
+PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_DEPENDENCY_TESTOWNERS = (
+    "tests/meta/test_secure_handoff_envelope_v1.py",
+    "tests/scripts/test_run_secure_handoff_envelope_v1.py",
+    "tests/meta/test_authority_lease_and_revocation_v1.py",
+    "tests/scripts/test_run_authority_lease_and_revocation_v1.py",
+    "tests/meta/test_handoff_trust_policy_v1.py",
+    "tests/scripts/test_run_handoff_trust_policy_v1.py",
+    "tests/meta/test_versioned_strategy_model_parameter_artifact_v1.py",
+    "tests/meta/test_ai_promotion_assessment_v1.py",
+    "tests/meta/test_comparison_promotion_policy_decision_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_model_parameter_identity_binding_v1.py",
+    "tests/meta/test_comparison_promotion_candidate_eligibility_evidence_v1.py",
+    "tests/meta/test_config_patch_manifest_v1_contract.py",
+    "tests/meta/test_learning_manifest_durable_evidence_binding_v1.py",
+    "tests/governance/promotion_loop/test_candidate_lineage_manifest_v1_contract.py",
+    "tests/experiments/test_experiment_identity_manifest_v1.py",
+    "tests/meta/test_contract_safety_v1.py",
+    "tests/ci/test_ci_diff_aware_test_selection_v1.py",
+)
+PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_ALL_PRODUCTION = (
+    PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_PRODUCTION,
+    PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_SCRIPT,
+)
+PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_ALL_TESTOWNERS = (
+    PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_TESTOWNER,
+    PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_CLI_TESTOWNER,
+    *PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_DEPENDENCY_TESTOWNERS,
+)
+
+
+def test_selector_package_handoff_atomic_claim_consume_v1_production_pr_bounded_full_includes_testowners() -> (
+    None
+):
+    sel = _run_selector(PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_PRODUCTION)
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_ALL_TESTOWNERS:
+        assert path in bounded
+
+
+def test_selector_package_handoff_atomic_claim_consume_v1_combined_diff_pr_bounded_full_includes_all_testowners_once() -> (
+    None
+):
+    sel = _run_selector(
+        *PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_ALL_PRODUCTION,
+    )
+    assert sel["test_selection_mode"] == "PR_BOUNDED_FULL"
+    bounded = _bounded_targets(sel)
+    for path in PACKAGE_HANDOFF_ATOMIC_CLAIM_CONSUME_V1_ALL_TESTOWNERS:
+        assert path in bounded
+        assert bounded.count(path) == 1

--- a/tests/meta/handoff_atomic_claim_consume_v1_fixtures.py
+++ b/tests/meta/handoff_atomic_claim_consume_v1_fixtures.py
@@ -1,0 +1,66 @@
+"""Fixtures for handoff_atomic_claim_consume_v1 tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.meta.learning_loop.handoff_atomic_claim_consume_v1 import (
+    HandoffAtomicClaimConsumeInputs,
+    default_claim_consume_request,
+    produce_handoff_atomic_claim_consume_v1,
+    verify_secure_handoff_envelope_bundle,
+)
+from tests.meta.secure_handoff_envelope_v1_fixtures import produce_secure_handoff_envelope_fixture
+
+
+@dataclass(frozen=True)
+class HandoffAtomicClaimConsumeFixtureBundle:
+    secure_handoff_envelope_bundle_dir: Path
+    handoff_atomic_claim_consume_bundle_dir: Path | None = None
+
+
+def produce_handoff_atomic_claim_consume_fixture(
+    tmp_path: Path,
+    durable_root: Path,
+    *,
+    all_domains_pass: bool = True,
+    use_candidate_lineage: bool = True,
+    include_ai_assessment: bool = False,
+    evaluation_time: str = "2026-06-29T12:00:00+00:00",
+    valid_from: str = "2026-06-29T00:00:00+00:00",
+    valid_until: str = "2026-06-30T00:00:00+00:00",
+    revocation_state: str = "NOT_REVOKED",
+    produce_output: bool = True,
+    claim_consume_name: str = "handoff_atomic_claim_consume",
+) -> HandoffAtomicClaimConsumeFixtureBundle:
+    envelope = produce_secure_handoff_envelope_fixture(
+        tmp_path,
+        durable_root,
+        all_domains_pass=all_domains_pass,
+        use_candidate_lineage=use_candidate_lineage,
+        include_ai_assessment=include_ai_assessment,
+        evaluation_time=evaluation_time,
+        valid_from=valid_from,
+        valid_until=valid_until,
+        revocation_state=revocation_state,
+    )
+    assert envelope.secure_handoff_envelope_bundle_dir is not None
+    claim_consume_dir: Path | None = None
+    if produce_output:
+        verified = verify_secure_handoff_envelope_bundle(
+            envelope.secure_handoff_envelope_bundle_dir
+        )
+        request = default_claim_consume_request(envelope=verified)
+        claim_consume_dir = durable_root / claim_consume_name
+        produce_handoff_atomic_claim_consume_v1(
+            inputs=HandoffAtomicClaimConsumeInputs(
+                secure_handoff_envelope_bundle_dir=envelope.secure_handoff_envelope_bundle_dir,
+                claim_consume_request=request,
+            ),
+            output_dir=claim_consume_dir,
+        )
+    return HandoffAtomicClaimConsumeFixtureBundle(
+        secure_handoff_envelope_bundle_dir=envelope.secure_handoff_envelope_bundle_dir,
+        handoff_atomic_claim_consume_bundle_dir=claim_consume_dir,
+    )

--- a/tests/meta/test_handoff_atomic_claim_consume_v1.py
+++ b/tests/meta/test_handoff_atomic_claim_consume_v1.py
@@ -1,0 +1,559 @@
+"""Contract tests for handoff_atomic_claim_consume_v1."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = [
+    "tests.meta.comparison_ssot_v1_fixtures",
+    "tests.meta.comparison_completion_research_validity_binding_v1_fixtures",
+    "tests.meta.comparison_completion_promotion_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_identity_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_eligibility_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_model_parameter_identity_binding_v1_fixtures",
+    "tests.meta.comparison_config_patch_manifest_cross_domain_lineage_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_input_v1_fixtures",
+    "tests.meta.comparison_eligibility_promotion_policy_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_policy_input_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_policy_decision_v1_fixtures",
+    "tests.meta.ai_promotion_assessment_v1_fixtures",
+    "tests.meta.versioned_strategy_model_parameter_artifact_v1_fixtures",
+    "tests.meta.handoff_trust_policy_v1_fixtures",
+    "tests.meta.authority_lease_and_revocation_v1_fixtures",
+    "tests.meta.secure_handoff_envelope_v1_fixtures",
+    "tests.meta.handoff_atomic_claim_consume_v1_fixtures",
+]
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.meta.learning_loop.comparison_ssot_v1.io import read_manifest
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+from src.meta.learning_loop.handoff_atomic_claim_consume_v1 import (
+    ARTIFACT_REL,
+    CLAIM_CONTRACT_VERSION,
+    CONSUME_CONTRACT_VERSION,
+    CONTRACT_NAME,
+    CONTRACT_VERSION,
+    CREATION_CONTRACT_VERSION,
+    DEFAULT_PRODUCER_IDENTITY_REF,
+    DETERMINISTIC_RULE_SET_VERSION,
+    EVIDENCE_LEVEL,
+    HANDOFF_ATOMIC_CLAIM_CONSUME_AUTHORITY_INVARIANTS,
+    MANIFEST_FILENAME,
+    PRODUCER_VERSION,
+    SCHEMA_VERSION,
+    SELF_VERIFICATION_REL,
+    ClaimStateContext,
+    HandoffAtomicClaimConsumeError,
+    HandoffAtomicClaimConsumeInputs,
+    HandoffAtomicClaimConsumeRequest,
+    build_handoff_atomic_claim_consume_v1,
+    default_claim_consume_request,
+    produce_handoff_atomic_claim_consume_v1,
+    reverify_handoff_atomic_claim_consume_v1,
+    serialize_handoff_atomic_claim_consume_v1,
+    verify_secure_handoff_envelope_bundle,
+)
+from src.meta.learning_loop.handoff_trust_policy_v1 import CONSUMER_CONTRACT_ID
+from src.meta.learning_loop.secure_handoff_envelope_v1 import (
+    ARTIFACT_REL as ENVELOPE_ARTIFACT_REL,
+)
+from tests.meta.handoff_atomic_claim_consume_v1_fixtures import (
+    produce_handoff_atomic_claim_consume_fixture,
+)
+from tests.meta.secure_handoff_envelope_v1_fixtures import produce_secure_handoff_envelope_fixture
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = (
+        "src.meta.learning_loop.handoff_atomic_claim_consume_v1.is_under_tmp",
+        "src.meta.learning_loop.secure_handoff_envelope_v1.is_under_tmp",
+        "src.meta.learning_loop.authority_lease_and_revocation_v1.is_under_tmp",
+        "src.meta.learning_loop.handoff_trust_policy_v1.is_under_tmp",
+        "src.meta.learning_loop.versioned_strategy_model_parameter_artifact_v1.is_under_tmp",
+        "src.meta.learning_loop.ai_promotion_assessment_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_policy_decision_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_policy_input_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_eligibility_promotion_policy_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_input_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_config_patch_manifest_cross_domain_lineage_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_model_parameter_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_eligibility_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_promotion_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_research_validity_binding_v1.is_under_tmp",
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
+    )
+    for target in targets:
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "claim_consume_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def _default_request(envelope) -> HandoffAtomicClaimConsumeRequest:
+    return default_claim_consume_request(envelope=envelope)
+
+
+def test_contract_constants() -> None:
+    assert CONTRACT_NAME == "handoff_atomic_claim_consume_v1"
+    assert CONTRACT_VERSION == "v1"
+    assert ARTIFACT_REL == "handoff_atomic_claim_consume_v1.json"
+    assert CLAIM_CONTRACT_VERSION == "handoff_atomic_claim_v1"
+    assert CONSUME_CONTRACT_VERSION == "handoff_atomic_consume_v1"
+    assert SCHEMA_VERSION == "handoff_atomic_claim_consume_schema_v1"
+    assert EVIDENCE_LEVEL == "LEVEL_3"
+
+
+def test_happy_path_contract_valid(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    assert fixture.handoff_atomic_claim_consume_bundle_dir is not None
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    assert payload["contract_status"] == "CONTRACT_VALID_FOR_OFFLINE_ATOMIC_CLAIM_CONSUME"
+    assert payload["handoff_atomic_claim_consume_complete"] is True
+    assert payload["secure_handoff_envelope_bound"] is True
+    assert payload["consumer_identity_bound"] is True
+    assert payload["replay_protection_bound"] is True
+    assert payload["atomic_transition_contract_bound"] is True
+
+
+def test_required_non_authorizing_flags(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    assert payload["claim_executed"] is False
+    assert payload["consume_executed"] is False
+    assert payload["state_mutated"] is False
+    assert payload["lock_acquired"] is False
+    assert payload["reservation_created"] is False
+    assert payload["ack_emitted"] is False
+    assert payload["payload_transferred"] is False
+    assert payload["files_transferred"] is False
+    assert payload["consumer_invoked"] is False
+    assert payload["consumer_mutated"] is False
+    assert payload["authority_activated"] is False
+    assert payload["lease_activated"] is False
+    assert payload["revocation_executed"] is False
+    assert payload["runtime_authorized"] is False
+    assert payload["live_authorized"] is False
+    assert payload["orders_allowed"] is False
+    assert payload["scheduler_runtime_allowed"] is False
+    assert (
+        payload["handoff_atomic_claim_consume_authority_invariants"]
+        == HANDOFF_ATOMIC_CLAIM_CONSUME_AUTHORITY_INVARIANTS
+    )
+
+
+def test_determinism(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = _default_request(verified)
+    out_a = _durable_output(tmp_path, "a")
+    out_b = _durable_output(tmp_path, "b")
+    inputs = HandoffAtomicClaimConsumeInputs(
+        secure_handoff_envelope_bundle_dir=fixture.secure_handoff_envelope_bundle_dir,
+        claim_consume_request=request,
+    )
+    produce_handoff_atomic_claim_consume_v1(inputs=inputs, output_dir=out_a)
+    produce_handoff_atomic_claim_consume_v1(inputs=inputs, output_dir=out_b)
+    assert (out_a / ARTIFACT_REL).read_text() == (out_b / ARTIFACT_REL).read_text()
+
+
+def test_contract_id_stability(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = _default_request(verified)
+    out_a = _durable_output(tmp_path, "id_a")
+    out_b = _durable_output(tmp_path, "id_b")
+    inputs = HandoffAtomicClaimConsumeInputs(
+        secure_handoff_envelope_bundle_dir=fixture.secure_handoff_envelope_bundle_dir,
+        claim_consume_request=request,
+    )
+    result_a = produce_handoff_atomic_claim_consume_v1(inputs=inputs, output_dir=out_a)
+    result_b = produce_handoff_atomic_claim_consume_v1(inputs=inputs, output_dir=out_b)
+    assert result_a.contract_id == result_b.contract_id
+    assert result_a.claim_identity == result_b.claim_identity
+    assert result_a.consume_identity == result_b.consume_identity
+
+
+def test_self_verification_and_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.handoff_atomic_claim_consume_bundle_dir
+    assert out is not None
+    ok, msg = verify_manifest_sha256(out)
+    assert ok, msg
+    self_payload = read_manifest(out / SELF_VERIFICATION_REL)
+    assert self_payload["overall_status"] == "PASS"
+    reverify_handoff_atomic_claim_consume_v1(output_dir=out)
+
+
+def test_missing_envelope_bundle(tmp_path) -> None:
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        verify_secure_handoff_envelope_bundle(tmp_path / "missing")
+
+
+def test_invalid_envelope_manifest(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_secure_handoff_envelope_fixture(tmp_path, ssot_durable_output_dir)
+    bundle_dir = fixture.secure_handoff_envelope_bundle_dir
+    (bundle_dir / MANIFEST_FILENAME).write_text("invalid", encoding="utf-8")
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        verify_secure_handoff_envelope_bundle(bundle_dir)
+
+
+def test_envelope_digest_mismatch_on_reverify(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.handoff_atomic_claim_consume_bundle_dir
+    artifact = read_manifest(out / ARTIFACT_REL)
+    artifact["envelope_digest"] = "0" * 64
+    (out / ARTIFACT_REL).write_text(deterministic_json_dumps(artifact), encoding="utf-8")
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        reverify_handoff_atomic_claim_consume_v1(output_dir=out)
+
+
+def test_consumer_identity_mismatch(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(_default_request(verified), consumer_identity_ref="unknown_consumer_v99")
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_INVALID"
+
+
+def test_expired_contract(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path,
+        ssot_durable_output_dir,
+        produce_output=False,
+        evaluation_time="2026-07-01T00:00:00+00:00",
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(_default_request(verified), evaluation_time="2026-07-01T00:00:00+00:00")
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_EXPIRED"
+
+
+def test_revoked_contract(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path,
+        ssot_durable_output_dir,
+        revocation_state="REVOKED",
+        claim_consume_name="revoked_claim_consume",
+    )
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    assert payload["contract_status"] == "CONTRACT_REVOKED"
+
+
+def test_duplicate_claim_replay(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CLAIM",
+        claim_state_context=ClaimStateContext(
+            current_state="CLAIMED",
+            current_revision=0,
+            claim_identity=build_handoff_atomic_claim_consume_v1(
+                envelope=verified, request=_default_request(verified)
+            )["claim_identity"],
+        ),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_REPLAY_REJECTED"
+
+
+def test_duplicate_claim_conflict(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CLAIM",
+        claim_state_context=ClaimStateContext(
+            current_state="CLAIMED",
+            current_revision=0,
+            claim_identity="0" * 64,
+        ),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_CONFLICT"
+
+
+def test_consume_without_claim(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CONSUME",
+        claim_state_context=ClaimStateContext(current_state="UNCLAIMED", current_revision=0),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_INVALID"
+
+
+def test_consume_foreign_claim(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CONSUME",
+        claim_state_context=ClaimStateContext(
+            current_state="CLAIMED",
+            current_revision=0,
+            claim_identity="0" * 64,
+        ),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_INVALID"
+
+
+def test_duplicate_consume_replay(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    base = build_handoff_atomic_claim_consume_v1(
+        envelope=verified, request=_default_request(verified)
+    )
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CONSUME",
+        claim_state_context=ClaimStateContext(
+            current_state="CONSUMED",
+            current_revision=0,
+            claim_identity=base["claim_identity"],
+            consume_identity=base["consume_identity"],
+        ),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_REPLAY_REJECTED"
+
+
+def test_stale_revision(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CLAIM",
+        claim_state_context=ClaimStateContext(current_state="UNCLAIMED", current_revision=5),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_CONFLICT"
+
+
+def test_claim_path_claimable(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CLAIM",
+        claim_state_context=ClaimStateContext(current_state="UNCLAIMED", current_revision=0),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_CLAIMABLE"
+    assert contract["claim_transition_allowed"] is True
+
+
+def test_consume_path_consumable(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    base = build_handoff_atomic_claim_consume_v1(
+        envelope=verified, request=_default_request(verified)
+    )
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CONSUME",
+        claim_state_context=ClaimStateContext(
+            current_state="CLAIMED",
+            current_revision=0,
+            claim_identity=base["claim_identity"],
+        ),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_CONSUMABLE"
+    assert contract["consume_transition_allowed"] is True
+
+
+def test_unknown_state(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(
+        _default_request(verified),
+        claim_state_context=ClaimStateContext(current_state="UNKNOWN_STATE", current_revision=0),
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_INVALID"
+
+
+def test_claim_replay_content_mismatch(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = replace(
+        _default_request(verified),
+        transition_evaluate="CLAIM",
+        claim_state_context=ClaimStateContext(
+            current_state="UNCLAIMED",
+            current_revision=0,
+            prior_claim_content_digest="a" * 64,
+        ),
+        proposed_claim_content_digest="b" * 64,
+    )
+    contract = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract["contract_status"] == "CONTRACT_REPLAY_REJECTED"
+
+
+def test_changed_input_changes_contract_id(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request_a = _default_request(verified)
+    request_b = replace(request_a, transition_evaluate="CLAIM")
+    contract_a = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request_a)
+    contract_b = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request_b)
+    assert contract_a["contract_id"] != contract_b["contract_id"]
+
+
+def test_same_input_same_contract_id(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(
+        tmp_path, ssot_durable_output_dir, produce_output=False
+    )
+    verified = verify_secure_handoff_envelope_bundle(fixture.secure_handoff_envelope_bundle_dir)
+    request = _default_request(verified)
+    contract_a = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    contract_b = build_handoff_atomic_claim_consume_v1(envelope=verified, request=request)
+    assert contract_a["contract_id"] == contract_b["contract_id"]
+
+
+def test_claim_executed_flag_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    payload["claim_executed"] = True
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        serialize_handoff_atomic_claim_consume_v1(payload)
+
+
+def test_consume_executed_flag_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    payload["consume_executed"] = True
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        serialize_handoff_atomic_claim_consume_v1(payload)
+
+
+def test_state_mutated_flag_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    payload["state_mutated"] = True
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        serialize_handoff_atomic_claim_consume_v1(payload)
+
+
+def test_lock_acquired_flag_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    payload["lock_acquired"] = True
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        serialize_handoff_atomic_claim_consume_v1(payload)
+
+
+def test_runtime_authorized_flag_rejected_on_serialize(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    payload["runtime_authorized"] = True
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        serialize_handoff_atomic_claim_consume_v1(payload)
+
+
+def test_manifest_self_hashing_not_allowed(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.handoff_atomic_claim_consume_bundle_dir
+    manifest_path = out / MANIFEST_FILENAME
+    content = manifest_path.read_text(encoding="utf-8")
+    assert "MANIFEST.sha256" not in content.splitlines()[0]
+
+
+def test_content_change_after_manifest_invalidates_reverify(
+    tmp_path, ssot_durable_output_dir
+) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    out = fixture.handoff_atomic_claim_consume_bundle_dir
+    artifact_path = out / ARTIFACT_REL
+    payload = read_manifest(artifact_path)
+    payload["producer_identity_ref"] = "tampered_producer"
+    artifact_path.write_text(deterministic_json_dumps(payload), encoding="utf-8")
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        reverify_handoff_atomic_claim_consume_v1(output_dir=out)
+
+
+def test_binding_fields_present(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    assert payload["envelope_ref"] == ENVELOPE_ARTIFACT_REL
+    assert payload["envelope_digest"]
+    assert payload["claim_identity"]
+    assert payload["consume_identity"]
+    assert payload["producer_identity_ref"] == DEFAULT_PRODUCER_IDENTITY_REF
+    assert payload["consumer_identity_ref"] == CONSUMER_CONTRACT_ID
+    assert payload["allowed_transitions"]
+    assert payload["forbidden_transitions"]
+    assert payload["transition_preconditions"]
+    assert payload["replay_protection_metadata"]["idempotency_key"]
+    assert payload["retry_semantics"]["retry_without_double_effect"] is True
+    assert (
+        payload["crash_consistency_semantics"]["atomicity_model"] == "COMPARE_AND_SWAP_ON_REVISION"
+    )
+    assert payload["cross_domain_lineage"]
+
+
+def test_wrong_envelope_contract_name(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_secure_handoff_envelope_fixture(tmp_path, ssot_durable_output_dir)
+    bundle_dir = fixture.secure_handoff_envelope_bundle_dir
+    artifact = read_manifest(bundle_dir / ENVELOPE_ARTIFACT_REL)
+    artifact["contract_name"] = "wrong_contract_v99"
+    (bundle_dir / ENVELOPE_ARTIFACT_REL).write_text(
+        deterministic_json_dumps(artifact), encoding="utf-8"
+    )
+    with pytest.raises(HandoffAtomicClaimConsumeError):
+        verify_secure_handoff_envelope_bundle(bundle_dir)
+
+
+def test_state_machine_transitions(tmp_path, ssot_durable_output_dir) -> None:
+    fixture = produce_handoff_atomic_claim_consume_fixture(tmp_path, ssot_durable_output_dir)
+    payload = read_manifest(fixture.handoff_atomic_claim_consume_bundle_dir / ARTIFACT_REL)
+    allowed = {(item["from_state"], item["to_state"]) for item in payload["allowed_transitions"]}
+    assert ("UNCLAIMED", "CLAIMABLE") in allowed
+    assert ("CLAIMABLE", "CLAIMED") in allowed
+    assert ("CLAIMED", "CONSUMABLE") in allowed
+    assert ("CONSUMABLE", "CONSUMED") in allowed
+    forbidden = {
+        (item["from_state"], item["to_state"]) for item in payload["forbidden_transitions"]
+    }
+    assert ("UNCLAIMED", "CONSUMED") in forbidden
+    assert ("CONSUMED", "CLAIMED") in forbidden

--- a/tests/scripts/test_run_handoff_atomic_claim_consume_v1.py
+++ b/tests/scripts/test_run_handoff_atomic_claim_consume_v1.py
@@ -1,0 +1,143 @@
+"""CLI tests for run_handoff_atomic_claim_consume_v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = [
+    "tests.meta.comparison_ssot_v1_fixtures",
+    "tests.meta.comparison_completion_research_validity_binding_v1_fixtures",
+    "tests.meta.comparison_completion_promotion_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_identity_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_eligibility_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_model_parameter_identity_binding_v1_fixtures",
+    "tests.meta.comparison_config_patch_manifest_cross_domain_lineage_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_candidate_input_v1_fixtures",
+    "tests.meta.comparison_eligibility_promotion_policy_input_binding_v1_fixtures",
+    "tests.meta.comparison_promotion_policy_input_evidence_v1_fixtures",
+    "tests.meta.comparison_promotion_policy_decision_v1_fixtures",
+    "tests.meta.ai_promotion_assessment_v1_fixtures",
+    "tests.meta.versioned_strategy_model_parameter_artifact_v1_fixtures",
+    "tests.meta.handoff_trust_policy_v1_fixtures",
+    "tests.meta.authority_lease_and_revocation_v1_fixtures",
+    "tests.meta.secure_handoff_envelope_v1_fixtures",
+    "tests.meta.handoff_atomic_claim_consume_v1_fixtures",
+]
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from scripts.run_handoff_atomic_claim_consume_v1 import (
+    EXIT_CONTRACT_ERROR,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    main,
+)
+from src.meta.learning_loop.handoff_atomic_claim_consume_v1 import (
+    ARTIFACT_REL,
+    SELF_VERIFICATION_REL,
+)
+from tests.meta.secure_handoff_envelope_v1_fixtures import produce_secure_handoff_envelope_fixture
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    targets = (
+        "src.meta.learning_loop.handoff_atomic_claim_consume_v1.is_under_tmp",
+        "src.meta.learning_loop.secure_handoff_envelope_v1.is_under_tmp",
+        "src.meta.learning_loop.authority_lease_and_revocation_v1.is_under_tmp",
+        "src.meta.learning_loop.handoff_trust_policy_v1.is_under_tmp",
+        "src.meta.learning_loop.versioned_strategy_model_parameter_artifact_v1.is_under_tmp",
+        "src.meta.learning_loop.ai_promotion_assessment_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_policy_decision_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_policy_input_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_eligibility_promotion_policy_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_input_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_config_patch_manifest_cross_domain_lineage_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_model_parameter_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_eligibility_evidence_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_promotion_candidate_identity_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_promotion_input_binding_v1.is_under_tmp",
+        "src.meta.learning_loop.comparison_completion_research_validity_binding_v1.is_under_tmp",
+        "src.experiments.experiment_identity_manifest_v1.is_under_tmp",
+    )
+    for target in targets:
+        monkeypatch.setattr(target, lambda _path: False)
+
+
+def _durable_output(tmp_path: Path, name: str = "cli_claim_consume_out") -> Path:
+    root = tmp_path / "evidence_root"
+    root.mkdir(exist_ok=True)
+    return root / name
+
+
+def test_cli_happy_path(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    envelope = produce_secure_handoff_envelope_fixture(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--secure-handoff-envelope-bundle-dir",
+            str(envelope.secure_handoff_envelope_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    captured = capsys.readouterr()
+    assert "contract_status=CONTRACT_VALID_FOR_OFFLINE_ATOMIC_CLAIM_CONSUME" in captured.out
+    assert (out / ARTIFACT_REL).is_file()
+    assert (out / SELF_VERIFICATION_REL).is_file()
+    ok, msg = verify_manifest_sha256(out)
+    assert ok, msg
+
+
+def test_cli_missing_envelope_bundle(tmp_path, capsys) -> None:
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--secure-handoff-envelope-bundle-dir",
+            str(tmp_path / "missing"),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_USAGE_ERROR
+    assert "not found" in capsys.readouterr().err.lower()
+
+
+def test_cli_claim_transition(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    envelope = produce_secure_handoff_envelope_fixture(tmp_path, ssot_durable_output_dir)
+    out = _durable_output(tmp_path, "claim_only")
+    rc = main(
+        [
+            "--secure-handoff-envelope-bundle-dir",
+            str(envelope.secure_handoff_envelope_bundle_dir),
+            "--transition-evaluate",
+            "CLAIM",
+            "--claim-state",
+            "UNCLAIMED",
+            "--claim-revision",
+            "0",
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_OK
+    assert "contract_status=CONTRACT_CLAIMABLE" in capsys.readouterr().out
+
+
+def test_cli_invalid_envelope_manifest(tmp_path, ssot_durable_output_dir, capsys) -> None:
+    envelope = produce_secure_handoff_envelope_fixture(tmp_path, ssot_durable_output_dir)
+    (envelope.secure_handoff_envelope_bundle_dir / "MANIFEST.sha256").write_text(
+        "invalid", encoding="utf-8"
+    )
+    out = _durable_output(tmp_path)
+    rc = main(
+        [
+            "--secure-handoff-envelope-bundle-dir",
+            str(envelope.secure_handoff_envelope_bundle_dir),
+            "--output-dir",
+            str(out),
+        ]
+    )
+    assert rc == EXIT_CONTRACT_ERROR


### PR DESCRIPTION
## Summary

- Implements **Runbook Phase 5 / RUNBOOK_STEP_11** (`handoff_atomic_claim_consume_v1`) as a rein **offline**, deterministischen, fail-closed LEVEL_3 Contract-Owner unter `src/meta/learning_loop/handoff_atomic_claim_consume_v1.py`.
- Bindet genau ein verifiziertes `secure_handoff_envelope_v1`-Bundle digest-/identitätsbasiert an Consumer-Identity; modelliert Claim-/Consume-State-Machine, CAS/Revision, Duplicate-/Replay-/Idempotency-Schutz sowie Retry-/Crash-Consistency **ohne** tatsächliche Claim-/Consume-Ausführung, State-Mutation, Lock, Reservation oder Consumer-Aufruf.
- Ergänzt Runner, fokussierte Contract-/Negative-/Determinism-Tests, CI-Selector-Anschluss (PR_BOUNDED_FULL) und additive Progress-Registry-Aktualisierung (STEP_10 COMPLETE, STEP_11 IN_PROGRESS).

## Scope / Safety

- `HANDOFF_ATOMIC_CLAIM_CONSUME_OFFLINE_ONLY=true`
- `CLAIM_EXECUTED=false`, `CONSUME_EXECUTED=false`, `STATE_MUTATED=false`
- `LOCK_ACQUIRED=false`, `RESERVATION_CREATED=false`, `CONSUMER_INVOKED=false`
- Keine Authority-/Lease-Aktivierung, keine Runtime-/Live-/Order-/Scheduler-Authority
- Primary Worktree unverändert; isolierter Feature-Worktree von `origin/main` (`841be8b4`)

## Validation

- Lokale Ruff format/check + `git diff --check`: RC=0
- Fokussierte Tests: `test_handoff_atomic_claim_consume_v1`, CLI-Tests, CI-Selector-Contract-Tests
- Implementation-Bundle: `handoff_atomic_claim_consume_v1_offline_slice_implementation_v0_20260629T030744Z` mit `MANIFEST_VERIFY_RC=0`

## Test plan

- [x] Happy-path offline contract production + manifest/self-verification
- [x] Duplicate claim/consume, consume-without-claim, stale revision, revoked/expired envelope
- [x] Non-authorizing flag enforcement on serialize
- [x] Determinism and state-machine transition contracts
- [x] CI selector PR_BOUNDED_FULL trigger/target mapping
- [ ] GitHub required checks (post-push)

## Next canonical step

`clock_trust_and_expiry_v1` (RUNBOOK_STEP_12) — separate GO required.


Made with [Cursor](https://cursor.com)