### PR TITLE
feat(backtest): MV2 research wiring offline slice (RUNBOOK STEP 29L)

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -104,8 +104,12 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29K_STARTED` | `true` |
 | `RUNBOOK_STEP_29K_IMPLEMENTED_SCOPE` | `strategy_registry_consolidation_v1_slice` |
 | `RUNBOOK_STEP_29K_COMPLETE` | `true` |
-| `STEP_29L_STARTED` | `false` |
-| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
+| `STEP_29L_STARTED` | `true` |
+| `RUNBOOK_STEP_29L_STARTED` | `true` |
+| `RUNBOOK_STEP_29L_IMPLEMENTED_SCOPE` | `mv2_research_wiring_v1_slice` |
+| `RUNBOOK_STEP_29L_COMPLETE` | `false` |
+| `STEP_29M_STARTED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
 | `FOLLOW_UP_DEVEX_SCOPE` | `CANONICAL_PRE_PR_RUFF_AND_DIFF_GUARD` |
 | `FOLLOW_UP_DEVEX_STATUS` | `PENDING_SEPARATE_PR` |
 | `SYSTEMWIDE_RANKING_REQUIRED` | `false` |
@@ -967,7 +971,33 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `RUNBOOK_STEP_29K_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29K_COMPLETE` | `true` |
 | `STRATEGY_REGISTRY_CONSOLIDATION_V1_IMPLEMENTED` | `true` |
-| `STEP_29L_STARTED` | `false` |
+| `STEP_29L_STARTED` | `true` |
+| `RUNBOOK_STEP_29L_STARTED` | `true` |
+| `RUNBOOK_STEP_29L_IMPLEMENTED_SCOPE` | `mv2_research_wiring_v1_slice` |
+| `RUNBOOK_STEP_29L_COMPLETE` | `false` |
+| `STEP_29M_STARTED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
+| `SEPARATE_GO_REQUIRED` | `true` |
+
+#### RUNBOOK_STEP_29L — MV2 Research Wiring v1
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `mv2_research_wiring_v1` |
+| `STATUS` | `IN_PROGRESS` |
+| `CANONICAL_OWNER` | `src/backtest/mv2_research_wiring_v1.py` |
+| `DEPENDENCIES` | RUNBOOK_STEP_29K |
+| `RUNBOOK_STEP_29L_STARTED` | `true` |
+| `RUNBOOK_STEP_29L_IMPLEMENTED_SCOPE` | `mv2_research_wiring_v1_slice` |
+| `RUNBOOK_STEP_29L_COMPLETE` | `false` |
+| `STEP_29M_STARTED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
+| `NEXT_REQUIRED_CONTRACT` | `step_29l_contract_test_matrix_and_closeout` |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `RUNTIME_EFFECT` | `false` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
 | `SEPARATE_GO_REQUIRED` | `true` |
 
 #### RUNBOOK_STEP_29J (legacy heading) — Backtest Engine Rewire Binding

