### PR TITLE
feat(backtest): STEP 29M EconomicValidityPolicyV1 contract binding

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -111,7 +111,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29L_COMPLETE` | `true` |
 | `STEP_29M_STARTED` | `true` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `false` |
 | `STEP_29N_STARTED` | `false` |
@@ -1023,7 +1023,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `STATUS` | `IN_PROGRESS` |
 | `CANONICAL_OWNER` | `src/backtest/economic_viability_evidence_v1.py` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29L |
-| `REMAINING_GAPS` | `versioned_economic_viability_policy_v1,admissible_versioned_futures_dataset,funding_model_binding,parameter_sensitivity_binding` |
+| `REMAINING_GAPS` | `admissible_versioned_futures_dataset,funding_model_binding,parameter_sensitivity_binding,economic_validity_policy_threshold_values` |
 | `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29M` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
@@ -1032,7 +1032,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `false` |
 | `STEP_29N_STARTED` | `false` |

--- a/src/backtest/economic_validity_policy_v1.py
+++ b/src/backtest/economic_validity_policy_v1.py
@@ -1,0 +1,382 @@
+"""
+Versioned Economic Validity Policy v1 (RUNBOOK STEP 29M).
+
+Fail-closed, non-authorizing policy contract for offline economic viability evidence.
+Thresholds must be explicitly versioned; missing values block economic validity claims.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence
+
+ECONOMIC_VALIDITY_POLICY_VERSION = "economic_validity_policy_v1"
+ECONOMIC_VALIDITY_POLICY_OWNER = "backtest.economic_validity_policy_v1"
+POLICY_THRESHOLD_STATUS_BLOCKED = "BLOCKED_BY_MISSING_VERSIONED_VALUES"
+
+_NUMERIC_THRESHOLD_FIELDS = (
+    "minimum_net_expectancy",
+    "minimum_profit_factor",
+    "maximum_max_drawdown",
+    "walk_forward_stability_threshold",
+    "minimum_trade_count",
+    "single_trade_dominance_limit",
+    "regime_dominance_limit",
+)
+
+_POLICY_REF_FIELDS = (
+    "out_of_sample_pass_policy",
+    "parameter_robustness_policy",
+    "monte_carlo_pass_policy",
+    "stress_pass_policy",
+)
+
+_ALL_THRESHOLD_FIELDS = _NUMERIC_THRESHOLD_FIELDS + _POLICY_REF_FIELDS
+
+
+class ThresholdBindingStatus(str, Enum):
+    CONFIGURED = "CONFIGURED"
+    REQUIRED_NOT_CONFIGURED = "REQUIRED_NOT_CONFIGURED"
+
+
+class EconomicValidityPolicyError(ValueError):
+    """Fail-closed economic validity policy error."""
+
+
+@dataclass(frozen=True)
+class VersionedThresholdV1:
+    status: ThresholdBindingStatus
+    value: Optional[float] = None
+    policy_ref: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"status": self.status.value}
+        if self.value is not None:
+            payload["value"] = self.value
+        if self.policy_ref is not None:
+            payload["policy_ref"] = self.policy_ref
+        return payload
+
+
+@dataclass(frozen=True)
+class EconomicValidityPolicyV1:
+    policy_version: str
+    owner: str
+    minimum_net_expectancy: VersionedThresholdV1
+    minimum_profit_factor: VersionedThresholdV1
+    maximum_max_drawdown: VersionedThresholdV1
+    walk_forward_stability_threshold: VersionedThresholdV1
+    out_of_sample_pass_policy: VersionedThresholdV1
+    parameter_robustness_policy: VersionedThresholdV1
+    monte_carlo_pass_policy: VersionedThresholdV1
+    stress_pass_policy: VersionedThresholdV1
+    minimum_trade_count: VersionedThresholdV1
+    single_trade_dominance_limit: VersionedThresholdV1
+    regime_dominance_limit: VersionedThresholdV1
+    authority_effect: str = "NONE"
+    runtime_effect: bool = False
+    order_effect: bool = False
+    promotion_effect: bool = False
+
+    def is_version_bound(self) -> bool:
+        return (
+            self.policy_version == ECONOMIC_VALIDITY_POLICY_VERSION
+            and self.owner == ECONOMIC_VALIDITY_POLICY_OWNER
+        )
+
+    def thresholds_configured(self) -> bool:
+        for field_name in _ALL_THRESHOLD_FIELDS:
+            threshold = getattr(self, field_name)
+            if threshold.status is not ThresholdBindingStatus.CONFIGURED:
+                return False
+            if field_name in _NUMERIC_THRESHOLD_FIELDS and threshold.value is None:
+                return False
+            if field_name in _POLICY_REF_FIELDS and not threshold.policy_ref:
+                return False
+        return True
+
+    def policy_threshold_status(self) -> str:
+        if self.thresholds_configured():
+            return "CONFIGURED"
+        return POLICY_THRESHOLD_STATUS_BLOCKED
+
+    def unconfigured_fields(self) -> tuple[str, ...]:
+        missing: list[str] = []
+        for field_name in _ALL_THRESHOLD_FIELDS:
+            threshold = getattr(self, field_name)
+            if threshold.status is not ThresholdBindingStatus.CONFIGURED:
+                missing.append(field_name)
+                continue
+            if field_name in _NUMERIC_THRESHOLD_FIELDS and threshold.value is None:
+                missing.append(field_name)
+            elif field_name in _POLICY_REF_FIELDS and not threshold.policy_ref:
+                missing.append(field_name)
+        return tuple(missing)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy_version": self.policy_version,
+            "owner": self.owner,
+            "minimum_net_expectancy": self.minimum_net_expectancy.to_dict(),
+            "minimum_profit_factor": self.minimum_profit_factor.to_dict(),
+            "maximum_max_drawdown": self.maximum_max_drawdown.to_dict(),
+            "walk_forward_stability_threshold": self.walk_forward_stability_threshold.to_dict(),
+            "out_of_sample_pass_policy": self.out_of_sample_pass_policy.to_dict(),
+            "parameter_robustness_policy": self.parameter_robustness_policy.to_dict(),
+            "monte_carlo_pass_policy": self.monte_carlo_pass_policy.to_dict(),
+            "stress_pass_policy": self.stress_pass_policy.to_dict(),
+            "minimum_trade_count": self.minimum_trade_count.to_dict(),
+            "single_trade_dominance_limit": self.single_trade_dominance_limit.to_dict(),
+            "regime_dominance_limit": self.regime_dominance_limit.to_dict(),
+            "policy_threshold_status": self.policy_threshold_status(),
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+            "order_effect": self.order_effect,
+            "promotion_effect": self.promotion_effect,
+        }
+
+    def config_digest(self) -> str:
+        return compute_economic_validity_policy_digest(self)
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_economic_validity_policy_digest(policy: EconomicValidityPolicyV1) -> str:
+    payload = policy.to_dict()
+    payload.pop("policy_threshold_status", None)
+    return _stable_digest(payload)
+
+
+def _required_not_configured() -> VersionedThresholdV1:
+    return VersionedThresholdV1(status=ThresholdBindingStatus.REQUIRED_NOT_CONFIGURED)
+
+
+def default_economic_validity_policy_v1() -> EconomicValidityPolicyV1:
+    """Canonical default policy with all thresholds explicitly not configured."""
+    unset = _required_not_configured()
+    return EconomicValidityPolicyV1(
+        policy_version=ECONOMIC_VALIDITY_POLICY_VERSION,
+        owner=ECONOMIC_VALIDITY_POLICY_OWNER,
+        minimum_net_expectancy=unset,
+        minimum_profit_factor=unset,
+        maximum_max_drawdown=unset,
+        walk_forward_stability_threshold=unset,
+        out_of_sample_pass_policy=unset,
+        parameter_robustness_policy=unset,
+        monte_carlo_pass_policy=unset,
+        stress_pass_policy=unset,
+        minimum_trade_count=unset,
+        single_trade_dominance_limit=unset,
+        regime_dominance_limit=unset,
+    )
+
+
+def _threshold_from_mapping(
+    payload: Mapping[str, Any] | None,
+    *,
+    field_name: str,
+    numeric: bool,
+) -> VersionedThresholdV1:
+    if payload is None:
+        return _required_not_configured()
+    status_raw = payload.get("status", ThresholdBindingStatus.REQUIRED_NOT_CONFIGURED.value)
+    try:
+        status = ThresholdBindingStatus(str(status_raw))
+    except ValueError as exc:
+        raise EconomicValidityPolicyError(f"threshold_status_invalid:{field_name}") from exc
+    if status is ThresholdBindingStatus.REQUIRED_NOT_CONFIGURED:
+        return VersionedThresholdV1(status=status)
+    if numeric:
+        if "value" not in payload:
+            raise EconomicValidityPolicyError(f"threshold_value_missing:{field_name}")
+        return VersionedThresholdV1(status=status, value=float(payload["value"]))
+    policy_ref = payload.get("policy_ref")
+    if not policy_ref:
+        raise EconomicValidityPolicyError(f"threshold_policy_ref_missing:{field_name}")
+    return VersionedThresholdV1(status=status, policy_ref=str(policy_ref))
+
+
+def load_economic_validity_policy_v1(
+    cfg: Mapping[str, Any] | None = None,
+) -> EconomicValidityPolicyV1:
+    """Load versioned policy from config or return canonical default (fail-closed thresholds)."""
+    if cfg is None:
+        return default_economic_validity_policy_v1()
+    section = cfg.get("economic_validity_policy")
+    if section is None:
+        return default_economic_validity_policy_v1()
+    if not isinstance(section, Mapping):
+        raise EconomicValidityPolicyError("economic_validity_policy_section_not_mapping")
+    policy_version = str(section.get("policy_version", ECONOMIC_VALIDITY_POLICY_VERSION))
+    if policy_version != ECONOMIC_VALIDITY_POLICY_VERSION:
+        raise EconomicValidityPolicyError(f"policy_version_mismatch:{policy_version}")
+    owner = str(section.get("owner", ECONOMIC_VALIDITY_POLICY_OWNER))
+    thresholds = section.get("thresholds")
+    if thresholds is not None and not isinstance(thresholds, Mapping):
+        raise EconomicValidityPolicyError("economic_validity_policy_thresholds_not_mapping")
+    thresholds = thresholds or {}
+    return EconomicValidityPolicyV1(
+        policy_version=policy_version,
+        owner=owner,
+        minimum_net_expectancy=_threshold_from_mapping(
+            thresholds.get("minimum_net_expectancy"),
+            field_name="minimum_net_expectancy",
+            numeric=True,
+        ),
+        minimum_profit_factor=_threshold_from_mapping(
+            thresholds.get("minimum_profit_factor"),
+            field_name="minimum_profit_factor",
+            numeric=True,
+        ),
+        maximum_max_drawdown=_threshold_from_mapping(
+            thresholds.get("maximum_max_drawdown"),
+            field_name="maximum_max_drawdown",
+            numeric=True,
+        ),
+        walk_forward_stability_threshold=_threshold_from_mapping(
+            thresholds.get("walk_forward_stability_threshold"),
+            field_name="walk_forward_stability_threshold",
+            numeric=True,
+        ),
+        out_of_sample_pass_policy=_threshold_from_mapping(
+            thresholds.get("out_of_sample_pass_policy"),
+            field_name="out_of_sample_pass_policy",
+            numeric=False,
+        ),
+        parameter_robustness_policy=_threshold_from_mapping(
+            thresholds.get("parameter_robustness_policy"),
+            field_name="parameter_robustness_policy",
+            numeric=False,
+        ),
+        monte_carlo_pass_policy=_threshold_from_mapping(
+            thresholds.get("monte_carlo_pass_policy"),
+            field_name="monte_carlo_pass_policy",
+            numeric=False,
+        ),
+        stress_pass_policy=_threshold_from_mapping(
+            thresholds.get("stress_pass_policy"),
+            field_name="stress_pass_policy",
+            numeric=False,
+        ),
+        minimum_trade_count=_threshold_from_mapping(
+            thresholds.get("minimum_trade_count"),
+            field_name="minimum_trade_count",
+            numeric=True,
+        ),
+        single_trade_dominance_limit=_threshold_from_mapping(
+            thresholds.get("single_trade_dominance_limit"),
+            field_name="single_trade_dominance_limit",
+            numeric=True,
+        ),
+        regime_dominance_limit=_threshold_from_mapping(
+            thresholds.get("regime_dominance_limit"),
+            field_name="regime_dominance_limit",
+            numeric=True,
+        ),
+    )
+
+
+def validate_economic_validity_policy_v1(policy: EconomicValidityPolicyV1) -> None:
+    """Validate policy structure and configured threshold values (fail-closed)."""
+    if not policy.is_version_bound():
+        raise EconomicValidityPolicyError("policy_not_version_bound")
+    for field_name in _NUMERIC_THRESHOLD_FIELDS:
+        threshold = getattr(policy, field_name)
+        if threshold.status is ThresholdBindingStatus.CONFIGURED:
+            if threshold.value is None:
+                raise EconomicValidityPolicyError(
+                    f"configured_threshold_missing_value:{field_name}"
+                )
+            if not math.isfinite(threshold.value):
+                raise EconomicValidityPolicyError(f"configured_threshold_non_finite:{field_name}")
+    for field_name in _POLICY_REF_FIELDS:
+        threshold = getattr(policy, field_name)
+        if threshold.status is ThresholdBindingStatus.CONFIGURED and not threshold.policy_ref:
+            raise EconomicValidityPolicyError(
+                f"configured_threshold_missing_policy_ref:{field_name}"
+            )
+
+
+@dataclass(frozen=True)
+class EconomicValidityGateEvaluationV1:
+    gates_pass: bool
+    reason_codes: tuple[str, ...]
+    policy_threshold_status: str
+
+
+def evaluate_economic_validity_gates_v1(
+    *,
+    policy: EconomicValidityPolicyV1,
+    net_expectancy: Optional[float],
+    profit_factor: Optional[float],
+    max_drawdown: Optional[float],
+    trade_count: Optional[int],
+) -> EconomicValidityGateEvaluationV1:
+    """
+    Evaluate evidence metrics against versioned policy thresholds.
+
+    Fail-closed when thresholds are not configured or metrics are missing.
+    Does not mutate policy based on results.
+    """
+    validate_economic_validity_policy_v1(policy)
+    reason_codes: list[str] = []
+    threshold_status = policy.policy_threshold_status()
+    if threshold_status == POLICY_THRESHOLD_STATUS_BLOCKED:
+        reason_codes.append("economic_validity_policy_thresholds_not_configured")
+        for field_name in policy.unconfigured_fields():
+            reason_codes.append(f"policy_threshold_required_not_configured:{field_name}")
+        return EconomicValidityGateEvaluationV1(
+            gates_pass=False,
+            reason_codes=tuple(sorted(set(reason_codes))),
+            policy_threshold_status=threshold_status,
+        )
+
+    if net_expectancy is None or not math.isfinite(net_expectancy):
+        reason_codes.append("gate_metric_missing:net_expectancy")
+    elif net_expectancy < policy.minimum_net_expectancy.value:  # type: ignore[operator]
+        reason_codes.append("gate_failed:minimum_net_expectancy")
+
+    if profit_factor is None or not math.isfinite(profit_factor):
+        reason_codes.append("gate_metric_missing:profit_factor")
+    elif profit_factor < policy.minimum_profit_factor.value:  # type: ignore[operator]
+        reason_codes.append("gate_failed:minimum_profit_factor")
+
+    if max_drawdown is None or not math.isfinite(max_drawdown):
+        reason_codes.append("gate_metric_missing:max_drawdown")
+    elif abs(max_drawdown) > policy.maximum_max_drawdown.value:  # type: ignore[operator]
+        reason_codes.append("gate_failed:maximum_max_drawdown")
+
+    if trade_count is None:
+        reason_codes.append("gate_metric_missing:trade_count")
+    elif trade_count < int(policy.minimum_trade_count.value):  # type: ignore[arg-type]
+        reason_codes.append("gate_failed:minimum_trade_count")
+
+    gates_pass = len(reason_codes) == 0
+    return EconomicValidityGateEvaluationV1(
+        gates_pass=gates_pass,
+        reason_codes=tuple(sorted(set(reason_codes))),
+        policy_threshold_status=threshold_status,
+    )
+
+
+def economic_validity_policy_schema_v1() -> dict[str, Any]:
+    return {
+        "contract_name": "economic_validity_policy_v1",
+        "policy_version": ECONOMIC_VALIDITY_POLICY_VERSION,
+        "owner": ECONOMIC_VALIDITY_POLICY_OWNER,
+        "numeric_threshold_fields": list(_NUMERIC_THRESHOLD_FIELDS),
+        "policy_ref_fields": list(_POLICY_REF_FIELDS),
+        "threshold_binding_statuses": [status.value for status in ThresholdBindingStatus],
+        "default_threshold_status": ThresholdBindingStatus.REQUIRED_NOT_CONFIGURED.value,
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+        "promotion_effect": False,
+    }

--- a/src/backtest/economic_viability_evidence_v1.py
+++ b/src/backtest/economic_viability_evidence_v1.py
@@ -25,6 +25,12 @@ from scripts.ops.primary_evidence_retention_v0 import (
 )
 from src.backtest import mv2_research_wiring_v1 as mv2_wiring
 from src.backtest.cost_config_v0 import FUNDING_MODEL_VERSION
+from src.backtest.economic_validity_policy_v1 import (
+    ECONOMIC_VALIDITY_POLICY_VERSION,
+    evaluate_economic_validity_gates_v1,
+    load_economic_validity_policy_v1,
+    validate_economic_validity_policy_v1,
+)
 from src.experiments.monte_carlo import MonteCarloConfig, MonteCarloSummaryResult
 from src.trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
     INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
@@ -32,7 +38,6 @@ from src.trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
 
 ECONOMIC_VIABILITY_EVIDENCE_LAYER_VERSION = "v1"
 ECONOMIC_VIABILITY_EVIDENCE_OWNER = "backtest.economic_viability_evidence_v1"
-ECONOMIC_VIABILITY_POLICY_VERSION = "NOT_BOUND"
 ARTIFACT_FILENAME = "economic_viability_evidence_v1.json"
 SCHEMA_FILENAME = "economic_viability_evidence_schema_v1.json"
 OFFLINE_DETERMINISTIC_CREATED_AT = "1970-01-01T00:00:00+00:00"
@@ -144,7 +149,9 @@ class EconomicViabilityEvidenceV1:
     randomness_seed: int
     data_admissibility: Mapping[str, Any]
     cost_binding: Mapping[str, Any]
-    policy_version: str = ECONOMIC_VIABILITY_POLICY_VERSION
+    policy_version: str = ECONOMIC_VALIDITY_POLICY_VERSION
+    policy_digest: str = ""
+    policy_threshold_status: str = ""
     economic_validity_proven: bool = False
     profitability_claim_allowed: bool = False
     authority_effect: str = "NONE"
@@ -203,6 +210,8 @@ class EconomicViabilityEvidenceV1:
             "data_admissibility": dict(self.data_admissibility),
             "cost_binding": dict(self.cost_binding),
             "policy_version": self.policy_version,
+            "policy_digest": self.policy_digest,
+            "policy_threshold_status": self.policy_threshold_status,
             "economic_validity_proven": self.economic_validity_proven,
             "profitability_claim_allowed": self.profitability_claim_allowed,
             "authority_effect": self.authority_effect,
@@ -457,8 +466,14 @@ def build_economic_viability_evidence_v1(
         reason_codes.append("admissible_versioned_futures_dataset_missing")
     if data_admissibility.source_kind is DataSourceKind.INADMISSIBLE:
         reason_codes.append("data_source_inadmissible")
-    if ECONOMIC_VIABILITY_POLICY_VERSION == "NOT_BOUND":
+    policy = load_economic_validity_policy_v1(cfg)
+    validate_economic_validity_policy_v1(policy)
+    if not policy.is_version_bound():
         reason_codes.append("economic_viability_policy_not_versioned")
+    if not policy.thresholds_configured():
+        reason_codes.append("economic_validity_policy_thresholds_not_configured")
+        for field_name in policy.unconfigured_fields():
+            reason_codes.append(f"policy_threshold_required_not_configured:{field_name}")
     if FUNDING_MODEL_VERSION == "NOT_BOUND" or cost.funding_model_version == "NOT_BOUND":
         reason_codes.append("funding_model_not_bound")
     if cost.zero_cost_explicitly_requested:
@@ -471,13 +486,17 @@ def build_economic_viability_evidence_v1(
     reason_codes.extend(robustness_failures)
 
     trade_count_value = int(stats.get("total_trades", 0))
-    gates_pass = False
-    if trade_count_value > 0 and stats.get("expectancy", 0.0) > 0.0:
-        gates_pass = True
-    else:
-        reason_codes.append("economic_gate_trade_or_expectancy_insufficient")
+    gate_eval = evaluate_economic_validity_gates_v1(
+        policy=policy,
+        net_expectancy=stats.get("expectancy"),
+        profit_factor=stats.get("profit_factor"),
+        max_drawdown=stats.get("max_drawdown"),
+        trade_count=trade_count_value,
+    )
+    gates_pass = gate_eval.gates_pass
+    reason_codes.extend(gate_eval.reason_codes)
 
-    policy_version_bound = ECONOMIC_VIABILITY_POLICY_VERSION != "NOT_BOUND"
+    policy_version_bound = policy.is_version_bound()
     funding_bound = cost.funding_model_version != "NOT_BOUND"
     parameter_sensitivity_bound = False
 
@@ -639,6 +658,9 @@ def build_economic_viability_evidence_v1(
             "partial_fill_assumption": cost.partial_fill_assumption,
             "spread_application_policy": cost.spread_application_policy,
         },
+        policy_version=policy.policy_version,
+        policy_digest=policy.config_digest(),
+        policy_threshold_status=policy.policy_threshold_status(),
         economic_validity_proven=economic_validity_proven,
         profitability_claim_allowed=False,
     )
@@ -695,7 +717,7 @@ def economic_viability_evidence_schema_v1() -> dict[str, Any]:
         ],
         "metric_semantics": [semantic.value for semantic in MetricSemantic],
         "data_source_kinds": [kind.value for kind in DataSourceKind],
-        "policy_version": ECONOMIC_VIABILITY_POLICY_VERSION,
+        "policy_version": ECONOMIC_VALIDITY_POLICY_VERSION,
         "authority_effect": "NONE",
         "runtime_effect": False,
         "order_effect": False,
@@ -846,7 +868,9 @@ def economic_viability_evidence_from_dict_v1(
             payload.get("data_admissibility", {}), field_name="data_admissibility"
         ),
         cost_binding=_mapping_from_dict(payload.get("cost_binding", {}), field_name="cost_binding"),
-        policy_version=str(payload.get("policy_version", ECONOMIC_VIABILITY_POLICY_VERSION)),
+        policy_version=str(payload.get("policy_version", ECONOMIC_VALIDITY_POLICY_VERSION)),
+        policy_digest=str(payload.get("policy_digest", "")),
+        policy_threshold_status=str(payload.get("policy_threshold_status", "")),
         economic_validity_proven=bool(payload.get("economic_validity_proven", False)),
         profitability_claim_allowed=bool(payload.get("profitability_claim_allowed", False)),
     )

--- a/tests/backtest/test_economic_validity_policy_v1.py
+++ b/tests/backtest/test_economic_validity_policy_v1.py
@@ -1,0 +1,203 @@
+"""RUNBOOK STEP 29M — versioned economic validity policy v1 contract tests."""
+
+from __future__ import annotations
+
+import copy
+import math
+from typing import Any, Mapping
+
+import pytest
+
+from src.backtest import economic_validity_policy_v1 as policy
+
+
+def _fully_configured_cfg() -> dict[str, Any]:
+    return {
+        "economic_validity_policy": {
+            "policy_version": policy.ECONOMIC_VALIDITY_POLICY_VERSION,
+            "owner": policy.ECONOMIC_VALIDITY_POLICY_OWNER,
+            "thresholds": {
+                "minimum_net_expectancy": {"status": "CONFIGURED", "value": 0.0},
+                "minimum_profit_factor": {"status": "CONFIGURED", "value": 1.0},
+                "maximum_max_drawdown": {"status": "CONFIGURED", "value": 0.25},
+                "walk_forward_stability_threshold": {"status": "CONFIGURED", "value": 0.5},
+                "out_of_sample_pass_policy": {
+                    "status": "CONFIGURED",
+                    "policy_ref": "oos_pass_v1",
+                },
+                "parameter_robustness_policy": {
+                    "status": "CONFIGURED",
+                    "policy_ref": "param_robust_v1",
+                },
+                "monte_carlo_pass_policy": {
+                    "status": "CONFIGURED",
+                    "policy_ref": "mc_pass_v1",
+                },
+                "stress_pass_policy": {"status": "CONFIGURED", "policy_ref": "stress_pass_v1"},
+                "minimum_trade_count": {"status": "CONFIGURED", "value": 10.0},
+                "single_trade_dominance_limit": {"status": "CONFIGURED", "value": 0.5},
+                "regime_dominance_limit": {"status": "CONFIGURED", "value": 0.6},
+            },
+        }
+    }
+
+
+class TestDefaultPolicyContract:
+    def test_policy_version_bound(self) -> None:
+        p = policy.default_economic_validity_policy_v1()
+        assert p.is_version_bound() is True
+        assert p.policy_version == policy.ECONOMIC_VALIDITY_POLICY_VERSION
+
+    def test_default_thresholds_not_configured(self) -> None:
+        p = policy.default_economic_validity_policy_v1()
+        assert p.thresholds_configured() is False
+        assert p.policy_threshold_status() == policy.POLICY_THRESHOLD_STATUS_BLOCKED
+        assert len(p.unconfigured_fields()) == 11
+
+    def test_config_digest_stable(self) -> None:
+        a = policy.default_economic_validity_policy_v1()
+        b = policy.default_economic_validity_policy_v1()
+        assert a.config_digest() == b.config_digest()
+        assert len(a.config_digest()) == 64
+
+    def test_no_runtime_or_promotion_effect(self) -> None:
+        p = policy.default_economic_validity_policy_v1()
+        assert p.runtime_effect is False
+        assert p.order_effect is False
+        assert p.promotion_effect is False
+        assert p.authority_effect == "NONE"
+
+
+class TestPolicyLoader:
+    def test_load_without_section_returns_default(self) -> None:
+        p = policy.load_economic_validity_policy_v1({})
+        assert p.is_version_bound()
+        assert not p.thresholds_configured()
+
+    def test_load_fully_configured(self) -> None:
+        p = policy.load_economic_validity_policy_v1(_fully_configured_cfg())
+        assert p.thresholds_configured() is True
+        assert p.policy_threshold_status() == "CONFIGURED"
+
+    def test_version_mismatch_rejected(self) -> None:
+        cfg = _fully_configured_cfg()
+        cfg["economic_validity_policy"]["policy_version"] = "wrong_v9"
+        with pytest.raises(policy.EconomicValidityPolicyError, match="policy_version_mismatch"):
+            policy.load_economic_validity_policy_v1(cfg)
+
+    def test_invalid_threshold_section_rejected(self) -> None:
+        with pytest.raises(policy.EconomicValidityPolicyError, match="not_mapping"):
+            policy.load_economic_validity_policy_v1({"economic_validity_policy": "bad"})
+
+
+class TestPolicyValidation:
+    def test_validate_default_passes_structure(self) -> None:
+        p = policy.default_economic_validity_policy_v1()
+        policy.validate_economic_validity_policy_v1(p)
+
+    def test_nan_threshold_rejected(self) -> None:
+        cfg = _fully_configured_cfg()
+        cfg["economic_validity_policy"]["thresholds"]["minimum_net_expectancy"]["value"] = float(
+            "nan"
+        )
+        p = policy.load_economic_validity_policy_v1(cfg)
+        with pytest.raises(
+            policy.EconomicValidityPolicyError, match="configured_threshold_non_finite"
+        ):
+            policy.validate_economic_validity_policy_v1(p)
+
+    def test_inf_threshold_rejected(self) -> None:
+        cfg = _fully_configured_cfg()
+        cfg["economic_validity_policy"]["thresholds"]["minimum_profit_factor"]["value"] = float(
+            "inf"
+        )
+        p = policy.load_economic_validity_policy_v1(cfg)
+        with pytest.raises(
+            policy.EconomicValidityPolicyError, match="configured_threshold_non_finite"
+        ):
+            policy.validate_economic_validity_policy_v1(p)
+
+    def test_configured_numeric_missing_value_rejected(self) -> None:
+        cfg = _fully_configured_cfg()
+        del cfg["economic_validity_policy"]["thresholds"]["minimum_trade_count"]["value"]
+        with pytest.raises(policy.EconomicValidityPolicyError, match="threshold_value_missing"):
+            policy.load_economic_validity_policy_v1(cfg)
+
+    def test_configured_policy_ref_missing_rejected(self) -> None:
+        cfg = _fully_configured_cfg()
+        del cfg["economic_validity_policy"]["thresholds"]["stress_pass_policy"]["policy_ref"]
+        with pytest.raises(
+            policy.EconomicValidityPolicyError, match="threshold_policy_ref_missing"
+        ):
+            policy.load_economic_validity_policy_v1(cfg)
+
+
+class TestGateEvaluation:
+    def test_missing_thresholds_fail_closed(self) -> None:
+        p = policy.default_economic_validity_policy_v1()
+        result = policy.evaluate_economic_validity_gates_v1(
+            policy=p,
+            net_expectancy=1.0,
+            profit_factor=2.0,
+            max_drawdown=-0.05,
+            trade_count=100,
+        )
+        assert result.gates_pass is False
+        assert "economic_validity_policy_thresholds_not_configured" in result.reason_codes
+
+    def test_configured_gates_pass(self) -> None:
+        p = policy.load_economic_validity_policy_v1(_fully_configured_cfg())
+        result = policy.evaluate_economic_validity_gates_v1(
+            policy=p,
+            net_expectancy=0.01,
+            profit_factor=1.5,
+            max_drawdown=-0.10,
+            trade_count=20,
+        )
+        assert result.gates_pass is True
+        assert result.reason_codes == ()
+
+    def test_configured_gates_fail_on_expectancy(self) -> None:
+        p = policy.load_economic_validity_policy_v1(_fully_configured_cfg())
+        result = policy.evaluate_economic_validity_gates_v1(
+            policy=p,
+            net_expectancy=-0.01,
+            profit_factor=1.5,
+            max_drawdown=-0.10,
+            trade_count=20,
+        )
+        assert result.gates_pass is False
+        assert "gate_failed:minimum_net_expectancy" in result.reason_codes
+
+    def test_configured_gates_fail_on_drawdown(self) -> None:
+        p = policy.load_economic_validity_policy_v1(_fully_configured_cfg())
+        result = policy.evaluate_economic_validity_gates_v1(
+            policy=p,
+            net_expectancy=0.01,
+            profit_factor=1.5,
+            max_drawdown=-0.30,
+            trade_count=20,
+        )
+        assert result.gates_pass is False
+        assert "gate_failed:maximum_max_drawdown" in result.reason_codes
+
+    def test_gate_evaluation_does_not_mutate_policy(self) -> None:
+        p = policy.default_economic_validity_policy_v1()
+        before = p.to_dict()
+        policy.evaluate_economic_validity_gates_v1(
+            policy=p,
+            net_expectancy=999.0,
+            profit_factor=999.0,
+            max_drawdown=-0.01,
+            trade_count=999,
+        )
+        assert p.to_dict() == before
+
+
+class TestPolicySchema:
+    def test_schema_contract(self) -> None:
+        schema = policy.economic_validity_policy_schema_v1()
+        assert schema["contract_name"] == "economic_validity_policy_v1"
+        assert schema["runtime_effect"] is False
+        assert len(schema["numeric_threshold_fields"]) == 7
+        assert len(schema["policy_ref_fields"]) == 4

--- a/tests/backtest/test_economic_viability_evidence_v1.py
+++ b/tests/backtest/test_economic_viability_evidence_v1.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping
 import pandas as pd
 import pytest
 
+from src.backtest import economic_validity_policy_v1 as policy_mod
 from src.backtest import economic_viability_evidence_v1 as ev
 from src.backtest import mv2_research_wiring_v1 as wiring
 
@@ -76,8 +77,11 @@ def test_contract_layer_version() -> None:
     assert ev.ECONOMIC_VIABILITY_EVIDENCE_LAYER_VERSION == "v1"
 
 
-def test_policy_not_bound_fail_closed() -> None:
-    assert ev.ECONOMIC_VIABILITY_POLICY_VERSION == "NOT_BOUND"
+def test_policy_version_bound_fail_closed_thresholds() -> None:
+    assert ev.ECONOMIC_VALIDITY_POLICY_VERSION == policy_mod.ECONOMIC_VALIDITY_POLICY_VERSION
+    p = policy_mod.default_economic_validity_policy_v1()
+    assert p.is_version_bound() is True
+    assert p.policy_threshold_status() == policy_mod.POLICY_THRESHOLD_STATUS_BLOCKED
 
 
 def test_build_evidence_research_only_for_synthetic_fixture() -> None:
@@ -86,7 +90,10 @@ def test_build_evidence_research_only_for_synthetic_fixture() -> None:
     assert result.economic_validity_proven is False
     assert result.profitability_claim_allowed is False
     assert "admissible_versioned_futures_dataset_missing" in result.reason_codes
-    assert "economic_viability_policy_not_versioned" in result.reason_codes
+    assert "economic_validity_policy_thresholds_not_configured" in result.reason_codes
+    assert result.policy_version == policy_mod.ECONOMIC_VALIDITY_POLICY_VERSION
+    assert len(result.policy_digest) == 64
+    assert result.policy_threshold_status == policy_mod.POLICY_THRESHOLD_STATUS_BLOCKED
 
 
 def test_build_evidence_deterministic_semantics() -> None:


### PR DESCRIPTION
## Summary

- Introduces versioned `EconomicValidityPolicyV1` contract with loader, config digest, and fail-closed validation (`REQUIRED_NOT_CONFIGURED` threshold semantics).
- Wires policy binding into `economic_viability_evidence_v1` without authorizing economic validity claims or runtime/order effects.
- Extends STEP 29M registry scope append-only; remaining gaps: admissible dataset, funding binding, parameter sensitivity, versioned threshold values.

## Test plan

- [x] `pytest tests/backtest/test_economic_validity_policy_v1.py tests/backtest/test_economic_viability_evidence_v1.py`
- [x] ruff format --check / ruff check on changed Python files
- [x] git diff --check
- [x] Policy version bound but thresholds fail-closed (no ECONOMICALLY_VIABLE_OFFLINE without configured values)
- [x] Futures-only / no BTC negative tests preserved


Made with [Cursor](https://cursor.com)