### PR TITLE
feat(master_v2): DirectionalAssessmentV1 offline contract slice (STEP 29E)

### DIFF
--- a/src/trading/master_v2/directional_assessment_v1.py
+++ b/src/trading/master_v2/directional_assessment_v1.py
@@ -1,0 +1,549 @@
+# src/trading/master_v2/directional_assessment_v1.py
+"""
+Pure Directional Assessment v1: shared Bull/Bear offline assessment contract.
+
+Consumes immutable scope-event references and explicit feature inputs. Produces
+fachliche directional assessment evidence only — no runtime, authority, order,
+risk, sizing, or survival-formula effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping, Optional, Tuple
+
+from trading.master_v2.canonical_market_context_v1 import (
+    BarFinalityStatus,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+)
+from trading.master_v2.deterministic_scope_event_generator_v1 import mirror_price_for_short
+
+DIRECTIONAL_ASSESSMENT_LAYER_VERSION = "v1"
+DIRECTIONAL_ASSESSMENT_POLICY_VERSION = "directional_assessment_policy_v1"
+
+_AUTHORITY_EFFECT_NONE = "NONE"
+_RUNTIME_EFFECT_NONE = "NONE"
+_ORDER_EFFECT_NONE = "NONE"
+_RISK_EFFECT_NONE = "NONE"
+
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+
+
+class DirectionalAssessmentSide(str, Enum):
+    """Unified side semantics: LONG/BULL and SHORT/BEAR share one contract."""
+
+    LONG = "long"
+    SHORT = "short"
+
+
+class DirectionalAssessmentStatus(str, Enum):
+    INVALID = "invalid"
+    BLOCKED = "blocked"
+    OBSERVE = "observe"
+    CANDIDATE = "candidate"
+    CONFIRMED = "confirmed"
+
+
+class DirectionalAssessmentHardBlockReason(str, Enum):
+    INSTRUMENT_KIND_FORBIDDEN = "instrument_kind_forbidden"
+    INPUT_INCOMPLETE = "input_incomplete"
+    PRICE_PATH_TOO_SHORT = "price_path_too_short"
+    REFERENCE_PRICE_NON_POSITIVE = "reference_price_non_positive"
+    SCOPE_EVENT_REF_INVALID = "scope_event_ref_invalid"
+    SCOPE_EVENT_REF_STALE = "scope_event_ref_stale"
+    POLICY_VERSION_INVALID = "policy_version_invalid"
+    POLICY_CANDIDATE_THRESHOLD_INVALID = "policy_candidate_threshold_invalid"
+    POLICY_CONFIRMATION_THRESHOLD_INVALID = "policy_confirmation_threshold_invalid"
+    POLICY_OBSERVE_THRESHOLD_INVALID = "policy_observe_threshold_invalid"
+    POLICY_CONFIRMATION_EPOCHS_INVALID = "policy_confirmation_epochs_invalid"
+    POLICY_VALIDITY_EPOCHS_INVALID = "policy_validity_epochs_invalid"
+    POLICY_THRESHOLD_ORDER_INVALID = "policy_threshold_order_invalid"
+    BAR_UNFINALIZED = "bar_unfinalized"
+    DATA_INTEGRITY_UNTRUSTED = "data_integrity_untrusted"
+    DATA_INTEGRITY_UNKNOWN = "data_integrity_unknown"
+    CLOCK_TRUST_UNTRUSTED = "clock_trust_untrusted"
+    CLOCK_TRUST_UNKNOWN = "clock_trust_unknown"
+    TRUSTED_DATA_FALSE = "trusted_data_false"
+    TRADING_EPOCH_OUT_OF_ORDER = "trading_epoch_out_of_order"
+    TRADING_EPOCH_STALE = "trading_epoch_stale"
+    EXPLICIT_HARD_BLOCK = "explicit_hard_block"
+
+
+_BULL_BEAR_ALIASES: Mapping[str, DirectionalAssessmentSide] = {
+    "long": DirectionalAssessmentSide.LONG,
+    "bull": DirectionalAssessmentSide.LONG,
+    "short": DirectionalAssessmentSide.SHORT,
+    "bear": DirectionalAssessmentSide.SHORT,
+}
+
+
+def normalize_bull_bear_side(label: str) -> DirectionalAssessmentSide:
+    """Map LONG/BULL and SHORT/BEAR labels to the unified side enum."""
+    key = label.strip().lower()
+    if key not in _BULL_BEAR_ALIASES:
+        msg = f"unsupported bull/bear side label: {label!r}"
+        raise ValueError(msg)
+    return _BULL_BEAR_ALIASES[key]
+
+
+@dataclass(frozen=True)
+class ScopeEventRefV1:
+    """Immutable scope-event reference; never mutates underlying evidence."""
+
+    scope_event_id: str
+    semantic_digest: str
+    event_type: str
+    trading_epoch: int
+
+    def __post_init__(self) -> None:
+        if self.semantic_digest and not _valid_sha256_hex(self.semantic_digest):
+            msg = "semantic_digest must be empty or a 64-char lowercase sha256 hex"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class DirectionalConfirmationStateV1:
+    candidate_count: int
+    last_evaluated_trading_epoch: int
+    last_signal_strength: float
+
+
+@dataclass(frozen=True)
+class DirectionalAssessmentPolicyV1:
+    observe_signal_threshold: float
+    candidate_signal_threshold: float
+    confirmation_signal_threshold: float
+    confirmation_epochs: int
+    validity_epochs: int
+    policy_version: str = DIRECTIONAL_ASSESSMENT_POLICY_VERSION
+
+
+@dataclass(frozen=True)
+class DirectionalAssessmentInputV1:
+    instrument_id: str
+    trading_epoch: int
+    side: DirectionalAssessmentSide
+    price_path: Tuple[float, ...]
+    reference_price: float
+    feature_refs: Tuple[str, ...]
+    scope_event_ref: ScopeEventRefV1
+    survival_preconditions: Tuple[str, ...]
+    confirmation_state: DirectionalConfirmationStateV1
+    data_integrity_status: DataIntegrityStatus
+    clock_trust_status: ClockTrustStatus
+    bar_finality_status: BarFinalityStatus
+    trusted_data: bool
+    input_complete: bool
+    explicit_hard_block_reasons: Tuple[DirectionalAssessmentHardBlockReason, ...]
+    policy_version: str
+
+
+@dataclass(frozen=True)
+class DirectionalAssessmentV1:
+    assessment_id: str
+    side: DirectionalAssessmentSide
+    instrument_id: str
+    trading_epoch: int
+    status: DirectionalAssessmentStatus
+    signal_strength: float
+    confidence: float
+    feature_refs: Tuple[str, ...]
+    scope_event_ref: ScopeEventRefV1
+    survival_preconditions: Tuple[str, ...]
+    hard_block_reasons: Tuple[str, ...]
+    reason_codes: Tuple[str, ...]
+    valid_until_epoch: int
+    semantic_digest: str
+    authority_effect: str = _AUTHORITY_EFFECT_NONE
+    runtime_effect: str = _RUNTIME_EFFECT_NONE
+    order_effect: str = _ORDER_EFFECT_NONE
+    risk_effect: str = _RISK_EFFECT_NONE
+
+    def __post_init__(self) -> None:
+        if self.semantic_digest and not _valid_sha256_hex(self.semantic_digest):
+            msg = "semantic_digest must be empty or a 64-char lowercase sha256 hex"
+            raise ValueError(msg)
+        if self.valid_until_epoch <= self.trading_epoch:
+            msg = "valid_until_epoch must be strictly greater than trading_epoch"
+            raise ValueError(msg)
+
+
+def _valid_sha256_hex(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{64}", value))
+
+
+def _positive_finite(value: object) -> bool:
+    return isinstance(value, (int, float)) and float(value) > 0.0
+
+
+def _positive_int(value: object) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+def _instrument_id_allowed(instrument_id: str) -> bool:
+    lowered = instrument_id.lower()
+    return not any(token in lowered for token in _FORBIDDEN_INSTRUMENT_SUBSTRINGS)
+
+
+def _sorted_reason_values(
+    reasons: Tuple[DirectionalAssessmentHardBlockReason, ...],
+) -> Tuple[str, ...]:
+    return tuple(sorted(r.value for r in reasons))
+
+
+def validate_directional_assessment_policy(
+    policy: DirectionalAssessmentPolicyV1,
+    *,
+    policy_version: str,
+) -> Tuple[DirectionalAssessmentHardBlockReason, ...]:
+    blocks: list[DirectionalAssessmentHardBlockReason] = []
+    if not policy.policy_version or policy.policy_version != DIRECTIONAL_ASSESSMENT_POLICY_VERSION:
+        blocks.append(DirectionalAssessmentHardBlockReason.POLICY_VERSION_INVALID)
+    if policy_version != DIRECTIONAL_ASSESSMENT_POLICY_VERSION:
+        blocks.append(DirectionalAssessmentHardBlockReason.POLICY_VERSION_INVALID)
+    if not _positive_finite(policy.observe_signal_threshold):
+        blocks.append(DirectionalAssessmentHardBlockReason.POLICY_OBSERVE_THRESHOLD_INVALID)
+    if not _positive_finite(policy.candidate_signal_threshold):
+        blocks.append(DirectionalAssessmentHardBlockReason.POLICY_CANDIDATE_THRESHOLD_INVALID)
+    if not _positive_finite(policy.confirmation_signal_threshold):
+        blocks.append(DirectionalAssessmentHardBlockReason.POLICY_CONFIRMATION_THRESHOLD_INVALID)
+    if not _positive_int(policy.confirmation_epochs):
+        blocks.append(DirectionalAssessmentHardBlockReason.POLICY_CONFIRMATION_EPOCHS_INVALID)
+    if not _positive_int(policy.validity_epochs):
+        blocks.append(DirectionalAssessmentHardBlockReason.POLICY_VALIDITY_EPOCHS_INVALID)
+    if (
+        DirectionalAssessmentHardBlockReason.POLICY_OBSERVE_THRESHOLD_INVALID not in blocks
+        and DirectionalAssessmentHardBlockReason.POLICY_CANDIDATE_THRESHOLD_INVALID not in blocks
+        and DirectionalAssessmentHardBlockReason.POLICY_CONFIRMATION_THRESHOLD_INVALID not in blocks
+        and not (
+            policy.observe_signal_threshold
+            < policy.candidate_signal_threshold
+            < policy.confirmation_signal_threshold
+        )
+    ):
+        blocks.append(DirectionalAssessmentHardBlockReason.POLICY_THRESHOLD_ORDER_INVALID)
+    return tuple(dict.fromkeys(blocks))
+
+
+def compute_signal_strength(
+    *,
+    price_path: Tuple[float, ...],
+    side: DirectionalAssessmentSide,
+    reference_price: float,
+) -> float:
+    if len(price_path) < 2 or not _positive_finite(reference_price):
+        return 0.0
+    start = float(price_path[0])
+    end = float(price_path[-1])
+    raw_return = (end - start) / float(reference_price)
+    if side is DirectionalAssessmentSide.SHORT:
+        raw_return = -raw_return
+    return raw_return
+
+
+def mirror_price_path_for_short(
+    price_path: Tuple[float, ...],
+    reference: float,
+) -> Tuple[float, ...]:
+    """Structural mirror for Bull/Bear symmetry tests."""
+    return tuple(mirror_price_for_short(float(p), float(reference)) for p in price_path)
+
+
+def compute_directional_confidence(
+    signal_strength: float,
+    confirmation_threshold: float,
+) -> float:
+    if not _positive_finite(confirmation_threshold) or signal_strength <= 0.0:
+        return 0.0
+    return min(1.0, float(signal_strength) / float(confirmation_threshold))
+
+
+def _collect_input_gate_blocks(
+    inp: DirectionalAssessmentInputV1,
+) -> Tuple[DirectionalAssessmentHardBlockReason, ...]:
+    blocks: list[DirectionalAssessmentHardBlockReason] = []
+    if not inp.input_complete:
+        blocks.append(DirectionalAssessmentHardBlockReason.INPUT_INCOMPLETE)
+    if len(inp.price_path) < 2:
+        blocks.append(DirectionalAssessmentHardBlockReason.PRICE_PATH_TOO_SHORT)
+    if not _positive_finite(inp.reference_price):
+        blocks.append(DirectionalAssessmentHardBlockReason.REFERENCE_PRICE_NON_POSITIVE)
+    if not inp.scope_event_ref.scope_event_id or not inp.scope_event_ref.semantic_digest:
+        blocks.append(DirectionalAssessmentHardBlockReason.SCOPE_EVENT_REF_INVALID)
+    if not _instrument_id_allowed(inp.instrument_id):
+        blocks.append(DirectionalAssessmentHardBlockReason.INSTRUMENT_KIND_FORBIDDEN)
+    if inp.bar_finality_status is not BarFinalityStatus.FINALIZED:
+        blocks.append(DirectionalAssessmentHardBlockReason.BAR_UNFINALIZED)
+    if inp.data_integrity_status in (DataIntegrityStatus.UNTRUSTED, DataIntegrityStatus.INVALID):
+        blocks.append(DirectionalAssessmentHardBlockReason.DATA_INTEGRITY_UNTRUSTED)
+    elif inp.data_integrity_status is DataIntegrityStatus.UNKNOWN:
+        blocks.append(DirectionalAssessmentHardBlockReason.DATA_INTEGRITY_UNKNOWN)
+    if inp.clock_trust_status in (ClockTrustStatus.UNTRUSTED, ClockTrustStatus.INVALID):
+        blocks.append(DirectionalAssessmentHardBlockReason.CLOCK_TRUST_UNTRUSTED)
+    elif inp.clock_trust_status is ClockTrustStatus.UNKNOWN:
+        blocks.append(DirectionalAssessmentHardBlockReason.CLOCK_TRUST_UNKNOWN)
+    if not inp.trusted_data:
+        blocks.append(DirectionalAssessmentHardBlockReason.TRUSTED_DATA_FALSE)
+    if inp.explicit_hard_block_reasons:
+        blocks.append(DirectionalAssessmentHardBlockReason.EXPLICIT_HARD_BLOCK)
+    return tuple(dict.fromkeys(blocks))
+
+
+def _resolve_epoch_semantics(
+    *,
+    trading_epoch: int,
+    last_evaluated_trading_epoch: int,
+    scope_event_epoch: int,
+) -> Tuple[str, Optional[DirectionalAssessmentHardBlockReason]]:
+    if scope_event_epoch > trading_epoch:
+        return "stale_scope_ref", DirectionalAssessmentHardBlockReason.SCOPE_EVENT_REF_STALE
+    if last_evaluated_trading_epoch < 0:
+        return "first", None
+    if trading_epoch < last_evaluated_trading_epoch:
+        return "out_of_order", DirectionalAssessmentHardBlockReason.TRADING_EPOCH_OUT_OF_ORDER
+    if trading_epoch > last_evaluated_trading_epoch + 1:
+        return "skipped", None
+    if trading_epoch == last_evaluated_trading_epoch:
+        return "duplicate", None
+    return "consecutive", None
+
+
+def _derive_assessment_id(
+    instrument_id: str,
+    trading_epoch: int,
+    side: DirectionalAssessmentSide,
+    status: DirectionalAssessmentStatus,
+) -> str:
+    return f"dir-assess-{instrument_id}-epoch{trading_epoch}-{side.value}-{status.value}"
+
+
+def _status_for_signal(
+    *,
+    signal_strength: float,
+    policy: DirectionalAssessmentPolicyV1,
+    confirmation_state: DirectionalConfirmationStateV1,
+    epoch_mode: str,
+) -> Tuple[DirectionalAssessmentStatus, Tuple[str, ...], int]:
+    if signal_strength < policy.observe_signal_threshold:
+        return DirectionalAssessmentStatus.OBSERVE, ("signal_below_observe_threshold",), 0
+
+    if signal_strength < policy.candidate_signal_threshold:
+        return DirectionalAssessmentStatus.OBSERVE, ("signal_between_observe_and_candidate",), 0
+
+    next_count = 1
+    if (
+        epoch_mode == "consecutive"
+        and confirmation_state.last_signal_strength >= policy.candidate_signal_threshold
+    ):
+        next_count = confirmation_state.candidate_count + 1
+    elif epoch_mode == "duplicate":
+        next_count = confirmation_state.candidate_count
+
+    if (
+        signal_strength >= policy.confirmation_signal_threshold
+        and next_count >= policy.confirmation_epochs
+    ):
+        return (
+            DirectionalAssessmentStatus.CONFIRMED,
+            ("signal_meets_confirmation_threshold", "confirmation_epochs_satisfied"),
+            next_count,
+        )
+
+    return (
+        DirectionalAssessmentStatus.CANDIDATE,
+        ("signal_meets_candidate_threshold", "confirmation_pending"),
+        next_count,
+    )
+
+
+def serialize_directional_assessment_canonical(assessment: DirectionalAssessmentV1) -> str:
+    scope_ref = assessment.scope_event_ref
+    payload = {
+        "assessment_id": assessment.assessment_id,
+        "authority_effect": assessment.authority_effect,
+        "confidence": assessment.confidence,
+        "feature_refs": sorted(assessment.feature_refs),
+        "hard_block_reasons": sorted(assessment.hard_block_reasons),
+        "instrument_id": assessment.instrument_id,
+        "layer_version": DIRECTIONAL_ASSESSMENT_LAYER_VERSION,
+        "order_effect": assessment.order_effect,
+        "policy_version": DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+        "reason_codes": sorted(assessment.reason_codes),
+        "risk_effect": assessment.risk_effect,
+        "runtime_effect": assessment.runtime_effect,
+        "scope_event_id": scope_ref.scope_event_id,
+        "scope_event_digest": scope_ref.semantic_digest,
+        "scope_event_epoch": scope_ref.trading_epoch,
+        "scope_event_type": scope_ref.event_type,
+        "side": assessment.side.value,
+        "signal_strength": assessment.signal_strength,
+        "status": assessment.status.value,
+        "survival_preconditions": sorted(assessment.survival_preconditions),
+        "trading_epoch": assessment.trading_epoch,
+        "valid_until_epoch": assessment.valid_until_epoch,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def compute_directional_assessment_semantic_digest(assessment: DirectionalAssessmentV1) -> str:
+    canonical = serialize_directional_assessment_canonical(assessment)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def with_computed_directional_assessment_digest(
+    assessment: DirectionalAssessmentV1,
+) -> DirectionalAssessmentV1:
+    digest = compute_directional_assessment_semantic_digest(assessment)
+    return DirectionalAssessmentV1(
+        assessment_id=assessment.assessment_id,
+        side=assessment.side,
+        instrument_id=assessment.instrument_id,
+        trading_epoch=assessment.trading_epoch,
+        status=assessment.status,
+        signal_strength=assessment.signal_strength,
+        confidence=assessment.confidence,
+        feature_refs=assessment.feature_refs,
+        scope_event_ref=assessment.scope_event_ref,
+        survival_preconditions=assessment.survival_preconditions,
+        hard_block_reasons=assessment.hard_block_reasons,
+        reason_codes=assessment.reason_codes,
+        valid_until_epoch=assessment.valid_until_epoch,
+        semantic_digest=digest,
+        authority_effect=assessment.authority_effect,
+        runtime_effect=assessment.runtime_effect,
+        order_effect=assessment.order_effect,
+        risk_effect=assessment.risk_effect,
+    )
+
+
+def _finalize_assessment(
+    inp: DirectionalAssessmentInputV1,
+    policy: DirectionalAssessmentPolicyV1,
+    *,
+    status: DirectionalAssessmentStatus,
+    signal_strength: float,
+    confidence: float,
+    hard_block_reasons: Tuple[str, ...],
+    reason_codes: Tuple[str, ...],
+) -> DirectionalAssessmentV1:
+    valid_until = inp.trading_epoch + policy.validity_epochs
+    assessment = DirectionalAssessmentV1(
+        assessment_id=_derive_assessment_id(inp.instrument_id, inp.trading_epoch, inp.side, status),
+        side=inp.side,
+        instrument_id=inp.instrument_id,
+        trading_epoch=inp.trading_epoch,
+        status=status,
+        signal_strength=signal_strength,
+        confidence=confidence,
+        feature_refs=inp.feature_refs,
+        scope_event_ref=inp.scope_event_ref,
+        survival_preconditions=inp.survival_preconditions,
+        hard_block_reasons=hard_block_reasons,
+        reason_codes=reason_codes,
+        valid_until_epoch=valid_until,
+        semantic_digest="",
+    )
+    return with_computed_directional_assessment_digest(assessment)
+
+
+def evaluate_directional_assessment_v1(
+    inp: DirectionalAssessmentInputV1,
+    policy: DirectionalAssessmentPolicyV1,
+) -> DirectionalAssessmentV1:
+    """
+    Deterministic Bull/Bear directional assessment evaluator.
+
+    Fail-closed on untrusted, incomplete, or epoch-invalid inputs. Never mutates
+    ``inp.scope_event_ref`` or upstream scope-event evidence.
+    """
+    policy_blocks = validate_directional_assessment_policy(
+        policy, policy_version=inp.policy_version
+    )
+    if policy_blocks:
+        return _finalize_assessment(
+            inp,
+            policy,
+            status=DirectionalAssessmentStatus.BLOCKED,
+            signal_strength=0.0,
+            confidence=0.0,
+            hard_block_reasons=_sorted_reason_values(policy_blocks),
+            reason_codes=("policy_validation_failed",),
+        )
+
+    gate_blocks = _collect_input_gate_blocks(inp)
+    if gate_blocks:
+        status = (
+            DirectionalAssessmentStatus.INVALID
+            if any(
+                r
+                in {
+                    DirectionalAssessmentHardBlockReason.INPUT_INCOMPLETE,
+                    DirectionalAssessmentHardBlockReason.PRICE_PATH_TOO_SHORT,
+                    DirectionalAssessmentHardBlockReason.REFERENCE_PRICE_NON_POSITIVE,
+                    DirectionalAssessmentHardBlockReason.SCOPE_EVENT_REF_INVALID,
+                }
+                for r in gate_blocks
+            )
+            else DirectionalAssessmentStatus.BLOCKED
+        )
+        return _finalize_assessment(
+            inp,
+            policy,
+            status=status,
+            signal_strength=0.0,
+            confidence=0.0,
+            hard_block_reasons=_sorted_reason_values(gate_blocks),
+            reason_codes=("input_gate_failed",),
+        )
+
+    epoch_mode, epoch_block = _resolve_epoch_semantics(
+        trading_epoch=inp.trading_epoch,
+        last_evaluated_trading_epoch=inp.confirmation_state.last_evaluated_trading_epoch,
+        scope_event_epoch=inp.scope_event_ref.trading_epoch,
+    )
+    if epoch_block is not None:
+        status = (
+            DirectionalAssessmentStatus.INVALID
+            if epoch_block is DirectionalAssessmentHardBlockReason.TRADING_EPOCH_OUT_OF_ORDER
+            else DirectionalAssessmentStatus.BLOCKED
+        )
+        return _finalize_assessment(
+            inp,
+            policy,
+            status=status,
+            signal_strength=0.0,
+            confidence=0.0,
+            hard_block_reasons=(epoch_block.value,),
+            reason_codes=("epoch_semantics_failed",),
+        )
+
+    signal_strength = compute_signal_strength(
+        price_path=inp.price_path,
+        side=inp.side,
+        reference_price=inp.reference_price,
+    )
+    confidence = compute_directional_confidence(
+        signal_strength, policy.confirmation_signal_threshold
+    )
+
+    status, reason_codes, _next_count = _status_for_signal(
+        signal_strength=signal_strength,
+        policy=policy,
+        confirmation_state=inp.confirmation_state,
+        epoch_mode=epoch_mode,
+    )
+
+    return _finalize_assessment(
+        inp,
+        policy,
+        status=status,
+        signal_strength=signal_strength,
+        confidence=confidence,
+        hard_block_reasons=(),
+        reason_codes=reason_codes,
+    )

--- a/tests/trading/master_v2/test_directional_assessment_v1.py
+++ b/tests/trading/master_v2/test_directional_assessment_v1.py
@@ -1,0 +1,462 @@
+# tests/trading/master_v2/test_directional_assessment_v1.py
+from __future__ import annotations
+
+import ast
+import inspect
+from dataclasses import fields, replace
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.canonical_market_context_v1 import (
+    BarFinalityStatus,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+)
+from trading.master_v2.deterministic_scope_event_generator_v1 import mirror_price_for_short
+from trading.master_v2.directional_assessment_v1 import (
+    DIRECTIONAL_ASSESSMENT_LAYER_VERSION,
+    DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    DirectionalAssessmentHardBlockReason,
+    DirectionalAssessmentInputV1,
+    DirectionalAssessmentPolicyV1,
+    DirectionalAssessmentSide,
+    DirectionalAssessmentStatus,
+    DirectionalAssessmentV1,
+    DirectionalConfirmationStateV1,
+    ScopeEventRefV1,
+    compute_directional_assessment_semantic_digest,
+    compute_directional_confidence,
+    compute_signal_strength,
+    evaluate_directional_assessment_v1,
+    mirror_price_path_for_short,
+    normalize_bull_bear_side,
+    serialize_directional_assessment_canonical,
+    validate_directional_assessment_policy,
+    with_computed_directional_assessment_digest,
+)
+
+
+def _scope_ref(**overrides: object) -> ScopeEventRefV1:
+    base: dict = {
+        "scope_event_id": "scope-event-inst-eth-usdt-perp-epoch42-upscope_candidate",
+        "semantic_digest": "a" * 64,
+        "event_type": "upscope_candidate",
+        "trading_epoch": 42,
+    }
+    base.update(overrides)
+    return ScopeEventRefV1(**base)
+
+
+def _confirmation(**overrides: object) -> DirectionalConfirmationStateV1:
+    base: dict = {
+        "candidate_count": 0,
+        "last_evaluated_trading_epoch": -1,
+        "last_signal_strength": 0.0,
+    }
+    base.update(overrides)
+    return DirectionalConfirmationStateV1(**base)
+
+
+def _policy(**overrides: object) -> DirectionalAssessmentPolicyV1:
+    base: dict = {
+        "observe_signal_threshold": 0.001,
+        "candidate_signal_threshold": 0.005,
+        "confirmation_signal_threshold": 0.01,
+        "confirmation_epochs": 2,
+        "validity_epochs": 3,
+        "policy_version": DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return DirectionalAssessmentPolicyV1(**base)
+
+
+def _input(**overrides: object) -> DirectionalAssessmentInputV1:
+    base: dict = {
+        "instrument_id": "inst-eth-usdt-perp",
+        "trading_epoch": 43,
+        "side": DirectionalAssessmentSide.LONG,
+        "price_path": (3500.0, 3540.0),
+        "reference_price": 3500.0,
+        "feature_refs": ("feat-momentum-v1", "feat-trend-v1"),
+        "scope_event_ref": _scope_ref(),
+        "survival_preconditions": ("survival_precondition_ref_only",),
+        "confirmation_state": _confirmation(last_evaluated_trading_epoch=42),
+        "data_integrity_status": DataIntegrityStatus.TRUSTED,
+        "clock_trust_status": ClockTrustStatus.TRUSTED,
+        "bar_finality_status": BarFinalityStatus.FINALIZED,
+        "trusted_data": True,
+        "input_complete": True,
+        "explicit_hard_block_reasons": (),
+        "policy_version": DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return DirectionalAssessmentInputV1(**base)
+
+
+def _evaluate(**kwargs: object) -> DirectionalAssessmentV1:
+    inp = kwargs.pop("inp", _input(**{k: v for k, v in kwargs.items() if k != "policy"}))
+    policy = kwargs.pop("policy", _policy())
+    return evaluate_directional_assessment_v1(inp, policy)
+
+
+def test_1_contract_schema_complete() -> None:
+    names = {f.name for f in fields(DirectionalAssessmentV1)}
+    required = {
+        "assessment_id",
+        "side",
+        "instrument_id",
+        "trading_epoch",
+        "status",
+        "signal_strength",
+        "confidence",
+        "feature_refs",
+        "scope_event_ref",
+        "survival_preconditions",
+        "hard_block_reasons",
+        "reason_codes",
+        "valid_until_epoch",
+        "semantic_digest",
+    }
+    assert required.issubset(names)
+
+
+def test_2_status_enum_exhaustiveness() -> None:
+    assert {s.value for s in DirectionalAssessmentStatus} == {
+        "invalid",
+        "blocked",
+        "observe",
+        "candidate",
+        "confirmed",
+    }
+
+
+def test_3_deterministic_serialization() -> None:
+    assessment = _evaluate()
+    first = serialize_directional_assessment_canonical(assessment)
+    second = serialize_directional_assessment_canonical(assessment)
+    assert first == second
+    assert json_loads_safe(first) == json_loads_safe(second)
+
+
+def json_loads_safe(text: str) -> dict:
+    import json
+
+    return json.loads(text)
+
+
+def test_4_stable_semantic_digest() -> None:
+    assessment = _evaluate()
+    recomputed = compute_directional_assessment_semantic_digest(assessment)
+    assert assessment.semantic_digest == recomputed
+
+
+def test_5_digest_changes_on_semantic_input_change() -> None:
+    first = _evaluate(price_path=(3500.0, 3540.0))
+    second = _evaluate(price_path=(3500.0, 3550.0))
+    assert first.semantic_digest != second.semantic_digest
+
+
+def test_6_identical_inputs_identical_assessment() -> None:
+    inp = _input()
+    policy = _policy()
+    assert evaluate_directional_assessment_v1(inp, policy) == evaluate_directional_assessment_v1(
+        inp, policy
+    )
+
+
+def test_7_bull_bear_mirror_structural_outcome() -> None:
+    anchor = 4000.0
+    long_path = (anchor, anchor + 50.0)
+    short_path = mirror_price_path_for_short(long_path, anchor)
+    long_result = _evaluate(
+        side=DirectionalAssessmentSide.LONG,
+        price_path=long_path,
+        reference_price=anchor,
+    )
+    short_result = _evaluate(
+        side=DirectionalAssessmentSide.SHORT,
+        price_path=short_path,
+        reference_price=anchor,
+    )
+    assert long_result.status is DirectionalAssessmentStatus.CANDIDATE
+    assert short_result.status is DirectionalAssessmentStatus.CANDIDATE
+    assert long_result.signal_strength == pytest.approx(short_result.signal_strength)
+    assert long_result.confidence == pytest.approx(short_result.confidence)
+
+
+def test_8_bull_bear_same_contract_type() -> None:
+    long_result = _evaluate(side=DirectionalAssessmentSide.LONG)
+    short_result = _evaluate(
+        side=DirectionalAssessmentSide.SHORT,
+        price_path=mirror_price_path_for_short((3500.0, 3540.0), 3500.0),
+    )
+    assert type(long_result) is DirectionalAssessmentV1
+    assert type(short_result) is DirectionalAssessmentV1
+    assert normalize_bull_bear_side("bull") is DirectionalAssessmentSide.LONG
+    assert normalize_bull_bear_side("bear") is DirectionalAssessmentSide.SHORT
+
+
+def test_9_untrusted_input_no_candidate_or_confirmed() -> None:
+    assessment = _evaluate(trusted_data=False)
+    assert assessment.status not in {
+        DirectionalAssessmentStatus.CANDIDATE,
+        DirectionalAssessmentStatus.CONFIRMED,
+    }
+
+
+def test_10_incomplete_input_invalid_or_blocked() -> None:
+    assessment = _evaluate(input_complete=False)
+    assert assessment.status in {
+        DirectionalAssessmentStatus.INVALID,
+        DirectionalAssessmentStatus.BLOCKED,
+    }
+
+
+def test_11_hard_block_reasons_force_fail_closed_status() -> None:
+    assessment = _evaluate(
+        explicit_hard_block_reasons=(DirectionalAssessmentHardBlockReason.EXPLICIT_HARD_BLOCK,),
+        price_path=(3500.0, 3600.0),
+    )
+    assert assessment.status is DirectionalAssessmentStatus.BLOCKED
+    assert (
+        DirectionalAssessmentHardBlockReason.EXPLICIT_HARD_BLOCK.value
+        in assessment.hard_block_reasons
+    )
+
+
+def test_12_reason_codes_nonempty_for_nontrivial_result() -> None:
+    for status in (
+        DirectionalAssessmentStatus.CANDIDATE,
+        DirectionalAssessmentStatus.CONFIRMED,
+        DirectionalAssessmentStatus.BLOCKED,
+        DirectionalAssessmentStatus.INVALID,
+    ):
+        if status is DirectionalAssessmentStatus.CANDIDATE:
+            result = _evaluate(price_path=(3500.0, 3540.0))
+        elif status is DirectionalAssessmentStatus.CONFIRMED:
+            first = _evaluate(
+                trading_epoch=43,
+                price_path=(3500.0, 3540.0),
+                confirmation_state=_confirmation(last_evaluated_trading_epoch=42),
+            )
+            result = _evaluate(
+                trading_epoch=44,
+                price_path=(3500.0, 3550.0),
+                confirmation_state=DirectionalConfirmationStateV1(
+                    candidate_count=1,
+                    last_evaluated_trading_epoch=43,
+                    last_signal_strength=first.signal_strength,
+                ),
+                scope_event_ref=_scope_ref(trading_epoch=43),
+            )
+        elif status is DirectionalAssessmentStatus.BLOCKED:
+            result = _evaluate(trusted_data=False)
+        else:
+            result = _evaluate(price_path=(3500.0,))
+        assert result.status is status
+        assert result.reason_codes
+
+
+def test_13_stale_trading_epoch_blocked_or_invalid() -> None:
+    assessment = _evaluate(
+        trading_epoch=40,
+        confirmation_state=_confirmation(last_evaluated_trading_epoch=43),
+        scope_event_ref=_scope_ref(trading_epoch=39),
+    )
+    assert assessment.status in {
+        DirectionalAssessmentStatus.BLOCKED,
+        DirectionalAssessmentStatus.INVALID,
+    }
+    assert (
+        DirectionalAssessmentHardBlockReason.TRADING_EPOCH_OUT_OF_ORDER.value
+        in assessment.hard_block_reasons
+    )
+
+
+def test_14_scope_event_ref_immutable() -> None:
+    scope_ref = _scope_ref()
+    assessment = _evaluate(scope_event_ref=scope_ref)
+    assert assessment.scope_event_ref is scope_ref
+    assert assessment.scope_event_ref.semantic_digest == scope_ref.semantic_digest
+
+
+def test_15_no_runtime_adapter_order_imports_or_side_effects() -> None:
+    root = Path(__file__).resolve().parent.parent.parent.parent / "src" / "trading" / "master_v2"
+    path = root / "directional_assessment_v1.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bad_roots = {
+        "ccxt",
+        "requests",
+        "urllib3",
+        "httpx",
+        "aiohttp",
+        "socket",
+        "websockets",
+        "boto3",
+        "subprocess",
+        "execution",
+        "risk",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                assert n.name.split(".")[0] not in bad_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in bad_roots
+    source = inspect.getsource(evaluate_directional_assessment_v1)
+    assert "open(" not in source
+    assert "requests." not in source
+
+
+def test_16_futures_only_spot_instrument_rejected() -> None:
+    assessment = _evaluate(instrument_id="inst-spot-eth-usdt")
+    assert (
+        DirectionalAssessmentHardBlockReason.INSTRUMENT_KIND_FORBIDDEN.value
+        in assessment.hard_block_reasons
+    )
+
+
+def test_17_no_bitcoin_semantics_in_output() -> None:
+    assessment = _evaluate(instrument_id="inst-sol-usdt-perp")
+    serialized = serialize_directional_assessment_canonical(assessment).lower()
+    assert "btc" not in serialized
+    assert "bitcoin" not in serialized
+    assert "xbt" not in serialized
+
+
+def test_18_long_short_symmetry_thresholds() -> None:
+    anchor = 100.0
+    policy = _policy(
+        observe_signal_threshold=0.001,
+        candidate_signal_threshold=0.01,
+        confirmation_signal_threshold=0.02,
+        confirmation_epochs=2,
+    )
+    long_strength = compute_signal_strength(
+        price_path=(anchor, anchor * 1.02),
+        side=DirectionalAssessmentSide.LONG,
+        reference_price=anchor,
+    )
+    short_strength = compute_signal_strength(
+        price_path=mirror_price_path_for_short((anchor, anchor * 1.02), anchor),
+        side=DirectionalAssessmentSide.SHORT,
+        reference_price=anchor,
+    )
+    assert long_strength == pytest.approx(short_strength)
+    long_conf = compute_directional_confidence(long_strength, policy.confirmation_signal_threshold)
+    short_conf = compute_directional_confidence(
+        short_strength, policy.confirmation_signal_threshold
+    )
+    assert long_conf == pytest.approx(short_conf)
+
+
+def test_19_no_implicit_strategy_selection() -> None:
+    assessment = _evaluate()
+    serialized = serialize_directional_assessment_canonical(assessment)
+    assert "strategy" not in serialized.lower()
+    assert "selected_strategy" not in serialized.lower()
+
+
+def test_20_step29b_c_d_regression_imports_still_work() -> None:
+    from trading.master_v2.canonical_market_context_v1 import CanonicalMarketContextV1
+    from trading.master_v2.canonical_scope_initialization_v1 import initialize_canonical_scope
+    from trading.master_v2.deterministic_scope_event_generator_v1 import (
+        generate_deterministic_scope_event,
+    )
+
+    assert CanonicalMarketContextV1 is not None
+    assert initialize_canonical_scope is not None
+    assert generate_deterministic_scope_event is not None
+
+
+def test_layer_version_constant() -> None:
+    assert DIRECTIONAL_ASSESSMENT_LAYER_VERSION == "v1"
+
+
+def test_observe_status_below_threshold() -> None:
+    assessment = _evaluate(price_path=(3500.0, 3501.0))
+    assert assessment.status is DirectionalAssessmentStatus.OBSERVE
+
+
+def test_candidate_status_on_strong_move() -> None:
+    assessment = _evaluate(price_path=(3500.0, 3540.0))
+    assert assessment.status is DirectionalAssessmentStatus.CANDIDATE
+
+
+def test_confirmed_after_consecutive_epochs() -> None:
+    first = _evaluate(
+        trading_epoch=43,
+        price_path=(3500.0, 3540.0),
+        confirmation_state=_confirmation(last_evaluated_trading_epoch=42),
+    )
+    second = _evaluate(
+        trading_epoch=44,
+        price_path=(3500.0, 3550.0),
+        confirmation_state=DirectionalConfirmationStateV1(
+            candidate_count=1,
+            last_evaluated_trading_epoch=43,
+            last_signal_strength=first.signal_strength,
+        ),
+        scope_event_ref=_scope_ref(trading_epoch=43),
+    )
+    assert second.status is DirectionalAssessmentStatus.CONFIRMED
+
+
+def test_valid_until_epoch_explicit_and_bounded() -> None:
+    assessment = _evaluate(trading_epoch=43)
+    assert assessment.valid_until_epoch == 46
+
+
+def test_no_authority_runtime_order_or_risk_effects() -> None:
+    assessment = _evaluate()
+    assert assessment.authority_effect == "NONE"
+    assert assessment.runtime_effect == "NONE"
+    assert assessment.order_effect == "NONE"
+    assert assessment.risk_effect == "NONE"
+
+
+def test_with_computed_directional_assessment_digest_round_trip() -> None:
+    assessment = _evaluate()
+    bare = replace(assessment, semantic_digest="")
+    bound = with_computed_directional_assessment_digest(bare)
+    assert bound.semantic_digest == assessment.semantic_digest
+
+
+def test_policy_threshold_order_invalid() -> None:
+    blocks = validate_directional_assessment_policy(
+        _policy(
+            observe_signal_threshold=0.02,
+            candidate_signal_threshold=0.01,
+            confirmation_signal_threshold=0.005,
+        ),
+        policy_version=DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    )
+    assert DirectionalAssessmentHardBlockReason.POLICY_THRESHOLD_ORDER_INVALID in blocks
+
+
+def test_scope_event_ref_stale_epoch() -> None:
+    assessment = _evaluate(
+        trading_epoch=41,
+        scope_event_ref=_scope_ref(trading_epoch=42),
+    )
+    assert assessment.status is DirectionalAssessmentStatus.BLOCKED
+    assert (
+        DirectionalAssessmentHardBlockReason.SCOPE_EVENT_REF_STALE.value
+        in assessment.hard_block_reasons
+    )
+
+
+def test_synthetic_spot_instrument_rejected() -> None:
+    assessment = _evaluate(instrument_id="inst-synthetic_spot-eth")
+    assert (
+        DirectionalAssessmentHardBlockReason.INSTRUMENT_KIND_FORBIDDEN.value
+        in assessment.hard_block_reasons
+    )
+
+
+def test_mirror_price_for_short_used_in_path_mirror() -> None:
+    anchor = 3500.0
+    price = 3600.0
+    mirrored = mirror_price_path_for_short((price,), anchor)[0]
+    assert mirrored == pytest.approx(mirror_price_for_short(price, anchor))


### PR DESCRIPTION
## Summary
- Introduces shared offline `DirectionalAssessmentV1` contract for Bull/Bear (LONG/SHORT) directional assessment with explicit status semantics: INVALID, BLOCKED, OBSERVE, CANDIDATE, CONFIRMED.
- Adds deterministic serialization, stable `semantic_digest`, fail-closed gates (untrusted/incomplete/epoch/hard-block), and Bull/Bear mirror symmetry tests.
- Consumes STEP 29B/C/D surfaces only (market-context enums, immutable `ScopeEventRefV1`); no runtime, authority, order, or risk effects.

## Test plan
- [x] `tests/trading/master_v2/test_directional_assessment_v1.py` (31 contract tests)
- [x] STEP 29B/C/D regression: `test_canonical_market_context_v1`, `test_canonical_scope_initialization_v1`, `test_deterministic_scope_event_generator_v1`
- [x] Local PR_BOUNDED_FULL path (751 tests, 46s)
- [x] `ruff format --check`, `ruff check`, `git diff --check`
- [x] `PRE_PR_VALIDATION_PASS` + `MANIFEST_VERIFY_RC=0`

## Runbook
- STEP: `RUNBOOK_STEP_29E` — Bull/Bear Directional Assessment Completion (Rank-1 contract slice)
- `STEP_29E_COMPLETE=false` (progress registry closeout deferred)
- Durable evidence: `runbook_step29e_directional_assessment_v1_offline_slice_implementation_v0_20260630T140000Z`

Made with [Cursor](https://cursor.com)