### PR TITLE
feat(runbook): STEP 29M EconomicViabilityEvidenceV1 offline slice

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -109,7 +109,12 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29L_IMPLEMENTED_SCOPE` | `mv2_research_wiring_v1_slice,mv2_research_wiring_v1_residual_walkforward_stress_warmup_evidence_slice` |
 | `RUNBOOK_STEP_29L_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29L_COMPLETE` | `true` |
-| `STEP_29M_STARTED` | `false` |
+| `STEP_29M_STARTED` | `true` |
+| `RUNBOOK_STEP_29M_STARTED` | `true` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
+| `RUNBOOK_STEP_29M_COMPLETE` | `false` |
+| `STEP_29N_STARTED` | `false` |
 | `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
 | `FOLLOW_UP_DEVEX_SCOPE` | `CANONICAL_PRE_PR_RUFF_AND_DIFF_GUARD` |
 | `FOLLOW_UP_DEVEX_STATUS` | `PENDING_SEPARATE_PR` |
@@ -1008,6 +1013,36 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `STEP_29M_STARTED` | `false` |
 | `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
 | `SEPARATE_GO_REQUIRED` | `true` |
+
+#### RUNBOOK_STEP_29M — Economic Viability Evidence v1
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `economic_viability_evidence_v1` |
+| `STATUS` | `IN_PROGRESS` |
+| `CANONICAL_OWNER` | `src/backtest/economic_viability_evidence_v1.py` |
+| `DEPENDENCIES` | RUNBOOK_STEP_29L |
+| `REMAINING_GAPS` | `versioned_economic_viability_policy_v1,admissible_versioned_futures_dataset,funding_model_binding,parameter_sensitivity_binding` |
+| `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29M` |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `RUNTIME_EFFECT` | `false` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `ECONOMIC_VALIDITY_PROVEN` | `false` |
+| `PROFITABILITY_CLAIM_ALLOWED` | `false` |
+| `RUNBOOK_STEP_29M_STARTED` | `true` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
+| `RUNBOOK_STEP_29M_COMPLETE` | `false` |
+| `STEP_29N_STARTED` | `false` |
+| `STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_LIVE` | `true` |
+| `STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME` | `true` |
+| `STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS` | `true` |
+| `STEP_29M_COMPLETION_DOES_NOT_CLAIM_ECONOMIC_VALIDITY` | `true` |
+| `STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE` | `true` |
+| `offline_only` | `true` |
+| `non_authorizing` | `true` |
 
 #### RUNBOOK_STEP_29J (legacy heading) — Backtest Engine Rewire Binding
 

--- a/src/backtest/economic_viability_evidence_v1.py
+++ b/src/backtest/economic_viability_evidence_v1.py
@@ -1,0 +1,779 @@
+"""
+Economic Viability Evidence v1 (RUNBOOK STEP 29M).
+
+Fail-closed offline evidence contract bound to the canonical MV2 research chain
+from STEP 29L. Non-authorizing: does not claim profitability or economic validity
+unless all versioned policy gates pass.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+import pandas as pd
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    MANIFEST_FILENAME,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.backtest import mv2_research_wiring_v1 as mv2_wiring
+from src.backtest.cost_config_v0 import FUNDING_MODEL_VERSION
+from src.experiments.monte_carlo import MonteCarloConfig, MonteCarloSummaryResult
+from src.trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
+    INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+)
+
+ECONOMIC_VIABILITY_EVIDENCE_LAYER_VERSION = "v1"
+ECONOMIC_VIABILITY_EVIDENCE_OWNER = "backtest.economic_viability_evidence_v1"
+ECONOMIC_VIABILITY_POLICY_VERSION = "NOT_BOUND"
+ARTIFACT_FILENAME = "economic_viability_evidence_v1.json"
+SCHEMA_FILENAME = "economic_viability_evidence_schema_v1.json"
+OFFLINE_DETERMINISTIC_CREATED_AT = "1970-01-01T00:00:00+00:00"
+
+_STEP29M_ALLOWED_STATUSES = frozenset(
+    {
+        "RESEARCH_ONLY",
+        "PROMISING",
+        "ROBUSTNESS_FAILED",
+        "ECONOMICALLY_VIABLE_OFFLINE",
+    }
+)
+
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+
+
+class EconomicViabilityStatus(str, Enum):
+    RESEARCH_ONLY = "RESEARCH_ONLY"
+    PROMISING = "PROMISING"
+    ROBUSTNESS_FAILED = "ROBUSTNESS_FAILED"
+    ECONOMICALLY_VIABLE_OFFLINE = "ECONOMICALLY_VIABLE_OFFLINE"
+
+
+class DataSourceKind(str, Enum):
+    VERSIONED_CANONICAL_FUTURES = "versioned_canonical_futures"
+    SYNTHETIC_CONTRACT_FIXTURE = "synthetic_contract_fixture"
+    INADMISSIBLE = "inadmissible"
+
+
+class MetricSemantic(str, Enum):
+    COMPUTED = "COMPUTED"
+    UNKNOWN = "UNKNOWN"
+    NOT_COMPUTED = "NOT_COMPUTED"
+
+
+@dataclass(frozen=True)
+class DataAdmissibilityV1:
+    source_kind: DataSourceKind
+    instrument_id: str
+    data_digest: str
+    data_ref: str
+    versioned_dataset_id: Optional[str] = None
+
+    def is_admissible_for_economic_claim(self) -> bool:
+        return self.source_kind is DataSourceKind.VERSIONED_CANONICAL_FUTURES
+
+
+@dataclass(frozen=True)
+class MetricFieldV1:
+    semantic: MetricSemantic
+    value: Optional[float] = None
+    reason_code: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"semantic": self.semantic.value}
+        if self.value is not None:
+            payload["value"] = self.value
+        if self.reason_code is not None:
+            payload["reason_code"] = self.reason_code
+        return payload
+
+
+@dataclass(frozen=True)
+class EconomicViabilityEvidenceV1:
+    contract_version: str
+    owner: str
+    strategy_id: str
+    strategy_version: str
+    instrument_id_or_universe: str
+    canonical_trading_logic_version: str
+    data_period: str
+    training_period: str
+    validation_period: str
+    out_of_sample_period: str
+    fee_model_version: str
+    slippage_model_version: str
+    funding_model_version: str
+    execution_model_version: str
+    config_digest: str
+    implementation_digest: str
+    data_digest: str
+    gross_return: MetricFieldV1
+    net_return: MetricFieldV1
+    net_expectancy: MetricFieldV1
+    profit_factor: MetricFieldV1
+    sharpe: MetricFieldV1
+    sortino: MetricFieldV1
+    max_drawdown: MetricFieldV1
+    calmar: MetricFieldV1
+    trade_count: MetricFieldV1
+    turnover: MetricFieldV1
+    fee_drag: MetricFieldV1
+    funding_drag: MetricFieldV1
+    slippage_impact: MetricFieldV1
+    tail_loss: MetricFieldV1
+    time_in_market: MetricFieldV1
+    long_contribution: MetricFieldV1
+    short_contribution: MetricFieldV1
+    regime_breakdown: Mapping[str, Any]
+    portfolio_contribution: Mapping[str, Any]
+    walk_forward_results: Mapping[str, Any]
+    monte_carlo_results: Mapping[str, Any]
+    stress_results: Mapping[str, Any]
+    parameter_sensitivity_results: Mapping[str, Any]
+    status: EconomicViabilityStatus
+    reason_codes: tuple[str, ...]
+    manifest_digest: str
+    wiring_chain_digest: str
+    randomness_seed: int
+    data_admissibility: Mapping[str, Any]
+    cost_binding: Mapping[str, Any]
+    policy_version: str = ECONOMIC_VIABILITY_POLICY_VERSION
+    economic_validity_proven: bool = False
+    profitability_claim_allowed: bool = False
+    authority_effect: str = "NONE"
+    runtime_effect: bool = False
+    order_effect: bool = False
+    futures_only: bool = True
+    bitcoin_direction_allowed: bool = False
+
+    def to_semantic_dict(self) -> dict[str, Any]:
+        payload = {
+            "contract_version": self.contract_version,
+            "owner": self.owner,
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "instrument_id_or_universe": self.instrument_id_or_universe,
+            "canonical_trading_logic_version": self.canonical_trading_logic_version,
+            "data_period": self.data_period,
+            "training_period": self.training_period,
+            "validation_period": self.validation_period,
+            "out_of_sample_period": self.out_of_sample_period,
+            "fee_model_version": self.fee_model_version,
+            "slippage_model_version": self.slippage_model_version,
+            "funding_model_version": self.funding_model_version,
+            "execution_model_version": self.execution_model_version,
+            "config_digest": self.config_digest,
+            "implementation_digest": self.implementation_digest,
+            "data_digest": self.data_digest,
+            "gross_return": self.gross_return.to_dict(),
+            "net_return": self.net_return.to_dict(),
+            "net_expectancy": self.net_expectancy.to_dict(),
+            "profit_factor": self.profit_factor.to_dict(),
+            "sharpe": self.sharpe.to_dict(),
+            "sortino": self.sortino.to_dict(),
+            "max_drawdown": self.max_drawdown.to_dict(),
+            "calmar": self.calmar.to_dict(),
+            "trade_count": self.trade_count.to_dict(),
+            "turnover": self.turnover.to_dict(),
+            "fee_drag": self.fee_drag.to_dict(),
+            "funding_drag": self.funding_drag.to_dict(),
+            "slippage_impact": self.slippage_impact.to_dict(),
+            "tail_loss": self.tail_loss.to_dict(),
+            "time_in_market": self.time_in_market.to_dict(),
+            "long_contribution": self.long_contribution.to_dict(),
+            "short_contribution": self.short_contribution.to_dict(),
+            "regime_breakdown": dict(self.regime_breakdown),
+            "portfolio_contribution": dict(self.portfolio_contribution),
+            "walk_forward_results": dict(self.walk_forward_results),
+            "monte_carlo_results": dict(self.monte_carlo_results),
+            "stress_results": dict(self.stress_results),
+            "parameter_sensitivity_results": dict(self.parameter_sensitivity_results),
+            "status": self.status.value,
+            "reason_codes": list(self.reason_codes),
+            "manifest_digest": self.manifest_digest,
+            "wiring_chain_digest": self.wiring_chain_digest,
+            "randomness_seed": self.randomness_seed,
+            "data_admissibility": dict(self.data_admissibility),
+            "cost_binding": dict(self.cost_binding),
+            "policy_version": self.policy_version,
+            "economic_validity_proven": self.economic_validity_proven,
+            "profitability_claim_allowed": self.profitability_claim_allowed,
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+            "order_effect": self.order_effect,
+            "futures_only": self.futures_only,
+            "bitcoin_direction_allowed": self.bitcoin_direction_allowed,
+        }
+        return payload
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.to_semantic_dict()
+        payload["created_at"] = OFFLINE_DETERMINISTIC_CREATED_AT
+        return payload
+
+
+class EconomicViabilityEvidenceError(ValueError):
+    """Fail-closed economic viability evidence error."""
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _fail_closed(condition: bool, reason: str) -> None:
+    if condition:
+        raise EconomicViabilityEvidenceError(reason)
+
+
+def _reject_forbidden_instrument(instrument_id: str) -> None:
+    lowered = instrument_id.lower()
+    for token in _FORBIDDEN_INSTRUMENT_SUBSTRINGS:
+        if token in lowered:
+            raise EconomicViabilityEvidenceError(f"instrument_kind_forbidden:{instrument_id}")
+
+
+def compute_bars_data_digest(bars: pd.DataFrame) -> str:
+    if bars.empty:
+        return _stable_digest({"empty": True})
+    frame = bars.sort_index()
+    payload = {
+        "columns": list(frame.columns),
+        "index_start": str(frame.index[0]),
+        "index_end": str(frame.index[-1]),
+        "row_count": len(frame),
+        "close_digest": _stable_digest(frame["close"].astype(float).tolist()),
+    }
+    return _stable_digest(payload)
+
+
+def _period_label(bars: pd.DataFrame) -> str:
+    if bars.empty:
+        return "empty"
+    return f"{bars.index[0]}..{bars.index[-1]}"
+
+
+def _metric_from_stats(key: str, stats: Mapping[str, float]) -> MetricFieldV1:
+    if key not in stats:
+        return MetricFieldV1(semantic=MetricSemantic.UNKNOWN, reason_code=f"metric_missing:{key}")
+    value = float(stats[key])
+    if not math.isfinite(value):
+        return MetricFieldV1(
+            semantic=MetricSemantic.NOT_COMPUTED,
+            reason_code=f"metric_non_finite:{key}",
+        )
+    return MetricFieldV1(semantic=MetricSemantic.COMPUTED, value=value)
+
+
+def _not_computed_metric(reason_code: str) -> MetricFieldV1:
+    return MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED, reason_code=reason_code)
+
+
+def _serialize_monte_carlo(summary: MonteCarloSummaryResult) -> dict[str, Any]:
+    return {
+        "num_runs": summary.num_runs,
+        "seed": summary.config.seed,
+        "method": summary.config.method,
+        "metric_quantiles": {
+            metric: dict(quantiles) for metric, quantiles in summary.metric_quantiles.items()
+        },
+    }
+
+
+def _serialize_walk_forward(
+    wf: mv2_wiring.MV2WalkForwardWiringResultV1,
+) -> dict[str, Any]:
+    windows = []
+    for window in wf.windows:
+        metrics = mv2_wiring.compute_mv2_backtest_metrics_v1(
+            window.oos_wiring_result.backtest_result
+        )
+        windows.append(
+            {
+                "window_index": window.window_index,
+                "train_period_digest": window.train_period_digest,
+                "test_period_digest": window.test_period_digest,
+                "config_digest": window.config_digest,
+                "oos_total_return": metrics.get("total_return"),
+                "oos_trade_count": metrics.get("total_trades"),
+            }
+        )
+    return {
+        "split_contract_digest": wf.split_contract_digest,
+        "window_count": len(windows),
+        "windows": windows,
+    }
+
+
+def _serialize_stress(outcome: mv2_wiring.StressClassBindingOutcomeV1) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "class_statuses": {k: v.value for k, v in outcome.statuses.items()},
+    }
+    if outcome.suite_result is None:
+        payload["suite"] = None
+        return payload
+    payload["suite"] = {
+        "scenario_count": len(outcome.suite_result.scenario_results),
+        "scenarios": [
+            {
+                "scenario_type": result.scenario.scenario_type,
+                "stressed_total_return": result.stressed_metrics.get("total_return"),
+                "stressed_max_drawdown": result.stressed_metrics.get("max_drawdown"),
+            }
+            for result in outcome.suite_result.scenario_results
+        ],
+    }
+    return payload
+
+
+def _evaluate_robustness_failures(
+    *,
+    wf: Optional[mv2_wiring.MV2WalkForwardWiringResultV1],
+    mc: Optional[MonteCarloSummaryResult],
+    stress: Optional[mv2_wiring.StressClassBindingOutcomeV1],
+) -> list[str]:
+    failures: list[str] = []
+    if wf is not None:
+        negative_windows = 0
+        for window in wf.windows:
+            metrics = mv2_wiring.compute_mv2_backtest_metrics_v1(
+                window.oos_wiring_result.backtest_result
+            )
+            if metrics.get("total_return", 0.0) < 0.0:
+                negative_windows += 1
+        if negative_windows == len(wf.windows) and len(wf.windows) > 0:
+            failures.append("walk_forward_all_oos_negative")
+    if mc is not None:
+        total_return_q = mc.metric_quantiles.get("total_return", {})
+        p50 = total_return_q.get("p50")
+        if p50 is not None and p50 < 0.0:
+            failures.append("monte_carlo_median_return_negative")
+    if stress is not None and stress.suite_result is not None:
+        for result in stress.suite_result.scenario_results:
+            stressed_return = result.stressed_metrics.get("total_return")
+            if stressed_return is not None and stressed_return < -0.5:
+                failures.append(f"stress_severe_loss:{result.scenario.scenario_type}")
+    return failures
+
+
+def _resolve_status(
+    *,
+    reason_codes: Sequence[str],
+    robustness_failures: Sequence[str],
+    data_admissible: bool,
+    policy_version_bound: bool,
+    funding_bound: bool,
+    parameter_sensitivity_bound: bool,
+    gates_pass: bool,
+) -> EconomicViabilityStatus:
+    if robustness_failures:
+        return EconomicViabilityStatus.ROBUSTNESS_FAILED
+    if (
+        gates_pass
+        and data_admissible
+        and policy_version_bound
+        and funding_bound
+        and parameter_sensitivity_bound
+    ):
+        return EconomicViabilityStatus.ECONOMICALLY_VIABLE_OFFLINE
+    if not data_admissible or not policy_version_bound or not funding_bound:
+        return EconomicViabilityStatus.RESEARCH_ONLY
+    return EconomicViabilityStatus.PROMISING
+
+
+def build_economic_viability_evidence_v1(
+    *,
+    bars: pd.DataFrame,
+    data_admissibility: DataAdmissibilityV1,
+    strategy_id: str,
+    cfg: Mapping[str, Any],
+    instrument_id: str = mv2_wiring.MV2_REQUIRED_INSTRUMENT_ID,
+    walk_forward_train_bars: int = 8,
+    walk_forward_test_bars: int = 4,
+    walk_forward_step_bars: int = 4,
+    monte_carlo_runs: int = 16,
+    monte_carlo_seed: int = 42,
+    explicit_zero_cost_non_economic: bool = False,
+) -> EconomicViabilityEvidenceV1:
+    _reject_forbidden_instrument(instrument_id)
+    _fail_closed(bars.empty, "bars_empty")
+    if data_admissibility.instrument_id != instrument_id:
+        raise EconomicViabilityEvidenceError("data_admissibility_instrument_mismatch")
+    computed_data_digest = compute_bars_data_digest(bars)
+    if data_admissibility.data_digest != computed_data_digest:
+        raise EconomicViabilityEvidenceError("data_digest_mismatch")
+
+    wiring_result = mv2_wiring.run_mv2_research_backtest_wiring_v1(
+        bars,
+        strategy_id=strategy_id,
+        cfg=cfg,
+        instrument_id=instrument_id,
+        explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+    )
+    stats = mv2_wiring.compute_mv2_backtest_metrics_v1(wiring_result.backtest_result)
+    cost = wiring_result.effective_cost_config
+
+    wf_result: Optional[mv2_wiring.MV2WalkForwardWiringResultV1] = None
+    mc_result: Optional[MonteCarloSummaryResult] = None
+    stress_result: Optional[mv2_wiring.StressClassBindingOutcomeV1] = None
+    reason_codes: list[str] = []
+
+    if len(bars) >= walk_forward_train_bars + walk_forward_test_bars:
+        wf_result = mv2_wiring.run_mv2_walk_forward_wiring_v1(
+            bars,
+            strategy_id=strategy_id,
+            cfg=cfg,
+            train_bars=walk_forward_train_bars,
+            test_bars=walk_forward_test_bars,
+            step_bars=walk_forward_step_bars,
+            instrument_id=instrument_id,
+            explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+        )
+    else:
+        reason_codes.append("walk_forward_insufficient_bars")
+
+    if monte_carlo_runs > 0:
+        mc_result = mv2_wiring.bind_monte_carlo_analysis_v1(
+            wiring_result.backtest_result,
+            MonteCarloConfig(num_runs=monte_carlo_runs, seed=monte_carlo_seed),
+        )
+    else:
+        reason_codes.append("monte_carlo_not_run")
+
+    returns = wiring_result.backtest_result.equity_curve.pct_change().dropna()
+    if not returns.empty:
+        stress_result = mv2_wiring.bind_stress_class_suite_v1(returns)
+    else:
+        reason_codes.append("stress_returns_empty")
+
+    if not data_admissibility.is_admissible_for_economic_claim():
+        reason_codes.append("admissible_versioned_futures_dataset_missing")
+    if data_admissibility.source_kind is DataSourceKind.INADMISSIBLE:
+        reason_codes.append("data_source_inadmissible")
+    if ECONOMIC_VIABILITY_POLICY_VERSION == "NOT_BOUND":
+        reason_codes.append("economic_viability_policy_not_versioned")
+    if FUNDING_MODEL_VERSION == "NOT_BOUND" or cost.funding_model_version == "NOT_BOUND":
+        reason_codes.append("funding_model_not_bound")
+    if cost.zero_cost_explicitly_requested:
+        reason_codes.append("explicit_zero_cost_non_economic_mode")
+    reason_codes.append("parameter_sensitivity_not_bound_in_step29m_scope")
+
+    robustness_failures = _evaluate_robustness_failures(
+        wf=wf_result, mc=mc_result, stress=stress_result
+    )
+    reason_codes.extend(robustness_failures)
+
+    trade_count_value = int(stats.get("total_trades", 0))
+    gates_pass = False
+    if trade_count_value > 0 and stats.get("expectancy", 0.0) > 0.0:
+        gates_pass = True
+    else:
+        reason_codes.append("economic_gate_trade_or_expectancy_insufficient")
+
+    policy_version_bound = ECONOMIC_VIABILITY_POLICY_VERSION != "NOT_BOUND"
+    funding_bound = cost.funding_model_version != "NOT_BOUND"
+    parameter_sensitivity_bound = False
+
+    status = _resolve_status(
+        reason_codes=reason_codes,
+        robustness_failures=robustness_failures,
+        data_admissible=data_admissibility.is_admissible_for_economic_claim(),
+        policy_version_bound=policy_version_bound,
+        funding_bound=funding_bound,
+        parameter_sensitivity_bound=parameter_sensitivity_bound,
+        gates_pass=gates_pass,
+    )
+    _fail_closed(status.value not in _STEP29M_ALLOWED_STATUSES, "status_not_allowed_for_step29m")
+
+    first_outcome = wiring_result.bar_outcomes[0]
+    chain = mv2_wiring.compute_mv2_evidence_chain_digests_v1(
+        context=first_outcome.context,
+        evidence=first_outcome.evidence,
+        registry_snapshot=wiring_result.registry_snapshot,
+        cost_config=cost,
+        strategy_id=strategy_id,
+        data_period=_period_label(bars),
+        fee_model_version=cost.fee_model_version,
+        slippage_model_version=cost.slippage_model_version,
+        funding_model_version_or_status=cost.funding_model_version,
+        execution_model_version=cost.execution_model_version,
+        config_digest=_stable_digest(
+            {"cfg": dict(cfg), "owner": ECONOMIC_VIABILITY_EVIDENCE_OWNER}
+        ),
+        data_digest=computed_data_digest,
+        walk_forward_result_digest_or_status=(
+            wf_result.split_contract_digest if wf_result is not None else "not_run"
+        ),
+        monte_carlo_result_digest_or_status=(
+            _stable_digest(_serialize_monte_carlo(mc_result))
+            if mc_result is not None
+            else "not_run"
+        ),
+        stress_result_digest_or_status=(
+            _stable_digest(_serialize_stress(stress_result))
+            if stress_result is not None
+            else "not_run"
+        ),
+        metrics_digest=_stable_digest({k: float(v) for k, v in stats.items()}),
+    )
+
+    strategy_version = "unknown"
+    for entry in wiring_result.registry_snapshot.entries:
+        if entry.strategy_id == strategy_id:
+            strategy_version = entry.strategy_version
+            break
+
+    semantic_payload = {
+        "strategy_id": strategy_id,
+        "status": status.value,
+        "wiring_chain_digest": chain["wiring_chain_digest"],
+        "reason_codes": sorted(set(reason_codes)),
+    }
+    manifest_digest = _stable_digest(semantic_payload)
+
+    economic_validity_proven = status is EconomicViabilityStatus.ECONOMICALLY_VIABLE_OFFLINE
+
+    return EconomicViabilityEvidenceV1(
+        contract_version=ECONOMIC_VIABILITY_EVIDENCE_LAYER_VERSION,
+        owner=ECONOMIC_VIABILITY_EVIDENCE_OWNER,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        instrument_id_or_universe=instrument_id,
+        canonical_trading_logic_version=INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+        data_period=_period_label(bars),
+        training_period=(
+            _period_label(bars.iloc[wf_result.windows[0].train_slice])
+            if wf_result is not None and wf_result.windows
+            else "not_run"
+        ),
+        validation_period="not_applicable_offline_slice",
+        out_of_sample_period=(
+            _period_label(bars.iloc[wf_result.windows[0].test_slice])
+            if wf_result is not None and wf_result.windows
+            else "not_run"
+        ),
+        fee_model_version=cost.fee_model_version,
+        slippage_model_version=cost.slippage_model_version,
+        funding_model_version=cost.funding_model_version,
+        execution_model_version=cost.execution_model_version,
+        config_digest=_stable_digest(
+            {"cfg": dict(cfg), "owner": ECONOMIC_VIABILITY_EVIDENCE_OWNER}
+        ),
+        implementation_digest=chain["implementation_digest"],
+        data_digest=computed_data_digest,
+        gross_return=_metric_from_stats("total_return", stats),
+        net_return=_metric_from_stats("total_return", stats),
+        net_expectancy=_metric_from_stats("expectancy", stats),
+        profit_factor=_metric_from_stats("profit_factor", stats),
+        sharpe=_metric_from_stats("sharpe", stats),
+        sortino=_metric_from_stats("sortino", stats),
+        max_drawdown=_metric_from_stats("max_drawdown", stats),
+        calmar=_metric_from_stats("calmar", stats),
+        trade_count=MetricFieldV1(semantic=MetricSemantic.COMPUTED, value=float(trade_count_value)),
+        turnover=_not_computed_metric("turnover_not_bound_in_step29m_scope"),
+        fee_drag=_not_computed_metric("fee_drag_decomposition_not_bound"),
+        funding_drag=_not_computed_metric("funding_drag_not_bound"),
+        slippage_impact=_not_computed_metric("slippage_impact_decomposition_not_bound"),
+        tail_loss=_not_computed_metric("tail_loss_metric_not_bound"),
+        time_in_market=_not_computed_metric("time_in_market_not_bound"),
+        long_contribution=_not_computed_metric("long_short_attribution_not_bound"),
+        short_contribution=_not_computed_metric("long_short_attribution_not_bound"),
+        regime_breakdown={
+            "semantic": MetricSemantic.NOT_COMPUTED.value,
+            "reason_code": "regime_breakdown_not_bound",
+        },
+        portfolio_contribution={
+            "semantic": MetricSemantic.NOT_COMPUTED.value,
+            "reason_code": "single_strategy_slice",
+        },
+        walk_forward_results=(
+            _serialize_walk_forward(wf_result)
+            if wf_result is not None
+            else {
+                "semantic": MetricSemantic.NOT_COMPUTED.value,
+                "reason_code": "walk_forward_not_run",
+            }
+        ),
+        monte_carlo_results=(
+            _serialize_monte_carlo(mc_result)
+            if mc_result is not None
+            else {
+                "semantic": MetricSemantic.NOT_COMPUTED.value,
+                "reason_code": "monte_carlo_not_run",
+            }
+        ),
+        stress_results=(
+            _serialize_stress(stress_result)
+            if stress_result is not None
+            else {"semantic": MetricSemantic.NOT_COMPUTED.value, "reason_code": "stress_not_run"}
+        ),
+        parameter_sensitivity_results={
+            "semantic": MetricSemantic.NOT_COMPUTED.value,
+            "reason_code": "parameter_sensitivity_not_bound_in_step29m_scope",
+        },
+        status=status,
+        reason_codes=tuple(sorted(set(reason_codes))),
+        manifest_digest=manifest_digest,
+        wiring_chain_digest=chain["wiring_chain_digest"],
+        randomness_seed=monte_carlo_seed,
+        data_admissibility={
+            "source_kind": data_admissibility.source_kind.value,
+            "instrument_id": data_admissibility.instrument_id,
+            "data_digest": data_admissibility.data_digest,
+            "data_ref": data_admissibility.data_ref,
+            "versioned_dataset_id": data_admissibility.versioned_dataset_id,
+        },
+        cost_binding={
+            "cost_model_version": cost.cost_model_version,
+            "economic_interpretation_allowed": cost.economic_interpretation_allowed,
+            "zero_cost_explicitly_requested": cost.zero_cost_explicitly_requested,
+            "reason_codes": list(cost.reason_codes),
+            "latency_assumption": cost.latency_assumption,
+            "partial_fill_assumption": cost.partial_fill_assumption,
+            "spread_application_policy": cost.spread_application_policy,
+        },
+        economic_validity_proven=economic_validity_proven,
+        profitability_claim_allowed=False,
+    )
+
+
+def economic_viability_evidence_schema_v1() -> dict[str, Any]:
+    return {
+        "contract_name": "economic_viability_evidence_v1",
+        "contract_version": ECONOMIC_VIABILITY_EVIDENCE_LAYER_VERSION,
+        "owner": ECONOMIC_VIABILITY_EVIDENCE_OWNER,
+        "allowed_statuses_step29m": sorted(_STEP29M_ALLOWED_STATUSES),
+        "required_fields": [
+            "strategy_id",
+            "strategy_version",
+            "instrument_id_or_universe",
+            "canonical_trading_logic_version",
+            "data_period",
+            "training_period",
+            "validation_period",
+            "out_of_sample_period",
+            "fee_model_version",
+            "slippage_model_version",
+            "funding_model_version",
+            "execution_model_version",
+            "config_digest",
+            "implementation_digest",
+            "data_digest",
+            "gross_return",
+            "net_return",
+            "net_expectancy",
+            "profit_factor",
+            "sharpe",
+            "sortino",
+            "max_drawdown",
+            "calmar",
+            "trade_count",
+            "turnover",
+            "fee_drag",
+            "funding_drag",
+            "slippage_impact",
+            "tail_loss",
+            "time_in_market",
+            "long_contribution",
+            "short_contribution",
+            "regime_breakdown",
+            "portfolio_contribution",
+            "walk_forward_results",
+            "monte_carlo_results",
+            "stress_results",
+            "parameter_sensitivity_results",
+            "status",
+            "reason_codes",
+            "manifest_digest",
+        ],
+        "metric_semantics": [semantic.value for semantic in MetricSemantic],
+        "data_source_kinds": [kind.value for kind in DataSourceKind],
+        "policy_version": ECONOMIC_VIABILITY_POLICY_VERSION,
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+    }
+
+
+@dataclass(frozen=True)
+class PersistedEconomicViabilityEvidenceBundleV1:
+    output_dir: Path
+    evidence_path: Path
+    schema_path: Path
+    manifest_path: Path
+    manifest_verify_rc: int
+
+
+def persist_economic_viability_evidence_bundle_v1(
+    output_dir: Path,
+    evidence: EconomicViabilityEvidenceV1,
+    *,
+    config_snapshot: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+    input_provenance: Mapping[str, Any],
+) -> PersistedEconomicViabilityEvidenceBundleV1:
+    if output_dir.exists():
+        raise EconomicViabilityEvidenceError(
+            f"output directory already exists (fail-closed): {output_dir}"
+        )
+    output_dir.mkdir(parents=True, exist_ok=False)
+
+    evidence_path = output_dir / ARTIFACT_FILENAME
+    schema_path = output_dir / SCHEMA_FILENAME
+    evidence_path.write_text(
+        json.dumps(evidence.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    schema_path.write_text(
+        json.dumps(economic_viability_evidence_schema_v1(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "CONFIG_SNAPSHOT.json").write_text(
+        json.dumps(dict(config_snapshot), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "METRICS.json").write_text(
+        json.dumps(dict(metrics), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "INPUT_PROVENANCE.json").write_text(
+        json.dumps(dict(input_provenance), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "WALK_FORWARD_RESULTS.json").write_text(
+        json.dumps(evidence.walk_forward_results, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "MONTE_CARLO_RESULTS.json").write_text(
+        json.dumps(evidence.monte_carlo_results, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "STRESS_RESULTS.json").write_text(
+        json.dumps(evidence.stress_results, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "PARAMETER_SENSITIVITY_RESULTS.json").write_text(
+        json.dumps(evidence.parameter_sensitivity_results, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    write_manifest_sha256(output_dir)
+    ok, message = verify_manifest_sha256(output_dir)
+    manifest_verify_rc = 0 if ok else 1
+    if not ok:
+        raise EconomicViabilityEvidenceError(f"manifest_verify_failed:{message}")
+
+    return PersistedEconomicViabilityEvidenceBundleV1(
+        output_dir=output_dir,
+        evidence_path=evidence_path,
+        schema_path=schema_path,
+        manifest_path=output_dir / MANIFEST_FILENAME,
+        manifest_verify_rc=manifest_verify_rc,
+    )

--- a/tests/backtest/test_economic_viability_evidence_v1.py
+++ b/tests/backtest/test_economic_viability_evidence_v1.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+import pandas as pd
+import pytest
+
+from src.backtest import economic_viability_evidence_v1 as ev
+from src.backtest import mv2_research_wiring_v1 as wiring
+
+
+def _cfg(*, fee_bps: float = 10.0, slippage_bps: float = 5.0) -> Mapping[str, Any]:
+    return {
+        "backtest": {
+            "initial_cash": 10_000.0,
+            "cost_model_version": "backtest_cost_v0",
+            "fee_bps": fee_bps,
+            "slippage_bps": slippage_bps,
+        },
+        "risk": {
+            "risk_per_trade": 0.02,
+            "max_position_size": 0.25,
+            "min_position_value": 10.0,
+            "min_stop_distance": 0.0001,
+        },
+    }
+
+
+def _bars(n: int = 20) -> pd.DataFrame:
+    idx = pd.date_range("2026-06-01", periods=n, freq="1h", tz="UTC")
+    close = [100.0 + float(i) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": close,
+            "index_price": [v - 0.1 for v in close],
+            "best_bid": [v - 0.05 for v in close],
+            "best_ask": [v + 0.05 for v in close],
+            "spread": [0.1 for _ in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": [0.0001 for _ in close],
+            "volatility_estimate": [0.2 for _ in close],
+            "is_final": [True for _ in close],
+            "bar_interval": ["1m" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def _admissibility(bars: pd.DataFrame) -> ev.DataAdmissibilityV1:
+    return ev.DataAdmissibilityV1(
+        source_kind=ev.DataSourceKind.SYNTHETIC_CONTRACT_FIXTURE,
+        instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+        data_digest=ev.compute_bars_data_digest(bars),
+        data_ref="tests/backtest/test_economic_viability_evidence_v1.py::_bars",
+    )
+
+
+def _build(**kwargs: Any) -> ev.EconomicViabilityEvidenceV1:
+    bars = kwargs.pop("bars", _bars())
+    return ev.build_economic_viability_evidence_v1(
+        bars=bars,
+        data_admissibility=kwargs.pop("data_admissibility", _admissibility(bars)),
+        strategy_id=kwargs.pop("strategy_id", "ma_crossover"),
+        cfg=kwargs.pop("cfg", _cfg()),
+        **kwargs,
+    )
+
+
+def test_contract_layer_version() -> None:
+    assert ev.ECONOMIC_VIABILITY_EVIDENCE_LAYER_VERSION == "v1"
+
+
+def test_policy_not_bound_fail_closed() -> None:
+    assert ev.ECONOMIC_VIABILITY_POLICY_VERSION == "NOT_BOUND"
+
+
+def test_build_evidence_research_only_for_synthetic_fixture() -> None:
+    result = _build()
+    assert result.status is ev.EconomicViabilityStatus.RESEARCH_ONLY
+    assert result.economic_validity_proven is False
+    assert result.profitability_claim_allowed is False
+    assert "admissible_versioned_futures_dataset_missing" in result.reason_codes
+    assert "economic_viability_policy_not_versioned" in result.reason_codes
+
+
+def test_build_evidence_deterministic_semantics() -> None:
+    a = _build()
+    b = _build()
+    assert a.to_semantic_dict() == b.to_semantic_dict()
+    assert a.manifest_digest == b.manifest_digest
+
+
+def test_data_digest_mismatch_fail_closed() -> None:
+    bars = _bars()
+    bad = ev.DataAdmissibilityV1(
+        source_kind=ev.DataSourceKind.SYNTHETIC_CONTRACT_FIXTURE,
+        instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+        data_digest="0" * 64,
+        data_ref="bad",
+    )
+    with pytest.raises(ev.EconomicViabilityEvidenceError, match="data_digest_mismatch"):
+        _build(bars=bars, data_admissibility=bad)
+
+
+def test_forbidden_bitcoin_instrument_rejected() -> None:
+    bars = _bars()
+    with pytest.raises(ev.EconomicViabilityEvidenceError, match="instrument_kind_forbidden"):
+        ev.build_economic_viability_evidence_v1(
+            bars=bars,
+            data_admissibility=_admissibility(bars),
+            strategy_id="ma_crossover",
+            cfg=_cfg(),
+            instrument_id="inst-btc-usdt-perp",
+        )
+
+
+def test_zero_cost_without_flag_rejected() -> None:
+    with pytest.raises(Exception):
+        _build(cfg=_cfg(fee_bps=0.0, slippage_bps=0.0))
+
+
+def test_zero_cost_explicit_flag_sets_reason_code() -> None:
+    result = _build(cfg=_cfg(fee_bps=0.0, slippage_bps=0.0), explicit_zero_cost_non_economic=True)
+    assert "explicit_zero_cost_non_economic_mode" in result.reason_codes
+
+
+def test_required_metric_fields_present() -> None:
+    result = _build()
+    payload = result.to_dict()
+    for key in ev.economic_viability_evidence_schema_v1()["required_fields"]:
+        assert key in payload
+
+
+def test_not_computed_metrics_not_zero_filled() -> None:
+    result = _build()
+    assert result.turnover.semantic is ev.MetricSemantic.NOT_COMPUTED
+    assert result.turnover.value is None
+    assert result.funding_drag.reason_code == "funding_drag_not_bound"
+
+
+def test_walk_forward_monte_carlo_stress_sections_present() -> None:
+    result = _build()
+    assert "window_count" in result.walk_forward_results
+    assert "num_runs" in result.monte_carlo_results
+    assert "class_statuses" in result.stress_results
+
+
+def test_mv2_chain_digest_present() -> None:
+    result = _build()
+    assert len(result.wiring_chain_digest) == 64
+
+
+def test_cost_binding_present() -> None:
+    result = _build()
+    assert result.cost_binding["economic_interpretation_allowed"] is False
+    assert result.fee_model_version
+    assert result.slippage_model_version
+
+
+def test_schema_contract() -> None:
+    schema = ev.economic_viability_evidence_schema_v1()
+    assert schema["contract_name"] == "economic_viability_evidence_v1"
+    assert schema["runtime_effect"] is False
+
+
+def test_persist_bundle_manifest_verify(tmp_path) -> None:
+    result = _build()
+    out = tmp_path / "evidence"
+    bundle = ev.persist_economic_viability_evidence_bundle_v1(
+        out,
+        result,
+        config_snapshot={"cfg": dict(_cfg())},
+        metrics={"total_return": result.gross_return.value},
+        input_provenance={"source": "synthetic_fixture"},
+    )
+    assert bundle.manifest_verify_rc == 0
+    assert bundle.evidence_path.is_file()
+    loaded = json.loads(bundle.evidence_path.read_text(encoding="utf-8"))
+    assert loaded["status"] == "RESEARCH_ONLY"
+
+
+def test_inadmissible_data_source_reason_code() -> None:
+    bars = _bars()
+    adm = ev.DataAdmissibilityV1(
+        source_kind=ev.DataSourceKind.INADMISSIBLE,
+        instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+        data_digest=ev.compute_bars_data_digest(bars),
+        data_ref="inadmissible",
+    )
+    result = _build(bars=bars, data_admissibility=adm)
+    assert "data_source_inadmissible" in result.reason_codes
+
+
+def test_walk_forward_insufficient_bars_reason() -> None:
+    bars = _bars(10)
+    result = _build(bars=bars)
+    assert "walk_forward_insufficient_bars" in result.reason_codes
+
+
+def test_parameter_sensitivity_not_computed() -> None:
+    result = _build()
+    assert result.parameter_sensitivity_results["semantic"] == "NOT_COMPUTED"
+
+
+def test_status_never_exceeds_step29m_allowed_set() -> None:
+    result = _build()
+    assert result.status.value in ev._STEP29M_ALLOWED_STATUSES
+
+
+def test_economically_viable_offline_not_claimed_without_policy() -> None:
+    result = _build()
+    assert result.status is not ev.EconomicViabilityStatus.ECONOMICALLY_VIABLE_OFFLINE


### PR DESCRIPTION
## Summary
- Adds `EconomicViabilityEvidenceV1` contract and pipeline bound to the canonical MV2 research chain from STEP 29L (backtest → walk-forward → Monte Carlo → stress → metrics).
- Fail-closed status resolution: no profitability claim, no economic validity without versioned policy and admissible versioned futures data.
- Updates progress registry to mark `RUNBOOK_STEP_29M_STARTED=true`, `RUNBOOK_STEP_29M_COMPLETE=false`.

## Test plan
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] `git diff --check`
- [x] `pytest tests/backtest/test_economic_viability_evidence_v1.py`
- [x] `pytest tests/backtest/test_mv2_research_wiability_evidence_v1.py` (STEP 29L regression)
- [x] CI selector: `PR_BOUNDED_FULL` (central `src/` change)
- [x] Durable evidence bundle with `MANIFEST_VERIFY_RC=0`

## Scope boundaries
- Offline only; no runtime, orders, credentials, promotion gates, or STEP 29N start.
- Status capped at `RESEARCH_ONLY`/`PROMISING`/`ROBUSTNESS_FAILED` for this slice.
- `ECONOMIC_VALIDITY_PROVEN=false`, `PROFITABILITY_CLAIM_ALLOWED=false`.


Made with [Cursor](https://cursor.com)