--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -1,0 +1,647 @@
+"""
+Canonical MV2 research wiring owner (RUNBOOK STEP 29L).
+
+Fail-closed offline wiring:
+Historical bars -> CanonicalMarketContextV1 -> integrated replay ->
+CanonicalTradingDecisionEvidenceV1 -> {-1,0,1} position signals ->
+BacktestEngine with cost_config_v0 and strategy registry snapshot binding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import timedelta
+from enum import Enum
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+import pandas as pd
+
+from src.backtest.cost_config_v0 import (
+    EffectiveBacktestCostConfigV0,
+    resolve_effective_backtest_cost_config,
+)
+from src.backtest.engine import BacktestEngine
+from src.backtest.result import BacktestResult
+from src.backtest.stats import compute_backtest_stats
+from src.experiments.monte_carlo import (
+    MonteCarloConfig,
+    MonteCarloSummaryResult,
+    run_monte_carlo_from_equity,
+)
+from src.experiments.stress_tests import (
+    StressScenarioConfig,
+    StressScenarioResult,
+    StressTestSuiteResult,
+    run_stress_test_suite,
+)
+from src.strategies.registry import (
+    REGISTRY_SCHEMA_VERSION,
+    StrategyRegistrySnapshotV1,
+    build_registry_snapshot,
+)
+from src.strategies.suitability_registry_adapter_v1 import build_suitability_registry_from_snapshot
+from src.trading.master_v2.canonical_market_context_v1 import (
+    CANONICAL_MARKET_CONTEXT_LAYER_VERSION,
+    FEATURE_CONTRACT_VERSION,
+    BarFinalityStatus,
+    CanonicalMarketContextBindingStateV1,
+    CanonicalMarketContextV1,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+    WarmupStatus,
+    with_computed_input_digest,
+)
+from src.trading.master_v2.canonical_scope_initialization_v1 import (
+    CANONICAL_SCOPE_INITIALIZATION_LAYER_VERSION,
+    CanonicalScopeInitializationPolicyV1,
+    ScopeInitializationPrerequisitesV1,
+    ScopeReinitializationGuardV1,
+    SCOPE_INITIALIZATION_POLICY_VERSION,
+)
+from src.trading.master_v2.canonical_trading_decision_evidence_v1 import (
+    CANONICAL_TRADING_DECISION_EVIDENCE_LAYER_VERSION,
+    CanonicalTradingDecisionEvidenceV1,
+)
+from src.trading.master_v2.deterministic_scope_event_generator_v1 import (
+    DETERMINISTIC_SCOPE_EVENT_GENERATOR_LAYER_VERSION,
+    SCOPE_EVENT_GENERATOR_POLICY_VERSION,
+    ScopeConfirmationStateV1,
+    ScopeCooldownStateV1,
+    ScopeDirectionState,
+    ScopeEventGeneratorPolicyV1,
+)
+from src.trading.master_v2.directional_assessment_v1 import (
+    DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    DirectionalAssessmentPolicyV1,
+    DirectionalConfirmationStateV1,
+)
+from src.trading.master_v2.double_play_composition_matrix_v1 import (
+    DOUBLE_PLAY_COMPOSITION_MATRIX_POLICY_VERSION,
+    BothCandidateOutcome,
+    BothInvalidOutcome,
+    CompositionDirectionState,
+    DoublePlayCompositionPolicyV1,
+    PositionManagementContext,
+)
+from src.trading.master_v2.double_play_entry_exit_policy_v0 import (
+    ENTRY_EXIT_POLICY_VERSION,
+    DoublePlayEntryExitPolicyV0,
+    EntryExitDirectionState,
+    ExistingPositionSide,
+    PolicySignalV0,
+    PositionState,
+    ReconciliationState,
+    SafetyMode,
+    TradingGate,
+)
+from src.trading.master_v2.double_play_futures_input import FuturesMarketType
+from src.trading.master_v2.double_play_state import SideState
+from src.trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
+    INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+    IntegratedOfflineReplayInputV1,
+    IntegratedOfflineReplayPoliciesV1,
+    run_integrated_offline_trading_logic_replay_v1,
+)
+from src.trading.master_v2.suitability_binding_v1 import (
+    SUITABILITY_RANKING_POLICY_VERSION,
+    SuitabilityBindingStatus,
+    SuitabilityRankingPolicyV1,
+    SuitabilityRegimeStatus,
+)
+from src.trading.master_v2.survival_assessment_v1 import (
+    SURVIVAL_ASSESSMENT_POLICY_VERSION,
+    SurvivalAssessmentPolicyV1,
+)
+
+MV2_RESEARCH_WIRING_LAYER_VERSION = "v1"
+MV2_RESEARCH_WIRING_OWNER = "backtest.mv2_research_wiring_v1"
+MV2_REQUIRED_INSTRUMENT_ID = "inst-eth-usdt-perp"
+
+_REPLAY_IMPLEMENTATION_DIGEST = hashlib.sha256(
+    b"trading.master_v2.integrated_offline_trading_logic_replay_v1"
+).hexdigest()
+_SUPPORTED_STRESS_CLASSES = (
+    "single_crash_bar",
+    "vol_spike",
+    "drawdown_extension",
+    "gap_down_open",
+)
+
+
+class StressClassBindingStatus(str, Enum):
+    BOUND = "BOUND"
+    SUPPORTED_BY_EXISTING_OWNER = "SUPPORTED_BY_EXISTING_OWNER"
+    ADAPTER_REQUIRED_AND_IMPLEMENTED = "ADAPTER_REQUIRED_AND_IMPLEMENTED"
+    DEFERRED_EXPLICIT = "DEFERRED_EXPLICIT"
+    UNSUPPORTED_BLOCKING = "UNSUPPORTED_BLOCKING"
+
+
+@dataclass(frozen=True)
+class MV2ReplayBarOutcomeV1:
+    trading_epoch: int
+    context: CanonicalMarketContextV1
+    evidence: CanonicalTradingDecisionEvidenceV1
+    position_signal: int
+    replay_pass: bool
+    fail_reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MV2ResearchWiringResultV1:
+    instrument_id: str
+    registry_snapshot: StrategyRegistrySnapshotV1
+    effective_cost_config: EffectiveBacktestCostConfigV0
+    bar_outcomes: tuple[MV2ReplayBarOutcomeV1, ...]
+    signals: pd.Series
+    backtest_result: BacktestResult
+
+
+@dataclass(frozen=True)
+class StressClassBindingOutcomeV1:
+    statuses: Mapping[str, StressClassBindingStatus]
+    suite_result: Optional[StressTestSuiteResult]
+
+
+def _fail_closed(condition: bool, reason: str) -> None:
+    if condition:
+        raise ValueError(reason)
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _default_component_versions() -> dict[str, str]:
+    return {
+        "canonical_market_context": CANONICAL_MARKET_CONTEXT_LAYER_VERSION,
+        "canonical_scope_initialization": CANONICAL_SCOPE_INITIALIZATION_LAYER_VERSION,
+        "deterministic_scope_event_generator": DETERMINISTIC_SCOPE_EVENT_GENERATOR_LAYER_VERSION,
+        "directional_assessment": "v1",
+        "survival_assessment": "v1",
+        "suitability_binding": "v1",
+        "double_play_composition_matrix": "v1",
+        "double_play_entry_exit_policy": "v0",
+        "double_play_state": "v0",
+        "integrated_offline_trading_logic_replay": INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+        "canonical_trading_decision_evidence": CANONICAL_TRADING_DECISION_EVIDENCE_LAYER_VERSION,
+    }
+
+
+def _default_policy_versions() -> dict[str, str]:
+    return {
+        "scope_initialization": SCOPE_INITIALIZATION_POLICY_VERSION,
+        "scope_event_generator": SCOPE_EVENT_GENERATOR_POLICY_VERSION,
+        "directional": DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+        "survival": SURVIVAL_ASSESSMENT_POLICY_VERSION,
+        "suitability": SUITABILITY_RANKING_POLICY_VERSION,
+        "composition": DOUBLE_PLAY_COMPOSITION_MATRIX_POLICY_VERSION,
+        "entry_exit": ENTRY_EXIT_POLICY_VERSION,
+    }
+
+
+def _default_policies() -> IntegratedOfflineReplayPoliciesV1:
+    return IntegratedOfflineReplayPoliciesV1(
+        scope_initialization=CanonicalScopeInitializationPolicyV1(
+            min_scope_band=30.0,
+            max_scope_band=800.0,
+            policy_version=SCOPE_INITIALIZATION_POLICY_VERSION,
+        ),
+        scope_event_generator=ScopeEventGeneratorPolicyV1(
+            hard_max_scope_distance=2000.0,
+            hard_max_adverse_distance=900.0,
+            hard_max_reversal_distance=1200.0,
+            policy_version=SCOPE_EVENT_GENERATOR_POLICY_VERSION,
+        ),
+        directional=DirectionalAssessmentPolicyV1(
+            observe_signal_threshold=0.001,
+            candidate_signal_threshold=0.005,
+            confirmation_signal_threshold=0.01,
+            confirmation_epochs=2,
+            validity_epochs=3,
+            policy_version=DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+        ),
+        survival=SurvivalAssessmentPolicyV1(
+            min_net_edge=0.001,
+            min_volatility_survival_ratio=0.5,
+            min_sequence_survival_ratio=0.5,
+            min_drawdown_survival_ratio=0.5,
+            min_liquidation_buffer_ratio=0.1,
+            validity_epochs=3,
+            policy_version=SURVIVAL_ASSESSMENT_POLICY_VERSION,
+        ),
+        suitability=SuitabilityRankingPolicyV1(
+            validity_epochs=3,
+            no_match_status=SuitabilityBindingStatus.FAIL,
+            policy_version=SUITABILITY_RANKING_POLICY_VERSION,
+        ),
+        composition=DoublePlayCompositionPolicyV1(
+            validity_epochs=3,
+            both_candidate_outcome=BothCandidateOutcome.OBSERVE,
+            both_invalid_outcome=BothInvalidOutcome.BLOCKED,
+            policy_version=DOUBLE_PLAY_COMPOSITION_MATRIX_POLICY_VERSION,
+        ),
+        entry_exit=DoublePlayEntryExitPolicyV0(policy_version=ENTRY_EXIT_POLICY_VERSION),
+    )
+
+
+def _ensure_supported_instrument(instrument_id: str) -> None:
+    lowered = instrument_id.lower()
+    _fail_closed(
+        instrument_id != MV2_REQUIRED_INSTRUMENT_ID, "instrument_not_supported_for_step29l"
+    )
+    _fail_closed("btc" in lowered or "xbt" in lowered, "bitcoin_instrument_forbidden")
+    _fail_closed("spot" in lowered, "spot_instrument_forbidden")
+
+
+def _ensure_no_lookahead(bars: pd.DataFrame) -> None:
+    _fail_closed(not isinstance(bars.index, pd.DatetimeIndex), "bars_must_use_datetimeindex")
+    _fail_closed(not bars.index.is_monotonic_increasing, "lookahead_index_not_monotonic")
+    if "decision_time" in bars.columns:
+        for ts, decision_time in zip(bars.index, bars["decision_time"]):
+            decision_ts = pd.Timestamp(decision_time)
+            _fail_closed(decision_ts > ts, "lookahead_decision_after_market_event")
+
+
+def _price(row: pd.Series, key: str, fallback: str = "close") -> float:
+    value = row.get(key, row.get(fallback))
+    if value is None:
+        raise ValueError(f"missing_price_field:{key}")
+    return float(value)
+
+
+def bind_historical_bar_to_canonical_market_context_v1(
+    *,
+    bar: pd.Series,
+    instrument_id: str,
+    trading_epoch: int,
+) -> CanonicalMarketContextV1:
+    _ensure_supported_instrument(instrument_id)
+    is_final = bool(bar.get("is_final", True))
+    _fail_closed(not is_final, "bar_unfinalized")
+
+    ts = pd.Timestamp(bar.name)
+    market_event_time = ts.isoformat()
+    decision_ts = pd.Timestamp(bar.get("decision_time", ts + timedelta(seconds=1)))
+    _fail_closed(decision_ts < ts, "decision_time_before_market_event")
+
+    best_bid = _price(bar, "best_bid")
+    best_ask = _price(bar, "best_ask")
+    spread = float(bar.get("spread", best_ask - best_bid))
+    context = CanonicalMarketContextV1(
+        context_id=f"mv2-ctx-{instrument_id}-{trading_epoch}",
+        instrument_id=instrument_id,
+        market_type=FuturesMarketType.PERPETUAL,
+        trading_epoch=trading_epoch,
+        market_event_time=market_event_time,
+        decision_time=decision_ts.isoformat(),
+        bar_interval=str(bar.get("bar_interval", "1m")),
+        bar_finality_status=BarFinalityStatus.FINALIZED
+        if is_final
+        else BarFinalityStatus.UNFINALIZED,
+        mark_price=_price(bar, "mark_price"),
+        index_price=_price(bar, "index_price"),
+        best_bid=best_bid,
+        best_ask=best_ask,
+        spread=spread,
+        volume=float(bar.get("volume", 0.0)),
+        open_interest=float(bar.get("open_interest", 0.0)),
+        funding_rate=float(bar.get("funding_rate", 0.0)),
+        volatility_estimate=float(bar.get("volatility_estimate", 0.2)),
+        trend_feature_set={"trend_slope": float(bar.get("trend_slope", 0.01))},
+        momentum_feature_set={"momentum": float(bar.get("momentum", 0.01))},
+        liquidity_feature_set={"liq_score": float(bar.get("liq_score", 0.9))},
+        market_structure_feature_set={"range_ratio": float(bar.get("range_ratio", 0.4))},
+        data_integrity_status=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        warmup_status=WarmupStatus.WARMUP_COMPLETE,
+        feature_contract_version=FEATURE_CONTRACT_VERSION,
+    )
+    return with_computed_input_digest(context)
+
+
+def map_decision_evidence_to_position_signal_v1(
+    evidence: CanonicalTradingDecisionEvidenceV1,
+) -> int:
+    """Adapter-only mapping from canonical decision outcome to backtest signal."""
+    outcome = str(evidence.decision_outcome).lower()
+    if outcome in {"enter_long"}:
+        return 1
+    if outcome in {"enter_short"}:
+        return -1
+    return 0
+
+
+def bind_walk_forward_windows_v1(
+    bars: pd.DataFrame,
+    *,
+    train_bars: int,
+    test_bars: int,
+    step_bars: int,
+) -> tuple[tuple[slice, slice], ...]:
+    _fail_closed(train_bars <= 0, "walk_forward_train_bars_invalid")
+    _fail_closed(test_bars <= 0, "walk_forward_test_bars_invalid")
+    _fail_closed(step_bars <= 0, "walk_forward_step_bars_invalid")
+    _fail_closed(len(bars) < train_bars + test_bars, "walk_forward_insufficient_bars")
+
+    windows: list[tuple[slice, slice]] = []
+    start = 0
+    while start + train_bars + test_bars <= len(bars):
+        train_slice = slice(start, start + train_bars)
+        test_slice = slice(start + train_bars, start + train_bars + test_bars)
+        windows.append((train_slice, test_slice))
+        start += step_bars
+    return tuple(windows)
+
+
+def bind_monte_carlo_analysis_v1(
+    backtest_result: BacktestResult,
+    config: MonteCarloConfig,
+) -> MonteCarloSummaryResult:
+    return run_monte_carlo_from_equity(backtest_result.equity_curve, config)
+
+
+def bind_stress_class_suite_v1(
+    returns: pd.Series,
+    *,
+    requested_classes: Optional[Sequence[str]] = None,
+    stats_fn: Optional[Callable[[pd.Series], Mapping[str, float]]] = None,
+) -> StressClassBindingOutcomeV1:
+    if stats_fn is None:
+
+        def _default_stats_fn(ret: pd.Series) -> Mapping[str, float]:
+            equity = (1.0 + ret).cumprod() * 10_000.0
+            return compute_backtest_stats([], equity)
+
+        stats_fn = _default_stats_fn
+
+    classes = tuple(requested_classes or _SUPPORTED_STRESS_CLASSES)
+    statuses: dict[str, StressClassBindingStatus] = {}
+    scenarios: list[StressScenarioConfig] = []
+    for cls in classes:
+        if cls in _SUPPORTED_STRESS_CLASSES:
+            statuses[cls] = StressClassBindingStatus.SUPPORTED_BY_EXISTING_OWNER
+            scenarios.append(StressScenarioConfig(scenario_type=cls))
+        else:
+            statuses[cls] = StressClassBindingStatus.UNSUPPORTED_BLOCKING
+
+    for required in _SUPPORTED_STRESS_CLASSES:
+        statuses.setdefault(required, StressClassBindingStatus.BOUND)
+        _fail_closed(
+            statuses[required] is StressClassBindingStatus.UNSUPPORTED_BLOCKING,
+            f"required_stress_class_unsupported:{required}",
+        )
+
+    suite: Optional[StressTestSuiteResult] = None
+    if scenarios:
+        suite = run_stress_test_suite(returns=returns, scenarios=scenarios, stats_fn=stats_fn)
+
+    return StressClassBindingOutcomeV1(statuses=statuses, suite_result=suite)
+
+
+def compute_mv2_evidence_chain_digests_v1(
+    *,
+    context: CanonicalMarketContextV1,
+    evidence: CanonicalTradingDecisionEvidenceV1,
+    registry_snapshot: StrategyRegistrySnapshotV1,
+    cost_config: EffectiveBacktestCostConfigV0,
+) -> Mapping[str, str]:
+    chain = {
+        "market_context_input_digest": context.input_digest,
+        "decision_evidence_semantic_digest": evidence.semantic_digest,
+        "registry_input_digest": registry_snapshot.input_digest,
+        "registry_semantic_digest": registry_snapshot.semantic_digest,
+        "cost_config_digest": cost_config.config_digest,
+    }
+    chain_digest = _stable_digest(chain)
+    return {**chain, "wiring_chain_digest": chain_digest}
+
+
+def compute_mv2_backtest_metrics_v1(result: BacktestResult) -> Mapping[str, float]:
+    trades: list[dict[str, Any]] = []
+    if result.trades is not None and not result.trades.empty:
+        trades = result.trades.to_dict(orient="records")
+    return compute_backtest_stats(trades=trades, equity_curve=result.equity_curve)
+
+
+def _build_replay_input(
+    *,
+    replay_id: str,
+    instrument_id: str,
+    trading_epoch: int,
+    context: CanonicalMarketContextV1,
+    strategy_registry: Any,
+    config_digest: str,
+    implementation_digest: str,
+    input_digest: str,
+) -> IntegratedOfflineReplayInputV1:
+    price_path = (float(context.mark_price), float(context.mark_price + 5.0))
+    return IntegratedOfflineReplayInputV1(
+        replay_id=replay_id,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        canonical_market_context=context,
+        market_context_binding_state=CanonicalMarketContextBindingStateV1(),
+        scope_prerequisites=ScopeInitializationPrerequisitesV1(
+            required_window_complete=True,
+            instrument_metadata_valid=True,
+            finalized_market_context=True,
+        ),
+        scope_reinitialization_guard=ScopeReinitializationGuardV1(),
+        existing_scope=None,
+        scope_direction_state=ScopeDirectionState.LONG,
+        scope_confirmation_state=ScopeConfirmationStateV1(
+            candidate_kind=None,
+            candidate_count=1,
+            last_evaluated_trading_epoch=trading_epoch - 1,
+        ),
+        scope_cooldown_state=ScopeCooldownStateV1(
+            active=False,
+            remaining_epochs=0,
+            policy_version=SCOPE_EVENT_GENERATOR_POLICY_VERSION,
+        ),
+        up_distance=120.0,
+        adverse_exit_distance=60.0,
+        reversal_distance=90.0,
+        confirmation_epochs=2,
+        current_price=float(context.mark_price),
+        price_path=price_path,
+        directional_confirmation_state=DirectionalConfirmationStateV1(
+            candidate_count=1,
+            last_evaluated_trading_epoch=trading_epoch - 1,
+            last_signal_strength=0.02,
+        ),
+        strategy_registry=strategy_registry,
+        regime_id="trending",
+        regime_status=SuitabilityRegimeStatus.KNOWN,
+        previous_composition_direction_state=CompositionDirectionState.NEUTRAL,
+        position_management_context=PositionManagementContext.FLAT,
+        last_evaluated_trading_epoch=trading_epoch - 1,
+        side_state=SideState.LONG_ARMED,
+        direction_state=EntryExitDirectionState.LONG_ARMED,
+        position_state=PositionState.FLAT_RECONCILED,
+        reconciliation_state=ReconciliationState.RECONCILED,
+        trading_gate=TradingGate.ENTRY_ALLOWED,
+        safety_mode=SafetyMode.NORMAL,
+        existing_position_side=ExistingPositionSide.NONE,
+        venue_flat=True,
+        cooldown_pass=True,
+        scope_adverse_exit_signal=PolicySignalV0(triggered=False),
+        profit_protection_signal=PolicySignalV0(triggered=False),
+        time_exit_signal=PolicySignalV0(triggered=False),
+        strategy_invalidation_signal=PolicySignalV0(triggered=False),
+        hard_risk_reduction_signal=PolicySignalV0(triggered=False),
+        safety_exit_signal=PolicySignalV0(triggered=False),
+        policies=_default_policies(),
+        component_versions=_default_component_versions(),
+        policy_versions=_default_policy_versions(),
+        config_digest=config_digest,
+        implementation_digest=implementation_digest,
+        input_digest=input_digest,
+        expected_component_contracts=_default_component_versions(),
+        context_reference=f"mv2-research-{trading_epoch}",
+        now_tick=trading_epoch,
+    )
+
+
+def run_mv2_research_backtest_wiring_v1(
+    bars: pd.DataFrame,
+    *,
+    strategy_id: str,
+    cfg: Mapping[str, Any],
+    instrument_id: str = MV2_REQUIRED_INSTRUMENT_ID,
+    expected_registry_input_digest: Optional[str] = None,
+    expected_registry_semantic_digest: Optional[str] = None,
+    expected_registry_schema_version: str = REGISTRY_SCHEMA_VERSION,
+    expected_cost_model_version: str = "backtest_cost_v0",
+    expected_data_layer_version: str = CANONICAL_MARKET_CONTEXT_LAYER_VERSION,
+    expected_replay_layer_version: str = INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+    expected_implementation_digest: Optional[str] = None,
+    explicit_zero_cost_non_economic: bool = False,
+) -> MV2ResearchWiringResultV1:
+    _fail_closed(bars.empty, "bars_empty")
+    _ensure_supported_instrument(instrument_id)
+    _ensure_no_lookahead(bars)
+
+    snapshot = build_registry_snapshot()
+    _fail_closed(
+        snapshot.registry_schema_version != expected_registry_schema_version,
+        "registry_schema_version_mismatch",
+    )
+    if expected_registry_input_digest is not None:
+        _fail_closed(
+            snapshot.input_digest != expected_registry_input_digest,
+            "registry_input_digest_mismatch",
+        )
+    if expected_registry_semantic_digest is not None:
+        _fail_closed(
+            snapshot.semantic_digest != expected_registry_semantic_digest,
+            "registry_semantic_digest_mismatch",
+        )
+
+    _fail_closed(strategy_id not in set(snapshot.strategy_ids_sorted), "unknown_strategy")
+    suitability_registry = build_suitability_registry_from_snapshot(snapshot)
+    _fail_closed(
+        suitability_registry is None or len(suitability_registry.entries) == 0, "missing_registry"
+    )
+
+    effective_cost = resolve_effective_backtest_cost_config(
+        cfg,
+        explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+    )
+    _fail_closed(
+        effective_cost.taker_fee_bps == 0.0
+        and effective_cost.entry_slippage_bps == 0.0
+        and not explicit_zero_cost_non_economic,
+        "zero_cost_without_explicit_flag",
+    )
+    _fail_closed(
+        effective_cost.cost_model_version != expected_cost_model_version,
+        "cost_model_version_mismatch",
+    )
+    _fail_closed(
+        expected_data_layer_version != CANONICAL_MARKET_CONTEXT_LAYER_VERSION,
+        "data_layer_version_mismatch",
+    )
+    _fail_closed(
+        expected_replay_layer_version != INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+        "replay_layer_version_mismatch",
+    )
+
+    implementation_digest = expected_implementation_digest or _REPLAY_IMPLEMENTATION_DIGEST
+    _fail_closed(
+        expected_implementation_digest is not None
+        and expected_implementation_digest != _REPLAY_IMPLEMENTATION_DIGEST,
+        "implementation_digest_mismatch",
+    )
+
+    replay_id = f"mv2-research-{len(bars)}"
+    config_digest = _stable_digest({"cfg": dict(cfg), "owner": MV2_RESEARCH_WIRING_OWNER})
+    outcomes: list[MV2ReplayBarOutcomeV1] = []
+    signals: list[int] = []
+    signal_index: list[pd.Timestamp] = []
+    for i, (_, row) in enumerate(bars.iterrows()):
+        context = bind_historical_bar_to_canonical_market_context_v1(
+            bar=row,
+            instrument_id=instrument_id,
+            trading_epoch=i,
+        )
+        input_digest = _stable_digest(
+            {
+                "context_digest": context.input_digest,
+                "epoch": i,
+                "registry_input_digest": snapshot.input_digest,
+                "cost_digest": effective_cost.config_digest,
+            }
+        )
+        replay_input = _build_replay_input(
+            replay_id=replay_id,
+            instrument_id=instrument_id,
+            trading_epoch=i,
+            context=context,
+            strategy_registry=suitability_registry,
+            config_digest=config_digest,
+            implementation_digest=implementation_digest,
+            input_digest=input_digest,
+        )
+        replay_result = run_integrated_offline_trading_logic_replay_v1(replay_input)
+        signal = map_decision_evidence_to_position_signal_v1(replay_result.evidence)
+        outcomes.append(
+            MV2ReplayBarOutcomeV1(
+                trading_epoch=i,
+                context=context,
+                evidence=replay_result.evidence,
+                position_signal=signal,
+                replay_pass=replay_result.replay_pass,
+                fail_reasons=replay_result.fail_reasons,
+            )
+        )
+        signals.append(signal)
+        signal_index.append(pd.Timestamp(row.name))
+
+    signal_series = pd.Series(signals, index=pd.DatetimeIndex(signal_index), dtype=int)
+
+    def _signal_fn(df: pd.DataFrame, params: Mapping[str, Any]) -> pd.Series:  # noqa: ARG001
+        return signal_series.reindex(df.index).fillna(0).astype(int)
+
+    engine = BacktestEngine(use_execution_pipeline=False)
+    engine.config = dict(cfg)
+    backtest_result = engine.run_realistic(
+        df=bars,
+        strategy_signal_fn=_signal_fn,
+        strategy_params={"strategy_id": strategy_id},
+        symbol=instrument_id,
+        cost_config=effective_cost,
+        explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+    )
+
+    return MV2ResearchWiringResultV1(
+        instrument_id=instrument_id,
+        registry_snapshot=snapshot,
+        effective_cost_config=effective_cost,
+        bar_outcomes=tuple(outcomes),
+        signals=signal_series,
+        backtest_result=backtest_result,
+    )

--- a/tests/backtest/test_mv2_research_wiring_v1.py
+++ b/tests/backtest/test_mv2_research_wiring_v1.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Mapping
+
+import pandas as pd
+import pytest
+
+from src.backtest import mv2_research_wiring_v1 as wiring
+from src.experiments.stress_tests import StressScenarioResult
+from src.trading.master_v2.canonical_trading_decision_evidence_v1 import (
+    CanonicalTradingDecisionEvidenceV1,
+    with_computed_evidence_semantic_digest,
+)
+
+
+def _cfg(*, fee_bps: float = 10.0, slippage_bps: float = 5.0) -> Mapping[str, Any]:
+    return {
+        "backtest": {
+            "initial_cash": 10_000.0,
+            "cost_model_version": "backtest_cost_v0",
+            "fee_bps": fee_bps,
+            "slippage_bps": slippage_bps,
+        },
+        "risk": {
+            "risk_per_trade": 0.02,
+            "max_position_size": 0.25,
+            "min_position_value": 10.0,
+            "min_stop_distance": 0.0001,
+        },
+    }
+
+
+def _bars(n: int = 12) -> pd.DataFrame:
+    idx = pd.date_range("2026-06-01", periods=n, freq="1h", tz="UTC")
+    close = [100.0 + float(i) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": close,
+            "index_price": [v - 0.1 for v in close],
+            "best_bid": [v - 0.05 for v in close],
+            "best_ask": [v + 0.05 for v in close],
+            "spread": [0.1 for _ in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": [0.0001 for _ in close],
+            "volatility_estimate": [0.2 for _ in close],
+            "is_final": [True for _ in close],
+            "bar_interval": ["1m" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def _run(**kwargs: Any) -> wiring.MV2ResearchWiringResultV1:
+    return wiring.run_mv2_research_backtest_wiring_v1(
+        bars=kwargs.pop("bars", _bars()),
+        strategy_id=kwargs.pop("strategy_id", "ma_crossover"),
+        cfg=kwargs.pop("cfg", _cfg()),
+        **kwargs,
+    )
+
+
+def test_matrix_01_layer_version_constant() -> None:
+    assert wiring.MV2_RESEARCH_WIRING_LAYER_VERSION == "v1"
+
+
+def test_matrix_02_owner_constant() -> None:
+    assert wiring.MV2_RESEARCH_WIRING_OWNER == "backtest.mv2_research_wiring_v1"
+
+
+def test_matrix_03_required_instrument_constant() -> None:
+    assert wiring.MV2_REQUIRED_INSTRUMENT_ID == "inst-eth-usdt-perp"
+
+
+def test_matrix_04_reject_non_step29l_instrument() -> None:
+    with pytest.raises(ValueError, match="instrument_not_supported_for_step29l"):
+        _run(instrument_id="inst-sol-usdt-perp")
+
+
+def test_matrix_05_reject_bitcoin_instrument() -> None:
+    with pytest.raises(ValueError, match="instrument_not_supported_for_step29l"):
+        _run(instrument_id="inst-btc-usdt-perp")
+
+
+def test_matrix_06_reject_spot_instrument() -> None:
+    with pytest.raises(ValueError, match="instrument_not_supported_for_step29l"):
+        _run(instrument_id="inst-eth-usdt-spot")
+
+
+def test_matrix_07_fail_on_unfinalized_bar() -> None:
+    bars = _bars()
+    bars.loc[bars.index[0], "is_final"] = False
+    with pytest.raises(ValueError, match="bar_unfinalized"):
+        _run(bars=bars)
+
+
+def test_matrix_08_fail_on_lookahead_decision_time() -> None:
+    bars = _bars()
+    bars["decision_time"] = [ts + pd.Timedelta(hours=2) for ts in bars.index]
+    with pytest.raises(ValueError, match="lookahead_decision_after_market_event"):
+        _run(bars=bars)
+
+
+def test_matrix_09_fail_on_non_monotonic_index() -> None:
+    bars = _bars().sort_index(ascending=False)
+    with pytest.raises(ValueError, match="lookahead_index_not_monotonic"):
+        _run(bars=bars)
+
+
+def test_matrix_10_fail_on_missing_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _EmptyRegistry:
+        entries: tuple[Any, ...] = ()
+
+    monkeypatch.setattr(
+        wiring, "build_suitability_registry_from_snapshot", lambda s: _EmptyRegistry()
+    )
+    with pytest.raises(ValueError, match="missing_registry"):
+        _run()
+
+
+def test_matrix_11_fail_on_registry_input_digest_mismatch() -> None:
+    with pytest.raises(ValueError, match="registry_input_digest_mismatch"):
+        _run(expected_registry_input_digest="0" * 64)
+
+
+def test_matrix_12_fail_on_registry_semantic_digest_mismatch() -> None:
+    with pytest.raises(ValueError, match="registry_semantic_digest_mismatch"):
+        _run(expected_registry_semantic_digest="0" * 64)
+
+
+def test_matrix_13_fail_on_cost_model_version_mismatch() -> None:
+    with pytest.raises(ValueError, match="cost_model_version_mismatch"):
+        _run(expected_cost_model_version="backtest_cost_v999")
+
+
+def test_matrix_14_fail_on_data_layer_version_mismatch() -> None:
+    with pytest.raises(ValueError, match="data_layer_version_mismatch"):
+        _run(expected_data_layer_version="v999")
+
+
+def test_matrix_15_fail_on_replay_layer_version_mismatch() -> None:
+    with pytest.raises(ValueError, match="replay_layer_version_mismatch"):
+        _run(expected_replay_layer_version="v999")
+
+
+def test_matrix_16_fail_on_implementation_digest_mismatch() -> None:
+    with pytest.raises(ValueError, match="implementation_digest_mismatch"):
+        _run(expected_implementation_digest="f" * 64)
+
+
+def test_matrix_17_fail_on_zero_cost_without_explicit_flag() -> None:
+    with pytest.raises(Exception):
+        _run(cfg=_cfg(fee_bps=0.0, slippage_bps=0.0))
+
+
+def test_matrix_18_allow_zero_cost_with_explicit_flag() -> None:
+    result = _run(cfg=_cfg(fee_bps=0.0, slippage_bps=0.0), explicit_zero_cost_non_economic=True)
+    assert result.effective_cost_config.zero_cost_explicitly_requested is True
+
+
+def test_matrix_19_fail_on_unknown_strategy() -> None:
+    with pytest.raises(ValueError, match="unknown_strategy"):
+        _run(strategy_id="does_not_exist")
+
+
+def test_matrix_20_signal_adapter_enter_long() -> None:
+    ev = CanonicalTradingDecisionEvidenceV1(
+        decision_id="d",
+        replay_id="r",
+        instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+        trading_epoch=1,
+        market_context_ref="m",
+        scope_initialization_ref="s",
+        scope_event_ref="se",
+        bull_assessment_ref="b1",
+        bear_assessment_ref="b2",
+        state_switch_ref="sw",
+        bull_survival_ref="su1",
+        bear_survival_ref="su2",
+        bull_suitability_ref="sb1",
+        bear_suitability_ref="sb2",
+        composition_result_ref="c",
+        entry_exit_policy_ref="p",
+        current_scope_ref="cs",
+        next_scope_ref="ns",
+        previous_direction_state="NEUTRAL",
+        next_direction_state="LONG_ARMED",
+        selected_side="long",
+        selected_strategy_ref="st",
+        decision_outcome="enter_long",
+        entry_or_exit_policy_ref="p",
+        reason_codes=(),
+        decision_precedence_trace=(),
+        component_versions={},
+        policy_versions={},
+        config_digest="a" * 64,
+        implementation_digest="b" * 64,
+        input_digest="c" * 64,
+        semantic_digest="",
+    )
+    ev = with_computed_evidence_semantic_digest(ev)
+    assert wiring.map_decision_evidence_to_position_signal_v1(ev) == 1
+
+
+def test_matrix_21_signal_adapter_enter_short() -> None:
+    ev = replace(_run().bar_outcomes[0].evidence, decision_outcome="enter_short")
+    assert wiring.map_decision_evidence_to_position_signal_v1(ev) == -1
+
+
+def test_matrix_22_signal_adapter_other_to_flat() -> None:
+    ev = replace(_run().bar_outcomes[0].evidence, decision_outcome="blocked")
+    assert wiring.map_decision_evidence_to_position_signal_v1(ev) == 0
+
+
+def test_matrix_23_end_to_end_returns_signal_series() -> None:
+    result = _run()
+    assert len(result.signals) == len(_bars())
+
+
+def test_matrix_24_end_to_end_returns_backtest_result() -> None:
+    result = _run()
+    assert result.backtest_result is not None
+    assert "cost_model_version" in result.backtest_result.metadata
+
+
+def test_matrix_25_backtest_uses_bound_cost_config() -> None:
+    result = _run()
+    assert result.backtest_result.metadata["fee_bps"] == 10.0
+    assert result.backtest_result.metadata["slippage_bps"] == 5.0
+
+
+def test_matrix_26_registry_snapshot_bound() -> None:
+    result = _run()
+    assert result.registry_snapshot.registry_schema_version == "strategy_registry_v1"
+    assert result.registry_snapshot.input_digest
+
+
+def test_matrix_27_context_digest_is_populated() -> None:
+    result = _run()
+    assert result.bar_outcomes[0].context.input_digest
+
+
+def test_matrix_28_evidence_digest_is_populated() -> None:
+    result = _run()
+    assert result.bar_outcomes[0].evidence.semantic_digest
+
+
+def test_matrix_29_walk_forward_binding_valid() -> None:
+    windows = wiring.bind_walk_forward_windows_v1(_bars(20), train_bars=8, test_bars=4, step_bars=4)
+    assert len(windows) == 3
+
+
+def test_matrix_30_walk_forward_train_invalid() -> None:
+    with pytest.raises(ValueError, match="walk_forward_train_bars_invalid"):
+        wiring.bind_walk_forward_windows_v1(_bars(20), train_bars=0, test_bars=4, step_bars=2)
+
+
+def test_matrix_31_walk_forward_test_invalid() -> None:
+    with pytest.raises(ValueError, match="walk_forward_test_bars_invalid"):
+        wiring.bind_walk_forward_windows_v1(_bars(20), train_bars=8, test_bars=0, step_bars=2)
+
+
+def test_matrix_32_walk_forward_step_invalid() -> None:
+    with pytest.raises(ValueError, match="walk_forward_step_bars_invalid"):
+        wiring.bind_walk_forward_windows_v1(_bars(20), train_bars=8, test_bars=4, step_bars=0)
+
+
+def test_matrix_33_walk_forward_insufficient_data() -> None:
+    with pytest.raises(ValueError, match="walk_forward_insufficient_bars"):
+        wiring.bind_walk_forward_windows_v1(_bars(10), train_bars=8, test_bars=4, step_bars=2)
+
+
+def test_matrix_34_monte_carlo_binding_runs() -> None:
+    result = _run()
+    summary = wiring.bind_monte_carlo_analysis_v1(
+        result.backtest_result, wiring.MonteCarloConfig(num_runs=8, seed=42)
+    )
+    assert summary.num_runs > 0
+
+
+def test_matrix_35_monte_carlo_binding_deterministic_seed() -> None:
+    result = _run()
+    cfg = wiring.MonteCarloConfig(num_runs=8, seed=42)
+    s1 = wiring.bind_monte_carlo_analysis_v1(result.backtest_result, cfg)
+    s2 = wiring.bind_monte_carlo_analysis_v1(result.backtest_result, cfg)
+    assert s1.metric_quantiles["total_return"]["p50"] == s2.metric_quantiles["total_return"]["p50"]
+
+
+def test_matrix_36_stress_binding_required_classes_supported() -> None:
+    returns = _run().backtest_result.equity_curve.pct_change().dropna()
+    outcome = wiring.bind_stress_class_suite_v1(returns)
+    for cls in ("single_crash_bar", "vol_spike", "drawdown_extension", "gap_down_open"):
+        assert outcome.statuses[cls] != wiring.StressClassBindingStatus.UNSUPPORTED_BLOCKING
+
+
+def test_matrix_37_stress_binding_marks_unknown_class_blocking() -> None:
+    returns = _run().backtest_result.equity_curve.pct_change().dropna()
+    outcome = wiring.bind_stress_class_suite_v1(returns, requested_classes=("unknown_class",))
+    assert outcome.statuses["unknown_class"] == wiring.StressClassBindingStatus.UNSUPPORTED_BLOCKING
+
+
+def test_matrix_38_stress_binding_returns_suite_for_supported() -> None:
+    returns = _run().backtest_result.equity_curve.pct_change().dropna()
+    outcome = wiring.bind_stress_class_suite_v1(returns, requested_classes=("single_crash_bar",))
+    assert outcome.suite_result is not None
+    assert isinstance(outcome.suite_result.scenario_results, list)
+
+
+def test_matrix_39_stress_binding_keeps_required_classes_present() -> None:
+    returns = _run().backtest_result.equity_curve.pct_change().dropna()
+    outcome = wiring.bind_stress_class_suite_v1(returns, requested_classes=("single_crash_bar",))
+    assert set(("single_crash_bar", "vol_spike", "drawdown_extension", "gap_down_open")).issubset(
+        set(outcome.statuses.keys())
+    )
+
+
+def test_matrix_40_stress_suite_produces_scenario_result() -> None:
+    returns = _run().backtest_result.equity_curve.pct_change().dropna()
+    outcome = wiring.bind_stress_class_suite_v1(
+        returns, requested_classes=("single_crash_bar", "vol_spike")
+    )
+    assert outcome.suite_result is not None
+    assert len(outcome.suite_result.scenario_results) == 2
+    assert isinstance(outcome.suite_result.scenario_results[0], StressScenarioResult)
+
+
+def test_matrix_41_metrics_binding_has_total_return() -> None:
+    result = _run()
+    metrics = wiring.compute_mv2_backtest_metrics_v1(result.backtest_result)
+    assert "total_return" in metrics
+
+
+def test_matrix_42_metrics_binding_has_trade_count() -> None:
+    result = _run()
+    metrics = wiring.compute_mv2_backtest_metrics_v1(result.backtest_result)
+    assert metrics["total_trades"] >= 0
+
+
+def test_matrix_43_evidence_chain_digest_shape() -> None:
+    result = _run()
+    first = result.bar_outcomes[0]
+    chain = wiring.compute_mv2_evidence_chain_digests_v1(
+        context=first.context,
+        evidence=first.evidence,
+        registry_snapshot=result.registry_snapshot,
+        cost_config=result.effective_cost_config,
+    )
+    assert "wiring_chain_digest" in chain
+    assert len(chain["wiring_chain_digest"]) == 64
+
+
+def test_matrix_44_evidence_chain_digest_deterministic() -> None:
+    result = _run()
+    first = result.bar_outcomes[0]
+    chain_a = wiring.compute_mv2_evidence_chain_digests_v1(
+        context=first.context,
+        evidence=first.evidence,
+        registry_snapshot=result.registry_snapshot,
+        cost_config=result.effective_cost_config,
+    )
+    chain_b = wiring.compute_mv2_evidence_chain_digests_v1(
+        context=first.context,
+        evidence=first.evidence,
+        registry_snapshot=result.registry_snapshot,
+        cost_config=result.effective_cost_config,
+    )
+    assert chain_a["wiring_chain_digest"] == chain_b["wiring_chain_digest"]
+
+
+def test_matrix_45_evidence_chain_digest_changes_with_evidence() -> None:
+    result = _run()
+    first = result.bar_outcomes[0]
+    chain_a = wiring.compute_mv2_evidence_chain_digests_v1(
+        context=first.context,
+        evidence=first.evidence,
+        registry_snapshot=result.registry_snapshot,
+        cost_config=result.effective_cost_config,
+    )
+    ev2 = replace(first.evidence, decision_outcome="observe")
+    ev2 = with_computed_evidence_semantic_digest(ev2)
+    chain_b = wiring.compute_mv2_evidence_chain_digests_v1(
+        context=first.context,
+        evidence=ev2,
+        registry_snapshot=result.registry_snapshot,
+        cost_config=result.effective_cost_config,
+    )
+    assert chain_a["wiring_chain_digest"] != chain_b["wiring_chain_digest"]
+
+
+def test_matrix_46_signals_are_only_minus1_zero_plus1() -> None:
+    result = _run()
+    assert set(result.signals.unique()).issubset({-1, 0, 1})
+
+
+def test_matrix_47_outcomes_signals_are_only_minus1_zero_plus1() -> None:
+    result = _run()
+    assert set(o.position_signal for o in result.bar_outcomes).issubset({-1, 0, 1})
+
+
+def test_matrix_48_stress_outcome_type_contract() -> None:
+    returns = _run().backtest_result.equity_curve.pct_change().dropna()
+    outcome = wiring.bind_stress_class_suite_v1(returns)
+    assert isinstance(outcome, wiring.StressClassBindingOutcomeV1)


### PR DESCRIPTION
## Summary

- Adds canonical `mv2_research_wiring_v1` owner binding STEP 29B–29I integrated offline replay to backtest, walk-forward, Monte Carlo, stress, metrics, and evidence-chain surfaces.
- Fail-closed digest guards for cost (29J), registry (29K), data, implementation, and replay version; no parallel signal SSOT.
- 48 contract tests plus progress registry marks `RUNBOOK_STEP_29L_STARTED=true` (completion closeout deferred).

## Test plan

- [x] `pytest tests/backtest/test_mv2_research_wiring_v1.py` (48 passed)
- [x] PR-bounded-full CI path locally (768 passed, ~52s)
- [x] Regression: integrated replay, cost binding, registry consolidation, walkforward, monte carlo, stress, evidence chain (144 passed)
- [x] `ruff format --check` / `ruff check`
- [x] `ci_test_selection_v1.py` → `PR_BOUNDED_FULL`

## Safety

- `RUNTIME_EFFECT=false`, `ORDER_EFFECT=false`, `LIVE_AUTHORIZED=false`
- `FUTURES_ONLY=true`, `BITCOIN_DIRECTION_ALLOWED=false`
- No economic validity or promotion gates (STEP 29M/29N not started)


Made with [Cursor](https://cursor.com)