### PR TITLE
feat(backtest): STEP 29M funding model binding v1 slice

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -111,7 +111,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29L_COMPLETE` | `true` |
 | `STEP_29M_STARTED` | `true` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `false` |
 | `STEP_29N_STARTED` | `false` |
@@ -1023,7 +1023,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `STATUS` | `IN_PROGRESS` |
 | `CANONICAL_OWNER` | `src/backtest/economic_viability_evidence_v1.py` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29L |
-| `REMAINING_GAPS` | `admissible_versioned_futures_dataset,funding_model_binding,parameter_sensitivity_binding,economic_validity_policy_threshold_values` |
+| `REMAINING_GAPS` | `admissible_versioned_futures_dataset,parameter_sensitivity_binding,economic_validity_policy_threshold_values` |
 | `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29M` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
@@ -1032,7 +1032,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `false` |
 | `STEP_29N_STARTED` | `false` |

--- a/src/backtest/cost_config_v0.py
+++ b/src/backtest/cost_config_v0.py
@@ -14,6 +14,14 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Mapping, Optional
 
 from ..core.errors import BacktestError
+from .funding_model_v1 import (
+    FUNDING_APPLICATION_POLICY,
+    FUNDING_MODEL_VERSION as BOUND_FUNDING_MODEL_VERSION,
+    FUNDING_RATE_SOURCE_BARS_COLUMN,
+    REASON_FUNDING_BOUND,
+    funding_binding_requested,
+    load_funding_model_config_v1,
+)
 
 COST_MODEL_VERSION = "backtest_cost_v0"
 FEE_MODEL_VERSION = "backtest_fee_taker_symmetric_v0"
@@ -263,21 +271,38 @@ def resolve_effective_backtest_cost_config(
             "Zero-cost economic backtest is forbidden without explicit_zero_cost_non_economic=True"
         )
 
+    funding_bound = funding_binding_requested(cfg)
+    funding_model_version = BOUND_FUNDING_MODEL_VERSION if funding_bound else FUNDING_MODEL_VERSION
+    funding_rate_source = FUNDING_RATE_SOURCE_BARS_COLUMN if funding_bound else "NOT_BOUND"
+    funding_application_policy = (
+        FUNDING_APPLICATION_POLICY if funding_bound else "DEFERRED_TO_LATER_STEP"
+    )
+    if funding_bound:
+        funding_config = load_funding_model_config_v1(cfg)
+        if funding_config.model_version != BOUND_FUNDING_MODEL_VERSION:
+            raise BacktestCostConfigError("funding_model_version_mismatch")
+        reason_codes = [code for code in reason_codes if code != REASON_FUNDING_NOT_BOUND]
+        if REASON_FUNDING_BOUND not in reason_codes:
+            reason_codes.append(REASON_FUNDING_BOUND)
+    else:
+        if REASON_FUNDING_NOT_BOUND not in reason_codes:
+            reason_codes.append(REASON_FUNDING_NOT_BOUND)
+
     base_fields = {
         "cost_model_version": str(section.get("cost_model_version", COST_MODEL_VERSION)),
         "fee_model_version": str(section.get("fee_model_version", FEE_MODEL_VERSION)),
         "slippage_model_version": str(
             section.get("slippage_model_version", SLIPPAGE_MODEL_VERSION)
         ),
-        "funding_model_version": FUNDING_MODEL_VERSION,
+        "funding_model_version": funding_model_version,
         "spread_model_version": SPREAD_MODEL_VERSION,
         "execution_model_version": EXECUTION_MODEL_VERSION,
         "maker_fee_bps": effective_fee,
         "taker_fee_bps": effective_fee,
         "entry_slippage_bps": effective_slippage,
         "exit_slippage_bps": effective_slippage,
-        "funding_rate_source": "NOT_BOUND",
-        "funding_application_policy": "DEFERRED_TO_LATER_STEP",
+        "funding_rate_source": funding_rate_source,
+        "funding_application_policy": funding_application_policy,
         "spread_application_policy": "NOT_APPLICABLE",
         "latency_assumption": "NOT_BOUND",
         "partial_fill_assumption": "NOT_BOUND",
@@ -290,7 +315,7 @@ def resolve_effective_backtest_cost_config(
             _canonical_json([asdict(p) for p in provenance]).encode("utf-8")
         ).hexdigest()
 
-    # Futures-only path: funding not yet bound — no economic validity claim (STEP 29J boundary).
+    # Economic validity remains blocked until admissible data, policy thresholds, and sensitivity.
     economic_allowed = False
 
     return EffectiveBacktestCostConfigV0(
@@ -329,7 +354,7 @@ def append_cost_accounting_fields(
             "net_return": net_return,
             "fee_drag": fee_drag,
             "slippage_impact": slippage_impact,
-            "funding_drag_or_status": FUNDING_MODEL_VERSION,
+            "funding_drag_or_status": effective_cost.funding_model_version,
             "economic_interpretation_allowed": effective_cost.economic_interpretation_allowed,
         }
     )
@@ -350,7 +375,7 @@ def build_cost_result_metadata(
         "slippage_bps": effective_cost.entry_slippage_bps,
         "economic_interpretation_allowed": effective_cost.economic_interpretation_allowed,
         "reason_codes": list(effective_cost.reason_codes),
-        "funding_binding_status": FUNDING_MODEL_VERSION,
+        "funding_binding_status": effective_cost.funding_model_version,
     }
     if extra:
         meta.update(extra)

--- a/src/backtest/economic_viability_evidence_v1.py
+++ b/src/backtest/economic_viability_evidence_v1.py
@@ -25,6 +25,11 @@ from scripts.ops.primary_evidence_retention_v0 import (
 )
 from src.backtest import mv2_research_wiring_v1 as mv2_wiring
 from src.backtest.cost_config_v0 import FUNDING_MODEL_VERSION
+from src.backtest.funding_model_v1 import (
+    FundingModelError,
+    compute_funding_drag_v1,
+    load_funding_model_config_v1,
+)
 from src.backtest.economic_validity_policy_v1 import (
     ECONOMIC_VALIDITY_POLICY_VERSION,
     evaluate_economic_validity_gates_v1,
@@ -474,7 +479,7 @@ def build_economic_viability_evidence_v1(
         reason_codes.append("economic_validity_policy_thresholds_not_configured")
         for field_name in policy.unconfigured_fields():
             reason_codes.append(f"policy_threshold_required_not_configured:{field_name}")
-    if FUNDING_MODEL_VERSION == "NOT_BOUND" or cost.funding_model_version == "NOT_BOUND":
+    if cost.funding_model_version == "NOT_BOUND":
         reason_codes.append("funding_model_not_bound")
     if cost.zero_cost_explicitly_requested:
         reason_codes.append("explicit_zero_cost_non_economic_mode")
@@ -499,6 +504,27 @@ def build_economic_viability_evidence_v1(
     policy_version_bound = policy.is_version_bound()
     funding_bound = cost.funding_model_version != "NOT_BOUND"
     parameter_sensitivity_bound = False
+
+    funding_drag_result = None
+    funding_drag_metric = _not_computed_metric("funding_drag_not_bound")
+    if funding_bound:
+        try:
+            initial_equity = float(cfg.get("backtest", {}).get("initial_cash", 10_000.0))
+            funding_drag_result = compute_funding_drag_v1(
+                bars=bars,
+                position_series=wiring_result.signals,
+                initial_equity=initial_equity,
+                config=load_funding_model_config_v1(cfg),
+                data_digest=computed_data_digest,
+            )
+            funding_drag_metric = MetricFieldV1(
+                semantic=MetricSemantic.COMPUTED,
+                value=float(funding_drag_result.funding_drag),
+            )
+        except FundingModelError as exc:
+            reason_codes.append(f"funding_drag_compute_failed:{exc}")
+            funding_bound = False
+            reason_codes.append("funding_model_not_bound")
 
     status = _resolve_status(
         reason_codes=reason_codes,
@@ -598,7 +624,7 @@ def build_economic_viability_evidence_v1(
         trade_count=MetricFieldV1(semantic=MetricSemantic.COMPUTED, value=float(trade_count_value)),
         turnover=_not_computed_metric("turnover_not_bound_in_step29m_scope"),
         fee_drag=_not_computed_metric("fee_drag_decomposition_not_bound"),
-        funding_drag=_not_computed_metric("funding_drag_not_bound"),
+        funding_drag=funding_drag_metric,
         slippage_impact=_not_computed_metric("slippage_impact_decomposition_not_bound"),
         tail_loss=_not_computed_metric("tail_loss_metric_not_bound"),
         time_in_market=_not_computed_metric("time_in_market_not_bound"),
@@ -657,6 +683,15 @@ def build_economic_viability_evidence_v1(
             "latency_assumption": cost.latency_assumption,
             "partial_fill_assumption": cost.partial_fill_assumption,
             "spread_application_policy": cost.spread_application_policy,
+            "funding_model_version": cost.funding_model_version,
+            "funding_rate_source": cost.funding_rate_source,
+            "funding_application_policy": cost.funding_application_policy,
+            "funding_binding_status": (
+                "BOUND" if funding_bound and funding_drag_result is not None else "NOT_BOUND"
+            ),
+            "funding_evidence_digest": (
+                funding_drag_result.evidence_digest() if funding_drag_result is not None else ""
+            ),
         },
         policy_version=policy.policy_version,
         policy_digest=policy.config_digest(),

--- a/src/backtest/funding_model_v1.py
+++ b/src/backtest/funding_model_v1.py
@@ -1,0 +1,362 @@
+"""
+Deterministic offline perpetual-futures funding model v1 (RUNBOOK STEP 29M).
+
+Fail-closed binding for funding-rate series, interval-aligned payments, and
+funding-drag evidence. No live fetch, no credentials, no implicit zero funding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence
+
+import pandas as pd
+
+from ..core.errors import BacktestError
+
+FUNDING_MODEL_VERSION = "backtest_funding_perpetual_interval_v1"
+FUNDING_MODEL_OWNER = "backtest.funding_model_v1"
+LONG_SHORT_SIGN_SEMANTICS = "long_pays_positive_rate"
+DEFAULT_PAYMENT_INTERVAL_HOURS = 8
+FUNDING_RATE_SOURCE_BARS_COLUMN = "bars_funding_rate_column"
+FUNDING_APPLICATION_POLICY = "interval_aligned_position_notional"
+DEFAULT_RATE_COLUMN = "funding_rate"
+MARK_PRICE_COLUMN = "mark_price"
+
+REASON_FUNDING_BOUND = "FUNDING_MODEL_BOUND"
+REASON_EXPLICIT_ZERO_RATE = "EXPLICIT_ZERO_FUNDING_RATE"
+REASON_MISSING_FUNDING_SERIES = "FUNDING_SERIES_MISSING"
+REASON_MISSING_FUNDING_RATE = "FUNDING_RATE_MISSING_AT_PAYMENT"
+REASON_DUPLICATE_FUNDING_EVENT = "DUPLICATE_FUNDING_EVENT"
+REASON_OUT_OF_ORDER_FUNDING_EVENT = "OUT_OF_ORDER_FUNDING_EVENT"
+
+
+class FundingModelError(BacktestError):
+    """Fail-closed funding model error."""
+
+
+class FundingRatePresence(str, Enum):
+    PRESENT = "PRESENT"
+    EXPLICIT_ZERO = "EXPLICIT_ZERO"
+    MISSING = "MISSING"
+
+
+@dataclass(frozen=True)
+class FundingModelConfigV1:
+    model_version: str
+    owner: str
+    payment_interval_hours: int
+    rate_source: str
+    rate_column: str
+    mark_price_column: str
+    long_short_sign_semantics: str
+    funding_application_policy: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_version": self.model_version,
+            "owner": self.owner,
+            "payment_interval_hours": self.payment_interval_hours,
+            "rate_source": self.rate_source,
+            "rate_column": self.rate_column,
+            "mark_price_column": self.mark_price_column,
+            "long_short_sign_semantics": self.long_short_sign_semantics,
+            "funding_application_policy": self.funding_application_policy,
+        }
+
+    def config_digest(self) -> str:
+        return _stable_digest(self.to_dict())
+
+
+@dataclass(frozen=True)
+class FundingPaymentEventV1:
+    timestamp: str
+    position_sign: int
+    mark_price: float
+    funding_rate: float
+    rate_presence: FundingRatePresence
+    notional: float
+    payment_amount: float
+    payment_index: int
+
+
+@dataclass(frozen=True)
+class FundingDragResultV1:
+    model_version: str
+    owner: str
+    config_digest: str
+    data_digest: str
+    implementation_digest: str
+    total_payment_amount: float
+    funding_drag: float
+    payment_count: int
+    explicit_zero_rate_count: int
+    missing_rate_count: int
+    payment_events: tuple[FundingPaymentEventV1, ...]
+    reason_codes: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_version": self.model_version,
+            "owner": self.owner,
+            "config_digest": self.config_digest,
+            "data_digest": self.data_digest,
+            "implementation_digest": self.implementation_digest,
+            "total_payment_amount": self.total_payment_amount,
+            "funding_drag": self.funding_drag,
+            "payment_count": self.payment_count,
+            "explicit_zero_rate_count": self.explicit_zero_rate_count,
+            "missing_rate_count": self.missing_rate_count,
+            "payment_events": [
+                {
+                    "timestamp": event.timestamp,
+                    "position_sign": event.position_sign,
+                    "mark_price": event.mark_price,
+                    "funding_rate": event.funding_rate,
+                    "rate_presence": event.rate_presence.value,
+                    "notional": event.notional,
+                    "payment_amount": event.payment_amount,
+                    "payment_index": event.payment_index,
+                }
+                for event in self.payment_events
+            ],
+            "reason_codes": list(self.reason_codes),
+        }
+
+    def evidence_digest(self) -> str:
+        payload = self.to_dict()
+        payload.pop("payment_events", None)
+        return _stable_digest(payload)
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def default_funding_model_config_v1() -> FundingModelConfigV1:
+    return FundingModelConfigV1(
+        model_version=FUNDING_MODEL_VERSION,
+        owner=FUNDING_MODEL_OWNER,
+        payment_interval_hours=DEFAULT_PAYMENT_INTERVAL_HOURS,
+        rate_source=FUNDING_RATE_SOURCE_BARS_COLUMN,
+        rate_column=DEFAULT_RATE_COLUMN,
+        mark_price_column=MARK_PRICE_COLUMN,
+        long_short_sign_semantics=LONG_SHORT_SIGN_SEMANTICS,
+        funding_application_policy=FUNDING_APPLICATION_POLICY,
+    )
+
+
+def load_funding_model_config_v1(cfg: Mapping[str, Any] | None = None) -> FundingModelConfigV1:
+    if cfg is None:
+        return default_funding_model_config_v1()
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        return default_funding_model_config_v1()
+    funding = backtest.get("funding")
+    if funding is None:
+        return default_funding_model_config_v1()
+    if not isinstance(funding, Mapping):
+        raise FundingModelError("backtest_funding_section_not_mapping")
+    model_version = str(funding.get("model_version", FUNDING_MODEL_VERSION))
+    if model_version != FUNDING_MODEL_VERSION:
+        raise FundingModelError(f"funding_model_version_mismatch:{model_version}")
+    interval = int(funding.get("payment_interval_hours", DEFAULT_PAYMENT_INTERVAL_HOURS))
+    if interval <= 0:
+        raise FundingModelError("payment_interval_hours_invalid")
+    rate_source = str(funding.get("rate_source", FUNDING_RATE_SOURCE_BARS_COLUMN))
+    if rate_source != FUNDING_RATE_SOURCE_BARS_COLUMN:
+        raise FundingModelError(f"funding_rate_source_unsupported:{rate_source}")
+    rate_column = str(funding.get("rate_column", DEFAULT_RATE_COLUMN))
+    mark_column = str(funding.get("mark_price_column", MARK_PRICE_COLUMN))
+    return FundingModelConfigV1(
+        model_version=model_version,
+        owner=str(funding.get("owner", FUNDING_MODEL_OWNER)),
+        payment_interval_hours=interval,
+        rate_source=rate_source,
+        rate_column=rate_column,
+        mark_price_column=mark_column,
+        long_short_sign_semantics=str(
+            funding.get("long_short_sign_semantics", LONG_SHORT_SIGN_SEMANTICS)
+        ),
+        funding_application_policy=str(
+            funding.get("funding_application_policy", FUNDING_APPLICATION_POLICY)
+        ),
+    )
+
+
+def funding_binding_requested(cfg: Mapping[str, Any]) -> bool:
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        return False
+    funding = backtest.get("funding")
+    if not isinstance(funding, Mapping):
+        return False
+    bind_flag = funding.get("bind")
+    if bind_flag is True:
+        return True
+    return str(funding.get("model_version", "")) == FUNDING_MODEL_VERSION
+
+
+def classify_funding_rate_value(value: Any) -> FundingRatePresence:
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return FundingRatePresence.MISSING
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise FundingModelError(f"funding_rate_invalid:{value!r}") from exc
+    if not math.isfinite(numeric):
+        raise FundingModelError(f"funding_rate_non_finite:{value!r}")
+    if numeric == 0.0:
+        return FundingRatePresence.EXPLICIT_ZERO
+    return FundingRatePresence.PRESENT
+
+
+def is_funding_payment_timestamp(ts: pd.Timestamp, interval_hours: int) -> bool:
+    normalized = pd.Timestamp(ts).tz_convert("UTC") if ts.tzinfo else pd.Timestamp(ts, tz="UTC")
+    return (
+        normalized.minute == 0
+        and normalized.second == 0
+        and normalized.microsecond == 0
+        and normalized.hour % interval_hours == 0
+    )
+
+
+def _resolve_mark_price(bar: pd.Series, config: FundingModelConfigV1) -> float:
+    if config.mark_price_column in bar.index:
+        return float(bar[config.mark_price_column])
+    if "close" in bar.index:
+        return float(bar["close"])
+    raise FundingModelError("mark_price_column_missing")
+
+
+def _payment_amount(position_sign: int, notional: float, funding_rate: float) -> float:
+    if position_sign == 0:
+        return 0.0
+    return -float(position_sign) * abs(notional) * funding_rate
+
+
+def compute_funding_drag_v1(
+    *,
+    bars: pd.DataFrame,
+    position_series: pd.Series,
+    initial_equity: float,
+    config: FundingModelConfigV1 | None = None,
+    data_digest: str = "",
+    fail_closed_on_missing_rate: bool = True,
+) -> FundingDragResultV1:
+    """
+    Compute interval-aligned funding payments and funding drag.
+
+    Long pays positive rates; short receives positive rates. Explicit 0.0 is valid.
+    Missing rates fail-closed when fail_closed_on_missing_rate is True.
+    """
+    model = config or default_funding_model_config_v1()
+    if model.model_version != FUNDING_MODEL_VERSION:
+        raise FundingModelError("funding_model_not_version_bound")
+    if model.rate_column not in bars.columns:
+        raise FundingModelError(REASON_MISSING_FUNDING_SERIES)
+    if bars.empty:
+        raise FundingModelError("bars_empty")
+    if initial_equity <= 0.0:
+        raise FundingModelError("initial_equity_non_positive")
+    if bars.index.has_duplicates:
+        raise FundingModelError(REASON_DUPLICATE_FUNDING_EVENT)
+
+    aligned_positions = position_series.reindex(bars.index).fillna(0).astype(int)
+    events: list[FundingPaymentEventV1] = []
+    reason_codes: list[str] = []
+    explicit_zero_count = 0
+    missing_rate_count = 0
+    seen_timestamps: set[str] = set()
+    last_timestamp: Optional[pd.Timestamp] = None
+
+    payment_index = 0
+    for ts, bar in bars.iterrows():
+        timestamp = pd.Timestamp(ts)
+        if last_timestamp is not None and timestamp < last_timestamp:
+            raise FundingModelError(REASON_OUT_OF_ORDER_FUNDING_EVENT)
+        last_timestamp = timestamp
+        if not is_funding_payment_timestamp(timestamp, model.payment_interval_hours):
+            continue
+        ts_key = timestamp.isoformat()
+        if ts_key in seen_timestamps:
+            raise FundingModelError(REASON_DUPLICATE_FUNDING_EVENT)
+        seen_timestamps.add(ts_key)
+
+        position_value = aligned_positions.loc[timestamp]
+        if isinstance(position_value, pd.Series):
+            raise FundingModelError(REASON_DUPLICATE_FUNDING_EVENT)
+        position_sign = int(position_value)
+        rate_presence = classify_funding_rate_value(bar[model.rate_column])
+        if rate_presence is FundingRatePresence.MISSING:
+            missing_rate_count += 1
+            if fail_closed_on_missing_rate:
+                raise FundingModelError(REASON_MISSING_FUNDING_RATE)
+            continue
+        funding_rate = float(bar[model.rate_column])
+        if rate_presence is FundingRatePresence.EXPLICIT_ZERO:
+            explicit_zero_count += 1
+            reason_codes.append(REASON_EXPLICIT_ZERO_RATE)
+
+        mark_price = _resolve_mark_price(bar, model)
+        notional = abs(position_sign) * mark_price
+        payment = _payment_amount(position_sign, notional, funding_rate)
+        events.append(
+            FundingPaymentEventV1(
+                timestamp=ts_key,
+                position_sign=position_sign,
+                mark_price=mark_price,
+                funding_rate=funding_rate,
+                rate_presence=rate_presence,
+                notional=notional,
+                payment_amount=payment,
+                payment_index=payment_index,
+            )
+        )
+        payment_index += 1
+
+    total_payment = sum(event.payment_amount for event in events)
+    funding_drag = total_payment / initial_equity
+    if events:
+        reason_codes.append(REASON_FUNDING_BOUND)
+
+    return FundingDragResultV1(
+        model_version=model.model_version,
+        owner=model.owner,
+        config_digest=model.config_digest(),
+        data_digest=data_digest,
+        implementation_digest=_stable_digest(
+            {
+                "owner": FUNDING_MODEL_OWNER,
+                "model_version": FUNDING_MODEL_VERSION,
+                "long_short_sign_semantics": LONG_SHORT_SIGN_SEMANTICS,
+            }
+        ),
+        total_payment_amount=total_payment,
+        funding_drag=funding_drag,
+        payment_count=len(events),
+        explicit_zero_rate_count=explicit_zero_count,
+        missing_rate_count=missing_rate_count,
+        payment_events=tuple(events),
+        reason_codes=tuple(sorted(set(reason_codes))),
+    )
+
+
+def funding_model_schema_v1() -> dict[str, Any]:
+    return {
+        "contract_name": "funding_model_v1",
+        "model_version": FUNDING_MODEL_VERSION,
+        "owner": FUNDING_MODEL_OWNER,
+        "payment_interval_hours": DEFAULT_PAYMENT_INTERVAL_HOURS,
+        "rate_source": FUNDING_RATE_SOURCE_BARS_COLUMN,
+        "long_short_sign_semantics": LONG_SHORT_SIGN_SEMANTICS,
+        "funding_application_policy": FUNDING_APPLICATION_POLICY,
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+    }

--- a/tests/backtest/test_economic_viability_evidence_v1.py
+++ b/tests/backtest/test_economic_viability_evidence_v1.py
@@ -28,6 +28,17 @@ def _cfg(*, fee_bps: float = 10.0, slippage_bps: float = 5.0) -> Mapping[str, An
     }
 
 
+def _cfg_with_funding(**kwargs: Any) -> Mapping[str, Any]:
+    cfg = dict(_cfg(**kwargs))
+    backtest = dict(cfg["backtest"])
+    backtest["funding"] = {
+        "bind": True,
+        "model_version": "backtest_funding_perpetual_interval_v1",
+    }
+    cfg["backtest"] = backtest
+    return cfg
+
+
 def _bars(n: int = 20) -> pd.DataFrame:
     idx = pd.date_range("2026-06-01", periods=n, freq="1h", tz="UTC")
     close = [100.0 + float(i) for i in range(n)]
@@ -149,6 +160,30 @@ def test_not_computed_metrics_not_zero_filled() -> None:
     assert result.turnover.semantic is ev.MetricSemantic.NOT_COMPUTED
     assert result.turnover.value is None
     assert result.funding_drag.reason_code == "funding_drag_not_bound"
+
+
+def test_funding_binding_computes_funding_drag() -> None:
+    result = _build(cfg=_cfg_with_funding())
+    assert result.funding_model_version == "backtest_funding_perpetual_interval_v1"
+    assert "funding_model_not_bound" not in result.reason_codes
+    assert result.funding_drag.semantic is ev.MetricSemantic.COMPUTED
+    assert result.funding_drag.value is not None
+    assert result.cost_binding["funding_binding_status"] == "BOUND"
+    assert len(result.cost_binding["funding_evidence_digest"]) == 64
+
+
+def test_funding_binding_still_research_only_without_admissible_data() -> None:
+    result = _build(cfg=_cfg_with_funding())
+    assert result.status is ev.EconomicViabilityStatus.RESEARCH_ONLY
+    assert result.economic_validity_proven is False
+    assert "admissible_versioned_futures_dataset_missing" in result.reason_codes
+
+
+def test_funding_binding_deterministic() -> None:
+    a = _build(cfg=_cfg_with_funding())
+    b = _build(cfg=_cfg_with_funding())
+    assert a.funding_drag.value == b.funding_drag.value
+    assert a.cost_binding["funding_evidence_digest"] == b.cost_binding["funding_evidence_digest"]
 
 
 def test_walk_forward_monte_carlo_stress_sections_present() -> None:

--- a/tests/backtest/test_funding_model_v1.py
+++ b/tests/backtest/test_funding_model_v1.py
@@ -1,0 +1,304 @@
+"""RUNBOOK STEP 29M — deterministic offline funding model v1 tests."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping
+
+import pandas as pd
+import pytest
+
+from src.backtest import funding_model_v1 as fm
+
+
+def _bars(
+    *,
+    n: int = 24,
+    start: str = "2026-06-01",
+    funding_rates: list[float] | None = None,
+    mark_prices: list[float] | None = None,
+) -> pd.DataFrame:
+    idx = pd.date_range(start, periods=n, freq="1h", tz="UTC")
+    close = [100.0 + float(i) for i in range(n)]
+    rates = funding_rates if funding_rates is not None else [0.0001 for _ in range(n)]
+    marks = mark_prices if mark_prices is not None else close
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": marks,
+            "index_price": [v - 0.1 for v in close],
+            "best_bid": [v - 0.05 for v in close],
+            "best_ask": [v + 0.05 for v in close],
+            "spread": [0.1 for _ in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": rates,
+            "volatility_estimate": [0.2 for _ in close],
+            "is_final": [True for _ in close],
+            "bar_interval": ["1h" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def _positions(bars: pd.DataFrame, sign: int) -> pd.Series:
+    return pd.Series([sign for _ in bars.index], index=bars.index, dtype=int)
+
+
+def _cfg_with_funding() -> Mapping[str, Any]:
+    return {
+        "backtest": {
+            "initial_cash": 10_000.0,
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+            "funding": {
+                "bind": True,
+                "model_version": fm.FUNDING_MODEL_VERSION,
+            },
+        }
+    }
+
+
+class TestFundingModelConfig:
+    def test_default_config_version_bound(self) -> None:
+        cfg = fm.default_funding_model_config_v1()
+        assert cfg.model_version == fm.FUNDING_MODEL_VERSION
+        assert len(cfg.config_digest()) == 64
+
+    def test_load_from_cfg(self) -> None:
+        loaded = fm.load_funding_model_config_v1(_cfg_with_funding())
+        assert loaded.payment_interval_hours == fm.DEFAULT_PAYMENT_INTERVAL_HOURS
+
+    def test_binding_requested(self) -> None:
+        assert fm.funding_binding_requested(_cfg_with_funding()) is True
+        assert fm.funding_binding_requested({"backtest": {"fee_bps": 1.0}}) is False
+
+
+class TestFundingRateClassification:
+    def test_explicit_zero_distinct_from_missing(self) -> None:
+        assert fm.classify_funding_rate_value(0.0) is fm.FundingRatePresence.EXPLICIT_ZERO
+        assert fm.classify_funding_rate_value(None) is fm.FundingRatePresence.MISSING
+        assert fm.classify_funding_rate_value(float("nan")) is fm.FundingRatePresence.MISSING
+
+    def test_positive_rate_present(self) -> None:
+        assert fm.classify_funding_rate_value(0.0001) is fm.FundingRatePresence.PRESENT
+
+    def test_negative_rate_present(self) -> None:
+        assert fm.classify_funding_rate_value(-0.0002) is fm.FundingRatePresence.PRESENT
+
+
+class TestFundingPayments:
+    def test_long_positive_rate_payment(self) -> None:
+        bars = _bars(n=9, funding_rates=[0.0] * 8 + [0.001])
+        bars.index = pd.DatetimeIndex(
+            [
+                "2026-06-01T00:00:00+00:00",
+                "2026-06-01T01:00:00+00:00",
+                "2026-06-01T02:00:00+00:00",
+                "2026-06-01T03:00:00+00:00",
+                "2026-06-01T04:00:00+00:00",
+                "2026-06-01T05:00:00+00:00",
+                "2026-06-01T06:00:00+00:00",
+                "2026-06-01T07:00:00+00:00",
+                "2026-06-01T08:00:00+00:00",
+            ]
+        )
+        result = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=_positions(bars, 1),
+            initial_equity=10_000.0,
+        )
+        assert result.payment_count == 2
+        assert result.total_payment_amount < 0.0
+
+    def test_short_positive_rate_payment(self) -> None:
+        bars = _bars(n=9, funding_rates=[0.0] * 8 + [0.001])
+        bars.index = pd.DatetimeIndex(
+            [
+                "2026-06-01T00:00:00+00:00",
+                "2026-06-01T01:00:00+00:00",
+                "2026-06-01T02:00:00+00:00",
+                "2026-06-01T03:00:00+00:00",
+                "2026-06-01T04:00:00+00:00",
+                "2026-06-01T05:00:00+00:00",
+                "2026-06-01T06:00:00+00:00",
+                "2026-06-01T07:00:00+00:00",
+                "2026-06-01T08:00:00+00:00",
+            ]
+        )
+        long_result = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=_positions(bars, 1),
+            initial_equity=10_000.0,
+        )
+        short_result = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=_positions(bars, -1),
+            initial_equity=10_000.0,
+        )
+        assert short_result.total_payment_amount == pytest.approx(-long_result.total_payment_amount)
+
+    def test_negative_rate(self) -> None:
+        bars = _bars(n=1, funding_rates=[-0.001])
+        bars.index = pd.DatetimeIndex(["2026-06-01T00:00:00+00:00"])
+        result = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=_positions(bars, 1),
+            initial_equity=10_000.0,
+        )
+        assert result.total_payment_amount > 0.0
+
+    def test_explicit_zero_rate(self) -> None:
+        bars = _bars(n=1, funding_rates=[0.0])
+        bars.index = pd.DatetimeIndex(["2026-06-01T00:00:00+00:00"])
+        result = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=_positions(bars, 1),
+            initial_equity=10_000.0,
+        )
+        assert result.total_payment_amount == 0.0
+        assert result.explicit_zero_rate_count == 1
+        assert fm.REASON_EXPLICIT_ZERO_RATE in result.reason_codes
+
+    def test_missing_rate_fail_closed(self) -> None:
+        bars = _bars(n=1, funding_rates=[float("nan")])
+        bars.index = pd.DatetimeIndex(["2026-06-01T00:00:00+00:00"])
+        with pytest.raises(fm.FundingModelError, match=fm.REASON_MISSING_FUNDING_RATE):
+            fm.compute_funding_drag_v1(
+                bars=bars,
+                position_series=_positions(bars, 1),
+                initial_equity=10_000.0,
+            )
+
+    def test_missing_series_fail_closed(self) -> None:
+        bars = _bars()
+        del bars["funding_rate"]
+        with pytest.raises(fm.FundingModelError, match=fm.REASON_MISSING_FUNDING_SERIES):
+            fm.compute_funding_drag_v1(
+                bars=bars,
+                position_series=_positions(bars, 1),
+                initial_equity=10_000.0,
+            )
+
+    def test_interval_boundary_only(self) -> None:
+        bars = _bars(n=3, funding_rates=[0.001, 0.002, 0.003])
+        bars.index = pd.DatetimeIndex(
+            [
+                "2026-06-01T00:00:00+00:00",
+                "2026-06-01T01:00:00+00:00",
+                "2026-06-01T08:00:00+00:00",
+            ]
+        )
+        result = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=_positions(bars, 1),
+            initial_equity=10_000.0,
+        )
+        assert result.payment_count == 2
+
+    def test_duplicate_event_fail_closed(self) -> None:
+        bars = _bars(n=2, funding_rates=[0.001, 0.002])
+        bars.index = pd.DatetimeIndex(
+            [
+                "2026-06-01T00:00:00+00:00",
+                "2026-06-01T00:00:00+00:00",
+            ]
+        )
+        with pytest.raises(fm.FundingModelError, match=fm.REASON_DUPLICATE_FUNDING_EVENT):
+            fm.compute_funding_drag_v1(
+                bars=bars,
+                position_series=_positions(bars, 1),
+                initial_equity=10_000.0,
+            )
+
+    def test_out_of_order_event_fail_closed(self) -> None:
+        bars = _bars(n=2, funding_rates=[0.001, 0.002])
+        bars.index = pd.DatetimeIndex(
+            [
+                "2026-06-01T08:00:00+00:00",
+                "2026-06-01T00:00:00+00:00",
+            ]
+        )
+        with pytest.raises(fm.FundingModelError, match=fm.REASON_OUT_OF_ORDER_FUNDING_EVENT):
+            fm.compute_funding_drag_v1(
+                bars=bars,
+                position_series=_positions(bars, 1),
+                initial_equity=10_000.0,
+            )
+
+    def test_funding_drag_aggregation(self) -> None:
+        bars = _bars(n=17, funding_rates=[0.0005 for _ in range(17)])
+        result = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=_positions(bars, 1),
+            initial_equity=10_000.0,
+        )
+        assert result.funding_drag == pytest.approx(result.total_payment_amount / 10_000.0)
+
+    def test_deterministic_replay(self) -> None:
+        bars = _bars()
+        positions = _positions(bars, 1)
+        a = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=positions,
+            initial_equity=10_000.0,
+            data_digest="abc",
+        )
+        b = fm.compute_funding_drag_v1(
+            bars=bars,
+            position_series=positions,
+            initial_equity=10_000.0,
+            data_digest="abc",
+        )
+        assert a.to_dict() == b.to_dict()
+        assert a.evidence_digest() == b.evidence_digest()
+
+    def test_digest_binding_changes_with_data(self) -> None:
+        bars_a = _bars()
+        bars_b = _bars(funding_rates=[0.0002 for _ in range(24)])
+        pos = _positions(bars_a, 1)
+        a = fm.compute_funding_drag_v1(
+            bars=bars_a,
+            position_series=pos,
+            initial_equity=10_000.0,
+            data_digest="digest_a",
+        )
+        b = fm.compute_funding_drag_v1(
+            bars=bars_b,
+            position_series=_positions(bars_b, 1),
+            initial_equity=10_000.0,
+            data_digest="digest_b",
+        )
+        assert a.evidence_digest() != b.evidence_digest()
+
+
+class TestCostConfigFundingBinding:
+    def test_cost_config_binds_funding_when_requested(self) -> None:
+        from src.backtest.cost_config_v0 import (
+            REASON_FUNDING_BOUND,
+            resolve_effective_backtest_cost_config,
+        )
+
+        cost = resolve_effective_backtest_cost_config(_cfg_with_funding())
+        assert cost.funding_model_version == fm.FUNDING_MODEL_VERSION
+        assert REASON_FUNDING_BOUND in cost.reason_codes
+
+    def test_cost_config_unbound_without_funding_section(self) -> None:
+        from src.backtest.cost_config_v0 import (
+            FUNDING_MODEL_VERSION,
+            resolve_effective_backtest_cost_config,
+        )
+
+        cost = resolve_effective_backtest_cost_config(
+            {"backtest": {"fee_bps": 10.0, "slippage_bps": 5.0}}
+        )
+        assert cost.funding_model_version == FUNDING_MODEL_VERSION
+
+
+def test_schema_contract() -> None:
+    schema = fm.funding_model_schema_v1()
+    assert schema["runtime_effect"] is False
+    assert schema["order_effect"] is False


### PR DESCRIPTION
## Summary

- Rank-1 STEP 29M residual slice: deterministic offline perpetual-futures **funding model binding v1**
- Adds `src/backtest/funding_model_v1.py` with interval-aligned payments, long/short sign semantics, explicit-zero vs missing fail-closed handling, and digest-bound `funding_drag` evidence
- Wires funding binding into `cost_config_v0` (via `[backtest.funding] bind=true`) and `economic_viability_evidence_v1` without runtime/order/risk effects

## Audit verdict

| Blocker | Status before | Status after |
|---|---|---|
| FUNDING_BINDING | MISSING | PARTIAL (contract bound; real admissible dataset still required for economic claims) |
| PARAMETER_SENSITIVITY | MISSING | MISSING |
| ADMISSIBLE_FUTURES_DATA | TEST_FIXTURE_ONLY | TEST_FIXTURE_ONLY |
| POLICY_THRESHOLDS | BLOCKED_BY_MISSING_VERSIONED_VALUES | unchanged |

## Safety invariants

- `RUNBOOK_STEP_29M_COMPLETE=false`, `STEP_29N_STARTED=false`
- `ECONOMIC_VALIDITY_PROVEN=false`, `PROFITABILITY_CLAIM_ALLOWED=false`
- No runtime, order, risk, scheduler, credential, or network effects

## Test plan

- [x] `tests/backtest/test_funding_model_v1.py` (long/short, +/- rate, explicit zero, missing rate/series, interval boundary, duplicate/out-of-order, drag aggregation, deterministic replay, digest binding)
- [x] `tests/backtest/test_economic_viability_evidence_v1.py` funding integration tests
- [x] STEP 29M regression: economic validity policy + default cost binding
- [x] `ruff format --check` + `ruff check` on changed Python files
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)