### PR TITLE
feat(master-v2): bind canonical scope initialization v1

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -66,6 +66,8 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `CANARY_MICRO_LIVE_READINESS_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29B_IMPLEMENTED` | `true` |
 | `CANONICAL_MARKET_CONTEXT_BINDING_V1_IMPLEMENTED` | `true` |
+| `RUNBOOK_STEP_29C_IMPLEMENTATION_STARTED` | `true` |
+| `CANONICAL_SCOPE_INITIALIZATION_V1_IMPLEMENTATION_STARTED` | `true` |
 | `FOLLOW_UP_DEVEX_SCOPE` | `CANONICAL_PRE_PR_RUFF_AND_DIFF_GUARD` |
 | `FOLLOW_UP_DEVEX_STATUS` | `PENDING_SEPARATE_PR` |
 | `SYSTEMWIDE_RANKING_REQUIRED` | `false` |
@@ -679,6 +681,8 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `RUNTIME_EFFECT` | `false` |
 | `FUTURES_ONLY` | `true` |
 | `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `RUNBOOK_STEP_29C_IMPLEMENTED` | `false` |
+| `CANONICAL_SCOPE_INITIALIZATION_V1_IMPLEMENTED` | `false` |
 | `SCOPE_INITIALIZATION_IMPLEMENTED` | `false` |
 | `SCOPE_EVENT_GENERATOR_IMPLEMENTED` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |
@@ -690,10 +694,15 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `RUNBOOK_PHASE` | 9 |
 | `RUNBOOK_STEP_ID` | `canonical_scope_initialization` |
 | `CONTRACT_OR_CAPABILITY` | `canonical_scope_initialization_v1` |
-| `STATUS` | `NOT_STARTED` |
+| `STATUS` | `IN_PROGRESS` |
+| `CANONICAL_OWNER` | `src/trading/master_v2/canonical_scope_initialization_v1.py` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29B |
+| `NEXT_REQUIRED_CONTRACT` | `deterministic_scope_event_generator` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `SCOPE_EVENT_GENERATOR_IMPLEMENTED` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |
 
 ---

--- a/src/trading/master_v2/canonical_scope_initialization_v1.py
+++ b/src/trading/master_v2/canonical_scope_initialization_v1.py
@@ -1,0 +1,460 @@
+# src/trading/master_v2/canonical_scope_initialization_v1.py
+"""
+Pure Canonical Scope Initialization v1: data-only scope lifecycle and initialization.
+
+Bound to ``canonical_market_context_v1`` and Master V2 dynamic-scope conventions.
+No I/O, runtime, adapter, order, scope-event generation, or execution authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+from trading.master_v2.canonical_market_context_v1 import (
+    BarFinalityStatus,
+    CanonicalMarketContextV1,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+    WarmupStatus,
+    canonical_market_type_allowed,
+    validate_canonical_market_context_fields,
+    with_computed_input_digest,
+)
+
+CANONICAL_SCOPE_INITIALIZATION_LAYER_VERSION = "v1"
+SCOPE_INITIALIZATION_POLICY_VERSION = "canonical_scope_initialization_policy_v1"
+_RECONCILED_STATUS = "RECONCILED"
+
+
+class CanonicalScopeLifecycleState(str, Enum):
+    SCOPE_UNINITIALIZED = "scope_uninitialized"
+    SCOPE_WARMING_UP = "scope_warming_up"
+    SCOPE_VALID = "scope_valid"
+    SCOPE_STALE = "scope_stale"
+    SCOPE_INVALID = "scope_invalid"
+
+
+class CanonicalScopeBlockReason(str, Enum):
+    SCOPE_ALREADY_INITIALIZED = "scope_already_initialized"
+    REINITIALIZATION_OPEN_POSITION = "reinitialization_open_position"
+    REINITIALIZATION_UNKNOWN_POSITION = "reinitialization_unknown_position"
+    REINITIALIZATION_UNRESOLVED_INCREASE_ORDER = "reinitialization_unresolved_increase_order"
+    REINITIALIZATION_UNRESOLVED_REDUCE_ORDER = "reinitialization_unresolved_reduce_order"
+    REINITIALIZATION_SUBMISSION_UNKNOWN = "reinitialization_submission_unknown"
+    REINITIALIZATION_NOT_RECONCILED = "reinitialization_not_reconciled"
+    WARMUP_INCOMPLETE = "warmup_incomplete"
+    WARMUP_INVALID = "warmup_invalid"
+    BAR_UNFINALIZED = "bar_unfinalized"
+    DATA_INTEGRITY_UNTRUSTED = "data_integrity_untrusted"
+    DATA_INTEGRITY_UNKNOWN = "data_integrity_unknown"
+    CLOCK_TRUST_UNTRUSTED = "clock_trust_untrusted"
+    CLOCK_TRUST_UNKNOWN = "clock_trust_unknown"
+    REQUIRED_WINDOW_INCOMPLETE = "required_window_incomplete"
+    INSTRUMENT_METADATA_INVALID = "instrument_metadata_invalid"
+    MARKET_CONTEXT_NOT_FINALIZED = "market_context_not_finalized"
+    MARKET_CONTEXT_FIELD_INVALID = "market_context_field_invalid"
+    INSTRUMENT_KIND_FORBIDDEN = "instrument_kind_forbidden"
+    MARK_PRICE_NON_POSITIVE = "mark_price_non_positive"
+    VOLATILITY_NEGATIVE = "volatility_negative"
+    MIN_SCOPE_BAND_NON_POSITIVE = "min_scope_band_non_positive"
+    MAX_SCOPE_BAND_LT_MIN = "max_scope_band_lt_min"
+    SCOPE_CONTEXT_STALE = "scope_context_stale"
+
+
+@dataclass(frozen=True)
+class CanonicalScopeInitializationPolicyV1:
+    """Explicit scope-band policy; no implicit defaults for safety-relevant bounds."""
+
+    min_scope_band: float
+    max_scope_band: float
+    policy_version: str = SCOPE_INITIALIZATION_POLICY_VERSION
+
+
+@dataclass(frozen=True)
+class ScopeInitializationPrerequisitesV1:
+    """Explicit offline prerequisites; caller must supply all gates."""
+
+    required_window_complete: bool
+    instrument_metadata_valid: bool
+    finalized_market_context: bool
+
+
+@dataclass(frozen=True)
+class ScopeReinitializationGuardV1:
+    """Offline reinitialization guard; no runtime access in this slice."""
+
+    has_open_position: bool = False
+    has_unknown_position: bool = False
+    has_unresolved_increase_order: bool = False
+    has_unresolved_reduce_order: bool = False
+    has_submission_unknown: bool = False
+    reconciliation_status: str = _RECONCILED_STATUS
+
+
+@dataclass(frozen=True)
+class CanonicalScopeSnapshotV1:
+    scope_id: str
+    instrument_id: str
+    initialized_at_trading_epoch: int
+    source_market_context_id: str
+    source_input_digest: str
+    lifecycle_state: CanonicalScopeLifecycleState
+    reference_price: float
+    volatility_estimate: float
+    initial_volatility_distance: float
+    scope_band: float
+    neutral_upper_boundary: float
+    neutral_lower_boundary: float
+    trailing_anchor: float
+    min_scope_band: float
+    max_scope_band: float
+    policy_version: str
+    semantic_digest: str
+    reason_codes: Tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.semantic_digest and not _valid_sha256_hex(self.semantic_digest):
+            msg = "semantic_digest must be empty or a 64-char lowercase sha256 hex"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class CanonicalScopeInitializationResultV1:
+    scope: Optional[CanonicalScopeSnapshotV1]
+    lifecycle_state: CanonicalScopeLifecycleState
+    block_reasons: Tuple[CanonicalScopeBlockReason, ...]
+    scope_event_generated: bool = False
+    is_authority: bool = False
+    is_signal: bool = False
+    execution_eligible: bool = False
+    live_authorization: bool = False
+    order_effect: bool = False
+    runtime_effect: bool = False
+
+
+def _valid_sha256_hex(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{64}", value))
+
+
+def _positive_finite(value: object) -> bool:
+    return isinstance(value, (int, float)) and float(value) > 0.0
+
+
+def _non_negative_finite(value: object) -> bool:
+    return isinstance(value, (int, float)) and float(value) >= 0.0
+
+
+def validate_scope_initialization_policy(
+    policy: CanonicalScopeInitializationPolicyV1,
+) -> Tuple[CanonicalScopeBlockReason, ...]:
+    blocks: list[CanonicalScopeBlockReason] = []
+    if not _positive_finite(policy.min_scope_band):
+        blocks.append(CanonicalScopeBlockReason.MIN_SCOPE_BAND_NON_POSITIVE)
+    if not _positive_finite(policy.max_scope_band):
+        blocks.append(CanonicalScopeBlockReason.MAX_SCOPE_BAND_LT_MIN)
+    elif (
+        CanonicalScopeBlockReason.MIN_SCOPE_BAND_NON_POSITIVE not in blocks
+        and policy.max_scope_band < policy.min_scope_band
+    ):
+        blocks.append(CanonicalScopeBlockReason.MAX_SCOPE_BAND_LT_MIN)
+    if not policy.policy_version or policy.policy_version != SCOPE_INITIALIZATION_POLICY_VERSION:
+        blocks.append(CanonicalScopeBlockReason.MARKET_CONTEXT_FIELD_INVALID)
+    return tuple(dict.fromkeys(blocks))
+
+
+def clamp_scope_band(
+    initial_volatility_distance: float,
+    min_scope_band: float,
+    max_scope_band: float,
+) -> float:
+    """Clamp volatility distance into [min_scope_band, max_scope_band]."""
+    lo = float(min_scope_band)
+    hi = float(max_scope_band)
+    if hi < lo:
+        return lo
+    return max(lo, min(hi, float(initial_volatility_distance)))
+
+
+def _derive_scope_id(instrument_id: str, trading_epoch: int, context_id: str) -> str:
+    return f"scope-{instrument_id}-epoch{trading_epoch}-{context_id}"
+
+
+def _sorted_reason_code_values(
+    reasons: Tuple[CanonicalScopeBlockReason, ...],
+) -> Tuple[str, ...]:
+    return tuple(sorted(r.value for r in reasons))
+
+
+def _reinitialization_guard_blocks(
+    guard: ScopeReinitializationGuardV1,
+) -> Tuple[CanonicalScopeBlockReason, ...]:
+    blocks: list[CanonicalScopeBlockReason] = []
+    if guard.has_open_position:
+        blocks.append(CanonicalScopeBlockReason.REINITIALIZATION_OPEN_POSITION)
+    if guard.has_unknown_position:
+        blocks.append(CanonicalScopeBlockReason.REINITIALIZATION_UNKNOWN_POSITION)
+    if guard.has_unresolved_increase_order:
+        blocks.append(CanonicalScopeBlockReason.REINITIALIZATION_UNRESOLVED_INCREASE_ORDER)
+    if guard.has_unresolved_reduce_order:
+        blocks.append(CanonicalScopeBlockReason.REINITIALIZATION_UNRESOLVED_REDUCE_ORDER)
+    if guard.has_submission_unknown:
+        blocks.append(CanonicalScopeBlockReason.REINITIALIZATION_SUBMISSION_UNKNOWN)
+    if guard.reconciliation_status != _RECONCILED_STATUS:
+        blocks.append(CanonicalScopeBlockReason.REINITIALIZATION_NOT_RECONCILED)
+    return tuple(blocks)
+
+
+def _collect_prerequisite_blocks(
+    context: CanonicalMarketContextV1,
+    prerequisites: ScopeInitializationPrerequisitesV1,
+) -> Tuple[CanonicalScopeBlockReason, ...]:
+    blocks: list[CanonicalScopeBlockReason] = []
+
+    if not canonical_market_type_allowed(context.market_type):
+        blocks.append(CanonicalScopeBlockReason.INSTRUMENT_KIND_FORBIDDEN)
+
+    context_field_blocks = validate_canonical_market_context_fields(context)
+    if context_field_blocks:
+        blocks.append(CanonicalScopeBlockReason.MARKET_CONTEXT_FIELD_INVALID)
+
+    if context.warmup_status is WarmupStatus.WARMUP_INVALID:
+        blocks.append(CanonicalScopeBlockReason.WARMUP_INVALID)
+    elif context.warmup_status is WarmupStatus.WARMUP_REQUIRED:
+        blocks.append(CanonicalScopeBlockReason.WARMUP_INCOMPLETE)
+
+    if context.bar_finality_status is not BarFinalityStatus.FINALIZED:
+        blocks.append(CanonicalScopeBlockReason.BAR_UNFINALIZED)
+
+    if context.data_integrity_status in (
+        DataIntegrityStatus.UNTRUSTED,
+        DataIntegrityStatus.INVALID,
+    ):
+        blocks.append(CanonicalScopeBlockReason.DATA_INTEGRITY_UNTRUSTED)
+    elif context.data_integrity_status is DataIntegrityStatus.UNKNOWN:
+        blocks.append(CanonicalScopeBlockReason.DATA_INTEGRITY_UNKNOWN)
+
+    if context.clock_trust_status in (ClockTrustStatus.UNTRUSTED, ClockTrustStatus.INVALID):
+        blocks.append(CanonicalScopeBlockReason.CLOCK_TRUST_UNTRUSTED)
+    elif context.clock_trust_status is ClockTrustStatus.UNKNOWN:
+        blocks.append(CanonicalScopeBlockReason.CLOCK_TRUST_UNKNOWN)
+
+    if not prerequisites.required_window_complete:
+        blocks.append(CanonicalScopeBlockReason.REQUIRED_WINDOW_INCOMPLETE)
+    if not prerequisites.instrument_metadata_valid:
+        blocks.append(CanonicalScopeBlockReason.INSTRUMENT_METADATA_INVALID)
+    if not prerequisites.finalized_market_context:
+        blocks.append(CanonicalScopeBlockReason.MARKET_CONTEXT_NOT_FINALIZED)
+
+    if not _positive_finite(context.mark_price):
+        blocks.append(CanonicalScopeBlockReason.MARK_PRICE_NON_POSITIVE)
+    if not _non_negative_finite(context.volatility_estimate):
+        blocks.append(CanonicalScopeBlockReason.VOLATILITY_NEGATIVE)
+
+    return tuple(dict.fromkeys(blocks))
+
+
+def _is_warming_up_block(reason: CanonicalScopeBlockReason) -> bool:
+    return reason in (
+        CanonicalScopeBlockReason.WARMUP_INCOMPLETE,
+        CanonicalScopeBlockReason.REQUIRED_WINDOW_INCOMPLETE,
+    )
+
+
+def _is_hard_invalid_block(reason: CanonicalScopeBlockReason) -> bool:
+    return reason in (
+        CanonicalScopeBlockReason.WARMUP_INVALID,
+        CanonicalScopeBlockReason.MARK_PRICE_NON_POSITIVE,
+        CanonicalScopeBlockReason.VOLATILITY_NEGATIVE,
+        CanonicalScopeBlockReason.MIN_SCOPE_BAND_NON_POSITIVE,
+        CanonicalScopeBlockReason.MAX_SCOPE_BAND_LT_MIN,
+        CanonicalScopeBlockReason.INSTRUMENT_KIND_FORBIDDEN,
+    )
+
+
+def classify_scope_lifecycle_state(
+    block_reasons: Tuple[CanonicalScopeBlockReason, ...],
+) -> CanonicalScopeLifecycleState:
+    if any(_is_hard_invalid_block(r) for r in block_reasons):
+        return CanonicalScopeLifecycleState.SCOPE_INVALID
+    if block_reasons and all(_is_warming_up_block(r) for r in block_reasons):
+        return CanonicalScopeLifecycleState.SCOPE_WARMING_UP
+    if any(_is_warming_up_block(r) for r in block_reasons):
+        return CanonicalScopeLifecycleState.SCOPE_WARMING_UP
+    if block_reasons:
+        return CanonicalScopeLifecycleState.SCOPE_UNINITIALIZED
+    return CanonicalScopeLifecycleState.SCOPE_VALID
+
+
+def serialize_canonical_scope_canonical(scope: CanonicalScopeSnapshotV1) -> str:
+    """Deterministic JSON serialization for semantic digest (excludes semantic_digest)."""
+    payload = {
+        "initialized_at_trading_epoch": scope.initialized_at_trading_epoch,
+        "initial_volatility_distance": scope.initial_volatility_distance,
+        "instrument_id": scope.instrument_id,
+        "layer_version": CANONICAL_SCOPE_INITIALIZATION_LAYER_VERSION,
+        "lifecycle_state": scope.lifecycle_state.value,
+        "max_scope_band": scope.max_scope_band,
+        "min_scope_band": scope.min_scope_band,
+        "neutral_lower_boundary": scope.neutral_lower_boundary,
+        "neutral_upper_boundary": scope.neutral_upper_boundary,
+        "policy_version": scope.policy_version,
+        "reason_codes": sorted(scope.reason_codes),
+        "reference_price": scope.reference_price,
+        "scope_band": scope.scope_band,
+        "source_input_digest": scope.source_input_digest,
+        "source_market_context_id": scope.source_market_context_id,
+        "trailing_anchor": scope.trailing_anchor,
+        "volatility_estimate": scope.volatility_estimate,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_canonical_scope_semantic_digest(scope: CanonicalScopeSnapshotV1) -> str:
+    canonical = serialize_canonical_scope_canonical(scope)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def with_computed_semantic_digest(scope: CanonicalScopeSnapshotV1) -> CanonicalScopeSnapshotV1:
+    digest = compute_canonical_scope_semantic_digest(scope)
+    return CanonicalScopeSnapshotV1(
+        scope_id=scope.scope_id,
+        instrument_id=scope.instrument_id,
+        initialized_at_trading_epoch=scope.initialized_at_trading_epoch,
+        source_market_context_id=scope.source_market_context_id,
+        source_input_digest=scope.source_input_digest,
+        lifecycle_state=scope.lifecycle_state,
+        reference_price=scope.reference_price,
+        volatility_estimate=scope.volatility_estimate,
+        initial_volatility_distance=scope.initial_volatility_distance,
+        scope_band=scope.scope_band,
+        neutral_upper_boundary=scope.neutral_upper_boundary,
+        neutral_lower_boundary=scope.neutral_lower_boundary,
+        trailing_anchor=scope.trailing_anchor,
+        min_scope_band=scope.min_scope_band,
+        max_scope_band=scope.max_scope_band,
+        policy_version=scope.policy_version,
+        semantic_digest=digest,
+        reason_codes=scope.reason_codes,
+    )
+
+
+def _build_initialized_scope(
+    context: CanonicalMarketContextV1,
+    policy: CanonicalScopeInitializationPolicyV1,
+    *,
+    reason_codes: Tuple[str, ...] = (),
+) -> CanonicalScopeSnapshotV1:
+    bound_context = context if context.input_digest else with_computed_input_digest(context)
+    reference_price = float(bound_context.mark_price)
+    volatility_estimate = float(bound_context.volatility_estimate)
+    initial_volatility_distance = volatility_estimate * reference_price
+    scope_band = clamp_scope_band(
+        initial_volatility_distance,
+        policy.min_scope_band,
+        policy.max_scope_band,
+    )
+    neutral_upper_boundary = reference_price + scope_band
+    neutral_lower_boundary = reference_price - scope_band
+    trailing_anchor = reference_price
+
+    scope = CanonicalScopeSnapshotV1(
+        scope_id=_derive_scope_id(
+            bound_context.instrument_id,
+            bound_context.trading_epoch,
+            bound_context.context_id,
+        ),
+        instrument_id=bound_context.instrument_id,
+        initialized_at_trading_epoch=bound_context.trading_epoch,
+        source_market_context_id=bound_context.context_id,
+        source_input_digest=bound_context.input_digest,
+        lifecycle_state=CanonicalScopeLifecycleState.SCOPE_VALID,
+        reference_price=reference_price,
+        volatility_estimate=volatility_estimate,
+        initial_volatility_distance=initial_volatility_distance,
+        scope_band=scope_band,
+        neutral_upper_boundary=neutral_upper_boundary,
+        neutral_lower_boundary=neutral_lower_boundary,
+        trailing_anchor=trailing_anchor,
+        min_scope_band=policy.min_scope_band,
+        max_scope_band=policy.max_scope_band,
+        policy_version=policy.policy_version,
+        semantic_digest="",
+        reason_codes=reason_codes,
+    )
+    return with_computed_semantic_digest(scope)
+
+
+def initialize_canonical_scope(
+    market_context: CanonicalMarketContextV1,
+    policy: CanonicalScopeInitializationPolicyV1,
+    prerequisites: ScopeInitializationPrerequisitesV1,
+    *,
+    existing_scope: Optional[CanonicalScopeSnapshotV1] = None,
+    reinitialization_guard: Optional[ScopeReinitializationGuardV1] = None,
+) -> CanonicalScopeInitializationResultV1:
+    """
+    Initialize canonical scope from a finalized futures market context.
+
+    Fail-closed: no implicit defaults, no authority/order/runtime effects,
+    no scope-event generation.
+    """
+    blocks: list[CanonicalScopeBlockReason] = []
+
+    policy_blocks = validate_scope_initialization_policy(policy)
+    blocks.extend(policy_blocks)
+
+    if existing_scope is not None:
+        if existing_scope.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_VALID:
+            bound = (
+                market_context
+                if market_context.input_digest
+                else with_computed_input_digest(market_context)
+            )
+            if (
+                existing_scope.source_input_digest
+                and bound.input_digest
+                and existing_scope.source_input_digest != bound.input_digest
+            ):
+                return CanonicalScopeInitializationResultV1(
+                    scope=existing_scope,
+                    lifecycle_state=CanonicalScopeLifecycleState.SCOPE_STALE,
+                    block_reasons=(CanonicalScopeBlockReason.SCOPE_CONTEXT_STALE,),
+                )
+            blocks.append(CanonicalScopeBlockReason.SCOPE_ALREADY_INITIALIZED)
+            guard = reinitialization_guard or ScopeReinitializationGuardV1()
+            blocks.extend(_reinitialization_guard_blocks(guard))
+
+    prereq_blocks = _collect_prerequisite_blocks(market_context, prerequisites)
+    blocks.extend(prereq_blocks)
+    all_blocks = tuple(dict.fromkeys(blocks))
+
+    lifecycle = classify_scope_lifecycle_state(all_blocks)
+
+    if all_blocks:
+        if (
+            existing_scope is not None
+            and existing_scope.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_VALID
+            and CanonicalScopeBlockReason.SCOPE_ALREADY_INITIALIZED in all_blocks
+        ):
+            return CanonicalScopeInitializationResultV1(
+                scope=existing_scope,
+                lifecycle_state=lifecycle,
+                block_reasons=all_blocks,
+            )
+        return CanonicalScopeInitializationResultV1(
+            scope=None,
+            lifecycle_state=lifecycle,
+            block_reasons=all_blocks,
+        )
+
+    scope = _build_initialized_scope(market_context, policy)
+    return CanonicalScopeInitializationResultV1(
+        scope=scope,
+        lifecycle_state=CanonicalScopeLifecycleState.SCOPE_VALID,
+        block_reasons=(),
+    )

--- a/tests/trading/master_v2/test_canonical_scope_initialization_v1.py
+++ b/tests/trading/master_v2/test_canonical_scope_initialization_v1.py
@@ -1,0 +1,479 @@
+# tests/trading/master_v2/test_canonical_scope_initialization_v1.py
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.canonical_market_context_v1 import (
+    FEATURE_CONTRACT_VERSION,
+    BarFinalityStatus,
+    CanonicalMarketContextV1,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+    WarmupStatus,
+    with_computed_input_digest,
+)
+from trading.master_v2.canonical_scope_initialization_v1 import (
+    CANONICAL_SCOPE_INITIALIZATION_LAYER_VERSION,
+    SCOPE_INITIALIZATION_POLICY_VERSION,
+    CanonicalScopeBlockReason,
+    CanonicalScopeInitializationPolicyV1,
+    CanonicalScopeInitializationResultV1,
+    CanonicalScopeSnapshotV1,
+    CanonicalScopeLifecycleState,
+    ScopeInitializationPrerequisitesV1,
+    ScopeReinitializationGuardV1,
+    clamp_scope_band,
+    classify_scope_lifecycle_state,
+    compute_canonical_scope_semantic_digest,
+    initialize_canonical_scope,
+    serialize_canonical_scope_canonical,
+    validate_scope_initialization_policy,
+    with_computed_semantic_digest,
+)
+from trading.master_v2.double_play_futures_input import FuturesMarketType
+
+
+def _features(**kwargs: float) -> dict[str, float]:
+    return dict(kwargs)
+
+
+def _context(**overrides: object) -> CanonicalMarketContextV1:
+    base: dict = {
+        "context_id": "ctx-eth-perp-epoch42-ev1",
+        "instrument_id": "inst-eth-usdt-perp",
+        "market_type": FuturesMarketType.PERPETUAL,
+        "trading_epoch": 42,
+        "market_event_time": "2026-06-30T12:00:00+00:00",
+        "decision_time": "2026-06-30T12:00:01+00:00",
+        "bar_interval": "1m",
+        "bar_finality_status": BarFinalityStatus.FINALIZED,
+        "mark_price": 3500.0,
+        "index_price": 3499.5,
+        "best_bid": 3499.8,
+        "best_ask": 3500.2,
+        "spread": 0.4,
+        "volume": 1_250_000.0,
+        "open_interest": 85_000_000.0,
+        "funding_rate": 0.00012,
+        "volatility_estimate": 0.38,
+        "trend_feature_set": _features(slope=0.02, strength=0.71),
+        "momentum_feature_set": _features(rsi=55.0, roc=0.015),
+        "liquidity_feature_set": _features(depth_score=0.88),
+        "market_structure_feature_set": _features(range_ratio=0.42),
+        "data_integrity_status": DataIntegrityStatus.TRUSTED,
+        "clock_trust_status": ClockTrustStatus.TRUSTED,
+        "warmup_status": WarmupStatus.WARMUP_COMPLETE,
+        "feature_contract_version": FEATURE_CONTRACT_VERSION,
+        "input_digest": "",
+    }
+    base.update(overrides)
+    return CanonicalMarketContextV1(**base)
+
+
+def _policy(**overrides: object) -> CanonicalScopeInitializationPolicyV1:
+    base: dict = {
+        "min_scope_band": 50.0,
+        "max_scope_band": 500.0,
+        "policy_version": SCOPE_INITIALIZATION_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return CanonicalScopeInitializationPolicyV1(**base)
+
+
+def _prerequisites(**overrides: object) -> ScopeInitializationPrerequisitesV1:
+    base: dict = {
+        "required_window_complete": True,
+        "instrument_metadata_valid": True,
+        "finalized_market_context": True,
+    }
+    base.update(overrides)
+    return ScopeInitializationPrerequisitesV1(**base)
+
+
+def _initialize(**kwargs: object) -> CanonicalScopeInitializationResultV1:
+    ctx = kwargs.pop("market_context", _context())
+    policy = kwargs.pop("policy", _policy())
+    prereq = kwargs.pop("prerequisites", _prerequisites())
+    return initialize_canonical_scope(ctx, policy, prereq, **kwargs)
+
+
+def test_layer_version_and_policy_constants() -> None:
+    assert CANONICAL_SCOPE_INITIALIZATION_LAYER_VERSION == "v1"
+    assert SCOPE_INITIALIZATION_POLICY_VERSION == "canonical_scope_initialization_policy_v1"
+
+
+def test_successful_initialization_from_valid_finalized_futures_context() -> None:
+    result = _initialize()
+    assert result.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_VALID
+    assert result.scope is not None
+    assert not result.block_reasons
+    assert result.scope.instrument_id == "inst-eth-usdt-perp"
+    assert result.scope.initialized_at_trading_epoch == 42
+    assert result.scope.source_market_context_id == "ctx-eth-perp-epoch42-ev1"
+    assert len(result.scope.source_input_digest) == 64
+
+
+def test_reference_price_bound_to_mark_price() -> None:
+    result = _initialize(market_context=_context(mark_price=4200.0))
+    assert result.scope is not None
+    assert result.scope.reference_price == 4200.0
+    assert result.scope.trailing_anchor == 4200.0
+
+
+def test_volatility_distance_computed_correctly() -> None:
+    result = _initialize(
+        market_context=_context(mark_price=1000.0, volatility_estimate=0.25),
+        policy=_policy(min_scope_band=10.0, max_scope_band=10_000.0),
+    )
+    assert result.scope is not None
+    assert result.scope.initial_volatility_distance == pytest.approx(250.0)
+
+
+def test_scope_band_clamped_to_minimum() -> None:
+    result = _initialize(
+        market_context=_context(mark_price=100.0, volatility_estimate=0.01),
+        policy=_policy(min_scope_band=50.0, max_scope_band=500.0),
+    )
+    assert result.scope is not None
+    assert result.scope.initial_volatility_distance == pytest.approx(1.0)
+    assert result.scope.scope_band == 50.0
+
+
+def test_scope_band_clamped_to_maximum() -> None:
+    result = _initialize(
+        market_context=_context(mark_price=10_000.0, volatility_estimate=0.5),
+        policy=_policy(min_scope_band=50.0, max_scope_band=200.0),
+    )
+    assert result.scope is not None
+    assert result.scope.initial_volatility_distance == pytest.approx(5000.0)
+    assert result.scope.scope_band == 200.0
+
+
+def test_scope_band_unchanged_within_bounds() -> None:
+    result = _initialize(
+        market_context=_context(mark_price=1000.0, volatility_estimate=0.1),
+        policy=_policy(min_scope_band=50.0, max_scope_band=500.0),
+    )
+    assert result.scope is not None
+    assert result.scope.scope_band == pytest.approx(100.0)
+
+
+def test_neutral_boundaries_and_trailing_anchor() -> None:
+    result = _initialize(
+        market_context=_context(mark_price=2000.0, volatility_estimate=0.05),
+        policy=_policy(min_scope_band=10.0, max_scope_band=500.0),
+    )
+    assert result.scope is not None
+    band = result.scope.scope_band
+    assert result.scope.neutral_upper_boundary == pytest.approx(2000.0 + band)
+    assert result.scope.neutral_lower_boundary == pytest.approx(2000.0 - band)
+    assert result.scope.trailing_anchor == 2000.0
+
+
+def test_clamp_scope_band_unit_cases() -> None:
+    assert clamp_scope_band(5.0, 50.0, 500.0) == 50.0
+    assert clamp_scope_band(900.0, 50.0, 500.0) == 500.0
+    assert clamp_scope_band(120.0, 50.0, 500.0) == 120.0
+
+
+def test_deterministic_scope_output() -> None:
+    a = _initialize()
+    b = _initialize()
+    assert a.scope is not None and b.scope is not None
+    assert a.scope == b.scope
+
+
+def test_deterministic_semantic_digest() -> None:
+    result = _initialize()
+    assert result.scope is not None
+    d1 = compute_canonical_scope_semantic_digest(result.scope)
+    d2 = compute_canonical_scope_semantic_digest(result.scope)
+    assert d1 == d2
+    assert d1 == result.scope.semantic_digest
+
+
+def test_semantic_digest_changes_on_decision_relevant_field() -> None:
+    base = _initialize()
+    changed = _initialize(market_context=_context(volatility_estimate=0.39))
+    assert base.scope is not None and changed.scope is not None
+    assert base.scope.semantic_digest != changed.scope.semantic_digest
+
+
+def test_reason_code_order_does_not_affect_semantic_digest() -> None:
+    result = _initialize()
+    assert result.scope is not None
+    scope_a = result.scope
+    scope_b = replace(scope_a, reason_codes=("a", "b"))
+    scope_c = replace(scope_a, reason_codes=("b", "a"))
+    assert scope_b.reason_codes != scope_c.reason_codes
+    assert compute_canonical_scope_semantic_digest(
+        scope_b
+    ) == compute_canonical_scope_semantic_digest(scope_c)
+
+
+def test_warmup_required_yields_warming_up() -> None:
+    result = _initialize(market_context=_context(warmup_status=WarmupStatus.WARMUP_REQUIRED))
+    assert result.scope is None
+    assert result.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_WARMING_UP
+    assert CanonicalScopeBlockReason.WARMUP_INCOMPLETE in result.block_reasons
+
+
+def test_warmup_invalid_yields_invalid() -> None:
+    result = _initialize(market_context=_context(warmup_status=WarmupStatus.WARMUP_INVALID))
+    assert result.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_INVALID
+    assert CanonicalScopeBlockReason.WARMUP_INVALID in result.block_reasons
+
+
+def test_unfinalized_bar_blocked() -> None:
+    result = _initialize(market_context=_context(bar_finality_status=BarFinalityStatus.UNFINALIZED))
+    assert result.scope is None
+    assert CanonicalScopeBlockReason.BAR_UNFINALIZED in result.block_reasons
+
+
+def test_data_integrity_untrusted_blocked() -> None:
+    result = _initialize(
+        market_context=_context(data_integrity_status=DataIntegrityStatus.UNTRUSTED)
+    )
+    assert result.scope is None
+    assert CanonicalScopeBlockReason.DATA_INTEGRITY_UNTRUSTED in result.block_reasons
+
+
+def test_data_integrity_unknown_blocked() -> None:
+    result = _initialize(market_context=_context(data_integrity_status=DataIntegrityStatus.UNKNOWN))
+    assert CanonicalScopeBlockReason.DATA_INTEGRITY_UNKNOWN in result.block_reasons
+
+
+def test_clock_trust_untrusted_blocked() -> None:
+    result = _initialize(market_context=_context(clock_trust_status=ClockTrustStatus.UNTRUSTED))
+    assert CanonicalScopeBlockReason.CLOCK_TRUST_UNTRUSTED in result.block_reasons
+
+
+def test_clock_trust_unknown_blocked() -> None:
+    result = _initialize(market_context=_context(clock_trust_status=ClockTrustStatus.UNKNOWN))
+    assert CanonicalScopeBlockReason.CLOCK_TRUST_UNKNOWN in result.block_reasons
+
+
+def test_required_window_incomplete_blocked() -> None:
+    result = _initialize(prerequisites=_prerequisites(required_window_complete=False))
+    assert result.scope is None
+    assert CanonicalScopeBlockReason.REQUIRED_WINDOW_INCOMPLETE in result.block_reasons
+    assert result.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_WARMING_UP
+
+
+def test_instrument_metadata_invalid_blocked() -> None:
+    result = _initialize(prerequisites=_prerequisites(instrument_metadata_valid=False))
+    assert CanonicalScopeBlockReason.INSTRUMENT_METADATA_INVALID in result.block_reasons
+
+
+def test_market_context_not_finalized_flag_blocked() -> None:
+    result = _initialize(prerequisites=_prerequisites(finalized_market_context=False))
+    assert CanonicalScopeBlockReason.MARKET_CONTEXT_NOT_FINALIZED in result.block_reasons
+
+
+def test_mark_price_non_positive_invalid() -> None:
+    result = _initialize(market_context=_context(mark_price=0.0))
+    assert result.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_INVALID
+    assert CanonicalScopeBlockReason.MARK_PRICE_NON_POSITIVE in result.block_reasons
+
+
+def test_negative_volatility_invalid() -> None:
+    result = _initialize(market_context=_context(volatility_estimate=-0.01))
+    assert result.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_INVALID
+    assert CanonicalScopeBlockReason.VOLATILITY_NEGATIVE in result.block_reasons
+
+
+def test_min_scope_band_non_positive_invalid() -> None:
+    blocks = validate_scope_initialization_policy(_policy(min_scope_band=0.0))
+    assert CanonicalScopeBlockReason.MIN_SCOPE_BAND_NON_POSITIVE in blocks
+    result = _initialize(policy=_policy(min_scope_band=0.0))
+    assert result.lifecycle_state is CanonicalScopeLifecycleState.SCOPE_INVALID
+
+
+def test_max_scope_band_lt_min_invalid() -> None:
+    blocks = validate_scope_initialization_policy(
+        _policy(min_scope_band=100.0, max_scope_band=50.0)
+    )
+    assert CanonicalScopeBlockReason.MAX_SCOPE_BAND_LT_MIN in blocks
+
+
+def test_no_implicit_policy_defaults_required_explicit_policy() -> None:
+    with pytest.raises(TypeError):
+        CanonicalScopeInitializationPolicyV1()  # type: ignore[call-arg]
+
+
+def test_reinitialization_blocked_open_position() -> None:
+    first = _initialize()
+    assert first.scope is not None
+    second = _initialize(
+        existing_scope=first.scope,
+        reinitialization_guard=ScopeReinitializationGuardV1(has_open_position=True),
+    )
+    assert CanonicalScopeBlockReason.REINITIALIZATION_OPEN_POSITION in second.block_reasons
+
+
+def test_reinitialization_blocked_unknown_position() -> None:
+    first = _initialize()
+    assert first.scope is not None
+    second = _initialize(
+        existing_scope=first.scope,
+        reinitialization_guard=ScopeReinitializationGuardV1(has_unknown_position=True),
+    )
+    assert CanonicalScopeBlockReason.REINITIALIZATION_UNKNOWN_POSITION in second.block_reasons
+
+
+def test_reinitialization_blocked_unresolved_increase_order() -> None:
+    first = _initialize()
+    assert first.scope is not None
+    second = _initialize(
+        existing_scope=first.scope,
+        reinitialization_guard=ScopeReinitializationGuardV1(has_unresolved_increase_order=True),
+    )
+    assert (
+        CanonicalScopeBlockReason.REINITIALIZATION_UNRESOLVED_INCREASE_ORDER in second.block_reasons
+    )
+
+
+def test_reinitialization_blocked_unresolved_reduce_order() -> None:
+    first = _initialize()
+    assert first.scope is not None
+    second = _initialize(
+        existing_scope=first.scope,
+        reinitialization_guard=ScopeReinitializationGuardV1(has_unresolved_reduce_order=True),
+    )
+    assert (
+        CanonicalScopeBlockReason.REINITIALIZATION_UNRESOLVED_REDUCE_ORDER in second.block_reasons
+    )
+
+
+def test_reinitialization_blocked_submission_unknown() -> None:
+    first = _initialize()
+    assert first.scope is not None
+    second = _initialize(
+        existing_scope=first.scope,
+        reinitialization_guard=ScopeReinitializationGuardV1(has_submission_unknown=True),
+    )
+    assert CanonicalScopeBlockReason.REINITIALIZATION_SUBMISSION_UNKNOWN in second.block_reasons
+
+
+def test_reinitialization_blocked_not_reconciled() -> None:
+    first = _initialize()
+    assert first.scope is not None
+    second = _initialize(
+        existing_scope=first.scope,
+        reinitialization_guard=ScopeReinitializationGuardV1(reconciliation_status="PENDING"),
+    )
+    assert CanonicalScopeBlockReason.REINITIALIZATION_NOT_RECONCILED in second.block_reasons
+
+
+def test_no_authority_runtime_or_order_effects() -> None:
+    result = _initialize()
+    assert not result.is_authority
+    assert not result.runtime_effect
+    assert not result.order_effect
+    assert not result.execution_eligible
+    assert not result.live_authorization
+    assert not result.scope_event_generated
+
+
+def test_no_scope_event_generated() -> None:
+    result = _initialize()
+    assert result.scope_event_generated is False
+
+
+def test_existing_market_context_regression_still_importable() -> None:
+    from trading.master_v2.canonical_market_context_v1 import (
+        evaluate_canonical_market_context_eligibility,
+    )
+
+    ctx = with_computed_input_digest(_context())
+    elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert elig.trading_decision_allowed
+
+
+def test_futures_only_spot_instrument_id_rejected() -> None:
+    result = _initialize(market_context=_context(instrument_id="inst-spot-eth"))
+    assert CanonicalScopeBlockReason.MARKET_CONTEXT_FIELD_INVALID in result.block_reasons
+
+
+def test_synthetic_spot_instrument_id_rejected() -> None:
+    result = _initialize(market_context=_context(instrument_id="inst-synthetic_spot-eth"))
+    assert CanonicalScopeBlockReason.MARKET_CONTEXT_FIELD_INVALID in result.block_reasons
+
+
+def test_no_bitcoin_semantics_in_scope_output() -> None:
+    result = _initialize(
+        market_context=_context(
+            instrument_id="inst-sol-usdt-perp",
+            context_id="ctx-sol-perp-epoch1-ev1",
+        )
+    )
+    assert result.scope is not None
+    serialized = serialize_canonical_scope_canonical(result.scope).lower()
+    assert "btc" not in serialized
+    assert "bitcoin" not in serialized
+    assert "xbt" not in serialized
+
+
+def test_classify_scope_lifecycle_state_helpers() -> None:
+    assert (
+        classify_scope_lifecycle_state((CanonicalScopeBlockReason.WARMUP_INCOMPLETE,))
+        is CanonicalScopeLifecycleState.SCOPE_WARMING_UP
+    )
+    assert (
+        classify_scope_lifecycle_state((CanonicalScopeBlockReason.VOLATILITY_NEGATIVE,))
+        is CanonicalScopeLifecycleState.SCOPE_INVALID
+    )
+
+
+def test_with_computed_semantic_digest_round_trip() -> None:
+    result = _initialize()
+    assert result.scope is not None
+    bare = CanonicalScopeSnapshotV1(
+        scope_id=result.scope.scope_id,
+        instrument_id=result.scope.instrument_id,
+        initialized_at_trading_epoch=result.scope.initialized_at_trading_epoch,
+        source_market_context_id=result.scope.source_market_context_id,
+        source_input_digest=result.scope.source_input_digest,
+        lifecycle_state=result.scope.lifecycle_state,
+        reference_price=result.scope.reference_price,
+        volatility_estimate=result.scope.volatility_estimate,
+        initial_volatility_distance=result.scope.initial_volatility_distance,
+        scope_band=result.scope.scope_band,
+        neutral_upper_boundary=result.scope.neutral_upper_boundary,
+        neutral_lower_boundary=result.scope.neutral_lower_boundary,
+        trailing_anchor=result.scope.trailing_anchor,
+        min_scope_band=result.scope.min_scope_band,
+        max_scope_band=result.scope.max_scope_band,
+        policy_version=result.scope.policy_version,
+        semantic_digest="",
+        reason_codes=result.scope.reason_codes,
+    )
+    bound = with_computed_semantic_digest(bare)
+    assert bound.semantic_digest == result.scope.semantic_digest
+
+
+def test_no_runtime_order_or_execution_side_effects_in_module() -> None:
+    root = Path(__file__).resolve().parent.parent.parent.parent / "src" / "trading" / "master_v2"
+    path = root / "canonical_scope_initialization_v1.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bad_roots = {
+        "ccxt",
+        "requests",
+        "urllib3",
+        "httpx",
+        "aiohttp",
+        "socket",
+        "websockets",
+        "boto3",
+        "subprocess",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                assert n.name.split(".")[0] not in bad_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in bad_roots


### PR DESCRIPTION
## Summary
- Bind canonical scope initialization v1 to existing `canonical_market_context_v1` owner (STEP 29C / RUNBOOK_STEP_29C)
- Implement explicit lifecycle states (`SCOPE_UNINITIALIZED`, `SCOPE_WARMING_UP`, `SCOPE_VALID`, `SCOPE_STALE`, `SCOPE_INVALID`) with fail-closed initialization gates
- Add deterministic `semantic_digest`, volatility-distance band clamp, neutral boundaries, trailing anchor, and offline reinitialization guards

## Reuse owner
- **Market context SSOT:** `src/trading/master_v2/canonical_market_context_v1.py` (`REUSE_AS_IS`)
- **Dynamic scope hot-path:** `double_play_state.RuntimeScopeState` / `DynamicScopeRules` unchanged (`REUSE_WITH_NARROW_ADAPTER`)
- **New scope init owner:** `src/trading/master_v2/canonical_scope_initialization_v1.py`

## Initialization formulas
- `reference_price = finalized_mark_price`
- `initial_volatility_distance = volatility_estimate * reference_price`
- `scope_band = clamp(initial_volatility_distance, min_scope_band, max_scope_band)`
- `neutral_upper_boundary = reference_price + scope_band`
- `neutral_lower_boundary = reference_price - scope_band`
- `trailing_anchor = reference_price`

## Lifecycle semantics
- `SCOPE_UNINITIALIZED`: gates not met, no scope event eligibility
- `SCOPE_WARMING_UP`: warmup/window incomplete, observation-only
- `SCOPE_VALID`: fully initialized, deterministic consumable output
- `SCOPE_STALE`: prior valid scope with changed market-context digest
- `SCOPE_INVALID`: hard contract/policy violations, fail-closed

## Reinitialization guards
Explicit offline `ScopeReinitializationGuardV1` blocks reinit on open/unknown position, unresolved orders, submission unknown, or non-`RECONCILED` state.

## Safety boundaries
- Futures-only (reuses canonical market type gates)
- Bitcoin direction forbidden; no BTC/XBT defaults
- No scope events generated
- No runtime / order / authority effects
- Registry: `RUNBOOK_STEP_29C=IN_PROGRESS` (closeout separate post-merge)

## Tests
- `tests/trading/master_v2/test_canonical_scope_initialization_v1.py` (43 cases)
- Regression: `tests/trading/master_v2/test_canonical_market_context_v1.py`
- Registry contract: `tests/ops/test_runbook_execution_governance_and_progress_registry_static_crosslink_contract_v0.py`

## Evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/runbook_step29c_canonical_scope_initialization_v1_offline_slice_implementation_v0_20260630T225257Z` (`MANIFEST_VERIFY_RC=0`)

## Residual gaps
- Scope event generator deferred to STEP 29D
- `SCOPE_STALE` limited to digest-drift detection in this slice
- Registry closeout to `COMPLETE` in separate post-merge PR per policy

## Test plan
- [x] Focused unit/contract tests for initialization, clamp, boundaries, digest determinism
- [x] Negative cases: warmup, trust, unfinalized bar, policy bounds, reinit guards
- [x] Futures-only / spot / synthetic-spot rejection
- [x] ruff format/check + git diff --check
- [x] CI selector snapshot (`PR_BOUNDED_FULL`)


Made with [Cursor](https://cursor.com)