### PR TITLE
feat(master_v2): SuitabilityResultV1 offline binding for STEP 29F Rank-2

### DIFF
--- a/src/trading/master_v2/suitability_binding_v1.py
+++ b/src/trading/master_v2/suitability_binding_v1.py
@@ -1,0 +1,699 @@
+# src/trading/master_v2/suitability_binding_v1.py
+"""
+Pure Suitability Binding v1: offline strategy suitability contract for STEP 29F Rank-2.
+
+Consumes immutable DirectionalAssessmentV1 and SurvivalResultV1 evidence, explicit regime
+binding, and an offline strategy registry snapshot. Produces fachliche suitability evidence
+only — no runtime, authority, order, risk, sizing, or double-play composition effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping, Optional, Tuple
+
+from trading.master_v2.directional_assessment_v1 import (
+    DirectionalAssessmentSide,
+    DirectionalAssessmentV1,
+)
+from trading.master_v2.survival_assessment_v1 import (
+    SurvivalAssessmentStatus,
+    SurvivalResultV1,
+    directional_assessment_ref_from_assessment,
+)
+from trading.master_v2.survival_assessment_v1 import (
+    DirectionalAssessmentRefV1 as SurvivalDirectionalAssessmentRefV1,
+)
+
+SUITABILITY_BINDING_LAYER_VERSION = "v1"
+SUITABILITY_RANKING_POLICY_VERSION = "suitability_ranking_policy_v1"
+
+_AUTHORITY_EFFECT_NONE = "NONE"
+_RUNTIME_EFFECT_NONE = "NONE"
+_ORDER_EFFECT_NONE = "NONE"
+_RISK_EFFECT_NONE = "NONE"
+
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+
+_UNKNOWN_REGIME_ID = "unknown_regime"
+
+
+class SuitabilityBindingStatus(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    BLOCKED = "blocked"
+
+
+class SuitabilityRegimeStatus(str, Enum):
+    KNOWN = "known"
+    UNKNOWN = "unknown"
+
+
+class SuitabilityHardBlockReason(str, Enum):
+    NO_SUITABLE_STRATEGY = "no_suitable_strategy"
+    SURVIVAL_NOT_PASS = "survival_not_pass"
+    EXPLICIT_HARD_BLOCK = "explicit_hard_block"
+
+
+class SuitabilityBlockedReason(str, Enum):
+    DIRECTIONAL_ASSESSMENT_REF_MISMATCH = "directional_assessment_ref_mismatch"
+    DIRECTIONAL_ASSESSMENT_REF_STALE = "directional_assessment_ref_stale"
+    INPUT_INCOMPLETE = "input_incomplete"
+    INSTRUMENT_KIND_FORBIDDEN = "instrument_kind_forbidden"
+    MISSING_RANKING_POLICY = "missing_ranking_policy"
+    MISSING_STRATEGY_REGISTRY = "missing_strategy_registry"
+    POLICY_VERSION_INVALID = "policy_version_invalid"
+    POLICY_VALIDITY_EPOCHS_INVALID = "policy_validity_epochs_invalid"
+    RANKING_POLICY_VERSION_INVALID = "ranking_policy_version_invalid"
+    REGIME_UNKNOWN = "regime_unknown"
+    SIDE_MISMATCH = "side_mismatch"
+    STRATEGY_REGISTRY_EMPTY = "strategy_registry_empty"
+    SURVIVAL_RESULT_BLOCKED = "survival_result_blocked"
+    SURVIVAL_RESULT_REF_MISMATCH = "survival_result_ref_mismatch"
+    SURVIVAL_RESULT_REF_STALE = "survival_result_ref_stale"
+    TRADING_EPOCH_OUT_OF_ORDER = "trading_epoch_out_of_order"
+    EXPLICIT_BLOCKED = "explicit_blocked"
+
+
+@dataclass(frozen=True)
+class DirectionalAssessmentRefV1:
+    """Immutable reference to upstream DirectionalAssessmentV1 evidence."""
+
+    assessment_id: str
+    semantic_digest: str
+    trading_epoch: int
+    side: DirectionalAssessmentSide
+    status: str
+
+    def __post_init__(self) -> None:
+        if self.semantic_digest and not _valid_sha256_hex(self.semantic_digest):
+            msg = "semantic_digest must be empty or a 64-char lowercase sha256 hex"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class SurvivalResultRefV1:
+    """Immutable reference to upstream SurvivalResultV1 evidence."""
+
+    survival_id: str
+    semantic_digest: str
+    trading_epoch: int
+    side: DirectionalAssessmentSide
+    status: SurvivalAssessmentStatus
+
+    def __post_init__(self) -> None:
+        if self.semantic_digest and not _valid_sha256_hex(self.semantic_digest):
+            msg = "semantic_digest must be empty or a 64-char lowercase sha256 hex"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class SuitabilityStrategyEntryV1:
+    """Offline strategy eligibility snapshot; not the runtime strategy registry."""
+
+    strategy_id: str
+    supported_regime_ids: Tuple[str, ...]
+    supported_sides: Tuple[DirectionalAssessmentSide, ...]
+    priority_rank: int
+    disabled: bool = False
+    confidence_score: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class SuitabilityStrategyRegistryV1:
+    """Immutable registry snapshot evaluated in strategy_id order, never list position."""
+
+    entries: Tuple[SuitabilityStrategyEntryV1, ...]
+
+
+@dataclass(frozen=True)
+class SuitabilityRankingPolicyV1:
+    """Versioned ranking policy with explicit tie-break on strategy_id."""
+
+    validity_epochs: int
+    no_match_status: SuitabilityBindingStatus
+    policy_version: str = SUITABILITY_RANKING_POLICY_VERSION
+    tie_break_field: str = "strategy_id"
+
+
+@dataclass(frozen=True)
+class SuitabilityBindingInputV1:
+    instrument_id: str
+    trading_epoch: int
+    side: DirectionalAssessmentSide
+    directional_assessment: DirectionalAssessmentV1
+    survival_result: SurvivalResultV1
+    regime_id: str
+    regime_status: SuitabilityRegimeStatus
+    strategy_registry: Optional[SuitabilityStrategyRegistryV1]
+    last_evaluated_trading_epoch: int
+    input_complete: bool
+    explicit_hard_block_reasons: Tuple[SuitabilityHardBlockReason, ...]
+    explicit_blocked_reasons: Tuple[SuitabilityBlockedReason, ...]
+    ranking_policy_version: str
+
+
+@dataclass(frozen=True)
+class SuitabilityResultV1:
+    suitability_id: str
+    instrument_id: str
+    side: DirectionalAssessmentSide
+    trading_epoch: int
+    directional_assessment_ref: DirectionalAssessmentRefV1
+    survival_result_ref: SurvivalResultRefV1
+    regime_id: str
+    regime_status: SuitabilityRegimeStatus
+    eligible_strategy_ids: Tuple[str, ...]
+    selected_strategy_id: Optional[str]
+    ranking_policy_version: str
+    tie_break_trace: Tuple[str, ...]
+    status: SuitabilityBindingStatus
+    hard_block_reasons: Tuple[str, ...]
+    reason_codes: Tuple[str, ...]
+    valid_until_epoch: int
+    semantic_digest: str
+    authority_effect: str = _AUTHORITY_EFFECT_NONE
+    runtime_effect: str = _RUNTIME_EFFECT_NONE
+    order_effect: str = _ORDER_EFFECT_NONE
+    risk_effect: str = _RISK_EFFECT_NONE
+
+    def __post_init__(self) -> None:
+        if self.semantic_digest and not _valid_sha256_hex(self.semantic_digest):
+            msg = "semantic_digest must be empty or a 64-char lowercase sha256 hex"
+            raise ValueError(msg)
+        if self.valid_until_epoch <= self.trading_epoch:
+            msg = "valid_until_epoch must be strictly greater than trading_epoch"
+            raise ValueError(msg)
+        if self.status in (SuitabilityBindingStatus.FAIL, SuitabilityBindingStatus.BLOCKED):
+            if self.selected_strategy_id is not None:
+                msg = "selected_strategy_id must be unset for FAIL or BLOCKED"
+                raise ValueError(msg)
+
+
+def _valid_sha256_hex(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-f]{64}", value))
+
+
+def _positive_int(value: object) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+def _instrument_id_allowed(instrument_id: str) -> bool:
+    lowered = instrument_id.lower()
+    return not any(token in lowered for token in _FORBIDDEN_INSTRUMENT_SUBSTRINGS)
+
+
+def directional_assessment_ref_from_assessment_v1(
+    assessment: DirectionalAssessmentV1,
+) -> DirectionalAssessmentRefV1:
+    return DirectionalAssessmentRefV1(
+        assessment_id=assessment.assessment_id,
+        semantic_digest=assessment.semantic_digest,
+        trading_epoch=assessment.trading_epoch,
+        side=assessment.side,
+        status=assessment.status.value,
+    )
+
+
+def survival_result_ref_from_result(result: SurvivalResultV1) -> SurvivalResultRefV1:
+    return SurvivalResultRefV1(
+        survival_id=result.survival_id,
+        semantic_digest=result.semantic_digest,
+        trading_epoch=result.trading_epoch,
+        side=result.side,
+        status=result.status,
+    )
+
+
+def validate_suitability_ranking_policy(
+    policy: SuitabilityRankingPolicyV1,
+    *,
+    ranking_policy_version: str,
+) -> Tuple[SuitabilityBlockedReason, ...]:
+    blocks: list[SuitabilityBlockedReason] = []
+    if not policy.policy_version or policy.policy_version != SUITABILITY_RANKING_POLICY_VERSION:
+        blocks.append(SuitabilityBlockedReason.POLICY_VERSION_INVALID)
+    if ranking_policy_version != SUITABILITY_RANKING_POLICY_VERSION:
+        blocks.append(SuitabilityBlockedReason.RANKING_POLICY_VERSION_INVALID)
+    if not _positive_int(policy.validity_epochs):
+        blocks.append(SuitabilityBlockedReason.POLICY_VALIDITY_EPOCHS_INVALID)
+    if policy.no_match_status not in (
+        SuitabilityBindingStatus.FAIL,
+        SuitabilityBindingStatus.BLOCKED,
+    ):
+        blocks.append(SuitabilityBlockedReason.POLICY_VERSION_INVALID)
+    if policy.tie_break_field != "strategy_id":
+        blocks.append(SuitabilityBlockedReason.POLICY_VERSION_INVALID)
+    return tuple(dict.fromkeys(blocks))
+
+
+def _is_unknown_regime(regime_id: str, regime_status: SuitabilityRegimeStatus) -> bool:
+    return (
+        regime_status is SuitabilityRegimeStatus.UNKNOWN
+        or regime_id.strip().lower() == _UNKNOWN_REGIME_ID
+    )
+
+
+def _strategy_supports_side(
+    entry: SuitabilityStrategyEntryV1,
+    side: DirectionalAssessmentSide,
+) -> bool:
+    return side in entry.supported_sides
+
+
+def _strategy_supports_regime(entry: SuitabilityStrategyEntryV1, regime_id: str) -> bool:
+    normalized = regime_id.strip().lower()
+    return normalized in {rid.strip().lower() for rid in entry.supported_regime_ids}
+
+
+def filter_eligible_strategies(
+    registry: SuitabilityStrategyRegistryV1,
+    *,
+    side: DirectionalAssessmentSide,
+    regime_id: str,
+) -> Tuple[SuitabilityStrategyEntryV1, ...]:
+    eligible = [
+        entry
+        for entry in registry.entries
+        if not entry.disabled
+        and _strategy_supports_side(entry, side)
+        and _strategy_supports_regime(entry, regime_id)
+    ]
+    return tuple(sorted(eligible, key=lambda e: (e.priority_rank, e.strategy_id)))
+
+
+def rank_eligible_strategies(
+    eligible: Tuple[SuitabilityStrategyEntryV1, ...],
+    *,
+    policy: SuitabilityRankingPolicyV1,
+) -> Tuple[SuitabilityStrategyEntryV1, ...]:
+    """Deterministic ranking: priority_rank asc, then strategy_id lexicographic asc."""
+
+    del policy  # version validated separately; criteria are fixed for v1
+    return tuple(sorted(eligible, key=lambda e: (e.priority_rank, e.strategy_id)))
+
+
+def select_strategy_deterministic(
+    eligible: Tuple[SuitabilityStrategyEntryV1, ...],
+    *,
+    policy: SuitabilityRankingPolicyV1,
+) -> Tuple[Optional[str], Tuple[str, ...]]:
+    ranked = rank_eligible_strategies(eligible, policy=policy)
+    if not ranked:
+        return None, ("no_eligible_strategies",)
+    if len(ranked) == 1:
+        return ranked[0].strategy_id, ("single_eligible_strategy",)
+    trace = (
+        "ranking_policy_version="
+        + policy.policy_version
+        + ";criteria=priority_rank,strategy_id;order=asc,asc;"
+        + f"tie_break={policy.tie_break_field};candidates="
+        + ",".join(e.strategy_id for e in ranked)
+    )
+    return ranked[0].strategy_id, (trace,)
+
+
+def _derive_suitability_id(
+    instrument_id: str,
+    trading_epoch: int,
+    side: DirectionalAssessmentSide,
+    status: SuitabilityBindingStatus,
+) -> str:
+    return f"suitability-{instrument_id}-epoch{trading_epoch}-{side.value}-{status.value}"
+
+
+def serialize_suitability_result_canonical(result: SuitabilityResultV1) -> str:
+    dref = result.directional_assessment_ref
+    sref = result.survival_result_ref
+    payload = {
+        "authority_effect": result.authority_effect,
+        "directional_assessment_digest": dref.semantic_digest,
+        "directional_assessment_epoch": dref.trading_epoch,
+        "directional_assessment_id": dref.assessment_id,
+        "directional_assessment_side": dref.side.value,
+        "directional_assessment_status": dref.status,
+        "eligible_strategy_ids": list(result.eligible_strategy_ids),
+        "hard_block_reasons": sorted(result.hard_block_reasons),
+        "instrument_id": result.instrument_id,
+        "layer_version": SUITABILITY_BINDING_LAYER_VERSION,
+        "order_effect": result.order_effect,
+        "ranking_policy_version": result.ranking_policy_version,
+        "reason_codes": sorted(result.reason_codes),
+        "regime_id": result.regime_id,
+        "regime_status": result.regime_status.value,
+        "risk_effect": result.risk_effect,
+        "runtime_effect": result.runtime_effect,
+        "selected_strategy_id": result.selected_strategy_id,
+        "side": result.side.value,
+        "status": result.status.value,
+        "suitability_id": result.suitability_id,
+        "survival_result_digest": sref.semantic_digest,
+        "survival_result_epoch": sref.trading_epoch,
+        "survival_result_id": sref.survival_id,
+        "survival_result_side": sref.side.value,
+        "survival_result_status": sref.status.value,
+        "tie_break_trace": list(result.tie_break_trace),
+        "trading_epoch": result.trading_epoch,
+        "valid_until_epoch": result.valid_until_epoch,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def compute_suitability_result_semantic_digest(result: SuitabilityResultV1) -> str:
+    canonical = serialize_suitability_result_canonical(result)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def with_computed_suitability_result_digest(result: SuitabilityResultV1) -> SuitabilityResultV1:
+    digest = compute_suitability_result_semantic_digest(result)
+    return SuitabilityResultV1(
+        suitability_id=result.suitability_id,
+        instrument_id=result.instrument_id,
+        side=result.side,
+        trading_epoch=result.trading_epoch,
+        directional_assessment_ref=result.directional_assessment_ref,
+        survival_result_ref=result.survival_result_ref,
+        regime_id=result.regime_id,
+        regime_status=result.regime_status,
+        eligible_strategy_ids=result.eligible_strategy_ids,
+        selected_strategy_id=result.selected_strategy_id,
+        ranking_policy_version=result.ranking_policy_version,
+        tie_break_trace=result.tie_break_trace,
+        status=result.status,
+        hard_block_reasons=result.hard_block_reasons,
+        reason_codes=result.reason_codes,
+        valid_until_epoch=result.valid_until_epoch,
+        semantic_digest=digest,
+        authority_effect=result.authority_effect,
+        runtime_effect=result.runtime_effect,
+        order_effect=result.order_effect,
+        risk_effect=result.risk_effect,
+    )
+
+
+def _resolve_epoch_semantics(
+    *,
+    trading_epoch: int,
+    last_evaluated_trading_epoch: int,
+    assessment_epoch: int,
+    survival_epoch: int,
+) -> Tuple[str, Optional[SuitabilityBlockedReason]]:
+    if assessment_epoch > trading_epoch:
+        return "stale_assessment_ref", SuitabilityBlockedReason.DIRECTIONAL_ASSESSMENT_REF_STALE
+    if survival_epoch > trading_epoch:
+        return "stale_survival_ref", SuitabilityBlockedReason.SURVIVAL_RESULT_REF_STALE
+    if last_evaluated_trading_epoch < 0:
+        return "first", None
+    if trading_epoch < last_evaluated_trading_epoch:
+        return "out_of_order", SuitabilityBlockedReason.TRADING_EPOCH_OUT_OF_ORDER
+    return "ok", None
+
+
+def _refs_consistent(
+    inp: SuitabilityBindingInputV1,
+) -> Tuple[Optional[SuitabilityBlockedReason], ...]:
+    blocks: list[SuitabilityBlockedReason] = []
+    assessment = inp.directional_assessment
+    survival = inp.survival_result
+    if assessment.instrument_id != inp.instrument_id:
+        blocks.append(SuitabilityBlockedReason.DIRECTIONAL_ASSESSMENT_REF_MISMATCH)
+    if survival.instrument_id != inp.instrument_id:
+        blocks.append(SuitabilityBlockedReason.SURVIVAL_RESULT_REF_MISMATCH)
+    if assessment.side != inp.side:
+        blocks.append(SuitabilityBlockedReason.SIDE_MISMATCH)
+    if survival.side != inp.side:
+        blocks.append(SuitabilityBlockedReason.SIDE_MISMATCH)
+    if assessment.trading_epoch != survival.trading_epoch:
+        blocks.append(SuitabilityBlockedReason.SURVIVAL_RESULT_REF_MISMATCH)
+    surv_dref: SurvivalDirectionalAssessmentRefV1 = survival.directional_assessment_ref
+    if surv_dref.assessment_id != assessment.assessment_id:
+        blocks.append(SuitabilityBlockedReason.SURVIVAL_RESULT_REF_MISMATCH)
+    if surv_dref.semantic_digest != assessment.semantic_digest:
+        blocks.append(SuitabilityBlockedReason.SURVIVAL_RESULT_REF_MISMATCH)
+    return tuple(dict.fromkeys(blocks))
+
+
+def _finalize_result(
+    inp: SuitabilityBindingInputV1,
+    policy: SuitabilityRankingPolicyV1,
+    *,
+    status: SuitabilityBindingStatus,
+    eligible_strategy_ids: Tuple[str, ...],
+    selected_strategy_id: Optional[str],
+    tie_break_trace: Tuple[str, ...],
+    hard_block_reasons: Tuple[str, ...],
+    reason_codes: Tuple[str, ...],
+) -> SuitabilityResultV1:
+    valid_until = inp.trading_epoch + policy.validity_epochs
+    result = SuitabilityResultV1(
+        suitability_id=_derive_suitability_id(
+            inp.instrument_id, inp.trading_epoch, inp.side, status
+        ),
+        instrument_id=inp.instrument_id,
+        side=inp.side,
+        trading_epoch=inp.trading_epoch,
+        directional_assessment_ref=directional_assessment_ref_from_assessment_v1(
+            inp.directional_assessment
+        ),
+        survival_result_ref=survival_result_ref_from_result(inp.survival_result),
+        regime_id=inp.regime_id,
+        regime_status=inp.regime_status,
+        eligible_strategy_ids=eligible_strategy_ids,
+        selected_strategy_id=selected_strategy_id,
+        ranking_policy_version=policy.policy_version,
+        tie_break_trace=tie_break_trace,
+        status=status,
+        hard_block_reasons=hard_block_reasons,
+        reason_codes=reason_codes,
+        valid_until_epoch=valid_until,
+        semantic_digest="",
+    )
+    return with_computed_suitability_result_digest(result)
+
+
+def evaluate_suitability_binding_v1(
+    inp: SuitabilityBindingInputV1,
+    policy: SuitabilityRankingPolicyV1,
+) -> SuitabilityResultV1:
+    """
+    Deterministic suitability evaluator.
+
+    Fail-closed on incomplete, untrusted, ambiguous, or epoch-invalid inputs.
+    Never mutates ``inp.directional_assessment``, ``inp.survival_result``, or upstream evidence.
+    """
+
+    def blocked(
+        reason: SuitabilityBlockedReason,
+        *,
+        reason_code: str,
+        hard: Tuple[str, ...] = (),
+    ) -> SuitabilityResultV1:
+        return _finalize_result(
+            inp,
+            policy,
+            status=SuitabilityBindingStatus.BLOCKED,
+            eligible_strategy_ids=(),
+            selected_strategy_id=None,
+            tie_break_trace=(),
+            hard_block_reasons=hard,
+            reason_codes=(reason_code, reason.value),
+        )
+
+    policy_blocks = validate_suitability_ranking_policy(
+        policy, ranking_policy_version=inp.ranking_policy_version
+    )
+    if policy_blocks:
+        return blocked(
+            SuitabilityBlockedReason.POLICY_VERSION_INVALID,
+            reason_code="policy_validation_failed",
+        )
+
+    if not _instrument_id_allowed(inp.instrument_id):
+        return blocked(
+            SuitabilityBlockedReason.INSTRUMENT_KIND_FORBIDDEN,
+            reason_code="instrument_gate_failed",
+        )
+
+    if not inp.input_complete:
+        return blocked(
+            SuitabilityBlockedReason.INPUT_INCOMPLETE,
+            reason_code="input_gate_failed",
+        )
+
+    if inp.explicit_blocked_reasons:
+        return _finalize_result(
+            inp,
+            policy,
+            status=SuitabilityBindingStatus.BLOCKED,
+            eligible_strategy_ids=(),
+            selected_strategy_id=None,
+            tie_break_trace=(),
+            hard_block_reasons=(),
+            reason_codes=("explicit_blocked",)
+            + tuple(sorted(r.value for r in inp.explicit_blocked_reasons)),
+        )
+
+    ref_blocks = _refs_consistent(inp)
+    if ref_blocks:
+        return blocked(ref_blocks[0], reason_code="reference_consistency_failed")
+
+    assessment = inp.directional_assessment
+    survival = inp.survival_result
+
+    epoch_mode, epoch_block = _resolve_epoch_semantics(
+        trading_epoch=inp.trading_epoch,
+        last_evaluated_trading_epoch=inp.last_evaluated_trading_epoch,
+        assessment_epoch=assessment.trading_epoch,
+        survival_epoch=survival.trading_epoch,
+    )
+    if epoch_block is not None:
+        return blocked(epoch_block, reason_code=f"epoch_semantics_failed:{epoch_mode}")
+
+    if survival.status is SurvivalAssessmentStatus.BLOCKED:
+        return blocked(
+            SuitabilityBlockedReason.SURVIVAL_RESULT_BLOCKED,
+            reason_code="survival_gate_blocked",
+        )
+
+    if survival.status is not SurvivalAssessmentStatus.PASS:
+        hard = (SuitabilityHardBlockReason.SURVIVAL_NOT_PASS.value,)
+        if inp.explicit_hard_block_reasons:
+            hard = tuple(
+                dict.fromkeys(
+                    [SuitabilityHardBlockReason.SURVIVAL_NOT_PASS.value]
+                    + [r.value for r in inp.explicit_hard_block_reasons]
+                )
+            )
+        status = (
+            SuitabilityBindingStatus.FAIL
+            if survival.status is SurvivalAssessmentStatus.FAIL
+            else SuitabilityBindingStatus.BLOCKED
+        )
+        return _finalize_result(
+            inp,
+            policy,
+            status=status,
+            eligible_strategy_ids=(),
+            selected_strategy_id=None,
+            tie_break_trace=(),
+            hard_block_reasons=hard,
+            reason_codes=("survival_not_pass",),
+        )
+
+    if _is_unknown_regime(inp.regime_id, inp.regime_status):
+        return blocked(
+            SuitabilityBlockedReason.REGIME_UNKNOWN,
+            reason_code="unknown_regime_blocked",
+        )
+
+    if inp.strategy_registry is None:
+        return blocked(
+            SuitabilityBlockedReason.MISSING_STRATEGY_REGISTRY,
+            reason_code="registry_missing",
+        )
+
+    if not inp.strategy_registry.entries:
+        return blocked(
+            SuitabilityBlockedReason.STRATEGY_REGISTRY_EMPTY,
+            reason_code="registry_empty",
+        )
+
+    eligible_entries = filter_eligible_strategies(
+        inp.strategy_registry,
+        side=inp.side,
+        regime_id=inp.regime_id,
+    )
+    eligible_ids = tuple(e.strategy_id for e in eligible_entries)
+
+    if not eligible_entries:
+        status = policy.no_match_status
+        hard: Tuple[str, ...] = ()
+        if status is SuitabilityBindingStatus.FAIL:
+            hard = (SuitabilityHardBlockReason.NO_SUITABLE_STRATEGY.value,)
+        return _finalize_result(
+            inp,
+            policy,
+            status=status,
+            eligible_strategy_ids=(),
+            selected_strategy_id=None,
+            tie_break_trace=("no_eligible_strategies",),
+            hard_block_reasons=hard,
+            reason_codes=("no_suitable_strategy",),
+        )
+
+    if inp.explicit_hard_block_reasons:
+        return _finalize_result(
+            inp,
+            policy,
+            status=SuitabilityBindingStatus.FAIL,
+            eligible_strategy_ids=eligible_ids,
+            selected_strategy_id=None,
+            tie_break_trace=(),
+            hard_block_reasons=tuple(sorted(r.value for r in inp.explicit_hard_block_reasons)),
+            reason_codes=("explicit_hard_block",),
+        )
+
+    selected_id, tie_trace = select_strategy_deterministic(eligible_entries, policy=policy)
+    assert selected_id is not None
+    return _finalize_result(
+        inp,
+        policy,
+        status=SuitabilityBindingStatus.PASS,
+        eligible_strategy_ids=eligible_ids,
+        selected_strategy_id=selected_id,
+        tie_break_trace=tie_trace,
+        hard_block_reasons=(),
+        reason_codes=("strategy_selected",),
+    )
+
+
+def mirror_suitability_strategy_entry_for_short(
+    entry: SuitabilityStrategyEntryV1,
+) -> SuitabilityStrategyEntryV1:
+    """Structural mirror helper for Long/Short symmetry tests."""
+    mirrored_sides = tuple(
+        DirectionalAssessmentSide.SHORT
+        if s is DirectionalAssessmentSide.LONG
+        else DirectionalAssessmentSide.LONG
+        for s in entry.supported_sides
+    )
+    return SuitabilityStrategyEntryV1(
+        strategy_id=entry.strategy_id,
+        supported_regime_ids=entry.supported_regime_ids,
+        supported_sides=mirrored_sides,
+        priority_rank=entry.priority_rank,
+        disabled=entry.disabled,
+        confidence_score=entry.confidence_score,
+    )
+
+
+__all__ = [
+    "SUITABILITY_BINDING_LAYER_VERSION",
+    "SUITABILITY_RANKING_POLICY_VERSION",
+    "DirectionalAssessmentRefV1",
+    "SurvivalResultRefV1",
+    "SuitabilityBindingInputV1",
+    "SuitabilityBindingStatus",
+    "SuitabilityBlockedReason",
+    "SuitabilityHardBlockReason",
+    "SuitabilityRankingPolicyV1",
+    "SuitabilityRegimeStatus",
+    "SuitabilityResultV1",
+    "SuitabilityStrategyEntryV1",
+    "SuitabilityStrategyRegistryV1",
+    "compute_suitability_result_semantic_digest",
+    "directional_assessment_ref_from_assessment_v1",
+    "evaluate_suitability_binding_v1",
+    "filter_eligible_strategies",
+    "mirror_suitability_strategy_entry_for_short",
+    "rank_eligible_strategies",
+    "select_strategy_deterministic",
+    "serialize_suitability_result_canonical",
+    "survival_result_ref_from_result",
+    "validate_suitability_ranking_policy",
+    "with_computed_suitability_result_digest",
+]

--- a/tests/trading/master_v2/test_suitability_binding_v1.py
+++ b/tests/trading/master_v2/test_suitability_binding_v1.py
@@ -1,0 +1,618 @@
+# tests/trading/master_v2/test_suitability_binding_v1.py
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from dataclasses import fields, replace
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.canonical_market_context_v1 import (
+    BarFinalityStatus,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+)
+from trading.master_v2.directional_assessment_v1 import (
+    DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    DirectionalAssessmentInputV1,
+    DirectionalAssessmentPolicyV1,
+    DirectionalAssessmentSide,
+    DirectionalAssessmentStatus,
+    DirectionalAssessmentV1,
+    DirectionalConfirmationStateV1,
+    ScopeEventRefV1,
+    evaluate_directional_assessment_v1,
+    mirror_price_path_for_short,
+)
+from trading.master_v2.survival_assessment_v1 import (
+    SURVIVAL_ASSESSMENT_POLICY_VERSION,
+    SurvivalAssessmentInputV1,
+    SurvivalAssessmentPolicyV1,
+    SurvivalAssessmentStatus,
+    SurvivalCostInputsV1,
+    SurvivalMetricInputsV1,
+    SurvivalResultV1,
+    evaluate_survival_assessment_v1,
+)
+from trading.master_v2.suitability_binding_v1 import (
+    SUITABILITY_BINDING_LAYER_VERSION,
+    SUITABILITY_RANKING_POLICY_VERSION,
+    SuitabilityBindingInputV1,
+    SuitabilityBindingStatus,
+    SuitabilityBlockedReason,
+    SuitabilityHardBlockReason,
+    SuitabilityRankingPolicyV1,
+    SuitabilityRegimeStatus,
+    SuitabilityResultV1,
+    SuitabilityStrategyEntryV1,
+    SuitabilityStrategyRegistryV1,
+    compute_suitability_result_semantic_digest,
+    directional_assessment_ref_from_assessment_v1,
+    evaluate_suitability_binding_v1,
+    filter_eligible_strategies,
+    mirror_suitability_strategy_entry_for_short,
+    rank_eligible_strategies,
+    select_strategy_deterministic,
+    serialize_suitability_result_canonical,
+    survival_result_ref_from_result,
+    validate_suitability_ranking_policy,
+    with_computed_suitability_result_digest,
+)
+
+
+def _scope_ref(**overrides: object) -> ScopeEventRefV1:
+    base: dict = {
+        "scope_event_id": "scope-event-inst-eth-usdt-perp-epoch42-upscope_candidate",
+        "semantic_digest": "a" * 64,
+        "event_type": "upscope_candidate",
+        "trading_epoch": 42,
+    }
+    base.update(overrides)
+    return ScopeEventRefV1(**base)
+
+
+def _directional_policy(**overrides: object) -> DirectionalAssessmentPolicyV1:
+    base: dict = {
+        "observe_signal_threshold": 0.001,
+        "candidate_signal_threshold": 0.005,
+        "confirmation_signal_threshold": 0.01,
+        "confirmation_epochs": 2,
+        "validity_epochs": 3,
+        "policy_version": DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return DirectionalAssessmentPolicyV1(**base)
+
+
+def _directional_input(**overrides: object) -> DirectionalAssessmentInputV1:
+    base: dict = {
+        "instrument_id": "inst-eth-usdt-perp",
+        "trading_epoch": 43,
+        "side": DirectionalAssessmentSide.LONG,
+        "price_path": (3500.0, 3540.0),
+        "reference_price": 3500.0,
+        "feature_refs": ("feat-momentum-v1",),
+        "scope_event_ref": _scope_ref(),
+        "survival_preconditions": ("survival_precondition_ref_only",),
+        "confirmation_state": DirectionalConfirmationStateV1(
+            candidate_count=0,
+            last_evaluated_trading_epoch=42,
+            last_signal_strength=0.0,
+        ),
+        "data_integrity_status": DataIntegrityStatus.TRUSTED,
+        "clock_trust_status": ClockTrustStatus.TRUSTED,
+        "bar_finality_status": BarFinalityStatus.FINALIZED,
+        "trusted_data": True,
+        "input_complete": True,
+        "explicit_hard_block_reasons": (),
+        "policy_version": DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return DirectionalAssessmentInputV1(**base)
+
+
+def _directional_assessment(**overrides: object) -> DirectionalAssessmentV1:
+    inp = _directional_input(**{k: v for k, v in overrides.items() if k != "policy"})
+    policy = overrides.get("policy", _directional_policy())
+    return evaluate_directional_assessment_v1(inp, policy)
+
+
+def _survival_policy(**overrides: object) -> SurvivalAssessmentPolicyV1:
+    base: dict = {
+        "min_net_edge": 0.001,
+        "min_volatility_survival_ratio": 0.5,
+        "min_sequence_survival_ratio": 0.5,
+        "min_drawdown_survival_ratio": 0.5,
+        "min_liquidation_buffer_ratio": 0.1,
+        "validity_epochs": 3,
+        "policy_version": SURVIVAL_ASSESSMENT_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return SurvivalAssessmentPolicyV1(**base)
+
+
+def _survival_input(**overrides: object) -> SurvivalAssessmentInputV1:
+    assessment = overrides.pop("directional_assessment", None)
+    if assessment is None:
+        assessment = _directional_assessment()
+    base: dict = {
+        "instrument_id": "inst-eth-usdt-perp",
+        "trading_epoch": 43,
+        "side": DirectionalAssessmentSide.LONG,
+        "directional_assessment": assessment,
+        "cost_inputs": SurvivalCostInputsV1(
+            entry_fee=0.0005,
+            expected_entry_slippage=0.0002,
+            exit_fee=0.0005,
+            expected_exit_slippage=0.0002,
+            expected_funding_cost=0.0001,
+            expected_gross_edge=0.02,
+            funding_cost_required=True,
+        ),
+        "metric_inputs": SurvivalMetricInputsV1(
+            data_completeness_complete=True,
+            volatility_survival_ratio=0.8,
+            sequence_survival_ratio=0.8,
+            drawdown_survival_ratio=0.8,
+            liquidation_buffer_ratio=0.2,
+        ),
+        "last_evaluated_trading_epoch": 42,
+        "input_complete": True,
+        "explicit_hard_fail_reasons": (),
+        "explicit_blocked_reasons": (),
+        "policy_version": SURVIVAL_ASSESSMENT_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return SurvivalAssessmentInputV1(**base)
+
+
+def _survival_result(**overrides: object) -> SurvivalResultV1:
+    inp = _survival_input(**{k: v for k, v in overrides.items() if k != "policy"})
+    policy = overrides.get("policy", _survival_policy())
+    return evaluate_survival_assessment_v1(inp, policy)
+
+
+def _strategy_entry(**overrides: object) -> SuitabilityStrategyEntryV1:
+    base: dict = {
+        "strategy_id": "strat-momentum-v1",
+        "supported_regime_ids": ("trending", "ranging"),
+        "supported_sides": (DirectionalAssessmentSide.LONG,),
+        "priority_rank": 10,
+        "disabled": False,
+        "confidence_score": 0.75,
+    }
+    base.update(overrides)
+    return SuitabilityStrategyEntryV1(**base)
+
+
+def _registry(*entries: SuitabilityStrategyEntryV1) -> SuitabilityStrategyRegistryV1:
+    return SuitabilityStrategyRegistryV1(entries=entries)
+
+
+def _ranking_policy(**overrides: object) -> SuitabilityRankingPolicyV1:
+    base: dict = {
+        "validity_epochs": 3,
+        "no_match_status": SuitabilityBindingStatus.FAIL,
+        "policy_version": SUITABILITY_RANKING_POLICY_VERSION,
+        "tie_break_field": "strategy_id",
+    }
+    base.update(overrides)
+    return SuitabilityRankingPolicyV1(**base)
+
+
+def _binding_input(**overrides: object) -> SuitabilityBindingInputV1:
+    assessment = overrides.pop("directional_assessment", None)
+    survival = overrides.pop("survival_result", None)
+    if assessment is None:
+        assessment = _directional_assessment()
+    if survival is None:
+        survival = _survival_result(directional_assessment=assessment)
+    base: dict = {
+        "instrument_id": "inst-eth-usdt-perp",
+        "trading_epoch": 43,
+        "side": DirectionalAssessmentSide.LONG,
+        "directional_assessment": assessment,
+        "survival_result": survival,
+        "regime_id": "trending",
+        "regime_status": SuitabilityRegimeStatus.KNOWN,
+        "strategy_registry": _registry(_strategy_entry()),
+        "last_evaluated_trading_epoch": 42,
+        "input_complete": True,
+        "explicit_hard_block_reasons": (),
+        "explicit_blocked_reasons": (),
+        "ranking_policy_version": SUITABILITY_RANKING_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return SuitabilityBindingInputV1(**base)
+
+
+def _evaluate(**kwargs: object) -> SuitabilityResultV1:
+    inp = kwargs.pop("inp", _binding_input(**{k: v for k, v in kwargs.items() if k != "policy"}))
+    policy = kwargs.pop("policy", _ranking_policy())
+    return evaluate_suitability_binding_v1(inp, policy)
+
+
+def test_1_contract_schema_complete() -> None:
+    names = {f.name for f in fields(SuitabilityResultV1)}
+    required = {
+        "suitability_id",
+        "instrument_id",
+        "side",
+        "trading_epoch",
+        "directional_assessment_ref",
+        "survival_result_ref",
+        "regime_id",
+        "regime_status",
+        "eligible_strategy_ids",
+        "selected_strategy_id",
+        "ranking_policy_version",
+        "tie_break_trace",
+        "status",
+        "hard_block_reasons",
+        "reason_codes",
+        "valid_until_epoch",
+        "semantic_digest",
+    }
+    assert required.issubset(names)
+
+
+def test_2_status_exhaustiveness() -> None:
+    assert {s.value for s in SuitabilityBindingStatus} == {"pass", "fail", "blocked"}
+
+
+def test_3_deterministic_serialization() -> None:
+    result = _evaluate()
+    first = serialize_suitability_result_canonical(result)
+    second = serialize_suitability_result_canonical(result)
+    assert first == second
+    assert json.loads(first) == json.loads(second)
+
+
+def test_4_stable_semantic_digest() -> None:
+    result = _evaluate()
+    recomputed = compute_suitability_result_semantic_digest(result)
+    assert result.semantic_digest == recomputed
+
+
+def test_5_digest_changes_on_semantic_input_change() -> None:
+    first = _evaluate(regime_id="trending")
+    second = _evaluate(regime_id="ranging")
+    assert first.semantic_digest != second.semantic_digest
+
+
+def test_6_identical_inputs_identical_result() -> None:
+    inp = _binding_input()
+    policy = _ranking_policy()
+    assert evaluate_suitability_binding_v1(inp, policy) == evaluate_suitability_binding_v1(
+        inp, policy
+    )
+
+
+def test_7_survival_not_pass_implies_suitability_not_pass() -> None:
+    failed_survival = replace(
+        _survival_result(),
+        status=SurvivalAssessmentStatus.FAIL,
+    )
+    result = _evaluate(survival_result=failed_survival)
+    assert result.status is not SuitabilityBindingStatus.PASS
+    assert SuitabilityHardBlockReason.SURVIVAL_NOT_PASS.value in result.hard_block_reasons
+
+
+def test_8_unknown_regime_blocks() -> None:
+    result = _evaluate(regime_id="unknown_regime", regime_status=SuitabilityRegimeStatus.KNOWN)
+    assert result.status is SuitabilityBindingStatus.BLOCKED
+    assert "unknown_regime_blocked" in result.reason_codes
+
+    result2 = _evaluate(regime_id="trending", regime_status=SuitabilityRegimeStatus.UNKNOWN)
+    assert result2.status is SuitabilityBindingStatus.BLOCKED
+
+
+def test_9_missing_registry_blocks() -> None:
+    result = _evaluate(strategy_registry=None)
+    assert result.status is SuitabilityBindingStatus.BLOCKED
+    assert SuitabilityBlockedReason.MISSING_STRATEGY_REGISTRY.value in result.reason_codes
+
+
+def test_10_no_matching_strategy_fail_closed() -> None:
+    entry = _strategy_entry(supported_regime_ids=("breakout",))
+    result = _evaluate(strategy_registry=_registry(entry), regime_id="trending")
+    assert result.status is SuitabilityBindingStatus.FAIL
+    assert result.selected_strategy_id is None
+    assert SuitabilityHardBlockReason.NO_SUITABLE_STRATEGY.value in result.hard_block_reasons
+
+
+def test_11_single_eligible_strategy_selected() -> None:
+    result = _evaluate()
+    assert result.status is SuitabilityBindingStatus.PASS
+    assert result.selected_strategy_id == "strat-momentum-v1"
+    assert result.tie_break_trace == ("single_eligible_strategy",)
+
+
+def test_12_multiple_eligible_requires_ranking_policy() -> None:
+    entries = (
+        _strategy_entry(strategy_id="strat-b", priority_rank=20),
+        _strategy_entry(strategy_id="strat-a", priority_rank=10),
+    )
+    result = _evaluate(strategy_registry=_registry(*entries))
+    assert result.status is SuitabilityBindingStatus.PASS
+    assert result.selected_strategy_id == "strat-a"
+    assert result.tie_break_trace[0].startswith("ranking_policy_version=")
+
+
+def test_13_invalid_ranking_policy_blocks() -> None:
+    blocks = validate_suitability_ranking_policy(
+        _ranking_policy(policy_version="suitability_ranking_policy_v0"),
+        ranking_policy_version=SUITABILITY_RANKING_POLICY_VERSION,
+    )
+    assert SuitabilityBlockedReason.POLICY_VERSION_INVALID in blocks
+    result = _evaluate(ranking_policy_version="suitability_ranking_policy_v0")
+    assert result.status is SuitabilityBindingStatus.BLOCKED
+
+
+def test_14_stable_tie_break_by_strategy_id() -> None:
+    entries = (
+        _strategy_entry(strategy_id="strat-z", priority_rank=10),
+        _strategy_entry(strategy_id="strat-a", priority_rank=10),
+    )
+    selected, trace = select_strategy_deterministic(
+        entries,
+        policy=_ranking_policy(),
+    )
+    assert selected == "strat-a"
+    assert "tie_break=strategy_id" in trace[0]
+
+
+def test_15_selection_independent_of_list_order() -> None:
+    entries_ab = (
+        _strategy_entry(strategy_id="strat-a", priority_rank=10),
+        _strategy_entry(strategy_id="strat-b", priority_rank=10),
+    )
+    entries_ba = (
+        _strategy_entry(strategy_id="strat-b", priority_rank=10),
+        _strategy_entry(strategy_id="strat-a", priority_rank=10),
+    )
+    reg_ab = _registry(*entries_ab)
+    reg_ba = _registry(*entries_ba)
+    result_ab = _evaluate(strategy_registry=reg_ab)
+    result_ba = _evaluate(strategy_registry=reg_ba)
+    assert result_ab.selected_strategy_id == result_ba.selected_strategy_id == "strat-a"
+
+
+def test_16_selection_independent_of_dict_like_registry_order() -> None:
+    eligible_ab = filter_eligible_strategies(
+        _registry(
+            _strategy_entry(strategy_id="strat-a", priority_rank=5),
+            _strategy_entry(strategy_id="strat-b", priority_rank=5),
+        ),
+        side=DirectionalAssessmentSide.LONG,
+        regime_id="trending",
+    )
+    eligible_ba = filter_eligible_strategies(
+        _registry(
+            _strategy_entry(strategy_id="strat-b", priority_rank=5),
+            _strategy_entry(strategy_id="strat-a", priority_rank=5),
+        ),
+        side=DirectionalAssessmentSide.LONG,
+        regime_id="trending",
+    )
+    ranked_ab = rank_eligible_strategies(eligible_ab, policy=_ranking_policy())
+    ranked_ba = rank_eligible_strategies(eligible_ba, policy=_ranking_policy())
+    assert [e.strategy_id for e in ranked_ab] == [e.strategy_id for e in ranked_ba]
+
+
+def test_17_no_default_strategy_when_none_eligible() -> None:
+    result = _evaluate(
+        strategy_registry=_registry(_strategy_entry(disabled=True)),
+    )
+    assert result.selected_strategy_id is None
+
+
+def test_18_no_fallback_strategy_on_blocked_survival() -> None:
+    blocked_survival = replace(
+        _survival_result(),
+        status=SurvivalAssessmentStatus.BLOCKED,
+    )
+    result = _evaluate(survival_result=blocked_survival)
+    assert result.selected_strategy_id is None
+
+
+def test_19_selected_strategy_unset_on_fail_and_blocked() -> None:
+    fail_result = _evaluate(
+        strategy_registry=_registry(_strategy_entry(supported_regime_ids=("breakout",))),
+        regime_id="trending",
+    )
+    assert fail_result.status is SuitabilityBindingStatus.FAIL
+    assert fail_result.selected_strategy_id is None
+
+    blocked_result = _evaluate(strategy_registry=None)
+    assert blocked_result.status is SuitabilityBindingStatus.BLOCKED
+    assert blocked_result.selected_strategy_id is None
+
+
+def test_20_nontrivial_result_has_reason_codes() -> None:
+    result = _evaluate()
+    assert result.reason_codes
+
+
+def test_21_stale_trading_epoch_blocks() -> None:
+    assessment = _directional_assessment(trading_epoch=44)
+    survival = _survival_result(directional_assessment=assessment, trading_epoch=44)
+    result = _evaluate(
+        trading_epoch=43,
+        directional_assessment=assessment,
+        survival_result=survival,
+    )
+    assert result.status is SuitabilityBindingStatus.BLOCKED
+    assert "epoch_semantics_failed" in result.reason_codes[0]
+
+
+def test_22_untrusted_input_no_pass() -> None:
+    result = _evaluate(input_complete=False)
+    assert result.status is not SuitabilityBindingStatus.PASS
+
+
+def test_23_long_short_mirror_contract_types() -> None:
+    anchor = 4000.0
+    long_path = (anchor, anchor + 50.0)
+    short_path = mirror_price_path_for_short(long_path, anchor)
+    long_assessment = _directional_assessment(
+        side=DirectionalAssessmentSide.LONG,
+        price_path=long_path,
+        reference_price=anchor,
+    )
+    short_assessment = _directional_assessment(
+        side=DirectionalAssessmentSide.SHORT,
+        price_path=short_path,
+        reference_price=anchor,
+    )
+    long_survival = _survival_result(
+        side=DirectionalAssessmentSide.LONG,
+        directional_assessment=long_assessment,
+    )
+    short_survival = _survival_result(
+        side=DirectionalAssessmentSide.SHORT,
+        directional_assessment=short_assessment,
+    )
+    long_entry = _strategy_entry(supported_sides=(DirectionalAssessmentSide.LONG,))
+    short_entry = mirror_suitability_strategy_entry_for_short(long_entry)
+    long_result = _evaluate(
+        side=DirectionalAssessmentSide.LONG,
+        directional_assessment=long_assessment,
+        survival_result=long_survival,
+        strategy_registry=_registry(long_entry),
+    )
+    short_result = _evaluate(
+        side=DirectionalAssessmentSide.SHORT,
+        directional_assessment=short_assessment,
+        survival_result=short_survival,
+        strategy_registry=_registry(short_entry),
+    )
+    assert long_result.status is SuitabilityBindingStatus.PASS
+    assert short_result.status is SuitabilityBindingStatus.PASS
+    assert type(long_result) is type(short_result) is SuitabilityResultV1
+
+
+def test_24_directional_assessment_immutable() -> None:
+    assessment = _directional_assessment()
+    before = assessment
+    _evaluate(directional_assessment=assessment)
+    assert assessment == before
+
+
+def test_25_survival_result_immutable() -> None:
+    assessment = _directional_assessment()
+    survival = _survival_result(directional_assessment=assessment)
+    before = survival
+    _evaluate(directional_assessment=assessment, survival_result=survival)
+    assert survival == before
+
+
+def test_26_no_runtime_order_risk_sizing_side_effects() -> None:
+    result = _evaluate()
+    assert result.authority_effect == "NONE"
+    assert result.runtime_effect == "NONE"
+    assert result.order_effect == "NONE"
+    assert result.risk_effect == "NONE"
+
+
+def test_27_futures_only_negative_instrument() -> None:
+    assessment = _directional_assessment(instrument_id="inst-spot-eth-usdt")
+    survival = _survival_result(
+        instrument_id="inst-spot-eth-usdt",
+        directional_assessment=assessment,
+    )
+    result = _evaluate(
+        instrument_id="inst-spot-eth-usdt",
+        directional_assessment=assessment,
+        survival_result=survival,
+    )
+    assert result.status is SuitabilityBindingStatus.BLOCKED
+    assert SuitabilityBlockedReason.INSTRUMENT_KIND_FORBIDDEN.value in result.reason_codes
+
+
+def test_28_no_bitcoin_semantics_in_output() -> None:
+    result = _evaluate(instrument_id="inst-sol-usdt-perp")
+    serialized = serialize_suitability_result_canonical(result).lower()
+    assert "btc" not in serialized
+    assert "bitcoin" not in serialized
+    assert "xbt" not in serialized
+
+
+def test_29_step29f_survival_tests_still_importable() -> None:
+    from trading.master_v2.survival_assessment_v1 import (
+        SurvivalResultV1 as SurvivalResultV1Type,
+        evaluate_survival_assessment_v1,
+    )
+
+    assert SurvivalResultV1Type is not None
+    assert evaluate_survival_assessment_v1 is not None
+
+
+def test_30_no_runtime_adapter_order_imports_or_side_effects() -> None:
+    module_path = Path("src/trading/master_v2/suitability_binding_v1.py")
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append(node.module)
+    forbidden = ("execution", "adapter", "scheduler", "broker", "exchange", "strategies.registry")
+    for imp in imports:
+        for token in forbidden:
+            assert token not in imp
+
+
+def test_no_confidence_only_selection() -> None:
+    high_conf = _strategy_entry(
+        strategy_id="strat-high-confidence",
+        priority_rank=50,
+        confidence_score=0.99,
+    )
+    low_conf = _strategy_entry(
+        strategy_id="strat-low-confidence",
+        priority_rank=10,
+        confidence_score=0.1,
+    )
+    result = _evaluate(strategy_registry=_registry(high_conf, low_conf))
+    assert result.selected_strategy_id == "strat-low-confidence"
+
+
+def test_refs_match_upstream() -> None:
+    assessment = _directional_assessment()
+    survival = _survival_result(directional_assessment=assessment)
+    result = _evaluate(directional_assessment=assessment, survival_result=survival)
+    assert result.directional_assessment_ref == directional_assessment_ref_from_assessment_v1(
+        assessment
+    )
+    assert result.survival_result_ref == survival_result_ref_from_result(survival)
+
+
+def test_with_computed_digest_round_trip() -> None:
+    result = _evaluate()
+    bare = replace(result, semantic_digest="")
+    bound = with_computed_suitability_result_digest(bare)
+    assert bound.semantic_digest == result.semantic_digest
+
+
+def test_layer_version_constant() -> None:
+    assert SUITABILITY_BINDING_LAYER_VERSION == "v1"
+
+
+def test_valid_until_epoch_explicit_and_bounded() -> None:
+    result = _evaluate(trading_epoch=43)
+    assert result.valid_until_epoch == 46
+
+
+def test_module_has_no_evaluate_import_side_effects() -> None:
+    source = inspect.getsource(evaluate_suitability_binding_v1)
+    assert "import execution" not in source
+    assert "import adapter" not in source
+
+
+def test_empty_registry_blocks() -> None:
+    result = _evaluate(strategy_registry=_registry())
+    assert result.status is SuitabilityBindingStatus.BLOCKED
+    assert SuitabilityBlockedReason.STRATEGY_REGISTRY_EMPTY.value in result.reason_codes


### PR DESCRIPTION
## Summary
- Add `SuitabilityResultV1` offline contract with immutable binding to `SurvivalResultV1` and `DirectionalAssessmentV1`.
- Implement explicit regime binding (`unknown_regime` fail-closed), offline strategy registry snapshot evaluation, and versioned ranking policy with deterministic `strategy_id` tie-break.
- Add 37 contract tests covering determinism, survival gate, selection invariants, and Long/Short symmetry.

## Scope boundaries
- No runtime, order, risk, sizing, or authority effects.
- No STEP 29G composition, no progress registry closeout, no legacy consumer rewire.

## Test plan
- [x] `pytest tests/trading/master_v2/test_suitability_binding_v1.py`
- [x] Regression: `pytest tests/trading/master_v2/test_survival_assessment_v1.py`
- [x] PR-bounded timing suite (793 tests, ~48s)
- [x] `ruff format --check` / `ruff check`


Made with [Cursor](https://cursor.com)