### PR TITLE
feat(master-v2): bind canonical futures market context v1

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -19,8 +19,8 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `LAST_VERIFIED_ORIGIN_MAIN` | `3f392ee05a78c275c049ee603eb0b02f65d8f386` |
 | `LAST_VERIFIED_AT` | `2026-06-29T21:00:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
-| `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29` |
-| `NEXT_CANONICAL_STEP` | `full_autonomous_production_operation` |
+| `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29C` |
+| `NEXT_CANONICAL_STEP` | `canonical_scope_initialization` |
 | `RUNBOOK_STEP_13_IMPLEMENTED` | `true` |
 | `TRADING_SESSION_SINGLE_WRITER_IMPLEMENTED` | `true` |
 | `RUNTIME_SINGLE_WRITER_ACTIVATED` | `false` |
@@ -630,14 +630,62 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `RUNTIME_EFFECT` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |
 
-#### RUNBOOK_STEP_29 — Vollautonomer Produktionsbetrieb
+#### RUNBOOK_STEP_29 — Vollautonomer Produktionsbetrieb (Phase-Container)
 
 | Feld | Wert |
 |---|---|
 | `RUNBOOK_PHASE` | 9 |
 | `RUNBOOK_STEP_ID` | `full_autonomous_production_operation` |
-| `STATUS` | `NOT_STARTED` |
+| `STATUS` | `IN_PROGRESS` |
 | `DEPENDENCIES` | RUNBOOK_STEP_28 |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `RUNTIME_EFFECT` | `false` |
+| `SEPARATE_GO_REQUIRED` | `true` |
+| `SUBSTEP_SEQUENCE` | `29A → 29B → 29C → …` |
+
+#### RUNBOOK_STEP_29A — Finalized Trading Epoch Binding
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `finalized_trading_epoch_binding` |
+| `CONTRACT_OR_CAPABILITY` | `trading_epoch` field semantics within canonical market context |
+| `STATUS` | `COMPLETE` |
+| `CANONICAL_OWNER` | `src/trading/master_v2/canonical_market_context_v1.py` (epoch binding subsumed in 29B contract) |
+| `DEPENDENCIES` | RUNBOOK_STEP_28 |
+| `NEXT_REQUIRED_CONTRACT` | `canonical_market_context_binding_v1` |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `RUNTIME_EFFECT` | `false` |
+| `SEPARATE_GO_REQUIRED` | `true` |
+
+#### RUNBOOK_STEP_29B — Canonical Market Context Binding v1
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `canonical_market_context_binding_v1` |
+| `CONTRACT_OR_CAPABILITY` | `CanonicalMarketContextV1` bound to `double_play_futures_input` |
+| `STATUS` | `IN_PROGRESS` |
+| `CANONICAL_OWNER` | `src/trading/master_v2/canonical_market_context_v1.py` |
+| `DEPENDENCIES` | RUNBOOK_STEP_29A |
+| `NEXT_REQUIRED_CONTRACT` | `canonical_scope_initialization` |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `RUNTIME_EFFECT` | `false` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `SCOPE_INITIALIZATION_IMPLEMENTED` | `false` |
+| `SCOPE_EVENT_GENERATOR_IMPLEMENTED` | `false` |
+| `SEPARATE_GO_REQUIRED` | `true` |
+
+#### RUNBOOK_STEP_29C — Canonical Scope Initialization
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `canonical_scope_initialization` |
+| `CONTRACT_OR_CAPABILITY` | `canonical_scope_initialization_v1` |
+| `STATUS` | `NOT_STARTED` |
+| `DEPENDENCIES` | RUNBOOK_STEP_29B |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |

--- a/src/trading/master_v2/canonical_market_context_v1.py
+++ b/src/trading/master_v2/canonical_market_context_v1.py
@@ -1,0 +1,537 @@
+# src/trading/master_v2/canonical_market_context_v1.py
+"""
+Pure Canonical Market Context v1: data-only futures market context contract.
+
+Bound to Master V2 / Double Play futures input infrastructure via shared
+``FuturesMarketType`` and narrow adapter helpers. No I/O, runtime, adapter,
+order, or execution authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping, Optional, Tuple
+
+from trading.master_v2.double_play_futures_input import (
+    FuturesInputSnapshot,
+    FuturesMarketType,
+)
+
+CANONICAL_MARKET_CONTEXT_LAYER_VERSION = "v1"
+FEATURE_CONTRACT_VERSION = "canonical_market_context_feature_contract_v1"
+PRIMARY_DECISION_PRICE = "VENUE_MARK_PRICE"
+
+_FORBIDDEN_INSTRUMENT_KINDS = frozenset(
+    {"spot", "synthetic_spot", "synthetic-spot", "syntheticspot"}
+)
+_SPREAD_TOLERANCE = 1e-9
+_ISO8601_UTC_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(\+00:00|Z)$")
+
+
+class BarFinalityStatus(str, Enum):
+    FINALIZED = "finalized"
+    UNFINALIZED = "unfinalized"
+    UNKNOWN = "unknown"
+
+
+class WarmupStatus(str, Enum):
+    WARMUP_REQUIRED = "warmup_required"
+    WARMUP_COMPLETE = "warmup_complete"
+    WARMUP_INVALID = "warmup_invalid"
+
+
+class DataIntegrityStatus(str, Enum):
+    TRUSTED = "trusted"
+    UNTRUSTED = "untrusted"
+    UNKNOWN = "unknown"
+    INVALID = "invalid"
+
+
+class ClockTrustStatus(str, Enum):
+    TRUSTED = "trusted"
+    UNTRUSTED = "untrusted"
+    UNKNOWN = "unknown"
+    INVALID = "invalid"
+
+
+_TRUSTED_DATA_INTEGRITY = frozenset({DataIntegrityStatus.TRUSTED})
+_TRUSTED_CLOCK_TRUST = frozenset({ClockTrustStatus.TRUSTED})
+
+
+class CanonicalMarketContextBlockReason(str, Enum):
+    INSTRUMENT_KIND_FORBIDDEN = "instrument_kind_forbidden"
+    INSTRUMENT_KIND_UNKNOWN = "instrument_kind_unknown"
+    INSTRUMENT_ID_INVALID = "instrument_id_invalid"
+    TRADING_EPOCH_INVALID = "trading_epoch_invalid"
+    MARKET_EVENT_TIME_INVALID = "market_event_time_invalid"
+    DECISION_TIME_INVALID = "decision_time_invalid"
+    DECISION_TIME_BEFORE_MARKET_EVENT = "decision_time_before_market_event"
+    BAR_INTERVAL_INVALID = "bar_interval_invalid"
+    BAR_FINALITY_UNKNOWN = "bar_finality_unknown"
+    BAR_UNFINALIZED = "bar_unfinalized"
+    MARK_PRICE_INVALID = "mark_price_invalid"
+    INDEX_PRICE_INVALID = "index_price_invalid"
+    BEST_BID_INVALID = "best_bid_invalid"
+    BEST_ASK_INVALID = "best_ask_invalid"
+    SPREAD_INCONSISTENT = "spread_inconsistent"
+    SPREAD_INVALID = "spread_invalid"
+    VOLUME_INVALID = "volume_invalid"
+    OPEN_INTEREST_INVALID = "open_interest_invalid"
+    FUNDING_RATE_INVALID = "funding_rate_invalid"
+    VOLATILITY_ESTIMATE_INVALID = "volatility_estimate_invalid"
+    FEATURE_CONTRACT_VERSION_INVALID = "feature_contract_version_invalid"
+    DATA_INTEGRITY_UNTRUSTED = "data_integrity_untrusted"
+    DATA_INTEGRITY_UNKNOWN = "data_integrity_unknown"
+    CLOCK_TRUST_UNTRUSTED = "clock_trust_untrusted"
+    CLOCK_TRUST_UNKNOWN = "clock_trust_unknown"
+    WARMUP_REQUIRED = "warmup_required"
+    WARMUP_INVALID = "warmup_invalid"
+    OUT_OF_ORDER_MARKET_EVENT = "out_of_order_market_event"
+    FUTURES_INPUT_INSTRUMENT_MISMATCH = "futures_input_instrument_mismatch"
+    FUTURES_INPUT_MARKET_TYPE_MISMATCH = "futures_input_market_type_mismatch"
+
+
+class CanonicalMarketContextBindingOutcome(str, Enum):
+    ACCEPTED = "accepted"
+    DUPLICATE_IDEMPOTENT = "duplicate_idempotent"
+    BLOCKED = "blocked"
+
+
+def futures_market_type_to_canonical(market_type: FuturesMarketType) -> FuturesMarketType:
+    """Narrow reuse bridge: canonical context uses the same futures market type enum."""
+    return market_type
+
+
+def canonical_market_type_allowed(market_type: FuturesMarketType) -> bool:
+    return market_type in (
+        FuturesMarketType.FUTURES,
+        FuturesMarketType.PERPETUAL,
+        FuturesMarketType.SWAP,
+    )
+
+
+def _normalize_feature_set(features: Mapping[str, float]) -> Tuple[Tuple[str, float], ...]:
+    return tuple(sorted((str(k), float(v)) for k, v in features.items()))
+
+
+@dataclass(frozen=True)
+class CanonicalMarketContextV1:
+    context_id: str
+    instrument_id: str
+    market_type: FuturesMarketType
+    trading_epoch: int
+    market_event_time: str
+    decision_time: str
+    bar_interval: str
+    bar_finality_status: BarFinalityStatus
+    mark_price: float
+    index_price: float
+    best_bid: float
+    best_ask: float
+    spread: float
+    volume: float
+    open_interest: float
+    funding_rate: float
+    volatility_estimate: float
+    trend_feature_set: Mapping[str, float]
+    momentum_feature_set: Mapping[str, float]
+    liquidity_feature_set: Mapping[str, float]
+    market_structure_feature_set: Mapping[str, float]
+    data_integrity_status: DataIntegrityStatus
+    clock_trust_status: ClockTrustStatus
+    warmup_status: WarmupStatus
+    feature_contract_version: str = FEATURE_CONTRACT_VERSION
+    input_digest: str = ""
+
+    def __post_init__(self) -> None:
+        if self.input_digest and not _valid_sha256_hex(self.input_digest):
+            msg = "input_digest must be empty or a 64-char lowercase sha256 hex"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class CanonicalMarketContextEligibilityV1:
+    """Non-authority eligibility labels for downstream scope/trading gates."""
+
+    binding_outcome: CanonicalMarketContextBindingOutcome
+    decision_price_source: str
+    primary_decision_price: float
+    trading_decision_allowed: bool
+    scope_confirmation_allowed: bool
+    new_directional_exposure_allowed: bool
+    observation_and_reconciliation_only: bool
+    block_reasons: Tuple[CanonicalMarketContextBlockReason, ...]
+    is_authority: bool = False
+    is_signal: bool = False
+    execution_eligible: bool = False
+    live_authorization: bool = False
+
+
+@dataclass(frozen=True)
+class CanonicalMarketContextBindingStateV1:
+    """Immutable idempotence and ordering state for sequential event binding."""
+
+    last_market_event_time: Optional[str] = None
+    seen_context_ids: Tuple[str, ...] = ()
+    last_input_digest: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CanonicalMarketContextBindingResultV1:
+    context: Optional[CanonicalMarketContextV1]
+    eligibility: CanonicalMarketContextEligibilityV1
+    next_state: CanonicalMarketContextBindingStateV1
+    validation_errors: Tuple[str, ...] = ()
+
+
+def _valid_sha256_hex(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{64}", value))
+
+
+def _parse_utc_instant(value: str) -> Optional[str]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    stripped = value.strip()
+    if not _ISO8601_UTC_PATTERN.match(stripped):
+        return None
+    return stripped
+
+
+def _instrument_id_valid(instrument_id: str) -> bool:
+    if not isinstance(instrument_id, str):
+        return False
+    stripped = instrument_id.strip()
+    if not stripped or len(stripped) > 256:
+        return False
+    lowered = stripped.lower()
+    for forbidden in _FORBIDDEN_INSTRUMENT_KINDS:
+        if forbidden in lowered:
+            return False
+    return True
+
+
+def _positive_finite(value: object) -> bool:
+    return isinstance(value, (int, float)) and float(value) > 0.0
+
+
+def _non_negative_finite(value: object) -> bool:
+    return isinstance(value, (int, float)) and float(value) >= 0.0
+
+
+def _spread_matches_bid_ask(spread: float, best_bid: float, best_ask: float) -> bool:
+    if best_ask < best_bid:
+        return False
+    expected = best_ask - best_bid
+    return abs(spread - expected) <= _SPREAD_TOLERANCE
+
+
+def validate_canonical_market_context_fields(
+    context: CanonicalMarketContextV1,
+) -> Tuple[CanonicalMarketContextBlockReason, ...]:
+    blocks: list[CanonicalMarketContextBlockReason] = []
+
+    if not context.context_id or not str(context.context_id).strip():
+        blocks.append(CanonicalMarketContextBlockReason.INSTRUMENT_ID_INVALID)
+
+    if not _instrument_id_valid(context.instrument_id):
+        blocks.append(CanonicalMarketContextBlockReason.INSTRUMENT_ID_INVALID)
+
+    if context.market_type is FuturesMarketType.UNKNOWN:
+        blocks.append(CanonicalMarketContextBlockReason.INSTRUMENT_KIND_UNKNOWN)
+    elif not canonical_market_type_allowed(context.market_type):
+        blocks.append(CanonicalMarketContextBlockReason.INSTRUMENT_KIND_FORBIDDEN)
+
+    if not isinstance(context.trading_epoch, int) or context.trading_epoch < 0:
+        blocks.append(CanonicalMarketContextBlockReason.TRADING_EPOCH_INVALID)
+
+    market_event_time = _parse_utc_instant(context.market_event_time)
+    if market_event_time is None:
+        blocks.append(CanonicalMarketContextBlockReason.MARKET_EVENT_TIME_INVALID)
+
+    decision_time = _parse_utc_instant(context.decision_time)
+    if decision_time is None:
+        blocks.append(CanonicalMarketContextBlockReason.DECISION_TIME_INVALID)
+    elif market_event_time is not None and decision_time < market_event_time:
+        blocks.append(CanonicalMarketContextBlockReason.DECISION_TIME_BEFORE_MARKET_EVENT)
+
+    if not context.bar_interval or not str(context.bar_interval).strip():
+        blocks.append(CanonicalMarketContextBlockReason.BAR_INTERVAL_INVALID)
+
+    if context.bar_finality_status is BarFinalityStatus.UNKNOWN:
+        blocks.append(CanonicalMarketContextBlockReason.BAR_FINALITY_UNKNOWN)
+    elif context.bar_finality_status is BarFinalityStatus.UNFINALIZED:
+        blocks.append(CanonicalMarketContextBlockReason.BAR_UNFINALIZED)
+
+    if not _positive_finite(context.mark_price):
+        blocks.append(CanonicalMarketContextBlockReason.MARK_PRICE_INVALID)
+    if not _positive_finite(context.index_price):
+        blocks.append(CanonicalMarketContextBlockReason.INDEX_PRICE_INVALID)
+    if not _positive_finite(context.best_bid):
+        blocks.append(CanonicalMarketContextBlockReason.BEST_BID_INVALID)
+    if not _positive_finite(context.best_ask):
+        blocks.append(CanonicalMarketContextBlockReason.BEST_ASK_INVALID)
+    if not _non_negative_finite(context.spread):
+        blocks.append(CanonicalMarketContextBlockReason.SPREAD_INVALID)
+    elif _positive_finite(context.best_bid) and _positive_finite(context.best_ask):
+        if not _spread_matches_bid_ask(context.spread, context.best_bid, context.best_ask):
+            blocks.append(CanonicalMarketContextBlockReason.SPREAD_INCONSISTENT)
+
+    if not _non_negative_finite(context.volume):
+        blocks.append(CanonicalMarketContextBlockReason.VOLUME_INVALID)
+    if not _non_negative_finite(context.open_interest):
+        blocks.append(CanonicalMarketContextBlockReason.OPEN_INTEREST_INVALID)
+    if not isinstance(context.funding_rate, (int, float)):
+        blocks.append(CanonicalMarketContextBlockReason.FUNDING_RATE_INVALID)
+    if not _non_negative_finite(context.volatility_estimate):
+        blocks.append(CanonicalMarketContextBlockReason.VOLATILITY_ESTIMATE_INVALID)
+
+    if (
+        not context.feature_contract_version
+        or context.feature_contract_version != FEATURE_CONTRACT_VERSION
+    ):
+        blocks.append(CanonicalMarketContextBlockReason.FEATURE_CONTRACT_VERSION_INVALID)
+
+    if context.data_integrity_status in (
+        DataIntegrityStatus.UNTRUSTED,
+        DataIntegrityStatus.INVALID,
+    ):
+        blocks.append(CanonicalMarketContextBlockReason.DATA_INTEGRITY_UNTRUSTED)
+    elif context.data_integrity_status is DataIntegrityStatus.UNKNOWN:
+        blocks.append(CanonicalMarketContextBlockReason.DATA_INTEGRITY_UNKNOWN)
+
+    if context.clock_trust_status in (ClockTrustStatus.UNTRUSTED, ClockTrustStatus.INVALID):
+        blocks.append(CanonicalMarketContextBlockReason.CLOCK_TRUST_UNTRUSTED)
+    elif context.clock_trust_status is ClockTrustStatus.UNKNOWN:
+        blocks.append(CanonicalMarketContextBlockReason.CLOCK_TRUST_UNKNOWN)
+
+    if context.warmup_status is WarmupStatus.WARMUP_REQUIRED:
+        blocks.append(CanonicalMarketContextBlockReason.WARMUP_REQUIRED)
+    elif context.warmup_status is WarmupStatus.WARMUP_INVALID:
+        blocks.append(CanonicalMarketContextBlockReason.WARMUP_INVALID)
+
+    return tuple(dict.fromkeys(blocks))
+
+
+def serialize_canonical_market_context_canonical(context: CanonicalMarketContextV1) -> str:
+    """Deterministic JSON serialization for digest (excludes input_digest field)."""
+    payload = {
+        "bar_finality_status": context.bar_finality_status.value,
+        "bar_interval": context.bar_interval,
+        "best_ask": context.best_ask,
+        "best_bid": context.best_bid,
+        "clock_trust_status": context.clock_trust_status.value,
+        "context_id": context.context_id,
+        "data_integrity_status": context.data_integrity_status.value,
+        "decision_time": context.decision_time,
+        "feature_contract_version": context.feature_contract_version,
+        "funding_rate": context.funding_rate,
+        "index_price": context.index_price,
+        "instrument_id": context.instrument_id,
+        "layer_version": CANONICAL_MARKET_CONTEXT_LAYER_VERSION,
+        "liquidity_feature_set": list(_normalize_feature_set(context.liquidity_feature_set)),
+        "mark_price": context.mark_price,
+        "market_event_time": context.market_event_time,
+        "market_structure_feature_set": list(
+            _normalize_feature_set(context.market_structure_feature_set)
+        ),
+        "market_type": context.market_type.value,
+        "momentum_feature_set": list(_normalize_feature_set(context.momentum_feature_set)),
+        "open_interest": context.open_interest,
+        "primary_decision_price_source": PRIMARY_DECISION_PRICE,
+        "spread": context.spread,
+        "trading_epoch": context.trading_epoch,
+        "trend_feature_set": list(_normalize_feature_set(context.trend_feature_set)),
+        "volatility_estimate": context.volatility_estimate,
+        "volume": context.volume,
+        "warmup_status": context.warmup_status.value,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_canonical_market_context_input_digest(context: CanonicalMarketContextV1) -> str:
+    """Deterministic digest over normalized decision-relevant inputs."""
+    canonical = serialize_canonical_market_context_canonical(context)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def with_computed_input_digest(context: CanonicalMarketContextV1) -> CanonicalMarketContextV1:
+    digest = compute_canonical_market_context_input_digest(context)
+    return CanonicalMarketContextV1(
+        context_id=context.context_id,
+        instrument_id=context.instrument_id,
+        market_type=context.market_type,
+        trading_epoch=context.trading_epoch,
+        market_event_time=context.market_event_time,
+        decision_time=context.decision_time,
+        bar_interval=context.bar_interval,
+        bar_finality_status=context.bar_finality_status,
+        mark_price=context.mark_price,
+        index_price=context.index_price,
+        best_bid=context.best_bid,
+        best_ask=context.best_ask,
+        spread=context.spread,
+        volume=context.volume,
+        open_interest=context.open_interest,
+        funding_rate=context.funding_rate,
+        volatility_estimate=context.volatility_estimate,
+        trend_feature_set=context.trend_feature_set,
+        momentum_feature_set=context.momentum_feature_set,
+        liquidity_feature_set=context.liquidity_feature_set,
+        market_structure_feature_set=context.market_structure_feature_set,
+        data_integrity_status=context.data_integrity_status,
+        clock_trust_status=context.clock_trust_status,
+        warmup_status=context.warmup_status,
+        feature_contract_version=context.feature_contract_version,
+        input_digest=digest,
+    )
+
+
+def _warmup_blocks_directional_and_scope(
+    warmup_status: WarmupStatus,
+) -> bool:
+    return warmup_status in (WarmupStatus.WARMUP_REQUIRED, WarmupStatus.WARMUP_INVALID)
+
+
+def evaluate_canonical_market_context_eligibility(
+    context: CanonicalMarketContextV1,
+    *,
+    binding_outcome: CanonicalMarketContextBindingOutcome = CanonicalMarketContextBindingOutcome.ACCEPTED,
+    extra_blocks: Tuple[CanonicalMarketContextBlockReason, ...] = (),
+) -> CanonicalMarketContextEligibilityV1:
+    """Evaluate non-authority eligibility from a validated canonical market context."""
+    field_blocks = validate_canonical_market_context_fields(context)
+    all_blocks = tuple(dict.fromkeys((*field_blocks, *extra_blocks)))
+
+    trusted_integrity = context.data_integrity_status in _TRUSTED_DATA_INTEGRITY
+    trusted_clock = context.clock_trust_status in _TRUSTED_CLOCK_TRUST
+    finalized_bar = context.bar_finality_status is BarFinalityStatus.FINALIZED
+    warmup_ok = context.warmup_status is WarmupStatus.WARMUP_COMPLETE
+
+    base_ok = (
+        binding_outcome
+        in (
+            CanonicalMarketContextBindingOutcome.ACCEPTED,
+            CanonicalMarketContextBindingOutcome.DUPLICATE_IDEMPOTENT,
+        )
+        and not all_blocks
+    )
+
+    trading_allowed = (
+        base_ok and finalized_bar and trusted_integrity and trusted_clock and warmup_ok
+    )
+    scope_allowed = trading_allowed
+    directional_allowed = trading_allowed
+    observation_only = _warmup_blocks_directional_and_scope(context.warmup_status) or bool(
+        all_blocks
+    )
+
+    if binding_outcome is CanonicalMarketContextBindingOutcome.BLOCKED:
+        trading_allowed = False
+        scope_allowed = False
+        directional_allowed = False
+        observation_only = True
+
+    return CanonicalMarketContextEligibilityV1(
+        binding_outcome=binding_outcome,
+        decision_price_source=PRIMARY_DECISION_PRICE,
+        primary_decision_price=context.mark_price,
+        trading_decision_allowed=trading_allowed,
+        scope_confirmation_allowed=scope_allowed,
+        new_directional_exposure_allowed=directional_allowed,
+        observation_and_reconciliation_only=observation_only,
+        block_reasons=all_blocks,
+        is_authority=False,
+        is_signal=False,
+        execution_eligible=False,
+        live_authorization=False,
+    )
+
+
+def validate_futures_input_snapshot_binding(
+    context: CanonicalMarketContextV1,
+    snapshot: FuturesInputSnapshot,
+) -> Tuple[CanonicalMarketContextBlockReason, ...]:
+    """Narrow adapter: ensure canonical context aligns with futures input snapshot identity."""
+    blocks: list[CanonicalMarketContextBlockReason] = []
+    if snapshot.candidate.instrument_id != context.instrument_id:
+        blocks.append(CanonicalMarketContextBlockReason.FUTURES_INPUT_INSTRUMENT_MISMATCH)
+    if snapshot.candidate.market_type != context.market_type:
+        blocks.append(CanonicalMarketContextBlockReason.FUTURES_INPUT_MARKET_TYPE_MISMATCH)
+    return tuple(blocks)
+
+
+def bind_canonical_market_context_event(
+    context: CanonicalMarketContextV1,
+    state: CanonicalMarketContextBindingStateV1,
+    *,
+    futures_input_snapshot: Optional[FuturesInputSnapshot] = None,
+) -> CanonicalMarketContextBindingResultV1:
+    """
+    Bind one canonical market context event with fail-closed ordering and idempotence.
+
+    Duplicate ``context_id`` returns idempotent eligibility without mutating ordering state.
+    Out-of-order ``market_event_time`` is blocked fail-closed.
+    """
+    extra_blocks: list[CanonicalMarketContextBlockReason] = []
+    validation_errors: list[str] = []
+
+    market_event_time = _parse_utc_instant(context.market_event_time)
+    if market_event_time is None:
+        validation_errors.append("market_event_time must be canonical UTC ISO8601")
+
+    if context.context_id in state.seen_context_ids:
+        bound = with_computed_input_digest(context)
+        eligibility = evaluate_canonical_market_context_eligibility(
+            bound,
+            binding_outcome=CanonicalMarketContextBindingOutcome.DUPLICATE_IDEMPOTENT,
+        )
+        return CanonicalMarketContextBindingResultV1(
+            context=bound,
+            eligibility=eligibility,
+            next_state=state,
+            validation_errors=tuple(validation_errors),
+        )
+
+    if (
+        state.last_market_event_time is not None
+        and market_event_time is not None
+        and market_event_time < state.last_market_event_time
+    ):
+        extra_blocks.append(CanonicalMarketContextBlockReason.OUT_OF_ORDER_MARKET_EVENT)
+
+    if futures_input_snapshot is not None:
+        extra_blocks.extend(
+            validate_futures_input_snapshot_binding(context, futures_input_snapshot)
+        )
+
+    bound = with_computed_input_digest(context)
+    outcome = (
+        CanonicalMarketContextBindingOutcome.BLOCKED
+        if extra_blocks or validate_canonical_market_context_fields(bound)
+        else CanonicalMarketContextBindingOutcome.ACCEPTED
+    )
+    eligibility = evaluate_canonical_market_context_eligibility(
+        bound,
+        binding_outcome=outcome,
+        extra_blocks=tuple(extra_blocks),
+    )
+
+    if outcome is CanonicalMarketContextBindingOutcome.ACCEPTED and market_event_time is not None:
+        next_state = CanonicalMarketContextBindingStateV1(
+            last_market_event_time=market_event_time,
+            seen_context_ids=state.seen_context_ids + (context.context_id,),
+            last_input_digest=bound.input_digest,
+        )
+    else:
+        next_state = state
+
+    return CanonicalMarketContextBindingResultV1(
+        context=bound,
+        eligibility=eligibility,
+        next_state=next_state,
+        validation_errors=tuple(validation_errors),
+    )

--- a/tests/trading/master_v2/test_canonical_market_context_v1.py
+++ b/tests/trading/master_v2/test_canonical_market_context_v1.py
@@ -1,0 +1,415 @@
+# tests/trading/master_v2/test_canonical_market_context_v1.py
+from __future__ import annotations
+
+import ast
+import copy
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.canonical_market_context_v1 import (
+    CANONICAL_MARKET_CONTEXT_LAYER_VERSION,
+    FEATURE_CONTRACT_VERSION,
+    PRIMARY_DECISION_PRICE,
+    BarFinalityStatus,
+    CanonicalMarketContextBindingOutcome,
+    CanonicalMarketContextBindingStateV1,
+    CanonicalMarketContextBlockReason,
+    CanonicalMarketContextV1,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+    WarmupStatus,
+    bind_canonical_market_context_event,
+    canonical_market_type_allowed,
+    compute_canonical_market_context_input_digest,
+    evaluate_canonical_market_context_eligibility,
+    futures_market_type_to_canonical,
+    serialize_canonical_market_context_canonical,
+    validate_canonical_market_context_fields,
+    validate_futures_input_snapshot_binding,
+    with_computed_input_digest,
+)
+from trading.master_v2.double_play_futures_input import (
+    FuturesCandidateSnapshot,
+    FuturesDerivativesProfile,
+    FuturesFreshnessState,
+    FuturesInputSnapshot,
+    FuturesInstrumentMetadataStatus,
+    FuturesLiquidityProfile,
+    FuturesMarketDataProvenanceStatus,
+    FuturesMarketType,
+    FuturesOpportunityProfile,
+    FuturesRankingSnapshot,
+    FuturesVolatilityProfile,
+)
+
+
+def _features(**kwargs: float) -> dict[str, float]:
+    return dict(kwargs)
+
+
+def _context(**overrides: object) -> CanonicalMarketContextV1:
+    base: dict = {
+        "context_id": "ctx-eth-perp-epoch42-ev1",
+        "instrument_id": "inst-eth-usdt-perp",
+        "market_type": FuturesMarketType.PERPETUAL,
+        "trading_epoch": 42,
+        "market_event_time": "2026-06-30T12:00:00+00:00",
+        "decision_time": "2026-06-30T12:00:01+00:00",
+        "bar_interval": "1m",
+        "bar_finality_status": BarFinalityStatus.FINALIZED,
+        "mark_price": 3500.0,
+        "index_price": 3499.5,
+        "best_bid": 3499.8,
+        "best_ask": 3500.2,
+        "spread": 0.4,
+        "volume": 1_250_000.0,
+        "open_interest": 85_000_000.0,
+        "funding_rate": 0.00012,
+        "volatility_estimate": 0.38,
+        "trend_feature_set": _features(slope=0.02, strength=0.71),
+        "momentum_feature_set": _features(rsi=55.0, roc=0.015),
+        "liquidity_feature_set": _features(depth_score=0.88),
+        "market_structure_feature_set": _features(range_ratio=0.42),
+        "data_integrity_status": DataIntegrityStatus.TRUSTED,
+        "clock_trust_status": ClockTrustStatus.TRUSTED,
+        "warmup_status": WarmupStatus.WARMUP_COMPLETE,
+        "feature_contract_version": FEATURE_CONTRACT_VERSION,
+        "input_digest": "",
+    }
+    base.update(overrides)
+    return CanonicalMarketContextV1(**base)
+
+
+def _futures_snapshot(**overrides: object) -> FuturesInputSnapshot:
+    candidate = FuturesCandidateSnapshot(
+        candidate_id="c-eth-1",
+        instrument_id="inst-eth-usdt-perp",
+        symbol="ETH-USDT-PERP",
+        market_type=FuturesMarketType.PERPETUAL,
+        exchange="example",
+        base_currency="ETH",
+        quote_currency="USDT",
+        live_authorization=False,
+    )
+    parts: dict = {
+        "candidate": candidate,
+        "ranking": FuturesRankingSnapshot(
+            source_universe_size=100,
+            selected_top_n=20,
+            rank=2,
+            score=0.87,
+            score_components_complete=True,
+            is_top_n_member=True,
+        ),
+        "instrument": FuturesInstrumentMetadataStatus(
+            complete=True,
+            contract_size_known=True,
+            tick_size_known=True,
+            step_size_known=True,
+            min_qty_known=True,
+            min_notional_known=True,
+            margin_asset_known=True,
+            settlement_asset_known=True,
+            leverage_bounds_known=True,
+            missing_fields=(),
+        ),
+        "provenance": FuturesMarketDataProvenanceStatus(
+            complete=True,
+            freshness_state=FuturesFreshnessState.FRESH,
+            dataset_id="ds-eth-1",
+            source="fixture",
+            mark_available=True,
+            index_available=True,
+            last_available=True,
+            ohlcv_available=True,
+            funding_available=True,
+            open_interest_available=True,
+            missing_fields=(),
+        ),
+        "volatility": FuturesVolatilityProfile(
+            realized_volatility=0.38,
+            atr_or_rolling_range=45.0,
+            volatility_regime="medium",
+            dynamic_scope_usable=True,
+        ),
+        "liquidity": FuturesLiquidityProfile(
+            spread_bps=1.1,
+            average_spread_bps=1.3,
+            volume=1_250_000.0,
+            quote_volume=4_375_000_000.0,
+            liquidity_regime="deep",
+            spread_quality="tight",
+        ),
+        "derivatives": FuturesDerivativesProfile(
+            funding_available=True,
+            funding_rate=0.00012,
+            funding_regime="neutral",
+            open_interest_available=True,
+            open_interest=85_000_000.0,
+            open_interest_regime="high",
+        ),
+        "opportunity": FuturesOpportunityProfile(
+            opportunity_score=0.72,
+            inactivity_score=0.08,
+            movement_above_fee_slippage_breakeven=True,
+            chop_risk="low",
+            candidate_is_inactive=False,
+        ),
+    }
+    parts.update(overrides)
+    return FuturesInputSnapshot(**parts)
+
+
+def test_layer_version_and_primary_decision_price_constants() -> None:
+    assert CANONICAL_MARKET_CONTEXT_LAYER_VERSION == "v1"
+    assert PRIMARY_DECISION_PRICE == "VENUE_MARK_PRICE"
+
+
+def test_complete_valid_futures_context_forms_and_passes_validation() -> None:
+    ctx = _context()
+    blocks = validate_canonical_market_context_fields(ctx)
+    assert not blocks
+    bound = with_computed_input_digest(ctx)
+    assert len(bound.input_digest) == 64
+    elig = evaluate_canonical_market_context_eligibility(bound)
+    assert elig.trading_decision_allowed
+    assert elig.scope_confirmation_allowed
+    assert elig.new_directional_exposure_allowed
+    assert not elig.observation_and_reconciliation_only
+    assert elig.primary_decision_price == ctx.mark_price
+    assert elig.decision_price_source == PRIMARY_DECISION_PRICE
+    assert not elig.execution_eligible
+    assert not elig.is_authority
+
+
+def test_input_digest_is_deterministic() -> None:
+    ctx = _context()
+    d1 = compute_canonical_market_context_input_digest(ctx)
+    d2 = compute_canonical_market_context_input_digest(ctx)
+    assert d1 == d2
+    assert d1 == with_computed_input_digest(ctx).input_digest
+
+
+def test_identical_inputs_yield_identical_digest() -> None:
+    a = compute_canonical_market_context_input_digest(_context())
+    b = compute_canonical_market_context_input_digest(_context())
+    assert a == b
+
+
+def test_feature_dictionary_order_does_not_affect_digest() -> None:
+    ctx_a = _context(trend_feature_set={"b": 2.0, "a": 1.0})
+    ctx_b = _context(trend_feature_set={"a": 1.0, "b": 2.0})
+    assert compute_canonical_market_context_input_digest(
+        ctx_a
+    ) == compute_canonical_market_context_input_digest(ctx_b)
+
+
+def test_decision_relevant_field_change_changes_digest() -> None:
+    base = compute_canonical_market_context_input_digest(_context())
+    changed = compute_canonical_market_context_input_digest(_context(mark_price=3501.0))
+    assert base != changed
+
+
+def test_duplicate_event_is_idempotent() -> None:
+    ctx = _context()
+    state = CanonicalMarketContextBindingStateV1()
+    first = bind_canonical_market_context_event(ctx, state)
+    assert first.eligibility.binding_outcome is CanonicalMarketContextBindingOutcome.ACCEPTED
+    second = bind_canonical_market_context_event(ctx, first.next_state)
+    assert (
+        second.eligibility.binding_outcome
+        is CanonicalMarketContextBindingOutcome.DUPLICATE_IDEMPOTENT
+    )
+    assert second.next_state == first.next_state
+
+
+def test_out_of_order_event_fail_closed() -> None:
+    earlier = _context(
+        context_id="ctx-earlier",
+        market_event_time="2026-06-30T12:00:00+00:00",
+        decision_time="2026-06-30T12:00:01+00:00",
+    )
+    later = _context(
+        context_id="ctx-later",
+        market_event_time="2026-06-30T12:01:00+00:00",
+        decision_time="2026-06-30T12:01:01+00:00",
+    )
+    state = CanonicalMarketContextBindingStateV1()
+    accepted = bind_canonical_market_context_event(later, state)
+    assert accepted.eligibility.binding_outcome is CanonicalMarketContextBindingOutcome.ACCEPTED
+    ooo = bind_canonical_market_context_event(earlier, accepted.next_state)
+    assert ooo.eligibility.binding_outcome is CanonicalMarketContextBindingOutcome.BLOCKED
+    assert (
+        CanonicalMarketContextBlockReason.OUT_OF_ORDER_MARKET_EVENT in ooo.eligibility.block_reasons
+    )
+    assert not ooo.eligibility.trading_decision_allowed
+
+
+def test_unfinalized_bar_blocks_entry_and_scope_confirmation() -> None:
+    ctx = with_computed_input_digest(_context(bar_finality_status=BarFinalityStatus.UNFINALIZED))
+    elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert not elig.trading_decision_allowed
+    assert not elig.scope_confirmation_allowed
+    assert CanonicalMarketContextBlockReason.BAR_UNFINALIZED in elig.block_reasons
+
+
+def test_warmup_required_blocks_directional_exposure() -> None:
+    ctx = with_computed_input_digest(_context(warmup_status=WarmupStatus.WARMUP_REQUIRED))
+    elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert not elig.new_directional_exposure_allowed
+    assert not elig.scope_confirmation_allowed
+    assert elig.observation_and_reconciliation_only
+    assert CanonicalMarketContextBlockReason.WARMUP_REQUIRED in elig.block_reasons
+
+
+def test_warmup_invalid_blocks() -> None:
+    ctx = with_computed_input_digest(_context(warmup_status=WarmupStatus.WARMUP_INVALID))
+    elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert not elig.new_directional_exposure_allowed
+    assert elig.observation_and_reconciliation_only
+    assert CanonicalMarketContextBlockReason.WARMUP_INVALID in elig.block_reasons
+
+
+@pytest.mark.parametrize(
+    "status",
+    [DataIntegrityStatus.UNTRUSTED, DataIntegrityStatus.UNKNOWN, DataIntegrityStatus.INVALID],
+)
+def test_data_integrity_untrusted_or_unknown_blocks(status: DataIntegrityStatus) -> None:
+    ctx = with_computed_input_digest(_context(data_integrity_status=status))
+    elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert not elig.trading_decision_allowed
+    assert elig.observation_and_reconciliation_only
+
+
+@pytest.mark.parametrize(
+    "status",
+    [ClockTrustStatus.UNTRUSTED, ClockTrustStatus.UNKNOWN, ClockTrustStatus.INVALID],
+)
+def test_clock_trust_untrusted_or_unknown_blocks(status: ClockTrustStatus) -> None:
+    ctx = with_computed_input_digest(_context(clock_trust_status=status))
+    elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert not elig.trading_decision_allowed
+    assert elig.observation_and_reconciliation_only
+
+
+def test_mark_price_is_canonical_decision_price() -> None:
+    ctx = with_computed_input_digest(_context(mark_price=4123.45))
+    elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert elig.primary_decision_price == 4123.45
+    serialized = serialize_canonical_market_context_canonical(ctx)
+    assert PRIMARY_DECISION_PRICE in serialized
+
+
+def test_spread_validated_against_bid_ask() -> None:
+    blocks = validate_canonical_market_context_fields(_context(spread=9.99))
+    assert CanonicalMarketContextBlockReason.SPREAD_INCONSISTENT in blocks
+
+
+def test_invalid_bid_ask_time_and_instrument_rejected() -> None:
+    assert (
+        CanonicalMarketContextBlockReason.BEST_BID_INVALID
+        in validate_canonical_market_context_fields(_context(best_bid=-1.0))
+    )
+    assert (
+        CanonicalMarketContextBlockReason.BEST_ASK_INVALID
+        in validate_canonical_market_context_fields(_context(best_ask=0.0))
+    )
+    assert (
+        CanonicalMarketContextBlockReason.MARKET_EVENT_TIME_INVALID
+        in validate_canonical_market_context_fields(_context(market_event_time="not-a-time"))
+    )
+    assert (
+        CanonicalMarketContextBlockReason.INSTRUMENT_ID_INVALID
+        in validate_canonical_market_context_fields(_context(instrument_id=""))
+    )
+
+
+def test_futures_only_enforced_via_market_type() -> None:
+    assert canonical_market_type_allowed(FuturesMarketType.PERPETUAL)
+    assert not canonical_market_type_allowed(FuturesMarketType.UNKNOWN)
+    blocks = validate_canonical_market_context_fields(
+        _context(market_type=FuturesMarketType.UNKNOWN)
+    )
+    assert CanonicalMarketContextBlockReason.INSTRUMENT_KIND_UNKNOWN in blocks
+
+
+def test_spot_and_synthetic_spot_instrument_id_rejected() -> None:
+    for instrument_id in ("inst-spot-eth", "inst-synthetic_spot-eth", "inst-synthetic-spot-eth"):
+        blocks = validate_canonical_market_context_fields(_context(instrument_id=instrument_id))
+        assert CanonicalMarketContextBlockReason.INSTRUMENT_ID_INVALID in blocks
+
+
+def test_bitcoin_not_required_in_semantics_generic_instrument_works() -> None:
+    ctx = _context(
+        instrument_id="inst-sol-usdt-perp",
+        context_id="ctx-sol-perp-epoch1-ev1",
+    )
+    assert not validate_canonical_market_context_fields(ctx)
+    digest = compute_canonical_market_context_input_digest(ctx)
+    assert "btc" not in digest
+    assert "bitcoin" not in serialize_canonical_market_context_canonical(ctx).lower()
+
+
+def test_futures_input_binding_adapter_consistency() -> None:
+    ctx = _context()
+    snap = _futures_snapshot()
+    assert not validate_futures_input_snapshot_binding(ctx, snap)
+    mismatch = validate_futures_input_snapshot_binding(
+        ctx,
+        _futures_snapshot(
+            candidate=FuturesCandidateSnapshot(
+                candidate_id="x",
+                instrument_id="other",
+                symbol="OTHER-PERP",
+                market_type=FuturesMarketType.FUTURES,
+                exchange="example",
+                base_currency="SOL",
+                quote_currency="USDT",
+            )
+        ),
+    )
+    assert CanonicalMarketContextBlockReason.FUTURES_INPUT_INSTRUMENT_MISMATCH in mismatch
+
+
+def test_bind_with_futures_input_snapshot_narrow_adapter() -> None:
+    ctx = _context()
+    snap = _futures_snapshot()
+    result = bind_canonical_market_context_event(
+        ctx, CanonicalMarketContextBindingStateV1(), futures_input_snapshot=snap
+    )
+    assert result.eligibility.binding_outcome is CanonicalMarketContextBindingOutcome.ACCEPTED
+
+
+def test_no_runtime_order_or_execution_side_effects_in_module() -> None:
+    root = Path(__file__).resolve().parent.parent.parent.parent / "src" / "trading" / "master_v2"
+    path = root / "canonical_market_context_v1.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bad_roots = {
+        "ccxt",
+        "requests",
+        "urllib3",
+        "httpx",
+        "aiohttp",
+        "socket",
+        "websockets",
+        "boto3",
+        "subprocess",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                assert n.name.split(".")[0] not in bad_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in bad_roots
+
+
+def test_futures_market_type_reuse_bridge() -> None:
+    assert futures_market_type_to_canonical(FuturesMarketType.SWAP) is FuturesMarketType.SWAP
+
+
+def test_existing_double_play_futures_input_regression_still_importable() -> None:
+    from trading.master_v2.double_play_futures_input import evaluate_futures_input_snapshot
+
+    d = evaluate_futures_input_snapshot(_futures_snapshot())
+    assert d.ready_for_downstream_model_use


### PR DESCRIPTION
## Summary

- Implements **STEP 29B** (`CanonicalMarketContextV1`) as a pure, non-authorizing contract bound to the existing `double_play_futures_input` owner via shared `FuturesMarketType` and a narrow futures-input adapter.
- Adds deterministic `input_digest`, fail-closed out-of-order blocking, duplicate idempotence, warmup/clock-trust/data-integrity gates, and futures-only instrument guards (no spot/synthetic-spot, no Bitcoin-specific semantics).
- Updates `PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md` with 29A/29B/29C sub-steps; next canonical step is **STEP 29C** (scope initialization — not in this PR).

## Reuse decision

`REUSE_WITH_NARROW_ADAPTER` — extended Master V2 futures input surface; no parallel market-context SSOT.

## Invariants (enforced)

- `PRIMARY_DECISION_PRICE=VENUE_MARK_PRICE`
- `TRADING_DECISION_ON_UNFINALIZED_BAR_ALLOWED=false`
- `SCOPE_CONFIRMATION_ON_UNFINALIZED_BAR_ALLOWED=false`
- `OUT_OF_ORDER_MARKET_EVENT_ALLOWED=false`
- `DUPLICATE_MARKET_EVENT_MUST_BE_IDEMPOTENT=true`
- Warmup REQUIRED/INVALID → observation/reconciliation only; no new directional exposure
- No `execution_eligible`, runtime, adapter, or order effects

## Tests

- `tests/trading/master_v2/test_canonical_market_context_v1.py` (new)
- Regression: `test_double_play_futures_input.py`, `test_double_play_futures_input_producer.py`
- Local CI selector path: `PR_BOUNDED_FULL` (central `src/`)

## Excluded scope

Scope initialization, scope event generator, bull/bear assessment, backtest economic rewire, runtime/adapter/order wiring.

## Evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/runbook_step29b_canonical_market_context_binding_v1_offline_slice_implementation_v0_20260630T120000Z` (`MANIFEST_VERIFY_RC=0`)

## Test plan

- [x] Focused master_v2 contract tests (63 passed)
- [x] PR-bounded CI contract tests (636 passed)
- [x] `ruff format --check` / `ruff check`
- [ ] GitHub required checks terminal green


Made with [Cursor](https://cursor.com)